### PR TITLE
@alloy => Support alternative partner type for Bid Now label on /collect

### DIFF
--- a/components/artwork_item/templates/artwork.jade
+++ b/components/artwork_item/templates/artwork.jade
@@ -7,7 +7,7 @@
 - hasInstitutionPartner = artwork.get('partner') && artwork.get('partner').type === 'Institution'
 - displayPrice != null ? displayPrice : displayPrice = true
 - saleArtwork = artwork.related().saleArtwork
-- hasAuctionPartner = artwork.get('partner') && (artwork.get('partner').type === 'Auction' || artwork.get('partner').type === 'Auction House')
+- hasAuctionPartner = (artwork.get('partner') && (artwork.get('partner').type === 'Auction' || artwork.get('partner').type === 'Auction House')) || artwork.get('is_biddable')
 - showContact = !isAuction && artwork.isContactable()
 - showBuyButton = displayPurchase && artwork.get('acquireable')
 - showBuyLink = artwork.get('acquireable') && artwork.get('ecommerce') && !showBuyButton

--- a/components/artwork_item/templates/artwork.jade
+++ b/components/artwork_item/templates/artwork.jade
@@ -7,7 +7,7 @@
 - hasInstitutionPartner = artwork.get('partner') && artwork.get('partner').type === 'Institution'
 - displayPrice != null ? displayPrice : displayPrice = true
 - saleArtwork = artwork.related().saleArtwork
-- hasAuctionPartner = artwork.get('partner') && artwork.get('partner').type === 'Auction'
+- hasAuctionPartner = artwork.get('partner') && (artwork.get('partner').type === 'Auction' || artwork.get('partner').type === 'Auction House')
 - showContact = !isAuction && artwork.isContactable()
 - showBuyButton = displayPurchase && artwork.get('acquireable')
 - showBuyLink = artwork.get('acquireable') && artwork.get('ecommerce') && !showBuyButton

--- a/components/commercial_filter/queries/artwork.coffee
+++ b/components/commercial_filter/queries/artwork.coffee
@@ -31,6 +31,7 @@ module.exports = """
     sale_message
     is_for_sale
     is_inquireable
+    is_biddable
     partner {
       name
       href


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/641

It looks like this might have been a bug for a while? This code (`artwork_item`) is used in several contexts, some from Metaphysics and some from not.

The Metaphysics context just coerces the GraphQL JSON into a Backbone Model. We override the `type` here: https://github.com/artsy/metaphysics/blob/b0436d6920c69ac3fde882d3096a1d2cde16762e/schema/partner.js#L52-L61

So I just added that condition below, this fixes the issue.

Really though it's just a bandaid, we should consolidate this code, switch to using `is_biddable`, etc.