### PR TITLE
@kanaabe => Fix signup

### DIFF
--- a/components/email/client/gallery_insights.coffee
+++ b/components/email/client/gallery_insights.coffee
@@ -19,7 +19,7 @@ module.exports = class GalleryInsightsView extends Backbone.View
     @renderCTA => @setupCTAWaypoints()
 
   inGIArticlePage: ->
-    sd.GALLERY_INSIGHTS_CHANNEL is sd.ARTICLE?.get('channel_id')
+    sd.GALLERY_INSIGHTS_CHANNEL is sd.ARTICLE?.channel_id
 
   inGIVerticalPage: ->
     sd.SECTION?.id is sd.GALLERY_INSIGHTS_SECTION_ID


### PR DESCRIPTION
Gallery insights signup was choking because the reference to `sd.ARTICLE` is a JSON object, not a backbone model