### PR TITLE
@sweir => Auction Cleanup 

### DIFF
--- a/desktop/apps/artwork/routes.coffee
+++ b/desktop/apps/artwork/routes.coffee
@@ -87,10 +87,10 @@ bootstrap = ->
       res.locals.sd.INCLUDE_SAILTHRU = data.artwork?.fair?
       res.locals.sd.QUERY = req.query
 
+      # If a saleId is found, then check to see if user has been qualified for
+      # bidding so that bid button UI is correct from the server down.
       saleId = get(data, 'artwork.sale.id', false)
 
-      # If a saleId is found, then check to see if user has been qualified for
-      # bidding so that bidder registration UI is correct from the server down.
       if saleId
         fetchMeData(meQuery, req.user, saleId)
           .then (meData) ->

--- a/desktop/apps/artwork/routes.coffee
+++ b/desktop/apps/artwork/routes.coffee
@@ -1,10 +1,12 @@
-{ extend } = require 'underscore'
-metaphysics = require '../../../lib/metaphysics'
 Artwork = require '../../models/artwork'
 Fair = require '../../models/fair'
-request = require 'superagent'
 PendingOrder = require '../../models/pending_order'
+get = require 'lodash.get'
+metaphysics = require '../../../lib/metaphysics'
+request = require 'superagent'
+sd = require('sharify').data
 splitTest = require '../../components/split_test/index.coffee'
+{ extend } = require 'underscore'
 
 query = """
   query artwork($id: String!) {
@@ -35,6 +37,16 @@ query = """
   #{require './components/meta/query'}
   #{require './components/metadata/query'}
   #{require './components/partner_stub/query'}
+"""
+
+meQuery = """
+  query artwork($sale_id: String!) {
+    me {
+      bidders(sale_id: $sale_id) {
+        qualified_for_bidding
+      }
+    }
+  }
 """
 
 helpers = extend [
@@ -74,8 +86,18 @@ bootstrap = ->
       res.locals.sd.PARAMS = req.params
       res.locals.sd.INCLUDE_SAILTHRU = data.artwork?.fair?
       res.locals.sd.QUERY = req.query
-      res.render 'index', data
 
+      saleId = get(data, 'artwork.sale.id', false)
+
+      # If a saleId is found, then check to see if user has been qualified for
+      # bidding so that bidder registration UI is correct from the server down.
+      if saleId
+        fetchMeData(meQuery, req.user, saleId)
+          .then (meData) ->
+            res.render 'index', extend data, meData
+          .catch next
+      else
+        res.render 'index', data
     .catch next
 
 @acquire = (req, res, next) ->
@@ -107,3 +129,18 @@ bootstrap = ->
     else
       res.status 403
       next new Error 'Not authorized to download this image'
+
+# Helpers
+fetchMeData = (query, user, saleId) ->
+  new Promise (resolve, reject) ->
+    metaphysics
+      method: 'post'
+      query: query,
+      req:
+        user: user
+      variables:
+        sale_id: saleId
+    .then (response) ->
+      resolve(response)
+    .catch (error) ->
+      reject(error)

--- a/desktop/apps/artwork/routes.coffee
+++ b/desktop/apps/artwork/routes.coffee
@@ -140,7 +140,5 @@ fetchMeData = (query, user, saleId) ->
         user: user
       variables:
         sale_id: saleId
-    .then (response) ->
-      resolve(response)
-    .catch (error) ->
-      reject(error)
+    .then resolve
+    .catch reject

--- a/desktop/apps/auction/components/artist_filter/index.js
+++ b/desktop/apps/auction/components/artist_filter/index.js
@@ -60,7 +60,7 @@ ArtistFilter.propTypes = {
   filterParams: PropTypes.object.isRequired,
   numArtistsYouFollow: PropTypes.number.isRequired,
   updateArtistParamsAction: PropTypes.func.isRequired,
-  user: PropTypes.object.isRequired
+  user: PropTypes.object
 }
 
 const mapStateToProps = (state) => {

--- a/desktop/apps/auction/routes.js
+++ b/desktop/apps/auction/routes.js
@@ -13,6 +13,24 @@ export const index = async (req, res) => {
   const { articles } = await metaphysics({ query: ArticlesQuery(sale._id) })
 
   res.locals.sd.AUCTION = sale
+
+  /**
+   * Ensure user model is in sync as updates to it during bidder registration
+   * route transitions will incidentally trigger a client-side reload.
+   * See: https://github.com/artsy/force/blob/master/desktop/lib/global_client_setup.coffee#L37
+   */
+  if (req.user) {
+    try {
+      const user = await req.user.fetch()
+      res.locals.sd.CURRENT_USER = {
+        ...res.locals.sd.CURRENT_USER,
+        ...user
+      }
+    } catch (error) {
+      console.log('(auction/routes.js) Error fetching user: ', error)
+    }
+  }
+
   const newAuction = new Auction(sale)
   const auctionArticles = new Articles(articles)
   res.render('index', {

--- a/desktop/apps/auction_support/client/index.coffee
+++ b/desktop/apps/auction_support/client/index.coffee
@@ -11,7 +11,6 @@ BidForm = require './bid_form.coffee'
 setupClocks = require './clocks.coffee'
 mediator = require '../../../lib/mediator.coffee'
 
-
 module.exports.AuctionRouter = class AuctionRouter extends Backbone.Router
 
   routes:

--- a/desktop/apps/auction_support/client/registration_form.coffee
+++ b/desktop/apps/auction_support/client/registration_form.coffee
@@ -125,4 +125,3 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
         @showError error
       .then =>
         @trigger('submitted')
-

--- a/desktop/components/credit_card/client/confirm_registration.coffee
+++ b/desktop/components/credit_card/client/confirm_registration.coffee
@@ -11,6 +11,9 @@ module.exports = class ConfirmRegistrationModal extends ModalView
 
   template: template
 
+  events: -> _.extend super,
+    'click .bid-close-button': 'close'
+
   initialize: ({ @auction }) ->
     @user = CurrentUser.orNull()
     _.extend @templateData, paddleNumber: @user.get('paddle_number')
@@ -21,11 +24,19 @@ module.exports = class ConfirmRegistrationModal extends ModalView
     @user.fetchBidderForAuction @auction,
       error: @isLoaded
       success: (bidder) =>
-        if bidder and not bidder.get 'qualified_for_bidding'
+        qualifiedForBidding = bidder && bidder.get 'qualified_for_bidding'
+
+        if !qualifiedForBidding
           @$('.credit-card-unqualified-msg').show()
           analyticsHooks.trigger 'creditcard:unqualified',
             auction_slug: @auction.get('id')
             bidder_id: bidder.get('id')
             user_id: @user.get('id')
+
         @updatePosition()
         @isLoaded()
+
+  close: (event) ->
+    replaceModalTriggerPath = location.pathname.replace('/confirm-registration', '')
+    history.replaceState({}, document.title, replaceModalTriggerPath)
+    super

--- a/desktop/lib/global_client_setup.coffee
+++ b/desktop/lib/global_client_setup.coffee
@@ -34,6 +34,13 @@ ensureFreshUser = (data) ->
   return unless sd.CURRENT_USER
   for attr in ['id', 'type', 'name', 'email', 'phone', 'lab_features',
                'default_profile_id', 'has_partner_access', 'collector_level']
+
+    # NOTE:
+    # If any of the above props have changed between two routes, and the second
+    # route fails to mount sd.locals.CURRENT_USER with the latest req.user.fetch()
+    # data, a hard refresh will occur once the client-side mounts as the two
+    # will be out of sync.
+
     if not _.isEqual data[attr], sd.CURRENT_USER[attr]
       $.ajax('/user/refresh').then -> window.location.reload()
 

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "qs": "^6.3.0",
     "raven": "^1.2.1",
     "raven-js": "^3.14.2",
-    "rc-slider": "^6.1.2",
+    "rc-slider": "^7.0.8",
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5796,14 +5796,15 @@ rc-animate@2.x:
     css-animation "^1.3.0"
     prop-types "^15.5.6"
 
-rc-slider@^6.1.2:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/rc-slider/-/rc-slider-6.3.1.tgz#67ce34360902d69258efe0010b69de80db750cc3"
+rc-slider@^7.0.8:
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/rc-slider/-/rc-slider-7.0.8.tgz#1bdd7cbfd8ec1b6418ba55e506888bbb50159556"
   dependencies:
     babel-runtime "6.x"
     classnames "^2.2.5"
+    prop-types "^15.5.4"
     rc-tooltip "^3.4.2"
-    rc-util "^4.0.0"
+    rc-util "^4.0.4"
     warning "^3.0.0"
 
 rc-tooltip@^3.4.2:
@@ -5824,11 +5825,19 @@ rc-trigger@1.x:
     rc-animate "2.x"
     rc-util "4.x"
 
-rc-util@4.x, rc-util@^4.0.0:
+rc-util@4.x:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.0.2.tgz#5804f8b141a13c8c14d7c265a7d21d298195af46"
   dependencies:
     add-dom-event-listener "1.x"
+    shallowequal "^0.2.2"
+
+rc-util@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.0.4.tgz#99813dd90aee7e29b64939a70ac176ead3f4ff39"
+  dependencies:
+    add-dom-event-listener "1.x"
+    babel-runtime "6.x"
     shallowequal "^0.2.2"
 
 rc@^1.1.2, rc@^1.1.7:


### PR DESCRIPTION
This PR cleans up a few rough edges around Auctions in Force:

**1** - After bidder registration, when clicking into an auction artwork and then hitting back `/confirm-registration` would trigger the previously dismissed registration status modal

**To Test:**

```sh
git checkout -b damassi-auctions-polish master
git pull https://github.com/damassi/force.git auctions-polish
yarn install && yarn start
```

- Log out and create a new account
- Navigate to http://localhost:5000/auction/members-only and click `Register to Bid` 
- Fill out form and submit
- Click the `x` or surrounding area and notice that the `/confirm-registration` route fragment is replaced in the URL bar

**2** - On `/artwork/:id`, an additional client-side query was necessary to update the "Bid' button so that it displays the right state. Now this is performed on the server enabling server to render correct state, and polled on the client should updates be needed. (Note that as this is bootstrap data, existing tests cover button state.)

**To Test:**
- Log out and create a new account
- Navigate to http://localhost:5000/auction/members-only and click `Register to Bid` 
- Fill out form and submit
- Navigate to http://localhost:5000/artwork/cesar-trinca-painting and note that the button state is immediately correct (`Registration Pending`)

**3** - After bidder registration, the status modal is triggered twice with the second appearance occurring due to a strange hard page refresh thats triggered due to discrepancies between form updates made during registration and sync checks in https://github.com/artsy/force/blob/master/desktop/lib/global_client_setup.coffee#L37. See https://artsy.slack.com/archives/C0C4AJ1PF/p1494988497731780 for more background. 
