### PR TITLE
@craigspaeth => [Bugfix] Home hero button hover state

### DIFF
--- a/desktop/apps/home/stylesheets/hero_units.styl
+++ b/desktop/apps/home/stylesheets/hero_units.styl
@@ -76,6 +76,7 @@ hhu-credit-height = 30px
     &:focus
     &:active
       background white
+      color black
 
 #home-hero-units-controls
   width 100%


### PR DESCRIPTION
When hovering over the `home-hero-unit` cta, the text doesn't flip when the button color is filled:

<img width="219" alt="screen shot 2017-03-04 at 4 28 01 pm" src="https://cloud.githubusercontent.com/assets/236943/23583384/bb2b9480-00f7-11e7-9192-e33bf5c53d17.png">

Fixed by making the button color text black: 

<img width="236" alt="screen shot 2017-03-04 at 4 28 10 pm" src="https://cloud.githubusercontent.com/assets/236943/23583385/c57ccb5c-00f7-11e7-82a8-ddc384a29a7f.png">
