### PR TITLE
[memory] Add process unique identifier and fix S3 ACL.

### DIFF
--- a/lib/memory_profiler.js
+++ b/lib/memory_profiler.js
@@ -1,59 +1,67 @@
-const memwatch = require('memwatch-ng')
+const chalk = require('chalk')
 const heapdump = require('heapdump')
 const knox = require('knox')
-const path = require('path')
+const memwatch = require('memwatch-ng')
+const moment = require('moment')
 const os = require('os')
-const chalk = require('chalk')
+const path = require('path')
+const uuid = require('uuid')
 
 const { NODE_ENV } = process.env
 const { S3_KEY, S3_SECRET, S3_BUCKET } = require('../desktop/config')
 
-function log (message) {
-  console.log(chalk.red(`[MEMORY] ${message}`))
-}
-
-function upload (pathname, callback) {
-  const filename = path.basename(pathname)
-  const remotePathname = path.join('/heap-dumps', filename)
-  const client = knox.createClient({ key: S3_KEY, secret: S3_SECRET, bucket: S3_BUCKET })
-  client.putFile(pathname, remotePathname, (err, res) => {
-    if (err) {
-      log(`Failed to upload heap dump ${pathname}: ${err.message}`)
-    } else {
-      if (res.statusCode === 200) {
-        log(`Uploaded heap dump to https://${S3_BUCKET}.s3.amazonaws.com/${S3_BUCKET}${remotePathname}`)
-      } else {
-        log(`Failed to upload heap dump ${pathname}: HTTP ${res.statusCode}`)
-      }
-      res.resume()
-    }
-    callback()
-  })
-}
-
-// Every second, this program "leaks" a little bit. Add `--enable-gc` to the `node` CLI options of the `start` script.
-function startLeaking () {
-  log('Start leaking in order to test memory profiling!')
-  var leak = []
-  setInterval(() => {
-    for (var i = 0; i < 10; i++) {
-      var str = i.toString() + ' on a stick, short and stout!'
-      leak.push(str)
-    }
-  }, 1000)
-  setInterval(global.gc, 10000)
-}
-
 module.exports = () => {
-  log('Enabling memory profiling.')
+  // Keep track of heap dumps from specific processes.
+  const profileID = uuid().replace(/-/g, '')
+  // Ignore initial startup heap size increase.
+  let starting = true
+  // Don’t generate multiple reports at the same time.
+  let working = false
+  // Report timeframe in which leaks occur.
+  let lastReportedAt = new Date()
 
+  function log (message) {
+    console.log(chalk.red(`[memory:${profileID}] ${message}`))
+  }
+
+  function upload (pathname, callback) {
+    const filename = path.basename(pathname)
+    const remotePathname = path.join('/heap-dumps', filename)
+    const client = knox.createClient({ key: S3_KEY, secret: S3_SECRET, bucket: S3_BUCKET })
+    const headers = { 'Content-Type': 'application/json', 'x-amz-acl': 'bucket-owner-full-control' }
+    client.putFile(pathname, remotePathname, headers, (err, res) => {
+      if (err) {
+        log(`Failed to upload heap dump ${pathname}: ${err.message}`)
+      } else {
+        if (res.statusCode === 200) {
+          log(`Uploaded heap dump to https://${S3_BUCKET}.s3.amazonaws.com/${S3_BUCKET}${remotePathname}`)
+        } else {
+          log(`Failed to upload heap dump ${pathname}: HTTP ${res.statusCode}`)
+        }
+        res.resume()
+      }
+      callback()
+    })
+  }
+
+  // Every second, this program "leaks" a little bit and every 10 seconds a GC cycle is triggered.
+  // Add `--enable-gc` to the `node` CLI options of the `start` script.
+  function startLeaking () {
+    log('Start leaking in order to test memory profiling')
+    var leak = []
+    setInterval(() => {
+      for (var i = 0; i < 10; i++) {
+        var str = i.toString() + ' on a stick, short and stout!'
+        leak.push(str)
+      }
+    }, 1000)
+    setInterval(global.gc, 10000)
+  }
+
+  log('Enabling memory profiling')
   if (NODE_ENV !== 'production' && global.gc) {
     startLeaking()
   }
-
-  let lastReportedAt = new Date()
-  let working = false
-  let starting = true
 
   memwatch.on('leak', ({ growth }) => {
     if (starting) {
@@ -67,14 +75,14 @@ module.exports = () => {
 
     const start = prev.toLocaleTimeString()
     const end = now.toLocaleTimeString()
-    log(`A leak was detected between ${start} and ${end} which grew the heap by ${growth} bytes.`)
+    log(`A leak was detected between ${start} and ${end} which grew the heap by ${growth} bytes`)
 
     if (working) {
-      log(`Still processing previous leak, skipping this report.`)
+      log('Still processing previous leak, skipping this report')
     } else {
       working = true
 
-      const pathname = path.join(os.tmpdir(), `heapdump-${Date.now()}.heapsnapshot`)
+      const pathname = path.join(os.tmpdir(), `${profileID}-${moment().format('YYYYMMDDHHmmss')}.heapsnapshot`)
       heapdump.writeSnapshot(pathname, (err) => {
         if (err) {
           log(`Failed to generate heap dump ${pathname}: ${err.message}`)

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "underscore": "^1.8.3",
     "underscore.string": "^3.2.2",
     "updeep": "^1.0.0",
+    "uuid": "^3.0.1",
     "validator": "^6.1.0",
     "xss-filters": "^1.2.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7191,7 +7191,7 @@ uuid@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0:
+uuid@^3.0.0, uuid@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 


### PR DESCRIPTION
* To be able to diff heap dumps, they need to be of the same process, so adding a process specific UUID to the filenames (and logs).
* The default S3 ACL doesn’t allow us to download the heap dumps just by AWS KEY and SECRET, I think giving the ‘bucket owner’ full control should fix that (please correct me).