### PR TITLE
Change the ratio of partner cover images to 3:2, as suggested in CMS.

### DIFF
--- a/apps/galleries_institutions/queries/partner_fragment.coffee
+++ b/apps/galleries_institutions/queries/partner_fragment.coffee
@@ -12,7 +12,7 @@ module.exports =
       id
       href
       image {
-        cropped(width:400, height:300, version: ["wide", "large", "featured", "larger"]) {
+        cropped(width:400, height:266, version: ["wide", "large", "featured", "larger"]) {
           url
         }
       }


### PR DESCRIPTION
Currently we suggest partners to upload their cover images with w/h ratio 3:2 but we crop and display them on the site as 4:3. Let's keep them consistent.

<img width="961" alt="screen shot 2016-08-24 at 1 48 23 pm" src="https://cloud.githubusercontent.com/assets/796573/17941926/4dc8e158-6a03-11e6-8083-a3986ba9293c.png">

Before vs. After

![screen shot 2016-08-24 at 1 49 35 pm](https://cloud.githubusercontent.com/assets/796573/17941943/5a8fea08-6a03-11e6-8be2-d397bd3b240d.png)