### PR TITLE
Fix mocha tests in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "scroll-frame": "1.0.0",
     "should": "^11.1.1",
     "sinon": "^1.17.1",
+    "source-map-support": "^0.4.14",
     "sqwish": "^0.2.2",
     "stickyfill": "^1.1.1",
     "stylus": "^0.54.5",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "npm": "4.x.x"
   },
   "scripts": {
-    "mocha": "sh scripts/acceptance.sh",
+    "mocha": "sh scripts/mocha.sh",
     "acceptance-record": "sh scripts/acceptance-record.sh",
     "acceptance": "sh scripts/acceptance.sh",
     "test": "sh scripts/test.sh",

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -7,4 +7,6 @@ mocha \
   --compilers coffee:coffee-script/register,js:babel-core/register \
   -r dotenv/config \
   -r should \
-  -t 300000 dotenv_config_path=.env.test test/acceptance/*.js
+  -t 300000 \
+  dotenv_config_path=.env.test \
+  test/acceptance/*.js

--- a/scripts/mocha.sh
+++ b/scripts/mocha.sh
@@ -5,6 +5,7 @@ set -e -x
 for file in "$@"
   do
     mocha \
+      --require source-map-support/register \
       -r should \
       --compilers coffee:coffee-script/register,js:babel-core/register \
       -t 30000 $file

--- a/scripts/mocha.sh
+++ b/scripts/mocha.sh
@@ -2,7 +2,10 @@
 
 set -e -x
 
-mocha \
-  -r should \
-  --compilers coffee:coffee-script/register,js:babel-core/register \
-  -t 30000
+for file in "$@"
+  do
+    mocha \
+      -r should \
+      --compilers coffee:coffee-script/register,js:babel-core/register \
+      -t 30000 $file
+  done

--- a/yarn.lock
+++ b/yarn.lock
@@ -6615,7 +6615,7 @@ socks@~1.1.5:
     ip "^1.1.4"
     smart-buffer "^1.0.13"
 
-source-map-support@^0.4.2:
+source-map-support@^0.4.14, source-map-support@^0.4.2:
   version "0.4.14"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.14.tgz#9d4463772598b86271b4f523f6c1f4e02a7d6aef"
   dependencies:
@@ -7007,7 +7007,7 @@ supertest@^2.0.1:
     methods "1.x"
     superagent "^2.0.0"
 
-supports-color@3.1.2:
+supports-color@3.1.2, supports-color@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -7021,7 +7021,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.2, supports-color@^3.2.3:
+supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:


### PR DESCRIPTION
Eve reported [an issue](https://artsy.slack.com/archives/C0350895E/p1493034977010574) with running `yarn mocha [filename]`. 

The problem was that yarn was passing the filename or directory to `sh scripts/mocha.sh` but the script was just ignoring it. The solution is to stop ignoring and append the filenames or directories to the script's invocation of mocha.