### PR TITLE
@craigspaeth - Filters out problematic URLs for FollowedArtistsRailView

### DIFF
--- a/desktop/apps/home/client/setup_home_page_modules.coffee
+++ b/desktop/apps/home/client/setup_home_page_modules.coffee
@@ -74,6 +74,7 @@ module.exports = ->
       if module.key is 'active_bids'
         $el.find('.abrv-header h1').html(module.title)
         return setupActiveBidsView(module, $el.find('.abrv-content'), user)
+      
       return setupFollowedArtistsView(module, $el, user) if module.key is 'followed_artists'
 
       options =

--- a/desktop/apps/home/components/followed_artists/test/view.coffee
+++ b/desktop/apps/home/components/followed_artists/test/view.coffee
@@ -1,0 +1,46 @@
+_ = require 'underscore'
+benv = require 'benv'
+sinon = require 'sinon'
+Backbone = require 'backbone'
+{ resolve } = require 'path'
+{ fabricate } = require 'antigravity'
+Q = require 'bluebird-q'
+Items = require '../../../../../collections/items.coffee'
+FollowedArtistsRailView = benv.requireWithJadeify require.resolve('../view.coffee'), ['template']
+
+describe 'FollowedArtistsRailView', ->
+  before (done) ->
+
+    benv.setup ->
+      benv.expose $: benv.require('jquery'), jQuery: benv.require('jquery')
+      Backbone.$ = $
+      done()
+
+    sinon.stub Backbone, 'sync'
+      .onCall(0)
+      .returns Q.resolve fabricate 'artist', id: 'charles-broskoski'
+      .onCall(1)
+      .returns Q.resolve fabricate 'artist', id: 'damon-zucconi'
+    
+    @featuredArtists = new Items [
+      fabricate 'featured_link' # href: /cat/bitty
+      fabricate 'featured_link', href: 'https://www.artsy.net/artist/damon-zucconi'
+      fabricate 'featured_link', href: 'https://www.artsy.net/artwork/damon-zucconi'
+      fabricate 'featured_link', href: 'https://www.artsy.net/artist/charles-broskoski?fake=true'
+    ]
+
+  after ->
+    benv.teardown()
+    Backbone.sync.restore()
+
+  beforeEach ->
+    @view = new FollowedArtistsRailView
+      el: $('body')
+    
+  describe '#_parseAndFetchArtists', ->
+    it 'filters out weird urls', ->
+      @view._parseAndFetchArtists(@featuredArtists)
+        .then (artists) -> 
+          artists.length.should.equal 2
+          artists[0].id.should.equal 'charles-broskoski'
+          artists[1].id.should.equal 'damon-zucconi'

--- a/desktop/apps/home/components/followed_artists/view.coffee
+++ b/desktop/apps/home/components/followed_artists/view.coffee
@@ -78,7 +78,6 @@ module.exports = class FollowedArtistsRailView extends Backbone.View
   _renderEmptyView: ->
     # pre-populate search with featured artists or use initial artists
     if @useInitialArtists
-      console.log('useInitialArtists')
       initialArtists = new Artists []
       @subViews.push sav = new SearchArtistsView
         el: @$('.arbv-follow-search-container')
@@ -107,8 +106,6 @@ module.exports = class FollowedArtistsRailView extends Backbone.View
         @subViews.push fav = new FollowedArtistsView
           el: @$('.arbv-context--followed-artists')
           collection: followedArtists
-      .catch (err) ->
-        console.warn('Error rendering Followed Artist Rail', err.stack)
 
   _parseAndFetchArtists: (featuredArtists) =>
     # get the artist from the ids of the featured links :|


### PR DESCRIPTION
Regarding https://github.com/artsy/force/issues/1303

This broke when your favorite model (`FeaturedLink`) got a malformed URL. This filters bad urls out and adds a spec.
