### PR TITLE
@mzikherman : keyword filtering on collect

### DIFF
--- a/desktop/apps/collect/client.coffee
+++ b/desktop/apps/collect/client.coffee
@@ -62,9 +62,11 @@ module.exports.init = ->
     categoryMap: sd.CATEGORIES
 
   # Main Artworks view
-  keywordView = new KeywordFilterView
-    el: $('.cf-keyword')
-    params: params
+  if @user?.hasLabFeature('Keyword Search')
+    keywordView = new KeywordFilterView
+      el: $('.cf-keyword')
+      params: params
+      aggregations: filter.aggregations
 
   filter.artworks.on 'reset', ->
     artworkView = new ArtworkColumnsView

--- a/desktop/apps/collect/client.coffee
+++ b/desktop/apps/collect/client.coffee
@@ -16,6 +16,7 @@ PopularArtistsView = require '../../components/commercial_filter/views/popular_a
 PriceFilterView = require '../../components/commercial_filter/filters/price/price_filter_view.coffee'
 ColorFilterView = require '../../components/commercial_filter/filters/color/color_filter_view.coffee'
 SizeFilterView = require '../../components/commercial_filter/filters/size/size_filter_view.coffee'
+KeywordFilterView = require '../../components/commercial_filter/filters/keyword/keyword_filter_view.coffee'
 PillboxView = require '../../components/commercial_filter/views/pillbox/pillbox_view.coffee'
 ArtworkColumnsView = require '../../components/artwork_columns/view.coffee'
 scrollFrame = require 'scroll-frame'
@@ -61,6 +62,10 @@ module.exports.init = ->
     categoryMap: sd.CATEGORIES
 
   # Main Artworks view
+  keywordView = new KeywordFilterView
+    el: $('.cf-keyword')
+    params: params
+
   filter.artworks.on 'reset', ->
     artworkView = new ArtworkColumnsView
       collection: filter.artworks

--- a/desktop/apps/collect/client.coffee
+++ b/desktop/apps/collect/client.coffee
@@ -19,6 +19,7 @@ SizeFilterView = require '../../components/commercial_filter/filters/size/size_f
 KeywordFilterView = require '../../components/commercial_filter/filters/keyword/keyword_filter_view.coffee'
 PillboxView = require '../../components/commercial_filter/views/pillbox/pillbox_view.coffee'
 ArtworkColumnsView = require '../../components/artwork_columns/view.coffee'
+CurrentUser = require '../../models/current_user.coffee'
 scrollFrame = require 'scroll-frame'
 sd = require('sharify').data
 { fullyQualifiedLocations } = require '../../components/commercial_filter/filters/location/location_map.coffee'
@@ -62,7 +63,7 @@ module.exports.init = ->
     categoryMap: sd.CATEGORIES
 
   # Main Artworks view
-  if @user?.hasLabFeature('Keyword Search')
+  if CurrentUser.orNull()?.hasLabFeature('Keyword Search')
     keywordView = new KeywordFilterView
       el: $('.cf-keyword')
       params: params

--- a/desktop/apps/collect/templates/index.jade
+++ b/desktop/apps/collect/templates/index.jade
@@ -37,6 +37,8 @@ block body
           //- rendered on the client
       .cf-pillboxes
         //- rendered on the client
+      .cf-keyword
+        //- rendered on the client
       .cf-artworks
         //- rendered on the client
       hr

--- a/desktop/components/commercial_filter/filters/keyword/index.jade
+++ b/desktop/components/commercial_filter/filters/keyword/index.jade
@@ -5,7 +5,7 @@
     itemprop='query-input'
     type='text'
     name='keyword'
-    value= term
+    value= keyword
     autocomplete="off"
     autocorrect="off"
     autocapitalize="off"

--- a/desktop/components/commercial_filter/filters/keyword/index.jade
+++ b/desktop/components/commercial_filter/filters/keyword/index.jade
@@ -1,0 +1,13 @@
+#keyword-search-bar-container.typeahead
+  input#keyword-search-bar-input.bordered-input(
+    placeholder='Search…'
+    tabindex='1'
+    itemprop='query-input'
+    type='text'
+    name='keyword'
+    value= term
+    autocomplete="off"
+    autocorrect="off"
+    autocapitalize="off"
+    spellcheck="false"
+  )

--- a/desktop/components/commercial_filter/filters/keyword/index.styl
+++ b/desktop/components/commercial_filter/filters/keyword/index.styl
@@ -1,3 +1,2 @@
-.cf-keyword
-  height 60px
-  width 100%
+#keyword-search-bar-container
+  margin-bottom 20px

--- a/desktop/components/commercial_filter/filters/keyword/index.styl
+++ b/desktop/components/commercial_filter/filters/keyword/index.styl
@@ -1,0 +1,3 @@
+.cf-keyword
+  height 60px
+  width 100%

--- a/desktop/components/commercial_filter/filters/keyword/keyword_filter_view.coffee
+++ b/desktop/components/commercial_filter/filters/keyword/keyword_filter_view.coffee
@@ -1,0 +1,25 @@
+Backbone = require 'backbone'
+
+template = -> require('./index.jade') arguments...
+
+module.exports = class KeywordFilterView extends Backbone.View
+  className: 'cf-keyword'
+  events:
+    "change input#keyword-search-bar-input" : 'setKeyword'
+
+  initialize: ({ @params, aggregations }) ->
+    throw new Error "Requires a params model" unless @params
+    @listenToOnce @params, 'change', @render
+
+  setKeyword: (e) ->
+    if $('input[name=keyword]').val().length > 0
+      console.log('setting keyword to ' + $('input[name=keyword]').val())
+      @params.set keyword: $('input[name=keyword]').val()
+    else
+      console.log('unsetting keyword')
+      @params.unset 'keyword'
+
+  render: ->
+    #return if @params.get('include_artworks_by_followed_artists')
+    @$el.html template
+

--- a/desktop/components/commercial_filter/filters/keyword/keyword_filter_view.coffee
+++ b/desktop/components/commercial_filter/filters/keyword/keyword_filter_view.coffee
@@ -10,16 +10,16 @@ module.exports = class KeywordFilterView extends Backbone.View
   initialize: ({ @params, aggregations }) ->
     throw new Error "Requires a params model" unless @params
     @listenToOnce @params, 'change', @render
+    @listenTo @aggregations, 'reset', @render
 
   setKeyword: (e) ->
     if $('input[name=keyword]').val().length > 0
-      console.log('setting keyword to ' + $('input[name=keyword]').val())
       @params.set keyword: $('input[name=keyword]').val()
     else
-      console.log('unsetting keyword')
       @params.unset 'keyword'
 
   render: ->
-    #return if @params.get('include_artworks_by_followed_artists')
     @$el.html template
 
+    if @params.get('keyword')
+      $('input[name=keyword]').val(@params.get('keyword'))

--- a/desktop/components/commercial_filter/filters/keyword/keyword_filter_view.coffee
+++ b/desktop/components/commercial_filter/filters/keyword/keyword_filter_view.coffee
@@ -20,6 +20,4 @@ module.exports = class KeywordFilterView extends Backbone.View
 
   render: ->
     @$el.html template
-
-    if @params.get('keyword')
-      $('input[name=keyword]').val(@params.get('keyword'))
+      keyword: @params.get('keyword')

--- a/desktop/components/commercial_filter/models/filter.coffee
+++ b/desktop/components/commercial_filter/models/filter.coffee
@@ -68,7 +68,8 @@ module.exports = class Filter extends Backbone.Model
         $major_periods: [String],
         $partner_cities: [String],
         $aggregation_partner_cities: [String],
-        $include_artworks_by_followed_artists: Boolean
+        $include_artworks_by_followed_artists: Boolean,
+        $keyword: String
       ){
         filter_artworks(
           aggregations: $aggregations,
@@ -90,7 +91,8 @@ module.exports = class Filter extends Backbone.Model
           major_periods: $major_periods,
           partner_cities: $partner_cities,
           aggregation_partner_cities: $aggregation_partner_cities,
-          include_artworks_by_followed_artists: $include_artworks_by_followed_artists
+          include_artworks_by_followed_artists: $include_artworks_by_followed_artists,
+          keyword: $keyword
         ){
           total
           followed_artists_total

--- a/desktop/components/commercial_filter/models/params.coffee
+++ b/desktop/components/commercial_filter/models/params.coffee
@@ -17,7 +17,8 @@ module.exports = class Params extends Backbone.Model
     'partner_cities',
     'sale_id',
     'gene_ids',
-    'artist_ids'
+    'artist_ids',
+    'keyword'
   ]
 
   defaults:

--- a/desktop/components/commercial_filter/stylesheets/index.styl
+++ b/desktop/components/commercial_filter/stylesheets/index.styl
@@ -47,6 +47,7 @@ padding-unit = 15px
 @require '../../../../node_modules/artsy-ezel-components/pagination'
 @require '../../slider/index'
 @require '../filters/color'
+@require '../filters/keyword'
 @require '../filters/category'
 @require '../filters/period'
 @require '../filters/location'


### PR DESCRIPTION
This adds a new lab feature to `/collect` for keyword filtering of artworks. It's a free-form text field which searches genes, tags, auto tags and artwork titles, so you can type in anything from 'snow' to 'female portrait' to 'person on a beach' to 'furniture' and it gives pretty good results. 

Interaction is a bit clunky in that you have to hit enter for the keyword filter to execute. The filter can be combined with any other filter on collect - i've tested it with most. It can also be set via url as a `keyword=` param. 

I'd like to add artist names and medium to the list of searched fields, in order to make the search box more powerful, but i can follow up with that.

This depends on artsy/metaphysics#573.

cc @anandaroop 

![screen shot 2017-03-17 at 3 40 47 pm](https://cloud.githubusercontent.com/assets/64404/24048455/3c3e338a-0b29-11e7-8e22-bb871be45b29.png)

![screen shot 2017-03-17 at 3 47 15 pm](https://cloud.githubusercontent.com/assets/64404/24048573/a1933618-0b29-11e7-8d89-f2de1c1ade2f.png)


cc @anandaroop 