### PR TITLE
@craigspaeth - update city state and zip

### DIFF
--- a/apps/artwork_purchase/helpers.coffee
+++ b/apps/artwork_purchase/helpers.coffee
@@ -18,13 +18,13 @@ module.exports =
       Please note that the collector will review your quote before agreeing to purchase \
       the work and notify you of the final decision."
 
+    cityStateZip = "#{city}, #{state} #{zip}"
+
     address = _.compact([
       name,
       street1,
       street2,
-      city,
-      state,
-      zip,
+      cityStateZip,
       country
     ]).join '\n'
 


### PR DESCRIPTION
I didn't realized that one of the things that needed fixing in the message formatting was the fact that city, state, and zip were being displayed on different lines. This should fix!