### PR TITLE
@mzikherman => ignore my own retracted bids when validating my price

### DIFF
--- a/collections/bidder_positions.coffee
+++ b/collections/bidder_positions.coffee
@@ -8,7 +8,7 @@ module.exports = class BidderPositions extends Backbone.Collection
   model: BidderPosition
 
   url: ->
-    "#{API_URL}/api/v1/me/bidder_positions?sale_id=#{@sale.id}&artwork_id=#{@saleArtwork.id}"
+    "#{API_URL}/api/v1/me/bidder_positions?sale_id=#{@sale.id}&artwork_id=#{@saleArtwork.id}&retracted=false"
 
   initialize: (models, options = {}) ->
     { @saleArtwork, @sale } = options


### PR DESCRIPTION
As a follow-up to https://github.com/artsy/gravity/pull/10612, we don't want to validate the amount you can bid against bids that have been retracted. (i.e. let's say you bid at $8,000 and $8,500 but we retract the $8,500 bid because your kid placed it while you were in the bathroom. If you bid again on that artwork, we want to allow you to place a bid at $8,500. Right now we would force you to place your next bid at $9,000).