### PR TITLE
@kanaabe: fix scroll on jobs page

### DIFF
--- a/apps/jobs/templates/index.jade
+++ b/apps/jobs/templates/index.jade
@@ -21,13 +21,13 @@ block body
     section.jobs-category-section
       nav.jobs-category-nav.js-jobs-category-nav
         for jobs, name in categories
-          a.jobs-category.js-jobs-category( href="##{name}" )
+          a.jobs-category.js-jobs-category( href="##{name.replace(' ', '-')}" )
             h3= name
             p #{jobs.length} Open Position#{jobs.length === 1 ? '' : 's'}
 
       .jobs-category-items
         for jobs, name in categories
-          .jobs-items.large-chevron-list.js-jobs-items( id= name )
+          .jobs-items.large-chevron-list.js-jobs-items( id= name.replace(' ', '-') )
             for job in jobs
               a( href= job.href )
                 .jobs-item


### PR DESCRIPTION
The link is setup using an id containing the department name. Departments with a space in the name don't work. By replacing the space with a dash the scroll is restored.

![fix scroll](https://cloud.githubusercontent.com/assets/5201004/17824443/fec68b72-662f-11e6-97b7-e5ff201c7045.gif)
