### PR TITLE
@sweir27 => Reference to PARSELY shall no longer assume window

### DIFF
--- a/analytics/before_ready.js
+++ b/analytics/before_ready.js
@@ -1,5 +1,5 @@
 /* Analytics code that needs to run before page load and analytics.ready */
 
 if (!location.pathname.match(/^\/article/) && !sd.SECTION){
-  PARSELY = {autotrack: false};
+  window.PARSELY = {autotrack: false};
 } /* Disable Parsely firing on non-article/section pages */


### PR DESCRIPTION
Be more specific about this PARSELY variable. Maybe it's Node 6 related since it's only on staging right now but idk, we should be doing this anyway.