### PR TITLE
@broskoski: Remove Fusion url from artwork model

### DIFF
--- a/models/artwork.coffee
+++ b/models/artwork.coffee
@@ -18,7 +18,7 @@ module.exports = class Artwork extends Backbone.Model
   _.extend @prototype, ArtworkHelpers
 
   urlRoot: ->
-    "#{sd.FUSION_URL or sd.API_URL}/api/v1/artwork"
+    "#{sd.API_URL}/api/v1/artwork"
 
   bidSuccessUrl: -> "#{@href()}/confirm-bid"
 


### PR DESCRIPTION
Fusion is this little service that keeps a stale copy of Gravity's artwork data for the [sake of serving sitemaps](https://github.com/artsy/gravity/pull/9196#issuecomment-143883082). Pre-metaphysics it would help keep its data fresh by being swapped in place of /api/v1/artwork/:id requests (it also falls back to proxying Gravity). Now-a-days it just [crawls the latest artworks](https://api.artsy.net/api/v1/artworks?sort=-created_at) daily and lets the data eventually get somewhat in sync.

Ashkan noticed [an issue](https://github.com/artsy/force-merge/issues/24) in staging where it was requesting from Fusion (which doesn't have a staging version) and therefore returning a 404. So just simply removing it from the artwork model to address this.