### PR TITLE
@eessex => Use mobile footer without svg

### DIFF
--- a/desktop/apps/article/templates/amp_article.jade
+++ b/desktop/apps/article/templates/amp_article.jade
@@ -34,4 +34,4 @@ html(amp)
             +amp_callout(section)
           when 'image_set'
             +amp_image_set(section)
-    include ../../../components/main_layout/footer/template
+    include ../../../components/main_layout/footer/mobile_footer_menu


### PR DESCRIPTION
Looks like AMP was unhappy with us using inline styles. The only place that it's being used in AMP is on the generic footer. Mobile footer doesn't have the inline styles so let's use that instead.