### PR TITLE
@damassi => link to sale on artwork partner line

### DIFF
--- a/desktop/components/artwork_metadata_stub/queries/contact.coffee
+++ b/desktop/components/artwork_metadata_stub/queries/contact.coffee
@@ -4,6 +4,7 @@ module.exports = """
     href
     is_inquireable
     sale {
+      href
       is_auction
       is_live_open
       is_open

--- a/desktop/components/artwork_metadata_stub/templates/didactics.jade
+++ b/desktop/components/artwork_metadata_stub/templates/didactics.jade
@@ -18,6 +18,9 @@ a.artwork-metadata-stub__title.artwork-metadata-stub__line( href= artwork.href )
 if artwork.collecting_institution
   .artwork-metadata-stub__partner.artwork-metadata-stub__line
     = artwork.collecting_institution
+else if artwork.sale && artwork.sale.is_auction
+  a.artwork-metadata-stub__partner.artwork-metadata-stub__line( href= artwork.sale.href )
+    = artwork.partner.name
 else
   a.artwork-metadata-stub__partner.artwork-metadata-stub__line( href= artwork.partner.href )
     = artwork.partner.name


### PR DESCRIPTION
For artworks that are in sales, we want to link to the _sale_ on the partner byline (but still show the partner name, which will be something like "Phillips Auctions" once we do the migration).

![image](https://cloud.githubusercontent.com/assets/2081340/24778440/9905acfe-1af8-11e7-9606-e994b79cf844.png)
