### PR TITLE
[WIP] redirect previous year fair editions

### DIFF
--- a/desktop/apps/fair/index.coffee
+++ b/desktop/apps/fair/index.coffee
@@ -22,7 +22,7 @@ getFairByOrganizerYear = [
 ]
 
 app.use routes.microsite
-app.get '/:id', getFairData, routes.overview
+app.get '/:id', getFairByOrganizerYear, routes.overview
 app.get '/:id/:year([0-9]{4})', getFairByOrganizerYear, routes.overview
 app.get '/:id/overview', getFairData, routes.overview
 app.get '/:id/articles', getFairData, routes.fairArticles

--- a/desktop/apps/fair/routes.coffee
+++ b/desktop/apps/fair/routes.coffee
@@ -183,20 +183,32 @@ InfoMenu = require '../../components/info_menu/index.coffee'
 @fetchFairByOrganizerYear = (req, res, next) ->
   profile = res.locals.profile
 
-  return next() unless profile?.isFairOrganizer()
+  if profile?.isFairOrganizer()
+    fairOrgId = profile.related().owner.id
+  else
+    fairOrgId = profile.related().owner?.get('organizer')?.profile_id
+
+  return next() unless fairOrgId
 
   fairOrg = profile.related().owner
 
-  # Get all fairs for the requested fair organizer
-  pastFairs = new Fairs
-  pastFairs.fetch
+  fairs = new Fairs
+  fairs.fetch
     cache: true
     data:
-      fair_organizer_id: fairOrg.id
+      fair_organizer_id: fairOrgId
+      sort: 'start_at'
     success: ->
+      # checks for a current fair
+      current = fairs.find (fair) ->
+        moment().utc().isBetween fair.get('autopublish_artworks_at'), fair.get('end_at')
+
+      # redirects to current fair if there is one running and it comes from search
+      return res.redirect(current.href()) if current # && sd.MEDIUM is 'search'
+
       # find the fair whose year matches the requested year
-      fair = pastFairs.find (fair) ->
-        fair.formatYear() is parseInt req.params.year
+      fair = fairs.find (fair) ->
+        (fair.formatYear() is parseInt req.params.year) || (fair.id is req.params.id)
 
       return next() unless fair
 

--- a/desktop/apps/fair/routes.coffee
+++ b/desktop/apps/fair/routes.coffee
@@ -204,9 +204,9 @@ InfoMenu = require '../../components/info_menu/index.coffee'
         moment().utc().isBetween fair.get('autopublish_artworks_at'), fair.get('end_at')
 
       # redirects to current fair if there is one running and it comes from search
-      return res.redirect(current.href()) if current # && sd.MEDIUM is 'search'
+      return res.redirect(current.href()) if current && res.locals.sd.MEDIUM is 'search'
 
-      # find the fair whose year matches the requested year
+      # find the fair whose year matches the requested year or by fair id
       fair = fairs.find (fair) ->
         (fair.formatYear() is parseInt req.params.year) || (fair.id is req.params.id)
 


### PR DESCRIPTION
This is WIP because I'm sticking a pin in it to work on something with a bit higher priority. Essentially this work is to redirect previous year fair editions from search traffic to current editions of the fair when there is one that is active.

https://github.com/artsy/collector-experience/issues/159 for context.