### PR TITLE
@damassi => correctly handle the upper bound of the estimate range filter

### DIFF
--- a/desktop/apps/auction/client/reducers.js
+++ b/desktop/apps/auction/client/reducers.js
@@ -161,9 +161,15 @@ function auctionArtworks(state = initialState, action) {
       }, state)
     }
     case actions.UPDATE_ESTIMATE_RANGE: {
+      let maxRange
+      if (action.payload.max === state.filterParams.ranges.estimate_range.max) {
+        maxRange = '*'
+      } else {
+        maxRange = action.payload.max * 100
+      }
       return u({
         filterParams: {
-          estimate_range: `${action.payload.min * 100}-${action.payload.max * 100}`
+          estimate_range: `${action.payload.min * 100}-${maxRange}`
         }
       }, state)
     }

--- a/desktop/apps/auction/components/range_slider/index.js
+++ b/desktop/apps/auction/components/range_slider/index.js
@@ -15,14 +15,18 @@ function RangeSlider(props) {
   } = props
 
   const minEstimate = filterParams.ranges.estimate_range.min
-  const maxEstimate = filterParams.ranges.estimate_range.max
   const formattedMinDisplay = formatMoney(minEstimateRangeDisplay, { symbol: symbol, precision: 0 })
+
+  const maxEstimate = filterParams.ranges.estimate_range.max
+  const isAbsoluteMax = maxEstimate === maxEstimateRangeDisplay
   const formattedMaxDisplay = formatMoney(maxEstimateRangeDisplay, { symbol: '', precision: 0 })
   return (
     <div className='auction-range-slider'>
       <div className='auction-range-slider__metadata'>
         <div className='auction-range-slider__title'>Price</div>
-        <div className='auction-range-slider__caption'>{`${formattedMinDisplay} - ${formattedMaxDisplay}+`}</div>
+        <div className='auction-range-slider__caption'>{
+          `${formattedMinDisplay} - ${formattedMaxDisplay}${isAbsoluteMax ? '+' : ''}`
+        }</div>
       </div>
       <Range
         allowCross={false}

--- a/desktop/apps/auction/test/components.js
+++ b/desktop/apps/auction/test/components.js
@@ -7,6 +7,7 @@ import AuctionGridArtwork from '../components/auction_grid_artwork'
 import AuctionListArtwork from '../components/auction_list_artwork'
 import FilterSort from '../components/filter_sort'
 import MediumFilter from '../components/medium_filter'
+import RangeSlider from '../components/range_slider'
 import Sidebar from '../components/sidebar'
 import { shallow } from 'enzyme'
 import React from 'react'
@@ -208,6 +209,38 @@ describe('React components', () => {
         rendered.find('input[value="mediums-all"]:checked').length.should.eql(0)
         rendered.find('input[value="painting"]:checked').length.should.eql(1)
       })
+    })
+  })
+
+  describe('RangeSlider', () => {
+    it('renders the range correctly initially', () => {
+      const wrapper = shallow(
+        <Provider><RangeSlider store={initialStore} /></Provider>
+      )
+      const rendered = wrapper.render()
+      rendered.find('.auction-range-slider__caption').length.should.eql(1)
+      const renderedText = rendered.text()
+      renderedText.should.containEql('$0 - 50,000+')
+    })
+    it('renders the range correctly for a middle bucket', () => {
+      initialStore.dispatch(actions.updateEstimateDisplay(200, 4000))
+      const wrapper = shallow(
+        <Provider><RangeSlider store={initialStore} /></Provider>
+      )
+      const rendered = wrapper.render()
+      rendered.find('.auction-range-slider__caption').length.should.eql(1)
+      const renderedText = rendered.text()
+      renderedText.should.containEql('$200 - 4,000')
+    })
+    it('renders the range correctly for an upper bucket', () => {
+      initialStore.dispatch(actions.updateEstimateDisplay(500, 50000))
+      const wrapper = shallow(
+        <Provider><RangeSlider store={initialStore} /></Provider>
+      )
+      const rendered = wrapper.render()
+      rendered.find('.auction-range-slider__caption').length.should.eql(1)
+      const renderedText = rendered.text()
+      renderedText.should.containEql('$500 - 50,000+')
     })
   })
 

--- a/desktop/apps/auction/test/reducers.js
+++ b/desktop/apps/auction/test/reducers.js
@@ -240,6 +240,16 @@ describe('Reducers', () => {
           const updatedEstimateRange = auctions(initialResponse, actions.updateEstimateRangeParams(100, 20000))
           updatedEstimateRange.auctionArtworks.filterParams.estimate_range.should.eql('10000-2000000')
         })
+
+        it('updates the estimate range params correctly if they are at the max', () => {
+          initialResponse.auctionArtworks.filterParams.estimate_range.should.eql('')
+          const updatedEstimateRange = auctions(initialResponse, actions.updateEstimateRangeParams(100, 20000))
+          updatedEstimateRange.auctionArtworks.filterParams.estimate_range.should.eql('10000-2000000')
+          const highestBucket = auctions(updatedEstimateRange, actions.updateEstimateRangeParams(400, 50000))
+          highestBucket.auctionArtworks.filterParams.estimate_range.should.eql('40000-*')
+          const lowerBucket = auctions(highestBucket, actions.updateEstimateRangeParams(400, 20000))
+          lowerBucket.auctionArtworks.filterParams.estimate_range.should.eql('40000-2000000')
+        })
       })
 
       describe('#updateInitialMediumMap', () => {


### PR DESCRIPTION
We were not handling the upper bound of the estimate range filter correctly!

The initial fetch filters by `estimate_range: ''` which will return everything.

On `change`, it sets the filter to match the slider, which was immediately capping the upper bound at `50000` since that's how high the slider goes. We _should_ be querying for `*` on the upper bound, to get everything _above_ the high amount.

This PR updates the slider to query for the correct values, and also updates the display to only show the `+` after the upper bound if you have selected the max.

![price-filter-fix](https://cloud.githubusercontent.com/assets/2081340/25289908/97b0b338-2699-11e7-9f43-4a4e5cf71d6a.gif)
