### PR TITLE
Auctions#420: live links login

### DIFF
--- a/desktop/apps/artwork/components/auction/helpers.coffee
+++ b/desktop/apps/artwork/components/auction/helpers.coffee
@@ -1,4 +1,5 @@
 { compact } = require 'underscore'
+{ liveAuctionUrl } = require '../../../../utils/domain/auctions/urls'
 
 pluralize = (word, count, irregular = null) ->
   if count is 1
@@ -6,10 +7,12 @@ pluralize = (word, count, irregular = null) ->
   else
     "#{count} #{irregular or word + 's'}"
 
-module.exports =
+module.exports = {
+  liveAuctionUrl,
   count: ({ counts, reserve_message }) ->
     compact [
       pluralize 'bid', counts.bidder_positions if counts.bidder_positions
       reserve_message
     ]
       .join ', '
+}

--- a/desktop/apps/artwork/components/auction/helpers.coffee
+++ b/desktop/apps/artwork/components/auction/helpers.coffee
@@ -1,5 +1,5 @@
 { compact } = require 'underscore'
-{ liveAuctionUrl } = require '../../../../utils/domain/auctions/urls'
+{ liveAuctionUrl } = require '../../../../../utils/domain/auctions/urls'
 
 pluralize = (word, count, irregular = null) ->
   if count is 1

--- a/desktop/apps/artwork/components/auction/templates/live.jade
+++ b/desktop/apps/artwork/components/auction/templates/live.jade
@@ -1,6 +1,6 @@
 if auction.is_live_open
   .artwork-auction__live-button
     a.avant-garde-button-black.is-block(
-      href="#{sd.PREDICTION_URL}/#{auction.id}"
+      href=helpers.auction.liveAuctionUrl(auction.id, {isLoggedIn: Boolean(me)})
       target='_blank'
     ) Enter Live Auction

--- a/desktop/apps/auction/routes.js
+++ b/desktop/apps/auction/routes.js
@@ -1,11 +1,11 @@
-import metaphysics from '../../../lib/metaphysics'
-import ArticlesQuery from './queries/articles'
 import Articles from '../../collections/articles.coffee'
+import ArticlesQuery from './queries/articles'
 import Auction from '../../models/auction.coffee'
-import footerItems from './footer_items'
-import SaleQuery from './queries/sale'
 import MeQuery from './queries/me'
-import { PREDICTION_URL } from '../../config'
+import SaleQuery from './queries/sale'
+import footerItems from './footer_items'
+import metaphysics from '../../../lib/metaphysics'
+import { liveAuctionUrl } from '../../utils/domain/auctions/urls'
 
 export const index = async (req, res) => {
   const { me } = await metaphysics({ query: MeQuery(req.params.id), req: req })
@@ -19,6 +19,7 @@ export const index = async (req, res) => {
     articles: auctionArticles,
     auction: newAuction,
     footerItems: footerItems,
+    helpers: { auction: { liveAuctionUrl } },
     me: me
   })
 }
@@ -26,10 +27,9 @@ export const index = async (req, res) => {
 export const redirectLive = async (req, res, next) => {
   const { sale } = await metaphysics({ query: SaleQuery(req.params.id) })
   if (sale && sale.is_live_open) {
-    const liveUrl = `${PREDICTION_URL}/${sale.id}/login`
     const { me } = await metaphysics({ query: MeQuery(req.params.id), req: req })
     if (me && me.bidders && me.bidders.length > 0 && me.bidders[0].qualified_for_bidding) {
-      res.redirect(liveUrl)
+      res.redirect(liveAuctionUrl(sale.id, {isLoggedIn: Boolean(me)}))
     } else {
       next()
     }

--- a/desktop/apps/auction/routes.js
+++ b/desktop/apps/auction/routes.js
@@ -5,7 +5,7 @@ import MeQuery from './queries/me'
 import SaleQuery from './queries/sale'
 import footerItems from './footer_items'
 import metaphysics from '../../../lib/metaphysics'
-import { liveAuctionUrl } from '../../utils/domain/auctions/urls'
+import { liveAuctionUrl } from '../../../utils/domain/auctions/urls'
 
 export const index = async (req, res) => {
   const { me } = await metaphysics({ query: MeQuery(req.params.id), req: req })

--- a/desktop/apps/auction/templates/banner.jade
+++ b/desktop/apps/auction/templates/banner.jade
@@ -8,7 +8,7 @@ if auction.isLiveOpen()
     .auction-banner-live-details
       h1 Live Bidding Now Open
       a.avant-garde-button-white(
-        href="#{sd.PREDICTION_URL}/#{auction.get('id')}#{user ? '/login' : ''}"
+        href=helpers.auction.liveAuctionUrl(auction.get('id'), {isLoggedIn: Boolean(me)})
         target='_blank'
       ) Enter live auction
 else

--- a/desktop/apps/auction/templates/my_active_bids.jade
+++ b/desktop/apps/auction/templates/my_active_bids.jade
@@ -23,7 +23,7 @@ if myActiveBids && myActiveBids.length
         .auction-my-active-bids__bids-num (#{bidCount} Bid#{bidCount > 1 ? 's' : ''})
         if bid.sale_artwork.sale.is_live_open
           a.avant-garde-button-white.auction-my-active-bids__bid-live-button(
-              href=ViewHelpers.liveAuctionUrl(bid.sale_artwork.sale_id)
+              href=helpers.auction.liveAuctionUrl(bid.sale_artwork.sale_id, {isLoggedIn: Boolean(me)})
             ) Bid Live
         else
           .bid-status-cell

--- a/desktop/apps/auction/test/routes.js
+++ b/desktop/apps/auction/test/routes.js
@@ -102,7 +102,7 @@ describe('#redirectLive', () => {
     RoutesRewireApi.__Rewire__('metaphysics', sinon.stub().returns(Promise.resolve(auctionQueries)))
     res = {
       redirect: (url) => {
-        url.should.equal('https://live.artsy.net/foo/login')
+        url.should.containEql('/foo/login')
       }
     }
     routes.redirectLive(req, res, next).then(() => {

--- a/desktop/apps/auction/test/templates.js
+++ b/desktop/apps/auction/test/templates.js
@@ -17,7 +17,8 @@ describe('auction templates', () => {
       asset: () => {},
       auction: new Auction(),
       footerItems: footerItems,
-      me: null
+      me: null,
+      helpers: { auction: {liveAuctionUrl: () => 'placeholderauctionurl.com'}}
     }
   })
 
@@ -97,7 +98,10 @@ describe('auction templates', () => {
         benv.setup(() => {
           benv.expose({$: benv.require('jquery')})
           const data = _.extend({}, baseData,
-            { auction: new Auction(fabricate('sale', { name: 'An Auction', auction_state: 'open', live_start_at: moment().subtract(3, 'days') })) })
+            {
+              auction: new Auction(fabricate('sale', { name: 'An Auction', auction_state: 'open', live_start_at: moment().subtract(3, 'days') }))
+            }
+          )
           benv.render(resolve(__dirname, '../templates/index.jade'), data, () => done())
         })
       })

--- a/desktop/apps/auction_support/client/bid_form.coffee
+++ b/desktop/apps/auction_support/client/bid_form.coffee
@@ -7,6 +7,7 @@ BidderPosition = require '../../../models/bidder_position.coffee'
 CurrentUser = require '../../../models/current_user.coffee'
 ErrorHandlingForm = require '../../../components/credit_card/client/error_handling_form.coffee'
 { SESSION_ID } = require('sharify').data
+{ liveAuctionUrl } = require '../../../utils/domain/auctions/urls.js'
 
 module.exports = class BidForm extends ErrorHandlingForm
 
@@ -14,7 +15,7 @@ module.exports = class BidForm extends ErrorHandlingForm
   maxTimesPolledForBidPlacement: sd.MAX_POLLS_FOR_MAX_BIDS
   errors: -> {
     "Sale Closed to Bids": "Sorry, your bid wasn't received before the auction closed."
-    "Live Bidding has Started": "Sorry, your bid wasn't received before live bidding started. <br/>To continue bidding, please <a href=\"#{@model.liveAuctionUrl()}\">join the live auction</a>."
+    "Live Bidding has Started": "Sorry, your bid wasn't received before live bidding started. <br/>To continue bidding, please <a href=\"#{liveAuctionUrl(@model.get('id'), {isLoggedIn: Boolean(@user)} )}\">join the live auction</a>."
     connection: "Your bid didn't make it to us. Please check your network connectivity and try again."
     "Bidder not qualified to bid on this auction.": "Sorry, we could not process your bid. <br>Please contact <a href='#' class='js-contact-specialist'>Artsy staff</a> for support."
   }

--- a/desktop/apps/auction_support/client/bid_form.coffee
+++ b/desktop/apps/auction_support/client/bid_form.coffee
@@ -7,7 +7,7 @@ BidderPosition = require '../../../models/bidder_position.coffee'
 CurrentUser = require '../../../models/current_user.coffee'
 ErrorHandlingForm = require '../../../components/credit_card/client/error_handling_form.coffee'
 { SESSION_ID } = require('sharify').data
-{ liveAuctionUrl } = require '../../../utils/domain/auctions/urls.js'
+{ liveAuctionUrl } = require '../../../../utils/domain/auctions/urls.js'
 
 module.exports = class BidForm extends ErrorHandlingForm
 

--- a/desktop/components/main_layout/templates/index.jade
+++ b/desktop/components/main_layout/templates/index.jade
@@ -1,6 +1,6 @@
 //- Override any locals with `append locals`
 block locals
-  - bodyClass = helpers ? helpers.buildBodyClass(sd, 'body-header-fixed') : '';
+  - bodyClass = helpers && helpers.buildBodyClass ? helpers.buildBodyClass(sd, 'body-header-fixed') : '';
 
 doctype html
 html(

--- a/desktop/components/my_active_bids/helpers.coffee
+++ b/desktop/components/my_active_bids/helpers.coffee
@@ -1,6 +1,0 @@
-moment = require 'moment'
-{ PREDICTION_URL } = require('sharify').data
-
-module.exports =
-  liveAuctionUrl: (saleId) ->
-    "#{PREDICTION_URL}/#{saleId}"

--- a/desktop/components/my_active_bids/template.jade
+++ b/desktop/components/my_active_bids/template.jade
@@ -16,7 +16,7 @@ if myActiveBids && myActiveBids.length
               p #{bid.sale_artwork.highest_bid.display} (#{bid.sale_artwork.counts.bidder_positions} Bids)
           if bid.sale_artwork.sale.is_live_open
             a.avant-garde-button-black.my-active-bids-bid-live-button(
-              href=ViewHelpers.liveAuctionUrl(bid.sale_artwork.sale_id)
+              href=helpers.auction.liveAuctionUrl(bid.sale_artwork.sale_id, {isLoggedIn: true})
             ) Bid Live
           else
             +bidStatus(bid, bid.sale_artwork)

--- a/desktop/components/my_active_bids/test/template.coffee
+++ b/desktop/components/my_active_bids/test/template.coffee
@@ -1,7 +1,7 @@
 template = require('jade').compileFile(require.resolve '../template.jade')
 cheerio = require 'cheerio'
 moment = require 'moment'
-{liveAuctionUrl} = require('../../../utils/domain/auctions/urls')
+{liveAuctionUrl} = require('../../../../utils/domain/auctions/urls')
 
 fixture = -> [
   {

--- a/desktop/components/my_active_bids/test/template.coffee
+++ b/desktop/components/my_active_bids/test/template.coffee
@@ -1,7 +1,7 @@
 template = require('jade').compileFile(require.resolve '../template.jade')
 cheerio = require 'cheerio'
 moment = require 'moment'
-ViewHelpers = require('../helpers.coffee')
+{liveAuctionUrl} = require('../../../utils/domain/auctions/urls')
 
 fixture = -> [
   {
@@ -37,7 +37,7 @@ describe 'My Active Bids template', ->
   beforeEach ->
     @locals =
       myActiveBids: fixture()
-      ViewHelpers: ViewHelpers
+      helpers: auction: { liveAuctionUrl }
       accounting: formatMoney: (s) -> s
 
   it 'renders highest bid if user is leading bidder and reserve met\
@@ -79,4 +79,4 @@ describe 'My Active Bids template', ->
     $('.my-active-bids-bid-live-button').length.should.eql 1
     $('.my-active-bids-bid-live-button').text().should.containEql 'Bid Live'
     $('.my-active-bids-bid-live-button').attr('href')
-      .should.containEql('mauction-evening-sale')
+      .should.containEql('mauction-evening-sale/login')

--- a/desktop/components/my_active_bids/view.coffee
+++ b/desktop/components/my_active_bids/view.coffee
@@ -4,7 +4,7 @@ query = require './query.coffee'
 metaphysics = require '../../../lib/metaphysics.coffee'
 CurrentUser = require '../../models/current_user.coffee'
 template = -> require('./template.jade') arguments...
-ViewHelpers = require('./helpers.coffee')
+{liveAuctionUrl} = require('../../utils/domain/auctions/urls')
 
 module.exports = class MyActiveBids extends Backbone.View
 
@@ -29,7 +29,7 @@ module.exports = class MyActiveBids extends Backbone.View
       @bidderPositions = data.me?.lot_standings
 
   render: =>
-    @$el.html @template myActiveBids: @bidderPositions, ViewHelpers: ViewHelpers
+    @$el.html @template myActiveBids: @bidderPositions, helpers: { auction: { liveAuctionUrl } }
     this
 
   remove: ->

--- a/desktop/components/my_active_bids/view.coffee
+++ b/desktop/components/my_active_bids/view.coffee
@@ -4,7 +4,7 @@ query = require './query.coffee'
 metaphysics = require '../../../lib/metaphysics.coffee'
 CurrentUser = require '../../models/current_user.coffee'
 template = -> require('./template.jade') arguments...
-{liveAuctionUrl} = require('../../utils/domain/auctions/urls')
+{liveAuctionUrl} = require('../../../utils/domain/auctions/urls')
 
 module.exports = class MyActiveBids extends Backbone.View
 

--- a/desktop/models/sale.coffee
+++ b/desktop/models/sale.coffee
@@ -8,7 +8,7 @@ Clock = require './mixins/clock.coffee'
 Relations = require './mixins/relations/sale.coffee'
 ImageSizes = require './mixins/image_sizes.coffee'
 Eventable = require './mixins/eventable.coffee'
-{ liveAuctionUrl } = require '../utils/domain/auctions/urls'
+{ liveAuctionUrl } = require '../../utils/domain/auctions/urls'
 
 module.exports = class Sale extends Backbone.Model
   _.extend @prototype, Clock

--- a/desktop/models/sale.coffee
+++ b/desktop/models/sale.coffee
@@ -1,14 +1,14 @@
 _ = require 'underscore'
-{ API_URL, SECURE_IMAGES_URL, PREDICTION_URL } = require('sharify').data
+{ API_URL, SECURE_IMAGES_URL } = require('sharify').data
 moment = require 'moment'
 tz = require 'moment-timezone'
 Backbone = require 'backbone'
 { Fetch, Markdown, Image, CalendarUrls } = require 'artsy-backbone-mixins'
-
 Clock = require './mixins/clock.coffee'
 Relations = require './mixins/relations/sale.coffee'
 ImageSizes = require './mixins/image_sizes.coffee'
 Eventable = require './mixins/eventable.coffee'
+{ liveAuctionUrl } = require '../utils/domain/auctions/urls'
 
 module.exports = class Sale extends Backbone.Model
   _.extend @prototype, Clock
@@ -40,8 +40,6 @@ module.exports = class Sale extends Backbone.Model
   bidUrl: (artwork) ->
     "#{@href()}/bid/#{artwork.id}"
 
-  liveAuctionUrl: -> "#{PREDICTION_URL}/#{@get('id')}"
-
   redirectUrl: (artwork) ->
     if @isBidable() and artwork?
       @bidUrl artwork
@@ -63,7 +61,7 @@ module.exports = class Sale extends Backbone.Model
     if @isClosed()
       label: 'Auction Closed', enabled: false, classes: 'is-disabled', href: ''
     else if @isLiveOpen()
-      label: 'Enter Live Auction', enabled: true, href: "#{PREDICTION_URL}/#{@get 'id'}"
+      label: 'Enter Live Auction', enabled: true, href: liveAuctionUrl(@get('id'), { isLoggedIn: Boolean(user) })
     else if artwork.get('sold') and not artwork.get('acquireable')
       label: 'Sold', enabled: false, classes: 'is-disabled', href: ''
     else

--- a/desktop/test/models/sale.coffee
+++ b/desktop/test/models/sale.coffee
@@ -2,8 +2,8 @@ moment = require 'moment'
 sinon = require 'sinon'
 Backbone = require 'backbone'
 { fabricate } = require 'antigravity'
-Sale = require '../../models/sale'
 Artwork = require '../../models/artwork'
+Sale = require '../../models/sale'
 
 describe 'Sale', ->
   beforeEach ->
@@ -211,7 +211,6 @@ describe 'Sale', ->
       Backbone.sync.args[0][1].url().should.match /// /api/v1/sale/.*/sale_artworks ///
 
   describe '#registerUrl', ->
-
     it 'points to the secure auction registration page'
     it 'points to the signup page when not logged in'
 

--- a/desktop/test/utils/domain/auctions/urls_test.js
+++ b/desktop/test/utils/domain/auctions/urls_test.js
@@ -1,5 +1,5 @@
 const rewire = require('rewire')
-const urls = rewire('../../../../utils/domain/auctions/urls')
+const urls = rewire('../../../../../utils/domain/auctions/urls')
 
 describe('Url Utilities', () => {
   let PREDICTION_URL = 'http://www.liveauctions.com'

--- a/desktop/test/utils/domain/auctions/urls_test.js
+++ b/desktop/test/utils/domain/auctions/urls_test.js
@@ -1,0 +1,20 @@
+const rewire = require('rewire')
+const urls = rewire('../../../../utils/domain/auctions/urls')
+
+describe('Url Utilities', () => {
+  let PREDICTION_URL = 'http://www.liveauctions.com'
+  before(() => {
+    urls.__set__('sd', {PREDICTION_URL})
+  })
+  describe('#liveAuctionUrl builds a url to a live auction', () => {
+    it('appends /login with a true "isLoggedIn" option in the second argument', () => {
+      urls.liveAuctionUrl('foo', { isLoggedIn: true }).should.equal(`${PREDICTION_URL}/foo/login`)
+    })
+    it('does not append login with a falsey user option', () => {
+      urls.liveAuctionUrl('foo', {isLoggedIn: false}).should.equal(`${PREDICTION_URL}/foo`)
+    })
+    it('does not append login with no options', () => {
+      urls.liveAuctionUrl('foo').should.equal(`${PREDICTION_URL}/foo`)
+    })
+  })
+})

--- a/desktop/utils/domain/auctions/urls.js
+++ b/desktop/utils/domain/auctions/urls.js
@@ -1,0 +1,18 @@
+const sd = require('sharify').data
+const config = require('../../../../config')
+/** Get the live auction url with /login appended when a user is present
+ * @param {String} id - auction id/slug
+ * @param {Object} [options]
+ * @param {Boolean} [options.isLoggedIn] - whether there is a user present
+ * @return {String} live auction url
+ */
+export const liveAuctionUrl = (id, options = {}) => {
+  const liveAuctionRoot = sd.PREDICTION_URL || config.PREDICTION_URL
+  const url = `${liveAuctionRoot}/${id}`
+
+  if (options.isLoggedIn) {
+    return `${url}/login`
+  } else {
+    return url
+  }
+}

--- a/mobile/apps/auction/routes.coffee
+++ b/mobile/apps/auction/routes.coffee
@@ -5,7 +5,7 @@ SaleArtworks = require '../../collections/sale_artworks'
 Artworks = require '../../collections/artworks'
 State = require '../../components/auction_artwork_list/state'
 request = require 'superagent'
-{ liveAuctionUrl } = require '../../../desktop/utils/domain/auctions/urls'
+{ liveAuctionUrl } = require '../../../utils/domain/auctions/urls'
 {
   MAILCHIMP_KEY
   MAILCHIMP_AUCTION_LIST_ID

--- a/mobile/apps/auction/routes.coffee
+++ b/mobile/apps/auction/routes.coffee
@@ -5,10 +5,10 @@ SaleArtworks = require '../../collections/sale_artworks'
 Artworks = require '../../collections/artworks'
 State = require '../../components/auction_artwork_list/state'
 request = require 'superagent'
+{ liveAuctionUrl } = require '../../../desktop/utils/domain/auctions/urls'
 {
   MAILCHIMP_KEY
   MAILCHIMP_AUCTION_LIST_ID
-  PREDICTION_URL
 } = require '../../config'
 
 nav = ->
@@ -40,10 +40,7 @@ module.exports.index = (req, res, next) ->
   ]).catch(next)
   promise.done ->
     if auction.isLiveOpen()
-      return res.redirect(
-        "#{PREDICTION_URL}/#{auction.get 'id'}" +
-        if req.user then '/login' else ''
-      )
+      return res.redirect(liveAuctionUrl(id, { isLoggedIn: Boolean(req.user) }))
     artworks.reset Artworks.__fromSale__(saleArtworks)
     res.locals.sd.AUCTION = auction.toJSON()
     res.locals.sd.ARTWORKS = artworks.toJSON()

--- a/mobile/apps/auction/test/routes.coffee
+++ b/mobile/apps/auction/test/routes.coffee
@@ -56,7 +56,7 @@ describe '/auction routes', ->
         Backbone.sync.args[1][2].success {}
         _.defer => _.defer =>
           @res.redirect.args[0][0].should
-            .equal 'https://live.artsy.net/foobar-auction'
+            .containEql "/foobar-auction"
           done()
 
     describe '#subscribe', ->

--- a/utils/domain/auctions/urls.js
+++ b/utils/domain/auctions/urls.js
@@ -1,5 +1,5 @@
 const sd = require('sharify').data
-const config = require('../../../../config')
+
 /** Get the live auction url with /login appended when a user is present
  * @param {String} id - auction id/slug
  * @param {Object} [options]
@@ -7,7 +7,8 @@ const config = require('../../../../config')
  * @return {String} live auction url
  */
 export const liveAuctionUrl = (id, options = {}) => {
-  const liveAuctionRoot = sd.PREDICTION_URL || config.PREDICTION_URL
+  console.log(sd)
+  const liveAuctionRoot = sd.PREDICTION_URL
   const url = `${liveAuctionRoot}/${id}`
 
   if (options.isLoggedIn) {

--- a/utils/domain/auctions/urls.js
+++ b/utils/domain/auctions/urls.js
@@ -7,10 +7,8 @@ const sd = require('sharify').data
  * @return {String} live auction url
  */
 export const liveAuctionUrl = (id, options = {}) => {
-  console.log(sd)
   const liveAuctionRoot = sd.PREDICTION_URL
   const url = `${liveAuctionRoot}/${id}`
-
   if (options.isLoggedIn) {
     return `${url}/login`
   } else {


### PR DESCRIPTION
https://github.com/artsy/auctions/issues/420 tracks this.
This pr standardizes our live auction linking to use a method in a new global `/utils` folder.

The `liveAuctionUrl` method takes one argument for the saleId, appending `/login` if there is a sharify CURRENT_USER.

To test both states, we can look at:
- my active bids components (should only show /login because there is a user)
- auction pages
- artwork pages
- the banners
- loading a bid window before and placing a bid after the sale goes live

When possible, I passed helpers to templates with the locals structure `helpers: {auction: {liveAuctionUrl}}`.

the `Sale` model has many other methods that might want to live in /utils.