### PR TITLE
@xtina-starr => Dont include reference shows in show rail

### DIFF
--- a/apps/artist/client/views/overview.coffee
+++ b/apps/artist/client/views/overview.coffee
@@ -63,8 +63,10 @@ module.exports = class OverviewView extends Backbone.View
     @$('.artist-related-rail').map ->
       section = ($el = $(this)).data('id')
       items = artist[section]
+      items = _.where(items, { is_reference: false }) if section is 'shows'
       count = artist.counts[section]
       return if not items
+
       renderRail _.extend $el: $el.find('.js-artist-rail'), { section, count, items, following, baseHref }
 
   renderExhibitionHighlights: ({shows, counts}) ->

--- a/apps/artist/queries/show_fragment.coffee
+++ b/apps/artist/queries/show_fragment.coffee
@@ -22,5 +22,6 @@ module.exports =
     start_at
     end_at
     exhibition_period
+    is_reference
   }
   """


### PR DESCRIPTION
cc @briansw 

Kinda weird one, we want to include reference shows in the exhibition highlights and list of shows...but that same data is _also_ used to render this rail.

So, just for purposes of rendering the show rail, we want to remove ref shows.