### PR TITLE
@joeyAghion => Remove fragment metatag on article

### DIFF
--- a/desktop/apps/article/templates/meta.jade
+++ b/desktop/apps/article/templates/meta.jade
@@ -55,8 +55,6 @@ if article.get('published')
   meta( name="sailthru.tags" content=keywords.join(','))
   meta( name="sailthru.date" content=article.get('published_at'))
 
-if sd.INCLUDE_ESCAPED_FRAGMENT
-  meta( name='fragment', content='!' )
 if article.get('contributing_authors') && article.get('contributing_authors').length
   - for author in article.get('contributing_authors')
       if author.name


### PR DESCRIPTION
The main issue is that recent articles aren't being indexed as News in Google and sometimes they aren't appearing in regular search. I don't _think_ this PR solves it, but at the least -- it's unnecessary to have. Based on [this slack convo](https://artsy.slack.com/archives/C02BDPZPC/p1494268425535679), I can confirm that articles are rendered server-side so there's no need for Reflection to crawl.

[This page](https://www.google.com/webmasters/tools/sitemap-details?hl=en&authuser=3&siteUrl=https%3A%2F%2Fwww.artsy.net%2F&sitemapUrl=https%3A%2F%2Fwww.artsy.net%2Fsitemap-news.xml&gwtPl=L3dlYm1hc3RlcnMvdG9vbHMvc2l0ZW1hcC1saXN0P2hsPWVuJmF1dGh1c2VyPTMmc2l0ZVVybD1odHRwczovL3d3dy5hcnRzeS5uZXQvI01BSU5fVEFCPTAmQ0FSRF9UQUI9LTE%3D#CARD_TAB=-1) tells me that News articles are submitted via the sitemap, but none have been indexed. Is that because we block Google from crawling when Reflection is configured to crawl it instead? 

TODO
- [ ] Tell Reflection not to crawl article pages (signed up for Reflection but I think i'm missing `site.site_users.create!(user: dB)`) 