### PR TITLE
@mzikherman => Hide non-partner contact information

### DIFF
--- a/desktop/apps/partner/templates/overview.jade
+++ b/desktop/apps/partner/templates/overview.jade
@@ -17,9 +17,3 @@
 
   section.partner-overview-section.partner-overview-artists
     .loading-spinner
-
-  unless isPartner
-    section.partner-overview-section.partner-overview-locations
-      h2.avant-garde-header-center Locations
-      ul.locations
-        .loading-spinner


### PR DESCRIPTION
This is one of the items in https://github.com/artsy/collector-experience/issues/74. There may be other pages that show non-partner information, but let me know if there is anything I missed that I should update.