### PR TITLE
@kanaabe => [Venice] Responsive video completion  

### DIFF
--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/carousel.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/carousel.styl
@@ -252,6 +252,31 @@ nav-height = 54px
     .mgr-dots
       display none
 
+  .venice-overlay--completed
+    &__buttons
+      flex-direction column
+      align-items center
+      button:first-child
+        margin-bottom 20px
+    .venice-body__item-share
+      justify-content center
+      a:hover
+        background-color black
+        opacity .7
+        i
+          color white
+    .share-item
+      width 50px
+    &__follow
+      width 100%
+      margin-left 0
+      left 0
+    .venice-body__follow
+      max-width 80%
+      margin 0 auto
+      p
+        font-size 18px
+
 @media screen and (max-width: 400px)
   .venice-overlay
     &__title


### PR DESCRIPTION
![screen shot 2017-05-02 at 6 18 09 am](https://cloud.githubusercontent.com/assets/1497424/25616048/913f7a9e-2f08-11e7-857e-4fb0b474a841.png)
