### PR TITLE
@anyone => Dont use homepage template in shows page

### DIFF
--- a/apps/shows/templates/featured_shows.jade
+++ b/apps/shows/templates/featured_shows.jade
@@ -1,0 +1,5 @@
+- var allShows = shows
+- shows = allShows.slice(0, 2)
+include ../../../components/featured_shows/large
+- shows = allShows.slice(2)
+include ../../../components/featured_shows/small 

--- a/apps/shows/templates/index.jade
+++ b/apps/shows/templates/index.jade
@@ -15,7 +15,7 @@ block body
     if shows.length
       h1.shows-page-header Featured Shows
       - displayLocation = true
-      include ../../home/templates/featured_shows
+      include ./featured_shows
 
     h2.shows-page-header.shows-page-feed-header Current Museum & Gallery Shows
     #shows-feed.shows-feed.feed: .loading-spinner


### PR DESCRIPTION
cc @broskoski 

The /shows app was reaching into the /home app and using a template (which changed with the new homepage). The /shows app should use its own template, and not re-use another app's.