### PR TITLE
 @craigspaeth => switch back to referencing the auction artwork set

### DIFF
--- a/apps/feature/client/view.coffee
+++ b/apps/feature/client/view.coffee
@@ -42,6 +42,7 @@ module.exports = class FeatureView extends Backbone.View
         setHeight: 400
         gutterWidth: 0
         showBlurbs: true
+        isAuction: false
         context_page: 'Feature page'
 
     # Always append

--- a/components/artwork_columns/template.jade
+++ b/components/artwork_columns/template.jade
@@ -1,6 +1,7 @@
 - artworkSize = artworkSize || 'tall'
 - setHeight = setHeight || false
 - displayPurchase = displayPurchase || false
+- isAuction = isAuction || false
 
 if artworkColumns
   for column in artworkColumns

--- a/components/artwork_columns/view.coffee
+++ b/components/artwork_columns/view.coffee
@@ -162,6 +162,7 @@ module.exports = class ArtworkColumns extends Backbone.View
       maxDimension: @maxArtworkHeight
       notes: (if @displayNotes && notes then notes)
       displayBid: @displayBid
+      isAuction: @isAuction
       displayPurchase: @displayPurchase
       displaySold: @displaySold
       displayMoreInfo: @displayMoreInfo

--- a/components/artwork_item/templates/artwork.jade
+++ b/components/artwork_item/templates/artwork.jade
@@ -3,7 +3,7 @@
 - imageHeight = imageHeight || false
 - displayPurchase = displayPurchase || false
 - showBlurbs = showBlurbs || false
-- isAuction = artwork.get('sale_ids') && artwork.get('sale_ids').length > 0 || false
+- isAuction = isAuction || (set && set.get('type') === 'auction artworks') || false
 - hasInstitutionPartner = artwork.get('partner') && artwork.get('partner').type === 'Institution'
 - displayPrice != null ? displayPrice : displayPrice = true
 - saleArtwork = artwork.related().saleArtwork
@@ -19,7 +19,7 @@ figure.artwork-item( data-artwork= artwork.get('id') data-id= artwork.get('_id')
       include ./partials/save
 
   figcaption.artwork-item-caption
-    if hasAuctionPartner && isAuction
+    if hasAuctionPartner && !isAuction
       include ./partials/lot_number
     include ./partials/artist
     include ./partials/title

--- a/components/artwork_item/templates/artwork.jade
+++ b/components/artwork_item/templates/artwork.jade
@@ -19,8 +19,6 @@ figure.artwork-item( data-artwork= artwork.get('id') data-id= artwork.get('_id')
       include ./partials/save
 
   figcaption.artwork-item-caption
-    if hasAuctionPartner && !isAuction
-      include ./partials/lot_number
     include ./partials/artist
     include ./partials/title
     include ./partials/partner

--- a/components/artwork_item/templates/partials/lot_number.jade
+++ b/components/artwork_item/templates/partials/lot_number.jade
@@ -1,3 +1,0 @@
-if artwork.get('sale_artwork') && artwork.get('sale_artwork').lot_number
-  p.artwork-item-lot-number.artwork-item-overflow
-    | Lot #{artwork.get('sale_artwork').lot_number}

--- a/components/artwork_item/test/artwork.coffee
+++ b/components/artwork_item/test/artwork.coffee
@@ -211,27 +211,30 @@ describe 'Artwork Item template', ->
 
   describe 'is auction', ->
     it 'displays a buy now price', ->
-      @artwork = new Artwork fabricate 'artwork', { sale_message: '$10,000', sale_ids: ['sale_1'] }
+      @artwork = new Artwork fabricate 'artwork', { sale_message: '$10,000' }
       @artwork.set 'sale_artwork', fabricate 'sale_artwork'
       $ = cheerio.load render('artwork')
         artwork: @artwork
+        isAuction: true
         sd: {}
       $('.artwork-item-buy-now-price').text().should.containEql '$10,000'
 
     it 'displays estimate', ->
-      @artwork = new Artwork fabricate 'artwork', { sale_ids: ['sale_1'] }
+      @artwork = new Artwork fabricate 'artwork'
       @artwork.set 'sale_artwork', fabricate 'sale_artwork', { display_low_estimate_dollars: '$3,000', display_high_estimate_dollars: '$7,000' }
       $ = cheerio.load render('artwork')
         artwork: @artwork
+        isAuction: true
         sd: {}
       $('.artwork-item-estimate').text().should.containEql 'Estimate: $3,000–$7,000'
 
     it 'displays lot numbers', ->
-      @artwork = new Artwork fabricate 'artwork', { sale_ids: ['sale_1'] }
+      @artwork = new Artwork fabricate 'artwork'
       @artwork.set 'sale_artwork', fabricate 'sale_artwork',
         { low_estimate_cents: 300000, high_estimate_cents: 700000, lot_number: 10 }
       $ = cheerio.load render('artwork')
         artwork: @artwork
+        isAuction: true
         sd: {}
       $('.artwork-item-lot-number').text().should.containEql 'Lot 10'
 


### PR DESCRIPTION
I still think we could fix some naming because this logic/name is a little odd. But apparently we do use this set on the /consign page!

Fixes it:
![image](https://cloud.githubusercontent.com/assets/2081340/22273832/028a60cc-e271-11e6-9507-8f1764e9aeb7.png)
