### PR TITLE
@kanabe => Revise animations

### DIFF
--- a/apps/editorial_features/components/eoy/client.coffee
+++ b/apps/editorial_features/components/eoy/client.coffee
@@ -31,8 +31,8 @@ module.exports.EoyView = class EoyView extends Backbone.View
 
   watchWindow: =>
     $(window).scroll () =>
-      throttled = _.throttle(@trackDirection, 100)
       if window.scrollY != @windowPosition
+        throttled = _.throttle(@trackDirection, 30)
         throttled()
     $(window).resize () =>
       @setupSliderHeight()
@@ -59,13 +59,9 @@ module.exports.EoyView = class EoyView extends Backbone.View
     if scrollTop == 0
       $('.scroller__items section[data-section!="0"]').attr('data-state', 'closed')
       $('.scroller__items section[data-section="0"]').attr('data-state', 'open').height(@containerHeight)
-    #else if scrollTop > @windowPosition
-      #downscrolling
-    #else
-      #upscrolling
-    @doSlider(scrollTop)
+    if scrollTop <= @openHeight
+      @doSlider(scrollTop)
     if scrollTop >= @getScrollZones()[6]
-      # throttled = _.throttle(@animateBody, 100)
       @loadBody()
       @animateBody(scrollTop)
     @windowPosition = scrollTop
@@ -110,18 +106,6 @@ module.exports.EoyView = class EoyView extends Backbone.View
         if this.getScrollZones()[9] < scrollTop
           $('.scroller__items section[data-section!="10"]').attr('data-state', 'closed').removeAttr('style').removeClass('bottom')
           $('.scroller__items section[data-section="10"]').height(active - scrollTop).attr('data-state', 'open').addClass('bottom')
-
-  setImage: ->
-    $img = $(this)
-    src = $img.attr 'src'
-    if src != ''
-      width = 800
-      src = resize(src, width: width * (window.devicePixelRatio or 1))
-      $img.attr 'src', src
-
-  setImages: ->
-    $('.article-body__content img').each @setImage
-
 
   deferredLoadBody: =>
     $('.article-body__content').append bodyView
@@ -169,6 +153,10 @@ module.exports.EoyView = class EoyView extends Backbone.View
     $('.article-body section[data-section!="' + active + '"] .article-body--section').removeClass('active')
     $active = $('.article-body section[data-section="' + active + '"]')
     $active.find('.article-body--section').addClass('active')
+    @animateActiveSection($active, scrollTop)
+
+  animateActiveSection: ($active, scrollTop) =>
+    active = $active.data('section')
     spacers = []
     switch
       when active == 1
@@ -223,6 +211,17 @@ module.exports.EoyView = class EoyView extends Backbone.View
 
   setupCarousel: ->
     initCarousel $('.carousel'), imagesLoaded: true
+
+  setImage: ->
+    $img = $(this)
+    src = $img.attr 'src'
+    if src != ''
+      width = 800
+      src = resize(src, width: width * (window.devicePixelRatio or 1))
+      $img.attr 'src', src
+
+  setImages: ->
+    $('.article-body__content img').each @setImage
 
 module.exports.init = ->
   new EoyView

--- a/apps/editorial_features/components/eoy/client.coffee
+++ b/apps/editorial_features/components/eoy/client.coffee
@@ -14,7 +14,6 @@ Q = require 'bluebird-q'
 module.exports.EoyView = class EoyView extends Backbone.View
 
   el: $('body')
-
   events:
     'click .video-controls': 'playVideo'
 

--- a/apps/editorial_features/components/eoy/client.coffee
+++ b/apps/editorial_features/components/eoy/client.coffee
@@ -7,6 +7,7 @@ initCarousel = require '../../../../components/merry_go_round/horizontal_nav_mgr
 bodyView = -> require('./templates/body.jade') arguments...
 sd = require('sharify').data
 markdown = require '../../../../components/util/markdown.coffee'
+Q = require 'bluebird-q'
 
 module.exports.EoyView = class EoyView extends Backbone.View
 
@@ -18,7 +19,7 @@ module.exports.EoyView = class EoyView extends Backbone.View
   initialize: ->
     $('.scroller__items section').attr('data-state', 'closed')
     @curation = new Curation sd.CURATION
-    @windowHeight = $(window).scrollTop()
+    @windowPosition = $(window).scrollTop()
     @setupSliderHeight()
     @loadBody = _.once @deferredLoadBody
     @trackDirection()
@@ -35,13 +36,12 @@ module.exports.EoyView = class EoyView extends Backbone.View
 
   getScrollZones: =>
     scrollZones = []
-    scrollZones.push @firstHeight
+    scrollZones.push @containerHeight
     for i in [1..($('.scroller__items section').length - 1)]
-      scrollZones.push( (i * @activeHeight) + @firstHeight )
+      scrollZones.push( (i * @activeHeight) + @containerHeight )
     return scrollZones
 
-  closestSection: (scrollTop) =>
-    scrollZones = @getScrollZones()
+  closestSection: (scrollTop, scrollZones) =>
     closest = Math.max.apply(null, scrollZones)
     for i in [0..scrollZones.length + 1]
       if scrollZones[i] >= scrollTop and scrollZones[i] < closest
@@ -52,33 +52,35 @@ module.exports.EoyView = class EoyView extends Backbone.View
     scrollTop = $(window).scrollTop()
     if scrollTop == 0
       $('.scroller__items section[data-section!="0"]').attr('data-state', 'closed')
-      $('.scroller__items section[data-section="0"]').attr('data-state', 'open').height(@firstHeight)
-    #else if scrollTop > @windowHeight
+      $('.scroller__items section[data-section="0"]').attr('data-state', 'open').height(@containerHeight)
+    #else if scrollTop > @windowPosition
       #downscrolling
     #else
       #upscrolling
     @doSlider(scrollTop)
     if scrollTop >= @getScrollZones()[6]
       @loadBody()
-    @windowHeight = scrollTop
+      @animateBody(scrollTop)
+    @windowPosition = scrollTop
 
   setupSliderHeight: =>
     #height of bounding box / title section
-    @firstHeight = $(window).height() - 75 - 20
+    @containerHeight = $(window).height() - 75 - 20
     #height of one section open
     @activeHeight = $(window).height() - 75 - ($(window).height() * .33)
     #bottom scroll border of header content
     @openHeight = @getScrollZones()[10] + 75
     $('.eoy-feature__content').height(@openHeight)
-    $('.scroller__items section').first().height(@firstHeight)
+    $('.scroller__items section').first().height(@containerHeight)
     $('.scroller__items section[data-section!="0"][data-state="open"]').css('max-height', @activeHeight)
-    $('.scroller').height(@firstHeight).fadeIn(500)
+    $('.scroller').height(@containerHeight).fadeIn(500)
     $('.article-body').fadeIn(500)
 
   doSlider: (scrollTop) =>
-    active = @closestSection(scrollTop)
+    scrollZones = @getScrollZones()
+    active = @closestSection(scrollTop, scrollZones)
     $primarySection = $('.scroller__items section[data-section="' + active + '"]').attr('data-state', 'open')
-    nextHeight = @firstHeight - $primarySection.height() - @activeHeight
+    nextHeight = @containerHeight - $primarySection.height() - @activeHeight
     diff = @getScrollZones()[active] - scrollTop
     if active < 1
       $primarySection.height(diff).removeClass('bottom')
@@ -91,11 +93,11 @@ module.exports.EoyView = class EoyView extends Backbone.View
     else
       $primarySection.prev().attr('data-state', 'closed').removeAttr('style').removeClass('bottom')
       $primarySection.height(diff).removeClass('bottom')
-      if diff + @activeHeight < @firstHeight
+      if diff + @activeHeight < @containerHeight
         $primarySection.next().attr('data-state', 'open').height(@activeHeight).removeClass('bottom')
         $primarySection.next().next().attr('data-state', 'open').height(nextHeight).addClass('bottom')
       else
-        $primarySection.next().height(@firstHeight - diff).attr('data-state', 'open').addClass('bottom')
+        $primarySection.next().height(@containerHeight - diff).attr('data-state', 'open').addClass('bottom')
         $primarySection.next().next().attr('data-state', 'closed').removeAttr('style').removeClass('bottom')
       if active >= 9
         if this.getScrollZones()[9] < scrollTop
@@ -160,6 +162,14 @@ module.exports.EoyView = class EoyView extends Backbone.View
       $(this).find('.article-body--section__sub-text .spacer').toggleClass('active')
     , {offset: '60%'}
 
+  animateBody: (scrollTop) =>
+    boundaries = @getBodySectionBoundaries()
+    active = @closestSection(scrollTop, boundaries.top)
+    console.log active
+    if active == 1
+      $('.article-body section[data-section="' + active + '"] spacer').first()
+      debugger
+
   playVideo: (e) =>
     $(e.target).toggleClass('active')
     video = $(e.target).prev()
@@ -169,6 +179,18 @@ module.exports.EoyView = class EoyView extends Backbone.View
       video[0].pause()
     video[0].onended = () ->
       $(e.target).removeClass('active')
+
+  getBodySectionBoundaries: () =>
+    sectionBoundaries = []
+    sectionTopBoundaries = []
+    for section in $('.article-body section[data-section!="0"]')
+      top = $(section).position().top
+      bottom = top + $(section).height()
+      left = $(section).position().left
+      right = left + $(section).width()
+      sectionBoundaries.push {top: top, bottom: bottom, left: left, right: right}
+      sectionTopBoundaries.push top - $(window).height() + 400
+    return { boundaries: sectionBoundaries, top: sectionTopBoundaries }
 
   setupCarousel: ->
     initCarousel $('.carousel'), imagesLoaded: true

--- a/apps/editorial_features/components/eoy/stylesheets/body.styl
+++ b/apps/editorial_features/components/eoy/stylesheets/body.styl
@@ -80,7 +80,7 @@ flex-display(justify = space-between, align = center)
       width 100%
       img
         height auto
-        width 76%
+        width 75%
         max-width 100%
         transition all 1s
   &__sub-text
@@ -200,7 +200,7 @@ flex-display(justify = space-between, align = center)
     &__cover-image
       .image
         img
-          width 83%
+          width 85%
           margin-right 15%
           margin-left auto
       .spacer
@@ -247,7 +247,7 @@ flex-display(justify = space-between, align = center)
     &.active
       .image
         img
-          width 85%
+          // width 85%
       .spacer
         width calc(100% \- 20px)
         &:nth-child(3)

--- a/apps/editorial_features/components/eoy/stylesheets/body.styl
+++ b/apps/editorial_features/components/eoy/stylesheets/body.styl
@@ -138,8 +138,7 @@ flex-display(justify = space-between, align = center)
         top 20px
         left 0
         bottom 0
-        height 0
-        // transition all 4s
+        height 100%
         max-height calc(100% \- 40px)
       .image
         flex-display(space-between, flex-end)
@@ -184,12 +183,9 @@ flex-display(justify = space-between, align = center)
       top 0
       height 0
       max-height 100%
-      // transition all 7s
       &.active
         height 100%
     &.active
-      header .spacer
-        // height calc(100% \- 40px)
       header .image
         img
           width 75%
@@ -247,9 +243,6 @@ flex-display(justify = space-between, align = center)
       .callout
         display none
     &.active
-      .image
-        img
-          // width 85%
       .spacer
         width calc(100% \- 20px)
         &:nth-child(3)
@@ -340,7 +333,6 @@ flex-display(justify = space-between, align = center)
     &__cover-image
       border-top 1px solid
       border-bottom 1px solid
-      // padding 20px 0
       .spacer:first-child
         position absolute
         top 20px
@@ -349,9 +341,6 @@ flex-display(justify = space-between, align = center)
         height 100%
         max-height calc(100% \- 40px)
         border-right 1px solid
-      .image
-        // padding 50px 20px
-        // border-right 1px solid
     article
       position relative
       .spacer--article
@@ -434,7 +423,6 @@ flex-display(justify = space-between, align = center)
     &__cover-image
       padding 0
       .image
-        // border-top 1px solid
         border-bottom 1px solid
         margin-right 20px
         padding 70px 20px
@@ -506,7 +494,6 @@ flex-display(justify = space-between, align = center)
         flex-direction column
         padding 70px 0
     &__text
-      // border-right 1px solid
       position relative
       .spacer
         position absolute

--- a/apps/editorial_features/components/eoy/stylesheets/body.styl
+++ b/apps/editorial_features/components/eoy/stylesheets/body.styl
@@ -139,7 +139,8 @@ flex-display(justify = space-between, align = center)
         left 0
         bottom 0
         height 0
-        transition all 4s
+        // transition all 4s
+        max-height calc(100% \- 40px)
       .image
         flex-display(space-between, flex-end)
         flex-direction column
@@ -182,12 +183,13 @@ flex-display(justify = space-between, align = center)
       right 0
       top 0
       height 0
-      transition all 7s
+      max-height 100%
+      // transition all 7s
       &.active
         height 100%
     &.active
       header .spacer
-        height calc(100% \- 40px)
+        // height calc(100% \- 40px)
       header .image
         img
           width 75%
@@ -282,10 +284,18 @@ flex-display(justify = space-between, align = center)
           margin-right 20px
           margin-left auto
     article
-      border-right 1px solid
       margin-top 20px
       display flex
       flex-direction column-reverse
+      position relative
+      .spacer--article
+        position absolute
+        top 0
+        right 0
+        bottom 0
+        height 0
+        max-height 100%
+        border-right 1px solid
     &__text
       border-bottom 1px solid
       margin-bottom -20px
@@ -309,6 +319,8 @@ flex-display(justify = space-between, align = center)
         border-right 1px solid
         padding-left 20px
         margin-right 20px
+        max-height 100%
+        height 0
     &.active
       header
         .spacer
@@ -328,12 +340,30 @@ flex-display(justify = space-between, align = center)
     &__cover-image
       border-top 1px solid
       border-bottom 1px solid
-      padding 20px 0
-      .image
-        padding 50px 20px
+      // padding 20px 0
+      .spacer:first-child
+        position absolute
+        top 20px
+        right 0
+        bottom 0
+        height 100%
+        max-height calc(100% \- 40px)
         border-right 1px solid
+      .image
+        // padding 50px 20px
+        // border-right 1px solid
     article
       position relative
+      .spacer--article
+        border-right 10px solid white
+        border-left 10px solid white
+        position absolute
+        left 15%
+        top 20px
+        bottom 0
+        background black
+        width 21px
+        max-height calc(100% \- 40px)
     &__text
       display flex
       justify-content flex-end
@@ -344,19 +374,6 @@ flex-display(justify = space-between, align = center)
       align-items flex-end
     &__sub-text
       border-bottom 1px solid
-      .spacer
-        border-right 10px solid white
-        border-left 10px solid white
-        position absolute
-        left 15%
-        top 20px
-        bottom 0
-        background black
-        width 21px
-        height 0
-        transition all 4s
-        &.active
-          height calc(100% \- 40px)
       .image
         padding-left calc(20% \+ 100px)
         display flex
@@ -389,26 +406,52 @@ flex-display(justify = space-between, align = center)
 [data-section='5']
   .article-body--section
     margin-left 0
-    &__title
-      h2
+    header
+      position relative
+      .spacer--article
+        position absolute
+        top 0
+        right 0
+        bottom 0
+        height 100%
+        max-height 100%
         border-right 1px solid
+    &__title
+      position relative
+      .spacer
+        position absolute
+        left 0
+        right 20px
+        bottom 0
+        border-bottom 1px solid
+        width 0
+        margin-right 0
+        margin-left auto
+        transition all 4s
+    &.active
+      .article-body--section__title .spacer
+        width calc(100% \- 20px)
     &__cover-image
-      border-right 1px solid
       padding 0
       .image
-        border-top 1px solid
+        // border-top 1px solid
         border-bottom 1px solid
         margin-right 20px
         padding 70px 20px
-    &.active .image
-      img
-        width 75%
     &__text
-      border-left 1px solid
       margin 20px 0
+      position relative
       p
         margin-right 0
         margin-left auto
+      .spacer
+        position absolute
+        top 0
+        left 0
+        bottom 0
+        height 100%
+        max-height 100%
+        border-right 1px solid
     &__sub-text
       display flex
       border-top 1px solid
@@ -449,9 +492,6 @@ flex-display(justify = space-between, align = center)
         left 0
         top 0
         height 0
-        transition all 7s
-    &.active .spacer--article
-      height 100%
     &__title
       h2
         margin-left 20px
@@ -466,7 +506,16 @@ flex-display(justify = space-between, align = center)
         flex-direction column
         padding 70px 0
     &__text
-      border-right 1px solid
+      // border-right 1px solid
+      position relative
+      .spacer
+        position absolute
+        top 0
+        right 0
+        bottom 0
+        height 100%
+        max-height 100%
+        border-right 1px solid
     &__sub-text
       margin-top 20px
       padding-top 20px
@@ -547,10 +596,50 @@ flex-display(justify = space-between, align = center)
   .article-body--section
     margin 0 auto
 
+@media screen and (max-width: 1200px)
+  .article-body--section
+    width 100%
 @media screen and (max-width: 550px)
   .article-body
     padding 0 10px
+    &__intro-inner
+      h3
+        min-width 100%
+        font-size 20px
+        line-height 30px
+        margin-left 0
+        padding 40px 10px
+    &__intro-inner.active
+      .spacer
+        width 100%
+        left 0
+  .article-body--section
+    &__title
+      min-width 100%
+    &__cover-image
+      padding 40px 10px
+      img
+        min-width 85%
+    &__text
+      p
+        font-size 20px
+        line-height 30px
+    &__sub-text
+      flex-direction column
+      .spacer--article
+        display none
   .article-body__intro-inner
     width 100%
-  .article-body--section
-    width 100%
+
+  [data-section='1']
+    .article-body--section
+      &__sub-text
+        .image
+          width calc(100% \- 20px)
+          padding 40px 40px 40px 60px
+          border-bottom 1px solid
+          border-right none
+          margin-right 20px
+        .callout
+          padding 80px 60px
+          width 100%

--- a/apps/editorial_features/components/eoy/stylesheets/index.styl
+++ b/apps/editorial_features/components/eoy/stylesheets/index.styl
@@ -63,3 +63,6 @@ flex-display(justify = space-between, align = center)
     font-size 50px
   .item h2
     font-size 25px
+  .eoy-feature .article-body--section h2
+      font-size 30px
+      padding 40px 20px

--- a/apps/editorial_features/components/eoy/templates/body.jade
+++ b/apps/editorial_features/components/eoy/templates/body.jade
@@ -2,7 +2,7 @@ for section, i in curation.get('sections')
   section(data-section='#{i + 1}')
     .article-body--section
       header
-        if i == 5
+        if i == 4 || i == 5
           .spacer--article
         .article-body--section__title
           h2=section.headline
@@ -21,7 +21,11 @@ for section, i in curation.get('sections')
               img(src=section.image width='800')
             .caption!= markdown(section.caption)
       article
+        if i == 2 || i == 3
+          .spacer--article
         .article-body--section__text!= markdown(section.body)
+          if i == 4 || i == 5
+            .spacer
         .article-body--section__sub-text
           .image
             if section.image_second.indexOf('mp4') > -1

--- a/apps/editorial_features/components/eoy/templates/index.jade
+++ b/apps/editorial_features/components/eoy/templates/index.jade
@@ -10,7 +10,7 @@ block body
 
   .eoy-feature
     video(class='video' autoplay='autoplay' loop='loop' muted='').eoy-feature__background.active
-      source(src='https://artsy-vanity-files-production.s3.amazonaws.com/videos/year-end-six.mp4' type='video/mp4')
+      source(src='#{curation.get("header_video")}' type='video/mp4')
     nav.eoy-feature__menu
       a(href='/')
         img.logo(src='https://artsy-vanity-files-production.s3.amazonaws.com/images/artsy_logo.png')
@@ -29,7 +29,7 @@ block body
           .col
         .article-body__intro-inner
           .spacer
-          h3 Article Intro statement: Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Vestibulum id ligula porta felis euismod semper. Curabitur blandit tempus porttitor.
+          h3!= markdown(curation.get('intro'))
           .spacer
       .article-body__content
         //- rendered on client

--- a/apps/editorial_features/routes.coffee
+++ b/apps/editorial_features/routes.coffee
@@ -4,6 +4,7 @@ sd = require('sharify').data
 Curation = require '../../models/curation.coffee'
 Article = require '../../models/article.coffee'
 Articles = require '../../collections/articles.coffee'
+markdown = require '../../components/util/markdown.coffee'
 Q = require 'bluebird-q'
 
 @eoy = (req, res, next) ->
@@ -24,4 +25,5 @@ Q = require 'bluebird-q'
       res.render 'components/eoy/templates/index',
         curation: @curation,
         article: @article,
-        superSubArticles: @superSubArticles
+        superSubArticles: @superSubArticles,
+        markdown: markdown


### PR DESCRIPTION
Waypoints have mostly been taken out, and many css transitions have been replaced by pixel-by-pixel animations (for vertical lines in body) -- this is currently very laggy so today I'm going to investigate using GSAP instead of jQuery.  Let me know if you have ideas on this!

- Beginnings of responsive theming
- Support for additional writer fields
- Uses resized cloudfront images
