### PR TITLE
@eessex => Adds parsely analytics to amp pages

### DIFF
--- a/desktop/apps/article/templates/amp_mixins.jade
+++ b/desktop/apps/article/templates/amp_mixins.jade
@@ -100,6 +100,13 @@ mixin amp_analytics
           "properties.headline": "#{article.get('thumbnail_title')}"
         }
       }
+  amp-analytics(type="parsely")
+    script(type="application/json").
+      {
+        "vars": {
+          "apikey": "#{sd.PARSELY_KEY}"
+        }
+      }
 
 mixin amp_head
   meta(charset='utf-8')

--- a/desktop/config.coffee
+++ b/desktop/config.coffee
@@ -74,7 +74,7 @@ module.exports =
   GEOIP_ENDPOINT: 'https://artsy-geoip.herokuapp.com/'
   ACTIVE_BIDS_POLL_INTERVAL: 5000
   MAX_POLLS_FOR_MAX_BIDS: 20
-  PARSELY_KEY: null
+  PARSELY_KEY: 'artsy.net'
   PARSELY_SECRET: null
   PREDICTION_URL: 'https://live.artsy.net'
   SEGMENT_WRITE_KEY_MICROGRAVITY: null

--- a/desktop/lib/setup_sharify.coffee
+++ b/desktop/lib/setup_sharify.coffee
@@ -71,6 +71,7 @@ sharify.data = _.extend _.pick(config,
   'EOY_2016_ARTICLE'
   'RAYGUN_KEY'
   'API_REQUEST_TIMEOUT'
+  'PARSELY_KEY'
 ), {
   JS_EXT: if config.NODE_ENV in ["production", "staging"] then \
     ".min.js.cgz" else ".js"


### PR DESCRIPTION
This adds Parsely tracking to our AMP pages alongside Segment. I've checked in with Parsely support and this was their recommendation in order to bucket correctly. 