### PR TITLE
@craigspaeth => submission flow artist autocomplete

### DIFF
--- a/desktop/apps/auction/test/analytics_middleware.js
+++ b/desktop/apps/auction/test/analytics_middleware.js
@@ -1,4 +1,3 @@
-import analyticsHooks from '../../../lib/analytics_hooks.coffee'
 import analyticsMiddleware from '../client/analytics_middleware'
 import auctions from '../client/reducers'
 import { applyMiddleware, createStore } from 'redux'
@@ -14,8 +13,7 @@ describe('analytics middleware', () => {
     })
   })
 
-  it ('tracks changes in mediums', () => {
-    const fakeNext = sinon.spy()
+  it('tracks changes in mediums', () => {
     const action = { type: 'UPDATE_MEDIUM_ID', payload: { mediumId: 'painting' } }
     const store = createStore(auctions, applyMiddleware(analyticsMiddleware))
 
@@ -34,8 +32,7 @@ describe('analytics middleware', () => {
     })
   })
 
-  it ('tracks changes in artists', () => {
-    const fakeNext = sinon.spy()
+  it('tracks changes in artists', () => {
     const action = { type: 'UPDATE_ARTIST_ID', payload: { artistId: 'andy-warhol' } }
     const store = createStore(auctions, applyMiddleware(analyticsMiddleware))
 
@@ -55,7 +52,6 @@ describe('analytics middleware', () => {
   })
 
   it('correctly tracks artists when Artists You Follow is clicked', () => {
-    const fakeNext = sinon.spy()
     const action = { type: 'UPDATE_ARTIST_ID', payload: { artistId: 'artists-you-follow' } }
     const store = createStore(auctions, applyMiddleware(analyticsMiddleware))
 
@@ -74,8 +70,7 @@ describe('analytics middleware', () => {
     })
   })
 
-  it ('tracks changes in price', () => {
-    const fakeNext = sinon.spy()
+  it('tracks changes in price', () => {
     const action = { type: 'UPDATE_ESTIMATE_RANGE', payload: { min: 100, max: 50000 } }
     const store = createStore(auctions, applyMiddleware(analyticsMiddleware))
 
@@ -94,8 +89,7 @@ describe('analytics middleware', () => {
     })
   })
 
-  it ('tracks changes in sort', () => {
-    const fakeNext = sinon.spy()
+  it('tracks changes in sort', () => {
     const action = { type: 'UPDATE_SORT', payload: { sort: 'lot_number' } }
     const store = createStore(auctions, applyMiddleware(analyticsMiddleware))
 
@@ -114,8 +108,7 @@ describe('analytics middleware', () => {
     })
   })
 
-  it ('does not track other actions', () => {
-    const fakeNext = sinon.spy()
+  it('does not track other actions', () => {
     const action = { type: 'TOGGLE_LIST_VIEW', payload: { isListView: true } }
     const store = createStore(auctions, applyMiddleware(analyticsMiddleware))
 

--- a/desktop/apps/auction/test/reducers.js
+++ b/desktop/apps/auction/test/reducers.js
@@ -1,8 +1,5 @@
-import AuctionGridArtwork from '../components/auction_grid_artwork'
-import AuctionListArtwork from '../components/auction_list_artwork'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
-import { renderToString } from 'react-dom/server'
 import auctions from '../client/reducers'
 import * as actions from '../client/actions'
 import { __RewireAPI__ as ActionsRewireApi } from '../client/actions'
@@ -60,7 +57,7 @@ describe('Reducers', () => {
                 }
               }
             }
-          )));
+          )))
         })
         it('calls the correct actions', () => {
           const expectedActions = [

--- a/desktop/apps/consignments2/client/actions.js
+++ b/desktop/apps/consignments2/client/actions.js
@@ -1,11 +1,32 @@
+import request from 'superagent'
+import { data as sd } from 'sharify'
 import { push } from 'react-router-redux'
 
 // Action types
+export const CLEAR_ARTIST_SUGGESTIONS = 'CLEAR_ARTIST_SUGGESTIONS'
+export const HIDE_NOT_CONSIGNING_MESSAGE = 'HIDE_NOT_CONSIGNING_MESSAGE'
 export const INCREMENT_STEP = 'INCREMENT_STEP'
+export const SHOW_NOT_CONSIGNING_MESSAGE = 'SHOW_NOT_CONSIGNING_MESSAGE'
+export const UPDATE_ARTIST_AUTOCOMPLETE_VALUE = 'UPDATE_ARTIST_AUTOCOMPLETE_VALUE'
+export const UPDATE_ARTIST_ID = 'UPDATE_ARTIST_ID'
+export const UPDATE_ARTIST_SUGGESTIONS = 'UPDATE_ARTIST_SUGGESTIONS'
 export const UPDATE_INPUTS = 'UPDATE_INPUTS'
 export const UPDATE_SUBMISSION = 'UPDATE_SUBMISSION'
 
 // Action creators
+export function chooseArtistAndAdvance (value) {
+  return (dispatch) => {
+    dispatch(updateArtistId(value._id))
+    dispatch(incrementStep()) // move to next step
+  }
+}
+
+export function clearArtistSuggestions () {
+  return {
+    type: CLEAR_ARTIST_SUGGESTIONS
+  }
+}
+
 export function createSubmission () {
   return (dispatch) => {
     // TODO: async request to convection to create submission
@@ -14,9 +35,39 @@ export function createSubmission () {
   }
 }
 
+export function fetchArtistSuggestions (value) {
+  return async (dispatch, getState) => {
+    try {
+      request.get(`${sd.API_URL}/api/v1/match/artists`)
+        .query({ visible_to_public: 'true', term: value })
+        .set('X-ACCESS-TOKEN', sd.CURRENT_USER.accessToken)
+        .end((err, res) => {
+          if (!err || res.ok) {
+            dispatch(updateArtistSuggestions(res.body))
+            dispatch(hideNotConsigningMessage())
+          }
+        })
+    } catch (error) {
+      console.error('error!', error)
+    }
+  }
+}
+
+export function hideNotConsigningMessage () {
+  return {
+    type: HIDE_NOT_CONSIGNING_MESSAGE
+  }
+}
+
 export function incrementStep () {
   return {
     type: INCREMENT_STEP
+  }
+}
+
+export function showNotConsigningMessage () {
+  return {
+    type: SHOW_NOT_CONSIGNING_MESSAGE
   }
 }
 
@@ -36,6 +87,33 @@ export function submitPhoto () {
     }
     dispatch(updateSubmission(dummySubmission))
     dispatch(push('/consign2/submission/thank_you'))
+  }
+}
+
+export function updateArtistAutocompleteValue (value) {
+  return {
+    type: UPDATE_ARTIST_AUTOCOMPLETE_VALUE,
+    payload: {
+      value
+    }
+  }
+}
+
+export function updateArtistId (artistId) {
+  return {
+    type: UPDATE_ARTIST_ID,
+    payload: {
+      artistId
+    }
+  }
+}
+
+export function updateArtistSuggestions (suggestions) {
+  return {
+    type: UPDATE_ARTIST_SUGGESTIONS,
+    payload: {
+      suggestions
+    }
   }
 }
 

--- a/desktop/apps/consignments2/client/reducers.js
+++ b/desktop/apps/consignments2/client/reducers.js
@@ -30,8 +30,11 @@ const stepsMapping = [
 ]
 
 const initialState = {
+  artistAutocompleteSuggestions: [],
+  artistAutocompleteValue: '',
   currentStep: 0,
   inputs: {
+    artist_id: '',
     authenticity_certificate: 'yes',
     depth: '',
     dimensions_metric: 'in',
@@ -45,6 +48,7 @@ const initialState = {
     width: '',
     year: ''
   },
+  notConsigningArtist: false,
   steps: sd && sd.CURRENT_USER ? last(stepsMapping, 3) : stepsMapping,
   submission: null,
   user: sd.CURRENT_USER
@@ -52,6 +56,16 @@ const initialState = {
 
 function submissionFlow (state = initialState, action) {
   switch (action.type) {
+    case actions.CLEAR_ARTIST_SUGGESTIONS: {
+      return u({
+        artistAutocompleteSuggestions: []
+      }, state)
+    }
+    case actions.HIDE_NOT_CONSIGNING_MESSAGE: {
+      return u({
+        notConsigningArtist: false
+      }, state)
+    }
     case actions.INCREMENT_STEP: {
       const step = state.currentStep
       if (step < state.steps.length) {
@@ -61,6 +75,28 @@ function submissionFlow (state = initialState, action) {
       } else {
         return state
       }
+    }
+    case actions.SHOW_NOT_CONSIGNING_MESSAGE: {
+      return u({
+        notConsigningArtist: true
+      }, state)
+    }
+    case actions.UPDATE_ARTIST_AUTOCOMPLETE_VALUE: {
+      return u({
+        artistAutocompleteValue: action.payload.value
+      }, state)
+    }
+    case actions.UPDATE_ARTIST_ID: {
+      return u({
+        inputs: {
+          artist_id: action.payload.artistId
+        }
+      }, state)
+    }
+    case actions.UPDATE_ARTIST_SUGGESTIONS: {
+      return u({
+        artistAutocompleteSuggestions: action.payload.suggestions
+      }, state)
     }
     case actions.UPDATE_INPUTS: {
       return u({

--- a/desktop/apps/consignments2/components/choose_artist/index.js
+++ b/desktop/apps/consignments2/components/choose_artist/index.js
@@ -1,33 +1,122 @@
+import Autosuggest from 'react-autosuggest'
 import PropTypes from 'prop-types'
 import React from 'react'
 import block from 'bem-cn'
 import { connect } from 'react-redux'
-import { incrementStep } from '../../client/actions'
+import { get } from 'lodash'
+import {
+  clearArtistSuggestions,
+  chooseArtistAndAdvance,
+  fetchArtistSuggestions,
+  showNotConsigningMessage,
+  updateArtistAutocompleteValue
+} from '../../client/actions'
 
-function ChooseArtist ({ incrementStepAction }) {
-  const b = block('consignments2-submission-choose-artist')
+function getSuggestionValue (suggestion) {
+  return suggestion.name
+}
 
+function renderSuggestion (suggestion) {
+  const imageUrl = get(suggestion, 'image_urls.square', '/images/missing_image.png')
   return (
-    <div className={b()}>
-      <div
-        className={b('next-button').mix('avant-garde-button-black')}
-        onClick={incrementStepAction}
-      >
-        Next
-      </div>
+    <div className='autosuggest-suggestion'>
+      <img src={imageUrl} />
+      <div>{suggestion.name}</div>
     </div>
   )
 }
 
-const mapDispatchToProps = {
-  incrementStepAction: incrementStep
+function ChooseArtist (props) {
+  const {
+    artistAutocompleteSuggestions,
+    artistAutocompleteValue,
+    clearArtistSuggestionsAction,
+    chooseArtistAndAdvanceAction,
+    fetchArtistSuggestionsAction,
+    notConsigningArtist,
+    showNotConsigningMessageAction,
+    onSuggestionsClearRequested,
+    updateArtistAutocompleteValueAction
+  } = props
+  const b = block('consignments2-submission-choose-artist')
+
+  const inputProps = {
+    value: artistAutocompleteValue,
+    onChange: updateArtistAutocompleteValueAction
+  }
+
+  const renderInputComponent = inputProps => (
+    <div>
+      <input {...inputProps} className={b('input').mix('bordered-input')} />
+    </div>
+  )
+
+  const nextEnabled = artistAutocompleteValue.length > 0
+
+  return (
+    <div className={b()}>
+      <div className={b('label')}>Artist/Designer Name</div>
+      <div className={b('autosuggest')}>
+        <Autosuggest
+          suggestions={artistAutocompleteSuggestions}
+          onSuggestionsFetchRequested={fetchArtistSuggestionsAction}
+          onSuggestionsClearRequested={clearArtistSuggestionsAction}
+          onSuggestionSelected={chooseArtistAndAdvanceAction}
+          getSuggestionValue={getSuggestionValue}
+          renderInputComponent={renderInputComponent}
+          renderSuggestion={renderSuggestion}
+          inputProps={inputProps}
+        />
+      </div>
+      <div
+        className={b('next-button').mix('avant-garde-button-black')}
+        onClick={showNotConsigningMessageAction}
+        disabled={!nextEnabled}
+      >
+        Next
+      </div>
+      {
+        notConsigningArtist &&
+        <div className={b('not-consigning')}>
+          Unfortunately, we are not currently consigning works for {artistAutocompleteValue}.<br /><a href='/'>Back to Artsy</a>
+        </div>
+      }
+    </div>
+  )
+}
+
+const mapStateToProps = (state) => {
+  return {
+    artistAutocompleteSuggestions: state.submissionFlow.artistAutocompleteSuggestions,
+    artistAutocompleteValue: state.submissionFlow.artistAutocompleteValue,
+    notConsigningArtist: state.submissionFlow.notConsigningArtist
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    chooseArtistAndAdvanceAction (event, { suggestion, suggestionValue }) {
+      dispatch(chooseArtistAndAdvance(suggestion))
+    },
+    clearArtistSuggestionsAction () {
+      dispatch(clearArtistSuggestions())
+    },
+    fetchArtistSuggestionsAction ({ value }) {
+      dispatch(fetchArtistSuggestions(value))
+    },
+    showNotConsigningMessageAction () {
+      dispatch(showNotConsigningMessage())
+    },
+    updateArtistAutocompleteValueAction (event, { newValue }) {
+      dispatch(updateArtistAutocompleteValue(newValue))
+    }
+  }
 }
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(ChooseArtist)
 
 ChooseArtist.propTypes = {
-  incrementStepAction: PropTypes.func.isRequired
 }

--- a/desktop/apps/consignments2/components/choose_artist/index.styl
+++ b/desktop/apps/consignments2/components/choose_artist/index.styl
@@ -1,3 +1,43 @@
 .consignments2-submission-choose-artist
   &__next-button
     width 100%
+    margin-top 20px !important
+
+  &__next-button[disabled]
+    pointer-events none
+    background-color white
+    color gray-color
+    border 1px solid gray-color
+
+  &__not-consigning
+    background-color yellow-light-color
+    margin-top 23px
+    padding 20px
+
+  &__label
+    avant-garde-size('s-headline')
+    margin-bottom 4px
+
+  &__input
+    height 40px
+    width 100%
+
+  .react-autosuggest__suggestions-list
+    background-color white
+
+  .react-autosuggest__suggestion
+    height 60px
+    border 1px solid gray-lighter-color
+
+    &:hover
+      cursor pointer
+      background-color gray-lightest-color
+
+  .autosuggest-suggestion
+    display flex
+    align-items center
+    padding 10px
+
+    img
+      height 40px
+      margin-right 12px

--- a/desktop/apps/consignments2/test/components.js
+++ b/desktop/apps/consignments2/test/components.js
@@ -1,9 +1,9 @@
 import * as actions from '../client/actions'
+import ChooseArtist from '../components/choose_artist'
 import StepMarker from '../components/step_marker'
 import SubmissionFlow from '../components/submission_flow'
 import React from 'react'
 import reducers from '../client/reducers'
-import { Provider } from 'react-redux'
 import { createStore } from 'redux'
 import { shallow } from 'enzyme'
 
@@ -18,7 +18,7 @@ describe('React components', () => {
     describe('non-logged-in user', () => {
       it('displays four steps', () => {
         const wrapper = shallow(
-          <Provider><StepMarker store={initialStore} /></Provider>
+          <StepMarker store={initialStore} />
         )
         const rendered = wrapper.render()
         rendered.find('.consignments2-step-marker__dot').length.should.eql(4)
@@ -26,13 +26,48 @@ describe('React components', () => {
 
       it('updates the color of step labels', () => {
         const wrapper = shallow(
-          <Provider><StepMarker store={initialStore} /></Provider>
+          <StepMarker store={initialStore} />
         )
         const rendered = wrapper.render()
         rendered.find('.consignments2-step-marker__step_active').length.should.eql(1)
         const activeText = rendered.text()
         activeText.should.containEql('Create Account')
       })
+    })
+  })
+
+  describe('ChooseArtist', () => {
+    it('disables the button when there is no input', () => {
+      const wrapper = shallow(
+        <ChooseArtist store={initialStore} />
+      )
+      const rendered = wrapper.render()
+      rendered.find('.consignments2-submission-choose-artist__next-button[disabled]').length.should.eql(1)
+    })
+
+    it('enables the button when there is an input', () => {
+      initialStore.dispatch(actions.updateArtistAutocompleteValue('andy'))
+      const wrapper = shallow(
+        <ChooseArtist store={initialStore} />
+      )
+      const rendered = wrapper.render()
+      rendered.find('.consignments2-submission-choose-artist__next-button[disabled]').length.should.eql(0)
+    })
+
+    it('shows and hides warning message', () => {
+      initialStore.dispatch(actions.showNotConsigningMessage())
+      const wrapper = shallow(
+        <ChooseArtist store={initialStore} />
+      )
+      const rendered = wrapper.render()
+      rendered.find('.consignments2-submission-choose-artist__not-consigning').length.should.eql(1)
+
+      initialStore.dispatch(actions.hideNotConsigningMessage())
+      const newWrapper = shallow(
+        <ChooseArtist store={initialStore} />
+      )
+      const newRendered = newWrapper.render()
+      newRendered.find('.consignments2-submission-choose-artist__not-consigning').length.should.eql(0)
     })
   })
 
@@ -56,7 +91,7 @@ describe('React components', () => {
     describe('non-logged-in user, stepping through', () => {
       it('shows the create account step first', () => {
         const wrapper = shallow(
-          <Provider><SubmissionFlow store={initialStore} /></Provider>
+          <SubmissionFlow store={initialStore} />
         )
         const rendered = wrapper.render()
         rendered.find('.consignments2-submission__step-title').length.should.eql(1)
@@ -67,7 +102,7 @@ describe('React components', () => {
       it('shows the choose artist step second', () => {
         initialStore.dispatch(actions.incrementStep())
         const wrapper = shallow(
-          <Provider><SubmissionFlow store={initialStore} /></Provider>
+          <SubmissionFlow store={initialStore} />
         )
         const rendered = wrapper.render()
         rendered.find('.consignments2-submission__step-title').length.should.eql(1)
@@ -80,7 +115,7 @@ describe('React components', () => {
         initialStore.dispatch(actions.incrementStep())
         initialStore.dispatch(actions.incrementStep())
         const wrapper = shallow(
-          <Provider><SubmissionFlow store={initialStore} /></Provider>
+          <SubmissionFlow store={initialStore} />
         )
         const rendered = wrapper.render()
         rendered.find('.consignments2-submission__step-title').length.should.eql(1)
@@ -94,7 +129,7 @@ describe('React components', () => {
         initialStore.dispatch(actions.incrementStep())
         initialStore.dispatch(actions.incrementStep())
         const wrapper = shallow(
-          <Provider><SubmissionFlow store={initialStore} /></Provider>
+          <SubmissionFlow store={initialStore} />
         )
         const rendered = wrapper.render()
         rendered.find('.consignments2-submission__step-title').length.should.eql(1)

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "rc-slider": "^6.1.2",
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
+    "react-autosuggest": "^9.0.1",
     "react-dom": "^15.4.2",
     "react-redux": "^5.0.2",
     "react-router": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1830,7 +1830,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.6.0, concat-stream@^1.4.6, concat-stream@^1.4.7:
+concat-stream@1.6.0, concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -5847,6 +5847,22 @@ react-addons-test-utils@^15.4.2:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
+react-autosuggest@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-9.0.1.tgz#b56eaf8fc3dd46d36b92c5395b6b07174bc10912"
+  dependencies:
+    prop-types "^15.5.8"
+    react-autowhatever "^10.0.0"
+    shallow-equal "^1.0.0"
+
+react-autowhatever@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/react-autowhatever/-/react-autowhatever-10.0.0.tgz#2d7fd54f0a330e33c06c53a83ef789da0ebb65bf"
+  dependencies:
+    prop-types "^15.5.8"
+    react-themeable "^1.1.0"
+    section-iterator "^2.0.0"
+
 react-dom@^15.4.2:
   version "15.5.4"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
@@ -5906,6 +5922,12 @@ react-test-renderer@^15.5.4:
   dependencies:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
+
+react-themeable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
+  dependencies:
+    object-assign "^3.0.0"
 
 react@^15.4.2:
   version "15.5.4"
@@ -6417,6 +6439,10 @@ scroll-frame@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/scroll-frame/-/scroll-frame-1.0.0.tgz#f562eb69d7ece50a06466f0e3cb2ef7bc3713b27"
 
+section-iterator@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/section-iterator/-/section-iterator-2.0.0.tgz#bf444d7afeeb94ad43c39ad2fb26151627ccba2a"
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
@@ -6486,6 +6512,10 @@ sha.js@^2.3.6, sha.js@~2.4.4:
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.8.tgz#37068c2c476b6baf402d14a49c67f597921f634f"
   dependencies:
     inherits "^2.0.1"
+
+shallow-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.0.0.tgz#508d1838b3de590ab8757b011b25e430900945f7"
 
 shallowequal@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
This PR adds the artist autocomplete page to the consignment submission flow.

It uses `react-autosuggest` which has helpful bindings for controlling what happens when you need to fetch suggestions, clear suggestions, select a suggestion, etc. In our case, these methods all correspond to redux actions that modify our state.

Selecting a valid artist takes you to the next page in the flow. Typing in an invalid artist (that returns no results) prompts you with a warning message.

![artist-autocomplete](https://cloud.githubusercontent.com/assets/2081340/26154134/4822beea-3adc-11e7-9247-3a483f5e18fc.gif)

There's also just a bunch of little semicolon/unused dependencies cleanup.