### PR TITLE
Adds missing check for query redirect URI

### DIFF
--- a/mobile/apps/auth/routes.coffee
+++ b/mobile/apps/auth/routes.coffee
@@ -10,6 +10,7 @@ sanitizeRedirect = require '../../components/sanitize_redirect'
 redirectUrl = (req) ->
   url = req.body['redirect-to'] or
   req.query['redirect-to'] or
+  req.query['redirect_uri'] or
   req.params['redirect_uri'] or
 
   if (referrer = req.get('Referrer')) && (referrer.indexOf('/log_in') > -1) and (referrer.indexOf('/sign_up') > -1)

--- a/mobile/apps/auth/test/routes.coffee
+++ b/mobile/apps/auth/test/routes.coffee
@@ -91,6 +91,18 @@ describe '#login', ->
     routes.login req, res
     @render.args[0][1].redirectTo.should.equal '%2Ffollowing%2Fprofiles'
 
+
+  it 'passes the redirect query param to the template', ->
+    req =
+      query: { 'redirect_uri': '%2Ffollowing%2Fprofiles' }
+      body: {}
+      params: {}
+      get: (-> false)
+    res = { render: @render = sinon.stub() }
+
+    routes.login req, res
+    @render.args[0][1].redirectTo.should.equal '%2Ffollowing%2Fprofiles'
+
   it 'ignores malicious redirects', ->
     req =
       query: { 'redirect-to': 'http://www.iamveryverysorry.com/' }


### PR DESCRIPTION
The `redirect_uri` from a sale artwork page is sent in the query string but the mobile auth helper wasn't looking for it. 

This is a fix for https://github.com/artsy/auctions/issues/349 .