### PR TITLE
@craigspaeth => Revert "Remove unneeded login analytics tracks"

### DIFF
--- a/desktop/analytics/account_creation.js
+++ b/desktop/analytics/account_creation.js
@@ -89,6 +89,10 @@ if (Cookies.get('analytics-signup')) {
   }
 }
 
+analyticsHooks.on('auth:login', function (options) {
+  analytics.track('Successfully logged in')
+})
+
 // Triggered sign up form via save button
 if (!sd.CURRENT_USER) {
   $('.artwork-item-image-container .overlay-button-save').click(function () {

--- a/mobile/analytics/auth.js
+++ b/mobile/analytics/auth.js
@@ -38,4 +38,9 @@ if (Cookies.get('analytics-signup')) {
       user_id: sd.CURRENT_USER.id
     })
   }
-};
+}
+
+// Successfully logged in
+analyticsHooks.on('auth:login', function(options) {
+  analytics.track('Successfully logged in');
+});

--- a/mobile/apps/auth/client/login.coffee
+++ b/mobile/apps/auth/client/login.coffee
@@ -47,6 +47,7 @@ module.exports.LoginView = class LoginView extends Backbone.View
       type: 'POST'
       data: serialized
       success: =>
+        analyticsHooks.trigger 'auth:login'
         @undelegateEvents()
         @$form.submit()
       error: (xhr) =>


### PR DESCRIPTION
These were in fact... needed.  😢 

Our `window.analytics`-wrapping analytics.js client-side code makes different calls/payloads than the server-side node Segment analytics lib we use. This makes sense since there's different information available, different contexts, etc.

So we need these client-side too.