### PR TITLE
exclude non-auction SHOW page routes from regex

### DIFF
--- a/desktop/assets/auctions.coffee
+++ b/desktop/assets/auctions.coffee
@@ -8,7 +8,7 @@ routes =
 
   '''
   /sale/.*
-  /auction/.*
+  ^/auction/[^/]+/?$
   ''': require('../apps/auction/client/index.coffee').init
 
   '''


### PR DESCRIPTION
Closes https://github.com/artsy/auctions/issues/308 - The issue was that while the bid form is part of the `auctions_support` app in force, the regex test matches on all routes like `/auction/*.`. It's possible this is happening in other places- the error only came up because of an inconsistency in how we make the sale object between the [auction_support](https://github.com/artsy/force/blob/fa899e00c0c25c728c10b90ddcb15e808b6b4983/desktop/apps/auction_support/client/index.coffee#L50-L50) and [auction](https://github.com/artsy/force/blob/fa899e00c0c25c728c10b90ddcb15e808b6b4983/desktop/apps/auction/client/index.coffee#L18-L18) apps (`sd.SALE` vs `sc.AUCTION`).
I used www.regex101.com to test this:

regular expression:  `^\/auction\/[^\/]+\/?$`
with urls:
`/auction/eriks-timed-artwork-auction`
`/auction/eriks-timed-artwork-auction/bid/sophie-dickens-painting?bid=1800`
