### PR TITLE
@xtina-starr : truncate filter aggregations after given amount, add 'see all' button

### DIFF
--- a/components/artwork_filter_2/stylesheets/filter.styl
+++ b/components/artwork_filter_2/stylesheets/filter.styl
@@ -14,10 +14,21 @@
       font-size small-avant-garde-size
     section
       margin 20px 0
+
+    &__for-sale
+    &__criterion
+    &__view-all
+      line-height 1.6
+      text-decoration none
+
     &__for-sale
     &__criterion
       display flex
-      line-height 1.6
+
+    &__criterion
+    &__view-all
+      font-size 18px
+
     &__for-sale
       margin 0
       &.is-disabled
@@ -44,6 +55,10 @@
         cursor arrow
         pointer-events none
         color gray-dark-color
+
+    &__view-all
+      display block
+      faux-underline(black)
 
     .artwork-filter-label
       overflow ellipsis

--- a/components/artwork_filter_2/templates/filters.jade
+++ b/components/artwork_filter_2/templates/filters.jade
@@ -21,11 +21,13 @@ if aggregations
   for mapped in aggregationsMap
     - var aggregation = aggregations[mapped.slice]
     if aggregation && aggregation.length
+      - var param = mapped.param
+      - var isTruncated = truncate[param] && (aggregation.length > truncate[param])
+      - var items = isTruncated ? aggregation.slice(0, truncate[param]) : aggregation
       section
         h3= mapped.label
         ul
-          - var param = mapped.param
-          for item in aggregation
+          for item in items
             - var isActive = params.get(param) == item.id
             li.artwork-filter-criteria__criterion(
               class=(isActive ? 'is-active' : 'is-inactive')
@@ -46,3 +48,8 @@ if aggregations
                   data-key= param
                   class= 'js-artwork-filter-remove'
                 ) Clear
+        if isTruncated
+          a.artwork-filter-criteria__view-all(
+            data-key= param
+            class= 'js-artwork-filter-view-all'
+          ) See All

--- a/components/artwork_filter_2/views/filters_view.coffee
+++ b/components/artwork_filter_2/views/filters_view.coffee
@@ -5,10 +5,15 @@ aggregationsMap = require '../aggregations_map.coffee'
 template = -> require('../templates/filters.jade') arguments...
 
 module.exports = class ArtworkFiltersView extends Backbone.View
+  truncate:
+    institution: 5
+    gallery: 5
+
   events:
-    'click .js-artwork-filter-select' : 'filterSelected'
-    'click .js-artwork-filter-toggle' : 'toggleBool'
-    'click .js-artwork-filter-remove': 'filterDeselected'
+    'click .js-artwork-filter-select'   : 'filterSelected'
+    'click .js-artwork-filter-toggle'   : 'toggleBool'
+    'click .js-artwork-filter-remove'   : 'filterDeselected'
+    'click .js-artwork-filter-view-all' : 'seeAllClicked'
 
   initialize: ({ @params, @counts, stickyOffset = 0 }) ->
     @sticky = new Sticky
@@ -20,13 +25,22 @@ module.exports = class ArtworkFiltersView extends Backbone.View
       @listenTo @counts, 'change', @render
 
     @listenTo @params, "change:for_sale", @render
+    @listenTo this, 'filterExpanded', @render
 
   render: ->
     forSaleTotal = @counts.get 'for_sale'
     key = if forSale = @params.get 'for_sale' then 'for_sale' else 'all'
     aggregations = @counts.aggregations?[key]
 
-    @$el.html template { aggregationsMap, forSaleTotal, aggregations, forSale, @counts, @params }
+    @$el.html template {
+      aggregationsMap,
+      forSaleTotal,
+      aggregations,
+      forSale,
+      @counts,
+      @params,
+      @truncate
+    }
 
   toggleBool: (e) ->
     key = ($el = $(e.target)).prop('name')
@@ -46,3 +60,8 @@ module.exports = class ArtworkFiltersView extends Backbone.View
     e.preventDefault()
     key = ($el = $(e.target)).data('key')
     @params.unset key
+
+  seeAllClicked: (e) =>
+    key = ($el = $(e.target)).data('key')
+    delete @truncate[key]
+    @trigger 'filterExpanded'


### PR DESCRIPTION
closes https://github.com/artsy/force/issues/88

![expand](https://cloud.githubusercontent.com/assets/3171662/19273376/99d3036e-8fcc-11e6-9efd-33040af82c91.gif)


There is additional work required on gravity to display _all_ galleries and institutions upon clicking 'see more', which is currently in a PR, but this can be merged independently. Right now a max of ten galleries + institutions can be shown.