### PR TITLE
@alloy - Fixes some commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BIN = node_modules/.bin
 
 # Start the server with the OSS env vars instead of the developer's `.env`
 oss:
-	APP_URL=http://localhost:5000 APPLICATION_NAME=force-development $(BIN)/nf start --env .env.oss
+	APP_URL=http://localhost:5000 APPLICATION_NAME=force-staging $(BIN)/nf start --env .env.oss
 
 # Start the server
 s:
@@ -46,11 +46,11 @@ spc:
 
 # Start the server pointing to production with debugger
 spd:
-	$(BIN)/node-inspector --web-port=8081 & APP_URL=http://localhost:5000 APPLICATION_NAME=force-production API_URL=https://api.artsy.net $(BIN)/nf start -f ./Procfile.dev
+	$(BIN)/node-inspector --web-port=8081 & APP_URL=http://localhost:5000 APPLICATION_NAME=force-production API_URL=https://api.artsy.net $(BIN)/nf start -j ./Procfile.dev
 
 # Start the server pointing to staging with debugger
 ssd:
-	$(BIN)/node-inspector --web-port=8081 & APP_URL=http://localhost:5000 APPLICATION_NAME=force-staging API_URL=https://stagingapi.artsy.net $(BIN)/nf start -f ./Procfile.dev
+	$(BIN)/node-inspector --web-port=8081 & APP_URL=http://localhost:5000 APPLICATION_NAME=force-staging API_URL=https://stagingapi.artsy.net $(BIN)/nf start -j ./Procfile.dev
 
 # Run all of the project-level tests, followed by app-level tests
 test:


### PR DESCRIPTION
`make oss` was returning a '500 internal error' because the web server is looking for a local API server. Changed it to point to staging.
![screen shot 2017-01-03 at 4 13 21 pm](https://cloud.githubusercontent.com/assets/296775/21623299/b2d891f4-d1cf-11e6-99c6-f26206361df3.png)

`make spd` & `make ssd` the option to specify a Procfile to `nf` is `-j` not `-f` so debugging wasn't working
![screen shot 2017-01-03 at 4 15 20 pm](https://cloud.githubusercontent.com/assets/296775/21623344/e68dda40-d1cf-11e6-87bc-f7de02eab389.png)
