### PR TITLE
@ashkan18 => Support markdown on partner profile pages for partner-submitted bios

### DIFF
--- a/apps/partner2/client/artists_artist.coffee
+++ b/apps/partner2/client/artists_artist.coffee
@@ -89,7 +89,7 @@ module.exports = class PartnerArtistsArtistView extends Backbone.View
     if @partnerArtist.get('use_default_biography')
       @$('.partner-artist-blurb').html @artist.mdToHtml('blurb')
     else if not _s.isBlank(@partnerArtist.get('biography'))
-      @$('.partner-artist-blurb').html(@partnerArtist.get('biography'))
+      @$('.partner-artist-blurb').html @partnerArtist.mdToHtml('biography')
         .after "<div class='partner-artist-blurb-postfix'>&mdash; Submitted by #{@partner.get('name')}</div>"
     @initializeBlurb()
 

--- a/apps/partner2/test/client/artists_artist.coffee
+++ b/apps/partner2/test/client/artists_artist.coffee
@@ -65,7 +65,7 @@ describe 'PartnerArtistsArtistView', ->
     it 'renders the partner provided artist bio if not use_default_biography', ->
       @view.partnerArtist.set use_default_biography: false, biography: 'partner provided bio'
       @view.initializeBio()
-      @view.$('.partner-artist-blurb').html().should.containEql 'partner provided bio'
+      @view.$('.partner-artist-blurb').html().should.containEql '<p>partner provided bio'
       @view.$('.partner-artist-blurb-postfix').html().should.containEql "Submitted by #{@partnerArtist.get('partner').name}"
 
     it 'does not render the attribution line if not use_default_biography and blank provided artist bio', ->

--- a/models/partner_artist.coffee
+++ b/models/partner_artist.coffee
@@ -1,11 +1,12 @@
 _ = require 'underscore'
 Backbone = require 'backbone'
-{ Image } = require 'artsy-backbone-mixins'
+{ Image, Markdown } = require 'artsy-backbone-mixins'
 { API_URL } = require('sharify').data
 { SECURE_IMAGES_URL } = require('sharify').data
 
 module.exports = class PartnerArtist extends Backbone.Model
 
   _.extend @prototype, Image(SECURE_IMAGES_URL)
+  _.extend @prototype, Markdown
 
   href: -> "/#{@get('partner').default_profile_id}/artist/#{@get('artist').id}"


### PR DESCRIPTION
Now that partner-submitted bios support Markdown, we want to display that on the front-end.

Luckily, the artist and artwork page fetch the converted HTML from Metaphysics and render it directly, so those will just work. This updates the partner profile page to render them as markdown. I think that completes making sure they're displayed consistently on the front-end!