### PR TITLE
@craigspaeth => Alias lodash.get to _.get

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -4,6 +4,7 @@
 // populating sharify data
 //
 import _ from 'underscore'
+import lodashGet from 'lodash.get'
 import artsyPassport from 'artsy-passport'
 import artsyXapp from 'artsy-xapp'
 import Backbone from 'backbone'
@@ -40,6 +41,9 @@ import backboneErrorHelper from './middleware/backbone_error_helper'
 import CurrentUser from './current_user'
 import splitTestMiddleware from '../desktop/components/split_test/middleware'
 import config from '../config'
+
+// https://lodash.com/docs/4.17.4#get
+_.get = lodashGet
 
 const {
   API_REQUEST_TIMEOUT,


### PR DESCRIPTION
This PR aliases the very useful (plucked) `lodash.get` (https://lodash.com/docs/4.17.4#get) to `_.get` for easy access. Allows for things like 

```javascript
import { get } from 'underscore'

const foo = {a: { b: { c: [0, 1, 2, 3, 4] }}} 
const get4 = get(foo, 'a.b.c.5', someDefaultIfNotFound)
console.log(get4) // => 4
```

which helps reduce guard boilerplate. 

Note that I've already added it to [here](https://github.com/artsy/force/blob/master/desktop/lib/global_client_setup.coffee#L10) but I'm not sure if this is necessary anymore with the changes made within this PR. 