### PR TITLE
@anadaroop preserve ordering of multiple buckets in partner rails

### DIFF
--- a/apps/partner2/components/fixed_cells_count_carousel/test/view.coffee
+++ b/apps/partner2/components/fixed_cells_count_carousel/test/view.coffee
@@ -61,15 +61,17 @@ describe 'FixedCellsCountCarousel', ->
         _.isFunction(@view.fetch().then).should.be.ok()
 
       it 'fetches and returns collection', ->
-        fetched = new PartnerShows [fabricate 'show']
+        shows = [fabricate('show'), fabricate('show'), fabricate('show')]
+        console.log shows
         Backbone.sync
           .onCall 0
-          .yieldsTo 'success', fetched.models
+          .yieldsTo 'success', shows
+          .returns Promise.resolve shows
 
         @view.fetch().then (collection) =>
-          collection.length.should.equal 1
-          collection.models.should.eql fetched.models
-          collection.models.should.eql @collection.models
+          collection.length.should.equal 3
+          _.pluck(collection.models, 'attributes').should.deepEqual shows
+          collection.models.should.deepEqual @collection.models
 
     describe 'with multiple fetch', ->
       beforeEach ->
@@ -96,20 +98,23 @@ describe 'FixedCellsCountCarousel', ->
         _.isFunction(@view.fetch().then).should.be.ok()
 
       it 'fetches and returns collection', ->
-        fetched1 = new PartnerShows [fabricate 'show']
+        shows1 = [fabricate('show'), fabricate('show'), fabricate('show')]
+        shows2 = [fabricate('show'), fabricate('show')]
         Backbone.sync
           .onCall 0
-          .yieldsTo 'success', fetched1.models
+          .yieldsTo 'success', shows1
+          .returns Promise.resolve shows1
 
-        fetched2 = new PartnerShows [fabricate('show'), fabricate('show')]
         Backbone.sync
           .onCall 1
-          .yieldsTo 'success', fetched2.models
+          .yieldsTo 'success', shows2
+          .returns Promise.resolve shows2
 
         @view.fetch().then (collection) =>
-          collection.length.should.equal 3
-          collection.models.should.eql fetched1.models.concat fetched2.models
-          collection.models.should.eql @collection.models
+          collection.length.should.equal 5
+          _.pluck(collection.models, 'attributes').should.deepEqual shows1.concat shows2
+          collection.models.should.deepEqual @collection.models
+
 
   describe '#consolidate', ->
     beforeEach ->

--- a/apps/partner2/components/fixed_cells_count_carousel/view.coffee
+++ b/apps/partner2/components/fixed_cells_count_carousel/view.coffee
@@ -28,7 +28,9 @@ module.exports = class FixedCellsCountCarousel extends Backbone.View
     Q.allSettled(
       _.map @fetchOptions, (options) =>
         @collection.fetch data: options, remove: false
-    ).then =>
+    ).then (values) =>
+      objects = [].concat.apply [], _.pluck values, 'value'
+      @collection.reset objects
       @collection
 
   # Only keep the first cellsCountPerPage * pagesCount items.


### PR DESCRIPTION
fixes https://github.com/artsy/force/issues/855

The issue was, we already had code in place to allow for the rails on the gallery pages to be populated by multiple fetches (id, one fetch with parameters to return only current shows, another for upcoming). The intent was for the results from the first fetch to precede the results from the second. However there was a race condition between multiple fetches performed in parallel, and whichever results were returned first would be displayed at the beginning of the carousel. I modified things to preserve the ordering of the results _after_ all parallel fetches are complete.