### PR TITLE
Added CR+LF to sitemaps.txt.

### DIFF
--- a/desktop/apps/sitemaps/routes.coffee
+++ b/desktop/apps/sitemaps/routes.coffee
@@ -254,6 +254,7 @@ resultToBingJSON = (result) ->
     Disallow: ?from-show-guide=
     Sitemap: #{APP_URL}/sitemap.xml
     Sitemap: #{APP_URL}/images_sitemap.xml
+
   """
   res.send switch NODE_ENV
     when 'production'

--- a/desktop/apps/sitemaps/test/routes.coffee
+++ b/desktop/apps/sitemaps/test/routes.coffee
@@ -31,11 +31,17 @@ describe 'Sitemaps', ->
       @res.send.args[0][0]
         .should.equal  'User-agent: *\nNoindex: /'
 
-    it 'renders the normal robots with sitemap in production', ->
-      routes.__set__ NODE_ENV: 'production', APP_URL: 'https://www.artsy.net'
-      routes.robots null, @res
-      @res.send.args[0][0]
-        .should.containEql  'User-agent: *\nNoindex: ?sort=\nNoindex: ?dimension_range=\nDisallow: ?dns_source=\nDisallow: ?microsite=\nDisallow: ?from-show-guide=\nSitemap: https://www.artsy.net/sitemap.xml\nSitemap: https://www.artsy.net/images_sitemap.xml'
+    describe 'production', ->
+      beforeEach ->
+        routes.__set__ NODE_ENV: 'production', APP_URL: 'https://www.artsy.net'
+        routes.robots null, @res
+
+      it 'renders the normal robots with sitemap in production', ->
+        @res.send.args[0][0]
+          .should.containEql  'User-agent: *\nNoindex: ?sort=\nNoindex: ?dimension_range=\nDisallow: ?dns_source=\nDisallow: ?microsite=\nDisallow: ?from-show-guide=\nSitemap: https://www.artsy.net/sitemap.xml\nSitemap: https://www.artsy.net/images_sitemap.xml'
+
+      it 'includes a CR/LF at the end of robots.txt', ->
+        @res.send.args[0][0].slice(-1).should.eql('\n')
 
   describe '#news_sitemap', ->
 


### PR DESCRIPTION
What if https://github.com/artsy/collector-experience/issues/62 was just a CR+LF problem?

```
curl https://www.artsy.net/robots.txt
User-agent: *
Noindex: ?sort=
Noindex: ?dimension_range=
Disallow: ?dns_source=
Disallow: ?microsite=
Disallow: ?from-show-guide=
Sitemap: https://www.artsy.net/sitemap.xml
Sitemap: https://www.artsy.net/images_sitemap.xml~/source/artsy/force/dblock (sitemap-crlf)$ 
```