### PR TITLE
@broskoski: Stop sitemapping 500K missing pages

### DIFF
--- a/apps/sitemaps/templates/artworks.jade
+++ b/apps/sitemaps/templates/artworks.jade
@@ -6,7 +6,3 @@ urlset(
   for slug in slugs
     url
       loc=sd.APP_URL + '/artwork/' + slug
-    url
-      //-redirects to '/artwork/slug' if there are no auction results
-      loc=sd.APP_URL + '/artwork/' + slug + '/auction-results'
-    


### PR DESCRIPTION
No wonder there are so many pre-rendering failures. We sitemap 500K+ pages that redirect _all_ of the time. Metrics for the `artwork/.../comparable_sales` endpoints confirm this change:

![](https://cl.ly/3u3R3z0b0u2p/Screen%20Shot%202016-10-27%20at%202.11.29%20PM.png)

Background:

https://trello.com/c/czdebbbD/334-remove-comparable-auction-results-for-an-individual-artwork

https://github.com/artsy/force/commit/1f4fc5d7c7478f6f441efc8c7deea771e5661e0d