### PR TITLE
@eessex => Fixes date error on articles

### DIFF
--- a/models/article.coffee
+++ b/models/article.coffee
@@ -115,7 +115,7 @@ module.exports = class Article extends Backbone.Model
     crop @get(attr), args...
 
   date: (attr) ->
-    moment(@get(attr), 'ddd MMM DD YYYY hh:mm:ss Z ZZ').local()
+    moment(@get(attr)).local()
 
   strip: (attr) ->
     stripTags(@get attr)

--- a/models/article.coffee
+++ b/models/article.coffee
@@ -115,7 +115,7 @@ module.exports = class Article extends Backbone.Model
     crop @get(attr), args...
 
   date: (attr) ->
-    moment(@get(attr)).local()
+    moment(new Date(@get(attr))).local()
 
   strip: (attr) ->
     stripTags(@get attr)


### PR DESCRIPTION
I naively assumed that the formatting coming back from GraphQL was the same as the database, but it's actually returning a ISO date. This converts the date to a JS Date format first, which allows us to pass either format.
