### PR TITLE
@mzikherman: Change /press redirect

### DIFF
--- a/lib/routers/hardcoded_redirects.coffee
+++ b/lib/routers/hardcoded_redirects.coffee
@@ -21,7 +21,7 @@ redirects =
   '/settings': '/user/edit'
   '/collector/edit': '/profile/edit'
   '/_=_': '/' # Facebook passport bug, see: https://github.com/jaredhanson/passport-facebook/issues/12#issuecomment-5913711
-  '/press': '/press/press-releases'
+  '/press': '/press/in-the-media'
   '/about/press': '/press/press-releases'
   '/about/page/press': '/press/press-releases'
   '/about/page/events': '/press/in-the-media'


### PR DESCRIPTION
We have to do this to work around not being able to create shortcuts for certain pages. I wonder if we should drop this [blacklist in Gravity](https://github.com/artsy/gravity/blob/c9d9487efb2eaf15d520afc481b905b6cf1757fd/app/models/util/handle_blacklist.rb) and replace these hard-coded redirects with shortcuts 🤔 