### PR TITLE
sort auction lots by position, not lot_label

### DIFF
--- a/mobile/apps/auction/routes.coffee
+++ b/mobile/apps/auction/routes.coffee
@@ -31,8 +31,7 @@ module.exports.index = (req, res, next) ->
   auction = new Auction id: id
   saleArtworks = new SaleArtworks [], id: id
   artworks = new Artworks
-  artworks.comparator = (artwork) ->
-    (saleArtwork = artwork.related().saleArtwork).get('lot_label') or saleArtwork.id
+  artworks.comparator = (artwork) -> (saleArtwork = artwork.related().saleArtwork).get('position') or saleArtwork.id
 
   promise = Q.all([
     auction.fetch(cache: true)


### PR DESCRIPTION
This fixes a bug that was introduced on the switch to using `lot_label`s. It was caught for the desktop view in the following thread, but not mobile. https://github.com/artsy/force/pull/1139/files#diff-96509af377373c5b4d73eef6026785c5
relates to #1139

The fix, with proper ordering:
![image](https://cloud.githubusercontent.com/assets/9088720/25095706/dc82f4f8-236a-11e7-9991-4800a3f5f62e.png)

The broken view:
![image](https://cloud.githubusercontent.com/assets/9088720/25095730/fb33ec22-236a-11e7-822c-b6f4794246b3.png)
