### PR TITLE
@erikdstock => Fix Auction bidder registration flow 

### DIFF
--- a/desktop/analytics/bidding.js
+++ b/desktop/analytics/bidding.js
@@ -81,7 +81,7 @@ $(document).on('click', '.my-active-bids-bid-button', function (e) {
 })
 
 // Clicked "Bid" (context_type: artwork page)
-$(document).on('click', '.artwork-auction__bid-form__button', function () {
+$(document).on('click', 'button.artwork-auction__bid-form__button', function () {
   analytics.track('Clicked "Bid"', {
     auction_slug: AUCTION_ID,
     user_id: USER_ID,

--- a/desktop/analytics/bidding.js
+++ b/desktop/analytics/bidding.js
@@ -90,6 +90,16 @@ $(document).on('click', 'button.artwork-auction__bid-form__button', function () 
   })
 })
 
+// Clicked "Bid" but needs to register (context_type: artwork page)
+$(document).on('click', 'a.artwork-auction__bid-form__button', function () {
+  analytics.track('Clicked "Bid"', {
+    auction_slug: AUCTION_ID,
+    user_id: USER_ID,
+    context_type: 'artwork page',
+    artwork_slug: sd.PARAMS.id
+  })
+})
+
 // Confirm bid failed
 analyticsHooks.on('error', function (message) {
   if (message.match('bid must be higher')) {

--- a/desktop/analytics/bidding.js
+++ b/desktop/analytics/bidding.js
@@ -80,18 +80,8 @@ $(document).on('click', '.my-active-bids-bid-button', function (e) {
   })
 })
 
-// Clicked "Bid" (context_type: artwork page)
-$(document).on('click', 'button.artwork-auction__bid-form__button', function () {
-  analytics.track('Clicked "Bid"', {
-    auction_slug: AUCTION_ID,
-    user_id: USER_ID,
-    context_type: 'artwork page',
-    artwork_slug: sd.PARAMS.id
-  })
-})
-
-// Clicked "Bid" but needs to register (context_type: artwork page)
-$(document).on('click', 'a.artwork-auction__bid-form__button', function () {
+// Clicked "Bid" (context_type: artwork page: pre-register before bidding, approval required before bidding)
+$(document).on('click', 'button.artwork-auction__bid-form__button, a.artwork-auction__bid-form__button', function () {
   analytics.track('Clicked "Bid"', {
     auction_slug: AUCTION_ID,
     user_id: USER_ID,

--- a/desktop/apps/artwork/components/auction/bootstrap.coffee
+++ b/desktop/apps/artwork/components/auction/bootstrap.coffee
@@ -4,3 +4,4 @@ module.exports = (sd, { artwork }) ->
       artwork_id: artwork._id
       id: artwork.sale.id
       minimum_next_bid: artwork.sale_artwork.minimum_next_bid
+      sale: artwork.sale

--- a/desktop/apps/artwork/components/auction/helpers.coffee
+++ b/desktop/apps/artwork/components/auction/helpers.coffee
@@ -15,8 +15,8 @@ module.exports = {
     # Due to falsy behavior we need to check for the existence of a
     # qualified_for_bidding key and then check its value. This handles conditions
     # where we want to display the "Bid Now" button, but only to trigger a
-    # login modal for the user.
-    foundKey = me && get(me, 'bidders.0', {}).hasOwnProperty('qualified_for_bidding')
+    # login modal or redirect to register transition for the user.
+    foundKey = get(me, 'bidders.0', {}).hasOwnProperty('qualified_for_bidding')
 
     if foundKey
       isQualified = get(me, 'bidders.0.qualified_for_bidding')
@@ -24,6 +24,8 @@ module.exports = {
         'qualified'
       else
         'registration-pending'
+    else if me
+      'register-to-bid'
     else
       'logged-out'
 

--- a/desktop/apps/artwork/components/auction/helpers.coffee
+++ b/desktop/apps/artwork/components/auction/helpers.coffee
@@ -16,7 +16,7 @@ module.exports = {
     # qualified_for_bidding key and then check its value. This handles conditions
     # where we want to display the "Bid Now" button, but only to trigger a
     # login modal for the user.
-    foundKey = get(me, 'bidders.0', {}).hasOwnProperty('qualified_for_bidding')
+    foundKey = me && get(me, 'bidders.0', {}).hasOwnProperty('qualified_for_bidding')
 
     if foundKey
       isQualified = get(me, 'bidders.0.qualified_for_bidding')

--- a/desktop/apps/artwork/components/auction/helpers.coffee
+++ b/desktop/apps/artwork/components/auction/helpers.coffee
@@ -1,3 +1,4 @@
+get  = require 'lodash.get'
 { compact } = require 'underscore'
 { liveAuctionUrl } = require '../../../../../utils/domain/auctions/urls'
 
@@ -9,6 +10,29 @@ pluralize = (word, count, irregular = null) ->
 
 module.exports = {
   liveAuctionUrl,
+  getBidderStatus: (me) ->
+
+    # Due to falsy behavior we need to check for the existence of a
+    # qualified_for_bidding key and then check its value. This handles conditions
+    # where we want to display the "Bid Now" button, but only to trigger a
+    # login modal for the user.
+    foundKey = get(me, 'bidders.0', {}).hasOwnProperty('qualified_for_bidding')
+
+    if foundKey
+      isQualified = get(me, 'bidders.0.qualified_for_bidding')
+      if isQualified
+        'qualified'
+      else
+        'registration-pending'
+    else
+      'logged-out'
+
+  getRedirectActionUrl: (bidderStatus, artwork, auction) ->
+    if bidderStatus == 'qualified'
+      "/auction/#{auction.id}/bid/#{artwork.id}"
+    else
+      "/artwork/#{artwork.id}"
+
   count: ({ counts, reserve_message }) ->
     compact [
       pluralize 'bid', counts.bidder_positions if counts.bidder_positions

--- a/desktop/apps/artwork/components/auction/helpers.coffee
+++ b/desktop/apps/artwork/components/auction/helpers.coffee
@@ -16,18 +16,19 @@ module.exports = {
     # qualified_for_bidding key and then check its value. This handles conditions
     # where we want to display the "Bid Now" button, but only to trigger a
     # login modal or redirect to register transition for the user.
-    foundKey = get(me, 'bidders.0', {}).hasOwnProperty('qualified_for_bidding')
+    foundQualifiedForBiddingKey = get(me, 'bidders.0', {}).hasOwnProperty('qualified_for_bidding')
 
-    if foundKey
+    if foundQualifiedForBiddingKey
       isQualified = get(me, 'bidders.0.qualified_for_bidding')
+
       if isQualified
-        'qualified'
+        'qualified-to-bid'
       else
         'registration-pending'
     else if me && auction.require_bidder_approval
-      'register-for-bid-approval'
+      'registration-required'
     else if me
-      'bidding-enabled'
+      'logged-in'
     else
       'logged-out'
 

--- a/desktop/apps/artwork/components/auction/helpers.coffee
+++ b/desktop/apps/artwork/components/auction/helpers.coffee
@@ -10,7 +10,7 @@ pluralize = (word, count, irregular = null) ->
 
 module.exports = {
   liveAuctionUrl,
-  getBidderStatus: (me) ->
+  getBidderStatus: (me, auction) ->
 
     # Due to falsy behavior we need to check for the existence of a
     # qualified_for_bidding key and then check its value. This handles conditions
@@ -24,8 +24,10 @@ module.exports = {
         'qualified'
       else
         'registration-pending'
+    else if me && auction.require_bidder_approval
+      'register-for-bid-approval'
     else if me
-      'register-to-bid'
+      'bidding-enabled'
     else
       'logged-out'
 

--- a/desktop/apps/artwork/components/auction/query.coffee
+++ b/desktop/apps/artwork/components/auction/query.coffee
@@ -16,6 +16,7 @@ module.exports = """
       is_auction
       is_auction_promo
       is_with_buyers_premium
+      require_bidder_approval
     }
     sale_artwork {
       id

--- a/desktop/apps/artwork/components/auction/templates/bid.jade
+++ b/desktop/apps/artwork/components/auction/templates/bid.jade
@@ -43,7 +43,6 @@ if showAuctionForm
           class='js-artwork-auction-bid-button'
         ) Bid #{accounting.formatMoney(firstIncr / 100, sale_artwork.symbol, 0)}
 
-
     small.artwork-auction__bid-form__conditions
       | By placing your bid you agree to Artsy's&nbsp;
       a(
@@ -51,5 +50,3 @@ if showAuctionForm
         class='js-artwork-auction-help-modal'
         data-id='how-auctions-work-conditions-of-sale'
       ) Conditions of Sale
-    
-      

--- a/desktop/apps/artwork/components/auction/templates/bid.jade
+++ b/desktop/apps/artwork/components/auction/templates/bid.jade
@@ -1,16 +1,21 @@
 include ../../../../../components/bid_status/index
+- bidderStatus = helpers.auction.getBidderStatus(me)
+- actionUrl = helpers.auction.getRedirectActionUrl(bidderStatus, artwork, auction)
 - myLastMaxBid = me && me.lot_standing && me.lot_standing.most_recent_bid.max_bid.cents
 - increments = sale_artwork.bid_increments.filter(function(i) { return i > (myLastMaxBid || 0) })
 - firstIncr = increments[0]
-if auction.is_open && !artwork.is_sold && !auction.is_live_open
+- showAuctionForm = auction.is_open && !artwork.is_sold && !auction.is_live_open
+
+if showAuctionForm
   form.artwork-auction__bid-form(
     method='GET'
-    action='/auction/#{auction.id}/bid/#{artwork.id}'
+    action='#{actionUrl}'
     class='js-artwork-auction-bid'
   )
     .artwork-auction__bid-form__errors.form-errors( class='js-form-errors' )
-      //- Rendered client-side
-    if user
+      
+    //- Rendered client-side
+    if user && bidderStatus === 'qualified'
       .artwork-auction__bid-form__max-bid
         if me && me.lot_standing
           +bidStatus(me.lot_standing, sale_artwork, {winningMessage: 'Highest Bidder', reserveMessage: 'Highest bidder, Reserve not met'})
@@ -29,9 +34,16 @@ if auction.is_open && !artwork.is_sold && !auction.is_live_open
             - display = accounting.formatMoney(val, sale_artwork.symbol, 0)
             option( value=val data-display=display )= display
 
-    button.artwork-auction__bid-form__button.avant-garde-button-black.is-block(
-      class='js-artwork-auction-bid-button'
-    ) Bid #{accounting.formatMoney(firstIncr / 100, sale_artwork.symbol, 0)}
+    case bidderStatus
+      when 'registration-pending'
+        .artwork-auction__bid-form__button.avant-garde-button-black.is-block.is-disabled
+          | REGISTRATION PENDING
+      default
+        button.artwork-auction__bid-form__button.avant-garde-button-black.is-block(
+          class='js-artwork-auction-bid-button'
+        ) Bid #{accounting.formatMoney(firstIncr / 100, sale_artwork.symbol, 0)}
+
+
     small.artwork-auction__bid-form__conditions
       | By placing your bid you agree to Artsy's&nbsp;
       a(
@@ -39,3 +51,5 @@ if auction.is_open && !artwork.is_sold && !auction.is_live_open
         class='js-artwork-auction-help-modal'
         data-id='how-auctions-work-conditions-of-sale'
       ) Conditions of Sale
+    
+      

--- a/desktop/apps/artwork/components/auction/templates/bid.jade
+++ b/desktop/apps/artwork/components/auction/templates/bid.jade
@@ -1,5 +1,5 @@
 include ../../../../../components/bid_status/index
-- bidderStatus = helpers.auction.getBidderStatus(me)
+- bidderStatus = helpers.auction.getBidderStatus(me, auction)
 - actionUrl = helpers.auction.getRedirectActionUrl(bidderStatus, artwork, auction)
 - myLastMaxBid = me && me.lot_standing && me.lot_standing.most_recent_bid.max_bid.cents
 - increments = sale_artwork.bid_increments.filter(function(i) { return i > (myLastMaxBid || 0) })
@@ -34,20 +34,24 @@ if showAuctionForm
             - display = accounting.formatMoney(val, sale_artwork.symbol, 0)
             option( value=val data-display=display )= display
 
-    - bidAmount = 'Bid' + accounting.formatMoney(firstIncr / 100, sale_artwork.symbol, 0)
+    - bidAmount = 'Bid ' + accounting.formatMoney(firstIncr / 100, sale_artwork.symbol, 0)
     
     case bidderStatus
       when 'registration-pending'
         .artwork-auction__bid-form__button.avant-garde-button-black.is-block.is-disabled
           | Registration Pending
-      when 'register-to-bid'
+      when 'register-for-bid-approval'
         a.artwork-auction__bid-form__button.avant-garde-button-black.is-block.js-register-button(
           href='/auction-registration/#{auction.id}'
-        ) #{bidAmount}
+        )= bidAmount
+      when 'bidding-enabled'
+        a.artwork-auction__bid-form__button.avant-garde-button-black.is-block.js-register-button(
+          href='/auction/#{auction.id}/bid/#{artwork.id}'
+        )= bidAmount
       default
         button.artwork-auction__bid-form__button.avant-garde-button-black.is-block(
           class='js-artwork-auction-bid-button'
-        ) #{bidAmount}
+        )= bidAmount
 
     small.artwork-auction__bid-form__conditions
       | By placing your bid you agree to Artsy's&nbsp;

--- a/desktop/apps/artwork/components/auction/templates/bid.jade
+++ b/desktop/apps/artwork/components/auction/templates/bid.jade
@@ -15,7 +15,7 @@ if showAuctionForm
     .artwork-auction__bid-form__errors.form-errors( class='js-form-errors' )
       
     //- Rendered client-side
-    if user && bidderStatus === 'qualified'
+    if user && bidderStatus === 'qualified-to-bid'
       .artwork-auction__bid-form__max-bid
         if me && me.lot_standing
           +bidStatus(me.lot_standing, sale_artwork, {winningMessage: 'Highest Bidder', reserveMessage: 'Highest bidder, Reserve not met'})
@@ -40,11 +40,11 @@ if showAuctionForm
       when 'registration-pending'
         .artwork-auction__bid-form__button.avant-garde-button-black.is-block.is-disabled
           | Registration Pending
-      when 'register-for-bid-approval'
+      when 'registration-required'
         a.artwork-auction__bid-form__button.avant-garde-button-black.is-block.js-register-button(
           href='/auction-registration/#{auction.id}'
         )= bidAmount
-      when 'bidding-enabled'
+      when 'logged-in'
         a.artwork-auction__bid-form__button.avant-garde-button-black.is-block.js-register-button(
           href='/auction/#{auction.id}/bid/#{artwork.id}'
         )= bidAmount

--- a/desktop/apps/artwork/components/auction/templates/bid.jade
+++ b/desktop/apps/artwork/components/auction/templates/bid.jade
@@ -34,14 +34,20 @@ if showAuctionForm
             - display = accounting.formatMoney(val, sale_artwork.symbol, 0)
             option( value=val data-display=display )= display
 
+    - bidAmount = 'Bid' + accounting.formatMoney(firstIncr / 100, sale_artwork.symbol, 0)
+    
     case bidderStatus
       when 'registration-pending'
         .artwork-auction__bid-form__button.avant-garde-button-black.is-block.is-disabled
-          | REGISTRATION PENDING
+          | Registration Pending
+      when 'register-to-bid'
+        a.artwork-auction__bid-form__button.avant-garde-button-black.is-block.js-register-button(
+          href='/auction-registration/#{auction.id}'
+        ) #{bidAmount}
       default
         button.artwork-auction__bid-form__button.avant-garde-button-black.is-block(
           class='js-artwork-auction-bid-button'
-        ) Bid #{accounting.formatMoney(firstIncr / 100, sale_artwork.symbol, 0)}
+        ) #{bidAmount}
 
     small.artwork-auction__bid-form__conditions
       | By placing your bid you agree to Artsy's&nbsp;

--- a/desktop/apps/artwork/components/auction/test/view.coffee
+++ b/desktop/apps/artwork/components/auction/test/view.coffee
@@ -119,7 +119,8 @@ describe 'auction', ->
           .should.have.lengthOf 0
 
       describe 'bid qualification', ->
-        it 'renders a disabled REGISTRATION PENDING button', ->
+        it 'renders a disabled "Registration Pending" button', ->
+          @data.accounting = accounting
           @data.me = {
             bidders: [{
               qualified_for_bidding: false
@@ -128,7 +129,16 @@ describe 'auction', ->
           view = new @ArtworkAuctionView data: @data
           view.render()
           view.$('.artwork-auction__bid-form__button').text()
-            .should.containEql 'REGISTRATION PENDING'
+            .should.containEql 'Registration Pending'
+
+        it 'renders a auction registration button', ->
+          @data.accounting = accounting
+          @data.me = {}
+          view = new @ArtworkAuctionView data: @data
+          view.render()
+          view.$('a.artwork-auction__bid-form__button').length.should.equal 1
+          view.$('a.artwork-auction__bid-form__button').attr('href')
+            .should.equal "/auction-registration/#{@data.artwork.sale.id}"
 
       describe 'post-bid messages', ->
         beforeEach ->

--- a/desktop/apps/artwork/components/auction/test/view.coffee
+++ b/desktop/apps/artwork/components/auction/test/view.coffee
@@ -21,6 +21,11 @@ describe 'auction', ->
       ['template']
     )
     @data =
+      user: true
+      me:
+        bidders: [{
+          qualified_for_bidding: true
+        }]
       artwork:
         id: 'peter-alexander-wedge-with-puff'
         is_in_auction: true
@@ -112,16 +117,30 @@ describe 'auction', ->
 
         @view.$('.artwork-auction__buy-now')
           .should.have.lengthOf 0
+
+      describe 'bid qualification', ->
+        it 'renders a disabled REGISTRATION PENDING button', ->
+          @data.me = {
+            bidders: [{
+              qualified_for_bidding: false
+            }]
+          }
+          view = new @ArtworkAuctionView data: @data
+          view.render()
+          view.$('.artwork-auction__bid-form__button').text()
+            .should.containEql 'REGISTRATION PENDING'
+
       describe 'post-bid messages', ->
         beforeEach ->
           @data = Object.assign(@data, {
             user: 'existy',
             accounting: accounting
           })
+
         describe 'leading bidder & reserve met', ->
           it 'gives a winning message', ->
             @data.artwork.sale_artwork.reserve_status = 'reserve_met'
-            @data.me = {
+            @data.me = Object.assign @data.me, {
               lot_standing:
                 is_leading_bidder: true
                 most_recent_bid:
@@ -137,7 +156,7 @@ describe 'auction', ->
         describe 'leading bidder & reserve not met', ->
           it 'gives a reserve not met message', ->
             @data.artwork.sale_artwork.reserve_status = 'reserve_not_met'
-            @data.me = {
+            @data.me = Object.assign @data.me, {
               lot_standing:
                 is_leading_bidder: true
                 most_recent_bid:
@@ -154,7 +173,7 @@ describe 'auction', ->
         describe 'not leading bidder & reserve not met', ->
           it 'gives an outbid message', ->
             @data.artwork.sale_artwork.reserve_status = 'reserve_not_met'
-            @data.me = {
+            @data.me = Object.assign @data.me, {
               lot_standing:
                 is_leading_bidder: false
                 most_recent_bid:
@@ -171,7 +190,7 @@ describe 'auction', ->
         describe 'not leading bidder & reserve met', ->
           it 'gives an outbid message', ->
             @data.artwork.sale_artwork.reserve_status = 'reserve_met'
-            @data.me = {
+            @data.me = Object.assign @data.me, {
               lot_standing:
                 is_leading_bidder: false
                 most_recent_bid:

--- a/desktop/apps/artwork/components/auction/test/view.coffee
+++ b/desktop/apps/artwork/components/auction/test/view.coffee
@@ -133,12 +133,23 @@ describe 'auction', ->
 
         it 'renders a auction registration button', ->
           @data.accounting = accounting
+          @data.artwork.sale.require_bidder_approval = true
           @data.me = {}
           view = new @ArtworkAuctionView data: @data
           view.render()
           view.$('a.artwork-auction__bid-form__button').length.should.equal 1
           view.$('a.artwork-auction__bid-form__button').attr('href')
             .should.equal "/auction-registration/#{@data.artwork.sale.id}"
+
+        it 'renders an open registration bid button', ->
+          @data.accounting = accounting
+          @data.artwork.sale.require_bidder_approval = false
+          @data.me = {}
+          view = new @ArtworkAuctionView data: @data
+          view.render()
+          view.$('a.artwork-auction__bid-form__button').length.should.equal 1
+          view.$('a.artwork-auction__bid-form__button').attr('href')
+            .should.equal "/auction/#{@data.artwork.sale.id}/bid/#{@data.artwork.id}"
 
       describe 'post-bid messages', ->
         beforeEach ->

--- a/desktop/apps/artwork/components/auction/view.coffee
+++ b/desktop/apps/artwork/components/auction/view.coffee
@@ -113,6 +113,9 @@ module.exports = class ArtworkAuctionView extends Backbone.View
       query: """
         query artwork($id: String!, $sale_id: String!) {
           me {
+            bidders(sale_id: $sale_id) {
+              qualified_for_bidding
+            }
             lot_standing(artwork_id: $id, sale_id: $sale_id) {
               is_leading_bidder
               most_recent_bid {

--- a/desktop/lib/global_client_setup.coffee
+++ b/desktop/lib/global_client_setup.coffee
@@ -7,6 +7,7 @@
 Backbone = require 'backbone'
 Backbone.$ = $
 _ = require 'underscore'
+_.get = require 'lodash.get'
 Cookies = require 'cookies-js'
 imagesLoaded = require 'imagesloaded'
 Raven = require 'raven-js'

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "jquery-touch-events": "git+https://github.com/benmajor/jQuery-Touch-Events.git",
     "jquery.payment": "^3.0.0",
     "knox": "^0.9.2",
+    "lodash.get": "^4.4.2",
     "mailcheck": "^1.1.1",
     "memwatch-ng": "^1.2.0",
     "moment": "~2.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -322,26 +322,7 @@ artsy-gemini-upload@0.0.6:
     chalk "^1.1.3"
     morgan "^1.8.1"
 
-artsy-passport@^1.6.1:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/artsy-passport/-/artsy-passport-1.7.2.tgz#d5ae66a1024b31f0b07a48cebe9cbad1e2aa3ed0"
-  dependencies:
-    analytics-node "^2.1.0"
-    async "^1.5.0"
-    coffee-script "^1.9.2"
-    csurf "^1.8.3"
-    dotenv "^4.0.0"
-    express "^4.12.3"
-    mailcheck "^1.1.1"
-    passport "^0.2.1"
-    passport-facebook "^2.0.0"
-    passport-linkedin "^1.0.0"
-    passport-local "^1.0.0"
-    passport-twitter "^1.0.3"
-    superagent "^1.2.0"
-    underscore.string "^3.2.2"
-
-artsy-passport@^1.7.4:
+artsy-passport@^1.6.1, artsy-passport@^1.7.4:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/artsy-passport/-/artsy-passport-1.7.4.tgz#6e7e32c38e41f223e21f4a70a480022278782d3c"
   dependencies:
@@ -4615,6 +4596,10 @@ lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -7036,7 +7021,7 @@ supertest@^2.0.1:
     methods "1.x"
     superagent "^2.0.0"
 
-supports-color@3.1.2:
+supports-color@3.1.2, supports-color@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -7050,7 +7035,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.2, supports-color@^3.2.3:
+supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:


### PR DESCRIPTION
This PR fixes an issue where a user who is not yet qualified to bid is able to bid via an erroneously enabled UI, leading to an error. Addresses item 1 on https://github.com/artsy/auctions/issues/442. 

**To Test:** 

```sh
git checkout -b damassi-bugfix-check-qualified-for-bidding master
git pull https://github.com/damassi/force.git bugfix-check-qualified-for-bidding
```

### Test Path 1

- Create a new account, remember the details, and sign in
- Go to http://localhost:5000/auction/chris-ohm-retraction-round-2 and click 'Register to Bid'
- Fill in fake CC info (but note that in Ohm, the sale has been set to `require bidder approval = true` to get around immediate credit card approval)
- Note that the view looks like 

<img width="349" alt="screen shot 2017-05-11 at 8 31 55 pm" src="https://cloud.githubusercontent.com/assets/236943/25981282/1ce721b4-3689-11e7-9800-65ad7d8f519d.png">

- Navigate to http://localhost:5000/artwork/gerrit-engel-painting and notice 

<img width="360" alt="screen shot 2017-05-11 at 8 34 05 pm" src="https://cloud.githubusercontent.com/assets/236943/25981299/3d5d1534-3689-11e7-85c4-5529656d7a78.png">

- Sign out
- Navigate to https://auctions-staging.artsy.net/sales/chris-ohm-retraction-round-2/edit and uncheck the `Require bidder approval` button
- Back in Force, create a new account
- Go to http://localhost:5000/auction/chris-ohm-retraction-round-2 and click 'Register to Bid'
- Fill out the form and notice that the Bid button is there and works as expected
- Sign out again
- Sign in with the first account and notice its back in a `Pending` state
- ...repeat 

### Test Path 2

- Sign out
- Create a new account and sign in
- Navigate directly to an auction artwork that requires bid registration approvals: http://localhost:5000/artwork/doug-thielscher-transcendence
- Click the bid button and notice that it redirects you to http://localhost:5000/auction/chris-ohm-retraction-round-2/confirm-registration with a notice of your new bidder number

<img width="609" alt="screen shot 2017-05-12 at 3 03 02 pm" src="https://cloud.githubusercontent.com/assets/236943/26018524/35df97be-3724-11e7-9901-d1969a00151f.png">

### Test Path 3

- Sign out
- Navigate to http://localhost:5000/artwork/harold-ancart-untitled-25
- Sign in with a **new account**
- Click bid and notice that you'll be taken to this screen:

<img width="648" alt="screen shot 2017-05-12 at 3 05 18 pm" src="https://cloud.githubusercontent.com/assets/236943/26018566/78caf186-3724-11e7-84f4-20d7efcd6cd9.png">

- Bid, and notice that it redirects you back to the artwork
