### PR TITLE
@eessex => Omit sailthru clicks from receiving a signup

### DIFF
--- a/analytics/articles.js
+++ b/analytics/articles.js
@@ -115,7 +115,7 @@ if(location.pathname.match('/article/') || location.pathname.match('/articles') 
 
   analyticsHooks.on('dismiss:editorial-signup', function(options){
     analytics.track('Dismiss editorial signup', {
-      context_type: context
+      context_type: options.type
     });
   });
 

--- a/components/email/client/editorial_signup.coffee
+++ b/components/email/client/editorial_signup.coffee
@@ -12,6 +12,7 @@ mailcheck = require '../../mailcheck/index.coffee'
 mediator = require '../../../lib/mediator.coffee'
 FlashMessage = require '../../flash/index.coffee'
 splitTest = require '../../split_test/index.coffee'
+qs = require 'querystring'
 
 module.exports = class EditorialSignupView extends Backbone.View
 
@@ -26,7 +27,9 @@ module.exports = class EditorialSignupView extends Backbone.View
     @setupAEMagazinePage() if @inAEMagazinePage()
 
   eligibleToSignUp: ->
-    (@inAEArticlePage() or @inAEMagazinePage()) and not sd.SUBSCRIBED_TO_EDITORIAL
+    (@inAEArticlePage() or @inAEMagazinePage()) and
+    not sd.SUBSCRIBED_TO_EDITORIAL and
+    qs.parse(location.search.replace(/^\?/, '')).utm_source isnt 'sailthru'
 
   inAEArticlePage: ->
     sd.ARTICLE? and

--- a/components/email/test/editorial_signup.coffee
+++ b/components/email/test/editorial_signup.coffee
@@ -5,6 +5,7 @@ Backbone = require 'backbone'
 { resolve } = require 'path'
 mediator = require '../../../lib/mediator.coffee'
 { stubChildClasses } = require '../../../test/helpers/stubs'
+qs = require 'querystring'
 
 describe 'EditorialSignupView', ->
 
@@ -89,6 +90,14 @@ describe 'EditorialSignupView', ->
         ARTICLE: channel_id: '333'
         ARTSY_EDITORIAL_CHANNEL: '123'
         SUBSCRIBED_TO_EDITORIAL: false
+      @view.eligibleToSignUp().should.not.be.ok()
+
+    it 'checks if the utm_source is sailthru', ->
+      @EditorialSignupView.__set__ 'qs', parse: sinon.stub().returns utm_source: 'sailthru'
+      @EditorialSignupView.__set__ 'sd',
+        ARTICLE: channel_id: '333'
+        SUBSCRIBED_TO_EDITORIAL: false
+        ARTSY_EDITORIAL_CHANNEL: '333'
       @view.eligibleToSignUp().should.not.be.ok()
 
   describe '#showEditorialCTA', ->

--- a/components/email/test/editorial_signup.coffee
+++ b/components/email/test/editorial_signup.coffee
@@ -5,7 +5,6 @@ Backbone = require 'backbone'
 { resolve } = require 'path'
 mediator = require '../../../lib/mediator.coffee'
 { stubChildClasses } = require '../../../test/helpers/stubs'
-qs = require 'querystring'
 
 describe 'EditorialSignupView', ->
 


### PR DESCRIPTION
Mimicking current behavior on MG. We confirmed a while ago with @sperle that `utm_source=sailthru` is the best thing to check against viewing a signup from campaign emails.