### PR TITLE
@broskoski => add Your Active Bids title to home page

### DIFF
--- a/desktop/apps/home/client/setup_home_page_modules.coffee
+++ b/desktop/apps/home/client/setup_home_page_modules.coffee
@@ -24,7 +24,7 @@ contexts =
       auctionTimeLabel: auctionTimeLabel(module.context)
       auctionClosesLabel: auctionClosesLabel(module.context)
   current_fairs: (module) ->
-    fairTemplate fair: module.context, timeSpan: timeSpan    
+    fairTemplate fair: module.context, timeSpan: timeSpan
 
 setupFollowedArtistsView = (module, $el, user) ->
   view = new FollowedArtistsRailView
@@ -70,12 +70,13 @@ module.exports = ->
       req: { user: user }
     ).then ({ home_page: { artwork_module } }) ->
       module = artwork_module
-
       return $el.remove() unless module.results?.length or module.key is 'followed_artists'
-      return setupActiveBidsView(module, $el.find('.abrv-content'), user) if module.key is 'active_bids'
+      if module.key is 'active_bids'
+        $el.find('.abrv-header h1').html(module.title)
+        return setupActiveBidsView(module, $el.find('.abrv-content'), user)
       return setupFollowedArtistsView(module, $el, user) if module.key is 'followed_artists'
 
-      options = 
+      options =
         $el: $el
         artworks: module.results
         title: module.title
@@ -85,11 +86,11 @@ module.exports = ->
         category: module.key is 'genes' or module.key is 'generic_gene'
 
       if module.key is 'related_artists'
-        options.annotation = relatedArtistsAnnotation 
+        options.annotation = relatedArtistsAnnotation
           based_on: module.context?.based_on
 
       view = new ArtworkBrickRailView options
-        
+
       view.on 'post-render', ->
 
         setupFollowButton

--- a/desktop/apps/home/stylesheets/modules.styl
+++ b/desktop/apps/home/stylesheets/modules.styl
@@ -19,6 +19,8 @@
       garamond-size('l-caption', true)
     .my-active-bids-warning, .my-active-bids-bid-button
       right 15px
+    .bid-status
+      padding-right 10px
     @media screen and (max-width: 1200px)
       width calc(50% \- 15px)
 


### PR DESCRIPTION
Since: https://github.com/artsy/metaphysics/pull/579, the `active_bids` module returns actual bids and not just an empty array. This means they show up on the homepage, but I noticed that in staging, the rail looks a little odd:
![image](https://cloud.githubusercontent.com/assets/2081340/24315897/5ce4db74-10c0-11e7-9e06-5e762da46073.png)

Turns out the module was not displaying the title because the "my active bids" rail skips the generic `ArtworkBrickRailView` template in favor of a custom one. Since that custom template is used elsewhere on Force, I ended up manually setting the `.abrv-header` element here to the `module.title` to keep backwards compatibility. 

Fixed like so:
![image](https://cloud.githubusercontent.com/assets/2081340/24315921/9d91e46e-10c0-11e7-8069-000c8d2ad712.png)
