### PR TITLE
@starsirius - Fix "Ask a Specialist" button on auction pages

### DIFF
--- a/apps/artwork/lib/inquire.coffee
+++ b/apps/artwork/lib/inquire.coffee
@@ -11,6 +11,8 @@ module.exports = (id) ->
 
   Promise artwork.fetch()
     .then ->
+      artwork.set('is_in_auction', true) if sd.AUCTION?
+
       openInquiryQuestionnaireFor
         user: user
         artwork: artwork

--- a/components/inquiry_questionnaire/map/decisions.coffee
+++ b/components/inquiry_questionnaire/map/decisions.coffee
@@ -5,8 +5,7 @@ hasSeenThisSession = (steps...) -> ({ logger }) -> logger.hasLoggedThisSession s
 
 decisions =
   is_auction: ({ artwork }) ->
-    artwork.related()
-      .partner.get('type') is "Auction"
+    artwork.get('is_in_auction') is true
 
   pre_qualify: ({ artwork }) ->
     artwork.related()

--- a/components/inquiry_questionnaire/map/decisions.coffee
+++ b/components/inquiry_questionnaire/map/decisions.coffee
@@ -4,6 +4,10 @@ hasSeen = (steps...) -> ({ logger }) -> logger.hasLogged steps...
 hasSeenThisSession = (steps...) -> ({ logger }) -> logger.hasLoggedThisSession steps...
 
 decisions =
+  is_auction: ({ artwork }) ->
+    artwork.related()
+      .partner.get('type') is "Auction"
+
   pre_qualify: ({ artwork }) ->
     artwork.related()
       .partner.get('pre_qualify') is true

--- a/components/inquiry_questionnaire/map/steps.coffee
+++ b/components/inquiry_questionnaire/map/steps.coffee
@@ -1,4 +1,5 @@
 module.exports = [
+  { is_auction: true: ['specialist'] }
   { is_logged_out_but_has_account: true: ['account'] }
   pre_qualify: {
     true: [

--- a/components/inquiry_questionnaire/map/steps.coffee
+++ b/components/inquiry_questionnaire/map/steps.coffee
@@ -1,57 +1,61 @@
 module.exports = [
-  { is_auction: true: ['specialist'] }
-  { is_logged_out_but_has_account: true: ['account'] }
-  pre_qualify: {
-    true: [
-      { has_seen_commercial_interest: false: ['commercial_interest'] }
-      {
-        is_collector:
-          true: [
-            { has_basic_info: false: ['basic_info'] }
-            { has_seen_artists_in_collection: false: ['artists_in_collection'] }
-            { has_seen_galleries_you_work_with: false: ['galleries_you_work_with'] }
-            { has_seen_auction_houses_you_work_with: false: ['auction_houses_you_work_with'] }
-            { has_seen_fairs_you_attend: false: ['fairs_you_attend'] }
-            { has_seen_institutional_affiliations: false: ['institutional_affiliations'] }
-            'inquiry'
-          ]
-          false: [
-            'how_can_we_help'
-            {
-              help_by:
-                price: ['specialist']
-                purchase: [
-                  { has_basic_info: false: ['basic_info'] }
-                  'inquiry'
-                ]
-                student_research_question: ['specialist']
-                journalist_question: ['inquiry']
-                other_question: ['specialist']
-            }
-          ]
-      }
-    ]
+  is_auction: {
+    true: ['specialist']
     false: [
-      'inquiry'
       { is_logged_out_but_has_account: true: ['account'] }
-      { has_completed_profile: false: ['confirmation'] }
-      { has_seen_commercial_interest: false: ['commercial_interest'] }
-      { has_basic_info: false: ['basic_info'] }
-      {
-        is_collector: true: [
-          { has_seen_artists_in_collection: false: ['artists_in_collection'] }
-          { has_seen_galleries_you_work_with: false: ['galleries_you_work_with'] }
-          { has_seen_auction_houses_you_work_with: false: ['auction_houses_you_work_with'] }
-          { has_seen_fairs_you_attend: false: ['fairs_you_attend'] }
-          { has_seen_institutional_affiliations: false: ['institutional_affiliations'] }
+      pre_qualify: {
+        true: [
+          { has_seen_commercial_interest: false: ['commercial_interest'] }
+          {
+            is_collector:
+              true: [
+                { has_basic_info: false: ['basic_info'] }
+                { has_seen_artists_in_collection: false: ['artists_in_collection'] }
+                { has_seen_galleries_you_work_with: false: ['galleries_you_work_with'] }
+                { has_seen_auction_houses_you_work_with: false: ['auction_houses_you_work_with'] }
+                { has_seen_fairs_you_attend: false: ['fairs_you_attend'] }
+                { has_seen_institutional_affiliations: false: ['institutional_affiliations'] }
+                'inquiry'
+              ]
+              false: [
+                'how_can_we_help'
+                {
+                  help_by:
+                    price: ['specialist']
+                    purchase: [
+                      { has_basic_info: false: ['basic_info'] }
+                      'inquiry'
+                    ]
+                    student_research_question: ['specialist']
+                    journalist_question: ['inquiry']
+                    other_question: ['specialist']
+                }
+              ]
+          }
+        ]
+        false: [
+          'inquiry'
+          { is_logged_out_but_has_account: true: ['account'] }
+          { has_completed_profile: false: ['confirmation'] }
+          { has_seen_commercial_interest: false: ['commercial_interest'] }
+          { has_basic_info: false: ['basic_info'] }
+          {
+            is_collector: true: [
+              { has_seen_artists_in_collection: false: ['artists_in_collection'] }
+              { has_seen_galleries_you_work_with: false: ['galleries_you_work_with'] }
+              { has_seen_auction_houses_you_work_with: false: ['auction_houses_you_work_with'] }
+              { has_seen_fairs_you_attend: false: ['fairs_you_attend'] }
+              { has_seen_institutional_affiliations: false: ['institutional_affiliations'] }
+            ]
+          }
         ]
       }
-    ]
-  }
-  {
-    is_logged_in: false: [
-      { has_seen_confirmation_this_session: false: ['confirmation'] }
-      'account'
+      {
+        is_logged_in: false: [
+          { has_seen_confirmation_this_session: false: ['confirmation'] }
+          'account'
+        ]
+      }
     ]
   }
   'done'

--- a/components/inquiry_questionnaire/map/test_steps.coffee
+++ b/components/inquiry_questionnaire/map/test_steps.coffee
@@ -1,4 +1,5 @@
 module.exports = [
+  { is_auction: true: ['specialist'] }
   { is_logged_out_but_has_account: true: ['account'] }
   pre_qualify: {
     true: [

--- a/components/inquiry_questionnaire/map/test_steps.coffee
+++ b/components/inquiry_questionnaire/map/test_steps.coffee
@@ -1,71 +1,78 @@
 module.exports = [
-  { is_auction: true: ['specialist'] }
-  { is_logged_out_but_has_account: true: ['account'] }
-  pre_qualify: {
+  is_auction: {
     true: [
-      { has_seen_commercial_interest: false: ['commercial_interest'] }
-      {
-        is_collector:
-          true: [
-            { has_basic_info: false: ['basic_info'] }
-            { has_seen_artists_in_collection: false: ['artists_in_collection'] }
-            { has_seen_galleries_you_work_with: false: ['galleries_you_work_with'] }
-            { has_seen_auction_houses_you_work_with: false: ['auction_houses_you_work_with'] }
-            { has_seen_fairs_you_attend: false: ['fairs_you_attend'] }
-            { has_seen_institutional_affiliations: false: ['institutional_affiliations'] }
-            'test_inquiry'
-            { is_logged_out: true: ['test_account'] }
-          ]
-          false: [
-            'how_can_we_help'
-            {
-              help_by:
-                price: [
-                  'test_specialist'
-                  { is_logged_out: true: ['test_account'] }
-                ]
-                purchase: [
-                  { has_basic_info: false: ['basic_info'] }
-                  'test_inquiry'
-                  { is_logged_out: true: ['test_account'] }
-                ]
-                student_research_question: [
-                  'test_specialist'
-                  { is_logged_out: true: ['test_account'] }
-                ]
-                journalist_question: [
-                  'test_inquiry'
-                  { is_logged_out: true: ['test_account'] }
-                ]
-                other_question: [
-                  'test_specialist'
-                  { is_logged_out: true: ['test_account'] }
-                ]
-            }
-          ]
-      }
+      'test_specialist'
+      { is_logged_out: true: ['test_account'] }
     ]
     false: [
-      'test_inquiry'
-      { is_logged_out: true: ['test_account'] }
-      { has_completed_profile: false: ['confirmation'] }
-      { has_seen_commercial_interest: false: ['commercial_interest'] }
-      { has_basic_info: false: ['basic_info'] }
-      {
-        is_collector: true: [
-          { has_seen_artists_in_collection: false: ['artists_in_collection'] }
-          { has_seen_galleries_you_work_with: false: ['galleries_you_work_with'] }
-          { has_seen_auction_houses_you_work_with: false: ['auction_houses_you_work_with'] }
-          { has_seen_fairs_you_attend: false: ['fairs_you_attend'] }
-          { has_seen_institutional_affiliations: false: ['institutional_affiliations'] }
+      { is_logged_out_but_has_account: true: ['account'] }
+      pre_qualify: {
+        true: [
+          { has_seen_commercial_interest: false: ['commercial_interest'] }
+          {
+            is_collector:
+              true: [
+                { has_basic_info: false: ['basic_info'] }
+                { has_seen_artists_in_collection: false: ['artists_in_collection'] }
+                { has_seen_galleries_you_work_with: false: ['galleries_you_work_with'] }
+                { has_seen_auction_houses_you_work_with: false: ['auction_houses_you_work_with'] }
+                { has_seen_fairs_you_attend: false: ['fairs_you_attend'] }
+                { has_seen_institutional_affiliations: false: ['institutional_affiliations'] }
+                'test_inquiry'
+                { is_logged_out: true: ['test_account'] }
+              ]
+              false: [
+                'how_can_we_help'
+                {
+                  help_by:
+                    price: [
+                      'test_specialist'
+                      { is_logged_out: true: ['test_account'] }
+                    ]
+                    purchase: [
+                      { has_basic_info: false: ['basic_info'] }
+                      'test_inquiry'
+                      { is_logged_out: true: ['test_account'] }
+                    ]
+                    student_research_question: [
+                      'test_specialist'
+                      { is_logged_out: true: ['test_account'] }
+                    ]
+                    journalist_question: [
+                      'test_inquiry'
+                      { is_logged_out: true: ['test_account'] }
+                    ]
+                    other_question: [
+                      'test_specialist'
+                      { is_logged_out: true: ['test_account'] }
+                    ]
+                }
+              ]
+          }
+        ]
+        false: [
+          'test_inquiry'
+          { is_logged_out: true: ['test_account'] }
+          { has_completed_profile: false: ['confirmation'] }
+          { has_seen_commercial_interest: false: ['commercial_interest'] }
+          { has_basic_info: false: ['basic_info'] }
+          {
+            is_collector: true: [
+              { has_seen_artists_in_collection: false: ['artists_in_collection'] }
+              { has_seen_galleries_you_work_with: false: ['galleries_you_work_with'] }
+              { has_seen_auction_houses_you_work_with: false: ['auction_houses_you_work_with'] }
+              { has_seen_fairs_you_attend: false: ['fairs_you_attend'] }
+              { has_seen_institutional_affiliations: false: ['institutional_affiliations'] }
+            ]
+          }
         ]
       }
-    ]
-  }
-  {
-    is_logged_in: false: [
-      { has_seen_confirmation_this_session: false: ['confirmation'] }
-      'account'
+      {
+        is_logged_in: false: [
+          { has_seen_confirmation_this_session: false: ['confirmation'] }
+          'account'
+        ]
+      }
     ]
   }
   'done'

--- a/components/inquiry_questionnaire/test/map.coffee
+++ b/components/inquiry_questionnaire/test/map.coffee
@@ -74,6 +74,16 @@ describe 'map', ->
           @state.next().should.equal 'done'
           @state.isEnd().should.be.true()
 
+    describe 'the partner belongs to an auction', ->
+      beforeEach ->
+        @artwork.related().partner.set 'type', 'Auction'
+
+      describe 'starts with a specialist inquiry', ->
+        it 'and ends after the specialist step', ->
+          @state.current().should.equal 'specialist'
+          @state.next().should.equal 'done'
+          @state.isEnd().should.be.true()
+
     describe 'A user that has previously seen some steps', ->
       beforeEach ->
         @logger.log 'artists_in_collection'

--- a/components/inquiry_questionnaire/test/map.coffee
+++ b/components/inquiry_questionnaire/test/map.coffee
@@ -76,7 +76,7 @@ describe 'map', ->
 
     describe 'the partner belongs to an auction', ->
       beforeEach ->
-        @artwork.related().partner.set 'type', 'Auction'
+        @artwork.set 'is_in_auction', true
 
       describe 'starts with a specialist inquiry', ->
         it 'and ends after the specialist step', ->


### PR DESCRIPTION
cc @ashkan18 @alloy @acjay 

Picks up where https://github.com/artsy/force/pull/386 left off! The basic idea is to modify the inquiry map to first check whether the work is in an auction or not. If so, just show the `specialist` view, if not, go through the inquiry flow as normal.

![ask-a-specialist](https://cloud.githubusercontent.com/assets/821469/20328519/3d5ea3da-ab61-11e6-99b0-9c14e2471b69.gif)

![ask-a-specialist](https://cloud.githubusercontent.com/assets/821469/20328573/75afe5c8-ab61-11e6-8b61-aad6ffb74ff7.gif)

