### PR TITLE
@anyone => GI callout label width

### DIFF
--- a/desktop/components/email/stylesheets/gallery_insights.styl
+++ b/desktop/components/email/stylesheets/gallery_insights.styl
@@ -108,6 +108,7 @@
     border white
   label
     color white
+    min-width 100%
   & + .cta-bar-defer
     position absolute
     top 20px


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/1134

- Removes appearance of linebreak in marketo form header

Share buttons will be addressed separately. 