### PR TITLE
@mzikherman => fix checkbox label spacing #minor

### DIFF
--- a/desktop/apps/auction2/actions.js
+++ b/desktop/apps/auction2/actions.js
@@ -16,6 +16,7 @@ export const UPDATE_ALL_FETCHED = 'UPDATE_ALL_FETCHED'
 export const UPDATE_ARTIST_ID = 'UPDATE_ARTIST_ID'
 export const UPDATE_ESTIMATE_DISPLAY = 'UPDATE_ESTIMATE_DISPLAY'
 export const UPDATE_ESTIMATE_RANGE = 'UPDATE_ESTIMATE_RANGE'
+export const UPDATE_INITIAL_MEDIUM_MAP = 'UPDATE_INITIAL_MEDIUM_MAP'
 export const UPDATE_IS_LAST_FOLLOWED_ARTISTS_PAGE = 'UPDATE_IS_LAST_FOLLOWED_ARTISTS_PAGE'
 export const UPDATE_MEDIUM_ID = 'UPDATE_MEDIUM_ID'
 export const UPDATE_NUM_ARTISTS_YOU_FOLLOW = 'UPDATE_NUM_ARTISTS_YOU_FOLLOW'
@@ -76,6 +77,7 @@ export function fetchArtworks() {
 
       dispatch(updateAggregatedArtists(artistAggregation[0].counts))
       dispatch(updateAggregatedMediums(mediumAggregation[0].counts))
+      dispatch(updateInitialMediumMap(mediumAggregation[0].counts))
       dispatch(updateTotal(filter_sale_artworks.counts.total))
       dispatch(updateNumArtistsYouFollow(filter_sale_artworks.counts.followed_artists))
       dispatch(updateSaleArtworks(filter_sale_artworks.hits))
@@ -280,6 +282,15 @@ export function updateEstimateRangeParams(min, max) {
     payload: {
       min,
       max
+    }
+  }
+}
+
+export function updateInitialMediumMap(initialMediumMap) {
+  return {
+    type: UPDATE_INITIAL_MEDIUM_MAP,
+    payload: {
+      initialMediumMap
     }
   }
 }

--- a/desktop/apps/auction2/components/auction_grid_artwork/index.styl
+++ b/desktop/apps/auction2/components/auction_grid_artwork/index.styl
@@ -17,6 +17,7 @@
   &__image > img
     max-height 260px
     margin auto
+    max-width 100%
 
   &__metadata
     padding-top 30px

--- a/desktop/apps/auction2/components/basic_checkbox/index.styl
+++ b/desktop/apps/auction2/components/basic_checkbox/index.styl
@@ -1,6 +1,15 @@
 .auction2-basic-checkbox
   padding-top 5px
   padding-bottom 5px
+
+  .artsy-checkbox--checkbox
+    float left
+    margin-right 10px
+
+  .artsy-checkbox--label
+    overflow auto
+    display block
+
   .disabled
     pointer-events none
     .artsy-checkbox--label

--- a/desktop/apps/auction2/components/medium_filter/index.js
+++ b/desktop/apps/auction2/components/medium_filter/index.js
@@ -8,7 +8,7 @@ function MediumFilter(props) {
   const {
     aggregatedMediums,
     filterParams,
-    mediumMap,
+    initialMediumMap,
     updateMediumParamsAction
   } = props
   const mediumIds = filterParams.gene_ids
@@ -26,13 +26,13 @@ function MediumFilter(props) {
         checked={allMediumsSelected}
       />
       {
-        _.map(mediumMap, (name, id) => {
-          const mediumSelected = contains(mediumIds, id)
-          const includedMedium = aggregatedMediums.find((agg) => agg.id === id)
+        _.map(initialMediumMap, (initialAgg) => {
+          const mediumSelected = contains(mediumIds, initialAgg.id)
+          const includedMedium = aggregatedMediums.find((agg) => agg.id === initialAgg.id)
           return (
             <BasicCheckbox
-              key={id}
-              item={{id, name, count: includedMedium && includedMedium.count}}
+              key={initialAgg.id}
+              item={{id: initialAgg.id, name: initialAgg.name, count: includedMedium && includedMedium.count}}
               onClick={updateMediumParamsAction}
               checked={mediumSelected}
               disabled={includedMedium === undefined}
@@ -48,7 +48,7 @@ const mapStateToProps = (state) => {
   return {
     aggregatedMediums: state.auctionArtworks.aggregatedMediums,
     filterParams: state.auctionArtworks.filterParams,
-    mediumMap: state.auctionArtworks.mediumMap
+    initialMediumMap: state.auctionArtworks.initialMediumMap
   }
 }
 

--- a/desktop/apps/auction2/reducers.js
+++ b/desktop/apps/auction2/reducers.js
@@ -31,11 +31,11 @@ const initialState = {
   followedArtistRailMax: 50,
   followedArtistRailPage: 1,
   followedArtistRailSize: 4,
+  initialMediumMap: [],
   isFetchingArtworks: false,
   isLastFollowedArtistsPage: false,
   isListView: false,
   maxEstimateRangeDisplay: 50000,
-  mediumMap,
   minEstimateRangeDisplay: 0,
   numArtistsYouFollow: 0,
   saleArtworks: [],
@@ -163,6 +163,15 @@ function auctionArtworks(state = initialState, action) {
           estimate_range: `${action.payload.min * 100}-${action.payload.max * 100}`
         }
       }, state)
+    }
+    case actions.UPDATE_INITIAL_MEDIUM_MAP: {
+      if (state.initialMediumMap.length === 0) {
+        return u({
+          initialMediumMap: action.payload.initialMediumMap
+        }, state)
+      } else {
+        return state
+      }
     }
     case actions.UPDATE_IS_LAST_FOLLOWED_ARTISTS_PAGE: {
       if (state.followedArtistRailPage >=

--- a/desktop/apps/auction2/stylesheets/banner.styl
+++ b/desktop/apps/auction2/stylesheets/banner.styl
@@ -1,5 +1,5 @@
 .auction2-banner
-  height 300px
+  height 240px
   position relative
   overflow hidden
   margin-bottom 40px

--- a/desktop/apps/auction2/test/components.js
+++ b/desktop/apps/auction2/test/components.js
@@ -110,20 +110,21 @@ describe('React components', () => {
 
     beforeEach(() => {
       aggregatedMediums = [
-        { id: 'painting', count: 23 },
-        { id: 'work-on-paper', count: 44 },
-        { id: 'design', count: 57 }
+        { id: 'painting', name: 'Painting', count: 23 },
+        { id: 'work-on-paper', name: 'Works on Paper', count: 44 },
+        { id: 'design', name: 'Design', count: 57 }
       ]
     })
 
     describe('no mediums selected', () => {
       it('checks the mediums-all box', () => {
+        initialStore.dispatch(actions.updateInitialMediumMap(aggregatedMediums))
         initialStore.dispatch(actions.updateAggregatedMediums(aggregatedMediums))
         const wrapper = shallow(
           <Provider><MediumFilter store={initialStore} /></Provider>
         )
         const rendered = wrapper.render()
-        rendered.find('.artsy-checkbox').length.should.eql(9)
+        rendered.find('.artsy-checkbox').length.should.eql(4)
         const renderedText = rendered.text()
         renderedText.should.containEql('All')
         renderedText.should.containEql('Painting(23)')
@@ -135,13 +136,14 @@ describe('React components', () => {
 
     describe('some mediums selected', () => {
       it('checks the correct medium boxes', () => {
+        initialStore.dispatch(actions.updateInitialMediumMap(aggregatedMediums))
         initialStore.dispatch(actions.updateAggregatedMediums(aggregatedMediums))
         initialStore.dispatch(actions.updateMediumId('painting'))
         const wrapper = shallow(
           <Provider><MediumFilter store={initialStore} /></Provider>
         )
         const rendered = wrapper.render()
-        rendered.find('.artsy-checkbox').length.should.eql(9)
+        rendered.find('.artsy-checkbox').length.should.eql(4)
         const renderedText = rendered.text()
         renderedText.should.containEql('All')
         renderedText.should.containEql('Painting(23)')

--- a/desktop/apps/auction2/test/reducers.js
+++ b/desktop/apps/auction2/test/reducers.js
@@ -231,6 +231,21 @@ describe('Reducers', () => {
         })
       })
 
+      describe('#updateInitialMediumMap', () => {
+        it('sets the initial medium map the first time', () => {
+          initialResponse.auctionArtworks.initialMediumMap.should.eql([])
+          const updatedMap = [
+            { count: 1, name: 'Prints', id: 'prints' },
+            { count: 2, name: 'Painting', id: 'painting' },
+            { count: 2, name: 'Works On Paper', id: 'works-on-paper' }
+          ]
+          const updatedInitialMediumMap = auctions(initialResponse, actions.updateInitialMediumMap(updatedMap))
+          updatedInitialMediumMap.auctionArtworks.initialMediumMap.should.eql(updatedMap)
+          const updatedAgain = auctions(updatedInitialMediumMap, actions.updateInitialMediumMap([]))
+          updatedAgain.auctionArtworks.initialMediumMap.should.eql(updatedMap)
+        })
+      })
+
       describe('#updateMediumId', () => {
         it('updates the medium id', () => {
           initialResponse.auctionArtworks.filterParams.gene_ids.should.eql([])


### PR DESCRIPTION
Updates the checkbox label to respect long names.

![image](https://cloud.githubusercontent.com/assets/2081340/24210033/3edd5c46-0efe-11e7-9086-5298f3d01bbe.png)

(instead of)
![image](https://cloud.githubusercontent.com/assets/2081340/24210462/98f2b716-0eff-11e7-8f3f-acc05a7ad601.png)

Late addition:

Instead of showing _all_ of the possible mediums, this PR sets the `initialMediumMap` on the first fetch, and then uses that to disable/enable them in future filters. i.e.:

![image](https://cloud.githubusercontent.com/assets/2081340/24252636/637ddba0-0fb4-11e7-93ab-7c148a5afe58.png)
