### PR TITLE
Refactors artworks for-sale filter

### DIFF
--- a/apps/partner/client/artworks_filter.coffee
+++ b/apps/partner/client/artworks_filter.coffee
@@ -15,7 +15,7 @@ module.exports = class PartnerArtworksView extends Backbone.View
       @profile,
       @partner,
       @aggregations,
-      @forSaleOnly,
+      @forSale,
       @hideForSaleButton,
       @counts,
       @filterRoot
@@ -44,6 +44,5 @@ module.exports = class PartnerArtworksView extends Backbone.View
       facets: @aggregations
       aggregations: @aggregations
       startHistory: false
-      forSale: @forSaleOnly
+      forSale: @forSale
       filterRoot: @filterRoot
-

--- a/apps/partner/client/filter_settings.coffee
+++ b/apps/partner/client/filter_settings.coffee
@@ -3,19 +3,19 @@ module.exports =
     # A gallery's 'WORKS' section, if enabled. Includes for-sale & not-for-sale, all search facets
     'works':
       'aggregations': ['dimension_range', 'medium', 'price_range', 'total', 'for_sale']
-      'forSaleOnly': null
+      'forSale': null
       'hideForSaleButton': false
 
     # An institution's 'WORKS' section. Includes for-sale and not-for-sale works, excludes filtering based on price and saleability.
     'collection':
       'aggregations': ['dimension_range', 'medium', 'total']
-      'forSaleOnly': false
+      'forSale': false
       'hideForSaleButton': true
 
     # An institution's 'SHOP' section, if enabled. Includes only for-sale works, excludes filtering based on saleability.
     'shop':
       'aggregations': ['dimension_range', 'price_range', 'medium', 'total']
-      'forSaleOnly': true
+      'forSale': true
       'hideForSaleButton': true
 
   filterRoot: (partner, section) ->

--- a/apps/partner/client/filter_settings.coffee
+++ b/apps/partner/client/filter_settings.coffee
@@ -3,7 +3,7 @@ module.exports =
     # A gallery's 'WORKS' section, if enabled. Includes for-sale & not-for-sale, all search facets
     'works':
       'aggregations': ['dimension_range', 'medium', 'price_range', 'total', 'for_sale']
-      'forSaleOnly': false
+      'forSaleOnly': null
       'hideForSaleButton': false
 
     # An institution's 'WORKS' section. Includes for-sale and not-for-sale works, excludes filtering based on price and saleability.

--- a/apps/partner/test/client/router.coffee
+++ b/apps/partner/test/client/router.coffee
@@ -48,7 +48,7 @@ describe 'PartnerRouter', ->
 
       settings = {
         'aggregations': ['dimension_range', 'medium', 'price_range', 'total', 'for_sale']
-        'forSaleOnly': false
+        'forSale': false
         'hideForSaleButton': false
         'filterRoot': '/partner-id/section-id'
       }
@@ -61,7 +61,7 @@ describe 'PartnerRouter', ->
       @router.baseView.renderSection.called.should.be.ok()
       @router.baseView.renderSection.args[0][0].should.equal('section-name')
       @router.baseView.renderSection.args[0][1].aggregations.should.equal(settings.aggregations)
-      @router.baseView.renderSection.args[0][1].forSaleOnly.should.equal(settings.forSaleOnly)
+      @router.baseView.renderSection.args[0][1].forSale.should.equal(settings.forSale)
       @router.baseView.renderSection.args[0][1].hideForSaleButton.should.equal(settings.hideForSaleButton)
       @router.baseView.renderSection.args[0][1].filterRoot.should.equal(settings.filterRoot)
       @router.baseView.renderSection.args[0][1].counts.should.equal(counts)

--- a/apps/partner2/client/artworks_filter.coffee
+++ b/apps/partner2/client/artworks_filter.coffee
@@ -46,4 +46,4 @@ module.exports = class PartnerArtworksView extends Backbone.View
       startHistory: false
       forSale: @forSaleOnly
       filterRoot: @filterRoot
-
+      defaultHeading: 'Artworks'

--- a/apps/partner2/client/artworks_filter.coffee
+++ b/apps/partner2/client/artworks_filter.coffee
@@ -15,7 +15,7 @@ module.exports = class PartnerArtworksView extends Backbone.View
       @profile,
       @partner,
       @aggregations,
-      @forSaleOnly,
+      @forSale,
       @hideForSaleButton,
       @counts,
       @filterRoot
@@ -44,6 +44,6 @@ module.exports = class PartnerArtworksView extends Backbone.View
       facets: @aggregations
       aggregations: @aggregations
       startHistory: false
-      forSale: @forSaleOnly
+      forSale: @forSale
       filterRoot: @filterRoot
       defaultHeading: 'Artworks'

--- a/apps/partner2/client/filter_settings.coffee
+++ b/apps/partner2/client/filter_settings.coffee
@@ -3,19 +3,19 @@ module.exports =
     # A gallery's 'WORKS' section, if enabled. Includes for-sale & not-for-sale, all search facets
     'works':
       'aggregations': ['dimension_range', 'medium', 'price_range', 'total', 'for_sale']
-      'forSaleOnly': null
+      'forSale': null
       'hideForSaleButton': false
 
     # An institution's 'WORKS' section. Includes for-sale and not-for-sale works, excludes filtering based on price and saleability.
     'collection':
       'aggregations': ['dimension_range', 'medium', 'total']
-      'forSaleOnly': false
+      'forSale': false
       'hideForSaleButton': true
 
     # An institution's 'SHOP' section, if enabled. Includes only for-sale works, excludes filtering based on saleability.
     'shop':
       'aggregations': ['dimension_range', 'price_range', 'medium', 'total']
-      'forSaleOnly': true
+      'forSale': true
       'hideForSaleButton': true
 
   filterRoot: (partner, section) ->

--- a/apps/partner2/client/filter_settings.coffee
+++ b/apps/partner2/client/filter_settings.coffee
@@ -3,7 +3,7 @@ module.exports =
     # A gallery's 'WORKS' section, if enabled. Includes for-sale & not-for-sale, all search facets
     'works':
       'aggregations': ['dimension_range', 'medium', 'price_range', 'total', 'for_sale']
-      'forSaleOnly': false
+      'forSaleOnly': null
       'hideForSaleButton': false
 
     # An institution's 'WORKS' section. Includes for-sale and not-for-sale works, excludes filtering based on price and saleability.

--- a/apps/partner2/test/client/router.coffee
+++ b/apps/partner2/test/client/router.coffee
@@ -47,7 +47,7 @@ describe 'PartnerRouter', ->
 
       settings = {
         'aggregations': ['dimension_range', 'medium', 'price_range', 'total', 'for_sale']
-        'forSaleOnly': false
+        'forSale': false
         'hideForSaleButton': false
         'filterRoot': '/partner-id/section-id'
       }
@@ -60,6 +60,6 @@ describe 'PartnerRouter', ->
       @router.baseView.renderSection.called.should.be.ok()
       @router.baseView.renderSection.args[0][0].should.equal 'section-name'
       @router.baseView.renderSection.args[0][1].aggregations.should.equal settings.aggregations
-      @router.baseView.renderSection.args[0][1].forSaleOnly.should.equal settings.forSaleOnly
+      @router.baseView.renderSection.args[0][1].forSale.should.equal settings.forSale
       @router.baseView.renderSection.args[0][1].hideForSaleButton.should.equal settings.hideForSaleButton
       @router.baseView.renderSection.args[0][1].filterRoot.should.equal settings.filterRoot

--- a/components/filter2/dropdown_group/view.coffee
+++ b/components/filter2/dropdown_group/view.coffee
@@ -35,7 +35,7 @@ module.exports = class DropdownGroupView extends Backbone.View
 
   toggleForSale: ->
     if @params.get('for_sale') is 'true'
-      @params.set 'for_sale', 'false'
+      @params.set 'for_sale', null
     else
       @params.set 'for_sale', 'true'
 

--- a/components/filter2/headline/view.coffee
+++ b/components/filter2/headline/view.coffee
@@ -30,7 +30,7 @@ module.exports = class HeadlineView extends Backbone.View
     @collection.counts?[facet]?[@params.get(facet)]?.name
 
   anyFacetsSelected: ->
-    @params.get('for_sale') is 'true' || _.any @facets, (facet) => @params.has facet
+    _.any @facets, (facet) => @params.has facet
 
   humanizeMedium: ->
     # replace the 'slash' in 'film-slash-video'

--- a/components/filter2/index.coffee
+++ b/components/filter2/index.coffee
@@ -14,7 +14,7 @@ module.exports =
       includeFixedHeader: includeFixedHeader
       includeAllWorksButton: false
       hideForSaleButton: false
-      forSale: 'true'
+      forSale: null
 
     { aggregations,
       el,


### PR DESCRIPTION
Previously, the `for_sale` artworks filter showed either all artworks or only ones that were for sale. 

This PR refactors it to filter:
- all artworks when `for_sale` is null,
- only for-sale artworks when it's true,
- and only not-for-sale artworks when false

