### PR TITLE
@ashkan18: Disable right click on certain images to make downloading them harder

### DIFF
--- a/lib/global_client_setup.coffee
+++ b/lib/global_client_setup.coffee
@@ -28,6 +28,7 @@ module.exports = ->
   listenForBounce()
   confirmation.check()
   setupAnalytics()
+  disableRightClick()
 
 ensureFreshUser = (data) ->
   return unless sd.CURRENT_USER
@@ -85,3 +86,16 @@ setupJquery = ->
     'X-XAPP-TOKEN': sd.ARTSY_XAPP_TOKEN
     'X-ACCESS-TOKEN': sd.CURRENT_USER?.accessToken
   window[key] = helper for key, helper of templateModules
+
+# We tell our partners, importantly institutions like Museums, that we'll
+# disable right click to "protect" their images. Yes, it's just smoke and
+# mirrors, but it makes them _feel_ better so please be mindful of that.
+disableRightClick = ->
+  # Allow it for admins (e.g. it's super annoying to the design team)
+  return if sd.CURRENT_USER?.type is 'Admin'
+  $(document).on 'contextmenu', (e) ->
+    # Grenade for selecting any images with the name 'artwork' in their,
+    # or their parent's, class
+    disable = $(e.target).is('[class*=artwork]') or
+              $(e.target).parent().is('[class*=artwork]')
+    return false if disable


### PR DESCRIPTION
We tell our partners we disable right click on images. This was probably lost in all the redesigns happening on the CE&GMV teams. Related thread: https://artsy.slack.com/archives/partner-success/p1475769855001210

This adds a global event handler to disable right click on any images with "artwork" in their, or their parent's, class.

For lulz see this [SO question](http://stackoverflow.com/questions/737022/how-do-i-disable-right-click-on-my-web-page):

![image](https://cloud.githubusercontent.com/assets/555859/19171798/a1f3613a-8bec-11e6-9580-8351c5aadad5.png)

