### PR TITLE
Tweak inquire via phone modal

### DIFF
--- a/desktop/apps/artwork/components/partner_stub/index.coffee
+++ b/desktop/apps/artwork/components/partner_stub/index.coffee
@@ -7,7 +7,6 @@ module.exports = ($el) ->
       e.preventDefault()
       @modal = new InquireViaPhoneModalView
         width: '500px'
-        title: 'Call gallery'
         copy:
           login: 'Log in to Artsy to call gallery'
           signup: 'Create an Artsy account to call gallery'

--- a/desktop/apps/artwork/components/partner_stub/index.jade
+++ b/desktop/apps/artwork/components/partner_stub/index.jade
@@ -29,7 +29,7 @@ unless artwork.is_in_auction
         .artwork-partner-stub__phone
           if sd.QUERY.inquire_via_phone
             a(
-              class='js-artwork-partner-stub-inquire-via-phone analytics-artwork-show-phone-number'
+              class='js-artwork-partner-stub-inquire-via-phone analytics-artwork-show-phone-number garamond-s-body'
               data-partner_id= partner._id
               data-artwork_id= artwork._id
               data-partner= partner

--- a/desktop/apps/artwork/components/partner_stub/index.styl
+++ b/desktop/apps/artwork/components/partner_stub/index.styl
@@ -34,3 +34,8 @@
 
       &__location
         margin distance(gutter / 2) 0
+
+  &__inquire-via-phone
+    &__modal
+      padding-top 40px
+      vertical-align inherit

--- a/desktop/apps/artwork/components/partner_stub/templates/phone_number.jade
+++ b/desktop/apps/artwork/components/partner_stub/templates/phone_number.jade
@@ -1,9 +1,10 @@
-p.avant-garde-l-headline.auth-modal__title= title
+p.avant-garde-body.auth-modal__title Call Gallery
 
 #auth-page.vam-outer
-  .vam-inner
+  .vam-inner.garamond-l-body.artwork-partner-stub__inquire-via-phone__modal
     header#auth-header
-      aside= partner.name
+      aside
+        b= partner.name
 
     section#auth-body
       for location in partner.locations
@@ -11,7 +12,5 @@ p.avant-garde-l-headline.auth-modal__title= title
           p
             = location.city
             if location.state
-              | ,
-              = location.state
+              = ", " + location.state
           p= location.phone
-

--- a/desktop/components/auth_modal/index.styl
+++ b/desktop/components/auth_modal/index.styl
@@ -3,10 +3,6 @@
     padding 20px
     text-align center
 
-.modal-body
-  .auth-modal__title
-    margin-top 8px
-
 #auth-page
   height 520px
   overflow-y auto

--- a/desktop/components/auth_modal/templates/login.jade
+++ b/desktop/components/auth_modal/templates/login.jade
@@ -1,11 +1,6 @@
-if title
-  p.avant-garde-l-headline.auth-modal__title= title
-
 #auth-page.vam-outer
   .vam-inner
-    header#auth-header
-      unless title
-        #auth-header-logo.icon-logotype
+    include ./_header
       aside= copy.get('login') || 'Log in to Artsy'
 
     section#auth-body

--- a/desktop/components/auth_modal/templates/register.jade
+++ b/desktop/components/auth_modal/templates/register.jade
@@ -1,11 +1,6 @@
-if title
-  p.avant-garde-l-headline.auth-modal__title= title
-
 #auth-page.vam-outer
   .vam-inner
-    header#auth-header
-      unless title
-        #auth-header-logo.icon-logotype
+    include ./_header
       aside
         = copy.get('register') || 'Enter your name, email and password to join'
 

--- a/desktop/components/auth_modal/templates/signup.jade
+++ b/desktop/components/auth_modal/templates/signup.jade
@@ -1,11 +1,6 @@
-if title
-  p.avant-garde-l-headline.auth-modal__title= title
-
 #auth-page.vam-outer
   .vam-inner
-    header#auth-header
-      unless title
-        #auth-header-logo.icon-logotype
+    include ./_header
       aside
         if copy.has('signup')
           = copy.get('signup')

--- a/desktop/components/auth_modal/test/view.coffee
+++ b/desktop/components/auth_modal/test/view.coffee
@@ -90,10 +90,6 @@ describe 'AuthModalView', ->
       @view.preInitialize userData: email: 'foo@bar.com'
       @view.templateData.email.should.containEql 'foo@bar.com'
 
-    it 'can render custom title for the default individual mode', ->
-      @view.preInitialize title: 'Call gallery'
-      @view.templateData.title.should.equal 'Call gallery'
-
   describe '#submit', ->
     beforeEach ->
       sinon.stub location, 'assign'

--- a/desktop/components/auth_modal/view.coffee
+++ b/desktop/components/auth_modal/view.coffee
@@ -45,7 +45,6 @@ module.exports = class AuthModalView extends ModalView
     @state = new State mode
 
     @templateData = _.extend {
-      title: options.title
       copy: @renderCopy(options.copy)
       redirectTo: switch @state.get 'mode'
         when 'login' then @redirectTo or location.pathname


### PR DESCRIPTION
This fixes most of the QA items in https://github.com/artsy/collector-experience/issues/229#issuecomment-298762022

  * Just show the normal signup modal with “Create an Artsy account to call gallery” as the header
  * Inquire via phone needs to be garamond-s-body
  * CALL GALLERY header should be AVANT-GARDE-BODY
  * Gallery name should be bold and garamond-l-body
  * Phone and location information should be garamond-l-body
  * Missing space after comma between city and state
  * Don't vertically center the content inside the modal
