### PR TITLE
@mzikherman: display fair year-round link when the profile is visible to the public

### DIFF
--- a/desktop/apps/fairs/query.coffee
+++ b/desktop/apps/fairs/query.coffee
@@ -21,6 +21,10 @@ module.exports = '''
       banner_size
       organizer {
         profile_id
+        profile {
+          is_publically_visible
+          href
+        }
       }
       image {
         url(version: "wide")

--- a/desktop/apps/fairs/templates/fair_upcoming.jade
+++ b/desktop/apps/fairs/templates/fair_upcoming.jade
@@ -1,6 +1,6 @@
 .fairs__upcoming-fair
-  if fair.organizer && fair.organizer.profile_id
-    a(href="/#{fair.organizer.profile_id}").fairs-fair__name #{fair.name}
+  if fair.organizer && fair.organizer.profile && fair.organizer.profile.is_publically_visible && fair.organizer.profile.href
+    a(href="#{fair.organizer.href}").fairs-fair__name #{fair.name}
   else
     .fairs-fair__name #{fair.name}
   .fairs-fair__info #{ViewHelpers.formatDates(fair)}


### PR DESCRIPTION
**This PR is blocked by https://github.com/artsy/metaphysics/pull/611.**

This adds a more strict conditional for displaying year-round pages for fairs. The `is_publically_visible` property ensures that a link is created for the year-round page only when a fair organizer profile is published and not private.