### PR TITLE
@kanaabe add identify call to application analytics stack WIP

### DIFF
--- a/desktop/analytics/partner_application.js
+++ b/desktop/analytics/partner_application.js
@@ -12,13 +12,13 @@ if (location.pathname.match('/gallery-partnerships')) {
     )
   })
 
-  $('#mktoForm_1238 .mktoButtonRow').click(function (e) {
-    window.email = $("#Email").val();
+  analyticsHooks.on('marketo:partner-apply', function (options) {
     analytics.track('Clicked bottom apply on gallery partnerships',
       {session_id: sd.SESSION_ID}
     );
     analytics.identify(
-      {session_id: sd.SESSION_ID, email: email }
+      {session_id: sd.SESSION_ID, email: options.email }
     );
+    console.log(`${session_id} ${email}`);
   })
 }

--- a/desktop/analytics/partner_application.js
+++ b/desktop/analytics/partner_application.js
@@ -19,6 +19,5 @@ if (location.pathname.match('/gallery-partnerships')) {
     analytics.identify(
       {session_id: sd.SESSION_ID, email: options.email }
     );
-    console.log(`${session_id} ${email}`);
   })
 }

--- a/desktop/analytics/partner_application.js
+++ b/desktop/analytics/partner_application.js
@@ -13,8 +13,12 @@ if (location.pathname.match('/gallery-partnerships')) {
   })
 
   $('#mktoForm_1238 .mktoButtonRow').click(function (e) {
+    window.email = $("#Email").val();
     analytics.track('Clicked bottom apply on gallery partnerships',
       {session_id: sd.SESSION_ID}
-    )
+    );
+    analytics.identify(
+      {session_id: sd.SESSION_ID, email: email }
+    );
   })
 }

--- a/desktop/apps/partnerships/client/view.coffee
+++ b/desktop/apps/partnerships/client/view.coffee
@@ -4,10 +4,12 @@ imagesLoaded = require 'imagesloaded'
 mediator = require '../../../lib/mediator.coffee'
 { resize } = require '../../../components/resizer/index.coffee'
 { jump } = require '../../../components/jump/view.coffee'
+analyticsHooks = require '../../../lib/mediator.coffee'
 
 module.exports = class PartnershipsView extends Backbone.View
   events:
     'click .partnerships-nav-link.internal': 'intercept'
+    'click #mktoForm_1238 .mktoButtonRow': 'trackPartner'
 
   initialize: ->
     @$window = $(window)
@@ -121,3 +123,9 @@ module.exports = class PartnershipsView extends Backbone.View
       @["#{name}Frame"] + 1
     else
       0
+
+  trackPartner: (e) ->
+    e.preventDefault()
+    email = $("#Email").val()
+    analyticsHooks.trigger 'marketo:partner-apply', email: email
+    window.location.replace('http://apply.artsy.net/galleries-2.html')


### PR DESCRIPTION
Hey @kanaabe can you take a look and test this out. I have tested also and it seems to do what we want which is to call identify with `session_id` and `email` included. 

Two concerns are, can't figure out if this will apply for all of the partnership forms (auctions, etc) or just galleries.

Also is there enough time for the function to grab the email value before the page switches?

cc @anipetrov @eessex 