### PR TITLE
@mzikherman: add item_id to search result analytics

### DIFF
--- a/desktop/apps/search/client/index.coffee
+++ b/desktop/apps/search/client/index.coffee
@@ -75,6 +75,7 @@ module.exports.SearchResultsView = class SearchResultsView extends Backbone.View
       query: term
       item_number: $searchResult.parent().children().index($searchResult)
       item_type: $searchResult.attr('class').replace('search-result ', '')
+      item_id: $searchResult.data('mongo-id')
       destination_path: "#{sd.APP_URL}#{$searchResult.attr('href')}"
 
 module.exports.init = ->

--- a/desktop/apps/search/templates/search_result.jade
+++ b/desktop/apps/search/templates/search_result.jade
@@ -1,4 +1,4 @@
-a.search-result( href=result.href(), class=_s.decapitalize(result.get('display_model')), data-id=result.get('id') )
+a.search-result( href=result.href(), class=_s.decapitalize(result.get('display_model')), data-id=result.get('id'), data-mongo-id=result.get('_id') )
   if result.imageUrl() != null && result.get('display_model') != 'Artist'
     .search-result-thumbnail
       .search-result-thumbnail-fallback

--- a/desktop/components/search_bar/view.coffee
+++ b/desktop/components/search_bar/view.coffee
@@ -181,6 +181,7 @@ module.exports = class SearchBarView extends Backbone.View
       query: @query
       item_number: model.collection.models.findIndex( (result) -> return result.id == model.id ) + 1
       item_type: model.get('display_model')
+      item_id: model.get('_id')
       destination_path: "#{sd.APP_URL}#{model.href()}"
     @selected = true
     location.assign model.href()


### PR DESCRIPTION
Per [request](https://github.com/artsy/collector-experience/issues/251#issuecomment-306265105), we are adding the `item_id` to the search results analytics tracking.