### PR TITLE
@damassi => upload photo landing page + login prompt

### DIFF
--- a/desktop/apps/consignments2/client/actions.js
+++ b/desktop/apps/consignments2/client/actions.js
@@ -116,7 +116,7 @@ export function completeSubmission () {
       } = getState()
       const token = await fetchToken(user)
 
-      const submissionQueryParam = submission ? submission.id : submissionIdFromServer
+      const submissionQueryParam = submission.id || submissionIdFromServer
       const submissionResponse = await request
                           .put(`${sd.CONVECTION_APP_URL}/api/submissions/${submissionQueryParam}`)
                           .set('Authorization', `Bearer ${token}`)
@@ -524,10 +524,11 @@ export function updateUser (user) {
 export function uploadImageToConvection (geminiToken, fileName) {
   return async (dispatch, getState) => {
     try {
-      const { submissionFlow: { submission, user } } = getState()
+      const { submissionFlow: { submission, submissionIdFromServer, user } } = getState()
+      const submissionId = submission.id || submissionIdFromServer
       const token = await fetchToken(user)
       const inputs = {
-        submission_id: submission.id,
+        submission_id: submissionId,
         gemini_token: geminiToken
       }
       await request
@@ -546,14 +547,15 @@ export function uploadImageToConvection (geminiToken, fileName) {
 export function uploadImageToGemini (key, bucket, fileName) {
   return async (dispatch, getState) => {
     try {
-      const { submissionFlow: { submission } } = getState()
+      const { submissionFlow: { submission, submissionIdFromServer } } = getState()
+      const submissionId = submission.id || submissionIdFromServer
       const inputs = {
         entry: {
           template_key: sd.CONVECTION_GEMINI_APP,
           source_key: key,
           source_bucket: bucket,
           metadata: {
-            id: submission.id,
+            id: submissionId,
             _type: 'Consignment'
           }
         }

--- a/desktop/apps/consignments2/components/upload_photo/index.js
+++ b/desktop/apps/consignments2/components/upload_photo/index.js
@@ -11,6 +11,7 @@ import { selectPhoto, submitPhoto, updateSkipPhotoSubmission } from '../../clien
 function UploadPhoto (props) {
   const {
     error,
+    hideCheckbox,
     processingImages,
     selectPhotoAction,
     skipPhotoSubmission,
@@ -52,12 +53,16 @@ function UploadPhoto (props) {
       <div className={b('upload-instructions')}>
         Please upload JPG or PNG image files 1000x1000 pixels or more. Image files should have a file size less than 30mb.
       </div>
-      <CheckboxInput
-        item={'skip'}
-        label={'No photo currently available'}
-        onChange={updateSkipPhotoSubmissionAction}
-        value={skipPhotoSubmission}
-      />
+      {
+        !hideCheckbox && (
+          <CheckboxInput
+            item={'skip'}
+            label={'No photo currently available'}
+            onChange={updateSkipPhotoSubmissionAction}
+            value={skipPhotoSubmission}
+          />
+        )
+      }
       {
         uploadedImages.map((file, index) =>
           <UploadedImage file={file} key={`${file.fileName}-${index}`} />
@@ -94,6 +99,7 @@ const mapStateToProps = (state) => {
     uploadedImages: state.submissionFlow.uploadedImages
   }
 }
+
 const mapDispatchToProps = {
   selectPhotoAction: selectPhoto,
   submitPhotoAction: submitPhoto,
@@ -107,6 +113,7 @@ export default connect(
 
 UploadPhoto.propTypes = {
   error: PropTypes.string,
+  hideCheckbox: PropTypes.bool,
   processingImages: PropTypes.array.isRequired,
   selectPhotoAction: PropTypes.func.isRequired,
   skipPhotoSubmission: PropTypes.bool.isRequired,

--- a/desktop/apps/consignments2/components/upload_photo_landing/index.js
+++ b/desktop/apps/consignments2/components/upload_photo_landing/index.js
@@ -1,21 +1,44 @@
+import CreateAccount from '../create_account'
+import PropTypes from 'prop-types'
 import React from 'react'
 import UploadPhoto from '../upload_photo'
 import block from 'bem-cn'
+import { connect } from 'react-redux'
 
-export default function UploadPhotoLanding () {
+function UploadPhotoLanding ({ user }) {
   const b = block('consignments2-submission-upload-photo-landing')
-
   return (
     <div className={b()}>
-      <div className={b('title')}>
-        Consign your work to Artsy in just a few steps
-      </div>
-      <div className={b('step-title')}>
-        Upload a Photo
-      </div>
-      <div className={b('step-form')}>
-        <UploadPhoto />
-      </div>
+      {
+        user ? (
+          <div>
+            <div className={b('title')}>
+              Upload a Photo
+            </div>
+            <div className={b('step-form')}>
+              <UploadPhoto hideCheckbox />
+            </div>
+          </div>
+        ) : (
+          <div className={b('step-form')}>
+            <CreateAccount />
+          </div>
+        )
+      }
     </div>
   )
+}
+
+const mapStateToProps = (state) => {
+  return {
+    user: state.submissionFlow.user
+  }
+}
+
+export default connect(
+  mapStateToProps,
+)(UploadPhotoLanding)
+
+UploadPhotoLanding.propTypes = {
+  user: PropTypes.object
 }

--- a/desktop/apps/consignments2/components/upload_photo_landing/index.styl
+++ b/desktop/apps/consignments2/components/upload_photo_landing/index.styl
@@ -2,12 +2,7 @@
   &__title
     text-align center
     font-size 50px
-
-  &__step-title
-    margin-top 50px
-    text-align center
-    garamond-size('headline')
-    margin-bottom 30px
+    margin-bottom 50px
 
   &__step-form
     max-width 550px


### PR DESCRIPTION
This PR fixes some issues around uploading a photo when you visit the `/consign2/submission/:submission_id/upload` path directly. I removed the `No photos at this time` checkbox since at this point we want you to upload a photo, and added a login path if you visit the page while logged out.

If you try to submit a photo for a submission that is not your own, convection will reject the request, so we don't have to worry about that here.

![upload-photo-after](https://cloud.githubusercontent.com/assets/2081340/26691724/3698a882-46cc-11e7-8e58-34b4bd5fc2f6.gif)
