### PR TITLE
@craigspaeth - Allow cross domain requests from mobile artsy

### DIFF
--- a/lib/setup.coffee
+++ b/lib/setup.coffee
@@ -5,8 +5,8 @@
 #
 
 {
-  API_URL, NODE_ENV, ARTSY_ID, ARTSY_SECRET, SESSION_SECRET,
-  SESSION_COOKIE_MAX_AGE, DEFAULT_CACHE_TIME, COOKIE_DOMAIN, AUTO_GRAVITY_LOGIN,
+  API_URL, APP_URL, NODE_ENV, ARTSY_ID, ARTSY_SECRET, SESSION_SECRET,
+  SESSION_COOKIE_MAX_AGE, MICROGRAVITY_URL, DEFAULT_CACHE_TIME, COOKIE_DOMAIN, AUTO_GRAVITY_LOGIN,
   SESSION_COOKIE_KEY, SENTRY_DSN, API_REQUEST_TIMEOUT, FUSION_URL, IP_BLACKLIST,
   LOGGER_FORMAT
 } = config = require "../config"
@@ -16,7 +16,8 @@ express = require "express"
 Backbone = require "backbone"
 sharify = require "sharify"
 http = require 'http'
-path = require "path"
+path = require 'path'
+cors = require 'cors'
 artsyPassport = require 'artsy-passport'
 artsyEigenWebAssociation = require 'artsy-eigen-web-association'
 redirectMobile = require './middleware/redirect_mobile'
@@ -154,6 +155,10 @@ module.exports = (app) ->
   app.use logger LOGGER_FORMAT
   app.use unsupportedBrowserCheck
   app.use splitTestMiddleware
+  # We want the user to be able to log-in to force via the microgravity subdomain
+  # the initial use case being the professional buyer application
+  # (this is specific to responsive pages that require log-in)
+  app.use cors origin: [APP_URL, MICROGRAVITY_URL]
 
   # Mount apps
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1063,6 +1063,11 @@
       "from": "core-util-is@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
+    "cors": {
+      "version": "2.8.1",
+      "from": "cors@*",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.1.tgz"
+    },
     "create-ecdh": {
       "version": "4.0.0",
       "from": "create-ecdh@>=4.0.0 <5.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "connect-timeout": "^1.7.0",
     "cookie-parser": "^1.4.0",
     "cookie-session": "^1.2.0",
+    "cors": "^2.8.1",
     "diacritics": "^1.2.2",
     "dompurify": "^0.7.1",
     "embedly-view-helpers": "git://github.com/artsy/embedly-view-helpers.git",


### PR DESCRIPTION
This is a tricky one, comments welcome! cc @dblock @mzikherman 

We are figuring out a bug on microgravity that has to do with our weird proxy / responsive dance that we do between force and microgravity. 

The issue is:

1. A user is logged out and goes to the /professional-buyer route
2. Because this page is responsive (and lives in force) they are now proxy-ing Force but with a microgravity subdomain (m.artsy.net/professional-buyer)
3. When they submit an application, we try and log them in and redirect them to complete the form (which allows the user to set a profession, a budget, etc.)
4. Initially, we were running into issues where the `csrf` token didn't match (because the user is trying to submit a form from Force to a Microgravity /log_in route). We "fixed" this by making the log_in path absolute in force (see: https://github.com/artsy/force/pull/140)
5. The second part of this is now erroring because Force is deny-ing the request for Cross-Domain reasons. This PR sets the CORS headers on force to allow requests from its own domain _as well as_ microgravity.

Obviously, this is not a perfect solution, but @xtina-starr and I want to open it for conversation. Our best hope here is that this gets merged as a band-aid (to allow potential professional buyers to successfully submit an application from a mobile device). Worst-case, we duplicate the code from Force and insert into Microgravity (but then the page will no longer be "responsive").

This issue is going to continue to come up when we have responsive pages on force that are anything more than informational. Anything that requires a user to be logged in is going to run into this problem.