### PR TITLE
Gallery name should be same size as contact info in Inquire via Phone modal

### DIFF
--- a/desktop/apps/artwork/components/inquire_via_phone/templates/phone_number.jade
+++ b/desktop/apps/artwork/components/inquire_via_phone/templates/phone_number.jade
@@ -1,14 +1,14 @@
 p.avant-garde-body.inquire-via-phone-modal__title Call Gallery
 
 #auth-page.vam-outer
-  .vam-inner.garamond-l-body.inquire-via-phone-modal__body
+  .vam-inner.inquire-via-phone-modal__body
     header#auth-header
       aside
-        b= partner.name
+        b.garamond-l-body= partner.name
 
     section#auth-body
       for location in partner.locations
-        .artwork-partner-stub__phone__locations__location
+        .artwork-partner-stub__phone__locations__location.garamond-l-body
           p
             = location.city
             if location.state


### PR DESCRIPTION
I should've sent this PR as part of the previous one, but [as requested](https://artsy.slack.com/archives/C03JJ2RDG/p1494596003336575) I changed the font size for the gallery name in the Inquire via Phone modal.

### Before:

![screen shot 2017-05-12 at 4 14 23 pm](https://cloud.githubusercontent.com/assets/386234/26015226/2000b5ea-372e-11e7-9ea8-285a05e46a5f.png)

### After:

![screen shot 2017-05-12 at 4 14 28 pm](https://cloud.githubusercontent.com/assets/386234/26015222/1b042c2a-372e-11e7-9904-507a2b3c0660.png)