### PR TITLE
@kanaabe => Update CTA test analytics

### DIFF
--- a/analytics/articles.js
+++ b/analytics/articles.js
@@ -85,24 +85,32 @@ if(location.pathname.match('/article/')){
     }
   });
 
-  analyticsHooks.on('view:editorial-signup', function() {
+  analyticsHooks.on('view:editorial-signup', function(options) {
+    if (options.type != 'banner') {
+      var context = 'article_popup'
+    } else {
+      var context = 'article_fixed'
+    }
     analytics.track('Article impression', {
       article_id: null,
       destination_path: null,
       impression_type: 'newsletter_signup',
-      context_type: 'article_popup'
+      context_type: context,
+      experiment_id: 'editorial-cta-banner',
+      variation_id: options.type,
     }, { integrations: { 'Mixpanel': false } } );
   });
 }
 
 // Applies to both /article/* and /articles
 if(location.pathname.match('/article/') || location.pathname.match('/articles') || location.pathname.match('/gallery-insights')){
-
   analyticsHooks.on('submit:editorial-signup', function(options){
     analytics.track('Sign up for editorial email', {
       article_id: $(this).closest('.article-container').data('id'),
       context_type: options.type,
-      user_email: options.email
+      user_email: options.email,
+      experiment_id: 'editorial-cta-banner',
+      variation_id: options.variation_id
     });
   });
 
@@ -114,8 +122,17 @@ if(location.pathname.match('/article/') || location.pathname.match('/articles') 
     });
   });
 
-  analyticsHooks.on('dismiss:editorial-signup', function(){
-    analytics.track('Dismiss editorial signup', { context: 'article cta-popup'});
+  analyticsHooks.on('dismiss:editorial-signup', function(options){
+    if (options.type != 'banner') {
+      var context = 'article_popup'
+    } else {
+      var context = 'article_fixed'
+    }
+    analytics.track('Dismiss editorial signup', {
+      experiment_id: 'editorial-cta-banner',
+      variation_id: options.type,
+      context_type: context
+    });
   });
 
 }

--- a/components/email/client/editorial_signup.coffee
+++ b/components/email/client/editorial_signup.coffee
@@ -53,13 +53,14 @@ module.exports = class EditorialSignupView extends Backbone.View
       @showEditorialCTA 'modal'
 
   setupAEArticlePage: ->
+    @outcome = splitTest('editorial_cta_banner').outcome()
     @ctaBarView = new CTABarView
       mode: 'editorial-signup'
       name: 'editorial-signup-dismissed'
       persist: true
       email: sd.CURRENT_USER?.email or ''
     if not @ctaBarView.previouslyDismissed() and @eligibleToSignUp()
-      @showEditorialCTA splitTest('editorial_cta_banner').outcome()
+      @showEditorialCTA @outcome
     @fetchSignupImages (images) =>
       @$('.article-content').append editorialSignupLushTemplate
         email: sd.CURRENT_USER?.email or ''
@@ -152,7 +153,7 @@ module.exports = class EditorialSignupView extends Backbone.View
         # CTA Banner
         @$('.articles-es-cta--banner.banner').height(0)
         @$('.articles-es-cta--banner').css('opacity', 0).attr('data-state', 'out')
-        analyticsHooks.trigger('submit:editorial-signup', type: @getSubmissionType(e), email: @email)
+        analyticsHooks.trigger('submit:editorial-signup', variation_id: @outcome, type: @getSubmissionType(e), email: @email)
 
   getSubmissionType: (e)->
     type = $(e.currentTarget).data('type')
@@ -165,4 +166,4 @@ module.exports = class EditorialSignupView extends Backbone.View
 
   onDismiss: ->
     @ctaBarView.logDimissal()
-    analyticsHooks.trigger('dismiss:editorial-signup', type: splitTest('editorial_cta_banner').outcome())
+    analyticsHooks.trigger('dismiss:editorial-signup', type: @outcome)


### PR DESCRIPTION
Added experiment_id and variation_id to editorial signup tracking. 

The AB test was not tracking correctly in redshift, after some discussion with analytics we've added these options.  Do you know if any other changes are necessary for SplitTest outcomes to be tracked?  