### PR TITLE
@kanaabe => [EOY] safari bugs

### DIFF
--- a/apps/editorial_features/components/eoy/stylesheets/index.styl
+++ b/apps/editorial_features/components/eoy/stylesheets/index.styl
@@ -55,6 +55,12 @@ flex-display(justify = space-between, align = center)
   &__sa-header
     .mgr-horizontal-nav .mgr-cell
       margin-right 0px
+      .article-sa-related
+        display flex
+        align-items center
+        height 105px
+        img
+          height auto
     .article-sa-sticky-left
       left 40px
     .article-sa-sticky-right
@@ -63,11 +69,6 @@ flex-display(justify = space-between, align = center)
         height 30px
     .article-sa-sticky__presented
       margin-right 12px
-  video[poster]
-    min-height 100%
-    background-size cover
-    background-repeat no-repeat
-    background-position center
 
   .share
     display flex


### PR DESCRIPTION
- Gets rid of poster styles on html5 videos
- Makes header image height auto in SA menu (was distorting aspect ratios)