### PR TITLE
Added video captions.

### DIFF
--- a/desktop/apps/article/templates/amp_mixins.jade
+++ b/desktop/apps/article/templates/amp_mixins.jade
@@ -61,6 +61,9 @@ mixin amp_video(section)
       amp-youtube(data-videoid=embed.getId(section.url) layout="responsive" width="480" height="270")
     else if section.url.match('vimeo')
       amp-vimeo(data-videoid=embed.getId(section.url) layout="responsive" width="480" height="270")
+    if section.caption && section.caption.length > 0
+      figcaption
+        != section.caption
 
 mixin amp_embed(section)
   .article-section-container.responsive-layout-container

--- a/desktop/components/article/stylesheets/video.styl
+++ b/desktop/components/article/stylesheets/video.styl
@@ -9,6 +9,13 @@ body-width = 580px
     height 100%
     max-width 100%
     max-height ((default-max-page-width * .5625) - 50)
+  figcaption
+      margin-top 10px
+      text-align left
+      color gray-darker-color
+      garamond-size('l-caption')
+      a
+        color gray-darker-color
 
 .article-section-container.responsive-layout-container[data-section-type="video"]
   &[data-layout="column_width"]

--- a/desktop/components/article/templates/mixins.jade
+++ b/desktop/components/article/templates/mixins.jade
@@ -18,6 +18,8 @@ mixin video(video)
           .article-video-play-button-caret
     .article-video
       != embed(video.url, { query: { title: 0, portrait: 0, badge: 0, byline: 0, showinfo: 0, rel: 0, controls: 2, modestbranding: 1, iv_load_policy: 3, color: "E5E5E5" } })
+      if video.caption
+        figcaption!= video.caption
 
 mixin fullscreen(article)
   figure.article-fullscreen( class= article.get('is_super_article') ? 'article-sa-fullscreen' : '' )

--- a/mobile/components/article/test/view.coffee
+++ b/mobile/components/article/test/view.coffee
@@ -22,6 +22,7 @@ describe 'ArticleView', ->
           {
             type: 'video'
             url: 'http://youtube.com'
+            caption: 'caption'
             cover_image_url: 'http://artsy.net/cover_image_url.jpg'
             layout: 'full-width'
             background_color: 'black'

--- a/mobile/test/helpers/fixtures.coffee
+++ b/mobile/test/helpers/fixtures.coffee
@@ -44,7 +44,7 @@ moment = require 'moment'
       items: [
         { type: 'artwork', id: '54276766fd4f50996aeca2b8' }
         { type: 'image', url: '', caption: '' }
-        { type: 'video', url: ''  }
+        { type: 'video', url: '', caption: '' }
       ]
     }
     {
@@ -82,7 +82,8 @@ moment = require 'moment'
     }
     {
       type: 'video',
-      url: 'http://youtu.be/yYjLrJRuMnY'
+      url: 'http://youtu.be/yYjLrJRuMnY',
+      caption: 'Doug and Claire get sucked into a marathon of Battlestar Galactica from Season 2 of Portlandia on IFC.'
     }
   ]
   featured_artist_ids: ['5086df098523e60002000012']


### PR DESCRIPTION
Companion to https://github.com/artsy/positron/pull/1007, displays video captions when available.

![screen shot 2017-04-07 at 11 34 19 am](https://cloud.githubusercontent.com/assets/542335/24807446/362f632a-1b86-11e7-945c-b4d2f353adae.png)

I am not sure how to test AMP.