### PR TITLE
Replaced artist and gene sitemaps with Spark-generated ones.

### DIFF
--- a/desktop/apps/sitemaps/index.coffee
+++ b/desktop/apps/sitemaps/index.coffee
@@ -13,5 +13,7 @@ app.get '/sitemap-cities.xml', routes.cities
 app.get '/sitemap.xml', routes.index
 app.get ['/sitemap-artworks.xml', '/sitemap-artworks-:timestamp.xml'], routes.sitemaps
 app.get ['/sitemap-images.xml', '/sitemap-images-:timestamp.xml'], routes.sitemaps
+app.get ['/sitemap-artists.xml', '/sitemap-artists-:timestamp.xml'], routes.sitemaps
+app.get ['/sitemap-genes.xml', '/sitemap-genes-:timestamp.xml'], routes.sitemaps
 app.get '/sitemap-articles-:page.xml', routes.articlesPage # archive of all articles (for main sitemap, not news-specific sitemap)
 app.get '/sitemap-:resource-:page.xml', routes.resourcePage

--- a/desktop/apps/sitemaps/routes.coffee
+++ b/desktop/apps/sitemaps/routes.coffee
@@ -27,7 +27,7 @@ sitemapProxy = httpProxy.createProxyServer(target: SITEMAP_BASE_URL)
       res.render('news_sitemap', { pretty: true, articles: recentArticles })
 
 @index = (req, res, next) ->
-  resources = ['artists', 'genes', 'partners', 'features', 'shows', 'fairs']
+  resources = ['partners', 'features', 'shows', 'fairs']
   async.parallel [
     # Get articles counts
     (cb) ->
@@ -120,6 +120,8 @@ sitemapProxy = httpProxy.createProxyServer(target: SITEMAP_BASE_URL)
     Disallow: ?microsite=
     Disallow: ?from-show-guide=
     Sitemap: #{APP_URL}/sitemap.xml
+    Sitemap: #{APP_URL}/sitemap-artists.xml
+    Sitemap: #{APP_URL}/sitemap-genes.xml
     Sitemap: #{APP_URL}/sitemap-artworks.xml
     Sitemap: #{APP_URL}/sitemap-images.xml
 

--- a/desktop/apps/sitemaps/test/routes.coffee
+++ b/desktop/apps/sitemaps/test/routes.coffee
@@ -47,6 +47,8 @@ Disallow: ?dns_source=
 Disallow: ?microsite=
 Disallow: ?from-show-guide=
 Sitemap: https://www.artsy.net/sitemap.xml
+Sitemap: https://www.artsy.net/sitemap-artists.xml
+Sitemap: https://www.artsy.net/sitemap-genes.xml
 Sitemap: https://www.artsy.net/sitemap-artworks.xml
 Sitemap: https://www.artsy.net/sitemap-images.xml
 """
@@ -96,7 +98,7 @@ Sitemap: https://www.artsy.net/sitemap-images.xml
       routes.index(@req, @res)
       @res.render.args[0][1].articlePages.should.equal 5
       @res.render.args[0][1].allPages.should.equal 10
-      @res.render.args[0][1].resources.length.should.equal 6
+      @res.render.args[0][1].resources.length.should.equal 4
 
   describe '#misc', ->
 
@@ -131,14 +133,14 @@ Sitemap: https://www.artsy.net/sitemap-images.xml
 
     it 'fetches and displays a resource page', ->
       routes.__set__ 'request', get: -> set: -> query: -> end: (cb) ->
-        cb null, { body: [{ id: 'gene-1' }, {id: 'gene-2'}] }
+        cb null, { body: [{ id: 'partner-1' }, {id: 'partner-2'}] }
       req =
         params:
           page: 1
-          resource: 'genes'
+          resource: 'partners'
       routes.resourcePage req, @res
-      @res.render.args[0][1].models[0].id.should.equal 'gene-1'
-      @res.render.args[0][1].models[1].id.should.equal 'gene-2'
+      @res.render.args[0][1].models[0].id.should.equal 'partner-1'
+      @res.render.args[0][1].models[1].id.should.equal 'partner-2'
 
   describe '#video', ->
 


### PR DESCRIPTION
You can see these:

https://s3.amazonaws.com/artsy-sitemaps/sitemap-genes.xml

https://s3.amazonaws.com/artsy-sitemaps/sitemap-artists.xml
https://s3.amazonaws.com/artsy-sitemaps/sitemap-artists-2017.xml