### PR TITLE
@xtina-starr => Provides Parse.ly with an absolute url

### DIFF
--- a/models/article.coffee
+++ b/models/article.coffee
@@ -222,7 +222,7 @@ module.exports = class Article extends Backbone.Model
       "@context": "http://schema.org"
       "@type": "NewsArticle"
       "headline": @get('thumbnail_title')
-      "url": @href()
+      "url": @fullHref()
       "thumbnailUrl": @get('thumbnail_image')
       "dateCreated": @get('published_at')
       "articleSection": @getParselySection()


### PR DESCRIPTION
#minor Parse.ly, our analytics tool for Editorial recently made a change to their crawler and they want us to provide absolute urls now instead of relative ones. 