### PR TITLE
@alloy => Support line-breaks for p tags in markdown for partner-submitted bios

### DIFF
--- a/apps/artist/stylesheets/header.styl
+++ b/apps/artist/stylesheets/header.styl
@@ -46,6 +46,10 @@
   margin 20px 0
 
 .artist-blurb
+  p
+    margin 0 0 11px
+    &:last-child
+      margin 0
   p > a
     text-decoration underline
   &__credit


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/572

We want the `<p>` tags in the blurb (except the last one) to have a space.

<img width="650" alt="screen shot 2016-12-20 at 3 28 01 pm" src="https://cloud.githubusercontent.com/assets/1457859/21366706/f1cca47a-c6c8-11e6-8936-2d9ccbaa0ca1.png">
