### PR TITLE
@broskoski: related artists rail qa items

### DIFF
--- a/apps/artwork/components/related_artists/index.coffee
+++ b/apps/artwork/components/related_artists/index.coffee
@@ -31,6 +31,7 @@ module.exports = ->
   relatedArtists = sd.CLIENT.artists[0].artists
   showMore = relatedArtists.length > 15
   $el = $('.js-artwork-artist-related-rail__content')
+  relatedArtists = _.take(relatedArtists, 15)
 
   $el.find('.js-mgr-cells').html render({ relatedArtists, showMore })
   _.defer ->

--- a/apps/artwork/components/related_artists/index.styl
+++ b/apps/artwork/components/related_artists/index.styl
@@ -20,6 +20,10 @@
   .artwork-artist-rail-cell
     mgr-n-up(4, 30px, (3/4), false)
 
+  &:hover
+    .mgr-navigation
+      opacity 1
+
 .artwork-artist-related-rail__view-all
   position absolute
   right 0


### PR DESCRIPTION
This ensures no more than 15 related artists display and puts a hover event on the entire rail section.

![related artists rail qa](https://cloud.githubusercontent.com/assets/5201004/18356679/bab5473e-75bb-11e6-84e6-54722cdd7dda.gif)
