### PR TITLE
@craigspaeth => center auction page content for large widths

### DIFF
--- a/apps/auction/stylesheets/index.styl
+++ b/apps/auction/stylesheets/index.styl
@@ -10,6 +10,8 @@
 
 .auction-page
   padding-bottom 20px
+  .responsive-layout-container
+    margin 0px auto
 
 .auction-page-section
   block-margins(30px)


### PR DESCRIPTION
This fixes: https://github.com/artsy/force/issues/200#event-800980796

Before, this page was inheriting `margin 0 200px`, and left-aligning at large widths:
![image](https://cloud.githubusercontent.com/assets/2081340/18802038/78ae962e-81b4-11e6-921d-25bd04bf2118.png)


Now, the content is centered:
![image](https://cloud.githubusercontent.com/assets/2081340/18802023/673ad45c-81b4-11e6-8cc3-3267e0c8162f.png)
