### PR TITLE
@kanaabe => Restore portrait resizing logic

### DIFF
--- a/components/article/client/view.coffee
+++ b/components/article/client/view.coffee
@@ -91,10 +91,10 @@ module.exports = class ArticleView extends Backbone.View
       .each (i, img) ->
         optimizedHeight = window.innerHeight * 0.9
         newWidth = ((img.width * optimizedHeight) / img.height)
-        if img.width < (img.height * 0.9)
-          $(img).parent().addClass('portrait')
         if newWidth < 580
           $(img).parent().css('max-width', 580)
+        else if img.width < (img.height * 0.9)
+          $(img).parent().addClass('portrait')
     @$('.article-section-artworks, .article-section-container[data-section-type=image]').addClass 'images-loaded'
     @loadedImageHeights = true
     @maybeFinishedLoading()


### PR DESCRIPTION
In [this commit](https://github.com/artsy/force/commit/2506fca055403408c6fc5321a3de39f781805119) I tried cleaning up a bit but ended up slightly changing the logic and introducing a bug with portrait image heights.