### PR TITLE
@craigspaeth: Remove deploy tasks and just let it be split up in Semaphore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,21 +74,4 @@ test-s:
 	$(BIN)/ezel-assets
 	$(BIN)/coffee test/helpers/integration.coffee
 
-# Runs all the necessary build tasks to push to staging or production.
-# Run with `make deploy env=staging` or `make deploy env=production`.
-deploy:
-	$(BIN)/ezel-assets
-	$(BIN)/bucket-assets --bucket force-$(env)
-	heroku config:set ASSET_MANIFEST=$(shell cat manifest.json) --app=force-$(env)
-	git push --force git@heroku.com:force-$(env).git
-
-# Runs all the necessary build tasks to push the currently checked out branch
-# to a personal heroku app.
-# Run with `make deploy_custom app=app_name`.
-deploy_custom:
-	$(BIN)/ezel-assets
-	$(BIN)/bucket-assets --bucket $(app)
-	heroku config:set ASSET_MANIFEST=$(shell cat manifest.json) --app=$(app)
-	git push -f git@heroku.com:$(app).git $(shell git rev-parse --symbolic-full-name --abbrev-ref HEAD):master
-
 .PHONY: test

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1148,9 +1148,9 @@
       "dev": true
     },
     "bucket-assets": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "from": "bucket-assets@latest",
-      "resolved": "https://registry.npmjs.org/bucket-assets/-/bucket-assets-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/bucket-assets/-/bucket-assets-1.0.1.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "bluebird": "^3.4.6",
     "bluebird-q": "^2.1.1",
     "body-parser": "^1.14.1",
-    "bucket-assets": "^1.0.0",
+    "bucket-assets": "^1.0.1",
     "cheerio": "^0.22.0",
     "coffee-script": "^1.10.0",
     "connect-flash": "^0.1.1",


### PR DESCRIPTION
Makefiles will try to run `$(shell ...)` commands in a first step ([read more](http://stackoverflow.com/questions/9081841/makefile-assign-command-output-to-variable)) before running things which causes a race condition in our deploy script. I'd like to move us off these Makefiles into package.json anyways, so I'm just going to let the script be split up in Semaphore.