### PR TITLE
@craigspaeth: Fix IP-blacklisting, at least for desktop

### DIFF
--- a/desktop/lib/setup.coffee
+++ b/desktop/lib/setup.coffee
@@ -66,7 +66,7 @@ ipfilter = require('express-ipfilter').IpFilter
 
 module.exports = (app) ->
   # Blacklist IPs
-  app.use ipfilter([IP_BLACKLIST.split(',')], log: false, mode: 'deny')
+  app.use ipfilter(IP_BLACKLIST.split(','), log: false, mode: 'deny')
 
   # Rate limited
   if OPENREDIS_URL and cache.client


### PR DESCRIPTION
Thanks for the pointer. This was an error in how we initialized [the `express-ipfilter` middleware](https://www.npmjs.com/package/express-ipfilter). I tested and confirmed that, with this update, the listed IPs are correctly blocked.

_Sort of:_ I still ran into https://github.com/artsy/force/issues/1148 which means the error page can't actually render. After removing the many `sd` references from the common layout, I was able to trigger the expected error.

However, this can still be much improved. In particular, the error is a 500 that clearly states the IP is being blocked: 

![](https://cl.ly/2P0i1m2N0q1V/download/Screen%20Shot%202017-03-31%20at%201.04.48%20PM.png)

It should be a `429` or at least a `4xx` error instead of crashing the app. This requires handling the `IpDeniedError` as mentioned in [the docs](https://www.npmjs.com/package/express-ipfilter#error-handling). If you can point me to an example of where we handle global errors elsewhere, I can work on that.

Also to-do: move this middleware up so that it's shared by desktop and mobile.