### PR TITLE
@mzikherman - Explicitly sort fairs by reverse chron start_at

### DIFF
--- a/apps/fair_organizer/routes.coffee
+++ b/apps/fair_organizer/routes.coffee
@@ -43,6 +43,7 @@ representation = (fair) ->
     cache: true
     data:
       fair_organizer_id: fairOrg.get('_id')
+      sort: "-start_at"
     success: (models, response, options)->
       articles = new Articles()
 


### PR DESCRIPTION
Closes https://github.com/artsy/collector-experience/issues/79
Closes https://github.com/artsy/collector-experience/issues/78

I guess this never came up because fairs were always created in the order that they happened. Now we explicitly pass in `-start_at` to get the fair order we expect.

![screenshot 2017-01-10 12 04 25](https://cloud.githubusercontent.com/assets/821469/21816204/498ef9f0-d72d-11e6-9da4-1a351faba3ed.png)
