### PR TITLE
@kanaabe => Team channel home

### DIFF
--- a/apps/articles/stylesheets/team_channel.styl
+++ b/apps/articles/stylesheets/team_channel.styl
@@ -1,11 +1,5 @@
 - header-height = 400px
 
-.team-channel-featured
-.team-channel-grid
-.team-channel-header__text-container
-  max-width 1250px
-  margin auto
-
 .team-channel-body
   margin-bottom 80px
 
@@ -78,6 +72,7 @@
     margin-top 60px
 
 @media (min-width: 1660px)
+  .team-channel-nav__container,
   .team-channel-featured,
   .team-channel-grid,
   .team-channel-header__text-container,
@@ -97,6 +92,3 @@
   .team-channel-grid
     .articles-grid__header
       margin-top 30px
-@media (max-width: 600px)
-  .body-responsive .team-channel-footer #main-layout-footer
-    display block

--- a/apps/articles/stylesheets/team_channel.styl
+++ b/apps/articles/stylesheets/team_channel.styl
@@ -77,6 +77,13 @@
   .articles-grid__figure
     margin-top 60px
 
+@media (min-width: 1660px)
+  .team-channel-featured,
+  .team-channel-grid,
+  .team-channel-header__text-container,
+  .articles-grid__more-button
+    max-width 1600px
+    min-width 1600px
 @media (max-width: 900px)
   .team-channel-featured
     .mgr-cell:nth-child(1n)

--- a/apps/articles/stylesheets/team_channel.styl
+++ b/apps/articles/stylesheets/team_channel.styl
@@ -81,9 +81,11 @@
   .team-channel-featured,
   .team-channel-grid,
   .team-channel-header__text-container,
-  .articles-grid__more-button
+  .js-articles-grid-more.articles-grid__more-button,
+  .team-channel-footer .mlf,
+  .team-channel-footer .main-layout-container
     max-width 1600px
-    min-width 1600px
+    margin 0 auto
 @media (max-width: 900px)
   .team-channel-featured
     .mgr-cell:nth-child(1n)
@@ -95,3 +97,6 @@
   .team-channel-grid
     .articles-grid__header
       margin-top 30px
+@media (max-width: 600px)
+  .body-responsive .team-channel-footer #main-layout-footer
+    display block

--- a/apps/articles/templates/team_channel.jade
+++ b/apps/articles/templates/team_channel.jade
@@ -43,5 +43,5 @@ block body
       //- Grid
       .team-channel-grid
         //- Rendered on Client
-
-  include ../../../components/main_layout/footer/template
+  .team-channel-footer
+    include ../../../components/main_layout/footer/template

--- a/components/channel_nav/index.styl
+++ b/components/channel_nav/index.styl
@@ -68,11 +68,6 @@ stickynav()
 body.is-sticky
   stickynav()
 
-@media (min-width: 1660px)
-  .team-channel-nav .responsive-layout-container
-    max-width 1600px
-    margin 0 auto
-
 @media (max-width: 975px)
   .responsive-layout-container
     margin 0px 30px

--- a/components/main_layout/footer/index.styl
+++ b/components/main_layout/footer/index.styl
@@ -131,8 +131,6 @@ mlf-upper-column-width = ((100% - mlf-upper-column-aside-width) / 4)
 @media (max-width: 600px)
   #main-layout-footer
     padding 0
-  .body-responsive #main-layout-footer
-    display none
   .mlf.mlf__fullwidth
     display none
   .mlf.mlf__mobile


### PR DESCRIPTION
Following up on https://github.com/artsy/force/issues/628
- Adds new max width to home pages for team-channels
- Footer menu matches width of team channels, and displays mobile menu 

It looks like the mobile footer defaults to display: none everywhere, do you know why this might be?  I enabled it for team-channel pages only.
