### PR TITLE
@1aurabrown - Do not handle keypress unless accessiblity is set to true

### DIFF
--- a/components/artwork_brick_rail/view.coffee
+++ b/components/artwork_brick_rail/view.coffee
@@ -46,6 +46,7 @@ module.exports = class ArtworkBrickRailView extends Backbone.View
       imagesLoaded: false
       wrapAround: false
       groupCells: true
+      accessibility: false
     , (carousel) =>
       @trigger 'post-render'
       @carousel = carousel

--- a/components/merry_go_round/view.coffee
+++ b/components/merry_go_round/view.coffee
@@ -18,6 +18,7 @@ module.exports = class MerryGoRoundNavView extends Backbone.View
     $(document).on 'keydown.mgr', @keypress
 
   keypress: (e) =>
+    return unless @flickity.options.accessibility
     return if $(e.target).is(':input')
     switch e.keyCode
       when 37


### PR DESCRIPTION
Closes #101 

See: http://flickity.metafizzy.co/options.html#accessibility

This will make it so you explicitly have to pass true to get a carousel to handle keyboard shortcuts.