### PR TITLE
@yuki24: Moves the hover and focus styles to the inputs container

### DIFF
--- a/desktop/components/main_layout/header/view.coffee
+++ b/desktop/components/main_layout/header/view.coffee
@@ -22,6 +22,8 @@ module.exports = class HeaderView extends Backbone.View
     'click .mlh-signup': 'signup'
     'click .user-nav-profile-link': 'showProfilePrivateDialog'
     'click .mlh-logout': 'logout'
+    'click #main-layout-search-bar-container': 'highlightSearch'
+    'blur #main-layout-search-bar-container': 'unhighlightSearch'
 
   initialize: ->
     @currentUser = CurrentUser.orNull()
@@ -126,3 +128,10 @@ module.exports = class HeaderView extends Backbone.View
       new FlashMessage message: 'Thank you for personalizing your profile'
     else if document.referrer.match '/artsy-primer-personalize/'
       new FlashMessage message: 'Thank you. Please expect your personalized portfolio in the next 2 business days.'
+
+  highlightSearch: (e) ->
+    if $('.html-highlight-header-search-split-test #main-layout-search-bar-input').is(':focus')
+      $('#main-layout-search-bar-container').addClass('focused')
+
+  unhighlightSearch: (e) ->
+    $(e.currentTarget).removeClass('focused')

--- a/desktop/components/main_layout/stylesheets/body_with_header_split_test.styl
+++ b/desktop/components/main_layout/stylesheets/body_with_header_split_test.styl
@@ -37,13 +37,21 @@ search-bar-input-placeholder()
   #main-layout-search-bar-container
     border-color #e5e5e5
     background-color #f0f0f0 !important
+    &:hover
+      border 1px solid black
+
+  #main-layout-header
+    #main-layout-search-bar-container.focused
+      &:hover
+        border-color #6e00ff !important
+
+  #main-layout-header
+    #main-layout-search-bar-container.focused
+      border-color #6e00ff !important
+
     #main-layout-search-bar-input
       &::placeholder
         color #666 !important
-      &:hover
-        border 1px solid black
-      &:focus
-        border 1px solid #6e00ff
   #main-layout-search-bar-icon
     color #666
 
@@ -89,8 +97,6 @@ search-bar-input-placeholder()
           background-color #f0f0f0 !important
           &::placeholder
             color #666
-          &:focus
-            border 1px solid #6e00ff
   .body-hide-header
     #main-layout-header
       display none
@@ -116,8 +122,6 @@ search-bar-input-placeholder()
         color #000
         &::placeholder
           color #666
-        &:focus
-          border 1px solid #6e00ff !important
       #main-layout-header
         border-color rgba(white, 0.3)
         *:not(.tt-suggestion):not(.tt-dropdown-menu)
@@ -125,6 +129,18 @@ search-bar-input-placeholder()
         #main-layout-search-bar-container
           background-color #f0f0f0
           border-color #e5e5e5
+          &:hover
+            border-color black !important
+
+      #main-layout-header
+        #main-layout-search-bar-container.focused
+          &:hover
+            border-color #6e00ff !important
+
+      #main-layout-header
+        #main-layout-search-bar-container.focused
+          border-color #6e00ff !important
+
       #main-layout-search-bar-container.is-loading .loading-spinner-small
         background black
       #main-layout-header-home-logo::after


### PR DESCRIPTION
closes: https://github.com/artsy/force/issues/1499

This PR moves the hover and focus border styles to its outer container to prevent the nav bar texts from jumping.

![qa header search](https://cloud.githubusercontent.com/assets/5201004/26743299/4a148258-47af-11e7-88c4-9d0bf20adfe6.gif)

