### PR TITLE
@anyone Criteo updates

### DIFF
--- a/analytics/criteo.js
+++ b/analytics/criteo.js
@@ -10,7 +10,6 @@ var userEmail = function() {
 if (pathSplit[1] === 'auctions') {
   // http://www.artsy.net/auctions - (AUCTIONS viewHome)
   //              0          1
-  console.log('auctions viewHome')
   window.criteo_q.push(
     { event: 'setAccount', account: sd.CRITEO_AUCTIONS_ACCOUNT_NUMBER },
     { event: 'setSiteType', type: 'd' },
@@ -20,7 +19,6 @@ if (pathSplit[1] === 'auctions') {
   if (!pathSplit[3]) {
     // https://www.artsy.net/auction/:auction_id - (AUCTIONS viewList)
     //              0          1          2
-    console.log('auctions viewList')
     window.criteo_q.push(
       { event: 'setAccount', account: sd.CRITEO_AUCTIONS_ACCOUNT_NUMBER },
       { event: 'setSiteType', type: 'd' },
@@ -55,14 +53,12 @@ if (pathSplit[1] === 'auctions') {
   // We cannot send both ids on product pages, so, send the Auctions account ID
   // if the artwork is in an auction, otherwise send the Artworks account ID.
   if (sd.AUCTION && sd.AUCTION.artwork_id) {
-    console.log('auctions viewItem')
     window.criteo_q.push(
       { event: "setAccount", account: sd.CRITEO_AUCTIONS_ACCOUNT_NUMBER },
       { event: "setSiteType", type: "m" },
       { event: "viewItem", item: sd.AUCTION && sd.AUCTION.artwork_id }
     )
   } else {
-    console.log('artworks viewItem')
     window.criteo_q.push(
       { event: 'setAccount', account: sd.CRITEO_ARTWORKS_ACCOUNT_NUMBER },
       { event: 'setSiteType', type: 'd' },
@@ -72,7 +68,6 @@ if (pathSplit[1] === 'auctions') {
   }
   // ARTWORKS viewBasket
   analyticsHooks.on('inquiry_questionnaire:modal:opened', function(data) {
-    console.log('artworks viewBasket')
     window.criteo_q.push(
       { event: 'setAccount', account: sd.CRITEO_ARTWORKS_ACCOUNT_NUMBER },
       { event: 'setSiteType', type: 'd' },
@@ -91,7 +86,6 @@ if (pathSplit[1] === 'auctions') {
   })
   // ARTWORKS trackTransaction
   analyticsHooks.on('inquiry:sent', function(data) {
-    console.log('artworks trackTransaction')
     window.criteo_q.push(
       { event: 'setAccount', account: sd.CRITEO_ARTWORKS_ACCOUNT_NUMBER },
       { event: 'setSiteType', type: 'd' },
@@ -112,7 +106,6 @@ if (pathSplit[1] === 'auctions') {
   if (pathSplit[1] === 'collect') {
     // https://www.artsy.net/collect - (ARTWORKS viewHome)
     //              0          1
-    console.log('artworks viewHome')
     window.criteo_q.push(
       { event: 'setAccount', account: sd.CRITEO_ARTWORKS_ACCOUNT_NUMBER },
       { event: 'setSiteType', type: 'd' },
@@ -122,7 +115,6 @@ if (pathSplit[1] === 'auctions') {
   } else if (pathSplit[1] === 'artist' && !pathSplit[3]) {
     // https://www.artsy.net/artist/:artist_id - (ARTWORKS viewList)
     //              0          1         2
-    console.log('artworks viewList')
     window.criteo_q.push(
       { event: 'setAccount', account: sd.CRITEO_ARTWORKS_ACCOUNT_NUMBER },
       { event: 'setSiteType', type: 'd' },

--- a/analytics/criteo.js
+++ b/analytics/criteo.js
@@ -8,7 +8,9 @@ var userEmail = function() {
   return sd.CURRENT_USER ? [sd.CURRENT_USER.email] : [];
 }()
 if (pathSplit[1] === 'auctions') {
-  // Auctions events
+  // http://www.artsy.net/auctions - (AUCTIONS viewHome)
+  //              0          1
+  console.log('auctions viewHome')
   window.criteo_q.push(
     { event: 'setAccount', account: sd.CRITEO_AUCTIONS_ACCOUNT_NUMBER },
     { event: 'setSiteType', type: 'd' },
@@ -16,12 +18,17 @@ if (pathSplit[1] === 'auctions') {
   )
 } else if (pathSplit[1] === 'auction') {
   if (!pathSplit[3]) {
+    // https://www.artsy.net/auction/:auction_id - (AUCTIONS viewList)
+    //              0          1          2
+    console.log('auctions viewList')
     window.criteo_q.push(
       { event: 'setAccount', account: sd.CRITEO_AUCTIONS_ACCOUNT_NUMBER },
       { event: 'setSiteType', type: 'd' },
       { event: 'viewList', item: sd.ARTWORKS.map(function(a) { return a._id }) }
     )
   } else if (pathSplit[3] === 'bid') {
+    // https://www.artsy.net/auction/:auction_id/bid - (AUCTIONS trackTransaction)
+    //              0          1          2       3
     analyticsHooks.on('confirm:bid:form:success', function(data) {
       const price = data.max_bid_amount_cents ? data.max_bid_amount_cents / 100 : null
       window.criteo_q.push(
@@ -42,20 +49,30 @@ if (pathSplit[1] === 'auctions') {
     })
   }
 } else if (pathSplit[1] === 'artwork' && !pathSplit[3]) {
-  // Auctions event
-  window.criteo_q.push(
-    { event: 'setAccount', account: sd.CRITEO_AUCTIONS_ACCOUNT_NUMBER },
-    { event: 'setSiteType', type: 'd' },
-    { event: 'viewItem', item: sd.AUCTION && sd.AUCTION.artwork_id }
-  )
-  // Artworks events
-  window.criteo_q.push(
-    { event: 'setAccount', account: sd.CRITEO_ARTWORKS_ACCOUNT_NUMBER },
-    { event: 'setSiteType', type: 'd' },
-    { event: 'setEmail', email: userEmail },
-    { event: 'viewItem', item: sd.COMMERCIAL.artwork._id }
-  )
+  // https://www.artsy.net/artwork/:artwork_id - (AUCTIONS & ARTWORKS viewItem)
+  //              0          1          2  
+  //
+  // We cannot send both ids on product pages, so, send the Auctions account ID
+  // if the artwork is in an auction, otherwise send the Artworks account ID.
+  if (sd.AUCTION && sd.AUCTION.artwork_id) {
+    console.log('auctions viewItem')
+    window.criteo_q.push(
+      { event: "setAccount", account: sd.CRITEO_AUCTIONS_ACCOUNT_NUMBER },
+      { event: "setSiteType", type: "m" },
+      { event: "viewItem", item: sd.AUCTION && sd.AUCTION.artwork_id }
+    )
+  } else {
+    console.log('artworks viewItem')
+    window.criteo_q.push(
+      { event: 'setAccount', account: sd.CRITEO_ARTWORKS_ACCOUNT_NUMBER },
+      { event: 'setSiteType', type: 'd' },
+      { event: 'setEmail', email: userEmail },
+      { event: 'viewItem', item: sd.COMMERCIAL.artwork._id }
+    )
+  }
+  // ARTWORKS viewBasket
   analyticsHooks.on('inquiry_questionnaire:modal:opened', function(data) {
+    console.log('artworks viewBasket')
     window.criteo_q.push(
       { event: 'setAccount', account: sd.CRITEO_ARTWORKS_ACCOUNT_NUMBER },
       { event: 'setSiteType', type: 'd' },
@@ -72,7 +89,9 @@ if (pathSplit[1] === 'auctions') {
       }
     )
   })
-  analyticsHooks.on('inquiry:sync', function(data) {
+  // ARTWORKS trackTransaction
+  analyticsHooks.on('inquiry:sent', function(data) {
+    console.log('artworks trackTransaction')
     window.criteo_q.push(
       { event: 'setAccount', account: sd.CRITEO_ARTWORKS_ACCOUNT_NUMBER },
       { event: 'setSiteType', type: 'd' },
@@ -90,8 +109,10 @@ if (pathSplit[1] === 'auctions') {
     )
   })
 } else {
-  // Artworks events
   if (pathSplit[1] === 'collect') {
+    // https://www.artsy.net/collect - (ARTWORKS viewHome)
+    //              0          1
+    console.log('artworks viewHome')
     window.criteo_q.push(
       { event: 'setAccount', account: sd.CRITEO_ARTWORKS_ACCOUNT_NUMBER },
       { event: 'setSiteType', type: 'd' },
@@ -99,6 +120,9 @@ if (pathSplit[1] === 'auctions') {
       { event: 'viewHome' }
     )
   } else if (pathSplit[1] === 'artist' && !pathSplit[3]) {
+    // https://www.artsy.net/artist/:artist_id - (ARTWORKS viewList)
+    //              0          1         2
+    console.log('artworks viewList')
     window.criteo_q.push(
       { event: 'setAccount', account: sd.CRITEO_ARTWORKS_ACCOUNT_NUMBER },
       { event: 'setSiteType', type: 'd' },


### PR DESCRIPTION
A couple fixes from Criteo.

First, we intended to track viewItem event for our Auctions feed AND Artworks feed on artwork pages, but Criteo won't accept this.  So, on [L55](https://github.com/artsy/force/compare/master...OLI9292:criteo_updates?expand=1#diff-15c581b95b1b523b1ab4c35946c5a9a2R55), we send the Auctions account ID if the artwork is in an auction, otherwise we send the Artworks account ID.

Second fix is changing `inquiry:sync` to `inquiry:sent` on [L88](https://github.com/artsy/force/compare/master...OLI9292:criteo_updates?expand=1#diff-15c581b95b1b523b1ab4c35946c5a9a2R88) to properly track an inquiry.

Also added some comments to document the path splits.