### PR TITLE
@eessex => Video controls

### DIFF
--- a/desktop/apps/editorial_features/components/venice_2017/client.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client.coffee
@@ -1,24 +1,67 @@
 Backbone = require 'backbone'
 sd = require('sharify').data
+moment = require 'moment'
 
 module.exports.VeniceView = class VeniceView extends Backbone.View
 
   events:
     'click .venice-overlay__play': 'playVideo'
+    'click #toggleplay': 'onTogglePlay'
+    'click #togglemute': 'onToggleMute'
 
   initialize: ->
+    @$playButton = $('#toggleplay')
+    @$time = $('#time')
+    @$muteButton = $('#togglemute')
+    @scrubberWidth = $('.venice-video__scrubber').width()
+    @$scrubberMarker = $('.venice-video__scrubber-inner')
+    @$scrubberTime = $('.venice-video__scrubber-time')
     @setupVideo()
+    $(window).resize @onResizeWindow
 
   setupVideo: ->
-    vrView = new VRView.Player '#vrvideo',
+    @vrView = new VRView.Player '#vrvideo',
       video: "#{sd.APP_URL}/vanity/videos/scenic_mono_3.mp4",
       is_stereo: false,
       is_vr_off: false,
       width: '100%',
-      height: '100%'
+      height: '100%',
+      loop: false
+    @vrView.on 'timeupdate', @updateTime
 
   playVideo: ->
     $('.venice-nav, .venice-overlay').fadeOut()
+
+  onTogglePlay: ->
+    if @vrView.isPaused
+      @vrView.play()
+    else
+      @vrView.pause()
+    @$playButton.toggleClass 'paused'
+
+  onToggleMute: ->
+    if @$muteButton.hasClass 'muted'
+      @vrView.setVolume 1
+    else
+      @vrView.setVolume 0
+    @$muteButton.toggleClass 'muted'
+
+  updateTime: (e) =>
+    $(@$scrubberTime).html @formatTime(e.currentTime)
+    percentComplete = (e.currentTime / e.duration) * 100
+    $(@$scrubberMarker).css { 'transform': "translateX(-(#{100 - percentComplete})%)" }
+
+  formatTime: (time) ->
+    minutes = Math.floor(time / 60) % 60
+    seconds = Math.floor(time % 60)
+    minutes = if minutes <= 0 then 0 else minutes
+    seconds = if seconds <= 0 then 0 else seconds
+
+    result = (if minutes < 10 then '0' + minutes else minutes) + ':'
+    result += if seconds < 10 then '0' + seconds else seconds
+
+  onResizeWindow: ->
+    @scrubberWidth = $('.venice-video__scrubber').width()
 
 module.exports.init = ->
   new VeniceView el: $('.venice-feature')

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -1,0 +1,14 @@
+Backbone = require 'backbone'
+sd = require('sharify').data
+VeniceVideoView = require './video.coffee'
+
+module.exports = class VeniceView extends Backbone.View
+
+  events:
+    'click .venice-overlay__play': 'fadeOutCover'
+
+  initialize: ->
+    @VeniceVideoView = new VeniceVideoView el: $('.venice-video')
+
+  fadeOutCover: ->
+    $('.venice-nav, .venice-overlay').fadeOut()

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -12,3 +12,4 @@ module.exports = class VeniceView extends Backbone.View
 
   fadeOutCover: ->
     $('.venice-nav, .venice-overlay').fadeOut()
+    @VeniceVideoView.vrView.play()

--- a/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
@@ -2,10 +2,9 @@ Backbone = require 'backbone'
 sd = require('sharify').data
 moment = require 'moment'
 
-module.exports.VeniceView = class VeniceView extends Backbone.View
+module.exports = class VeniceVideoView extends Backbone.View
 
   events:
-    'click .venice-overlay__play': 'playVideo'
     'click #toggleplay': 'onTogglePlay'
     'click #togglemute': 'onToggleMute'
 
@@ -29,9 +28,6 @@ module.exports.VeniceView = class VeniceView extends Backbone.View
       loop: false
     @vrView.on 'timeupdate', @updateTime
 
-  playVideo: ->
-    $('.venice-nav, .venice-overlay').fadeOut()
-
   onTogglePlay: ->
     if @vrView.isPaused
       @vrView.play()
@@ -49,7 +45,7 @@ module.exports.VeniceView = class VeniceView extends Backbone.View
   updateTime: (e) =>
     $(@$scrubberTime).html @formatTime(e.currentTime)
     percentComplete = (e.currentTime / e.duration) * 100
-    $(@$scrubberMarker).css { 'transform': "translateX(-(#{100 - percentComplete})%)" }
+    $(@$scrubberMarker).css { 'transform': "translateX(-#{100 - percentComplete}%)" }
 
   formatTime: (time) ->
     minutes = Math.floor(time / 60) % 60
@@ -62,6 +58,3 @@ module.exports.VeniceView = class VeniceView extends Backbone.View
 
   onResizeWindow: ->
     @scrubberWidth = $('.venice-video__scrubber').width()
-
-module.exports.init = ->
-  new VeniceView el: $('.venice-feature')

--- a/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
@@ -7,17 +7,10 @@ module.exports = class VeniceVideoView extends Backbone.View
 
   events:
     'click #toggleplay': 'onTogglePlay'
-    'click #togglemute': 'onToggleMute'
 
   initialize: ->
     @$playButton = $('#toggleplay')
-    @$time = $('#time')
-    @$muteButton = $('#togglemute')
-    @scrubberWidth = $('.venice-video__scrubber').width()
-    @$scrubberMarker = $('.venice-video__scrubber-inner')
-    @$scrubberTime = $('.venice-video__scrubber-time')
     @setupVideo()
-    $(window).resize @onResizeWindow
 
   setupVideo: ->
     @vrView = new VRView.Player '#vrvideo',
@@ -34,6 +27,7 @@ module.exports = class VeniceVideoView extends Backbone.View
     @scrubber.set(e.currentTime)
 
   onVRViewReady: =>
+    @vrView.pause()
     @scrubber = noUiSlider.create $('.venice-video__scrubber')[0],
       start: 0
       behaviour: 'snap'
@@ -50,13 +44,7 @@ module.exports = class VeniceVideoView extends Backbone.View
       @vrView.pause()
     @$playButton.toggleClass 'paused'
 
-  onToggleMute: ->
-    if @$muteButton.hasClass 'muted'
-      @vrView.setVolume 1
-    else
-      @vrView.setVolume 0
-    @$muteButton.toggleClass 'muted'
-
+  # Currently unused but will implement next
   formatTime: (time) ->
     minutes = Math.floor(time / 60) % 60
     seconds = Math.floor(time % 60)
@@ -65,6 +53,3 @@ module.exports = class VeniceVideoView extends Backbone.View
 
     result = (if minutes < 10 then '0' + minutes else minutes) + ':'
     result += if seconds < 10 then '0' + seconds else seconds
-
-  onResizeWindow: ->
-    @scrubberWidth = $('.venice-video__scrubber').width()

--- a/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
@@ -1,6 +1,7 @@
 Backbone = require 'backbone'
 sd = require('sharify').data
 moment = require 'moment'
+noUiSlider = require 'nouislider'
 
 module.exports = class VeniceVideoView extends Backbone.View
 
@@ -26,7 +27,21 @@ module.exports = class VeniceVideoView extends Backbone.View
       width: '100%',
       height: '100%',
       loop: false
+    @vrView.on 'ready', @onVRViewReady
     @vrView.on 'timeupdate', @updateTime
+
+  updateTime: (e) =>
+    @scrubber.set(e.currentTime)
+
+  onVRViewReady: =>
+    @scrubber = noUiSlider.create $('.venice-video__scrubber')[0],
+      start: 0
+      behaviour: 'snap'
+      range:
+        min: 0
+        max: @vrView.getDuration()
+    @scrubber.on 'change', (value) =>
+      @vrView.setCurrentTime parseFloat(value[0])
 
   onTogglePlay: ->
     if @vrView.isPaused
@@ -41,11 +56,6 @@ module.exports = class VeniceVideoView extends Backbone.View
     else
       @vrView.setVolume 0
     @$muteButton.toggleClass 'muted'
-
-  updateTime: (e) =>
-    $(@$scrubberTime).html @formatTime(e.currentTime)
-    percentComplete = (e.currentTime / e.duration) * 100
-    $(@$scrubberMarker).css { 'transform': "translateX(-#{100 - percentComplete}%)" }
 
   formatTime: (time) ->
     minutes = Math.floor(time / 60) % 60

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/index.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/index.styl
@@ -1,4 +1,5 @@
 @require './video'
+@require '../../../../../components/slider'
 
 .venice-feature
   background-color black

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/index.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/index.styl
@@ -1,3 +1,5 @@
+@require './video'
+
 .venice-feature
   background-color black
   color white

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/index.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/index.styl
@@ -7,7 +7,7 @@
 .venice-nav
   position absolute
   top 0
-  z-index 10
+  z-index 11
   border-bottom 1px solid white
   display flex
   flex-direction row
@@ -49,6 +49,7 @@
   justify-content center
   align-items center
   color white
+  z-index 10
   &__title
     garamond()
     font-size 80px

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
@@ -1,0 +1,60 @@
+#controls
+  position absolute
+  width 100vw
+  padding 30px
+  bottom 0
+  display flex
+  align-items center
+  svg
+    width 50px
+    height 50px
+
+#toggleplay
+  avant-garde-size('s-headline')
+  cursor pointer
+  display flex
+  justify-content center
+  align-items center
+  width 95px
+  height 50px
+  border 1px solid white
+  background-color rgba(0,0,0,0.5)
+  &__icon
+    width 9px
+    height 9px
+    border-right 3px solid white
+    border-left 3px solid white
+    border-top none
+    border-bottom none
+    margin-right 10px
+  &::after
+    content "Pause"
+  &.paused
+    #toggleplay__icon
+      width 9px
+      height 9px
+      border-top 5px solid transparent
+      border-left 9px solid white
+      border-bottom 5px solid transparent
+      border-right none
+    &::after
+      content "Play"
+  &:hover
+    background-color rgba(0,0,0,1)
+
+.venice-video__scrubber
+  width 100%
+  height 50px
+  margin 0px 30px
+  display flex
+  align-items center
+  &-outer
+    width 100%
+    height 2px
+    background-color white
+  &-inner
+    position absolute
+    width 15px
+    height 15px
+    border-radius 50%
+    background-color white

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
@@ -19,6 +19,7 @@
   height 50px
   border 1px solid white
   background-color rgba(0,0,0,0.5)
+  z-index 5
   &__icon
     width 9px
     height 9px
@@ -44,8 +45,8 @@
 
 .venice-video__scrubber
   width 100%
-  height 50px
   margin 0px 30px
+  position relative
   display flex
   align-items center
   &-outer
@@ -53,8 +54,16 @@
     height 2px
     background-color white
   &-inner
+    width 100%
     position absolute
+    display flex
+    align-items flex-end
+    flex-direction column
+    margin-top 14px
+  &-marker
     width 15px
     height 15px
     border-radius 50%
     background-color white
+  &-time
+    margin 5px -11px 0 0

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
@@ -49,21 +49,3 @@
   position relative
   display flex
   align-items center
-  &-outer
-    width 100%
-    height 2px
-    background-color white
-  &-inner
-    width 100%
-    position absolute
-    display flex
-    align-items flex-end
-    flex-direction column
-    margin-top 14px
-  &-marker
-    width 15px
-    height 15px
-    border-radius 50%
-    background-color white
-  &-time
-    margin 5px -11px 0 0

--- a/desktop/apps/editorial_features/components/venice_2017/templates/index.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/index.jade
@@ -11,7 +11,7 @@ block body
     include ./nav
 
     .venice-header
-      div#vrvideo
+      include ./video
       include ./cover
 
     .venice-footer

--- a/desktop/apps/editorial_features/components/venice_2017/templates/video.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/video.jade
@@ -1,0 +1,10 @@
+.venice-video
+  #vrvideo
+  #controls
+    #toggleplay
+      #toggleplay__icon
+    .venice-video__scrubber
+      .venice-video__scrubber-outer
+      .venice-video__scrubber-inner
+      .venice-video__scrubber-time 00:00
+    include ../../../public/icons/vr-icon.svg

--- a/desktop/apps/editorial_features/components/venice_2017/templates/video.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/video.jade
@@ -4,8 +4,4 @@
     #toggleplay
       #toggleplay__icon
     .venice-video__scrubber
-      .venice-video__scrubber-outer
-      .venice-video__scrubber-inner
-        .venice-video__scrubber-marker
-        .venice-video__scrubber-time 00:00
     include ../../../public/icons/vr-icon.svg

--- a/desktop/apps/editorial_features/components/venice_2017/templates/video.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/video.jade
@@ -4,4 +4,4 @@
     #toggleplay
       #toggleplay__icon
     .venice-video__scrubber
-    include ../../../public/icons/vr-icon.svg
+    include ../../../icons/vr-icon.svg

--- a/desktop/apps/editorial_features/components/venice_2017/templates/video.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/video.jade
@@ -6,5 +6,6 @@
     .venice-video__scrubber
       .venice-video__scrubber-outer
       .venice-video__scrubber-inner
-      .venice-video__scrubber-time 00:00
+        .venice-video__scrubber-marker
+        .venice-video__scrubber-time 00:00
     include ../../../public/icons/vr-icon.svg

--- a/desktop/apps/editorial_features/icons/vr-icon.svg
+++ b/desktop/apps/editorial_features/icons/vr-icon.svg
@@ -1,0 +1,14 @@
+<svg width="52px" height="52px" viewBox="0 0 52 52" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 43.1 (39012) - http://www.bohemiancoding.com/sketch -->
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="003" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Header-on-an-Article-Copy-49" transform="translate(-1344.000000, -865.000000)" stroke="#FFFFFF">
+            <g id="Group-24" transform="translate(1345.000000, 866.000000)">
+                <ellipse id="Oval-4" fill-opacity="0.4" fill="#000000" cx="25" cy="25" rx="25" ry="25"></ellipse>
+                <path d="M39.8492424,10.1507576 C31.6482323,1.94974747 18.3517677,1.94974747 10.1507576,10.1507576 L18.636039,18.636039 C22.1507576,15.1213203 27.8492424,15.1213203 31.363961,18.636039 L39.8492424,10.1507576 Z" id="Oval-4" fill="#FFFFFF"></path>
+                <circle id="Oval-4" fill="#FFFFFF" cx="25" cy="25" r="5"></circle>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
@@ -1,0 +1,35 @@
+_ = require 'underscore'
+benv = require 'benv'
+sinon = require 'sinon'
+Backbone = require 'backbone'
+{ resolve } = require 'path'
+
+describe 'Venice Main', ->
+
+  before (done) ->
+    benv.setup =>
+      benv.expose
+        $: benv.require('jquery')
+        jQuery: benv.require('jquery')
+      Backbone.$ = $
+      @options =
+        asset: ->
+        sd: APP_URL: 'localhost'
+      benv.render resolve(__dirname, '../../../components/venice_2017/templates/index.jade'), @options, =>
+        VeniceView = benv.requireWithJadeify resolve(__dirname, '../../../components/venice_2017/client/index'), []
+        VeniceView.__set__ 'sd', APP_URL: 'localhost'
+        VeniceView.__set__ 'VeniceVideoView', @VeniceVideoView = sinon.stub().returns
+          vrView: play: @play = sinon.stub()
+        @view = new VeniceView
+          el: $('body')
+        done()
+
+  after ->
+    benv.teardown()
+
+  it 'initializes VeniceVideoView', ->
+    @VeniceVideoView.args[0][0].el.selector.should.equal '.venice-video'
+
+  it '#fadeOutCover', ->
+    $('.venice-overlay__play').click()
+    @play.callCount.should.equal 1

--- a/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
@@ -4,7 +4,7 @@ sinon = require 'sinon'
 Backbone = require 'backbone'
 { resolve } = require 'path'
 
-describe 'Venice Biennale', ->
+describe 'Venice Video', ->
 
   before (done) ->
     benv.setup =>
@@ -17,9 +17,9 @@ describe 'Venice Biennale', ->
         asset: ->
         sd: APP_URL: 'localhost'
       benv.render resolve(__dirname, '../../../components/venice_2017/templates/index.jade'), @options, =>
-        { VeniceView } = mod = benv.requireWithJadeify resolve(__dirname, '../../../components/venice_2017/client'), []
+        { VeniceVideoView } = mod = benv.requireWithJadeify resolve(__dirname, '../../../components/venice_2017/video'), []
         mod.__set__ 'sd', APP_URL: 'localhost'
-        @view = new VeniceView
+        @view = new VeniceVideoView
           el: $('body')
           videoIndex: 1
         done()

--- a/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
@@ -11,14 +11,20 @@ describe 'Venice Video', ->
       benv.expose
         $: benv.require('jquery')
         jQuery: benv.require('jquery')
-        VRView: Player: @player = sinon.stub()
+        VRView: Player: (@player = sinon.stub()).returns
+          on: sinon.stub()
+          play: @play = sinon.stub()
+          pause: @pause = sinon.stub()
+          getDuration: sinon.stub().returns 10
       Backbone.$ = $
       @options =
         asset: ->
         sd: APP_URL: 'localhost'
       benv.render resolve(__dirname, '../../../components/venice_2017/templates/index.jade'), @options, =>
-        { VeniceVideoView } = mod = benv.requireWithJadeify resolve(__dirname, '../../../components/venice_2017/video'), []
-        mod.__set__ 'sd', APP_URL: 'localhost'
+        VeniceVideoView = benv.requireWithJadeify resolve(__dirname, '../../../components/venice_2017/client/video'), []
+        VeniceVideoView.__set__ 'sd', APP_URL: 'localhost'
+        VeniceVideoView.__set__ 'noUiSlider', create: (@scrubberCreate = sinon.stub()).returns
+          on: @scrubberOn = sinon.stub()
         @view = new VeniceVideoView
           el: $('body')
           videoIndex: 1
@@ -30,3 +36,20 @@ describe 'Venice Video', ->
   it 'sets up video', ->
     @player.args[0][0].should.equal '#vrvideo'
     @player.args[0][1].video.should.equal 'localhost/vanity/videos/scenic_mono_3.mp4'
+
+  it 'sets up scrubber #onVRViewReady', ->
+    @view.onVRViewReady()
+    @scrubberCreate.args[0][1].behaviour.should.equal 'snap'
+    @scrubberCreate.args[0][1].start.should.equal 0
+    @scrubberCreate.args[0][1].range.min.should.equal 0
+    @scrubberCreate.args[0][1].range.max.should.equal 10
+
+  it 'toggles play', ->
+    @view.vrView.isPaused = true
+    @view.onTogglePlay()
+    @play.callCount.should.equal 1
+
+  it 'toggles pause', ->
+    @view.vrView.isPaused = false
+    @view.onTogglePlay()
+    @pause.callCount.should.equal 2 # one for init

--- a/desktop/assets/editorial_features.coffee
+++ b/desktop/assets/editorial_features.coffee
@@ -2,5 +2,5 @@ require('backbone').$ = $
 $ ->
   if location.pathname is '/2016-year-in-art'
     require('../apps/editorial_features/components/eoy/client.coffee').init
-  else if location.pathname.includes('/venice-biennale')
+  else if location.pathname.indexOf('/venice-biennale') > -1
     require('../apps/editorial_features/components/venice_2017/client.coffee').init()

--- a/desktop/assets/editorial_features.coffee
+++ b/desktop/assets/editorial_features.coffee
@@ -1,6 +1,8 @@
 require('backbone').$ = $
+VeniceView = require '../apps/editorial_features/components/venice_2017/client/index.coffee'
+
 $ ->
   if location.pathname is '/2016-year-in-art'
     require('../apps/editorial_features/components/eoy/client.coffee').init
   else if location.pathname.indexOf('/venice-biennale') > -1
-    require('../apps/editorial_features/components/venice_2017/client.coffee').init()
+    new VeniceView el: $('.venice-feature')

--- a/desktop/components/auction_reminders/blacklist.coffee
+++ b/desktop/components/auction_reminders/blacklist.coffee
@@ -20,6 +20,7 @@ module.exports =
     TEAM_BLOGS or '^/test'
     '^/2016-year-in-art'
     '^/artist/.*'
+    '^/venice-biennale/.*'
   ]
 
   check: ->


### PR DESCRIPTION
Hopefully this merge will be painless on your end, but this cleans up some of the client-side code and adds video controls on the player. The scrubber is using `nouislider` which I conveniently took from the /collect page's slider. Thanks @broskoski for adding that! Was pretty fun to hack a playback scrubber on top of it. 


![venice](https://cloud.githubusercontent.com/assets/2236794/25163946/c41e1564-249b-11e7-99ae-43c8d3127ded.gif)
