### PR TITLE
@eessex => [Venice] Video close, ready, adaptive streaming, smooth scrubbing

### DIFF
--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -60,7 +60,6 @@ module.exports = class VeniceView extends Backbone.View
     @VeniceVideoView.vrView.pause()
 
   onVideoReady: ->
-    console.log 'here'
     $('.venice-overlay__play').attr 'data-state', 'ready'
 
   swapVideo: ->

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -27,6 +27,7 @@ module.exports = class VeniceView extends Backbone.View
     @VeniceVideoView = new VeniceVideoView
       el: $('.venice-video')
       video: @chooseVideoFile()
+    @listenTo @VeniceVideoView, 'closeVideo', @fadeInCoverAndPauseVideo
 
   setupCarousel: ->
     @carousel = initCarousel $('.venice-carousel'),
@@ -51,6 +52,10 @@ module.exports = class VeniceView extends Backbone.View
   fadeOutCoverAndStartVideo: ->
     $('.venice-nav, .venice-carousel').fadeOut()
     @VeniceVideoView.vrView.play()
+
+  fadeInCoverAndPauseVideo: ->
+    $('.venice-nav, .venice-carousel').fadeIn()
+    @VeniceVideoView.vrView.pause()
 
   swapVideo: ->
     @VeniceVideoView.trigger 'swapVideo',

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -74,10 +74,7 @@ module.exports = class VeniceView extends Backbone.View
     $('.venice-body--article').addClass('active')
 
   chooseVideoFile: ->
-    if @section.published
-      section = @section
-    else
-      section = @curation.get('sections')[0]
+    section = if @section.published then @section else @curation.get('sections')[0]
     if @parser.getOS().name is 'iOS'
       sd.APP_URL + section.video_url_medium
     else if @parser.getDevice().type is 'mobile'

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -69,12 +69,16 @@ module.exports = class VeniceView extends Backbone.View
     $('.venice-body--article').addClass('active')
 
   chooseVideoFile: ->
-    if @parser.getOS().name is 'iOS'
-      sd.APP_URL + @section.video_url_medium
-    else if @parser.getDevice().type is 'mobile'
-      sd.APP_URL + @section.video_url_adaptive
+    if @section.published
+      section = @section
     else
-      sd.APP_URL + @section.video_url
+      section = @curation.get('sections')[0]
+    if @parser.getOS().name is 'iOS'
+      sd.APP_URL + section.video_url_medium
+    else if @parser.getDevice().type is 'mobile'
+      sd.APP_URL + section.video_url_adaptive
+    else
+      sd.APP_URL + section.video_url
 
   showCta: (e) ->
     @$(e.target).fadeOut()

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -69,16 +69,12 @@ module.exports = class VeniceView extends Backbone.View
     $('.venice-body--article').addClass('active')
 
   chooseVideoFile: ->
-    console.log @parser.getDevice()
     if @parser.getOS().name is 'iOS'
-      console.log 'choosing medium quality mp4'
       sd.APP_URL + @section.video_url_medium
-    else if @parser.getDevice().model is 'console'
-      console.log 'choosing high quality mp4'
-      sd.APP_URL + @section.video_url
-    else
-      console.log 'choosing adaptive'
+    else if @parser.getDevice().type is 'mobile'
       sd.APP_URL + @section.video_url_adaptive
+    else
+      sd.APP_URL + @section.video_url
 
   showCta: (e) ->
     @$(e.target).fadeOut()

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -69,12 +69,16 @@ module.exports = class VeniceView extends Backbone.View
     $('.venice-body--article').addClass('active')
 
   chooseVideoFile: ->
-    if @parser.getBrowser().name is 'Safari'
-      sd.APP_URL + @section.video_url_hls
-    else if @parser.getDevice().type is 'mobile'
+    console.log @parser.getDevice()
+    if @parser.getOS().name is 'iOS'
+      console.log 'choosing medium quality mp4'
       sd.APP_URL + @section.video_url_medium
-    else
+    else if @parser.getDevice().model is 'console'
+      console.log 'choosing high quality mp4'
       sd.APP_URL + @section.video_url
+    else
+      console.log 'choosing adaptive'
+      sd.APP_URL + @section.video_url_adaptive
 
   showCta: (e) ->
     @$(e.target).fadeOut()

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -28,6 +28,7 @@ module.exports = class VeniceView extends Backbone.View
       el: $('.venice-video')
       video: @chooseVideoFile()
     @listenTo @VeniceVideoView, 'closeVideo', @fadeInCoverAndPauseVideo
+    @listenTo @VeniceVideoView, 'videoReady', @onVideoReady
 
   setupCarousel: ->
     @carousel = initCarousel $('.venice-carousel'),
@@ -49,13 +50,18 @@ module.exports = class VeniceView extends Backbone.View
     @swapDescription()
     @setupFollowButtons()
 
-  fadeOutCoverAndStartVideo: ->
+  fadeOutCoverAndStartVideo: (e) ->
+    return unless e.currentTarget.getAttribute('data-state') is 'ready'
     $('.venice-nav, .venice-carousel').fadeOut()
     @VeniceVideoView.vrView.play()
 
   fadeInCoverAndPauseVideo: ->
     $('.venice-nav, .venice-carousel').fadeIn()
     @VeniceVideoView.vrView.pause()
+
+  onVideoReady: ->
+    console.log 'here'
+    $('.venice-overlay__play').attr 'data-state', 'ready'
 
   swapVideo: ->
     @VeniceVideoView.trigger 'swapVideo',

--- a/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
@@ -18,6 +18,7 @@ module.exports = class VeniceVideoView extends Backbone.View
     @$muteButton = $('#togglemute')
     @setupVideo()
     @on 'swapVideo', @swapVideo
+    @scrubbing = false
 
   setupVideo: ->
     @vrView = new VRView.Player '#vrvideo',
@@ -31,6 +32,7 @@ module.exports = class VeniceVideoView extends Backbone.View
     @vrView.on 'timeupdate', @updateTime
 
   updateTime: (e) =>
+    return if @scrubbing
     if e.currentTime > @quarterDuration
       @trackQuarter()
     if e.currentTime > @halfDuration
@@ -50,12 +52,12 @@ module.exports = class VeniceVideoView extends Backbone.View
       range:
         min: 0
         max: @duration
-    throttledSetTime = _.throttle @setVideoTime, 200
-    @scrubber.on 'slide', (value) => throttledSetTime value[0]
+    @scrubber.on 'start', =>
+      @scrubbing = true
+    @scrubber.on 'change', (value) =>
+      @vrView.setCurrentTime parseFloat(value[0])
+      @scrubbing = false
     @trigger 'videoReady'
-
-  setVideoTime: (value) =>
-    @vrView.setCurrentTime parseFloat(value)
 
   onTogglePlay: ->
     if @vrView.isPaused

--- a/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
@@ -10,6 +10,7 @@ module.exports = class VeniceVideoView extends Backbone.View
   events:
     'click #toggleplay': 'onTogglePlay'
     'click #togglemute': 'onToggleMute'
+    'click .venice-video__close': 'onCloseVideo'
 
   initialize: (options) ->
     @video = options.video
@@ -93,6 +94,9 @@ module.exports = class VeniceVideoView extends Backbone.View
       analyticsHooks.trigger('video:duration',{duration: '75%'})
     @trackFull = _.once ->
       analyticsHooks.trigger('video:duration',{duration: '100%'})
+
+  onCloseVideo: ->
+    @trigger 'closeVideo'
 
   # Currently unused but will implement next
   formatTime: (time) ->

--- a/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
@@ -50,8 +50,12 @@ module.exports = class VeniceVideoView extends Backbone.View
       range:
         min: 0
         max: @duration
-    @scrubber.on 'change', (value) =>
-      @vrView.setCurrentTime parseFloat(value[0])
+    throttledSetTime = _.throttle @setVideoTime, 200
+    @scrubber.on 'slide', (value) => throttledSetTime value[0]
+    @trigger 'videoReady'
+
+  setVideoTime: (value) =>
+    @vrView.setCurrentTime parseFloat(value)
 
   onTogglePlay: ->
     if @vrView.isPaused

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/index.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/index.styl
@@ -111,23 +111,14 @@ nav-height = 54px
     align-items center
     transition background-color 0.5
     cursor pointer
-    &:hover
-      background-color white
-      color black
-      .venice-overlay__play-button
-        border-color transparent transparent transparent black
     &-text
-      margin-right 20px
       avant-garde-size('s-headline')
+      &:after
+        content 'Loading...'
     &-length
-      garamond-size('l-caption')
+      display none
     &-button
-      margin-right 10px
-      width 0
-      height 0
-      border-style solid
-      border-width 5px 0 5px 10px
-      border-color transparent transparent transparent white
+      display none
   &__subscribe
     position absolute
     bottom 50px
@@ -169,6 +160,29 @@ nav-height = 54px
       border none
       font-size 17px
       padding-left 10px
+
+.venice-overlay__play[data-state="ready"]
+  .venice-overlay__play
+    &-text
+      margin-right 20px
+      &:after
+        content 'Play Video'
+    &-length
+      display block
+      garamond-size('l-caption')
+    &-button
+      display block
+      margin-right 10px
+      width 0
+      height 0
+      border-style solid
+      border-width 5px 0 5px 10px
+      border-color transparent transparent transparent white
+    &:hover
+      background-color white
+      color black
+      .venice-overlay__play-button
+        border-color transparent transparent transparent black
 
 .venice-overlay, .venice-nav
   transition display 0.5s ease

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
@@ -1,3 +1,12 @@
+i.icon-close.venice-video__close
+  position absolute
+  top 0
+  left 0
+  margin 30px
+  cursor pointer
+  &:hover
+    color gray-lighter-color
+
 #controls
   position absolute
   width 100vw
@@ -96,6 +105,9 @@
       display block
 
 @media screen and (max-width: 550px)
+  i.icon-close.venice-video__close
+    margin 15px
+
   #controls
     padding 15px
 

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
@@ -20,8 +20,6 @@ i.icon-close.venice-video__close
     min-height 50px
     z-index 12
     float right
-.unpublished #controls
-  display none
 
 #toggleplay
   avant-garde-size('s-headline')

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
@@ -68,7 +68,7 @@ i.icon-close.venice-video__close
   position relative
   display flex
   align-items center
-  height 1px
+  // height 5px
   .noUi-handle
     top -7px
 

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
@@ -68,7 +68,7 @@ i.icon-close.venice-video__close
   position relative
   display flex
   align-items center
-  // height 5px
+  height 3px
   .noUi-handle
     top -7px
 

--- a/desktop/apps/editorial_features/components/venice_2017/templates/carousel.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/carousel.jade
@@ -8,9 +8,9 @@
               .venice-overlay__title Inside the Biennale
               .venice-overlay__sub-title= section.title
               if section.published
-                .venice-overlay__play
+                .venice-overlay__play(data-state="loading")
                   .venice-overlay__play-button
-                  .venice-overlay__play-text Play Video
+                  .venice-overlay__play-text
                   .venice-overlay__play-length= section.video_length
               else
                 .venice-overlay__subscribe

--- a/desktop/apps/editorial_features/components/venice_2017/templates/index.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/index.jade
@@ -11,7 +11,7 @@ block body
   .venice-feature
     include ./nav
 
-    .venice-header(class=!section.published? 'unpublished':undefined)
+    .venice-header(class=!section.published? 'unpublished': '')
       include ./video
       include ./carousel
 

--- a/desktop/apps/editorial_features/components/venice_2017/templates/video.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/video.jade
@@ -1,6 +1,7 @@
 .venice-video
   #vrvideo
   #controls
+    .venice-video__close
     #togglemute(data-state='unmuted')
       .muted
         include ../icons/icon_muted.svg

--- a/desktop/apps/editorial_features/components/venice_2017/templates/video.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/video.jade
@@ -1,7 +1,7 @@
 .venice-video
   #vrvideo
+  i.icon-close.venice-video__close
   #controls
-    .venice-video__close
     #togglemute(data-state='unmuted')
       .muted
         include ../icons/icon_muted.svg

--- a/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
@@ -84,6 +84,10 @@ describe 'Venice Main', ->
     @view.VeniceVideoView.trigger.args[0][0].should.equal 'swapVideo'
     @view.VeniceVideoView.trigger.args[0][1].video.should.equal 'localhost/vanity/url2.mp4'
 
+  it '#fadeOutCoverAndStartVideo does not play if it is not ready', ->
+    $('.venice-overlay__play').click()
+    @play.callCount.should.equal 0
+
   it '#fadeOutCoverAndStartVideo', ->
     $('.venice-overlay__play').attr 'data-state', 'ready'
     $('.venice-overlay__play').click()

--- a/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
@@ -24,7 +24,7 @@ describe 'Venice Main', ->
             cover_image: ''
             video_url: '/vanity/url.mp4'
             video_url_medium: '/vanity/url-medium.mp4'
-            video_url_hls: '/vanity/url.m3u8'
+            video_url_adaptive: '/vanity/url.mpd'
             slug: 'slug-one'
             artist_ids: []
           },
@@ -33,7 +33,7 @@ describe 'Venice Main', ->
             cover_image: ''
             video_url: '/vanity/url2.mp4'
             video_url_medium: '/vanity/url2-medium.mp4'
-            video_url_hls: '/vanity/url2.m3u8'
+            video_url_adaptive: '/vanity/url2.mpd'
             slug: 'slug-two'
             published: true
             artist_ids: []
@@ -86,20 +86,20 @@ describe 'Venice Main', ->
     $('.venice-overlay__play').click()
     @play.callCount.should.equal 1
 
-  it 'chooses an hls video for Safari', ->
-    @view.parser = getBrowser: sinon.stub().returns name: 'Safari'
-    @view.chooseVideoFile().should.equal 'localhost/vanity/url2.m3u8'
-
-  it 'chooses a medium quality video for mobile', ->
-    @view.parser =
-      getBrowser: sinon.stub().returns name: 'Chrome'
-      getDevice: sinon.stub().returns type: 'mobile'
+  it 'chooses a medium quality mp4 video for iOS', ->
+    @view.parser = getOS: sinon.stub().returns name: 'iOS'
     @view.chooseVideoFile().should.equal 'localhost/vanity/url2-medium.mp4'
 
-  it 'chooses a high quality video as a default', ->
+  it 'chooses an adaptive video for mobile', ->
     @view.parser =
-      getBrowser: sinon.stub().returns name: 'Chrome'
-      getDevice: sinon.stub().returns type: 'desktop'
+      getOS: sinon.stub().returns name: 'Android'
+      getDevice: sinon.stub().returns type: 'mobile'
+    @view.chooseVideoFile().should.equal 'localhost/vanity/url2.mpd'
+
+  it 'chooses a high quality video for desktop', ->
+    @view.parser =
+      getOS: sinon.stub().returns name: 'Mac OS'
+      getDevice: sinon.stub().returns type: null
     @view.chooseVideoFile().should.equal 'localhost/vanity/url2.mp4'
 
   it '#showCta reveals a signup form', ->

--- a/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
@@ -51,7 +51,9 @@ describe 'Venice Main', ->
           VIDEO_INDEX: 0
           CURATION: @curation
         VeniceView.__set__ 'VeniceVideoView', @VeniceVideoView = sinon.stub().returns
-          vrView: play: @play = sinon.stub()
+          vrView:
+            play: @play = sinon.stub()
+            pause: @pause = sinon.stub()
           trigger: sinon.stub()
         VeniceView.__set__ 'initCarousel', @initCarousel = sinon.stub().yields
           cells: flickity:
@@ -83,8 +85,17 @@ describe 'Venice Main', ->
     @view.VeniceVideoView.trigger.args[0][1].video.should.equal 'localhost/vanity/url2.mp4'
 
   it '#fadeOutCoverAndStartVideo', ->
+    $('.venice-overlay__play').attr 'data-state', 'ready'
     $('.venice-overlay__play').click()
     @play.callCount.should.equal 1
+
+  it '#fadeInCoverAndPauseVideo', ->
+    @view.fadeInCoverAndPauseVideo()
+    @pause.callCount.should.equal 1
+
+  it '#onVideoReady', ->
+    @view.onVideoReady()
+    $('.venice-overlay__play').attr('data-state').should.equal 'ready'
 
   it 'chooses a medium quality mp4 video for iOS', ->
     @view.parser = getOS: sinon.stub().returns name: 'iOS'

--- a/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
@@ -21,6 +21,7 @@ describe 'Venice Video', ->
           iframe: src: ''
           setVolume: @setVolume = sinon.stub()
           getCurrentTime: @getCurrentTime = sinon.stub()
+          setCurrentTime: @setCurrentTime = sinon.stub()
       Backbone.$ = $
       @options =
         asset: ->
@@ -39,7 +40,7 @@ describe 'Venice Video', ->
         VeniceVideoView = benv.requireWithJadeify resolve(__dirname, '../../../components/venice_2017/client/video'), []
         VeniceVideoView.__set__ 'sd', APP_URL: 'localhost'
         VeniceVideoView.__set__ 'noUiSlider', create: (@scrubberCreate = sinon.stub()).returns
-          on: sinon.stub()
+          on: @on = sinon.stub()
           set: sinon.stub()
         VeniceVideoView.__set__ 'analyticsHooks', trigger: @analytics = sinon.stub()
         @view = new VeniceVideoView
@@ -61,6 +62,17 @@ describe 'Venice Video', ->
     @scrubberCreate.args[0][1].start.should.equal 0
     @scrubberCreate.args[0][1].range.min.should.equal 0
     @scrubberCreate.args[0][1].range.max.should.equal 100
+
+  it 'does not try to update scrubber while dragging', ->
+    @view.onVRViewReady()
+    @on.args[0][1]()
+    @view.scrubbing.should.be.true()
+
+  it 'sets the time on scrubber change', ->
+    @view.onVRViewReady()
+    @on.args[1][1]([12])
+    @setCurrentTime.args[0][0].should.equal 12
+    @view.scrubbing.should.be.false()
 
   it 'toggles play', ->
     @view.vrView.isPaused = true

--- a/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
@@ -45,6 +45,7 @@ describe 'Venice Video', ->
         @view = new VeniceVideoView
           el: $('body')
           video: '/vanity/videos/scenic_mono_3.mp4'
+        @view.trigger = sinon.stub()
         done()
 
   afterEach ->
@@ -116,3 +117,7 @@ describe 'Venice Video', ->
     @view.updateTime(currentTime: 100)
     @analytics.args[3][0].should.equal 'video:duration'
     @analytics.args[3][1].duration.should.equal '100%'
+
+  it 'triggers closeVideo', ->
+    $('.venice-video__close').click()
+    @view.trigger.args[0][0].should.equal 'closeVideo'


### PR DESCRIPTION
- Creates a loading state while the canvas/WebGL is being prepped: 
![image](https://cloud.githubusercontent.com/assets/2236794/25463261/feffe428-2ac2-11e7-9485-03ce9fee28e9.png)
- Considers adaptive streaming for mobile browsers (except iOS which uses a medium mp4)
- Ability to close the video:
![close](https://cloud.githubusercontent.com/assets/2236794/25463381/d0f6d310-2ac3-11e7-8fdc-1787e0a5c55d.gif)
- Smooths out scrubber by pausing updates while in a "scrubbing" state:
![smooth-scrub](https://cloud.githubusercontent.com/assets/2236794/25463882/50909b3a-2ac7-11e7-9b84-dd655c3aceaf.gif)
