### PR TITLE
@broskoski => Prevent editorial form from being redirected to mobile

### DIFF
--- a/lib/middleware/redirect_mobile.coffee
+++ b/lib/middleware/redirect_mobile.coffee
@@ -37,6 +37,7 @@ router.get '/inquiry/*', isResponsive
 router.get '/consign', isResponsive
 router.get '/professional-buyer*', isResponsive
 router.get '/2016-year-in-art', isResponsive
+router.post '/editorial/form', isResponsive
 router.get TEAM_BLOGS, isResponsive
 router.use redirect
 module.exports = router


### PR DESCRIPTION
No more m.artsy.net on /editorial-signup/form! Need this in asap for the teaser going out at 1pm. 