### PR TITLE
@izakp : fix fair locations to use profile slugs in search

### DIFF
--- a/models/search_result.coffee
+++ b/models/search_result.coffee
@@ -30,8 +30,10 @@ module.exports = class SearchResult extends Backbone.Model
     _s.trim(_s.truncate(@get('display'), 75))
 
   location: ->
-    if @get('model') is 'profile' || @get('model') is 'fair'
+    if @get('model') is 'profile'
       "/#{@get('id')}"
+    else if @get('model') is 'fair'
+      "/#{@get('profile_id')}"
     else if @get('model') is 'partnershow'
       "/show/#{@get('id')}"
     else if @get('model') is 'sale'

--- a/test/models/search_result.coffee
+++ b/test/models/search_result.coffee
@@ -23,6 +23,10 @@ describe 'SearchResult', ->
         model = new SearchResult(fabricate('article', model: 'article'))
         model.href().should.containEql '/article/' + model.id
 
+      it 'has a location attribute when it is a fair', ->
+        model = new SearchResult(fabricate('fair', model: 'fair', profile_id: 'foo-profile'))
+        model.href().should.containEql '/foo-profile'
+
     describe '#displayModel', ->
       it 'has a display_model attribute when it is a artwork', ->
         model = new SearchResult(fabricate('artwork', model: 'artwork'))


### PR DESCRIPTION
- Fixes fair locations returned from search to always use profile slugs.
- Depends on deployment of [Gravity#10587](https://github.com/artsy/gravity/pull/10587)
