### PR TITLE
@sweir27: Defer auctions2 client-side require

### DIFF
--- a/assets/auctions.coffee
+++ b/assets/auctions.coffee
@@ -31,7 +31,7 @@ routes =
 
   '''
   /auction2/.*
-  ''': require('../apps/auction2/client.js').default
+  ''': -> require('../apps/auction2/client.js').default
 
 for paths, init of routes
   for path in paths.split('\n')


### PR DESCRIPTION
Most of our client-side code is wrapped in an `init` function to defer running code for ease of testing/loading. In my refactor fury I accidentally assumed this was the same for Auctions2. This simply wraps that in a function to achieve the same thing, but I think ideally we'd thin out some of the root-level auctions2 code and wrap it in a `export default () =>` as I started to allude to in [my PR comment](https://github.com/artsy/force/pull/727#discussion_r97174703).