### PR TITLE
@sweir27 => use sale.live instead of sale.end_at in isLiveOpen check

### DIFF
--- a/apps/auction/routes.coffee
+++ b/apps/auction/routes.coffee
@@ -125,6 +125,7 @@ setupUser = (user, auction) ->
     error: res.backboneError
     success: ->
       liveUrl = "#{PREDICTION_URL}/#{auction.get('id')}/login"
+      console.log auction.get('some_property'), auction.get('auction_state'), auction.get('live_start_at')?.format()
       if auction.isLiveOpen()
         req.user.fetchBidderForAuction auction,
           error: res.backboneError

--- a/apps/auction/routes.coffee
+++ b/apps/auction/routes.coffee
@@ -125,7 +125,6 @@ setupUser = (user, auction) ->
     error: res.backboneError
     success: ->
       liveUrl = "#{PREDICTION_URL}/#{auction.get('id')}/login"
-      console.log auction.get('some_property'), auction.get('auction_state'), auction.get('live_start_at')?.format()
       if auction.isLiveOpen()
         req.user.fetchBidderForAuction auction,
           error: res.backboneError

--- a/apps/auction/test/routes.coffee
+++ b/apps/auction/test/routes.coffee
@@ -141,7 +141,7 @@ describe '#redirectLive', ->
     auction = fabricate 'sale',
       id: 'foo'
       is_auction: true
-      auction_state: 'open'
+      start_at: moment().startOf('day')
       live_start_at: moment().startOf('day')
       end_at: moment().endOf('day')
     bidder = {
@@ -162,7 +162,7 @@ describe '#redirectLive', ->
     auction = fabricate 'sale',
       id: 'foo'
       is_auction: true
-      auction_state: 'open'
+      start_at: moment().startOf('day')
       live_start_at: moment().startOf('day')
       end_at: moment().endOf('day')
     bidder = {

--- a/apps/auction/test/routes.coffee
+++ b/apps/auction/test/routes.coffee
@@ -141,6 +141,7 @@ describe '#redirectLive', ->
     auction = fabricate 'sale',
       id: 'foo'
       is_auction: true
+      auction_state: 'open'
       live_start_at: moment().startOf('day')
       end_at: moment().endOf('day')
     bidder = {
@@ -161,6 +162,7 @@ describe '#redirectLive', ->
     auction = fabricate 'sale',
       id: 'foo'
       is_auction: true
+      auction_state: 'open'
       live_start_at: moment().startOf('day')
       end_at: moment().endOf('day')
     bidder = {
@@ -179,6 +181,7 @@ describe '#redirectLive', ->
     auction = fabricate 'sale',
       id: 'foo'
       is_auction: true
+      auction_state: 'open'
       live_start_at: null
       end_at: moment().endOf('day')
     routes.redirectLive @req, @res, @next

--- a/apps/auction/test/routes.coffee
+++ b/apps/auction/test/routes.coffee
@@ -181,7 +181,6 @@ describe '#redirectLive', ->
     auction = fabricate 'sale',
       id: 'foo'
       is_auction: true
-      auction_state: 'open'
       live_start_at: null
       end_at: moment().endOf('day')
     routes.redirectLive @req, @res, @next

--- a/components/auction_reminders/fetch.coffee
+++ b/components/auction_reminders/fetch.coffee
@@ -18,6 +18,7 @@ module.exports = class AuctionReminders
     'is_auction'
     'image_versions'
     'image_url'
+    'live'
   ]
 
   constructor: ->

--- a/components/auction_reminders/fetch.coffee
+++ b/components/auction_reminders/fetch.coffee
@@ -18,7 +18,7 @@ module.exports = class AuctionReminders
     'is_auction'
     'image_versions'
     'image_url'
-    'live'
+    'auction_state'
   ]
 
   constructor: ->

--- a/components/auction_reminders/test/fetch.coffee
+++ b/components/auction_reminders/test/fetch.coffee
@@ -17,14 +17,14 @@ describe 'AuctionReminders', ->
     auctionClosingSoon = fabricate 'sale',
       id: 'closing-soon'
       is_auction: true
-      auction_state: 'live'
+      auction_state: 'open'
       some_key_we_dont_want: true
       end_at: moment().add(1, 'hour').format()
 
     auctionNotClosingSoon = fabricate 'sale',
       id: 'not-closing-soon'
       is_auction: true
-      auction_state: 'live'
+      auction_state: 'open'
       end_at: moment().add(10, 'days').format()
 
     auctionAlreadyOver = fabricate 'sale',
@@ -36,21 +36,21 @@ describe 'AuctionReminders', ->
     auctionLiveOpenSoon = fabricate 'sale',
       id: 'live-soon'
       is_auction: true
-      auction_state: 'live'
+      auction_state: 'open'
       end_at: moment().add(3, 'hours').format()
       live_start_at: moment().add(9, 'minutes').format()
     
     auctionLiveOpenNow = fabricate 'sale',
       id: 'live-open'
       is_auction: true
-      auction_state: 'live'
+      auction_state: 'open'
       end_at: moment().add(1, 'hours').format()
       live_start_at: moment().subtract(1, 'hours').format()
 
     auctionClosingSoonAsWell = fabricate 'sale',
       id: 'closing-soon-as-well'
       is_auction: true
-      auction_state: 'live'
+      auction_state: 'open'
       some_key_we_dont_want: true
       end_at: moment().add(12, 'hours').format()
 

--- a/components/auction_reminders/test/fetch.coffee
+++ b/components/auction_reminders/test/fetch.coffee
@@ -18,7 +18,6 @@ describe 'AuctionReminders', ->
       id: 'closing-soon'
       is_auction: true
       auction_state: 'open'
-      some_key_we_dont_want: true
       end_at: moment().add(1, 'hour').format()
 
     auctionNotClosingSoon = fabricate 'sale',
@@ -51,7 +50,6 @@ describe 'AuctionReminders', ->
       id: 'closing-soon-as-well'
       is_auction: true
       auction_state: 'open'
-      some_key_we_dont_want: true
       end_at: moment().add(12, 'hours').format()
 
     @reminders.auctions.reset [

--- a/components/auction_reminders/test/fetch.coffee
+++ b/components/auction_reminders/test/fetch.coffee
@@ -17,34 +17,40 @@ describe 'AuctionReminders', ->
     auctionClosingSoon = fabricate 'sale',
       id: 'closing-soon'
       is_auction: true
+      auction_state: 'live'
       some_key_we_dont_want: true
       end_at: moment().add(1, 'hour').format()
 
     auctionNotClosingSoon = fabricate 'sale',
       id: 'not-closing-soon'
       is_auction: true
+      auction_state: 'live'
       end_at: moment().add(10, 'days').format()
 
     auctionAlreadyOver = fabricate 'sale',
       id: 'already-over'
       is_auction: true
+      auction_state: 'closed'
       end_at: moment().subtract(1, 'day').format()
 
     auctionLiveOpenSoon = fabricate 'sale',
       id: 'live-soon'
       is_auction: true
+      auction_state: 'live'
       end_at: moment().add(3, 'hours').format()
       live_start_at: moment().add(9, 'minutes').format()
     
     auctionLiveOpenNow = fabricate 'sale',
       id: 'live-open'
       is_auction: true
+      auction_state: 'live'
       end_at: moment().add(1, 'hours').format()
       live_start_at: moment().subtract(1, 'hours').format()
 
     auctionClosingSoonAsWell = fabricate 'sale',
       id: 'closing-soon-as-well'
       is_auction: true
+      auction_state: 'live'
       some_key_we_dont_want: true
       end_at: moment().add(12, 'hours').format()
 

--- a/models/sale.coffee
+++ b/models/sale.coffee
@@ -121,7 +121,7 @@ module.exports = class Sale extends Backbone.Model
     @get('live_start_at') and moment(@get('live_start_at')).isBefore(moment(@get('end_at')))
 
   isLiveOpen: ->
-    !!@get('live') and moment().isAfter(@get 'live_start_at')
+    @get('auction_state') == 'live' and moment().isAfter(@get 'live_start_at')
 
   isAuctionPromo: ->
     @get('sale_type') is 'auction promo'

--- a/models/sale.coffee
+++ b/models/sale.coffee
@@ -121,7 +121,7 @@ module.exports = class Sale extends Backbone.Model
     @get('live_start_at') and moment(@get('live_start_at')).isBefore(moment(@get('end_at')))
 
   isLiveOpen: ->
-    @get('auction_state') == 'live' and moment().isAfter(@get 'live_start_at')
+    @get('auction_state') == 'open' and moment().isAfter(@get 'live_start_at')
 
   isAuctionPromo: ->
     @get('sale_type') is 'auction promo'

--- a/models/sale.coffee
+++ b/models/sale.coffee
@@ -120,9 +120,8 @@ module.exports = class Sale extends Backbone.Model
   isLiveAuction: ->
     @get('live_start_at') and moment(@get('live_start_at')).isBefore(moment(@get('end_at')))
 
-  # Is there a way to manually end/close out a live sale besides looking at end_at?
   isLiveOpen: ->
-    @get('live') != false and moment().isAfter(@get 'live_start_at')
+    !!@get('live') and moment().isAfter(@get 'live_start_at')
 
   isAuctionPromo: ->
     @get('sale_type') is 'auction promo'

--- a/models/sale.coffee
+++ b/models/sale.coffee
@@ -122,7 +122,7 @@ module.exports = class Sale extends Backbone.Model
 
   # Is there a way to manually end/close out a live sale besides looking at end_at?
   isLiveOpen: ->
-    moment().isBefore(@get 'end_at') and moment().isAfter(@get 'live_start_at')
+    @get('live') != false and moment().isAfter(@get 'live_start_at')
 
   isAuctionPromo: ->
     @get('sale_type') is 'auction promo'

--- a/test/models/sale.coffee
+++ b/test/models/sale.coffee
@@ -94,6 +94,13 @@ describe 'Sale', ->
         sale = new Sale fabricate 'sale',
           end_at: moment().add(1, 'hours').format()
         sale.isLiveOpen().should.be.false()
+      it 'returns false if sale has a live property of false', ->
+        sale = new Sale fabricate 'sale',
+          end_at: moment().add(10, 'hours').format()
+          live_start_at: moment().subtract(30, 'minutes').format()
+          live: false
+        sale.isLiveOpen().should.be.false()
+
 
     describe '#isRegistrationEnded', ->
       it 'returns false if there is no registration_ends_at', ->

--- a/test/models/sale.coffee
+++ b/test/models/sale.coffee
@@ -20,21 +20,21 @@ describe 'Sale', ->
       @liveOpenSale = new Sale fabricate 'sale',
         end_at: moment().add(1, 'hours').format()
         live_start_at: moment().subtract(1, 'hours').format()
-        live: true
+        auction_state: 'live'
       @liveSoonSale = new Sale fabricate 'sale',
         end_at: moment().add(13, 'hours').format()
         live_start_at: moment().add(8, 'minutes').format()
-        live: true
+        auction_state: 'live'
       @closingSoonSale = new Sale fabricate 'sale',
         end_at: moment().add(12, 'hours')
-        live: true
+        auction_state: 'live'
       @closedSale = new Sale fabricate 'sale',
         end_at: moment().subtract(1, 'day').format()
-        live: false
+        auction_state: 'closed'
       @liveClosedSale = new Sale fabricate 'sale',
         end_at: moment().add(1, 'day').format()
         live_start_at: moment().subtract(1, 'hours').format()
-        live: false
+        auction_state: 'closed'
 
     describe '#reminderStatus', ->
       it 'returns a string for a valid reminder state', ->
@@ -96,13 +96,13 @@ describe 'Sale', ->
         sale = new Sale fabricate 'sale',
           end_at: moment().add(1, 'hours').format()
           live_start_at: moment().add(30, 'minutes').format()
-          live: true
+          auction_state: 'live'
         sale.isLiveOpen().should.be.false()
       it 'returns false if sale has a live property of false', ->
         sale = new Sale fabricate 'sale',
           end_at: moment().add(10, 'hours').format()
           live_start_at: moment().subtract(30, 'minutes').format()
-          live: false
+          auction_state: 'closed'
         sale.isLiveOpen().should.be.false()
       it 'returns false if sale is not a live auction', ->
         sale = new Sale fabricate 'sale',
@@ -231,7 +231,7 @@ describe 'Sale', ->
         @sale.bidButtonState(@user, @artwork).label.should.equal 'Bid'
 
       it 'shows Enter Live Auction if live auction has opened', ->
-        @sale.set is_auction: true, live_start_at: moment().subtract(2, 'days').format(), end_at: moment().add(1, 'days').format(), live: true
+        @sale.set is_auction: true, live_start_at: moment().subtract(2, 'days').format(), end_at: moment().add(1, 'days').format(), auction_state: 'live'
         @sale.set is_auction: true, registration_ends_at: moment().subtract(2, 'days').format()
         @user.set 'registered_to_bid', true
         @user.set 'qualified_for_bidding', true

--- a/test/models/sale.coffee
+++ b/test/models/sale.coffee
@@ -20,14 +20,14 @@ describe 'Sale', ->
       @liveOpenSale = new Sale fabricate 'sale',
         end_at: moment().add(1, 'hours').format()
         live_start_at: moment().subtract(1, 'hours').format()
-        auction_state: 'live'
+        auction_state: 'open'
       @liveSoonSale = new Sale fabricate 'sale',
         end_at: moment().add(13, 'hours').format()
         live_start_at: moment().add(8, 'minutes').format()
-        auction_state: 'live'
+        auction_state: 'open'
       @closingSoonSale = new Sale fabricate 'sale',
         end_at: moment().add(12, 'hours')
-        auction_state: 'live'
+        auction_state: 'open'
       @closedSale = new Sale fabricate 'sale',
         end_at: moment().subtract(1, 'day').format()
         auction_state: 'closed'
@@ -96,7 +96,7 @@ describe 'Sale', ->
         sale = new Sale fabricate 'sale',
           end_at: moment().add(1, 'hours').format()
           live_start_at: moment().add(30, 'minutes').format()
-          auction_state: 'live'
+          auction_state: 'open'
         sale.isLiveOpen().should.be.false()
       it 'returns false if sale has a live property of false', ->
         sale = new Sale fabricate 'sale',
@@ -231,7 +231,7 @@ describe 'Sale', ->
         @sale.bidButtonState(@user, @artwork).label.should.equal 'Bid'
 
       it 'shows Enter Live Auction if live auction has opened', ->
-        @sale.set is_auction: true, live_start_at: moment().subtract(2, 'days').format(), end_at: moment().add(1, 'days').format(), auction_state: 'live'
+        @sale.set is_auction: true, live_start_at: moment().subtract(2, 'days').format(), end_at: moment().add(1, 'days').format(), auction_state: 'open'
         @sale.set is_auction: true, registration_ends_at: moment().subtract(2, 'days').format()
         @user.set 'registered_to_bid', true
         @user.set 'qualified_for_bidding', true

--- a/test/models/sale.coffee
+++ b/test/models/sale.coffee
@@ -20,11 +20,21 @@ describe 'Sale', ->
       @liveOpenSale = new Sale fabricate 'sale',
         end_at: moment().add(1, 'hours').format()
         live_start_at: moment().subtract(1, 'hours').format()
+        live: true
       @liveSoonSale = new Sale fabricate 'sale',
         end_at: moment().add(13, 'hours').format()
         live_start_at: moment().add(8, 'minutes').format()
-      @closingSoonSale = new Sale fabricate 'sale', end_at: moment().add(12, 'hours')
-      @closedSale = new Sale fabricate 'sale', end_at: moment().subtract(1, 'day').format()
+        live: true
+      @closingSoonSale = new Sale fabricate 'sale',
+        end_at: moment().add(12, 'hours')
+        live: true
+      @closedSale = new Sale fabricate 'sale',
+        end_at: moment().subtract(1, 'day').format()
+        live: false
+      @liveClosedSale = new Sale fabricate 'sale',
+        end_at: moment().add(1, 'day').format()
+        live_start_at: moment().subtract(1, 'hours').format()
+        live: false
 
     describe '#reminderStatus', ->
       it 'returns a string for a valid reminder state', ->
@@ -81,24 +91,22 @@ describe 'Sale', ->
 
     describe '#isLiveOpen', ->
       it 'returns true if sale is currently open for live bidding', ->
-        sale = new Sale fabricate 'sale',
-          end_at: moment().add(1, 'hours').format()
-          live_start_at: moment().subtract(1, 'hours').format()
-        sale.isLiveOpen().should.be.true()
-      it 'returns false if sale is not open for live bidding', ->
+        @liveOpenSale.isLiveOpen().should.be.true()
+      it 'returns false if it is not live_start_at time yet', ->
         sale = new Sale fabricate 'sale',
           end_at: moment().add(1, 'hours').format()
           live_start_at: moment().add(30, 'minutes').format()
-        sale.isLiveOpen().should.be.false()
-      it 'returns false if sale is not a live auction', ->
-        sale = new Sale fabricate 'sale',
-          end_at: moment().add(1, 'hours').format()
+          live: true
         sale.isLiveOpen().should.be.false()
       it 'returns false if sale has a live property of false', ->
         sale = new Sale fabricate 'sale',
           end_at: moment().add(10, 'hours').format()
           live_start_at: moment().subtract(30, 'minutes').format()
           live: false
+        sale.isLiveOpen().should.be.false()
+      it 'returns false if sale is not a live auction', ->
+        sale = new Sale fabricate 'sale',
+          end_at: moment().add(1, 'hours').format()
         sale.isLiveOpen().should.be.false()
 
 
@@ -223,7 +231,7 @@ describe 'Sale', ->
         @sale.bidButtonState(@user, @artwork).label.should.equal 'Bid'
 
       it 'shows Enter Live Auction if live auction has opened', ->
-        @sale.set is_auction: true, live_start_at: moment().subtract(2, 'days').format(), end_at: moment().add(1, 'days').format()
+        @sale.set is_auction: true, live_start_at: moment().subtract(2, 'days').format(), end_at: moment().add(1, 'days').format(), live: true
         @sale.set is_auction: true, registration_ends_at: moment().subtract(2, 'days').format()
         @user.set 'registered_to_bid', true
         @user.set 'qualified_for_bidding', true


### PR DESCRIPTION
I think this will be a more reliable way of showing reminders for live sales- the reminder status will go back to false once the `live: false` property is set.