### PR TITLE
@wrgoldstein => Replace Segment Write Key with AMP-specific one

### DIFF
--- a/desktop/apps/article/templates/amp_mixins.jade
+++ b/desktop/apps/article/templates/amp_mixins.jade
@@ -86,7 +86,7 @@ mixin amp_analytics
     script(type="application/json").
       {
         "vars": {
-          "writeKey": "#{sd.SEGMENT_WRITE_KEY}",
+          "writeKey": "#{sd.SEGMENT_AMP_WRITE_KEY}",
           "name": "#{article.href()}"
         },
         "extraUrlParams": {

--- a/desktop/config.coffee
+++ b/desktop/config.coffee
@@ -99,6 +99,7 @@ module.exports =
   FORCE_MERGE_URL: 'https://merged.artsy.net'
   FORCE_MERGE_WEIGHT: 0
   S3_BUCKET: null
+  SEGMENT_AMP_WRITE_KEY: null
 
 # Override any values with env variables if they exist.
 # You can set JSON-y values for env variables as well such as "true" or

--- a/desktop/lib/setup_sharify.coffee
+++ b/desktop/lib/setup_sharify.coffee
@@ -73,6 +73,7 @@ sharify.data = _.extend _.pick(config,
   'API_REQUEST_TIMEOUT'
   'PARSELY_KEY'
   'S3_BUCKET'
+  'SEGMENT_AMP_WRITE_KEY'
 ), {
   JS_EXT: if config.NODE_ENV in ["production", "staging"] then \
     ".min.js.cgz" else ".js"


### PR DESCRIPTION
We created a new Segment source that has a server type. The `SEGMENT_AMP_WRITE_KEY` points to this new source. This is required by Segment in order to send AMP analytics to GA. 