### PR TITLE
@dblock => Articles use s3 sitemap

### DIFF
--- a/desktop/apps/sitemaps/index.coffee
+++ b/desktop/apps/sitemaps/index.coffee
@@ -16,5 +16,5 @@ app.get ['/sitemap-images.xml', '/sitemap-images-:timestamp.xml'], routes.sitema
 app.get ['/sitemap-artists.xml', '/sitemap-artists-:timestamp.xml'], routes.sitemaps
 app.get ['/sitemap-genes.xml', '/sitemap-genes-:timestamp.xml'], routes.sitemaps
 app.get ['/sitemap-partners.xml', '/sitemap-partners-:timestamp.xml'], routes.sitemaps
-app.get '/sitemap-articles-:page.xml', routes.articlesPage # archive of all articles (for main sitemap, not news-specific sitemap)
+app.get ['/sitemap-articles.xml', '/sitemap-articles-:timestamp.xml'], routes.sitemaps  # archive of all articles (for main sitemap, not news-specific sitemap)
 app.get '/sitemap-:resource-:page.xml', routes.resourcePage

--- a/desktop/apps/sitemaps/test/routes.coffee
+++ b/desktop/apps/sitemaps/test/routes.coffee
@@ -47,6 +47,7 @@ Disallow: ?dns_source=
 Disallow: ?microsite=
 Disallow: ?from-show-guide=
 Sitemap: https://www.artsy.net/sitemap.xml
+Sitemap: https://www.artsy.net/sitemap-articles.xml
 Sitemap: https://www.artsy.net/sitemap-artists.xml
 Sitemap: https://www.artsy.net/sitemap-genes.xml
 Sitemap: https://www.artsy.net/sitemap-artworks.xml
@@ -96,9 +97,8 @@ Sitemap: https://www.artsy.net/sitemap-partners.xml
   describe '#index', ->
 
     it 'renders index with data', ->
-      routes.__set__ 'async', parallel: sinon.stub().yields null, [5, 10]
+      routes.__set__ 'async', parallel: sinon.stub().yields null, [10]
       routes.index(@req, @res)
-      @res.render.args[0][1].articlePages.should.equal 5
       @res.render.args[0][1].allPages.should.equal 10
       @res.render.args[0][1].resources.length.should.equal 3
 
@@ -116,20 +116,6 @@ Sitemap: https://www.artsy.net/sitemap-partners.xml
       @res.render.args[0][1].citySlugs.length.should.equal 2
       @res.render.args[0][1].citySlugs[0].should.containEql 'new-york-city'
       @res.render.args[0][1].citySlugs[1].should.containEql 'tokyo'
-
-  describe '#articlesPage', ->
-
-    it 'fetches articles and displays slugs', ->
-      articles = [{slug: 'artsy-editorial-slug-1'}, {slug: 'artsy-editorial-slug-2'}]
-      request = get: -> query: -> end: (cb) ->
-        cb null, { body: results: articles}
-      routes.__set__ 'request', request
-      req =
-        params:
-          page: 1
-      routes.articlesPage(req, @res)
-      @res.render.args[0][1].slugs[0].should.equal 'artsy-editorial-slug-1'
-      @res.render.args[0][1].slugs[1].should.equal 'artsy-editorial-slug-2'
 
   describe '#resourcePage', ->
 


### PR DESCRIPTION
Uses s3 proxy for articles sitemaps.
'News' specific feed is still untouched. 