### PR TITLE
@eessex Bumps up resizer to 90%

### DIFF
--- a/components/article/client/view.coffee
+++ b/components/article/client/view.coffee
@@ -83,11 +83,11 @@ module.exports = class ArticleView extends Backbone.View
   setupMaxImageHeights: ->
     @$(".article-section-artworks[data-layout=overflow] img, .article-section-container[data-section-type=image] img")
       .each (i, img) ->
-        newWidth = ((img.width * window.innerHeight * 0.7) / img.height)
+        newWidth = ((img.width * window.innerHeight * 0.9) / img.height)
         if newWidth < 580
           $(img).css('max-width', 580)
         else
-          $(img).css('max-height', window.innerHeight * 0.7 )
+          $(img).css('max-height', window.innerHeight * 0.9 )
     @$('.article-section-artworks, .article-section-container[data-section-type=image]').addClass 'images-loaded'
     @loadedImageHeights = true
     @maybeFinishedLoading()


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/154

The resizer is a little thing we do to normalize images in articles that get way too large. The resizer previously maxed out the image height to 70% of the inner height of the window, but as per the issue, let's try 90% after some requests from Editorial. 