### PR TITLE
Fix flexbox layout of the news section on GPP for safari.

### DIFF
--- a/apps/partner2/components/news/index.styl
+++ b/apps/partner2/components/news/index.styl
@@ -1,7 +1,4 @@
-.partner2-news
-  display flex
 .partner2-news-item
-  flex-basis 33.33%
   margin 0 10px
   &:first-child
     margin-left 0

--- a/apps/partner2/stylesheets/overview.styl
+++ b/apps/partner2/stylesheets/overview.styl
@@ -17,10 +17,10 @@
     &[data-module=news]
       border-top none
     &[data-module=about]
-      flex-basis 720px
+      flex-basis calc(66% \- 40px)
       margin-right 40px
     &[data-module=news]
-      flex 1 1 0
+      flex-basis 33%
       .partner-overview-section-title
         display none
     &[data-module=about]


### PR DESCRIPTION
Fixes https://github.com/artsy/force/issues/253

The row on GPP may contains 0-2 sections. Let's simplify the layout by setting percentage to the `flexbox-basis` for each section. This also provides us better responsiveness.

## Screenshots

**With About and News**

![screen shot 2016-10-10 at 11 06 52 am](https://cloud.githubusercontent.com/assets/796573/19240744/bfbee730-8ed9-11e6-97b2-471494e4d0c2.png)

**With only About**
![screen shot 2016-10-10 at 11 07 03 am](https://cloud.githubusercontent.com/assets/796573/19240756/cfcceea6-8ed9-11e6-9954-a56b7e8f70d7.png)

**With only News** (hide the title when if only 1 entry)
![screen shot 2016-10-10 at 11 07 14 am](https://cloud.githubusercontent.com/assets/796573/19240763/d8eba4d2-8ed9-11e6-9098-66203dec46c8.png)
