### PR TITLE
@xtina-starr: Support markdown in hero unit template

### DIFF
--- a/apps/home/index.coffee
+++ b/apps/home/index.coffee
@@ -4,12 +4,14 @@
 
 express = require 'express'
 routes = require './routes'
+markdown = require '../../components/util/markdown'
 { resize } = require '../../components/resizer'
 
 app = module.exports = express()
 app.set 'views', __dirname + '/templates'
 app.set 'view engine', 'jade'
 app.locals.resize = resize
+app.locals.markdown = markdown
 app.get '/', routes.index
 app.get '/log_in', routes.redirectLoggedInHome, routes.index
 app.get '/sign_up', routes.redirectLoggedInHome, routes.index

--- a/apps/home/templates/hero_unit.jade
+++ b/apps/home/templates/hero_unit.jade
@@ -17,8 +17,8 @@
           alt= heroUnit.title
         )
       .hhu-subheading
-        != heroUnit.subtitle
+        != markdown(heroUnit.subtitle)
       .avant-garde-button(
       )= heroUnit.link_text
 
-    .hhu-credit= heroUnit.credit_line
+    .hhu-credit!= markdown(heroUnit.credit_line)

--- a/apps/home/test/templates.coffee
+++ b/apps/home/test/templates.coffee
@@ -1,0 +1,16 @@
+_ = require 'underscore'
+_s = require 'underscore.string'
+jade = require 'jade'
+markdown = require '../../../components/util/markdown'
+
+render = (data) ->
+  template = jade.compileFile(require.resolve '../templates/hero_unit.jade')
+  template _.extend {}, {
+    _s: _s
+    markdown: markdown
+  }, data
+
+describe 'Hero unit template', ->
+  it 'renders markdown subtitles', ->
+    render heroUnit: subtitle: 'This is a *subtitle*'
+      .should.containEql '<em>subtitle</em>'


### PR DESCRIPTION
I added [randomized homepage banners](https://github.com/artsy/force/pull/768) by refactoring them to use Metaphysics. Unfortunately, this introduced a [regression to markdown support](https://artsy.slack.com/archives/help/p1485531304000831)—so this adds it back with a test.