### PR TITLE
Fix Artwork layout for non-sale artworks 

### DIFF
--- a/desktop/apps/artwork/stylesheets/index.styl
+++ b/desktop/apps/artwork/stylesheets/index.styl
@@ -38,8 +38,9 @@ artwork-page = {
     align-items stretch
 
     &__metadata
-      z-index 1
+      position relative
       width: artwork-page.metadata.width
+      z-index 1
 
     &__overview
       width calc('100% - %s' % (artwork-page.metadata.width + gutter))

--- a/desktop/apps/artwork/stylesheets/index.styl
+++ b/desktop/apps/artwork/stylesheets/index.styl
@@ -34,8 +34,10 @@ artwork-page = {
   //
 
   &__main
+    display flex
+    align-items stretch
+
     &__metadata
-      float right
       z-index 1
       width: artwork-page.metadata.width
 

--- a/desktop/apps/artwork/templates/index.jade
+++ b/desktop/apps/artwork/templates/index.jade
@@ -7,25 +7,42 @@ block head
   include ../components/meta/index
 
 block body
-  .artwork-page.main-layout-container
-    section.artwork
-      .artwork__main
-        .artwork__main__metadata(
-          class= inPurchaseTestGroup && artwork.is_purchasable ? 'purchase-flow' : ''
-        )
-          include ../components/metadata/index
-          include ../components/commercial/index
-          include ../components/auction/index
-
-        .artwork__main__overview
-          include ../components/banner/index
-          include ../components/images/index
-          include ../components/actions/index
-          include ../components/additional_info/index
-          include ../components/artists/index
-
+  - isAuction = artwork.context && artwork.context.__typename == 'ArtworkContextAuction'
+  
+  if isAuction
+    .artwork-page.main-layout-container
+      section.artwork
+        .artwork__main
+          .artwork__main__overview
+            include ../components/banner/index
+            include ../components/images/index
+            include ../components/actions/index
+            include ../components/additional_info/index
+            include ../components/artists/index
+            
+          include ./metadata
+            
         .artwork__main__overview__fold( class='js-artwork-fold' )
           include ../client/fold
+        
+        .artwork__footer( class='js-artwork-footer' )
+          include ../client/footer
+  
+  else 
+    .artwork-page.main-layout-container
+      section.artwork
+        .artwork__main
+          .artwork__main__overview
+            include ../components/banner/index
+            include ../components/images/index
+            include ../components/actions/index
+            include ../components/additional_info/index
+            include ../components/artists/index
 
-      .artwork__footer( class='js-artwork-footer' )
-        include ../client/footer
+            .artwork__main__overview__fold( class='js-artwork-fold' )
+              include ../client/fold
+
+          include ./metadata
+
+        .artwork__footer( class='js-artwork-footer' )
+          include ../client/footer

--- a/desktop/apps/artwork/templates/metadata.jade
+++ b/desktop/apps/artwork/templates/metadata.jade
@@ -1,0 +1,6 @@
+.artwork__main__metadata(
+  class= inPurchaseTestGroup && artwork.is_purchasable ? 'purchase-flow' : ''
+)
+  include ../components/metadata/index
+  include ../components/commercial/index
+  include ../components/auction/index


### PR DESCRIPTION
This fixes an issue where we were seeing the new 4-column layout extend to pages that were not related to Auctions. 

To test: 

```sh
git checkout -b damassi-artwork-auction-layout-fix master
git pull https://github.com/damassi/force.git artwork-auction-layout-fix
yarn start
```

Then navigate to: 
- Artwork that is in an Auction: http://localhost:5000/artwork/jack-tan-painting?auction_id=worlds-biggest-mauction
- Artwork that isn't, retaining side "sticky" column: 
  - http://localhost:5000/artwork/pierre-jeanneret-conference-armchair
  - http://localhost:5000/artwork/quayola-natures-number-3b
  - http://localhost:5000/artwork/arne-jacobsen-egg-chair

@sweir27 / @erikdstock - if either of you know how to navigate into the less-known-about artwork pages for test can you let me know? I've navigated all around Artsy trying to dig up random artwork pages as defined [by their different contexts](https://github.com/damassi/force/blame/artwork-auction-layout-fix/desktop/apps/artwork/client/index.coffee#L62) but haven't been able to find anything inconsistent. 