### PR TITLE
@broskoski: Load prevent right click early and prevent right clicking on canvas

### DIFF
--- a/components/fair_layout/templates/head.jade
+++ b/components/fair_layout/templates/head.jade
@@ -1,3 +1,4 @@
+include ../../prevent_right_click/index
 != newRelicHead
 meta( charset='utf-8' )
 meta( name='msapplication-config', content=asset('/images/browserconfig.xml') )

--- a/components/main_layout/templates/head.jade
+++ b/components/main_layout/templates/head.jade
@@ -1,3 +1,4 @@
+include ../../prevent_right_click/index
 != newRelicHead
 meta( charset='utf-8' )
 meta( name='msapplication-config', content=asset('/images/browserconfig.xml') )

--- a/components/prevent_right_click/README.md
+++ b/components/prevent_right_click/README.md
@@ -1,0 +1,9 @@
+# Prevent Right Click
+
+This little partial is used to inject a script that globally prevents right clicking on our artwork images. We need to load this in the head to make sure we load this as soon as possible in case some partner with a bad internet connection is able to right click before the bigger JS payload downloads.
+
+```
+head
+  // ...
+  include prevent_right_click
+```

--- a/components/prevent_right_click/index.jade
+++ b/components/prevent_right_click/index.jade
@@ -1,0 +1,11 @@
+script.
+  var isAdmin = #{!!(user && user.get('type') === 'Admin')};
+  document.addEventListener('contextmenu', function(e) {
+    if (isAdmin) return;
+    if (['IMG', 'CANVAS'].indexOf(e.target.nodeName) < 0) return;
+    var classes = e.target.className + ' ' + e.target.parentElement.className;
+    if (
+      classes.match('artwork') ||
+      classes.match('seadragon')
+    ) e.preventDefault();
+  });

--- a/lib/global_client_setup.coffee
+++ b/lib/global_client_setup.coffee
@@ -26,7 +26,6 @@ module.exports = ->
   listenForInvert()
   listenForBounce()
   confirmation.check()
-  disableRightClick()
 
 ensureFreshUser = (data) ->
   return unless sd.CURRENT_USER
@@ -78,18 +77,3 @@ setupJquery = ->
     'X-XAPP-TOKEN': sd.ARTSY_XAPP_TOKEN
     'X-ACCESS-TOKEN': sd.CURRENT_USER?.accessToken
   window[key] = helper for key, helper of templateModules
-
-# We tell our partners, importantly institutions like Museums, that we'll
-# disable right click to "protect" their images. Yes, it's just smoke and
-# mirrors, but it makes them _feel_ better so please be mindful of that.
-disableRightClick = ->
-  # Allow it for admins (e.g. it's super annoying to the design team)
-  return if sd.CURRENT_USER?.type is 'Admin'
-  $(document).on 'contextmenu', (e) ->
-    # Grenade for selecting any images with the name 'artwork' in their,
-    # or their parent's, class
-    $target = $(e.target)
-    return unless $target.is('img')
-    disable = $target.is('[class*=artwork]') or
-              $target.parent().is('[class*=artwork]')
-    return false if disable


### PR DESCRIPTION
One of Yulia's partners was able to do this, and the only theory I can come up with is they managed to right click before the main JS payload downloads. Yulia also pointed out that in deep zoom mode you can apparently right click save canvas to an image, so we prevent on `img` and `canvas` tags now.