### PR TITLE
@craigspaeth => [Venice] Cleaner initial load on episodes 2+

### DIFF
--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -52,7 +52,7 @@ module.exports = class VeniceView extends Backbone.View
       friction: 0.8
       selectedAttraction: 0.2
     , (carousel) =>
-      $('.venice-header__overlay').hide()
+      $('.venice-header__overlay').fadeOut()
       @flickity = carousel.cells.flickity
       # Use 'settle' for changes that should have a delay ie: video swapping
       @flickity.on 'settle', =>

--- a/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -52,6 +52,7 @@ module.exports = class VeniceView extends Backbone.View
       friction: 0.8
       selectedAttraction: 0.2
     , (carousel) =>
+      $('.venice-header__overlay').hide()
       @flickity = carousel.cells.flickity
       # Use 'settle' for changes that should have a delay ie: video swapping
       @flickity.on 'settle', =>

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/body.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/body.styl
@@ -30,9 +30,6 @@
       flex-direction column
     .venice-body__right .venice-body__help
       display none
-  &--credit
-    garamond-size('l-caption')
-    margin-bottom 15px
   &__left
     width 50%
   &__right

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/index.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/index.styl
@@ -47,7 +47,7 @@ nav-height = 54px
   min-height 100vh
 
 .venice-header__overlay
-  background-color white
+  background-color black
   width 100vw
   height 100vh
   position absolute

--- a/desktop/apps/editorial_features/components/venice_2017/stylesheets/index.styl
+++ b/desktop/apps/editorial_features/components/venice_2017/stylesheets/index.styl
@@ -46,6 +46,13 @@ nav-height = 54px
 .venice-header
   min-height 100vh
 
+.venice-header__overlay
+  background-color white
+  width 100vw
+  height 100vh
+  position absolute
+  top 0
+
 .venice-info-icon
   position absolute
   bottom 0

--- a/desktop/apps/editorial_features/components/venice_2017/templates/body.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/body.jade
@@ -17,5 +17,3 @@ include ./mixins
       each section, i in curation.get('sections')
         +index_item(section, i)
     +help
-
-.venice-body--credit Cover photos by Alex John Beck for Artsy.

--- a/desktop/apps/editorial_features/components/venice_2017/templates/index.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/index.jade
@@ -17,6 +17,7 @@ block body
         include ../icons/icon_i.svg
       include ./video
       include ./carousel
+      .venice-header__overlay
 
     .venice-body
       include ./body

--- a/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
+++ b/desktop/apps/editorial_features/test/components/venice_2017/index.coffee
@@ -21,6 +21,7 @@ describe 'Venice Main', ->
         markdown: markdown
         crop: crop = sinon.stub().returns 'http://artsy.net/image.jpg'
       Backbone.$ = $
+      $.fn.fadeOut = @fadeOut = sinon.stub()
       @animateSpy = sinon.spy $.fn, 'animate'
       @curation =
         description: 'description'
@@ -99,6 +100,8 @@ describe 'Venice Main', ->
     @initCarousel.args[0][1].advanceBy.should.equal 1
     @initCarousel.args[0][1].wrapAround.should.be.true()
     @initCarousel.args[0][1].initialIndex.should.equal 0
+    @initCarousel.args[0][2](cells: flickity: on: ->)
+    @fadeOut.callCount.should.equal 2
 
   it 'Sets up the footer carousel', ->
     $(@view.el).find('.venice-footer').html().should.containEql '<h2 class="title">The Venice Biennale</h2>'


### PR DESCRIPTION
Since the carousel dictates routing on client-side, going to https://www.artsy.net/venice-biennale/episode-2 (Episode 2) feels a little clunky since Flickity always "shows" the first item before going to the right index. This problem is better understood visually: 

Problem: 
![fade_before_venice](https://cloud.githubusercontent.com/assets/2236794/26417612/b17da14c-4087-11e7-96a8-218c03ab6d76.gif)

Solution:
![fade_after_venice](https://cloud.githubusercontent.com/assets/2236794/26417622/b64dfd2a-4087-11e7-8d51-3fdd496db16c.gif)
