### PR TITLE
Move inline-react-svg to prod dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel": "^6.5.2",
     "babel-core": "^6.17.0",
     "babel-eslint": "^7.0.0",
+    "babel-plugin-inline-react-svg": "https://registry.npmjs.org/babel-plugin-inline-react-svg/-/babel-plugin-inline-react-svg-0.2.0.tgz",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.22.0",


### PR DESCRIPTION
Otherwise we get `Uncaught Exception ReferenceError: Unknown plugin "inline-react-svg" specified in "/app/package.json" at 0, attempted to resolve relative to "/app"` taking merged.artsy.net down (not clear to me yet why staging is working—maybe NODE_ENV=staging installs dev dependencies).

And now for a philosophical rant that I encourage anyone to participate in:

We encountered a, somewhat, related issues when trying to use WebPack to import stylus files in Prediction. This caused trouble on the server-side and sent us down a whole world of pain trying to compile the server with Webpack. I think it highlights an interesting part of writing universal JS—where do you draw the line of tricking out the language itself and do you try to target a platform like "Node.js or Modern Browser Standard ES2017" or do you treat everything as a compilation target and write "WebPack/Babel Lang". On one extreme end of the spectrum, you potentially limit yourself from features we take for granted now like ES6 modules by targeting the lowest common denominator. On the other end of the spectrum you could end up with a significantly different customized language and it begs the question at that point why not just go all the way and adopt something like [Elm](http://elm-lang.org/), [Imba](http://imba.io/home), or [Clojurescript](https://github.com/clojure/clojurescript) (or supersets like Typescript)? 

My personal philosophy is that somewhere in the middle is best. That is to target [stage 4 approved Ecmascript](https://github.com/tc39/proposals/blob/master/finished-proposals.md) and when missing convenient features like filesystem access for loading SVGs, consider using JS library APIs that are first class in Node.js and can be supported cross-platform such as how you can use `fs` [with Browserify](https://github.com/substack/brfs), [React Native](https://github.com/johanneslumpe/react-native-fs), Electron, etc. before thinking about modifying the language itself with webpack/babel/browserify plugins/transforms. This can make life easier when trying to run code in various places by reducing the need to do things like how we often have to stub jade template requires for tests or constantly wiring up transpilers.

However, that's just my current thinking and I really don't know what's a good attitude to have towards all of the language customization you can do with JS world these days—so I'd love to hear other's thoughts on it.