### PR TITLE
@anipetrov => Fix follow artist analytics tracking on the homepage/artist CTA widget

### DIFF
--- a/apps/artist/client/index.coffee
+++ b/apps/artist/client/index.coffee
@@ -20,6 +20,7 @@ module.exports.init = ->
       useInitialArtists: true
       includeContext: false
       showHeader: false
+      analyticsMessage: 'artist page sign up prompt payoff screen'
 
     view.render()
     return

--- a/apps/home/components/followed_artists/search_artists_view.coffee
+++ b/apps/home/components/followed_artists/search_artists_view.coffee
@@ -24,7 +24,7 @@ module.exports = class SearchArtistsView extends Backbone.View
   emptyInput: ->
     trim(@input().val()) == ""
 
-  initialize: ({ @initialSuggestions, @followedArtists }) ->
+  initialize: ({ @initialSuggestions, @followedArtists, @analyticsMessage }) ->
     @match = new Match
     @match.kind = 'artists'
 
@@ -35,6 +35,8 @@ module.exports = class SearchArtistsView extends Backbone.View
     @listenTo @match, 'sync reset', @renderResults
 
     @pastMatches = new Backbone.Collection
+
+    @analyticsMessage ?= 'Homepage followed artists'
 
     @input().focus()
 
@@ -82,13 +84,15 @@ module.exports = class SearchArtistsView extends Backbone.View
   followAndSwap: (e) ->
     e.preventDefault()
     $suggestion = $(e.currentTarget)
+    slug = $suggestion.data('artist-slug')
     id = $suggestion.data('artist-id')
     @following.follow(id) if @user
     $suggestion.find('.typeahead-suggestion-follow').attr 'data-state', 'following'
     analyticsHooks.trigger 'followable:followed',  {
       modelName: @match.kind
-      entity_slug: id
-      context_module: 'Homepage followed artists'
+      entity_slug: slug
+      entity_id: id
+      context_module: @analyticsMessage
     }
     $suggestion.addClass 'tt-suggestion-inner__selected'
     @$('input').select()

--- a/apps/home/components/followed_artists/templates/result.jade
+++ b/apps/home/components/followed_artists/templates/result.jade
@@ -1,5 +1,5 @@
 .tt-suggestion
-  .tt-suggestion-inner(data-artist-id=suggestion.get('id'))
+  .tt-suggestion-inner(data-artist-slug=suggestion.get('id'), data-artist-id=suggestion.get('_id'))
     .typeahead-suggestion-thumbnail
       span: img(
         src= suggestion.has('thumb') ? suggestion.get('thumb').cropped.url : suggestion.cropUrlFor({ width: 32, height: 32 })

--- a/apps/home/components/followed_artists/view.coffee
+++ b/apps/home/components/followed_artists/view.coffee
@@ -20,7 +20,7 @@ module.exports = class FollowedArtistsRailView extends Backbone.View
     includeContext: true
 
   initialize: (options = {}) ->
-    { @module, @$el, @user, @useInitialArtists, @showHeader, @includeContext } = _.defaults options, @defaults
+    { @module, @$el, @user, @useInitialArtists, @showHeader, @includeContext, @analyticsMessage } = _.defaults options, @defaults
 
   render: ->
     artists = new Backbone.Collection @module.context.artists
@@ -83,6 +83,7 @@ module.exports = class FollowedArtistsRailView extends Backbone.View
         el: @$('.arbv-follow-search-container')
         initialSuggestions: initialArtists
         followedArtists: new Artists []
+        analyticsMessage: @analyticsMessage
       initialArtists.add @module.context.artists
     else
       featuredArtists = new Items [], id: '523089cd139b214d46000568', item_type: 'FeaturedLink'

--- a/components/artist_page_cta/query.coffee
+++ b/components/artist_page_cta/query.coffee
@@ -6,6 +6,7 @@ module.exports = """
     me {
       suggested_artists(artist_id: $artist_id, exclude_followed_artists: true, exclude_artists_without_artworks: true, size: 4) {
         id
+        _id
         name
         thumb: image {
           cropped(width: 32, height: 32) {


### PR DESCRIPTION
This updates the follow analytics on the homepage widget to have the correct properties (and a different `context_module` for its use in the artist page CTA).

