### PR TITLE
@alloy add analytics to email gallery link and gallery website

### DIFF
--- a/analytics/partner.js
+++ b/analytics/partner.js
@@ -9,15 +9,15 @@
     analytics.track('Non-claimed partner page', _.extend(options, {nonInteraction: 1}))
   })
 
-  $('#partner-contact .email-gallery').click(function () {
+  $('#partner-contact .email-gallery').click(function (e) {
     analytics.track('Clicked Contact Gallery Via Email', {
-      gallery_id: sd.CURRENT_PATH.split('/')[1] // gallery id
+      gallery_id: $(e.currentTarget).data('id')
     })
   })
 
-  $('#partner-contact .partner-website').click(function () {
+  $('#partner-contact .partner-website').click(function (e) {
     analytics.track('Clicked Gallery Website', {
-      gallery_id: sd.CURRENT_PATH.split('/')[1] // gallery id
+      gallery_id: $(e.currentTarget).data('id')
     })
   })
 })()

--- a/analytics/partner.js
+++ b/analytics/partner.js
@@ -8,4 +8,16 @@
   analyticsHooks.on('partner:non-claimed', function (options) {
     analytics.track('Non-claimed partner page', _.extend(options, {nonInteraction: 1}))
   })
+
+  $('#partner-contact .email-gallery').click(function () {
+    analytics.track('Clicked Contact Gallery Via Email', {
+      gallery_id: sd.CURRENT_PATH.split('/')[1] // gallery id
+    })
+  })
+
+  $('#partner-contact .partner-website').click(function () {
+    analytics.track('Clicked Gallery Website', {
+      gallery_id: sd.CURRENT_PATH.split('/')[1] // gallery id
+    })
+  })
 })()

--- a/apps/partner2/templates/contact_info.jade
+++ b/apps/partner2/templates/contact_info.jade
@@ -1,7 +1,7 @@
 if profile.isGallery() && partner.has('email')
   .purchase
     p Interested in purchasing works?
-    a.email-gallery( href=partner.getMailTo() ) Contact #{partner.displayName()} via email.
+    a.email-gallery( data-id=partner.get('id'), href=partner.getMailTo() ) Contact #{partner.displayName()} via email.
 if partner.has('website')
   .contact-website
-    a.partner-website( href=partner.get('website'), target='_blank' )= partner.getSimpleWebsite()
+    a.partner-website( data-id=partner.get('id'), href=partner.get('website'), target='_blank' )= partner.getSimpleWebsite()


### PR DESCRIPTION
Per the conversation during sprint planning meeting, this adds analytics to the contact gallery via email link and the gallery website.

![screen shot 2017-01-17 at 11 57 23 am](https://cloud.githubusercontent.com/assets/5201004/22030816/e13d33f0-dcac-11e6-8cb3-9ed46beca7e3.png)
