### PR TITLE
@oxaudo => Fix margins on partner2 profile page

### DIFF
--- a/desktop/apps/partner2/stylesheets/index.styl
+++ b/desktop/apps/partner2/stylesheets/index.styl
@@ -17,7 +17,7 @@
 @require './contact'
 
 #partner
-  margin 50px 0 0 0
+  margin 50px 45px 0 45px
   .loading-spinner
     position relative
     top 50px


### PR DESCRIPTION
Closes #1108 

Small fix for a layout glitch reported on #help last week. Ensures that partner profile has left and right margin at smaller window widths:

![margins3](https://cloud.githubusercontent.com/assets/140521/24358646/cf915c36-12cf-11e7-95ee-988f0d712b06.gif)
