### PR TITLE
@damassi => fix link to works by artists you follow

### DIFF
--- a/desktop/apps/auction/queries/works_by_followed_artists.js
+++ b/desktop/apps/auction/queries/works_by_followed_artists.js
@@ -25,6 +25,7 @@ export const worksByFollowedArtists = `
         }
         artwork {
           _id
+          id
           href
           title
           date


### PR DESCRIPTION
Turns out when I [fixed the artwork grid elements](https://github.com/artsy/force/pull/1189/files#diff-6a3cbee550d2318c7216c367fabab1b7R17) to link to a url with the artwork slug, I broke the works by artists you follow rail on this page (as the query did not include `id`). 