### PR TITLE
@broskoski => Dont display blank textbox for inquiry

### DIFF
--- a/apps/artwork/components/commercial/templates/inquire.jade
+++ b/apps/artwork/components/commercial/templates/inquire.jade
@@ -24,13 +24,14 @@ if artwork.is_inquireable
       )
 
     unless artwork.partner.is_pre_qualify
-      textarea.bordered-input(
-        rows='4'
-        name='message'
-        required
-      )
-        = artwork.contact_message
-        = ' '
+      if artwork.contact_message
+        textarea.bordered-input(
+          rows='4'
+          name='message'
+          required
+        )
+          = artwork.contact_message
+          = ' '
 
     if fair
       .artsy-checkbox


### PR DESCRIPTION
Reported by @tayapage6 , in the case of states where there's no pre-filled inquiry text, we shouldn't show any textbox in the embedded form.