### PR TITLE
[EOY] Use the same color for anchors as text.

### DIFF
--- a/components/eoy_artist_list/index.styl
+++ b/components/eoy_artist_list/index.styl
@@ -17,6 +17,8 @@
     padding-bottom 20px
     max-width 530px
     margin 0 auto
+    a
+      color gray-darker-color
   &__lists
     &__list
       margin-top 40px
@@ -31,4 +33,3 @@
       &__artists
         margin-top 20px
         text-align left
-  


### PR DESCRIPTION
<img width="520" alt="screen shot 2016-12-16 at 16 47 10" src="https://cloud.githubusercontent.com/assets/2320/21279672/5b18101c-c3af-11e6-88f6-bfa70f5550b7.png">

VS

<img width="525" alt="screen shot 2016-12-16 at 16 47 23" src="https://cloud.githubusercontent.com/assets/2320/21279673/5ed41688-c3af-11e6-9886-0568aa2861f7.png">
