### PR TITLE
@broskoski => Render exhibition highlights and CV when only ref shows are present

### DIFF
--- a/desktop/apps/artist/client/views/cv.coffee
+++ b/desktop/apps/artist/client/views/cv.coffee
@@ -20,7 +20,7 @@ module.exports = class CVView extends Backbone.View
       variables:
         artist_id: @model.get('id')
         articles: @statuses.articles
-        shows: @statuses.shows
+        shows: @statuses.shows || @statuses.cv
     .then ({ artist }) => @trigger 'artist:cv:sync', artist
 
   postRender: ->

--- a/desktop/apps/artist/client/views/overview.coffee
+++ b/desktop/apps/artist/client/views/overview.coffee
@@ -31,7 +31,7 @@ module.exports = class OverviewView extends Backbone.View
         artist_id: @model.get('id')
         artists: @statuses.artists
         articles: @statuses.articles
-        shows: @statuses.shows
+        shows: @statuses.shows || @statuses.cv
     .then ({ artist }) => @trigger 'artist:overview:sync', artist
 
   setupBlurb: ->
@@ -67,7 +67,7 @@ module.exports = class OverviewView extends Backbone.View
       renderRail _.extend $el: $el.find('.js-artist-rail'), { section, count, items, following, baseHref }
 
   renderExhibitionHighlights: ({shows, counts}) ->
-    return if not @statuses.shows
+    return unless @statuses.shows || @statuses.cv
     $el = @$('.artist-overview-header .artist-exhibition-highlights')
     # If there are more than 15 shows, take ten and show a 'see more' link
     # If there are less than 15 shows, show them all, grouped by kind of show.
@@ -105,7 +105,7 @@ module.exports = class OverviewView extends Backbone.View
     @listenTo subView.collection, 'sync', =>
       artist = @model.toJSON()
       hasGenes = subView.collection.length
-      hasShows = @statuses.shows
+      hasShows = @statuses.shows || @statuses.cv
       hasMeta = viewHelpers.hasOverviewHeaderMeta(artist)
 
       if not (hasGenes or hasShows or hasMeta)

--- a/desktop/apps/artist/templates/sections/overview.jade
+++ b/desktop/apps/artist/templates/sections/overview.jade
@@ -15,7 +15,7 @@ mixin rail(title, viewAllUrl, section)
     - var artistMeta = viewHelpers.artistMeta(artist)
 
     - var hasMeta = viewHelpers.hasOverviewHeaderMeta(artist)
-    - var hasShows = statuses.shows
+    - var hasShows = statuses.shows || statuses.cv
 
     .bisected-header-cell.js-artist-overview-header-left
       if hasMeta


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/938

Basically, we were using the `shows` part of the statuses to determine whether we should even be rendering or fetching that data.

`shows` status is correctly defined as having any shows on Artsy. The `cv` status is correctly defined as having any shows period (whether they are reference or not is immaterial). That is useful to be able to render the tabs.

However, since ref shows can show up in the overview/exhibition highlights and in the CV tab, relying on _just_ the `statuses.shows` property to determine whether to fetch/render those pieces is off for artists with just reference shows. So this updates several of those places to consider both.


