### PR TITLE
@broskoski => Update legacy sale messaging for new inquireability logic

### DIFF
--- a/components/artwork_item/test/artwork.coffee
+++ b/components/artwork_item/test/artwork.coffee
@@ -133,7 +133,7 @@ describe 'Artwork Item template', ->
       $ = cheerio.load render('artwork')
         artwork: @artwork
         sd: {}
-      $('.artwork-item-availability').text().should.equal 'On hold - $5,200'
+      $('.artwork-item-sale-price').text().should.equal '$5,200, on hold'
 
   describe 'nopin', ->
     beforeEach ->

--- a/models/artwork.coffee
+++ b/models/artwork.coffee
@@ -103,7 +103,7 @@ module.exports = class Artwork extends Backbone.Model
   #
   isContactable: ->
     return false if @isAtLimitedFairPartner()
-    return true if @get('is_inquireable')
+    return true if @get('inquireable') or @get('is_inquireable')
     return true if @isPartOfContactableAuctionPromo()
     return false if @isPartOfAuction()
     @isArtworkContactable()
@@ -282,18 +282,21 @@ module.exports = class Artwork extends Backbone.Model
     ]).join(", ")
 
   saleMessage: ->
-    return if @get('sale_message') is 'Contact For Price'
+    return if @get('sale_message') is 'Contact For Price' or @get('availability') is 'not for sale'
+
+    if @get('availability') is 'on hold'
+      if @get('price')
+        return "#{@get('price')}, on hold"
+      return 'On hold'
+
     if @get('sale_message')?.indexOf('Sold') > - 1
-      _.compact([
-        'Sold'
-        @get('price')
-      ]).join(' - ')
-    else
-      @get 'sale_message'
+      return 'Sold'
+
+    @get 'sale_message'
 
   availabilityMessage: ->
     return if @get('partner')?.type is "Institutional Seller"
-    return if @get('availability') is 'for sale'
+    return if @get('availability') is 'for sale' or @get('availability') is 'not for sale'
     if @get('partner')?.has_limited_fair_partnership
       'Not inquireable'
     else if @get('availability')?.indexOf('on hold') > - 1

--- a/test/models/artwork.coffee
+++ b/test/models/artwork.coffee
@@ -14,15 +14,24 @@ describe 'Artwork', ->
     Backbone.sync.restore()
 
   describe '#saleMessage', ->
-    it 'formats sold sale message', ->
-      @artwork.set sale_message: '$6,000 - Sold', price: '$6,000'
-      @artwork.saleMessage().should.equal "Sold - $6,000"
-      @artwork.set sale_message: '$6,000'
-      @artwork.saleMessage().should.equal '$6,000'
+    it 'returns sold when artwork is sold (w/ or w/o price)', ->
+      @artwork.set sale_message: '$6,000 - Sold'
+      @artwork.saleMessage().should.equal 'Sold'
+      @artwork.set sale_message: 'Sold'
+      @artwork.saleMessage().should.equal 'Sold'
 
-    describe 'sale_message is "Contact for Price"', ->
+    it 'returns the price when on hold', ->
+      @artwork.set availability: 'on hold', price: '$420'
+      @artwork.saleMessage().should.equal '$420, on hold'
+      @artwork.unset 'price'
+      @artwork.saleMessage().should.equal 'On hold'
+
+    describe 'sale_message is "Contact for Price" or availability is "not for sale"', ->
       it 'returns undefined', ->
         @artwork.set sale_message: 'Contact For Price', price: '$6,000'
+        _.isUndefined(@artwork.saleMessage()).should.be.true()
+        @artwork.unset 'sale_message', 'price'
+        @artwork.set availability: 'not for sale'
         _.isUndefined(@artwork.saleMessage()).should.be.true()
 
   describe '#downloadableFilename', ->


### PR DESCRIPTION
Luckily the [artwork_item_metaphysics](https://github.com/artsy/force/blob/67cf6e19ca5848b35a65d48a184e0ad1c53cad51/apps/show/components/artwork_item_metaphysics/templates/artwork.jade#L22-L27) component in the show app already handles the 'simple' rendering.

This is what's used in the legacy 'artwork item' contexts.