### PR TITLE
@alloy => Let them buy art

### DIFF
--- a/desktop/apps/artwork/components/commercial/templates/acquire.jade
+++ b/desktop/apps/artwork/components/commercial/templates/acquire.jade
@@ -3,7 +3,7 @@ if artwork.is_acquireable
     input( type='hidden', name='artwork_id', value= artwork.id )
 
     button.avant-garde-button-black.is-block( class='js-artwork-acquire-button' )
-      if inPurchaseTestGroup
+      if artwork.is_purchasable
         | Purchase
       else
         | Buy

--- a/desktop/apps/artwork/components/commercial/templates/index.jade
+++ b/desktop/apps/artwork/components/commercial/templates/index.jade
@@ -1,6 +1,6 @@
 .artwork-commercial( class='js-artwork-commercial' )
   form.artwork-commercial__form
-    if inPurchaseTestGroup && artwork.is_purchasable
+    if artwork.is_purchasable
       include ./purchase_flow_index
     else
       include ./standard_index

--- a/desktop/apps/artwork/components/commercial/view.coffee
+++ b/desktop/apps/artwork/components/commercial/view.coffee
@@ -1,5 +1,4 @@
 { pick, extend } = require 'underscore'
-{ PURCHASE_FLOW } = require('sharify').data
 Backbone = require 'backbone'
 User = require '../../../../models/user.coffee'
 Artwork = require '../../../../models/artwork.coffee'
@@ -27,11 +26,6 @@ module.exports = class ArtworkCommercialView extends Backbone.View
   initialize: ({ @data }) ->
     { artwork } = @data
 
-    if artwork.is_purchasable
-      splitTest('purchase_flow').view()
-
-    inPurchaseTestGroup = PURCHASE_FLOW is 'purchase'
-    @usePurchaseFlow = inPurchaseTestGroup and artwork.is_purchasable
     @artwork = new Artwork artwork
 
   acquire: (e) ->
@@ -82,7 +76,7 @@ module.exports = class ArtworkCommercialView extends Backbone.View
           .html confirmation()
 
   inquire: (e) =>
-    return @contactGallery(e) if @usePurchaseFlow
+    return @contactGallery(e) if @artwork.is_purchasable
     e.preventDefault()
     @inquiry = new ArtworkInquiry notification_delay: 600
 

--- a/desktop/apps/artwork/routes.coffee
+++ b/desktop/apps/artwork/routes.coffee
@@ -66,11 +66,9 @@ bootstrap = ->
   send = method: 'post', query: query, variables: req.params
 
   return if metaphysics.debug req, res, send
-  inPurchaseTestGroup = res.locals.sd.PURCHASE_FLOW is 'purchase'
   metaphysics send
     .then (data) ->
       data.fair = new Fair data.artwork.fair if data.artwork.fair
-      data.inPurchaseTestGroup = inPurchaseTestGroup
       extend res.locals.helpers, helpers
       bootstrap res.locals.sd, data
       res.locals.sd.PARAMS = req.params

--- a/desktop/apps/artwork/templates/metadata.jade
+++ b/desktop/apps/artwork/templates/metadata.jade
@@ -1,5 +1,5 @@
 .artwork__main__metadata(
-  class= inPurchaseTestGroup && artwork.is_purchasable ? 'purchase-flow' : ''
+  class= artwork.is_purchasable ? 'purchase-flow' : ''
 )
   include ../components/metadata/index
   include ../components/commercial/index

--- a/desktop/apps/artwork_purchase/routes.coffee
+++ b/desktop/apps/artwork_purchase/routes.coffee
@@ -1,5 +1,4 @@
 { extend } = require 'underscore'
-{ PURCHASE_FLOW } = require('sharify').data
 metaphysics = require '../../../lib/metaphysics'
 Artwork = require '../../models/artwork'
 request = require 'superagent'
@@ -37,8 +36,6 @@ Fair = require '../../models/fair.coffee'
   """
 
   return if metaphysics.debug req, res, send
-  inPurchaseTestGroup = res.locals.sd.PURCHASE_FLOW is 'purchase'
-  return res.redirect "/artwork/#{req.params.id}" unless inPurchaseTestGroup
   send = query: query, variables: req.params
   metaphysics send
     .then ({ artwork }) ->
@@ -76,8 +73,6 @@ Fair = require '../../models/fair.coffee'
 
   """
   return if metaphysics.debug req, res, send
-  inPurchaseTestGroup = res.locals.sd.PURCHASE_FLOW is 'purchase'
-  return res.redirect "/artwork/#{req.params.id}" unless inPurchaseTestGroup
   send = query: query, variables: req.params
   metaphysics send
     .then ({ artwork }) ->

--- a/desktop/apps/artwork_purchase/test/routes.coffee
+++ b/desktop/apps/artwork_purchase/test/routes.coffee
@@ -23,8 +23,7 @@ describe 'Artist routes', ->
       redirect: sinon.stub()
       send: sinon.stub()
       type: sinon.stub()
-      locals: sd:
-        PURCHASE_FLOW: 'purchase'
+      locals: sd: {}
 
   describe 'with a work that is not purchasable', ->
     beforeEach ->

--- a/desktop/components/split_test/running_tests.coffee
+++ b/desktop/components/split_test/running_tests.coffee
@@ -14,11 +14,4 @@
 # this should export empty Object
 # module.exports = {}
 
-module.exports =
-
-  purchase_flow:
-    key: 'purchase_flow'
-    edge: 'purchase'
-    outcomes:
-      default: 50
-      purchase: 50
+module.exports = {}


### PR DESCRIPTION
This resolves the purchase request test in favor of purchase requests!

In this case, there wasn't a ton of code to modify except removing the explicit conditionals and test code itself. Sometimes, if the resolution of an AB test results in removing functionality entirely, resolving the test can include a big code diff as well.

Since we're still going to have regular inquiries, and also purchase requests, I think these updates are sufficient. No major refactor necessary.