### PR TITLE
@mzikherman => Set contact_gallery to false for auction (ask specialist) inquiries

### DIFF
--- a/apps/artwork/components/auction/view.coffee
+++ b/apps/artwork/components/auction/view.coffee
@@ -52,7 +52,7 @@ module.exports = class ArtworkAuctionView extends Backbone.View
 
   inquire: (e) ->
     e.preventDefault()
-    inquire AUCTION.artwork_id
+    inquire AUCTION.artwork_id, false
 
   acquire: (e) ->
     e.preventDefault()

--- a/apps/artwork/components/commercial/test/view.coffee
+++ b/apps/artwork/components/commercial/test/view.coffee
@@ -85,6 +85,7 @@ describe 'ArtworkCommercialView', ->
             session_id: undefined,
             referring_url: undefined,
             landing_url: undefined,
+            contact_gallery: true,
             artwork: 'lynn-hershman-leeson-wrapped',
             name: 'Damon',
             email: 'damon@artsy',

--- a/apps/artwork/lib/inquire.coffee
+++ b/apps/artwork/lib/inquire.coffee
@@ -4,9 +4,9 @@ Artwork = require '../../../models/artwork.coffee'
 ArtworkInquiry = require '../../../models/artwork_inquiry.coffee'
 openInquiryQuestionnaireFor = require '../../../components/inquiry_questionnaire/index.coffee'
 
-module.exports = (id) ->
+module.exports = (id, contact_gallery = true) ->
   user = User.instantiate()
-  inquiry = new ArtworkInquiry notification_delay: 600
+  inquiry = new ArtworkInquiry notification_delay: 600, contact_gallery: contact_gallery
   artwork = new Artwork id: id
 
   Promise artwork.fetch()

--- a/components/contact/contact_partner.coffee
+++ b/components/contact/contact_partner.coffee
@@ -21,6 +21,7 @@ module.exports = class ContactPartnerView extends ContactView
       artwork: @artwork
       partner: @partner
       user: @user
+      contactGallery: @model.get('contact_gallery')
 
   formTemplate: (locals) =>
     formTemplate _.extend locals,

--- a/components/contact/inquiry.coffee
+++ b/components/contact/inquiry.coffee
@@ -22,7 +22,7 @@ module.exports = class InquiryView extends ContactView
     formTemplate _.extend locals,
       artwork: @artwork
       user: @user
-      contactGallery: false
+      contactGallery: @model.contact_gallery
 
   defaults: -> _.extend super,
     url: "#{API_URL}/api/v1/me/artwork_inquiry_request"
@@ -48,10 +48,8 @@ module.exports = class InquiryView extends ContactView
     super
 
     analyticsHooks.trigger 'inquiry:sync', artwork: @artwork, inquiry: @model
-
     contactGallery = if @partner.get('directly_contactable') and \
       @sales.findWhere(is_auction: true)? then yes else no
-
     @model.set
       artwork: @artwork.id
       contact_gallery: contactGallery

--- a/components/contact/inquiry.coffee
+++ b/components/contact/inquiry.coffee
@@ -22,7 +22,7 @@ module.exports = class InquiryView extends ContactView
     formTemplate _.extend locals,
       artwork: @artwork
       user: @user
-      contactGallery: @model.contact_gallery
+      contactGallery: @model.get('contact_gallery')
 
   defaults: -> _.extend super,
     url: "#{API_URL}/api/v1/me/artwork_inquiry_request"

--- a/components/inquiry_questionnaire/test/views/inquiry.coffee
+++ b/components/inquiry_questionnaire/test/views/inquiry.coffee
@@ -86,7 +86,7 @@ describe 'Inquiry', setup ->
       @view.__serialize__.then =>
         # Sets up the inquiry
         @inquiry.get('message').should.equal 'I wish to buy the foo bar'
-        @inquiry.get('contact_gallery').should.be.true()
+        @inquiry.get('contact_gallery').should.equal 'true'
         @inquiry.get('artwork').should.equal @artwork.id
 
         # Sets up the user
@@ -127,6 +127,30 @@ describe 'Inquiry', setup ->
       Backbone.sync.callCount.should.equal 3
 
       @view.nudged.restore()
+
+  describe 'in ask specialist context', ->
+    beforeEach ->
+      @state.set 'steps', ['inquiry', 'after_inquiry']
+      @inquiry.contact_gallery = false
+      @view = new Inquiry
+        user: @currentUser
+        artwork: @artwork
+        inquiry: @inquiry
+        state: @state
+
+      @view.render()
+
+    it 'sets up the inquiry and properly sets contact gallery', ->
+      @view.$('input[name="name"]').val 'Foo Bar'
+      @view.$('input[name="email"]').val 'foo@bar.com'
+      @view.$('textarea[name="message"]').val 'I wish to buy the foo bar'
+      @view.$('button').click()
+
+      @view.__serialize__.then =>
+        # Sets up the inquiry
+        @inquiry.get('message').should.equal 'I wish to buy the foo bar'
+        @inquiry.get('contact_gallery').should.equal 'true'
+        @inquiry.get('artwork').should.equal @artwork.id
 
   describe 'in a fair context', ->
     beforeEach ->

--- a/components/inquiry_questionnaire/test/views/test_inquiry.coffee
+++ b/components/inquiry_questionnaire/test/views/test_inquiry.coffee
@@ -83,7 +83,7 @@ describe 'Inquiry', setup ->
       @view.__serialize__.then =>
         # Sets up the inquiry
         @inquiry.get('message').should.equal 'I wish to buy the foo bar'
-        @inquiry.get('contact_gallery').should.be.true()
+        @inquiry.get('contact_gallery').should.equal 'true'
         @inquiry.get('artwork').should.equal @artwork.id
 
         # Sets up the user
@@ -126,7 +126,7 @@ describe 'Inquiry', setup ->
       @view.__serialize__.then =>
         # Sets up the inquiry
         @inquiry.get('message').should.equal 'I wish to buy the foo bar'
-        @inquiry.get('contact_gallery').should.be.true()
+        @inquiry.get('contact_gallery').should.equal 'true'
         @inquiry.get('artwork').should.equal @artwork.id
 
         # Sets up the user

--- a/components/inquiry_questionnaire/views/inquiry.coffee
+++ b/components/inquiry_questionnaire/views/inquiry.coffee
@@ -13,6 +13,7 @@ module.exports = class Inquiry extends StepView
     template _.extend data,
       fair: @artwork.related().fairs.first()
       message: @inquiry.get('message') or @defaultMessage()
+      contactGallery: @inquiry.get('contact_gallery')
 
   __events__:
     'click button': 'serialize'
@@ -49,7 +50,7 @@ module.exports = class Inquiry extends StepView
         .related().userFairActions.attendFair @artwork.related().fairs.first()
 
     @__serialize__ = Q.allSettled [
-      @inquiry.save _.extend { contact_gallery: true }, data
+      @inquiry.save _.extend { contact_gallery: @inquiry.get('contact_gallery') }, data
       @user.save @inquiry.pick('name', 'email')
       @user.related().account.fetch()
     ]

--- a/components/inquiry_questionnaire/views/specialist.coffee
+++ b/components/inquiry_questionnaire/views/specialist.coffee
@@ -35,7 +35,7 @@ module.exports = class Specialist extends StepView
     form.state 'loading'
 
     @__serialize__ = Q.all [
-      @inquiry.save _.extend { contact_gallery: false }, form.data()
+      @inquiry.save _.extend form.data(), { contact_gallery: false }
       @user.save @inquiry.pick('name', 'email')
     ]
       .then =>

--- a/components/inquiry_questionnaire/views/test_inquiry.coffee
+++ b/components/inquiry_questionnaire/views/test_inquiry.coffee
@@ -17,6 +17,7 @@ module.exports = class Inquiry extends StepView
     template _.extend data,
       fair: @artwork.related().fairs.first()
       message: @inquiry.get('message') or @defaultMessage()
+      contactGallery: @inquiry.get('contact_gallery')
 
   __events__:
     'click button': 'serialize'
@@ -29,7 +30,6 @@ module.exports = class Inquiry extends StepView
 
   maybeSaveInquiry: (data) ->
     promise = Q.defer()
-
     attributes = _.extend { contact_gallery: true }, data
 
     if @user.isLoggedOut()

--- a/components/simple_contact/templates/forms/inquiry.jade
+++ b/components/simple_contact/templates/forms/inquiry.jade
@@ -4,9 +4,9 @@
 form.scontact-form.stacked-form.js-inquiry-form
   .scontact-errors.js-form-errors
     //- Rendered separately
-
   .stacked-form-cell
     input( type='hidden', name='artwork', value= artwork.id )
+    input( type='hidden', name='contact_gallery', value="#{contactGallery}" )
 
     .scontact-artwork-details
       img( src=artwork.defaultImageUrl() )

--- a/models/artwork_inquiry.coffee
+++ b/models/artwork_inquiry.coffee
@@ -10,6 +10,7 @@ module.exports = class ArtworkInquiry extends Backbone.Model
     session_id: SESSION_ID
     referring_url: Cookies.get('force-referrer')
     landing_url: Cookies.get('force-session-start')
+    contact_gallery: true
 
   send: (attributes, options = {}) ->
     @save attributes, _.extend options,


### PR DESCRIPTION
# Problem
Currently for inquiries on artworks during an auction, we show _ask specialist_ button. Ask specialist inquiries are the ones that don't go to partners and are going to Artsy specialist staff. For that to work, the inquiry post request should set `contact_gallery` to `false` otherwise API will treat them as a normal `Contact Gallery` inquiry. Currently `contact_gallery` is `true` for Auction Inquiries.

# (_possible_) Solution
I've modified `apps/artwork/lib/inquire.coffee` to get a `contact_gallery` parameter which by default is `true`. Then this method will use that parameter to set `contact_gallery` on [`ArtworkInquiry`](https://github.com/artsy/force/compare/master...ashkan18:auction-ask-specialist?expand=1#diff-e8c1e8db53467ac60d7d0e7430e24eb8R9).
Then I modified all the places that we render `inquiry.jade` to pass `ContactGallery` using the inquiry's `contact_gallery`.
In `components/simple_contact/templates/forms/inquiry.jade` I added a new [hidden field](https://github.com/artsy/force/compare/master...ashkan18:auction-ask-specialist?expand=1#diff-ecc3eb67a1a685a02732109fc8846fa1R9) to the form which will be part of submitted form which makes sure we use proper `contact_gallery` value.

In `apps/artwork/components/auction/view.coffee` when calling `inquire` method we also pass `false` for `contact_gallery` to make sure it's properly set on inquiry. 

cc: @broskoski @starsirius 

fixes https://github.com/artsy/force/issues/388