### PR TITLE
@briansw - Fixes auction link in artwork brick metadata (closes #270)

### DIFF
--- a/components/artwork_metadata_stub/templates/didactics.jade
+++ b/components/artwork_metadata_stub/templates/didactics.jade
@@ -18,6 +18,9 @@ a.artwork-metadata-stub__title.artwork-metadata-stub__line( href= artwork.href )
 if artwork.collecting_institution
   .artwork-metadata-stub__partner.artwork-metadata-stub__line
     = artwork.collecting_institution
+else if artwork.is_in_auction
+  a.artwork-metadata-stub__partner.artwork-metadata-stub__line( href= "/auction#{artwork.partner.href}" )
+    = artwork.partner.name
 else
   a.artwork-metadata-stub__partner.artwork-metadata-stub__line( href= artwork.partner.href )
     = artwork.partner.name


### PR DESCRIPTION
Because auctions are listed as the `partner` on the artwork, we were incorrectly using the auction's `href` property. This adds an additional check to see if the artwork is in an auction.