### PR TITLE
@broskoski => get rid of dots in buyers premium for now

### DIFF
--- a/components/buyers_premium/index.coffee
+++ b/components/buyers_premium/index.coffee
@@ -23,10 +23,9 @@ module.exports = (auction, callback) ->
             <li>
               <div class='buyers-premium-pre'>
                 On the hammer price up to and including \
-                #{formatMoney(sortedSchedule[idx+1].min_amount_cents / 100, symbol, 0)}
+                #{formatMoney(sortedSchedule[idx+1].min_amount_cents / 100, symbol, 0)}:
+                #{sortedSchedule[idx].percent * 100}%
               </div>
-              <div class='buyers-premium-dots'></div>
-              <div class='buyers-premium-perc'>#{sortedSchedule[idx].percent * 100}%</div>
             </li>
             """
           else if idx == sortedSchedule.length - 1
@@ -34,10 +33,9 @@ module.exports = (auction, callback) ->
             <li>
               <div class='buyers-premium-pre'>
                 On the portion of the hammer price in excess of \
-                #{formatMoney(sortedSchedule[idx].min_amount_cents / 100, symbol, 0)}
+                #{formatMoney(sortedSchedule[idx].min_amount_cents / 100, symbol, 0)}:
+                #{sortedSchedule[idx].percent * 100}%
               </div>
-              <div class='buyers-premium-dots'></div>
-              <div class='buyers-premium-perc'>#{sortedSchedule[idx].percent * 100}%</div>
             </li>
             """
           else
@@ -47,10 +45,9 @@ module.exports = (auction, callback) ->
                 On the hammer price in excess of \
                 #{formatMoney(sortedSchedule[idx].min_amount_cents / 100, symbol, 0)} \
                 up to and including \
-                #{formatMoney(sortedSchedule[idx+1].min_amount_cents / 100, symbol, 0)} \
+                #{formatMoney(sortedSchedule[idx+1].min_amount_cents / 100, symbol, 0)}: \
+                #{sortedSchedule[idx].percent * 100}%
               </div>
-              <div class='buyers-premium-dots'></div>
-              <div class='buyers-premium-perc'>#{sortedSchedule[idx].percent * 100}%</div>
             </li>
             """
 
@@ -59,7 +56,7 @@ module.exports = (auction, callback) ->
             #{schedule.join('')}
           </ul>
           """
-      
+
       fullyRenderedHtml = """
         <div class='buyers-premium'>
           <div class='buyers-premium-page markdown-content'>
@@ -67,5 +64,5 @@ module.exports = (auction, callback) ->
             #{buyersPremiumHtml}
           </div>
         </div>
-      """    
+      """
       callback null, fullyRenderedHtml

--- a/components/buyers_premium/index.styl
+++ b/components/buyers_premium/index.styl
@@ -19,24 +19,13 @@
     border-bottom 1px solid gray-lightest-color
     margin-bottom 0 !important
     display flex
-    justify-content center
+    align-content left
     &:last-child
       border-bottom 0
     .buyers-premium-pre
       padding-right 4px
     .buyers-premium-perc
       padding-left 6px
-    .buyers-premium-dots
-      flex 1
-      position relative
-      top 1px
-      overflow hidden
-      font-size 14px
-      &:after
-        content '......................................................' // lolz
-        position absolute
-        left 0
-        width 100%
 
 @media (max-width: 600px)
   .buyers-premium-schedule li

--- a/components/buyers_premium/test/index.coffee
+++ b/components/buyers_premium/test/index.coffee
@@ -14,7 +14,8 @@ describe 'buyersPremium', ->
 
   it 'renders buyers premium based on the sale and page', (done) ->
     buyersPremium new Sale(fabricate 'sale'), (err, html) ->
-      html.should.containEql "<div class='buyers-premium-perc'>25%"
+      html.should.containEql "<div class='buyers-premium-pre'>"
+      html.should.containEql '25%'
       done()
     Backbone.sync.args[0][2].success fabricate 'page'
 

--- a/components/my_active_bids/view.coffee
+++ b/components/my_active_bids/view.coffee
@@ -26,7 +26,7 @@ module.exports = class MyActiveBids extends Backbone.View
       variables: live: true, sale_id: @saleId
       req: user: @user
     ).then (data) =>
-      @bidderPositions = data.me.lot_standings
+      @bidderPositions = data.me?.lot_standings
 
   render: =>
     @$el.html @template myActiveBids: @bidderPositions, ViewHelpers: ViewHelpers


### PR DESCRIPTION
The dots get cut off in some cases, causing the buyers premium view to appear like there is no buyers premium for certain price points when this view is embedded in microgravity and eigen:
![image](https://cloud.githubusercontent.com/assets/2081340/22342577/da16fe86-e3c2-11e6-9e4b-4d12dc20954a.png)

This changes the view to just have a colon and then the percentage. We can change this later, but for now this should avoid issues/bidders claiming they don't owe money.
![image](https://cloud.githubusercontent.com/assets/2081340/22342611/f8310f60-e3c2-11e6-87b6-47bf75349e0c.png)

