### PR TITLE
Replace fair sitemaps with cinder output.

### DIFF
--- a/desktop/apps/sitemaps/index.coffee
+++ b/desktop/apps/sitemaps/index.coffee
@@ -18,4 +18,5 @@ app.get ['/sitemap-genes.xml', '/sitemap-genes-:timestamp.xml'], routes.sitemaps
 app.get ['/sitemap-partners.xml', '/sitemap-partners-:timestamp.xml'], routes.sitemaps
 app.get ['/sitemap-articles.xml', '/sitemap-articles-:timestamp.xml'], routes.sitemaps  # archive of all articles (for main sitemap, not news-specific sitemap)
 app.get ['/sitemap-shows.xml', '/sitemap-shows-:timestamp.xml'], routes.sitemaps
+app.get ['/sitemap-fairs.xml', '/sitemap-fairs-:timestamp.xml'], routes.sitemaps
 app.get '/sitemap-:resource-:page.xml', routes.resourcePage

--- a/desktop/apps/sitemaps/routes.coffee
+++ b/desktop/apps/sitemaps/routes.coffee
@@ -27,7 +27,7 @@ sitemapProxy = httpProxy.createProxyServer(target: SITEMAP_BASE_URL)
       res.render('news_sitemap', { pretty: true, articles: recentArticles })
 
 @index = (req, res, next) ->
-  resources = ['features', 'fairs']
+  resources = ['features']
   async.parallel [
     # Get the resource counts
     (cb) ->
@@ -107,6 +107,7 @@ sitemapProxy = httpProxy.createProxyServer(target: SITEMAP_BASE_URL)
     Sitemap: #{APP_URL}/sitemap-images.xml
     Sitemap: #{APP_URL}/sitemap-partners.xml
     Sitemap: #{APP_URL}/sitemap-shows.xml
+    Sitemap: #{APP_URL}/sitemap-fairs.xml
 
   """
   res.send switch NODE_ENV

--- a/desktop/apps/sitemaps/test/routes.coffee
+++ b/desktop/apps/sitemaps/test/routes.coffee
@@ -54,6 +54,7 @@ Sitemap: https://www.artsy.net/sitemap-artworks.xml
 Sitemap: https://www.artsy.net/sitemap-images.xml
 Sitemap: https://www.artsy.net/sitemap-partners.xml
 Sitemap: https://www.artsy.net/sitemap-shows.xml
+Sitemap: https://www.artsy.net/sitemap-fairs.xml
 
 """
 
@@ -101,7 +102,7 @@ Sitemap: https://www.artsy.net/sitemap-shows.xml
       routes.__set__ 'async', parallel: sinon.stub().yields null, [10]
       routes.index(@req, @res)
       @res.render.args[0][1].allPages.should.equal 10
-      @res.render.args[0][1].resources.length.should.equal 2
+      @res.render.args[0][1].resources.length.should.equal 1
 
   describe '#misc', ->
 


### PR DESCRIPTION
Blocked by https://github.com/artsy/cinder/pull/127 getting merged and the data getting up onto s3.

closes: https://github.com/artsy/force/issues/1114