### PR TITLE
 @kanaabe : add article image thumbnails to auto-suggest #donotmerge

### DIFF
--- a/models/search_result.coffee
+++ b/models/search_result.coffee
@@ -46,7 +46,7 @@ module.exports = class SearchResult extends Backbone.Model
     text.replace new RegExp("(#{term})", 'ig'), '<span class="is-highlighted">$1</span>'
 
   imageUrl: ->
-    "#{sd.APP_URL}/search/image/#{@get('model')}/#{@get('id')}"
+    @get('image_url')
 
   updateForFair: (fair) ->
     if @get('display_model') == 'Show'


### PR DESCRIPTION
- Image urls are now returned as metadata by the Gravity Search API, so stop using the `/api/v1/:model/:id/image` endpoints to fetch these. 
- Adds article image thumbnails to our auto-suggest (as a side effect).
- Depends on [gravity#10564](https://github.com/artsy/gravity/pull/10564/), so please don't merge till that has been deployed (I will notify here).
- Depends on [positron#842](https://github.com/artsy/positron/pull/842)