### PR TITLE
@craigspaeth - A few fixes for contact gallery buttons on the show feed.

### DIFF
--- a/analytics/contact.js
+++ b/analytics/contact.js
@@ -1,0 +1,21 @@
+(function () {
+  'use strict'
+
+  // Hooks
+  analyticsHooks.on('show_feed:contact', function(context) {
+    analytics.track('Clicked "Contact Gallery"', {
+      show_id: context.show.get('_id'),
+      context_type: "fair exhibitors browse"
+    })
+  })
+
+  analyticsHooks.on('show_feed:inquiry:sent', function (context) {
+    track('Sent show inquiry', {
+      // inquiry_id: gravity id of the inquiry,
+      // show_id: gravity id of the partner show,
+      // show_slug: slug of the partner show,
+      // fair_id: id of the fair the show is in
+    })
+  })
+
+})()

--- a/analytics/contact.js
+++ b/analytics/contact.js
@@ -10,11 +10,11 @@
   })
 
   analyticsHooks.on('show_feed:inquiry:sent', function (context) {
-    track('Sent show inquiry', {
-      // inquiry_id: gravity id of the inquiry,
-      // show_id: gravity id of the partner show,
-      // show_slug: slug of the partner show,
-      // fair_id: id of the fair the show is in
+    analytics.track('Sent show inquiry', {
+      inquiry_id: context.inquiry.id,
+      show_id: context.show.get('_id'),
+      show_slug: context.show.id,
+      fair_id: context.fair_id
     })
   })
 

--- a/assets/analytics.coffee
+++ b/assets/analytics.coffee
@@ -29,6 +29,7 @@ $ -> analytics.ready ->
   require '../analytics/artworks_filter.js'
   require '../analytics/artist_page.js'
   require '../analytics/home.js'
+  require '../analytics/contact.js'
   require '../analytics/show_page.js'
   require '../analytics/account_creation.js'
   require '../analytics/account_login.js'
@@ -52,7 +53,5 @@ $ -> analytics.ready ->
   require '../analytics/pro_buyer.js'
   require '../analytics/recently_viewed_artworks.js'
   require '../analytics/save.js'
-
-  if route.test(/^\/inquiry\/.*/) or route.test(/^\/artwork\/.*/)
-    require '../analytics/embedded_inquiry.js'
-    require '../analytics/inquiry_questionnaire.js'
+  require '../analytics/embedded_inquiry.js'
+  require '../analytics/inquiry_questionnaire.js'

--- a/components/contact/show_inquiry_modal.coffee
+++ b/components/contact/show_inquiry_modal.coffee
@@ -35,8 +35,6 @@ module.exports = class ShowInquiryModal extends ContactView
   initialize: (options) ->
     { @show } = options
 
-    splitTest('forced_login_inquiry').view()
-
     @partner = new Partner @show.get('partner')
     @partner.related().locations.fetch complete: =>
       @renderTemplates()

--- a/components/contact/show_inquiry_modal.coffee
+++ b/components/contact/show_inquiry_modal.coffee
@@ -35,6 +35,8 @@ module.exports = class ShowInquiryModal extends ContactView
   initialize: (options) ->
     { @show } = options
 
+    analyticsHooks.trigger 'show_feed:contact', show: @show
+    
     @partner = new Partner @show.get('partner')
     @partner.related().locations.fetch complete: =>
       @renderTemplates()
@@ -53,9 +55,6 @@ module.exports = class ShowInquiryModal extends ContactView
 
   onSubmit: (e) ->
     super
-
-    analyticsHooks.trigger 'inquiry:show',
-      label: modelNameAndIdToLabel 'show', @show.get('id')
 
     @model.set
       inquireable_id: @show.get('id')

--- a/components/contact/show_inquiry_modal.coffee
+++ b/components/contact/show_inquiry_modal.coffee
@@ -2,7 +2,7 @@ _ = require 'underscore'
 Backbone = require 'backbone'
 ContactView = require './view.coffee'
 analyticsHooks = require '../../lib/analytics_hooks.coffee'
-splitTest = require '../split_test/index.coffee'
+FlashMessage = require '../flash/index.coffee'
 openInquiryQuestionnaireFor = require '../inquiry_questionnaire/index.coffee'
 User = require '../../models/user.coffee'
 { modelNameAndIdToLabel } = require '../../analytics/helpers.js'
@@ -71,13 +71,23 @@ module.exports = class ShowInquiryModal extends ContactView
 
     user.prepareForInquiry()
       .then =>
-        @close()
-        @modal = openInquiryQuestionnaireFor
-          inquiry: @model
-          user: user
-          bypass: ['account', 'done']
-          artwork: fakeArtwork
-          state_attrs: inquiry: @model
+        
+        if user.isLoggedIn()
+          @model.save null, success: =>
+            @close()
+            new FlashMessage message: 'Your inquiry has been sent'
+        else
+          @close()
+          @modal = openInquiryQuestionnaireFor
+            inquiry: @model
+            user: user
+            bypass: ['account', 'done']
+            artwork: fakeArtwork
+            state_attrs: inquiry: @model
 
-
+        @listenToOnce @model, 'sync', =>
+          analyticsHooks.trigger 'show_feed:inquiry:sent', 
+            inquiry: @model
+            show: @show
+            fair_id: @show.get('fair')?.id 
 

--- a/components/contact/templates/inquiry_show_form.jade
+++ b/components/contact/templates/inquiry_show_form.jade
@@ -34,8 +34,8 @@ form.contact-form.stacked-form
       required
     )
 
-  button#contact-submit.avant-garde-button-black( href='#', data-state='ok' )
+  button#contact-submit.js-send-inquiry.avant-garde-button-black( href='#', data-state='ok' )
     | Send
 
-a.contact-nevermind(href="#") Nevermind, cancel my inquiry
+a.contact-nevermind.js-nevermind(href="#") Nevermind, cancel my inquiry
 

--- a/components/inquiry_questionnaire/views/account.coffee
+++ b/components/inquiry_questionnaire/views/account.coffee
@@ -28,7 +28,8 @@ module.exports = class Account extends StepView
     super
 
   setup: ->
-    @sendResetOnce = _.once _.bind(@user.forgot, @user)
+    if @user.forgot?
+      @sendResetOnce = _.once _.bind(@user.forgot, @user)
 
   mode: ->
     if (mode = @active.get('mode')) is 'auth'


### PR DESCRIPTION
Closes #439 
Closes #236 

The big thing here is removing the restriction to only fire inquiry analytics when on the artwork page. 

Most of these tracking calls are namespaced so they should be fine, but the main issue is the inquiry questionnaire now gets used within the show feed, which is a little harder to single out.