### PR TITLE
@craigspaeth: Redirect from /city/:slug to /shows/:slug for consistency

### DIFF
--- a/desktop/apps/shows/index.coffee
+++ b/desktop/apps/shows/index.coffee
@@ -12,6 +12,7 @@ app.set 'view engine', 'jade'
 app.get '/shows', routes.index
 app.get '/shows/:city', routes.city
 app.get '/show', routes.redirectShow
+app.get '/city/:city', routes.redirectFromCity
 
 # Redirect pre-2015 location routes
 oldRedirects =

--- a/desktop/apps/shows/routes.coffee
+++ b/desktop/apps/shows/routes.coffee
@@ -24,6 +24,9 @@ PartnerFeaturedCities = require '../../collections/partner_featured_cities'
 @redirectShow = (req, res) ->
   res.redirect 301, req.url.replace 'show', 'shows'
 
+@redirectFromCity = (req, res) ->
+  res.redirect 302, req.url.replace '/city/', '/shows/'
+
 @city = (req, res, next) ->
   partnerCities = new PartnerCities()
   partnerFeaturedCities = new PartnerFeaturedCities()

--- a/desktop/apps/shows/test/routes.coffee
+++ b/desktop/apps/shows/test/routes.coffee
@@ -102,3 +102,11 @@ describe 'Shows routes', ->
         _.last(@res.render.args[0][1].past).should.equal showEndingFirst
 
         done()
+
+  describe '#redirectFromCity', ->
+    it 'redirects to /shows/... path', ->
+      req = { url: 'localhost:5000/city/new-york-ny-usa' }
+      res = { render: sinon.stub(), redirect: sinon.stub() }
+      routes.redirectFromCity req, res
+      res.redirect.args[0][0].should.equal 302
+      res.redirect.args[0][1].should.equal 'localhost:5000/shows/new-york-ny-usa'


### PR DESCRIPTION
This adds a redirect from `/city/...` paths to `/shows/...`. This was motivated by our realization (see https://github.com/artsy/gravity/pull/10824#discussion_r102097667) that all search result types _except cities_ could be easily perma-linked like `/:type/:slug`. For cities, the search results instead link to URLs like `/shows/new-york-ny-usa`.

In #seo and #web channels, there was mild agreement that it would be good to support the more conventional `/city/...` route as well, at least as a redirect, and maybe even as a more general landing page eventually that reflects, e.g., local galleries as well as local shows. (In addition, this change helps us avoid duplicating route logic in other systems.)

I briefly experimented with also marking the new route as `isResponsive` (in [redirect_mobile.coffee](https://github.com/artsy/force/blob/master/desktop/lib/middleware/redirect_mobile.coffee)), but found that actually mobile and desktop are inconsistent in their routes. Currently, the mobile page only supports short paths like `/shows/new-york` and 404s on `/shows/new-york-ny-usa`. The desktop page prefers `/shows/new-york-ny-usa` and redirects the short form to that. As is, this PR doesn't touch mobile handling at all.

Interestingly, mobile search deliberately excludes cities ([here](https://github.com/artsy/force/blob/e72c2a76da665d5601fa3586d8c266a8b4cd4583/mobile/apps/search/routes.coffee#L11)), so these routes are only accessible via the `/shows` page. Not sure why that is.