### PR TITLE
@craigspaeth => Responsive landing page for consignments + modal

### DIFF
--- a/desktop/apps/consignments2/client/index.js
+++ b/desktop/apps/consignments2/client/index.js
@@ -1,13 +1,13 @@
-import ArtworkRailView from '../../../components/artwork_rail/client/view.coffee'
-import Artworks from '../../../collections/artworks.coffee'
-import { data as sd } from 'sharify'
-
 export default () => {
-  // 'Recently Sold' rail
-  // const artworks = new Artworks(sd.RECENTLY_SOLD)
-  // const rail = new ArtworkRailView({
-  //   $el: $('.js-recently-sold-rail'),
-  //   collection: artworks
-  // })
-  // rail.render()
+  $('body').on('click', '#consignments2-open-faq-modal', (e) => {
+    e.preventDefault()
+    $('.consignments2-faq').show()
+    $('body').addClass('is-scrolling-disabled')
+  })
+
+  $('body').on('click', '.consignments2-faq__close', (e) => {
+    e.preventDefault()
+    $('.consignments2-faq').hide()
+    $('body').removeClass('is-scrolling-disabled')
+  })
 }

--- a/desktop/apps/consignments2/client/index.js
+++ b/desktop/apps/consignments2/client/index.js
@@ -4,10 +4,10 @@ import { data as sd } from 'sharify'
 
 export default () => {
   // 'Recently Sold' rail
-  const artworks = new Artworks(sd.RECENTLY_SOLD)
-  const rail = new ArtworkRailView({
-    $el: $('.js-recently-sold-rail'),
-    collection: artworks
-  })
-  rail.render()
+  // const artworks = new Artworks(sd.RECENTLY_SOLD)
+  // const rail = new ArtworkRailView({
+  //   $el: $('.js-recently-sold-rail'),
+  //   collection: artworks
+  // })
+  // rail.render()
 }

--- a/desktop/apps/consignments2/routes.js
+++ b/desktop/apps/consignments2/routes.js
@@ -7,7 +7,6 @@ import { extend } from 'underscore'
 const landing = new JSONPage({ name: 'consignments2/landing' })
 
 export const landingPage = async (req, res, next) => {
-  // const recentlySold = new Items([], { item_type: 'Artwork' })
   const inDemand = new Items([], { item_type: 'Artist' })
 
   try {

--- a/desktop/apps/consignments2/stylesheets/index.styl
+++ b/desktop/apps/consignments2/stylesheets/index.styl
@@ -2,6 +2,7 @@
 @require '../../../components/artwork_rail/stylesheets/index'
 
 @require './landing/desktop'
+@require './landing/faq'
 @require './landing/mobile'
 
 @require '../components/checkbox_input/index'

--- a/desktop/apps/consignments2/stylesheets/landing/desktop.styl
+++ b/desktop/apps/consignments2/stylesheets/landing/desktop.styl
@@ -1,4 +1,4 @@
-.consignments2-header
+.consignments2-header, .consignments2-footer
   position relative
   padding gutter
   text-align center
@@ -11,7 +11,7 @@
   flex-direction column
   background-size cover
   background-repeat none
-  background-position center center
+  background-position right
 
   &__consign-button
     avant-garde-size('body')
@@ -26,6 +26,7 @@
     max-width 750px
     margin-bottom 15px
     garamond-size('xl-headline')
+
   &__subheadline
     garamond-size('s-headline')
 
@@ -46,11 +47,7 @@
     garamond-size('headline')
 
 .consignments2-section
-  padding 0 55px
-  // @media screen and (min-width: 1440px)
-  //   padding 0 150px
-  // @media screen and (min-width: 1660px)
-  //   padding 0 200px
+  padding 60px 55px
 
   &__consign-button.avant-garde-button-black
     avant-garde-size('body')
@@ -65,6 +62,10 @@
     &__headline
       margin-bottom 38px
       garamond-size('xl-headline')
+
+      @media screen and (max-width: 768px)
+        font-size 40px
+
     &__description
       block-margins(gutter)
       garamond-size('l-body')
@@ -79,11 +80,12 @@
       display flex
       justify-content space-around
       align-items center
+
       img
         display block
         max-width 180px
         height auto
-        width auto
+        width 23%
 
 .consignments2-steps
   padding gutter
@@ -95,13 +97,16 @@
   &__steps
     display flex
     justify-content center
+    max-width 1100px
+    margin 0 auto
+
     &__step
       text-align center
       &__image
         max-width 100%
         display inline-block
         width 80px
-        margin-bottom 35px
+        margin-bottom 15px
 
       &__title
         avant-garde-size('body')
@@ -113,7 +118,7 @@
           margin-right gutter
           garamond-size('xxl-headline')
         > p
-          padding 0 (gutter * 2)
+          padding 0 20px
           garamond-size('l-body')
 
 .consignments2-how-consignments-work
@@ -133,8 +138,6 @@
     margin-bottom 60px
 
 .consignments2-top-sales
-  margin-top 85px
-  margin-bottom 40px
   margin-left auto
   margin-right auto
   max-width 1100px
@@ -147,24 +150,60 @@
 
 .consignments2-recently-sold
   padding-top 20px
+  max-width 1700px
+
+  &__artworks
+    display flex
+    overflow hidden
+    flex-wrap wrap
+    height 300px
+    justify-content center
+    padding-top 30px
+
+    &__artwork
+      text-align left
+      garamond-size('m-caption')
+      color gray-darker-color
+      padding 0 10px
+      padding-top 20px
+      position relative
+      height 300px
+
+      &__data
+        padding-top 10px
+        position absolute
+        max-width 100%
+        padding-right 15px
+
+        > *
+          overflow ellipsis
+
+      &__artists
+        font-weight bold
+
+      &__title
+        font-style italic
 
 .consignments2-in-demand
-  padding-top 70px
+  padding-top 20px
   padding-bottom 70px
-  max-width 1100px
+  max-width 1300px
   margin 0 auto
 
   &__artists
     display flex
     flex-wrap wrap
+    height 400px
+    overflow hidden
+    justify-content center
 
     &__artist
       padding 15px
-      width 165px
 
       h4
         padding-top 10px
         avant-garde-size('body')
+        max-width 150px
 
      img
         width 150px
@@ -173,15 +212,24 @@
 
 .consignments2-upcoming-sales
   height 480px
-  padding-top 60px
   color white
+  padding-top 60px
+  background-size cover
+  background-position right
+
+  &--mobile
+    @media screen and (min-width: 641px)
+      display none
 
   &__content
     max-width 900px
-    width 60%
     min-width 400px
-    margin-left 150px
+    margin-left 10%
     text-align left
+
+    @media screen and (max-width: 960px)
+      width 100%
+      margin-left 0px
 
   &__sales
     display flex
@@ -191,7 +239,7 @@
 
     &__sale, &__button
       width 45%
-      min-width 300px
+      min-width 250px
       padding-right 10px
       max-width 420px
 
@@ -203,7 +251,7 @@
         garamond-size('l-body')
 
 .consignments2-section__questions
-  padding-top 100px
+  padding-top 80px
   padding-bottom 70px
   text-align left
   max-width 1100px
@@ -215,15 +263,18 @@
 
     .consignments2-section__about, .consignments2-section__questions__crt-photos
       width 45%
-      min-width 400px
       padding-right 10px
       max-width 420px
 
   &__crt-photos
     display flex
 
-    &__photo
+    &__photo1, &__photo2
       padding-right 20px
+
+    &__photo1
+      @media screen and (max-width: 768px)
+        display none
 
   &__sections
     display flex
@@ -232,7 +283,6 @@
 
     &__section
       width 45%
-      min-width 400px
       padding-bottom 40px
       padding-right 10px
       max-width 420px
@@ -240,8 +290,8 @@
       h4
         padding-bottom 15px
 
-mpv-height = 665px
-mpv-padding = 20px
-// narrow mpv height based on 1024 x 768 viewport
-// to catch some differing FAQ lengths
-mpv-height-narrow = 710px
+#main-layout-footer
+  display none
+
+#main-layout-container
+  margin-top 0px !important

--- a/desktop/apps/consignments2/stylesheets/landing/faq.styl
+++ b/desktop/apps/consignments2/stylesheets/landing/faq.styl
@@ -1,0 +1,48 @@
+.consignments2-faq
+  display none
+
+  &__modal
+    position fixed
+    z-index 1000
+    left 0
+    top 0
+    width 100%
+    height 100%
+    background-color rgba(0,0,0,0.4)
+    display flex
+    justify-content center
+    align-items center
+
+  &__contents
+    background-color white
+    padding 60px
+    min-width 640px
+    max-width 850px
+    width 60%
+    height 90%
+    position relative
+    overflow-y scroll
+
+  &__close
+    position absolute
+    right 40px
+    top 40px
+    fill gray-color
+
+    &:hover
+      cursor pointer
+
+  &__header
+    garamond-size('l-headline')
+    margin-bottom 44px
+
+  &__item
+    &__question
+      garamond-size('l-body')
+
+    &__answer
+      garamond-size('s-body')
+      margin-bottom 20px
+
+  &__contact-us
+    garamond-size('s-body')

--- a/desktop/apps/consignments2/stylesheets/landing/mobile.styl
+++ b/desktop/apps/consignments2/stylesheets/landing/mobile.styl
@@ -87,3 +87,17 @@
         h4
           garamond-size('l-body')
           font-weight bold
+
+  .consignments2-faq
+    display none
+
+    &__contents
+      width 100%
+      height 100%
+      min-width 0
+      max-width none
+      padding 20px
+
+    &__close
+      top 15px
+      right 15px

--- a/desktop/apps/consignments2/stylesheets/landing/mobile.styl
+++ b/desktop/apps/consignments2/stylesheets/landing/mobile.styl
@@ -1,85 +1,89 @@
 @media (max-width: 640px)
-  .consignments2-header
-    height inherit
-    padding gutter
-
+  .consignments2-header, .consignments2-footer
     &__headline
-      garamond-size('l-headline')
-    &__subheadline
-      garamond-size('l-body')
-    &__cta
-      > h3
-        margin gutter 0
-        avant-garde-size('body')
+      font-size 40px
 
-  .consignments2-sections
-    padding 0 (gutter / 2)
+  .consignments2-footer
+    display none
 
   .consignments2-section
-    display block
-    padding gutter 0
+    padding 60px 20px
 
     &__about
       &__headline
-        garamond-size('headline')
+        font-size 30px
 
-    &--estimate
-    &--privacy
-      .consignments2-section__about
-        width 100%
-        padding 0
-      .consignments2-section__images
-        display none
+    &__images
+      &.consignments2-section__images--logos
+        flex-wrap wrap
 
-    &--logos
-      .consignments2-section__about
-      .consignments2-section__images
-        width 100%
-        padding 0
-      .consignments2-section__images
-        margin-bottom gutter
-        padding-bottom gutter
-        border-bottom 1px solid gray-lighter-color
+        img
+          width 120px
+          padding-bottom 40px
 
   .consignments2-steps
-    padding (gutter / 2) 0
-
-    &__headline
-      garamond-size('headline')
     &__steps
-      display block
-      &__step
-        width 100%
-        clearfix()
-        &__image
-          display none
-        &__description
-          > p
-            padding-right 0
+      flex-direction column
+
+  .consignments2-logos
+    padding-bottom 0px
 
   .consignments2-recently-sold
-    display none
+    padding-top 20px
+    max-width 1700px
 
-  .consignments2-in-demand
-    padding (gutter / 2) 0
-    h3
-      garamond-size('headline')
+    &__artworks
+      height 600px
+
+      &__artwork
+        max-width 50%
 
   .consignments2-in-demand
     &__artists
       &__artist
-        width 48%
-        &__name
-          avant-garde-size('s-headline')
-        &__button
-          display none
+        padding-bottom 15px 5px
 
-  .consignments2-footer
-    width 100%
-    padding gutter 0 (gutter * 2)
-    h3
-      garamond-size('headline')
+  .consignments2-upcoming-sales
+    &--desktop
+      display none
 
-  .consignments2-credit
-    padding gutter 0
-    garamond-size('l-caption')
+    &--mobile
+      height 640px
+      padding-top 0px
+      background-position bottom
+
+      .consignments2-section__about__headline
+        text-align center
+
+      .consignments2-upcoming-sales__sales__button
+        margin 0 auto
+        margin-bottom 30px
+        padding-right 0px
+        text-align center
+
+      .consignments2-upcoming-sales__sales__sale
+        padding-bottom 25px
+
+      .consignments2-upcoming-sales__content
+        max-width none
+        min-width 0
+        padding-top 28px
+
+  .consignments2-section__questions
+    &__header-section
+      .consignments2-section__about, .consignments2-section__questions__crt-photos
+        width 250px
+        text-align center
+        padding-right 0px
+
+    &__crt-photos
+      display none
+
+    &__sections
+      &__section
+        width 100%
+        padding-right 0px
+
+        h4
+          garamond-size('l-body')
+          font-weight bold

--- a/desktop/apps/consignments2/templates/faq.jade
+++ b/desktop/apps/consignments2/templates/faq.jade
@@ -1,0 +1,17 @@
+.consignments2-faq
+  .consignments2-faq__modal
+    .consignments2-faq__contents
+      .consignments2-faq__close
+        include ../../../components/main_layout/public/icons/close.svg
+      .consignments2-faq__header
+        = sections.faq.headline
+      for item in sections.faq.items
+        .consignments2-faq__item
+          .consignments2-faq__item__question
+            = item.question
+          .consignments2-faq__item__answer
+            = item.answer
+      .consignments2-faq__contact-us
+        | Need more assistance?&nbsp;
+        a( href='mailto:consignments@artsy.net' )
+          | Contact us

--- a/desktop/apps/consignments2/templates/landing.jade
+++ b/desktop/apps/consignments2/templates/landing.jade
@@ -18,129 +18,134 @@ block body
         a.avant-garde-button-white.consignments2-header__consign-button( href='/consign2/submission' )
           = header.button_cta
 
-  .consignments2-sections
-    //- How consignments work
-    section.consignments2-section.consignments2-how-consignments-work
-      .consignments2-section__about
-        h3.consignments2-section__about__headline
-          = sections.how_consignments_work.headline
-        .consignments2-steps__steps
-          for step, i in sections.how_consignments_work.steps
-            .consignments2-steps__steps__step
-              img.consignments2-steps__steps__step__image( src= step.icon )
-              .consignments2-steps__steps__step__title
-                = step.title
-              .consignments2-steps__steps__step__description
-                p= step.description
+    .consignments2-sections
+      //- How consignments work
+      section.consignments2-section.consignments2-how-consignments-work
+        .consignments2-section__about
+          h3.consignments2-section__about__headline
+            = sections.how_consignments_work.headline
+          .consignments2-steps__steps
+            for step, i in sections.how_consignments_work.steps
+              .consignments2-steps__steps__step
+                img.consignments2-steps__steps__step__image( src= step.icon )
+                .consignments2-steps__steps__step__title
+                  = step.title
+                .consignments2-steps__steps__step__description
+                  p= step.description
+          a.avant-garde-button-black.consignments2-section__consign-button( href='/consign2/submission' )
+            = sections.how_consignments_work.button_cta
+
+      //- Placement
+      section.consignments2-section.consignments2-logos
+        .consignments2-logos__content
+          .consignments2-section__about
+            h3.consignments2-section__about__headline
+              = sections.placement.headline
+          .consignments2-section__images.consignments2-section__images--logos
+            for logo in sections.placement.logos
+              img.consignments2-section__images__logo( src= logo.src )
+
+      //- Top sales
+      section.consignments2-section.consignments2-top-sales
+        .consignments2-section__about
+          h3.consignments2-section__about__headline
+            = sections.top_sales.headline
         a.avant-garde-button-black.consignments2-section__consign-button( href='/consign2/submission' )
-          = sections.how_consignments_work.button_cta
+            = sections.top_sales.button_cta
 
-    //- Placement
-    section.consignments2-section.consignments2-logos
-      .consignments2-logos__content
-        .consignments2-section__about
-          h3.consignments2-section__about__headline
-            = sections.placement.headline
-        .consignments2-section__images.consignments2-section__images--logos
-          for logo in sections.placement.logos
-            img.consignments2-section__images__logo( src= logo.src )
+      //- Recently Sold
+      section.consignments2-section.consignments2-recently-sold
+        h4= sections.recently_sold.sub_headline
+        .consignments2-recently-sold__artworks
+          for artwork in recentlySold
+            .consignments2-recently-sold__artworks__artwork
+              figure
+                img( src= artwork.image.thumb.url )
+                figcaption.consignments2-recently-sold__artworks__artwork__data
+                  .consignments2-recently-sold__artworks__artwork__artists
+                    = artwork.artists.map((aa) => aa.name).join(', ')
+                  .consignments2-recently-sold__artworks__artwork__title
+                    = artwork.title
+                  .consignments2-recently-sold__artworks__artwork__partner
+                    = artwork.partner.name
 
-    //- Top sales
-    section.consignments2-section.consignments2-top-sales
-      .consignments2-section__about
-        h3.consignments2-section__about__headline
-          = sections.top_sales.headline
-       a.avant-garde-button-black.consignments2-section__consign-button( href='/consign2/submission' )
-          = sections.top_sales.button_cta
+      //- In Demand
+      section.consignments2-section.consignments2-in-demand
+        h4= sections.in_demand.sub_headline
+        .consignments2-in-demand__artists
+          for artist in inDemand.models
+            .consignments2-in-demand__artists__artist
+              .consignments2-in-demand__artists__artist__thumbnail
+                img(
+                  src= artist.imageUrl('square')
+                  alt= artist.get('name')
+                )
 
-    //- Recently Sold
-    section.consignments2-section.consignments2-recently-sold
-      h4= sections.recently_sold.sub_headline
-      .consignments2-recently-sold__artworks
-        for artwork in recentlySold
-          .consignments2-recently-sold__artworks__artwork
-            figure
-              img( src= artwork.image.thumb.url )
-              figcaption.consignments2-recently-sold__artworks__artwork__data
-                .consignments2-recently-sold__artworks__artwork__artists
-                  = artwork.artists.map((aa) => aa.name).join(', ')
-                .consignments2-recently-sold__artworks__artwork__title
-                  = artwork.title
-                .consignments2-recently-sold__artworks__artwork__partner
-                  = artwork.partner.name
+              h4.consignments2-in-demand__artists__artist__name
+                = artist.get('name')
 
-    //- In Demand
-    section.consignments2-section.consignments2-in-demand
-      h4= sections.in_demand.sub_headline
-      .consignments2-in-demand__artists
-        for artist in inDemand.models
-          .consignments2-in-demand__artists__artist
-            .consignments2-in-demand__artists__artist__thumbnail
-              img(
-                src= artist.imageUrl('square')
-                alt= artist.get('name')
-              )
+      //- Upcoming sales, desktop version
+      section.consignments2-section.consignments2-upcoming-sales.consignments2-upcoming-sales--desktop(
+        style='background-image: url(#{sections.upcoming_sales.image.src});'
+      )
+        .consignments2-upcoming-sales__content
+          .consignments2-section__about
+            h3.consignments2-section__about__headline
+              = sections.upcoming_sales.headline
+          .consignments2-upcoming-sales__sales
+            for sale in sales
+              .consignments2-upcoming-sales__sales__sale
+                h5= moment(sale.start_at).format('MMM D')
+                p= sale.name
+            .consignments2-upcoming-sales__sales__button
+              a.avant-garde-button-black.consignments2-section__consign-button( href='/consign2/submission' )
+                  = sections.upcoming_sales.button_cta
 
-            h4.consignments2-in-demand__artists__artist__name
-              = artist.get('name')
-
-    //- Upcoming sales, desktop version
-    section.consignments2-section.consignments2-upcoming-sales.consignments2-upcoming-sales--desktop(
-      style='background-image: url(#{sections.upcoming_sales.image.src});'
-    )
-      .consignments2-upcoming-sales__content
-        .consignments2-section__about
-          h3.consignments2-section__about__headline
-            = sections.upcoming_sales.headline
-        .consignments2-upcoming-sales__sales
-          for sale in sales
-            .consignments2-upcoming-sales__sales__sale
-              h5= moment(sale.start_at).format('MMM D')
-              p= sale.name
+      //- Upcoming sales, mobile version
+      section.consignments2-section.consignments2-upcoming-sales.consignments2-upcoming-sales--mobile(
+        style='background-image: url(#{sections.upcoming_sales.mobile_image.src});'
+      )
+        .consignments2-upcoming-sales__content
+          .consignments2-section__about
+            h3.consignments2-section__about__headline
+              = sections.upcoming_sales.headline
           .consignments2-upcoming-sales__sales__button
             a.avant-garde-button-black.consignments2-section__consign-button( href='/consign2/submission' )
-                = sections.upcoming_sales.button_cta
-
-    //- Upcoming sales, mobile version
-    section.consignments2-section.consignments2-upcoming-sales.consignments2-upcoming-sales--mobile(
-      style='background-image: url(#{sections.upcoming_sales.mobile_image.src});'
-    )
-      .consignments2-upcoming-sales__content
-        .consignments2-section__about
-          h3.consignments2-section__about__headline
-            = sections.upcoming_sales.headline
-        .consignments2-upcoming-sales__sales__button
-          a.avant-garde-button-black.consignments2-section__consign-button( href='/consign2/submission' )
-            = sections.upcoming_sales.button_cta
-        .consignments2-upcoming-sales__sales
-          for sale in sales
-            .consignments2-upcoming-sales__sales__sale
-              h5= moment(sale.start_at).format('MMM D')
-              p= sale.name
+              = sections.upcoming_sales.button_cta
+          .consignments2-upcoming-sales__sales
+            for sale in sales
+              .consignments2-upcoming-sales__sales__sale
+                h5= moment(sale.start_at).format('MMM D')
+                p= sale.name
 
 
-    //- Questions
-    section.consignments2-section.consignments2-section__questions
-      .consignments2-section__questions__header-section
-        .consignments2-section__about
-          h3.consignments2-section__about__headline
-            = sections.questions.headline
-        .consignments2-section__questions__crt-photos
-          .consignments2-section__questions__crt-photos__photo1
-            img( src= sections.questions.crt_photo_1.src )
-          .consignments2-section__questions__crt-photos__photo2
-            img( src= sections.questions.crt_photo_2.src )
-      .consignments2-section__questions__sections
-        for section in sections.questions.sections
+      //- Questions
+      section.consignments2-section.consignments2-section__questions
+        .consignments2-section__questions__header-section
+          .consignments2-section__about
+            h3.consignments2-section__about__headline
+              = sections.questions.headline
+          .consignments2-section__questions__crt-photos
+            .consignments2-section__questions__crt-photos__photo1
+              img( src= sections.questions.crt_photo_1.src )
+            .consignments2-section__questions__crt-photos__photo2
+              img( src= sections.questions.crt_photo_2.src )
+        .consignments2-section__questions__sections
+          for section in sections.questions.sections
+            .consignments2-section__questions__sections__section
+              h4= section.sub_headline
+              p= section.description
           .consignments2-section__questions__sections__section
-            h4= section.sub_headline
-            p= section.description
+            h4 Want to learn more? Read our <a id='consignments2-open-faq-modal' href='#'>full FAQ</a> or&nbsp;
+              a( href='mailto:consignments@artsy.net' ) contact us.
 
-  .consignments2-footer(
-    style='background-image: url(#{sections.footer.image.src});'
-  )
-    h1.consignments2-header__headline
-      = sections.footer.headline
-    .consignments2-header__cta
-      a.avant-garde-button-white.consignments2-header__consign-button( href='/consign2/submission' )
-        = sections.footer.button_cta
+    .consignments2-footer(
+      style='background-image: url(#{sections.footer.image.src});'
+    )
+      h1.consignments2-header__headline
+        = sections.footer.headline
+      .consignments2-header__cta
+        a.avant-garde-button-white.consignments2-header__consign-button( href='/consign2/submission' )
+          = sections.footer.button_cta
+
+  include ./faq

--- a/desktop/apps/consignments2/templates/landing.jade
+++ b/desktop/apps/consignments2/templates/landing.jade
@@ -1,4 +1,4 @@
-extends ../../../components/main_layout/templates/index
+extends ../../../components/main_layout/templates/minimal_header
 
 block head
   include meta
@@ -56,10 +56,18 @@ block body
     //- Recently Sold
     section.consignments2-section.consignments2-recently-sold
       h4= sections.recently_sold.sub_headline
-      .consignments2-recently-sold__artworks( class='js-recently-sold-rail' )
-        - var artworks = recentlySold.models
-        - var imageHeight = 220
-        include ../../../components/artwork_rail/templates/index
+      .consignments2-recently-sold__artworks
+        for artwork in recentlySold
+          .consignments2-recently-sold__artworks__artwork
+            figure
+              img( src= artwork.image.thumb.url )
+              figcaption.consignments2-recently-sold__artworks__artwork__data
+                .consignments2-recently-sold__artworks__artwork__artists
+                  = artwork.artists.map((aa) => aa.name).join(', ')
+                .consignments2-recently-sold__artworks__artwork__title
+                  = artwork.title
+                .consignments2-recently-sold__artworks__artwork__partner
+                  = artwork.partner.name
 
     //- In Demand
     section.consignments2-section.consignments2-in-demand
@@ -76,8 +84,8 @@ block body
             h4.consignments2-in-demand__artists__artist__name
               = artist.get('name')
 
-    //- Upcoming sales
-    section.consignments2-section.consignments2-upcoming-sales(
+    //- Upcoming sales, desktop version
+    section.consignments2-section.consignments2-upcoming-sales.consignments2-upcoming-sales--desktop(
       style='background-image: url(#{sections.upcoming_sales.image.src});'
     )
       .consignments2-upcoming-sales__content
@@ -93,6 +101,24 @@ block body
             a.avant-garde-button-black.consignments2-section__consign-button( href='/consign2/submission' )
                 = sections.upcoming_sales.button_cta
 
+    //- Upcoming sales, mobile version
+    section.consignments2-section.consignments2-upcoming-sales.consignments2-upcoming-sales--mobile(
+      style='background-image: url(#{sections.upcoming_sales.mobile_image.src});'
+    )
+      .consignments2-upcoming-sales__content
+        .consignments2-section__about
+          h3.consignments2-section__about__headline
+            = sections.upcoming_sales.headline
+        .consignments2-upcoming-sales__sales__button
+          a.avant-garde-button-black.consignments2-section__consign-button( href='/consign2/submission' )
+            = sections.upcoming_sales.button_cta
+        .consignments2-upcoming-sales__sales
+          for sale in sales
+            .consignments2-upcoming-sales__sales__sale
+              h5= moment(sale.start_at).format('MMM D')
+              p= sale.name
+
+
     //- Questions
     section.consignments2-section.consignments2-section__questions
       .consignments2-section__questions__header-section
@@ -100,9 +126,9 @@ block body
           h3.consignments2-section__about__headline
             = sections.questions.headline
         .consignments2-section__questions__crt-photos
-          .consignments2-section__questions__crt-photos__photo
+          .consignments2-section__questions__crt-photos__photo1
             img( src= sections.questions.crt_photo_1.src )
-          .consignments2-section__questions__crt-photos__photo
+          .consignments2-section__questions__crt-photos__photo2
             img( src= sections.questions.crt_photo_2.src )
       .consignments2-section__questions__sections
         for section in sections.questions.sections
@@ -110,7 +136,7 @@ block body
             h4= section.sub_headline
             p= section.description
 
-  .consignments2-header(
+  .consignments2-footer(
     style='background-image: url(#{sections.footer.image.src});'
   )
     h1.consignments2-header__headline
@@ -118,13 +144,3 @@ block body
     .consignments2-header__cta
       a.avant-garde-button-white.consignments2-header__consign-button( href='/consign2/submission' )
         = sections.footer.button_cta
-
-
-extends ../../../components/main_layout/templates/index
-
-block head
-  include meta
-
-append locals
-  - assetPackage = 'misc'
-  - bodyClass = bodyClass + ' body-no-margins'

--- a/desktop/apps/consignments2/test/fixture.json
+++ b/desktop/apps/consignments2/test/fixture.json
@@ -1,109 +1,134 @@
 {
-    "header": {
-        "headline": "Sell your Works on Artsy",
-        "button_cta":  "Start consigning",
-        "image": {
-            "src": "https://artsy-media-uploads.s3.amazonaws.com/HZLuFUBchvFORQFMGjSRHg/banner-2.jpg"
-        }
-    },
-    "sections": {
-        "how_consignments_work": {
-            "headline": "See if we’re consigning works for your artist",
-            "button_cta": "Get started",
-            "steps": [
-                {
-                    "title": "Submit",
-                    "icon": "write.svg",
-                    "description": "Submit details about your work in a few steps"
-                },
-                {
-                    "title": "Select",
-                    "icon": "write.svg",
-                    "description": "Receive offers from Artsy's partner network, privacy 100% guaranteed"
-                },
-                {
-                    "title": "Sell",
-                    "icon": "write.svg",
-                    "description": "Get your work placed in an upcoming sale"
-                }
-            ]
-        },
-        "placement": {
-            "headline": "Artsy will connect you with our network of top tier partners",
-            "logos": [
-                {
-                    "src": "https://artsy-media-uploads.s3.amazonaws.com/0ikmO-lqXpXfgdqCN3fyKA/BqGweX7DFx.png"
-                },
-                {
-                    "src": "https://artsy-media-uploads.s3.amazonaws.com/1ZVFBUQXVTemsmTYVU7oVA/hSbNB9tVxP.png"
-                },
-                {
-                    "src": "https://artsy-media-uploads.s3.amazonaws.com/6YrPM2MptK9e7osEHSfR9Q/QOwua6I3rO.png"
-                },
-                {
-                    "src": "https://artsy-media-uploads.s3.amazonaws.com/vM3WsFaTc8SIvxeSiSiRYQ/5FjrGytqSh.png"
-                }
-            ]
-        },
-        "top_sales": {
-            "headline": "We've been helping collectors get their works placed in top sales",
-            "button_cta": "Submit my work"
-        },
-        "recently_sold": {
-            "sub_headline": "Recently sold on Artsy",
-            "set": {
-                "id": "56e057c8139b213d70002393"
-            }
-        },
-         "in_demand": {
-            "sub_headline": "Top Artists in demand",
-            "set": {
-                "id": "56e057c8139b213d70002393"
-            }
-        },
-        "upcoming_sales": {
-            "headline": "Have your work sold at one of our upcoming partner sales",
-            "button_cta": "Submit my work",
-            "image": {
-                "src": "https://artsy-media-uploads.s3.amazonaws.com/HZLuFUBchvFORQFMGjSRHg/banner-2.jpg"
-            },
-            "mobile_image": {
-                "src": "https://artsy-media-uploads.s3.amazonaws.com/HZLuFUBchvFORQFMGjSRHg/banner-2.jpg"
-            }
-        },
-        "questions": {
-            "headline": "Have questions? We're here to help",
-            "crt_photo_1": {
-                "src": "https://artsy-media-uploads.s3.amazonaws.com/HZLuFUBchvFORQFMGjSRHg/banner-2.jpg"
-            },
-            "crt_photo_2": {
-                "src": "https://artsy-media-uploads.s3.amazonaws.com/HZLuFUBchvFORQFMGjSRHg/banner-2.jpg"
-            },
-            "sections": [
-                {
-                    "sub_headline": "Why consign on Artsy?",
-                    "description": "Artsy wants to make it easy and effective to buy and sell art. We partner with premier auction houses and other third parties to remove the stress from the selling process, and to give you access to the highest level of service."
-                },
-                {
-                    "sub_headline": "What happens once I submit a work?",
-                    "description": "Submissions are routed to our network of auction house and third party partners. Our growing list of partners includes many of the top auction houses and galleries across the globe."
-                },
-                {
-                    "sub_headline": "Are there any fees?",
-                    "description": "Artsy does not charge the user any fees. When we connect you with a partner, the partner will provide you an estimate of the fees they may charge you for their services."
-                },
-                {
-                    "sub_headline": "Want to learn more? Read our full FAQ or contact us.",
-                    "description": ""
-                }
-            ]
-        },
-        "footer": {
-            "headline": "Start your consignment submission",
-            "button_cta":  "Get started",
-            "image": {
-                "src": "https://artsy-media-uploads.s3.amazonaws.com/HZLuFUBchvFORQFMGjSRHg/banner-2.jpg"
-            }
-        }
+  "header": {
+    "button_cta": "Start consigning",
+    "headline": "Sell your works on the most comprehensive art marketplace",
+    "image": {
+      "src": "https://artsy-media-uploads.s3.amazonaws.com/XhqxP8jmGYTi6I3JMFJTRQ/header.png"
     }
+  },
+  "sections": {
+    "footer": {
+      "button_cta": "Get started",
+      "headline": "Start your consignment submission",
+      "image": {
+        "src": "https://artsy-media-uploads.s3.amazonaws.com/af9HzQaXMuXKQZeSbQmHUQ/footer.png"
+      }
+    },
+    "how_consignments_work": {
+      "button_cta": "Get started",
+      "headline": "How consignments on Artsy work",
+      "steps": [
+        {
+          "description": "Submit details about your work in a few steps",
+          "icon": "https://artsy-media-uploads.s3.amazonaws.com/WG7T9b564mGJ4et6IgoZLw/submit_group.svg",
+          "title": "Submit"
+        },
+        {
+          "description": "Receive offers from Artsy's partner network, privacy 100% guaranteed",
+          "icon": "https://artsy-media-uploads.s3.amazonaws.com/UdQw9t4oTnstMPSysCkuzA/select_group.svg",
+          "title": "Select"
+        },
+        {
+          "description": "Get your work placed in an upcoming sale",
+          "icon": "https://artsy-media-uploads.s3.amazonaws.com/OBJ5TJr6laYr_LVYAgvUWA/sell_group.svg",
+          "title": "Sell"
+        }
+      ]
+    },
+    "in_demand": {
+      "set": {
+        "id": "56e05dfbcd530e6586000573"
+      },
+      "sub_headline": "Top Artists in demand"
+    },
+    "placement": {
+      "headline": "Artsy will connect you with our network of top tier partners",
+      "logos": [
+        {
+          "src": "https://artsy-media-uploads.s3.amazonaws.com/0ikmO-lqXpXfgdqCN3fyKA/BqGweX7DFx.png"
+        },
+        {
+          "src": "https://artsy-media-uploads.s3.amazonaws.com/1ZVFBUQXVTemsmTYVU7oVA/hSbNB9tVxP.png"
+        },
+        {
+          "src": "https://artsy-media-uploads.s3.amazonaws.com/6YrPM2MptK9e7osEHSfR9Q/QOwua6I3rO.png"
+        },
+        {
+          "src": "https://artsy-media-uploads.s3.amazonaws.com/vM3WsFaTc8SIvxeSiSiRYQ/5FjrGytqSh.png"
+        }
+      ]
+    },
+    "questions": {
+      "crt_photo_1": {
+        "src": "https://artsy-media-uploads.s3.amazonaws.com/5EnTyJ8igbN731AashjPhA/rebecca.png"
+      },
+      "crt_photo_2": {
+        "src": "https://artsy-media-uploads.s3.amazonaws.com/DnLHcbH6ZeZ7ge6kdzRUig/becca.png"
+      },
+      "headline": "Have questions? We're here to help",
+      "sections": [
+        {
+          "description": "Artsy wants to make it easy and effective to buy and sell art. We partner with premier auction houses and other third parties to remove the stress from the selling process, and to give you access to the highest level of service.",
+          "sub_headline": "Why consign on Artsy?"
+        },
+        {
+          "description": "Submissions are routed to our network of auction house and third party partners. Our growing list of partners includes many of the top auction houses and galleries across the globe.",
+          "sub_headline": "What happens once I submit a work?"
+        },
+        {
+          "description": "Artsy does not charge the user any fees. When we connect you with a partner, the partner will provide you an estimate of the fees they may charge you for their services.",
+          "sub_headline": "Are there any fees?"
+        },
+        {
+          "description": null,
+          "sub_headline": "Want to learn more? Read our full FAQ or contact us."
+        }
+      ]
+    },
+    "recently_sold": {
+      "set": {
+        "id": "56e057c8139b213d70002393"
+      },
+      "sub_headline": "Recently sold on Artsy"
+    },
+    "top_sales": {
+      "button_cta": "Submit my work",
+      "headline": "We've been helping collectors get their works placed in top sales"
+    },
+    "upcoming_sales": {
+      "button_cta": "Submit my work",
+      "headline": "Have your work sold at one of our upcoming partner sales",
+      "image": {
+        "src": "https://artsy-media-uploads.s3.amazonaws.com/RGoXGQiZdb1fwMPDGyaweQ/auctioneer.png"
+      },
+      "mobile_image": {
+        "src": "https://artsy-media-uploads.s3.amazonaws.com/HZLuFUBchvFORQFMGjSRHg/banner-2.jpg"
+      }
+    },
+    "faq": {
+        "headline": "Consignments at Artsy",
+        "items": [
+            {
+                "question": "",
+                "answer": "When collectors sell works of art, they generally do so through a gallery or auction house. The works are put in the care of - or consigned to - these establishments to be sold to potential buyers. The gallery or auction house receives a commission on each work sold."
+            },
+            {
+                "question": "What happens once I submit a work to Artsy Consignments?",
+                "answer": "When collectors sell works of art, they generally do so through a gallery or auction house. The works are put in the care of - or consigned to - these establishments to be sold to potential buyers. The gallery or auction house receives a commission on each work sold."
+            },
+            {
+                "question": "What happens once I submit a work to Artsy Consignments?",
+                "answer": "When collectors sell works of art, they generally do so through a gallery or auction house. The works are put in the care of - or consigned to - these establishments to be sold to potential buyers. The gallery or auction house receives a commission on each work sold."
+            },
+            {
+                "question": "What happens once I submit a work to Artsy Consignments?",
+                "answer": "When collectors sell works of art, they generally do so through a gallery or auction house. The works are put in the care of - or consigned to - these establishments to be sold to potential buyers. The gallery or auction house receives a commission on each work sold."
+            },
+            {
+                "question": "What happens once I submit a work to Artsy Consignments?",
+                "answer": "When collectors sell works of art, they generally do so through a gallery or auction house. The works are put in the care of - or consigned to - these establishments to be sold to potential buyers. The gallery or auction house receives a commission on each work sold."
+            }
+        ]
+    }
+  }
 }

--- a/desktop/apps/consignments2/test/fixture.json
+++ b/desktop/apps/consignments2/test/fixture.json
@@ -66,6 +66,9 @@
             "button_cta": "Submit my work",
             "image": {
                 "src": "https://artsy-media-uploads.s3.amazonaws.com/HZLuFUBchvFORQFMGjSRHg/banner-2.jpg"
+            },
+            "mobile_image": {
+                "src": "https://artsy-media-uploads.s3.amazonaws.com/HZLuFUBchvFORQFMGjSRHg/banner-2.jpg"
             }
         },
         "questions": {


### PR DESCRIPTION
Nothing super interesting here:
- Updated the `recentlySold` artworks to be fetched via a metaphysics query 
- Added an FAQ modal-- spent a while thrashing around seeing if there was a way to reuse one of the existing modal components in force but they all seem to require some form of backbone view/fetching. In this case we explicitly want to keep the FAQ text on the DOM for seo purposes, so I did a somewhat old-school approach of basic jquery to hide/show the modal div and pure css.
- Made the layout responsive
- Updated the fixtures file to add an additional background image for mobile-only

desktop:
![desktop-view](https://cloud.githubusercontent.com/assets/2081340/26469846/83202df0-4169-11e7-8395-32dba7cfcce0.gif)

mobile:
![mobile-view](https://cloud.githubusercontent.com/assets/2081340/26469851/87a33dea-4169-11e7-91a7-c2fedb6556fb.gif)
