### PR TITLE
@starsirius => Channel articles for APU RSS feed and avoid vanity fetches

### DIFF
--- a/apps/articles/index.coffee
+++ b/apps/articles/index.coffee
@@ -6,6 +6,7 @@ express = require 'express'
 routes = require './routes'
 { resize, crop } = require '../../components/resizer'
 { toSentence } = require 'underscore.string'
+sd = require('sharify').data
 
 app = module.exports = express()
 app.set 'views', __dirname + '/templates'
@@ -18,5 +19,6 @@ app.locals.toSentence = toSentence
 app.get '/posts', routes.redirectMagazine
 app.get '/magazine', routes.redirectMagazine
 app.get '/articles', routes.articles
-app.get '/:slug', routes.teamChannel
+app.get sd.TEAM_BLOGS, routes.teamChannel
+app.get '/venice-biennale-2015', routes.section
 app.post '/editorial-signup/form', routes.editorialForm

--- a/apps/articles/routes.coffee
+++ b/apps/articles/routes.coffee
@@ -41,11 +41,12 @@ setupEmailSubscriptions = (user, cb) ->
 @redirectMagazine = (req, res, next) ->
   res.redirect 301, req.url.replace 'magazine', 'articles'
 
+# Deprecated - only must-have is VB2015 and will eventually be removed
 @section = (req, res, next) ->
-  new Section(id: req.params.slug).fetch
+  new Section(id: 'venice-biennale-2015').fetch
+    cache: true
     error: -> next()
     success: (section) ->
-      return next() unless req.params.slug is section.get('slug')
       new Articles().fetch
         data:
           published: true
@@ -60,8 +61,9 @@ setupEmailSubscriptions = (user, cb) ->
           res.render 'section', section: section, articles: articles
 
 @teamChannel = (req, res, next) =>
-  new Channel(id: req.params.slug).fetch
-    error: => @section(req, res, next)
+  slug = last req.url.split('/')
+  new Channel(id: slug).fetch
+    error: => res.backboneError
     success: (channel) ->
       return next() unless channel.isTeam()
       topParselyArticles channel.get('name'), null, PARSELY_KEY, PARSELY_SECRET, (parselyArticles) ->

--- a/apps/articles/test/routes.coffee
+++ b/apps/articles/test/routes.coffee
@@ -45,7 +45,6 @@ describe 'Articles routes', ->
 
     it 'renders the section with its articles', ->
       section = _.extend _.clone(fixtures.section), slug: 'foo'
-      @req.params.slug = 'foo'
       routes.section @req, @res, @next
       Backbone.sync.args[0][2].success section
       Backbone.sync.args[1][2].data.section_id.should.equal section.id
@@ -62,7 +61,7 @@ describe 'Articles routes', ->
 
     it 'renders the channel with its articles', ->
       channel = _.extend _.clone(fixtures.channel), slug: 'foo', type: 'team'
-      @req.params.slug = 'foo'
+      @req.url = 'foo'
       routes.teamChannel @req, @res, @next
       Backbone.sync.args[0][2].success channel
       Backbone.sync.args[1][2].data.ids.length.should.equal 4
@@ -72,15 +71,7 @@ describe 'Articles routes', ->
 
     it 'nexts if channel is not a team channel', ->
       channel = _.extend _.clone(fixtures.channel), slug: 'foo', type: 'editorial'
-      @req.params.slug = 'foo'
+      @req.url = 'foo'
       routes.teamChannel @req, @res, @next
       Backbone.sync.args[0][2].success channel
       @next.called.should.be.ok()
-
-    it 'falls back to checking for a section if channel is not found', ->
-      @req.params.slug = 'foo'
-      routes.teamChannel @req, @res, @next
-      routes.section = sinon.stub()
-      Backbone.sync.args[0][2].error()
-      routes.section.called.should.be.ok()
-      routes.section.args[0][0].params.slug.should.equal 'foo'

--- a/apps/rss/routes.coffee
+++ b/apps/rss/routes.coffee
@@ -34,15 +34,13 @@ PAGE_SIZE_FACEBOOK = 50
         pretty: true
 
 @partnerUpdates = (req, res, next) ->
-  articles = new Articles
-
-  articles.fetch
+  new Articles().fetch
     data:
       channel_id: sd.ARTSY_PARTNER_UPDATES_CHANNEL
       published: true
       sort: '-published_at'
       limit: PAGE_SIZE
-  .then ->
-    res.set('Content-Type', 'application/rss+xml')
-    res.render('partner_updates', articles: articles, pretty: true)
-  .catch res.backboneError
+    error: -> res.backboneError
+    success: (articles) ->
+      res.set('Content-Type', 'application/rss+xml')
+      res.render('partner_updates', articles: articles, pretty: true)

--- a/apps/rss/routes.coffee
+++ b/apps/rss/routes.coffee
@@ -34,19 +34,15 @@ PAGE_SIZE_FACEBOOK = 50
         pretty: true
 
 @partnerUpdates = (req, res, next) ->
-  section = new Section id: 'artsy-partner-updates'
   articles = new Articles
 
-  section.fetch()
-    .then ->
-      articles.fetch
-        data:
-          section_id: section.get('id')
-          published: true
-          sort: '-published_at'
-          limit: PAGE_SIZE
-    .then ->
-      res.set('Content-Type', 'application/rss+xml')
-      res.render('partner_updates', articles: articles, pretty: true)
-    .catch res.backboneError
-
+  articles.fetch
+    data:
+      channel_id: sd.ARTSY_PARTNER_UPDATES_CHANNEL
+      published: true
+      sort: '-published_at'
+      limit: PAGE_SIZE
+  .then ->
+    res.set('Content-Type', 'application/rss+xml')
+    res.render('partner_updates', articles: articles, pretty: true)
+  .catch res.backboneError

--- a/apps/rss/test/routes.coffee
+++ b/apps/rss/test/routes.coffee
@@ -77,25 +77,9 @@ describe 'RSS', ->
       Backbone.sync
         .onCall 0
         .returns Q.resolve()
-        .yieldsTo 'success', @section
-
-      Backbone.sync
-        .onCall 1
-        .returns Q.resolve()
         .yieldsTo 'success', @articles
-
-    it 'fetches section and articles', ->
-      routes.partnerUpdates @req, @res
-        .then =>
-          Backbone.sync.args.should.have.lengthOf 2
-          Backbone.sync.args[1][2].data.should.eql
-            section_id: @section.id
-            published: true
-            sort: '-published_at'
-            limit: 100
 
     it 'renders articles', ->
       routes.partnerUpdates @req, @res
-        .then =>
-          @res.render.args[0][0].should.equal 'partner_updates'
-          @res.render.args[0][1].articles.should.have.lengthOf 2
+      @res.render.args[0][0].should.equal 'partner_updates'
+      @res.render.args[0][1].articles.should.have.lengthOf 2

--- a/components/auction_reminders/blacklist.coffee
+++ b/components/auction_reminders/blacklist.coffee
@@ -1,5 +1,5 @@
 blacklist = require '../../lib/blacklist.coffee'
-sd = require('sharify').data
+{ TEAM_BLOGS } = require('sharify').data
 
 module.exports =
   patterns: [
@@ -11,7 +11,7 @@ module.exports =
     '^/inquiry/.*'
     '^/jobs'
     '^/job/.*'
-    sd.TEAM_BLOGS
+    TEAM_BLOGS or '^/test'
   ]
 
   check: ->

--- a/components/auction_reminders/blacklist.coffee
+++ b/components/auction_reminders/blacklist.coffee
@@ -1,4 +1,5 @@
 blacklist = require '../../lib/blacklist.coffee'
+sd = require('sharify').data
 
 module.exports =
   patterns: [
@@ -10,6 +11,7 @@ module.exports =
     '^/inquiry/.*'
     '^/jobs'
     '^/job/.*'
+    sd.TEAM_BLOGS
   ]
 
   check: ->

--- a/config.coffee
+++ b/config.coffee
@@ -112,6 +112,7 @@ module.exports =
   GALLERY_INSIGHTS_CHANNEL: '5759e4a6b5989e6f98f77995'
   EDITORIAL_CTA_BANNER_IMG: 'http://files.artsy.net/images/iphone_email.png'
   ARTSY_PARTNER_UPDATES_CHANNEL: '5762d454b5989e6f98f7799a'
+  TEAM_BLOGS: '^\/life-at-artsy$|^\/artsy-education$|^\/gallery-insights$|^\/artsy-partner-updates$'
 
 # Override any values with env variables if they exist.
 # You can set JSON-y values for env variables as well such as "true" or

--- a/config.coffee
+++ b/config.coffee
@@ -111,6 +111,7 @@ module.exports =
   LOGGER_FORMAT: 'combined'
   GALLERY_INSIGHTS_CHANNEL: '5759e4a6b5989e6f98f77995'
   EDITORIAL_CTA_BANNER_IMG: 'http://files.artsy.net/images/iphone_email.png'
+  ARTSY_PARTNER_UPDATES_CHANNEL: '5762d454b5989e6f98f7799a'
 
 # Override any values with env variables if they exist.
 # You can set JSON-y values for env variables as well such as "true" or

--- a/lib/middleware/redirect_mobile.coffee
+++ b/lib/middleware/redirect_mobile.coffee
@@ -2,7 +2,7 @@
 # Detects a mobile browser by user agent and redirects it to Microgravity
 #
 
-{ MOBILE_URL } = require '../../config'
+{ MOBILE_URL, TEAM_BLOGS } = require '../../config'
 express = require 'express'
 router = express.Router()
 
@@ -36,6 +36,6 @@ router.get '/ArtsySocialMediaToolkit.pdf', isResponsive
 router.get '/inquiry/*', isResponsive
 router.get '/consign', isResponsive
 router.get '/professional-buyer*', isResponsive
-router.get '/^\/life-at-artsy$|^\/artsy-education$|^\/gallery-insights$|^\/artsy-partner-updates$', isResponsive
+router.get TEAM_BLOGS, isResponsive
 router.use redirect
 module.exports = router

--- a/lib/setup_sharify.coffee
+++ b/lib/setup_sharify.coffee
@@ -78,6 +78,7 @@ sharify.data = _.extend _.pick(config,
   'GALLERY_INSIGHTS_CHANNEL'
   'EDITORIAL_CTA_BANNER_IMG'
   'ARTSY_PARTNER_UPDATES_CHANNEL'
+  'TEAM_BLOGS'
 ), {
   JS_EXT: if config.NODE_ENV in ["production", "staging"] then \
     ".min.js.cgz" else ".js"

--- a/lib/setup_sharify.coffee
+++ b/lib/setup_sharify.coffee
@@ -77,6 +77,7 @@ sharify.data = _.extend _.pick(config,
   'PC_AUCTION_CHANNEL'
   'GALLERY_INSIGHTS_CHANNEL'
   'EDITORIAL_CTA_BANNER_IMG'
+  'ARTSY_PARTNER_UPDATES_CHANNEL'
 ), {
   JS_EXT: if config.NODE_ENV in ["production", "staging"] then \
     ".min.js.cgz" else ".js"


### PR DESCRIPTION
Closes: https://github.com/artsy/positron/issues/817

This PR replaces the Section fetch with a Channel fetch for the Artsy Partner Updates RSS feed.

I also noticed that we're hitting Positron's API pretty hard with trials to vanity-type URLS like /gagosian and /:id . "Sections" are now deprecated (only one left is Venice Biennale) and Team Blogs have to be manually created anyway (and not often). With that in place, we should instead just make the list of team blogs configurable in a `TEAM_BLOGS` string, and stop doing trials to `/sections/:id` and `/channels/:id` on Positron's API. 
