### PR TITLE
@kanaabe => Responsive Team Channels/ CTA

### DIFF
--- a/apps/article/client/index.coffee
+++ b/apps/article/client/index.coffee
@@ -149,5 +149,5 @@ module.exports = class ArticleIndexView extends Backbone.View
 
 module.exports.init = ->
   new ArticleIndexView el: $('body')
-  new GalleryInsightsView el: $('body')
+  new GalleryInsightsView el: $('body').addClass('body-responsive')
   new EditorialSignupView el: $('body')

--- a/components/articles_grid/stylesheets/index.styl
+++ b/components/articles_grid/stylesheets/index.styl
@@ -65,6 +65,8 @@ gutter-unit = 60px
       &__articles
         .grid-item
           width 100%
+          margin-right 0
+          margin-left 0
     @media (max-width: 550px)
       &__figcaption
         margin 20px 0px

--- a/components/articles_grid/stylesheets/index.styl
+++ b/components/articles_grid/stylesheets/index.styl
@@ -55,7 +55,7 @@ gutter-unit = 60px
 
 .responsive-layout-container
   .articles-grid
-    @media (min-width: 1600px)
+    @media (min-width: 1660px)
       max-width 1600px
       margin 0 auto
     @media (max-width: 1130px)

--- a/components/channel_nav/index.styl
+++ b/components/channel_nav/index.styl
@@ -68,7 +68,7 @@ stickynav()
 body.is-sticky
   stickynav()
 
-@media (min-width: 1600px)
+@media (min-width: 1660px)
   .team-channel-nav .responsive-layout-container
     max-width 1600px
     margin 0 auto

--- a/components/email/stylesheets/editorial_signup.styl
+++ b/components/email/stylesheets/editorial_signup.styl
@@ -182,6 +182,7 @@
     justify-content center
     align-items flex-end
     margin auto
+    flex-direction row
   &__left
     width 550px
     padding 50px 0

--- a/components/email/stylesheets/gallery_insights.styl
+++ b/components/email/stylesheets/gallery_insights.styl
@@ -150,7 +150,6 @@
     .mktoForm
       padding-left 0
       padding-right 0
-
     .mktoButtonWrap button
       width 120px
     .mktoFormRow .mktoFieldWrap input

--- a/components/email/stylesheets/gallery_insights.styl
+++ b/components/email/stylesheets/gallery_insights.styl
@@ -94,7 +94,7 @@
     display block !important
 
 .cta-bar-container .articles-insights-marketo-form
-  padding-right 20px !important
+  padding-right 20px
   .mktoFormRow
     display none
     &:first-of-type
@@ -108,11 +108,55 @@
     border white
   label
     color white
-  .cta-bar-header
-    min-width 390px !important
   & + .cta-bar-defer
     position absolute
     top 20px
     right 20px
     a
       border-bottom none
+
+.cta-bar[data-mode="gallery-insights"] .cta-bar-header
+  min-width 390px
+
+@media (max-width: 1000px)
+  .cta-bar-container
+    height auto
+    .articles-insights-marketo-form
+      .mktoFormRow .mktoFieldWrap
+        min-width 100%
+        input
+          max-width calc(100% \- 170px)
+
+@media (max-width: 900px)
+  .cta-bar[data-mode="gallery-insights"][data-state="in"]
+    bottom 50px
+    padding 30px
+    .articles-insights-marketo-form
+      padding-right 0
+    .cta-bar-small
+      flex-direction column
+    .cta-bar-header
+      margin-bottom 30px
+
+@media (max-width: 550px)
+  .cta-bar[data-mode="gallery-insights"][data-state="in"]
+    min-width calc(100vw \- 40px)
+    padding 30px 20px
+  .cta-bar-small, .cta-bar-header h3
+    max-width calc(100vw \- 40px)
+  h2
+    garamond-size('s-headline')
+  .articles-insights-marketo-form
+    .mktoForm
+      padding-left 0
+      padding-right 0
+
+    .mktoButtonWrap button
+      width 120px
+    .mktoFormRow .mktoFieldWrap input
+      min-width calc(100% \- 130px)
+      height 45px
+
+  @media (max-width: 480px)
+    .articles-insights-marketo-form .mktoButtonRow
+      top 7.5px


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/648

- GI CTA is responsive
- GI page has responsive body class
- Update articles-grid max-width breakpoint (to allow for some l/r spacing)

![screen shot 2017-01-05 at 4 43 55 pm](https://cloud.githubusercontent.com/assets/1497424/21699880/a47ef42a-d36b-11e6-8d53-2e9c8b91a0c9.png)
![screen shot 2017-01-05 at 4 44 16 pm](https://cloud.githubusercontent.com/assets/1497424/21699881/a47f5c3a-d36b-11e6-8f91-96a5560dbc41.png)
![screen shot 2017-01-05 at 11 11 29 am](https://cloud.githubusercontent.com/assets/1497424/21699882/a47ff988-d36b-11e6-8607-ad459437763e.png)

