### PR TITLE
@kanaabe: Replace process.cwd() with relative paths #minor

### DIFF
--- a/apps/artist/test/meta.coffee
+++ b/apps/artist/test/meta.coffee
@@ -1,6 +1,7 @@
 fs = require 'fs'
 jade = require 'jade'
 sinon = require 'sinon'
+path = require 'path'
 Artist = require '../../../models/artist'
 { fabricate } = require 'antigravity'
 artistJSON = require './fixtures'
@@ -10,7 +11,7 @@ _ = require 'underscore'
 
 describe 'Meta tags', ->
   before ->
-    @file = "#{process.cwd()}/apps/artist/templates/meta.jade"
+    @file = "#{path.resolve __dirname, '../'}/templates/meta.jade"
     @sd =
       APP_URL: 'http://localhost:5000'
       CANONICAL_MOBILE_URL: 'http://m.localhost:5000'

--- a/apps/collect/test/meta.coffee
+++ b/apps/collect/test/meta.coffee
@@ -1,10 +1,11 @@
 fs = require 'fs'
 jade = require 'jade'
+path = require 'path'
 
 describe 'Meta tags', ->
   describe 'browse page', ->
     before ->
-      @file = "#{process.cwd()}/apps/collect/templates/meta.jade"
+      @file = "#{path.resolve __dirname, '../'}/templates/meta.jade"
       @html = jade.render fs.readFileSync(@file).toString(),
         sd:
           CANONICAL_MOBILE_URL: 'http://m.localhost:5000'

--- a/apps/feature/test/templates/meta.coffee
+++ b/apps/feature/test/templates/meta.coffee
@@ -1,5 +1,6 @@
 fs = require 'fs'
 jade = require 'jade'
+path = require 'path'
 { fabricate } = require 'antigravity'
 Feature = require '../../../../models/feature'
 
@@ -10,7 +11,7 @@ describe 'Meta tags', ->
     before ->
       @sd =
         APP_URL: "http://localhost:5000"
-      @file = "#{process.cwd()}/apps/feature/templates/meta.jade"
+      @file = "#{path.resolve __dirname, '../../'}/templates/meta.jade"
       @feature = new Feature fabricate('feature')
       @feature.href = -> ''
       @html = jade.render fs.readFileSync(@file).toString(),

--- a/apps/page/test/meta.coffee
+++ b/apps/page/test/meta.coffee
@@ -1,5 +1,6 @@
 fs = require 'fs'
 jade = require 'jade'
+path = require 'path'
 Page = require '../../../models/page'
 { fabricate } = require 'antigravity'
 
@@ -8,7 +9,7 @@ describe 'Meta tags', ->
   describe 'press page', ->
 
     before ->
-      @file = "#{process.cwd()}/apps/page/meta/press.jade"
+      @file = "#{path.resolve __dirname, '../'}/meta/press.jade"
       @sd =
         CANONICAL_MOBILE_URL: 'http://m.localhost:5000'
         MOBILE_MEDIA_QUERY: 'mobile-media-query'
@@ -27,7 +28,7 @@ describe 'Meta tags', ->
   describe 'terms page', ->
 
     before ->
-      @file = "#{process.cwd()}/apps/page/meta/terms.jade"
+      @file = "#{path.resolve __dirname, '../'}/meta/terms.jade"
       @sd =
         CANONICAL_MOBILE_URL: 'http://m.localhost:5000'
         MOBILE_MEDIA_QUERY: 'mobile-media-query'
@@ -46,7 +47,7 @@ describe 'Meta tags', ->
   describe 'privacy page', ->
 
     before ->
-      @file = "#{process.cwd()}/apps/page/meta/privacy.jade"
+      @file = "#{path.resolve __dirname, '../'}/meta/privacy.jade"
       @sd =
         CANONICAL_MOBILE_URL: 'http://m.localhost:5000'
         MOBILE_MEDIA_QUERY: 'mobile-media-query'
@@ -65,7 +66,7 @@ describe 'Meta tags', ->
   describe 'security page', ->
 
     before ->
-      @file = "#{process.cwd()}/apps/page/meta/security.jade"
+      @file = "#{path.resolve __dirname, '../'}/meta/security.jade"
       @sd =
         CANONICAL_MOBILE_URL: 'http://m.localhost:5000'
         MOBILE_MEDIA_QUERY: 'mobile-media-query'

--- a/apps/show/test/meta.coffee
+++ b/apps/show/test/meta.coffee
@@ -10,7 +10,7 @@ xdescribe 'Meta tags', ->
   describe 'Partner Show', ->
 
     beforeEach ->
-      @file = "#{process.cwd()}/apps/show/templates/meta.jade"
+      @file = "#{path.resolve __dirname, '../'}/templates/meta.jade"
       @show = new PartnerShow fabricate('show')
       @html = jade.render fs.readFileSync(@file).toString(),
         sd: sd

--- a/apps/shows/test/meta.coffee
+++ b/apps/shows/test/meta.coffee
@@ -1,4 +1,5 @@
 fs = require 'fs'
+path = require 'path'
 jade = require 'jade'
 { fabricate } = require 'antigravity'
 
@@ -6,7 +7,7 @@ describe 'Meta tags', ->
   describe 'index', ->
     before ->
       @sd = APP_URL: 'http://localhost:5000'
-      @file = "#{process.cwd()}/apps/shows/templates/meta.jade"
+      @file = "#{path.resolve __dirname, '../'}/templates/meta.jade"
       @html = jade.render fs.readFileSync(@file).toString(), sd: @sd, asset: ((u) -> u)
 
     it 'includes canonical url, twitter card, og tags, title, description', ->
@@ -24,7 +25,7 @@ describe 'Meta tags', ->
   describe 'city', ->
     before ->
       @sd = APP_URL: 'http://localhost:5000'
-      @file = "#{process.cwd()}/apps/shows/templates/meta.jade"
+      @file = "#{path.resolve __dirname, '../'}/templates/meta.jade"
       @html = jade.render fs.readFileSync(@file).toString(), asset: ((u) -> u), sd: @sd, city: name: 'Cool Place'
 
     it 'includes canonical url, twitter card, og tags, title, description', ->

--- a/components/auction_lots/test/templates/artist-meta.coffee
+++ b/components/auction_lots/test/templates/artist-meta.coffee
@@ -1,12 +1,13 @@
 fs = require 'fs'
 jade = require 'jade'
+path = require 'path'
 Artist = require '../../../../models/artist'
 { fabricate } = require 'antigravity'
 
 describe 'Meta tags', ->
 
   before ->
-    @file = "#{process.cwd()}/components/auction_lots/templates/meta/artist.jade"
+    @file = "#{path.resolve __dirname, '../../'}/templates/meta/artist.jade"
     @sd =
       APP_URL: 'http://localhost:5000'
       API_URL: 'http://localhost:5000'


### PR DESCRIPTION
Another step towards the Force + MG merger. We were using [process.cwd()](https://nodejs.org/api/process.html#process_process_cwd) to dig into directories from the root of Force. Luckily this was an old habit we didn't repeat many places. This works okay for Force because tests are run from the root directory, but merging the apps changes directory structure slightly which breaks this, and in general it's a bad practice to have your code dependent on which  directory it's being run from.