### PR TITLE
@craigspaeth Update JSON-ld for articles to use Channels

### DIFF
--- a/models/article.coffee
+++ b/models/article.coffee
@@ -84,6 +84,7 @@ module.exports = class Article extends Backbone.Model
           success: (articles) ->
             superArticle = articles?.models[0]
 
+      # Partner Channel + Team Channels
       if @get('partner_channel_id')
         dfds.push (partner = new Partner(id: @get('partner_channel_id'))).fetch()
       else if @get('channel_id')
@@ -103,7 +104,7 @@ module.exports = class Article extends Backbone.Model
             relatedArticles.orderByIds(superArticle.get('super_article').related_articles) if superArticle and relatedArticles?.length
             @set('section', section) if section
             @set('channel', channel) if channel
-            @set('partner', partner)
+            @set('partner', partner) if partner
             options.success(
               article: this
               footerArticles: footerArticles

--- a/models/article.coffee
+++ b/models/article.coffee
@@ -114,7 +114,7 @@ module.exports = class Article extends Backbone.Model
               superSubArticleIds: superSubArticleIds
               section: section
               allSectionArticles: sectionArticles if section
-              partner: partner
+              partner: partner if partner
             )
 
   isTopTier: ->

--- a/models/channel.coffee
+++ b/models/channel.coffee
@@ -1,0 +1,8 @@
+_ = require 'underscore'
+sd = require('sharify').data
+Backbone = require 'backbone'
+{ Markdown } = require 'artsy-backbone-mixins'
+
+module.exports = class Channel extends Backbone.Model
+
+  urlRoot: "#{sd.POSITRON_URL}/api/channels"

--- a/test/helpers/fixtures.coffee
+++ b/test/helpers/fixtures.coffee
@@ -71,6 +71,12 @@ moment = require 'moment'
   thumbnail_url: 'http://gemini.herokuapp.com/123/miaart-banner.jpg'
   featured_links: [{ title: 'foo', thumbnail_url: 'bar.jpg', url: 'foo.com' }]
 
+@channel =
+  id: '55356a9deca560a0137aa4b7'
+  name: 'Artsy Editorial'
+  tagline: 'The coolest team'
+  slug: 'artsy-editorial'
+
 @article =
   id: '54276766fd4f50996aeca2b8'
   author_id: '4d8cd73191a5c50ce210002a'

--- a/test/models/article.coffee
+++ b/test/models/article.coffee
@@ -33,71 +33,108 @@ describe "Article", ->
         done()
 
     it 'gets the slideshow artworks', (done) ->
+      slideshowArticle = _.extend {}, fixtures.article,
+        title: 'Moo'
+        channel_id: null
+        sections: [
+          {
+            type: 'slideshow'
+            items: [
+              {
+                type: 'artwork', id: 'foo'
+              }
+            ]
+          }
+        ]
+
       Backbone.sync
         .onCall 0
-        .yieldsTo 'success', _.extend {}, fixtures.article,
-          title: 'Moo', sections: [type: 'slideshow', items: [type: 'artwork', id: 'foo']]
+        .yieldsTo 'success', slideshowArticle
         .onCall 1
         .yieldsTo 'success', [fixtures.article]
         .onCall 2
+        .yieldsTo 'success', [fixtures.article]
+        .onCall 3
         .yieldsTo 'success', fabricate 'artwork', title: 'foobar'
+        .onCall 4
+        .yieldsTo 'success', [fixtures.article]
 
       @article.fetchWithRelated success: (data) ->
-        # This spec appears to be incorrect, slideshowArtworks has a length of 0:
-        # data.slideshowArtworks.first().get('title').should.equal 'foobar'
+        data.slideshowArtworks.first().get('title').should.equal 'foobar'
         done()
 
     it 'fetches section content if need be', (done) ->
+      sectionArticle = _.extend {}, fixtures.article,
+        title: 'Moo'
+        section_ids: ['foo']
+        sections: []
+        channel_id: null
+
       Backbone.sync
         .onCall 0
-        .yieldsTo 'success', _.extend {}, fixtures.article, title: 'Moo', section_ids: ['foo']
+        .yieldsTo 'success', sectionArticle
         .onCall 1
         .yieldsTo 'success', [fixtures.article]
         .onCall 2
         .yieldsTo 'success', [fixtures.article]
         .onCall 3
         .yieldsTo 'success', fixtures.section
+        .onCall 4
+        .yieldsTo 'success', [fixtures.articles]
+        .onCall 5
+        .yieldsTo 'success', [fixtures.articles]
 
       @article.fetchWithRelated success: (data) ->
-        # This spec appears to be incorrect, title is 'Vennice Biennalez'
-        # data.slideshowArtworks.first().get('title').should.equal 'foobar'
+        data.section.get('title').should.equal 'Vennice Biennalez'
         done()
 
     it 'works for those rare sectionless articles', (done) ->
+      sectionlessArticle = _.extend {}, fixtures.article,
+        title: 'Moo'
+        sections: []
+        channel_id: null
+
       Backbone.sync
         .onCall 0
-        .yieldsTo 'success', _.extend {}, fixtures.article, title: 'Moo', sections: []
+        .yieldsTo 'success', sectionlessArticle
         .onCall 1
+        .yieldsTo 'success', [fixtures.article]
+        .onCall 2
         .yieldsTo 'success', [fixtures.article]
 
       @article.fetchWithRelated success: (data) ->
         data.article.get('title').should.equal 'Moo'
         done()
 
-    xit 'fetches related articles for super articles', (done) ->
-      @article.set sections: []
+    it 'fetches related articles for super articles', (done) ->
+      superArticle = _.extend {}, fixtures.article,
+        title: 'SuperArticle',
+        is_super_article: true
+        sections: []
+        channel_id: null
+        super_article:
+          related_articles: ['id-1']
+
+      relatedArticle = _.extend {}, fixtures.article,
+        title: 'RelatedArticle'
+        id: 'id-1'
 
       Backbone.sync
         .onCall 0
-        .yieldsTo 'success', _.extend {}, fixtures.article,
-          title: 'SuperArticle',
-          is_super_article: true
-          sections: []
-          super_article:
-            related_articles: ['id-1']
+        .yieldsTo 'success', superArticle
         .onCall 1
         .yieldsTo 'success', [fixtures.article]
         .onCall 2
         .yieldsTo 'success', [fixtures.article]
         .onCall 3
-        .yieldsTo 'success', _.extend {}, fixtures.article, title: 'RelatedArticle', id: 'id-1'
+        .yieldsTo 'success', relatedArticle
 
       @article.fetchWithRelated success: (data) ->
         data.relatedArticles.models[0].get('title').should.equal 'RelatedArticle'
         data.article.get('title').should.equal 'SuperArticle'
         done()
 
-    xit 'fetches related articles for article in super article', (done) ->
+    it 'fetches related articles for article in super article', (done) ->
       relatedArticle1 = _.extend {}, fixtures.article,
         id: 'id-1'
         title: 'RelatedArticle 1',
@@ -111,6 +148,7 @@ describe "Article", ->
         title: 'SuperArticle',
         is_super_article: true
         sections: []
+        channel_id: null
         super_article:
           related_articles: ['id-1', 'id-2']
 
@@ -118,17 +156,18 @@ describe "Article", ->
         .onCall 0
         .yieldsTo 'success', superArticle
         .onCall 1
-        .yieldsTo 'success', relatedArticle1
+        .yieldsTo 'success', [fixtures.article]
         .onCall 2
-        .yieldsTo 'success', relatedArticle2
+        .yieldsTo 'success', [fixtures.article]
         .onCall 3
         .yieldsTo 'success', relatedArticle1
+        .onCall 4
+        .yieldsTo 'success', relatedArticle2
 
       @article.fetchWithRelated success: (data) ->
         data.superArticle.get('title').should.equal 'SuperArticle'
         data.relatedArticles.first().get('title').should.equal 'RelatedArticle 1'
-        # This spec appears to be incorrect
-        # data.relatedArticles.last().get('title').should.equal 'RelatedArticle 2'
+        data.relatedArticles.last().get('title').should.equal 'RelatedArticle 2'
         done()
 
   describe '#strip', ->

--- a/test/models/article.coffee
+++ b/test/models/article.coffee
@@ -196,3 +196,26 @@ describe "Article", ->
     it 'returns multiple contributing authors', ->
       @article.set 'contributing_authors', [{name: 'Molly'}, {name: 'Kana'}, {name: 'Christina'}]
       @article.contributingByline().should.equal 'Molly, Kana and Christina'
+
+  describe 'getParselySection', ->
+
+    it 'returns Editorial', ->
+      @article.set 'channel', new Backbone.Model name: 'Artsy Editorial'
+      @article.getParselySection().should.equal 'Editorial'
+
+    it 'returns channel name', ->
+      @article.set 'channel', new Backbone.Model name: 'Life at Artsy'
+      @article.getParselySection().should.equal 'Life at Artsy'
+
+    it 'returns Section', ->
+      @article.set 'section', new Backbone.Model title: '56th Venice Biennale'
+      @article.getParselySection().should.equal '56th Venice Biennale'
+
+    it 'returns Partner', ->
+      @article.set 'partner', new Backbone.Model
+      @article.getParselySection().should.equal 'Partner'
+
+    it 'returns Other', ->
+      @article.reset()
+      @article.getParselySection().should.equal 'Other'
+

--- a/test/models/article.coffee
+++ b/test/models/article.coffee
@@ -74,7 +74,7 @@ describe "Article", ->
         data.article.get('title').should.equal 'Moo'
         done()
 
-    it 'fetches related articles for super articles', (done) ->
+    xit 'fetches related articles for super articles', (done) ->
       @article.set sections: []
 
       Backbone.sync
@@ -97,7 +97,7 @@ describe "Article", ->
         data.article.get('title').should.equal 'SuperArticle'
         done()
 
-    it 'fetches related articles for article in super article', (done) ->
+    xit 'fetches related articles for article in super article', (done) ->
       relatedArticle1 = _.extend {}, fixtures.article,
         id: 'id-1'
         title: 'RelatedArticle 1',
@@ -216,6 +216,5 @@ describe "Article", ->
       @article.getParselySection().should.equal 'Partner'
 
     it 'returns Other', ->
-      @article.reset()
+      @article.clear()
       @article.getParselySection().should.equal 'Other'
-


### PR DESCRIPTION
We need to be able to query Parsely for the top articles in a given Channel, so this updates the json-ld's `articleSection` to use channel names instead of the unused `Section`. I realize that's a mouthful and it's probably better understood by just looking at [this](https://github.com/artsy/force/compare/master...kanaabe:parsely-sections?expand=1#diff-1be63e5e28d2c42ad1766d25f40a770dR231)!

Also, this fixes a bunch of tests in `fetchWithRelated`