### PR TITLE
set node vm GC options

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "yarn mocha test/lib && yarn mocha $(find desktop/test -name '*.coffee') && yarn mocha $(find desktop/components/*/test -name '*.coffee') && yarn mocha $(find desktop/components/**/*/test -name '*.coffee') && yarn mocha $(find desktop/apps/*/test -name '*.coffee' -or -name '*.js') && yarn mocha $(find desktop/apps/*/**/*/test -name '*.coffee') && yarn mocha $(find mobile/test -name '*.coffee') && yarn mocha $(find mobile/components/*/test -name '*.coffee') && yarn mocha $(find mobile/components/**/*/test -name '*.coffee') && yarn mocha $(find mobile/apps/*/test -name '*.coffee') && yarn mocha $(find mobile/apps/*/**/*/test -name '*.coffee')",
     "deploy": "yarn deploy-assets && git push --force git@heroku.com:force-$DEPLOY_ENV.git master",
     "deploy-assets": "mkdir public; mkdir public/assets; ezel-assets mobile/assets/ && ezel-assets desktop/assets/ && bucket-assets --bucket artsy-force-$DEPLOY_ENV && heroku config:set ASSET_MANIFEST=$(cat manifest.json) --app=force-$DEPLOY_ENV",
-    "start": "node -r dotenv/config --max_old_space_size=960 ."
+    "start": "node -r dotenv/config --optimize_for_size --max_old_space_size=960 --gc_interval=100 ."
   },
   "dependencies": {
     "accounting": "^0.4.1",


### PR DESCRIPTION
I think although we set the `--max_old_space_size` option, node's GC was not being aggressive enough.  See: https://blog.heroku.com/node-habits-2016#7-avoid-garbage and https://github.com/nodejs/node/issues/3370#issuecomment-148108323

cc @craigspaeth @alloy  