### PR TITLE
@broskoski => fix ended time for live sales

### DIFF
--- a/apps/auctions/templates/index.jade
+++ b/apps/auctions/templates/index.jade
@@ -37,7 +37,7 @@ block body
             for auction in pastAuctions
               a.leader-dots-list-item( href= auction.href() )
                 span= auction.get('name')
-                span= auction.date('end_at').format('MMM D, YYYY')
+                span= auction.endedTime().format('MMM D, YYYY')
 
       .aggregate-page-items-upcoming
         .auctions-my-active-bids

--- a/models/sale.coffee
+++ b/models/sale.coffee
@@ -125,6 +125,9 @@ module.exports = class Sale extends Backbone.Model
   sortableDate: ->
     if @get('live_start_at')? then @get('live_start_at') else @get('end_at')
 
+  endedTime: ->
+    if @get('end_at')? then moment.utc(@get('end_at')) else moment.utc(@get('ended_at'))
+
   # if a reminder is in order, return relevant data. else undefined.
   reminderStatus: ->
     return 'closing_soon' if @isClosingSoon()

--- a/test/models/sale.coffee
+++ b/test/models/sale.coffee
@@ -196,6 +196,15 @@ describe 'Sale', ->
         @user.set 'qualified_for_bidding', true
         @sale.bidButtonState(@user, @artwork).label.should.equal 'Enter Live Auction'
 
+  describe 'endedTime', ->
+    it 'returns the end_at if the sale has an end_at', ->
+      @sale.set end_at: moment('2016-12-30')
+      @sale.endedTime().format('MMM D, YYYY').should.equal 'Dec 30, 2016'
+
+    it 'returns the ended_at if the sale has no end_at', ->
+      @sale.set end_at: null, ended_at: moment('2016-12-30')
+      @sale.endedTime().format('MMM D, YYYY').should.equal 'Dec 30, 2016'
+
   describe '#fetchArtworks', ->
 
     it 'fetches the sale artworks', ->


### PR DESCRIPTION
For auctions with no `end_at`, we still want to show when they technically ended. This will be encapsulated by the `ended_at` field, which gets set when a sale ends.

For some reason, some past sales have a different `end_at` than `ended_at`, (or it's close to midnight so it spills over), so in the case where a sale _does_ have an `end_at`, we'll prefer that.

Here is the affected view:
![image](https://cloud.githubusercontent.com/assets/2081340/21162556/1237c428-c15c-11e6-8d18-e4b7d4b5afb7.png)
