### PR TITLE
@eessex => Fix init on EOY page

### DIFF
--- a/desktop/assets/editorial_features.coffee
+++ b/desktop/assets/editorial_features.coffee
@@ -3,6 +3,6 @@ VeniceView = require '../apps/editorial_features/components/venice_2017/client/i
 
 $ ->
   if location.pathname is '/2016-year-in-art'
-    require('../apps/editorial_features/components/eoy/client.coffee').init
+    require('../apps/editorial_features/components/eoy/client.coffee').init()
   else if location.pathname.indexOf('/venice-biennale') > -1
     new VeniceView el: $('.venice-feature')


### PR DESCRIPTION
Before we relied on the `$` callback to evoke the init function but now that we have a little more logic and pass in our own callback, we need to explicitly evoke it.