### PR TITLE
Improves Danger rule about assignees

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -2,4 +2,5 @@
 warn("Please include a PR summary", sticky: false) if github.pr_body.length < 5
 
 # Ensure that we assign PRs to someone
-warn("Please assign someone to your PR", sticky: false) unless github.pr_title.include?("@")
+has_assignee = github.pr_title.include?("@") || github.pr_json["assignee"]
+warn("Please assign someone to your PR", sticky: false) unless has_assignee


### PR DESCRIPTION
Spotted in #700 that you got a Danger warning, but had assigned someone. This should not raise a warning.