### PR TITLE
@damassi => little visual fixes for consign2

### DIFF
--- a/desktop/apps/consignments2/client/reducers.js
+++ b/desktop/apps/consignments2/client/reducers.js
@@ -33,7 +33,7 @@ const initialState = {
   artistAutocompleteSuggestions: [],
   artistAutocompleteValue: '',
   artistName: '',
-  authFormState: 'logIn',
+  authFormState: 'signUp',
   categoryOptions: [
     'Painting',
     'Sculpture',

--- a/desktop/apps/consignments2/client/submission.js
+++ b/desktop/apps/consignments2/client/submission.js
@@ -11,6 +11,7 @@ import thunkMiddleware from 'redux-thunk'
 import { Provider } from 'react-redux'
 import { Router, Route } from 'react-router'
 import { createStore, applyMiddleware } from 'redux'
+import { updateAuthFormStateAndClearError } from './actions'
 import { render } from 'react-dom'
 import { routerMiddleware } from 'react-router-redux'
 
@@ -36,7 +37,13 @@ function setupSubmissionFlow () {
           <div>
             <Route exact path='/consign2/submission' component={SubmissionFlow} />
             <Route path='/consign2/submission/:submission_id/thank_you' component={ThankYou} />
-            <Route path='/consign2/submission/:submission_id/upload' component={UploadPhotoLanding} />
+            <Route
+              path='/consign2/submission/:submission_id/upload'
+              render={() => {
+                store.dispatch(updateAuthFormStateAndClearError('logIn'))
+                return (<UploadPhotoLanding />)
+              }}
+            />
           </div>
         </Router>
       </AppContainer>

--- a/desktop/apps/consignments2/components/choose_artist/index.js
+++ b/desktop/apps/consignments2/components/choose_artist/index.js
@@ -33,7 +33,6 @@ function ChooseArtist (props) {
     clearArtistSuggestionsAction,
     chooseArtistAndAdvanceAction,
     fetchArtistSuggestionsAction,
-    isMobile,
     notConsigningArtist,
     showNotConsigningMessageAction,
     updateArtistAutocompleteValueAction
@@ -41,6 +40,7 @@ function ChooseArtist (props) {
   const b = block('consignments2-submission-choose-artist')
 
   const inputProps = {
+    autoFocus: true,
     value: artistAutocompleteValue,
     onChange: updateArtistAutocompleteValueAction
   }
@@ -54,7 +54,7 @@ function ChooseArtist (props) {
   const nextEnabled = artistAutocompleteValue.length > 0
 
   return (
-    <div className={b({mobile: isMobile})}>
+    <div className={b()}>
       <div className={b('title')}>
         Enter the name of the artist/designer who created the work
       </div>
@@ -94,7 +94,6 @@ const mapStateToProps = (state) => {
   return {
     artistAutocompleteSuggestions: state.submissionFlow.artistAutocompleteSuggestions,
     artistAutocompleteValue: state.submissionFlow.artistAutocompleteValue,
-    isMobile: state.submissionFlow.isMobile,
     notConsigningArtist: state.submissionFlow.notConsigningArtist
   }
 }
@@ -130,7 +129,6 @@ ChooseArtist.propTypes = {
   clearArtistSuggestionsAction: PropTypes.func.isRequired,
   chooseArtistAndAdvanceAction: PropTypes.func.isRequired,
   fetchArtistSuggestionsAction: PropTypes.func.isRequired,
-  isMobile: PropTypes.bool.isRequired,
   notConsigningArtist: PropTypes.bool,
   showNotConsigningMessageAction: PropTypes.func.isRequired,
   updateArtistAutocompleteValueAction: PropTypes.func.isRequired

--- a/desktop/apps/consignments2/components/choose_artist/index.styl
+++ b/desktop/apps/consignments2/components/choose_artist/index.styl
@@ -49,10 +49,3 @@
     img
       height 40px
       margin-right 12px
-
-  &_mobile
-    .consignments2-submission-choose-artist__title
-      display none
-
-    .consignments2-submission-choose-artist__form
-      margin-top 50px

--- a/desktop/apps/consignments2/components/describe_work_desktop/index.js
+++ b/desktop/apps/consignments2/components/describe_work_desktop/index.js
@@ -76,6 +76,7 @@ function DescribeWorkDesktop (props) {
               item={'title'}
               instructions={'If the title is unknown, please enter your best guess.'}
               label={'Title*'}
+              autofocus
             />
           </div>
         </div>

--- a/desktop/apps/consignments2/components/describe_work_desktop/index.styl
+++ b/desktop/apps/consignments2/components/describe_work_desktop/index.styl
@@ -16,7 +16,7 @@
     margin 0 auto
 
   &__next-button.avant-garde-button-black
-    height 40px
+    height 45px
     margin-top 0px
     width 100%
     margin-bottom 10px

--- a/desktop/apps/consignments2/components/describe_work_mobile/index.js
+++ b/desktop/apps/consignments2/components/describe_work_mobile/index.js
@@ -33,6 +33,7 @@ function validate (values, props) {
 
 function DescribeWorkMobile (props) {
   const {
+    artistName,
     categoryOptions,
     error,
     loading,
@@ -48,6 +49,9 @@ function DescribeWorkMobile (props) {
 
   return (
     <div className={b()}>
+      <div className={b('title')}>
+        Enter details about the work by {artistName}
+      </div>
       <form className={b('form')} onSubmit={handleSubmit(submitDescribeWorkAction)}>
         <div className={b('row')}>
           <div className={b('row-item')}>
@@ -55,6 +59,7 @@ function DescribeWorkMobile (props) {
               item={'title'}
               instructions={'If the title is unknown, please enter your best guess.'}
               label={'Title*'}
+              autofocus
             />
           </div>
         </div>
@@ -146,6 +151,7 @@ const mapDispatchToProps = {
 }
 
 DescribeWorkMobile.propTypes = {
+  artistName: PropTypes.string.isRequired,
   categoryOptions: PropTypes.array.isRequired,
   error: PropTypes.string,
   loading: PropTypes.bool.isRequired,

--- a/desktop/apps/consignments2/components/describe_work_mobile/index.styl
+++ b/desktop/apps/consignments2/components/describe_work_mobile/index.styl
@@ -1,11 +1,18 @@
 .consignments2-submission-describe-work-mobile
+  &__title
+    margin-top 50px
+    text-align center
+    garamond-size('headline')
+    line-height 1.1
+    margin-bottom 5px
+
   &__form
     max-width 550px
     margin 0 auto
     margin-top 50px
 
   &__next-button.avant-garde-button-black
-    height 40px
+    height 45px
     margin-top 0px
     width 100%
     margin-bottom 10px

--- a/desktop/apps/consignments2/components/forgot_password/index.js
+++ b/desktop/apps/consignments2/components/forgot_password/index.js
@@ -41,12 +41,13 @@ function ForgotPassword (props) {
       <div className={b('subtitle')}>
         New to Artsy? <span className={b('clickable')} onClick={() => updateAuthFormStateAndClearErrorAction('signUp')}>Sign up</span>.
       </div>
-      <form className={b()} onSubmit={handleSubmit(resetPasswordAction)}>
+      <form className={b('form')} onSubmit={handleSubmit(resetPasswordAction)}>
         <div className={b('row')}>
           <div className={b('row-item')}>
             <Field name='email' component={renderTextInput}
               item={'email'}
               label={'Email'}
+              autofocus
             />
           </div>
         </div>

--- a/desktop/apps/consignments2/components/forgot_password/index.styl
+++ b/desktop/apps/consignments2/components/forgot_password/index.styl
@@ -16,6 +16,10 @@
     padding-bottom 15px
     text-align center
 
+  &__form
+    max-width 550px
+    margin 0 auto
+
   &__success
     background-color yellow-light-color
     border 1px solid yellow-color

--- a/desktop/apps/consignments2/components/location_autocomplete/index.styl
+++ b/desktop/apps/consignments2/components/location_autocomplete/index.styl
@@ -6,7 +6,7 @@
     width 100%
 
   .react-autosuggest__suggestion
-    height 40px
+    min-height 40px
     padding 10px
     border 1px solid gray-lighter-color
     border-top none
@@ -19,6 +19,9 @@
     input
       pointer-events none
       background-color gray-lightest-color
+
+      &:focus, &:active
+        border-color gray-lighter-color
 
   &__unfreeze
     position absolute

--- a/desktop/apps/consignments2/components/log_in/index.js
+++ b/desktop/apps/consignments2/components/log_in/index.js
@@ -51,6 +51,7 @@ function LogIn (props) {
             <Field name='email' component={renderTextInput}
               item={'email'}
               label={'Email'}
+              autofocus
             />
           </div>
         </div>

--- a/desktop/apps/consignments2/components/log_in/index.styl
+++ b/desktop/apps/consignments2/components/log_in/index.styl
@@ -11,6 +11,10 @@
     color gray-dark-color
     margin-bottom 37px
 
+  &__form
+    max-width 550px
+    margin 0 auto
+
   &__error
     color red-color
     padding-bottom 15px

--- a/desktop/apps/consignments2/components/select_input/index.js
+++ b/desktop/apps/consignments2/components/select_input/index.js
@@ -24,28 +24,22 @@ function SelectInput (props) {
   return (
     <div className={b({item})}>
       { label && <div className={b('label')}>{ label }</div> }
-      <div className={b('select').mix('bordered-pulldown')}>
-        <a className='bordered-pulldown-toggle' href='#'>
-          <span className='bordered-pulldown-text'>{ value || options[0] }</span>
-          <div className='bordered-pulldown-toggle-caret'>
-            <span className='caret' />
-          </div>
-        </a>
-        <div className='bordered-pulldown-options'>
+      <label className={b('select').mix('bordered-select')}>
+        <select>
           {
             map(options, (option) => {
               return (
-                <a
+                <option
                   href='#'
                   className='bordered-pulldown-active'
                   key={option}
                   onClick={() => onChange(option)}
-                >{ option }</a>
+                >{ option }</option>
               )
             })
           }
-        </div>
-      </div>
+        </select>
+      </label>
     </div>
   )
 }

--- a/desktop/apps/consignments2/components/select_input/index.styl
+++ b/desktop/apps/consignments2/components/select_input/index.styl
@@ -7,5 +7,8 @@
     height 40px
     width 100%
 
+  select
+    width 100%
+
   .bordered-pulldown-toggle-caret
     border-left none

--- a/desktop/apps/consignments2/components/sign_up/index.js
+++ b/desktop/apps/consignments2/components/sign_up/index.js
@@ -51,6 +51,7 @@ function SignUp (props) {
             <Field name='name' component={renderTextInput}
               item={'name'}
               label={'Full Name'}
+              autofocus
             />
           </div>
         </div>

--- a/desktop/apps/consignments2/components/sign_up/index.styl
+++ b/desktop/apps/consignments2/components/sign_up/index.styl
@@ -11,6 +11,10 @@
     color gray-dark-color
     margin-bottom 37px
 
+  &__form
+    max-width 550px
+    margin 0 auto
+
   &__clickable
     color gray-dark-color
     text-decoration underline

--- a/desktop/apps/consignments2/components/submission_flow/index.js
+++ b/desktop/apps/consignments2/components/submission_flow/index.js
@@ -18,8 +18,8 @@ function SubmissionFlow (props) {
   const { CurrentStepComponent, isMobile } = props
 
   return (
-    <div className={b()}>
-      <div className={b('title', {mobile: isMobile})}>
+    <div className={b({mobile: isMobile})}>
+      <div className={b('title')}>
         Consign your work through Artsy in just a few quick steps
       </div>
       <StepMarker />

--- a/desktop/apps/consignments2/components/submission_flow/index.styl
+++ b/desktop/apps/consignments2/components/submission_flow/index.styl
@@ -7,5 +7,6 @@
     font-size 50px
     line-height 1.1
 
-    &_mobile
-      garamond-size('headline')
+  &_mobile
+    .consignments2-submission__title
+      display none

--- a/desktop/apps/consignments2/components/text_input/index.js
+++ b/desktop/apps/consignments2/components/text_input/index.js
@@ -11,7 +11,7 @@ export const renderTextInput = ({ input, ...custom }) => (
 )
 
 function TextInput (props) {
-  const { item, label, instructions, onChange, type } = props
+  const { autofocus, item, label, instructions, onChange, type } = props
   const b = block('consignments2-submission-text-input')
 
   return (
@@ -19,6 +19,7 @@ function TextInput (props) {
       { label && <div className={b('label')}>{ label }</div> }
       { instructions && <div className={b('instructions')}>{ instructions }</div> }
       <input
+        autoFocus={autofocus}
         data={item}
         className={b('input').mix('bordered-input')}
         type={type || 'text'}
@@ -29,6 +30,7 @@ function TextInput (props) {
 }
 
 TextInput.propTypes = {
+  autofocus: PropTypes.bool,
   item: PropTypes.string.isRequired,
   label: PropTypes.string,
   instructions: PropTypes.string,

--- a/desktop/apps/consignments2/components/thank_you/index.styl
+++ b/desktop/apps/consignments2/components/thank_you/index.styl
@@ -28,8 +28,10 @@
     margin-bottom 60px
 
   &__next-steps
+    max-width 550px
+    margin 0 auto
     display flex
-    justify-content space-around
+    justify-content space-between
     > *
       max-width 290px
 
@@ -57,3 +59,10 @@
     .consignments2-submission-thank-you__personalize-button
       width 100%
       margin-top 30px
+
+    .consignments2-submission-thank-you__next-steps
+      flex-wrap wrap
+
+      > *
+        margin-top 30px
+        width 100%

--- a/desktop/apps/consignments2/components/upload_photo/index.js
+++ b/desktop/apps/consignments2/components/upload_photo/index.js
@@ -29,7 +29,7 @@ function UploadPhoto (props) {
         Upload photos
       </div>
       <div className={b('subtitle')}>
-        Take a quick snapshot of the work so we can better asses the condition of the work. We suggest a photo of the front and back of the work.
+        Take a quick snapshot of the work so we can better assess the condition of the work. We suggest a photo of the front and back of the work.
       </div>
       <div className={b('form')}>
         <label

--- a/desktop/apps/consignments2/components/upload_photo/index.styl
+++ b/desktop/apps/consignments2/components/upload_photo/index.styl
@@ -18,7 +18,7 @@
     margin 0 auto
 
   &__submit-button
-    height 40px
+    height 45px
     width 100%
     margin-top 40px
     margin-bottom 10px

--- a/desktop/apps/consignments2/components/uploaded_image/index.styl
+++ b/desktop/apps/consignments2/components/uploaded_image/index.styl
@@ -2,7 +2,7 @@
   &__image-wrapper
     padding-right 30px
     display flex
-    border 2px solid gray-dark-color
+    border 2px solid gray-lighter-color
     align-items center
     height 84px
     width 100%

--- a/desktop/apps/consignments2/stylesheets/landing/desktop.styl
+++ b/desktop/apps/consignments2/stylesheets/landing/desktop.styl
@@ -194,7 +194,7 @@
   &__artists
     display flex
     flex-wrap wrap
-    height 400px
+    height 415px
     overflow hidden
     justify-content center
 

--- a/desktop/apps/consignments2/stylesheets/landing/mobile.styl
+++ b/desktop/apps/consignments2/stylesheets/landing/mobile.styl
@@ -42,11 +42,21 @@
 
       &__artwork
         max-width 50%
+        padding-left 2px
+        padding-right 2px
+
+        img
+          width 100%
 
   .consignments2-in-demand
+    padding-left 10px
+    padding-right 10px
+
     &__artists
+      justify-content space-between
+
       &__artist
-        padding-bottom 15px 5px
+        padding 15px 0px
 
   .consignments2-upcoming-sales
     &--desktop

--- a/desktop/apps/consignments2/test/components.js
+++ b/desktop/apps/consignments2/test/components.js
@@ -69,9 +69,9 @@ describe('React components', () => {
           <CreateAccount store={initialStore} />
         )
         const rendered = wrapper.render()
-        rendered.find('.log-in').length.should.eql(1)
+        rendered.find('.log-in').length.should.eql(0)
         rendered.find('.forgot-password').length.should.eql(0)
-        rendered.find('.sign-up').length.should.eql(0)
+        rendered.find('.sign-up').length.should.eql(1)
       })
     })
 


### PR DESCRIPTION
Mostly little style things, but here's a list of fixes from Katarina and I's QA session today:
- Replace the hover-select box with one that you click into 👏 
- The default `authFormState` is now `'signUp'` unless you are entering from the `/upload` path
- In the responsive view, gets rid of the page-wide "Consign your work to Artsy..." title and includes the sub header on each page
![image](https://user-images.githubusercontent.com/2081340/26853227-26eeda8e-4adf-11e7-9dbb-b070088930b9.png)
- auto-focuses the first input element on each page
- Vertically stacks the elements on the `/thank_you` page
![image](https://user-images.githubusercontent.com/2081340/26853248-40ed8bce-4adf-11e7-9aa9-e5bf55550867.png)