### PR TITLE
@craigspaeth: fallback to country when fair city location is not available

### DIFF
--- a/desktop/apps/fairs/query.coffee
+++ b/desktop/apps/fairs/query.coffee
@@ -27,6 +27,7 @@ module.exports = '''
       }
       location {
         city
+        country
       }
       profile {
         id

--- a/desktop/apps/fairs/templates/current_fairs.jade
+++ b/desktop/apps/fairs/templates/current_fairs.jade
@@ -12,8 +12,8 @@ mixin current-fair-figure(fair)
           .fairs-fair__name= fair.name
           .fairs-fair__info
             | #{ViewHelpers.formatDates(fair)}
-            if fair.location && fair.location.city
-              | , #{fair.location.city}
+            if fair.location && (fair.location.city || fair.location.country)
+              | , #{fair.location.city ? fair.location.city : fair.location.country}
 
 each row in currentFairRows
   .fairs__current-fair-row(class="fairs__current-fair-row--#{row.type}")

--- a/desktop/apps/fairs/templates/fair_upcoming.jade
+++ b/desktop/apps/fairs/templates/fair_upcoming.jade
@@ -4,5 +4,5 @@
   else
     .fairs-fair__name #{fair.name}
   .fairs-fair__info #{ViewHelpers.formatDates(fair)}
-  if fair.location && fair.location.city
-    .fairs-fair__info= fair.location.city
+  if fair.location && (fair.location.city || fair.location.country)
+    .fairs-fair__info= fair.location.city ? fair.location.city : fair.location.country

--- a/desktop/apps/fairs/templates/past_fairs.jade
+++ b/desktop/apps/fairs/templates/past_fairs.jade
@@ -9,5 +9,5 @@ for fair in pastFairs
         .entity-follow.profile-follow( data-id= fair.profile.id )
     .fairs__past-fair__cell.fairs__past-fair__cell--info
       .fairs-fair__info #{ViewHelpers.formatDates(fair)}
-      if fair.location && fair.location.city
-        .fairs-fair__info= fair.location.city
+      if fair.location && (fair.location.city || fair.location.country)
+        .fairs-fair__info= fair.location.city ? fair.location.city : fair.location.country


### PR DESCRIPTION
Address: https://github.com/artsy/waves/issues/117

The [Geocoder gem](https://github.com/artsy/gravity/blob/master/app/models/domain/location.rb#L49-L62) in gravity is returning a `nil` value for cities with Hong Kong coordinates. This is a patch to fallback to the country when the city isn't return. I think it's worth investigating why `nil` gets return for Hong Kong cities but this is a quick fix for now.

![screen shot 2017-03-02 at 4 05 09 pm](https://cloud.githubusercontent.com/assets/5201004/23527017/3d92c606-ff62-11e6-82ec-0beb4d9fa634.png)

**Fair's addition in past fairs**
![screen shot 2017-03-02 at 4 05 56 pm](https://cloud.githubusercontent.com/assets/5201004/23527036/4d8c1800-ff62-11e6-9a9d-da4d746e7da4.png)

