### PR TITLE
Formatting for News when bio is absent

### DIFF
--- a/apps/partner2/stylesheets/overview.styl
+++ b/apps/partner2/stylesheets/overview.styl
@@ -28,7 +28,7 @@
       min-height 100px
       .partner-overview-section-title
         avant-garde-size('m-headline')
-    &[data-module=about] + [data-module=news]
+    &[data-module=news]
       .partner-overview-section-title
       .partner2-news
         display block


### PR DESCRIPTION
Fixes #453 

Formerly, the list of events in the New section was not correctly formatted when a bio was absent. 