### PR TITLE
@erikdstock - Fix viewHelpers reference on artwork page

### DIFF
--- a/desktop/apps/artwork/components/auction/templates/live.jade
+++ b/desktop/apps/artwork/components/auction/templates/live.jade
@@ -1,6 +1,6 @@
 if auction.is_live_open
   .artwork-auction__live-button
     a.avant-garde-button-black.is-block(
-      href=viewHelpers.liveAuctionUrl(auction.id, {isLoggedIn: Boolean(me)})
+      href=helpers.auction.liveAuctionUrl(auction.id, {isLoggedIn: Boolean(me)})
       target='_blank'
     ) Enter Live Auction

--- a/desktop/apps/artwork/components/auction/templates/status.jade
+++ b/desktop/apps/artwork/components/auction/templates/status.jade
@@ -1,4 +1,4 @@
-- var count = viewHelpers.count(sale_artwork);
+- var count = helpers.auction.count(sale_artwork);
 - var is_sold = artwork.is_sold;
 
 .artwork-auction__bid-status

--- a/desktop/apps/artwork/components/auction/view.coffee
+++ b/desktop/apps/artwork/components/auction/view.coffee
@@ -7,7 +7,7 @@ openBuyersPremiumModal = require './components/buyers_premium/index.coffee'
 AuthModalView = require '../../../../components/auth_modal/view.coffee'
 inquire = require '../../lib/inquire.coffee'
 acquire = require '../../lib/acquire.coffee'
-viewHelpers = require './helpers.coffee'
+helpers = require './helpers.coffee'
 metaphysics = require '../../../../../lib/metaphysics.coffee'
 template = -> require('./templates/index.jade') arguments...
 
@@ -99,7 +99,9 @@ module.exports = class ArtworkAuctionView extends Backbone.View
       defer -> form.error message
 
   render: ->
-    @$el.html template extend {}, @data, { viewHelpers: viewHelpers }
+    @$el.html template extend {}, @data, {
+      helpers: auction: helpers
+    }
     this
 
   setMaxBid: (e) ->


### PR DESCRIPTION
So on the Artwork app, helpers get passed in and referenced specifically as `helpers` here: https://github.com/artsy/force/blob/master/desktop/apps/artwork/routes.coffee#L40 (and documented here: https://github.com/artsy/force/tree/master/desktop/apps/artwork#helperscoffee

We can change them to be named something else, but we would then have to change all the references in the various components across the `Artwork` app (and then I'm not sure it would accomplish what you want it to).

Please take a look and let me know if I'm misunderstanding the prior bug that you were aiming to fix!