### PR TITLE
@broskoski: Further limit fields requested for image sitemap

### DIFF
--- a/apps/sitemaps/routes.coffee
+++ b/apps/sitemaps/routes.coffee
@@ -112,7 +112,14 @@ getArtworkBuckets = (callback) ->
       limit: FUSION_PAGE_SIZE
       'fields[]': switch template
         when 'artworks' then ['id']
-        when 'images' then ['id', 'images', 'title', 'artist', 'date']
+        when 'images' then [
+          'id'
+          'images.image_urls.large'
+          'images.image_urls.larger'
+          'title'
+          'artist.name'
+          'date'
+        ]
     )
     .end (err, sres) ->
       return next err if err

--- a/apps/sitemaps/routes.coffee
+++ b/apps/sitemaps/routes.coffee
@@ -116,6 +116,7 @@ getArtworkBuckets = (callback) ->
           'id'
           'images.image_urls.large'
           'images.image_urls.larger'
+          'images.is_default'
           'title'
           'artist.name'
           'date'


### PR DESCRIPTION
Sitemaps right now are requesting MBs of data from fusion because we didn't limit the artist and image fields for image sitemaps. My theory is this could be partly what's causing excess memory usage and performance hit from the transfer size.