### PR TITLE
@mzikherman => Hide contact information for non-active partners on mobile

### DIFF
--- a/mobile/apps/partner_profile/routes.coffee
+++ b/mobile/apps/partner_profile/routes.coffee
@@ -3,6 +3,7 @@ Artworks = require '../../collections/artworks'
 Artist = require '../../models/artist'
 PartnerShows = require '../../collections/partner_shows'
 Partner = require '../../models/partner'
+{ ACTIVE_PARTNER_LAYOUTS } = require '../../models/partner'
 Profile = require '../../models/profile'
 Articles = require '../../collections/articles'
 Article = require '../../models/article'
@@ -58,6 +59,7 @@ module.exports.index = (req, res, next) ->
             profile: req.profile
             partner: partner
             articles: articles
+            ACTIVE_PARTNER_LAYOUTS: ACTIVE_PARTNER_LAYOUTS
 
 module.exports.articles = (req, res, next) ->
   return next() unless partner = partnerFromProfile(req)
@@ -132,6 +134,13 @@ module.exports.artist = (req, res, next) ->
 
 module.exports.contact = (req, res, next) ->
   return next() unless partner = partnerFromProfile(req)
+
+  unless partner.get('profile_layout') in ACTIVE_PARTNER_LAYOUTS
+    err = new Error()
+    err.status = 404
+    err.message = 'Not Found'
+    return next(err)
+
   partner.fetch
     cache: true
     success: ->

--- a/mobile/apps/partner_profile/templates/index.jade
+++ b/mobile/apps/partner_profile/templates/index.jade
@@ -27,5 +27,6 @@ block content
       a( href="/#{profile.get('id')}/shop" ) Shop
     if partner.hasSection('articles', profile, articles)
       a( href="/#{profile.get('id')}/articles" ) Articles
-    a( href="/#{profile.get('id')}/contact" ) Contact
+    if ACTIVE_PARTNER_LAYOUTS.includes(partner.get('profile_layout'))
+      a( href="/#{profile.get('id')}/contact" ) Contact
   br

--- a/mobile/apps/partner_profile/test/routes.coffee
+++ b/mobile/apps/partner_profile/test/routes.coffee
@@ -74,7 +74,12 @@ describe 'Profile page', ->
 
     it 'renders the contact page by passing on the partner locations groupped by city', ->
       routes.contact(
-        { profile: new Profile(fabricate 'profile', name: 'Foobarz', owner_type: 'PartnerGallery') }
+        profile: new Profile fabricate('profile'
+          name: 'Foobarz'
+          owner_type: 'PartnerGallery'
+          owner: fabricate('partner'
+            id: 'foobarz'
+            profile_layout: 'gallery_one'))
         { render: renderStub = sinon.stub() }
       )
       _.last(Backbone.sync.args)[2].success fabricate('partner', id: 'foobar1', displayable_shows_count: 1)
@@ -86,6 +91,25 @@ describe 'Profile page', ->
       renderStub.args[0][0].should.equal 'contact'
       renderStub.args[0][1].profile.get('name').should.equal 'Foobarz'
       renderStub.args[0][1].locationGroups['Zoo York'].length.should.equal 2
+
+    it 'renders 404 page for non-active partners', ->
+      next = sinon.spy()
+      renderStub = sinon.stub()
+
+      routes.contact(
+        profile: new Profile fabricate('profile'
+          name: 'Foobarz'
+          owner_type: 'PartnerGallery'
+          owner: fabricate('partner'
+            id: 'foobarz'
+            profile_layout: 'gallery_default'))
+        { render: renderStub }
+        next
+      )
+
+      error = next.getCall(0).args[0]
+      error.status.should.equal(404)
+      error.message.should.equal('Not Found')
 
   describe '#fetchArtworksAndRender', ->
 

--- a/mobile/apps/partner_profile/test/templates.coffee
+++ b/mobile/apps/partner_profile/test/templates.coffee
@@ -8,6 +8,7 @@ Partner = require '../../../models/partner'
 { fabricate } = require 'antigravity'
 Artists = require '../../../collections/artists'
 fixtures = require '../../../test/helpers/fixtures'
+{ GALLERY_DEFAULT, GALLERY_ONE, ACTIVE_PARTNER_LAYOUTS } = require '../../../models/partner'
 
 render = (templateName) ->
   filename = path.resolve __dirname, "../templates/#{templateName}.jade"
@@ -41,6 +42,7 @@ describe 'Partner page templates', ->
       partner: new Partner profile.get('owner')
       profile: profile
       articles: []
+      ACTIVE_PARTNER_LAYOUTS: ACTIVE_PARTNER_LAYOUTS
       sd:
         PARTNER_PROFILE: profile
     $ = cheerio.load html
@@ -54,10 +56,11 @@ describe 'Partner page templates', ->
       articles: []
       represented: new Artists([fabricate 'artist']).models
       unrepresented: new Artists([fabricate 'artist']).models
+      ACTIVE_PARTNER_LAYOUTS: ACTIVE_PARTNER_LAYOUTS
       sd: {}
 
   it 'creates links to profile slugs, not partner slugs', ->
-    partner = new Partner fabricate 'partner', id: 'the-gagosian-gallery'
+    partner = new Partner fabricate 'partner', id: 'the-gagosian-gallery', profile_layout: GALLERY_ONE
     profile = new Profile fabricate 'profile', id: 'gagosian-gallery', icon: null
     html = render('index')
       partner: partner
@@ -65,10 +68,25 @@ describe 'Partner page templates', ->
       articles: []
       represented: new Artists([fabricate 'artist']).models
       unrepresented: new Artists([fabricate 'artist']).models
+      ACTIVE_PARTNER_LAYOUTS: ACTIVE_PARTNER_LAYOUTS
       sd: {}
     $ = cheerio.load html
     $("a[href*='#{partner.get('id')}']").length.should.equal 0
     $("a[href*='#{profile.get('id')}']").length.should.be.above 0
+
+  it 'does not create links to profiles for non-active partners', ->
+    partner = new Partner fabricate 'partner', id: 'the-gagosian-gallery', profile_layout: GALLERY_DEFAULT
+    profile = new Profile fabricate 'profile', id: 'gagosian-gallery', icon: null
+    html = render('index')
+      partner: partner
+      profile: profile
+      articles: []
+      represented: new Artists([fabricate 'artist']).models
+      unrepresented: new Artists([fabricate 'artist']).models
+      ACTIVE_PARTNER_LAYOUTS: ACTIVE_PARTNER_LAYOUTS
+      sd: {}
+    $ = cheerio.load html
+    $("a[href*='#{profile.get('id')}']").length.should.equal 0
 
   it 'hides missing telephone numbers', ->
     loc = new Backbone.Model fabricate 'location', phone: null
@@ -113,6 +131,7 @@ describe 'Partner page templates', ->
       articles: []
       represented: new Artists([fabricate 'artist']).models
       unrepresented: new Artists([fabricate 'artist']).models
+      ACTIVE_PARTNER_LAYOUTS: ACTIVE_PARTNER_LAYOUTS
       sd: {}
     $ = cheerio.load html
     $(".partner-profile-nav a[href*=articles]").length.should.equal 0
@@ -125,6 +144,7 @@ describe 'Partner page templates', ->
       articles: [ fixtures.article ]
       represented: new Artists([fabricate 'artist']).models
       unrepresented: new Artists([fabricate 'artist']).models
+      ACTIVE_PARTNER_LAYOUTS: ACTIVE_PARTNER_LAYOUTS
       sd: {}
     $ = cheerio.load html
     $(".partner-profile-nav a[href*=articles]").length.should.be.above 0
@@ -142,5 +162,6 @@ describe 'Partner page templates', ->
       articles: [ fixtures.article ]
       represented: new Artists([fabricate 'artist']).models
       unrepresented: new Artists([fabricate 'artist']).models
+      ACTIVE_PARTNER_LAYOUTS: ACTIVE_PARTNER_LAYOUTS
       sd: {}
     html.should.containEql 'foobarbaz.jpg'

--- a/mobile/models/partner.coffee
+++ b/mobile/models/partner.coffee
@@ -10,6 +10,15 @@ PartnerShows = require '../collections/partner_shows.coffee'
 fetchUntilEnd = require('artsy-backbone-mixins').Fetch().fetchUntilEnd
 Relations = require './mixins/relations/partner.coffee'
 
+INSTITUTION        = 'institution'
+GALLERY_DEFAULT    = 'gallery_default'
+GALLERY_DEPRECATED = 'gallery_deprecated'
+GALLERY_ONE        = 'gallery_one'
+GALLERY_TWO        = 'gallery_two'
+GALLERY_THREE      = 'gallery_three'
+
+ACTIVE_PARTNER_LAYOUTS = [ INSTITUTION, GALLERY_ONE, GALLERY_TWO, GALLERY_THREE ]
+
 module.exports = class Partner extends Backbone.Model
   _.extend @prototype, Relations
 
@@ -115,3 +124,12 @@ module.exports = class Partner extends Backbone.Model
       artist.set 'image_url': partnerArtist.get('image_url')
       artist.set 'image_versions': partnerArtist.get('image_versions')
     artist
+
+module.exports.INSTITUTION        = INSTITUTION
+module.exports.GALLERY_DEFAULT    = GALLERY_DEFAULT
+module.exports.GALLERY_DEPRECATED = GALLERY_DEPRECATED
+module.exports.GALLERY_ONE        = GALLERY_ONE
+module.exports.GALLERY_TWO        = GALLERY_TWO
+module.exports.GALLERY_THREE      = GALLERY_THREE
+
+module.exports.ACTIVE_PARTNER_LAYOUTS = ACTIVE_PARTNER_LAYOUTS

--- a/test/acceptance/helpers/index.js
+++ b/test/acceptance/helpers/index.js
@@ -6,6 +6,7 @@ import url from 'url'
 import chalk from 'chalk'
 import bodyParser from 'body-parser'
 import cors from 'cors'
+import { fabricate } from 'antigravity'
 
 const {
   ACCEPTANCE_TIMEOUT,
@@ -137,6 +138,15 @@ const startGravity = (port) =>
         xapp_token: 'xapp-token',
         expires_in: moment().add(100, 'days').utc().format()
       })
+    })
+    app.get('/api/v1/profile/pace-gallery', (req, res) => {
+      res.send(fabricate('profile', {
+        owner_type: 'PartnerGallery',
+        owner: fabricate('partner', {
+          id: 'pace-gallery',
+          profile_layout: 'gallery_one'
+        })
+      }))
     })
     servers.push(app.listen(port, (err) => {
       if (err) reject(err)

--- a/test/acceptance/partner_profile.js
+++ b/test/acceptance/partner_profile.js
@@ -23,8 +23,13 @@ describe('Partner profile page', () => {
     $.html().should.containEql('Articles')
   })
 
-  it('shows partner contact information', async () => {
+  it('does not show contact information for non-active partner', async () => {
     const $ = await browser.page('/gagosian-gallery/contact')
+    $.html().should.containEql('Sorry, the page you were looking for doesn&#x2019;t exist at this URL.')
+  })
+
+  it('show contact information for active partner', async () => {
+    const $ = await browser.page('/pace-gallery/contact')
     $.html().should.containEql('Contact')
     $.html().should.containEql('New York')
   })


### PR DESCRIPTION
This removes contact information for non-active partners on microgravity. Same work as https://github.com/artsy/force/pull/1458, this is just on mobile.