### PR TITLE
@craigspaeth better analytics messaging for purchases not completed

### DIFF
--- a/analytics/artwork_purchase.js
+++ b/analytics/artwork_purchase.js
@@ -23,6 +23,11 @@
     })
   })
   analyticsHooks.on('purchase:inquiry:failure', function (context) {
-    analytics.track('Purchase request failed to submit')
+    analytics.track('Purchase request failed to submit', {
+      artwork_id: context.artwork._id,
+      artwork_slug: context.artwork.id,
+      user_id: context.user.id,
+      message: context.message
+    })
   })
 })()

--- a/apps/artwork_purchase/client/purchase_form.coffee
+++ b/apps/artwork_purchase/client/purchase_form.coffee
@@ -27,8 +27,14 @@ module.exports = class PurchaseForm extends Backbone.View
       success: (model, response) =>
         analyticsHooks.trigger 'purchase:inquiry:success', { @artwork, @inquiry, user }
       error: (model, response, options) =>
-        analyticsHooks.trigger 'purchase:inquiry:failure'
-        @$('.js-ap-form-errors').html @errorMessage(response)
+        errorMessage = @errorMessage(response)
+        analyticsHooks.trigger 'purchase:inquiry:failure', {
+          @artwork,
+          @inquiry,
+          user,
+          message: errorMessage
+        }
+        @$('.js-ap-form-errors').html errorMessage
         error?()
     ]
 
@@ -39,4 +45,6 @@ module.exports = class PurchaseForm extends Backbone.View
           success: resolve
           error: resolve
 
-    Q.all(promises).then success
+    Q.all(promises)
+      .then success
+      .catch -> # handled by error callback


### PR DESCRIPTION
@anipetrov wants a notice sent to analytics any time that the user clicks the submit button on the purchase flow but the purchase does not submit. this may not necessarily be a request failure, it may be the modal prompting them to log in, form validation errors, etc. I also took out some promise stuff because the way they were being fulfilled was confusing and hard to debug when i was seeing uncaught errors. 