### PR TITLE
@alloy => Include pseudo feed in artist page CTA overlay

### DIFF
--- a/apps/artist/client/router.coffee
+++ b/apps/artist/client/router.coffee
@@ -17,6 +17,7 @@ mediator = require '../../../lib/mediator.coffee'
 attachCTA = require './cta.coffee'
 AuctionLots = require '../../../collections/auction_lots.coffee'
 ArtistAuctionResultsView = require './views/auction_results.coffee'
+Artist = require '../../../models/artist.coffee'
 
 module.exports = class ArtistRouter extends Backbone.Router
   routes:
@@ -63,8 +64,8 @@ module.exports = class ArtistRouter extends Backbone.Router
   overview: ->
     @view = new OverviewView @options
     $('body').append @jump.$el
-    @view.on 'artist:overview:sync', =>
-      attachCTA @model
+    @view.on 'artist:overview:sync', (artist) =>
+      attachCTA new Artist(_.extend({}, artist, @model.attributes))
 
   cv: ->
     @view = new CVView @options

--- a/apps/artist/queries/overview.coffee
+++ b/apps/artist/queries/overview.coffee
@@ -15,6 +15,14 @@ module.exports =
       artists (size: 15) @include(if: $artists){
         ... artistCell
       }
+      cta_artist: artists(size: 1) {
+        image {
+          thumb: resized(width: 150, version: "square") {
+            url
+          }
+        }
+        name
+      }
       articles (limit: 15, sort: PUBLISHED_AT_DESC) @include(if: $articles){
         href
         thumbnail_title

--- a/components/artist_page_cta/index.styl
+++ b/components/artist_page_cta/index.styl
@@ -2,6 +2,8 @@
 
 .artist-page-cta.fullscreen
   height calc(100%)
+  .main-layout-container
+    width 800px
 
 .artist-page-cta
   position fixed
@@ -41,6 +43,80 @@
     line-height 1.3em
     &__artist-name
       font-weight bold
+  &__feed
+    display inline-block
+    margin-top 50px
+    svg
+      fill black
+      width 25px
+      height 25px
+      vertical-align middle
+    &__pulldown
+      avant-garde()
+      font-size 16px
+      vertical-align middle
+      &:after
+        left 60%
+     &__count
+      avant-garde()
+      font-size 10px
+      display inline-block
+      background-color red
+      border-radius 50px
+      width 19px
+      height 19px
+      position relative
+      bottom 10px
+      right 20px
+      line-height 19px
+      color white
+      text-align center
+    &__items
+      box-shadow 2px -4px 20px rgba(0,0,0,0.3)
+      background-color white
+      width 300px
+      height 200px
+      &:after
+        display block
+        position absolute
+        content ''
+        right 0
+        bottom 0
+        left 0
+        height 125px
+        background-image linear-gradient(to bottom, rgba(255,255,255,0), white 100px)
+      li
+        display inline-block
+        border-bottom 1px solid gray-lighter-color
+        font-size 13px
+        margin-left 20px
+        margin-right 20px
+        &:last-child
+          border-bottom none
+          margin-top 20px
+      &__artist-count
+        color gray-darker-color
+        display inline-block
+        position relative
+        bottom 10px
+        font-size 11px
+      &__artist-name
+        display inline-block
+        position relative
+        left 75px
+        bottom 35px
+      &__artist-day
+        float right
+        position relative
+        top 9px
+        font-size 11px
+        color gray-darker-color
+      &__image
+        vertical-align middle
+        display inline
+        width 60px
+        border-radius 60px
+        margin-right 15px
   &__close
     position absolute
     right 20px

--- a/components/artist_page_cta/overlay.jade
+++ b/components/artist_page_cta/overlay.jade
@@ -2,4 +2,23 @@ div.artist-page-cta-overlay__headline Sign up to keep track of&nbsp;
   span.artist-page-cta-overlay__headline__artist-name
     | #{artist.get('name')}&nbsp;
   | and your other favorite artists
+
+div.artist-page-cta-overlay__feed
+  span.artist-page-cta-overlay__feed__pulldown.hover-pulldown(data-state='active') Works For You
+    .artist-page-cta-overlay__feed__items.hover-pulldown-menu
+      ul
+        li
+          - var image = artist.get('cta_image').thumb.url
+          - var count = 7
+          - var name = artist.get('name')
+          include ./row.jade
+        li
+          - var image = artist.get('cta_artist')[0].image.thumb.url
+          - var count = 3
+          - var name = artist.get('cta_artist')[0].name
+          include ./row.jade
+
+  include ../main_layout/public/icons/bell.svg
+  .artist-page-cta-overlay__feed__count 3
+
 span.artist-page-cta-overlay__close ×

--- a/components/artist_page_cta/row.jade
+++ b/components/artist_page_cta/row.jade
@@ -1,0 +1,5 @@
+img.artist-page-cta-overlay__feed__items__image(src=image)
+div.artist-page-cta-overlay__feed__items__artist-count #{count} New Works
+div.artist-page-cta-overlay__feed__items__artist-day Today
+div.artist-page-cta-overlay__feed__items__artist-name
+  | #{name}

--- a/components/hover_pulldown/index.styl
+++ b/components/hover_pulldown/index.styl
@@ -16,7 +16,7 @@ computed-padding(font-size, target-line-height)
     text-decoration none
 
   // Small tip
-  &:not(.mlh-hamburger):not(.mlh-notification):before
+  &:not(.mlh-hamburger):not(.mlh-notification):not(.artist-page-cta-overlay__feed__pulldown):before
     size = 4px
     display block
     position absolute


### PR DESCRIPTION
<img width="907" alt="screen shot 2017-01-05 at 3 07 38 pm" src="https://cloud.githubusercontent.com/assets/1457859/21695681/cf7b5668-d358-11e6-8fdc-07cebcf4bc7c.png">

This adds the pseudo feed for the artist page CTA overlay screen. You'll notice the caret just borrows the standard one for now...I was faffing around getting the CSS for that working and I was struggling a bit, will circle back!

Up next, the actual sign up form on the right hand side.