### PR TITLE
@mzikherman: explicitly provide the entire url instead of relative path

### DIFF
--- a/models/logged_out_user.coffee
+++ b/models/logged_out_user.coffee
@@ -1,7 +1,7 @@
 Q = require 'bluebird-q'
 _ = require 'underscore'
 Backbone = require 'backbone'
-{ API_URL, CSRF_TOKEN } = require('sharify').data
+{ API_URL, CSRF_TOKEN, APP_URL } = require('sharify').data
 syncWithSessionId = require '../lib/sync_with_session_id.coffee'
 User = require './user.coffee'
 sd = require('sharify').data
@@ -41,7 +41,7 @@ module.exports = class LoggedOutUser extends User
   login: (options = {}) ->
     new Backbone.Model()
       .save @pick('email', 'password', '_csrf'), _.extend {}, options,
-        url: sd.AP?.loginPagePath
+        url: "#{APP_URL}#{sd.AP?.loginPagePath}"
         success: _.wrap options.success, (success, model, response, options) =>
           @__isLoggedIn__ = true
           @trigger 'login'

--- a/test/models/logged_out_user.coffee
+++ b/test/models/logged_out_user.coffee
@@ -27,11 +27,12 @@ describe 'LoggedOutUser', ->
     describe '#login', ->
       it 'logs the user in', ->
         LoggedOutUser.__set__ 'sd', AP: loginPagePath: '/users/sign_in'
+        LoggedOutUser.__set__ 'APP_URL', 'artsy.net'
         user = new LoggedOutUser email: 'foo@bar.com', password: 'foobar'
         user.isLoggedIn().should.be.false()
         user.login()
         Backbone.sync.args[0][0].should.equal 'create'
-        Backbone.sync.args[0][2].url.should.equal '/users/sign_in'
+        Backbone.sync.args[0][2].url.should.equal 'artsy.net/users/sign_in'
         Backbone.sync.args[0][1].attributes.should.containEql email: 'foo@bar.com', password: 'foobar'
         _.include(_.keys(Backbone.sync.args[0][1].attributes), '_csrf').should.be.true()
         user.isLoggedIn().should.be.true()


### PR DESCRIPTION
I suspect that the relative path here is causing an [error](https://github.com/artsy/microgravity/issues/11) when trying to login via the professional buyer page. This page is mobile responsive where the logic lives in force. When logging in on this page from a mobile device, the relative path attempts to log you into microgravity when it should log in to force and redirect back to microgravity after the professional buyer registration is complete. The only way to see if this work is to deploy the change to staging and manually test.