### PR TITLE
Do not attempt to switch a ruby version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -35,12 +35,10 @@ deployment:
       - DEPLOY_ENV=production yarn deploy-assets
       - git push git@heroku.com:force-production.git $CIRCLE_SHA1:refs/heads/master
 dependencies:
-  pre:
-    - rvm install 2.3.1
   override:
     - yarn install
 test:
   override:
-    - "rvm use 2.3.1 && gem install danger  --version '~> 4.0' && danger"
+    - "gem install danger --version '~> 4.0' && danger"
     - case $CIRCLE_NODE_INDEX in 0) yarn mocha test && yarn mocha $(find desktop/test -name '*.coffee') && yarn mocha $(find mobile/test -name '*.coffee') ;; 1) yarn mocha $(find desktop/components/*/test -name '*.coffee') && yarn mocha $(find desktop/components/**/*/test -name '*.coffee') ;; 2) yarn mocha $(find desktop/apps/*/test -name '*.coffee') && yarn mocha $(find desktop/apps/*/**/*/test -name '*.coffee') ;; 3) yarn mocha $(find mobile/components/*/test -name '*.coffee') && yarn mocha $(find mobile/components/**/*/test -name '*.coffee') && yarn mocha $(find mobile/apps/*/test -name '*.coffee') && yarn mocha $(find mobile/apps/*/**/*/test -name '*.coffee'); esac:
         parallel: true


### PR DESCRIPTION
Installing ruby 2.3.1 and the danger gem before test caused the issue below:

```
Ignoring gem-wrappers-1.2.7 because its extensions are not built.  Try: gem pristine gem-wrappers --version 1.2.7
Error loading RubyGems plugin "/opt/circleci/.rvm/gems/ruby-2.3.1/gems/gem-wrappers-1.2.7/lib/rubygems_plugin.rb": cannot load such file -- gem-wrappers (LoadError)
```

The root cause is unknown, but seems to be related to the `rvm install ...` command that runs in the dependencies phase. There is no reason why we shouldn't use the default ruby, so let's not switch the version and use the default one.