### PR TITLE
@xtina-starr => Show any featured partner bio over Artsy one, if one exists, on the artist page

### DIFF
--- a/apps/artist/stylesheets/header.styl
+++ b/apps/artist/stylesheets/header.styl
@@ -48,6 +48,8 @@
 .artist-blurb
   p > a
     text-decoration underline
+  &__credit
+    font-style italic
 
 .artist-works-sort
   text-align right

--- a/apps/artist/templates/sections/overview.jade
+++ b/apps/artist/templates/sections/overview.jade
@@ -14,9 +14,6 @@ mixin rail(title, viewAllUrl, section)
   .evenly-bisected-header
     - var artistMeta = viewHelpers.artistMeta(artist)
 
-    //- Temporarily suppress partner-submitted bios until they are
-    //- improved.
-    - var hasArtsyBlurb = viewHelpers.hasArtsyBlurb(artist)
     - var hasMeta = viewHelpers.hasOverviewHeaderMeta(artist)
     - var hasShows = statuses.shows
 
@@ -24,10 +21,12 @@ mixin rail(title, viewAllUrl, section)
       if hasMeta
         .artist-blurb.bisected-header-cell-section
           h2 Biography
-          if hasArtsyBlurb
+          if artist.biography_blurb && artist.biography_blurb.text
             .blurb!= artist.biography_blurb.text
-          if hasArtsyBlurb && artistMeta.length
-            br
+            if artist.biography_blurb.credit
+              .artist-blurb__credit &mdash; #{artist.biography_blurb.credit}
+            if artistMeta.length
+              br
           if artistMeta.length
             .artist-meta-detail!= artistMeta
 

--- a/apps/artist/view_helpers.coffee
+++ b/apps/artist/view_helpers.coffee
@@ -114,7 +114,4 @@ module.exports =
     minuteFormat = if end.minute() > 0 then ':mm' else ''
     end.format('[Auction Closes] MMM D [at] h' + minuteFormat + ' A');
 
-  hasArtsyBlurb: (artist) ->
-    artist.biography_blurb?.text?.length && !artist.biography_blurb.credit
-
-  hasOverviewHeaderMeta: (artist) -> @hasArtsyBlurb(artist) || @artistMeta(artist).length
+  hasOverviewHeaderMeta: (artist) -> artist.biography_blurb?.text?.length || @artistMeta(artist).length


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/229

This is https://github.com/artsy/force/pull/312, except for the artist page.

This is a lot simpler because we were already fetching everything correctly (ie- Artsy bio w/ featured bio fallback), we were simply _only_ rendering the bio if it was an Artsy bio.

This opens it up to render the featured partner bio (plus credit) if it exists w/o an Artsy bio.