### PR TITLE
@joeyAghion: Make sure to save the inquiry first before sending

### DIFF
--- a/.env.oss
+++ b/.env.oss
@@ -6,7 +6,7 @@
 
 # Shared
 PORT=5000
-API_URL=https://api.artsy.net
+API_URL=https://stagingapi.artsy.net
 DEFAULT_CACHE_TIME=
 EMAIL_SIGNUP_IMAGES_ID=
 ERROR_PAGE_URL=
@@ -59,7 +59,7 @@ GEMINI_S3_ACCESS_KEY=
 GENOME_URL=https://helix.artsy.net
 IMAGE_PROXY=
 IP_BLACKLIST=
-METAPHYSICS_ENDPOINT=https://metaphysics-production.artsy.net
+METAPHYSICS_ENDPOINT=https://metaphysics-staging.artsy.net
 MOBILE_URL=https://m.artsy.net
 PARSELY_KEY=
 PARSELY_SECRET=

--- a/desktop/models/artwork_inquiry.coffee
+++ b/desktop/models/artwork_inquiry.coffee
@@ -2,6 +2,7 @@ _ = require 'underscore'
 Backbone = require 'backbone'
 { API_URL, SESSION_ID } = require('sharify').data
 Cookies = require '../components/cookies/index.coffee'
+Promise = require 'bluebird-q'
 
 module.exports = class ArtworkInquiry extends Backbone.Model
   urlRoot: "#{API_URL}/api/v1/me/artwork_inquiry_request"
@@ -12,5 +13,5 @@ module.exports = class ArtworkInquiry extends Backbone.Model
     landing_url: Cookies.get('force-session-start')
 
   send: (attributes, options = {}) ->
-    @save attributes, _.extend options,
-      url: "#{@url()}/send"
+    (if @isNew() then @save({}, error: options.error) else Promise.resolve())
+      .then => @save attributes, _.extend options, url: "#{@url()}/send"

--- a/desktop/test/models/artwork_inquiry.coffee
+++ b/desktop/test/models/artwork_inquiry.coffee
@@ -10,13 +10,19 @@ describe 'ArtworkInquiry', ->
     beforeEach ->
       sinon.stub Backbone, 'sync'
         .yieldsTo 'success'
+        .returns Promise.resolve()
 
     afterEach ->
       Backbone.sync.restore()
 
-    it 'sends the inquiry immediately', (done) ->
-      @inquiry.send null, success: ->
+    it 'sends the inquiry immediately', ->
+      @inquiry.set(id: 'foo').send(null, success: ->
         true.should.be.true()
-        done()
-      Backbone.sync.args[0][2].url
-        .should.containEql '/api/v1/me/artwork_inquiry_request/send'
+      ).then ->
+        Backbone.sync.args[0][2].url
+          .should.containEql '/api/v1/me/artwork_inquiry_request/foo/send'
+
+    it 'saves the inquiry first if its new', ->
+      @inquiry.save = sinon.stub().returns Promise.resolve()
+      @inquiry.send()
+      @inquiry.save.called.should.be.ok()

--- a/desktop/test/models/artwork_inquiry.coffee
+++ b/desktop/test/models/artwork_inquiry.coffee
@@ -16,9 +16,9 @@ describe 'ArtworkInquiry', ->
       Backbone.sync.restore()
 
     it 'sends the inquiry immediately', ->
-      @inquiry.set(id: 'foo').send(null, success: ->
-        true.should.be.true()
-      ).then ->
+      success = sinon.spy()
+      @inquiry.set(id: 'foo').send(null, success: success).then ->
+        success.called.should.be.ok()
         Backbone.sync.args[0][2].url
           .should.containEql '/api/v1/me/artwork_inquiry_request/foo/send'
 


### PR DESCRIPTION
It appears as if most of our use of `inquiry.send` expects the inquiry to be saved before—which seems to happen in the more involved inquiry flows. However, in the case of the uninvolved auction lot inquiry, the inquiry appears to be new. To fix this I've implemented a `if @isNew() then @save()` check at the Backbone model layer.