### PR TITLE
@eessex => Custom dimension tracking on AMP

### DIFF
--- a/desktop/apps/article/templates/amp_mixins.jade
+++ b/desktop/apps/article/templates/amp_mixins.jade
@@ -97,7 +97,8 @@ mixin amp_analytics
           "properties.articleSection": "#{article.getParselySection()}",
           "properties.thumbnailUrl": "#{article.get('thumbnail_image')}",
           "properties.url": "#{article.fullHref()}",
-          "properties.headline": "#{article.get('thumbnail_title')}"
+          "properties.headline": "#{article.get('thumbnail_title')}",
+          "properties.library": "amp"
         }
       }
   amp-analytics(type="parsely")


### PR DESCRIPTION
We need to add a custom dimension to be able to distinguish AMP content from regular search. Right now they're just bundled together. So many hoops -.- 