### PR TITLE
Removes default forSale filter from gene, tag and fair filters

### DIFF
--- a/apps/fair/components/browse/view.coffee
+++ b/apps/fair/components/browse/view.coffee
@@ -40,7 +40,6 @@ module.exports = class FairBrowseView extends Backbone.View
       includeAllWorksButton: true
       startHistory: false
       filterRoot: @fair.href() + '/browse/artworks'
-      forSale: false
 
     @artworkParams = params
 

--- a/apps/gene/client.coffee
+++ b/apps/gene/client.coffee
@@ -44,7 +44,6 @@ module.exports.init = ->
     defaultHeading: gene.displayName()
     stuckParam: { 'gene_id': gene.id }
     aggregations: aggregationParams
-    forSale: 'false'
     filterRoot: gene.href() + '/artworks'
     includeMediumFilterInAggregation: { include_medium_filter_in_aggregation: true }
 
@@ -78,5 +77,3 @@ module.exports.init = ->
     id: gene.id
 
   scrollFrame '#gene-filter-content a' unless sd.EIGEN
-
-

--- a/apps/tag/client.coffee
+++ b/apps/tag/client.coffee
@@ -20,5 +20,4 @@ module.exports.init = ->
     defaultHeading: tag.get('name')
     stuckParam: { 'tag_id': tag.id }
     aggregations: aggregationParams
-    forSale: 'false'
     filterRoot: tag.href() + '/artworks'


### PR DESCRIPTION
When set to `false` as the default this filter was giving the wrong count. 

Fixes #615 

See https://artsy.slack.com/archives/help/p1482416501000230.

