### PR TITLE
@sweir27: Removed artsy error handler

### DIFF
--- a/lib/middleware/backbone_error_helper.coffee
+++ b/lib/middleware/backbone_error_helper.coffee
@@ -1,0 +1,17 @@
+module.exports = (req, res, next) ->
+  res.backboneError = (model, err) ->
+    try
+      message = JSON.parse(err.text).error
+    catch e
+      message = err?.text or err?.response?.text or err?.stack or err?.message
+      message ?= try JSON.stringify(err) catch e; 'Unknown Error'
+    if err?.status in [404, 403, 401]
+      status = 404
+      message = 'Not Found'
+    else
+      status = err?.status or 500
+    err = new Error
+    err.message = message
+    err.status = status
+    next err
+  next()

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -4,7 +4,6 @@
 // populating sharify data
 //
 import _ from 'underscore'
-import artsyError from 'artsy-error-handler'
 import artsyPassport from 'artsy-passport'
 import artsyXapp from 'artsy-xapp'
 import Backbone from 'backbone'
@@ -36,6 +35,7 @@ import proxyGravity from './middleware/proxy_to_gravity'
 import proxyReflection from './middleware/proxy_to_reflection'
 import sameOriginMiddleware from './middleware/same_origin'
 import unsupportedBrowserCheck from './middleware/unsupported_browser'
+import backboneErrorHelper from './middleware/backbone_error_helper'
 import CurrentUser from './current_user'
 import splitTestMiddleware from '../desktop/components/split_test/middleware'
 import config from '../config'
@@ -196,7 +196,7 @@ export default function (app) {
     app.use(RavenServer.errorHandler())
   }
 
-  app.use(artsyError.helpers)
+  app.use(backboneErrorHelper)
   app.use(sameOriginMiddleware)
   app.use(escapedFragmentMiddleware)
   app.use(logger)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "analytics-node": "^2.4.0",
     "artsy-backbone-mixins": "git://github.com/artsy/artsy-backbone-mixins.git",
     "artsy-eigen-web-association": "git://github.com/artsy/artsy-eigen-web-association.git",
-    "artsy-error-handler": "^1.0.2",
     "artsy-ezel-components": "git://github.com/artsy/artsy-ezel-components.git",
     "artsy-morgan": "git://github.com/artsy/artsy-morgan.git",
     "artsy-passport": "^1.7.2",

--- a/test/lib/middleware/backbone_error_helper.coffee
+++ b/test/lib/middleware/backbone_error_helper.coffee
@@ -1,0 +1,45 @@
+rewire = require 'rewire'
+sinon = require 'sinon'
+express = require 'express'
+jade = require 'jade'
+fs = require 'fs'
+backboneErrorHelper = rewire '../../../lib/middleware/backbone_error_helper'
+
+describe 'Backbone error', ->
+
+  beforeEach ->
+    @req = {}
+    @res = { status: sinon.stub() }
+    @next = sinon.stub()
+    backboneErrorHelper @req, @res, @next
+
+  it 'adds a backbone error handler helper', ->
+    @res.backboneError {}, { text: '{"error":"Foo Err"}' }
+    @next.args[1][0].toString().should.containEql 'Foo Err'
+
+  it 'handles generic stringy errors', ->
+    @res.backboneError {}, { text: 'Foo Err' }
+    @next.args[1][0].toString().should.containEql 'Foo Err'
+
+  it 'turns 403 errors into 404s', ->
+    @res.backboneError {}, { status: 403 }
+    @next.args[1][0].toString().should.containEql 'Not Found'
+
+  it 'attaches API status to the errors', ->
+    @res.backboneError {}, { status: 404 }
+    @next.args[1][0].status.should.equal 404
+
+  it 'tries stack if its not an HTTP error', ->
+    @res.backboneError {}, { stack: 'foo' }
+    @next.args[1][0].message.should.equal 'foo'
+    @next.args[1][0].status.should.equal 500
+
+  it 'tries message if its not an HTTP error', ->
+    @res.backboneError {}, { message: 'foo' }
+    @next.args[1][0].message.should.equal 'foo'
+    @next.args[1][0].status.should.equal 500
+
+  it 'will even try stringifying before unknown', ->
+    @res.backboneError {}, { foo: 'bar' }
+    @next.args[1][0].message.should.equal '{"foo":"bar"}'
+    @next.args[1][0].status.should.equal 500

--- a/yarn.lock
+++ b/yarn.lock
@@ -305,14 +305,6 @@ arrify@^1.0.0:
   dependencies:
     express "*"
 
-artsy-error-handler@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/artsy-error-handler/-/artsy-error-handler-1.0.2.tgz#87db9eabb06fa297ffb0d2d97da742c9ff8346d4"
-  dependencies:
-    debug "^2.2.0"
-    jade "^1.11.0"
-    underscore "^1.8.3"
-
 "artsy-ezel-components@git://github.com/artsy/artsy-ezel-components.git":
   version "0.0.6"
   resolved "git://github.com/artsy/artsy-ezel-components.git#61983f3758ecc4a0a057aa9c830e3552abcaa50e"


### PR DESCRIPTION
This removes that [artsy-error-handler](github.com/artsy/artsy-error-handler) module that has caused us so much grief lately by just pulling out the `res.backboneError` helper which we use to support our old-school `model.fetch error: res.backboneError` callback-ways.

I've been wanting to do this anyways, but it is quite confusing why this resulted in some kind of transpiling madness that required uglify to be used.

For those interested this was the stack trace that pointed me here via `at Object.<anonymous> (/Users/craigspaeth/force/lib/setup.js:7:1)`

```
Error: Cannot find module 'uglify-js'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/craigspaeth/force/node_modules/jade/lib/filters.js:5:14)
    at Module._compile (module.js:570:32)
    at Module._extensions..js (module.js:579:10)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/craigspaeth/force/node_modules/babel-register/lib/node.js:152:7)
    at Module.load (/Users/craigspaeth/force/node_modules/coffee-script/lib/coffee-script/register.js:45:36)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/craigspaeth/force/node_modules/jade/lib/parser.js:6:15)
    at Module._compile (module.js:570:32)
    at Module._extensions..js (module.js:579:10)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/craigspaeth/force/node_modules/babel-register/lib/node.js:152:7)
    at Module.load (/Users/craigspaeth/force/node_modules/coffee-script/lib/coffee-script/register.js:45:36)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/craigspaeth/force/node_modules/jade/lib/index.js:13:14)
    at Module._compile (module.js:570:32)
    at Module._extensions..js (module.js:579:10)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/craigspaeth/force/node_modules/babel-register/lib/node.js:152:7)
    at Module.load (/Users/craigspaeth/force/node_modules/coffee-script/lib/coffee-script/register.js:45:36)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/craigspaeth/force/node_modules/artsy-error-handler/routes.coffee:8:10)
    at Object.<anonymous> (/Users/craigspaeth/force/node_modules/artsy-error-handler/routes.coffee:120:4)
    at Module._compile (module.js:570:32)
    at Object.loadFile (/Users/craigspaeth/force/node_modules/coffee-script/lib/coffee-script/register.js:16:19)
    at Module.load (/Users/craigspaeth/force/node_modules/coffee-script/lib/coffee-script/register.js:45:36)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/craigspaeth/force/node_modules/artsy-error-handler/index.coffee:4:12)
    at Object.<anonymous> (/Users/craigspaeth/force/node_modules/artsy-error-handler/index.coffee:18:4)
    at Module._compile (module.js:570:32)
    at Object.loadFile (/Users/craigspaeth/force/node_modules/coffee-script/lib/coffee-script/register.js:16:19)
    at Module.load (/Users/craigspaeth/force/node_modules/coffee-script/lib/coffee-script/register.js:45:36)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/craigspaeth/force/lib/setup.js:7:1)
    at Module._compile (module.js:570:32)
    at loader (/Users/craigspaeth/force/node_modules/babel-register/lib/node.js:144:5)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/craigspaeth/force/node_modules/babel-register/lib/node.js:154:7)
    at Module.load (/Users/craigspaeth/force/node_modules/coffee-script/lib/coffee-script/register.js:45:36)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/craigspaeth/force/index.js:7:37)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
```