### PR TITLE
reminders hooks

### DIFF
--- a/desktop/analytics/auction_reminder.js
+++ b/desktop/analytics/auction_reminder.js
@@ -1,0 +1,20 @@
+(function () {
+  'use strict'
+
+  // DOM events
+  var $document = $(document)
+
+  analyticsHooks.on('auction_reminder:click', function (data) {
+    analytics.track('Clicked Auction Reminder', {
+      slug: data.slug,
+      auction_state: data.auction_state
+    })
+  })
+
+  analyticsHooks.on('auction_reminder:close', function (data) {
+    analytics.track('Closed Auction Reminder', {
+      slug: data.slug,
+      auction_state: data.auction_state
+    })
+  })
+})()

--- a/desktop/assets/analytics.coffee
+++ b/desktop/assets/analytics.coffee
@@ -33,6 +33,7 @@ $ -> analytics.ready ->
   require '../analytics/show_page.js'
   require '../analytics/account_creation.js'
   require '../analytics/account_login.js'
+  require '../analytics/auction_reminder.js'
   require '../analytics/bidding.js'
   require '../analytics/collect.js'
   require '../analytics/criteo.js'

--- a/desktop/components/auction_reminders/view.coffee
+++ b/desktop/components/auction_reminders/view.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore'
 Q = require 'bluebird-q'
+analyticsHooks = require '../../lib/analytics_hooks.coffee'
 moment = require 'moment'
 Backbone = require 'backbone'
 template = -> require('./template.jade') arguments...
@@ -17,10 +18,16 @@ module.exports = class AuctionReminderView extends Backbone.View
 
   click: (e) ->
     @dismisser.dismiss()
-
+    analyticsData = {
+      slug: @model.id,
+      auction_state: @model.reminderStatus()
+    }
     if $(e.target).hasClass 'js-dismiss'
       e.preventDefault()
+      analyticsHooks.trigger('auction_reminder:close', analyticsData)
       return @close()
+    else
+      analyticsHooks.trigger('auction_reminder:click', analyticsData)
 
   getOffsetTimesPromise: ->
     Q.promise (resolve, reject, notify) =>


### PR DESCRIPTION
closes https://github.com/artsy/auctions/issues/379
cc @sweir27 @katarinabatina @joelauerbach 
This adds analytics for auction reminder interactions, with metadata for `slug` and `auction_state`. I was able to track analyticsHooks interactions in a mocha test with a bit of mocking, but it wasn't fun and @craigspaeth recommended I leave it off (we don't currently test analytics messages anywhere else).