### PR TITLE
@sweir27 : search static pages in global search

### DIFF
--- a/desktop/apps/search/routes.coffee
+++ b/desktop/apps/search/routes.coffee
@@ -21,7 +21,7 @@ imageUrl = require './components/image_url'
   return res.redirect("/") unless req.query.q
 
   term = removeDiacritics req.query.q
-  indexes = ['Artwork', 'Artist', 'Article', 'City', 'Fair', 'Tag', 'Gene', 'Feature', 'Profile', 'PartnerShow', 'Sale']
+  indexes = ['Artwork', 'Artist', 'Article', 'City', 'Fair', 'Tag', 'Gene', 'Feature', 'Page', 'Profile', 'PartnerShow', 'Sale']
   data = { term: term, size: 10 }
   data['indexes[]'] = indexes
 

--- a/desktop/components/search_bar/templates/item.jade
+++ b/desktop/components/search_bar/templates/item.jade
@@ -2,7 +2,7 @@ a.mlsb-suggestion
   span.mlsb-suggestion-thumbnail
     span.mlsb-suggestion-fallback
       img(
-        src= item.get('image_url')
+        src= item.imageUrl()
         width='32'
         height='32'
         onerror='this.style.display="none";'


### PR DESCRIPTION
I'd forgotten that we explicitly specify the indices we want to search in our front-end global search results query, so here I add the `Page` index to the list. 

This is preventing the consignments page from showing on the search results page right now. 