### PR TITLE
Use Node HTTP proxy for Reflection proxying

### DIFF
--- a/lib/middleware/proxy_to_reflection.coffee
+++ b/lib/middleware/proxy_to_reflection.coffee
@@ -2,21 +2,12 @@
 # When Google requests _escaped_fragement_ proxy to Reflection
 # https://github.com/artsy/reflection
 #
-
-request = require 'superagent'
-{ parse } = require 'url'
-{ REFLECTION_URL } = require '../../config'
+httpProxy = require 'http-proxy'
+proxy = httpProxy.createProxyServer()
+{ REFLECTION_URL } = process.env
 
 module.exports = (req, res, next) ->
   if req.query._escaped_fragment_?
-    request.get(reflectionUrl(req)).end (err, resp) ->
-      if resp?.status is 200 then res.send(resp.text) else next()
+    proxy.web req, res, target: REFLECTION_URL, changeOrigin: true
   else
     next()
-
-reflectionUrl = (req) ->
-  url = parse(req.url)
-  dest = REFLECTION_URL + url.pathname
-  query = url.query?.replace(/&?_escaped_fragment_=/, '')
-  dest += encodeURIComponent("?" + decodeURIComponent(query)) if query?.length
-  dest

--- a/test/lib/middleware/proxy_to_reflection.coffee
+++ b/test/lib/middleware/proxy_to_reflection.coffee
@@ -1,26 +1,18 @@
-_ = require 'underscore'
 sinon = require 'sinon'
 rewire = require 'rewire'
-{ REFLECTION_URL } = require '../../../config'
 proxyToReflection = rewire '../../../lib/middleware/proxy_to_reflection'
-{ parse } = require 'url'
-querystring = require 'querystring'
-
-endStub = sinon.stub()
-getStub = sinon.stub()
-proxyToReflection.__set__ 'request',
-  get: (url) ->
-    getStub url
-    end: endStub
 
 describe 'proxyToReflection', ->
   beforeEach ->
+    @req = query: {}
     @res = {}
     @next = sinon.stub()
+    proxyToReflection.__set__ 'proxy', @proxy = web: sinon.stub()
+    proxyToReflection.__set__ 'REFLECTION_URL', 'reflection.url'
 
   it 'passes through when there is no escaped fragment query param', ->
-    req = url: '/artwork/foo-bar', query: {}
-    proxyToReflection req, @res, @next
+    @req.query._escaped_fragment_= null
+    proxyToReflection @req, @res, @next
     @next.called.should.be.ok()
 
   context 'with _escaped_fragment_', ->
@@ -30,17 +22,9 @@ describe 'proxyToReflection', ->
       '/artwork/foo-bar?a=b&c=d&_escaped_fragment_=': '/artwork/foo-bar%3Fa%3Db%26c%3Dd'
       '/artwork/foo-bar?a=b&c=d%3Ae&_escaped_fragment_=': '/artwork/foo-bar%3Fa%3Db%26c%3Dd%3Ae'
 
-    it 'passes through when relfection returns a 403', ->
-      parsed = parse(source)
-      req = url: parsed.path, query: querystring.parse(parsed.query)
-      proxyToReflection req, @res, @next
-      endStub.args[0][0] null, status: 403
-      @next.called.should.be.ok()
-
     for source, dest of paths
       it "proxies #{source} to #{dest}", ->
-        parsed = parse(source)
-        req = url: parsed.path, query: querystring.parse(parsed.query)
-        proxyToReflection req, @res, @next
-        getStub.args[0][0].should.equal "#{REFLECTION_URL}#{dest}"
-        endStub.called.should.be.ok()
+        @req.query._escaped_fragment_= ''
+        proxyToReflection @req, @res, @next
+        options = @proxy.web.args[0][2]
+        options.target.should.equal 'reflection.url'


### PR DESCRIPTION
There's a number of [funny errors](https://sentry.io/artsynet/force-production/issues/256014515/) reported in Sentry from the reflection middleware. This uses Node HTTP proxy instead of our own superagent implementation to do the proxying—hopefully removing that noise and leveraging a mature library to cover other edge cases.