### PR TITLE
Rethinking Marketo Analytics PR:2 Fix Gallery Insights Tracking *round 2

### DIFF
--- a/desktop/analytics/articles.js
+++ b/desktop/analytics/articles.js
@@ -108,18 +108,37 @@ if (location.pathname.match('/article/') || location.pathname.match('/2016-year-
 
 // Applies to both /article/* and /articles
 if (location.pathname.match('/article/') || location.pathname.match('/articles') || location.pathname.match('/gallery-insights')) {
+  $('.cta-bar .mktoButtonRow').click(function(e) {
+    analytics.track('Sign up for gallery insights email', {
+      session_id: sd.SESSION_ID,
+      email: $('.cta-bar-container input').val(),
+      article_id: $(this).closest('.article-container').data('id'),
+      context_type: 'article_fixed'
+    });
+    analytics.identify({
+      session_id: sd.SESSION_ID,
+      email: $('.cta-bar-container input').val()
+    });
+  })
+
+  $('#articles-body-container .mktoButtonRow').click(function(e) {
+    window.email = $("#Email").val();
+    analytics.track('Sign up for gallery insights email', {
+      session_id: sd.SESSION_ID,
+      email: email,
+      article_id: $(this).closest('.article-container').data('id'),
+      context_type: 'article_fixed'
+    });
+    analytics.identify({
+      session_id: sd.SESSION_ID,
+      email: email
+    });
+  })
+
   analyticsHooks.on('submit:editorial-signup', function (options) {
     analytics.track('Sign up for editorial email', {
       article_id: $(this).closest('.article-container').data('id'),
       context_type: options.type,
-      user_email: options.email
-    })
-  })
-
-  analyticsHooks.on('submit:gi-signup', function (options) {
-    analytics.track('Sign up for gallery insights email', {
-      article_id: $(this).closest('.article-container').data('id'),
-      context_type: 'article_fixed',
       user_email: options.email
     })
   })

--- a/desktop/analytics/articles.js
+++ b/desktop/analytics/articles.js
@@ -122,7 +122,7 @@ if (location.pathname.match('/article/') || location.pathname.match('/articles')
   })
 
   $('#articles-body-container .mktoButtonRow').click(function(e) {
-    window.email = $("#Email").val();
+    var email = $("#Email").val();
     analytics.track('Sign up for gallery insights email', {
       session_id: sd.SESSION_ID,
       email: email,


### PR DESCRIPTION
sorry new computer and things are a little messed up. round 2

This PR fixes broken tracking around gallery insights sign up. Because we are using an embedded marketo form these calls fire on submit click rather than successful form submission.

I used beautify in atom and it changed some of your spacing @kanaabe let me know if it looks ok.

Another update on this project. We switched over to a new version of the Segment integration. It is working well, however some of the code implemented in #1291 may need to change due to new naming features. Segment Help doesn't even know themselves so waiting for them to figure it out before I do anything further.