### PR TITLE
remove link from missing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@ Set-Up
 
 See [CONTRIBUTING](CONTRIBUTING.md).
 
-Docs
-----
-
-You can find more documentation in [this repository's /doc directory](/doc).
-
 ````
                   ._,.
             ."..-..pf


### PR DESCRIPTION
Hi. Not sure if the docs will be added in, but noticed that the link pointed to a directory that no longer exists in the repo. Thanks.