### PR TITLE
@mzikherman => fix long artist name overflow in "my active bids" module

### DIFF
--- a/apps/auction/stylesheets/my_active_bids.styl
+++ b/apps/auction/stylesheets/my_active_bids.styl
@@ -14,6 +14,10 @@
 .auction-mab-artist-artwork-container
   max-width 300px
 
+.auction-mab-artwork-metadata
+  > *
+    overflow ellipsis
+
 .auction-mab-artist-artwork
   max-width 60%
   h3

--- a/apps/auction/templates/my_active_bids.jade
+++ b/apps/auction/templates/my_active_bids.jade
@@ -13,11 +13,12 @@ if myActiveBids && myActiveBids.length
               )
                 img.auction-mab-img( src=bid.sale_artwork.artwork.image.url )
                 .auction-mab-artist-artwork
-                  h3= bid.sale_artwork.artwork.artist.name
-                  .auction-mab-title
-                    em= bid.sale_artwork.artwork.title
-                    | ,&nbsp;
-                    = bid.sale_artwork.artwork.date
+                  .auction-mab-artwork-metadata
+                    h3= bid.sale_artwork.artwork.artist.name
+                    .auction-mab-title
+                      em= bid.sale_artwork.artwork.title
+                      | ,&nbsp;
+                      = bid.sale_artwork.artwork.date
             td.auction-mab-lot-number Lot #{bid.sale_artwork.lot_number}
             td.auction-mab-current-bid
               strong Current Bid: <em>#{bid.sale_artwork.highest_bid.display}</em>

--- a/apps/auctions/stylesheets/index.styl
+++ b/apps/auctions/stylesheets/index.styl
@@ -129,6 +129,9 @@
   margin-bottom 30px
   min-width 260px
 
+.my-active-bids-item-details
+  max-width 160px
+
 .auctions-header
   margin-bottom -17px
 

--- a/apps/user/pages/auctions/index.styl
+++ b/apps/user/pages/auctions/index.styl
@@ -1,3 +1,6 @@
 @require '../../../../components/my_active_bids'
 @require '../components/bid_history'
 @require '../components/auction_registrations'
+
+.my-active-bids-item-details
+  max-width 350px

--- a/components/my_active_bids/index.styl
+++ b/components/my_active_bids/index.styl
@@ -27,6 +27,8 @@ item-margin-bottom = 16px
     margin-right 12px
     width 60px
     height 60px
+  .my-active-bids-item-artist
+    overflow ellipsis
 
 .my-active-bids-item img, .my-active-bids-item-details
   display inline-block

--- a/components/my_active_bids/template.jade
+++ b/components/my_active_bids/template.jade
@@ -11,7 +11,8 @@ if myActiveBids && myActiveBids.length
             img( src=bid.sale_artwork.artwork.image.url )
             .my-active-bids-item-details
               h4 Lot #{bid.sale_artwork.lot_number}
-              strong= bid.sale_artwork.artwork.artist.name
+              .my-active-bids-item-artist
+                strong= bid.sale_artwork.artwork.artist.name
               p #{bid.sale_artwork.highest_bid.display} (#{bid.sale_artwork.counts.bidder_positions} Bids)
           if bid.sale_artwork.sale.is_live_open
             a.avant-garde-button-black.my-active-bids-bid-live-button(


### PR DESCRIPTION
Fixes https://github.com/artsy/force/issues/843 

This update the my active bids module to cap the div width so it now looks like:
![image](https://cloud.githubusercontent.com/assets/2081340/22847028/89dd0e4a-efb8-11e6-9d1f-f5d6a859725c.png)

![image](https://cloud.githubusercontent.com/assets/2081340/22847000/6dc2445a-efb8-11e6-8b13-94f65760c93b.png)
