### PR TITLE
@mzikherman => Standalone route for artist page CTA payoff

### DIFF
--- a/apps/artist/client/index.coffee
+++ b/apps/artist/client/index.coffee
@@ -1,11 +1,25 @@
-{ ARTIST } = sd = require('sharify').data
+{ ARTIST, IS_PAYOFF, CURRENT_USER } = sd = require('sharify').data
 Backbone = require 'backbone'
 scrollFrame = require 'scroll-frame'
 Artist = require '../../../models/artist.coffee'
 CurrentUser = require '../../../models/current_user.coffee'
 ArtistRouter = require './router.coffee'
+FollowedArtistsRailView = require '../../home/components/followed_artists/view.coffee'
 
 module.exports.init = ->
+  if IS_PAYOFF
+    view = new FollowedArtistsRailView
+      $el: $("#artist-page")
+      user: CURRENT_USER
+      module: 
+        context: 
+          artists: []
+          counts:
+            artists: 0
+        results: []
+
+    view.render()
+    return
   statuses = ARTIST.statuses
   artist = new Artist ARTIST
   user = CurrentUser.orNull()

--- a/apps/artist/index.coffee
+++ b/apps/artist/index.coffee
@@ -15,3 +15,5 @@ app.get '/artist/:id/follow', routes.follow
 app.get '/artist/:id', timeout('25s'), routes.index
 for { slug } in sections
   app.get "/artist/:id/#{slug}", routes.tab
+
+app.get '/artist/:id/payoff', routes.ctaPayoff

--- a/apps/artist/routes.coffee
+++ b/apps/artist/routes.coffee
@@ -67,3 +67,13 @@ sd = require('sharify').data
     error: res.backboneError
     success: ->
       res.redirect "/artist/#{req.params.id}"
+
+@ctaPayoff = (req, res) ->
+  if req.user?
+    req.user.fetch
+      success: (model, resp, options) ->
+        res.locals.sd.CURRENT_USER = _.extend(resp, res.locals.sd.CURRENT_USER)
+        res.locals.sd.IS_PAYOFF = true
+        res.render 'payoff'
+  else
+    res.redirect "/artist/#{req.params.id}"

--- a/apps/artist/stylesheets/index.styl
+++ b/apps/artist/stylesheets/index.styl
@@ -36,3 +36,4 @@
 @require './sections'
 @require '../../../components/auction_lots/stylesheets'
 @require '../../../node_modules/artsy-ezel-components/pagination'
+@require '../../../apps/home/components/followed_artists'

--- a/apps/artist/templates/payoff.jade
+++ b/apps/artist/templates/payoff.jade
@@ -1,0 +1,10 @@
+extends ../../../components/main_layout/templates/blank
+
+block head
+  title Personalize | Artsy
+
+append locals
+  - assetPackage = 'artist'
+
+block body
+  #artist-page


### PR DESCRIPTION
cc @alloy 

I'll self-merge, this is a start to the payoff screen. It's going to be a stand-alone page that after a successful signup/login you'll get redirected to.

It brings in the home page component directly, and so it's sort of functional(!), although it'll need to be modified.

As discussed, because this is a stand-alone new page (scaffolding set up in this PR), and its basically just using the existing component with some modifications, it could be a good task for someone else (Luc) to take on/pair.