### PR TITLE
@craigspaeth => allow for /consign to accept utm params on mobile

### DIFF
--- a/desktop/lib/middleware/redirect_mobile.coffee
+++ b/desktop/lib/middleware/redirect_mobile.coffee
@@ -34,7 +34,7 @@ router.get '/jobs', isResponsive
 router.get '/press/*', isResponsive
 router.get '/ArtsySocialMediaToolkit.pdf', isResponsive
 router.get '/inquiry/*', isResponsive
-router.get '/consign', isResponsive
+router.get '/consign*', isResponsive
 router.get '/professional-buyer*', isResponsive
 router.get '/2016-year-in-art*', isResponsive
 router.get '/article/*', isResponsive


### PR DESCRIPTION
Visiting a page like `http://localhost:5000/consign?utm_medium=p-search&utm_source=adwords&utm_campaign=Consignments` was throwing a 404 on mobile web. I believe this should fix it.