### PR TITLE
Spin off package.json scripts into a new directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "npm": "4.x.x"
   },
   "scripts": {
-    "mocha": "mocha -r should --compilers coffee:coffee-script/register,js:babel-core/register -t 30000",
-    "acceptance-record": "node -r dotenv/config -r coffee-script/register -r babel-core/register test/acceptance/helpers/record",
-    "acceptance": "mocha --retries 5 --compilers coffee:coffee-script/register,js:babel-core/register -r dotenv/config -r should -t 300000 dotenv_config_path=.env.test test/acceptance/*.js",
-    "test": "yarn acceptance && yarn mocha test/lib/* && yarn mocha $(find desktop/test -name '*.coffee') && yarn mocha $(find desktop/components/*/test -name '*.coffee') && yarn mocha $(find desktop/components/**/*/test -name '*.coffee') && yarn mocha $(find desktop/apps/*/test -name '*.coffee' -or -name '*.js') && yarn mocha $(find desktop/apps/*/**/*/test -name '*.coffee') && yarn mocha $(find mobile/test -name '*.coffee') && yarn mocha $(find mobile/components/*/test -name '*.coffee') && yarn mocha $(find mobile/components/**/*/test -name '*.coffee') && yarn mocha $(find mobile/apps/*/test -name '*.coffee') && yarn mocha $(find mobile/apps/*/**/*/test -name '*.coffee')",
-    "deploy": "yarn deploy-assets && git push --force git@heroku.com:force-$DEPLOY_ENV.git master",
-    "deploy-assets": "NODE_ENV=production mkdir public; mkdir public/assets; ezel-assets mobile/assets/ && ezel-assets desktop/assets/ && bucket-assets --bucket artsy-force-$DEPLOY_ENV && heroku config:set ASSET_MANIFEST=$(cat manifest.json) --app=force-$DEPLOY_ENV",
-    "start": "forever -c 'node -r dotenv/config --max_old_space_size=1024' ."
+    "mocha": "sh scripts/acceptance.sh",
+    "acceptance-record": "sh scripts/acceptance-record.sh",
+    "acceptance": "sh scripts/acceptance.sh",
+    "test": "sh scripts/test.sh",
+    "deploy": "sh scripts/deploy.sh",
+    "deploy-assets": "sh scripts/deploy-assets.sh",
+    "start": "sh scripts/start.sh"
   },
   "dependencies": {
     "@artsy/reaction-force": "^0.1.22",

--- a/scripts/acceptance-record.sh
+++ b/scripts/acceptance-record.sh
@@ -1,5 +1,7 @@
 # !/usr/bin/bash
 
+set -e -x
+
 node \
   -r dotenv/config \
   -r coffee-script/register \

--- a/scripts/acceptance-record.sh
+++ b/scripts/acceptance-record.sh
@@ -1,0 +1,6 @@
+# !/usr/bin/bash
+
+node \
+  -r dotenv/config \
+  -r coffee-script/register \
+  -r babel-core/register test/acceptance/helpers/record

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -7,4 +7,4 @@ mocha \
   --compilers coffee:coffee-script/register,js:babel-core/register \
   -r dotenv/config \
   -r should \
-  -t 300000 dotenv_config_path=../.env.test test/acceptance/*.js
+  -t 300000 dotenv_config_path=.env.test test/acceptance/*.js

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -1,0 +1,8 @@
+# !/usr/bin/bash
+
+mocha \
+  --retries 5 \
+  --compilers coffee:coffee-script/register,js:babel-core/register \
+  -r dotenv/config \
+  -r should \
+  -t 300000 dotenv_config_path=.env.test test/acceptance/*.js

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -1,5 +1,7 @@
 # !/usr/bin/bash
 
+set -e -x
+
 mocha \
   --retries 5 \
   --compilers coffee:coffee-script/register,js:babel-core/register \

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -7,4 +7,4 @@ mocha \
   --compilers coffee:coffee-script/register,js:babel-core/register \
   -r dotenv/config \
   -r should \
-  -t 300000 dotenv_config_path=.env.test test/acceptance/*.js
+  -t 300000 dotenv_config_path=../.env.test test/acceptance/*.js

--- a/scripts/deploy-assets.sh
+++ b/scripts/deploy-assets.sh
@@ -1,0 +1,8 @@
+# !/usr/bin/bash
+
+NODE_ENV=production mkdir public; \
+mkdir public/assets; \
+ezel-assets mobile/assets/ && \
+ezel-assets desktop/assets/ && \
+bucket-assets --bucket artsy-force-$DEPLOY_ENV && \
+heroku config:set ASSET_MANIFEST=$(cat manifest.json) --app=force-$DEPLOY_ENV

--- a/scripts/deploy-assets.sh
+++ b/scripts/deploy-assets.sh
@@ -1,8 +1,11 @@
 # !/usr/bin/bash
 
-NODE_ENV=production mkdir public; \
-mkdir public/assets; \
-ezel-assets mobile/assets/ && \
-ezel-assets desktop/assets/ && \
-bucket-assets --bucket artsy-force-$DEPLOY_ENV && \
+set -e -x
+
+NODE_ENV=production
+mkdir public;
+mkdir public/assets;
+ezel-assets mobile/assets/
+ezel-assets desktop/assets/
+bucket-assets --bucket artsy-force-$DEPLOY_ENV
 heroku config:set ASSET_MANIFEST=$(cat manifest.json) --app=force-$DEPLOY_ENV

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,6 @@
 # !/usr/bin/bash
 
-yarn deploy-assets && \
+set -e -x
+
+yarn deploy-assets
 git push --force git@heroku.com:force-$DEPLOY_ENV.git master

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,4 @@
+# !/usr/bin/bash
+
+yarn deploy-assets && \
+git push --force git@heroku.com:force-$DEPLOY_ENV.git master

--- a/scripts/mocha.sh
+++ b/scripts/mocha.sh
@@ -1,5 +1,7 @@
 # !/usr/bin/bash
 
+set -e -x
+
 mocha \
   -r should \
   --compilers coffee:coffee-script/register,js:babel-core/register \

--- a/scripts/mocha.sh
+++ b/scripts/mocha.sh
@@ -1,0 +1,6 @@
+# !/usr/bin/bash
+
+mocha \
+  -r should \
+  --compilers coffee:coffee-script/register,js:babel-core/register \
+  -t 30000

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,9 @@
+# !/usr/bin/bash
+
+node \
+  -r dotenv/config \
+  --optimize_for_size \
+  --max_semi_space_size=16 \
+  --max_old_space_size=1024 \
+  --max_executable_size=512 \
+  --gc_interval=100 .

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,9 +1,5 @@
 # !/usr/bin/bash
 
-node \
-  -r dotenv/config \
-  --optimize_for_size \
-  --max_semi_space_size=16 \
-  --max_old_space_size=1024 \
-  --max_executable_size=512 \
-  --gc_interval=100 .
+set -e -x
+
+forever -c 'node -r dotenv/config --max_old_space_size=1024' .

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,7 +1,10 @@
 # !/usr/bin/bash
 
-yarn mocha test/lib && \
-yarn mocha $(find desktop/test -name '*.coffee') && \
+set -e -x
+
+yarn acceptance
+yarn mocha test/lib/*
+yarn mocha $(find desktop/test -name '*.coffee')
 yarn mocha $(find desktop/components/*/test -name '*.coffee') && \
 yarn mocha $(find desktop/components/**/*/test -name '*.coffee') && \
 yarn mocha $(find desktop/apps/*/test -name '*.coffee' -or -name '*.js') && \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,12 +5,12 @@ set -e -x
 yarn acceptance
 yarn mocha test/lib/*
 yarn mocha $(find desktop/test -name '*.coffee')
-yarn mocha $(find desktop/components/*/test -name '*.coffee') && \
-yarn mocha $(find desktop/components/**/*/test -name '*.coffee') && \
-yarn mocha $(find desktop/apps/*/test -name '*.coffee' -or -name '*.js') && \
-yarn mocha $(find desktop/apps/*/**/*/test -name '*.coffee') && \
-yarn mocha $(find mobile/test -name '*.coffee') && \
-yarn mocha $(find mobile/components/*/test -name '*.coffee') && \
-yarn mocha $(find mobile/components/**/*/test -name '*.coffee') && \
-yarn mocha $(find mobile/apps/*/test -name '*.coffee') && \
+yarn mocha $(find desktop/components/*/test -name '*.coffee')
+yarn mocha $(find desktop/components/**/*/test -name '*.coffee')
+yarn mocha $(find desktop/apps/*/test -name '*.coffee' -or -name '*.js')
+yarn mocha $(find desktop/apps/*/**/*/test -name '*.coffee')
+yarn mocha $(find mobile/test -name '*.coffee')
+yarn mocha $(find mobile/components/*/test -name '*.coffee')
+yarn mocha $(find mobile/components/**/*/test -name '*.coffee')
+yarn mocha $(find mobile/apps/*/test -name '*.coffee')
 yarn mocha $(find mobile/apps/*/**/*/test -name '*.coffee')

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,13 @@
+# !/usr/bin/bash
+
+yarn mocha test/lib && \
+yarn mocha $(find desktop/test -name '*.coffee') && \
+yarn mocha $(find desktop/components/*/test -name '*.coffee') && \
+yarn mocha $(find desktop/components/**/*/test -name '*.coffee') && \
+yarn mocha $(find desktop/apps/*/test -name '*.coffee' -or -name '*.js') && \
+yarn mocha $(find desktop/apps/*/**/*/test -name '*.coffee') && \
+yarn mocha $(find mobile/test -name '*.coffee') && \
+yarn mocha $(find mobile/components/*/test -name '*.coffee') && \
+yarn mocha $(find mobile/components/**/*/test -name '*.coffee') && \
+yarn mocha $(find mobile/apps/*/test -name '*.coffee') && \
+yarn mocha $(find mobile/apps/*/**/*/test -name '*.coffee')


### PR DESCRIPTION
This PR breaks out the package.json `scripts` field into separate files. I'd like to merge this initial pass before moving on to [Circle](https://github.com/artsy/force/blob/master/circle.yml#L43). Thanks to @alloy for suggesting using `set` instead of `&& \`s all over the place.