### PR TITLE
@craigspaeth - Dont include escaped fragment on home

### DIFF
--- a/apps/home/templates/index.jade
+++ b/apps/home/templates/index.jade
@@ -2,8 +2,6 @@ extends ../../../components/main_layout/templates/index
 
 block head
   include meta
-  if sd.INCLUDE_ESCAPED_FRAGMENT
-    meta( name="fragment", content="!" )
 
 append locals
   - assetPackage = 'home'


### PR DESCRIPTION
This removes the escaped fragment meta tag on the homepage. AFAIK, we don't pre-render this page on reflection and I doubt Google is gonna hit home enough for us to notice.