### PR TITLE
@erikdstock => Cleanup user/auctions

### DIFF
--- a/desktop/components/my_active_bids/index.styl
+++ b/desktop/components/my_active_bids/index.styl
@@ -37,6 +37,10 @@ item-margin-bottom = 16px
 .my-active-bids-item-details
   line-height 20px
 
+.my-active-bids-item-details--hide-bid
+  @extends .my-active-bids-item-details
+  padding-top 10px
+
 .bid-status
   position absolute
   top 0
@@ -46,13 +50,11 @@ item-margin-bottom = 16px
 
 .my-active-bids-bid-button
   small-avant-garde()
+  margin-top 26px
   padding 7px 14px
   position absolute
-  bottom item-margin-bottom
   right 0
 
 .my-active-bids-bid-live-button
-  small-avant-garde()
-  padding 7px 14px
-  position absolute
-  right 0
+  @extends .my-active-bids-bid-button
+  margin-top 14px

--- a/desktop/components/my_active_bids/query.coffee
+++ b/desktop/components/my_active_bids/query.coffee
@@ -21,6 +21,7 @@ module.exports = """
             live_start_at
             end_at
             is_live_open
+            is_closed
           }
           artwork {
             href

--- a/desktop/components/my_active_bids/template.jade
+++ b/desktop/components/my_active_bids/template.jade
@@ -1,28 +1,48 @@
 include ../bid_status/index
 
+mixin bidBlock(saleArtwork, bid) 
+  - artwork = saleArtwork.artwork
+  - isLiveOpen = saleArtwork.sale.is_live_open
+  - isClosed = saleArtwork.sale.is_closed
+  - isLiveOpenOrClosed = isLiveOpen || isClosed
+  - detailsClass = isLiveOpenOrClosed ? 'my-active-bids-item-details--hide-bid' : 'my-active-bids-item-details'
+  - bidButtonLabel = isLiveOpen ? 'Bid Live' : isClosed ? 'View Lot' : 'Bid'
+  - bidButtonLink = isLiveOpen ? viewHelpers.liveAuctionUrl(saleArtwork.sale_id, {isLoggedIn: true}) : artwork.href
+  - bidButtonClass = isLiveOpenOrClosed ? 'my-active-bids-bid-live-button' : 'my-active-bids-bid-button'
+  
+  a( href=artwork.href )
+    img( src=artwork.image.url )
+      
+    div(class=detailsClass)
+      h4 Lot #{saleArtwork.lot_label}
+      
+      .my-active-bids-item-artist
+        strong= artwork.artist.name
+        
+      unless isLiveOpenOrClosed
+        p #{saleArtwork.highest_bid.display} (#{saleArtwork.counts.bidder_positions} Bids)
+        
+  unless isLiveOpenOrClosed
+    +bidStatus(bid, bid.sale_artwork)
+    
+  a.avant-garde-button-black(
+    class=bidButtonClass
+    href=bidButtonLink
+  )= bidButtonLabel
+
 if myActiveBids && myActiveBids.length
   ul
     for bid in myActiveBids
-      if bid.sale_artwork
+      - saleArtwork = bid.sale_artwork
+      
+      if saleArtwork
         - leadingBidder = bid.is_leading_bidder
-        - reserveNotMet = bid.sale_artwork.reserve_status === 'reserve_not_met'
-        li.my-active-bids-item( data-artwork_id=bid.sale_artwork.id class= (!reserveNotMet && leadingBidder) ? ' my-active-bids-winning' : '' )
-          a( href=bid.sale_artwork.artwork.href )
-            img( src=bid.sale_artwork.artwork.image.url )
-            .my-active-bids-item-details
-              h4 Lot #{bid.sale_artwork.lot_label}
-              .my-active-bids-item-artist
-                strong= bid.sale_artwork.artwork.artist.name
-              p #{bid.sale_artwork.highest_bid.display} (#{bid.sale_artwork.counts.bidder_positions} Bids)
-          if bid.sale_artwork.sale.is_live_open
-            a.avant-garde-button-black.my-active-bids-bid-live-button(
-              href=viewHelpers.liveAuctionUrl(bid.sale_artwork.sale_id, {isLoggedIn: true})
-            ) Bid Live
-          else
-            +bidStatus(bid, bid.sale_artwork)
-            a.avant-garde-button-black.my-active-bids-bid-button(
-              href=bid.sale_artwork.artwork.href
-            ) Bid
+        - reserveNotMet = saleArtwork.reserve_status === 'reserve_not_met'
+        - isLiveOpenOrClosed = saleArtwork.sale.is_live_open || saleArtwork.sale.is_closed
+        - activeBidsClass = (leadingBidder && !reserveNotMet && !isLiveOpenOrClosed) ? ' my-active-bids-winning' : '' 
+        
+        li.my-active-bids-item( data-artwork_id=saleArtwork.id class=activeBidsClass)
+          +bidBlock(saleArtwork, bid)
 
 else
   | Nothing yet.

--- a/desktop/components/my_active_bids/test/template.coffee
+++ b/desktop/components/my_active_bids/test/template.coffee
@@ -19,6 +19,8 @@ fixture = -> [
       "sale": {
         "end_at": "2016-10-31T04:28:00+00:00",
         "live_start_at": null
+        "is_live_open": false,
+        "is_closed": false
       },
       "artwork": {
         "image": {
@@ -70,13 +72,27 @@ describe 'My Active Bids template', ->
     $('.bid-status').text().should.containEql 'Outbid'
     $('.bid-status__is-losing').length.should.equal 1
 
-  it 'does not render bid status for open live sale', ->
-    @locals.myActiveBids[0].sale_artwork.sale.live_start_at = moment().subtract(1, 'day').format()
-    @locals.myActiveBids[0].sale_artwork.sale.is_live_open = true
-    @locals.myActiveBids[0].sale_artwork.sale.end_at = null
-    $ = cheerio.load(template(@locals))
-    $('.bid-status').length.should.eql 0
-    $('.my-active-bids-bid-live-button').length.should.eql 1
-    $('.my-active-bids-bid-live-button').text().should.containEql 'Bid Live'
-    $('.my-active-bids-bid-live-button').attr('href')
-      .should.containEql('mauction-evening-sale/login')
+  describe 'live sale', ->
+    it 'does not render bid status for open live sale', ->
+      @locals.myActiveBids[0].sale_artwork.sale.live_start_at = moment().subtract(1, 'day').format()
+      @locals.myActiveBids[0].sale_artwork.sale.is_live_open = true
+      @locals.myActiveBids[0].sale_artwork.sale.end_at = null
+      $ = cheerio.load(template(@locals))
+      $('.bid-status').length.should.eql 0
+      $('.my-active-bids-item-details--hide-bid').length.should.eql 1
+      $('.my-active-bids-bid-live-button').length.should.eql 1
+      $('.my-active-bids-bid-live-button').text().should.containEql 'Bid Live'
+      $('.my-active-bids-bid-live-button').attr('href')
+        .should.containEql('mauction-evening-sale/login')
+
+  describe 'closed', ->
+    it 'does not render bid status when closed', ->
+      @locals.myActiveBids[0].sale_artwork.sale.live_start_at = moment().subtract(1, 'day').format()
+      @locals.myActiveBids[0].sale_artwork.sale.is_live_open = false
+      @locals.myActiveBids[0].sale_artwork.sale.is_closed = true
+      $ = cheerio.load(template(@locals))
+      $('.bid-status').length.should.eql 0
+      $('.my-active-bids-bid-live-button').length.should.eql 1
+      $('.my-active-bids-bid-live-button').text().should.containEql 'View Lot'
+      $('.my-active-bids-bid-live-button').attr('href')
+        .should.containEql('/artwork/ed-ruscha-cockroaches-from-insects-portfolio')


### PR DESCRIPTION
This PR updates `user/auctions` to be more clear for the user:
- If live or closed, remove bid details and update button label and url
- Cleanup layout

#### Pre-bidding:
![screen shot 2017-05-17 at 7 17 19 pm](https://cloud.githubusercontent.com/assets/236943/26183741/ac1bb0b0-3b35-11e7-87d9-43dfc6ff37e6.png)

#### Live
![screen shot 2017-05-17 at 7 17 42 pm](https://cloud.githubusercontent.com/assets/236943/26183747/b4106af4-3b35-11e7-9c60-839113b9a0a0.png)

#### Closed
![screen shot 2017-05-17 at 7 19 50 pm](https://cloud.githubusercontent.com/assets/236943/26183772/d3384348-3b35-11e7-82aa-18683ab0df9c.png)





Fixes https://github.com/artsy/auctions/issues/476