### PR TITLE
@craigspaeth purchase request analytics

### DIFF
--- a/analytics/artwork.js
+++ b/analytics/artwork.js
@@ -3,7 +3,6 @@
 
   // DOM events
   var $document = $(document)
-
   $document
     .on('click', '.analytics-artwork-show-phone-number', function () {
       analytics.track("Clicked 'Show phone number'", $(this).data())
@@ -29,6 +28,13 @@
     .on('click', '.analytics-artwork-contact-seller', function () {
       var context = $(this).data()
       analytics.track('Clicked "Contact Gallery"', {
+        artwork_id: context.artwork_id,
+        context_type: context.context_type
+      })
+    })
+    .on('click', '.analytics-artwork-purchase', function () {
+      var context = $(this).data()
+      analytics.track('Clicked "Purchase"', {
         artwork_id: context.artwork_id,
         context_type: context.context_type
       })

--- a/analytics/artwork_purchase.js
+++ b/analytics/artwork_purchase.js
@@ -1,0 +1,31 @@
+(function () {
+  'use strict'
+
+  // DOM events
+  var $document = $(document)
+  $document.on('click', '.analytics-artwork-purchase-back-to-browsing', function () {
+    analytics.track("Clicked 'Back to Browsing' purchase flow")
+  })
+
+  analyticsHooks.on('purchase:signup:success', function (context) {
+    var user_id
+    if (context.user) {
+      user_id = context.user._id
+    }
+    analytics.track("Created account", {
+      context: 'purchase flow',
+      user_id: user_id
+    })
+  })
+
+  analyticsHooks.on('purchase:inquiry:success', function (context) {
+    analytics.track('Sent artwork inquiry', {
+      artwork_id: context.artwork._id,
+      artwork_slug: context.artwork.id,
+      inquiry_id: context.inquiry.id
+    })
+  })
+  analyticsHooks.on('purchase:inquiry:failure', function (context) {
+    analytics.track('Purchase request failed to submit')
+  })
+})()

--- a/analytics/artwork_purchase.js
+++ b/analytics/artwork_purchase.js
@@ -8,13 +8,9 @@
   })
 
   analyticsHooks.on('purchase:signup:success', function (context) {
-    var user_id
-    if (context.user) {
-      user_id = context.user._id
-    }
     analytics.track("Created account", {
       context: 'purchase flow',
-      user_id: user_id
+      user_id: context.user.id
     })
   })
 
@@ -22,7 +18,8 @@
     analytics.track('Sent artwork inquiry', {
       artwork_id: context.artwork._id,
       artwork_slug: context.artwork.id,
-      inquiry_id: context.inquiry.id
+      inquiry_id: context.inquiry.id,
+      user_id: context.user.id
     })
   })
   analyticsHooks.on('purchase:inquiry:failure', function (context) {

--- a/apps/artwork/components/commercial/templates/acquire.jade
+++ b/apps/artwork/components/commercial/templates/acquire.jade
@@ -3,7 +3,7 @@ if artwork.is_acquireable
     input( type='hidden', name='artwork_id', value= artwork.id )
 
     button.avant-garde-button-black.is-block( class='js-artwork-acquire-button' )
-      if purchaseFlow
+      if inPurchaseTestGroup
         | Purchase
       else
         | Buy

--- a/apps/artwork/components/commercial/templates/acquire.jade
+++ b/apps/artwork/components/commercial/templates/acquire.jade
@@ -3,7 +3,7 @@ if artwork.is_acquireable
     input( type='hidden', name='artwork_id', value= artwork.id )
 
     button.avant-garde-button-black.is-block( class='js-artwork-acquire-button' )
-      if inPurchaseTestGroup
+      if inPurchaseTestGroup && notProduction
         | Purchase
       else
         | Buy

--- a/apps/artwork/components/commercial/templates/index.jade
+++ b/apps/artwork/components/commercial/templates/index.jade
@@ -1,6 +1,6 @@
 .artwork-commercial( class='js-artwork-commercial' )
   form.artwork-commercial__form
-    if inPurchaseTestGroup && isPurchasable
+    if inPurchaseTestGroup && isPurchasable && notProduction
       include ./purchase_flow_index
     else
       include ./standard_index

--- a/apps/artwork/components/commercial/templates/index.jade
+++ b/apps/artwork/components/commercial/templates/index.jade
@@ -1,6 +1,6 @@
 .artwork-commercial( class='js-artwork-commercial' )
   form.artwork-commercial__form
-    if purchaseFlow && eligibleForPurchase
+    if inPurchaseTestGroup && isPurchasable
       include ./purchase_flow_index
     else
       include ./standard_index

--- a/apps/artwork/components/commercial/templates/purchase_flow_inquiry_buttons.jade
+++ b/apps/artwork/components/commercial/templates/purchase_flow_inquiry_buttons.jade
@@ -1,6 +1,6 @@
 .artwork-commercial__inquiry-buttons
   button.avant-garde-button-black.is-block(
-    class='js-artwork-purchase-button analytics-artwork-contact-seller'
+    class='js-artwork-purchase-button analytics-artwork-purchase'
     data-artwork_id= artwork._id
     data-context_type='sidebar'
   )

--- a/apps/artwork/components/commercial/view.coffee
+++ b/apps/artwork/components/commercial/view.coffee
@@ -26,12 +26,12 @@ module.exports = class ArtworkCommercialView extends Backbone.View
   initialize: ({ @data }) ->
     { artwork } = @data
 
+    inPurchaseTestGroup = PURCHASE_FLOW is 'purchase'
+
     if artwork.is_purchasable
       splitTest('purchase_flow').view()
-      # @usePurchaseFlow = PURCHASE_FLOW is 'purchase'
-      @usePurchaseFlow = NODE_ENV is 'development' or
-        NODE_ENV is 'staging' or
-        NODE_ENV is 'test'
+
+    @usePurchaseFlow = inPurchaseTestGroup and artwork.is_purchasable
 
     @artwork = new Artwork artwork
 

--- a/apps/artwork/components/commercial/view.coffee
+++ b/apps/artwork/components/commercial/view.coffee
@@ -55,12 +55,15 @@ module.exports = class ArtworkCommercialView extends Backbone.View
   # modal when there is no pre-filled form in the side bar.
   contactGallery: (e) ->
     e.preventDefault()
-    $button = $ '.js-artwork-inquire-button'
+
+    $button = @$ '.js-artwork-inquire-button'
     $button.attr 'data-state', 'loading'
-    $button.prop 'disabled', true
+    # Defer submit disable so as to allow
+    # event handlers to finish propagating
+    _.defer ->
+      $button.prop 'disabled', true
 
     @inquiry = new ArtworkInquiry notification_delay: 600
-
     @user = User.instantiate()
     @artwork.fetch().then =>
       @artwork.related().fairs.add @data.artwork.fair
@@ -82,7 +85,6 @@ module.exports = class ArtworkCommercialView extends Backbone.View
   inquire: (e) =>
     return @contactGallery(e) if @usePurchaseFlow
     e.preventDefault()
-
     @inquiry = new ArtworkInquiry notification_delay: 600
 
     form = new Form model: @inquiry, $form: @$el

--- a/apps/artwork/components/commercial/view.coffee
+++ b/apps/artwork/components/commercial/view.coffee
@@ -26,13 +26,14 @@ module.exports = class ArtworkCommercialView extends Backbone.View
   initialize: ({ @data }) ->
     { artwork } = @data
 
-    inPurchaseTestGroup = PURCHASE_FLOW is 'purchase'
-
     if artwork.is_purchasable
       splitTest('purchase_flow').view()
 
-    @usePurchaseFlow = inPurchaseTestGroup and artwork.is_purchasable
-
+    inPurchaseTestGroup = PURCHASE_FLOW is 'purchase'
+    notProduction = NODE_ENV is 'development' or
+      NODE_ENV is 'staging' or
+      NODE_ENV is 'test'
+    @usePurchaseFlow = inPurchaseTestGroup and artwork.is_purchasable and notProduction
     @artwork = new Artwork artwork
 
   acquire: (e) ->

--- a/apps/artwork/routes.coffee
+++ b/apps/artwork/routes.coffee
@@ -68,6 +68,9 @@ bootstrap = ->
   metaphysics send
     .then (data) ->
       data.inPurchaseTestGroup = inPurchaseTestGroup
+      data.notProduction = res.locals.sd.NODE_ENV is 'development' or
+        res.locals.sd.NODE_ENV is 'staging' or
+        res.locals.sd.NODE_ENV is 'test'
       data.isPurchasable = data.artwork.is_purchasable
       extend res.locals.helpers, helpers
       bootstrap res.locals.sd, data

--- a/apps/artwork/routes.coffee
+++ b/apps/artwork/routes.coffee
@@ -64,14 +64,11 @@ bootstrap = ->
   send = method: 'post', query: query, variables: req.params
 
   return if metaphysics.debug req, res, send
-  # purchaseFlow = res.locals.sd.PURCHASE_FLOW is 'purchase'
-  purchaseFlow = res.locals.sd.NODE_ENV is 'development' or
-    res.locals.sd.NODE_ENV is 'staging' or
-    res.locals.sd.NODE_ENV is 'test'
+  inPurchaseTestGroup = res.locals.sd.PURCHASE_FLOW is 'purchase'
   metaphysics send
     .then (data) ->
-      data.purchaseFlow = purchaseFlow
-      data.eligibleForPurchase = data.artwork.is_purchasable
+      data.inPurchaseTestGroup = inPurchaseTestGroup
+      data.isPurchasable = data.artwork.is_purchasable
       extend res.locals.helpers, helpers
       bootstrap res.locals.sd, data
       res.locals.sd.PARAMS = req.params

--- a/apps/artwork/templates/index.jade
+++ b/apps/artwork/templates/index.jade
@@ -21,7 +21,7 @@ block body
             include ../client/fold
 
         .artwork__main__metadata(
-          class= inPurchaseTestGroup && isPurchasable ? 'purchase-flow' : ''
+          class= inPurchaseTestGroup && isPurchasable && notProduction ? 'purchase-flow' : ''
         )
           include ../components/metadata/index
           include ../components/commercial/index

--- a/apps/artwork/templates/index.jade
+++ b/apps/artwork/templates/index.jade
@@ -21,7 +21,7 @@ block body
             include ../client/fold
 
         .artwork__main__metadata(
-          class= eligibleForPurchase && purchaseFlow ? 'purchase-flow' : ''
+          class= inPurchaseTestGroup && isPurchasable ? 'purchase-flow' : ''
         )
           include ../components/metadata/index
           include ../components/commercial/index

--- a/apps/artwork_purchase/client/purchase_form.coffee
+++ b/apps/artwork_purchase/client/purchase_form.coffee
@@ -29,8 +29,11 @@ module.exports = class PurchaseForm extends Backbone.View
 
     promises = [Q.promise (resolve) =>
       @inquiry.save null,
-        success: resolve
+        success: =>
+          analyticsHooks.trigger 'purchase:inquiry:success', { @artwork, @inquiry }
+          resolve()
         error: (model, response, options) =>
+          analyticsHooks.trigger 'purchase:inquiry:failiure'
           @$('.js-ap-form-errors').html @errorMessage(response)
           error?()
     ]

--- a/apps/artwork_purchase/client/purchase_form.coffee
+++ b/apps/artwork_purchase/client/purchase_form.coffee
@@ -6,16 +6,17 @@ User = require '../../../models/user.coffee'
 CurrentUser = require '../../../models/current_user.coffee'
 ArtworkInquiry = require '../../../models/artwork_inquiry.coffee'
 { formatMessage } = require '../helpers.coffee'
+UserFairAction = require '../../../models/user_fair_action.coffee'
 
 module.exports = class PurchaseForm extends Backbone.View
   _.extend @prototype, Form
 
-  initialize: ({ @artwork, @user }) ->
+  initialize: ({ @artwork }) ->
     @inquiry = new ArtworkInquiry
 
   submit: ({ success, error })->
     formData = @serializeForm()
-    message = formatMessage _.extend { @artwork, @user }, formData
+    message = formatMessage _.extend { @artwork }, formData
     { name } = formData
     @inquiry.set {
       name,
@@ -23,31 +24,21 @@ module.exports = class PurchaseForm extends Backbone.View
       artwork: @artwork.id,
       contact_gallery: true,
       inquiry_url: window.location.href,
-      user: @user
     }
-    @user.related().collectorProfile.findOrCreate() .then =>
 
     promises = [Q.promise (resolve) =>
       @inquiry.save null,
-        success: =>
-          analyticsHooks.trigger 'purchase:inquiry:success', { @artwork, @inquiry }
-          resolve()
+        success: (model, response) -> resolve response
         error: (model, response, options) =>
-          analyticsHooks.trigger 'purchase:inquiry:failiure'
           @$('.js-ap-form-errors').html @errorMessage(response)
           error?()
     ]
 
+    action = new UserFairAction
     if formData.attending
-      @user.related()
-        .collectorProfile.related()
-        .userFairActions
-        .attendFair @artwork.fair
+      promises.push Q.promise (resolve) ->
+        action.save fair_id: 'miami-project-2016',
+          success: (model, response) -> resolve response
+          error: -> resolve()
 
-      promises.push Q.allSettled(
-        @user
-          .related().collectorProfile
-          .related().userFairActions.invoke 'save'
-      )
-
-    Q.all(promises).then success
+    Q.all(promises).spread success

--- a/apps/artwork_purchase/client/purchase_signup_form.coffee
+++ b/apps/artwork_purchase/client/purchase_signup_form.coffee
@@ -1,38 +1,46 @@
 _ = require 'underscore'
+Q = require 'bluebird-q'
 Backbone = require 'backbone'
 Form = require '../../../components/mixins/form.coffee'
 mediator = require '../../../lib/mediator.coffee'
 analyticsHooks = require '../../../lib/analytics_hooks.coffee'
-User = require '../../../models/user.coffee'
+CurrentUser = require '../../../models/current_user.coffee'
 sanitizeRedirect = require 'artsy-passport/sanitize-redirect'
 Mailcheck = require '../../../components/mailcheck/index.coffee'
 Cookies = require 'cookies-js'
+LoggedOutUser = require '../../../models/logged_out_user.coffee'
 
 module.exports = class PurchaseSignupForm extends Backbone.View
   _.extend @prototype, Form
 
-  initialize: ({ @user }) -> #
+  initialize: -> #
+    @loggedOutUser = new LoggedOutUser
 
   submit: ({ success, error, isWithAccountCallback }) ->
-    @user.set (data = @serializeForm())
-    @user.prepareForInquiry().then =>
-      if @user.isWithAccount()
+    @loggedOutUser.set (data = @serializeForm())
+    @loggedOutUser.prepareForInquiry().then =>
+
+    userLookup = @loggedOutUser.findOrCreate silent: true
+      .then =>
+        Q.promise (resolve) =>
+          @loggedOutUser.related().account.fetch
+            silent: true
+            success: resolve
+            error: resolve
+
+    userLookup.then =>
+      if @loggedOutUser.isWithAccount()
         isWithAccountCallback()
       else
         @signup { success, error }
 
   signup: ({ success, error }) ->
-    @user.signup
+    @loggedOutUser.signup
       trigger_login: false
-      success: (model, { user }) =>
-        analyticsHooks.trigger "purchase:signup:success",
-          user: user
-        @user.repossess user.id,
-          success: ->
-            success?()
-          error: (model, response, options) =>
-            @showError @errorMessage response
-            error?()
+      success: success
+      error: (model, response, options) =>
+        @showError @errorMessage response
+        error?()
 
       error: (model, response, options) =>
         @showError @errorMessage response

--- a/apps/artwork_purchase/client/purchase_signup_form.coffee
+++ b/apps/artwork_purchase/client/purchase_signup_form.coffee
@@ -25,7 +25,8 @@ module.exports = class PurchaseSignupForm extends Backbone.View
     @user.signup
       trigger_login: false
       success: (model, { user }) =>
-        analyticsHooks.trigger "auth:signup"
+        analyticsHooks.trigger "purchase:signup:success",
+          user: user
         @user.repossess user.id,
           success: ->
             success?()

--- a/apps/artwork_purchase/routes.coffee
+++ b/apps/artwork_purchase/routes.coffee
@@ -36,18 +36,18 @@ Fair = require '../../models/fair.coffee'
   """
 
   return if metaphysics.debug req, res, send
-  # purchaseFlow = res.locals.sd.PURCHASE_FLOW is 'purchase'
-  purchaseFlow = res.locals.sd.NODE_ENV is 'development' or
+  inPurchaseTestGroup = res.locals.sd.PURCHASE_FLOW is 'purchase'
+  notProduction = res.locals.sd.NODE_ENV is 'development' or
     res.locals.sd.NODE_ENV is 'staging' or
     res.locals.sd.NODE_ENV is 'test'
-  return res.redirect "/artwork/#{req.params.id}" if not purchaseFlow
+  return res.redirect "/artwork/#{req.params.id}" unless inPurchaseTestGroup and notProduction
   send = query: query, variables: req.params
   metaphysics send
     .then ({ artwork }) ->
       cookie = req.cookies['purchase-inquiry']
       cachedData = JSON.parse cookie if cookie
       purchase = cachedData if cachedData?.artwork_id is artwork.id
-      return res.redirect "/artwork/#{req.params.id}" if not artwork.is_purchasable
+      return res.redirect "/artwork/#{req.params.id}" unless artwork.is_purchasable
       fair = new Fair artwork.fair if artwork.fair
       res.locals.sd.ARTWORK = artwork
       res.render 'index', {
@@ -78,15 +78,15 @@ Fair = require '../../models/fair.coffee'
 
   """
   return if metaphysics.debug req, res, send
-  # purchaseFlow = res.locals.sd.PURCHASE_FLOW is 'purchase'
-  purchaseFlow = res.locals.sd.NODE_ENV is 'development' or
+  inPurchaseTestGroup = res.locals.sd.PURCHASE_FLOW is 'purchase'
+  notProduction = res.locals.sd.NODE_ENV is 'development' or
     res.locals.sd.NODE_ENV is 'staging' or
     res.locals.sd.NODE_ENV is 'test'
-  return res.redirect "/artwork/#{req.params.id}" if not purchaseFlow
+  return res.redirect "/artwork/#{req.params.id}" unless inPurchaseTestGroup and notProduction
   send = query: query, variables: req.params
   metaphysics send
     .then ({ artwork }) ->
-      return res.redirect "/artwork/#{req.params.id}" if not artwork.is_purchasable
+      return res.redirect "/artwork/#{req.params.id}" unless artwork.is_purchasable
       res.locals.sd.ARTWORK = artwork
       res.render 'success', { artwork }
     .catch next

--- a/apps/artwork_purchase/templates/success.jade
+++ b/apps/artwork_purchase/templates/success.jade
@@ -37,5 +37,7 @@ block body
               | #{artwork.partner.name} will ship the work to your address
 
         .artwork-purchase__section
-          a.avant-garde-button-black.is-block(href= artwork.href)
-            | Back to Browsing
+          a.avant-garde-button-black.is-block(
+            href= artwork.href
+            class= 'analytics-artwork-purchase-back-to-browsing'
+          ) Back to Browsing

--- a/assets/analytics.coffee
+++ b/assets/analytics.coffee
@@ -38,6 +38,7 @@ $ -> analytics.ready ->
   require '../analytics/notifications.js'
   require '../analytics/artists.js'
   require '../analytics/artwork.js'
+  require '../analytics/artwork_purchase.js'
   require '../analytics/fair.js'
   require '../analytics/following.js'
   require '../analytics/follow_widget.js'


### PR DESCRIPTION
* enable the a/b test groups (on everything except production) -- this means people will have to manipulate their cookie or enter some query params to force the page into the test group. the query param method doesn't work well because there is a page refresh before the thankyou page.

* add analytics events as per https://github.com/artsy/force/issues/463

* refactored a bit after talking to @joeyAghion , it's actually unnecessary to do whole `prepareForInquiry` and the association of the anonymous session with the newly created user because we don't collect any info before account creation.