### PR TITLE
@kanaabe => No menu transition in non-fullscreen superarticles

### DIFF
--- a/components/article/client/super_article.coffee
+++ b/components/article/client/super_article.coffee
@@ -41,5 +41,5 @@ module.exports = class SuperArticleView extends Backbone.View
     @$(".article-container[data-id=#{@article.get('id')}] #{selector}").waypoint (direction) =>
       if direction == 'down'
         $stickyHeader.addClass 'visible'
-      else
+      else unless $stickyHeader.hasClass('no-transition')
         $stickyHeader.removeClass 'visible'


### PR DESCRIPTION
closes https://github.com/artsy/force/issues/186
Super-articles with "no transition" class on menu are excluded from transition

![superarticle-header](https://cloud.githubusercontent.com/assets/1497424/18762481/eade91e2-80d6-11e6-8d06-2ef7b1b0fbb0.gif)
. 