### PR TITLE
@damassi => fix asset loading for sub pages and criteo analytics

### DIFF
--- a/desktop/analytics/criteo.js
+++ b/desktop/analytics/criteo.js
@@ -1,7 +1,6 @@
 //
 // Criteo tracking for auctions product feed and artworks product feed
 //
-
 window.criteo_q = window.criteo_q || []
 var pathSplit = location.pathname.split('/')
 var userEmail = function() {
@@ -19,11 +18,13 @@ if (pathSplit[1] === 'auctions') {
   if (!pathSplit[3]) {
     // https://www.artsy.net/auction/:auction_id - (AUCTIONS viewList)
     //              0          1          2
-    window.criteo_q.push(
-      { event: 'setAccount', account: sd.CRITEO_AUCTIONS_ACCOUNT_NUMBER },
-      { event: 'setSiteType', type: 'd' },
-      { event: 'viewList', item: sd.ARTWORKS.map(function(a) { return a._id }) }
-    )
+    analyticsHooks.on('auction:artworks:loaded', function(artworks) {
+      window.criteo_q.push(
+        { event: 'setAccount', account: sd.CRITEO_AUCTIONS_ACCOUNT_NUMBER },
+        { event: 'setSiteType', type: 'd' },
+        { event: 'viewList', item: artworks }
+      )
+    })
   } else if (pathSplit[3] === 'bid') {
     // https://www.artsy.net/auction/:auction_id/bid - (AUCTIONS trackTransaction)
     //              0          1          2       3
@@ -48,7 +49,7 @@ if (pathSplit[1] === 'auctions') {
   }
 } else if (pathSplit[1] === 'artwork' && !pathSplit[3]) {
   // https://www.artsy.net/artwork/:artwork_id - (AUCTIONS & ARTWORKS viewItem)
-  //              0          1          2  
+  //              0          1          2
   //
   // We cannot send both ids on product pages, so, send the Auctions account ID
   // if the artwork is in an auction, otherwise send the Artworks account ID.

--- a/desktop/apps/auction2/client/actions.js
+++ b/desktop/apps/auction2/client/actions.js
@@ -1,3 +1,4 @@
+import analyticsHooks from '../../../lib/analytics_hooks.coffee'
 import metaphysics from '../../../../lib/metaphysics.coffee'
 import { filterQuery } from '../queries/filter'
 import { worksByFollowedArtists } from '../queries/works_by_followed_artists'
@@ -70,6 +71,13 @@ export function fetchArtworks() {
           user
         }
       })
+
+      if (filter_sale_artworks.hits && filter_sale_artworks.hits.length) {
+        analyticsHooks.trigger(
+          'auction:artworks:loaded',
+          { data: filter_sale_artworks.hits.map((sale_artwork) => sale_artwork.artwork._id) }
+        )
+      }
 
       const aggregations = filter_sale_artworks.aggregations
       const artistAggregation = aggregations.filter((agg) => agg.slice == 'ARTIST')

--- a/desktop/assets/auctions.coffee
+++ b/desktop/assets/auctions.coffee
@@ -11,6 +11,7 @@ routes =
   '''
   /sale/.*
   ^/auction/[^/]+/?$
+  /auction/.*/confirm-registration
   ''': require('../apps/auction2/client/index.js').default
 
   '''


### PR DESCRIPTION
This fixes a few things I noticed when QAing the new auction page in staging.
- We weren't loading assets when visiting the `auction/:id/confirm-registration` page, as it no longer fit into the regex pattern. Another reason to fix this to use actual routes.
- Previously, we loaded an `sd.ARTWORKS` object server side that we could send to criteo for tracking. As we now load the artworks client-side, I instead send an explicit `analyticsHook` event when we fetch artworks from the server.