### PR TITLE
@eessex => [EOY] Parsely, JSONLD, Sailthru

### DIFF
--- a/analytics/before_ready.js
+++ b/analytics/before_ready.js
@@ -1,5 +1,4 @@
 /* Analytics code that needs to run before page load and analytics.ready */
-
-if (!location.pathname.match(/^\/article/) && !sd.SECTION) {
+if (!location.pathname.match(/^\/article|^\/eoy-2016|^\/2016-year-in-art/)) {
   window.PARSELY = {autotrack: false}
 } /* Disable Parsely firing on non-article/section pages */

--- a/apps/editorial_features/components/eoy/stylesheets/index.styl
+++ b/apps/editorial_features/components/eoy/stylesheets/index.styl
@@ -46,10 +46,6 @@ flex-display(justify = space-between, align = center)
         line-height 15px
         margin-right 12px
 
-#recently-viewed-artworks
-  display none
-
-
 @media screen and (max-width: 550px)
   .eoy-feature__menu
     margin 0 10px

--- a/apps/editorial_features/components/eoy/templates/head.jade
+++ b/apps/editorial_features/components/eoy/templates/head.jade
@@ -31,19 +31,18 @@ if article.get('keywords') && article.get('keywords').length
 
 //- Sailthru Metatags
 if article.get('published')
-  if article.get('email_metadata')
-    if article.get('email_metadata').headline
-      meta( name="sailthru.title", content=article.get('email_metadata').headline)
-    if article.get('email_metadata').author
-      meta( name="sailthru.author" content=article.get('email_metadata').author)
-    if article.get('email_metadata').credit_url
-      meta( name="sailthru.credit_url" content=article.get('email_metadata').credit_url)
-    if article.get('email_metadata').credit_line
-      meta( name="sailthru.credit_line" content=article.get('email_metadata').credit_line)
-    if article.get('email_metadata').image_url
-      - var src = article.get('email_metadata').image_url
-      meta( name="sailthru.image.full" content=crop(src, { width: 1200, height: 706 } ))
-      meta( name="sailthru.image.thumb" content=crop(src, { width: 900, height: 530 } ))
+  if article.get('email_metadata').headline
+    meta( name="sailthru.title", content=article.get('email_metadata').headline)
+  if article.get('email_metadata').author
+    meta( name="sailthru.author" content=article.get('email_metadata').author)
+  if article.get('email_metadata').credit_url
+    meta( name="sailthru.credit_url" content=article.get('email_metadata').credit_url)
+  if article.get('email_metadata').credit_line
+    meta( name="sailthru.credit_line" content=article.get('email_metadata').credit_line)
+  if article.get('email_metadata').image_url
+    - var src = article.get('email_metadata').image_url
+    meta( name="sailthru.image.full" content=crop(src, { width: 1200, height: 706 } ))
+    meta( name="sailthru.image.thumb" content=crop(src, { width: 900, height: 530 } ))
   - var keywords = ['article', 'magazine']
   if article.get('keywords') && article.get('keywords').length
     - keywords = keywords.concat(article.get('keywords'))

--- a/apps/editorial_features/components/eoy/templates/head.jade
+++ b/apps/editorial_features/components/eoy/templates/head.jade
@@ -30,7 +30,7 @@ if article.get('keywords') && article.get('keywords').length
   meta( property="article:tag", content=(article.get('keywords')).join(', ') )
 
 //- Sailthru Metatags
-if article.get('published')
+if article.get('published') && article.get('email_metadata')
   if article.get('email_metadata').headline
     meta( name="sailthru.title", content=article.get('email_metadata').headline)
   if article.get('email_metadata').author

--- a/apps/editorial_features/components/eoy/templates/index.jade
+++ b/apps/editorial_features/components/eoy/templates/index.jade
@@ -31,4 +31,4 @@ block body
       section.footer
         include ../../../../../components/article/templates/super_article_footer.jade
 
-    #recently-viewed-artworks
+  include ../../../../../components/main_layout/templates/json_ld

--- a/apps/editorial_features/routes.coffee
+++ b/apps/editorial_features/routes.coffee
@@ -5,6 +5,7 @@ Curation = require '../../models/curation.coffee'
 Article = require '../../models/article.coffee'
 Articles = require '../../collections/articles.coffee'
 markdown = require '../../components/util/markdown.coffee'
+{ stringifyJSONForWeb } = require '../../components/util/json.coffee'
 Q = require 'bluebird-q'
 
 @eoy = (req, res, next) ->
@@ -23,6 +24,8 @@ Q = require 'bluebird-q'
     .then =>
       res.locals.sd.SUPER_ARTICLE = @article.toJSON()
       res.locals.sd.CURATION = @curation.toJSON()
+      res.locals.jsonLD = stringifyJSONForWeb(@article.toJSONLD())
+      res.locals.sd.INCLUDE_SAILTHRU = true
       res.render 'components/eoy/templates/index',
         curation: @curation,
         article: @article,

--- a/apps/editorial_features/test/components/eoy/client.coffee
+++ b/apps/editorial_features/test/components/eoy/client.coffee
@@ -97,7 +97,7 @@ describe 'EoyView', ->
         sd: sd,
         markdown: markdown,
         asset: ->
-        }
+      }
       benv.render resolve(__dirname, '../../../components/eoy/templates/index.jade'), @options, =>
         { EoyView } = mod = benv.requireWithJadeify resolve(__dirname, '../../../components/eoy/client'), ['bodyView']
         mod.__set__ 'initCarousel', @carousel = sinon.stub()

--- a/components/recently_viewed_artworks/exclude_list.coffee
+++ b/components/recently_viewed_artworks/exclude_list.coffee
@@ -16,5 +16,6 @@ module.exports =
     '/consign'
     '/professional-buyer'
     '/eoy-2016'
+    '/2016-year-in-art'
     /\/feature/     # any /feature page
   ]


### PR DESCRIPTION
- Makes sure autotrack doesn't get set to false for EOY (this is what disables Parsely tracking)
- Includes a JSONLD (what Parsely uses for metadata)
- Remove #recently-viewed-artwork: display none in favor of blacklisting
- Sets INCLUDE_SAILTHRU = true so Horizon (which tracks Sailthru pageviews) is on the page.