### PR TITLE
Update circle script with new assets script

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,8 +16,7 @@ deployment:
         EOF
       - chmod 600 ~/.netrc
       - "[[ ! -s \"$(git rev-parse --git-dir)/shallow\" ]] || git fetch --unshallow"
-      - DEPLOY_ENV=staging yarn deploy-assets
-      - git push --force git@heroku.com:force-staging.git $CIRCLE_SHA1:refs/heads/master
+      - DEPLOY_ENV=staging yarn deploy
   production:
     branch: release
     commands:
@@ -32,8 +31,7 @@ deployment:
         EOF
       - chmod 600 ~/.netrc
       - "[[ ! -s \"$(git rev-parse --git-dir)/shallow\" ]] || git fetch --unshallow"
-      - DEPLOY_ENV=production yarn deploy-assets
-      - git push --force git@heroku.com:force-production.git $CIRCLE_SHA1:refs/heads/master
+      - DEPLOY_ENV=production yarn deploy
 dependencies:
   override:
     - yarn install


### PR DESCRIPTION
Uses `yarn deploy` instead of the `deploy-assets` script which doesn't exist anymore.