### PR TITLE
@alloy => Rather than reject any metaphysics errors, allow them to resolve

### DIFF
--- a/desktop/apps/artwork/routes.coffee
+++ b/desktop/apps/artwork/routes.coffee
@@ -69,6 +69,7 @@ bootstrap = ->
   inPurchaseTestGroup = res.locals.sd.PURCHASE_FLOW is 'purchase'
   metaphysics send
     .then (data) ->
+      return next() unless data.artwork?
       data.fair = new Fair data.artwork.fair if data.artwork.fair
       data.inPurchaseTestGroup = inPurchaseTestGroup
       extend res.locals.helpers, helpers


### PR DESCRIPTION
but still notify NewRelic

Closes https://github.com/artsy/force/issues/781

Previously, any errors in resolving _any_ part of a GraphQL query would result in the whole promise being rejected. In some cases this is probably fine/preferable, but there are some cases where it seems silly to not be able to render the entire artwork or artist page just b/c Galaxy is down (and so that data isn't resolving). Or some other 'silly' Metaphysics issue.

So, this removes all rejections of Metaphysics promises (unless Metaphysics itself returns a non-200 status code), and instead allows them to resolve with whatever data is available, and also notifies NewRelic.

Then, we can see which parts of the data wind up not resolving, and how resilient our code/templates are to missing data (and we can start fixing). I already addressed one such issue here (going to `/artwork/invalid` throws a stack trace, now that app correctly `next()`s).