### PR TITLE
@xtina-starr => better sort for shows on an artist cv

### DIFF
--- a/apps/artist/view_helpers.coffee
+++ b/apps/artist/view_helpers.coffee
@@ -12,7 +12,7 @@ module.exports =
   showHelpers: showHelpers
 
   nShowsByDate: (shows, n) ->
-    _.sortBy(_.take(shows, n), 'end_at').reverse()
+    _.sortBy(_.take(shows, n), 'start_at').reverse()
 
   pageTitle: (artist) ->
     artist = new Artist


### PR DESCRIPTION
cc @briansw 

This updates the sort used for the highlights shown in an artist's overview tab, as well as the sorting for the sections of the shows tab.

Before:

<img width="1212" alt="screen shot 2016-09-12 at 3 38 14 pm" src="https://cloud.githubusercontent.com/assets/1457859/18451158/cbbbb0ea-7903-11e6-95f4-edd92d121af0.png">

After:

<img width="1204" alt="screen shot 2016-09-12 at 4 13 16 pm" src="https://cloud.githubusercontent.com/assets/1457859/18451171/d6aeb6fa-7903-11e6-8aa6-fb6e8905155a.png">

(note the bortolami show)
