### PR TITLE
@mzikherman => Center headline for fullscreen articles

### DIFF
--- a/components/main_layout/stylesheets/body.styl
+++ b/components/main_layout/stylesheets/body.styl
@@ -121,9 +121,9 @@ html[data-useragent*="iPad"]
   &.body-header-fixed
     #main-layout-container
       margin-top main-header-height
-    &.body-fullscreen-article
-      #main-layout-container
-        margin-top 0px
+  &.body-fullscreen-article
+    #main-layout-container
+      margin-top 0px
 
 .body-no-padding
   #main-layout-container


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/258
Remove extra tabs to restore top margin for fullscreen articles. 