### PR TITLE
@craigspaeth => little auction2 fixes

### DIFF
--- a/desktop/apps/auction2/client/index.js
+++ b/desktop/apps/auction2/client/index.js
@@ -11,7 +11,7 @@ import { setupCommercialFilter } from './commercial_filter'
 import { data as sd } from 'sharify'
 import _ from 'underscore'
 
-const auction = new Auction(_.pick(sd.AUCTION, 'start_at', 'live_start_at', 'end_at', 'associated_sale'))
+const auction = new Auction(sd.AUCTION)
 const user = sd.CURRENT_USER ? new CurrentUser(sd.CURRENT_USER) : null
 
 // If we are on the confirm-registration path then pop up a modal

--- a/desktop/apps/auction2/stylesheets/footer.styl
+++ b/desktop/apps/auction2/stylesheets/footer.styl
@@ -9,7 +9,8 @@
     width 50%
     height 100%
     vertical-align middle
-  .auction-articles
+
+  &__auction-articles
     padding-right 20px
     &:empty
       display none


### PR DESCRIPTION
This PR fixes the styling on the auction2 page and updates the backbone `auction` object that we pass around on the client to have all of the fields that we fetch, instead of just a few as it was buggy/confusing to just `pick` them as needed.