### PR TITLE
@broskoski: Middleware to proxy merged.artsy.net so we can drive traffic incrementally to it for testing purpose

### DIFF
--- a/config.coffee
+++ b/config.coffee
@@ -96,6 +96,8 @@ module.exports =
   EOY_2016_ARTICLE: null
   EOY_2016_TEASER: 'https://artsy-vanity-files-production.s3.amazonaws.com/documents/year-in-art-teaser.html'
   RAYGUN_KEY: null
+  FORCE_MERGE_URL: 'https://merged.artsy.net'
+  FORCE_MERGE_WEIGHT: 0
 
 # Override any values with env variables if they exist.
 # You can set JSON-y values for env variables as well such as "true" or

--- a/lib/middleware/proxy_to_merged.coffee
+++ b/lib/middleware/proxy_to_merged.coffee
@@ -1,0 +1,15 @@
+#
+# Sends a percent of traffic to a proxied merged Force + MG app.
+# See https://github.com/artsy/force-merge for more details.
+#
+
+httpProxy = require 'http-proxy'
+{ FORCE_MERGE_URL, FORCE_MERGE_WEIGHT } = require "../../config"
+
+proxy = httpProxy.createProxyServer()
+
+module.exports = (req, res, next) ->
+  if req.session.inMergedForce ?= Math.random() < Number FORCE_MERGE_WEIGHT
+    proxy.web req, res, target: FORCE_MERGE_URL
+  else
+    next()

--- a/lib/middleware/proxy_to_merged.coffee
+++ b/lib/middleware/proxy_to_merged.coffee
@@ -7,9 +7,11 @@ httpProxy = require 'http-proxy'
 { FORCE_MERGE_URL, FORCE_MERGE_WEIGHT } = require "../../config"
 
 proxy = httpProxy.createProxyServer()
+weight = Number FORCE_MERGE_WEIGHT
 
 module.exports = (req, res, next) ->
-  if req.session.inMergedForce ?= Math.random() < Number FORCE_MERGE_WEIGHT
+  inMerged = req.session.inMergedForce ?= Math.random() < weight
+  if weight > 0 and inMerged
     proxy.web req, res, target: FORCE_MERGE_URL
   else
     next()

--- a/lib/setup.coffee
+++ b/lib/setup.coffee
@@ -138,16 +138,14 @@ module.exports = (app) ->
 
   # Body parser has to be after proxy middleware for
   # node-http-proxy to work with POST/PUT/DELETE
-  app.all '/api*', proxyGravity.api
   app.use proxyToMerged
+  app.use '/api', proxyGravity.api
   app.use proxyReflection
-
-  # Setup Passport middleware for authentication along with the
-  # body/cookie parsing middleware needed for that.
   app.use bodyParser.json()
   app.use bodyParser.urlencoded(extended: true)
 
-  # We want the user to be able to log-in to force via the microgravity subdomain
+  # Passport middleware for authentication. CORS middleware above that because
+  # we want the user to be able to log-in to force via the microgravity subdomain
   # the initial use case being the professional buyer application
   # (this is specific to responsive pages that require log-in)
   app.use cors origin: [APP_URL, MOBILE_URL, /\.artsy\.net$/]

--- a/test/lib/middleware/proxy_to_merged.coffee
+++ b/test/lib/middleware/proxy_to_merged.coffee
@@ -26,7 +26,7 @@ describe 'proxy to merged', ->
     @proxy.web.args[0][2].target.should.equal 'https://merged.artsy.net'
 
   it 'regardless of the session will not proxy if the weight is 0', ->
-    proxyToMerged.__set__ 'FORCE_MERGE_WEIGHT', '0'
+    proxyToMerged.__set__ 'weight', 0
     @req.session.inMergedForce = true
     proxyToMerged @req, @res, @next
     @next.called.should.be.ok()

--- a/test/lib/middleware/proxy_to_merged.coffee
+++ b/test/lib/middleware/proxy_to_merged.coffee
@@ -1,0 +1,32 @@
+rewire = require 'rewire'
+proxyToMerged = rewire '../../../lib/middleware/proxy_to_merged'
+sinon = require 'sinon'
+
+describe 'proxy to merged', ->
+
+  beforeEach ->
+    proxyToMerged.__set__ 'proxy', @proxy = { web: sinon.stub() }
+    @Math = proxyToMerged.__get__ 'Math'
+    @Math.random = sinon.stub()
+    @req = session: {}
+    @res = {}
+    @next = sinon.stub()
+
+  it 'proxies merged force if the coin flip succeeds', ->
+    proxyToMerged.__set__ 'weight', 0.5
+    @Math.random.returns 0.4
+    proxyToMerged @req, @res, @next
+    @proxy.web.args[0][2].target.should.equal 'https://merged.artsy.net'
+
+  it 'keeps someone in merged force mode regardless of coin flip', ->
+    proxyToMerged.__set__ 'weight', 0.5
+    @Math.random.returns 0.6
+    @req.session.inMergedForce = true
+    proxyToMerged @req, @res, @next
+    @proxy.web.args[0][2].target.should.equal 'https://merged.artsy.net'
+
+  it 'regardless of the session will not proxy if the weight is 0', ->
+    proxyToMerged.__set__ 'FORCE_MERGE_WEIGHT', '0'
+    @req.session.inMergedForce = true
+    proxyToMerged @req, @res, @next
+    @next.called.should.be.ok()


### PR DESCRIPTION
Addresses https://github.com/artsy/force-merge/issues/6 without going down the rabbit hole of attempting to put a full on HAProxy/Nginx instance in front of Force and all of the DNS/session/config involved in attempting that. This simply uses [node-http-proxy](https://github.com/nodejitsu/node-http-proxy) to achieve a similar result where we can move over traffic by tuning up the `FORCE_MERGE_WEIGHT` config. The idea here is that we can get some real traffic stress testing the merged codebase this week before flipping the switch (by no means meant to be permanent).