### PR TITLE
Add default cookie domain to Dismisser component

### DIFF
--- a/desktop/components/has_seen/dismisser.coffee
+++ b/desktop/components/has_seen/dismisser.coffee
@@ -1,20 +1,24 @@
 _ = require 'underscore'
 Cookies = require '../cookies/index.coffee'
 
+# Get around inabilty to stub `document`
+domain = document.domain if typeof document isnt 'undefined'
+
 module.exports = class Dismisser
   defaults:
     limit: 5
     expires: 31536000 # 1 Year
+    domain: domain
 
   constructor: (options = {}) ->
-    { @name, @limit, @expires } = _.defaults options, @defaults
+    { @name, @limit, @expires, @domain } = _.defaults options, @defaults
 
   tick: =>
     return if @dismissed()
     @persist @get() + 1
 
   persist: (n) ->
-    Cookies.set @name, n, expires: @expires
+    Cookies.set @name, n, expires: @expires, domain: @domain
 
   get: ->
     parseInt(Cookies.get @name) or 0


### PR DESCRIPTION
Adds a domain to our Dismisser component cookie to help lock things down a bit. Set when the `x` button is clicked below: 

![screen shot 2017-03-06 at 3 47 02 pm](https://cloud.githubusercontent.com/assets/236943/23635377/482fd930-0284-11e7-97a0-c50f824c8b94.png)

as well as the [privacy policy](https://github.com/damassi/force/blob/add-domain-to-cookie/desktop/components/main_layout/header/policy.coffee#L13).

Note that this is difficult to write tests for due to the inability to stub out `window`, via rewire, in our test environment. See https://github.com/jhnns/rewire/issues/58 for more info. 
