### PR TITLE
@craigspaeth => avoid race condition when checking whether a bidder is qualified/registered 

### DIFF
--- a/apps/auction/routes.coffee
+++ b/apps/auction/routes.coffee
@@ -29,10 +29,9 @@ setupUser = (user, auction) ->
           user.set 'registered_to_bid', boolean
         error: ->
           user.set 'registered_to_bid', false
+      ).then( ([ bidder ]) ->
+        user.set 'qualified_for_bidding', bidder?.qualified_for_bidding
       )
-      user.fetchBidderForAuction auction,
-        success: (bidder) =>
-          user.set 'qualified_for_bidding', bidder?.get 'qualified_for_bidding'
     ]
   else
     Q.resolve()

--- a/apps/auction/test/routes.coffee
+++ b/apps/auction/test/routes.coffee
@@ -80,10 +80,11 @@ describe '/auction routes', ->
 
   describe 'with logged in user', ->
     beforeEach (done) ->
+      Backbone.sync.returns Promise.resolve(fabricate 'bidder')
       @req = user: new CurrentUser(id: 'foobar'), params: id: 'foobar'
       routes.index @req, @res, @next
       _.defer => _.defer =>
-        @userReqs = _.last Backbone.sync.args, 2
+        @userReqs = _.last Backbone.sync.args, 1
         done()
 
     it 'fetches the bidder positions', ->


### PR DESCRIPTION
Since `fetchBidderForAuction` doesn't return a promise, these requests were potentially not all completing. This means on the auction page, occasionally people would see "registration pending" instead of "Approved to bid."

Thanks @craigspaeth for the help in detangling this!