### PR TITLE
Mobile Sold artwork - adjust padding for better centering

### DIFF
--- a/mobile/apps/artwork/components/bid/index.styl
+++ b/mobile/apps/artwork/components/bid/index.styl
@@ -75,7 +75,7 @@
   garamond-size('l-body')
   line-height 1em
   font-weight bold
-  padding: 20px 0 20px 20px
+  padding: 14px 0 20px 20px
   border-bottom 1px solid gray-lighter-color
   margin-bottom 20px
   margin-left -20px


### PR DESCRIPTION
This pr adjusts the padding in the Bidding Closed/Sold message for better vertical centering. Requested by @briansw.

![image](https://cloud.githubusercontent.com/assets/9088720/25663765/8ec789da-2fe6-11e7-84d3-850754ea1996.png)
