### PR TITLE
@mzikherman: Guard against a downloadable image missing image urls

### DIFF
--- a/apps/artwork/routes.coffee
+++ b/apps/artwork/routes.coffee
@@ -95,8 +95,8 @@ bootstrap = ->
 @download = (req, res, next) ->
   artwork = new Artwork id: req.params.id
   artwork.fetch cache: true, success: ->
-    if artwork.isDownloadable(req.user)
-      imageRequest = request.get(artwork.downloadableUrl req.user)
+    if artwork.isDownloadable(req.user) and url = artwork.downloadableUrl(req.user)
+      imageRequest = request.get url
       imageRequest.set('X-ACCESS-TOKEN': req.user.get('accessToken')) if req.user
       req.pipe(imageRequest).pipe res
     else

--- a/apps/artwork/routes.coffee
+++ b/apps/artwork/routes.coffee
@@ -3,6 +3,7 @@ metaphysics = require '../../lib/metaphysics'
 Artwork = require '../../models/artwork'
 request = require 'superagent'
 PendingOrder = require '../../models/pending_order'
+{ parse } = require 'url'
 
 query = """
   query artwork($id: String!) {
@@ -95,7 +96,8 @@ bootstrap = ->
 @download = (req, res, next) ->
   artwork = new Artwork id: req.params.id
   artwork.fetch cache: true, success: ->
-    if artwork.isDownloadable(req.user) and url = artwork.downloadableUrl(req.user)
+    url = artwork.downloadableUrl(req.user)
+    if artwork.isDownloadable(req.user) and parse(url).host?
       imageRequest = request.get url
       imageRequest.set('X-ACCESS-TOKEN': req.user.get('accessToken')) if req.user
       req.pipe(imageRequest).pipe res

--- a/apps/artwork/test/routes.coffee
+++ b/apps/artwork/test/routes.coffee
@@ -45,6 +45,19 @@ describe 'Artwork routes', ->
           routes.download @req, @res, @next
           request.get.called.should.be.true()
 
+        it 'gracefully handles an artwork with bad image data', ->
+          Backbone.sync.restore()
+          sinon.stub(Backbone, 'sync')
+            .yieldsTo 'success', fabricate 'artwork', images: [
+              downloadable: true
+              image_url: ''
+              image_versions: ['larger']
+              image_urls: { larger: '' }
+            ]
+          routes.download @req, @res, @next
+          request.get.called.should.not.be.ok()
+          @res.status.args[0][0].should.equal 403
+
       describe 'when the image is not downloadable', ->
         beforeEach ->
           Backbone.sync.restore()

--- a/apps/artwork/test/routes.coffee
+++ b/apps/artwork/test/routes.coffee
@@ -45,15 +45,10 @@ describe 'Artwork routes', ->
           routes.download @req, @res, @next
           request.get.called.should.be.true()
 
-        it 'gracefully handles an artwork with bad image data', ->
+        it 'gracefully handles an artwork with missing images', ->
           Backbone.sync.restore()
           sinon.stub(Backbone, 'sync')
-            .yieldsTo 'success', fabricate 'artwork', images: [
-              downloadable: true
-              image_url: ''
-              image_versions: ['larger']
-              image_urls: { larger: '' }
-            ]
+            .yieldsTo 'success', fabricate 'artwork', images: []
           routes.download @req, @res, @next
           request.get.called.should.not.be.ok()
           @res.status.args[0][0].should.equal 403


### PR DESCRIPTION
Being surgical about the fix here, but I wrote a test that reproduces some data that could potentially cause an uncaught error to be thrown. Not saying it's likely we're returning empty strings in our image data, but maybe something similar is causing us to try and request a bad url.