### PR TITLE
@xtina-starr => Add support for featured artist bios w/ attribution on artwork page

### DIFF
--- a/apps/artwork/components/artists/helpers.coffee
+++ b/apps/artwork/components/artists/helpers.coffee
@@ -19,7 +19,7 @@ module.exports =
     has: (section) ->
       switch section
         when 'biography'
-          artist.biography? || artist.bio
+          artist.biography_blurb? || artist.bio
         when 'exhibition_highlights'
           artist.exhibition_highlights? && artist.exhibition_highlights.length > 15
         when 'articles'

--- a/apps/artwork/components/artists/helpers.coffee
+++ b/apps/artwork/components/artists/helpers.coffee
@@ -19,7 +19,7 @@ module.exports =
     has: (section) ->
       switch section
         when 'biography'
-          artist.biography_blurb? || artist.bio
+          artist.blurb || artist.bio || artist.biography_blurb
         when 'exhibition_highlights'
           artist.exhibition_highlights? && artist.exhibition_highlights.length > 15
         when 'articles'

--- a/apps/artwork/components/artists/index.coffee
+++ b/apps/artwork/components/artists/index.coffee
@@ -6,7 +6,7 @@ module.exports = ->
   tabs $('.js-artwork-artist-tabs')
 
   artistsWithTabs = _.filter(sd.CLIENT.artists, (artist) ->
-    return artist if artist.exhibition_highlights?.length > 0 or artist.biography or artist.articles?.length
+    return artist if artist.exhibition_highlights?.length > 0 or artist.biography_blurb or artist.articles?.length
   )
 
   _.each(artistsWithTabs, (artist, i) ->

--- a/apps/artwork/components/artists/index.coffee
+++ b/apps/artwork/components/artists/index.coffee
@@ -6,7 +6,7 @@ module.exports = ->
   tabs $('.js-artwork-artist-tabs')
 
   artistsWithTabs = _.filter(sd.CLIENT.artists, (artist) ->
-    return artist if artist.exhibition_highlights?.length > 0 or artist.biography_blurb or artist.articles?.length
+    return artist if artist.exhibition_highlights?.length > 0 or artist.blurb or artist.biography_blurb or artist.articles?.length
   )
 
   _.each(artistsWithTabs, (artist, i) ->

--- a/apps/artwork/components/artists/index.styl
+++ b/apps/artwork/components/artists/index.styl
@@ -16,7 +16,6 @@
     margin 0 0 distance(gutter) 0
   &__content
     &__short-bio
-      margin-top 30px
       margin-bottom 30px
     &__biography
       &__text
@@ -27,6 +26,7 @@
           margin-bottom 30px
       &__credit
         font-style italic
+        margin-bottom 30px
     &__exhibition-highlights
       &__item
         display flex

--- a/apps/artwork/components/artists/index.styl
+++ b/apps/artwork/components/artists/index.styl
@@ -15,13 +15,18 @@
     serif('headline')
     margin 0 0 distance(gutter) 0
   &__content
-    &__biography
+    &__short-bio
+      margin-top 30px
       margin-bottom 30px
-      serif('s-body')
-      a
-        fine-faux-underline()
-      > p
-        margin-bottom 30px
+    &__biography
+      &__text
+        serif('s-body')
+        a
+          fine-faux-underline()
+        > p
+          margin-bottom 30px
+      &__credit
+        font-style italic
     &__exhibition-highlights
       &__item
         display flex

--- a/apps/artwork/components/artists/query.coffee
+++ b/apps/artwork/components/artists/query.coffee
@@ -4,7 +4,10 @@ module.exports = """
       bio
       name
       href
-      biography: blurb(format: HTML)
+      biography_blurb(format: HTML) {
+        text
+        credit
+      }
       exhibition_highlights(size: 20) {
         kind
         name

--- a/apps/artwork/components/artists/query.coffee
+++ b/apps/artwork/components/artists/query.coffee
@@ -4,9 +4,11 @@ module.exports = """
       bio
       name
       href
-      biography_blurb(format: HTML) {
+      blurb(format: HTML)
+      biography_blurb(format: HTML, partner_bio: true) {
         text
         credit
+        partner_id
       }
       exhibition_highlights(size: 20) {
         kind

--- a/apps/artwork/components/artists/templates/biography.jade
+++ b/apps/artwork/components/artists/templates/biography.jade
@@ -1,6 +1,12 @@
 .artwork-artist__content__biography
-  if artist.biography
-    != artist.biography
+  
+  //- Can be Artsy or partner bio. Presence of 'credit' indicates partner.
+  if artist.biography_blurb
+    .artwork-artist__content__biography__text
+      != artist.biography_blurb.text
+    if artist.biography_blurb.credit
+      .artwork-artist__content__biography__credit
+        &mdash; #{artist.biography_blurb.credit}
 
   .artwork-artist__content__short-bio
     p= artist.bio.replace('born', 'b.')

--- a/apps/artwork/components/artists/templates/biography.jade
+++ b/apps/artwork/components/artists/templates/biography.jade
@@ -1,12 +1,15 @@
 .artwork-artist__content__biography
   
-  //- Can be Artsy or partner bio. Presence of 'credit' indicates partner.
-  if artist.biography_blurb
+  //- If featured bio's partner is the artwork's partner, show it.
+  if artist.biography_blurb && artist.biography_blurb.partner_id == artwork.partner.id
     .artwork-artist__content__biography__text
       != artist.biography_blurb.text
     if artist.biography_blurb.credit
       .artwork-artist__content__biography__credit
-        &mdash; #{artist.biography_blurb.credit}
+        | &mdash; #{artist.biography_blurb.credit}
+  else if artist.blurb
+    .artwork-artist__content__biography__text
+      != artist.blurb
 
   .artwork-artist__content__short-bio
     p= artist.bio.replace('born', 'b.')

--- a/apps/artwork/components/artists/test/artist_fixure.coffee
+++ b/apps/artwork/components/artists/test/artist_fixure.coffee
@@ -6,7 +6,10 @@ module.exports.artistsWithoutExhibitions =
       bio: 'American, born 1975, Los Angeles, California, based in New York, New York',
       name: 'Dustin Yellin',
       href: '/artist/dustin-yellin',
-      biography: 'Dustin Yellin is as known for his image-rich sculptures as he is for his entrepreneurship'
+      biography_blurb: {
+        text: 'Dustin Yellin is as known for his image-rich sculptures as he is for his entrepreneurship',
+        credit: 'Submitted by Catty Gallery'
+      }
       exhibition_highlights: null
       articles: [
         {
@@ -49,7 +52,10 @@ module.exports.artistsWithExhibitions =
       bio: 'American, born 1975, Los Angeles, California, based in New York, New York',
       name: 'Dustin Yellin',
       href: '/artist/dustin-yellin',
-      biography: 'Dustin Yellin is as known for his image-rich sculptures as he is for his entrepreneurship'
+      biography_blurb: {
+        text: 'Dustin Yellin is as known for his image-rich sculptures as he is for his entrepreneurship',
+        credit: 'Submitted by Catty Gallery'
+      }
       exhibition_highlights: [
         {
           kind: 'group',

--- a/apps/artwork/components/artists/test/templates/index.coffee
+++ b/apps/artwork/components/artists/test/templates/index.coffee
@@ -19,7 +19,10 @@ describe 'Artist Module template', ->
       artists: [
         fabricate('artist', {
           name: 'K Dot'
-          biography: "He is from Compton"
+          biography_blurb: {
+            text: "He is from Compton",
+            credit: 'Submitted by Catty Gallery'
+          }
           bio: "We do not know"
           exhibition_highlights: [
             fabricate('show'),
@@ -54,5 +57,6 @@ describe 'Artist Module template', ->
 
   it 'should display biography', ->
     @$('.side-tabs__nav').find('a[data-id=biography]').attr('data-id').should.equal 'biography'
-    @$('.artwork-artist__content__biography').html().should.containEql "He is from Compton"
+    @$('.artwork-artist__content__biography__text').html().should.containEql "He is from Compton"
+    @$('.artwork-artist__content__biography__credit').html().should.containEql "Submitted by Catty Gallery"
     @$('.artwork-artist__content__short-bio').html().should.containEql "We do not know"

--- a/apps/artwork/components/artists/test/templates/index.coffee
+++ b/apps/artwork/components/artists/test/templates/index.coffee
@@ -14,49 +14,109 @@ render = ->
   )
 
 describe 'Artist Module template', ->
-  beforeEach ->
-    @artwork = fabricate('artwork', {
-      artists: [
-        fabricate('artist', {
-          name: 'K Dot'
-          biography_blurb: {
-            text: "He is from Compton",
-            credit: 'Submitted by Catty Gallery'
-          }
-          bio: "We do not know"
-          exhibition_highlights: [
-            fabricate('show'),
-            fabricate('show'),
-            fabricate('show')
-          ]
-          articles: [
-            {
-              thumbnail_image: { cropped: { url: 'image.jpg' } }
-              title: "Jeff Koons’ Gazing Balls Glimmer at Art Basel"
-              author: {
-                name: 'Artsy Editorial'
-              }
+  describe 'when the artworks partner matches the featured partner', ->
+    beforeEach ->
+      @artwork = fabricate('artwork', {
+        partner: {
+          id: 'catty-partner'
+        }
+        artists: [
+          fabricate('artist', {
+            name: 'K Dot'
+            blurb: 'This is the Artsy blurb'
+            biography_blurb: {
+              text: "He is from Compton",
+              credit: 'Submitted by Catty Gallery'
+              partner_id: 'catty-partner'
             }
-          ]
-        })
-      ]
-    })
+            bio: "We do not know"
+            exhibition_highlights: [
+              fabricate('show'),
+              fabricate('show'),
+              fabricate('show')
+            ]
+            articles: [
+              {
+                thumbnail_image: { cropped: { url: 'image.jpg' } }
+                title: "Jeff Koons’ Gazing Balls Glimmer at Art Basel"
+                author: {
+                  name: 'Artsy Editorial'
+                }
+              }
+            ]
+          })
+        ]
+      })
 
-    @html = render()(
-      artwork: @artwork
-      helpers: {
-        artists:
-          build: sinon.stub().returns ['biography', 'exhibition highlights', 'articles']
-          name: sinon.stub()
-          groupBy: _.groupBy
-      }
-      asset: (->)
-    )
+      @html = render()(
+        artwork: @artwork
+        helpers: {
+          artists:
+            build: sinon.stub().returns ['biography', 'exhibition highlights', 'articles']
+            name: sinon.stub()
+            groupBy: _.groupBy
+        }
+        asset: (->)
+      )
 
-    @$ = cheerio.load(@html)
+      @$ = cheerio.load(@html)
 
-  it 'should display biography', ->
-    @$('.side-tabs__nav').find('a[data-id=biography]').attr('data-id').should.equal 'biography'
-    @$('.artwork-artist__content__biography__text').html().should.containEql "He is from Compton"
-    @$('.artwork-artist__content__biography__credit').html().should.containEql "Submitted by Catty Gallery"
-    @$('.artwork-artist__content__short-bio').html().should.containEql "We do not know"
+    it 'should display the featured biography and credit', ->
+      @$('.side-tabs__nav').find('a[data-id=biography]').attr('data-id').should.equal 'biography'
+      @$('.artwork-artist__content__biography__text').html().should.containEql "He is from Compton"
+      @$('.artwork-artist__content__biography__credit').html().should.containEql "Submitted by Catty Gallery"
+      @$('.artwork-artist__content__short-bio').html().should.containEql "We do not know"
+
+  describe 'when the artworks partner does not match the featured partner', ->
+    beforeEach ->
+      @artwork = fabricate('artwork', {
+        partner: {
+          id: 'catty-partner'
+        }
+        artists: [
+          fabricate('artist', {
+            name: 'K Dot'
+            blurb: 'This is the Artsy blurb'
+            biography_blurb: {
+              text: "He is from Compton",
+              credit: 'Submitted by Catty Gallery'
+              partner_id: 'some-other-partner'
+            }
+            bio: "We do not know"
+            exhibition_highlights: [
+              fabricate('show'),
+              fabricate('show'),
+              fabricate('show')
+            ]
+            articles: [
+              {
+                thumbnail_image: { cropped: { url: 'image.jpg' } }
+                title: "Jeff Koons’ Gazing Balls Glimmer at Art Basel"
+                author: {
+                  name: 'Artsy Editorial'
+                }
+              }
+            ]
+          })
+        ]
+      })
+
+      @html = render()(
+        artwork: @artwork
+        helpers: {
+          artists:
+            build: sinon.stub().returns ['biography', 'exhibition highlights', 'articles']
+            name: sinon.stub()
+            groupBy: _.groupBy
+        }
+        asset: (->)
+      )
+
+      @$ = cheerio.load(@html)
+
+    it 'should display the featured biography and credit', ->
+      @$('.side-tabs__nav').find('a[data-id=biography]').attr('data-id').should.equal 'biography'
+      @$('.artwork-artist__content__biography__text').html().should.containEql "This is the Artsy blurb"
+      @$('.artwork-artist__content__biography__credit').length.should.equal 0
+      @$('.artwork-artist__content__short-bio').html().should.containEql "We do not know"
+


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/230

Depends on https://github.com/artsy/metaphysics/pull/453

So, when you're on the artwork page of a partner, and that partner has submitted a featured bio for that artwork's artist...we want to show that w/ attribution.

Otherwise, keep the identical behavior, which is to only ever show Artsy bios. The only case where there's a change is the artwork pages of partners who have a featured bio for that artwork's artist.

cc @briansw 

Here's how that winds up looking:

<img width="908" alt="screen shot 2016-10-21 at 2 06 20 pm" src="https://cloud.githubusercontent.com/assets/1457859/19607694/6a658550-9799-11e6-8a99-32ed71b126de.png">
