### PR TITLE
Artwork Sale Lot Sorting 

### DIFF
--- a/desktop/apps/artwork/client/index.coffee
+++ b/desktop/apps/artwork/client/index.coffee
@@ -50,7 +50,7 @@ module.exports =
           #{require '../../../components/artwork_brick/query.coffee'}
           #{require '../components/partner/query.coffee'}
           #{require('../components/auction_artworks/query.coffee').auction_artworks}
-          #{require('../components/auction_artworks/query.coffee').followed_artist_ids}
+          #{require('../components/auction_artworks/query.coffee').followed_artist_ids(CurrentUser.orNull())}
           #{require '../components/artist_artworks/query.coffee'}
           #{require '../components/related_artworks/query.coffee'}
         """

--- a/desktop/apps/artwork/client/index.coffee
+++ b/desktop/apps/artwork/client/index.coffee
@@ -4,6 +4,7 @@
 metaphysics = require '../../../../lib/metaphysics.coffee'
 CurrentUser = require '../../../models/current_user.coffee'
 exec = require '../lib/exec.coffee'
+qs = require 'qs'
 fold = -> require('./fold.jade') arguments...
 footer = -> require('./footer.jade') arguments...
 
@@ -33,23 +34,29 @@ sharedInit = [
 module.exports =
   setup: setup = (context = {}) ->
     if context.__typename is 'ArtworkContextAuction'
+      queryParams = qs.parse(location.search.replace(/^\?/, ''))
+
       query: """
-          query artwork($id: String!, $isClosed: Boolean!) {
+          query artwork($id: String!, $isClosed: Boolean!, $auctionId: ID) {
             artwork(id: $id) {
               ... partner
               ... auction_artworks @skip(if: $isClosed)
               ... artist_artworks @include(if: $isClosed)
               ... related_artworks @include(if: $isClosed)
             }
+
+            ... followed_artist_ids @skip(if: $isClosed)
           }
           #{require '../../../components/artwork_brick/query.coffee'}
           #{require '../components/partner/query.coffee'}
-          #{require '../components/auction_artworks/query.coffee'}
+          #{require('../components/auction_artworks/query.coffee').auction_artworks}
+          #{require('../components/auction_artworks/query.coffee').followed_artist_ids}
           #{require '../components/artist_artworks/query.coffee'}
           #{require '../components/related_artworks/query.coffee'}
         """
       variables:
         isClosed: context.is_closed
+        auctionId: queryParams.auction_id
 
       init: compact [
           require '../components/partner/index.coffee'
@@ -151,7 +158,11 @@ module.exports =
 
     return unless query? and init?
     variables ?= {}
-    metaphysics query: query, variables: extend { id: CLIENT.id }, variables
+    metaphysics {
+      query: query,
+      variables: extend { id: CLIENT.id }, variables
+      req: user: CurrentUser.orNull()
+    }
       .then (data) ->
         renderTemplates(data)
         exec init

--- a/desktop/apps/artwork/client/index.coffee
+++ b/desktop/apps/artwork/client/index.coffee
@@ -4,7 +4,6 @@
 metaphysics = require '../../../../lib/metaphysics.coffee'
 CurrentUser = require '../../../models/current_user.coffee'
 exec = require '../lib/exec.coffee'
-qs = require 'qs'
 fold = -> require('./fold.jade') arguments...
 footer = -> require('./footer.jade') arguments...
 
@@ -34,8 +33,6 @@ sharedInit = [
 module.exports =
   setup: setup = (context = {}) ->
     if context.__typename is 'ArtworkContextAuction'
-      queryParams = qs.parse(location.search.replace(/^\?/, ''))
-
       query: """
           query artwork($id: String!, $isClosed: Boolean!, $auctionId: ID) {
             artwork(id: $id) {
@@ -56,7 +53,7 @@ module.exports =
         """
       variables:
         isClosed: context.is_closed
-        auctionId: queryParams.auction_id
+        auctionId: sd.AUCTION.id
 
       init: compact [
           require '../components/partner/index.coffee'

--- a/desktop/apps/artwork/client/test/index.coffee
+++ b/desktop/apps/artwork/client/test/index.coffee
@@ -1,54 +1,75 @@
-_ = require 'underscore'
-benv = require 'benv'
-sinon = require 'sinon'
 Backbone = require 'backbone'
+benv = require 'benv'
+sd = require('sharify').data
+sinon = require 'sinon'
+_ = require 'underscore'
 { resolve } = require 'path'
 { fabricate } = require 'antigravity'
 
 describe 'Artwork Client', ->
-  before (done) ->
+  before ->
+    global.OpenSeadragon = {}
+
     benv.setup =>
-      benv.expose $: benv.require('jquery'), jQuery: benv.require('jquery')
+      benv.expose
+        $: benv.require('jquery'),
+        jQuery: benv.require('jquery')
+        location:
+          search: '?auction_id=test-auction'
+        sd:
+          CLIENT:
+            artists: []
+
       Backbone.$ = $
       @clientSetup = benv.requireWithJadeify require.resolve('../index.coffee'), ['fold', 'footer']
-      done()
 
   after ->
     benv.teardown()
+    delete global.OpenSeadragon
 
   describe 'setup', ->
     describe 'Auction', ->
       describe 'preview or open', ->
         beforeEach ->
-          { @query, @variables, @init } = @clientSetup.setup __typename: 'ArtworkContextAuction', is_closed: false
+          { @query, @variables, @init } = @clientSetup.setup
+            __typename: 'ArtworkContextAuction'
+            is_closed: false
+            auction_id: 'test-auction'
 
         it 'formats query', ->
           @query.should.containEql('... partner')
           @query.should.containEql('... auction_artworks')
           @query.should.containEql('... artist_artworks')
           @query.should.containEql('... related_artworks')
+          @query.should.containEql('... followed_artist_ids')
 
         it 'sets variables', ->
           @variables.isClosed.should.not.be.true()
+          @variables.auctionId.should.equal 'test-auction'
 
         it 'sets up initializers', ->
-          @init.length.should.eql 2
+          @init.length.should.eql 3
 
       describe 'closed', ->
         beforeEach ->
-          { @query, @variables, @init } = @clientSetup.setup __typename: 'ArtworkContextAuction', is_closed: true
+          { @query, @variables, @init } = @clientSetup.setup
+            __typename: 'ArtworkContextAuction',
+            is_closed: true
+            auction_id: 'test-auction'
 
         it 'formats query', ->
           @query.should.containEql('... partner')
           @query.should.containEql('... auction_artworks')
           @query.should.containEql('... artist_artworks')
           @query.should.containEql('... related_artworks')
+          @query.should.containEql('... followed_artist_ids')
 
         it 'sets variables', ->
           @variables.isClosed.should.be.true()
+          @variables.auctionId.should.be.equal('test-auction')
 
         it 'sets up initializers', ->
-          @init.length.should.eql 3
+          @init.length.should.eql 4
 
     describe 'Fair', ->
       beforeEach ->
@@ -61,7 +82,7 @@ describe 'Artwork Client', ->
         @query.should.containEql('... related_artworks')
 
       it 'sets up initializers', ->
-        @init.length.should.eql 4
+        @init.length.should.eql 5
 
       xdescribe 'active', ->
 
@@ -79,7 +100,7 @@ describe 'Artwork Client', ->
         @query.should.containEql('... related_artworks')
 
       it 'sets up initializers', ->
-        @init.length.should.eql 5
+        @init.length.should.eql 6
 
     describe 'default', ->
       beforeEach ->
@@ -92,33 +113,41 @@ describe 'Artwork Client', ->
         @query.should.containEql('... related_artworks')
 
       it 'sets up initializers', ->
-        @init.length.should.eql 4
+        @init.length.should.eql 5
 
-  describe.only 'renderTemplates', ->
+  describe 'renderTemplates', ->
     beforeEach ->
-      @data = artwork:
-        sale_artwork: sale: {}, current_bid: {}, counts: {}
-        partner:
-          type: 'Gallery'
-          name: 'Partner Name'
-          href: '/partner-name'
-          counts: { artworks: '2 works' }
-          artworks: [{ id: 'artwork-1', partner: {}, image: { cell: {}, thumb: { height: 1 }}, title: 'Artwork 1'}]
-        artist:
-          name: 'Artwork Artist'
-          href: '/artwork-artist'
-          counts: { artworks: '2 works' }
-          artworks: [{ id: 'artwork-2', partner: {}, image: { cell: {}, thumb: { height: 1 }}, title: 'Artwork 2'}]
-        auction:
-          name: 'Auction Name'
-          href: '/auction-name'
-          artworks: [{ id: 'artwork-3', sale_artwork: { sale: {}, current_bid: {}, counts: {} }, partner: {}, image: { cell: {}, thumb: { height: 1 }}, title: 'Artwork 3'}]
-        show:
-          type: 'Show'
-          name: 'Some Show'
-          href: '/some-show'
-          counts: { artworks: '2 works' }
-          artworks:  [{ id: 'artwork-4', partner: {}, image: { cell: {}, thumb: { height: 1 }}, title: 'Artwork 4'}]
+      @data =
+        followed_artist_ids:
+          hits: [{ id: 'artwork-3' }]
+        artwork:
+          sale_artwork: sale: {}, current_bid: {}, counts: {}
+          partner:
+            type: 'Gallery'
+            name: 'Partner Name'
+            href: '/partner-name'
+            counts: { artworks: '2 works' }
+            artworks: [{ id: 'artwork-1', partner: {}, image: { cell: {}, thumb: { height: 1 }}, title: 'Artwork 1'}]
+          artist:
+            name: 'Artwork Artist'
+            href: '/artwork-artist'
+            counts: { artworks: '2 works' }
+            artworks: [{ id: 'artwork-2', partner: {}, image: { cell: {}, thumb: { height: 1 }}, title: 'Artwork 2'}]
+          auction:
+            name: 'Auction Name'
+            href: '/auction-name'
+            artworks: [
+              { id: 'artwork-1', sale_artwork: { sale: {}, current_bid: {}, counts: {} }, partner: {}, image: { cell: {}, thumb: { height: 1 }}, title: 'Artwork 1'}
+              { id: 'artwork-2', sale_artwork: { sale: {}, current_bid: {}, counts: {} }, partner: {}, image: { cell: {}, thumb: { height: 1 }}, title: 'Artwork 2'}
+              { id: 'artwork-3', sale_artwork: { sale: {}, current_bid: {}, counts: {} }, partner: {}, image: { cell: {}, thumb: { height: 1 }}, title: 'Artwork 3'}
+              { id: 'artwork-4', sale_artwork: { sale: {}, current_bid: {}, counts: {} }, partner: {}, image: { cell: {}, thumb: { height: 1 }}, title: 'Artwork 4'}
+            ]
+          show:
+            type: 'Show'
+            name: 'Some Show'
+            href: '/some-show'
+            counts: { artworks: '2 works' }
+            artworks:  [{ id: 'artwork-4', partner: {}, image: { cell: {}, thumb: { height: 1 }}, title: 'Artwork 4'}]
       $('body').html("""
         <div class="artwork__main__overview__fold js-artwork-fold"></div>
         <div class="artwork__footer js-artwork-footer"></div>
@@ -134,6 +163,7 @@ describe 'Artwork Client', ->
       $('.artwork-section.artwork-artist-artworks').length.should.eql 1
       $('.artwork-section.artwork-show-artworks').length.should.eql 1
       $('.artwork-section.artwork-auction-artworks').length.should.eql 1
+      $('.artwork-section.artwork-auction-artworks .artwork-brick').length.should.eql 4
 
 
       $('.artwork-section.artwork-partner-artworks').html().should.containEql 'Artwork 1'
@@ -147,6 +177,9 @@ describe 'Artwork Client', ->
       $('.artwork-section.artwork-auction-artworks').html().should.containEql 'Artwork 3'
       $('.artwork-section.artwork-auction-artworks').html().should.containEql '/auction-name'
       $('.artwork-section.artwork-auction-artworks').html().should.containEql 'Other Works from the Auction'
+
+      $('.artwork-section.artwork-auction-artworks [data-id]').first().html().should
+        .containEql @data.followed_artist_ids.hits[0].id
 
       $('.artwork-section.artwork-show-artworks').html().should.containEql 'Artwork 4'
       $('.artwork-section.artwork-show-artworks').html().should.containEql '/some-show'

--- a/desktop/apps/artwork/client/test/index.coffee
+++ b/desktop/apps/artwork/client/test/index.coffee
@@ -14,9 +14,9 @@ describe 'Artwork Client', ->
       benv.expose
         $: benv.require('jquery'),
         jQuery: benv.require('jquery')
-        location:
-          search: '?auction_id=test-auction'
         sd:
+          AUCTION:
+            id: 'test-auction'
           CLIENT:
             artists: []
 

--- a/desktop/apps/artwork/components/auction_artworks/helpers.coffee
+++ b/desktop/apps/artwork/components/auction_artworks/helpers.coffee
@@ -1,7 +1,7 @@
 masonry = require '../../../../components/artwork_masonry_4_column/index.coffee'
 moment = require 'moment'
 { ARTWORK_DISPLAY_NUM } = require './config.coffee'
-{ include, shuffle, take } = require 'underscore'
+{ include, partition, pluck, shuffle, take } = require 'underscore'
 
 isLiveOpen = (status, live_start_at) ->
   status == 'open' and moment().isAfter(live_start_at)
@@ -13,8 +13,16 @@ zone = (time) ->
   moment(time).tz('America/New_York')
 
 module.exports =
-  masonry: (artworks) ->
-    masonry take shuffle(artworks), ARTWORK_DISPLAY_NUM
+  masonry: (artworks, followed_artist_ids) ->
+    followIds = pluck followed_artist_ids.hits, 'id'
+
+    # Find followed artists and prepare to prepend to results array
+    [followed, rest] = partition artworks, (artwork) =>
+      followIds.some (id) =>
+        artwork.id == id
+
+    displayArtworkResults = take shuffle(followed).concat(shuffle(rest)), ARTWORK_DISPLAY_NUM
+    masonry displayArtworkResults
 
   upcomingLabel: (start_at, end_at, live_start_at, status) ->
     timeFormat = 'MMM D, h:mm A z'

--- a/desktop/apps/artwork/components/auction_artworks/helpers.coffee
+++ b/desktop/apps/artwork/components/auction_artworks/helpers.coffee
@@ -17,9 +17,9 @@ module.exports =
     followIds = pluck followed_artist_ids.hits, 'id'
 
     # Find followed artists and prepare to prepend to results array
-    [followed, rest] = partition artworks, (artwork) =>
-      followIds.some (id) =>
-        artwork.id == id
+    [followed, rest] = partition artworks,
+      (artwork) =>
+        followIds.some (id) => id == artwork.id
 
     displayArtworkResults = take shuffle(followed).concat(shuffle(rest)), ARTWORK_DISPLAY_NUM
     masonry displayArtworkResults

--- a/desktop/apps/artwork/components/auction_artworks/index.jade
+++ b/desktop/apps/artwork/components/auction_artworks/index.jade
@@ -19,7 +19,7 @@ if artwork.auction && artwork.auction.artworks && artwork.auction.artworks.lengt
     .artwork-auction-artworks__auction-name
       | #{auction.name} #{auctionLabel}
 
-    - var columns = helpers.auction_artworks.masonry(auction.artworks).columns
+    - var columns = helpers.auction_artworks.masonry(auction.artworks, followed_artist_ids).columns
     include ../../../../components/artwork_masonry_4_column/index
     
     .artwork-auction-artworks__view-all

--- a/desktop/apps/artwork/components/auction_artworks/index.jade
+++ b/desktop/apps/artwork/components/auction_artworks/index.jade
@@ -5,9 +5,10 @@ if artwork.auction && artwork.auction.artworks && artwork.auction.artworks.lengt
   - var end_at = auction.end_at
   - var live_start_at = auction.live_start_at
   - var status = auction.status
+  - var totalArtworks = auction.eligible_sale_artworks_count
   
   - var auctionLabel = upcomingLabel(start_at, end_at, live_start_at, status)
-
+  
   section.artwork-section.artwork-auction-artworks( class='js-artwork-auction-artworks' )
     header.artwork-auction-artworks__header
       h3.artwork-auction-artworks__header__name
@@ -26,4 +27,4 @@ if artwork.auction && artwork.auction.artworks && artwork.auction.artworks.lengt
       .artwork-auction-artworks__view-all__mask
       .artwork-auction-artworks__view-all__button
         a( href= auction.href )
-          | View All Lots
+          | View (#{totalArtworks}) Lots

--- a/desktop/apps/artwork/components/auction_artworks/query.coffee
+++ b/desktop/apps/artwork/components/auction_artworks/query.coffee
@@ -1,6 +1,6 @@
 { ARTWORK_DISPLAY_NUM } = require './config.coffee'
 
-module.exports = """
+module.exports.auction_artworks = """
   fragment auction_artworks on Artwork {
     auction: context {
       ... on ArtworkContextAuction {
@@ -18,4 +18,18 @@ module.exports = """
     }
   }
   #{require '../../../../components/auction_artwork_brick/query.coffee'}
+"""
+
+module.exports.followed_artist_ids = """
+  fragment followed_artist_ids on RootQueryType {
+    followed_artist_ids: filter_artworks(
+      sale_id: $auctionId
+      size: #{ARTWORK_DISPLAY_NUM},
+      include_artworks_by_followed_artists: true
+    ) {
+      hits {
+        id
+      }
+    }
+  }
 """

--- a/desktop/apps/artwork/components/auction_artworks/query.coffee
+++ b/desktop/apps/artwork/components/auction_artworks/query.coffee
@@ -10,6 +10,7 @@ module.exports.auction_artworks = """
         start_at
         live_start_at
         end_at
+        eligible_sale_artworks_count
 
         artworks(size: #{ARTWORK_DISPLAY_NUM}, exclude: [$id]) {
           ... auction_artwork_brick

--- a/desktop/apps/artwork/components/auction_artworks/query.coffee
+++ b/desktop/apps/artwork/components/auction_artworks/query.coffee
@@ -21,16 +21,26 @@ module.exports.auction_artworks = """
   #{require '../../../../components/auction_artwork_brick/query.coffee'}
 """
 
-module.exports.followed_artist_ids = """
+module.exports.followed_artist_ids = (CurrentUser) =>
+  isLoggedIn = Boolean(CurrentUser)
+
+  """
   fragment followed_artist_ids on RootQueryType {
     followed_artist_ids: filter_artworks(
       sale_id: $auctionId
       size: #{ARTWORK_DISPLAY_NUM},
-      include_artworks_by_followed_artists: true
+      #{
+        # Guard against this query field as it will throw, even if false, if
+        # not logged in.
+        if isLoggedIn
+          "include_artworks_by_followed_artists: true"
+        else
+          ""
+      }
     ) {
       hits {
         id
       }
     }
   }
-"""
+  """

--- a/desktop/apps/auction/test/templates.coffee
+++ b/desktop/apps/auction/test/templates.coffee
@@ -120,7 +120,7 @@ describe 'auction templates', ->
 
       it 'shows a timer for when live bidding opens', ->
         $('.auction-callout').text().should.containEql 'Live bidding begins'
-        $('.auction-callout').text().should.containEql 'EST'
+        $('.auction-callout').text().should.containEql 'EDT'
 
     describe 'live auction that is open for live bidding', ->
       before (done) ->
@@ -136,7 +136,7 @@ describe 'auction templates', ->
 
       it 'says live bidding now open', ->
         $('.auction-callout').text().should.containEql 'Live bidding now open'
-        $('.auction-callout').text().should.not.containEql 'EST'
+        $('.auction-callout').text().should.not.containEql 'EDT'
 
   describe 'open auction with no user', ->
     before (done) ->
@@ -201,4 +201,3 @@ describe 'auction templates', ->
     it 'shows Registration closed', ->
       $('.auction-header-metadata').text().should.containEql 'Registration closed'
       $('.auction-header-metadata').text().should.containEql 'Registration required to bid'
-


### PR DESCRIPTION
This PR finishes up #969 by 
- Taking associated artwork lots and sorting them first by artists that you follow and then everything else
- Returning the total number of lots and adding it to the "View All Lots" button 

#### To Test
```sh
git checkout -b damassi-cp-artwork-sort-auction-lots master
git pull https://github.com/damassi/force.git cp-artwork-sort-auction-lots
yarn start
```

1. Log out
1. Navigate to http://localhost:5000/auction/example-auction
1. Click into an artwork from the sale 
1. Make sure everything loads, and the associated lot artworks are coming back randomized and no page errors (fetching favorites without a favorite will throw)
1. Log in 
1. Favorite an artist from the sale 
1. Refresh and notice that that artist is always first in the queue 
  1. If you have favorited multiple artists from the sale, their order will be shuffled
1. Notice once you expand the full lot list that there is now a count associated with the `View (100) Lots` button at the bottom