### PR TITLE
@broskoski => Uses updated LotStanding endpoint instead of BidderStatus

### DIFF
--- a/apps/artwork/components/auction/templates/bid.jade
+++ b/apps/artwork/components/auction/templates/bid.jade
@@ -1,4 +1,4 @@
-- myLastMaxBid = me && me.bidder_status && me.bidder_status.most_recent_bid.max_bid.cents
+- myLastMaxBid = me && me.lot_standing && me.lot_standing.most_recent_bid.max_bid.cents
 - increments = sale_artwork.bid_increments.filter(function(i) { return i > (myLastMaxBid || 0) })
 - firstIncr = increments[0]
 
@@ -13,10 +13,10 @@ if auction.is_open && !artwork.is_sold && !auction.is_live_open
 
     if user
       .artwork-auction__bid-form__max-bid
-        if me && me.bidder_status.is_highest_bidder
+        if me && me.lot_standing.is_highest_bidder
           .artwork-auction__bid-form__max-bid-label.is_winning
             | You're the highest bidder
-        else if me && !me.bidder_status.is_highest_bidder
+        else if me && !me.lot_standing.is_highest_bidder
           .artwork-auction__bid-form__max-bid-label.is_losing
             | You've been outbid, increase your bid
         else

--- a/apps/artwork/components/auction/view.coffee
+++ b/apps/artwork/components/auction/view.coffee
@@ -107,7 +107,7 @@ module.exports = class ArtworkAuctionView extends Backbone.View
       query: """
         query artwork($id: String!, $sale_id: String!) {
           me {
-            bidder_status(artwork_id: $id, sale_id: $sale_id) {
+            lot_standing(artwork_id: $id, sale_id: $sale_id) {
               is_highest_bidder
               most_recent_bid {
                 max_bid {

--- a/apps/auction/templates/my_active_bids.jade
+++ b/apps/auction/templates/my_active_bids.jade
@@ -13,13 +13,13 @@ if myActiveBids && myActiveBids.length
                 h3= bid.sale_artwork.artwork.artist.name
                 .auction-mab-title
                   em= bid.sale_artwork.artwork.title
-                  | ,
+                  | ,&nbsp;
                   = bid.sale_artwork.artwork.date
           td.auction-mab-lot-number Lot #{bid.sale_artwork.lot_number}
           td.auction-mab-current-bid
             strong Current Bid: <em>#{bid.sale_artwork.highest_bid.display}</em>
           td.auction-mab-bid-num (#{bid.sale_artwork.counts.bidder_positions} Bids)
-          if bid.is_winning
+          if bid.is_highest_bidder
             td.auction-mab-warning.is-winning: p Highest Bid
           else
             td.auction-mab-warning: p Outbid

--- a/apps/user/components/bid_history/view.coffee
+++ b/apps/user/components/bid_history/view.coffee
@@ -12,7 +12,7 @@ module.exports = class BidHistoryView extends Backbone.View
   fetch: ->
     metaphysics
       query: query
-      variables: current: false
+      variables: live: false
       req: user: @user
 
     .then ({ @me }) =>
@@ -21,5 +21,5 @@ module.exports = class BidHistoryView extends Backbone.View
   render: ->
     @$el.html template
       button: false
-      myActiveBids: @me.bidder_positions
+      myActiveBids: @me.lot_standings
     this

--- a/components/my_active_bids/query.coffee
+++ b/components/my_active_bids/query.coffee
@@ -1,9 +1,11 @@
 module.exports = """
-  query my_active_bids($current: Boolean!, $sale_id: String) {
+  query my_active_bids($live: Boolean!, $sale_id: String) {
     me {
-      bidder_positions(current: $current, sale_id: $sale_id) {
-        id
-        is_winning
+      lot_standings(live: $live, sale_id: $sale_id) {
+        active_bid {
+          id
+        }
+        is_highest_bidder
         sale_artwork {
           id
           lot_number
@@ -17,6 +19,7 @@ module.exports = """
           artwork {
             href
             title
+            date
             image {
               url(version: "square")
             }

--- a/components/my_active_bids/template.jade
+++ b/components/my_active_bids/template.jade
@@ -1,14 +1,14 @@
 if myActiveBids && myActiveBids.length
   ul
     for bid in myActiveBids
-      li.my-active-bids-item( class= bid.is_winning ? ' my-active-bids-winning' : '' )
+      li.my-active-bids-item( class= bid.is_highest_bidder ? ' my-active-bids-winning' : '' )
         a( href=bid.sale_artwork.artwork.href )
           img( src=bid.sale_artwork.artwork.image.url )
           .my-active-bids-item-details
             h4 Lot #{bid.sale_artwork.lot_number}
             strong= bid.sale_artwork.artwork.artist.name
             p #{bid.sale_artwork.highest_bid.display} (#{bid.sale_artwork.counts.bidder_positions} Bids)
-        if bid.is_winning
+        if bid.is_highest_bidder
           p.my-active-bids-warning Highest Bid
         else
           p.my-active-bids-warning Outbid

--- a/components/my_active_bids/test/template.coffee
+++ b/components/my_active_bids/test/template.coffee
@@ -33,10 +33,10 @@ describe 'My Active Bids template', ->
 
   it 'renders highest bid if the highest_bid on the sale artwork and \
       bidder positon match', ->
-    @locals.myActiveBids[0].is_winning = true
+    @locals.myActiveBids[0].is_highest_bidder = true
     template(@locals).should.containEql 'Highest Bid'
 
   it 'renders losing if the highest_bid on the sale artwork and \
       bidder positon do not match', ->
-    @locals.myActiveBids[0].is_winning = false
+    @locals.myActiveBids[0].is_highest_bidder = false
     template(@locals).should.containEql 'Outbid'

--- a/components/my_active_bids/view.coffee
+++ b/components/my_active_bids/view.coffee
@@ -22,10 +22,10 @@ module.exports = class MyActiveBids extends Backbone.View
   fetch: ->
     metaphysics(
       query: query
-      variables: current: true, sale_id: @saleId
+      variables: live: true, sale_id: @saleId
       req: user: @user
     ).then (data) =>
-      @bidderPositions = data.me.bidder_positions
+      @bidderPositions = data.me.lot_standings
 
   render: =>
     @$el.html @template myActiveBids: @bidderPositions


### PR DESCRIPTION
This PR hopefully fixes some of the weirdness in the active bids module, following: https://github.com/artsy/metaphysics/pull/401 and https://github.com/artsy/gravity/pull/10349

Fixes a couple of things:
- Your `bidder_status` used to be incorrect if you'd bid more than 10 times (because it only looked at the first page of `me/bidder_positions`
- Date was not showing up next to the artwork title :)
![screen shot 2016-09-08 at 1 44 33 pm](https://cloud.githubusercontent.com/assets/2081340/18362285/2ceab9f8-75d3-11e6-81d4-b29991af642d.png)
- In your collector profile, it now shows the lots that you've bid on for all `live` auctions under "My Active Bids" and lots that you've bid on in now-closed auctions under "Bid History". This also fixes the bug where it was showing multiple widgets for each lot (one per position instead of one per lot).
![screen shot 2016-09-08 at 1 44 03 pm](https://cloud.githubusercontent.com/assets/2081340/18362329/5971dc40-75d3-11e6-96fb-7a57847cf745.png)
