### PR TITLE
Move SSL + WWW middleware up

### DIFF
--- a/lib/setup.coffee
+++ b/lib/setup.coffee
@@ -87,9 +87,10 @@ module.exports = (app) ->
   app.use require '../apps/blank'
 
   # Make sure we're on https://www
-  app.use hstsMiddleware
-  app.use ensureSSL
   app.use ensureWWW
+  app.use ensureSSL
+  app.use hstsMiddleware
+
 
   # Increase max sockets. The goal of this is to improve app -> api
   # performance but the downside is it limits client connection reuse with keep-alive

--- a/lib/setup.coffee
+++ b/lib/setup.coffee
@@ -91,7 +91,6 @@ module.exports = (app) ->
   app.use ensureSSL
   app.use hstsMiddleware
 
-
   # Increase max sockets. The goal of this is to improve app -> api
   # performance but the downside is it limits client connection reuse with keep-alive
   if typeof MAX_SOCKETS == 'number' and MAX_SOCKETS > 0


### PR DESCRIPTION
Because it avoids overhead and more importantly forces the proxied force merge to be under SSL too.