### PR TITLE
@eessex => [Venice] Fade out controls on mobile

### DIFF
--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -38,7 +38,7 @@ module.exports = class VeniceView extends Backbone.View
       el: $('.venice-video')
       video: @chooseVideoFile()
       slug: @section.slug
-      is_mobile: @parser.getDevice().type is 'mobile'
+      isMobile: @parser.getDevice().type is 'mobile'
     @listenTo @VeniceVideoView, 'videoCompleted', @onVideoCompleted
     @listenTo @VeniceVideoView, 'closeVideo', @fadeInCoverAndPauseVideo
     @listenTo @VeniceVideoView, 'videoReady', @onVideoReady

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -38,7 +38,7 @@ module.exports = class VeniceView extends Backbone.View
       el: $('.venice-video')
       video: @chooseVideoFile()
       slug: @section.slug
-      parser: @parser
+      is_mobile: @parser.getDevice().type is 'mobile'
     @listenTo @VeniceVideoView, 'videoCompleted', @onVideoCompleted
     @listenTo @VeniceVideoView, 'closeVideo', @fadeInCoverAndPauseVideo
     @listenTo @VeniceVideoView, 'videoReady', @onVideoReady
@@ -88,6 +88,7 @@ module.exports = class VeniceView extends Backbone.View
     return unless e.currentTarget.getAttribute('data-state') is 'ready'
     $('.venice-nav, .venice-carousel').fadeOut()
     @VeniceVideoView.vrView.play()
+    @VeniceVideoView.fadeOutControls()
 
   fadeInCoverAndPauseVideo: ->
     $('.venice-nav, .venice-carousel').fadeIn()

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -38,6 +38,7 @@ module.exports = class VeniceView extends Backbone.View
       el: $('.venice-video')
       video: @chooseVideoFile()
       slug: @section.slug
+      parser: @parser
     @listenTo @VeniceVideoView, 'videoCompleted', @onVideoCompleted
     @listenTo @VeniceVideoView, 'closeVideo', @fadeInCoverAndPauseVideo
     @listenTo @VeniceVideoView, 'videoReady', @onVideoReady

--- a/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
@@ -16,7 +16,7 @@ module.exports = class VeniceVideoView extends Backbone.View
   initialize: (options) ->
     @video = options.video
     @slug = options.slug
-    @parser = options.parser
+    @isMobile = options.is_mobile
     @$playButton = $('#toggleplay')
     @$muteButton = $('#togglemute')
     @$time = $('.venice-video__time')
@@ -37,7 +37,6 @@ module.exports = class VeniceVideoView extends Backbone.View
     @vrView.on 'ready', @onVRViewReady
     @vrView.on 'timeupdate', @updateTime
     @vrView.on 'error', @onVRViewError
-    @vrView.on 'play', @onVRViewPlay
 
   updateTime: (e) =>
     return if @scrubbing
@@ -55,7 +54,7 @@ module.exports = class VeniceVideoView extends Backbone.View
       @trigger 'videoCompleted'
       @trackFull()
     @scrubber.set(e.currentTime)
-    @$time.text @formatTime e.currentTime
+    @$time.text @formatTime e.currentTime if e.currentTime
 
   onVRViewReady: =>
     @duration = @vrView.getDuration()
@@ -85,10 +84,8 @@ module.exports = class VeniceVideoView extends Backbone.View
       @vrView.pause()
     @$playButton.toggleClass 'paused'
 
-  onVRViewPlay: =>
-    @fadeOutControls() if @parser.getDevice().type is 'mobile'
-
   fadeOutControls: =>
+    return unless @isMobile
     setTimeout =>
       @$controls.fadeOut()
       @$controlsOverlay.fadeIn()

--- a/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
@@ -11,13 +11,17 @@ module.exports = class VeniceVideoView extends Backbone.View
     'click #toggleplay': 'onTogglePlay'
     'click #togglemute': 'onToggleMute'
     'click .venice-video__close': 'onCloseVideo'
+    'click .venice-video__controls-overlay': 'fadeInControls'
 
   initialize: (options) ->
     @video = options.video
     @slug = options.slug
+    @parser = options.parser
     @$playButton = $('#toggleplay')
     @$muteButton = $('#togglemute')
     @$time = $('.venice-video__time')
+    @$controls = $('#controls, .venice-video__close, .venice-video__vr-icon, .venice-info-icon')
+    @$controlsOverlay = $('.venice-video__controls-overlay')
     @setupVideo()
     @on 'swapVideo', @swapVideo
     @scrubbing = false
@@ -33,6 +37,7 @@ module.exports = class VeniceVideoView extends Backbone.View
     @vrView.on 'ready', @onVRViewReady
     @vrView.on 'timeupdate', @updateTime
     @vrView.on 'error', @onVRViewError
+    @vrView.on 'play', @onVRViewPlay
 
   updateTime: (e) =>
     return if @scrubbing
@@ -79,6 +84,20 @@ module.exports = class VeniceVideoView extends Backbone.View
     else
       @vrView.pause()
     @$playButton.toggleClass 'paused'
+
+  onVRViewPlay: =>
+    @fadeOutControls() if @parser.getDevice().type is 'mobile'
+
+  fadeOutControls: =>
+    setTimeout =>
+      @$controls.fadeOut()
+      @$controlsOverlay.fadeIn()
+    , 3000
+
+  fadeInControls: =>
+    @$controls.fadeIn()
+    @$controlsOverlay.fadeOut()
+    @fadeOutControls()
 
   onToggleMute: ->
     if @$muteButton.attr('data-state') is 'muted'

--- a/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/video.coffee
@@ -16,7 +16,7 @@ module.exports = class VeniceVideoView extends Backbone.View
   initialize: (options) ->
     @video = options.video
     @slug = options.slug
-    @isMobile = options.is_mobile
+    @isMobile = options.isMobile
     @$playButton = $('#toggleplay')
     @$muteButton = $('#togglemute')
     @$time = $('.venice-video__time')

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/video.styl
@@ -109,6 +109,11 @@
     .unmuted
       display block
 
+.venice-video__controls-overlay
+  width 100%
+  height 100%
+  position absolute
+
 // Mobile
 @media screen and (max-width: 550px)
   .venice-video__close

--- a/desktop/apps/editorial_features/components/venice_2017/templates/video.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/video.jade
@@ -12,3 +12,4 @@
     .venice-video__scrubber
   .venice-video__vr-icon
     include ../icons/icon_vr.svg
+  .venice-video__controls-overlay

--- a/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
@@ -74,6 +74,7 @@ describe 'Venice Main', ->
             play: @play = sinon.stub()
             pause: @pause = sinon.stub()
           trigger: sinon.stub()
+          fadeOutControls: sinon.stub()
         VeniceView.__set__ 'initCarousel', @initCarousel = sinon.stub().yields
           cells: flickity:
             on: @on = sinon.stub()
@@ -125,6 +126,14 @@ describe 'Venice Main', ->
     $('.venice-overlay__play').first().attr 'data-state', 'ready'
     $('.venice-overlay__play').first().click()
     @play.callCount.should.equal 1
+    @view.VeniceVideoView.fadeOutControls.callCount.should.equal 1
+
+  it 'fades out controls after pressing play on mobile', ->
+    $('.venice-overlay__play').first().attr 'data-state', 'ready'
+    @view.parser =
+      getDevice: sinon.stub().returns type: 'mobile'
+    $('.venice-overlay__play').first().click()
+    @view.VeniceVideoView.fadeOutControls.callCount.should.equal 1
 
   it '#fadeInCoverAndPauseVideo', ->
     @view.fadeInCoverAndPauseVideo()

--- a/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
@@ -26,6 +26,9 @@ describe 'Venice Video', ->
           setVolume: @setVolume = sinon.stub()
           setCurrentTime: @setCurrentTime = sinon.stub()
       Backbone.$ = $
+      $.fn.fadeOut = sinon.stub()
+      $.fn.fadeIn = sinon.stub()
+      @clock = sinon.useFakeTimers()
       @options =
         asset: ->
         sd: APP_URL: 'localhost'
@@ -55,6 +58,7 @@ describe 'Venice Video', ->
         done()
 
   afterEach ->
+    @clock.restore()
     benv.teardown()
 
   it 'sets up video', ->
@@ -151,3 +155,12 @@ describe 'Venice Video', ->
     @view.onVRViewReady()
     @view.updateTime(currentTime: 26)
     @view.$time.text().should.equal '00:26'
+
+  it '#fadeInControls', ->
+    @view.fadeInControls()
+    $.fn.fadeIn.callCount.should.equal 1
+
+  it '#fadeOutControls', ->
+    @view.fadeOutControls()
+    @clock.tick(3000)
+    $.fn.fadeOut.callCount.should.equal 1

--- a/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/video.coffee
@@ -157,10 +157,12 @@ describe 'Venice Video', ->
     @view.$time.text().should.equal '00:26'
 
   it '#fadeInControls', ->
+    @view.isMobile = true
     @view.fadeInControls()
     $.fn.fadeIn.callCount.should.equal 1
 
   it '#fadeOutControls', ->
+    @view.isMobile = true
     @view.fadeOutControls()
     @clock.tick(3000)
     $.fn.fadeOut.callCount.should.equal 1


### PR DESCRIPTION
@owendodd there's a tradeoff in order to make this work: the video is no longer draggable on mobile and only relies on the gyroscope sensor. Reason is, there needs to be a cover on the player that listens for a touch that activates the controls again, which covers up the drag functionality. It hasn't really bothered me but just fyi.

![mobile-controls](https://cloud.githubusercontent.com/assets/2236794/26068180/f22f0164-399c-11e7-99f0-6c779a80db7f.gif)

