### PR TITLE
@starsirius : fix bug with artist display titles in auto-suggest

### DIFF
--- a/apps/search/templates/search_result.jade
+++ b/apps/search/templates/search_result.jade
@@ -8,7 +8,7 @@ a.search-result( href=result.href(), class=_s.decapitalize(result.get('display_m
   .search-result-info
     if result.get('display_model')
       .search-result-kind= _s.decapitalize(_s.humanize(result.get('display_model')))
-    .search-result-title= result.get('display')
+    .search-result-title= result.resultsPageTitle()
     if result.get('about')
       .search-result-about= result.get('about')
     if result.get('display_model') == 'Artist' || result.get('display_model') == 'Category'

--- a/models/search_result.coffee
+++ b/models/search_result.coffee
@@ -76,7 +76,7 @@ module.exports = class SearchResult extends Backbone.Model
       @formatEventAbout('Sale')
     else if @get('display_model') in ['Show', 'Booth']
       @formatShowAbout()
-    else if @get('display_model') in ['Artwork', 'Feature', 'Profile']
+    else if @get('display_model') in ['Artwork', 'Feature', 'Gallery']
       @get('description')
     else undefined
 

--- a/models/search_result.coffee
+++ b/models/search_result.coffee
@@ -24,10 +24,7 @@ module.exports = class SearchResult extends Backbone.Model
     @value = @display()
 
   display: ->
-    if @get('model') is 'artist'
-      _s.trim(@get('display')) + " - View & Collect Works"
-    else
-      _s.trim(@get('name') || @get('owner')?.name || @get('display'))
+    _s.trim(@get('name') || @get('owner')?.name || @get('display'))
 
   trimmedDisplay: ->
     _s.trim(_s.truncate(@get('display'), 75))
@@ -57,6 +54,12 @@ module.exports = class SearchResult extends Backbone.Model
   imageUrl: ->
     return null if @get('display_model') is 'Artist'
     @get('image_url')
+
+  resultsPageTitle: ->
+    if @get('display_model') == 'Artist'
+      @get('display') + " - View & Collect Works"
+    else
+      @get('display')
 
   updateForFair: (fair) ->
     if @get('display_model') == 'Show'

--- a/test/models/search_result.coffee
+++ b/test/models/search_result.coffee
@@ -102,6 +102,17 @@ describe 'SearchResult', ->
       result = new SearchResult(show)
       result.about().should.equal 'Past fair booth at Foo Fair New York Oct 5th – 10th 2015'
 
+    it 'uses a profile description', ->
+      profile = fabricate('profile',
+        model: 'profile',
+        id: 'foo-gallery',
+        display: 'Foo Gallery',
+        description: 'A description of foo gallery'
+      )
+
+      result = new SearchResult(profile)
+      result.about().should.equal 'A description of foo gallery'
+
   describe '#status', ->
     it 'correctly detects closed event status', ->
       show = fabricate('show',


### PR DESCRIPTION
Since we're reusing the `SearchResult` model in both the auto-suggest and search results page context now, there was a bug where the auto-suggest was showing the extended title for Artist results - this should only be shown on the search results page.