### PR TITLE
@craigspaeth => dont show status if live bidding is open

### DIFF
--- a/apps/auction/stylesheets/my_active_bids.styl
+++ b/apps/auction/stylesheets/my_active_bids.styl
@@ -40,7 +40,7 @@
   display inline-block
   vertical-align middle
 
-.auction-mab-bid-button
+.auction-mab-bid-button, .auction-mab-bid-button-live
   width 100%
 
 td.bid-status-cell

--- a/apps/auction/templates/my_active_bids.jade
+++ b/apps/auction/templates/my_active_bids.jade
@@ -1,4 +1,5 @@
 include ../../../components/bid_status/index
+
 if myActiveBids && myActiveBids.length
   h2 Your Active Bids
   table
@@ -21,9 +22,15 @@ if myActiveBids && myActiveBids.length
             td.auction-mab-current-bid
               strong Current Bid: <em>#{bid.sale_artwork.highest_bid.display}</em>
             td.auction-mab-bid-num (#{bid.sale_artwork.counts.bidder_positions} Bids)
-            td.bid-status-cell
-              +bidStatus(bid, bid.sale_artwork)
-            td
-              a.avant-garde-button-black.auction-mab-bid-button(
-                href=bid.sale_artwork.artwork.href
-              ) Bid
+            if ViewHelpers.mpLiveSaleIsOpen(bid.sale_artwork.sale)
+              td
+                a.avant-garde-button-black.auction-mab-bid-live-button(
+                    href=ViewHelpers.liveAuctionUrl(bid.sale_artwork.sale_id)
+                  ) Bid Live
+            else
+              td.bid-status-cell
+                +bidStatus(bid, bid.sale_artwork)
+              td
+                a.avant-garde-button-black.auction-mab-bid-button(
+                  href=bid.sale_artwork.artwork.href
+                ) Bid

--- a/apps/auction/test/lot_standings.coffee
+++ b/apps/auction/test/lot_standings.coffee
@@ -14,6 +14,10 @@ module.exports = [
       "highest_bid": {
         "display": "$750"
       },
+      "sale": {
+        "end_at": "2016-10-31T04:28:00+00:00",
+        "live_start_at": null
+      },
       "artwork": {
         "href": "/artwork/imhuge-brillo-condensed-soap",
         "title": "Brillo Condensed Soap",
@@ -40,6 +44,10 @@ module.exports = [
       "sale_id": "juliens-auctions-street-and-contemporary-art-day-sale",
       "highest_bid": {
         "display": "$1,500"
+      },
+      "sale": {
+        "end_at": "2016-10-31T04:28:00+00:00",
+        "live_start_at": null
       },
       "artwork": {
         "href": "/artwork/mr-brainwash-tomato-spray-25",

--- a/apps/auction/test/my_active_bids.coffee
+++ b/apps/auction/test/my_active_bids.coffee
@@ -1,14 +1,17 @@
 benv = require 'benv'
+moment = require 'moment'
 _ = require 'underscore'
 Backbone = require 'backbone'
 template = require('jade').compileFile(require.resolve '../templates/my_active_bids.jade')
 bidderPositions = require './lot_standings'
+sd = require('sharify').data
 
 describe 'my active bids auction page template', ->
   before (done) ->
     @baseData = -> bidderPositions
     benv.setup ->
       benv.expose $: benv.require 'jquery'
+      sd.PREDICTION_URL = 'http://live-test.artsy.net'
       Backbone.$ = $
       done()
 
@@ -21,41 +24,108 @@ describe 'my active bids auction page template', ->
     @view = new @MyActiveBidsView(template: template)
 
   describe 'my_active_bids', ->
-    describe 'leading bidder & reserve met', ->
-      it 'gives a highest bid message', ->
-        @data[0].is_leading_bidder = true
-        @data[0].sale_artwork.reserve_status = 'reserve_met'
+    describe 'live sale is open', ->
+      beforeEach ->
+        @data[0].sale_artwork.sale.live_start_at = moment().subtract(1, 'day').format()
+        @data[0].sale_artwork.sale.end_at = moment().add(1, 'day').format()
         @view.bidderPositions = @data
-
         @view.render()
-        @view.$('.bid-status').should.have.lengthOf 2
-        @view.$('.bid-status__is-winning').should.have.lengthOf 1
-        @view.$('.bid-status').text()
-          .should.containEql('Highest Bid')
 
-    describe 'leading bidder & reserve not met', ->
-      it 'gives a reserve not met bid message', ->
-        @data[0].is_leading_bidder = true
-        @data[0].sale_artwork.reserve_status = 'reserve_not_met'
-        @view.bidderPositions = @data
+      it 'does not display the bidder status', ->
+        @view.$('.bid-status').should.have.lengthOf 1
+        @view.$('.auction-mab-bid-live-button').should.have.lengthOf 1
+        @view.$('.auction-mab-bid-live-button').text().should.containEql('Bid Live')
 
-        @view.render()
-        @view.$('.bid-status').should.have.lengthOf 2
-        @view.$('.bid-status__is-winning-reserve-not-met').should.have.lengthOf 1
-        @view.$('.bid-status__is-winning-reserve-not-met').text()
-          .should.containEql('Highest Bid')
-    describe 'not leading bidder', ->
-      it 'gives an outbid message', ->
-        @data[0].is_leading_bidder = false
-        @data[0].sale_artwork.reserve_status = 'reserve_not_met'
-        @data[1].is_leading_bidder = false
-        @data[1].sale_artwork.reserve_status = 'reserve_met'
-        @view.bidderPositions = @data
+      it 'links to prediction', ->
+        @view.$('.auction-mab-bid-live-button').attr('href')
+          .should.containEql('http://live-test.artsy.net/juliens-auctions-street-and-contemporary-art-day-sale')
 
-        @view.render()
-        @view.$('.bid-status').should.have.lengthOf 2
-        @view.$('.bid-status__is-losing').should.have.lengthOf 2
-        @view.$('.bid-status__is-losing').text().should.containEql('Outbid')
-        # This doesn't work ... :/
-        # _.each(@view.$('.is-losing'), (el) -> 
-        #   el.text().should.containEql('Outbid'))
+    describe 'not live sale', ->
+      beforeEach ->
+        @data[0].sale_artwork.sale.live_start_at = null
+        @data[0].sale_artwork.sale.end_at = moment().add(1, 'day').format()
+
+      describe 'leading bidder & reserve met', ->
+        it 'gives a highest bid message', ->
+          @data[0].is_leading_bidder = true
+          @data[0].sale_artwork.reserve_status = 'reserve_met'
+          @view.bidderPositions = @data
+
+          @view.render()
+          @view.$('.bid-status').should.have.lengthOf 2
+          @view.$('.bid-status__is-winning').should.have.lengthOf 1
+          @view.$('.bid-status').text()
+            .should.containEql('Highest Bid')
+
+      describe 'leading bidder & reserve not met', ->
+        it 'gives a reserve not met bid message', ->
+          @data[0].is_leading_bidder = true
+          @data[0].sale_artwork.reserve_status = 'reserve_not_met'
+          @view.bidderPositions = @data
+
+          @view.render()
+          @view.$('.bid-status').should.have.lengthOf 2
+          @view.$('.bid-status__is-winning-reserve-not-met').should.have.lengthOf 1
+          @view.$('.bid-status__is-winning-reserve-not-met').text()
+            .should.containEql('Highest Bid')
+
+      describe 'not leading bidder', ->
+        it 'gives an outbid message', ->
+          @data[0].is_leading_bidder = false
+          @data[0].sale_artwork.reserve_status = 'reserve_not_met'
+          @data[1].is_leading_bidder = false
+          @data[1].sale_artwork.reserve_status = 'reserve_met'
+          @view.bidderPositions = @data
+
+          @view.render()
+          @view.$('.bid-status').should.have.lengthOf 2
+          @view.$('.bid-status__is-losing').should.have.lengthOf 2
+          @view.$('.bid-status__is-losing').text().should.containEql('Outbid')
+          # This doesn't work ... :/
+          # _.each(@view.$('.is-losing'), (el) ->
+          #   el.text().should.containEql('Outbid'))
+
+    describe 'live sale is not open', ->
+      beforeEach ->
+        @data[0].sale_artwork.sale.live_start_at = moment().add(1, 'day').format()
+        @data[0].sale_artwork.sale.end_at = moment().add(2, 'days').format()
+
+      describe 'leading bidder & reserve met', ->
+        it 'gives a highest bid message', ->
+          @data[0].is_leading_bidder = true
+          @data[0].sale_artwork.reserve_status = 'reserve_met'
+          @view.bidderPositions = @data
+
+          @view.render()
+          @view.$('.bid-status').should.have.lengthOf 2
+          @view.$('.bid-status__is-winning').should.have.lengthOf 1
+          @view.$('.bid-status').text()
+            .should.containEql('Highest Bid')
+
+      describe 'leading bidder & reserve not met', ->
+        it 'gives a reserve not met bid message', ->
+          @data[0].is_leading_bidder = true
+          @data[0].sale_artwork.reserve_status = 'reserve_not_met'
+          @view.bidderPositions = @data
+
+          @view.render()
+          @view.$('.bid-status').should.have.lengthOf 2
+          @view.$('.bid-status__is-winning-reserve-not-met').should.have.lengthOf 1
+          @view.$('.bid-status__is-winning-reserve-not-met').text()
+            .should.containEql('Highest Bid')
+
+      describe 'not leading bidder', ->
+        it 'gives an outbid message', ->
+          @data[0].is_leading_bidder = false
+          @data[0].sale_artwork.reserve_status = 'reserve_not_met'
+          @data[1].is_leading_bidder = false
+          @data[1].sale_artwork.reserve_status = 'reserve_met'
+          @view.bidderPositions = @data
+
+          @view.render()
+          @view.$('.bid-status').should.have.lengthOf 2
+          @view.$('.bid-status__is-losing').should.have.lengthOf 2
+          @view.$('.bid-status__is-losing').text().should.containEql('Outbid')
+          # This doesn't work ... :/
+          # _.each(@view.$('.is-losing'), (el) ->
+          #   el.text().should.containEql('Outbid'))

--- a/components/my_active_bids/helpers.coffee
+++ b/components/my_active_bids/helpers.coffee
@@ -1,0 +1,11 @@
+moment = require 'moment'
+{ PREDICTION_URL } = require('sharify').data
+
+module.exports =
+  mpLiveSaleIsOpen: (sale) ->
+    sale.live_start_at? and
+      moment().isBefore(sale.end_at) and
+      moment().isAfter(sale.live_start_at)
+
+  liveAuctionUrl: (saleId) ->
+    "#{PREDICTION_URL}/#{saleId}"

--- a/components/my_active_bids/index.styl
+++ b/components/my_active_bids/index.styl
@@ -3,7 +3,7 @@
 
 item-margin-bottom = 16px
 
-.my-active-bids-bid-button, .my-active-bids-warning, .my-active-bids-item h4
+.my-active-bids-bid-button, .my-active-bids-bid-live-button, .my-active-bids-warning, .my-active-bids-item h4
   avant-garde()
   font-size 10px
 
@@ -45,4 +45,10 @@ item-margin-bottom = 16px
   padding 7px 14px
   position absolute
   bottom item-margin-bottom
+  right 0
+
+.my-active-bids-bid-live-button
+  small-avant-garde()
+  padding 7px 14px
+  position absolute
   right 0

--- a/components/my_active_bids/query.coffee
+++ b/components/my_active_bids/query.coffee
@@ -17,6 +17,10 @@ module.exports = """
           highest_bid {
             display
           }
+          sale {
+            live_start_at
+            end_at
+          }
           artwork {
             href
             title

--- a/components/my_active_bids/template.jade
+++ b/components/my_active_bids/template.jade
@@ -1,4 +1,5 @@
 include ../bid_status/index
+
 if myActiveBids && myActiveBids.length
   ul
     for bid in myActiveBids
@@ -12,10 +13,15 @@ if myActiveBids && myActiveBids.length
               h4 Lot #{bid.sale_artwork.lot_number}
               strong= bid.sale_artwork.artwork.artist.name
               p #{bid.sale_artwork.highest_bid.display} (#{bid.sale_artwork.counts.bidder_positions} Bids)
-          +bidStatus(bid, bid.sale_artwork)
-          a.avant-garde-button-black.my-active-bids-bid-button(
-            href=bid.sale_artwork.artwork.href
-          ) Bid
+          if ViewHelpers.mpLiveSaleIsOpen(bid.sale_artwork.sale)
+            a.avant-garde-button-black.my-active-bids-bid-live-button(
+              href=ViewHelpers.liveAuctionUrl(bid.sale_artwork.sale_id)
+            ) Bid Live
+          else
+            +bidStatus(bid, bid.sale_artwork)
+            a.avant-garde-button-black.my-active-bids-bid-button(
+              href=bid.sale_artwork.artwork.href
+            ) Bid
 
 else
   | Nothing yet.

--- a/components/my_active_bids/test/helpers.coffee
+++ b/components/my_active_bids/test/helpers.coffee
@@ -1,0 +1,30 @@
+ViewHelpers = require '../helpers.coffee'
+sd = require('sharify').data
+moment = require 'moment'
+
+describe 'My Active Bids View Helpers', ->
+  describe '#mpLiveSaleIsOpen', ->
+    it 'returns true if the sale is a live sale that is open', ->
+      sale = {
+        live_start_at: moment().subtract(1, 'day').format(),
+        end_at: moment().add(1, 'day').format()
+      }
+      ViewHelpers.mpLiveSaleIsOpen(sale).should.eql true
+    it 'returns false if the sale is a live sale that is over', ->
+      sale = {
+        live_start_at: moment().subtract(2, 'days').format(),
+        end_at: moment().subtract(1, 'day').format()
+      }
+      ViewHelpers.mpLiveSaleIsOpen(sale).should.eql false
+    it 'returns false if the sale is a live sale that has not started', ->
+      sale = {
+        live_start_at: moment().add(1, 'day').format(),
+        end_at: moment().add(2, 'days').format()
+      }
+      ViewHelpers.mpLiveSaleIsOpen(sale).should.eql false
+    it 'returns false if the sale is not a live sale', ->
+      sale = {
+        live_start_at: null,
+        end_at: moment().add(2, 'days').format()
+      }
+      ViewHelpers.mpLiveSaleIsOpen(sale).should.eql false

--- a/components/my_active_bids/view.coffee
+++ b/components/my_active_bids/view.coffee
@@ -4,6 +4,7 @@ query = require './query.coffee'
 metaphysics = require '../../lib/metaphysics.coffee'
 CurrentUser = require '../../models/current_user.coffee'
 template = -> require('./template.jade') arguments...
+ViewHelpers = require('./helpers.coffee')
 
 module.exports = class MyActiveBids extends Backbone.View
 
@@ -28,7 +29,7 @@ module.exports = class MyActiveBids extends Backbone.View
       @bidderPositions = data.me.lot_standings
 
   render: =>
-    @$el.html @template myActiveBids: @bidderPositions
+    @$el.html @template myActiveBids: @bidderPositions, ViewHelpers: ViewHelpers
     this
 
   remove: ->


### PR DESCRIPTION
Relevant issue:
https://github.com/artsy/auctions/issues/155#event-820441814

cc @devangt @katarinabatina 

Once a live sale starts, we don't want to show whether or not you are the winner w.r.t. gravity's sale data, so instead we show a `Bid Live` button.

![image](https://cloud.githubusercontent.com/assets/2081340/19575569/3841bc2c-96dd-11e6-8f01-b9a9a3db653e.png)

![image](https://cloud.githubusercontent.com/assets/2081340/19575578/45830940-96dd-11e6-987a-2e0363f11198.png)

![image](https://cloud.githubusercontent.com/assets/2081340/19575595/71c3015e-96dd-11e6-9e67-fa97035a96af.png)
