### PR TITLE
@alloy => Display new CTA bar on artist page when lab feature is present

### DIFF
--- a/apps/artist/client/cta.coffee
+++ b/apps/artist/client/cta.coffee
@@ -1,7 +1,17 @@
 { MEDIUM, CURRENT_USER } = require('sharify').data
+{ contains } = require 'underscore'
 CTABarView = require '../../../components/cta_bar/view.coffee'
+ArtistPageCTAView = require '../../../components/artist_page_cta/view.coffee'
 
 module.exports = (artist) ->
+  # Temporarily always show new CTA to lab feature users
+  if CURRENT_USER? and contains(CURRENT_USER.lab_features, 'New Artist Page CTA')
+    artistPageCTAView = new ArtistPageCTAView
+      artist: artist
+
+    $('body').append artistPageCTAView.render().$el
+    return
+
   return unless MEDIUM is 'search' and not CURRENT_USER?
 
   name = 'artist_cta'

--- a/apps/artist/queries/server.coffee
+++ b/apps/artist/queries/server.coffee
@@ -32,6 +32,11 @@ module.exports = """
       ... statuses
       ... carousel
       ... jsonLD @include(if: $includeJSONLD)
+      cta_image: image {
+        thumb: resized(width: 150, version: "square") {
+          url
+        }
+      }
     }
   }
 

--- a/assets/artist.styl
+++ b/assets/artist.styl
@@ -14,6 +14,7 @@
 @require '../components/featured_shows'
 @require '../components/zig_zag_banner'
 @require '../components/cta_bar'
+@require '../components/artist_page_cta'
 @require '../components/jump'
 @require '../components/artwork_rail/stylesheets'
 @require '../apps/artist/stylesheets'

--- a/components/artist_page_cta/index.styl
+++ b/components/artist_page_cta/index.styl
@@ -1,0 +1,27 @@
+@require '../stylus_lib'
+
+.artist-page-cta
+  position fixed
+  right 0
+  bottom 0
+  left 0
+  height 100px
+  width calc(100%)
+  background-color white
+  transform translateY(0%)
+  z-index 999
+  border-top 2px solid purple-color
+  .main-layout-container
+    margin-top 20px
+  &__image
+    vertical-align middle
+    display inline
+    width 60px
+    border-radius 60px
+    margin-right 15px
+  &__headline
+    vertical-align middle
+    display inline-block
+    font-size 20px
+    &__artist-name
+      font-weight bold

--- a/components/artist_page_cta/template.jade
+++ b/components/artist_page_cta/template.jade
@@ -1,0 +1,7 @@
+.responsive-layout-container
+  .main-layout-container
+    img.artist-page-cta__image(src=artist.get('cta_image').thumb.url)
+    div.artist-page-cta__headline Follow&nbsp;
+      span.artist-page-cta__headline__artist-name
+        | #{artist.get('name')}&nbsp;
+      | and be the first to know when new works are available

--- a/components/artist_page_cta/view.coffee
+++ b/components/artist_page_cta/view.coffee
@@ -1,0 +1,15 @@
+Backbone = require 'backbone'
+template = -> require('./template.jade') arguments...
+
+module.exports = class ArtistPageCTAView extends Backbone.View
+
+  className: 'artist-page-cta'
+
+  initialize: ({ artist }) ->
+    @artist = artist
+
+  render: ->
+    @$el.html template
+      artist: @artist 
+    @
+


### PR DESCRIPTION
PR early and often!

As discussed, we will always be showing this new functionality to any users with the lab feature. At the end, we can switch that to be the correct condition. This and future PR's (until launch) are operating in that way.

![screen shot 2017-01-04 at 4 35 44 pm](https://cloud.githubusercontent.com/assets/1457859/21660259/ad69ad3e-d29c-11e6-8097-e714238286fb.png)
