### PR TITLE
@mzikherman => fixes calendar to be in same time zone as the sale start label

### DIFF
--- a/models/sale.coffee
+++ b/models/sale.coffee
@@ -157,23 +157,35 @@ module.exports = class Sale extends Backbone.Model
   fetchArtworks: ->
     @related().saleArtworks.fetchUntilEnd arguments...
 
+  zone: (time) ->
+    moment(time).tz('America/New_York')
+
   event: ->
+    timeFormat = 'YYYY-MM-DD[T]HH:mm:ss'
+    if @get('live_start_at')
+      start = @get('live_start_at') or moment()
+      end  = moment(@get('live_start_at')).add(4, 'hours')
+    else
+      start = @get('start_at') or moment()
+      end = @get('end_at') or moment()
+
     event = new Backbone.Model
-      start_at: @get('live_start_at') or @get('start_at') or moment()
-      end_at: @get('end_at') or moment()
+      start_at: @zone(start).format(timeFormat)
+      end_at: @zone(end).format(timeFormat)
       name: @get('name')
+
     _.extend event, CalendarUrls({ title: 'name' })
     event
 
   upcomingLabel: ->
-    zone = (attr) => moment(@get attr).tz('America/New_York').format 'MMM D h:mm:ssA z'
+    timeFormat = 'MMM D h:mm:ssA z'
     if @isClosed()
       "Auction Closed"
     else if @get('live_start_at') and not @isLiveOpen()
-      "Live bidding begins #{zone 'live_start_at'}"
+      "Live bidding begins #{@zone(@get('live_start_at')).format(timeFormat)}"
     else if @get('live_start_at')
       "Live bidding now open"
     else if @isPreviewState()
-      "Auction opens #{zone 'start_at'}"
+      "Auction opens #{@zone(@get('start_at')).format(timeFormat)}"
     else
-      "Bidding closes #{zone 'end_at'}"
+      "Bidding closes #{@zone(@get('end_at')).format(timeFormat)}"

--- a/test/models/sale.coffee
+++ b/test/models/sale.coffee
@@ -330,38 +330,59 @@ describe 'Sale', ->
         @sale.get('offsetStartAtMoment').unix().should.eql moment(@sale.get('start_at')).unix()
         @sale.get('offsetEndAtMoment').unix().should.eql moment(@sale.get('end_at')).unix()
 
-    describe '#upcomingLabel', ->
+  describe '#event', ->
+    it 'returns an event in the correct timezone for an online sale', ->
+      time = moment('2017-02-11T17:00:00+00:00').utc()
+      @sale.set
+        start_at: moment('2017-02-11T17:00:00+00:00')
+        end_at: moment('2017-02-13T17:00:00+00:00')
+      @sale.event().get('start_at').should
+        .eql '2017-02-11T12:00:00'
+      @sale.event().get('end_at').should
+        .eql '2017-02-13T12:00:00'
 
-      it 'renders the correct opening label when EDT', ->
-        time = moment('2016-11-02 12:00:00').utc()
-        @sale.isPreviewState = -> true
-        @sale.set
-          start_at: time
-          end_at: time.add(2, 'days')
-        @sale.upcomingLabel().should
-          .containEql 'Auction opens Nov 4'
-        @sale.upcomingLabel().should
-          .containEql 'EDT'
+    it 'returns an event in the correct timezone for a live sale', ->
+      time = moment('2017-02-11T17:00:00+00:00').utc()
+      @sale.set
+        start_at: moment('2017-02-09T17:00:00+00:00')
+        live_start_at: moment('2017-02-11T17:00:00+00:00')
+        end_at: moment('2017-02-13T17:00:00+00:00')
+      @sale.event().get('start_at').should
+        .eql '2017-02-11T12:00:00'
+      @sale.event().get('end_at').should
+        .eql '2017-02-11T16:00:00'
 
-      it 'renders the correct opening label when EST', ->
-        time = moment('2016-1-02 12:00:00').utc()
-        @sale.isPreviewState = -> true
-        @sale.set
-          start_at: time
-          end_at: time.add(2, 'days')
-        @sale.upcomingLabel().should
-          .containEql 'Auction opens Jan 4'
-        @sale.upcomingLabel().should
-          .containEql 'EST'
+  describe '#upcomingLabel', ->
+    it 'renders the correct opening label when EDT', ->
+      time = moment('2016-11-02 12:00:00').utc()
+      @sale.isPreviewState = -> true
+      @sale.set
+        start_at: time
+        end_at: time.add(2, 'days')
+      @sale.upcomingLabel().should
+        .containEql 'Auction opens Nov 4'
+      @sale.upcomingLabel().should
+        .containEql 'EDT'
 
-    describe '#sortableDate', ->
-      it 'returns the live_start_at if it exists', ->
-        @sale.set
-          end_at: moment().add 2, 'days'
-          live_start_at: moment().add 1, 'days'
-        @sale.sortableDate().should.eql @sale.get('live_start_at')
+    it 'renders the correct opening label when EST', ->
+      time = moment('2016-1-02 12:00:00').utc()
+      @sale.isPreviewState = -> true
+      @sale.set
+        start_at: time
+        end_at: time.add(2, 'days')
+      @sale.upcomingLabel().should
+        .containEql 'Auction opens Jan 4'
+      @sale.upcomingLabel().should
+        .containEql 'EST'
 
-      it 'returns the end_at if no live_start_at exists', ->
-        @sale.set
-          end_at: moment().add 2, 'days'
-        @sale.sortableDate().should.eql @sale.get('end_at')
+  describe '#sortableDate', ->
+    it 'returns the live_start_at if it exists', ->
+      @sale.set
+        end_at: moment().add 2, 'days'
+        live_start_at: moment().add 1, 'days'
+      @sale.sortableDate().should.eql @sale.get('live_start_at')
+
+    it 'returns the end_at if no live_start_at exists', ->
+      @sale.set
+        end_at: moment().add 2, 'days'
+      @sale.sortableDate().should.eql @sale.get('end_at')


### PR DESCRIPTION
This fixes the calendar link on the auction page to set events in Eastern Time (same as how we show it on the overview page).

Someday maybe we can do better-- i.e. using the timezone of the browser or specified by user or auction, but this is at least better than UTC.