### PR TITLE
Only admins should see the 'inquire via phone' modal for now

### DIFF
--- a/desktop/apps/artwork/components/partner_stub/index.coffee
+++ b/desktop/apps/artwork/components/partner_stub/index.coffee
@@ -14,3 +14,11 @@ module.exports = ($el) ->
           register: 'Create an Artsy account to call gallery'
         userData:
           partner: JSON.parse(e.toElement.dataset.partner)
+  $el
+    .find '.js-artwork-partner-stub-phone-toggle'
+    .click (e) ->
+      e.preventDefault()
+      $(this).hide()
+      $el
+        .find '.js-artwork-partner-stub-phone-toggleable'
+        .show()

--- a/desktop/apps/artwork/components/partner_stub/index.jade
+++ b/desktop/apps/artwork/components/partner_stub/index.jade
@@ -27,10 +27,29 @@ unless artwork.is_in_auction
 
       if artwork.is_inquireable && contacts && contacts.length
         .artwork-partner-stub__phone
-          a(
-            class='js-artwork-partner-stub-inquire-via-phone analytics-artwork-show-phone-number'
-            data-partner_id= partner._id
-            data-artwork_id= artwork._id
-            data-partner= partner
-          )
-            | Inquire via phone
+          if user && user.isAdmin()
+            a(
+              class='js-artwork-partner-stub-inquire-via-phone analytics-artwork-show-phone-number'
+              data-partner_id= partner._id
+              data-artwork_id= artwork._id
+              data-partner= partner
+            )
+              | Inquire via phone
+          else
+            a(
+              class='js-artwork-partner-stub-phone-toggle analytics-artwork-show-phone-number'
+              data-partner_id= partner._id
+              data-artwork_id= artwork._id
+            )
+              | Show phone number#{contacts.length === 1 ? '' : 's'}
+
+            .artwork-partner-stub__phone__locations(
+              class='js-artwork-partner-stub-phone-toggleable'
+              data-length= contacts.length
+            )
+              for location in contacts
+                .artwork-partner-stub__phone__locations__location
+                  if contacts.length > 1
+                    | #{location.city}:
+                    | &nbsp;
+                  = location.phone


### PR DESCRIPTION
This has been deployed to production by accident. This commit makes it impossible even for admins to QA, but right now no analytics is set up and it should be hidden as soon as possible.

/cc @briansw 