### PR TITLE
@damassi => artwork page callout should say "Join Live Auction" if auction is live

### DIFF
--- a/apps/artwork/components/banner/index.jade
+++ b/apps/artwork/components/banner/index.jade
@@ -60,6 +60,9 @@ if artwork.banner
           when 'ArtworkContextSale'
             | Explore Sale
           when 'ArtworkContextAuction'
-            | Explore Auction
+            if banner.is_live_open
+              | Join Live Auction
+            else
+              | Explore Auction
           when 'ArtworkContextPartnerShow'
             | Explore #{banner.type}

--- a/apps/artwork/components/banner/query.coffee
+++ b/apps/artwork/components/banner/query.coffee
@@ -9,6 +9,7 @@ module.exports = """
         end_at
         live_start_at
         is_auction
+        is_live_open
       }
       ... on ArtworkContextSale {
         name


### PR DESCRIPTION
Should fix: https://github.com/artsy/force/issues/834

Instead of "Explore Auction"
![image](https://cloud.githubusercontent.com/assets/2081340/22897748/e59cbe38-f1f2-11e6-848d-2715a8cfee62.png)

Before auction is live:
![image](https://cloud.githubusercontent.com/assets/2081340/22897726/d6285eee-f1f2-11e6-924c-97590dce9d71.png)
