### PR TITLE
@mzikherman: handles artwork without an image

### DIFF
--- a/apps/artwork/components/actions/bootstrap.coffee
+++ b/apps/artwork/components/actions/bootstrap.coffee
@@ -7,7 +7,7 @@ module.exports = (sd, { artwork }) ->
       _id: artwork._id
 
     share:
-      media: artwork.images[0].url
+      media: if artwork.images[0]?.url then artwork.images[0].url else null
       description: description artwork
 
     view_in_room:

--- a/apps/artwork/components/actions/index.jade
+++ b/apps/artwork/components/actions/index.jade
@@ -4,7 +4,7 @@
     class='js-artwork-save'
   ): i.icon-heart
 
-  if artwork.is_shareable
+  if artwork.is_shareable && artwork.images[0] && artwork.images[0].url
     a.artwork-action.artwork-action--share.black-tooltip(
       data-message='Share'
       class='js-artwork-share analytics-artwork-share'


### PR DESCRIPTION
context: https://github.com/artsy/force/issues/99

This is a temporary fix for artworks that don't have images. This just gets the page to not 500, but ideally we might want to show an image doesn't exist placeholder or not publish works without an image. 

![screen shot 2016-08-30 at 12 53 10 pm](https://cloud.githubusercontent.com/assets/5201004/18098568/c909f1f2-6eb0-11e6-95fa-66dc26c73445.png)
