### PR TITLE
@craigspaeth change copy to past tense for closed fairs

### DIFF
--- a/apps/artwork/components/commercial/bootstrap.coffee
+++ b/apps/artwork/components/commercial/bootstrap.coffee
@@ -10,3 +10,4 @@ module.exports = (sd, { artwork }) ->
     sd.COMMERCIAL.artwork.fair =
       id: artwork.fair.id
       name: artwork.fair.name
+      end_at: artwork.fair.end_at

--- a/apps/artwork/components/commercial/templates/inquire.jade
+++ b/apps/artwork/components/commercial/templates/inquire.jade
@@ -32,17 +32,17 @@ if artwork.is_inquireable
         = artwork.partner.contact_message
         = ' '
 
-    if artwork.fair
+    if fair
       .artsy-checkbox
         .artsy-checkbox--checkbox
           input( type='checkbox', name='attending', id='embedded-inquiry-form-attending' )
           label( for='embedded-inquiry-form-attending' )
 
         label.artsy-checkbox--label( for='embedded-inquiry-form-attending' )
-          | I will attend #{artwork.fair.name}
+          | I #{fair.isNotOver() ? 'will attend' : 'attended'} #{fair.nameSansYear()}
           span.help-tooltip(
             data-anchor='bottom-right'
-            data-message='This artwork is part of the art fair—#{artwork.fair.name}.Providing this information enables galleries to offer a more customized service, and helps us send better recommendations and event invitations to you.'
+            data-message='This artwork is part of the art fair—#{fair.nameSansYear()}.Providing this information enables galleries to offer a more customized service, and helps us send better recommendations and event invitations to you.'
           )
 
     button.avant-garde-button-black(

--- a/apps/artwork/components/commercial/test/view.coffee
+++ b/apps/artwork/components/commercial/test/view.coffee
@@ -102,22 +102,49 @@ describe 'ArtworkCommercialView', ->
               html.should.containEql 'You will receive an email receipt of your inquiry shortly.'
 
   describe 'an inquireable work, in a fair', ->
-    beforeEach ->
-      fixture = extend {}, require './fixtures/inquireable.json'
-      fixture.data.artwork.fair = id: 'foo-fair', name: 'Foo Fair'
-      @view = new ArtworkCommercialView fixture
-      @view.render()
 
-    describe '#render', ->
-      it 'correctly renders the template', ->
-        @view.$el.html()
-          .should.containEql 'I will attend Foo Fair'
+    describe 'fair is open', ->
+      beforeEach ->
+        fixture = extend {}, require './fixtures/inquireable.json'
+        tomorrow = new Date (new Date()).getTime() + (24*60*60*1000)
+        fixture.data.artwork.fair = id: 'foo-fair', name: 'Foo Fair 2016', end_at: tomorrow.toISOString()
+        @view = new ArtworkCommercialView fixture
 
-    describe '#inquiry', ->
-      it 'marks the attendance', ->
-        Backbone.sync.returns then: sinon.stub()
-        @view.$('input[name="attending"]').prop 'checked', true
-        @view.$('.js-artwork-inquire-button').click()
+        @view.render()
 
-        @view.user.isAttending id: 'foo-fair'
-          .should.be.true()
+      describe '#render', ->
+        it 'correctly renders the template', ->
+          @view.$el.html()
+            .should.containEql 'I will attend Foo Fair'
+
+      describe '#inquiry', ->
+        it 'marks the attendance', ->
+          Backbone.sync.returns then: sinon.stub()
+          @view.$('input[name="attending"]').prop 'checked', true
+          @view.$('.js-artwork-inquire-button').click()
+
+          @view.user.isAttending id: 'foo-fair'
+            .should.be.true()
+
+    describe 'fair is closed', ->
+      beforeEach ->
+        fixture = extend {}, require './fixtures/inquireable.json'
+        yesterday = new Date (new Date()).getTime() - (24*60*60*1000)
+        fixture.data.artwork.fair = id: 'foo-fair', name: 'Foo Fair 2016', end_at: yesterday.toISOString()
+        @view = new ArtworkCommercialView fixture
+
+        @view.render()
+
+      describe '#render', ->
+        it 'correctly renders the template', ->
+          @view.$el.html()
+            .should.containEql 'I attended Foo Fair'
+
+      describe '#inquiry', ->
+        it 'marks the attendance', ->
+          Backbone.sync.returns then: sinon.stub()
+          @view.$('input[name="attending"]').prop 'checked', true
+          @view.$('.js-artwork-inquire-button').click()
+
+          @view.user.isAttending id: 'foo-fair'
+            .should.be.true()

--- a/apps/artwork/components/commercial/view.coffee
+++ b/apps/artwork/components/commercial/view.coffee
@@ -3,6 +3,7 @@
 Backbone = require 'backbone'
 User = require '../../../../models/user.coffee'
 Artwork = require '../../../../models/artwork.coffee'
+Fair = require '../../../../models/fair.coffee'
 ArtworkInquiry = require '../../../../models/artwork_inquiry.coffee'
 Form = require '../../../../components/form/index.coffee'
 PendingOrder = require '../../../../models/pending_order.coffee'
@@ -128,7 +129,9 @@ module.exports = class ArtworkCommercialView extends Backbone.View
     openMultiPageModal 'collector-faqs'
 
   render: ->
-    html = template extend @data,
+    if @data.artwork.fair
+      fair = new Fair @data.artwork.fair
+    html = template extend @data, { fair },
       helpers: extend [
         {}
         commercial: require './helpers.coffee'

--- a/apps/artwork/routes.coffee
+++ b/apps/artwork/routes.coffee
@@ -1,6 +1,7 @@
 { extend } = require 'underscore'
 metaphysics = require '../../lib/metaphysics'
 Artwork = require '../../models/artwork'
+Fair = require '../../models/fair'
 request = require 'superagent'
 PendingOrder = require '../../models/pending_order'
 splitTest = require '../../components/split_test/index.coffee'
@@ -67,6 +68,7 @@ bootstrap = ->
   inPurchaseTestGroup = res.locals.sd.PURCHASE_FLOW is 'purchase'
   metaphysics send
     .then (data) ->
+      data.fair = new Fair data.artwork.fair if data.artwork.fair
       data.inPurchaseTestGroup = inPurchaseTestGroup
       data.notProduction = res.locals.sd.NODE_ENV is 'development' or
         res.locals.sd.NODE_ENV is 'staging' or

--- a/apps/artwork_purchase/routes.coffee
+++ b/apps/artwork_purchase/routes.coffee
@@ -22,6 +22,7 @@ Fair = require '../../models/fair.coffee'
         fair {
           id
           name
+          end_at
         }
         partner{
           name

--- a/apps/artwork_purchase/templates/main.jade
+++ b/apps/artwork_purchase/templates/main.jade
@@ -45,7 +45,7 @@
               )
               label( for= 'artwork-purchase-attending' )
             label.artsy-checkbox--label( for= 'artwork-purchase-attending' )
-              | I will attend #{fair.nameSansYear()}
+              | I #{fair.isNotOver() ? 'will attend' : 'attended'} #{fair.nameSansYear()}
               span.help-tooltip(
                 data-anchor='bottom-right'
                 data-message="This artwork is part of the art fair—#{fair.nameSansYear()}. Providing this information to us and the gallery will facilitate your inquiry and enable more customized service."

--- a/components/embedded_inquiry/templates/attendance.jade
+++ b/components/embedded_inquiry/templates/attendance.jade
@@ -3,7 +3,7 @@
     input( type='checkbox', name='attending', id='embedded-inquiry-form-attending' )
     label( for='embedded-inquiry-form-attending' )
   label.artsy-checkbox--label( for='embedded-inquiry-form-attending' )
-    | I will attend #{fair.nameSansYear()}
+    | I #{fair.isNotOver() ? 'will attend' : 'attended'} #{fair.nameSansYear()}
     span.help-tooltip(
       data-anchor='bottom-right'
       data-message="This artwork is part of the art fair—#{fair.nameSansYear()}. Providing this information to us and the gallery will facilitate your inquiry and enable more customized service."

--- a/components/embedded_inquiry/test/view.coffee
+++ b/components/embedded_inquiry/test/view.coffee
@@ -170,11 +170,22 @@ describe 'EmbeddedInquiryView', ->
       @artwork = new Artwork fabricate 'artwork'
       @artwork.related().fairs.add fabricate 'fair'
       @view = new EmbeddedInquiryView artwork: @artwork
-      @view.render()
 
-    it 'renders the attendance checkbox', ->
+    it 'renders the attendance checkbox for an open fair', ->
+      tomorrow = new Date (new Date()).getTime() + (24*60*60*1000)
+      @artwork.related().fairs.first().set 'end_at', tomorrow.toISOString()
+      @artwork.related().fairs.first().isOver()
+      @view.render()
       html = @view.$el.html()
       html.should.containEql 'I will attend Armory Show'
+      html.should.containEql 'This artwork is part of the art fair—Armory Show.'
+
+    it 'renders the attendance checkbox for an closed fair', ->
+      yesterday = new Date (new Date()).getTime() - (24*60*60*1000)
+      @artwork.related().fairs.first().set 'end_at', yesterday.toISOString()
+      @view.render()
+      html = @view.$el.html()
+      html.should.containEql 'I attended Armory Show'
       html.should.containEql 'This artwork is part of the art fair—Armory Show.'
 
     it 'renders if the sync comes post-render', ->
@@ -192,6 +203,7 @@ describe 'EmbeddedInquiryView', ->
 
     describe 'user is not attending', ->
       it 'does not add a user fair action', ->
+        @view.render()
         @view.$('input[name="name"]').val 'Not Attending'
         @view.$('button').click()
 
@@ -205,6 +217,7 @@ describe 'EmbeddedInquiryView', ->
 
     describe 'user is attending', ->
       it 'adds a user fair action, when the box is checked', ->
+        @view.render()
         @view.$('input[name="name"]').val 'Is Attending'
         @view.$('input[type="checkbox"]').click()
         @view.$('button').click()

--- a/components/inquiry_questionnaire/test/views/inquiry.coffee
+++ b/components/inquiry_questionnaire/test/views/inquiry.coffee
@@ -181,13 +181,23 @@ describe 'Inquiry', setup ->
         inquiry: @inquiry
         state: @state
 
-      @view.render()
-
     describe '#render', ->
-      it 'renders the attendance checkbox', ->
+      it 'renders the attendance checkbox for open fair', ->
+        tomorrow = new Date (new Date()).getTime() + (24*60*60*1000)
+        @artwork.related().fairs.first().set 'end_at', tomorrow.toISOString()
+        @view.render()
         @view.$el.html().should.containEql 'I will attend Armory Show'
 
+      it 'renders the attendance checkbox for closed fair', ->
+        yesterday = new Date (new Date()).getTime() - (24*60*60*1000)
+        @artwork.related().fairs.first().set 'end_at', yesterday.toISOString()
+        @view.render()
+        @view.$el.html().should.containEql 'I attended Armory Show'
+
     describe '#next', ->
+      beforeEach ->
+        @view.render()
+
       it 'saves the user fair action', ->
         @view.$('input[name="name"]').val 'Foo Bar'
         @view.$('input[name="email"]').val 'foo@bar.com'

--- a/components/simple_contact/templates/forms/attendance.jade
+++ b/components/simple_contact/templates/forms/attendance.jade
@@ -10,7 +10,7 @@
     )
     label( for= simpleContactFormAttendingId )
   label.artsy-checkbox--label( for= simpleContactFormAttendingId )
-    | I will attend #{fair.nameSansYear()}
+    | I #{fair.isNotOver() ? 'will attend' : 'attended'} #{fair.nameSansYear()}
     span.help-tooltip(
       data-anchor='bottom-right'
       data-message="This artwork is part of the art fair—#{fair.nameSansYear()}. Providing this information to us and the gallery will facilitate your inquiry and enable more customized service."


### PR DESCRIPTION
fixes https://github.com/artsy/force/issues/592

I also unified the fair name in all places. in 3/4 places we were dropping the year. In one we weren't (artwork side bar mini inquiry form). @briansw let me know if that one was different for a reason.

![screen shot 2016-12-20 at 6 02 59 pm](https://cloud.githubusercontent.com/assets/3171662/21361038/99de05a0-c6e2-11e6-963f-05f6195ad342.png)
(the fact that the icon is wrapping in an ugly way is unrelated)