### PR TITLE
@joeyAghion => switch lot_number to lot_label

### DIFF
--- a/desktop/apps/artwork/components/metadata/query.coffee
+++ b/desktop/apps/artwork/components/metadata/query.coffee
@@ -24,7 +24,7 @@ module.exports = """
     is_downloadable
     is_inquireable
     sale_artwork {
-      lot_number
+      lot_label
     }
   }
 """

--- a/desktop/apps/artwork/components/metadata/templates/lot_number.jade
+++ b/desktop/apps/artwork/components/metadata/templates/lot_number.jade
@@ -1,3 +1,3 @@
-if artwork.sale && artwork.sale_artwork && artwork.sale_artwork.lot_number
+if artwork.sale && artwork.sale_artwork && artwork.sale_artwork.lot_label
   .artwork-metadata__lot-number
-    | Lot #{artwork.sale_artwork.lot_number}
+    | Lot #{artwork.sale_artwork.lot_label}

--- a/desktop/apps/auction/routes.coffee
+++ b/desktop/apps/auction/routes.coffee
@@ -48,7 +48,6 @@ setupUser = (user, auction) ->
 
   artworks.comparator = (artwork) ->
     saleArtwork = artwork.related().saleArtwork
-    saleArtwork.get('lot_number') or
     saleArtwork.get('position') or
     saleArtwork.id
 

--- a/desktop/apps/auction/templates/my_active_bids.jade
+++ b/desktop/apps/auction/templates/my_active_bids.jade
@@ -19,7 +19,7 @@ if myActiveBids && myActiveBids.length
                       em= bid.sale_artwork.artwork.title
                       | ,&nbsp;
                       = bid.sale_artwork.artwork.date
-            td.auction-mab-lot-number Lot #{bid.sale_artwork.lot_number}
+            td.auction-mab-lot-number Lot #{bid.sale_artwork.lot_label}
             td.auction-mab-current-bid
               strong Current Bid: <em>#{bid.sale_artwork.highest_bid.display}</em>
             td.auction-mab-bid-num (#{bid.sale_artwork.counts.bidder_positions} Bids)

--- a/desktop/apps/auction/test/lot_standings.coffee
+++ b/desktop/apps/auction/test/lot_standings.coffee
@@ -5,7 +5,7 @@ module.exports = [
     "is_leading_bidder": false,
     "sale_artwork": {
       "id": "imhuge-brillo-condensed-soap",
-      "lot_number": "2",
+      "lot_label": "2",
       "reserve_status": "no_reserve",
       "counts": {
         "bidder_positions": 1
@@ -36,7 +36,7 @@ module.exports = [
     "is_leading_bidder": false,
     "sale_artwork": {
       "id": "mr-brainwash-tomato-spray-25",
-      "lot_number": "1",
+      "lot_label": "1",
       "reserve_status": "no_reserve",
       "counts": {
         "bidder_positions": 1

--- a/desktop/apps/auction2/client/filter_query.js
+++ b/desktop/apps/auction2/client/filter_query.js
@@ -35,7 +35,7 @@ export const filterQuery = `
       }
       hits {
         id
-        lot_number
+        lot_label
         counts {
           bidder_positions
         }

--- a/desktop/apps/auction2/components/auction_grid_artwork/index.js
+++ b/desktop/apps/auction2/components/auction_grid_artwork/index.js
@@ -26,7 +26,7 @@ export default function AuctionGridArtwork({ saleArtwork }) {
       <div className='auction2-grid-artwork__metadata'>
         <div className='auction2-grid-artwork__lot-information'>
           <div className='auction2-grid-artwork__lot-number'>
-            Lot {saleArtwork.lot_number}
+            Lot {saleArtwork.lot_label}
           </div>
           <div>{ bidStatus }</div>
         </div>

--- a/desktop/apps/auction2/components/auction_list_artwork/index.js
+++ b/desktop/apps/auction2/components/auction_list_artwork/index.js
@@ -26,7 +26,7 @@ export default function AuctionGridArtwork({ saleArtwork }) {
         <div className='auction2-list-artwork__title' dangerouslySetInnerHTML={{ __html: titleAndYear(artwork.title, artwork.date) }}></div>
       </div>
       <div className='auction2-list-artwork__lot-number'>
-        Lot {saleArtwork.lot_number}
+        Lot {saleArtwork.lot_label}
       </div>
       { bidStatus }
     </a>

--- a/desktop/apps/auction2/queries/filter.js
+++ b/desktop/apps/auction2/queries/filter.js
@@ -35,7 +35,7 @@ export const filterQuery = `
       }
       hits {
         id
-        lot_number
+        lot_label
         counts {
           bidder_positions
         }

--- a/desktop/apps/auction2/queries/works_by_followed_artists.js
+++ b/desktop/apps/auction2/queries/works_by_followed_artists.js
@@ -16,7 +16,7 @@ export const worksByFollowedArtists = `
       }
       hits {
         id
-        lot_number
+        lot_label
         counts {
           bidder_positions
         }

--- a/desktop/apps/auction2/templates/my_active_bids.jade
+++ b/desktop/apps/auction2/templates/my_active_bids.jade
@@ -11,7 +11,7 @@ if myActiveBids && myActiveBids.length
           )
             img.auction2-my-active-bids__img( src=bid.sale_artwork.artwork.image.url )
         .auction2-my-active-bids__artwork
-          .auction2-my-active-bids__lot-number Lot #{bid.sale_artwork.lot_number}
+          .auction2-my-active-bids__lot-number Lot #{bid.sale_artwork.lot_label}
           h3= bid.sale_artwork.artwork.artist.name
           .auction2-my-active-bids__title
             em= bid.sale_artwork.artwork.title

--- a/desktop/apps/auction2/test/components.js
+++ b/desktop/apps/auction2/test/components.js
@@ -25,7 +25,7 @@ describe('React components', () => {
 
     beforeEach(() => {
       saleArtwork = {
-        lot_number: 2,
+        lot_label: 2,
         current_bid: {
           display: '$100'
         },

--- a/desktop/apps/auction2/test/components.js
+++ b/desktop/apps/auction2/test/components.js
@@ -25,7 +25,7 @@ describe('React components', () => {
 
     beforeEach(() => {
       saleArtwork = {
-        lot_label: 2,
+        lot_label: '2',
         current_bid: {
           display: '$100'
         },

--- a/desktop/apps/auction2/test/my_active_bids.js
+++ b/desktop/apps/auction2/test/my_active_bids.js
@@ -65,7 +65,7 @@ describe('my active bids auction page template', () => {
             "is_leading_bidder": false,
             "sale_artwork": {
               "id": "imhuge-brillo-condensed-soap",
-              "lot_number": "2",
+              "lot_label": "2",
               "reserve_status": "no_reserve",
               "counts": {
                 "bidder_positions": 1

--- a/desktop/apps/auction_support/templates/bid-form.jade
+++ b/desktop/apps/auction_support/templates/bid-form.jade
@@ -13,7 +13,7 @@ block body
         .auction-support-artwork
           img.auction-support-artwork-img( src=artwork.defaultImageUrl() )
           .auction-support-details
-            .auction-support-lot-num Lot #{saleArtwork.get('lot_number')}
+            .auction-support-lot-num Lot #{saleArtwork.get('lot_label')}
             p!= artwork.titleAndYear()
             if artwork.get('artist')
               p= artwork.artistName()

--- a/desktop/components/artwork_item/templates/partials/title.jade
+++ b/desktop/components/artwork_item/templates/partials/title.jade
@@ -1,4 +1,4 @@
 a.faux-underline-hover( href=artwork.href() )
-  if isAuction && artwork.related().saleArtwork && artwork.related().saleArtwork.get('lot_number')
-    .artwork-item-lot-number Lot #{artwork.related().saleArtwork.get('lot_number')}
+  if isAuction && artwork.related().saleArtwork && artwork.related().saleArtwork.get('lot_label')
+    .artwork-item-lot-number Lot #{artwork.related().saleArtwork.get('lot_label')}
   p.artwork-item-title.artwork-item-overflow!= artwork.titleAndYear()

--- a/desktop/components/artwork_item/test/artwork.coffee
+++ b/desktop/components/artwork_item/test/artwork.coffee
@@ -231,7 +231,7 @@ describe 'Artwork Item template', ->
     it 'displays lot numbers', ->
       @artwork = new Artwork fabricate 'artwork'
       @artwork.set 'sale_artwork', fabricate 'sale_artwork',
-        { low_estimate_cents: 300000, high_estimate_cents: 700000, lot_number: 10 }
+        { low_estimate_cents: 300000, high_estimate_cents: 700000, lot_label: 10 }
       $ = cheerio.load render('artwork')
         artwork: @artwork
         isAuction: true

--- a/desktop/components/artwork_item/test/artwork.coffee
+++ b/desktop/components/artwork_item/test/artwork.coffee
@@ -231,7 +231,7 @@ describe 'Artwork Item template', ->
     it 'displays lot numbers', ->
       @artwork = new Artwork fabricate 'artwork'
       @artwork.set 'sale_artwork', fabricate 'sale_artwork',
-        { low_estimate_cents: 300000, high_estimate_cents: 700000, lot_label: 10 }
+        { low_estimate_cents: 300000, high_estimate_cents: 700000, lot_label: '10' }
       $ = cheerio.load render('artwork')
         artwork: @artwork
         isAuction: true

--- a/desktop/components/auction_artwork_brick/index.jade
+++ b/desktop/components/auction_artwork_brick/index.jade
@@ -9,9 +9,9 @@
   include ../artwork_brick/templates/auction_image
 
   .artwork-metadata-stub
-    if sale_artwork.lot_number
+    if sale_artwork.lot_label
       .artwork-metadata-stub__lot-number
-        | Lot #{sale_artwork.lot_number}
+        | Lot #{sale_artwork.lot_label}
 
     include ../artwork_metadata_stub/templates/didactics
     include ./templates/bid_status

--- a/desktop/components/auction_artwork_brick/query.coffee
+++ b/desktop/components/auction_artwork_brick/query.coffee
@@ -7,7 +7,7 @@ module.exports = """
     sale_message
 
     sale_artwork {
-      lot_number
+      lot_label
       symbol
       estimate
 

--- a/desktop/components/auction_artworks/templates/artwork/grid.jade
+++ b/desktop/components/auction_artworks/templates/artwork/grid.jade
@@ -8,9 +8,9 @@
 
   .aga-metadata
     a( href= href )
-      if saleArtwork.has('lot_number')
+      if saleArtwork.has('lot_label')
         .aga-lot-number
-          | Lot #{saleArtwork.get('lot_number')}
+          | Lot #{saleArtwork.get('lot_label')}
 
       .aga-primary-information
         h4.aga-artist

--- a/desktop/components/auction_artworks/templates/artwork/list.jade
+++ b/desktop/components/auction_artworks/templates/artwork/list.jade
@@ -17,9 +17,9 @@
       h3.ala-title
         != artwork.titleAndYear()
 
-  if saleArtwork.has('lot_number')
+  if saleArtwork.has('lot_label')
     .ala-lot-number: a( href= href )
-      | Lot #{saleArtwork.get('lot_number')}
+      | Lot #{saleArtwork.get('lot_label')}
 
   if auction.isOpen() && !auction.isAuctionPromo()
     .ala-bid-status: a( href= href )

--- a/desktop/components/auction_artworks/view.coffee
+++ b/desktop/components/auction_artworks/view.coffee
@@ -26,7 +26,7 @@ module.exports = class AuctionArtworksView extends Backbone.View
   sorts: (artwork) ->
     { saleArtwork, artist } = artwork.related()
 
-    default: saleArtwork.get('lot_number') or saleArtwork.get('position') or saleArtwork.id
+    default: saleArtwork.get('position') or saleArtwork.id
     name_asc: artist.get('sortable_id')
     bids_desc: -(saleArtwork.get('bidder_positions_count'))
     bids_asc: saleArtwork.get('bidder_positions_count')

--- a/desktop/components/commercial_filter/queries/artwork.coffee
+++ b/desktop/components/commercial_filter/queries/artwork.coffee
@@ -48,7 +48,7 @@ module.exports = """
       is_live_open
     }
     sale_artwork {
-      lot_number
+      lot_label
       counts {
         bidder_positions
       }

--- a/desktop/components/my_active_bids/query.coffee
+++ b/desktop/components/my_active_bids/query.coffee
@@ -8,7 +8,7 @@ module.exports = """
         is_leading_bidder
         sale_artwork {
           id
-          lot_number
+          lot_label
           reserve_status
           counts {
             bidder_positions

--- a/desktop/components/my_active_bids/template.jade
+++ b/desktop/components/my_active_bids/template.jade
@@ -10,7 +10,7 @@ if myActiveBids && myActiveBids.length
           a( href=bid.sale_artwork.artwork.href )
             img( src=bid.sale_artwork.artwork.image.url )
             .my-active-bids-item-details
-              h4 Lot #{bid.sale_artwork.lot_number}
+              h4 Lot #{bid.sale_artwork.lot_label}
               .my-active-bids-item-artist
                 strong= bid.sale_artwork.artwork.artist.name
               p #{bid.sale_artwork.highest_bid.display} (#{bid.sale_artwork.counts.bidder_positions} Bids)

--- a/desktop/components/my_active_bids/test/template.coffee
+++ b/desktop/components/my_active_bids/test/template.coffee
@@ -8,7 +8,7 @@ fixture = -> [
     "id": "56ba482e8b3b8167d7000000",
     "sale_artwork": {
       "id": "ed-ruscha-cockroaches-from-insects-portfolio",
-      "lot_number": "10",
+      "lot_label": "10",
       "counts": {
         "bidder_positions": 5,
       },

--- a/mobile/apps/artwork/components/related_artworks/queries/auction_query.coffee
+++ b/mobile/apps/artwork/components/related_artworks/queries/auction_query.coffee
@@ -8,7 +8,7 @@ module.exports = """
       is_open
       artworks(all: true, size: 50, exclude: [$id]) {
         sale_artwork {
-          lot_number
+          lot_label
         }
         #{require('./index.coffee')}
       }

--- a/mobile/apps/artwork/components/related_artworks/test/display_related_works.coffee
+++ b/mobile/apps/artwork/components/related_artworks/test/display_related_works.coffee
@@ -31,8 +31,8 @@ describe 'Render Related Artworks', ->
 
     it 'render related auction artworks', ->
       artwork1 = fabricate 'artwork', {
-        sale_artwork: lot_number: '24'
-        sale: { sale_artwork: lot_number: '24' }
+        sale_artwork: lot_label: '24'
+        sale: { sale_artwork: lot_label: '24' }
       }
       artwork2 = fabricate 'artwork'
       artwork3 = fabricate 'artwork', title: 'Funkadelic'

--- a/mobile/apps/artwork/components/related_artworks/test/index.coffee
+++ b/mobile/apps/artwork/components/related_artworks/test/index.coffee
@@ -44,8 +44,8 @@ describe 'Related Artworks', ->
             is_open: true
             artworks: [
               fabricate 'artwork', {
-                sale_artwork: lot_number: '24'
-                sale: { sale_artwork: lot_number: '24' }
+                sale_artwork: lot_label: '24'
+                sale: { sale_artwork: lot_label: '24' }
               }
             ]
 

--- a/mobile/apps/auction/routes.coffee
+++ b/mobile/apps/auction/routes.coffee
@@ -32,7 +32,7 @@ module.exports.index = (req, res, next) ->
   saleArtworks = new SaleArtworks [], id: id
   artworks = new Artworks
   artworks.comparator = (artwork) ->
-    (saleArtwork = artwork.related().saleArtwork).get('lot_number') or saleArtwork.id
+    (saleArtwork = artwork.related().saleArtwork).get('lot_label') or saleArtwork.id
 
   promise = Q.all([
     auction.fetch(cache: true)

--- a/mobile/apps/feature/templates/bid_page.jade
+++ b/mobile/apps/feature/templates/bid_page.jade
@@ -11,7 +11,7 @@ block body
     #feature-bid-page-detail
       img( src=artwork.defaultImageUrl() )
       h2
-        .feature-bid-page-lot-num Lot #{saleArtwork.get('lot_number')}
+        .feature-bid-page-lot-num Lot #{saleArtwork.get('lot_label')}
         if artwork.get('artist')
           = artwork.get('artist').name
           br

--- a/mobile/components/artwork_columns/auction_artwork.jade
+++ b/mobile/components/artwork_columns/auction_artwork.jade
@@ -4,9 +4,9 @@
   a( href='/artwork/' + artwork.get('id') )
     img( src=imageUrl data-id=artwork.get('_id') )
   .artwork-columns-artwork-details
-    if artwork.get('sale_artwork') && artwork.get('sale_artwork').lot_number
+    if artwork.get('sale_artwork') && artwork.get('sale_artwork').lot_label
       p.artwork-columns-artwork-details__auction-lot-number
-        | Lot #{artwork.get('sale_artwork').lot_number}
+        | Lot #{artwork.get('sale_artwork').lot_label}
 
     if artwork.get('artist')
       p= artwork.get('artist').name

--- a/mobile/components/auction_artwork_list/templates/artwork.jade
+++ b/mobile/components/auction_artwork_list/templates/artwork.jade
@@ -5,9 +5,9 @@ a.auction-artwork-list-item( href= auction.isAuctionPromo() ? ('/auction-artwork
 
   .auction-artwork-list-details
     section
-      if artwork.related().saleArtwork.get('lot_number')
+      if artwork.related().saleArtwork.get('lot_label')
         .aali-lot-number
-          | Lot #{artwork.related().saleArtwork.get('lot_number')}
+          | Lot #{artwork.related().saleArtwork.get('lot_label')}
 
       if artwork.related().artists.length
         h3.aali-artist-name

--- a/mobile/components/auction_artwork_list/view.coffee
+++ b/mobile/components/auction_artwork_list/view.coffee
@@ -21,7 +21,7 @@ module.exports = class AuctionArtworkListView extends Backbone.View
   sorts: (artwork) ->
     { saleArtwork, artist } = artwork.related()
 
-    default: saleArtwork.get('lot_number') or saleArtwork.get('position') or saleArtwork.id
+    default: saleArtwork.get('position') or saleArtwork.id
     name_asc: artist.get('sortable_id')
     bids_desc: -(saleArtwork.get('bidder_positions_count'))
     bids_asc: saleArtwork.get('bidder_positions_count')


### PR DESCRIPTION
Pretty innocuous (hopefully!) change. This updates to use `lot_label` instead of `lot_number`.

The only _slightly_ more involved change I describe inline.