### PR TITLE
@mzikherman - Refresh the user account whenever form submission happens on an inquiry

### DIFF
--- a/components/embedded_inquiry/view.coffee
+++ b/components/embedded_inquiry/view.coffee
@@ -35,6 +35,7 @@ module.exports = class EmbeddedInquiryView extends Backbone.View
 
     { attending } = data = form.serializer.data()
 
+    @user.related().account.clear()
     @user.set _.pick data, 'name', 'email'
     @inquiry.set _.extend { notification_delay: @delayBy }, data
 


### PR DESCRIPTION
Fixes an issues that wasn't totally fixed in https://github.com/artsy/force/issues/191

The issue being :"If I type in an email that exists, I can't type a new one: https://cl.ly/302b0r052D3d "

This fixes it by clearing the related account whenever the user submits (the related account is whats used to determine whether a user has an account and is not signed in).