### PR TITLE
fix undefined variable

### DIFF
--- a/mobile/analytics/criteo.js
+++ b/mobile/analytics/criteo.js
@@ -28,7 +28,7 @@ if (pathSplit[1] === "auctions") {
     // https://www.artsy.net/auction/:auction_id/bid - (AUCTIONS trackTransaction)
     //              0          1          2       3
     analyticsHooks.on("confirm:bid", function(bidderPosition) {
-      price = bidderPosition.get("max_bid_amount_cents") ? bidderPosition.get("max_bid_amount_cents") / 100 : null;
+      var price = bidderPosition.get("max_bid_amount_cents") ? bidderPosition.get("max_bid_amount_cents") / 100 : null;
       window.criteo_q.push(
         { event: "setAccount", account: sd.CRITEO_AUCTIONS_ACCOUNT_NUMBER },
         { event: "setSiteType", type: "m" },


### PR DESCRIPTION
Undefined variable `price` is causing our bid screen to fail to progress. Two questions, since I'm not very up to date on Force:

- Can we use linting to catch errors like this at build-time?
- This code runs on an event handler, but since the event mechanism is synchronous, it crashes the whole turn of the event loop, interrupting the process it's responding to. Is there a better pattern we could use to avoid this? (e.g. a variant of `on` that uses `setTimeout` or a variant of `trigger` that swallows exceptions?)

**Crash site:**
![image](https://cloud.githubusercontent.com/assets/1256382/24023294/afaca5b6-0a81-11e7-97ae-7221b9cf2750.png)

**Crash trigger:**
The `success` function at the top on line 11399 is meant to be triggered on line 11428, but `f.trigger` on the previous line throws an exception, as seen in the previous image, preventing this line from ever executing.

![image](https://cloud.githubusercontent.com/assets/1256382/24023310/d5c16232-0a81-11e7-9606-981a78230274.png)
