### PR TITLE
@broskoski: Bump Artsy Passport.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "artsy-error-handler": "^1.0.2",
     "artsy-ezel-components": "git://github.com/artsy/artsy-ezel-components.git",
     "artsy-newrelic": "^1.1.0",
-    "artsy-passport": "^1.5.2",
+    "artsy-passport": "^1.6.0",
     "artsy-xapp": "git://github.com/artsy/artsy-xapp.git",
     "async": "^2.1.2",
     "babel": "^6.5.2",


### PR DESCRIPTION
Updated AP to include [passing user agent for signup/login](https://github.com/artsy/artsy-passport/pull/99).