### PR TITLE
@kanaabe => Article caption link color

### DIFF
--- a/components/article/stylesheets/index.styl
+++ b/components/article/stylesheets/index.styl
@@ -167,7 +167,8 @@ body.body-article
     margin-top 10px
     color gray-dark-color
     text-align left
-
+    a
+      color gray-dark-color
 .article-section-artworks
   position relative
   a


### PR DESCRIPTION
closes https://github.com/artsy/force/issues/47
closes https://github.com/artsy/force/issues/180
Links in article caption are same color as surrounding text. 