### PR TITLE
@sweir27 => Search results fix css

### DIFF
--- a/components/search_bar/index.styl
+++ b/components/search_bar/index.styl
@@ -110,14 +110,13 @@ search-bar-input-placeholder()
     display none
 
 .mlsb-suggestion
-  display block
+  display flex
   width 100%
   text-decoration none
   overflow ellipsis
 
 .mlsb-suggestion-thumbnail,
 .mlsb-suggestion-value
-  display inline-block
   line-height suggestion-thumbnail-size
   height suggestion-height
   vertical-align top


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/366

We're still not sure how this bug got introduced, but this uses flexbox instead of block to show search results. 