### PR TITLE
@xtina-starr improve jumpy dropdown in artwork filter

### DIFF
--- a/components/artwork_filter_2/views/header_sorts_view.coffee
+++ b/components/artwork_filter_2/views/header_sorts_view.coffee
@@ -14,6 +14,7 @@ module.exports = class ArtworkFiltersSortsView extends BorderedPulldown
     # Render the template once when the params are first set.
     # Afterwards, the superclass handles changes in the selection.
     @listenToOnce @params, 'firstSet', @render
+    super
 
   render: ->
     sort = @params.get('sort')
@@ -22,8 +23,19 @@ module.exports = class ArtworkFiltersSortsView extends BorderedPulldown
     @$el.html template { currentSort, sorts }
 
   select: (e) ->
-    super
     e.preventDefault()
-    key = ($el = $(e.target)).data('key')
+
+    $el = $(e.currentTarget)
+    $el.addClass('bordered-pulldown-active')
+    @$('.bordered-pulldown-text').text $el.text()
+    ($pulldown = @$('.bordered-pulldown-options')).hide()
+    @$el.one 'mouseout', =>
+      @$('.bordered-pulldown-options').css display: ''
+
+    key = $el.data('key')
     value = $el.data('value')
     @params.updateWith key, value
+
+  remove: ->
+    @$el.off 'mouseout'
+    super


### PR DESCRIPTION
This dropdown menu is a subclass of another type of dropdown. The way the superclass works is that if you select the second, third or fourth etc item, when you over over the menu, the entire list of selections will be positioned up or down so that the selection is where the placeholder is. We don't want that behavior in this particular filter component.

Additionally, we want the menu to hide after you've clicked something. the css uses hover, and technically after you've clicked an item you're still hovering on the menu, so it wasn't being hidden after click.

see before and after:

![menu1](https://cloud.githubusercontent.com/assets/3171662/19270518/be0697a2-8fc0-11e6-8bbd-2091e0357eea.gif)

![menu2](https://cloud.githubusercontent.com/assets/3171662/19270522/c10819c6-8fc0-11e6-8285-41050c265a67.gif)

