### PR TITLE
Prefer slugged images where available.

### DIFF
--- a/desktop/test/models/mixins/image_sizes.coffee
+++ b/desktop/test/models/mixins/image_sizes.coffee
@@ -88,15 +88,15 @@ describe 'Image Sizes Mixin', ->
   describe '#imageUrlForMaxSize', ->
     it 'picks the last size in the list', ->
       @model.set { image_versions: ['small', 'large'] }
-      @model.imageUrlForMaxSize().should.equal @model.imageUrlFor('large.jpg')
+      @model.imageUrlForMaxSize().should.equal '/bitty/large'
 
     it 'ignores the normalized (private) size', ->
       @model.set { image_versions: ['small', 'large', 'normalized'] }
-      @model.imageUrlForMaxSize().should.equal @model.imageUrlFor('large.jpg')
+      @model.imageUrlForMaxSize().should.equal '/bitty/large'
 
     it 'favors the largest size', ->
       @model.set { image_versions: ['larger', 'large', 'tall'] }
-      @model.imageUrlForMaxSize().should.equal @model.imageUrlFor('larger.jpg')
+      @model.imageUrlForMaxSize().should.equal '/bitty/larger'
 
   describe '#aspectRatio', ->
     it 'returns the image aspect ratio', ->


### PR DESCRIPTION
Setting up an SEO experiment via https://github.com/artsy/barium-ion in which we added a "slugged" version for about 4000 artworks from a single sitemap. The goal of this PR is to make both the website and the sitemap to use that version as the preferred image version with the hope that google will like a file name such as `artist-artwork-title.jpg` more than `larger.jpg`. We don't currently have a plan of how to operationalize this if it works.

This also fixes a bug in the tests where `@model.imageUrlFor('large.jpg')` would always return `large`, that function takes a min width and height, not a JPG.
