### PR TITLE
Update Show gallery phone number functionality

### DIFF
--- a/desktop/apps/artwork/components/partner_stub/components/inquire_via_phone_modal.coffee
+++ b/desktop/apps/artwork/components/partner_stub/components/inquire_via_phone_modal.coffee
@@ -1,0 +1,29 @@
+AuthModalView = require '../../../../../components/auth_modal/view.coffee'
+{ templateMap } = require '../../../../../components/auth_modal/maps.coffee'
+mediator = require '../../../../../lib/mediator.coffee'
+
+templateMap['phone_number'] = -> require('../templates/phone_number.jade') arguments...
+
+module.exports = class InquireViaPhoneModalView extends AuthModalView
+  template: ->
+    templateToRender = if sd.CURRENT_USER then 'phone_number' else @state.get('mode')
+    templateMap[templateToRender] arguments...
+
+  onSubmitSuccess: (model, response, options) =>
+    analyticsHooks.trigger "auth:#{@state.get 'mode'}"
+    @reenableForm null, reset: false
+
+    if response.error?
+      mediator.trigger 'auth:error', _s.capitalize response.error
+    else
+      Cookies.set('destination', @destination, expires: 60 * 60 * 24) if @destination
+
+      switch @state.get('mode')
+        when 'login'
+          Cookies.set('signed_in', true, expires: 60 * 60 * 24 * 7)
+        when 'register'
+          mediator.trigger 'auth:sign_up:success'
+        when 'forgot'
+          mediator.trigger 'auth:change:mode', 'reset'
+
+      @state.set 'mode', 'phone_number'

--- a/desktop/apps/artwork/components/partner_stub/index.coffee
+++ b/desktop/apps/artwork/components/partner_stub/index.coffee
@@ -1,11 +1,16 @@
+InquireViaPhoneModalView = require './components/inquire_via_phone_modal.coffee'
+
 module.exports = ($el) ->
   $el
-    .find '.js-artwork-partner-stub-phone-toggle'
+    .find '.js-artwork-partner-stub-inquire-via-phone'
     .click (e) ->
       e.preventDefault()
-
-      $(this).hide()
-
-      $el
-        .find '.js-artwork-partner-stub-phone-toggleable'
-        .show()
+      @modal = new InquireViaPhoneModalView
+        width: '500px'
+        title: 'Call gallery'
+        copy:
+          login: 'Log in to Artsy to call gallery'
+          signup: 'Create an Artsy account to call gallery'
+          register: 'Create an Artsy account to call gallery'
+        userData:
+          partner: JSON.parse(e.toElement.dataset.partner)

--- a/desktop/apps/artwork/components/partner_stub/index.jade
+++ b/desktop/apps/artwork/components/partner_stub/index.jade
@@ -28,19 +28,9 @@ unless artwork.is_in_auction
       if artwork.is_inquireable && contacts && contacts.length
         .artwork-partner-stub__phone
           a(
-            class='js-artwork-partner-stub-phone-toggle analytics-artwork-show-phone-number'
+            class='js-artwork-partner-stub-inquire-via-phone analytics-artwork-show-phone-number'
             data-partner_id= partner._id
             data-artwork_id= artwork._id
+            data-partner= partner
           )
-            | Show phone number#{contacts.length === 1 ? '' : 's'}
-
-          .artwork-partner-stub__phone__locations(
-            class='js-artwork-partner-stub-phone-toggleable'
-            data-length= contacts.length
-          )
-            for location in contacts
-              .artwork-partner-stub__phone__locations__location
-                if contacts.length > 1
-                  | #{location.city}:
-                  | &nbsp;
-                = location.phone
+            | Inguire via phone

--- a/desktop/apps/artwork/components/partner_stub/index.styl
+++ b/desktop/apps/artwork/components/partner_stub/index.styl
@@ -33,4 +33,4 @@
         margin 0
 
       &__location
-        //
+        margin distance(gutter / 2) 0

--- a/desktop/apps/artwork/components/partner_stub/query.coffee
+++ b/desktop/apps/artwork/components/partner_stub/query.coffee
@@ -13,6 +13,7 @@ module.exports = """
       name
       locations {
         city
+        state
         phone
       }
     }

--- a/desktop/apps/artwork/components/partner_stub/templates/phone_number.jade
+++ b/desktop/apps/artwork/components/partner_stub/templates/phone_number.jade
@@ -1,0 +1,17 @@
+p.avant-garde-l-headline.auth-modal__title= title
+
+#auth-page.vam-outer
+  .vam-inner
+    header#auth-header
+      aside= partner.name
+
+    section#auth-body
+      for location in partner.locations
+        .artwork-partner-stub__phone__locations__location
+          p
+            = location.city
+            if location.state
+              | ,
+              = location.state
+          p= location.phone
+

--- a/desktop/components/auth_modal/index.styl
+++ b/desktop/components/auth_modal/index.styl
@@ -3,6 +3,10 @@
     padding 20px
     text-align center
 
+.modal-body
+  .auth-modal__title
+    margin-top 8px
+
 #auth-page
   height 520px
   overflow-y auto

--- a/desktop/components/auth_modal/templates/login.jade
+++ b/desktop/components/auth_modal/templates/login.jade
@@ -1,8 +1,12 @@
+if title
+  p.avant-garde-l-headline.auth-modal__title= title
+
 #auth-page.vam-outer
   .vam-inner
-    include ./_header
-      aside
-        = copy.get('login') || 'Log in to Artsy'
+    header#auth-header
+      unless title
+        #auth-header-logo.icon-logotype
+      aside= copy.get('login') || 'Log in to Artsy'
 
     section#auth-body
       .auth-login-social

--- a/desktop/components/auth_modal/templates/register.jade
+++ b/desktop/components/auth_modal/templates/register.jade
@@ -1,6 +1,11 @@
+if title
+  p.avant-garde-l-headline.auth-modal__title= title
+
 #auth-page.vam-outer
   .vam-inner
-    include ./_header
+    header#auth-header
+      unless title
+        #auth-header-logo.icon-logotype
       aside
         = copy.get('register') || 'Enter your name, email and password to join'
 

--- a/desktop/components/auth_modal/templates/signup.jade
+++ b/desktop/components/auth_modal/templates/signup.jade
@@ -1,6 +1,11 @@
+if title
+  p.avant-garde-l-headline.auth-modal__title= title
+
 #auth-page.vam-outer
   .vam-inner
-    include ./_header
+    header#auth-header
+      unless title
+        #auth-header-logo.icon-logotype
       aside
         if copy.has('signup')
           = copy.get('signup')

--- a/desktop/components/auth_modal/test/view.coffee
+++ b/desktop/components/auth_modal/test/view.coffee
@@ -90,6 +90,10 @@ describe 'AuthModalView', ->
       @view.preInitialize userData: email: 'foo@bar.com'
       @view.templateData.email.should.containEql 'foo@bar.com'
 
+    it 'can render custom title for the default individual mode', ->
+      @view.preInitialize title: 'Call gallery'
+      @view.templateData.title.should.equal 'Call gallery'
+
   describe '#submit', ->
     beforeEach ->
       sinon.stub location, 'assign'

--- a/desktop/components/auth_modal/view.coffee
+++ b/desktop/components/auth_modal/view.coffee
@@ -45,6 +45,7 @@ module.exports = class AuthModalView extends ModalView
     @state = new State mode
 
     @templateData = _.extend {
+      title: options.title
       copy: @renderCopy(options.copy)
       redirectTo: switch @state.get 'mode'
         when 'login' then @redirectTo or location.pathname


### PR DESCRIPTION
finishes https://github.com/artsy/collector-experience/issues/229.

To re-use the `AuthModalView` I added the ability to specify a custom title for the modal. if a title is passed in, the modal will show the title instead of showing the Artsy logo. I'm not sure if this is even a good approach, so I'm open to suggestions.

![login](https://cloud.githubusercontent.com/assets/386234/25501609/5e5919a0-2b61-11e7-887c-2e6fcfd718ca.gif)
