### PR TITLE
@kanaabe => Hide collector marketing pages for now

### DIFF
--- a/desktop/apps/auth/index.coffee
+++ b/desktop/apps/auth/index.coffee
@@ -5,6 +5,7 @@
 
 express = require 'express'
 routes = require './routes'
+adminOnly = require '../../lib/middleware/admin_only'
 { twitterLastStepPath } = require('artsy-passport').options
 
 app = module.exports = express()
@@ -12,6 +13,6 @@ app.set 'views', "#{__dirname}/templates"
 app.set 'view engine', 'jade'
 
 app.get '/reset_password', routes.resetPassword
-app.get '/signup', routes.signUp
-app.get '/login', routes.logIn
+app.get '/signup', adminOnly, routes.signUp
+app.get '/login', adminOnly, routes.logIn
 app.get twitterLastStepPath, routes.twitterLastStep

--- a/desktop/apps/buy_art/index.coffee
+++ b/desktop/apps/buy_art/index.coffee
@@ -15,7 +15,7 @@ landing = new JSONPage
 
 { data, edit, upload } = require('../../components/json_page/routes')(landing)
 
-app.get landing.paths.show, routes.landing
-app.get landing.paths.show + '/data', data
+app.get landing.paths.show, adminOnly, routes.landing
+app.get landing.paths.show + '/data', adminOnly, data
 app.get landing.paths.edit, adminOnly, edit
 app.post landing.paths.edit, adminOnly, upload


### PR DESCRIPTION
This would allow us to deploy without exposing unfinished work.