### PR TITLE
@eessex => Adds modal to /magazine and test

### DIFF
--- a/components/email/stylesheets/editorial_signup.styl
+++ b/components/email/stylesheets/editorial_signup.styl
@@ -122,7 +122,7 @@
   color black
   margin-bottom -53px
   margin-top 53px
-  transition all 1s ease-out
+  transition all 0.5s ease-out
   &.modal
     opacity 0
     background none transparent


### PR DESCRIPTION
Refactors some tests + adds the signup modal to the /magazine page -- cc @sperle. 

for @owendodd: Do we want the dismissal of this modal to affect the "viewability" of signups on article pages? Currently they're all connected (dismissing the modal in /magazine will also dismiss the modal on /article pages). Since modals block content, we'll likely see a much higher dismissal rate on modals in general -- maybe something worth reconsidering
