### PR TITLE
@mzikherman => Adds content module to news RSS feed

### DIFF
--- a/apps/rss/templates/news.jade
+++ b/apps/rss/templates/news.jade
@@ -1,5 +1,5 @@
 doctype xml
-rss(version='2.0', xmlns:atom='http://www.w3.org/2005/Atom')
+rss(version='2.0', xmlns:atom='http://www.w3.org/2005/Atom' xmlns:content='http://purl.org/rss/1.0/modules/content/')
   channel
     title Artsy News
     link= sd.APP_URL


### PR DESCRIPTION
Since we're now using `content:encoded` in our News RSS feed, we should import the module so RSS validation can be happy. 