### PR TITLE
@mzikherman => Dont run tests on travis for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,3 @@ before_install:
   - rvm install 2.3.1
 script:
   - "rvm use 2.3.1 && gem install danger  --version '~> 4.0' && danger"
-  - npm test


### PR DESCRIPTION
Since, until the consolidation, we'll have Travis running Danger and Semaphore running tests + deploys, remove the tests from Travis. Eventually, we'll just be on Travis for everything.