### PR TITLE
@alloy => Finish up facebook and login modal on signup screen of artist page CTA

### DIFF
--- a/components/artist_page_cta/index.styl
+++ b/components/artist_page_cta/index.styl
@@ -121,6 +121,28 @@
     float right
     width 500px
     margin-top 50px
+    .auth-signup-facebook
+      background-color #38409E
+      width 500px
+    button
+      margin-bottom 20px
+    h2
+      width 100%
+      text-align center
+      border-bottom 1px solid gray-darker-color
+      line-height 0.1em
+      margin 10px 0 20px
+      span 
+        avant-garde()
+        font-size 11px
+        color gray-darker-color
+        background #fff
+        padding 0 10px
+    #auth-footer
+      text-align center
+      p
+        opacity 0.8
+        color gray-darkest-color
   &__close
     position absolute
     right 20px

--- a/components/artist_page_cta/templates/register.jade
+++ b/components/artist_page_cta/templates/register.jade
@@ -4,21 +4,31 @@ div.artist-page-cta-overlay__register
     method='POST'
   )
     .auth-errors
+    input.bordered-input.is-block(
+      name='name', type='text', placeholder='Your full name', autofocus=true, required
+    )
     input#js-mailcheck-input-modal.bordered-input.is-block(
-      name='email', type='email', placeholder='Email', required
+      name='email', type='email', placeholder='Your email address', required
     )
     #js-mailcheck-hint-modal
     input.bordered-input.is-block(
       name= 'password'
       type= 'password'
-      placeholder= 'Password'
+      placeholder= 'Create a password'
       autocomplete= 'on'
       pattern= '.{6,}'
       title= '6 characters minimum'
       required
     )
-    input.bordered-input.is-block(
-      name='name', type='text', placeholder='Full Name', required
-    )
+
     input( type="hidden" name="_csrf" value=sd.CSRF_TOKEN )
-    button#auth-submit.avant-garde-button-black.is-block Join Artsy
+    button#auth-submit.avant-garde-button-black.is-block Sign Up
+
+  h2
+    span Or
+
+  a.auth-signup-facebook.avant-garde-button-black(href='/users/auth/facebook')
+    i.icon-facebook
+    | Continue with Facebook
+
+  include ./register_footer.jade

--- a/components/artist_page_cta/templates/register_footer.jade
+++ b/components/artist_page_cta/templates/register_footer.jade
@@ -1,0 +1,10 @@
+footer#auth-footer
+  aside
+    | By signing up, you agree to our&nbsp;
+    a.faux-underline( href='/terms' ) Terms of Use
+    | &nbsp;and&nbsp;
+    a.faux-underline( href='/privacy' ) Privacy Policy
+    | .
+  p
+    | Already have an account?&nbsp;
+    a.faux-underline.auth-toggle.small-caps Log in

--- a/components/artist_page_cta/view.coffee
+++ b/components/artist_page_cta/view.coffee
@@ -2,6 +2,7 @@ Backbone = require 'backbone'
 _ = require 'underscore'
 Form = require '../mixins/form.coffee'
 LoggedOutUser = require '../../models/logged_out_user.coffee'
+AuthModalView = require '../auth_modal/view.coffee'
 template = -> require('./templates/index.jade') arguments...
 overlayTemplate = -> require('./templates/overlay.jade') arguments...
 
@@ -13,8 +14,15 @@ module.exports = class ArtistPageCTAView extends Backbone.View
   events:
     'click': 'fullScreenOverlay'
     'submit .artist-page-cta-overlay__register': 'submit'
+    'click .auth-toggle': 'triggerLoginModal'
 
-  fullScreenOverlay: (e)->
+  triggerLoginModal: (e) ->
+    e.stopPropagation()
+    new AuthModalView
+      width: '500px'
+      mode: 'login'
+
+  fullScreenOverlay: (e) ->
     return if @$el.hasClass 'fullscreen'
     @$el.addClass 'fullscreen'
     @$('.main-layout-container').html overlayTemplate


### PR DESCRIPTION
![screen shot 2017-01-06 at 12 28 26 pm](https://cloud.githubusercontent.com/assets/1457859/21726917/d58cac6e-d40c-11e6-85fa-d2882887d608.png)


Because we're only showing this for logged-in users with the lab feature, it's a little funky when you click the 'Facebook' button. That basically just links your currently logged in account successfully.

However, I temporarily removed the logged-in guard, and verified that it successfully signs you up.

Up next:
- the payoff screen!

Something I'm realizing, is that successful login/signup via Facebook will redirect you, so I actually need to make the payoff screen a stand-alone server-side rendered page so that you can get successfully redirected to it.