### PR TITLE
@craigspaeth => Bump reaction-force and only display error stack if not production

### DIFF
--- a/desktop/apps/articles/routes.coffee
+++ b/desktop/apps/articles/routes.coffee
@@ -35,7 +35,7 @@ query = require './queries/editorial_articles.coffee'
           articles: articles
           crop: crop
 
-    .catch (err) -> next(err if NODE_ENV is 'development')
+    .catch next
 
 setupEmailSubscriptions = (user, cb) ->
   return cb({ editorial: false }) unless user?.email

--- a/desktop/apps/artist/routes.coffee
+++ b/desktop/apps/artist/routes.coffee
@@ -53,7 +53,7 @@ sd = require('sharify').data
       else
         res.redirect artist.href
 
-    .catch (err) -> next(err if NODE_ENV is 'development')
+    .catch next
 
 @tab = (req, res, next) =>
   req.params.tab = res.locals.sd.CURRENT_PATH.split('/').pop()
@@ -90,6 +90,6 @@ sd = require('sharify').data
                   name: user.name
                   href: "/artist/#{req.params.id}?#{qs.stringify req.query}"
                   artist: artist
-              .catch (err) -> next(err if NODE_ENV is 'development')
+              .catch (err) -> next
   else
     res.redirect "/artist/#{req.params.id}"

--- a/desktop/apps/fairs/routes.coffee
+++ b/desktop/apps/fairs/routes.coffee
@@ -18,5 +18,4 @@ query = require './query.coffee'
       upcomingFairs: upcomingFairs
       pastFairs: pastFairs
       ViewHelpers: ViewHelpers
-  .catch (err) ->
-    next(err if NODE_ENV is 'development')
+  .catch next

--- a/desktop/apps/show/routes.coffee
+++ b/desktop/apps/show/routes.coffee
@@ -146,5 +146,4 @@ query = """
       res.locals.jsonLD = JSON.stringify ViewHelpers.toJSONLD data.partner_show
       data.artworkColumns = ViewHelpers.groupByColumnsInOrder(data.partner_show.artworks)
       res.render 'index', data
-    .catch (err) ->
-      next(err if NODE_ENV is 'development')
+    .catch next

--- a/desktop/components/error_handler/index.jade
+++ b/desktop/components/error_handler/index.jade
@@ -20,9 +20,9 @@ html
             | Internal Error
 
         .error-handler-inner
-          if detail && code !== 404
+          if (detail || message) && code !== 404
             pre.error-handler-trace
-              = detail
+              = detail || message
           p
             | Please contact
             = ' '

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -233,8 +233,10 @@ export default function (app) {
     '../desktop/components/error_handler/index.jade'
   )
   app.use((err, req, res, next) => {
+    const isProduction = NODE_ENV === "production"
     const code = req.timedout ? 504 : (err.status || 500)
-    const message = err.message || err.text || err.toString()
-    res.status(code).render(file, { message, detail: err.stack, code })
+    const message = !isProduction ? err.message || err.text || err.toString() : ""
+    const detail = !isProduction ? err.stack && !isProduction : ""
+    res.status(code).render(file, { message, detail, code })
   })
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "sh scripts/test.sh"
   },
   "dependencies": {
-    "@artsy/reaction-force": "^0.1.34",
+    "@artsy/reaction-force": "^0.1.36",
     "accounting": "^0.4.1",
     "analytics-node": "^2.4.0",
     "artsy-backbone-mixins": "git://github.com/artsy/artsy-backbone-mixins.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@artsy/reaction-force@^0.1.34":
-  version "0.1.34"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.1.34.tgz#7ca4f799cd158423ff1191a3f5f2a51ecadc4c06"
+"@artsy/reaction-force@^0.1.36":
+  version "0.1.36"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.1.36.tgz#ee5bfc46ec91d002f9f8a826b9070cff2ce607d8"
   dependencies:
     artsy-passport "^1.6.1"
     artsy-xapp "^1.0.4"
@@ -26,6 +26,7 @@
     request "^2.81.0"
     sharify "^0.1.6"
     styled-components "^1.4.3"
+    uuid "^3.0.1"
 
 "@segment/loosely-validate-event@^1.1.2":
   version "1.1.2"
@@ -6974,7 +6975,7 @@ supertest@^2.0.1:
     methods "1.x"
     superagent "^2.0.0"
 
-supports-color@3.1.2, supports-color@^3.1.2:
+supports-color@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -6988,7 +6989,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.2.3:
+supports-color@^3.1.2, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:


### PR DESCRIPTION
- Bumps reaction-force

- Updates error handler to suppress output on production (since from reaction-force we do `next(err)`. This means that all lines such as https://github.com/artsy/force/blob/3f95087005fdd3c63e48183c8de96f01099d67fe/desktop/apps/artist/routes.coffee#L56 , should just also be `next(err)`.