### PR TITLE
Adds `is_inquireable` to graphql query

### DIFF
--- a/apps/show/components/artwork_columns_metaphysics/view.coffee
+++ b/apps/show/components/artwork_columns_metaphysics/view.coffee
@@ -42,6 +42,7 @@ module.exports = class ArtworkColumnsView extends Backbone.View
               date
               title
               sale_message
+              is_inquireable
             }
           }
         }


### PR DESCRIPTION
`is_inquireable` was missing from this metaphysics query, which caused artworks on partner show pages to not render an [inquire link](https://github.com/artsy/force/blob/master/apps/show/components/artwork_item_metaphysics/templates/artwork.jade#L23) to contact the gallery.