### PR TITLE
@eessex => [Venice] Multi-video support and route fix

### DIFF
--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -36,7 +36,7 @@ module.exports = class VeniceView extends Backbone.View
   changeSection: (i) ->
     @section = @curation.get('sections')[i]
     # Push route
-    window.history.replaceState {}, i, @section.slug
+    window.history.replaceState {}, i, '/venice-biennale/' + @section.slug
     # Swap video if it is published
     @swapVideo() if @section.published
 

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -50,7 +50,9 @@ module.exports = class VeniceView extends Backbone.View
 
   chooseVideoFile: ->
     if @parser.getBrowser().name is 'Safari'
-      "#{sd.APP_URL}/vanity/scenichls/hls400k.m3u8"
+      sd.APP_URL + @section.video_url_hls
+    else if @parser.getDevice().type is 'mobile'
+      sd.APP_URL + @section.video_url_medium
     else
       sd.APP_URL + @section.video_url
 

--- a/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
@@ -22,12 +22,16 @@ describe 'Venice Main', ->
             description: 'description'
             cover_image: ''
             video_url: '/vanity/url.mp4'
+            video_url_medium: '/vanity/url-medium.mp4'
+            video_url_hls: '/vanity/url.m3u8'
             slug: 'slug-one'
           },
           {
             description: 'description2'
             cover_image: ''
             video_url: '/vanity/url2.mp4'
+            video_url_medium: '/vanity/url2-medium.mp4'
+            video_url_hls: '/vanity/url2.m3u8'
             slug: 'slug-two'
             published: true
           }
@@ -71,13 +75,29 @@ describe 'Venice Main', ->
   it 'changes the section when a new carousel item is selected', ->
     @on.args[0][1]()
     @replaceState.args[0][1].should.equal 1
-    @replaceState.args[0][2].should.equal 'slug-two'
+    @replaceState.args[0][2].should.equal '/venice-biennale/slug-two'
     @view.VeniceVideoView.trigger.args[0][0].should.equal 'swapVideo'
     @view.VeniceVideoView.trigger.args[0][1].video.should.equal 'localhost/vanity/url2.mp4'
 
   it '#fadeOutCoverAndStartVideo', ->
     $('.venice-overlay__play').click()
     @play.callCount.should.equal 1
+
+  it 'chooses an hls video for Safari', ->
+    @view.parser = getBrowser: sinon.stub().returns name: 'Safari'
+    @view.chooseVideoFile().should.equal 'localhost/vanity/url2.m3u8'
+
+  it 'chooses a medium quality video for mobile', ->
+    @view.parser =
+      getBrowser: sinon.stub().returns name: 'Chrome'
+      getDevice: sinon.stub().returns type: 'mobile'
+    @view.chooseVideoFile().should.equal 'localhost/vanity/url2-medium.mp4'
+
+  it 'chooses a high quality video as a default', ->
+    @view.parser =
+      getBrowser: sinon.stub().returns name: 'Chrome'
+      getDevice: sinon.stub().returns type: 'desktop'
+    @view.chooseVideoFile().should.equal 'localhost/vanity/url2.mp4'
 
   it '#showCta reveals a signup form', ->
     $('.venice-overlay__cta-button').click()


### PR DESCRIPTION
Fixes the route to include `/venice-biennale`
Support `video_url_medium` and `video_url_hls` videos and pick the best video for your device/browser