### PR TITLE
@kanaabe => Dont crash on nil user agents

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,9 @@ const isResponsive = (url) => {
 
 const determineDevice = (req, res, next) => {
   const ua = req.get('user-agent')
+  if (!ua) {
+    return next()
+  }
   const isPhone = Boolean(
     (ua.match(/iPhone/i) && !ua.match(/iPad/i)) ||
     (ua.match(/Android/i) && ua.match(/Mobile/i)) ||


### PR DESCRIPTION
Noticed we lost the 'dont crash on nil user agents' in this version, whereas we have it in [this version](https://github.com/artsy/force/blob/137b426ea82bede31776186feb7c8f72e2213ba0/desktop/lib/middleware/redirect_mobile.coffee#L14).

Was seeing some of these in NewRelic.

Closes https://github.com/artsy/force/issues/1099