### PR TITLE
Switch to using new sale artworks endpoint and some little cleanup

### DIFF
--- a/desktop/apps/auction2/client.js
+++ b/desktop/apps/auction2/client.js
@@ -62,22 +62,29 @@ render(
 
 store.dispatch(actions.fetchArtworks())
 
-// 1 second delay for checkbox selections
-let timer = null
-function delayedScroll() {
-  clearTimeout(timer)
-  timer = setTimeout($('html,body').animate( { scrollTop: 0 }, 400), 1000)
+// scroll up if you select a checkbox or sort
+function scrollToTop() {
+  $('html,body').animate( {
+    scrollTop: $('.auction2-my-active-bids').offset().top - $('.mlh-navbar').height()
+  }, 400)
 }
+
+$('body').on('click', '.artsy-checkbox', () => scrollToTop())
+$('body').on('click', '.bordered-pulldown-options a', (e) => {
+  e.preventDefault()
+  $('.bordered-pulldown-options').hidehover()
+  scrollToTop()
+})
 
 // jump view
 const jump = new JumpView({
   threshold: $(window).height(),
   direction: 'bottom',
-  position: $('#cf-artworks').offset().top - $('.mlh-navbar').height()
+  position: $('.auction2-my-active-bids').offset().top - $('.mlh-navbar').height()
 })
 $('body').append(jump.$el)
 
-jump.scrollToPosition(0)
+jump.scrollToPosition($('.mlh-navbar').offset().top)
 
 // infinite scroll
 function infiniteScroll() {

--- a/desktop/apps/auction2/components/auction_artworks/index.js
+++ b/desktop/apps/auction2/components/auction_artworks/index.js
@@ -3,13 +3,13 @@ import AuctionListArtwork from '../auction_list_artwork'
 import { default as React, PropTypes } from 'react';
 import { connect } from 'react-redux'
 
-function AuctionArtworks({ allFetched, artworks, isFetchingArtworks, isListView }) {
+function AuctionArtworks({ allFetched, isFetchingArtworks, isListView, saleArtworks }) {
   const DisplayComponent = isListView ? AuctionListArtwork : AuctionGridArtwork
   return (
     <div className='auction2-artworks'>
       {
-        artworks.map((artwork) => (
-          <DisplayComponent key={artwork._id} artwork={artwork} />
+        saleArtworks.map((saleArtwork) => (
+          <DisplayComponent key={saleArtwork.id} saleArtwork={saleArtwork} />
         ))
       }
       { isFetchingArtworks && <div className='loading-spinner'></div> }
@@ -20,9 +20,9 @@ function AuctionArtworks({ allFetched, artworks, isFetchingArtworks, isListView 
 const mapStateToProps = (state) => {
   return {
     allFetched: state.auctionArtworks.allFetched,
-    artworks: state.auctionArtworks.artworks,
     isFetchingArtworks: state.auctionArtworks.isFetchingArtworks,
-    isListView: state.auctionArtworks.isListView
+    isListView: state.auctionArtworks.isListView,
+    saleArtworks: state.auctionArtworks.saleArtworks
   }
 }
 

--- a/desktop/apps/auction2/components/auction_grid_artwork/index.js
+++ b/desktop/apps/auction2/components/auction_grid_artwork/index.js
@@ -3,15 +3,14 @@ import { get } from 'lodash'
 import { default as React, PropTypes } from 'react';
 import { titleAndYear } from '../../utils/artwork'
 
-export default function AuctionGridArtwork({ artwork }) {
+export default function AuctionGridArtwork({ saleArtwork }) {
+  const artwork = saleArtwork.artwork
   const artists = artwork.artists
   const artistDisplay = artists && artists.length > 0 ? artists.map((aa) => aa.name).join(', ') : null
   const artworkImage = get(artwork, 'images.0.image_url', '/images/missing_image.png')
 
   let bidStatus
-  if (artwork.sale_artwork) {
-    bidStatus = <BidStatus artwork={artwork} />
-  }
+  bidStatus = <BidStatus saleArtwork={saleArtwork} />
 
   return (
     <div className='auction2-grid-artwork' key={artwork._id}>
@@ -27,7 +26,7 @@ export default function AuctionGridArtwork({ artwork }) {
       <div className='auction2-grid-artwork__metadata'>
         <div className='auction2-grid-artwork__lot-information'>
           <div className='auction2-grid-artwork__lot-number'>
-            Lot {artwork.sale_artwork && artwork.sale_artwork.lot_number}
+            Lot {saleArtwork.lot_number}
           </div>
           <div>{ bidStatus }</div>
         </div>

--- a/desktop/apps/auction2/components/auction_list_artwork/index.js
+++ b/desktop/apps/auction2/components/auction_list_artwork/index.js
@@ -3,15 +3,14 @@ import { get } from 'lodash'
 import { default as React, PropTypes } from 'react';
 import { titleAndYear } from '../../utils/artwork'
 
-export default function AuctionGridArtwork({ artwork }) {
+export default function AuctionGridArtwork({ saleArtwork }) {
+  const artwork = saleArtwork.artwork
   const artists = artwork.artists
   const artistDisplay = artists && artists.length > 0 ? artists.map((aa) => aa.name).join(', ') : null
   const artworkImage = get(artwork, 'images.0.image_url', '/images/missing_image.png')
 
   let bidStatus
-  if (artwork.sale_artwork) {
-    bidStatus = <BidStatus artwork={artwork} />
-  }
+  bidStatus = <BidStatus saleArtwork={saleArtwork} />
 
   return (
     <div className='auction2-list-artwork' key={artwork._id}>
@@ -25,7 +24,7 @@ export default function AuctionGridArtwork({ artwork }) {
         <div className='auction2-list-artwork__title' dangerouslySetInnerHTML={{ __html: titleAndYear(artwork.title, artwork.date) }}></div>
       </div>
       <div className='auction2-list-artwork__lot-number'>
-        Lot {artwork.sale_artwork && artwork.sale_artwork.lot_number}
+        Lot {saleArtwork.lot_number}
       </div>
       { bidStatus }
     </div>

--- a/desktop/apps/auction2/components/basic_checkbox/index.js
+++ b/desktop/apps/auction2/components/basic_checkbox/index.js
@@ -23,7 +23,7 @@ export default function BasicCheckbox(props) {
         </div>
         <label className='artsy-checkbox--label' htmlFor={item.id}>
           { item.name }
-          { item.count && <span className='artsy-checkbox--count'>({item.count})</span> }
+          { item.count !== undefined && <span className='artsy-checkbox--count'>({item.count})</span> }
         </label>
       </div>
     </div>

--- a/desktop/apps/auction2/components/bid_status/index.js
+++ b/desktop/apps/auction2/components/bid_status/index.js
@@ -1,10 +1,8 @@
 import { default as React, PropTypes } from 'react';
 
-export default function BidStatus({ artwork }) {
-  const saleArtwork = artwork.sale_artwork
-
+export default function BidStatus({ saleArtwork }) {
   let bidLabel
-  if (saleArtwork && saleArtwork.counts && saleArtwork.counts.bidder_positions > 0) {
+  if (saleArtwork.counts && saleArtwork.counts.bidder_positions > 0) {
     const bidOrBids = saleArtwork.counts.bidder_positions > 1 ? 'Bids' : 'Bid'
     bidLabel = `(${saleArtwork.counts.bidder_positions} ${bidOrBids})`
   } else {

--- a/desktop/apps/auction2/components/filter_sort/index.js
+++ b/desktop/apps/auction2/components/filter_sort/index.js
@@ -10,6 +10,10 @@ function FilterSort(props) {
     updateSortAction
   } = props
   const selectedSort = filterParams.sort
+  const itemHeight = 37
+  const itemIndex = Object.keys(sortMap).indexOf(selectedSort)
+  const optionsOffset = (itemIndex) * itemHeight
+
   return (
     <div className='auction2-filter-sort'>
       <span className='auction2-filter-sort__label bordered-pulldown-label'>Sort by:</span>
@@ -20,7 +24,7 @@ function FilterSort(props) {
             <span className='caret'></span>
           </div>
         </a>
-        <div className='bordered-pulldown-options'>
+        <div className='bordered-pulldown-options' style={ { top: -optionsOffset } }>
           {
             _.map(sortMap, (sortName, sort) => {
               const selected = sort == selectedSort

--- a/desktop/apps/auction2/components/header/index.js
+++ b/desktop/apps/auction2/components/header/index.js
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import Grid from '../../../../components/main_layout/public/icons/grid.svg'
 import List from '../../../../components/main_layout/public/icons/list.svg'
 import FilterSort from '../filter_sort'
-import { default as React, PropTypes } from 'react';
+import { default as React, PropTypes } from 'react'
 import { connect } from 'react-redux'
 
 function displayButtonClass(buttonType, displayType) {

--- a/desktop/apps/auction2/components/range_slider/index.js
+++ b/desktop/apps/auction2/components/range_slider/index.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux'
 
 function RangeSlider(props) {
   const {
+    currency,
     filterParams,
     minEstimateRangeDisplay,
     maxEstimateRangeDisplay,
@@ -15,8 +16,7 @@ function RangeSlider(props) {
 
   const minEstimate = filterParams.ranges.estimate_range.min
   const maxEstimate = filterParams.ranges.estimate_range.max
-  // TODO: Get currency from sale!!!!!
-  const formattedMinDisplay = formatMoney(minEstimateRangeDisplay, { precision: 0 })
+  const formattedMinDisplay = formatMoney(minEstimateRangeDisplay, { symbol: currency, precision: 0 })
   const formattedMaxDisplay = formatMoney(maxEstimateRangeDisplay, { symbol: '', precision: 0 })
   return (
     <div className='auction2-range-slider'>
@@ -40,6 +40,7 @@ function RangeSlider(props) {
 
 const mapStateToProps = (state) => {
   return {
+    currency: state.auctionArtworks.currency,
     filterParams: state.auctionArtworks.filterParams,
     minEstimateRangeDisplay: state.auctionArtworks.minEstimateRangeDisplay,
     maxEstimateRangeDisplay: state.auctionArtworks.maxEstimateRangeDisplay

--- a/desktop/apps/auction2/components/sidebar/index.js
+++ b/desktop/apps/auction2/components/sidebar/index.js
@@ -1,16 +1,60 @@
+import { updateArtistsYouFollowParam } from '../../actions'
 import ArtistFilter from '../artist_filter'
+import BasicCheckbox from '../basic_checkbox'
 import MediumFilter from '../medium_filter'
 import RangeSlider from '../range_slider'
-import { default as React, PropTypes } from 'react';
+import { default as React, PropTypes } from 'react'
+import { connect } from 'react-redux'
 
-export default function Sidebar() {
+function Sidebar(props) {
+  const {
+    filterParams,
+    numArtistsYouFollow,
+    updateArtistsYouFollowParamAction,
+    user
+  } = props
+
+  const artistsYouFollow = {
+    id: 'artists-you-follow',
+    count: numArtistsYouFollow,
+    name: 'Artists You Follow'
+  }
+
   return (
     <div className='auction2-artworks-sidebar'>
       <div className='auction2-artworks-sidebar__artist-filter'>
         <RangeSlider />
         <MediumFilter />
+        {
+          user &&
+          <div className='auction2-artworks-sidebar__artists-you-follow'>
+            <BasicCheckbox
+              key={artistsYouFollow.id}
+              item={artistsYouFollow}
+              onClick={updateArtistsYouFollowParamAction}
+              checked={filterParams.include_artworks_by_followed_artists}
+            />
+          </div>
+        }
         <ArtistFilter />
       </div>
     </div>
   )
 }
+
+const mapStateToProps = (state) => {
+  return {
+    filterParams: state.auctionArtworks.filterParams,
+    numArtistsYouFollow: state.auctionArtworks.numArtistsYouFollow,
+    user: state.auctionArtworks.user
+  }
+}
+
+const mapDispatchToProps = {
+  updateArtistsYouFollowParamAction: updateArtistsYouFollowParam
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Sidebar)

--- a/desktop/apps/auction2/components/sidebar/index.styl
+++ b/desktop/apps/auction2/components/sidebar/index.styl
@@ -1,0 +1,6 @@
+.auction2-artworks-sidebar
+  &__artists-you-follow
+    margin-top 10px
+    padding-top 20px
+    padding-bottom 10px
+    border-top 1px solid gray-lighter-color

--- a/desktop/apps/auction2/filter_query.js
+++ b/desktop/apps/auction2/filter_query.js
@@ -1,32 +1,26 @@
 export const filterQuery = `
-  query filterArtworks(
-    $aggregations: [ArtworkAggregation],
+  query filterSaleArtworks(
+    $aggregations: [SaleArtworkAggregation],
     $page: Int,
     $size: Int,
     $estimate_range: String,
-    $gene_id: String,
     $gene_ids: [String],
     $artist_ids: [String],
     $sale_id: ID,
-    $medium: String,
     $sort: String,
     $include_artworks_by_followed_artists: Boolean
   ){
-    filter_artworks(
+    filter_sale_artworks(
       aggregations: $aggregations,
       page: $page,
       size: $size,
       estimate_range: $estimate_range,
-      gene_id: $gene_id,
       gene_ids: $gene_ids,
       artist_ids: $artist_ids,
       sale_id: $sale_id,
-      medium: $medium,
       sort: $sort,
       include_artworks_by_followed_artists: $include_artworks_by_followed_artists
     ){
-      total
-      followed_artists_total
       aggregations {
         slice
         counts {
@@ -35,31 +29,35 @@ export const filterQuery = `
           count
         }
       }
+      counts {
+        total
+        followed_artists
+      }
       hits {
         id
-        _id
-        href
-        title
-        date
-        images {
-          id
-          image_url: url(version: ["tall"])
-          image_versions: versions
-          placeholder: resized(width: 30, height: 30, version: "tall") {
-            image_url: url
-          }
+        lot_number
+        counts {
+          bidder_positions
         }
-        artists {
-          id
-          name
+        current_bid {
+          display
         }
-        sale_artwork {
-          lot_number
-          counts {
-            bidder_positions
+        artwork {
+          _id
+          href
+          title
+          date
+          images {
+            id
+            image_url: url(version: ["tall"])
+            image_versions: versions
+            placeholder: resized(width: 30, height: 30, version: "tall") {
+              image_url: url
+            }
           }
-          current_bid {
-            display
+          artists {
+            id
+            name
           }
         }
       }

--- a/desktop/apps/auction2/queries/sale.js
+++ b/desktop/apps/auction2/queries/sale.js
@@ -6,6 +6,7 @@ export default function SaleQuery(id) {
           url
         }
       }
+      currency
       description
       end_at
       id

--- a/desktop/apps/auction2/reducers.js
+++ b/desktop/apps/auction2/reducers.js
@@ -8,41 +8,64 @@ const initialState = {
   aggregatedArtists: [],
   aggregatedMediums: [],
   allFetched: false,
-  artworks: [],
+  currency: sd.AUCTION && sd.AUCTION.currency,
   filterParams: {
     aggregations: ['ARTIST', 'FOLLOWED_ARTISTS', 'MEDIUM', 'TOTAL'],
     artist_ids: [],
     estimate_range: '',
     gene_ids: [],
+    include_artworks_by_followed_artists: false,
     page: 1,
     sale_id: sd.AUCTION && sd.AUCTION.id,
     size: 50,
     ranges: {
       estimate_range: {
-        min: 50,
+        min: 0,
         max: 50000
       }
     },
-    sort: 'lot_number'
+    sort: 'position'
   },
   isFetchingArtworks: false,
   isListView: false,
   maxEstimateRangeDisplay: 50000,
-  minEstimateRangeDisplay: 50,
+  minEstimateRangeDisplay: 0,
+  numArtistsYouFollow: 0,
+  saleArtworks: [],
   sortMap: {
-    "lot_number": "Lot Number (asc.)",
-    "-lot_number": "Lot Number (desc.)",
+    "bidder_positions_count": "Number of Bids (asc.)",
+    "-bidder_positions_count": "Number of Bids (desc.)",
+    "position": "Lot Number (asc.)",
+    "-position": "Lot Number (desc.)",
     "-searchable_estimate": "Most Expensive",
     "searchable_estimate": "Least Expensive"
   },
-  total: 0
+  total: 0,
+  user: sd.CURRENT_USER
 }
 
 function auctionArtworks(state = initialState, action) {
   switch (action.type) {
-    case actions.TOGGLE_FETCHING_ARTWORKS: {
+    case actions.GET_ARTWORKS_FAILURE: {
       return u({
-        isFetchingArtworks: action.payload.isFetchingArtworks
+        isFetchingArtworks: false
+      }, state)
+    }
+    case actions.GET_ARTWORKS_REQUEST: {
+      return u({
+        isFetchingArtworks: true
+      }, state)
+    }
+    case actions.GET_ARTWORKS_SUCCESS: {
+      return u({
+        isFetchingArtworks: false
+      }, state)
+    }
+    case actions.TOGGLE_ARTISTS_YOU_FOLLOW: {
+      return u({
+        filterParams: {
+          include_artworks_by_followed_artists: !state.filterParams.include_artworks_by_followed_artists
+        }
       }, state)
     }
     case actions.TOGGLE_LIST_VIEW: {
@@ -61,7 +84,7 @@ function auctionArtworks(state = initialState, action) {
       }, state)
     }
     case actions.UPDATE_ALL_FETCHED: {
-      if (state.artworks.length === state.total) {
+      if (state.saleArtworks.length === state.total) {
         return u({
           allFetched: true
         }, state)
@@ -90,17 +113,6 @@ function auctionArtworks(state = initialState, action) {
           filterParams: {
             artist_ids: state.filterParams.artist_ids.concat(artistId)
           }
-        }, state)
-      }
-    }
-    case actions.UPDATE_ARTWORKS: {
-      if (state.filterParams.page > 1) {
-        return u({
-          artworks: state.artworks.concat(action.payload.artworks)
-        }, state)
-      } else {
-        return u({
-          artworks: action.payload.artworks
         }, state)
       }
     }
@@ -139,6 +151,11 @@ function auctionArtworks(state = initialState, action) {
         }, state)
       }
     }
+    case actions.UPDATE_NUM_ARTISTS_YOU_FOLLOW: {
+      return u({
+        numArtistsYouFollow: action.payload.numArtistsYouFollow
+      }, state)
+    }
     case actions.UPDATE_PAGE: {
       const reset = action.payload.reset
       if (reset === true) {
@@ -153,6 +170,17 @@ function auctionArtworks(state = initialState, action) {
           filterParams: {
             page: currentPage + 1
           }
+        }, state)
+      }
+    }
+    case actions.UPDATE_SALE_ARTWORKS: {
+      if (state.filterParams.page > 1) {
+        return u({
+          saleArtworks: state.saleArtworks.concat(action.payload.saleArtworks)
+        }, state)
+      } else {
+        return u({
+          saleArtworks: action.payload.saleArtworks
         }, state)
       }
     }

--- a/desktop/apps/auction2/stylesheets/index.styl
+++ b/desktop/apps/auction2/stylesheets/index.styl
@@ -18,6 +18,7 @@
 @require '../components/header/index'
 @require '../components/medium_filter/index'
 @require '../components/range_slider/index'
+@require '../components/sidebar/index'
 @require './banner'
 @require './header'
 @require './my_active_bids'

--- a/desktop/apps/auction2/test/reducers.js
+++ b/desktop/apps/auction2/test/reducers.js
@@ -49,25 +49,25 @@ describe('Reducers', () => {
       describe('#updateAllFetched', () => {
         it('updates allFetched to true if the total matches the number of artworks', () => {
           initialResponse.auctionArtworks.allFetched.should.eql(false)
-          initialResponse.auctionArtworks.artworks.should.eql([])
+          initialResponse.auctionArtworks.saleArtworks.should.eql([])
           initialResponse.auctionArtworks.total.should.eql(0)
-          const newArtworks = auctions(initialResponse, actions.updateArtworks(['artwork1', 'artwork2', 'artwork3']))
+          const newArtworks = auctions(initialResponse, actions.updateSaleArtworks(['artwork1', 'artwork2', 'artwork3']))
           const newTotal = auctions(newArtworks, actions.updateTotal(3))
           const allArtworksFetched = auctions(newTotal, actions.updateAllFetched())
           allArtworksFetched.auctionArtworks.allFetched.should.eql(true)
-          allArtworksFetched.auctionArtworks.artworks.should.eql(['artwork1', 'artwork2', 'artwork3'])
+          allArtworksFetched.auctionArtworks.saleArtworks.should.eql(['artwork1', 'artwork2', 'artwork3'])
           allArtworksFetched.auctionArtworks.total.should.eql(3)
         })
 
         it('updates allFetched to false if the total does not match the number of artworks', () => {
           initialResponse.auctionArtworks.allFetched.should.eql(false)
-          initialResponse.auctionArtworks.artworks.should.eql([])
+          initialResponse.auctionArtworks.saleArtworks.should.eql([])
           initialResponse.auctionArtworks.total.should.eql(0)
-          const newArtworks = auctions(initialResponse, actions.updateArtworks(['artwork1', 'artwork2', 'artwork3']))
+          const newArtworks = auctions(initialResponse, actions.updateSaleArtworks(['artwork1', 'artwork2', 'artwork3']))
           const newTotal = auctions(newArtworks, actions.updateTotal(10))
           const notAllArtworksFetched = auctions(newTotal, actions.updateAllFetched())
           notAllArtworksFetched.auctionArtworks.allFetched.should.eql(false)
-          notAllArtworksFetched.auctionArtworks.artworks.should.eql(['artwork1', 'artwork2', 'artwork3'])
+          notAllArtworksFetched.auctionArtworks.saleArtworks.should.eql(['artwork1', 'artwork2', 'artwork3'])
           notAllArtworksFetched.auctionArtworks.total.should.eql(10)
         })
       })
@@ -98,24 +98,24 @@ describe('Reducers', () => {
 
       describe('#updateArtworks', () => {
         it('resets the artworks if the page does not change', () => {
-          initialResponse.auctionArtworks.artworks.should.eql([])
+          initialResponse.auctionArtworks.saleArtworks.should.eql([])
           const newArtworks = [{ id: 'artwork-1' }, { id: 'artwork-2' }]
-          const updatedArtworks = auctions(initialResponse, actions.updateArtworks(newArtworks))
-          updatedArtworks.auctionArtworks.artworks.should.eql(newArtworks)
+          const updatedArtworks = auctions(initialResponse, actions.updateSaleArtworks(newArtworks))
+          updatedArtworks.auctionArtworks.saleArtworks.should.eql(newArtworks)
           const resetArtworks = [{ id: 'artwork-3' }]
-          const resettedArtworks = auctions(updatedArtworks, actions.updateArtworks(resetArtworks))
-          resettedArtworks.auctionArtworks.artworks.should.eql(resetArtworks)
+          const resettedArtworks = auctions(updatedArtworks, actions.updateSaleArtworks(resetArtworks))
+          resettedArtworks.auctionArtworks.saleArtworks.should.eql(resetArtworks)
         })
 
         it('concatenates the artworks if the page is above 1', () => {
-          initialResponse.auctionArtworks.artworks.should.eql([])
+          initialResponse.auctionArtworks.saleArtworks.should.eql([])
           const newArtworks = [{ id: 'artwork-1' }, { id: 'artwork-2' }]
-          const updatedArtworks = auctions(initialResponse, actions.updateArtworks(newArtworks))
-          updatedArtworks.auctionArtworks.artworks.should.eql(newArtworks)
+          const updatedArtworks = auctions(initialResponse, actions.updateSaleArtworks(newArtworks))
+          updatedArtworks.auctionArtworks.saleArtworks.should.eql(newArtworks)
           const newPage = auctions(updatedArtworks, actions.updatePage(false))
           const concatArtworks = [{ id: 'artwork-3' }]
-          const concatenatedArtworks = auctions(newPage, actions.updateArtworks(concatArtworks))
-          concatenatedArtworks.auctionArtworks.artworks.should.eql([
+          const concatenatedArtworks = auctions(newPage, actions.updateSaleArtworks(concatArtworks))
+          concatenatedArtworks.auctionArtworks.saleArtworks.should.eql([
             { id: 'artwork-1' },
             { id: 'artwork-2' },
             { id: 'artwork-3' }
@@ -126,7 +126,7 @@ describe('Reducers', () => {
       describe('#updateEstimateDisplay', () => {
         it('updates the estimate display', () => {
           initialResponse.auctionArtworks.maxEstimateRangeDisplay.should.eql(50000)
-          initialResponse.auctionArtworks.minEstimateRangeDisplay.should.eql(50)
+          initialResponse.auctionArtworks.minEstimateRangeDisplay.should.eql(0)
           const updatedEstimateDisplay = auctions(initialResponse, actions.updateEstimateDisplay(100, 20000))
           updatedEstimateDisplay.auctionArtworks.maxEstimateRangeDisplay.should.eql(20000)
           updatedEstimateDisplay.auctionArtworks.minEstimateRangeDisplay.should.eql(100)
@@ -179,9 +179,9 @@ describe('Reducers', () => {
 
       describe('#updateSortParam', () => {
         it('updates the sort param', () => {
-          initialResponse.auctionArtworks.filterParams.sort.should.eql('lot_number')
-          const updatedSort = auctions(initialResponse, actions.updateSortParam('-lot_number'))
-          updatedSort.auctionArtworks.filterParams.sort.should.eql('-lot_number')
+          initialResponse.auctionArtworks.filterParams.sort.should.eql('position')
+          const updatedSort = auctions(initialResponse, actions.updateSortParam('-position'))
+          updatedSort.auctionArtworks.filterParams.sort.should.eql('-position')
         })
       })
 


### PR DESCRIPTION
Looks like a lot, but it's mostly just little things + cleanup:
- Updated our `filter_query` to point to the `filter_sale_artworks` endpoint instead of the `filter_artworks` endpoint. The fallout from this is that I renamed the top-level array to `saleArtworks`, and had to update a bunch of the references.
- Added a checkbox for "Artists You Follow" (which only shows up if you are a logged-in user)
![image](https://cloud.githubusercontent.com/assets/2081340/23921666/daf0d772-08d5-11e7-811a-e85778cad327.png)

- Updated the filter sort component to slide up and down depending on which item is selected.
![image](https://cloud.githubusercontent.com/assets/2081340/23921520/4b900198-08d5-11e7-9132-b3108bc202d5.png)
- Updated the range slider use `sale.currency`, which is still a bandaid (albeit better). A forthcoming gravity PR will export `symbol` in a sale's JSON so we can use that.
- It now jumps to the top of the "My Active Bids" section when you select a checkbox or use the jump arrow
- Following @damassi's suggestion, I got rid of `TOGGLE_FETCHING_ARTWORKS` and created multiple actions to represent what is actually happening (`GET_ARTWORKS_FAILURE`, `GET_ARTWORKS_REQUEST`, `GET_ARTWORKS_SUCCESS`)

TODO:
- Update range slider to display the sale currency _symbol_ (as mentioned)
- Update our ES aggregation logic to _also_ update the artist aggregation when `include_artworks_by_followed_artists=true` is passed in.