### PR TITLE
@1aurabrown => Add purchase flag to inquiry request

### DIFF
--- a/apps/artwork_purchase/client/purchase_form.coffee
+++ b/apps/artwork_purchase/client/purchase_form.coffee
@@ -21,6 +21,7 @@ module.exports = class PurchaseForm extends Backbone.View
       artwork: @artwork.id,
       contact_gallery: true,
       inquiry_url: window.location.href,
+      purchase: true,
     }
 
     promises = [@inquiry.save null,


### PR DESCRIPTION
This adds a flag so that inquiry requests can be called out as 'purchase requests' (primarily for use in CMS Inbox UI).