### PR TITLE
@xtina-starr - Adapt imageUrl for artwork to crop in the context of search results

### DIFF
--- a/apps/search/client/index.coffee
+++ b/apps/search/client/index.coffee
@@ -5,7 +5,7 @@ sd = require('sharify').data
 Artist = require '../../../models/artist.coffee'
 Gene = require '../../../models/gene.coffee'
 Artwork = require '../../../models/artwork.coffee'
-{ crop, fill } = require '../../../components/resizer/index.coffee'
+{ crop } = require '../../../components/resizer/index.coffee'
 
 imageTemplate = -> require('../templates/image-template.jade') arguments...
 resolvedImage = -> require('../templates/image.jade') arguments...

--- a/apps/search/client/index.coffee
+++ b/apps/search/client/index.coffee
@@ -5,6 +5,7 @@ sd = require('sharify').data
 Artist = require '../../../models/artist.coffee'
 Gene = require '../../../models/gene.coffee'
 Artwork = require '../../../models/artwork.coffee'
+{ crop, fill } = require '../../../components/resizer/index.coffee'
 
 imageTemplate = -> require('../templates/image-template.jade') arguments...
 resolvedImage = -> require('../templates/image.jade') arguments...
@@ -56,6 +57,10 @@ module.exports.SearchResultsView = class SearchResultsView extends Backbone.View
     artwork = new Artwork(id: result.id)
     artwork.fetch
       success: ->
+        artwork.set 'image_url', artwork.imageUrl()
+        artwork.imageUrl = ->
+          url = artwork.get('image_url')
+          crop url, width: 70, height: 70
         @$(".search-result[data-id='#{result.id}'] .search-result-thumbnail-fallback").html resolvedImage(result: artwork)
 
 module.exports.init = ->

--- a/apps/search/models/google_search_result.coffee
+++ b/apps/search/models/google_search_result.coffee
@@ -33,6 +33,7 @@ module.exports = class GooogleSearchResult extends Backbone.Model
   imageUrl: ->
     return null if @get('display_model') is 'artist'
     return "" if @get('display_model') is 'artwork'
+
     src = @get('pagemap')?.cse_thumbnail?[0].src or @get('pagemap')?.cse_image?[0].src
     if @get('display_model') is 'Gallery'
       fill src, width: 70, height: 70, color: 'fff'

--- a/apps/search/test/client/index.coffee
+++ b/apps/search/test/client/index.coffee
@@ -35,6 +35,6 @@ describe 'SearchResultsView', ->
 
     Backbone.sync.args[1][2].success(fabricate 'artwork', id: 'maya-hayuk-untitled')
 
-    @view.$el.html().should.containEql("/local/additional_images/4e7cb83e1c80dd00010038e2/1/small.jpg")
+    @view.$el.html().should.containEql("https://i.embed.ly/1/display/crop?url=%2Flocal%2Fadditional_images%2F4e7cb83e1c80dd00010038e2%2F1%2Fsmall.jpg")
 
 


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/389 
(sorry, sniped your issue!)

For these search results, we can't always rely on what google returns so we fetch the artwork again and render over the image, but since we are passing in an `Artwork` model, the `imageUrl` returns something different than the `SearchResult` model. This overrides the artwork `imageUrl` method to returned a cropped version of the image.