### PR TITLE
@sweir27: Add auction FAQs to Artsy Support

### DIFF
--- a/components/feedback_modal/index.coffee
+++ b/components/feedback_modal/index.coffee
@@ -17,6 +17,7 @@ module.exports = ->
           collector: ['collector']
           press: ['press']
           feedback: ['feedback']
+          auction: ['auction']
       }
     ]
 
@@ -44,6 +45,10 @@ module.exports = ->
       when 'feedback'
         modal.close ->
           openFeedback()
+
+      when 'auction'
+        modal.close ->
+          openMultiPageModal 'auction-faqs'
 
   modal.open()
   modal

--- a/components/feedback_modal/templates/how_can_we_help.jade
+++ b/components/feedback_modal/templates/how_can_we_help.jade
@@ -4,6 +4,8 @@ h1.fm-garamind-headline
   | How may we help you?
 
 nav.small-chevron-list.fm-multiple-choice
+  a( data-answer='auction' )
+    | I have auctions-related question.
   a( data-answer='artist' )
     | I’m an artist interested in listing my work.
   a( data-answer='collector' )
@@ -12,5 +14,3 @@ nav.small-chevron-list.fm-multiple-choice
     | I have a press inquiry.
   a( data-answer='feedback' )
     | I have another question.
-  a( data-answer='auction' )
-    | I have auctions-related question.

--- a/components/feedback_modal/templates/how_can_we_help.jade
+++ b/components/feedback_modal/templates/how_can_we_help.jade
@@ -5,7 +5,7 @@ h1.fm-garamind-headline
 
 nav.small-chevron-list.fm-multiple-choice
   a( data-answer='auction' )
-    | I have an auctions-related question.
+    | I have an auction-related question.
   a( data-answer='artist' )
     | I’m an artist interested in listing my work.
   a( data-answer='collector' )

--- a/components/feedback_modal/templates/how_can_we_help.jade
+++ b/components/feedback_modal/templates/how_can_we_help.jade
@@ -5,7 +5,7 @@ h1.fm-garamind-headline
 
 nav.small-chevron-list.fm-multiple-choice
   a( data-answer='auction' )
-    | I have auctions-related question.
+    | I have an auctions-related question.
   a( data-answer='artist' )
     | I’m an artist interested in listing my work.
   a( data-answer='collector' )

--- a/components/feedback_modal/templates/how_can_we_help.jade
+++ b/components/feedback_modal/templates/how_can_we_help.jade
@@ -12,3 +12,5 @@ nav.small-chevron-list.fm-multiple-choice
     | I have a press inquiry.
   a( data-answer='feedback' )
     | I have another question.
+  a( data-answer='auction' )
+    | I have auctions-related question.


### PR DESCRIPTION
@stasya Could use some help making her customer support role easier, so this quickly adds auction FAQs to our general support modal.

![cap](https://cloud.githubusercontent.com/assets/555859/19878801/5bb0fe72-9fc3-11e6-84e6-5ebd2bd5bd83.gif)
