### PR TITLE
@kanaabe => Modal closes

### DIFF
--- a/components/email/client/editorial_signup.coffee
+++ b/components/email/client/editorial_signup.coffee
@@ -86,24 +86,24 @@ module.exports = class EditorialSignupView extends Backbone.View
 
   showEditorialCTA: ->
     @test = splitTest('editorial_cta_banner')
-    outcome = @test.outcome()
-    if outcome is 'banner'
+    @outcome = @test.outcome()
+    if @outcome is 'banner'
       @$('#main-layout-container').css('margin-top', '53px').before editorialCTABannerTemplate
-        mode: outcome
+        mode: @outcome
         email: sd.CURRENT_USER?.email or ''
         image: sd.EDITORIAL_CTA_BANNER_IMG
       setTimeout((=> @$('.articles-es-cta--banner').height(315).attr('data-state', 'in') ), 1000)
-    else if outcome is 'modal'
+    else if @outcome is 'modal'
       @$('#modal-container').append editorialCTABannerTemplate
-        mode: outcome
+        mode: @outcome
         email: sd.CURRENT_USER?.email or ''
         image: sd.EDITORIAL_CTA_BANNER_IMG
       @$('#articles-show').waypoint (direction) =>
         if direction is 'down'
           setTimeout((=> @$('.articles-es-cta--banner').attr('data-state', 'in').css('opacity', 1)), 2000)
-    else if outcome is 'old_modal'
+    else if @outcome is 'old_modal'
       mediator.on 'auction-reminders:none', @setupCTAWaypoints
-    analyticsHooks.trigger('view:editorial-signup', type: outcome )
+    analyticsHooks.trigger('view:editorial-signup', type: @outcome )
 
   hideEditorialCTA: (e) ->
     e?.preventDefault()
@@ -111,6 +111,7 @@ module.exports = class EditorialSignupView extends Backbone.View
     @onDismiss()
     cta.height(0) if cta.hasClass('banner')
     cta.css('opacity', 0)
+    cta.hide() if cta.hasClass('modal')
     setTimeout((=> cta.attr('data-state', 'out')), 2000)
 
   setupCTAWaypoints: =>
@@ -169,4 +170,4 @@ module.exports = class EditorialSignupView extends Backbone.View
 
   onDismiss: ->
     @ctaBarView.logDimissal()
-    analyticsHooks.trigger('dismiss:editorial-signup')
+    analyticsHooks.trigger('dismiss:editorial-signup', type: @outcome)

--- a/components/email/client/editorial_signup.coffee
+++ b/components/email/client/editorial_signup.coffee
@@ -111,8 +111,10 @@ module.exports = class EditorialSignupView extends Backbone.View
     @onDismiss()
     cta.height(0) if cta.hasClass('banner')
     cta.css('opacity', 0)
-    cta.hide() if cta.hasClass('modal')
-    setTimeout((=> cta.attr('data-state', 'out')), 2000)
+    setTimeout((=>
+      cta.attr('data-state', 'out')
+      cta.hide() if cta.hasClass('modal')
+      ), 2000)
 
   setupCTAWaypoints: =>
     @$el.append @ctaBarView.render().$el


### PR DESCRIPTION
Hide modal after dismissal to prevent z-index conflicts.
Change scope of test outcome and add to dismiss analytics hook.
