### PR TITLE
@mzikherman : add click tracking to homepage recommendations

### DIFF
--- a/desktop/analytics/home.js
+++ b/desktop/analytics/home.js
@@ -24,6 +24,10 @@
     analytics.track('Clicked "New For You" on homepage')
   })
 
+  $(document).on('click', '#hpm-recommended_works-3 a', function () {
+    analytics.track('Clicked recommendation on homepage')
+  })
+
   // Artworks rail is rendered client-side
   var selectors = [
     '.js-homepage-featured-links[data-context="works by artists you follow"] a',


### PR DESCRIPTION
Adds click tracking on recommendations as it's a KPI (along with inquiries) for upcoming recs experiments.

I also need the mobile app equivalent - @alloy, any idea about click tracking on recommendations in eigen? Is that something we currently have or could add? 