### PR TITLE
@alloy make contact gallery button gray when shown with purchase button

### DIFF
--- a/apps/artwork/components/commercial/index.styl
+++ b/apps/artwork/components/commercial/index.styl
@@ -4,6 +4,8 @@
 
 .purchase-flow
   .artwork-commercial
+    .artwork-inquiry-button
+      color gray-darker-color
     &__limited-partner-message
     &__sale-message
       border 0px

--- a/apps/artwork/components/commercial/templates/purchase_flow_inquiry_buttons.jade
+++ b/apps/artwork/components/commercial/templates/purchase_flow_inquiry_buttons.jade
@@ -6,7 +6,7 @@
   )
     | Purchase
 
-  button.avant-garde-button-white.is-block(
+  button.avant-garde-button-white.artwork-inquiry-button.is-block(
     class='js-artwork-inquire-button analytics-artwork-contact-seller'
     data-artwork_id= artwork._id
     data-context_type='sidebar'


### PR DESCRIPTION
closes https://github.com/artsy/force/issues/529
gray-semibold is not a color in force, the desired color is #666 which is gray-darker-color