### PR TITLE
@kanaabe => List styles, h2 height

### DIFF
--- a/desktop/components/article/stylesheets/content.styl
+++ b/desktop/components/article/stylesheets/content.styl
@@ -110,6 +110,7 @@ body.body-article
   h2
     font-size 28px
     line-height 1.2em
+    min-height 1em
     @media screen and (max-width 550px)
       garamond-size('s-headline')
   h3
@@ -119,10 +120,12 @@ body.body-article
     text-decoration none
     medium-faux-underline()
     padding-bottom 3px
+  li
+    margin-bottom 10px
   ul li
-    list-style disc inside
+    list-style disc outside
   ol li
-    list-style decimal inside
+    list-style decimal outside
 
 .article-date
   avant-garde()


### PR DESCRIPTION
Update Force list styles to match writer
Add min height to h2, empty ones used for spacing were rendering at 0px tall 

![screen shot 2017-03-22 at 11 09 29 am](https://cloud.githubusercontent.com/assets/1497424/24204887/374fd7dc-0ef0-11e7-8502-d0851ce60619.png)
