### PR TITLE
@craigspaeth => add more specific class for bid+registration button

### DIFF
--- a/apps/auction_support/client/index.coffee
+++ b/apps/auction_support/client/index.coffee
@@ -61,4 +61,4 @@ module.exports.init = ->
     $('.js-auction-clock').addClass 'is-almost-over'
 
   mediator.once 'clock:is-over', ->
-    $('.avant-garde-button-black').addClass 'is-disabled'
+    $('.auction-bid-form-confirm.avant-garde-button-black').addClass 'is-disabled'

--- a/apps/auction_support/templates/bid-form.jade
+++ b/apps/auction_support/templates/bid-form.jade
@@ -39,7 +39,7 @@ block body
           .auction-bid-errors
         if isRegistered
           .registration-form-content
-            .avant-garde-button-black.is-block Confirm Bid
+            .auction-bid-form-confirm.avant-garde-button-black.is-block Confirm Bid
         else
           .bid-section-header= sd.BIDDER_H1_COPY
           p.note= sd.BIDDER_H2_COPY
@@ -47,4 +47,4 @@ block body
             .bid-registration-form-contents
               include ./registration-form
               .registration-form-content
-                .avant-garde-button-black.is-block Confirm Bid
+                .auction-bid-form-confirm.avant-garde-button-black.is-block Confirm Bid


### PR DESCRIPTION
resolves #562 
I worked with @sweir27 on this- there are 2 buttons in this force app with the same elan class, but only one actually should be affected by the auction closed event. the other is being triggered by live auctions which trigger the same clock:is-over event when if they are live. this changes the event to only effect the artwork bid form, not the registration form.