### PR TITLE
@broskoski: safeguard article thumbnail image

### DIFF
--- a/apps/artwork/components/artists/templates/articles.jade
+++ b/apps/artwork/components/artists/templates/articles.jade
@@ -1,8 +1,9 @@
 if artist.articles && artist.articles.length
   for article in artist.articles.slice(0,3)
     a.artwork-artist__content__article(href=article.href)
-      .artwork-artist__content__article-thumbnail
-        img(src=article.thumbnail_image.cropped.url)
+      if article.thumbnail_image && article.thumbnail_image.cropped && article.thumbnail_image.cropped.url
+        .artwork-artist__content__article-thumbnail
+          img(src=article.thumbnail_image.cropped.url)
       .artwork-artist__content__article-text
         p= article.title
         p= article.author.name


### PR DESCRIPTION
Noticed that not all articles have a thumbnail and the ones that didn't had broken pages. This adds a safeguard. I don't know if we would want to not show articles that don't have an image, but I figure this at least fixes the broken pages.
 
![screen shot 2016-08-29 at 3 21 17 pm](https://cloud.githubusercontent.com/assets/5201004/18064196/50927906-6dfc-11e6-8ef5-d93c3f2fb75f.png)
