### PR TITLE
@sweir27 => [Feature] Add reset filters button to /auction/:id

### DIFF
--- a/desktop/apps/auction/client/actions.js
+++ b/desktop/apps/auction/client/actions.js
@@ -9,6 +9,7 @@ export const GET_ARTWORKS_FAILURE = 'GET_ARTWORKS_FAILURE'
 export const GET_ARTWORKS_REQUEST = 'GET_ARTWORKS_REQUEST'
 export const GET_ARTWORKS_SUCCESS = 'GET_ARTWORKS_SUCCESS'
 export const INCREMENT_FOLLOWED_ARTISTS_PAGE = 'INCREMENT_FOLLOWED_ARTISTS_PAGE'
+export const RESET_FILTERS = 'RESET_FILTERS'
 export const SHOW_FOLLOWED_ARTISTS_RAIL = 'SHOW_FOLLOWED_ARTISTS_RAIL'
 export const TOGGLE_LIST_VIEW = 'TOGGLE_LIST_VIEW'
 export const UPDATE_AGGREGATED_ARTISTS = 'UPDATE_AGGREGATED_ARTISTS'
@@ -210,6 +211,15 @@ export function resetArtworks () {
       dispatch(updatePage(true))
       dispatch(fetchArtworks())
     }
+  }
+}
+
+export function resetFilters () {
+  return (dispatch) => {
+    dispatch({
+      type: RESET_FILTERS
+    })
+    dispatch(resetArtworks())
   }
 }
 

--- a/desktop/apps/auction/client/reducers.js
+++ b/desktop/apps/auction/client/reducers.js
@@ -90,6 +90,25 @@ function auctionArtworks (state = initialState, action) {
         }, state)
       }
     }
+    case actions.RESET_FILTERS: {
+      const {
+        aggregatedArtists,
+        aggregatedMediums,
+        initialMediumMap,
+        saleArtworks
+      } = state
+
+      return u({
+        ...initialState,
+
+        // Preserve current result state while resetting so that display doesn't
+        // perform a hard reset.
+        aggregatedArtists,
+        aggregatedMediums,
+        initialMediumMap,
+        saleArtworks
+      }, state)
+    }
     case actions.TOGGLE_LIST_VIEW: {
       return u({
         isListView: action.payload.isListView

--- a/desktop/apps/auction/components/range_slider/index.js
+++ b/desktop/apps/auction/components/range_slider/index.js
@@ -34,7 +34,7 @@ function RangeSlider (props) {
         min={minEstimate}
         max={maxEstimate}
         step={50}
-        defaultValue={[minEstimateRangeDisplay, maxEstimateRangeDisplay]}
+        value={[minEstimateRangeDisplay, maxEstimateRangeDisplay]}
         onChange={([min, max]) => updateEstimateDisplayAction(min, max)}
         onAfterChange={([min, max]) => updateEstimateRangeAction(min, max)}
       />

--- a/desktop/apps/auction/components/reset_filters_button/index.js
+++ b/desktop/apps/auction/components/reset_filters_button/index.js
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { resetFilters } from '../../client/actions'
+import { connect } from 'react-redux'
+
+function ResetFiltersButton ({ resetFiltersAction }) {
+  return (
+    <a className='auction-reset-filters-button' onClick={resetFiltersAction}>
+      Reset Filters
+    </a>
+  )
+}
+
+ResetFiltersButton.propTypes = {
+  resetFiltersAction: PropTypes.func.isRequired
+}
+
+const mapDispatchToProps = {
+  resetFiltersAction: resetFilters
+}
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(ResetFiltersButton)

--- a/desktop/apps/auction/components/reset_filters_button/index.styl
+++ b/desktop/apps/auction/components/reset_filters_button/index.styl
@@ -1,0 +1,8 @@
+.auction-reset-filters-button
+  cursor pointer
+  display block
+  garamond-size('m-caption')
+  margin-top 15px
+
+  &:hover
+    text-decoration underline

--- a/desktop/apps/auction/components/sidebar/index.js
+++ b/desktop/apps/auction/components/sidebar/index.js
@@ -3,6 +3,7 @@ import MediumFilter from '../medium_filter'
 import PropTypes from 'prop-types'
 import RangeSlider from '../range_slider'
 import React from 'react'
+import ResetFiltersButton from '../reset_filters_button'
 import { connect } from 'react-redux'
 
 function Sidebar ({ isClosed }) {
@@ -10,6 +11,7 @@ function Sidebar ({ isClosed }) {
     <div className='auction-artworks-sidebar'>
       <div className='auction-artworks-sidebar__artist-filter'>
         { !isClosed && <RangeSlider /> }
+        <ResetFiltersButton />
         <MediumFilter />
         <ArtistFilter />
       </div>
@@ -28,5 +30,5 @@ const mapStateToProps = (state) => {
 }
 
 export default connect(
-  mapStateToProps,
+  mapStateToProps
 )(Sidebar)

--- a/desktop/apps/auction/stylesheets/index.styl
+++ b/desktop/apps/auction/stylesheets/index.styl
@@ -19,6 +19,7 @@
 @require '../components/header/index'
 @require '../components/medium_filter/index'
 @require '../components/range_slider/index'
+@require '../components/reset_filters_button/index'
 @require '../components/works_by_followed_artists/index'
 @require './banner'
 @require './footer'


### PR DESCRIPTION
This PR adds a little `Reset Filters` button to the sidebar component that when clicked resets filter state. 

<img width="296" alt="screen shot 2017-05-13 at 6 13 47 pm" src="https://cloud.githubusercontent.com/assets/236943/26030411/f3c99bce-3807-11e7-8e13-ef04f01505d7.png">

**TODO:**
- [ ] Write tests

@katarinabatina - I winged it with this design; thoughts? 
cc @devangt 