### PR TITLE
Bugfix - duplicate bidder registration on combo form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dump.rdb
 /node_modules
 manifest.json
 public
+.vscode/settings.json

--- a/desktop/apps/auction_support/client/index.coffee
+++ b/desktop/apps/auction_support/client/index.coffee
@@ -35,6 +35,7 @@ module.exports.AuctionRouter = class AuctionRouter extends Backbone.Router
       new RegistrationForm
         el: $('#auction-registration-page')
         model: @sale
+        comboForm: true
         success: => @initBidForm(true)
 
   initBidForm: (submitImmediately=false) =>

--- a/desktop/apps/auction_support/client/registration_form.coffee
+++ b/desktop/apps/auction_support/client/registration_form.coffee
@@ -17,6 +17,7 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
   initialize: (options) ->
     @result = deferred.promise
     @success = options.success
+    @comboForm = options.comboForm
     @currentUser = CurrentUser.orNull()
     @$submit = @$('.registration-form-content .avant-garde-button-black')
     @setUpFields()
@@ -91,6 +92,8 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
               reject "Registration submission error: #{xhr.responseJSON?.message}"
     .then (bidder) =>
       analyticsHooks.trigger 'registration:success', bidder_id: bidder.id
+      @undelegateEvents() if @comboForm
+      @$('.auction-registration-form input, .auction-registration-form select').attr('disabled', true)
       @success()
 
   savePhoneNumber: ->

--- a/desktop/apps/auction_support/client/registration_form.coffee
+++ b/desktop/apps/auction_support/client/registration_form.coffee
@@ -94,8 +94,11 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
               resolve()
             else
               reject "Registration submission error: #{xhr.responseJSON?.message}"
-    .then (bidder) ->
+    .then (bidder) =>
+      # Executes if registration is successful
       analyticsHooks.trigger 'registration:success', bidder_id: bidder.id
+      @disableForm() if @comboForm
+      @success()
 
   savePhoneNumber: ->
     # Always resolves; just delays until the process completes
@@ -107,14 +110,11 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
       else
         resolve()
 
+  # Lock the form- action.finally() callback executes when form submission is complete regardless of success
   loadingLock: ($element, action) ->
     return if $element.hasClass('is-loading')
     $element.addClass 'is-loading'
-    action().finally =>
-      if @comboForm
-        @disableForm()
-      else
-        $element.removeClass 'is-loading'
+    action().finally => $element.removeClass 'is-loading' unless @comboForm
 
   onSubmit: =>
     analyticsHooks.trigger 'registration:submit-address'
@@ -125,5 +125,4 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
         @showError error
       .then =>
         @trigger('submitted')
-        @success()
 

--- a/desktop/apps/auction_support/stylesheets/index.styl
+++ b/desktop/apps/auction_support/stylesheets/index.styl
@@ -156,7 +156,7 @@
   sans('s-headline')
   margin-bottom 2px
 
-.auction-support-max-bid + .registration-form-content
+.auction-bid-form-container .registration-form-content:last-child
   margin-top 30px
 
 @media (max-width: 600px)

--- a/desktop/components/credit_card/stylesheets/index.styl
+++ b/desktop/components/credit_card/stylesheets/index.styl
@@ -50,6 +50,7 @@
         margin-right: 6%
       .error
         position absolute
+        top 4px
         bottom 0px
         left 0px
   .order-form-button


### PR DESCRIPTION
closes https://github.com/artsy/auctions/issues/306
cc @craigspaeth @damassi @sweir27 @mzikherman 

This addresses an issue where, upon clicking 'Confirm Bid' on the register+bid form, the credit card form remains in place and submits again. (see the linked issue above)

From the user's perspective I'm disabling the inputs and hiding the form, but I'm doing this across 2 different backbone views `RegistrationForm` and `BidForm`.

Since there is no page reload and the BidForm is actually creating a RegistrationForm view with a callback for placing the bid, I then undelegate the events on the RegistrationForm view to prevent the data from being submitted again.

To test: 
```bash
git checkout -b erikdstock-bugfix-bid-registration master
git pull https://github.com/erikdstock/force.git bugfix-bid-registration
```
- Find a lot and place a huge bid on it with one account (or use `auction/art-in-general-benefit-auction-2017/bid/paul-mpagi-sepuya-self-portrait-study-with-roses-at-night-1709-2`)
- With another, unregistered account, try the following:
  - Click bid & see the Confirm Bid + credit card form
  - Click confirm right away and *see the validations come up- the confirm button should still work (event still listening)*.
  - Fill in the form, bid the minimum, and *see the form update to remove its credit card portion and add an outbid message (assuming you are outbid)*
  - Bid again, possibly without raising your bid to try the other error message.

![register bid](https://cloud.githubusercontent.com/assets/9088720/24678346/30342e36-1958-11e7-8ed2-0c9840a0b2d3.gif)
