### PR TITLE
@anyone final change to criteo tracking code

### DIFF
--- a/analytics/criteo.js
+++ b/analytics/criteo.js
@@ -85,7 +85,7 @@ if (pathSplit[1] === 'auctions') {
     )
   })
   // ARTWORKS trackTransaction
-  analyticsHooks.on('inquiry:sent', function(data) {
+  analyticsHooks.on('inquiry_questionnaire:inquiry:sync', function(data) {
     window.criteo_q.push(
       { event: 'setAccount', account: sd.CRITEO_ARTWORKS_ACCOUNT_NUMBER },
       { event: 'setSiteType', type: 'd' },


### PR DESCRIPTION
The analytics trigger `inquiry:sent` is not triggered on a sent inquiry.  The trigger [here](https://github.com/artsy/force/blob/master/components/contact/inquiry.coffee#L50) is what we want (and we had before), but it's hook is concatenated with `inquiry_questionnaire` to make the correct hook `inquiry_questionnaire :inquiry:sync`, whereas before we just had `inquiry:sent`.