### PR TITLE
@xtina-starr Adds stricter regex for team blog mobile redirect

### DIFF
--- a/lib/middleware/redirect_mobile.coffee
+++ b/lib/middleware/redirect_mobile.coffee
@@ -36,6 +36,6 @@ router.get '/ArtsySocialMediaToolkit.pdf', isResponsive
 router.get '/inquiry/*', isResponsive
 router.get '/consign', isResponsive
 router.get '/professional-buyer*', isResponsive
-router.get '/life-at-artsy|/artsy-education|/gallery-insights|/artsy-partner-updates', isResponsive
+router.get '/^\/life-at-artsy$|^\/artsy-education$|^\/gallery-insights$|^\/artsy-partner-updates$', isResponsive
 router.use redirect
 module.exports = router


### PR DESCRIPTION
We're seeing an issue where `/article/gallery-insights-title` was getting redirected to Force because our Regex wasn't strict enough. This only allow urls that have the exact string match!