### PR TITLE
@craigspaeth => [Venice] Fixes test and onbeforeunload tracking

### DIFF
--- a/desktop/apps/auctions/test/template.coffee
+++ b/desktop/apps/auctions/test/template.coffee
@@ -27,7 +27,8 @@ describe 'Auctions template', ->
           upcomingAuctions: [@previewAuction]
           promoAuctions: []
           nextAuction: @previewAuction
-        done()
+        , ->
+          done()
 
     after ->
       benv.teardown()

--- a/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
@@ -77,9 +77,9 @@ module.exports = class VeniceVideoView extends Backbone.View
     "&is_stereo=false&is_vr_off=false&loop=false"
 
   setupAnalytics: ->
-    window.onbeforeunload = (e) =>
-      e.preventDefault()
+    window.onbeforeunload = =>
       analyticsHooks.trigger 'video:dropoff', dropoff: @vrView.getCurrentTime()
+      return
 
     @quarterDuration = @duration * .25
     @halfDuration = @duration * .5

--- a/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
@@ -17,6 +17,7 @@ describe 'Venice Main', ->
       Backbone.$ = $
       @curation =
         description: 'description'
+        sub_articles: []
         sections: [
           {
             description: 'description'
@@ -26,7 +27,6 @@ describe 'Venice Main', ->
             video_url_hls: '/vanity/url.m3u8'
             slug: 'slug-one'
             artist_ids: []
-            sub_articles: []
           },
           {
             description: 'description2'
@@ -37,7 +37,6 @@ describe 'Venice Main', ->
             slug: 'slug-two'
             published: true
             artist_ids: []
-            sub_articles: []
           }
         ]
       @options =

--- a/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
@@ -96,7 +96,8 @@ describe 'Venice Video', ->
 
   it 'tracks drop off time', ->
     @view.vrView.getCurrentTime = sinon.stub().returns 25
-    window.onbeforeunload(preventDefault: sinon.stub())
+    @view.onVRViewReady()
+    window.onbeforeunload()
     @analytics.args[0][0].should.equal 'video:dropoff'
     @analytics.args[0][1].dropoff.should.equal 25
 

--- a/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
@@ -27,6 +27,7 @@ describe 'Venice Video', ->
         sd: APP_URL: 'localhost'
         videoIndex: 0
         curation: new Curation
+          sub_articles: []
           description: 'description'
           sections: [
             {

--- a/mobile/apps/auctions/test/template.coffee
+++ b/mobile/apps/auctions/test/template.coffee
@@ -23,7 +23,8 @@ describe 'Auctions template', ->
           pastAuctions: [@closedSale]
           currentAuctions: [@openSale]
           upcomingAuctions: [@previewSale]
-        done()
+        , ->
+          done()
 
     after ->
       benv.teardown()

--- a/mobile/apps/how_auctions_work/test/template.coffee
+++ b/mobile/apps/how_auctions_work/test/template.coffee
@@ -19,7 +19,8 @@ describe '/how-auctions-work', ->
           markdown: markdown
           bidIncrements: bidIncrements
           user: null
-        done()
+        , ->
+          done()
 
     after ->
       benv.teardown()

--- a/mobile/apps/shows/test/template.coffee
+++ b/mobile/apps/shows/test/template.coffee
@@ -13,19 +13,21 @@ describe 'Shows template', ->
       done()
 
   describe '#index with cities and featured show', ->
-    before ->
+    before (done) ->
       benv.render resolve(__dirname, '../templates/index.jade'),
         sd: {}
         cities: Cities
         featuredCities: FeaturedCities
         featuredShow: new Show fabricate 'show'
+      , ->
+        done()
 
-    xit 'renders correctly', ->
+    it 'renders correctly', ->
       $('.shows-header').length.should.equal 1
       $('.shows-page-featured-cities a').length.should.equal 11
 
   describe '#cities with single city and shows', ->
-    before ->
+    before (done) ->
       @currentShow = new Show fabricate 'show', status: 'running', id: 'running-show', name: 'running-show'
       @upcomingShow = new Show fabricate 'show', status: 'upcoming', id: 'upcoming-show', name: 'upcoming-show'
       @pastShow = new Show fabricate 'show', status: 'closed', id: 'closed-show', name: 'closed-show'
@@ -37,6 +39,8 @@ describe 'Shows template', ->
         upcoming: [@upcomingShow]
         current: [@currentShow]
         past: [@pastShow]
+      , ->
+        done()
 
     it 'renders correctly', ->
       $('.shows-city--current-shows').length.should.equal 1
@@ -44,10 +48,12 @@ describe 'Shows template', ->
       $('.shows-city--past-shows').length.should.equal 1
 
   describe '#all-cities with every city', ->
-    before ->
+    before (done) ->
       benv.render resolve(__dirname, '../templates/all_cities.jade'),
         sd: {}
         cities: Cities
+      , ->
+        done()
 
     after ->
       benv.teardown()


### PR DESCRIPTION
Looks like there was a failing test that wasn't caught in my last PR before merge. This fixes that test and addresses a bug where a dialog was being shown on the `onbeforeunload` video dropoff tracking. I still feel like this dropoff tracking needs more fine tuning (ie, should we only count dropoff if the video is playing?), but I'm getting help from #analytics with that and for now this should unblock master merges. 