### PR TITLE
@broskoski: 'Send us feedback' faq bugs

### DIFF
--- a/components/feedback_modal/index.coffee
+++ b/components/feedback_modal/index.coffee
@@ -36,7 +36,7 @@ module.exports = ->
     switch step
       when 'collector'
         modal.close ->
-          openMultiPageModal 'collector-faqs'
+          openMultiPageModal 'collector-faqs', 'collector-faqs-selling-on-artsy'
 
       when 'artist'
         modal.close ->

--- a/components/feedback_modal/tests/index.coffee
+++ b/components/feedback_modal/tests/index.coffee
@@ -30,6 +30,7 @@ describe 'openFeedbackModal', ->
       .map -> $(this).text()
       .get()
         .should.eql [
+          "I have an auction-related question."
           'I’m an artist interested in listing my work.'
           'I’m an individual interested in selling artwork.'
           'I have a press inquiry.'

--- a/components/multi_page/config.coffee
+++ b/components/multi_page/config.coffee
@@ -3,7 +3,7 @@ module.exports =
     title: 'Auction FAQs'
     description: '
       How can we help you? Below are a few general categories to help you find the answers you’re looking for.\n\n
-      Need more immediate assistance? Please [contact us](mailto:support@artsy.net)
+      Need more immediate assistance? Please [contact us](mailto:specialist@artsy.net)
     '
     pages:
       'Bidding': 'how-auctions-work-bidding'
@@ -26,7 +26,6 @@ module.exports =
     title: 'Artist FAQs'
     description: '
       How can we help you? Below are answers to some of the most common questions from artists.\n\n
-      Need more immediate assistance? Please [contact us](mailto:support@artsy.net)
     '
     pages:
       'How Artsy Works': 'artist-faqs-how-artsy-works'

--- a/components/multi_page/index.coffee
+++ b/components/multi_page/index.coffee
@@ -2,6 +2,6 @@ _ = require 'underscore'
 MultiPageView = require './view.coffee'
 config = require './config.coffee'
 
-module.exports = (key, defaultPage) ->
-  options = _.extend config[key], defaultPage: defaultPage
+module.exports = (key, defaultPageId) ->
+  options = _.extend config[key], defaultPageId: defaultPageId
   new MultiPageView options

--- a/components/multi_page/index.coffee
+++ b/components/multi_page/index.coffee
@@ -1,5 +1,7 @@
+_ = require 'underscore'
 MultiPageView = require './view.coffee'
 config = require './config.coffee'
 
-module.exports = (key) ->
-  new MultiPageView config[key]
+module.exports = (key, defaultPage) ->
+  options = _.extend config[key], defaultPage: defaultPage
+  new MultiPageView options

--- a/components/multi_page/test/view.coffee
+++ b/components/multi_page/test/view.coffee
@@ -1,3 +1,4 @@
+_ = require 'underscore'
 benv = require 'benv'
 sinon = require 'sinon'
 Backbone = require 'backbone'
@@ -32,3 +33,13 @@ describe 'MultiPageView', ->
       @view.state.get('active').should.equal 'how-auctions-work-conditions-of-sale'
       @view.$('.mpv-nav a:last').hasClass('is-active').should.be.true()
       @view.$('.is-active').should.have.lengthOf 1
+
+  describe 'defaultPageId', ->
+    it 'displays default page when a defaultPageId is passed', ->
+      options = _.extend(config['collector-faqs'], { defaultPageId: 'collector-faqs-selling-on-artsy' })
+      view = new MultiPageView options
+      view.render()
+
+      view.state.get('active').should.equal 'collector-faqs-selling-on-artsy'
+      view.$('.mpv-nav a:last').hasClass('is-active').should.be.true()
+      view.$('.is-active').should.have.lengthOf 1

--- a/components/multi_page/view.coffee
+++ b/components/multi_page/view.coffee
@@ -10,11 +10,11 @@ module.exports = class MultiPageView extends Backbone.View
   events:
     'click .js-page': 'change'
 
-  initialize: ({ @title, @description, @pages, @defaultPage }) ->
+  initialize: ({ @title, @description, @pages, @defaultPageId }) ->
     @collection = new Backbone.Collection _.map @pages, (id, title) ->
       new Page id: id, title: title
 
-    @state = new Backbone.Model active: if @defaultPage then @defaultPage else @collection.first().id
+    @state = new Backbone.Model active: if @collection.get(@defaultPageId) then @defaultPageId else @collection.first().id
 
     @listenTo @state, 'change:active', @render
 

--- a/components/multi_page/view.coffee
+++ b/components/multi_page/view.coffee
@@ -10,11 +10,11 @@ module.exports = class MultiPageView extends Backbone.View
   events:
     'click .js-page': 'change'
 
-  initialize: ({ @title, @description, @pages }) ->
+  initialize: ({ @title, @description, @pages, @defaultPage }) ->
     @collection = new Backbone.Collection _.map @pages, (id, title) ->
       new Page id: id, title: title
 
-    @state = new Backbone.Model active: @collection.first().id
+    @state = new Backbone.Model active: if @defaultPage then @defaultPage else @collection.first().id
 
     @listenTo @state, 'change:active', @render
 

--- a/components/multi_page_modal/index.coffee
+++ b/components/multi_page_modal/index.coffee
@@ -1,8 +1,8 @@
 modalize = require '../modalize/index.coffee'
 multiPageView = require '../multi_page/index.coffee'
 
-module.exports = (key, defaultPage = null, cb = null) ->
-  view = multiPageView key, defaultPage
+module.exports = (key, defaultPageId = null, cb = null) ->
+  view = multiPageView key, defaultPageId
 
   modal = modalize view,
     dimensions: width: '900px', height: '580px'

--- a/components/multi_page_modal/index.coffee
+++ b/components/multi_page_modal/index.coffee
@@ -1,8 +1,8 @@
 modalize = require '../modalize/index.coffee'
 multiPageView = require '../multi_page/index.coffee'
 
-module.exports = (key, cb = null) ->
-  view = multiPageView key
+module.exports = (key, defaultPage = null, cb = null) ->
+  view = multiPageView key, defaultPage
 
   modal = modalize view,
     dimensions: width: '900px', height: '580px'


### PR DESCRIPTION
closes: https://github.com/artsy/collector-experience/issues/71

I have this as WIP because it could use a spec or two. I wanted to get feedback before investing in writing the tests though.

**Remove the “Need more immediate assistance? Please contact us” option:**
![screen shot 2016-12-29 at 4 31 19 pm](https://cloud.githubusercontent.com/assets/5201004/21555294/c93ce6d2-cde4-11e6-92a9-867a73992576.png)

**Selects the 'Selling On Artsy' page by default when clicked launched from the 'Send us feedback':**
![feedback default page](https://cloud.githubusercontent.com/assets/5201004/21555324/23e57bf8-cde5-11e6-9b64-7142f219c6b1.gif)
