### PR TITLE
Removed leftover article reference.

### DIFF
--- a/desktop/apps/sitemaps/templates/index.jade
+++ b/desktop/apps/sitemaps/templates/index.jade
@@ -12,7 +12,3 @@ sitemapindex(
     for n, j in new Array(allPages[i])
       sitemap
         loc=sd.APP_URL + '/sitemap-' + resource + '-' + (j + 1) + '.xml'
-
-  for n, i in new Array(articlePages)
-    sitemap
-      loc=sd.APP_URL + '/sitemap-articles-' + i + '.xml'


### PR DESCRIPTION
I was wondering why https://www.artsy.net/sitemap.xml is still showing https://www.artsy.net/sitemap-articles-0.xml, here's why,