### PR TITLE
@kanaabe => Use indexable for noindex meta tag

### DIFF
--- a/desktop/apps/article/templates/article.jade
+++ b/desktop/apps/article/templates/article.jade
@@ -2,8 +2,8 @@ extends ../../../components/fair_layout/templates/conditional
 
 block head
   include meta
-  if article.get('tags') && article.get('tags').indexOf('noindex') >= 0
-      meta( name='robots', content='noindex' )
+  if !article.get('indexable')
+    meta( name='robots', content='noindex' )
 
 append locals
   - assetPackage = 'article'

--- a/desktop/apps/article/test/templates.coffee
+++ b/desktop/apps/article/test/templates.coffee
@@ -80,14 +80,14 @@ describe 'article template', ->
     html.should.containEql 'team-channel-nav'
     html.should.containEql 'Editorial'
 
-  it "adds a noindex meta tag for articles tagged noindex", ->
+  it "adds a noindex meta tag for articles where indexable is false", ->
     html = render('article')
       article: new Article
         title: 'hi'
         sections: []
         section_ids: []
         contributing_authors: []
-        tags: ['noindex']
+        indexable: false
       crop: (url) -> url
       resize: (url) -> url
       moment: moment

--- a/desktop/apps/artsy_primer/templates/article.jade
+++ b/desktop/apps/artsy_primer/templates/article.jade
@@ -4,9 +4,6 @@ append locals
   - assetPackage = 'misc'
   - bodyClass = bodyClass + ' body-article'
 
-block head
-  meta( name='robots', content='noindex' )
-
 block body
   include header.jade
 

--- a/desktop/apps/artsy_primer/templates/article.jade
+++ b/desktop/apps/artsy_primer/templates/article.jade
@@ -4,6 +4,8 @@ append locals
   - assetPackage = 'misc'
   - bodyClass = bodyClass + ' body-article'
 
+block head
+
 block body
   include header.jade
 


### PR DESCRIPTION
Uses article's indexable tag to add noindex meta tag, rather than tags.
This should not be merged until a backfill of the indexable field is complete. 

I did not remove the meta from the [primer template](https://github.com/artsy/force/blob/a7850384aa163c362c1b7fb1014085c682a12f60/desktop/apps/artsy_primer/templates/article.jade), do you think this should be removed as well?