### PR TITLE
@damassi => add dot for inline script tag in jade

### DIFF
--- a/desktop/components/main_layout/templates/scripts.jade
+++ b/desktop/components/main_layout/templates/scripts.jade
@@ -1,5 +1,5 @@
 //- Marketo Tracking
-script(type='text/javascript', src='//du4pg90j806ok.cloudfront.net/js/touch-history/dist/conversionpath-0.3.8.min.js')
+script(type='text/javascript', src='//du4pg90j806ok.cloudfront.net/js/touch-history/dist/conversionpath-0.3.8.min.js').
   {
   "stageMappings": {
   "initial": [


### PR DESCRIPTION
Latest master appears to be broken on this added script-- in jade templates, there needs to be a `.` after the script tag for it to be interpreted correctly cc @nicholassewitz 