### PR TITLE
@erikdstock => fix contact gallery showing up on mobile web

### DIFF
--- a/mobile/components/artwork_columns/artwork.jade
+++ b/mobile/components/artwork_columns/artwork.jade
@@ -1,5 +1,6 @@
 - size = size || tall
 - imageUrl = artwork.defaultImageUrl(size) ? artwork.defaultImageUrl(size) : artwork.get('image').url
+- hasAuctionPartner = (artwork.get('partner') && (artwork.get('partner').type === 'Auction' || artwork.get('partner').type === 'Auction House')) || artwork.get('is_biddable')
 .artwork-columns-artwork
   a( href='/artwork/' + artwork.get('id') )
     img( src=imageUrl data-id=artwork.get('_id') )
@@ -23,12 +24,12 @@
     else if artwork.get('availability') !== 'not for sale'
       p= artwork.saleMessage()
 
-    if artwork.get('partner') && artwork.get('partner').type === 'Auction'
+    if hasAuctionPartner
       .artwork-columns-artwork-details__bid-now
         if artwork.get('forsale') || artwork.get('is_for_sale')
           p.bid-now-link Bid now
         else
           p.bid-now-link Auction closed
 
-    if artwork.get('inquireable')
+    if artwork.get('inquireable') && !hasAuctionPartner
       a( href='/artwork/' + artwork.get('id') ) Contact Gallery

--- a/mobile/components/artwork_columns/test/template.coffee
+++ b/mobile/components/artwork_columns/test/template.coffee
@@ -1,0 +1,50 @@
+Artwork = require '../../../models/artwork'
+Artworks = require '../../../collections/artworks'
+Partner = require '../../../models/partner'
+cheerio = require 'cheerio'
+{ fabricate } = require 'antigravity'
+path = require 'path'
+fs = require 'fs'
+jade = require 'jade'
+
+render = (locals) ->
+  filename = path.resolve __dirname, "../template.jade"
+  jade.compile(
+    fs.readFileSync(filename),
+    { filename: filename }
+  ) locals
+
+describe 'artwork_columns component', ->
+  it 'renders basic artwork columns', ->
+    artworks = new Artworks([
+      new Artwork fabricate 'artwork'
+      new Artwork fabricate 'artwork'
+    ])
+    $ = cheerio.load render(artworkColumns: [artworks.models])
+    $('.artwork-columns-artwork').length.should.eql 2
+
+  it 'renders contact gallery for inquireable artworks', ->
+    artworks = new Artworks([
+      new Artwork fabricate('artwork', inquireable: true)
+    ])
+    $ = cheerio.load render(artworkColumns: [artworks.models])
+    $.html().should.containEql('Contact Gallery')
+
+  it 'does not render contact gallery for non-inquireable artworks', ->
+    artworks = new Artworks([
+      new Artwork fabricate('artwork', inquireable: false)
+    ])
+    $ = cheerio.load render(artworkColumns: [artworks.models])
+    $.html().should.not.containEql('Contact Gallery')
+
+  it 'does not render contact gallery for auction artworks', ->
+    artworks = new Artworks([
+      new Artwork fabricate('artwork',
+        forsale: true,
+        inquireable: true,
+        partner: fabricate('partner', type: 'Auction')
+      )
+    ])
+    $ = cheerio.load render(artworkColumns: [artworks.models])
+    $.html().should.containEql('Bid now')
+    $.html().should.not.containEql('Contact Gallery')


### PR DESCRIPTION
Previously, artwork components were showing "Contact Gallery" on this page if the artwork was part of an auction. This fixes it to follow similar logic we use on desktop.

![image](https://cloud.githubusercontent.com/assets/2081340/24966631/8437f13e-1f75-11e7-867f-20136e1f5425.png)
