### PR TITLE
@damassi => auction2 fixes from QA session

### DIFF
--- a/desktop/apps/auction2/components/header/index.js
+++ b/desktop/apps/auction2/components/header/index.js
@@ -22,7 +22,7 @@ function Header(props) {
   const displayType = isListView ? 'list' : 'grid'
   const totalLabel = (total && total > 0)
     ? `${total} Artworks`
-    : 'Your search returned 0 results. Try removing some filters.'
+    : 'Loading results.'
 
   return (
     <div className='auction2-artworks-header'>

--- a/desktop/apps/auction2/components/range_slider/index.js
+++ b/desktop/apps/auction2/components/range_slider/index.js
@@ -6,17 +6,17 @@ import { connect } from 'react-redux'
 
 function RangeSlider(props) {
   const {
-    currency,
     filterParams,
     minEstimateRangeDisplay,
     maxEstimateRangeDisplay,
+    symbol,
     updateEstimateRangeAction,
     updateEstimateDisplayAction
   } = props
 
   const minEstimate = filterParams.ranges.estimate_range.min
   const maxEstimate = filterParams.ranges.estimate_range.max
-  const formattedMinDisplay = formatMoney(minEstimateRangeDisplay, { symbol: currency, precision: 0 })
+  const formattedMinDisplay = formatMoney(minEstimateRangeDisplay, { symbol: symbol, precision: 0 })
   const formattedMaxDisplay = formatMoney(maxEstimateRangeDisplay, { symbol: '', precision: 0 })
   return (
     <div className='auction2-range-slider'>
@@ -40,10 +40,10 @@ function RangeSlider(props) {
 
 const mapStateToProps = (state) => {
   return {
-    currency: state.auctionArtworks.currency,
     filterParams: state.auctionArtworks.filterParams,
     minEstimateRangeDisplay: state.auctionArtworks.minEstimateRangeDisplay,
-    maxEstimateRangeDisplay: state.auctionArtworks.maxEstimateRangeDisplay
+    maxEstimateRangeDisplay: state.auctionArtworks.maxEstimateRangeDisplay,
+    symbol: state.auctionArtworks.symbol
   }
 }
 

--- a/desktop/apps/auction2/components/works_by_followed_artists/index.js
+++ b/desktop/apps/auction2/components/works_by_followed_artists/index.js
@@ -11,7 +11,7 @@ function WorksByFollowedArtists(props) {
     followedArtistRailPage,
     followedArtistRailSize,
     nextPageOfFollowedArtistArtworksAction,
-    isLastFollowedArtistsPage,
+    numArtistsYouFollow,
     previousPageOfFollowedArtistArtworksAction,
     saleArtworksByFollowedArtists
   } = props
@@ -21,6 +21,7 @@ function WorksByFollowedArtists(props) {
     initialSlice,
     initialSlice + followedArtistRailSize
   )
+  const isOnlyFollowedArtistsPage = numArtistsYouFollow <= followedArtistRailSize
 
   const leftPageClasses = classNames(
     'auction2-works-by-followed-artists__page-left',
@@ -29,7 +30,7 @@ function WorksByFollowedArtists(props) {
 
   const rightPageClasses = classNames(
     'auction2-works-by-followed-artists__page-right',
-    { disabled: isLastFollowedArtistsPage }
+    { disabled: isOnlyFollowedArtistsPage }
   )
 
   return (
@@ -66,7 +67,7 @@ const mapStateToProps = (state) => {
   return {
     followedArtistRailPage: state.auctionArtworks.followedArtistRailPage,
     followedArtistRailSize: state.auctionArtworks.followedArtistRailSize,
-    isLastFollowedArtistsPage: state.auctionArtworks.isLastFollowedArtistsPage,
+    numArtistsYouFollow: state.auctionArtworks.numArtistsYouFollow,
     saleArtworksByFollowedArtists: state.auctionArtworks.saleArtworksByFollowedArtists
   }
 }

--- a/desktop/apps/auction2/queries/sale.js
+++ b/desktop/apps/auction2/queries/sale.js
@@ -18,6 +18,7 @@ export default function SaleQuery(id) {
       name
       start_at
       status
+      symbol
     }
   }`
 }

--- a/desktop/apps/auction2/reducers.js
+++ b/desktop/apps/auction2/reducers.js
@@ -9,7 +9,6 @@ const initialState = {
   aggregatedArtists: [],
   aggregatedMediums: [],
   allFetched: false,
-  currency: sd.AUCTION && sd.AUCTION.currency,
   displayFollowedArtistsRail: false,
   filterParams: {
     aggregations: ['ARTIST', 'FOLLOWED_ARTISTS', 'MEDIUM', 'TOTAL'],
@@ -49,6 +48,7 @@ const initialState = {
     "-searchable_estimate": "Most Expensive",
     "searchable_estimate": "Least Expensive"
   },
+  symbol: sd.AUCTION && sd.AUCTION.symbol,
   total: 0,
   user: sd.CURRENT_USER
 }
@@ -80,12 +80,14 @@ function auctionArtworks(state = initialState, action) {
     }
     case actions.INCREMENT_FOLLOWED_ARTISTS_PAGE: {
       const currentPage = state.followedArtistRailPage
-      if (!state.isLastFollowedArtistsPage) {
+      if (state.isLastFollowedArtistsPage) {
+        return u({
+          followedArtistRailPage: 1
+        }, state)
+      } else {
         return u({
           followedArtistRailPage: currentPage + 1
         }, state)
-      } else {
-        return state
       }
     }
     case actions.TOGGLE_LIST_VIEW: {
@@ -124,12 +126,21 @@ function auctionArtworks(state = initialState, action) {
           }
         }, state)
       } else if (artistId === 'artists-you-follow') {
-        return u({
-          filterParams: {
-            artist_ids: [],
-            include_artworks_by_followed_artists: true
-          }
-        }, state)
+        if (state.filterParams.include_artworks_by_followed_artists === true) {
+          return u({
+            filterParams: {
+              artist_ids: [],
+              include_artworks_by_followed_artists: false
+            }
+          }, state)
+        } else {
+          return u({
+            filterParams: {
+              artist_ids: [],
+              include_artworks_by_followed_artists: true
+            }
+          }, state)
+        }
       } else if (contains(state.filterParams.artist_ids, artistId)) {
         return u({
           filterParams: {

--- a/desktop/apps/auction2/reducers.js
+++ b/desktop/apps/auction2/reducers.js
@@ -126,21 +126,13 @@ function auctionArtworks(state = initialState, action) {
           }
         }, state)
       } else if (artistId === 'artists-you-follow') {
-        if (state.filterParams.include_artworks_by_followed_artists === true) {
-          return u({
-            filterParams: {
-              artist_ids: [],
-              include_artworks_by_followed_artists: false
-            }
-          }, state)
-        } else {
-          return u({
-            filterParams: {
-              artist_ids: [],
-              include_artworks_by_followed_artists: true
-            }
-          }, state)
-        }
+        const newState = !state.filterParams.include_artworks_by_followed_artists
+        return u({
+          filterParams: {
+            artist_ids: [],
+            include_artworks_by_followed_artists: newState
+          }
+        }, state)
       } else if (contains(state.filterParams.artist_ids, artistId)) {
         return u({
           filterParams: {

--- a/desktop/apps/auction2/test/reducers.js
+++ b/desktop/apps/auction2/test/reducers.js
@@ -184,6 +184,17 @@ describe('Reducers', () => {
           allArtists.auctionArtworks.filterParams.artist_ids.should.eql([])
           allArtists.auctionArtworks.filterParams.include_artworks_by_followed_artists.should.eql(true)
         })
+
+        it('updates the artist ids to all when artists-you-follow is already checked', () => {
+          initialResponse.auctionArtworks.filterParams.artist_ids.should.eql([])
+          initialResponse.auctionArtworks.filterParams.include_artworks_by_followed_artists.should.eql(false)
+          const artistsYouFollow = auctions(initialResponse, actions.updateArtistId('artists-you-follow'))
+          artistsYouFollow.auctionArtworks.filterParams.artist_ids.should.eql([])
+          artistsYouFollow.auctionArtworks.filterParams.include_artworks_by_followed_artists.should.eql(true)
+          const noArtistsYouFollow = auctions(artistsYouFollow, actions.updateArtistId('artists-you-follow'))
+          noArtistsYouFollow.auctionArtworks.filterParams.artist_ids.should.eql([])
+          noArtistsYouFollow.auctionArtworks.filterParams.include_artworks_by_followed_artists.should.eql(false)
+        })
       })
 
       describe('#updateArtworks', () => {

--- a/desktop/apps/auction2/test/reducers.js
+++ b/desktop/apps/auction2/test/reducers.js
@@ -88,7 +88,7 @@ describe('Reducers', () => {
           incrementedResponse.auctionArtworks.followedArtistRailPage.should.eql(2)
         })
 
-        it('does not increment if you are already at the final page', () => {
+        it('brings you to the first page if you were at the last', () => {
           initialResponse.auctionArtworks.followedArtistRailPage.should.eql(1)
           const incrementedResponse = auctions(initialResponse, actions.incrementFollowedArtistsPage())
           incrementedResponse.auctionArtworks.followedArtistRailPage.should.eql(2)
@@ -96,7 +96,7 @@ describe('Reducers', () => {
           const updatedIsLastPage = auctions(totalResponse, actions.updateIsLastFollowedArtistsPage())
           updatedIsLastPage.auctionArtworks.isLastFollowedArtistsPage.should.eql(true)
           const anotherIncrement = auctions(updatedIsLastPage, actions.incrementFollowedArtistsPage())
-          anotherIncrement.auctionArtworks.followedArtistRailPage.should.eql(2)
+          anotherIncrement.auctionArtworks.followedArtistRailPage.should.eql(1)
         })
       })
 


### PR DESCRIPTION
Here are few fixes that came out of yesterday's QA session:
- Make the "works by artists you follow" carousel loop (so you can always click the right arrow)
![works-loop](https://cloud.githubusercontent.com/assets/2081340/24301760/cde5b6d4-1086-11e7-9604-dc5ddb3e5fb0.gif)

- Clicking the "Artists you Follow" checkbox when it is checked should _uncheck_ the box and show works by all artists
![artists-you-follow](https://cloud.githubusercontent.com/assets/2081340/24301734/bbea933c-1086-11e7-928c-27e781801178.gif)

- Adds the currency symbol to the estimate slider
![image](https://cloud.githubusercontent.com/assets/2081340/24301684/9e984414-1086-11e7-9529-0c21248b6cd4.png)

- Don't show "Your search returned 0 results" warning. I actually just changed this message to say "Loading", since in the current UI there's actually no way to get to 0 results, so that message was misleading. We can remove the message entirely if we want also /shrug.