### PR TITLE
@joeyAghion => Allow artist CV to include non displayable shows

### DIFF
--- a/apps/artist/queries/cv.coffee
+++ b/apps/artist/queries/cv.coffee
@@ -3,10 +3,10 @@ module.exports =
   query artist($artist_id: String!, $shows: Boolean!, $articles: Boolean!) {
     artist(id: $artist_id) {
       ... on Artist @include(if: $shows) {
-        group_shows: shows(at_a_fair: false, solo_show:false, sort: start_at_desc, is_reference: true, size: 99) {
+        group_shows: shows(at_a_fair: false, solo_show:false, sort: start_at_desc, is_reference: true, visible_to_public: false, size: 99) {
           ... relatedShow
         }
-        solo_shows: shows(at_a_fair: false, solo_show:true, sort: start_at_desc, is_reference: true, size: 99) {
+        solo_shows: shows(at_a_fair: false, solo_show:true, sort: start_at_desc, is_reference: true, visible_to_public: false, size: 99) {
           ... relatedShow
         }
         fair_booths: shows(at_a_fair: true, sort: start_at_desc, size: 99) {


### PR DESCRIPTION
Using the new param to make the CV tab on an artist page include those shows.

The 'exhibition highlights' section will just work, no update needed there.