### PR TITLE
@broskoski: Move cookie-session down to stable version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1542,21 +1542,9 @@
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz"
     },
     "cookie-session": {
-      "version": "2.0.0-alpha.2",
-      "from": "cookie-session@>=2.0.0-alpha.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-2.0.0-alpha.2.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "2.3.2",
-          "from": "debug@2.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.2.tgz"
-        },
-        "ms": {
-          "version": "0.7.2",
-          "from": "ms@0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-        }
-      }
+      "version": "1.2.0",
+      "from": "cookie-session@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-1.2.0.tgz"
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -1569,9 +1557,9 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz"
     },
     "cookies": {
-      "version": "0.6.1",
-      "from": "cookies@0.6.1",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.6.1.tgz"
+      "version": "0.5.0",
+      "from": "cookies@0.5.0",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.5.0.tgz"
     },
     "cookies-js": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "connect-flash": "^0.1.1",
     "connect-timeout": "^1.7.0",
     "cookie-parser": "^1.4.0",
-    "cookie-session": "^2.0.0-alpha.2",
+    "cookie-session": "^1.2.0",
     "cors": "^2.8.1",
     "diacritics": "^1.2.2",
     "dompurify": "^0.8.4",


### PR DESCRIPTION
For some reason npm decided to install this on an alpha verison with breaking changes.