### PR TITLE
Fix opening a Inquire via Phone modal on FireFox and IEs

### DIFF
--- a/desktop/apps/artwork/components/partner_stub/index.coffee
+++ b/desktop/apps/artwork/components/partner_stub/index.coffee
@@ -11,9 +11,9 @@ module.exports = ($el) ->
           login: 'Log in to Artsy to call gallery'
           signup: 'Create an Artsy account to call gallery'
           register: 'Create an Artsy account to call gallery'
-        artistIds: JSON.parse(e.toElement.dataset.artist_ids)
+        artistIds: JSON.parse(e.target.dataset.artist_ids)
         userData:
-          partner: JSON.parse(e.toElement.dataset.partner)
+          partner: JSON.parse(e.target.dataset.partner)
   $el
     .find '.js-artwork-partner-stub-phone-toggle'
     .click (e) ->


### PR DESCRIPTION
It seems like the `#toElement`  is not implemented in FireFox or IEs and the `#target` should be used instead. I don't know I didn't use `target` in the first place...