### PR TITLE
@anandaroop: Add about/* to responsive pages

### DIFF
--- a/lib/middleware/redirect_mobile.coffee
+++ b/lib/middleware/redirect_mobile.coffee
@@ -38,6 +38,7 @@ router.get '/consign', isResponsive
 router.get '/professional-buyer*', isResponsive
 router.get '/2016-year-in-art*', isResponsive
 router.get '/article/*', isResponsive
+router.get '/about/*', isResponsive
 router.get TEAM_BLOGS, isResponsive
 router.use redirect
 module.exports = router


### PR DESCRIPTION
Solves https://github.com/artsy/force-merge/issues/21

We inspect the routing stack of this `redirect_mobile` middleware in force-merge to see if we should route the request to the Force or MG app. Currently when MG 404s we embed the Force view in it, so these responsive about/* pages worked by falling through to that, but we should really explicitly define it here.