### PR TITLE
@mzikherman - two minor seo items

### DIFF
--- a/apps/artist/routes.coffee
+++ b/apps/artist/routes.coffee
@@ -16,7 +16,7 @@ sd = require('sharify').data
 
 @index = (req, res, next) ->
   tab = if req.params.tab? then req.params.tab else ''
-  includeJSONLD = res.locals.userAgent is 'PhantomJS'
+  includeJSONLD = res.locals.sd.REFLECTION
   send =
     query: query,
     variables:

--- a/apps/artwork/components/images/index.styl
+++ b/apps/artwork/components/images/index.styl
@@ -56,7 +56,7 @@ artwork-images = {
         opacity 0
         background-color white
         transition opacity 0.25s
-        &[data-state='loaded']
+        &[data-state='loaded'], &--visible
           opacity 1
 
         > img

--- a/apps/artwork/components/images/templates/image.jade
+++ b/apps/artwork/components/images/templates/image.jade
@@ -1,3 +1,5 @@
+- extraDisplayStyle = sd.REFLECTION ? 'artwork-images__images__image__display--visible' : ''
+
 a.artwork-images__images__image(
   class='js-artwork-images__images__image analytics-artwork-zoom'
   data-id= image.id
@@ -10,7 +12,7 @@ a.artwork-images__images__image(
   )
 
   .artwork-images__images__image__display(
-    class='js-artwork-images__images__image__display'
+    class="js-artwork-images__images__image__display #{extraDisplayStyle}"
   )
     img.artwork-images__images__image__display__img(
       class='js-artwork-images__images__image__display__img'

--- a/lib/middleware/locals.coffee
+++ b/lib/middleware/locals.coffee
@@ -35,6 +35,7 @@ module.exports = (req, res, next) ->
   res.locals.sd.REFERRER = referrer = req.get 'Referrer'
   res.locals.sd.MEDIUM = new Referrer(referrer).medium if referrer
   res.locals.sd.EIGEN = req.headers?['user-agent']?.match('Artsy-Mobile')?
+  res.locals.sd.REFLECTION = req.headers?['user-agent']?.match('PhantomJS')?
   res.locals.sd.REQUEST_TIMESTAMP = Date.now()
   res.locals.sd.NOTIFICATION_COUNT = req.cookies?['notification-count']
 

--- a/test/lib/middleware/locals.coffee
+++ b/test/lib/middleware/locals.coffee
@@ -32,3 +32,8 @@ describe 'locals middleware', ->
       ->
     )
     res.locals.sd.MEDIUM.should.equal 'search'
+
+  it 'flags reflection', ->
+    middleware req = { url: 'localhost:3000/foo?bar=baz', headers: { 'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari' }, get: -> },
+      res = { locals: { sd: {} } }, ->
+    res.locals.sd.REFLECTION.should.be.ok()


### PR DESCRIPTION
We are still not getting the JSONLD schema showing up on the artist page. I actually ran reflection locally and got the whole user agent string, so I'm pretty sure checking this way will work.

This also uses the same variable to conditionally add a class to the artwork image on the artwork page to make it visible automatically if rendered on reflection. The issue this solves is we aren't getting  images indexed for individual artworks. The hypothesis is that Google is ignoring the larger image that has 0 opacity (see: https://www.artsy.net/artwork/1010-frappant-gallery-hamburg-germany?_escaped_fragment_= ). Because JS is not executing on the Reflection rendered page, the image never gets completely "loaded".