### PR TITLE
@mzikherman => sort auctions banners by end_at or live_start_at

### DIFF
--- a/collections/auctions.coffee
+++ b/collections/auctions.coffee
@@ -21,11 +21,7 @@ module.exports = class Auctions extends Sales
     .select (auction) ->
       auction.isAuction() and auction.isOpen()
     .sortBy (auction) ->
-      # hardcode sotheby's auction to appear at the top
-      if auction.id in ['input-output', 'input-slash-output']
-        return -1000000000000000000000
-      else
-        -(Date.parse auction.get('end_at'))
+      Date.parse auction.sortableDate()
     .value()
 
   closeds: ->

--- a/models/sale.coffee
+++ b/models/sale.coffee
@@ -135,6 +135,9 @@ module.exports = class Sale extends Backbone.Model
   isAuctionPromoInquirable: ->
     @isAuctionPromo() and @isPreview()
 
+  sortableDate: ->
+    if @get('live_start_at')? then @get('live_start_at') else @get('end_at')
+
   # Between 24 hours left and 10 seconds remaining
   isClosingSoon: (offset = 0) ->
     end = @date('end_at').add offset, 'milliseconds'

--- a/test/collections/auctions.coffee
+++ b/test/collections/auctions.coffee
@@ -1,22 +1,67 @@
 Auctions = require '../../collections/auctions'
 Auction = require '../../models/auction'
 { fabricate } = require 'antigravity'
+moment = require 'moment'
 
 describe 'Auctions', ->
   beforeEach ->
     @auctions = new Auctions
 
   describe '#opens', ->
-    it 'places sothebys auction at the top of the list', ->
+    it 'if there are only online auctions, just sorts by end_at', ->
       sothebys = new Auction fabricate 'sale',
         id: 'input-slash-output'
         is_auction: true
         auction_state: 'open'
+        end_at: moment().add 10, 'days'
 
       somethingelse = new Auction fabricate 'sale',
         id: 'cabbies-cool-auction'
         is_auction: true
         auction_state: 'open'
+        end_at: moment().add 5, 'days'
 
       @auctions.add [sothebys, somethingelse]
-      @auctions.opens()[0].id.should.equal 'input-slash-output'
+      @auctions.opens()[0].id.should.equal 'cabbies-cool-auction'
+      @auctions.opens()[1].id.should.equal 'input-slash-output'
+
+    it 'if there are only live auctions, just sorts by live_start_at', ->
+      sothebys = new Auction fabricate 'sale',
+        id: 'input-slash-output'
+        is_auction: true
+        auction_state: 'open'
+        live_start_at: moment().add 10, 'days'
+
+      somethingelse = new Auction fabricate 'sale',
+        id: 'cabbies-cool-auction'
+        is_auction: true
+        auction_state: 'open'
+        live_start_at: moment().add 5, 'days'
+
+      @auctions.add [sothebys, somethingelse]
+      @auctions.opens()[0].id.should.equal 'cabbies-cool-auction'
+      @auctions.opens()[1].id.should.equal 'input-slash-output'
+
+    it 'if there are online and live auctions, sorts by both end_at and live_start_at', ->
+      sothebys = new Auction fabricate 'sale',
+        id: 'input-slash-output'
+        is_auction: true
+        auction_state: 'open'
+        live_start_at: moment().add 10, 'days'
+
+      somethingelse = new Auction fabricate 'sale',
+        id: 'cabbies-cool-auction'
+        is_auction: true
+        auction_state: 'open'
+        live_start_at: moment().add 5, 'days'
+
+      anotherauction = new Auction fabricate 'sale',
+        id: 'cool-catty-auction'
+        is_auction: true
+        auction_state: 'open'
+        end_at: moment().add 7, 'days'
+
+      @auctions.add [sothebys, somethingelse, anotherauction]
+      @auctions.opens()[0].id.should.equal 'cabbies-cool-auction'
+      @auctions.opens()[1].id.should.equal 'cool-catty-auction'
+      @auctions.opens()[2].id.should.equal 'input-slash-output'

--- a/test/models/sale.coffee
+++ b/test/models/sale.coffee
@@ -295,3 +295,15 @@ describe 'Sale', ->
           end_at: time.add(2, 'days')
         @sale.upcomingLabel().should
           .equal "Auction opens #{time.format 'MMM D h:mm:ssA'} EST"
+
+    describe '#sortableDate', ->
+      it 'returns the live_start_at if it exists', ->
+        @sale.set
+          end_at: moment().add 2, 'days'
+          live_start_at: moment().add 1, 'days'
+        @sale.sortableDate().should.eql @sale.get('live_start_at')
+
+      it 'returns the end_at if no live_start_at exists', ->
+        @sale.set
+          end_at: moment().add 2, 'days'
+        @sale.sortableDate().should.eql @sale.get('end_at')


### PR DESCRIPTION
This PR updates the /auctions page to sort the banners by `live_start_at` if it exists, and `end_at` otherwise.

![image](https://cloud.githubusercontent.com/assets/2081340/18448356/cf2bdc42-78f8-11e6-93a8-677ea31dbb09.png)

