### PR TITLE
@craigspaeth => Flexible source + cors issue

### DIFF
--- a/apps/articles/routes.coffee
+++ b/apps/articles/routes.coffee
@@ -105,7 +105,7 @@ subscribedToEditorial = (email, cb) ->
       "#{sd.SAILTHRU_MASTER_LIST}": 1
     name: req.body.name
     vars:
-      source: 'editorial'
+      source: req.body.source or 'editorial'
       receive_editorial_email: true
       email_frequency: 'daily'
   , (err, response) ->

--- a/apps/editorial_features/index.coffee
+++ b/apps/editorial_features/index.coffee
@@ -1,6 +1,6 @@
 httpProxy = require 'http-proxy'
 proxy = httpProxy.createProxyServer(changeOrigin: true, ignorePath: true)
-{ EOY_2016_TEASER, EOY_2016_TEASER_THANKS } = require '../../config.coffee'
+{ EOY_2016_TEASER } = require '../../config.coffee'
 express = require 'express'
 routes = require './routes'
 adminOnly = require '../../lib/middleware/admin_only'
@@ -18,9 +18,3 @@ app.get '/2016-year-in-art', (req, res) ->
   proxy.on 'error', (err) ->
     res.redirect 301, "/articles"
   proxy.web req, res, target: EOY_2016_TEASER
-
-app.get '/2016-year-in-art-thanks', (req, res) ->
-  req.headers['host'] = 'artsy-vanity-files-production'
-  proxy.on 'error', (err) ->
-    res.redirect 301, "/articles"
-  proxy.web req, res, target: EOY_2016_TEASER_THANKS

--- a/config.coffee
+++ b/config.coffee
@@ -122,7 +122,6 @@ module.exports =
   MARKETING_SIGNUP_MODAL_SLUG: 'miami'
   EOY_2016_ARTICLE: null
   EOY_2016_TEASER: 'https://artsy-vanity-files-production.s3.amazonaws.com/documents/year-in-art-teaser.html'
-  EOY_2016_TEASER_THANKS: 'https://artsy-vanity-files-production.s3.amazonaws.com/documents/year-in-art-teaser-thanks.html'
 
 # Override any values with env variables if they exist.
 # You can set JSON-y values for env variables as well such as "true" or

--- a/lib/middleware/redirect_mobile.coffee
+++ b/lib/middleware/redirect_mobile.coffee
@@ -36,6 +36,7 @@ router.get '/ArtsySocialMediaToolkit.pdf', isResponsive
 router.get '/inquiry/*', isResponsive
 router.get '/consign', isResponsive
 router.get '/professional-buyer*', isResponsive
+router.get '/2016-year-in-art', isResponsive
 router.get TEAM_BLOGS, isResponsive
 router.use redirect
 module.exports = router

--- a/lib/middleware/same_origin.coffee
+++ b/lib/middleware/same_origin.coffee
@@ -4,4 +4,5 @@
 
 module.exports = (req, res, next) ->
   res.set('X-Frame-Options', 'SAMEORIGIN')
+  res.set('Access-Control-Allow-Origin', 'https://artsy-vanity-files-production.s3.amazonaws.com')
   next()

--- a/lib/middleware/same_origin.coffee
+++ b/lib/middleware/same_origin.coffee
@@ -4,5 +4,4 @@
 
 module.exports = (req, res, next) ->
   res.set('X-Frame-Options', 'SAMEORIGIN')
-  res.set('Access-Control-Allow-Origin', 'https://artsy-vanity-files-production.s3.amazonaws.com')
   next()


### PR DESCRIPTION
Use a configurable source so that pages like `/2016-year-in-art` can post to this route as well. 