### PR TITLE
@mzikherman - Add manual test for custom artwork image filenames

### DIFF
--- a/apps/artwork/components/images/helpers.coffee
+++ b/apps/artwork/components/images/helpers.coffee
@@ -1,4 +1,3 @@
-{ some } = require 'underscore'
 filenameMap = require './image_filename_map.coffee'
 
 module.exports =

--- a/apps/artwork/components/images/helpers.coffee
+++ b/apps/artwork/components/images/helpers.coffee
@@ -1,0 +1,7 @@
+{ some } = require 'underscore'
+filenameMap = require './image_filename_map.coffee'
+
+module.exports =
+  imageUrl: (image) ->
+    filenameMap[image.url] || image.url
+    

--- a/apps/artwork/components/images/image_filename_map.coffee
+++ b/apps/artwork/components/images/image_filename_map.coffee
@@ -1,0 +1,17 @@
+# 
+# Testing whether more descriptive filenames leads to increased image indexing on Google.
+# See https://github.com/artsy/collector-experience/issues/62
+# 
+
+module.exports = {
+  'https://d32dm0rphc51dk.cloudfront.net/j_c1AeGyO_tafX_DC1bgYQ/larger.jpg': 'https://d3vpvtm3t56z1n.cloudfront.net/images/max-ernst-soleil-jaune.jpg'
+  'https://d32dm0rphc51dk.cloudfront.net/GPH6LMrSoeQbn11LndV1Lg/larger.jpg': 'https://d3vpvtm3t56z1n.cloudfront.net/images/ai-weiwei-coloured-paintings.jpg'
+  'https://d32dm0rphc51dk.cloudfront.net/7SZ6RWBdWXfSSLB1hbqrCQ/larger.jpg': 'https://d3vpvtm3t56z1n.cloudfront.net/images/wolfgang-tillmans-birthday-party.jpg'
+  'https://d32dm0rphc51dk.cloudfront.net/GRHu4YqcBVXZ1M17x6mm0Q/larger.jpg': 'https://d3vpvtm3t56z1n.cloudfront.net/images/laurie-simmons-tourism-chartres.jpg'
+  'https://d32dm0rphc51dk.cloudfront.net/93Ik-Vsl8X79NGHGzCdCqA/larger.jpg': 'https://d3vpvtm3t56z1n.cloudfront.net/images/ugo-rondinone-achternovemberzweitausendundvierzehn.jpg'
+  'https://d32dm0rphc51dk.cloudfront.net/CNYTfs3hQSfN9F0xPfJL4w/larger.jpg': 'https://d3vpvtm3t56z1n.cloudfront.net/images/gerhard-richter-bagdad-p10.jpg'
+  'https://d32dm0rphc51dk.cloudfront.net/fS4xSNuxXehUfO7ykRCBoQ/larger.jpg': 'https://d3vpvtm3t56z1n.cloudfront.net/images/cy-twombly-untitled-bastian-38.jpg'
+  'https://d32dm0rphc51dk.cloudfront.net/kibso6MZ3IsLmRA31CJOQQ/larger.jpg': 'https://d3vpvtm3t56z1n.cloudfront.net/images/jean-michel-basquiat-swami-takes-all.jpg'
+  'https://d32dm0rphc51dk.cloudfront.net/9bPfEGgOEuf4QE7FX4Un7Q/larger.jpg': 'https://d3vpvtm3t56z1n.cloudfront.net/images/alex-da-corte-april-fools.jpg'
+  'https://d32dm0rphc51dk.cloudfront.net/E0mma-g39Fysk9cdPdX7Vw/larger.jpg': 'https://d3vpvtm3t56z1n.cloudfront.net/images/cai-guo-qiang-penglai-slash-horai-3.jpg'
+}

--- a/apps/artwork/components/images/templates/image.jade
+++ b/apps/artwork/components/images/templates/image.jade
@@ -16,7 +16,7 @@ a.artwork-images__images__image(
   )
     img.artwork-images__images__image__display__img(
       class='js-artwork-images__images__image__display__img'
-      data-src= image.url
+      data-src= helpers.images.imageUrl(image)
       data-default= (i === (artwork.images.length - 1))
       alt= artwork.image_alt
       title= artwork.image_title

--- a/apps/artwork/routes.coffee
+++ b/apps/artwork/routes.coffee
@@ -44,6 +44,7 @@ helpers = extend [
   artists: require './components/artists/helpers'
   auction: require './components/auction/helpers'
   banner: require './components/banner/helpers'
+  images: require './components/images/helpers'
   commercial: require './components/commercial/helpers'
   metadata: require './components/metadata/helpers'
   partner: require './components/partner/helpers'


### PR DESCRIPTION
Closes #743 

The idea is to add more descriptive filenames to encourage google to index images on the artwork pages 🙏 

![screenshot 2017-01-24 16 28 37](https://cloud.githubusercontent.com/assets/821469/22267696/d0470606-e252-11e6-8c86-e6e8202ebb86.png)

Filenames come from: https://docs.google.com/spreadsheets/d/1TtGEMZKEc2AjAj9JB-ri4b3WixYejgFkS9kCyDUAciE/edit#gid=0