### PR TITLE
@eessex => [Venice] Scrubber time, error messaging, and other minor qa

### DIFF
--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -16,7 +16,7 @@ module.exports = class VeniceView extends Backbone.View
   events:
     'click .venice-overlay__play': 'fadeOutCoverAndStartVideo'
     'click .venice-overlay__cta-button': 'showCta'
-    'click .venice-body__help a, .venice-guide__modal-bg, a.icon-close': 'toggleVideoGuide'
+    'click .venice-body__help a, .venice-guide__modal-bg, .venice-guide__body a.icon-close': 'toggleVideoGuide'
     'click .venice-overlay__subscribe-form button': 'onSubscribe'
     'click .venice-overlay--completed__buttons .next': 'onNextVideo'
     'click .venice-info-icon, .venice-overlay--completed__buttons .read-more': 'onReadMore'

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -44,18 +44,25 @@ module.exports = class VeniceView extends Backbone.View
       initialIndex: sd.VIDEO_INDEX
     , (carousel) =>
       @flickity = carousel.cells.flickity
+      # Use 'settle' for changes that should have a delay ie: video swapping
       @flickity.on 'settle', =>
-        @changeSection @flickity.selectedIndex
+        @settleSection @flickity.selectedIndex
+      # Use 'select' for changes that should happen immediately ie: loading
+      @flickity.on 'select', =>
+        @selectSection @flickity.selectedIndex
 
-  changeSection: (i) ->
+  settleSection: (i) ->
     @section = @curation.get('sections')[i]
     @sectionIndex = i
-    # Push route
-    window.history.replaceState {}, i, '/venice-biennale/' + @section.slug
-    # Swap video if it is published
     @swapVideo() if @section.published
     @swapDescription()
     @setupFollowButtons()
+
+  selectSection: (i) ->
+    @section = @curation.get('sections')[i]
+    @sectionIndex = i
+    $('.venice-overlay__play').attr 'data-state', 'loading'
+    window.history.replaceState {}, i, '/venice-biennale/' + @section.slug
 
   onNextVideo: ->
     @flickity.next true
@@ -80,7 +87,6 @@ module.exports = class VeniceView extends Backbone.View
     $(vid).css({'opacity': 1, 'z-index': 100})
 
   swapVideo: ->
-    $('.venice-overlay__play').attr 'data-state', 'loading'
     @VeniceVideoView.trigger 'swapVideo',
       video: @chooseVideoFile()
 

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -36,6 +36,7 @@ module.exports = class VeniceView extends Backbone.View
     @listenTo @VeniceVideoView, 'videoCompleted', @onVideoCompleted
     @listenTo @VeniceVideoView, 'closeVideo', @fadeInCoverAndPauseVideo
     @listenTo @VeniceVideoView, 'videoReady', @onVideoReady
+    @listenTo @VeniceVideoView, 'videoError', @onVideoError
 
   setupCarousel: ->
     initCarousel $('.venice-carousel'),
@@ -80,6 +81,10 @@ module.exports = class VeniceView extends Backbone.View
 
   onVideoReady: ->
     $('.venice-overlay__play').attr 'data-state', 'ready'
+
+  onVideoError: (msg) ->
+    $('.venice-overlay__play').attr 'data-state', 'error'
+    $('.venice-overlay__error').text msg
 
   onVideoCompleted: ->
     @fadeInCoverAndPauseVideo()

--- a/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
@@ -30,6 +30,7 @@ module.exports = class VeniceVideoView extends Backbone.View
       loop: false
     @vrView.on 'ready', @onVRViewReady
     @vrView.on 'timeupdate', @updateTime
+    @vrView.on 'error', @onVRViewError
 
   updateTime: (e) =>
     return if @scrubbing
@@ -64,6 +65,9 @@ module.exports = class VeniceVideoView extends Backbone.View
       @scrubbing = false
     @trigger 'videoReady'
 
+  onVRViewError: (options) =>
+    @trigger 'videoError', options.message
+
   onTogglePlay: ->
     if @vrView.isPaused
       @vrView.play()
@@ -79,7 +83,7 @@ module.exports = class VeniceVideoView extends Backbone.View
       @vrView.setVolume 0
       @$muteButton.attr 'data-state', 'muted'
 
-  swapVideo: (options) ->
+  swapVideo: (options) =>
     $('.venice-video__scrubber')[0].noUiSlider?.destroy()
     @vrView.iframe.src = @createIframeSrc options.video
 
@@ -107,7 +111,6 @@ module.exports = class VeniceVideoView extends Backbone.View
       analyticsHooks.trigger('video:seconds',{seconds: '10'})
 
   onCloseVideo: ->
-    console.log 'triggered close video'
     @trigger 'closeVideo'
 
   # Currently unused but will implement next

--- a/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
@@ -16,6 +16,7 @@ module.exports = class VeniceVideoView extends Backbone.View
     @video = options.video
     @$playButton = $('#toggleplay')
     @$muteButton = $('#togglemute')
+    @$time = $('.venice-video__time')
     @setupVideo()
     @on 'swapVideo', @swapVideo
     @scrubbing = false
@@ -48,6 +49,7 @@ module.exports = class VeniceVideoView extends Backbone.View
       @trigger 'videoCompleted'
       @trackFull()
     @scrubber.set(e.currentTime)
+    @$time.text @formatTime e.currentTime
 
   onVRViewReady: =>
     @duration = @vrView.getDuration()
@@ -63,6 +65,8 @@ module.exports = class VeniceVideoView extends Backbone.View
     @scrubber.on 'change', (value) =>
       @vrView.setCurrentTime parseFloat(value[0])
       @scrubbing = false
+    $('.noUi-handle').append '<div class="venice-video__time">00:00</div>'
+    @$time = $('.venice-video__time')
     @trigger 'videoReady'
 
   onVRViewError: (options) =>

--- a/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
@@ -107,6 +107,7 @@ module.exports = class VeniceVideoView extends Backbone.View
       analyticsHooks.trigger('video:seconds',{seconds: '10'})
 
   onCloseVideo: ->
+    console.log 'triggered close video'
     @trigger 'closeVideo'
 
   # Currently unused but will implement next

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/body.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/body.styl
@@ -65,7 +65,7 @@
       margin-left -15px
     &:first-child
       border-top 1px solid
-    .chapter, .title
+    .title
       margin-right 10px
   &__item-description
     margin-bottom 40px

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/carousel.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/carousel.styl
@@ -199,6 +199,15 @@ nav-height = 54px
       border-style solid
       border-width 5px 0 5px 10px
       border-color transparent transparent transparent white
+.venice-overlay__play[data-state="error"]
+  .venice-overlay__play
+    &-text
+      &:after
+        content 'Error'
+.venice-overlay__error
+  white-space normal
+  margin 30px
+  text-align center
 
 // Mobile
 @media screen and (max-width: 800px)

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
@@ -16,6 +16,9 @@
     width 50px
     height 50px
 
+.venice-video__time
+  margin 15px 0 0 -12px
+
 #controls
   position absolute
   width calc(100vw \- 50px)

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
@@ -2,10 +2,8 @@
   position absolute
   top 0
   left 0
-  margin 30px
+  padding 30px
   cursor pointer
-  width 32px
-  height 32px
   &:hover
     color gray-lighter-color
 
@@ -111,7 +109,7 @@
 // Mobile
 @media screen and (max-width: 550px)
   .venice-video__close
-    margin 15px
+    padding 15px
 
   #controls
     padding 15px

--- a/desktop/apps/editorial_features/components/venice_2017/templates/carousel.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/carousel.jade
@@ -11,6 +11,7 @@
                 .venice-overlay__play-button
                 .venice-overlay__play-text
                 .venice-overlay__play-length= section.video_length
+              .venice-overlay__error
             else
               .venice-overlay__subscribe
                 .venice-overlay__launch-date='Launching ' + moment(section.release_date, moment.ISO_8601).format('MMM Do')

--- a/desktop/apps/editorial_features/components/venice_2017/templates/head.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/head.jade
@@ -1,5 +1,7 @@
-title Venice Biennale 2017
+title Venice Biennale 2017 - Artsy
 link( rel="canonical", href=(sd.APP_URL + '/venice-biennale') )
+meta(name="description" content="Explore the 2017 Venice Biennale with a series of immersive 360° films featuring artists Christian Marclay, Carol Bove, Erwin Wurm, and more.")
+meta(name="keywords" content="Venice Biennale, 2017 Venice Biennale")
 meta( name='viewport', content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no' )
 meta(name="apple-mobile-web-app-capable" content="yes")
 script(src="#{sd.APP_URL}/vanity/vrview/build/vrview.min.js")

--- a/desktop/apps/editorial_features/components/venice_2017/templates/mixins.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/mixins.jade
@@ -2,7 +2,6 @@ mixin index_item(section, i)
   .venice-body__index-item
     a(href='#{sd.APP_URL}/venice-biennale/#{section.slug}' class=section.published? 'published':'')
       include ../icons/icon_play.svg
-      span.chapter= '0' + (i + 1) + '. '
       span.title=section.title
       if !section.published && section.release_date
         span='(' + moment(section.release_date).format('MMMM Do') + ')'
@@ -11,7 +10,7 @@ mixin help
   .venice-body__help
     p Having trouble viewing?
     p
-      a(href='#') Read our 360 video guide
+      a(href='#') Read our 360° video guide
 
 mixin follow(section)
   .venice-body__follow

--- a/desktop/apps/editorial_features/components/venice_2017/templates/video.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/video.jade
@@ -1,7 +1,6 @@
 .venice-video
   #vrvideo
-  .venice-video__close
-    i.icon-close
+  i.venice-video__close.icon-close
   #controls
     #togglemute(data-state='unmuted')
       .muted

--- a/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
@@ -169,3 +169,8 @@ describe 'Venice Main', ->
     $('.venice-overlay__subscribe-form input').val('email@email.com')
     $('.venice-overlay__subscribe-form button').click()
     $('.venice-overlay__cta-button').css('opacity').should.not.eql '0'
+
+  it 'displays an error if there is one', ->
+    @view.onVideoError 'Sorry, your browser is not supported.'
+    $('.venice-overlay__play').attr('data-state').should.equal 'error'
+    $('.venice-overlay__error').html().should.equal 'Sorry, your browser is not supported.'

--- a/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
@@ -93,12 +93,18 @@ describe 'Venice Main', ->
     @initCarousel.args[0][1].wrapAround.should.be.true()
     @initCarousel.args[0][1].initialIndex.should.equal 0
 
-  it 'changes the section when a new carousel item is selected', ->
+  it 'changes the section when flickity has settled #settleSection', ->
     @on.args[0][1]()
-    @replaceState.args[0][1].should.equal 1
-    @replaceState.args[0][2].should.equal '/venice-biennale/slug-two'
+    @on.args[0][0].should.equal 'settle'
     @view.VeniceVideoView.trigger.args[0][0].should.equal 'swapVideo'
     @view.VeniceVideoView.trigger.args[0][1].video.should.equal 'localhost/vanity/url2.mp4'
+
+  it 'changes the section when flickity item has been selected #selectSection', ->
+    @on.args[1][1]()
+    @on.args[1][0].should.equal 'select'
+    @replaceState.args[0][1].should.equal 1
+    @replaceState.args[0][2].should.equal '/venice-biennale/slug-two'
+    $('.venice-overlay__play').attr('data-state').should.equal 'loading'
 
   it '#fadeOutCoverAndStartVideo does not play if it is not ready', ->
     $('.venice-overlay__play').click()

--- a/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
@@ -64,6 +64,11 @@ describe 'Venice Video', ->
     @scrubberCreate.args[0][1].range.min.should.equal 0
     @scrubberCreate.args[0][1].range.max.should.equal 100
 
+  it 'emits an error if the browser is not supported', ->
+    @view.onVRViewError message: 'Sorry, browser not supported'
+    @view.trigger.args[0][0].should.equal 'videoError'
+    @view.trigger.args[0][1].should.equal 'Sorry, browser not supported'
+
   it 'does not try to update scrubber while dragging', ->
     @view.onVRViewReady()
     @on.args[0][1]()

--- a/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
@@ -141,3 +141,9 @@ describe 'Venice Video', ->
   it 'triggers closeVideo', ->
     $('.venice-video__close').click()
     @view.trigger.args[0][0].should.equal 'closeVideo'
+
+  it 'adds time to the scrubber', ->
+    $('body').append '<div class="noUi-handle"></div>'
+    @view.onVRViewReady()
+    @view.updateTime(currentTime: 26)
+    @view.$time.text().should.equal '00:26'


### PR DESCRIPTION
Covers the following:
![image](https://cloud.githubusercontent.com/assets/2236794/25602025/6d3b2e8a-2ebe-11e7-8274-f7e9970f44d7.png)

Error messaging (@owendodd just did my own thing here so let me know if you'd like to change this): 
![screen shot 2017-05-01 at 9 41 11 pm](https://cloud.githubusercontent.com/assets/2236794/25601976/0792c3ea-2ebe-11e7-9086-1872122bf513.png)
Scrubber time:
![screen shot 2017-05-01 at 10 30 53 pm](https://cloud.githubusercontent.com/assets/2236794/25601978/0b6563e2-2ebe-11e7-804f-8ff7aa4a762d.png)
