### PR TITLE
@broskoski => Always include pagination in commercial filtering

### DIFF
--- a/components/commercial_filter/filters/paginator/index.styl
+++ b/components/commercial_filter/filters/paginator/index.styl
@@ -1,0 +1,11 @@
+.bordered-pagination
+  &__hide-next
+    > ul
+      > li
+        &:last-child
+          display none
+        &:only-child
+          display inline-block
+    .paginator-next
+      opacity 0.3
+      pointer-events none

--- a/components/commercial_filter/filters/paginator/paginator_view.coffee
+++ b/components/commercial_filter/filters/paginator/paginator_view.coffee
@@ -22,10 +22,17 @@ module.exports = class PaginatorView extends Backbone.View
 
   totalPages: ->
     calculated = Math.ceil(@filter.get('total') / @params.get('size'))
-    total = Math.min calculated, @maxPage
+    Math.min calculated, @maxPage
+
+  adjustedTotal: ->
+    Math.max @totalPages(), 2
 
   render: ->
     @$el.html template
       current: parseInt @params.get('page')
-      total: @totalPages()
+      total: @adjustedTotal()
       pagesInterval: @pagesInterval
+    @_postRender()
+
+  _postRender: ->
+    @$('.bordered-pagination').addClass('bordered-pagination__hide-next') if @totalPages() is 1

--- a/components/commercial_filter/stylesheets/index.styl
+++ b/components/commercial_filter/stylesheets/index.styl
@@ -51,6 +51,7 @@ padding-unit = 15px
 @require '../filters/period'
 @require '../filters/location'
 @require '../filters/followed_artists'
+@require '../filters/paginator'
 @require '../views/headline'
 @require '../views/pillbox'
 @require '../views/sort'


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/69

<img width="255" alt="screen shot 2016-09-12 at 3 23 07 pm" src="https://cloud.githubusercontent.com/assets/1457859/18449372/e1e48e66-78fc-11e6-8595-7a775c71f4ea.png">

Kind of an odd one, basically it's like a new mode of displaying the pagination footer when there are only one page of results available. I first put it into the [component](https://github.com/artsy/artsy-ezel-components/blob/7d88dea9a488fca5a3bd63074445a5ac5e877ab1/pagination/paginator.jade), but it was somewhat messy and didn't feel worth it, especially to only use it here.

So for now, contain it within the cf component. 