### PR TITLE
@damassi => little auction fixes across the board

### DIFF
--- a/desktop/apps/artwork/components/additional_info/templates/about_the_work.jade
+++ b/desktop/apps/artwork/components/additional_info/templates/about_the_work.jade
@@ -7,7 +7,7 @@
     != artwork.additional_information
 
   if artwork.signature
-    p Signature: #{artwork.signature}
+    p Signature:&nbsp;#{artwork.signature}
 
   if artwork.publisher
     p Publisher: #{artwork.publisher}

--- a/desktop/apps/auction/client/reducers.js
+++ b/desktop/apps/auction/client/reducers.js
@@ -30,7 +30,7 @@ const initialState = {
   followedArtistRailPage: 1,
   followedArtistRailSize: 4,
   initialMediumMap: [],
-  isOpen: sd.AUCTION && sd.AUCTION.is_open,
+  isClosed: sd.AUCTION && sd.AUCTION.is_closed,
   isFetchingArtworks: false,
   isLastFollowedArtistsPage: false,
   isListView: false,

--- a/desktop/apps/auction/components/auction_grid_artwork/index.js
+++ b/desktop/apps/auction/components/auction_grid_artwork/index.js
@@ -4,7 +4,7 @@ import { get } from 'lodash'
 import React from 'react';
 import { titleAndYear } from '../../utils/artwork'
 
-function AuctionGridArtwork({ isOpen, saleArtwork }) {
+function AuctionGridArtwork({ isClosed, saleArtwork }) {
   const artwork = saleArtwork.artwork
   const artists = artwork.artists
   const artistDisplay = artists && artists.length > 0 ? artists.map((aa) => aa.name).join(', ') : null
@@ -29,7 +29,7 @@ function AuctionGridArtwork({ isOpen, saleArtwork }) {
           <div className='auction-page-grid-artwork__lot-number'>
             Lot {saleArtwork.lot_label}
           </div>
-          { isOpen && bidStatus }
+          { !isClosed && bidStatus }
         </div>
         <div className='auction-page-grid-artwork__artists'>
           {artistDisplay}
@@ -42,7 +42,7 @@ function AuctionGridArtwork({ isOpen, saleArtwork }) {
 
 const mapStateToProps = (state) => {
   return {
-    isOpen: state.auctionArtworks.isOpen
+    isClosed: state.auctionArtworks.isClosed
   }
 }
 

--- a/desktop/apps/auction/components/auction_list_artwork/index.js
+++ b/desktop/apps/auction/components/auction_list_artwork/index.js
@@ -5,7 +5,7 @@ import { get } from 'lodash'
 import React from 'react';
 import { titleAndYear } from '../../utils/artwork'
 
-function AuctionListArtwork({ isOpen, saleArtwork }) {
+function AuctionListArtwork({ isClosed, saleArtwork }) {
   const artwork = saleArtwork.artwork
   const artists = artwork.artists
   const artistDisplay = artists && artists.length > 0 ? artists.map((aa) => aa.name).join(', ') : null
@@ -13,7 +13,7 @@ function AuctionListArtwork({ isOpen, saleArtwork }) {
 
   const auctionArtworkClasses = classNames(
     'auction-page-list-artwork',
-    { 'auction-open': isOpen }
+    { 'auction-open': isClosed }
   )
 
   let bidStatus
@@ -35,14 +35,14 @@ function AuctionListArtwork({ isOpen, saleArtwork }) {
       <div className='auction-page-list-artwork__lot-number'>
         Lot {saleArtwork.lot_label}
       </div>
-      { isOpen && bidStatus }
+      { !isClosed && bidStatus }
     </a>
   );
 }
 
 const mapStateToProps = (state) => {
   return {
-    isOpen: state.auctionArtworks.isOpen
+    isClosed: state.auctionArtworks.isClosed
   }
 }
 

--- a/desktop/apps/auction/components/sidebar/index.js
+++ b/desktop/apps/auction/components/sidebar/index.js
@@ -5,11 +5,11 @@ import MediumFilter from '../medium_filter'
 import RangeSlider from '../range_slider'
 import React from 'react'
 
-function Sidebar({ isOpen }) {
+function Sidebar({ isClosed }) {
   return (
     <div className='auction-artworks-sidebar'>
       <div className='auction-artworks-sidebar__artist-filter'>
-        { isOpen && <RangeSlider /> }
+        { !isClosed && <RangeSlider /> }
         <MediumFilter />
         <ArtistFilter />
       </div>
@@ -19,7 +19,7 @@ function Sidebar({ isOpen }) {
 
 const mapStateToProps = (state) => {
   return {
-    isOpen: state.auctionArtworks.isOpen
+    isClosed: state.auctionArtworks.isClosed
   }
 }
 

--- a/desktop/apps/auction/queries/sale.js
+++ b/desktop/apps/auction/queries/sale.js
@@ -17,6 +17,7 @@ export default function SaleQuery(id) {
       end_at
       id
       is_auction
+      is_closed
       is_live_open
       is_open
       live_start_at

--- a/desktop/apps/auction/test/components.js
+++ b/desktop/apps/auction/test/components.js
@@ -48,33 +48,33 @@ describe('React components', () => {
     })
 
     it('renders an auction grid artwork component', () => {
-      const initialStoreOpenAuction = createStore(auctions, { auctionArtworks: { isOpen: true } })
       const wrapper = shallow(
-        <Provider><AuctionGridArtwork store={initialStoreOpenAuction} saleArtwork={saleArtwork} /></Provider>
+        <Provider><AuctionGridArtwork store={initialStore} saleArtwork={saleArtwork} /></Provider>
       )
       wrapper.render().html().should.containEql('$100')
       wrapper.render().html().should.containEql('<em>My Artwork</em>, 2002')
     })
 
     it('renders an auction list artwork component', () => {
-      const initialStoreOpenAuction = createStore(auctions, { auctionArtworks: { isOpen: true } })
       const wrapper = shallow(
-        <Provider><AuctionListArtwork store={initialStoreOpenAuction} saleArtwork={saleArtwork} /></Provider>
+        <Provider><AuctionListArtwork store={initialStore} saleArtwork={saleArtwork} /></Provider>
       )
       wrapper.render().html().should.containEql('$100')
       wrapper.render().html().should.containEql('<em>My Artwork</em>, 2002')
     })
 
     it('renders an auction grid artwork component without a bid status if the auction is closed', () => {
+      const initialStoreClosedAuction = createStore(auctions, { auctionArtworks: { isClosed: true } })
       const wrapper = shallow(
-        <Provider><AuctionGridArtwork store={initialStore} saleArtwork={saleArtwork} /></Provider>
+        <Provider><AuctionGridArtwork store={initialStoreClosedAuction} saleArtwork={saleArtwork} /></Provider>
       )
       wrapper.render().html().should.not.containEql('$100')
     })
 
     it('renders an auction list artwork component without a bid status if the auction is closed', () => {
+      const initialStoreClosedAuction = createStore(auctions, { auctionArtworks: { isClosed: true } })
       const wrapper = shallow(
-        <Provider><AuctionListArtwork store={initialStore} saleArtwork={saleArtwork} /></Provider>
+        <Provider><AuctionListArtwork store={initialStoreClosedAuction} saleArtwork={saleArtwork} /></Provider>
       )
       wrapper.render().html().should.not.containEql('$100')
     })
@@ -94,10 +94,8 @@ describe('React components', () => {
     })
 
     it('renders the range filter if the auction is open', () => {
-      const initialStoreOpenAuction = createStore(auctions, { auctionArtworks: { isOpen: true } })
-
       const wrapper = shallow(
-        <Provider><Sidebar store={initialStoreOpenAuction} /></Provider>
+        <Provider><Sidebar store={initialStore} /></Provider>
       )
       wrapper.render().find('.medium-filter').length.should.eql(1)
       wrapper.render().find('.artist-filter').length.should.eql(1)
@@ -105,8 +103,9 @@ describe('React components', () => {
     })
 
     it('does not render the range filter if the auction is closed', () => {
+      const initialStoreClosedAuction = createStore(auctions, { auctionArtworks: { isClosed: true } })
       const wrapper = shallow(
-        <Provider><Sidebar store={initialStore} /></Provider>
+        <Provider><Sidebar store={initialStoreClosedAuction} /></Provider>
       )
       wrapper.render().find('.medium-filter').length.should.eql(1)
       wrapper.render().find('.artist-filter').length.should.eql(1)

--- a/desktop/components/artwork_metadata_stub/queries/contact.coffee
+++ b/desktop/components/artwork_metadata_stub/queries/contact.coffee
@@ -6,9 +6,10 @@ module.exports = """
     sale {
       href
       is_auction
+      is_closed
       is_live_open
       is_open
-      is_closed
+      is_preview
     }
     sale_artwork {
       highest_bid {

--- a/desktop/components/artwork_metadata_stub/templates/contact.jade
+++ b/desktop/components/artwork_metadata_stub/templates/contact.jade
@@ -1,16 +1,19 @@
 if artwork.sale && artwork.sale.is_auction
   .artwork-metadata-stub__contact.artwork-metadata-stub__line.artwork-metadata-stub__bid-now
+    - var sa = artwork.sale_artwork
     if artwork.sale.is_live_open
       a(href= artwork.href) Enter Live Auction
     else if artwork.sale.is_open
       a(href= artwork.href)
-        - var sa = artwork.sale_artwork
         - var bids = sa.counts.bidder_positions
         if bids > 0
           | #{sa.highest_bid.display}&nbsp;
           = '(' + bids + (bids > 1 ? ' bids' : ' bid') + ')'
         else
           | #{sa.opening_bid.display}
+    else if artwork.sale.is_preview
+      a(href= artwork.href)
+        | #{sa.opening_bid.display}
     else if artwork.sale.is_closed
       | Auction closed
 else if artwork.is_inquireable

--- a/desktop/components/artwork_metadata_stub/test/index.js
+++ b/desktop/components/artwork_metadata_stub/test/index.js
@@ -1,0 +1,92 @@
+import cheerio from 'cheerio'
+import fs from 'fs'
+import jade from 'jade'
+import path from 'path'
+
+function render(locals) {
+  const filename = path.resolve(__dirname, '../index.jade')
+  return jade.compile(
+    fs.readFileSync(filename),
+    { filename: filename }
+  )(locals)
+}
+
+describe('metadata template', () => {
+  describe('auction artwork', () => {
+    let auctionArtwork
+    beforeEach(() => {
+      auctionArtwork = {
+        date: '2007',
+        title: 'My Artwork',
+        partner: {
+          type: 'Auction House',
+          href: '/partner/auction-partner'
+        },
+        sale: {
+          is_auction: true,
+          is_closed: true,
+          is_live_open: false,
+          is_open: false,
+          is_preview: false
+        },
+        sale_artwork: {
+          opening_bid: {
+            display: '$100'
+          },
+          counts: {
+            bidder_positions: 0
+          }
+        }
+      }
+    })
+
+    it('renders auction closed if the auction is closed', () => {
+      const $ = cheerio.load(render({ artwork: auctionArtwork }))
+      $.text().should.containEql('My Artwork, 2007')
+      $('.artwork-metadata-stub__bid-now').text().should.containEql('Auction closed')
+      $('.artwork-metadata-stub__sale-message').length.should.eql(0)
+    })
+
+    it('renders enter live auction if the auction is live', () => {
+      auctionArtwork.sale.is_closed = false
+      auctionArtwork.sale.is_live_open = true
+      const $ = cheerio.load(render({ artwork: auctionArtwork }))
+      $.text().should.containEql('My Artwork, 2007')
+      $('.artwork-metadata-stub__bid-now').text().should.containEql('Enter Live Auction')
+      $('.artwork-metadata-stub__sale-message').length.should.eql(0)
+    })
+
+    it('renders the opening bid if the auction is in preview', () => {
+      auctionArtwork.sale.is_closed = false
+      auctionArtwork.sale.is_preview = true
+      const $ = cheerio.load(render({ artwork: auctionArtwork }))
+      $.text().should.containEql('My Artwork, 2007')
+      $('.artwork-metadata-stub__bid-now').text().should.containEql('$100')
+      $('.artwork-metadata-stub__sale-message').length.should.eql(0)
+    })
+
+    describe('auction is open', () => {
+      beforeEach(() => {
+        auctionArtwork.sale.is_closed = false
+        auctionArtwork.sale.is_open = true
+      })
+
+      it('renders the opening bid if the auction is open and has no bids', () => {
+        const $ = cheerio.load(render({ artwork: auctionArtwork }))
+        $.text().should.containEql('My Artwork, 2007')
+        $('.artwork-metadata-stub__bid-now').text().should.containEql('$100')
+        $('.artwork-metadata-stub__sale-message').length.should.eql(0)
+      })
+
+      it('renders the number of bids if the auction is open and has bids', () => {
+        auctionArtwork.sale_artwork.counts = { bidder_positions: 3 }
+        auctionArtwork.sale_artwork.highest_bid = { display: '$200' }
+        const $ = cheerio.load(render({ artwork: auctionArtwork }))
+        $.text().should.containEql('My Artwork, 2007')
+        $('.artwork-metadata-stub__bid-now').text().should.containEql('$200')
+        $('.artwork-metadata-stub__bid-now').text().should.containEql('(3 bids)')
+        $('.artwork-metadata-stub__sale-message').length.should.eql(0)
+      })
+    })
+  })
+})

--- a/desktop/components/artwork_metadata_stub/test/index.js
+++ b/desktop/components/artwork_metadata_stub/test/index.js
@@ -7,7 +7,7 @@ function render(locals) {
   const filename = path.resolve(__dirname, '../index.jade')
   return jade.compile(
     fs.readFileSync(filename),
-    { filename: filename }
+    { filename }
   )(locals)
 }
 

--- a/desktop/components/my_active_bids/query.coffee
+++ b/desktop/components/my_active_bids/query.coffee
@@ -27,7 +27,7 @@ module.exports = """
             title
             date
             image {
-              url(version: "small")
+              url(version: "square")
             }
             artist {
               name

--- a/mobile/components/artwork_columns/artwork.jade
+++ b/mobile/components/artwork_columns/artwork.jade
@@ -1,6 +1,6 @@
 - size = size || tall
 - imageUrl = artwork.defaultImageUrl(size) ? artwork.defaultImageUrl(size) : artwork.get('image').url
-- hasAuctionPartner = (artwork.get('partner') && (artwork.get('partner').type === 'Auction' || artwork.get('partner').type === 'Auction House')) || artwork.get('is_biddable')
+- hasAuctionPartner = (artwork.get('partner') && (artwork.get('partner').type === 'Auction' || artwork.get('partner').type === 'Auction House'))
 .artwork-columns-artwork
   a( href='/artwork/' + artwork.get('id') )
     img( src=imageUrl data-id=artwork.get('_id') )

--- a/mobile/components/artwork_columns/auction_artwork.jade
+++ b/mobile/components/artwork_columns/auction_artwork.jade
@@ -17,9 +17,5 @@
         = artwork.get('date')
       p= artwork.partnerName()
 
-    if artwork.get('sale')
-      .artwork-columns-artwork-details__bid-now
-        if artwork.get('sale').is_open
-          p.bid-now-link Bid now
-        else
-          p.bid-now-link Auction closed
+    .artwork-columns-artwork-details__bid-now
+      p.bid-now-link Bid now

--- a/mobile/components/multi_page/config.coffee
+++ b/mobile/components/multi_page/config.coffee
@@ -3,7 +3,7 @@ module.exports =
     title: 'Auction FAQs'
     description: '
       How can we help you? Below are a few general categories to help you find the answers you’re looking for.\n\n
-      Need more immediate assistance? Please [contact us](mailto:support@artsy.net)
+      Need more immediate assistance? Please [contact us](mailto:specialist@artsy.net)
     '
     pages:
       'Bidding': 'how-auctions-work-bidding'


### PR DESCRIPTION
Phew. Bunch of little fixes in here:
- Makes the `Signature` show up on one line
(previously)
![image](https://cloud.githubusercontent.com/assets/2081340/25148963/c3beb2aa-244a-11e7-8fe9-b47e9ec0c150.png)
(updated)
![image](https://cloud.githubusercontent.com/assets/2081340/25148968/c94116f0-244a-11e7-91cc-e94e1fd01d95.png)

- Updates the auction page to show pricing information if the auction is in preview mode
![image](https://cloud.githubusercontent.com/assets/2081340/25149214/aaf8db3c-244b-11e7-8b9c-5b222d968739.png)

- Updates the artwork brick to show pricing info if the auction is in preview mode
- fixes the "my active bids" module to use the square version of artworks so it doesn't stretch
(previously)
![image](https://cloud.githubusercontent.com/assets/2081340/25149313/f8cd5810-244b-11e7-93b9-e121a2084112.png)
(updated)
![image](https://cloud.githubusercontent.com/assets/2081340/25149323/029a91f0-244c-11e7-8442-9a7561e4af53.png)

- Adds `Bid now` link to artworks brick in mobile mode
(previously)
![image](https://cloud.githubusercontent.com/assets/2081340/25148527/391cd574-2449-11e7-8fa1-729a79fb980a.png)
(updated)
![image](https://cloud.githubusercontent.com/assets/2081340/25148541/4a4aad80-2449-11e7-80a5-1c8c5fe7075f.png)


- Updates the Auction FAQ on mobile web to link to `specialist@artsy.net` instead of `support@artsy.net`