### PR TITLE
@sweir27: Use res.render to leverage view caching for error page

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -102,7 +102,7 @@ export default function (app) {
     options.headers['X-XAPP-TOKEN'] = artsyXapp.token || ''
     return superSync(method, model, options)
       .catch((err) => {
-        timeoutDebug(`BACKBONE SYNC ERROR`)
+        timeoutDebug('BACKBONE SYNC ERROR')
         timeoutDebug(_.result(model.url) || options.url)
         timeoutDebug(JSON.stringify(options))
         timeoutDebug(err)
@@ -221,17 +221,15 @@ export default function (app) {
   // TODO: Investigate race condition b/t reaction-force's use of AP
   artsyPassport.options.CurrentUser = CurrentUser
 
-  // Error handlers at the end
+  // Error handler at the end
+  const dir = path.resolve(__dirname, '../desktop/components/error_handler')
+  app.set('view engine', 'jade')
+  app.set('views', dir)
   app.use((err, req, res, next) => {
-    if (!req.timedout) return next(err)
-    timeoutDebug(`Error from: ${req.url}`)
-    timeoutDebug(err)
-    next(err)
-  })
-  artsyError.handlers(app, {
-    template: path.resolve(
-      __dirname,
-      '../desktop/components/error_handler/index.jade'
-    )
+    if (req.timedout) {
+      timeoutDebug(`Error from: ${req.url}`)
+      timeoutDebug(err)
+    }
+    res.status(err.status || 500).render('index')
   })
 }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -221,6 +221,14 @@ export default function (app) {
   // TODO: Investigate race condition b/t reaction-force's use of AP
   artsyPassport.options.CurrentUser = CurrentUser
 
+  // 404 handler
+  app.get('*', (req, res, next) => {
+    const err = new Error()
+    err.status = 404
+    err.message = 'Not Found'
+    next(err)
+  })
+
   // Error handler at the end
   const dir = path.resolve(__dirname, '../desktop/components/error_handler')
   app.set('view engine', 'jade')
@@ -230,6 +238,8 @@ export default function (app) {
       timeoutDebug(`Error from: ${req.url}`)
       timeoutDebug(err)
     }
-    res.status(err.status || 500).render('index')
+    const code = err.status || 500
+    const message = err.message || err.text || err.toString()
+    res.status(code).render('index', { message, stack: err.stack, code })
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,7 +1787,15 @@ concat-stream@1.5.0:
     readable-stream "~2.0.0"
     typedarray "~0.0.5"
 
-concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.5.2, concat-stream@~1.5.0, concat-stream@~1.5.1:
+concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.5.2:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
+concat-stream@~1.5.0, concat-stream@~1.5.1:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.5.2.tgz#708978624d856af41a5a741defdd261da752c266"
   dependencies:
@@ -3798,7 +3806,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -5803,7 +5811,7 @@ readable-stream@1.1.x, readable-stream@~1.1.9:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@2, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.6:
+readable-stream@2, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6:
   version "2.2.9"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.9.tgz#cf78ec6f4a6d1eb43d26488cac97f042e74b7fc8"
   dependencies:
@@ -7099,7 +7107,7 @@ typeahead.js@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/typeahead.js/-/typeahead.js-0.10.5.tgz#1d9971b0f44d385feadbf22c9f369db562912de1"
 
-typedarray@~0.0.5:
+typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 


### PR DESCRIPTION
The theory is that a couple errors cascade into a bunch of [blocking](https://github.com/artsy/artsy-error-handler/blob/master/routes.coffee#L8) calls that lock up the entire server. I think this was exaggerated by the fact that I inlined stylus to avoid the need for `asset` to pull down CDNed assets for error pages—that probably eats up a bunch of CPU too. By using `res.render` I'm hoping express's view caching is enough to solve this—if not we can do some pre-compilation/further de-styling of to the error page to make rendering it less expensive.