### PR TITLE
@broskoski => Use redirectTo instead of destination

### DIFF
--- a/apps/artist/client/cta.coffee
+++ b/apps/artist/client/cta.coffee
@@ -1,5 +1,4 @@
 { MEDIUM, CURRENT_USER } = require('sharify').data
-AuthModalView = require '../../../components/auth_modal/view.coffee'
 CTABarView = require '../../../components/cta_bar/view.coffee'
 
 module.exports = (artist) ->

--- a/apps/artwork/components/auction/view.coffee
+++ b/apps/artwork/components/auction/view.coffee
@@ -78,7 +78,7 @@ module.exports = class ArtworkAuctionView extends Backbone.View
         width: '500px',
         mode: 'register'
         copy: 'Sign up to bid'
-        destination: form.action()
+        redirectTo: form.action()
 
     return unless form.isReady()
 

--- a/apps/show/components/artwork_item_metaphysics/save_controls/view.coffee
+++ b/apps/show/components/artwork_item_metaphysics/save_controls/view.coffee
@@ -32,7 +32,7 @@ module.exports = class SaveControls extends Backbone.View
       mediator.trigger 'open:auth',
         mode: 'register'
         copy: 'Sign up to save artworks'
-        destination: "#{@artwork.href}/save"
+        redirectTo: "#{@artwork.href}/save"
       return false
 
     trackedProperties = {

--- a/components/artwork_item/save_controls/view.coffee
+++ b/components/artwork_item/save_controls/view.coffee
@@ -33,7 +33,7 @@ module.exports = class SaveControls extends Backbone.View
       mediator.trigger 'open:auth',
         mode: 'register'
         copy: 'Sign up to save artworks'
-        destination: "#{@model.href()}/save"
+        redirectTo: "#{@model.href()}/save"
       return false
 
     trackedProperties = {

--- a/components/artwork_save/view.coffee
+++ b/components/artwork_save/view.coffee
@@ -29,7 +29,7 @@ module.exports = class ArtworkSaveView extends Backbone.View
         width: '500px',
         mode: 'register'
         copy: 'Sign up to save artworks'
-        destination: "/artwork/#{@id}/save"
+        redirectTo: "/artwork/#{@id}/save"
 
     if @saved
       save = @savedArtworks.get @id

--- a/components/auction_artwork_brick/view.coffee
+++ b/components/auction_artwork_brick/view.coffee
@@ -20,7 +20,7 @@ module.exports = class AuctionArtworkBrickView extends Backbone.View
         width: '500px',
         mode: 'register'
         copy: 'Sign up to bid'
-        destination: $(e.currentTarget).attr 'href'
+        redirectTo: $(e.currentTarget).attr 'href'
 
     else
       # Passes through to `href`

--- a/components/follow_button/view.coffee
+++ b/components/follow_button/view.coffee
@@ -53,7 +53,7 @@ module.exports = class FollowButton extends Backbone.View
       mediator.trigger 'open:auth',
         mode: 'register'
         copy: "Sign up to follow #{@label}"
-        destination: @href || "#{@model.href()}/follow"
+        redirectTo: @href || "#{@model.href()}/follow"
       return false
 
     # remove null values


### PR DESCRIPTION
This is a quirky one.

It seems like there are different 'modes' the AuthModal can be in. The mode 'register' will skip onboarding, unless you explicitly pass in `redirectTo: '/personalize'` for example. This is handled in https://github.com/artsy/force/blob/ee57db1bfe85d29ec5713f3ed44cafa37fe9b87d/components/auth_modal/view.coffee#L49-L52

`destination` is what the onboarding flow will redirect you back to after the flow, using a cookie. `redirectTo` is what you will get redirected back to immediately after logging in or signing up.

So..any time you use the auth modal with a mode of 'register' (skipping onboarding), it doesn't make sense to use `destination` (only applicable during onboarding), you _have_ to use `redirectTo`.

I went thru and corrected some obvious places this was happening, but via a naïve `grep`, so there _may_ be some other lingering places. This should cover most of it though.

Closes https://github.com/artsy/force/issues/112