### PR TITLE
@craigspaeth => make auction page IE compatible

### DIFF
--- a/desktop/apps/auction2/components/medium_filter/index.js
+++ b/desktop/apps/auction2/components/medium_filter/index.js
@@ -2,7 +2,7 @@ import { updateMediumParams } from '../../client/actions'
 import BasicCheckbox from '../basic_checkbox'
 import React from 'react';
 import { connect } from 'react-redux'
-import _, { contains, find } from 'underscore'
+import _, { contains } from 'underscore'
 
 function MediumFilter(props) {
   const {
@@ -28,7 +28,7 @@ function MediumFilter(props) {
       {
         _.map(initialMediumMap, (initialAgg) => {
           const mediumSelected = contains(mediumIds, initialAgg.id)
-          const includedMedium = aggregatedMediums.find((agg) => agg.id === initialAgg.id)
+          const includedMedium = _.find(aggregatedMediums, (agg) => agg.id === initialAgg.id)
           return (
             <BasicCheckbox
               key={initialAgg.id}


### PR DESCRIPTION
Turns out the javascript `Array.find` method is [not supported in IE](http://stackoverflow.com/questions/37788536/the-find-method-is-supported-in-ie). Instead of including an explicit polyfill here, I instead grab the `find` method off of underscore, which has cross-browser support.