### PR TITLE
@broskoski: Set host header when proxying to Heroku for merged Force

### DIFF
--- a/lib/middleware/proxy_to_merged.coffee
+++ b/lib/middleware/proxy_to_merged.coffee
@@ -4,6 +4,7 @@
 #
 
 httpProxy = require 'http-proxy'
+url = require 'url'
 { FORCE_MERGE_URL, FORCE_MERGE_WEIGHT } = require "../../config"
 
 proxy = httpProxy.createProxyServer()
@@ -12,6 +13,8 @@ weight = Number FORCE_MERGE_WEIGHT
 module.exports = (req, res, next) ->
   inMerged = req.session.inMergedForce ?= Math.random() < weight
   if weight > 0 and inMerged
-    proxy.web req, res, target: FORCE_MERGE_URL
+    proxy.web req, res,
+      target: FORCE_MERGE_URL
+      headers: host: url.parse(FORCE_MERGE_URL).host
   else
     next()

--- a/test/lib/middleware/proxy_to_merged.coffee
+++ b/test/lib/middleware/proxy_to_merged.coffee
@@ -30,3 +30,9 @@ describe 'proxy to merged', ->
     @req.session.inMergedForce = true
     proxyToMerged @req, @res, @next
     @next.called.should.be.ok()
+
+  it 'sets the host header as the target host to appease Heroku routing', ->
+    proxyToMerged.__set__ 'weight', 1
+    @req.session.inMergedForce = true
+    proxyToMerged @req, @res, @next
+    @proxy.web.args[0][2].headers.host.should.equal 'merged.artsy.net'


### PR DESCRIPTION
This took way too long to hunt down but Node Http Proxy was having a hard time when pointing to a Heroku app because the way Heroku's routing layer works with it. More explained in [this SO question](http://stackoverflow.com/questions/6444280/heroku-no-such-app-error-with-node-js-node-http-proxy-module).