### PR TITLE
@joeyAghion cc @kanaabe: Fix settings page linked accounts UI bug

### DIFF
--- a/models/mixins/relations/user.coffee
+++ b/models/mixins/relations/user.coffee
@@ -21,7 +21,7 @@ module.exports =
       options.data = @pick('email')
       fetch.call account, options
 
-    authentications = new Backbone.Collection
+    authentications = new Backbone.Collection @get 'authentications'
     authentications.url = "#{API_URL}/api/v1/me/authentications"
 
     creditCards = new CreditCards

--- a/test/models/current_user.coffee
+++ b/test/models/current_user.coffee
@@ -128,6 +128,12 @@ describe 'CurrentUser', ->
         { id: '2', uid: '987654321', provider: 'facebook' }
       ]
 
+    describe 'relation', ->
+      it 'should inject initial authentications', ->
+        user = new CurrentUser authentications: @authentications
+        user.isLinkedTo('twitter').should.be.true()
+        user.isLinkedTo('facebook').should.be.true()
+
     describe '#isLinkedTo', ->
       it 'determines if an account is linked to an app provider', ->
         @user.isLinkedTo 'twitter'


### PR DESCRIPTION
The initial state of `user.related().authentications` wasn't being set. This is data retrieved from the /api/v1/me/authentications endpoint. It's likely it was assumed this wasn't available embedded in the initial user data b/c at one point it wasn't—but Artsy Passport [embeds this](https://github.com/artsy/artsy-passport/blob/d3309d63cf73255ba7236e7b5bd7ed97f86c7775/lib/passport/serializers.coffee#L19) into the session now, so we can leverage that initial data.

**warning:** Tangential philosophical rant time:

On a more philosophical takeaway, I think this speaks to something I've always felt about Backbone modeling—which is you can't sanely bring over concepts of server-side models (such as relations). I believe the reason it's so easy to run into bugs with this is b/c in the case of say Active Record, you have control of the database and the model code is in lock-step with how it affects the database. In Backbone, model code is not in lock-step with the database (REST API) it consumes, and often you don't have much, if any (in the case of a third party REST API), control over the API design. So, many edge cases like this appear where you have to explicitly work with the timing and association of objects. I encourage when using Backbone, to be really minimal with the abstractions on top of it and mostly work with the vanilla attributes.

Going further, this also speaks to why React's functional way of running vanilla JSON-like data unidirectionally through a tree of components is much saner to manage than the OO paradigms in front end MVCs like Backbone. Doing that reduces the OO black boxes like this case where you're not sure what the state of underlying objects are and end up manually managing a lot of bi-directional communication, updating (fetching/setting) of objects, and ensuring every object dependency is in the correct state throughout time. Add GraphQL to that and you also drastically simplify the data orchestrating story. For instance, this bug would have been avoided with these two technologies by 1. (w/ React) making it obvious where the data was missing in the first place and centralizing when and how the `authentications` data was fetched and 2. (w/ GraphQL) avoid the assumptions/complexity in composing the data across multiple endpoints over time by allowing all that data to be fetched in one place at one time.

_Puts aside Facebook soapbox_ 📦 

Thought I would take the opportunity to share some musings about interesting reasons behind the innovations in front end—hopefully that was more insightful than annoying and preachy 😁 