### PR TITLE
set container and individual active bid sizes

### DIFF
--- a/apps/auctions/stylesheets/index.styl
+++ b/apps/auctions/stylesheets/index.styl
@@ -128,6 +128,7 @@
 
 .auctions-my-active-bids h3
   margin-bottom 30px
+  min-width 260px
 
 .auctions-header
   margin-bottom -17px

--- a/components/my_active_bids/index.styl
+++ b/components/my_active_bids/index.styl
@@ -9,6 +9,8 @@ item-margin-bottom = 16px
 
 .my-active-bids-item
   position relative
+  height 77px
+  min-width 260px
   margin-bottom item-margin-bottom
   padding-bottom item-margin-bottom
   border-bottom 1px solid gray-lighter-color


### PR DESCRIPTION
*this doesn't affect the user settings page's active bids component- auctions page only*
I'd noticed this a getting crowded on narrower views a bit before but i think my recent changes to the my_active_bids component made it worse- here is the auctions page at 1000px wide:
![image](https://cloud.githubusercontent.com/assets/9088720/19602422/314179e6-977b-11e6-8d80-44097302c77c.png)

I made a quick fix that keeps these divs from expanding - not sure if there is a process i should be following, but I felt like this was worth addressing right away.
 with fix @ 1000px- buttons are moved because page is scrolled a little bit:
![image](https://cloud.githubusercontent.com/assets/9088720/19602487/6828cba8-977b-11e6-913e-6e0a9b699ae1.png)
