### PR TITLE
@xtina-starr: Fix styling of artworks in auction 

### DIFF
--- a/apps/artwork/components/auction_artworks/index.styl
+++ b/apps/artwork/components/auction_artworks/index.styl
@@ -42,7 +42,7 @@
   .artwork-brick.artwork-brick--auction.js-artwork-brick
     flex 1
     max-width calc(33% \- 12px)
-    height 520px
+    height 500px
     margin-right 20px
     position relative
 

--- a/apps/artwork/components/auction_artworks/index.styl
+++ b/apps/artwork/components/auction_artworks/index.styl
@@ -41,9 +41,10 @@
 
   .artwork-brick.artwork-brick--auction.js-artwork-brick
     flex 1
-    max-width 33%
-    height 500px
+    max-width calc(33% \- 12px)
+    height 520px
     margin-right 20px
+    position relative
 
     &:last-child
       margin-right 0

--- a/components/artwork_metadata_stub/index.styl
+++ b/components/artwork_metadata_stub/index.styl
@@ -7,6 +7,11 @@
   height (line-height-in-px('garamond-l-caption') * lines)
   overflow hidden
 
+  &__sale-artwork__buttons
+    width 100%
+    bottom 0
+    position absolute
+
   &__line
     display block
     overflow ellipsis

--- a/components/artwork_metadata_stub/index.styl
+++ b/components/artwork_metadata_stub/index.styl
@@ -7,10 +7,8 @@
   height (line-height-in-px('garamond-l-caption') * lines)
   overflow hidden
 
-  &__sale-artwork__buttons
-    width 100%
-    bottom 0
-    position absolute
+  &__sale-artwork__estimate
+    overflow ellipsis
 
   &__line
     display block


### PR DESCRIPTION
This does some minor style fixes on top of https://github.com/artsy/force/pull/347 Basically we are setting a height of 500px on these artwork "bricks" and that wasn't accommodating when artworks have prices that break on two lines as they do in this auction with prices in HKD (plus some other small things to tidy up the margins).

EDIT: Decided to use overflow: ellipsis instead to keep  things lining up

![image](https://cloud.githubusercontent.com/assets/555859/20157837/3b0cc1fe-a6a5-11e6-90db-261d823b7e09.png)
