### PR TITLE
@xtina-starr - Fix padding for other works in auction

### DIFF
--- a/apps/artwork/components/auction_artworks/index.styl
+++ b/apps/artwork/components/auction_artworks/index.styl
@@ -28,7 +28,7 @@
 
     .auction__image
       padding-bottom 100%
-      min-height 300px
+      height 300px
       background-color rgba(255,255,255, 0.125)
 
   .artwork-brick__image__img.auction__image__img
@@ -38,7 +38,6 @@
     background-repeat no-repeat
     background-position center
     position absolute
-
 
   .artwork-brick.artwork-brick--auction.js-artwork-brick
     flex 1

--- a/apps/artwork/components/auction_artworks/index.styl
+++ b/apps/artwork/components/auction_artworks/index.styl
@@ -25,3 +25,26 @@
       margin-bottom 20px
       width 100%
       height 100%
+
+    .auction__image
+      padding-bottom 100%
+      min-height 300px
+      background-color rgba(255,255,255, 0.125)
+
+  .artwork-brick__image__img.auction__image__img
+    height 100%
+    width 100%
+    background-size contain
+    background-repeat no-repeat
+    background-position center
+    position absolute
+
+
+  .artwork-brick.artwork-brick--auction.js-artwork-brick
+    flex 1
+    max-width 33%
+    height 500px
+    margin-right 20px
+
+    &:last-child
+      margin-right 0

--- a/components/artwork_brick/index.styl
+++ b/components/artwork_brick/index.styl
@@ -29,20 +29,3 @@
         position: absolute
         right: 5px
         bottom: 5px
-
-    &.auction__image
-      padding-bottom 100%
-      background-color rgba(255,255,255, 0.125)
-
-.artwork-brick__image__img.auction__image__img
-  height 100%
-  width 100%
-  background-size contain
-  background-repeat no-repeat
-  background-position center
-  position absolute
-
-.artwork-brick.artwork-brick--auction.js-artwork-brick
-  width 30%
-  height 100%
-  margin-right 20px


### PR DESCRIPTION
Closes #344

This moves the styles specific to this context over to the artwork app, removes the right margin on the last-child in a row and gives the image a static height.

![screen shot 2016-11-02 at 11 04 24 am](https://cloud.githubusercontent.com/assets/821469/19934188/2a684d5a-a0ec-11e6-8951-cafbb7643214.png)
