### PR TITLE
@craigspaeth => EOY splash page proxy to s3

### DIFF
--- a/apps/editorial_features/index.coffee
+++ b/apps/editorial_features/index.coffee
@@ -1,3 +1,6 @@
+httpProxy = require 'http-proxy'
+proxy = httpProxy.createProxyServer(changeOrigin: true, ignorePath: true)
+{ EOY_2016_TEASER, EOY_2016_TEASER_THANKS } = require '../../config.coffee'
 express = require 'express'
 routes = require './routes'
 adminOnly = require '../../lib/middleware/admin_only'
@@ -11,3 +14,15 @@ app.locals.markdown = markdown
 app.locals.crop = crop
 
 app.get '/eoy-2016', adminOnly, routes.eoy
+
+app.get '/2016-year-in-art', (req, res) ->
+  req.headers['host'] = 'artsy-vanity-files-production'
+  proxy.on 'error', (err) ->
+    res.redirect 301, "/articles"
+  proxy.web req, res, target: EOY_2016_TEASER
+
+app.get '/2016-year-in-art-thanks', (req, res) ->
+  req.headers['host'] = 'artsy-vanity-files-production'
+  proxy.on 'error', (err) ->
+    res.redirect 301, "/articles"
+  proxy.web req, res, target: EOY_2016_TEASER_THANKS

--- a/config.coffee
+++ b/config.coffee
@@ -119,6 +119,8 @@ module.exports =
   MARKETING_SIGNUP_MODAL_IMG: 'http://placekitten.com/700/1000'
   MARKETING_SIGNUP_MODAL_PATHS: '/miami-beach,/feature/miami*'
   EOY_2016_ARTICLE: null
+  EOY_2016_TEASER: 'https://artsy-vanity-files-production.s3.amazonaws.com/documents/year-in-art-teaser.html'
+  EOY_2016_TEASER_THANKS: 'https://artsy-vanity-files-production.s3.amazonaws.com/documents/year-in-art-teaser-thanks.html'
 
 # Override any values with env variables if they exist.
 # You can set JSON-y values for env variables as well such as "true" or


### PR DESCRIPTION
Use http-proxy to temporarily send the EOY route to a splash page. Once we are ready to go live with EOY, we can remove these lines and host @eessex's page instead. 

The "thanks" page is there because Sailthru forms need a `<form method="POST"` which requires a redirect url when submission is successful. 

cc @eessex 