### PR TITLE
@broskoski => allow admins to access unpublished artwork pages

### DIFF
--- a/apps/artwork/client/index.coffee
+++ b/apps/artwork/client/index.coffee
@@ -1,5 +1,5 @@
 { extend, map, compact } = require 'underscore'
-{ CLIENT } = require('sharify').data
+{ CLIENT, CURRENT_USER } = require('sharify').data
 { setCookie } = require '../../../components/recently_viewed_artworks/index.coffee'
 metaphysics = require '../../../lib/metaphysics.coffee'
 exec = require '../lib/exec.coffee'
@@ -145,7 +145,7 @@ module.exports =
 
     return unless query? and init?
     variables ?= {}
-    metaphysics query: query, variables: extend { id: CLIENT.id }, variables
+    metaphysics query: query, variables: extend({ id: CLIENT.id }, variables), req: user: CURRENT_USER
       .then (data) ->
         renderTemplates(data)
         exec init

--- a/apps/artwork/routes.coffee
+++ b/apps/artwork/routes.coffee
@@ -59,7 +59,7 @@ bootstrap = ->
   require('./components/video/bootstrap') arguments...
 
 @index = (req, res, next) ->
-  send = method: 'post', query: query, variables: req.params
+  send = method: 'post', query: query, variables: req.params, req: req
 
   return if metaphysics.debug req, res, send
 


### PR DESCRIPTION
Just for the record, this was all that was needed to get admins to be able to access unpublished artwork pages. Basically passing along the user's access token to some metaphysics requests.

Essentially the same update will be needed for other contexts.