### PR TITLE
Modal image

### DIFF
--- a/components/marketing_signup_modal/index.styl
+++ b/components/marketing_signup_modal/index.styl
@@ -12,7 +12,8 @@ divider-height = 40px
   align-items stretch
   &-left
     background-size cover
-    background-position bottom right
+    background-position-x right
+    background-position-y calc(100% \+ 1px)
 
     @media screen and (max-width 900px)
       display none

--- a/components/marketing_signup_modal/index.styl
+++ b/components/marketing_signup_modal/index.styl
@@ -12,7 +12,7 @@ divider-height = 40px
   align-items stretch
   &-left
     background-size cover
-    background-position center right
+    background-position bottom right
 
     @media screen and (max-width 900px)
       display none

--- a/components/marketing_signup_modal/index.styl
+++ b/components/marketing_signup_modal/index.styl
@@ -11,7 +11,7 @@ divider-height = 40px
   display flex
   align-items stretch
   &-left
-    background-size 100% 100%
+    background-size cover
     background-position center right
 
     @media screen and (max-width 900px)


### PR DESCRIPTION
By changing the background-size from cover to `background-size: 100% 100%` in [the last PR](https://github.com/artsy/force/pull/826), the modal image loses the responsiveness and cause the image to stretch. I set the property back to cover, but this hides the photo credit on the image. I then tried to set the background-position-y property to bottom, but this causes a just a tiny bit of whitespace beneath the image. Do you have any ideas for getting this just right?

![screen shot 2017-02-09 at 7 02 34 pm](https://cloud.githubusercontent.com/assets/5201004/22808527/5f660fae-eefa-11e6-8d9c-ba57df80ec0c.png)
