### PR TITLE
@mzikherman - Use test map on embedded inquiry view

### DIFF
--- a/apps/inquiry/client/map.coffee
+++ b/apps/inquiry/client/map.coffee
@@ -1,10 +1,17 @@
 _ = require 'underscore'
+{ FORCED_LOGIN_INQUIRY } = require('sharify').data
 views = require '../../../components/inquiry_questionnaire/map/views.coffee'
 views = _.extend {}, views,
   confirmation: require './views/confirmation.coffee'
   done: require './views/done.coffee'
 
+determineSteps = ->
+  if FORCED_LOGIN_INQUIRY is 'force_login'
+    require '../../../components/inquiry_questionnaire/map/test_steps.coffee'
+  else
+    require '../../../components/inquiry_questionnaire/map/steps.coffee'
+
 module.exports =
   decisions: require '../../../components/inquiry_questionnaire/map/decisions.coffee'
-  steps: require '../../../components/inquiry_questionnaire/map/steps.coffee'
+  steps: determineSteps()
   views: views


### PR DESCRIPTION
For inquiries placed on Microgravity, we proxy the `/inquiry/:artwork_id` page on Force. This page sets up its own map, so this handles the step determination in the same way, where if you land in the test bucket you get the test version of the steps.