### PR TITLE
@joeyAghion: fix analytics bug

### DIFF
--- a/analytics/artwork_purchase.js
+++ b/analytics/artwork_purchase.js
@@ -23,11 +23,14 @@
     })
   })
   analyticsHooks.on('purchase:inquiry:failure', function (context) {
-    analytics.track('Purchase request failed to submit', {
+    var data = {
       artwork_id: context.artwork._id,
       artwork_slug: context.artwork.id,
-      user_id: context.user.id,
       message: context.message
-    })
+    }
+    if (context.user && context.user.id) {
+      data.user_id = context.user.id;
+    }
+    analytics.track('Purchase request failed to submit', data)
   })
 })()

--- a/apps/artwork_purchase/client/index.coffee
+++ b/apps/artwork_purchase/client/index.coffee
@@ -64,7 +64,7 @@ class PurchaseView extends Backbone.View
     # Call 'forIsSubmitting' on both forms to disable them both while request is in-flight.
     signupValid = @signupForm.validateForm()
     unless (@purchaseForm.validateForm() and signupValid)
-      analyticsHooks.trigger "purchase:signup:failure",
+      analyticsHooks.trigger "purchase:inquiry:failure",
         artwork: @artwork
         message: "client-side form validation failed"
       return
@@ -86,18 +86,17 @@ class PurchaseView extends Backbone.View
       error: @purchaseError
     }
 
-  isWithAccount: (user) =>
-    analyticsHooks.trigger "purchase:signup:failure",
-      user: user
+  isWithAccount: (loggedOutUser) =>
+    analyticsHooks.trigger "purchase:inquiry:failure",
       artwork: @artwork
       message: "user already exists, login required"
     @reenableForm @signupForm
     @reenableForm @purchaseForm
     @normalButton()
-    @openLoginModal "We found an Artsy account associated with #{user.get 'email'}. Please log in to continue."
+    @openLoginModal "We found an Artsy account associated with #{loggedOutUser.get 'email'}. Please log in to continue."
 
   signupError: (errorMessage) =>
-    analyticsHooks.trigger "purchase:signup:failure",
+    analyticsHooks.trigger "purchase:inquiry:failure",
       artwork: @artwork
       message: errorMessage
     @reenableForm @signupForm
@@ -109,7 +108,7 @@ class PurchaseView extends Backbone.View
 
   submitPurchaseForm: (form, options) ->
     unless @purchaseForm.validateForm()
-      analyticsHooks.trigger "purchase:signup:failure",
+      analyticsHooks.trigger "purchase:inquiry:failure",
         artwork: @artwork
         message: "client-side form validation failed"
         user: CURRENT_USER


### PR DESCRIPTION
![screen shot 2016-12-22 at 1 50 47 pm](https://cloud.githubusercontent.com/assets/3171662/21426636/4445b9ac-c850-11e6-989f-0c8a2bd1b8a7.png)

see original pr here: https://github.com/artsy/force/pull/611

i was using the wrong name of the analytics hook, really dumb mistake. i wanted to be using this one: https://github.com/1aurabrown/force/blob/d1edc3852d0f751fa4f75392f34b88051d15b1b4/analytics/artwork_purchase.js#L25. i thought everything was working because there is a listener for all analyticsHooks events which prints whatever is sent to it (the messages in the image above prefixed `ANALYTICS HOOK`). However I wasn't using an event that had a specific handler and `analytics.track` was never being called for these events.

Also, joey maybe you have the answer to this: I took out the user from the data being passed to the analytics event in the case of a user who attempts to make an account with an email already associated with an account, and who is then prompted to log in -- Is it possible to get the user's actual gravity id at that point in time or only after login? The requests that have taken place are a request to /anonymous_session and a request for a related account. Nothing in these responses contains the user id that is available after login.