### PR TITLE
[WIP] The Mysterious Case of Disappearing Artist Bios

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "jquery-on-infinite-scroll": "^1.0.1",
     "jquery-ui": "^1.12.1",
     "jquery-waypoints": "^2.0.5",
-    "jquery.dotdotdot": "git://github.com/mzikherman/jquery.dotdotdot.git",
+    "jquery.dotdotdot": "1.7.4",
     "jquery.fillwidth": "^0.1.7",
     "jquery.iframe-transport": "^1.0.0",
     "jquery.transition": "git://github.com/dzucconi/jquery.transition.git",


### PR DESCRIPTION
@gnilekaw and I have been troubleshooting an issue where certain Artist Bios are disappearing from the Artist detail page. It's tricky to reproduce this issue, here's what I've had success with:

```
zero

one

two

three

four
```

I set one artist to have that bio and another artist to have one fewer lines. The former will have their `partner-artist-blurb` be empty and the latter works as expected. Upgrading the library fixed this bug, but there's a regression. Even though we're providing `ellipsis: ''` in our config object, an ellipsis is showing up.

So, what we're wondering, @mzikherman, is if you have any context here that we're missing and the reason for the forking of the library in the first place.