### PR TITLE
Rethinking Marketo Analytics Implementation PR: 1

### DIFF
--- a/desktop/analytics/account_creation.js
+++ b/desktop/analytics/account_creation.js
@@ -77,7 +77,15 @@ if (Cookies.get('analytics-signup')) {
       signup_service: data.service,
       user_id: sd.CURRENT_USER.id,
       context: data.context
-    })
+    });
+    analytics.identify( sd.CURRENT_USER.id, {
+      email: sd.CURRENT_USER.email
+    }, {
+      integrations: {
+        'All': false,
+        'Marketo': true
+      }
+    });
   }
 }
 

--- a/desktop/analytics/account_creation.js
+++ b/desktop/analytics/account_creation.js
@@ -24,8 +24,17 @@ $(document).on(
         acquisition_initiative: acquisition_initiative,
         signup_service: 'email',
         user_id: xhr.responseJSON.user.id,
-        context: options.context
-      })
+        context: options.context,
+        email: xhr.responseJSON.user.email
+      });
+      analytics.identify( xhr.responseJSON.user.id, {
+        email: xhr.responseJSON.user.email
+      }, {
+        integrations: {
+          'All': false,
+          'Marketo': true
+        }
+      });
     })
   }
 )

--- a/desktop/assets/analytics.coffee
+++ b/desktop/assets/analytics.coffee
@@ -15,8 +15,7 @@ $ -> analytics.ready ->
   if sd.CURRENT_USER?.id
     whitelist = ['collector_level', 'default_profile_id', 'email', 'id', 'name', 'phone', 'type'];
     traits = _.extend _.pick(sd.CURRENT_USER, whitelist), session_id: sd.SESSION_ID
-    integrations = 'Marketo': false
-    analytics.identify sd.CURRENT_USER.id, traits, integrations
+    analytics.identify sd.CURRENT_USER.id, traits, integrations: { 'Marketo': false }
     # clear analytics cache when user logs out
     analyticsHooks.on 'auth:logged-out', -> analytics.reset()
 

--- a/desktop/assets/analytics.coffee
+++ b/desktop/assets/analytics.coffee
@@ -15,7 +15,8 @@ $ -> analytics.ready ->
   if sd.CURRENT_USER?.id
     whitelist = ['collector_level', 'default_profile_id', 'email', 'id', 'name', 'phone', 'type'];
     traits = _.extend _.pick(sd.CURRENT_USER, whitelist), session_id: sd.SESSION_ID
-    analytics.identify sd.CURRENT_USER.id, traits
+    integrations = 'Marketo': false
+    analytics.identify sd.CURRENT_USER.id, traits, integrations
     # clear analytics cache when user logs out
     analyticsHooks.on 'auth:logged-out', -> analytics.reset()
 


### PR DESCRIPTION
This is the first pr in order to rethink how we handle the Marketo analytics implementation. Currently we are running out of Marketo API calls by 8am every day because of our segment integration. On every pageload we use a Segment Identify call which in turn pings Marketo's API. Additionally, while we have turned off the Marketo integration using the Segment UI for many tracking calls, we are still sending over 50k to Marketo within a few hours. 

After speaking with our consultants and looking into other options I propose three pr's make this data pipeline more efficient:

PR: 1. Remove Marketo from page load identify calls and add in new identify calls only for Marketo on Sign-Up, and Application Form submission (already done).

PR: 2. Fix identify and track calls for Gallery Insights sign Up. This is currently broken and only includes a track call. 

PR: 3a. Waiting to hear back from Segment, but either in this PR will create a new Analytics.js tracking call specifically intended for Marketo that will be implemented on high value b2b Artsy.net pages. In conjunction will turn off Marketo for all tracking calls except newly created one in Segment ui. 

My concern with this approach is if we cannot by default have Marketo turned off for any new tracking calls, then moving forward it will be difficult to contain this approach.

PR: 3b. If 3a does not seem feasible then after speaking with our consultants and looking at documentation the best way forward is to implement marketo's munchkin tracking on our website re: http://docs.marketo.com/display/public/DOCS/Add+Munchkin+Tracking+Code+to+Your+Website.