### PR TITLE
@gnilekaw: Allow synonyms to improve location filtering on /galleries

### DIFF
--- a/apps/galleries_institutions/components/filter_facet/init_filter_facets.coffee
+++ b/apps/galleries_institutions/components/filter_facet/init_filter_facets.coffee
@@ -1,6 +1,7 @@
 PartnerFilterFacet = require './partner_filter_facet.coffee'
 { CATEGORIES } = require('sharify').data
 { Cities, FeaturedCities } = require '../../../../components/partner_cities/index.coffee'
+locationSynonyms = require './locationSynonyms.coffee'
 
 _ = require 'underscore'
 facetDefaults = require './facet_defaults.coffee'
@@ -11,6 +12,7 @@ module.exports = ({params, aggregations}) -> [
       emptyStateItemIDs: _.pluck FeaturedCities, 'slug'
       params: params
       aggregations: aggregations
+      synonyms: locationSynonyms
     }, _.find facetDefaults(params.get('type')), facetName: 'location'
   ),
   new PartnerFilterFacet(_.extend {

--- a/apps/galleries_institutions/components/filter_facet/locationSynonyms.coffee
+++ b/apps/galleries_institutions/components/filter_facet/locationSynonyms.coffee
@@ -1,0 +1,4 @@
+module.exports = [
+  ['st', 'saint']
+]
+

--- a/apps/galleries_institutions/components/filter_facet/test/partner_filter_facet.coffee
+++ b/apps/galleries_institutions/components/filter_facet/test/partner_filter_facet.coffee
@@ -40,6 +40,7 @@ describe 'PartnerFilterFacet', ->
       facetName: 'location'
       displayName: 'Locations'
       aggregations: @aggregations
+      synonyms: [ ['st', 'saint'] ]
 
   describe '#initialize', ->
     it 'creates the item for all suggestions', ->
@@ -144,6 +145,9 @@ describe 'PartnerFilterFacet', ->
 
     it 'ignores diacritics', ->
       @facet.isMatched('zur', 'Zürich').should.be.ok()
+
+    it 'replaces synonyms', ->
+      @facet.isMatched('st ives', 'Saint Ives').should.be.ok()
 
   describe '#async_matcher', ->
     beforeEach ->

--- a/lib/normalizeSynonyms.coffee
+++ b/lib/normalizeSynonyms.coffee
@@ -1,0 +1,26 @@
+# Simplistic approach to providing synonym-matching, e.g. in typeahead queries.
+#
+# Usage:
+#
+# mySynonyms = [ ['saint', 'st'], ['harbor', 'harbour'] ]
+# normalizeSynonyms(mySynonyms, 'st ives')
+#  => returns 'saint ives'
+# normalizeSynonyms(mySynonyms, 'bal harbour')
+#  => returns 'bal harbor'
+
+normalizeSynonymList = (synonymList, inputString) ->
+  firstSynonym = synonymList[0]
+  synonymList.reduce (str, synonym) ->
+    regex = new RegExp '\\b' + synonym + '\\b', 'i'
+    str.replace(regex, firstSynonym)
+  , inputString
+
+normalizeSynonyms = (allSynonyms, inputString) ->
+  return inputString unless allSynonyms?
+  return inputString if allSynonyms is []
+  allSynonyms.reduce (str, synonymList) ->
+    normalizeSynonymList(synonymList, str)
+  , inputString
+
+module.exports = normalizeSynonyms
+

--- a/test/lib/normalizeSynonyms.coffee
+++ b/test/lib/normalizeSynonyms.coffee
@@ -1,0 +1,23 @@
+normalizeSynonyms = require '../../lib/normalizeSynonyms.coffee'
+
+describe 'normalizeSynonyms', ->
+  
+  it 'reduces each set of synonyms to the first one in the list', ->
+    normalizeSynonyms([['st', 'saint']], 'saint ives').should.equal 'st ives'
+
+  it 'replaces synonyms regardless of case', ->
+    normalizeSynonyms([['st', 'saint']], 'Saint Ives').should.equal 'st Ives'
+
+  it 'ignores synonyms when they are substrings of other words', ->
+    normalizeSynonyms([['st', 'saint']], 'East Bay').should.equal 'East Bay'
+    normalizeSynonyms([['st', 'saint']], 'Saintsburg').should.equal 'Saintsburg'
+
+  it 'reduces multiple sets of synonyms by iterating over each synonym list', ->
+    normalizeSynonyms([['st', 'saint'], ['harbor', 'harbour']], 'saint ives').should.equal 'st ives'
+    normalizeSynonyms([['st', 'saint'], ['harbor', 'harbour']], 'bal harbour').should.equal 'bal harbor'
+    normalizeSynonyms([['st', 'saint'], ['harbor', 'harbour']], 'saint ives harbour').should.equal 'st ives harbor'
+
+  it 'does nothing for empty synonym lists', ->
+    normalizeSynonyms(undefined, 'saint ives').should.equal 'saint ives'
+    normalizeSynonyms(null, 'saint ives').should.equal 'saint ives'
+    normalizeSynonyms([], 'saint ives').should.equal 'saint ives'


### PR DESCRIPTION
Fixes an issue that currently affects several of our geocoded cities, e.g…

* The geocoded name "Saint Ives" doesn't match the user input "st ives"
* The geocoded name "St. Louis" doesn't match the user input "saint louis"

Let's allow synonym-matching so that both of the above  typeahead queries will succeed:

![syns](https://cloud.githubusercontent.com/assets/140521/21163181/8bf99270-c15f-11e6-97bb-96a0e70d9aab.gif)
