### PR TITLE
@sweir27 => "SOLD" button label 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,14 @@
   "extends": [
     "standard",
     "standard-react"
-  ]
+  ],
+  "env": {
+    "browser": true,
+    "mocha": true,
+    "node": true
+  },
+  "rules": {
+    "camelcase": 0,
+    "no-new": 0
+  }
 }

--- a/desktop/apps/artwork/components/auction/index.styl
+++ b/desktop/apps/artwork/components/auction/index.styl
@@ -26,12 +26,10 @@
 
     &__bid
       sans('s-headline')
+      margin-bottom 5px
 
     &__closed
       serif('s-body')
-
-    &__bid
-      margin-bottom 5px
 
     &__amount
       serif('l-body')
@@ -41,6 +39,10 @@
 
     &__count
       color gray-dark-color
+
+    &__sold
+      sans('l-headline')
+      margin-top 2px
 
   &__bid-form
     &__errors
@@ -99,4 +101,3 @@
 
   &__live-button
     padding-top 10px
-

--- a/desktop/apps/artwork/components/auction/index.styl
+++ b/desktop/apps/artwork/components/auction/index.styl
@@ -40,10 +40,6 @@
     &__count
       color gray-dark-color
 
-    &__sold
-      sans('l-headline')
-      margin-top 2px
-
   &__bid-form
     &__errors
       serif('l-caption')

--- a/desktop/apps/artwork/components/auction/templates/status.jade
+++ b/desktop/apps/artwork/components/auction/templates/status.jade
@@ -3,8 +3,8 @@
 
 .artwork-auction__bid-status
   if is_sold 
-    .artwork-auction__bid-status__sold
-      | SOLD
+    .artwork-auction__bid-status__closed
+      | Sold
   else 
     .artwork-auction__bid-status__bid
       if sale_artwork.counts.bidder_positions

--- a/desktop/apps/artwork/components/auction/templates/status.jade
+++ b/desktop/apps/artwork/components/auction/templates/status.jade
@@ -1,15 +1,20 @@
 - var count = helpers.auction.count(sale_artwork);
+- var is_sold = artwork.is_sold;
 
 .artwork-auction__bid-status
-  .artwork-auction__bid-status__bid
-    if sale_artwork.counts.bidder_positions
-      | Current Bid
-    else
-      | Starting Bid
+  if is_sold 
+    .artwork-auction__bid-status__sold
+      | SOLD
+  else 
+    .artwork-auction__bid-status__bid
+      if sale_artwork.counts.bidder_positions
+        | Current Bid
+      else
+        | Starting Bid
 
-  .artwork-auction__bid-status__amount
-    = sale_artwork.current_bid.display
+    .artwork-auction__bid-status__amount
+      = sale_artwork.current_bid.display
 
-  if count
-    .artwork-auction__bid-status__count
-      | (#{count})
+    if count
+      .artwork-auction__bid-status__count
+        | (#{count})

--- a/desktop/apps/artwork/components/auction/test/view.coffee
+++ b/desktop/apps/artwork/components/auction/test/view.coffee
@@ -321,5 +321,5 @@ describe 'auction', ->
         view.$('.artwork-auction__bid-form__button')
           .should.have.lengthOf 0
 
-        view.$('.artwork-auction__bid-status__sold')
+        view.$('.artwork-auction__bid-status__closed')
           .should.have.lengthOf 1

--- a/desktop/apps/artwork/components/auction/test/view.coffee
+++ b/desktop/apps/artwork/components/auction/test/view.coffee
@@ -286,3 +286,40 @@ describe 'auction', ->
 
         view.$('.artwork-auction__buy-now')
           .should.have.lengthOf 1
+
+    describe  'is sold', ->
+      it 'renders correctly', ->
+        data =
+          accounting: accounting
+          artwork:
+            id: 'peter-alexander-wedge-with-puff'
+            is_in_auction: true
+            is_buy_nowable: true
+            is_sold: true
+            sale:
+              id: 'los-angeles-modern-auctions-march-2015'
+              name: 'Los Angeles Modern Auctions - March 2015'
+              is_open: true
+              is_preview: false
+              is_closed: false
+              is_auction: true
+              is_auction_promo: false
+              is_with_buyers_premium: true
+            sale_artwork:
+              id: 'peter-alexander-wedge-with-puff'
+              estimate: '$7,000–$9,000'
+              current_bid: amount: '$55,000'
+              counts: bidder_positions: 0
+              bid_increments: [100, 200]
+              minimum_next_bid:
+                amount: '$60,000'
+                cents: 6000000
+
+        view = new @ArtworkAuctionView data: data
+        view.render()
+
+        view.$('.artwork-auction__bid-form__button')
+          .should.have.lengthOf 0
+
+        view.$('.artwork-auction__bid-status__sold')
+          .should.have.lengthOf 1

--- a/desktop/apps/artwork/components/auction/view.coffee
+++ b/desktop/apps/artwork/components/auction/view.coffee
@@ -132,13 +132,12 @@ module.exports = class ArtworkAuctionView extends Backbone.View
     .then (data) =>
       old_data = @data
       @data = extend data, user: CURRENT_USER?
-      
+
       @render() unless isEqual(old_data, data)
-      
+
       @delayedUpdateBidLabel(remaining - 1) if remaining > 0
 
     .catch console.error.bind console
 
   delayedUpdateBidLabel: (remaining) ->
     setTimeout (=> @updateBidLabel remaining), LOT_STANDING_POLL_INTERVAL
-

--- a/desktop/apps/auction/client/actions.js
+++ b/desktop/apps/auction/client/actions.js
@@ -29,31 +29,31 @@ export const UPDATE_SORT = 'UPDATE_SORT'
 export const UPDATE_TOTAL = 'UPDATE_TOTAL'
 
 // Action creators
-export function decrementFollowedArtistsPage() {
+export function decrementFollowedArtistsPage () {
   return {
     type: DECREMENT_FOLLOWED_ARTISTS_PAGE
   }
 }
 
-export function getArtworksFailure() {
+export function getArtworksFailure () {
   return {
     type: GET_ARTWORKS_FAILURE
   }
 }
 
-export function getArtworksRequest() {
+export function getArtworksRequest () {
   return {
     type: GET_ARTWORKS_REQUEST
   }
 }
 
-export function getArtworksSuccess() {
+export function getArtworksSuccess () {
   return {
     type: GET_ARTWORKS_SUCCESS
   }
 }
 
-export function fetchArtworks() {
+export function fetchArtworks () {
   return async (dispatch, getState) => {
     const {
       auctionArtworks: {
@@ -81,8 +81,8 @@ export function fetchArtworks() {
       }
 
       const aggregations = filter_sale_artworks.aggregations
-      const artistAggregation = aggregations.filter((agg) => agg.slice == 'ARTIST')
-      const mediumAggregation = aggregations.filter((agg) => agg.slice == 'MEDIUM')
+      const artistAggregation = aggregations.filter((agg) => agg.slice === 'ARTIST')
+      const mediumAggregation = aggregations.filter((agg) => agg.slice === 'MEDIUM')
 
       dispatch(updateAggregatedArtists(artistAggregation[0].counts))
       dispatch(updateAggregatedMediums(mediumAggregation[0].counts))
@@ -92,14 +92,14 @@ export function fetchArtworks() {
       dispatch(updateSaleArtworks(filter_sale_artworks.hits))
       dispatch(updateAllFetched())
       dispatch(getArtworksSuccess())
-    } catch(error) {
+    } catch (error) {
       dispatch(getArtworksFailure())
       console.error('error!', error)
     }
   }
 }
 
-export function fetchArtworksByFollowedArtists() {
+export function fetchArtworksByFollowedArtists () {
   return async (dispatch, getState) => {
     const {
       auctionArtworks: {
@@ -130,13 +130,13 @@ export function fetchArtworksByFollowedArtists() {
         dispatch(updateIsLastFollowedArtistsPage())
         dispatch(showFollowedArtistsRail())
       }
-    } catch(error) {
+    } catch (error) {
       console.error('error!', error)
     }
   }
 }
 
-export function fetchMoreArtworks() {
+export function fetchMoreArtworks () {
   return async (dispatch, getState) => {
     const {
       auctionArtworks: {
@@ -157,14 +157,14 @@ export function fetchMoreArtworks() {
       dispatch(updateSaleArtworks(filter_sale_artworks.hits))
       dispatch(updateAllFetched())
       dispatch(getArtworksSuccess())
-    } catch(error) {
+    } catch (error) {
       dispatch(getArtworksFailure())
       console.error('error!', error)
     }
   }
 }
 
-export function infiniteScroll() {
+export function infiniteScroll () {
   return (dispatch, getState) => {
     const {
       auctionArtworks: {
@@ -179,27 +179,27 @@ export function infiniteScroll() {
   }
 }
 
-export function incrementFollowedArtistsPage() {
+export function incrementFollowedArtistsPage () {
   return {
     type: INCREMENT_FOLLOWED_ARTISTS_PAGE
   }
 }
 
-export function nextPageOfFollowedArtistArtworks() {
+export function nextPageOfFollowedArtistArtworks () {
   return (dispatch, getState) => {
     dispatch(incrementFollowedArtistsPage())
     dispatch(updateIsLastFollowedArtistsPage())
   }
 }
 
-export function previousPageOfFollowedArtistArtworks() {
+export function previousPageOfFollowedArtistArtworks () {
   return (dispatch, getState) => {
     dispatch(decrementFollowedArtistsPage())
     dispatch(updateIsLastFollowedArtistsPage())
   }
 }
 
-export function resetArtworks() {
+export function resetArtworks () {
   return (dispatch, getState) => {
     const {
       auctionArtworks: {
@@ -213,7 +213,7 @@ export function resetArtworks() {
   }
 }
 
-export function toggleListView(isListView) {
+export function toggleListView (isListView) {
   return {
     type: TOGGLE_LIST_VIEW,
     payload: {
@@ -222,7 +222,7 @@ export function toggleListView(isListView) {
   }
 }
 
-export function updateAggregatedArtists(aggregatedArtists) {
+export function updateAggregatedArtists (aggregatedArtists) {
   return {
     type: UPDATE_AGGREGATED_ARTISTS,
     payload: {
@@ -231,7 +231,7 @@ export function updateAggregatedArtists(aggregatedArtists) {
   }
 }
 
-export function updateAggregatedMediums(aggregatedMediums) {
+export function updateAggregatedMediums (aggregatedMediums) {
   return {
     type: UPDATE_AGGREGATED_MEDIUMS,
     payload: {
@@ -240,13 +240,13 @@ export function updateAggregatedMediums(aggregatedMediums) {
   }
 }
 
-export function updateAllFetched() {
+export function updateAllFetched () {
   return {
     type: UPDATE_ALL_FETCHED
   }
 }
 
-export function updateArtistId(artistId) {
+export function updateArtistId (artistId) {
   return {
     type: UPDATE_ARTIST_ID,
     payload: {
@@ -255,20 +255,20 @@ export function updateArtistId(artistId) {
   }
 }
 
-export function updateArtistParams(artistId) {
+export function updateArtistParams (artistId) {
   return (dispatch) => {
     dispatch(updateArtistId(artistId))
     dispatch(resetArtworks())
   }
 }
 
-export function showFollowedArtistsRail() {
+export function showFollowedArtistsRail () {
   return {
     type: SHOW_FOLLOWED_ARTISTS_RAIL
   }
 }
 
-export function updateEstimateDisplay(min, max) {
+export function updateEstimateDisplay (min, max) {
   return {
     type: UPDATE_ESTIMATE_DISPLAY,
     payload: {
@@ -278,14 +278,14 @@ export function updateEstimateDisplay(min, max) {
   }
 }
 
-export function updateEstimateRange(min, max) {
+export function updateEstimateRange (min, max) {
   return (dispatch) => {
     dispatch(updateEstimateRangeParams(min, max))
     dispatch(resetArtworks())
   }
 }
 
-export function updateEstimateRangeParams(min, max) {
+export function updateEstimateRangeParams (min, max) {
   return {
     type: UPDATE_ESTIMATE_RANGE,
     payload: {
@@ -295,7 +295,7 @@ export function updateEstimateRangeParams(min, max) {
   }
 }
 
-export function updateInitialMediumMap(initialMediumMap) {
+export function updateInitialMediumMap (initialMediumMap) {
   return {
     type: UPDATE_INITIAL_MEDIUM_MAP,
     payload: {
@@ -304,13 +304,13 @@ export function updateInitialMediumMap(initialMediumMap) {
   }
 }
 
-export function updateIsLastFollowedArtistsPage() {
+export function updateIsLastFollowedArtistsPage () {
   return {
     type: UPDATE_IS_LAST_FOLLOWED_ARTISTS_PAGE
   }
 }
 
-export function updateMediumId(mediumId) {
+export function updateMediumId (mediumId) {
   return {
     type: UPDATE_MEDIUM_ID,
     payload: {
@@ -319,14 +319,14 @@ export function updateMediumId(mediumId) {
   }
 }
 
-export function updateMediumParams(mediumId) {
+export function updateMediumParams (mediumId) {
   return (dispatch) => {
     dispatch(updateMediumId(mediumId))
     dispatch(resetArtworks())
   }
 }
 
-export function updateNumArtistsYouFollow(numArtistsYouFollow) {
+export function updateNumArtistsYouFollow (numArtistsYouFollow) {
   return {
     type: UPDATE_NUM_ARTISTS_YOU_FOLLOW,
     payload: {
@@ -335,7 +335,7 @@ export function updateNumArtistsYouFollow(numArtistsYouFollow) {
   }
 }
 
-export function updatePage(reset) {
+export function updatePage (reset) {
   return {
     type: UPDATE_PAGE,
     payload: {
@@ -344,7 +344,7 @@ export function updatePage(reset) {
   }
 }
 
-export function updateSaleArtworks(saleArtworks) {
+export function updateSaleArtworks (saleArtworks) {
   return {
     type: UPDATE_SALE_ARTWORKS,
     payload: {
@@ -353,7 +353,7 @@ export function updateSaleArtworks(saleArtworks) {
   }
 }
 
-export function updateSaleArtworksByFollowedArtists(saleArtworks) {
+export function updateSaleArtworksByFollowedArtists (saleArtworks) {
   return {
     type: UPDATE_SALE_ARTWORKS_BY_FOLLOWED_ARTISTS,
     payload: {
@@ -362,7 +362,7 @@ export function updateSaleArtworksByFollowedArtists(saleArtworks) {
   }
 }
 
-export function updateSaleArtworksByFollowedArtistsTotal(total) {
+export function updateSaleArtworksByFollowedArtistsTotal (total) {
   return {
     type: UPDATE_SALE_ARTWORKS_BY_FOLLOWED_ARTISTS_TOTAL,
     payload: {
@@ -371,14 +371,14 @@ export function updateSaleArtworksByFollowedArtistsTotal(total) {
   }
 }
 
-export function updateSort(sort) {
+export function updateSort (sort) {
   return (dispatch) => {
     dispatch(updateSortParam(sort))
     dispatch(resetArtworks())
   }
 }
 
-export function updateSortParam(sort) {
+export function updateSortParam (sort) {
   return {
     type: UPDATE_SORT,
     payload: {
@@ -387,7 +387,7 @@ export function updateSortParam(sort) {
   }
 }
 
-export function updateTotal(total) {
+export function updateTotal (total) {
   return {
     type: UPDATE_TOTAL,
     payload: {

--- a/desktop/apps/auction/client/analytics_middleware.js
+++ b/desktop/apps/auction/client/analytics_middleware.js
@@ -1,13 +1,13 @@
 import * as actions from './actions'
 import analyticsHooks from '../../../lib/analytics_hooks.coffee'
-import { contains, isEqual } from 'underscore'
+import { isEqual } from 'underscore'
 
 const analyticsMiddleware = store => next => action => {
   const result = next(action)
   const nextState = store.getState()
 
   // track certain types of actions
-  switch(action.type) {
+  switch (action.type) {
     case actions.UPDATE_MEDIUM_ID: {
       trackParamChange({ medium: action.payload.mediumId }, nextState)
       return result
@@ -30,7 +30,7 @@ const analyticsMiddleware = store => next => action => {
   }
 }
 
-function trackableArtistIds(changed, filterParams) {
+function trackableArtistIds (changed, filterParams) {
   if (isEqual(changed, { artist: 'artists-you-follow' })) {
     return ['artists-you-follow']
   } else {
@@ -38,7 +38,7 @@ function trackableArtistIds(changed, filterParams) {
   }
 }
 
-function trackParamChange(changed, newState) {
+function trackParamChange (changed, newState) {
   const { filterParams } = newState.auctionArtworks
   analyticsHooks.trigger(
     'auction:artworks:params:change',

--- a/desktop/apps/auction/client/commercial_filter.js
+++ b/desktop/apps/auction/client/commercial_filter.js
@@ -1,24 +1,28 @@
-import analyticsMiddleware from './analytics_middleware'
-import { data as sd } from 'sharify'
-import JumpView from '../../../components/jump/view.coffee'
-import React from 'react';
-import { render } from 'react-dom';
-import thunkMiddleware from 'redux-thunk'
-import createLogger from 'redux-logger'
-import { combineReducers, createStore, applyMiddleware } from 'redux'
-import { Provider } from 'react-redux'
-import auctions from './reducers'
-import AuctionPage from '../components/auction_page'
+import $ from 'jquery'
 import * as actions from './actions'
+import _ from 'underscore'
+import AuctionPage from '../components/auction_page'
+import JumpView from '../../../components/jump/view.coffee'
+import React from 'react'
+import analyticsMiddleware from './analytics_middleware'
+import auctions from './reducers'
+import createLogger from 'redux-logger'
+import thunkMiddleware from 'redux-thunk'
+import { Provider } from 'react-redux'
+import { createStore, applyMiddleware } from 'redux'
+import { data as sd } from 'sharify'
+import { render } from 'react-dom'
 
-export function setupCommercialFilter() {
-  const loggerMiddleware = createLogger()
+export function setupCommercialFilter () {
   const middleware = []
+
   middleware.push(thunkMiddleware) // lets us dispatch() functions
   middleware.push(analyticsMiddleware) // middleware to help us track previous and future states
 
   if (sd.NODE_ENV === 'development' || sd.NODE_ENV === 'staging') {
-    middleware.push(loggerMiddleware) // middleware that logs actions
+    middleware.push(createLogger({ // middleware that logs actions
+      collapsed: true
+    }))
   }
 
   const store = createStore(
@@ -38,8 +42,8 @@ export function setupCommercialFilter() {
   store.dispatch(actions.fetchArtworks())
 
   // scroll up if you select a checkbox or sort
-  function scrollToTop() {
-    $('html,body').animate( {
+  function scrollToTop () {
+    $('html,body').animate({
       scrollTop: $('.auction-artworks-header').offset().top - $('.mlh-navbar').height()
     }, 400)
   }
@@ -62,12 +66,14 @@ export function setupCommercialFilter() {
   jump.scrollToPosition(0)
 
   // infinite scroll
-  function infiniteScroll() {
+  function infiniteScroll () {
     const threshold = $(window).height() + $(window).scrollTop()
     const artworksEl = $('.auction-page-artworks')
-    const shouldFetch = artworksEl.height() > 0
-      && threshold > artworksEl.offset().top + artworksEl.height()
-    if (shouldFetch) { store.dispatch(actions.infiniteScroll()) }
+    const shouldFetch = artworksEl.height() > 0 &&
+                        threshold > artworksEl.offset().top + artworksEl.height()
+    if (shouldFetch) {
+      store.dispatch(actions.infiniteScroll())
+    }
   }
   $(window).on('scroll.auction-page-artworks', _.throttle(infiniteScroll, 200))
 }

--- a/desktop/apps/auction/client/filter_query.js
+++ b/desktop/apps/auction/client/filter_query.js
@@ -47,6 +47,7 @@ export const filterQuery = `
           href
           title
           date
+          is_sold
           images {
             id
             image_url: url(version: ["tall"])

--- a/desktop/apps/auction/client/index.js
+++ b/desktop/apps/auction/client/index.js
@@ -1,15 +1,14 @@
+import $ from 'jquery'
 import AddToCalendar from '../../../components/add_to_calendar/index.coffee'
 import Auction from '../../../models/auction.coffee'
-import Backbone from 'backbone'
 import ClockView from '../../../components/clock/view.coffee'
 import ConfirmRegistrationModal from '../../../components/credit_card/client/confirm_registration.coffee'
 import CurrentUser from '../../../models/current_user.coffee'
+import MyActiveBids from '../../../components/my_active_bids/view.coffee'
 import mediator from '../../../lib/mediator.coffee'
 import mountAuctionBlock from '../../../components/auction_block/index.jsx'
-import MyActiveBids from '../../../components/my_active_bids/view.coffee'
-import { setupCommercialFilter } from './commercial_filter'
 import { data as sd } from 'sharify'
-import _ from 'underscore'
+import { setupCommercialFilter } from './commercial_filter'
 
 export default () => {
   const auction = new Auction(sd.AUCTION)
@@ -28,7 +27,7 @@ export default () => {
   })
   clock.start()
 
-  const calendar = new AddToCalendar({
+  new AddToCalendar({
     el: $('.auction-callout')
   })
 

--- a/desktop/apps/auction/client/reducers.js
+++ b/desktop/apps/auction/client/reducers.js
@@ -41,19 +41,19 @@ const initialState = {
   saleArtworksByFollowedArtists: [],
   saleArtworksByFollowedArtistsTotal: 0,
   sortMap: {
-    "bidder_positions_count": "Number of Bids (asc.)",
-    "-bidder_positions_count": "Number of Bids (desc.)",
-    "position": "Lot Number (asc.)",
-    "-position": "Lot Number (desc.)",
-    "-searchable_estimate": "Most Expensive",
-    "searchable_estimate": "Least Expensive"
+    'bidder_positions_count': 'Number of Bids (asc.)',
+    '-bidder_positions_count': 'Number of Bids (desc.)',
+    'position': 'Lot Number (asc.)',
+    '-position': 'Lot Number (desc.)',
+    '-searchable_estimate': 'Most Expensive',
+    'searchable_estimate': 'Least Expensive'
   },
   symbol: sd.AUCTION && sd.AUCTION.symbol,
   total: 0,
   user: sd.CURRENT_USER
 }
 
-function auctionArtworks(state = initialState, action) {
+function auctionArtworks (state = initialState, action) {
   switch (action.type) {
     case actions.DECREMENT_FOLLOWED_ARTISTS_PAGE: {
       const currentPage = state.followedArtistRailPage

--- a/desktop/apps/auction/components/artist_filter/index.js
+++ b/desktop/apps/auction/components/artist_filter/index.js
@@ -1,18 +1,19 @@
-import { updateArtistParams } from '../../client/actions'
 import BasicCheckbox from '../basic_checkbox'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
-import { map, contains } from 'underscore'
+import { contains } from 'underscore'
+import { updateArtistParams } from '../../client/actions'
 
-function ArtistFilter(props) {
+function ArtistFilter (props) {
   const {
     aggregatedArtists,
     filterParams,
     numArtistsYouFollow,
     updateArtistParamsAction,
-    updateArtistsYouFollowParamAction,
     user
   } = props
+
   const artistIds = filterParams.artist_ids
   const allArtists = { id: 'artists-all', name: 'All' }
   const allArtistsSelected = artistIds.length === 0 && !filterParams.include_artworks_by_followed_artists
@@ -52,6 +53,14 @@ function ArtistFilter(props) {
       }
     </div>
   )
+}
+
+ArtistFilter.propTypes = {
+  aggregatedArtists: PropTypes.array.isRequired,
+  filterParams: PropTypes.object.isRequired,
+  numArtistsYouFollow: PropTypes.number.isRequired,
+  updateArtistParamsAction: PropTypes.func.isRequired,
+  user: PropTypes.object.isRequired
 }
 
 const mapStateToProps = (state) => {

--- a/desktop/apps/auction/components/auction_artworks/index.js
+++ b/desktop/apps/auction/components/auction_artworks/index.js
@@ -1,20 +1,33 @@
 import AuctionGridArtwork from '../auction_grid_artwork'
 import AuctionListArtwork from '../auction_list_artwork'
-import React from 'react';
+import PropTypes from 'prop-types'
+import React from 'react'
 import { connect } from 'react-redux'
 
-function AuctionArtworks({ allFetched, isFetchingArtworks, isListView, saleArtworks }) {
-  const DisplayComponent = isListView ? AuctionListArtwork : AuctionGridArtwork
+function AuctionArtworks ({ isFetchingArtworks, isListView, saleArtworks }) {
+  const DisplayComponent = isListView
+    ? AuctionListArtwork
+    : AuctionGridArtwork
+
   return (
     <div className='auction-page-artworks'>
       {
         saleArtworks.map((saleArtwork) => (
-          <DisplayComponent key={saleArtwork.id} saleArtwork={saleArtwork} />
+          <DisplayComponent
+            key={saleArtwork.id}
+            saleArtwork={saleArtwork}
+          />
         ))
       }
-      { isFetchingArtworks && <div className='loading-spinner'></div> }
+      { isFetchingArtworks && <div className='loading-spinner' /> }
     </div>
   )
+}
+
+AuctionArtworks.propTypes = {
+  isFetchingArtworks: PropTypes.bool.isRequired,
+  isListView: PropTypes.bool.isRequired,
+  saleArtworks: PropTypes.array.isRequired
 }
 
 const mapStateToProps = (state) => {

--- a/desktop/apps/auction/components/auction_grid_artwork/index.js
+++ b/desktop/apps/auction/components/auction_grid_artwork/index.js
@@ -1,17 +1,19 @@
 import BidStatus from '../bid_status'
+import PropTypes from 'prop-types'
+import React from 'react'
 import { connect } from 'react-redux'
 import { get } from 'lodash'
-import React from 'react';
 import { titleAndYear } from '../../utils/artwork'
 
-function AuctionGridArtwork({ isClosed, saleArtwork }) {
+function AuctionGridArtwork ({ isClosed, saleArtwork }) {
   const artwork = saleArtwork.artwork
   const artists = artwork.artists
-  const artistDisplay = artists && artists.length > 0 ? artists.map((aa) => aa.name).join(', ') : null
-  const artworkImage = get(artwork, 'images.0.image_url', '/images/missing_image.png')
 
-  let bidStatus
-  bidStatus = <BidStatus saleArtwork={saleArtwork} />
+  const artistDisplay = artists && artists.length > 0
+    ? artists.map((aa) => aa.name).join(', ')
+    : null
+
+  const artworkImage = get(artwork, 'images.0.image_url', '/images/missing_image.png')
 
   return (
     <a className='auction-page-grid-artwork' key={artwork._id} href={`/artwork/${artwork.id}`}>
@@ -19,7 +21,7 @@ function AuctionGridArtwork({ isClosed, saleArtwork }) {
         <div className='vam-outer'>
           <div className='vam-inner'>
             <div className='auction-page-grid-artwork__image'>
-              <img src={artworkImage} alt={artwork.title}></img>
+              <img src={artworkImage} alt={artwork.title} / >
             </div>
           </div>
         </div>
@@ -29,15 +31,28 @@ function AuctionGridArtwork({ isClosed, saleArtwork }) {
           <div className='auction-page-grid-artwork__lot-number'>
             Lot {saleArtwork.lot_label}
           </div>
-          { !isClosed && bidStatus }
+          { !isClosed &&
+            <BidStatus
+              saleArtwork={saleArtwork}
+            /> }
         </div>
         <div className='auction-page-grid-artwork__artists'>
           {artistDisplay}
         </div>
-        <div className='auction-page-grid-artwork__title' dangerouslySetInnerHTML={{ __html: titleAndYear(artwork.title, artwork.date) }}></div>
+        <div
+          className='auction-page-grid-artwork__title'
+          dangerouslySetInnerHTML={{
+            __html: titleAndYear(artwork.title, artwork.date)
+          }}
+        />
       </div>
     </a>
-  );
+  )
+}
+
+AuctionGridArtwork.propTypes = {
+  isClosed: PropTypes.bool.isRequired,
+  saleArtwork: PropTypes.object.isRequired
 }
 
 const mapStateToProps = (state) => {
@@ -49,4 +64,3 @@ const mapStateToProps = (state) => {
 export default connect(
   mapStateToProps
 )(AuctionGridArtwork)
-

--- a/desktop/apps/auction/components/auction_list_artwork/index.js
+++ b/desktop/apps/auction/components/auction_list_artwork/index.js
@@ -1,11 +1,12 @@
 import BidStatus from '../bid_status'
+import PropTypes from 'prop-types'
+import React from 'react'
 import classNames from 'classnames'
 import { connect } from 'react-redux'
 import { get } from 'lodash'
-import React from 'react';
 import { titleAndYear } from '../../utils/artwork'
 
-function AuctionListArtwork({ isClosed, saleArtwork }) {
+function AuctionListArtwork ({ isClosed, saleArtwork }) {
   const artwork = saleArtwork.artwork
   const artists = artwork.artists
   const artistDisplay = artists && artists.length > 0 ? artists.map((aa) => aa.name).join(', ') : null
@@ -16,28 +17,38 @@ function AuctionListArtwork({ isClosed, saleArtwork }) {
     { 'auction-open': isClosed }
   )
 
-  let bidStatus
-  bidStatus = <BidStatus saleArtwork={saleArtwork} />
-
   return (
     <a className={auctionArtworkClasses} key={artwork._id} href={`/artwork/${artwork.id}`}>
       <div className='auction-page-list-artwork__image-container'>
         <div className='auction-page-list-artwork__image'>
-          <img src={artworkImage} alt={artwork.title}></img>
+          <img src={artworkImage} alt={artwork.title} />
         </div>
       </div>
       <div className='auction-page-list-artwork__metadata'>
         <div className='auction-page-list-artwork__artists'>
           {artistDisplay}
         </div>
-        <div className='auction-page-list-artwork__title' dangerouslySetInnerHTML={{ __html: titleAndYear(artwork.title, artwork.date) }}></div>
+        <div
+          className='auction-page-list-artwork__title'
+          dangerouslySetInnerHTML={{
+            __html: titleAndYear(artwork.title, artwork.date)
+          }}
+        />
       </div>
       <div className='auction-page-list-artwork__lot-number'>
         Lot {saleArtwork.lot_label}
       </div>
-      { !isClosed && bidStatus }
+      { !isClosed &&
+        <BidStatus
+          saleArtwork={saleArtwork}
+        /> }
     </a>
-  );
+  )
+}
+
+AuctionListArtwork.propTypes = {
+  isClosed: PropTypes.bool.isRequired,
+  saleArtwork: PropTypes.object.isRequired
 }
 
 const mapStateToProps = (state) => {

--- a/desktop/apps/auction/components/auction_page/index.js
+++ b/desktop/apps/auction/components/auction_page/index.js
@@ -1,15 +1,20 @@
 import CommercialFilter from '../commercial_filter'
 import WorksByFollowedArtists from '../works_by_followed_artists'
-import React from 'react';
+import PropTypes from 'prop-types'
+import React from 'react'
 import { connect } from 'react-redux'
 
-function AuctionPage({ displayFollowedArtistsRail }) {
+function AuctionPage ({ displayFollowedArtistsRail }) {
   return (
     <div className='auction-main-page'>
       { displayFollowedArtistsRail && <WorksByFollowedArtists /> }
       <CommercialFilter />
     </div>
   )
+}
+
+AuctionPage.propTypes = {
+  displayFollowedArtistsRail: PropTypes.bool.isRequired
 }
 
 const mapStateToProps = (state) => {
@@ -21,4 +26,3 @@ const mapStateToProps = (state) => {
 export default connect(
   mapStateToProps
 )(AuctionPage)
-

--- a/desktop/apps/auction/components/basic_checkbox/index.js
+++ b/desktop/apps/auction/components/basic_checkbox/index.js
@@ -1,13 +1,13 @@
-import classNames from 'classnames'
+import PropTypes from 'prop-types'
 import React from 'react'
+import classNames from 'classnames'
 
-export default function BasicCheckbox(props) {
+export default function BasicCheckbox (props) {
   const {
     checked,
     disabled,
     item,
-    onClick,
-    onClickAction
+    onClick
   } = props
 
   const checkboxClasses = classNames(
@@ -30,9 +30,19 @@ export default function BasicCheckbox(props) {
         </div>
         <label className='artsy-checkbox--label' htmlFor={item.id}>
           { item.name }
-          { item.count !== undefined && <span className='artsy-checkbox--count'>({item.count})</span> }
+          { item.count !== undefined &&
+            <span className='artsy-checkbox--count'>
+              ({item.count})
+            </span> }
         </label>
       </div>
     </div>
   )
+}
+
+BasicCheckbox.propTypes = {
+  checked: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool,
+  item: PropTypes.object.isRequired,
+  onClick: PropTypes.func.isRequired
 }

--- a/desktop/apps/auction/components/bid_status/index.js
+++ b/desktop/apps/auction/components/bid_status/index.js
@@ -1,18 +1,45 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 
-export default function BidStatus({ saleArtwork }) {
+export default function BidStatus ({ saleArtwork }) {
+  const {
+    artwork,
+    counts = {},
+    current_bid
+  } = saleArtwork
+
+  const {
+    bidder_positions
+  } = counts
+
   let bidLabel
-  if (saleArtwork.counts && saleArtwork.counts.bidder_positions > 0) {
-    const bidOrBids = saleArtwork.counts.bidder_positions > 1 ? 'Bids' : 'Bid'
-    bidLabel = `(${saleArtwork.counts.bidder_positions} ${bidOrBids})`
+
+  if (counts && bidder_positions) {
+    const bidOrBids = bidder_positions > 1 ? 'Bids' : 'Bid'
+    bidLabel = `(${bidder_positions} ${bidOrBids})`
   } else {
     bidLabel = ''
   }
 
   return (
     <div className='auction-bid-status'>
-      <span className='auction-bid-status__bid-amount'>{ saleArtwork.current_bid.display }</span>
-      <span className='auction-bid-status__bid-label'>{ bidLabel }</span>
+      { artwork.is_sold
+        ? <span className='auction-bid-status__bid-label'>
+            SOLD
+          </span>
+        : <div>
+          <span className='auction-bid-status__bid-amount'>
+            {current_bid.display}
+          </span>
+          <span className=''>
+            {bidLabel}
+          </span>
+        </div>
+      }
     </div>
-  );
+  )
+}
+
+BidStatus.propTypes = {
+  saleArtwork: PropTypes.object.isRequired
 }

--- a/desktop/apps/auction/components/bid_status/index.js
+++ b/desktop/apps/auction/components/bid_status/index.js
@@ -25,7 +25,7 @@ export default function BidStatus ({ saleArtwork }) {
     <div className='auction-bid-status'>
       { artwork.is_sold
         ? <span className='auction-bid-status__bid-label'>
-            SOLD
+            Sold
           </span>
         : <div>
           <span className='auction-bid-status__bid-amount'>

--- a/desktop/apps/auction/components/commercial_filter/index.js
+++ b/desktop/apps/auction/components/commercial_filter/index.js
@@ -3,7 +3,7 @@ import Header from '../header'
 import React from 'react'
 import Sidebar from '../sidebar'
 
-export default function CommercialFilter() {
+export default function CommercialFilter () {
   return (
     <div className='auction-commercial-filter'>
       <div className='auction-commercial-filter__left cf-sidebar'>

--- a/desktop/apps/auction/components/filter_sort/index.js
+++ b/desktop/apps/auction/components/filter_sort/index.js
@@ -1,14 +1,16 @@
-import { updateSort } from '../../client/actions'
+import _ from 'underscore'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
-import _ from 'underscore'
+import { updateSort } from '../../client/actions'
 
-function FilterSort(props) {
+function FilterSort (props) {
   const {
     filterParams,
     sortMap,
     updateSortAction
   } = props
+
   const selectedSort = filterParams.sort
   const itemHeight = 37
   const itemIndex = Object.keys(sortMap).indexOf(selectedSort)
@@ -21,16 +23,16 @@ function FilterSort(props) {
         <a className='bordered-pulldown-toggle' href='#'>
           <span className='bordered-pulldown-text'>{ sortMap[selectedSort] }</span>
           <div className='bordered-pulldown-toggle-caret'>
-            <span className='caret'></span>
+            <span className='caret' />
           </div>
         </a>
-        <div className='bordered-pulldown-options' style={ { top: -optionsOffset } }>
+        <div className='bordered-pulldown-options' style={{ top: -optionsOffset }}>
           {
             _.map(sortMap, (sortName, sort) => {
-              const selected = sort == selectedSort
+              const selected = sort === selectedSort
               return <a
                 href='#'
-                className={ selected ? 'borderd-pulldown-active' : '' }
+                className={selected ? 'borderd-pulldown-active' : ''}
                 key={sort}
                 onClick={() => updateSortAction(sort)}
               >{sortName}</a>
@@ -40,6 +42,12 @@ function FilterSort(props) {
       </div>
     </div>
   )
+}
+
+FilterSort.propTypes = {
+  filterParams: PropTypes.object.isRequired,
+  sortMap: PropTypes.object.isRequired,
+  updateSortAction: PropTypes.func.isRequired
 }
 
 const mapStateToProps = (state) => {

--- a/desktop/apps/auction/components/header/index.js
+++ b/desktop/apps/auction/components/header/index.js
@@ -1,28 +1,31 @@
-import { toggleListView, updateSort } from '../../client/actions'
-import classNames from 'classnames'
+import FilterSort from '../filter_sort'
 import Grid from '../../../../components/main_layout/public/icons/grid.svg'
 import List from '../../../../components/main_layout/public/icons/list.svg'
-import FilterSort from '../filter_sort'
+import PropTypes from 'prop-types'
 import React from 'react'
+import classNames from 'classnames'
 import { connect } from 'react-redux'
+import { toggleListView } from '../../client/actions'
 
-function displayButtonClass(buttonType, displayType) {
+function displayButtonClass (buttonType, displayType) {
   return classNames(
     `auction-artworks-header__${buttonType}`,
     { active: displayType === buttonType }
   )
 }
 
-function Header(props) {
+function Header (props) {
   const {
+    isFetchingArtworks,
     isListView,
     toggleListViewAction,
     total
   } = props
+
   const displayType = isListView ? 'list' : 'grid'
-  const totalLabel = (total && total > 0)
-    ? `${total} Artworks`
-    : 'Loading results.'
+  const totalLabel = isFetchingArtworks
+    ? 'Loading results.'
+    : `${total} Artworks`
 
   return (
     <div className='auction-artworks-header'>
@@ -48,10 +51,18 @@ function Header(props) {
   )
 }
 
+Header.propTypes = {
+  isFetchingArtworks: PropTypes.bool.isRequired,
+  isListView: PropTypes.bool.isRequired,
+  toggleListViewAction: PropTypes.func.isRequired,
+  total: PropTypes.number.isRequired
+}
+
 const mapStateToProps = (state) => {
   return {
+    isFetchingArtworks: state.auctionArtworks.isFetchingArtworks,
     isListView: state.auctionArtworks.isListView,
-    total: state.auctionArtworks.total,
+    total: state.auctionArtworks.total
   }
 }
 

--- a/desktop/apps/auction/components/medium_filter/index.js
+++ b/desktop/apps/auction/components/medium_filter/index.js
@@ -1,19 +1,23 @@
-import { updateMediumParams } from '../../client/actions'
 import BasicCheckbox from '../basic_checkbox'
-import React from 'react';
-import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
+import React from 'react'
 import _, { contains } from 'underscore'
+import { connect } from 'react-redux'
+import { updateMediumParams } from '../../client/actions'
 
-function MediumFilter(props) {
+function MediumFilter (props) {
   const {
     aggregatedMediums,
     filterParams,
     initialMediumMap,
     updateMediumParamsAction
   } = props
+
   const mediumIds = filterParams.gene_ids
   const allMediums = { id: 'mediums-all', name: 'All' }
-  const allMediumsSelected = mediumIds.length == 0
+  const allMediumsSelected = mediumIds.length === 0
+
+  // FIXME: Is this needed somehow?
   const aggregatedMediumIds = aggregatedMediums.map((agg) => agg.id)
 
   return (
@@ -32,7 +36,11 @@ function MediumFilter(props) {
           return (
             <BasicCheckbox
               key={initialAgg.id}
-              item={{id: initialAgg.id, name: initialAgg.name, count: includedMedium && includedMedium.count}}
+              item={{
+                id: initialAgg.id,
+                name: initialAgg.name,
+                count: includedMedium && includedMedium.count
+              }}
               onClick={updateMediumParamsAction}
               checked={mediumSelected}
               disabled={includedMedium === undefined}
@@ -42,6 +50,13 @@ function MediumFilter(props) {
       }
     </div>
   )
+}
+
+MediumFilter.propTypes = {
+  aggregatedMediums: PropTypes.array.isRequired,
+  filterParams: PropTypes.object.isRequired,
+  initialMediumMap: PropTypes.array.isRequired,
+  updateMediumParamsAction: PropTypes.func.isRequired
 }
 
 const mapStateToProps = (state) => {

--- a/desktop/apps/auction/components/range_slider/index.js
+++ b/desktop/apps/auction/components/range_slider/index.js
@@ -1,10 +1,11 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { Range } from 'rc-slider'
+import { connect } from 'react-redux'
 import { formatMoney } from 'accounting'
 import { updateEstimateRange, updateEstimateDisplay } from '../../client/actions'
-import Slider, { Range } from 'rc-slider'
-import React from 'react'
-import { connect } from 'react-redux'
 
-function RangeSlider(props) {
+function RangeSlider (props) {
   const {
     filterParams,
     minEstimateRangeDisplay,
@@ -15,7 +16,7 @@ function RangeSlider(props) {
   } = props
 
   const minEstimate = filterParams.ranges.estimate_range.min
-  const formattedMinDisplay = formatMoney(minEstimateRangeDisplay, { symbol: symbol, precision: 0 })
+  const formattedMinDisplay = formatMoney(minEstimateRangeDisplay, { symbol, precision: 0 })
 
   const maxEstimate = filterParams.ranges.estimate_range.max
   const isAbsoluteMax = maxEstimate === maxEstimateRangeDisplay
@@ -37,9 +38,20 @@ function RangeSlider(props) {
         onChange={([min, max]) => updateEstimateDisplayAction(min, max)}
         onAfterChange={([min, max]) => updateEstimateRangeAction(min, max)}
       />
-      <div className='auction-range-slider__info'>Based on the estimate for the lot</div>
+      <div className='auction-range-slider__info'>
+        Based on the estimate for the lot
+      </div>
     </div>
   )
+}
+
+RangeSlider.propTypes = {
+  filterParams: PropTypes.object.isRequired,
+  minEstimateRangeDisplay: PropTypes.number.isRequired,
+  maxEstimateRangeDisplay: PropTypes.number.isRequired,
+  symbol: PropTypes.string.isRequired,
+  updateEstimateRangeAction: PropTypes.func.isRequired,
+  updateEstimateDisplayAction: PropTypes.func.isRequired
 }
 
 const mapStateToProps = (state) => {

--- a/desktop/apps/auction/components/sidebar/index.js
+++ b/desktop/apps/auction/components/sidebar/index.js
@@ -1,11 +1,11 @@
 import ArtistFilter from '../artist_filter'
-import BasicCheckbox from '../basic_checkbox'
-import { connect } from 'react-redux'
 import MediumFilter from '../medium_filter'
+import PropTypes from 'prop-types'
 import RangeSlider from '../range_slider'
 import React from 'react'
+import { connect } from 'react-redux'
 
-function Sidebar({ isClosed }) {
+function Sidebar ({ isClosed }) {
   return (
     <div className='auction-artworks-sidebar'>
       <div className='auction-artworks-sidebar__artist-filter'>
@@ -15,6 +15,10 @@ function Sidebar({ isClosed }) {
       </div>
     </div>
   )
+}
+
+Sidebar.propTypes = {
+  isClosed: PropTypes.bool.isRequired
 }
 
 const mapStateToProps = (state) => {

--- a/desktop/apps/auction/components/works_by_followed_artists/index.js
+++ b/desktop/apps/auction/components/works_by_followed_artists/index.js
@@ -1,12 +1,17 @@
-import { nextPageOfFollowedArtistArtworks, previousPageOfFollowedArtistArtworks } from '../../client/actions'
-import classNames from 'classnames'
 import AuctionGridArtwork from '../auction_grid_artwork'
 import ChevronLeft from '../../../../components/main_layout/public/icons/chevron-left.svg'
 import ChevronRight from '../../../../components/main_layout/public/icons/chevron-right.svg'
+import PropTypes from 'prop-types'
 import React from 'react'
+import classNames from 'classnames'
 import { connect } from 'react-redux'
 
-function WorksByFollowedArtists(props) {
+import {
+  nextPageOfFollowedArtistArtworks,
+  previousPageOfFollowedArtistArtworks
+} from '../../client/actions'
+
+function WorksByFollowedArtists (props) {
   const {
     followedArtistRailPage,
     followedArtistRailSize,
@@ -40,7 +45,7 @@ function WorksByFollowedArtists(props) {
       </div>
       <div className='auction-works-by-followed-artists__content'>
         <div
-          className={ leftPageClasses }
+          className={leftPageClasses}
           onClick={() => { previousPageOfFollowedArtistArtworksAction() }}
         >
           <ChevronLeft />
@@ -53,7 +58,7 @@ function WorksByFollowedArtists(props) {
           }
         </div>
         <div
-          className={ rightPageClasses }
+          className={rightPageClasses}
           onClick={() => { nextPageOfFollowedArtistArtworksAction() }}
         >
           <ChevronRight />
@@ -61,6 +66,15 @@ function WorksByFollowedArtists(props) {
       </div>
     </div>
   )
+}
+
+WorksByFollowedArtists.propTypes = {
+  followedArtistRailPage: PropTypes.string.isRequired,
+  followedArtistRailSize: PropTypes.number.isRequired,
+  nextPageOfFollowedArtistArtworksAction: PropTypes.func.isRequired,
+  numArtistsYouFollow: PropTypes.number.isRequired,
+  previousPageOfFollowedArtistArtworksAction: PropTypes.func.isRequired,
+  saleArtworksByFollowedArtists: PropTypes.array.isRequired
 }
 
 const mapStateToProps = (state) => {

--- a/desktop/apps/auction/queries/filter.js
+++ b/desktop/apps/auction/queries/filter.js
@@ -48,6 +48,7 @@ export const filterQuery = `
           date
           href
           title
+          is_sold
           images {
             id
             image_url: url(version: ["tall"])

--- a/desktop/apps/auction/queries/works_by_followed_artists.js
+++ b/desktop/apps/auction/queries/works_by_followed_artists.js
@@ -29,6 +29,7 @@ export const worksByFollowedArtists = `
           href
           title
           date
+          is_sold
           images {
             id
             image_url: url(version: ["tall"])

--- a/desktop/apps/auction/test/components.js
+++ b/desktop/apps/auction/test/components.js
@@ -11,7 +11,6 @@ import RangeSlider from '../components/range_slider'
 import Sidebar from '../components/sidebar'
 import { shallow } from 'enzyme'
 import React from 'react'
-import { renderToString } from 'react-dom/server'
 import { Provider } from 'react-redux'
 import { createStore } from 'redux'
 
@@ -83,9 +82,9 @@ describe('React components', () => {
 
   describe('Sidebar', () => {
     beforeEach(() => {
-      Sidebar.__Rewire__('ArtistFilter', React.createClass({ render: () => <div className='artist-filter'></div> }))
-      Sidebar.__Rewire__('MediumFilter', React.createClass({ render: () => <div className='medium-filter'></div> }))
-      Sidebar.__Rewire__('RangeSlider', React.createClass({ render: () => <div className='range-slider'></div> }))
+      Sidebar.__Rewire__('ArtistFilter', () => <div className='artist-filter' />)
+      Sidebar.__Rewire__('MediumFilter', () => <div className='medium-filter' />)
+      Sidebar.__Rewire__('RangeSlider', () => <div className='range-slider' />)
     })
 
     afterEach(() => {

--- a/desktop/components/artwork_metadata_stub/templates/contact.jade
+++ b/desktop/components/artwork_metadata_stub/templates/contact.jade
@@ -1,21 +1,25 @@
 if artwork.sale && artwork.sale.is_auction
-  .artwork-metadata-stub__contact.artwork-metadata-stub__line.artwork-metadata-stub__bid-now
-    - var sa = artwork.sale_artwork
-    if artwork.sale.is_live_open
-      a(href= artwork.href) Enter Live Auction
-    else if artwork.sale.is_open
-      a(href= artwork.href)
-        - var bids = sa.counts.bidder_positions
-        if bids > 0
-          | #{sa.highest_bid.display}&nbsp;
-          = '(' + bids + (bids > 1 ? ' bids' : ' bid') + ')'
-        else
+  if artwork.is_sold
+    .artwork-metadata-stub__contact.artwork-metadata-stub__line
+      | SOLD
+  else 
+    .artwork-metadata-stub__contact.artwork-metadata-stub__line.artwork-metadata-stub__bid-now
+      - var sa = artwork.sale_artwork
+      if artwork.sale.is_live_open
+        a(href= artwork.href) Enter Live Auction
+      else if artwork.sale.is_open
+        a(href= artwork.href)
+          - var bids = sa.counts.bidder_positions
+          if bids > 0
+            | #{sa.highest_bid.display}&nbsp;
+            = '(' + bids + (bids > 1 ? ' bids' : ' bid') + ')'
+          else
+            | #{sa.opening_bid.display}
+      else if artwork.sale.is_preview
+        a(href= artwork.href)
           | #{sa.opening_bid.display}
-    else if artwork.sale.is_preview
-      a(href= artwork.href)
-        | #{sa.opening_bid.display}
-    else if artwork.sale.is_closed
-      | Auction closed
+      else if artwork.sale.is_closed
+        | Auction closed
 else if artwork.is_inquireable
   .artwork-metadata-stub__contact.artwork-metadata-stub__line
     a(

--- a/desktop/components/artwork_metadata_stub/templates/contact.jade
+++ b/desktop/components/artwork_metadata_stub/templates/contact.jade
@@ -1,7 +1,7 @@
 if artwork.sale && artwork.sale.is_auction
   if artwork.is_sold
     .artwork-metadata-stub__contact.artwork-metadata-stub__line
-      | SOLD
+      | Sold
   else 
     .artwork-metadata-stub__contact.artwork-metadata-stub__line.artwork-metadata-stub__bid-now
       - var sa = artwork.sale_artwork

--- a/desktop/components/artwork_metadata_stub/test/index.js
+++ b/desktop/components/artwork_metadata_stub/test/index.js
@@ -3,7 +3,7 @@ import fs from 'fs'
 import jade from 'jade'
 import path from 'path'
 
-function render(locals) {
+function render (locals) {
   const filename = path.resolve(__dirname, '../index.jade')
   return jade.compile(
     fs.readFileSync(filename),
@@ -63,6 +63,14 @@ describe('metadata template', () => {
       $.text().should.containEql('My Artwork, 2007')
       $('.artwork-metadata-stub__bid-now').text().should.containEql('$100')
       $('.artwork-metadata-stub__sale-message').length.should.eql(0)
+    })
+
+    it('renders SOLD if artwork is sold', () => {
+      auctionArtwork.is_sold = true
+      const $ = cheerio.load(render({ artwork: auctionArtwork }))
+      $.text().should.containEql('My Artwork, 2007')
+      $('.artwork-metadata-stub__contact.artwork-metadata-stub__line').text().should.containEql('SOLD')
+      $('.artwork-metadata-stub__bid-now').length.should.eql(0)
     })
 
     describe('auction is open', () => {

--- a/desktop/components/artwork_metadata_stub/test/index.js
+++ b/desktop/components/artwork_metadata_stub/test/index.js
@@ -65,11 +65,11 @@ describe('metadata template', () => {
       $('.artwork-metadata-stub__sale-message').length.should.eql(0)
     })
 
-    it('renders SOLD if artwork is sold', () => {
+    it('renders "Sold" if artwork is sold', () => {
       auctionArtwork.is_sold = true
       const $ = cheerio.load(render({ artwork: auctionArtwork }))
       $.text().should.containEql('My Artwork, 2007')
-      $('.artwork-metadata-stub__contact.artwork-metadata-stub__line').text().should.containEql('SOLD')
+      $('.artwork-metadata-stub__contact.artwork-metadata-stub__line').text().should.containEql('Sold')
       $('.artwork-metadata-stub__bid-now').length.should.eql(0)
     })
 

--- a/mobile/components/artwork_list/template.jade
+++ b/mobile/components/artwork_list/template.jade
@@ -14,7 +14,7 @@ ul.artwork-list
           if artwork.get('price')
             p= artwork.get('price')
           if artwork.get('sold')
-            p SOLD
+            p Sold
       if artwork.has('sale_artwork')
         p!= artwork.related().saleArtwork.mdToHtml('user_notes')
       else


### PR DESCRIPTION
This PR fixes a few places where an artwork that is has been purchased does not show up as "SOLD" in its description. 

Fixes https://github.com/artsy/auctions/issues/404 
Related https://github.com/artsy/auctions/issues/405

**To Test:**
```sh
git checkout -b damassi-bugfix-buy-now-button-transition master
git pull https://github.com/damassi/force.git bugfix-buy-now-button-transition
```

**Additional Fixes:**
- Fixed all linter errors in `apps/auctions`
- Fixed a zero-state error in the slider, where result-sets containing no results would return a "Loading results" label

<img width="404" alt="screen shot 2017-04-27 at 4 41 42 pm" src="https://cloud.githubusercontent.com/assets/236943/25508649/71632304-2b68-11e7-99a1-fa872ea0160d.png">

- http://localhost:5000/auction/chris-buy-now-bug (look for francine-tint-untitled - third over)
---
![screen shot 2017-04-27 at 5 34 25 pm](https://cloud.githubusercontent.com/assets/236943/25509728/f6ca1e38-2b6f-11e7-9ccc-3cb361d34deb.png)

- http://localhost:5000/artwork/francine-tint-untitled (right-hand column)
---
![screen shot 2017-04-27 at 5 32 54 pm](https://cloud.githubusercontent.com/assets/236943/25509738/00f690f8-2b70-11e7-85e5-6ac390450d9c.png)

- http://localhost:5000/artwork/linda-carrara-ennui (search "francine" in artworks)
---
![screen shot 2017-04-27 at 5 32 21 pm](https://cloud.githubusercontent.com/assets/236943/25509739/06349bc8-2b70-11e7-88e8-e93557c99541.png)

