### PR TITLE
@kanaabe: Rename remaining asset packages to their consolidated ones

### DIFF
--- a/apps/how_auctions_work/templates/index.jade
+++ b/apps/how_auctions_work/templates/index.jade
@@ -5,7 +5,7 @@ block head
 
 append locals
   - bodyClass = bodyClass + ' body-no-margins'
-  - assetPackage = 'how_auctions_work'
+  - assetPackage = 'auctions'
 
 block body
   .how-auctions-work-page

--- a/apps/page/template.jade
+++ b/apps/page/template.jade
@@ -18,7 +18,7 @@ block head
       include meta/default
 
 append locals
-  - assetPackage = 'page'
+  - assetPackage = 'misc'
 
 block body
   #page-markdown-content!= page.mdToHtml('content')

--- a/apps/press/templates/index.jade
+++ b/apps/press/templates/index.jade
@@ -2,7 +2,7 @@ extends ../../../components/main_layout/templates/index
 include ../../../components/util/activator
 
 append locals
-  - assetPackage = 'press'
+  - assetPackage = 'misc'
 
 block body
   .press-page.responsive-layout-container: .main-layout-container

--- a/apps/search/templates/template.jade
+++ b/apps/search/templates/template.jade
@@ -5,7 +5,7 @@ block head
   include meta
 
 append locals
-  - assetPackage = 'search'
+  - assetPackage = 'misc'
 
 block body
   #search-page.main-layout-container

--- a/apps/static/templates/christies.jade
+++ b/apps/static/templates/christies.jade
@@ -16,7 +16,7 @@ block head
   meta( property='twitter:card', content='summary' )
 
 append locals
-  - assetPackage = 'static'
+  - assetPackage = 'misc'
   - bodyClass = bodyClass + ' body-no-margins body-no-padding'
 
 block body

--- a/apps/static/templates/future_of_art.jade
+++ b/apps/static/templates/future_of_art.jade
@@ -14,7 +14,7 @@ block head
   meta( property="twitter:card", content="summary" )
 
 append locals
-  - assetPackage = 'static'
+  - assetPackage = 'misc'
   - bodyClass = bodyClass + ' body-no-header body-no-margins'
 
 block body


### PR DESCRIPTION
I must have not save all'ed correctly one some of my search + replace. I searched through the rest of the codebase for `- assetPackage = (.*)`  and diffed that against what `ls assets` returned and uncovered a couple places, such as the search results page, that were still pointing to old assets packages. 😅  my bad.