### PR TITLE
@sweir27 => use shared object not backbone model

### DIFF
--- a/desktop/apps/auction2/client.js
+++ b/desktop/apps/auction2/client.js
@@ -44,7 +44,7 @@ if (user && sd.AUCTION && sd.AUCTION.is_open && sd.AUCTION.is_live_open === fals
     user: user,
     el: $('.auction2-my-active-bids'),
     template: myActiveBidsTemplate,
-    saleId: auction.get('_id')
+    saleId: sd.AUCTION.id
   })
   activeBids.start()
 }


### PR DESCRIPTION
`auction.get('_id')` is undefined (should be `id`), but I think we should just use the object from metaphysics here anyways.