### PR TITLE
@alloy: replace deprecated method

### DIFF
--- a/components/fair_layout/client/teleport.coffee
+++ b/components/fair_layout/client/teleport.coffee
@@ -4,11 +4,11 @@ sd = require('sharify').data
 # like it when you set window.location
 
 module.exports = (location) ->
+  return window.location = location unless sd.EIGEN
   a = document.createElement 'a'
   a.setAttribute 'href', location
 
-  dispatch = document.createEvent 'HTMLEvents'
-  dispatch.initEvent 'click', true, true
+  dispatch = new Event 'click', { 'bubbles': true, 'cancelable': true }
 
   {
     event: dispatch

--- a/components/fair_layout/test/client/teleport.coffee
+++ b/components/fair_layout/test/client/teleport.coffee
@@ -1,11 +1,13 @@
 benv = require 'benv'
 sinon = require 'sinon'
-teleport = require '../../client/teleport.coffee'
+rewire = require 'rewire'
+teleport = rewire '../../client/teleport.coffee'
 
 describe 'teleport', ->
   beforeEach (done) ->
     benv.setup =>
-
+      benv.expose({ Event: window.Event })
+      teleport.__set__ 'sd', { EIGEN: true }
       done()
 
   afterEach ->


### PR DESCRIPTION
This addresses https://github.com/artsy/force/issues/232. Looks like `initEvent` is a [deprecated method](https://developer.mozilla.org/en-US/docs/Web/API/Event/initEvent) which explains why it no longer works in Chrome and (I'm assuming) is still supported by Safari. This teleport module seems to exist specifically for Eigen to simulate a click. The work around I found is to set the location on the window when not in Eigen and instantiate a new click event if it is within Eigen. I'm not sure how a generic click event would be handle in Eigen so I wanted to run this by you. 

![microsite search](https://cloud.githubusercontent.com/assets/5201004/19327779/9a39443a-909e-11e6-9924-4ccb519bff73.gif)
