### PR TITLE
@xtina-starr => dont show 0 bids label if there arent any bids

### DIFF
--- a/components/artwork_item/templates/partials/auction_info.jade
+++ b/components/artwork_item/templates/partials/auction_info.jade
@@ -18,7 +18,7 @@ if displayBuyNowPrice || displayBidStatus
         .artwork-item-auction-bid-status
           | #{saleArtwork.bidLabel()}: #{saleArtwork.currentBid()}
           if saleArtwork.get('bidder_positions_count') >= 1
-            | &nbsp;(#{saleArtwork.bidCount()})
+            | &nbsp;#{saleArtwork.formatBidCount()}
 
       if displayBuyNowPrice
         .artwork-item-buy-now-price

--- a/components/auction_artworks/templates/artwork/grid.jade
+++ b/components/auction_artworks/templates/artwork/grid.jade
@@ -43,7 +43,7 @@
                   | Sold
               else
                 .aabs-label
-                  | <strong>#{saleArtwork.bidLabel()}</strong> (#{saleArtwork.bidCount()})
+                  | <strong>#{saleArtwork.bidLabel()}</strong> #{saleArtwork.formatBidCount()}
                 .aabs-price
                   = saleArtwork.currentBid()
 

--- a/components/auction_artworks/templates/artwork/list.jade
+++ b/components/auction_artworks/templates/artwork/list.jade
@@ -48,7 +48,7 @@
                 = artwork.saleMessage() || 'Unavailable'
 
     .ala-bid-count: a( href= href )
-      | (#{saleArtwork.bidCount()})
+      | #{saleArtwork.formatBidCount()}
   else
     .ala-estimate
       if saleArtwork.estimate()

--- a/components/auction_artworks/test/template.coffee
+++ b/components/auction_artworks/test/template.coffee
@@ -26,13 +26,13 @@ describe 'templates', ->
           $template = $(templates.list @data)
           $template.find('.ala-bid-status strong').text().should.equal 'Current Bid: '
           $template.find('.ala-current-bid').text().should.equal '$1,000'
-          $template.find('.ala-bid-count').text().should.equal '(0 bids)'
+          $template.find('.ala-bid-count').text().should.equal ''
           $template.find('.js-bid-button').text().should.equal 'Bid'
 
       describe 'grid', ->
         it 'renders correctly', ->
           $template = $(templates.grid @data)
-          $template.find('.aabs-label').text().should.equal 'Current Bid (0 bids)'
+          $template.find('.aabs-label').text().should.equal 'Current Bid '
           $template.find('.aabs-price').first().text().should.equal '$1,000' # `last` contains a nbsp; for spacing hack
           $template.find('.js-bid-button').text().should.equal 'Bid'
 
@@ -108,13 +108,13 @@ describe 'templates', ->
         it 'renders correctly', ->
           $template = $(templates.list @data)
           $template.find('.ala-current-bid').text().should.equal '$10,000'
-          $template.find('.ala-bid-count').text().should.equal '(0 bids)' # Can still bid on it
+          $template.find('.ala-bid-count').text().should.equal '' # Can still bid on it
           $template.find('.js-acquire-button').text().should.equal 'Buy Now'
 
       describe 'grid', ->
         it 'renders correctly', ->
           $template = $(templates.grid @data)
-          $template.find('.aabs-label').text().should.equal 'Starting Bid (0 bids)Buy Now Price'
+          $template.find('.aabs-label').text().should.equal 'Starting Bid Buy Now Price'
           $template.find('.aabs-price').text().should.equal '$10,000'
           $template.find('.js-acquire-button').text().should.equal 'Buy Now'
 
@@ -127,13 +127,13 @@ describe 'templates', ->
       describe 'list', ->
         it 'renders correctly', ->
           $template = $(templates.list @data)
-          $template.find('.ala-bid-count').text().should.equal '(0 bids)' # Can still bid on it
+          $template.find('.ala-bid-count').text().should.equal '' # Can still bid on it
           $template.find('.avant-garde-button').text().should.equal 'Sold'
 
       describe 'grid', ->
         it 'renders correctly', ->
           $template = $(templates.grid @data)
-          $template.find('.aabs-label').text().should.equal 'Starting Bid (0 bids)Buy Now Price'
+          $template.find('.aabs-label').text().should.equal 'Starting Bid Buy Now Price'
           $template.find('.aabs-price').text().should.equal 'Sold'
           $template.find('.js-acquire-button').should.have.lengthOf 0
           $template.find('.avant-garde-button').text().should.equal 'Sold'

--- a/models/sale_artwork.coffee
+++ b/models/sale_artwork.coffee
@@ -52,17 +52,23 @@ module.exports = class SaleArtwork extends Backbone.Model
     if @get('highest_bid_amount_cents') then 'Current Bid' else 'Starting Bid'
 
   bidCount: ->
-    n = @get('bidder_positions_count') or 0
-    n = 0 unless @get('highest_bid_amount_cents')
-    count = "#{n} bid"
-    count += if n is 1 then '' else 's'
+    count = @get('bidder_positions_count') or 0
+    count = 0 unless @get('highest_bid_amount_cents')
     count
+
+  bidCountLabel: ->
+    count = @bidCount()
+    bids = "#{count} bid"
+    bids += if count is 1 then '' else 's'
+
+  formatBidCount: ->
+    if @bidCount() is 0 then '' else "(#{@bidCountLabel()})"
 
   reserveLabel: ->
     @reserveFormat[@get 'reserve_status']
 
   formatBidsAndReserve: ->
-    bid = if (@get('bidder_positions_count') is 0) then '' else @bidCount()
+    bid = if @bidCount() is 0 then '' else @bidCountLabel()
     reserve = @reserveLabel() unless @get('reserve_status') is 'no_reserve'
     reserve = "This work has a reserve" if reserve? and not bid
     bidAndReserve = _.compact([bid, reserve]).join(', ')

--- a/test/models/sale_artwork.coffee
+++ b/test/models/sale_artwork.coffee
@@ -46,32 +46,48 @@ describe 'SaleArtwork', ->
       @saleArtwork.unset 'display_low_estimate_dollars'
       @saleArtwork.estimate().should.equal '$600'
 
-  describe '#bidCount', ->
+  describe '#bidCountLabel', ->
 
     it 'returns bid count in singular form if 1', ->
       @saleArtwork.set bidder_positions_count: 1
       @saleArtwork.set highest_bid_amount_cents: 100
-      @saleArtwork.bidCount().should.equal '1 bid'
+      @saleArtwork.bidCountLabel().should.equal '1 bid'
 
     it 'returns bid count in plural form if greater than 1', ->
       @saleArtwork.set bidder_positions_count: 6
       @saleArtwork.set highest_bid_amount_cents: 100
-      @saleArtwork.bidCount().should.equal '6 bids'
+      @saleArtwork.bidCountLabel().should.equal '6 bids'
 
     it 'returns 0 if the highest_bid_amount_cents is not set (i.e. all bids were cancelled)', ->
       @saleArtwork.set bidder_positions_count: 6
       @saleArtwork.unset 'highest_bid_amount_cents'
-      @saleArtwork.bidCount().should.equal '0 bids'
+      @saleArtwork.bidCountLabel().should.equal '0 bids'
 
     it 'returns a 0 bids string if attribute not present', ->
       @saleArtwork.unset 'bidder_positions_count'
-      @saleArtwork.bidCount().should.equal '0 bids'
+      @saleArtwork.bidCountLabel().should.equal '0 bids'
 
     # Pending this until someone tells me why it shouldn't be
     # it 'returns a blank string if highest_bid_amount_cents null', ->
     #   @saleArtwork.set bidder_positions_count: 6
     #   @saleArtwork.unset 'highest_bid_amount_cents'
     #   @saleArtwork.bidCount().should.equal ''
+
+  describe '#formatBidCount', ->
+
+    it 'returns an empty string if there are no bids because of no highest_bid_amount_cents', ->
+      @saleArtwork.set bidder_positions_count: 6
+      @saleArtwork.unset 'highest_bid_amount_cents'
+      @saleArtwork.formatBidCount().should.equal ''
+
+    it 'returns an empty string if there are no bids', ->
+      @saleArtwork.unset 'bidder_positions_count'
+      @saleArtwork.formatBidCount().should.equal ''
+
+    it 'returns the original count in parentheses if it exists', ->
+      @saleArtwork.set bidder_positions_count: 6
+      @saleArtwork.set highest_bid_amount_cents: 100
+      @saleArtwork.formatBidCount().should.equal '(6 bids)'
 
   describe '#formatBidsAndReserve', ->
     describe 'with no bids', ->


### PR DESCRIPTION
For huge sales, it gets annoying to keep seeing "(0 bids)" everywhere on the auctions page. This PR removes the label if there are no bids.

![image](https://cloud.githubusercontent.com/assets/2081340/18368103/38b9d944-75ec-11e6-83ba-e1b0cc565b38.png)
