### PR TITLE
@kanaabe => exclude text-only callouts from custom template

### DIFF
--- a/desktop/components/article/client/view.coffee
+++ b/desktop/components/article/client/view.coffee
@@ -395,9 +395,10 @@ module.exports = class ArticleView extends Backbone.View
       data: ids: ids
       success: (articles) =>
         for section in calloutSections
-          @$articleContainer.find(".article-section-callout[data-id=#{section.article}]").html calloutTemplate
-            section: section
-            calloutArticles: articles
-            crop: crop
+          if section.article
+            @$articleContainer.find(".article-section-callout[data-id=#{section.article}]").html calloutTemplate
+              section: section
+              calloutArticles: articles
+              crop: crop
         @loadedCallouts = true
         @maybeFinishedLoading()

--- a/desktop/components/article/test/view.coffee
+++ b/desktop/components/article/test/view.coffee
@@ -132,6 +132,13 @@ describe 'ArticleView', ->
               text: '',
               title: ''
               hide_image: false
+            },
+            {
+              type: 'callout',
+              article: null,
+              text: 'This is a text only callout',
+              title: ''
+              hide_image: false
             }
           ]
         author: new Backbone.Model fabricate 'user'
@@ -235,7 +242,10 @@ describe 'ArticleView', ->
 
   describe '#renderCalloutSections', ->
 
-    it 'renders callouts', ->
+    it 'renders callouts without articles', ->
+      @view.$el.html().should.containEql 'This is a text only callout'
+
+    it 'renders callouts with articles', ->
       articles = [_.extend({}, fixtures.article, { thumbnail_title: 'callout article' })]
       Backbone.sync.args[0][2].success results: articles
       @view.$el.html().should.containEql 'callout article'


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/986
Stops calling the related article template unless a callout section has a related article. 
