### PR TITLE
@kanaabe margin below images instead of below caption

### DIFF
--- a/components/article/stylesheets/image.styl
+++ b/components/article/stylesheets/image.styl
@@ -63,6 +63,7 @@
     max-width 1100px
     li
       margin-right 30px
+      margin-bottom 10px
     li:last-child
       margin-right 0
 
@@ -75,7 +76,7 @@
 
   @media screen and (max-width 900px)
     &[data-layout="overflow_fillwidth"] figcaption
-      margin 10px 20px
+      margin 10px 20px 0 20px
 
   @media screen and (max-width 650px)
     &[data-layout="column_width"]


### PR DESCRIPTION
fixes https://github.com/artsy/force/issues/799

now all images will have the same space below them that previously was only given to images with a caption