### PR TITLE
@craigspaeth => Allow superarticle drafts to be fully previewable

### DIFF
--- a/apps/editorial_features/routes.coffee
+++ b/apps/editorial_features/routes.coffee
@@ -11,7 +11,7 @@ Q = require 'bluebird-q'
   @curation = new Curation(id: sd.EOY_2016)
   @article = new Article(id: sd.EOY_2016_ARTICLE)
   Q.all([
-  	@curation.fetch(cache: true)
+    @curation.fetch(cache: true)
     @article.fetch(
       cache:  true
       headers: 'X-Access-Token': req.user?.get('accessToken') or ''

--- a/apps/editorial_features/routes.coffee
+++ b/apps/editorial_features/routes.coffee
@@ -10,16 +10,17 @@ Q = require 'bluebird-q'
 @eoy = (req, res, next) ->
   @curation = new Curation(id: sd.EOY_2016)
   @article = new Article(id: sd.EOY_2016_ARTICLE)
-
   Q.all([
-  	@curation.fetch()
-    @article.fetch()
+  	@curation.fetch(cache: true)
+    @article.fetch(
+      cache:  true
+      headers: 'X-Access-Token': req.user?.get('accessToken') or ''
+    )
   ]).then (result) =>
-    @superSubArticles = new Articles()
+    @superSubArticles = new Articles
 
-    Q.all(
-      @article.fetchSuperSubArticles(@superSubArticles)
-    ).then =>
+    Q.all(@article.fetchSuperSubArticles(@superSubArticles, req.user?.get('accessToken')))
+    .then =>
       res.locals.sd.SUPER_ARTICLE = @article.toJSON()
       res.locals.sd.CURATION = @curation.toJSON()
       res.render 'components/eoy/templates/index',

--- a/models/article.coffee
+++ b/models/article.coffee
@@ -188,10 +188,11 @@ module.exports = class Article extends Backbone.Model
         section
     @set 'sections', sections
 
-  fetchSuperSubArticles: (superSubArticles) ->
+  fetchSuperSubArticles: (superSubArticles, accessToken = '') ->
     for id in @get('super_article').related_articles
       new Article(id: id).fetch
         cache: true
+        headers: 'X-Access-Token': accessToken
         success: (article) =>
           superSubArticles.add article
 


### PR DESCRIPTION
This lets you preview super article drafts fully. By that I mean with its nav and sub articles. Before you were able to see the superarticle, but it would have trouble rendering the nav because its sub articles were drafts that needed to be fetched with an access token.

This makes the accessToken an option in the `fetchSuperSubArticles` method, and also fetches the super article with a token in the EOY feature. 