### PR TITLE
Fix the bug where uploading/seeding a json file stopped working

### DIFF
--- a/desktop/components/json_page/seed.coffee
+++ b/desktop/components/json_page/seed.coffee
@@ -15,13 +15,12 @@ catch error
 
 display = ['..'].concat(_.last path.split('/'), 2).join '/'
 
-inquirer.prompt [
+inquirer.prompt([
   type: 'confirm'
   name: 'confirm'
   message: "Update `#{name}` in the bucket `#{bucket}` with data from `#{display}`?"
-], ({ confirm }) ->
+]).then ({ confirm }) ->
   if confirm
-
     page = new JSONPage name: name, bucket: bucket
     page.set data, (err, { req }) ->
       return console.log(err) if err?

--- a/desktop/components/json_page/update.coffee
+++ b/desktop/components/json_page/update.coffee
@@ -14,11 +14,11 @@ catch
 
 display = ['..'].concat(_.last path.split('/'), 2).join '/'
 
-inquirer.prompt [
+inquirer.prompt([
   type: 'confirm'
   name: 'confirm'
   message: "Update `#{display}` with data from `#{name}` in the bucket `#{bucket}`?"
-], ({ confirm }) ->
+]).then ({ confirm }) ->
   if confirm
 
     page = new JSONPage name: name, bucket: bucket


### PR DESCRIPTION
closes #1066

As of Inquirejs 1.0.0 (https://github.com/SBoudrias/Inquirer.js/releases/tag/v1.0.0), it no longer accepts callbacks and returns a promise object instead. This broke the command line tool we use to [upload json files](https://github.com/artsy/force/tree/master/desktop/components/json_page#development). This commit fixes the issue by changing the script to use promises.

Signed-off-by: Yuki Nishijima <yuki@artsymail.com>