### PR TITLE
@craigspaeth fix sticky

### DIFF
--- a/apps/artist/client/views/overview.coffee
+++ b/apps/artist/client/views/overview.coffee
@@ -42,7 +42,11 @@ module.exports = class OverviewView extends Backbone.View
       limit: 170,
       label: 'Read More',
       heightBreakOffset: 20
-      onExpand: => @sticky.rebuild()
+      onExpand: =>
+        if @useNewArtworkFilter
+          @filterView.sticky.rebuild()
+        else
+          @sticky.rebuild()
     _.defer =>
       @$('.artist-blurb').addClass('is-fade-in')
       @$('.artist-exhibition-highlights').addClass 'is-fade-in'
@@ -92,7 +96,7 @@ module.exports = class OverviewView extends Backbone.View
     # Main section
 
     if @useNewArtworkFilter
-      { @sticky } = @filterView = (new ArtworkFilterView
+      @filterView = (new ArtworkFilterView
         el: @$('#artwork-section')
         artistID: @model.get('id')
         topOffset: $('.artist-sticky-header-container').height()


### PR DESCRIPTION
fixes https://github.com/artsy/force/issues/300

There are two artwork filters, one of which is a lab feature. they are set up a little bit differently, and for the new one, the @sticky is not available at the time of render but happens in a deferred post render. Therefore we can't grab it immediately when `render` returns, but can find it when we want to `rebuild` the sticky.

