### PR TITLE
@xtina-starr => Always display a featured bio over the Artsy one

### DIFF
--- a/apps/artist/queries/server.coffee
+++ b/apps/artist/queries/server.coffee
@@ -14,7 +14,7 @@ module.exports = """
       location
       hometown
       is_consignable
-      biography_blurb (format: HTML) @include(if: $includeBlurb) {
+      biography_blurb (format: HTML, partner_bio: true) @include(if: $includeBlurb) {
         text
         credit
       }


### PR DESCRIPTION
Minor miscommunication, if we have a featured partner bio we _always_ want to display it on the Artist page, and not just when there's also no Artsy bio.

The additional param here does just that, always returns a featured bio if there is one, irregardless of the presence of an Artsy bio.