### PR TITLE
@yuki24: remove exhibitor count on mobile

### DIFF
--- a/mobile/apps/fair/stylesheets/exhibitors_az.styl
+++ b/mobile/apps/fair/stylesheets/exhibitors_az.styl
@@ -25,11 +25,8 @@
 
 .fair-page-subheader
   position relative
-  .a-z-feed-exhibitor-count
-    serif()
-    font-style italic
   .a-z-feed-toggle-container
-    top 0px
+    top -15px
   .a-z-page-toggle
     serif()
     text-transform none

--- a/mobile/apps/fair/templates/exhibitors_subheader.jade
+++ b/mobile/apps/fair/templates/exhibitors_subheader.jade
@@ -1,7 +1,5 @@
 .fair-page-subheader
   if displayToggle
-    .a-z-feed-exhibitor-count
-      | Showing #{fair.get('partner_shows_count')} exhibitors
     .a-z-feed-toggle-container
       a.a-z-page-toggle(
         class=(setToggle == 'grid' ? 'is-active' : '')


### PR DESCRIPTION
This is removes the exhibitor count from the fair microsite on mobile. It is the microgravity equivalent of https://github.com/artsy/force/pull/1218