### PR TITLE
@craigspaeth => roughing in /categories2

### DIFF
--- a/apps/categories2/index.coffee
+++ b/apps/categories2/index.coffee
@@ -1,0 +1,9 @@
+express = require 'express'
+routes = require './routes'
+adminOnly = require '../../lib/middleware/admin_only'
+
+app = module.exports = express()
+app.set 'views', "#{__dirname}/templates"
+app.set 'view engine', 'jade'
+
+app.get '/categories2', adminOnly, routes.index

--- a/apps/categories2/routes.coffee
+++ b/apps/categories2/routes.coffee
@@ -1,0 +1,2 @@
+@index = (req, res) ->
+	res.render 'index'

--- a/apps/categories2/stylesheets/index.styl
+++ b/apps/categories2/stylesheets/index.styl
@@ -1,0 +1,4 @@
+.categories-page
+  padding 40px 0
+
+.categories-page__header

--- a/apps/categories2/templates/index.jade
+++ b/apps/categories2/templates/index.jade
@@ -1,0 +1,12 @@
+extends ../../../components/main_layout/templates/index
+
+block head
+  include meta
+
+append locals
+  - assetPackage = 'categories2'
+
+block body
+  .categories-page.main-layout-container
+    h1.categories-page__header
+      | The Art Genome Project

--- a/apps/categories2/templates/meta.jade
+++ b/apps/categories2/templates/meta.jade
@@ -1,0 +1,11 @@
+title Categories | Artsy
+- var description = 'Browse over 1,000 categories in The Art Genome Project, the classification system that powers Artsy.'
+meta( property='og:title', content='Categories | Artsy' )
+meta( name='description', content= description )
+meta( property='og:description', content= description )
+meta( property='twitter:description', content= description )
+link( rel='canonical', href='#{sd.APP_URL}/categories' )
+meta( property='og:url', content='#{sd.APP_URL}/categories' )
+meta( property='og:image', content= asset('/images/og_image.jpg') )
+meta( property='og:type', content='website' )
+meta( property='twitter:card', content='summary' )

--- a/assets/categories2.styl
+++ b/assets/categories2.styl
@@ -1,0 +1,1 @@
+@require '../apps/categories2/stylesheets'

--- a/lib/setup.coffee
+++ b/lib/setup.coffee
@@ -174,6 +174,7 @@ module.exports = (app) ->
   app.use require "../apps/about"
   app.use require "../apps/collect"
   app.use require "../apps/categories"
+  app.use require "../apps/categories2"
   app.use require "../apps/consignments"
   app.use require "../apps/contact"
   app.use require "../apps/how_auctions_work"


### PR DESCRIPTION
So this is the starting point for properly re-implementing the Hackathon `/categories` hack.

The current PR merely roughs in some simple boilerplate to get the ball rolling, copying from the original `/categories` as needed

But the desired end state is something like this…

![categories-2](https://cloud.githubusercontent.com/assets/140521/18556971/165fad16-7b3b-11e6-94cb-d88d585254c3.gif)