### PR TITLE
@1aurabrown: update price format and add shipping info

### DIFF
--- a/apps/artwork/components/commercial/index.styl
+++ b/apps/artwork/components/commercial/index.styl
@@ -45,16 +45,29 @@
 .artwork-commercial
   clearfix()
   &__form
-    padding (gutter / 2) 0
+    padding 22px 0
     serif('s-body')
     line-height 1.25 // compact-line-height
 
-  &__limited-partner-message
   &__sale-message
-    block-margins(gutter / 2)
-    padding distance(gutter / 2) 0
+    garamond-size('l-body')
+    font-weight bold
+    line-height 1.5
+  &__price-label
+    avant-garde-size('s-headline')
+    color gray-darker-color
+    line-height 1.5
+    .help-tooltip
+      margin-bottom -1px
+  &__container
+    block-margins 25px
+    padding 25px 0
     border-top 1px solid gray-lighter-color
     border-bottom @border-top
+  &__shipping-info
+    garamond-size('l-caption')
+    color gray-darker-color
+    line-height 1.5
 
   &__consignables
     margin (gutter + (gutter / 3)) 0

--- a/apps/artwork/components/commercial/query.coffee
+++ b/apps/artwork/components/commercial/query.coffee
@@ -7,6 +7,8 @@ module.exports = """
     is_purchasable
     is_in_auction
     sale_message
+    is_price_range
+    price
     artists {
       name
       is_consignable

--- a/apps/artwork/components/commercial/templates/price.jade
+++ b/apps/artwork/components/commercial/templates/price.jade
@@ -1,3 +1,18 @@
 if artwork.sale_message
-  .artwork-commercial__sale-message
-    = artwork.sale_message
+  .artwork-commercial__container
+    .artwork-commercial__sale-message
+      if artwork.price
+        .artwork-commercial__price-label= !artwork.is_price_range ? 'Price' : 'Price Range'
+        .artwork-commerical__price
+          | #{artwork.price}
+          span(
+            class= artwork.is_price_range ? 'help-tooltip' : ''
+            data-message= 'The range is an approximate indication of the work’s price point, and the exact price is quoted upon request.'
+            data-anchor= 'bottom-right'
+          )
+      else
+        | #{artwork.sale_message}
+
+    if artwork.price
+      .artwork-commercial__shipping-info
+        | Shipping, tax, and service quoted by seller


### PR DESCRIPTION
This PR updates price format and adds shipping info per https://github.com/artsy/collector-experience/issues/27. This is dependent on metaphysics work https://github.com/artsy/metaphysics/pull/488 which should be merged first.

Exact Price:
![screen shot 2016-12-06 at 12 43 39 am](https://cloud.githubusercontent.com/assets/5201004/20914365/2ac38802-bb4d-11e6-81fe-bee89e36cf81.png)

Range: 
![screen shot 2016-12-06 at 12 48 36 am](https://cloud.githubusercontent.com/assets/5201004/20914469/cfa484fc-bb4d-11e6-901b-4255752cb196.png)
