### PR TITLE
@mzikherman: fix typo

### DIFF
--- a/desktop/apps/fairs/templates/fair_upcoming.jade
+++ b/desktop/apps/fairs/templates/fair_upcoming.jade
@@ -1,6 +1,6 @@
 .fairs__upcoming-fair
   if fair.organizer && fair.organizer.profile && fair.organizer.profile.is_publically_visible && fair.organizer.profile.href
-    a(href="#{fair.organizer.href}").fairs-fair__name #{fair.name}
+    a(href="#{fair.organizer.profile.href}").fairs-fair__name #{fair.name}
   else
     .fairs-fair__name #{fair.name}
   .fairs-fair__info #{ViewHelpers.formatDates(fair)}


### PR DESCRIPTION
closes: https://github.com/artsy/collector-experience/issues/132

This is a follow up to https://github.com/artsy/force/pull/1252 and fixes the typo where `href` is meant to be called on `profile`.