### PR TITLE
@mzikherman => dont explicitly set null for commercial filter params

### DIFF
--- a/components/commercial_filter/models/params.coffee
+++ b/components/commercial_filter/models/params.coffee
@@ -19,11 +19,8 @@ module.exports = class Params extends Backbone.Model
     size: 50
     page: 1
     for_sale: true
-    color: null
-    medium: null
     major_periods: []
     partner_cities: []
-    include_artworks_by_followed_artists: null
     aggregations: ['TOTAL', 'COLOR', 'MEDIUM', 'MAJOR_PERIOD', 'PARTNER_CITY', 'FOLLOWED_ARTISTS', 'MERCHANDISABLE_ARTISTS']
     ranges:
       price_range:


### PR DESCRIPTION
As discussed in [#metaphysics](https://artsy.slack.com/archives/metaphysics/p1480631685000539), because of the graphQL update these null defaults are no longer scrubbed in our requests to gravity. Requesting `include_artworks_by_followed_artists=` or `medium=` means something to our API, but it is not what we intend. This should fix the issues on the `/collect` page that we're seeing in staging.

We can also add some safeguards in metaphysics, but as @joeyAghion pointed out, we may not want to scrub `null` _everywhere_, especially if we intend to allow metaphysics to make PUT/POST requests.

cc @alloy does eigen staging look okay? We could potentially punt this PR and roll back metaphysics to an earlier version of graphql if there's more client fallout.