### PR TITLE
@eessex => Adds count flag to article fetches when needed

### DIFF
--- a/desktop/apps/articles/client/magazine.coffee
+++ b/desktop/apps/articles/client/magazine.coffee
@@ -6,7 +6,6 @@ sd = require('sharify').data
 
 module.exports.init = ->
   articles = new Articles sd.ARTICLES
-  articles.count = sd.ARTICLES_COUNT + 4
   articles.reset articles.feed()
   feedView = new ArticlesFeedView
     el: $('.articles-articles-feed')

--- a/desktop/apps/articles/client/section.coffee
+++ b/desktop/apps/articles/client/section.coffee
@@ -6,7 +6,6 @@ sd = require('sharify').data
 
 module.exports.init = ->
   articles = new Articles sd.ARTICLES
-  articles.count = sd.ARTICLES_COUNT + 4
   articles.reset articles.feed()
   feedView = new ArticlesFeedView
     el: $('.articles-articles-feed')
@@ -17,5 +16,5 @@ module.exports.init = ->
       featured: true
       section_id: sd.SECTION.id
       sort: '-published_at'
-  feedView.render() if sd.ARTICLES_COUNT > sd.ARTICLES.length
+  feedView.render()
   new GalleryInsightsView el: $('body')

--- a/desktop/apps/articles/client/team_channel.coffee
+++ b/desktop/apps/articles/client/team_channel.coffee
@@ -13,7 +13,7 @@ module.exports.TeamChannelView = class TeamChannelView extends Backbone.View
     @$body = $('body')
     @channel = new Channel sd.CHANNEL
     @gridArticles = new Articles
-    @gridArticles.url = "#{@gridArticles.url}/?&published=true&limit=12&sort=-published_at&channel_id=#{@channel.get('id')}"
+    @gridArticles.url = "#{@gridArticles.url}/?&published=true&limit=12&sort=-published_at&channel_id=#{@channel.get('id')}&count=true"
     @renderGrid()
     @renderFeatured()
     @nav = new TeamChannelNavView

--- a/desktop/apps/articles/routes.coffee
+++ b/desktop/apps/articles/routes.coffee
@@ -60,7 +60,6 @@ setupEmailSubscriptions = (user, cb) ->
         error: res.backboneError
         success: (articles) ->
           res.locals.sd.ARTICLES = articles.toJSON()
-          res.locals.sd.ARTICLES_COUNT = articles.count
           res.locals.sd.SECTION = section.toJSON()
           res.render 'section', section: section, articles: articles
 

--- a/desktop/apps/fair/client/articles.coffee
+++ b/desktop/apps/fair/client/articles.coffee
@@ -12,6 +12,7 @@ module.exports = class ArticlesAdapter
         fair_id: fair.get('_id')
         sort: '-published_at'
         limit: 5
+        count: true
     el.html '<div class="loading-spinner"></div>'
     el.addClass view.className
     collection.fetch
@@ -20,4 +21,5 @@ module.exports = class ArticlesAdapter
         fair_id: fair.get('_id')
         sort: '-published_at'
         limit: 5
+        count: true
     view

--- a/desktop/apps/partner/client/articles.coffee
+++ b/desktop/apps/partner/client/articles.coffee
@@ -21,7 +21,7 @@ module.exports = class ArticlesAdapter
 
   renderArticlesGrid: ->
     @collection = new Articles
-    @collection.url = "#{@collection.url}/?partner_id=#{@partner.get('_id')}&published=true&limit=12&sort=-published_at"
+    @collection.url = "#{@collection.url}/?partner_id=#{@partner.get('_id')}&published=true&limit=12&sort=-published_at&count=true"
     view = new ArticlesGridView
       el: @el
       collection: @collection

--- a/desktop/apps/partner/client/view.coffee
+++ b/desktop/apps/partner/client/view.coffee
@@ -77,6 +77,7 @@ module.exports = class PartnerView extends Backbone.View
       partner_id: @partner.get('_id')
       published: true
       limit: 1
+      count: true
 
     Q.allSettled([@partner.fetch(), articles.fetch(data: articlesFetchData)])
       .then => @partnerArticlesCount = articles.count

--- a/desktop/apps/partner/test/client/view.coffee
+++ b/desktop/apps/partner/test/client/view.coffee
@@ -149,7 +149,7 @@ describe 'PartnerView', ->
         requests = _.last(Backbone.sync.args, 2)
         requests[0][1].url().should.endWith "/api/v1/partner/#{@partner.get('id')}"
         requests[1][1].url.should.endWith '/api/articles'
-        requests[1][2].data.should.eql partner_id: @partner.get('_id'), limit: 1, published: true
+        requests[1][2].data.should.eql partner_id: @partner.get('_id'), limit: 1, published: true, count: true
 
       it 'fetches and returns partner and articles and sets articles count', ->
         nextSyncCall = Backbone.sync.args.length

--- a/desktop/apps/partner2/client/articles.coffee
+++ b/desktop/apps/partner2/client/articles.coffee
@@ -21,7 +21,7 @@ module.exports = class ArticlesAdapter
 
   renderArticlesGrid: ->
     @collection = new Articles
-    @collection.url = "#{@collection.url}/?partner_id=#{@partner.get('_id')}&published=true&limit=12&sort=-published_at"
+    @collection.url = "#{@collection.url}/?partner_id=#{@partner.get('_id')}&published=true&limit=12&sort=-published_at&count=true"
     view = new ArticlesGridView
       el: @el
       collection: @collection

--- a/desktop/apps/partner2/client/view.coffee
+++ b/desktop/apps/partner2/client/view.coffee
@@ -77,6 +77,7 @@ module.exports = class PartnerView extends Backbone.View
       partner_id: @partner.get('_id')
       published: true
       limit: 1
+      count: true
 
     Q.allSettled([@partner.fetch(), articles.fetch(data: articlesFetchData)])
       .then => @partnerArticlesCount = articles.count

--- a/desktop/apps/partner2/test/client/view.coffee
+++ b/desktop/apps/partner2/test/client/view.coffee
@@ -166,7 +166,7 @@ describe 'PartnerView', ->
         requests = _.last(Backbone.sync.args, 2)
         requests[0][1].url().should.endWith "/api/v1/partner/#{@partner.get('id')}"
         requests[1][1].url.should.endWith '/api/articles'
-        requests[1][2].data.should.eql partner_id: @partner.get('_id'), limit: 1, published: true
+        requests[1][2].data.should.eql partner_id: @partner.get('_id'), limit: 1, published: true, count: true
 
       it 'fetches and returns partner and articles and sets articles count', ->
         nextSyncCall = Backbone.sync.args.length


### PR DESCRIPTION
This is a follow-up to https://github.com/artsy/positron/pull/951. For views that use `ArticleFeedView` and `ArticleGridView`, we'll need `count`. This is safe to merge regardless of if https://github.com/artsy/positron/pull/951 is deployed yet since it will ignore the field until available. 