### PR TITLE
@broskoski => Proper sale_message display on artwork page + inquiry update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ sd:
 
 # Start the server pointing to staging
 ss:
-	APP_URL=http://localhost:5000 METAPHYSICS_ENDPOINT=http://localhost:5001 APPLICATION_NAME=force-staging API_URL=https://stagingapi.artsy.net $(BIN)/nf start
+	APP_URL=http://localhost:5000 METAPHYSICS_ENDPOINT=https://metaphysics-staging.artsy.net APPLICATION_NAME=force-staging API_URL=https://stagingapi.artsy.net $(BIN)/nf start
 
 # Start the server pointing to staging with cache
 ssc:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ sd:
 
 # Start the server pointing to staging
 ss:
-	APP_URL=http://localhost:5000 METAPHYSICS_ENDPOINT=https://metaphysics-staging.artsy.net APPLICATION_NAME=force-staging API_URL=https://stagingapi.artsy.net $(BIN)/nf start
+	APP_URL=http://localhost:5000 METAPHYSICS_ENDPOINT=http://localhost:5001 APPLICATION_NAME=force-staging API_URL=https://stagingapi.artsy.net $(BIN)/nf start
 
 # Start the server pointing to staging with cache
 ssc:

--- a/apps/artwork/components/commercial/query.coffee
+++ b/apps/artwork/components/commercial/query.coffee
@@ -7,6 +7,7 @@ module.exports = """
     is_purchasable
     is_in_auction
     sale_message
+    availability
     is_price_range
     price
     artists {

--- a/apps/artwork/components/commercial/query.coffee
+++ b/apps/artwork/components/commercial/query.coffee
@@ -8,6 +8,7 @@ module.exports = """
     is_in_auction
     sale_message
     availability
+    contact_message
     is_price_range
     price
     artists {
@@ -19,7 +20,6 @@ module.exports = """
       name
       type
       is_pre_qualify
-      contact_message
     }
     fair {
       id

--- a/apps/artwork/components/commercial/templates/inquire.jade
+++ b/apps/artwork/components/commercial/templates/inquire.jade
@@ -29,7 +29,7 @@ if artwork.is_inquireable
         name='message'
         required
       )
-        = artwork.partner.contact_message
+        = artwork.contact_message
         = ' '
 
     if fair

--- a/apps/artwork/components/commercial/templates/price.jade
+++ b/apps/artwork/components/commercial/templates/price.jade
@@ -1,10 +1,11 @@
+- var showPriceLabel = artwork.price && artwork.availability !== 'sold'
 if artwork.sale_message
   .artwork-commercial__container
     .artwork-commercial__sale-message
-      if artwork.price
+      if showPriceLabel
         .artwork-commercial__price-label Price
         .artwork-commerical__price
-          | #{artwork.price}
+          | #{artwork.sale_message}
           span(
             class= artwork.is_price_range ? 'help-tooltip' : ''
             data-message= 'The range is an approximate indication of the work’s price point, and the exact price is quoted upon request.'
@@ -13,6 +14,6 @@ if artwork.sale_message
       else
         | #{artwork.sale_message}
 
-    if artwork.price
+    if showPriceLabel
       .artwork-commercial__shipping-info
         | Shipping, tax, and service quoted by seller

--- a/apps/artwork/components/commercial/test/fixtures/inquireable.json
+++ b/apps/artwork/components/commercial/test/fixtures/inquireable.json
@@ -7,12 +7,12 @@
       "is_inquireable": true,
       "is_in_auction": false,
       "sale_message": "Contact for price",
+      "contact_message": "Hi, I’m interested in purchasing this work. Could you please provide more information about the piece?",
       "partner": {
         "id": "bitforms-gallery",
         "name": "bitforms gallery",
         "type": "Gallery",
-        "is_pre_qualify": false,
-        "contact_message": "Hi, I’m interested in purchasing this work. Could you please provide more information about the piece?"
+        "is_pre_qualify": false
       },
       "fair": null,
       "edition_sets": [

--- a/components/contact/default_message.coffee
+++ b/components/contact/default_message.coffee
@@ -3,5 +3,9 @@ module.exports = (artwork, partner) ->
     'Hello, I am interested in placing a bid on this work. ' +
     'Please send me more information.'
   else
-    'Hi, I’m interested in purchasing this work. ' +
-    'Could you please provide more information about the piece?'
+    if artwork.get('availability') is 'sold'
+      'Hi, I’m interested in similar works by this artist. ' +
+      'Could you please let me know if you have anything available?'
+    else if artwork.get('availability') isnt 'not for sale'
+      'Hi, I’m interested in purchasing this work. ' +
+      'Could you please provide more information about the piece?'

--- a/components/contact/test/default_message.coffee
+++ b/components/contact/test/default_message.coffee
@@ -25,6 +25,17 @@ describe 'defaultMessage', ->
           .should.equal 'Hi, I’m interested in purchasing this work. ' +
             'Could you please provide more information about the piece?'
 
+      it 'returns a cusotm message when the artwork is sold', ->
+        @artwork.set availability: 'sold'
+        defaultMessage @artwork, @partner
+          .should.equal 'Hi, I’m interested in similar works by this artist. ' +
+            'Could you please let me know if you have anything available?'
+
+      it 'returns nothing when the artwork is not for sale', ->
+        @artwork.set availability: 'not for sale'
+        (typeof defaultMessage @artwork, @partner)
+          .should.equal 'undefined'
+
     describe 'of Auction type', ->
       beforeEach ->
         @partner.set 'type', 'Auction'


### PR DESCRIPTION
This is now all that's needed to display the appropriate sale messaging on the artwork page (cc @xtina-starr this may help you for the microgravity artwork page).

Still to do:
- move the pre-filled inquiry text (based on availability) up to Metaphysics (for use in multiple clients)
- update pre-filled inquiry text in Force to use that

This PR is probably mergeable w/o the above steps, but no rush- let's hold this open for those issues as well.