### PR TITLE
@erikdstock => consider est vs edt on auction page

### DIFF
--- a/models/sale.coffee
+++ b/models/sale.coffee
@@ -1,6 +1,7 @@
 _ = require 'underscore'
 { API_URL, SECURE_IMAGES_URL, PREDICTION_URL } = require('sharify').data
 moment = require 'moment'
+tz = require 'moment-timezone'
 Backbone = require 'backbone'
 { Fetch, Markdown, Image, CalendarUrls } = require 'artsy-backbone-mixins'
 
@@ -163,12 +164,12 @@ module.exports = class Sale extends Backbone.Model
     event
 
   upcomingLabel: ->
-    est = (attr) => moment.utc(@get attr).utcOffset(-4).format 'MMM D h:mm:ssA'
+    zone = (attr) => moment(@get attr).tz('America/New_York').format 'MMM D h:mm:ssA z'
     if @isClosed()
       "Auction Closed"
     else if @get('live_start_at') and not @isLiveOpen()
-      "Live bidding begins #{est 'live_start_at'} EST"
+      "Live bidding begins #{zone 'live_start_at'}"
     else if @isPreviewState()
-      "Auction opens #{est 'start_at'} EST"
+      "Auction opens #{zone 'start_at'}"
     else
-      "Bidding closes #{est 'end_at'} EST"
+      "Bidding closes #{zone 'end_at'}"

--- a/test/models/sale.coffee
+++ b/test/models/sale.coffee
@@ -287,14 +287,27 @@ describe 'Sale', ->
 
     describe '#upcomingLabel', ->
 
-      it 'renders the correct opening label', ->
-        time = moment().add(2, 'days').utcOffset(-4)
+      it 'renders the correct opening label when EDT', ->
+        time = moment('2016-11-02 12:00:00').utc()
         @sale.isPreviewState = -> true
         @sale.set
           start_at: time
           end_at: time.add(2, 'days')
         @sale.upcomingLabel().should
-          .equal "Auction opens #{time.format 'MMM D h:mm:ssA'} EST"
+          .containEql 'Auction opens Nov 4'
+        @sale.upcomingLabel().should
+          .containEql 'EDT'
+
+      it 'renders the correct opening label when EST', ->
+        time = moment('2016-1-02 12:00:00').utc()
+        @sale.isPreviewState = -> true
+        @sale.set
+          start_at: time
+          end_at: time.add(2, 'days')
+        @sale.upcomingLabel().should
+          .containEql 'Auction opens Jan 4'
+        @sale.upcomingLabel().should
+          .containEql 'EST'
 
     describe '#sortableDate', ->
       it 'returns the live_start_at if it exists', ->


### PR DESCRIPTION
This PR updates the auction's `upcomingLabel` to respect EST vs. EDT (for now we still report auctions in Eastern time, but in the future we may want to respect system time).

![image](https://cloud.githubusercontent.com/assets/2081340/19906794/9d55a226-a052-11e6-8578-7c3877bc00e5.png)

