### PR TITLE
@1aurabrown => Animate initial CTA bumper

### DIFF
--- a/apps/artist/client/cta.coffee
+++ b/apps/artist/client/cta.coffee
@@ -10,6 +10,7 @@ module.exports = (artist) ->
       artist: artist
 
     $('body').append artistPageCTAView.render().$el
+    setTimeout (=> artistPageCTAView.$el.removeClass 'initial'), 500
     return
 
   # When user is logged-out and the referrer is an external source

--- a/components/artist_page_cta/index.styl
+++ b/components/artist_page_cta/index.styl
@@ -31,6 +31,8 @@
   width calc(100%)
 
 .artist-page-cta
+  &.initial
+    bottom -100px
   position fixed
   right 0
   bottom 0

--- a/components/artist_page_cta/view.coffee
+++ b/components/artist_page_cta/view.coffee
@@ -11,7 +11,7 @@ overlayTemplate = -> require('./templates/overlay.jade') arguments...
 module.exports = class ArtistPageCTAView extends Backbone.View
   _.extend @prototype, Form
 
-  className: 'artist-page-cta'
+  className: 'artist-page-cta initial'
 
   events:
     'click': 'fullScreenOverlay'


### PR DESCRIPTION
This finishes the initial animation of the bumper, leaving just that opacity overlay thing.

I'm not 100% sure if this is the 'best' way to do it. There's already transition on the CTA bar, so I added an 'initial' class that has it hidden, so removing that class causes it to animate in. Currently it's just rendered/appended, so you don't really see that transition at all.

However...I couldn't figure out a good time to remove that initial class. Even with just using `setTimeout`, it seems like sometimes the browser is still painting the artist page (images, client-side JS stuff, etc.), and so the animation is not super smooth all the time, but it's not bad.