### PR TITLE
@anandaroop: Fix uncommon session based homepage bug

### DIFF
--- a/apps/home/routes.coffee
+++ b/apps/home/routes.coffee
@@ -24,12 +24,15 @@ positionWelcomeHeroMethod = (req, res) ->
   res.cookie 'hide-welcome-hero', '1', expires: new Date(Date.now() + 31536000000)
   method
 
-maybeFetchHomepageRails = (req)->
+fetchMetaphysicsData = (req)->
   deferred = Q.defer()
   metaphysics(query: query, req: req)
     .then (data) -> deferred.resolve data
-    .catch -> deferred.resolve home_page: { artwork_modules: [] }
-
+    .catch (err) ->
+      deferred.resolve
+        home_page:
+          artwork_modules: []
+          hero_units: err.data.home_page.hero_units
   deferred.promise
 
 @index = (req, res, next) ->
@@ -57,7 +60,7 @@ maybeFetchHomepageRails = (req)->
 
   Q
     .all [
-      maybeFetchHomepageRails req
+      fetchMetaphysicsData req
       featuredLinks.fetch cache: true
       featuredArticles.fetch
         cache: true

--- a/apps/home/test/routes.coffee
+++ b/apps/home/test/routes.coffee
@@ -93,6 +93,20 @@ describe 'Home routes', ->
             @res.render.args[0][1].heroUnits[0].subtitle
               .should.equal 'My hero'
 
+      it 'catches error fetching homepage rails and still renders hero units', ->
+        err = new Error 'Failed to get rails'
+        err.data = home_page: hero_units: [heroUnit]
+        @metaphysics.returns Promise.reject err
+        Backbone.sync
+          .onCall 0
+          .yieldsTo 'success', [fabricate 'featured_link']
+        routes.index extend({ user: 'existy' }, @req), @res
+          .then =>
+            @res.render.args[0][0].should.equal 'index'
+            @res.render.args[0][1].modules[0].key.should.equal 'followed_artists'
+            @res.render.args[0][1].heroUnits[0].subtitle
+              .should.equal 'My hero'
+
   describe '#redirectToSignup', ->
     it 'redirects to signup', ->
       routes.redirectToSignup @req, @res

--- a/lib/metaphysics.coffee
+++ b/lib/metaphysics.coffee
@@ -31,6 +31,7 @@ metaphysics = ({ method, query, variables, req } = {}) ->
       if response.body.errors?
         error = new Error JSON.stringify response.body.errors
         error.status = 404 if some(response.body.errors, ({ message }) -> message.match /Not Found/)
+        error.data = response.body.data
         return reject error
 
       resolve response.body.data

--- a/test/lib/metaphysics.coffee
+++ b/test/lib/metaphysics.coffee
@@ -94,6 +94,25 @@ describe 'metaphysics', ->
       .catch (err) ->
         err.message.should.equal 'some error'
 
+    it 'includes the data', ->
+      @request.end.yields null,
+        body:
+          errors: [message: 'some error']
+          data: foo: 'bar'
+
+      metaphysics
+        variables: id: 'foo-bar'
+        query: '
+          query artist($id: String!) {
+            artist(id: $id) {
+              id
+            }
+          }
+        '
+      .catch (err) ->
+        console.log err.data
+        err.data.foo.should.equal 'bar'
+
   describe 'partial error', ->
     it 'rejects with the errors', ->
       @request.end.yields null, ok: true, body:

--- a/test/lib/metaphysics.coffee
+++ b/test/lib/metaphysics.coffee
@@ -110,7 +110,6 @@ describe 'metaphysics', ->
           }
         '
       .catch (err) ->
-        console.log err.data
         err.data.foo.should.equal 'bar'
 
   describe 'partial error', ->


### PR DESCRIPTION
We have this `maybeFetchHomepageRails` function that tells the homepage to continue rendering in case fetching certain homepage rails didn't succeed—which seems to be more common when logged in b/c that data varies depending on the user requesting it. When I refactored hero units to MP I looped it into the same query here, which caused that behavior to continue without homepage rails _and_ hero unit data. Not clear to me why we catch failed homepage rails, but maybe @broskoski knows off hand.

This refactors it to pass through the hero unit data in the error case—fixing that `.length of undefined` bug you spotted.