### PR TITLE
@joeyAghion - Only submit form if the state isnt password reset

### DIFF
--- a/components/auth_modal/test/view.coffee
+++ b/components/auth_modal/test/view.coffee
@@ -122,3 +122,21 @@ describe 'AuthModalView', ->
       @view.state.set mode: 'register'
       @view.submit $.Event('click')
       Backbone.sync.args[1][1].toJSON()._csrf.should.equal 'csrfoo'
+
+  describe '#onSubmitSuccess', ->
+    beforeEach ->
+      @view.state = new Backbone.Model mode: 'reset'
+      @view.user = new LoggedOutUser
+      sinon.stub @view, 'reenableForm'
+      @submitSpy = sinon.spy $.fn, 'submit'
+
+    afterEach ->
+      @view.reenableForm.restore()
+      @submitSpy.restore()
+
+    it 'does not submit form if the the mode is password reset', ->
+      @view.onSubmitSuccess @view.user, { success: 200 }
+      @submitSpy.should.be.calledOnce
+      
+
+

--- a/components/auth_modal/view.coffee
+++ b/components/auth_modal/view.coffee
@@ -130,8 +130,7 @@ module.exports = class AuthModalView extends ModalView
 
       @undelegateEvents()
 
-      @$('form').submit()
-
+      @$('form').submit() unless @state.get('mode') is 'reset'
 
   showError: (msg) =>
     @$('button').attr 'data-state', 'error'


### PR DESCRIPTION
Closes #436

The `reset` form shouldn't actually be submitted (what is causing the redirect after the notice appears) because the user `forgot` is already fired on the step before (see here: https://github.com/artsy/force/blob/master/components/auth_modal/view.coffee#L107 and here: https://github.com/artsy/force/blob/master/models/logged_out_user.coffee#L64 )