### PR TITLE
@craigspaeth - Add prundupify to asset build

### DIFF
--- a/desktop/assets/categories.coffee
+++ b/desktop/assets/categories.coffee
@@ -13,7 +13,7 @@ routes =
 
   '''
   /tag
-  ''': require('../apps/tag/client.coffee').init
+  ''': require('../apps/tag/client.js').default.init
 
   '''
   /gene/.*

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "places": "git://github.com/artsy/places.git",
     "popover": "^2.4.0",
     "prop-types": "^15.5.8",
+    "prundupify": "^1.0.0",
     "qs": "^6.3.0",
     "raven": "^1.2.1",
     "raven-js": "^3.14.2",

--- a/scripts/assets.sh
+++ b/scripts/assets.sh
@@ -11,7 +11,7 @@ NODE_ENV=production browserify \
   -t babelify \
   -t caching-coffeeify \
   -t jadeify \
-  -p [ factor-bundle -o 'uglifyjs -b > public/assets/`basename $FILE .coffee`.js' ] \
+  -p [ factor-bundle -o 'uglifyjs > public/assets/`basename $FILE .coffee`.js' ] \
   | uglifyjs > public/assets/common.js
 stylus \
   $(find desktop/assets mobile/assets -name '*.styl') \

--- a/scripts/assets.sh
+++ b/scripts/assets.sh
@@ -7,10 +7,11 @@ mkdir public
 mkdir public/assets
 NODE_ENV=production browserify \
   $(find desktop/assets mobile/assets -name '*.coffee') \
+  -p prundupify \
   -t babelify \
   -t caching-coffeeify \
   -t jadeify \
-  -p [ factor-bundle -o 'uglifyjs > public/assets/`basename $FILE .coffee`.js' ] \
+  -p [ factor-bundle -o 'uglifyjs -b > public/assets/`basename $FILE .coffee`.js' ] \
   | uglifyjs > public/assets/common.js
 stylus \
   $(find desktop/assets mobile/assets -name '*.styl') \

--- a/yarn.lock
+++ b/yarn.lock
@@ -5608,6 +5608,12 @@ proxy-agent@2:
     pac-proxy-agent "1"
     socks-proxy-agent "2"
 
+prundupify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prundupify/-/prundupify-1.0.0.tgz#772874e2a6b355e8f7179313e71f9f0545ec98ee"
+  dependencies:
+    through2 "^2.0.1"
+
 ps-tree@0.0.x:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-0.0.3.tgz#dbf8d752a7fe22fa7d58635689499610e9276ddc"
@@ -6975,7 +6981,7 @@ supertest@^2.0.1:
     methods "1.x"
     superagent "^2.0.0"
 
-supports-color@3.1.2:
+supports-color@3.1.2, supports-color@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -6989,7 +6995,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.2, supports-color@^3.2.3:
+supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
@@ -7110,7 +7116,7 @@ through2@^1.0.0:
     readable-stream ">=1.1.13-1 <1.2.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
-through2@^2.0.0, through2@^2.0.2:
+through2@^2.0.0, through2@^2.0.1, through2@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   dependencies:


### PR DESCRIPTION
Sigh, so after banging my head against this ( https://github.com/artsy/force/issues/1380 ) for two days, I found this issue: https://github.com/substack/factor-bundle/issues/51 . Apparently factor-bundle's de-dupe feature is incompatible with our Browserify. Someone in this thread made a browserify plugin which de-dupe's the required modules ( https://github.com/tellnes/prundupify ). 

I did a cursory comparison, and it doesn't look like file sizes are much different, but you might know whether this is a bad idea or not. It _does_ however fix the issue that I was getting with importing reaction-force client-side in production.