### PR TITLE
@craigspaeth remove confusing double console message for analytics

### DIFF
--- a/analytics/main_layout.js
+++ b/analytics/main_layout.js
@@ -16,14 +16,9 @@ setTimeout(function () {
   analytics.track('time on page more than 3 minutes', { category: '3 Minutes', message: sd.CURRENT_PATH })
 }, 180000)
 
-// debug tracking calls in development
+// debug tracking calls in development and staging
 if (sd.NODE_ENV !== 'production') {
   analytics.on('track', function () {
     console.debug('TRACKED: ', arguments[0], JSON.stringify(arguments[1]))
-  })
-}
-if (sd.NODE_ENV === 'development') {
-  analyticsHooks.on('all', function (name, data) {
-    console.info('ANALYTICS HOOK: ', name, data)
   })
 }


### PR DESCRIPTION
@craigspaeth i encountered a confusing situation because all events sent to analyticsHooks were producing console messages, however i didn't realize that the event i was sending was not being handled anywhere (except for in this handler that does the logging). This made me think everything was working as expected. What I actually should have been looking for was a message showing that `analytics.track` was called. @joeyAghion and @alloy and I thought that disabling this misleading logging would be best. 

see by broken pr: https://github.com/artsy/force/pull/611

and fixed pr: https://github.com/artsy/force/pull/614