### PR TITLE
@mzikherman => Auction page analytics QA plus new events

### DIFF
--- a/desktop/analytics/bidding.js
+++ b/desktop/analytics/bidding.js
@@ -7,74 +7,9 @@ var AUCTION_ID = sd.AUCTION && sd.AUCTION.id
 var AUCTION_STATE = sd.AUCTION && sd.AUCTION.auction_state
 
 // Clicked "Register to bid" (context_type: 'auctions landing')
-$('.auctions-placeholder-metadata .avant-garde-button-black').click(function () {
+$('.auction2-registration-wrapper .avant-garde-button-black').click(function () {
   analytics.track('Clicked "Register to bid"', {
     context_type: 'auctions landing',
-    auction_slug: sd.UPCOMING_AUCTIONS[0].id,
-    auction_state: sd.UPCOMING_AUCTIONS[0].auction_state,
-    user_id: USER_ID
-  })
-})
-
-// Sign up to be noti..... goes here
-// $(".auctions-placeholder-metadata .avant-garde-button-black, .auctions-placeholder-hero img")
-
-// Clicked "Register to bid" (context_type: 'upcoming auction feature')
-$('.auction-preview-sidebar .avant-garde-button-black').click(function () {
-  if (sd.CURRENT_USER) {
-    analytics.track('Clicked "Register to bid"', {
-      context_type: 'upcoming auction feature',
-      auction_slug: AUCTION_ID,
-      auction_state: AUCTION_STATE,
-      user_id: USER_ID
-    })
-  }
-})
-
-// Clicked "Register to bid" (context_type: 'notify me register now')
-$('.auction-preview-register-now a').click(function () {
-  analytics.track('Clicked "Register to bid"', {
-    context_type: 'notify me register now',
-    auction_slug: AUCTION_ID,
-    auction_state: AUCTION_STATE,
-    user_id: USER_ID
-  })
-})
-
-// Notify me auction form submitted
-$('.auction-preview-sidebar-form').submit(function () {
-  analytics.track('Notify me auction form submitted', {
-    auction_slug: AUCTION_ID,
-    user_id: USER_ID
-  })
-})
-
-// TODO: Clicked "Register to bid" (context_type: "notify me thank you modal")
-$(document).on('click', '.email-to-registration-transition-register', function () {
-  analytics.track('Clicked "Register to bid"', {
-    context_type: 'notify me thank you modal',
-    auction_slug: AUCTION_ID,
-    auction_state: AUCTION_STATE,
-    user_id: USER_ID
-  })
-})
-
-// Clicked "Register to bid" (context_type: 'current auction feature top')
-analytics.trackLink(
-  $('.auction-info-register-button .avant-garde-button-black'),
-  'Clicked "Register to bid"',
-  {
-    context_type: 'current auction feature top',
-    auction_slug: AUCTION_ID,
-    auction_state: AUCTION_STATE,
-    user_id: USER_ID
-  }
-)
-
-// Clicked "Register to bid" (context_type: 'current auction feature banner')
-$(document).on('click', '[href*=auction-registration].cta-bar-button', function () {
-  analytics.track('Clicked "Register to bid"', {
-    context_type: 'current auction feature banner',
     auction_slug: AUCTION_ID,
     auction_state: AUCTION_STATE,
     user_id: USER_ID
@@ -123,47 +58,35 @@ analyticsHooks.on('creditcard:unqualified', function (data) {
   analytics.track('Credit card not valid', data)
 })
 
-// Clicked "Bid" (context_type: auction grid artwork)
-$(document).on('click', '.aga-bid-button .avant-garde-button-black', function () {
+// Clicked "Bid" (context_type: your active bids on auction page)
+$(document).on('click', '.auction2-my-active-bids__bid-button', function (e) {
+  const artworkId = $(e.target).parent().data('artwork_id')
   analytics.track('Clicked "Bid"', {
     auction_slug: AUCTION_ID,
     user_id: USER_ID,
-    context_type: 'auction grid artwork',
-    artwork_slug: $(this).attr('data-id')
-  })
-})
-
-// Clicked "Bid" (context_type: auction list artwork)
-$(document).on('click', '.ala-bid-button .avant-garde-button-black', function () {
-  analytics.track('Clicked "Bid"', {
-    auction_slug: AUCTION_ID,
-    user_id: USER_ID,
-    context_type: 'auction list artwork',
-    artwork_slug: $(this).attr('data-id')
+    context_type: 'your active bids',
+    artwork_slug: artworkId
   })
 })
 
 // Clicked "Bid" (context_type: your active bids)
-$('.auction-mab-bid-button').each(function () {
-  analytics.trackLink(
-    $(this),
-    'Clicked "Bid"',
-    {
-      auction_slug: AUCTION_ID,
-      user_id: USER_ID,
-      context_type: 'your active bids',
-      artwork_slug: $(this).attr('href').replace('/artwork/', '')
-    }
-  )
+$(document).on('click', '.my-active-bids-bid-button', function (e) {
+  const artworkId = $(e.target).parent().data('artwork_id')
+  analytics.track('Clicked "Bid"', {
+    auction_slug: AUCTION_ID,
+    user_id: USER_ID,
+    context_type: 'your active bids',
+    artwork_slug: artworkId
+  })
 })
 
 // Clicked "Bid" (context_type: artwork page)
-analyticsHooks.on('artwork:auction:bid:success', function (data) {
+$(document).on('click', '.artwork-auction__bid-form__button', function () {
   analytics.track('Clicked "Bid"', {
-    auction_slug: data.auction_slug,
+    auction_slug: AUCTION_ID,
     user_id: USER_ID,
     context_type: 'artwork page',
-    artwork_slug: sd.ARTWORK.id
+    artwork_slug: sd.PARAMS.id
   })
 })
 
@@ -186,5 +109,16 @@ analyticsHooks.on('confirm:bid:form:success', function (data) {
     artwork_slug: sd.SALE_ARTWORK.artwork.id,
     bidder_position_id: data.bidder_position_id,
     bidder_id: data.bidder_id
+  })
+})
+
+// Changed filter params on /auction page
+analyticsHooks.on('auction:artworks:params:change', function (data) {
+  analytics.track('Commercial filter params changed', {
+    sale_id: AUCTION_ID,
+    auction_slug: sd.AUCTION.slug,
+    user_id: USER_ID,
+    type: ['price', 'medium', 'artists', 'sort'],
+    value: [data.estimate_range, data.gene_ids, data.artist_ids, data.sort]
   })
 })

--- a/desktop/apps/auction2/client/actions.js
+++ b/desktop/apps/auction2/client/actions.js
@@ -64,6 +64,11 @@ export function fetchArtworks() {
 
     try {
       dispatch(getArtworksRequest())
+      analyticsHooks.trigger(
+        'auction:artworks:params:change',
+        filterParams
+      )
+
       const { filter_sale_artworks } = await metaphysics({
         query: filterQuery,
         variables: filterParams,

--- a/desktop/apps/auction2/templates/my_active_bids.jade
+++ b/desktop/apps/auction2/templates/my_active_bids.jade
@@ -4,7 +4,7 @@ if myActiveBids && myActiveBids.length
   h2 Your Active Bids
   for bid in myActiveBids
     if bid.sale_artwork
-      .auction2-my-active-bids__active-bid
+      .auction2-my-active-bids__active-bid( data-artwork_id=bid.sale_artwork.id )
         .auction2-my-active-bids__artwork-container
           a(
             href=bid.sale_artwork.artwork.href

--- a/desktop/components/my_active_bids/template.jade
+++ b/desktop/components/my_active_bids/template.jade
@@ -6,7 +6,7 @@ if myActiveBids && myActiveBids.length
       if bid.sale_artwork
         - leadingBidder = bid.is_leading_bidder
         - reserveNotMet = bid.sale_artwork.reserve_status === 'reserve_not_met'
-        li.my-active-bids-item( class= (!reserveNotMet && leadingBidder) ? ' my-active-bids-winning' : '' )
+        li.my-active-bids-item( data-artwork_id=bid.sale_artwork.id class= (!reserveNotMet && leadingBidder) ? ' my-active-bids-winning' : '' )
           a( href=bid.sale_artwork.artwork.href )
             img( src=bid.sale_artwork.artwork.image.url )
             .my-active-bids-item-details


### PR DESCRIPTION
Following the analytics schema here: https://docs.google.com/spreadsheets/d/17oqFli15x1SmNBu_-fPZhFifMw2BNSPJe9VdOgs1aKs/edit#gid=2024361038

This PR removes/updates the following events:
- Removed "Notify me auction form submitted" (we removed this feature)
- Only include the "Clicked Register to bid" event for the settings and auction landing page contexts (we couldn't find the other ones, I think the CTAs have been removed)
- Fixed the "Clicked Bid" events as they weren't firing anywhere, and made sure they work for the 'my active bids' modules throughout the site
- Added tracking for "Commercial filter params changed" events, which fire on the first new fetch of artworks after a param has changed.

cc @joelauerbach 