### PR TITLE
@craigspaeth => Article footer grid view

### DIFF
--- a/apps/article/client/index.coffee
+++ b/apps/article/client/index.coffee
@@ -6,6 +6,7 @@ Articles = require '../../../collections/articles.coffee'
 ArticleView = require '../../../components/article/client/view.coffee'
 GalleryInsightsView = require '../../../components/email/client/gallery_insights.coffee'
 EditorialSignupView = require '../../../components/email/client/editorial_signup.coffee'
+ArticlesGridView = require '../../../components/articles_grid/view.coffee'
 Sale = require '../../../models/sale.coffee'
 Partner = require '../../../models/partner.coffee'
 Profile = require '../../../models/profile.coffee'
@@ -35,7 +36,11 @@ module.exports = class ArticleIndexView extends Backbone.View
       waypointUrls: true
       lushSignup: true
 
-    @setupInfiniteScroll() if sd.SCROLL_ARTICLE is 'infinite'
+    if sd.SCROLL_ARTICLE is 'infinite'
+      @setupInfiniteScroll()
+    else if not sd.SUPER_SUB_ARTICLES.length
+      @setupFooterArticles()
+
     @setupPromotedContent() if @article.get('channel_id') is sd.PC_ARTSY_CHANNEL or
       @article.get('channel_id') is sd.PC_AUCTION_CHANNEL
 
@@ -112,6 +117,34 @@ module.exports = class ArticleIndexView extends Backbone.View
             name: sale.get('name')
             href: sale.href()
             type: 'Auction'
+
+  setupFooterArticles: ->
+    data =
+      published: true
+      sort: '-published_at'
+      limit: 13
+    if @article.get('channel_id')
+      _.extend data,
+        channel_id: @article.get('channel_id')
+    else
+      _.extend data,
+        featured: true
+        channel_id: sd.ARTSY_EDITORIAL_CHANNEL
+    @collection = new Articles
+    new ArticlesGridView
+      el: $('#articles-footer')
+      hideMore: true
+      article: @article
+      header: "More from #{@article.get('channel')?.name or 'Artsy'}"
+      collection: @collection
+    @collection.fetch
+      data: data
+
+        # $('#articles-footer').append footerTemplate
+        #   articles: articles
+        #   name: @article.get('channel')?.name
+        #   galleryInsights: @article.get('channel_id') is sd.GALLERY_INSIGHTS_CHANNEL
+        #   currentArticle: @article.get('id')
 
 module.exports.init = ->
   new ArticleIndexView el: $('body')

--- a/apps/article/client/index.coffee
+++ b/apps/article/client/index.coffee
@@ -38,7 +38,7 @@ module.exports = class ArticleIndexView extends Backbone.View
 
     if sd.SCROLL_ARTICLE is 'infinite'
       @setupInfiniteScroll()
-    else if not sd.SUPER_SUB_ARTICLES.length
+    else unless sd.SUPER_SUB_ARTICLES.length
       @setupFooterArticles()
 
     @setupPromotedContent() if @article.get('channel_id') is sd.PC_ARTSY_CHANNEL or
@@ -122,29 +122,20 @@ module.exports = class ArticleIndexView extends Backbone.View
     data =
       published: true
       sort: '-published_at'
-      limit: 13
+      limit: 12
     if @article.get('channel_id')
-      _.extend data,
-        channel_id: @article.get('channel_id')
+      data.channel_id = @article.get('channel_id')
     else
-      _.extend data,
-        featured: true
-        channel_id: sd.ARTSY_EDITORIAL_CHANNEL
+      data.featured = true
+      data.channel_id = sd.ARTSY_EDITORIAL_CHANNEL
     @collection = new Articles
     new ArticlesGridView
       el: $('#articles-footer')
       hideMore: true
-      article: @article
       header: "More from #{@article.get('channel')?.name or 'Artsy'}"
       collection: @collection
     @collection.fetch
       data: data
-
-        # $('#articles-footer').append footerTemplate
-        #   articles: articles
-        #   name: @article.get('channel')?.name
-        #   galleryInsights: @article.get('channel_id') is sd.GALLERY_INSIGHTS_CHANNEL
-        #   currentArticle: @article.get('id')
 
 module.exports.init = ->
   new ArticleIndexView el: $('body')

--- a/apps/article/routes.coffee
+++ b/apps/article/routes.coffee
@@ -23,8 +23,7 @@ sailthru = require('sailthru-client').createSailthruClient(SAILTHRU_KEY,SAILTHRU
       res.locals.sd.SLIDESHOW_ARTWORKS = data.slideshowArtworks?.toJSON()
       res.locals.sd.ARTICLE = data.article.toJSON()
       res.locals.sd.INCLUDE_SAILTHRU = res.locals.sd.ARTICLE && res.locals.sd.ARTICLE.published
-      res.locals.sd.FOOTER_ARTICLES = data.footerArticles.toJSON()
-      res.locals.sd.RELATED_ARTICLES = data.relatedArticles?.toJSON()
+      res.locals.sd.SUPER_SUB_ARTICLES = data.superSubArticles?.toJSON()
       res.locals.sd.SUPER_SUB_ARTICLE_IDS = data.superSubArticleIds
       res.locals.sd.SCROLL_ARTICLE = getArticleScrollType(data)
       res.locals.jsonLD = stringifyJSONForWeb(data.article.toJSONLD())
@@ -51,7 +50,7 @@ setupEmailSubscriptions = (user, article, cb) ->
 
 getArticleScrollType = (data) ->
   # Only Artsy Editorial and non super/subsuper articles can have an infinite scroll
-  if data.relatedArticles?.length or data.article.get('channel_id') isnt sd.ARTSY_EDITORIAL_CHANNEL
+  if data.superSubArticles?.length or data.article.get('channel_id') isnt sd.ARTSY_EDITORIAL_CHANNEL
     'static'
   else
     'infinite'

--- a/apps/article/stylesheets/index.styl
+++ b/apps/article/stylesheets/index.styl
@@ -15,24 +15,11 @@
 .body-welcome-header #articles-show
   margin-top 180px
 
-#articles-footer
-  // width 570px
-  // margin 80px auto
-  h1
-    avant-garde()
-    font-size default-avant-garde-font-size - 1
-  // li, h1
-  //   margin-bottom 20px
-  //   padding-bottom 20px
-  //   border-bottom 1px solid gray-lighter-color
-
-// #articles-footer-list figure
-//   margin-bottom 20px
-//   padding-bottom 20px
-//   border-bottom 1px solid gray-lighter-color
-
 #articles-body-container
   position relative
+
+#articles-footer
+  padding 30px
 
 .articles-promoted
   display flex

--- a/apps/article/stylesheets/index.styl
+++ b/apps/article/stylesheets/index.styl
@@ -16,20 +16,20 @@
   margin-top 180px
 
 #articles-footer
-  width 570px
-  margin 80px auto
+  // width 570px
+  // margin 80px auto
   h1
     avant-garde()
     font-size default-avant-garde-font-size - 1
-  li, h1
-    margin-bottom 20px
-    padding-bottom 20px
-    border-bottom 1px solid gray-lighter-color
+  // li, h1
+  //   margin-bottom 20px
+  //   padding-bottom 20px
+  //   border-bottom 1px solid gray-lighter-color
 
-#articles-footer-list figure
-  margin-bottom 20px
-  padding-bottom 20px
-  border-bottom 1px solid gray-lighter-color
+// #articles-footer-list figure
+//   margin-bottom 20px
+//   padding-bottom 20px
+//   border-bottom 1px solid gray-lighter-color
 
 #articles-body-container
   position relative

--- a/apps/article/templates/article.jade
+++ b/apps/article/templates/article.jade
@@ -1,5 +1,4 @@
 extends ../../../components/fair_layout/templates/conditional
-include ../../articles/templates/mixin
 
 block head
   include meta
@@ -18,25 +17,7 @@ block body
     if sd.SCROLL_ARTICLE === "infinite"
       #article-loading: .loading-spinner
 
-  //- if sd.SCROLL_ARTICLE === "static" && !superArticle
-    //- Article footer content
-  section#articles-footer
-      //- Rendered on the client
-
-      //- if article.get('section_ids').length
-      //-   if article.get('section_ids')[0] === sd.GALLERY_INSIGHTS_SECTION_ID
-      //-     .articles-insights-show
-      //-       include ../../../components/email/templates/gallery_insights_form
-      //-   ul#articles-footer-list
-
-      //-     //- for sectionArticle in allSectionArticles.models
-      //-     //-   unless article.id === sectionArticle.get('id')
-      //-     //-     +article-figure(sectionArticle, 440, false, false)
-      //- else
-      //-   h1 What to Read Next
-      //-   ul#articles-footer-list
-      //-     for footerArticle in footerArticles.models
-      //-       unless article.id === footerArticle.get('id')
-      //-         +article-figure(footerArticle, 440, false, false)
+  section#articles-footer.main-layout-container
+    //- Rendered on client
 
   include ../../../components/main_layout/templates/json_ld

--- a/apps/article/templates/article.jade
+++ b/apps/article/templates/article.jade
@@ -18,23 +18,25 @@ block body
     if sd.SCROLL_ARTICLE === "infinite"
       #article-loading: .loading-spinner
 
-  if sd.SCROLL_ARTICLE === "static" && !superArticle
+  //- if sd.SCROLL_ARTICLE === "static" && !superArticle
     //- Article footer content
-    section#articles-footer
-      if article.get('section_ids').length
-        if article.get('section_ids')[0] === sd.GALLERY_INSIGHTS_SECTION_ID
-          .articles-insights-show
-            include ../../../components/email/templates/gallery_insights_form
-        h1 More From #{section.get('title')}
-        ul#articles-footer-list
-          for sectionArticle in allSectionArticles.models
-            unless article.id === sectionArticle.get('id')
-              +article-figure(sectionArticle, 440, false, false)
-      else
-        h1 What to Read Next
-        ul#articles-footer-list
-          for footerArticle in footerArticles.models
-            unless article.id === footerArticle.get('id')
-              +article-figure(footerArticle, 440, false, false)
+  section#articles-footer
+      //- Rendered on the client
+
+      //- if article.get('section_ids').length
+      //-   if article.get('section_ids')[0] === sd.GALLERY_INSIGHTS_SECTION_ID
+      //-     .articles-insights-show
+      //-       include ../../../components/email/templates/gallery_insights_form
+      //-   ul#articles-footer-list
+
+      //-     //- for sectionArticle in allSectionArticles.models
+      //-     //-   unless article.id === sectionArticle.get('id')
+      //-     //-     +article-figure(sectionArticle, 440, false, false)
+      //- else
+      //-   h1 What to Read Next
+      //-   ul#articles-footer-list
+      //-     for footerArticle in footerArticles.models
+      //-       unless article.id === footerArticle.get('id')
+      //-         +article-figure(footerArticle, 440, false, false)
 
   include ../../../components/main_layout/templates/json_ld

--- a/apps/article/test/client/index.coffee
+++ b/apps/article/test/client/index.coffee
@@ -28,19 +28,24 @@ describe 'ArticleIndexView', ->
           }
         ]
       @options = {
-        sd: _.extend sd, { PC_ARTSY_CHANNEL: '5086df098523e60002000013', PC_AUCTION_CHANNEL: '5086df098523e60002000012', ARTICLE: @model.attributes }
+        sd: _.extend sd, {
+          PC_ARTSY_CHANNEL: '5086df098523e60002000013'
+          PC_AUCTION_CHANNEL: '5086df098523e60002000012'
+          ARTICLE: @model.attributes
+          SUPER_SUB_ARTICLES: []
+        }
         resize: resize
         crop: crop
         article: @model
         moment: moment
         asset: ->
-        footerArticles: new Backbone.Collection
       }
       $.onInfiniteScroll = sinon.stub()
       $.fn.waypoint = sinon.stub()
       sinon.stub Backbone, 'sync'
       @ArticleIndexView = benv.requireWithJadeify resolve(__dirname, '../../client/index'), ['articleTemplate', 'promotedTemplate']
       @ArticleIndexView.__set__ 'ArticleView', sinon.stub()
+      @ArticleIndexView.__set__ 'ArticlesGridView', @ArticlesGridView = sinon.stub()
       done()
 
   after ->
@@ -56,8 +61,10 @@ describe 'ArticleIndexView', ->
           el: $('body')
         done()
 
-    it 'renders the template with footer', ->
-      $('#articles-footer').text().should.containEql 'What to Read Next'
+    it 'calls renders a grid view with appropriate arguments', ->
+      @ArticlesGridView.args[0][0].header.should.equal 'More from Artsy'
+      @ArticlesGridView.args[0][0].hideMore.should.be.true()
+      @ArticlesGridView.args[0][0].el.selector.should.equal '#articles-footer'
 
     it 'does not display promoted content banner for non-promoted', ->
       $('.articles-promoted').length.should.equal 0
@@ -66,6 +73,7 @@ describe 'ArticleIndexView', ->
 
     before (done) ->
       @options.sd.SCROLL_ARTICLE = 'infinite'
+      @ArticlesGridView.reset()
       benv.render resolve(__dirname, '../../templates/article.jade'), _.extend(@options, {
         sd: sd
       }), =>
@@ -94,6 +102,9 @@ describe 'ArticleIndexView', ->
     it 'does not display promoted content banner for non-promoted', ->
       $('.articles-promoted').length.should.equal 0
 
+    it 'does not try to render a grid view', ->
+      @ArticlesGridView.called.should.be.false()
+
   describe 'promoted content gallery', ->
 
     before (done) ->
@@ -104,8 +115,8 @@ describe 'ArticleIndexView', ->
         done()
 
     it 'displays promoted content banner for partner', ->
-      Backbone.sync.args[2][2].success fabricate 'partner'
-      Backbone.sync.args[3][2].success fabricate 'partner_profile'
+      Backbone.sync.args[3][2].success fabricate 'partner'
+      Backbone.sync.args[4][2].success fabricate 'partner_profile'
       $('.articles-promoted__img').attr('src').should.equal '/images/missing_image.png'
       $('.articles-promoted__name').text().should.equal 'Gagosian Gallery'
       $('.articles-promoted__explore').text().should.equal 'Explore Institution'
@@ -122,7 +133,7 @@ describe 'ArticleIndexView', ->
         done()
 
     it 'displays promoted content banner for auction', ->
-      Backbone.sync.args[4][2].success fabricate 'sale'
+      Backbone.sync.args[5][2].success fabricate 'sale'
       $('.articles-promoted__img').attr('src').should.equal 'https://i.embed.ly/1/display/crop?url=%2Fimages%2Fmissing_image.png&width=250&height=165&quality=95'
       $('.articles-promoted__name').text().should.equal 'Whitney Art Party'
       $('.articles-promoted__explore').text().should.equal 'Explore Auction'

--- a/apps/article/test/routes.coffee
+++ b/apps/article/test/routes.coffee
@@ -39,13 +39,10 @@ describe 'Article routes', ->
       routes.article @req, @res
       Article::fetchWithRelated.args[0][0].success(
         article: new Article(_.extend fixtures.article, title: 'Foo', slug: 'bar')
-        footerArticles: new Articles([_.extend fixtures.article, title: 'Bar'])
         superArticles: new Articles([_.extend fixtures.article, title: 'Super'])
       )
       @res.render.args[0][0].should.equal 'article'
       @res.render.args[0][1].article.get('title').should.equal 'Foo'
-      @res.render.args[0][1].footerArticles.first().get('title')
-        .should.equal 'Bar'
       @res.render.args[0][1].superArticles.first().get('title')
         .should.equal 'Super'
 

--- a/apps/article/test/templates.coffee
+++ b/apps/article/test/templates.coffee
@@ -16,20 +16,49 @@ render = (templateName) ->
 
 describe 'article template', ->
 
-  it "renders related footer articles", ->
+  it "renders a container for the footer", ->
     html = render('article')
       article: new Article
         title: 'hi'
         sections: []
         section_ids: []
         contributing_authors: []
-      footerArticles: new Articles [_.extend(_.clone(fixtures.article),
-        thumbnail_title: "This is a footer article"
-        section_ids: [])]
       crop: (url) -> url
       resize: (url) -> url
       moment: moment
       sd:
         SCROLL_ARTICLE: 'static'
       asset: ->
-    html.should.containEql 'This is a footer article'
+    html.should.containEql 'articles-footer'
+
+  it "renders article sections", ->
+    html = render('article')
+      article: new Article
+        title: 'hi'
+        sections: [
+          { type: 'text', body: 'Hello...' }
+        ]
+        section_ids: []
+        contributing_authors: []
+      crop: (url) -> url
+      resize: (url) -> url
+      moment: moment
+      sd:
+        SCROLL_ARTICLE: 'static'
+      asset: ->
+    html.should.containEql 'Hello...'
+
+  it 'renders a loading spinner for infinite scroll articles', ->
+    html = render('article')
+      article: new Article
+        title: 'Title Page'
+        sections: []
+        contributing_authors: []
+      crop: (url) -> url
+      resize: (url) -> url
+      moment: moment
+      sd:
+        SCROLL_ARTICLE: 'infinite'
+      asset: ->
+    html.should.containEql 'loading-spinner'
+

--- a/assets/article.styl
+++ b/assets/article.styl
@@ -4,7 +4,6 @@
 @require '../components/share'
 @require '../components/merry_go_round'
 @require '../components/article_figure'
-@require '../components/articles_feed/stylesheets'
 @require '../components/article/stylesheets'
 @require '../components/grid'
 @require '../components/cta_bar'

--- a/assets/article.styl
+++ b/assets/article.styl
@@ -11,4 +11,5 @@
 @require '../components/gradient_blurb'
 @require '../components/jump'
 @require '../components/email/stylesheets'
+@require '../components/articles_grid/stylesheets'
 @require '../apps/article/stylesheets'

--- a/components/article/client/view.coffee
+++ b/components/article/client/view.coffee
@@ -66,7 +66,7 @@ module.exports = class ArticleView extends Backbone.View
     # FS and Super Article setup
     if ($header = @$('.article-fullscreen')).length
       new FullscreenView el: @$el, article: @article, header: $header
-    if sd.RELATED_ARTICLES?.length > 0
+    if sd.SUPER_SUB_ARTICLES?.length > 0
       new SuperArticleView el: @$el, article: @article
 
     # Utility
@@ -258,7 +258,7 @@ module.exports = class ArticleView extends Backbone.View
 
   setupFooterArticles: =>
     # Do not render footer articles if the article has related articles (is/is in a super article)
-    if sd.SCROLL_ARTICLE is 'infinite' and sd.RELATED_ARTICLES?.length < 1 and not @lushSignup
+    if sd.SCROLL_ARTICLE is 'infinite' and sd.SUPER_SUB_ARTICLES?.length < 1 and not @lushSignup
       Q.allSettled([
         (tagRelated = new Articles).fetch
           data: _.extend _.clone DATA,

--- a/components/article/templates/super_article_footer.jade
+++ b/components/article/templates/super_article_footer.jade
@@ -25,5 +25,5 @@
 
   .article-sa-footer-right
     .article-sa-related
-      for relatedArticle in relatedArticles.models
-        a( href=relatedArticle.href() )= relatedArticle.get('thumbnail_title')
+      for subArticle in superSubArticles.models
+        a( href=subArticle.href() )= subArticle.get('thumbnail_title')

--- a/components/article/templates/super_article_sticky_header.jade
+++ b/components/article/templates/super_article_sticky_header.jade
@@ -10,8 +10,8 @@
     a.article-sa-sticky-title( href=superArticle.href() )= superArticle.get('title')
     .article-sa-related-container
       .article-sa-related
-        for relatedArticle in relatedArticles.models
-          a( href=relatedArticle.href() )= relatedArticle.get('thumbnail_title')
+        for subArticle in superSubArticles.models
+          a( href=subArticle.href() )= subArticle.get('thumbnail_title')
       if superArticle.get('super_article').partner_link_title
         a.article-sa-cta-sticky.faux-underline( href=superArticle.get('super_article').partner_link )= superArticle.get('super_article').partner_link_title
 

--- a/components/articles_grid/view.coffee
+++ b/components/articles_grid/view.coffee
@@ -19,7 +19,7 @@ module.exports = class ArticlesGridView extends Backbone.View
       # For GPP, don't render empty state if there are no articles
       return if @partner and @collection.length is 0
       @$el.html template(articles: @collection, hideMore: @hideMore?, header: @header)
-
+      # console.log 'hereee....'
     @listenTo @collection, 'sync', @render
 
   more: (e) ->

--- a/components/articles_grid/view.coffee
+++ b/components/articles_grid/view.coffee
@@ -19,7 +19,6 @@ module.exports = class ArticlesGridView extends Backbone.View
       # For GPP, don't render empty state if there are no articles
       return if @partner and @collection.length is 0
       @$el.html template(articles: @collection, hideMore: @hideMore?, header: @header)
-      # console.log 'hereee....'
     @listenTo @collection, 'sync', @render
 
   more: (e) ->

--- a/components/email/client/editorial_signup.coffee
+++ b/components/email/client/editorial_signup.coffee
@@ -27,7 +27,7 @@ module.exports = class EditorialSignupView extends Backbone.View
   inAEArticlePage: ->
     sd.ARTICLE? and
     sd.ARTICLE.channel_id is sd.ARTSY_EDITORIAL_CHANNEL and
-    not sd.RELATED_ARTICLES?.length > 0
+    not sd.SUPER_SUB_ARTICLES?.length > 0
 
   inAEMagazinePage: ->
     sd.CURRENT_PATH is '/articles'

--- a/components/email/client/gallery_insights.coffee
+++ b/components/email/client/gallery_insights.coffee
@@ -19,7 +19,7 @@ module.exports = class GalleryInsightsView extends Backbone.View
     @renderCTA => @setupCTAWaypoints()
 
   inGIArticlePage: ->
-    sd.GALLERY_INSIGHTS_SECTION_ID in (sd.ARTICLE?.section_ids or [])
+    sd.GALLERY_INSIGHTS_CHANNEL is sd.ARTICLE?.get('channel_id')
 
   inGIVerticalPage: ->
     sd.SECTION?.id is sd.GALLERY_INSIGHTS_SECTION_ID

--- a/components/email/test/gallery_insights.coffee
+++ b/components/email/test/gallery_insights.coffee
@@ -5,7 +5,7 @@ Backbone = require 'backbone'
 { resolve } = require 'path'
 { stubChildClasses } = require '../../../test/helpers/stubs'
 
-describe 'ArticleIndexView', ->
+describe 'GalleryInsightsView', ->
 
   before (done) ->
     benv.setup =>
@@ -30,6 +30,7 @@ describe 'ArticleIndexView', ->
     it 'only sets up waypoints for vertical page if in vertical page', ->
       @GalleryInsightsView.__set__ 'sd',
         GALLERY_INSIGHTS_SECTION_ID: 'foo'
+        GALLERY_INSIGHTS_CHANNEL: 'foo'
         ARTICLE: null
         SECTION: { id: 'foo' }
       @view.setupCTAWaypoints()

--- a/models/article.coffee
+++ b/models/article.coffee
@@ -65,12 +65,10 @@ module.exports = class Article extends Backbone.Model
             data: access_token: options.accessToken
             success: (artwork) ->
               slideshowArtworks.add(artwork)
+
       # Get related section content if a part of one
       if @get('section_ids')?.length
         dfds.push (section = new Section(id: @get('section_ids')[0])).fetch()
-        dfds.push (sectionArticles = new Articles).fetch(
-          data: section_id: @get('section_ids')[0], published: true, limit: 50
-        )
 
       # Check if the article is a super article
       if @get('is_super_article')
@@ -113,7 +111,6 @@ module.exports = class Article extends Backbone.Model
               relatedArticles: relatedArticles
               superSubArticleIds: superSubArticleIds
               section: section
-              allSectionArticles: sectionArticles if section
               partner: partner if partner
             )
 

--- a/models/article.coffee
+++ b/models/article.coffee
@@ -6,7 +6,6 @@ moment = require 'moment'
 { POSITRON_URL, APP_URL, ARTSY_EDITORIAL_CHANNEL } = sd = require('sharify').data
 request = require 'superagent'
 Artwork = require '../models/artwork.coffee'
-Section = require '../models/section.coffee'
 Artworks = require '../collections/artworks.coffee'
 Partner = require '../models/partner.coffee'
 Channel = require '../models/channel.coffee'

--- a/test/models/article.coffee
+++ b/test/models/article.coffee
@@ -18,17 +18,16 @@ describe "Article", ->
 
   describe '#fetchWithRelated', ->
     it 'gets all the related data from the article', (done) ->
-      @article.set sections: []
-
       Backbone.sync
         .onCall 0
-        .yieldsTo 'success', _.extend {}, fixtures.article, title: 'Moo'
+        .yieldsTo 'success', _.extend {}, fixtures.article, title: 'Moo', sections: []
         .onCall 1
-        .yieldsTo 'success', [fixtures.article]
+        .yieldsTo 'success', []
         .onCall 2
-        .yieldsTo 'success', [fixtures.article]
+        .yieldsTo 'success', []
+        .onCall 3
+        .yieldsTo 'success', [fixtures.channel]
       @article.fetchWithRelated success: (data) ->
-        console.log Backbone.sync.args
         data.article.get('title').should.equal 'Moo'
         done()
 
@@ -53,39 +52,12 @@ describe "Article", ->
         .onCall 1
         .yieldsTo 'success', [fixtures.article]
         .onCall 2
-        .yieldsTo 'success', [fixtures.article]
-        .onCall 3
         .yieldsTo 'success', fabricate 'artwork', title: 'foobar'
-        .onCall 4
+        .onCall 3
         .yieldsTo 'success', [fixtures.article]
 
       @article.fetchWithRelated success: (data) ->
         data.slideshowArtworks.first().get('title').should.equal 'foobar'
-        done()
-
-    it 'fetches section content if need be', (done) ->
-      sectionArticle = _.extend {}, fixtures.article,
-        title: 'Moo'
-        section_ids: ['foo']
-        sections: []
-        channel_id: null
-
-      Backbone.sync
-        .onCall 0
-        .yieldsTo 'success', sectionArticle
-        .onCall 1
-        .yieldsTo 'success', [fixtures.article]
-        .onCall 2
-        .yieldsTo 'success', [fixtures.article]
-        .onCall 3
-        .yieldsTo 'success', fixtures.section
-        .onCall 4
-        .yieldsTo 'success', [fixtures.articles]
-        .onCall 5
-        .yieldsTo 'success', [fixtures.articles]
-
-      @article.fetchWithRelated success: (data) ->
-        data.section.get('title').should.equal 'Vennice Biennalez'
         done()
 
     it 'works for those rare sectionless articles', (done) ->
@@ -125,12 +97,10 @@ describe "Article", ->
         .onCall 1
         .yieldsTo 'success', [fixtures.article]
         .onCall 2
-        .yieldsTo 'success', [fixtures.article]
-        .onCall 3
         .yieldsTo 'success', relatedArticle
 
       @article.fetchWithRelated success: (data) ->
-        data.relatedArticles.models[0].get('title').should.equal 'RelatedArticle'
+        data.superSubArticles.models[0].get('title').should.equal 'RelatedArticle'
         data.article.get('title').should.equal 'SuperArticle'
         done()
 
@@ -158,16 +128,14 @@ describe "Article", ->
         .onCall 1
         .yieldsTo 'success', [fixtures.article]
         .onCall 2
-        .yieldsTo 'success', [fixtures.article]
-        .onCall 3
         .yieldsTo 'success', relatedArticle1
-        .onCall 4
+        .onCall 3
         .yieldsTo 'success', relatedArticle2
 
       @article.fetchWithRelated success: (data) ->
         data.superArticle.get('title').should.equal 'SuperArticle'
-        data.relatedArticles.first().get('title').should.equal 'RelatedArticle 1'
-        data.relatedArticles.last().get('title').should.equal 'RelatedArticle 2'
+        data.superSubArticles.first().get('title').should.equal 'RelatedArticle 1'
+        data.superSubArticles.last().get('title').should.equal 'RelatedArticle 2'
         done()
 
   describe '#strip', ->

--- a/test/models/article.coffee
+++ b/test/models/article.coffee
@@ -27,8 +27,8 @@ describe "Article", ->
         .yieldsTo 'success', [fixtures.article]
         .onCall 2
         .yieldsTo 'success', [fixtures.article]
-
       @article.fetchWithRelated success: (data) ->
+        console.log Backbone.sync.args
         data.article.get('title').should.equal 'Moo'
         done()
 


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/39

This PR also considers speed by moving the footer article fetching to the client side, and reduces the number of server-side requests by 1 or 3. We also rename the confusing `relatedArticles` to `superSubArticles`. 

![image](https://cloud.githubusercontent.com/assets/2236794/18843885/d61ab2da-83e8-11e6-9a68-cda134bb598c.png)
