### PR TITLE
[mobile] Show 'Sold' instead of bid/auction closed for bought-now artwork

### DIFF
--- a/mobile/apps/artwork/components/bid/index.jade
+++ b/mobile/apps/artwork/components/bid/index.jade
@@ -2,7 +2,7 @@
 if artwork.auction
   .js-artwork-auction-container
     .artwork-auction-bid-module
-      if artwork.auction.is_open
+      if artwork.auction.is_open && !artwork.is_sold
         .artwork-auction-bid-module__current-bid
           include ./templates/bid.jade
 
@@ -20,7 +20,9 @@ if artwork.auction
           a.js-auction-multipage(data-id="auction-faqs") AUCTION FAQ
           a.conditions-of-sale(href='/conditions-of-sale') Conditions of Sale
           a.ask-a-specialist(href="/artwork/#{artwork.id}/ask_specialist") Ask a Specialist
-
+      else if artwork.is_sold
+        .artwork-auction-bid-module__sold
+          | Sold
       else
         .artwork-auction-bid-module__closed
           | Auction Closed

--- a/mobile/apps/artwork/components/bid/index.styl
+++ b/mobile/apps/artwork/components/bid/index.styl
@@ -71,14 +71,15 @@
       background black
       right 5px
 
-.artwork-auction-bid-module__closed
-  padding-bottom 10px
+.artwork-auction-bid-module__closed, .artwork-auction-bid-module__sold
+  garamond-size('l-body')
+  line-height 1em
+  font-weight bold
+  padding: 20px 0 20px 20px
   border-bottom 1px solid gray-lighter-color
   margin-bottom 20px
   margin-left -20px
   margin-right -20px
-  padding-left 20px
-
 
 // Styles for the contact a gallery and ask a specialist page,
 // when clicking "Chat with Artsy Specialist" or "Contact Gallery".

--- a/mobile/apps/artwork/components/bid/test/template.coffee
+++ b/mobile/apps/artwork/components/bid/test/template.coffee
@@ -33,7 +33,39 @@ describe 'Artwork bid templates', ->
   afterEach ->
     delete global.window
 
-  describe 'artwork in open auction', ->
+  describe 'sold artwork in open auction', ->
+
+    beforeEach ->
+      @artwork.auction.is_open = true
+      @artwork.is_sold = true
+
+      @html = render('index')(
+        artwork: @artwork
+        sd: {}
+        asset: (->)
+      )
+
+      @$ = cheerio.load(@html)
+
+    it 'displays sold', ->
+      @$('.artwork-auction-bid-module__sold').text().should.equal 'Sold'
+
+    it 'does not display a bid button', ->
+      @$('.auction-avant-garde-black-button').should.not.exist
+
+    it 'does not show bidding info', ->
+      @artwork.auction.sale_artwork.counts.bidder_positions = 1
+      @html = render('index')(
+        artwork: @artwork
+        me: @me
+        sd: {}
+        asset: (->)
+        _: _
+      )
+      @$ = cheerio.load(@html)
+      @$('.artwork-auction-bid-module__bid-status-count').should.not.exist
+
+  describe 'artwork in open auction that is not sold', ->
 
     beforeEach ->
       @artwork.auction.is_open = true
@@ -232,6 +264,22 @@ describe 'Artwork bid templates', ->
 
     it 'displays auction closed', ->
       @$('.artwork-auction-bid-module__closed').text().should.equal 'Auction Closed'
+
+    describe 'sold artwork in open auction', ->
+      beforeEach ->
+        @artwork.is_sold = true
+
+        @html = render('index')(
+          artwork: @artwork
+          sd: {}
+          asset: (->)
+        )
+
+        @$ = cheerio.load(@html)
+
+      it 'displays sold', ->
+        @$('.artwork-auction-bid-module__sold').text().should.equal 'Sold'
+        
 
   describe 'artwork in auction with zero bids', ->
     beforeEach ->


### PR DESCRIPTION
cc @joeyAghion @katarinabatina @damassi 
This fixes an issue we found earlier today where an artwork at auction that has been purchased through Buy Now still shows the Bid button rather than 'Sold.'

I talked through design with Katarina and @briansw. This message now shows in the same place and with the same [updated] styling as the 'Auction Closed' message, but it takes precedence if the artwork `is_sold`. The bid button section will not render unless the auction is open and the artwork is not sold.

![image](https://cloud.githubusercontent.com/assets/9088720/25641416/f932bc7a-2f61-11e7-82b0-ee767a84fe24.png)
