### PR TITLE
@anyone Remove followers count on GPP for institutions as well.

### DIFF
--- a/apps/partner/templates/header.jade
+++ b/apps/partner/templates/header.jade
@@ -11,7 +11,4 @@ header.partner-header
       p.partner-bio= profile.get('bio')
       .partner-actions
         button.avant-garde-follow-button-black.follow-button
-        if profile.isInstitution() && profile.get('follows_count')
-          .partner-followers
-            = profile.formatFollowText()
   .partner-nav

--- a/apps/partner/test/templates.coffee
+++ b/apps/partner/test/templates.coffee
@@ -72,19 +72,8 @@ describe 'Partner header', ->
         beforeEach ->
           @profile = new Profile fabricate 'profile', owner_type: 'PartnerInstitution'
 
-        it 'has a follower count if there are followers', ->
+        it 'does not display follower count', ->
           @profile.set follows_count: 2222
-          @template = render('index')(
-            profile: @profile
-            tab: 'overview'
-            sd: APP_URL: 'http://localhost:3004', CURRENT_PATH: '/philadelphia-museum-of-art'
-            asset: (->)
-            params: id: 'philadelphia-museum-of-art'
-          )
-          @template.should.containEql 'class="partner-followers">2,222 Followers'
-
-        it 'does not display the follower count if there are no followers', ->
-          @profile.set follows_count: 0
           @template = render('index')(
             profile: @profile
             tab: 'overview'

--- a/apps/partner2/templates/header.jade
+++ b/apps/partner2/templates/header.jade
@@ -5,9 +5,6 @@ header.partner-header
       .partner-locations
       .partner-actions
         button.avant-garde-follow-button-black.follow-button.is-small
-        if profile.isInstitution() && profile.get('follows_count')
-          .partner-followers
-            = profile.formatFollowText()
     a.profile-badge.partner-icon( href=profile.href() )
       .profile-badge-icon
         if profile.hasIconImage()

--- a/apps/partner2/test/templates.coffee
+++ b/apps/partner2/test/templates.coffee
@@ -72,19 +72,8 @@ describe 'Partner header', ->
         beforeEach ->
           @profile = new Profile fabricate 'profile', owner_type: 'PartnerInstitution'
 
-        it 'has a follower count if there are followers', ->
+        it 'does not display follower count', ->
           @profile.set follows_count: 2222
-          @template = render('index')(
-            profile: @profile
-            tab: 'overview'
-            sd: APP_URL: 'http://localhost:3004', CURRENT_PATH: '/philadelphia-museum-of-art'
-            asset: (->)
-            params: id: 'philadelphia-museum-of-art'
-          )
-          @template.should.containEql 'class="partner-followers">2,222 Followers'
-
-        it 'does not display the follower count if there are no followers', ->
-          @profile.set follows_count: 0
           @template = render('index')(
             profile: @profile
             tab: 'overview'


### PR DESCRIPTION
Re: https://trello.com/c/A1p2GVuN/654-remove-follow-counts-on-institutional-profile-pages
## Problem

Given that we've launched analytics emails with follow counts we can remove follow counts from institutional profile pages.
## Solution

In https://github.com/artsy/force/pull/177, we only display the counts for institutions. Let's remove them entirely.
