### PR TITLE
@eessex: Update selector to make test happy #minor

### DIFF
--- a/apps/editorial_features/components/eoy/client.coffee
+++ b/apps/editorial_features/components/eoy/client.coffee
@@ -217,7 +217,7 @@ module.exports.EoyView = class EoyView extends Backbone.View
         }, 1000)
 
   smoothAnchorScroll: =>
-    $('.scroller a[href*=#]:not([href=#])').click (e) ->
+    $('.scroller a[href*="#"]:not([href="#"])').click (e) ->
       e.preventDefault()
       if (location.pathname.replace(/^\//,'') == this.pathname.replace(/^\//,'') && location.hostname == this.hostname)
         target = this.hash.slice(1)


### PR DESCRIPTION
When running the Force + MG merge I think it's pulling in a different version of jQuery and the tests are complaining here with `Uncaught Error: Syntax error, unrecognized expression: .scroller a[href*=#]:not([href=#])`. It's a simple fix to just add quotes around the attribute selector here to make it 💚 