### PR TITLE
@broskoski modifying object in one test was making another test fail

### DIFF
--- a/apps/artwork/components/commercial/test/template.coffee
+++ b/apps/artwork/components/commercial/test/template.coffee
@@ -16,7 +16,8 @@ render = (templateName) ->
   )
 
 renderArtwork = (artworkOptions = {}, sdOptions = {}) ->
-  artwork = _.extend(inquireableArtwork.data.artwork, artworkOptions)
+  artwork = _.clone inquireableArtwork.data.artwork
+  _.extend artwork, artworkOptions
   sd = _.extend { CLIENT: artwork: artwork }, sdOptions
 
   html = render('index')(


### PR DESCRIPTION
I was getting a failure in the `view` test of this component, but only when it was run following the `template` test. this is because the object being used to sub artworks was being modified. I don't really get how that works, since the object is being included from a file, do you? It's not as though the contents of the file are being modified. In any case, this fixes it.