### PR TITLE
@dblock => Update city sitemap

### DIFF
--- a/desktop/apps/sitemaps/index.coffee
+++ b/desktop/apps/sitemaps/index.coffee
@@ -11,7 +11,7 @@ app.get ['/sitemap-articles.xml', '/sitemap-articles-:timestamp.xml'], routes.si
 app.get ['/sitemap-artists.xml', '/sitemap-artists-:timestamp.xml'], routes.sitemaps
 app.get ['/sitemap-artist-images.xml', '/sitemap-artist-images-:slug.xml'], routes.sitemaps
 app.get ['/sitemap-artworks.xml', '/sitemap-artworks-:timestamp.xml'], routes.sitemaps
-app.get '/sitemap-cities.xml', routes.cities
+app.get '/sitemap-cities.xml', routes.sitemaps
 app.get ['/sitemap-fairs.xml', '/sitemap-fairs-:timestamp.xml'], routes.sitemaps
 app.get ['/sitemap-features.xml', '/sitemap-features-:timestamp.xml'], routes.sitemaps
 app.get '/sitemap-genes.xml', routes.sitemaps

--- a/desktop/apps/sitemaps/routes.coffee
+++ b/desktop/apps/sitemaps/routes.coffee
@@ -30,13 +30,6 @@ sitemapProxy = httpProxy.createProxyServer(target: SITEMAP_BASE_URL)
   res.set 'Content-Type', 'text/xml'
   res.render('misc', pretty: true)
 
-@cities = (req, res, next) ->
-  partnerFeaturedCities = new PartnerFeaturedCities()
-  partnerFeaturedCities.fetch
-    success: ->
-      res.set 'Content-Type', 'text/xml'
-      res.render 'cities', pretty: true, citySlugs: partnerFeaturedCities.pluck('slug')
-
 # sitemaps for artworks and images are generated in Spark by Cinder and written to the artsy-sitemaps s3 bucket
 # see https://github.com/artsy/cinder/blob/master/doc/sitemaps.md for more information
 @sitemaps = (req, res, next) ->

--- a/desktop/apps/sitemaps/templates/cities.jade
+++ b/desktop/apps/sitemaps/templates/cities.jade
@@ -1,7 +1,0 @@
-doctype xml
-urlset(
-  xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'
-)
- for slug in citySlugs
-  url
-    loc=sd.APP_URL + '/shows/' + slug

--- a/desktop/apps/sitemaps/test/routes.coffee
+++ b/desktop/apps/sitemaps/test/routes.coffee
@@ -105,11 +105,3 @@ Sitemap: https://www.artsy.net/sitemap-videos.xml
     it 'renders the misc template', ->
       routes.misc(@req, @res)
       @res.render.args[0][0].should.equal 'misc'
-
-  describe '#cities', ->
-    it 'fetches and displays city slugs', ->
-      routes.cities(@req, @res)
-      Backbone.sync.args[0][2].success [{ slug: 'new-york-city' }, { slug: 'tokyo' }]
-      @res.render.args[0][1].citySlugs.length.should.equal 2
-      @res.render.args[0][1].citySlugs[0].should.containEql 'new-york-city'
-      @res.render.args[0][1].citySlugs[1].should.containEql 'tokyo'

--- a/desktop/apps/sitemaps/test/templates.coffee
+++ b/desktop/apps/sitemaps/test/templates.coffee
@@ -17,15 +17,6 @@ render = (templateName) ->
     { filename: filename }
   )
 
-describe 'cities sitemap template', ->
-
-  it 'renders the correct city show URLs', ->
-    xml = render('cities')
-      citySlugs: ['new-york', 'tokyo']
-      sd: APP_URL: 'www.artsy.net'
-    xml.should.containEql 'www.artsy.net/shows/new-york'
-    xml.should.containEql 'www.artsy.net/shows/tokyo'
-
 describe 'misc sitemap template', ->
 
   it 'renders the correct misc URLs', ->

--- a/yarn.lock
+++ b/yarn.lock
@@ -6998,7 +6998,7 @@ supertest@^2.0.1:
     methods "1.x"
     superagent "^2.0.0"
 
-supports-color@3.1.2:
+supports-color@3.1.2, supports-color@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -7012,7 +7012,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.2, supports-color@^3.2.3:
+supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:


### PR DESCRIPTION
This removes the previous special behavior for `sitemap-cities.xml` in favor of the standard proxy to S3 for the [new Cinder-generated sitemap](https://github.com/artsy/cinder/pull/173) located at https://s3.amazonaws.com/artsy-sitemaps/sitemap-cities.xml

