### PR TITLE
@xtina-starr => Bump artsy-passport for redirect bug, and also maintain current filters

### DIFF
--- a/apps/artist/routes.coffee
+++ b/apps/artist/routes.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore'
 Q = require 'bluebird-q'
+qs = require 'qs'
 fs = require 'fs'
 request = require 'superagent'
 Backbone = require 'backbone'
@@ -69,7 +70,7 @@ sd = require('sharify').data
   req.user.followArtist req.params.id,
     error: res.backboneError
     success: ->
-      res.redirect "/artist/#{req.params.id}"
+      res.redirect "/artist/#{req.params.id}?#{qs.stringify req.query}"
 
 @ctaPayoff = (req, res) ->
   if req.user?
@@ -90,7 +91,7 @@ sd = require('sharify').data
             res.locals.sd.IS_PAYOFF = true
             res.render 'payoff',
               name: user.name
-              href: "/artist/#{req.params.id}/follow"
+              href: "/artist/#{req.params.id}/follow?#{qs.stringify req.query}"
           .catch (err) -> next(err if NODE_ENV is 'development')
   else
     res.redirect "/artist/#{req.params.id}"

--- a/apps/artist/test/routes.coffee
+++ b/apps/artist/test/routes.coffee
@@ -71,11 +71,12 @@ describe 'Artist routes', ->
       routes.follow @req, @res
       @res.redirect.args[0][0].should.equal '/artist/foo'
 
-    it 'follows an artist and redirects to the artist page', ->
+    it 'follows an artist and redirects to the artist page with any query params', ->
       @res.redirect = sinon.stub()
       @req.user = new CurrentUser fabricate 'user'
+      @req.query = { medium: 'work-on-paper' }
       routes.follow @req, @res
       Backbone.sync.args[0][1].url().should.containEql '/api/v1/me/follow/artist'
       Backbone.sync.args[0][1].get('artist_id').should.equal 'foo'
       Backbone.sync.args[0][2].success()
-      @res.redirect.args[0][0].should.equal '/artist/foo'
+      @res.redirect.args[0][0].should.equal '/artist/foo?medium=work-on-paper'

--- a/components/artist_page_cta/templates/register.jade
+++ b/components/artist_page_cta/templates/register.jade
@@ -27,7 +27,7 @@ div.artist-page-cta-overlay__register
   h2
     span Or
 
-  a.auth-signup-facebook.avant-garde-button-black(href="/users/auth/facebook?redirect-to=#{artist.get('href')}/payoff")
+  a.auth-signup-facebook.avant-garde-button-black(href="/users/auth/facebook?skip-onboarding=true&redirect-to=#{afterAuthPath}")
     i.icon-facebook
     | Continue with Facebook
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -263,9 +263,9 @@
       "resolved": "https://registry.npmjs.org/artsy-newrelic/-/artsy-newrelic-1.1.0.tgz"
     },
     "artsy-passport": {
-      "version": "1.3.0",
-      "from": "artsy-passport@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/artsy-passport/-/artsy-passport-1.3.0.tgz",
+      "version": "1.4.0",
+      "from": "artsy-passport@latest",
+      "resolved": "https://registry.npmjs.org/artsy-passport/-/artsy-passport-1.4.0.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -2011,9 +2011,9 @@
       }
     },
     "esprima": {
-      "version": "3.1.2",
+      "version": "3.1.3",
       "from": "esprima@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
     },
     "estraverse": {
       "version": "1.9.3",
@@ -4473,9 +4473,9 @@
       "dev": true
     },
     "oauth": {
-      "version": "0.9.14",
+      "version": "0.9.15",
       "from": "oauth@>=0.9.0 <0.10.0",
-      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.14.tgz"
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz"
     },
     "oauth-sign": {
       "version": "0.8.2",
@@ -4696,9 +4696,9 @@
       "resolved": "https://registry.npmjs.org/passport-oauth1/-/passport-oauth1-1.1.0.tgz"
     },
     "passport-oauth2": {
-      "version": "1.3.0",
+      "version": "1.4.0",
       "from": "passport-oauth2@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.4.0.tgz"
     },
     "passport-strategy": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "artsy-error-handler": "^1.0.2",
     "artsy-ezel-components": "git://github.com/artsy/artsy-ezel-components.git",
     "artsy-newrelic": "^1.1.0",
-    "artsy-passport": "^1.3.0",
+    "artsy-passport": "^1.4.0",
     "artsy-xapp": "git://github.com/artsy/artsy-xapp.git",
     "async": "^2.1.2",
     "babel": "^6.5.2",


### PR DESCRIPTION
Last bit of functional work needed for the CTA!

Up next:
- address some largely visual QA in https://github.com/artsy/force/issues/688
- add analytics/AB test with @anipetrov 

This PR:
- bumps artsy-passport for a fix that didn't let you skip onboarding after social auth
- maintains the current filter state (like `?medium=works-on-paper`) through the /payoff and /follow screens