### PR TITLE
@craigspaeth fix failure message typo, fix error in existing account callback

### DIFF
--- a/apps/artwork_purchase/client/index.coffee
+++ b/apps/artwork_purchase/client/index.coffee
@@ -80,11 +80,11 @@ class PurchaseView extends Backbone.View
       error: @purchaseError
     }
 
-  isWithAccount: =>
+  isWithAccount: (user) =>
     @signupForm.reenableForm()
     @purchaseForm.reenableForm()
     @normalButton()
-    @openLoginModal "We found an Artsy account associated with #{@user.get 'email'}. Please log in to continue."
+    @openLoginModal "We found an Artsy account associated with #{user.get 'email'}. Please log in to continue."
 
   signupError: =>
     @signupForm.reenableForm()

--- a/apps/artwork_purchase/client/purchase_form.coffee
+++ b/apps/artwork_purchase/client/purchase_form.coffee
@@ -27,7 +27,7 @@ module.exports = class PurchaseForm extends Backbone.View
       success: (model, response) =>
         analyticsHooks.trigger 'purchase:inquiry:success', { @artwork, @inquiry, user }
       error: (model, response, options) =>
-        analyticsHooks.trigger 'purchase:inquiry:failiure'
+        analyticsHooks.trigger 'purchase:inquiry:failure'
         @$('.js-ap-form-errors').html @errorMessage(response)
         error?()
     ]

--- a/apps/artwork_purchase/client/purchase_signup_form.coffee
+++ b/apps/artwork_purchase/client/purchase_signup_form.coffee
@@ -29,7 +29,7 @@ module.exports = class PurchaseSignupForm extends Backbone.View
 
     userLookup.then =>
       if @loggedOutUser.isWithAccount()
-        isWithAccountCallback()
+        isWithAccountCallback @loggedOutUser
       else
         @signup { success, error }
 


### PR DESCRIPTION
some dumb mistakes! previously the purchase view had a user property, which i got rid of because the user object is only actually needed for a couple things in subviews, since requests automatically go to the `/me` endpoint and are associated with the user on gravity's side that way. there was one outstanding place where i didn't update the code correctly. also made a spelling mistake in an analytics event.