### PR TITLE
@kanaabe => Follow button bug

### DIFF
--- a/desktop/apps/editorial_features/components/venice_2017/templates/index.jade
+++ b/desktop/apps/editorial_features/components/venice_2017/templates/index.jade
@@ -3,7 +3,7 @@ extends ../../../../../components/main_layout/templates/blank.jade
 append locals
   - assetPackage = 'editorial_features'
   - section = curation.get('sections')[videoIndex]
-  - options = {modal: false, stripe: false, marketo: false}
+  - options = {stripe: false, marketo: false}
 
 block head
   include head


### PR DESCRIPTION
Restores modal to the Venice template. Was causing a bug when logged out users attempted to follow, which renders a login prompt using the modal. 