### PR TITLE
@broskoski suppress sale message when auction info is displayed

### DIFF
--- a/components/artwork_metadata_stub/templates/didactics.jade
+++ b/components/artwork_metadata_stub/templates/didactics.jade
@@ -22,6 +22,6 @@ else
   a.artwork-metadata-stub__partner.artwork-metadata-stub__line( href= artwork.partner.href )
     = artwork.partner.name
 
-if artwork.sale_message && artwork.sale_message != 'Contact For Price'
+if artwork.sale_message && artwork.sale_message != 'Contact For Price' && !(artwork.sale && artwork.sale.is_auction)
   .artwork-metadata-stub__sale-message.artwork-metadata-stub__line
     = artwork.sale_message


### PR DESCRIPTION
fixes https://github.com/artsy/force/issues/797
@broskoski I know you are working on standardizing artwork metadata components. This might just be a temporary fix that might later get incorporated into your changes, but there was an issue open for it so I wanted to fix it for now. Works that are/were part of an auction should _only_ look one of the following ways, none of which include the `sale_message`:


![](https://cloud.githubusercontent.com/assets/6482926/22255802/8daba3aa-e226-11e6-8ec5-7e5839316e2d.png)
