### PR TITLE
@craigspaeth => removes uglifyify

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
     "stickyfill": "^1.1.1",
     "supertest": "^2.0.1",
     "typeahead.js": "^0.10.5",
-    "uglifyify": "^3.0.4",
     "waypoints": "^4.0.0"
   },
   "license": "MIT",

--- a/scripts/assets.sh
+++ b/scripts/assets.sh
@@ -10,7 +10,6 @@ NODE_ENV=production browserify \
   -t babelify \
   -t caching-coffeeify \
   -t jadeify \
-  -t uglifyify \
   -p [ factor-bundle -o 'uglifyjs > public/assets/`basename $FILE .coffee`.js' ] \
   | uglifyjs > public/assets/common.js
 stylus \

--- a/yarn.lock
+++ b/yarn.lock
@@ -3015,10 +3015,6 @@ extend@3, extend@3.0.0, extend@^3.0.0, extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
 
-extend@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-1.3.0.tgz#d1516fb0ff5624d2ebf9123ea1dac5a1994004f8"
-
 external-editor@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-1.1.1.tgz#12d7b0db850f7ff7e7081baf4005700060c4600b"
@@ -7194,7 +7190,7 @@ ua-parser@^0.3.5:
   dependencies:
     yamlparser ">=0.0.2"
 
-uglify-js@2.x.x, uglify-js@^2.8.22:
+uglify-js@^2.8.22:
   version "2.8.22"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.22.tgz#d54934778a8da14903fa29a326fb24c0ab51a1a0"
   dependencies:
@@ -7213,16 +7209,6 @@ uglify-js@~2.2.5:
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
-
-uglifyify@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/uglifyify/-/uglifyify-3.0.4.tgz#487e080a5a7798880e68e90def9b06681fb13bd2"
-  dependencies:
-    convert-source-map "~1.1.0"
-    extend "^1.2.1"
-    minimatch "^3.0.2"
-    through "~2.3.4"
-    uglify-js "2.x.x"
 
 uid-number@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
Testing `yarn assets && NODE_ENV=x yarn start` locally, removing `uglifyify` seems to fix the errors we were seeing on the auction pages and gene pages.