### PR TITLE
@craigspaeth => [Venice] QA + text links

### DIFF
--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -183,7 +183,7 @@ module.exports = class VeniceView extends Backbone.View
     @following.syncFollows(_.pluck @artists, 'id') if sd.CURRENT_USER?
     @$('.venice-body__follow-item').show()
 
-  submitPhoneLink:(e) ->
+  submitPhoneLink: (e) ->
     e.preventDefault()
     @$('.venice-body__text-link button').addClass 'is-loading'
     url = @curation.get('sections')[@sectionIndex].video_url_external
@@ -194,6 +194,7 @@ module.exports = class VeniceView extends Backbone.View
         to: $('.venice-body__text-link input').val()
         message: 'Explore Venice in 360°: ' + url
       error: (xhr) ->
+        console.log xhr.responseJSON.msg
         new FlashMessage message: xhr.responseJSON.msg
       success: ->
         new FlashMessage message: 'Message sent, please check your phone.'

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -111,7 +111,7 @@ module.exports = class VeniceView extends Backbone.View
   onReadMore: ->
     vid = $('.venice-overlay--completed').get(@sectionIndex)
     $(vid).animate({'opacity': 0, 'z-index': -1}, 500)
-    window.scrollTo(0,window.innerHeight)
+    $('html,body').animate({ scrollTop: window.innerHeight }, 400)
 
   swapDescription: ->
     $('.venice-body--article').remove()

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -194,7 +194,6 @@ module.exports = class VeniceView extends Backbone.View
         to: $('.venice-body__text-link input').val()
         message: 'Explore Venice in 360°: ' + url
       error: (xhr) ->
-        console.log xhr.responseJSON.msg
         new FlashMessage message: xhr.responseJSON.msg
       success: ->
         new FlashMessage message: 'Message sent, please check your phone.'

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -22,6 +22,7 @@ module.exports = class VeniceView extends Backbone.View
     'click .venice-overlay__subscribe-form button': 'onSubscribe'
     'click .venice-overlay--completed__buttons .next': 'onNextVideo'
     'click .venice-info-icon, .venice-overlay--completed__buttons .read-more': 'onReadMore'
+    'submit .venice-body__text-link': 'submitPhoneLink'
 
   initialize: ->
     @parser = new UAParser()
@@ -181,3 +182,20 @@ module.exports = class VeniceView extends Backbone.View
         href: sd.APP_URL + sd.CURRENT_PATH
     @following.syncFollows(_.pluck @artists, 'id') if sd.CURRENT_USER?
     @$('.venice-body__follow-item').show()
+
+  submitPhoneLink:(e) ->
+    e.preventDefault()
+    @$('.venice-body__text-link button').addClass 'is-loading'
+    url = @curation.get('sections')[@sectionIndex].video_url_external
+    $.ajax
+      type: 'POST'
+      url: '/venice-biennale/sms'
+      data:
+        to: $('.venice-body__text-link input').val()
+        message: 'Explore Venice in 360°: ' + url
+      error: (xhr) ->
+        new FlashMessage message: xhr.responseJSON.msg
+      success: ->
+        new FlashMessage message: 'Message sent, please check your phone.'
+      complete: ->
+        $('.venice-body__text-link button').removeClass 'is-loading'

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/body.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/body.styl
@@ -118,6 +118,30 @@
     clear both
     display none
 
+  &__text-link
+    display flex
+    margin-top 30px
+    max-width 600px
+    input
+      background-color white
+      color black
+      border none
+      flex 1
+      padding-left 20px
+    .avant-garde-button
+      border 2px solid gray-color
+      padding 12px 20px
+      font-size 11px
+      margin-left 10px
+      color white
+      background-color black
+      &:hover, &:active, &.is-loading
+        color black
+        background-color white
+        border-color white
+      &.is-loading:before
+        background black
+
 @media screen and (max-width: 900px)
   .venice-body
     padding 0 1em

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/guide.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/guide.styl
@@ -34,6 +34,8 @@
     ul
       margin-left 1.25em
       margin-top .5em
+    a
+      color black
   h2
     garamond-size('headline')
     text-align center

--- a/desktop/apps/editorial_features/components/venice_2017/templates/video_description.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/video_description.jade
@@ -10,8 +10,13 @@ if section.published
         p!=markdown(section.description)
       .venice-body__headset-prompt
         p For the most immersive 3D experience, watch in Google Cardboard via the YouTube app.
-        a(href=section.video_url_external).open-youtube
-          button.avant-garde-button Open in YouTube app
+        if sd.IS_MOBILE
+          a(href=section.video_url_external).open-youtube
+            button.avant-garde-button Open in YouTube app
+        else
+          form.venice-body__text-link
+            input.bordered-input( placeholder='Enter phone number...', type='tel', required )
+            button.avant-garde-button Text Me A Link To App
 
     .venice-body__right
       h2 About the Film

--- a/desktop/apps/editorial_features/index.coffee
+++ b/desktop/apps/editorial_features/index.coffee
@@ -11,5 +11,6 @@ app.locals.markdown = markdown
 
 app.get '/2016-year-in-art', routes.eoy
 app.get '/venice-biennale', (_, res) -> res.redirect '/venice-biennale/toward-venice'
+app.post '/venice-biennale/sms', routes.sendSMS
 app.get '/venice-biennale/:slug', routes.venice
 app.get '/vanity/*', routes.vanity

--- a/desktop/apps/editorial_features/routes.coffee
+++ b/desktop/apps/editorial_features/routes.coffee
@@ -44,16 +44,18 @@ proxy = httpProxy.createProxyServer(changeOrigin: true, ignorePath: true)
   @veniceSubArticles = new Articles
   @videoGuide = new Article(id: sd.EF_VIDEO_GUIDE)
   @curation.fetch
+    cache: true
     error: next
     success: (curation) =>
       promises = [
         if req.user then subscribedToEditorial(req.user.get('email')) else Promise.resolve()
         @videoGuide.fetch(
+          cache: true
           headers: 'X-Access-Token': req.user?.get('accessToken') or ''
         )
       ]
       if @curation.get('sub_articles').length
-        promises.push( @veniceSubArticles.fetch(data: 'ids[]': @curation.get('sub_articles')) )
+        promises.push( @veniceSubArticles.fetch(data: 'ids[]': @curation.get('sub_articles'), cache: true) )
       Q.all(promises)
       .then =>
         videoIndex = setVideoIndex(curation, req.params.slug)
@@ -90,7 +92,7 @@ proxy = httpProxy.createProxyServer(changeOrigin: true, ignorePath: true)
     from: TWILIO_NUMBER
     body: message
   , (err, data) ->
-    return res.json err.status or 400, { msg: err.message } if err
+    return res.send err.status or 400, { msg: err.message } if err
     res.send 201, { msg: "success", data: data }
 
 @vanity = (req, res, next) ->

--- a/desktop/apps/editorial_features/routes.coffee
+++ b/desktop/apps/editorial_features/routes.coffee
@@ -2,6 +2,7 @@ Backbone = require 'backbone'
 _ = require 'underscore'
 sd = require('sharify').data
 Q = require 'bluebird-q'
+twilio = require 'twilio'
 markdown = require '../../components/util/markdown.coffee'
 httpProxy = require 'http-proxy'
 Curation = require '../../models/curation.coffee'
@@ -9,7 +10,7 @@ Article = require '../../models/article.coffee'
 Channel = require '../../models/channel.coffee'
 Articles = require '../../collections/articles.coffee'
 { stringifyJSONForWeb } = require '../../components/util/json.coffee'
-{ WHITELISTED_VANITY_ASSETS, VANITY_BUCKET, SAILTHRU_KEY, SAILTHRU_SECRET } = require '../../config.coffee'
+{ WHITELISTED_VANITY_ASSETS, VANITY_BUCKET, SAILTHRU_KEY, SAILTHRU_SECRET, TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_NUMBER } = require '../../config.coffee'
 sailthru = require('sailthru-client').createSailthruClient(SAILTHRU_KEY,SAILTHRU_SECRET)
 proxy = httpProxy.createProxyServer(changeOrigin: true, ignorePath: true)
 
@@ -79,6 +80,18 @@ proxy = httpProxy.createProxyServer(changeOrigin: true, ignorePath: true)
           isSubscribed: @isSubscribed or false
           sub_articles: @veniceSubArticles?.toJSON()
           videoGuide: @videoGuide
+
+@sendSMS = (req, res, next) ->
+  twilioClient = new twilio.RestClient TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN
+  to = req.body.to.replace /[^\d\+]/g, ''
+  message = req.body.message
+  twilioClient.sendSms
+    to: to
+    from: TWILIO_NUMBER
+    body: message
+  , (err, data) ->
+    return res.json err.status or 400, { msg: err.message } if err
+    res.send 201, { msg: "success", data: data }
 
 @vanity = (req, res, next) ->
   whitelistedAssets = WHITELISTED_VANITY_ASSETS

--- a/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
@@ -16,12 +16,12 @@ describe 'Venice Main', ->
         jQuery: benv.require('jquery')
         window:
           history: replaceState: @replaceState = sinon.stub()
-          scrollTo: @scrollTo = sinon.stub()
           innerHeight: 900
         moment: require 'moment'
         markdown: markdown
         crop: crop = sinon.stub().returns 'http://artsy.net/image.jpg'
       Backbone.$ = $
+      @animateSpy = sinon.spy $.fn, 'animate'
       @curation =
         description: 'description'
         sub_articles: [{thumbnail_title:{'Sub 1'}, thumbnail_image: 'http://artsy.net/image.jpg'}, {thumbnail_title:{'Sub 2'}, thumbnail_image: 'http://artsy.net/image2.jpg'}]
@@ -86,6 +86,7 @@ describe 'Venice Main', ->
         done()
 
   afterEach ->
+    @animateSpy.restore()
     benv.teardown()
 
   it 'initializes VeniceVideoView', ->
@@ -163,12 +164,16 @@ describe 'Venice Main', ->
   it '#onReadMore scrolls to the video description and hides completed cover (read-more)', ->
     @view.onVideoCompleted()
     $('.venice-overlay--completed .read-more').click()
-    @scrollTo.args[0][1].should.eql 900
+    @animateSpy.args[1][0].opacity.should.eql 0
+    @animateSpy.args[1][0]['z-index'].should.eql -1
+    @animateSpy.args[2][0].scrollTop.should.eql 900
 
   it '#onReadMore scrolls to the video description and hides completed cover (info icon)', ->
     @view.onVideoCompleted()
     $('.venice-info-icon').click()
-    @scrollTo.args[0][1].should.eql 900
+    @animateSpy.args[1][0].opacity.should.eql 0
+    @animateSpy.args[1][0]['z-index'].should.eql -1
+    @animateSpy.args[2][0].scrollTop.should.eql 900
 
   it '#showCta reveals a signup form', ->
     $('.venice-overlay__cta-button').click()
@@ -194,7 +199,6 @@ describe 'VeniceView isSubscribed', ->
         jQuery: benv.require('jquery')
         window:
           history: replaceState: @replaceState = sinon.stub()
-          scrollTo: @scrollTo = sinon.stub()
           innerHeight: 900
         moment: require 'moment'
         markdown: markdown

--- a/desktop/apps/editorial_features/test/routes.coffee
+++ b/desktop/apps/editorial_features/test/routes.coffee
@@ -45,7 +45,7 @@ describe 'EOY route', ->
       @res.render.args[0][1].superSubArticles.length.should.equal 2
       done()
 
-xdescribe 'Venice route', ->
+describe 'Venice route', ->
 
   beforeEach ->
     sinon.stub Backbone, 'sync'
@@ -67,30 +67,30 @@ xdescribe 'Venice route', ->
   it 'sets a video index', ->
     @req = { params: { slug: 'venice-2' } }
     routes.venice(@req, @res, @next)
-    _.defer => _.defer =>
+    _.defer => _.defer => _.defer =>
       @res.render.args[0][0].should.equal 'components/venice_2017/templates/index'
       @res.render.args[0][1].videoIndex.should.equal 1
 
-  it 'defaults to the first video', ->
+  xit 'defaults to the first video', ->
     @req = { params: { slug: 'blah' } }
     routes.venice(@req, @res, @next)
     _.defer => _.defer =>
       @res.redirect.args[0].should.eql [ 301, '/venice-biennale/toward-venice' ]
 
-  it 'sets a curation', ->
+  xit 'sets a curation', ->
     @req = { params: { slug: 'venice' } }
     routes.venice(@req, @res, @next)
     _.defer => _.defer =>
       @res.render.args[0][0].should.equal 'components/venice_2017/templates/index'
       @res.render.args[0][1].curation.get('name').should.eql 'Inside the Biennale'
 
-  it 'sets the 360 video guide', ->
+  xit 'sets the 360 video guide', ->
     @req = { params: { slug: 'venice' } }
     routes.venice(@req, @res, @next)
     _.defer => _.defer =>
       @res.render.args[0][1].videoGuide.get('title').should.eql 'Video Guide'
 
-  it 'Fetches sub articles', ->
+  xit 'Fetches sub articles', ->
     @req = { params: { slug: 'venice' } }
     routes.venice(@req, @res, @next)
     _.defer => _.defer => _.defer =>
@@ -126,3 +126,30 @@ describe 'Vanity route', ->
     @web.args[0][3]('Error')
     @res.redirect.args[0][0].should.equal 301
     @res.redirect.args[0][1].should.equal '/articles'
+
+describe 'SMS route', ->
+  twilioConstructorArgs = null
+  twilioSendSmsArgs = null
+  send = null
+  status = null
+  json = null
+
+  beforeEach ->
+    @req = body: to: '+1 555 111 2222', message: 'Explore Venice in 360°: link'
+    @res = send: send = sinon.stub(), json: json = sinon.stub(), status: status = sinon.stub()
+    twilio = routes.__get__ 'twilio'
+    twilio.RestClient = class TwilioClientStub
+      constructor: -> twilioConstructorArgs = arguments
+      sendSms: -> twilioSendSmsArgs = arguments
+    routes.sendSMS @req, @res
+
+  it 'sends a link with a valid phone number', ->
+    twilioSendSmsArgs[0].to.should.equal '+15551112222'
+    twilioSendSmsArgs[0].body.should.match 'Explore Venice in 360°: link'
+    twilioSendSmsArgs[1] null, 'SUCCESS!'
+    send.args[0][0].should.equal 201
+    send.args[0][1].msg.should.containEql 'success'
+
+  it 'throws an error if twilio doesnt like it', ->
+    twilioSendSmsArgs[1] message: 'Error!'
+    send.args[0][1].msg.should.equal 'Error!'


### PR DESCRIPTION
- Adds twilio sms form to desktop view, shows 'open in app' link for mobile
- Fixes link color in video guide
- Adds animation to scrolling on info icon click
- Caches curation, sub-articles and video guide on fetch

![screen shot 2017-05-11 at 3 44 13 pm](https://cloud.githubusercontent.com/assets/1497424/25968810/bb60c18e-3660-11e7-86cf-5a4004c06c6c.png)
