### PR TITLE
@briansw - Fix small typo on commercial template for inquiry split test

### DIFF
--- a/apps/artwork/components/commercial/templates/inquire.jade
+++ b/apps/artwork/components/commercial/templates/inquire.jade
@@ -7,7 +7,7 @@ if artwork.is_inquireable
     .form-errors.js-form-errors
       //- Rendered client-side
 
-    if sd.FORCE_INQUIRY_LOGIN == 'forced_login' || !artwork.partner.is_pre_qualify
+    if sd.FORCE_INQUIRY_LOGIN == 'force_login' || !artwork.partner.is_pre_qualify
 
       if user && user.isWithAnonymousSession()
         input( type='hidden', name='anonymous_session_id', value= user.id )

--- a/apps/artwork/components/commercial/test/template.coffee
+++ b/apps/artwork/components/commercial/test/template.coffee
@@ -34,7 +34,7 @@ renderArtwork = (artworkOptions = {}, sdOptions = {}) ->
 describe 'Commercial template', ->
 
   it 'name and password display for prequalified work (with forced log in test result as "forced_login")', ->
-    html = renderArtwork { partner: is_pre_qualify: true }, { FORCE_INQUIRY_LOGIN: 'forced_login' }
+    html = renderArtwork { partner: is_pre_qualify: true }, { FORCE_INQUIRY_LOGIN: 'force_login' }
     $ = cheerio.load(html)
     $('input[name=email]').length.should.eql 1
 


### PR DESCRIPTION
Fixes typo that causes the name and email fields not to appear for the test group