### PR TITLE
Auctions 372 live sale bid messaging

### DIFF
--- a/desktop/apps/auction_support/client/bid_form.coffee
+++ b/desktop/apps/auction_support/client/bid_form.coffee
@@ -14,7 +14,7 @@ module.exports = class BidForm extends ErrorHandlingForm
   maxTimesPolledForBidPlacement: sd.MAX_POLLS_FOR_MAX_BIDS
   errors: -> {
     "Sale Closed to Bids": "Sorry, your bid wasn't received before the auction closed."
-    "Live bidding has started. Please join the online auction room.": => "Live bidding on this sale has begun. <br>To continue bidding, please <a href=\"#{@model.predictionUrl()}\">join our Live Auction Room</a>."
+    "Live Bidding has Started": => "Live bidding on this sale has begun. <br>To continue bidding, please <a href=\"#{@model.liveAuctionUrl()}\">join our Live Auction Room</a>."
     connection: "Your bid didn't make it to us. Please check your network connectivity and try again."
     "Bidder not qualified to bid on this auction.": "Sorry, we could not process your bid. <br>Please contact <a href='#' class='js-contact-specialist'>Artsy staff</a> for support."
   }

--- a/desktop/apps/auction_support/client/bid_form.coffee
+++ b/desktop/apps/auction_support/client/bid_form.coffee
@@ -14,7 +14,7 @@ module.exports = class BidForm extends ErrorHandlingForm
   maxTimesPolledForBidPlacement: sd.MAX_POLLS_FOR_MAX_BIDS
   errors: -> {
     "Sale Closed to Bids": "Sorry, your bid wasn't received before the auction closed."
-    "Live Bidding has Started": => "Live bidding on this sale has begun. <br>To continue bidding, please <a href=\"#{@model.liveAuctionUrl()}\">join our Live Auction Room</a>."
+    "Live Bidding has Started": => "Sorry, your bid wasn't received before live bidding started. <br/>To continue bidding, please <a href=\"#{@model.liveAuctionUrl()}\">join the live auction</a>."
     connection: "Your bid didn't make it to us. Please check your network connectivity and try again."
     "Bidder not qualified to bid on this auction.": "Sorry, we could not process your bid. <br>Please contact <a href='#' class='js-contact-specialist'>Artsy staff</a> for support."
   }

--- a/desktop/apps/auction_support/client/bid_form.coffee
+++ b/desktop/apps/auction_support/client/bid_form.coffee
@@ -12,10 +12,12 @@ module.exports = class BidForm extends ErrorHandlingForm
 
   timesPolledForBidPlacement: 0
   maxTimesPolledForBidPlacement: sd.MAX_POLLS_FOR_MAX_BIDS
-  errors:
-    "Sale Closed to Bids": @saleClosedToBidsMessage # this doesn't attach to the correct `this`
+  errors: -> {
+    "Sale Closed to Bids": "Sorry, your bid wasn't received before the auction closed."
+    "Live bidding has started. Please join the online auction room.": => "Live bidding on this sale has begun. <br>To continue bidding, please <a href=\"#{@model.predictionUrl()}\">join our Live Auction Room</a>."
     connection: "Your bid didn't make it to us. Please check your network connectivity and try again."
     "Bidder not qualified to bid on this auction.": "Sorry, we could not process your bid. <br>Please contact <a href='#' class='js-contact-specialist'>Artsy staff</a> for support."
+  }
 
   events:
     'click .registration-form-content .avant-garde-button-black': 'placeBid'
@@ -26,17 +28,7 @@ module.exports = class BidForm extends ErrorHandlingForm
     @$submit = @$('.registration-form-content .avant-garde-button-black')
     @placeBid() if @submitImmediately
     @$('.max-bid').focus() unless @submitImmediately
-    @errors["Sale Closed to Bids"] = @saleClosedToBidsMessage # This works :(
-    console.log(@errors["Sale Closed to Bids"])
-    # extend form's errors with our own
     @errors = _.defaults @errors, ErrorHandlingForm.prototype.errors
-
-  saleClosedToBidsMessage: =>
-    @model.fetch()
-    if (@model.isLiveOpen())
-      return "The sale is live so you better get in there"
-    else
-      return "Sorry, your bid wasn't received before the auction closed."
 
   showBiddingDialog: (e) ->
     e.preventDefault()

--- a/desktop/apps/auction_support/client/bid_form.coffee
+++ b/desktop/apps/auction_support/client/bid_form.coffee
@@ -14,7 +14,7 @@ module.exports = class BidForm extends ErrorHandlingForm
   maxTimesPolledForBidPlacement: sd.MAX_POLLS_FOR_MAX_BIDS
   errors: -> {
     "Sale Closed to Bids": "Sorry, your bid wasn't received before the auction closed."
-    "Live Bidding has Started": => "Sorry, your bid wasn't received before live bidding started. <br/>To continue bidding, please <a href=\"#{@model.liveAuctionUrl()}\">join the live auction</a>."
+    "Live Bidding has Started": "Sorry, your bid wasn't received before live bidding started. <br/>To continue bidding, please <a href=\"#{@model.liveAuctionUrl()}\">join the live auction</a>."
     connection: "Your bid didn't make it to us. Please check your network connectivity and try again."
     "Bidder not qualified to bid on this auction.": "Sorry, we could not process your bid. <br>Please contact <a href='#' class='js-contact-specialist'>Artsy staff</a> for support."
   }

--- a/desktop/apps/auction_support/client/bid_form.coffee
+++ b/desktop/apps/auction_support/client/bid_form.coffee
@@ -13,7 +13,7 @@ module.exports = class BidForm extends ErrorHandlingForm
   timesPolledForBidPlacement: 0
   maxTimesPolledForBidPlacement: sd.MAX_POLLS_FOR_MAX_BIDS
   errors:
-    "Sale Closed to Bids": "Sorry, your bid wasn't received before the auction closed."
+    "Sale Closed to Bids": @saleClosedToBidsMessage # this doesn't attach to the correct `this`
     connection: "Your bid didn't make it to us. Please check your network connectivity and try again."
     "Bidder not qualified to bid on this auction.": "Sorry, we could not process your bid. <br>Please contact <a href='#' class='js-contact-specialist'>Artsy staff</a> for support."
 
@@ -26,9 +26,17 @@ module.exports = class BidForm extends ErrorHandlingForm
     @$submit = @$('.registration-form-content .avant-garde-button-black')
     @placeBid() if @submitImmediately
     @$('.max-bid').focus() unless @submitImmediately
-
+    @errors["Sale Closed to Bids"] = @saleClosedToBidsMessage # This works :(
+    console.log(@errors["Sale Closed to Bids"])
     # extend form's errors with our own
     @errors = _.defaults @errors, ErrorHandlingForm.prototype.errors
+
+  saleClosedToBidsMessage: =>
+    @model.fetch()
+    if (@model.isLiveOpen())
+      return "The sale is live so you better get in there"
+    else
+      return "Sorry, your bid wasn't received before the auction closed."
 
   showBiddingDialog: (e) ->
     e.preventDefault()

--- a/desktop/apps/auction_support/test/client/bid_form.coffee
+++ b/desktop/apps/auction_support/test/client/bid_form.coffee
@@ -86,7 +86,7 @@ describe 'BidForm', ->
 
     it 'handles live sale errors', ->
       @view.showError 'description', { responseText: "{ \"error\": \"Live Bidding has Started\"}" }
-      @view.$('.error').text().should.containEql "Live bidding on this sale has begun."
+      @view.$('.error').text().should.containEql "Sorry, your bid wasn't received before live bidding started."
 
     it 'validates against the bidder position min', ->
       @view.bidderPositions.first().set suggested_next_bid_cents: 100000, display_suggested_next_bid_dollars: '$1,000'

--- a/desktop/apps/auction_support/test/client/bid_form.coffee
+++ b/desktop/apps/auction_support/test/client/bid_form.coffee
@@ -85,7 +85,7 @@ describe 'BidForm', ->
       @view.$('.error').text().should.equal "Sorry, your bid wasn't received before the auction closed."
 
     it 'handles live sale errors', ->
-      @view.showError 'description', { responseText: "{ \"error\": \"Live bidding has started. Please join the online auction room.\"}" }
+      @view.showError 'description', { responseText: "{ \"error\": \"Live Bidding has Started\"}" }
       @view.$('.error').text().should.containEql "Live bidding on this sale has begun."
 
     it 'validates against the bidder position min', ->

--- a/desktop/apps/auction_support/test/client/bid_form.coffee
+++ b/desktop/apps/auction_support/test/client/bid_form.coffee
@@ -84,6 +84,11 @@ describe 'BidForm', ->
       @view.showError 'description', { responseText: "{ \"error\": \"Sale Closed to Bids\"}" }
       @view.$('.error').text().should.equal "Sorry, your bid wasn't received before the auction closed."
 
+    it 'handles live sale errors', ->
+      sinon.stub(@view.model, 'isLiveOpen').returns(true)
+      @view.showError 'description', { responseText: "{ \"error\": \"Sale Closed to Bids\"}" }
+      @view.$('.error').text().should.equal "Sorry, your bid wasn't received before the auction closed."
+
     it 'validates against the bidder position min', ->
       @view.bidderPositions.first().set suggested_next_bid_cents: 100000, display_suggested_next_bid_dollars: '$1,000'
       @view.$('.max-bid').replaceWith('<input class="max-bid" value="$50.00">')

--- a/desktop/apps/auction_support/test/client/bid_form.coffee
+++ b/desktop/apps/auction_support/test/client/bid_form.coffee
@@ -85,9 +85,8 @@ describe 'BidForm', ->
       @view.$('.error').text().should.equal "Sorry, your bid wasn't received before the auction closed."
 
     it 'handles live sale errors', ->
-      sinon.stub(@view.model, 'isLiveOpen').returns(true)
-      @view.showError 'description', { responseText: "{ \"error\": \"Sale Closed to Bids\"}" }
-      @view.$('.error').text().should.equal "Sorry, your bid wasn't received before the auction closed."
+      @view.showError 'description', { responseText: "{ \"error\": \"Live bidding has started. Please join the online auction room.\"}" }
+      @view.$('.error').text().should.containEql "Live bidding on this sale has begun."
 
     it 'validates against the bidder position min', ->
       @view.bidderPositions.first().set suggested_next_bid_cents: 100000, display_suggested_next_bid_dollars: '$1,000'

--- a/desktop/components/credit_card/client/error_handling_form.coffee
+++ b/desktop/components/credit_card/client/error_handling_form.coffee
@@ -58,6 +58,9 @@ module.exports = class ErrorHandlingForm extends Backbone.View
       # we either want to override or fallback to the message sent from gravity
       if errorJson.error?
         message = @errors[errorJson.error] || errorJson.error
+
+        console.log('in error? block', typeof message)
+        message = message() if ( typeof message == 'function' )
     else if response.statusText == 'timeout'
       message = @errors.timeout
     else if response.status == 400 or response.status == 403

--- a/desktop/components/credit_card/client/error_handling_form.coffee
+++ b/desktop/components/credit_card/client/error_handling_form.coffee
@@ -46,6 +46,7 @@ module.exports = class ErrorHandlingForm extends Backbone.View
       field.el.val xssFilters.inHTMLData(field.el.val())
 
   showError: (description, response={}) =>
+    @errors = if (_.isFunction @errors) then @errors() else @errors
     if response.responseText? and (errorJson = try JSON.parse response.responseText)
       switch errorJson.type
         when 'payment_error'
@@ -58,9 +59,7 @@ module.exports = class ErrorHandlingForm extends Backbone.View
       # we either want to override or fallback to the message sent from gravity
       if errorJson.error?
         message = @errors[errorJson.error] || errorJson.error
-
-        console.log('in error? block', typeof message)
-        message = message() if ( typeof message == 'function' )
+        message = message() if ( _.isFunction message)
     else if response.statusText == 'timeout'
       message = @errors.timeout
     else if response.status == 400 or response.status == 403

--- a/desktop/components/credit_card/client/error_handling_form.coffee
+++ b/desktop/components/credit_card/client/error_handling_form.coffee
@@ -59,7 +59,6 @@ module.exports = class ErrorHandlingForm extends Backbone.View
       # we either want to override or fallback to the message sent from gravity
       if errorJson.error?
         message = @errors[errorJson.error] || errorJson.error
-        message = message() if ( _.isFunction message)
     else if response.statusText == 'timeout'
       message = @errors.timeout
     else if response.status == 400 or response.status == 403

--- a/desktop/components/credit_card/test/error_handling_form.coffee
+++ b/desktop/components/credit_card/test/error_handling_form.coffee
@@ -72,11 +72,6 @@ describe 'FavoritesStatusModalView', ->
       @errorHandlingForm.showError 'description', { responseText: "{ \"type\": \"param_error\", \"message\": \"Meow meow meow\" } " }
       $('.error').text().should.equal 'Sorry, this endpoint is for cats'
 
-    it 'handles error messages returned from a function', ->
-      @errorHandlingForm.errors['Stolen Credit Card'] = () -> "Please hold, I need to check with my manager..."
-      @errorHandlingForm.showError 'foo', { responseText: "{ \"error\": \"Stolen Credit Card\"}" }
-      $('.error').text().should.equal "Please hold, I need to check with my manager..."
-
     it 'handles error messages that are a string', ->
       @errorHandlingForm.errors['Stolen Credit Card'] = "You have encountered an error."
       @errorHandlingForm.showError 'foo', { responseText: "{ \"error\": \"Stolen Credit Card\"}" }

--- a/desktop/components/credit_card/test/error_handling_form.coffee
+++ b/desktop/components/credit_card/test/error_handling_form.coffee
@@ -67,7 +67,17 @@ describe 'FavoritesStatusModalView', ->
       @errorHandlingForm.showError 'description', { status: 400, error: { additional: 'additional info'} }
       $('.error').text().should.equal 'Your card appears to be missing or malformed. Please try another card or contact support. additional info'
 
-    it 'handles errors that are a function', ->
-      animal = 'jackal'
-      @errorHandlingForm.showError () -> "Expected a breed of dog, you gave #{animal}"
-      $('.error').text().should.equal 'Expected a breed of dog, you gave jackal'
+    it 'handles @errors properties that are a function (that return an errors object)', ->
+      @errorHandlingForm.errors = -> {"Meow meow meow": 'Sorry, this endpoint is for cats'}
+      @errorHandlingForm.showError 'description', { responseText: "{ \"type\": \"param_error\", \"message\": \"Meow meow meow\" } " }
+      $('.error').text().should.equal 'Sorry, this endpoint is for cats'
+
+    it 'handles error messages returned from a function', ->
+      @errorHandlingForm.errors['Stolen Credit Card'] = () -> "Please hold, I need to check with my manager..."
+      @errorHandlingForm.showError 'foo', { responseText: "{ \"error\": \"Stolen Credit Card\"}" }
+      $('.error').text().should.equal "Please hold, I need to check with my manager..."
+
+    it 'handles error messages that are a string', ->
+      @errorHandlingForm.errors['Stolen Credit Card'] = "You have encountered an error."
+      @errorHandlingForm.showError 'foo', { responseText: "{ \"error\": \"Stolen Credit Card\"}" }
+      $('.error').text().should.equal "You have encountered an error."

--- a/desktop/components/credit_card/test/error_handling_form.coffee
+++ b/desktop/components/credit_card/test/error_handling_form.coffee
@@ -66,3 +66,8 @@ describe 'FavoritesStatusModalView', ->
     it 'adds stripe errors', ->
       @errorHandlingForm.showError 'description', { status: 400, error: { additional: 'additional info'} }
       $('.error').text().should.equal 'Your card appears to be missing or malformed. Please try another card or contact support. additional info'
+
+    it 'handles errors that are a function', ->
+      animal = 'jackal'
+      @errorHandlingForm.showError () -> "Expected a breed of dog, you gave #{animal}"
+      $('.error').text().should.equal 'Expected a breed of dog, you gave jackal'

--- a/desktop/models/sale.coffee
+++ b/desktop/models/sale.coffee
@@ -40,7 +40,7 @@ module.exports = class Sale extends Backbone.Model
   bidUrl: (artwork) ->
     "#{@href()}/bid/#{artwork.id}"
   
-  liveAuctionUrl: -> "#{PREDICTION_URL}/#{@get('slug')}"
+  liveAuctionUrl: -> "#{PREDICTION_URL}/#{@get('id')}"
 
   redirectUrl: (artwork) ->
     if @isBidable() and artwork?

--- a/desktop/models/sale.coffee
+++ b/desktop/models/sale.coffee
@@ -39,6 +39,8 @@ module.exports = class Sale extends Backbone.Model
 
   bidUrl: (artwork) ->
     "#{@href()}/bid/#{artwork.id}"
+  
+  predictionUrl: -> "#{PREDICTION_URL}/#{@get('slug')}"
 
   redirectUrl: (artwork) ->
     if @isBidable() and artwork?

--- a/desktop/models/sale.coffee
+++ b/desktop/models/sale.coffee
@@ -40,7 +40,7 @@ module.exports = class Sale extends Backbone.Model
   bidUrl: (artwork) ->
     "#{@href()}/bid/#{artwork.id}"
   
-  predictionUrl: -> "#{PREDICTION_URL}/#{@get('slug')}"
+  liveAuctionUrl: -> "#{PREDICTION_URL}/#{@get('slug')}"
 
   redirectUrl: (artwork) ->
     if @isBidable() and artwork?


### PR DESCRIPTION
relates to https://github.com/artsy/auctions/issues/372
blocked by https://github.com/artsy/gravity/pull/10972
This adds more specific messaging in the case that a user opens the timed auction biding dialogue and the auction goes live. It would currently say 'sale closed to bids'.

The message now includes a link to the sale on prediction. I think the way I'm doing this link might be wrong.