### PR TITLE
@starsirius => Fix occasionally empty primary carousel

### DIFF
--- a/desktop/apps/galleries_institutions/components/partner_cell/index.jade
+++ b/desktop/apps/galleries_institutions/components/partner_cell/index.jade
@@ -1,23 +1,37 @@
 - var profile = partner.profile
 - var hasImage = profile && profile.image && profile.image.cropped && profile.image.cropped.url
 
-a.partner-featured-image(
-  href= profile.href
-)
-  .hoverable-image.is-three-two(
-    class= hasImage ? '' : 'is-missing'
-    data-initials= partner.initials
-    style= hasImage ? 'background-image: url(' + profile.image.cropped.url + ');' : undefined
+if profile
+  a.partner-featured-image(
+    href= profile.href
   )
+    .hoverable-image.is-three-two(
+      class= hasImage ? '' : 'is-missing'
+      data-initials= partner.initials
+      style= hasImage ? 'background-image: url(' + profile.image.cropped.url + ');' : undefined
+    )
 
-.partner-cell-metadata
-  .partner-cell-metadata-text
-    a.partner-cell-name.avant-garde-header( href= profile.href )
+  .partner-cell-metadata
+    .partner-cell-metadata-text
+      a.partner-cell-name.avant-garde-header( href= profile.href )
+        = partner.name
+      br
+      .partner-cell-location
+        = ViewHelpers.displayLocations(partner.locations, preferredCity) || ''
+
+    button.partner-cell-follow-button.is-small.avant-garde-follow-button-black.follow-button.js-follow-button(
+      data-id= profile.id
+    )
+else
+  .partner-featured-image
+    .hoverable-image.is-three-two(
+      class= 'is-missing'
+      data-initials= partner.initials
+    )
+
+  .partner-cell-metadata
+    .partner-cell-metadata-text
       = partner.name
-    br
-    .partner-cell-location
-      = ViewHelpers.displayLocations(partner.locations, preferredCity) || ''
-
-  button.partner-cell-follow-button.is-small.avant-garde-follow-button-black.follow-button.js-follow-button(
-    data-id= profile.id
-  )
+      br
+      .partner-cell-location
+        = ViewHelpers.displayLocations(partner.locations, preferredCity) || ''

--- a/desktop/apps/galleries_institutions/components/primary_carousel/template.jade
+++ b/desktop/apps/galleries_institutions/components/primary_carousel/template.jade
@@ -1,52 +1,54 @@
 - var length = profiles.length
 
-if length > 1
-  .gpc-bumpers.js-gpc-navigation
-    .gpc-bumper-prev.gi-carousel-arrow-prev.js-gpc-prev: i.icon-chevron-left
-    .gpc-bumber-next.gi-carousel-arrow-next.js-gpc-next: i.icon-chevron-right
+if length > 0
 
-.gpc-body
-  .gpc-overlays
-    for profile, i in profiles
-      - var show = profile.related().owner.related().shows.featured()
-      .gpc-overlay.js-gpc-overlay( data-idx= i )
-        a.gpc-headline( href= profile.related().owner.href() )
-          = profile.related().owner.get('name')
+  if length > 1
+    .gpc-bumpers.js-gpc-navigation
+      .gpc-bumper-prev.gi-carousel-arrow-prev.js-gpc-prev: i.icon-chevron-left
+      .gpc-bumber-next.gi-carousel-arrow-next.js-gpc-next: i.icon-chevron-right
 
-        if show
-          a( href= show.href() )
-            .gpc-subheadline
-              | #{show.statusLabel()} #{show.has('location') ? show.formatCity() : ''} Show
-            .gpc-subheadline-alt
-              = show.get('name')
-            .gpc-location-dates
-              include ../../../../components/featured_shows/metadata/location_with_dates
-
-        button.gpc-follow-button.is-small.avant-garde-follow-button-black.follow-button.js-follow-button(
-          data-id= profile.id
-        )
-
-    - var index = 0
-    .mgr-dots
-      if length > 1
-        for x, i in new Array(length)
-          .mgr-dot.js-gpc-dot(
-            class= (index === i ? 'is-active' : undefined)
-            data-index= i
-          ) •
-
-  .gpc-carousel
-    .gpc-carousel-cells.js-mgr-cells
-      for profile in profiles
+  .gpc-body
+    .gpc-overlays
+      for profile, i in profiles
         - var show = profile.related().owner.related().shows.featured()
-        .gpc-carousel-cell.js-mgr-cell
-          if show && show.isWithImages()
-            - var imageUrl = show.hasImage('featured') ? show.imageUrl('featured') : show.imageUrlForMaxSize()
-          else if profile.get('cover_image')
-            - var imageUrl = profile.coverImage().imageUrlForMaxSize()
-          else
-            - var imageUrl = ''
-          a.gpc-carousel-figure(
-            href= (show && show.href()) || profile.related().owner.href()
-            style='background-image: url(' + imageUrl + ')'
+        .gpc-overlay.js-gpc-overlay( data-idx= i )
+          a.gpc-headline( href= profile.related().owner.href() )
+            = profile.related().owner.get('name')
+
+          if show
+            a( href= show.href() )
+              .gpc-subheadline
+                | #{show.statusLabel()} #{show.has('location') ? show.formatCity() : ''} Show
+              .gpc-subheadline-alt
+                = show.get('name')
+              .gpc-location-dates
+                include ../../../../components/featured_shows/metadata/location_with_dates
+
+          button.gpc-follow-button.is-small.avant-garde-follow-button-black.follow-button.js-follow-button(
+            data-id= profile.id
           )
+
+      - var index = 0
+      .mgr-dots
+        if length > 1
+          for x, i in new Array(length)
+            .mgr-dot.js-gpc-dot(
+              class= (index === i ? 'is-active' : undefined)
+              data-index= i
+            ) •
+
+    .gpc-carousel
+      .gpc-carousel-cells.js-mgr-cells
+        for profile in profiles
+          - var show = profile.related().owner.related().shows.featured()
+          .gpc-carousel-cell.js-mgr-cell
+            if show && show.isWithImages()
+              - var imageUrl = show.hasImage('featured') ? show.imageUrl('featured') : show.imageUrlForMaxSize()
+            else if profile.get('cover_image')
+              - var imageUrl = profile.coverImage().imageUrlForMaxSize()
+            else
+              - var imageUrl = ''
+            a.gpc-carousel-figure(
+              href= (show && show.href()) || profile.related().owner.href()
+              style='background-image: url(' + imageUrl + ')'
+            )

--- a/desktop/apps/galleries_institutions/components/primary_carousel/test/template.coffee
+++ b/desktop/apps/galleries_institutions/components/primary_carousel/test/template.coffee
@@ -6,18 +6,36 @@ Profile = require '../../../../../models/profile'
 template = jade.compile fs.readFileSync(filename = require.resolve '../template.jade'), filename: filename
 
 describe 'PrimaryCarousel template', ->
-  beforeEach ->
-    @profile = new Profile fabricate 'profile', owner_type: 'PartnerGallery'
-    partner = @profile.related().owner
-    partner.set fabricate 'partner'
-    partner.related().shows.add fabricate 'show'
 
-  it 'renders correctly', ->
-    @html = template profiles: [@profile]
-    @$ = $.load @html
+  describe 'with at least one profile to show', ->    
+    before ->
+      @profile = new Profile fabricate 'profile', owner_type: 'PartnerGallery'
+      partner = @profile.related().owner
+      partner.set fabricate 'partner'
+      partner.related().shows.add fabricate 'show'
 
-    @$('.gpc-subheadline').text()
-      .should.equal 'Past New York Show'
+    it 'displays the carousel', ->
+      @html = template profiles: [@profile]
+      @$ = $.load @html
+      @$('.gpc-body').should.not.be.empty()
 
-    @$('.gpc-location-dates').text()
-      .should.equal 'New York, Jul 12 – Aug 23, 2013'
+    it 'renders correctly', ->
+      @html = template profiles: [@profile]
+      @$ = $.load @html
+
+      @$('.gpc-subheadline').text()
+        .should.equal 'Past New York Show'
+
+      @$('.gpc-location-dates').text()
+        .should.equal 'New York, Jul 12 – Aug 23, 2013'
+
+    describe 'with more than one profile to show', ->    
+      it 'shows navigation arrows', ->
+        @html = template profiles: [@profile, @profile]
+        @$ = $.load @html
+        @$*('.gpc-bumpers').should.not.be.empty()
+
+  describe 'with no profiles to show', ->
+    it 'does not display the carousel', ->
+      @html = template profiles: []
+      @html.should.be.empty()


### PR DESCRIPTION
Fixes #95 

Occasionally the filter pulldown selections on /gallleries will result in an empty carousel, and a big blank space on the page, because there are no eligible profiles to display in it.

Let's selectively only render the carousel based on if we _actually_ get any profiles back for display. (Watch for Miami in the screencap below)

![empty](https://cloud.githubusercontent.com/assets/140521/24964086/4a2a3ee0-1f6e-11e7-94c1-5eaedf01a591.gif)