### PR TITLE
@eessex => FB Instant Articles signup embed

### DIFF
--- a/apps/rss/templates/instant_article.jade
+++ b/apps/rss/templates/instant_article.jade
@@ -50,4 +50,6 @@ html(lang="en" prefix="op: http://media.facebook.com/op#")
           when 'image_set'
             +imageSet(section)
 
+      +editorialSignup
+
       include tracking

--- a/apps/rss/templates/instant_article_mixins.jade
+++ b/apps/rss/templates/instant_article_mixins.jade
@@ -55,3 +55,7 @@ mixin artworkCaption(artwork)
 mixin embed(section)
   figure.op-interactive
     iframe(class='no-margin' src=section.url height="#{section.mobile_height || section.height }")
+
+mixin editorialSignup
+  figure.op-interactive
+    iframe(class='no-margin' src='http://link.artsy.net/join/sign-up-editorial-facebook' height="250")

--- a/apps/rss/test/instant_articles.coffee
+++ b/apps/rss/test/instant_articles.coffee
@@ -86,3 +86,8 @@ describe '/instant_articles', ->
       rendered.should.containEql '<figcaption><p>Sterling Ruby, Los Angeles, 2013. Photo by CG Watkins. Courtesy Sterling Ruby Studio and Gagosian Gallery</p></figcaption>'
       rendered.should.containEql '<p>Installation view of&nbsp;“The Los Angeles Project” at Ullens Center for Contemporary Art, Beijing. Courtesy UCCA</p>'
       rendered.should.containEql '<a href="https://artsy.net/ucca">'
+
+    it 'renders a signup embed for every article', ->
+      article = new Article fabricate 'article'
+      rendered = iaTemplate(sd: sd, article: article)
+      rendered.should.containEql 'link.artsy.net/join/sign-up-editorial-facebook'


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/184

We use a special RSS feed for [Instant Articles](https://instantarticles.fb.com/) which ends up being some metadata and HTML in IA formatting. We give FB that RSS link, which is consumed and saved on their end.

The url of the signup is a Sailthru hosted page, which links to our email lists directly!

![image](https://cloud.githubusercontent.com/assets/2236794/18764256/8eb1b27a-80de-11e6-8ca0-77764ecc63a5.png)

