### PR TITLE
@damassi => fix timer on artwork page

### DIFF
--- a/apps/artwork/components/banner/helpers.coffee
+++ b/apps/artwork/components/banner/helpers.coffee
@@ -2,6 +2,10 @@ moment = require 'moment'
 clock = require '../clock/index.coffee'
 
 module.exports =
+  showCountdown: (startAt, liveStartAt) ->
+    return false if liveStartAt and moment(liveStartAt).isBefore()
+    true
+
   countdownLabel: (startAt, liveStartAt) ->
     if liveStartAt and moment(startAt).isBefore()
       'Live bidding opening in'

--- a/apps/artwork/components/banner/index.jade
+++ b/apps/artwork/components/banner/index.jade
@@ -44,12 +44,12 @@ if artwork.banner
         a( href= banner.href )
           = banner.name
 
-      if banner.end_at
+      if helpers.banner.showCountdown(banner.start_at, banner.live_start_at)
         .artwork-banner__countdown(
           class='js-artwork-banner__countdown'
         )
-          - var label = helpers.banner.countdownLabel(banner.start_at)
-          - var countdown = helpers.banner.countdownClock(banner.start_at, banner.end_at)
+          - var label = helpers.banner.countdownLabel(banner.start_at, banner.live_start_at)
+          - var countdown = helpers.banner.countdownClock(banner.start_at, banner.end_at, banner.live_start_at)
           include ../clock/index
 
     .artwork-banner__jump

--- a/apps/artwork/components/banner/test/helpers.coffee
+++ b/apps/artwork/components/banner/test/helpers.coffee
@@ -1,6 +1,6 @@
 sinon = require 'sinon'
 moment = require 'moment'
-{ countdownLabel } = require '../helpers'
+{ countdownLabel, showCountdown } = require '../helpers'
 
 describe 'auction_artworks helpers', ->
   describe '#countdownLabel', ->
@@ -17,3 +17,23 @@ describe 'auction_artworks helpers', ->
     it 'renders the correct label if the auction is open', ->
       countdownLabel moment().subtract(1, 'day').format()
         .should.equal 'Auction closes in'
+
+    it 'renders the correct label if the live auction has not started yet', ->
+      countdownLabel moment().subtract(1, 'day').format(), moment().add(1, 'day').format()
+        .should.equal 'Live bidding opening in'
+
+  describe '#showCountdown', ->
+    beforeEach ->
+      @clock = sinon.useFakeTimers()
+
+    afterEach ->
+      @clock.restore()
+
+    it 'returns true if it is after start at but before the live start at', ->
+      showCountdown moment().subtract(1, 'day').format(), moment().add(1, 'day').format()
+        .should.equal true
+
+    it 'returns false if it is after the live start at', ->
+      showCountdown moment().subtract(2, 'days').format(), moment().subtract(1, 'day').format()
+        .should.equal false
+


### PR DESCRIPTION
This PR addresses this issue: https://github.com/artsy/force/issues/834#issuecomment-278696349 cc @katarinabatina @briansw  

The fix was just to be clearer with the logic around whether or not the timer should be shown. Right now, it is shown in all cases _except_ once the live auction integration part has started, because at that point we don't have an `end_at` so we can't count down to anything. 

The states of the timer on the artwork/auction page are:

**Preview: Before auction opens**
![image](https://cloud.githubusercontent.com/assets/2081340/22803556/7a2945de-eee3-11e6-972b-a55148e24880.png)

**Online-only auction: After auction starts, before auction closes**
![image](https://cloud.githubusercontent.com/assets/2081340/22803540/6cbfcaf8-eee3-11e6-8432-fff3c15adb1d.png)

**Live auction integration: After auction starts, before live auction starts**
![image](https://cloud.githubusercontent.com/assets/2081340/22803608/ad9e51b6-eee3-11e6-8621-6b4b963db9a4.png)

**Live auction integration: After live auction has begun**
![image](https://cloud.githubusercontent.com/assets/2081340/22803631/c36852d0-eee3-11e6-8e91-71fd911bd0e4.png)

