### PR TITLE
@mzikherman : hide popular artists on jewelry and design categories

### DIFF
--- a/apps/collect/client.coffee
+++ b/apps/collect/client.coffee
@@ -55,6 +55,7 @@ module.exports.init = ->
     totalView = new PopularArtistsView
       el: $('.cf-artworks')
       artists: filter.popular_artists
+      params: params
 
   pillboxView = new PillboxView
     el: $('.cf-pillboxes')

--- a/components/commercial_filter/views/popular_artists/popular_artists_view.coffee
+++ b/components/commercial_filter/views/popular_artists/popular_artists_view.coffee
@@ -2,11 +2,15 @@ Backbone = require 'backbone'
 template = -> require('./index.jade') arguments...
 
 module.exports = class PopularArtistsView extends Backbone.View
-  initialize: ({ @artists }) ->
+  initialize: ({ @artists, @params }) ->
     throw new Error 'Requires artists' unless @artists?
 
     @listenTo @artists, 'reset', @render
 
   render: ->
-    @$('.artwork-column').last().prepend template
-      artists: @artists.models
+    if @params.get('medium') in ['design', 'jewelry']
+      $('.cf-popular_artists').hide()
+    else
+      $('.cf-popular_artists').show()
+      @$('.artwork-column').last().prepend template
+        artists: @artists.models


### PR DESCRIPTION
- Hides 'popular artists' component on jewelry and design categories on `/collect`
- Paves way for A/B test of feature (currently a lab feature)

I had to abandon my attempt at a [parent-child mapping](https://www.elastic.co/guide/en/elasticsearch/guide/current/parent-child-mapping.html) between Artists and Artworks on Elasticsearch as a means of filtering artists in this component by primary media. That mapping requires that "the parent document and all of its children must live on the same shard", so it would require a complete reindexing of the Artwork index and would potentially affect ES performance more broadly in terms of traffic balancing.

The other approach would be to denormalize artist data on artwork documents in ES and I didn't consider that a worthwhile change just for an A/B test.