### PR TITLE
@craigspaeth => Group genes by family

### DIFF
--- a/apps/categories2/client/index.coffee
+++ b/apps/categories2/client/index.coffee
@@ -1,0 +1,2 @@
+module.exports.init = ->
+  # TODO

--- a/apps/categories2/routes.coffee
+++ b/apps/categories2/routes.coffee
@@ -7,6 +7,8 @@ Genes = require '../../collections/genes'
   Q.all([
     genes.fetchUntilEndInParallel(cache: true, data: published: true, sort: 'name')
   ]).done ->
+    geneFamilies = genes.groupByFamily()
 
     res.render 'index', 
       genes: genes
+      geneFamilies: geneFamilies

--- a/apps/categories2/routes.coffee
+++ b/apps/categories2/routes.coffee
@@ -1,2 +1,2 @@
 @index = (req, res) ->
-	res.render 'index'
+  res.render 'index'

--- a/apps/categories2/routes.coffee
+++ b/apps/categories2/routes.coffee
@@ -1,2 +1,12 @@
+Q = require 'bluebird-q'
+Genes = require '../../collections/genes'
+
 @index = (req, res) ->
-  res.render 'index'
+  genes = new Genes
+
+  Q.all([
+    genes.fetchUntilEndInParallel(cache: true, data: published: true, sort: 'name')
+  ]).done ->
+
+    res.render 'index', 
+      genes: genes

--- a/apps/categories2/routes.coffee
+++ b/apps/categories2/routes.coffee
@@ -9,6 +9,6 @@ Genes = require '../../collections/genes'
   ]).done ->
     geneFamilies = genes.groupByFamily()
 
-    res.render 'index', 
+    res.render 'index',
       genes: genes
       geneFamilies: geneFamilies

--- a/apps/categories2/stylesheets/index.styl
+++ b/apps/categories2/stylesheets/index.styl
@@ -1,39 +1,39 @@
 @require '../../../components/stylus_lib'
 
-.l-categories-page
+.l-categories2-page
   padding 40px 0
 
-.l-categories-page__nav
+.l-categories2-page__nav
   display inline-block
   width 25%
   vertical-align top
 
-.l-categories-page__content
+.l-categories2-page__content
   display inline-block
   width 75%
   vertical-align top
 
-.categories-page__header
+.categories2-page__header
   garamond-size('xl-headline')
 
-.categories-page__blurb
+.categories2-page__blurb
   garamond-size('s-headline')
   margin 35px 0
 
-.categories-list
+.categories2-list
   display block
 
-.categories-list__family
+.categories2-list__family
   display block
 
-.categories-list__family__name
+.categories2-list__family__name
   garamond-size('l-headline')
   margin 1em 0 0.5em 0
 
-.categories-list__family__genes
+.categories2-list__family__genes
   display block
 
-.categories-list__family__genes__gene
+.categories2-list__family__genes__gene
   garamond-size('l-body')
   a
     text-decoration none

--- a/apps/categories2/stylesheets/index.styl
+++ b/apps/categories2/stylesheets/index.styl
@@ -14,8 +14,30 @@
   vertical-align top
 
 .categories-page__header
-  font-size 50px
+  garamond-size('xl-headline')
 
 .categories-page__blurb
   garamond-size('s-headline')
   margin 35px 0
+
+.categories-list
+  display block
+
+.categories-list__family
+  display block
+
+.categories-list__family__name
+  garamond-size('l-headline')
+  margin 1em 0 0.5em 0
+
+.categories-list__family__genes
+  display block
+
+.categories-list__family__genes__gene
+  garamond-size('l-body')
+  a
+    text-decoration none
+    transition color 0.125s
+    color black
+    &:hover
+      color purple-color

--- a/apps/categories2/stylesheets/index.styl
+++ b/apps/categories2/stylesheets/index.styl
@@ -1,5 +1,21 @@
-.categories-page
+@require '../../../components/stylus_lib'
+
+.l-categories-page
   padding 40px 0
+
+.l-categories-page__nav
+  display inline-block
+  width 25%
+  vertical-align top
+
+.l-categories-page__content
+  display inline-block
+  width 75%
+  vertical-align top
 
 .categories-page__header
   font-size 50px
+
+.categories-page__blurb
+  garamond-size('s-headline')
+  margin 35px 0

--- a/apps/categories2/stylesheets/index.styl
+++ b/apps/categories2/stylesheets/index.styl
@@ -1,5 +1,5 @@
 .categories-page
   padding 40px 0
 
-// To be added
-// .categories-page__header
+.categories-page__header
+  font-size 50px

--- a/apps/categories2/templates/index.jade
+++ b/apps/categories2/templates/index.jade
@@ -7,6 +7,23 @@ append locals
   - assetPackage = 'categories2'
 
 block body
-  .categories-page.main-layout-container
-    h1.categories-page__header
-      | The Art Genome Project
+  .l-categories-page.main-layout-container
+
+    .l-categories-page__nav
+      | Categories sticky nav TK
+
+    .l-categories-page__content
+
+      h1.categories-page__header
+        | The Art Genome Project
+
+      p.categories-page__blurb
+        | The Art Genome Project is the classification system and technological framework that powers Artsy.
+        | It maps the characteristics (we call them &ldquo;genes&rdquo;) that connect artists, artworks, architecture, and design objects across history.
+        | There are currently over 1,000 characteristics in The Art Genome Project, including art historical movements, subject matter, and formal qualities.
+
+      .wip
+          ul
+            each g in genes.models
+              li
+                = g.get('name')

--- a/apps/categories2/templates/index.jade
+++ b/apps/categories2/templates/index.jade
@@ -7,27 +7,27 @@ append locals
   - assetPackage = 'categories2'
 
 block body
-  .l-categories-page.main-layout-container
+  .l-categories2-page.main-layout-container
 
-    .l-categories-page__nav
+    .l-categories2-page__nav
       | Categories sticky nav TK
 
-    .l-categories-page__content
+    .l-categories2-page__content
 
-      h1.categories-page__header
+      h1.categories2-page__header
         | The Art Genome Project
 
-      p.categories-page__blurb
+      p.categories2-page__blurb
         | The Art Genome Project is the classification system and technological framework that powers Artsy.
         | It maps the characteristics (we call them &ldquo;genes&rdquo;) that connect artists, artworks, architecture, and design objects across history.
         | There are currently over 1,000 characteristics in The Art Genome Project, including art historical movements, subject matter, and formal qualities.
 
-      .categories-list
+      .categories2-list
           each family in geneFamilies
-            .categories-list__family
-              .categories-list__family__name
+            .categories2-list__family
+              .categories2-list__family__name
                 = family.name
-              .categories-list__family__genes
+              .categories2-list__family__genes
                 each gene in family.genes
-                  .categories-list__family__genes__gene
+                  .categories2-list__family__genes__gene
                     a( href = gene.href() )= gene.get('name')

--- a/apps/categories2/templates/index.jade
+++ b/apps/categories2/templates/index.jade
@@ -22,8 +22,12 @@ block body
         | It maps the characteristics (we call them &ldquo;genes&rdquo;) that connect artists, artworks, architecture, and design objects across history.
         | There are currently over 1,000 characteristics in The Art Genome Project, including art historical movements, subject matter, and formal qualities.
 
-      .wip
-          ul
-            each g in genes.models
-              li
-                = g.get('name')
+      .categories-list
+          each family in geneFamilies
+            .categories-list__family
+              .categories-list__family__name
+                = family.name
+              .categories-list__family__genes
+                each gene in family.genes
+                  .categories-list__family__genes__gene
+                    a( href = gene.href() )= gene.get('name')

--- a/assets/categories2.coffee
+++ b/assets/categories2.coffee
@@ -1,0 +1,2 @@
+require('backbone').$ = $
+$ require('../apps/categories2/client/index.coffee').init

--- a/collections/genes.coffee
+++ b/collections/genes.coffee
@@ -13,3 +13,12 @@ module.exports = class Genes extends Backbone.Collection
   model: Gene
 
   url: "#{sd.API_URL}/api/v1/genes"
+
+  groupByFamily: ->
+    grouped = @groupBy (g) -> g.familyName()
+    for familyName, genes of grouped
+      {
+        name: familyName
+        genes: _.sortBy genes, (g) -> g.get('name')
+      }
+

--- a/models/gene.coffee
+++ b/models/gene.coffee
@@ -23,6 +23,8 @@ module.exports = class Gene extends Backbone.Model
 
   displayName: -> @get('display_name') or @get('name') 
 
+  familyName: -> @related().family.get('name')
+
   alphaSortKey: -> @get('id')
 
   toPageTitle: ->

--- a/models/mixins/relations/gene.coffee
+++ b/models/mixins/relations/gene.coffee
@@ -1,4 +1,5 @@
 { API_URL } = require('sharify').data
+Backbone = require 'backbone'
 
 module.exports =
   related: ->
@@ -13,6 +14,9 @@ module.exports =
     artworks = new Artworks
     artworks.url = "#{@url()}/artworks?published=true"
 
+    family = new Backbone.Model @get('family')
+
     @__related__ =
       artists: artists
       artworks: artworks
+      family: family

--- a/test/collections/genes.coffee
+++ b/test/collections/genes.coffee
@@ -1,0 +1,16 @@
+sinon = require 'sinon'
+Backbone = require 'backbone'
+
+describe 'Genes', ->
+
+  beforeEach ->
+    sinon.stub Backbone, 'sync'
+    # @articles = new Articles [fixtures.articles]
+
+  afterEach ->
+    Backbone.sync.restore()
+
+  describe '#groupByFamily', ->
+
+    it 'groups genes by "gene family"', ->
+      'foo'.should.equal 'foo'

--- a/test/collections/genes.coffee
+++ b/test/collections/genes.coffee
@@ -1,16 +1,35 @@
 sinon = require 'sinon'
 Backbone = require 'backbone'
+Gene = require '../../models/gene'
+Genes = require '../../collections/genes'
+{ fabricate } = require 'antigravity'
+_ = require 'underscore'
 
 describe 'Genes', ->
 
   beforeEach ->
     sinon.stub Backbone, 'sync'
-    # @articles = new Articles [fixtures.articles]
+
+    @brown = new Gene fabricate 'gene', family: { id: 'colors', name: 'Colors' }, id: 'brown', name: 'Brown'
+    @purple = new Gene fabricate 'gene', family: { id: 'colors', name: 'Colors' }, id: 'purple', name: 'Purple'
+    @green = new Gene fabricate 'gene', family: { id: 'colors', name: 'Colors' }, id: 'green', name: 'Green'
+    @round = new Gene fabricate 'gene', family: { id: 'shapes', name: 'Shapes' }, id: 'round', name: 'Round'
+    @squiggly = new Gene fabricate 'gene', family: { id: 'shapes', name: 'Shapes' }, id: 'squiggly', name: 'Squiggly'
 
   afterEach ->
     Backbone.sync.restore()
 
   describe '#groupByFamily', ->
 
-    it 'groups genes by "gene family"', ->
-      'foo'.should.equal 'foo'
+    it 'groups genes by gene family"', ->
+      genes = new Genes [ @brown, @purple, @round, @squiggly ]
+      grouped = genes.groupByFamily()
+      grouped.should.eql [
+        { name: 'Colors', genes: [ @brown, @purple ] },
+        { name: 'Shapes', genes: [ @round, @squiggly ] }
+      ]
+
+    it 'sorts each group of genes alphabetically', ->
+      genes = new Genes [ @green, @purple, @brown ]
+      grouped = genes.groupByFamily()
+      grouped[0].genes.should.eql [ @brown, @green, @purple ]

--- a/test/collections/genes.coffee
+++ b/test/collections/genes.coffee
@@ -1,5 +1,3 @@
-sinon = require 'sinon'
-Backbone = require 'backbone'
 Gene = require '../../models/gene'
 Genes = require '../../collections/genes'
 { fabricate } = require 'antigravity'
@@ -8,16 +6,12 @@ _ = require 'underscore'
 describe 'Genes', ->
 
   beforeEach ->
-    sinon.stub Backbone, 'sync'
 
     @brown = new Gene fabricate 'gene', family: { id: 'colors', name: 'Colors' }, id: 'brown', name: 'Brown'
     @purple = new Gene fabricate 'gene', family: { id: 'colors', name: 'Colors' }, id: 'purple', name: 'Purple'
     @green = new Gene fabricate 'gene', family: { id: 'colors', name: 'Colors' }, id: 'green', name: 'Green'
     @round = new Gene fabricate 'gene', family: { id: 'shapes', name: 'Shapes' }, id: 'round', name: 'Round'
     @squiggly = new Gene fabricate 'gene', family: { id: 'shapes', name: 'Shapes' }, id: 'squiggly', name: 'Squiggly'
-
-  afterEach ->
-    Backbone.sync.restore()
 
   describe '#groupByFamily', ->
 

--- a/test/models/gene.coffee
+++ b/test/models/gene.coffee
@@ -40,3 +40,9 @@ describe "Gene", ->
         done()
       Backbone.sync.args[0][2].data.sort.should.equal '-foo'
       Backbone.sync.args[0][2].success { total: 100 }
+
+  describe '#familyName', ->
+  
+    it 'returns the name of the related GeneFamily', ->
+      @gene = new Gene fabricate 'gene', family: { name: 'Materials' }
+      @gene.familyName().should.equal 'Materials'

--- a/test/models/gene.coffee
+++ b/test/models/gene.coffee
@@ -42,7 +42,7 @@ describe "Gene", ->
       Backbone.sync.args[0][2].success { total: 100 }
 
   describe '#familyName', ->
-  
+
     it 'returns the name of the related GeneFamily', ->
       @gene = new Gene fabricate 'gene', family: { name: 'Materials' }
       @gene.familyName().should.equal 'Materials'


### PR DESCRIPTION
Incremental progress towards **/categories2** …

This PR:

* cleans up some cruft from the first PR
* makes the `Gene` model and `Genes` collection aware of the `GeneFamily` relation
* continues to rough in the layout for /categories2, this time adding a full list of genes, grouped by family

![cat2](https://cloud.githubusercontent.com/assets/140521/18797930/36a58c76-819e-11e6-8b9d-ef44f84924ce.gif)


