### PR TITLE
@craigspaeth => Add support for server-side React rendering

### DIFF
--- a/desktop/apps/auction/server.js
+++ b/desktop/apps/auction/server.js
@@ -4,6 +4,10 @@ import express from 'express'
 const app = module.exports = express()
 
 app.set('view engine', 'jade')
+app.engine('jsx', require('express-react-views').createEngine({
+  transformViews: false // No need since we're already importing `babel-core/register`
+}))
+
 app.set('views', `${__dirname}/templates`)
 
 app.get('/sale/:id', routes.index)

--- a/desktop/apps/auction/templates/index.jsx
+++ b/desktop/apps/auction/templates/index.jsx
@@ -1,0 +1,14 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+export default function IndexRoute ({ html }) {
+  return (
+    <div
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}
+
+IndexRoute.propTypes = {
+  html: PropTypes.string.isRequired
+}

--- a/desktop/apps/auction/utils/artwork.js
+++ b/desktop/apps/auction/utils/artwork.js
@@ -1,7 +1,7 @@
 import _ from 'underscore'
 
 // Logic borrowed from the artwork Backbone model
-export function titleAndYear(title, date) {
+export function titleAndYear (title, date) {
   return _.compact([
     title && `<em>${title}</em>`, date
   ]).join(', ')

--- a/desktop/lib/partial_renderer.js
+++ b/desktop/lib/partial_renderer.js
@@ -1,0 +1,77 @@
+import invariant from 'invariant'
+import { isArray, isFunction, isString } from 'underscore'
+
+/**
+ * Render one or many partials and return a Promise on success
+ *
+ * @example
+ *
+ * try {
+ *   const [header,  footer] = await partialRenderer(res, [
+ *     '/path/to/header.jade',
+ *     '/path/to/footer.jade'
+ *   ])
+ *
+ *   res.render('index.jsx', {
+ *     header,
+ *     footer
+ *   })
+ * } catch (error) {
+ *   next()
+ * }
+ *
+ * @param  {Function} res An express `response` object
+ * @return {Promise} If success, an array of rendered html partials
+ */
+export default function partialRenderer (res, partials, locals) {
+  invariant(isFunction(res.render),
+    '(lib/partial_renderer.js) ' +
+    'Error rendering partials: `res.render` must be a function'
+  )
+
+  const isValid = isArray(partials) || isString(partials)
+
+  invariant(isValid,
+    '(lib/partial_renderer.js) ' +
+    'Error rendering partials: `partials` must be a string or array of ' +
+    'strings representing the path to the template'
+  )
+
+  const partialSet = isArray(partials)
+    ? partials
+    : [partials]
+
+  const { render } = renderPartial(res, locals)
+
+  return Promise.all(
+    partialSet.map(render)
+  )
+}
+
+export function renderPartial (res, locals = {}) {
+  invariant(isFunction(res.render),
+    '(lib/partial_renderer.js) ' +
+    'Error rendering partial: `res.render` must be a function'
+  )
+
+  return {
+    render: (path) => {
+      const isValid = isString(path) || isFunction(path)
+
+      invariant(isValid,
+        '(lib/partial_renderer.js) ' +
+        'Error rendering partial: `path` must be a string'
+      )
+
+      return new Promise((resolve, reject) => {
+        res.render(path, locals, (error, html) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(html)
+          }
+        })
+      })
+    }
+  }
+}

--- a/desktop/test/lib/partial_renderer_spec.js
+++ b/desktop/test/lib/partial_renderer_spec.js
@@ -1,0 +1,122 @@
+import partialRenderer, { renderPartial } from '../../lib/partial_renderer'
+
+describe('lib/partial_renderer.js', () => {
+  describe('#partialRenderer', () => {
+    it('throws if a renderer is not provided', () => {
+      (() => {
+        partialRenderer()
+      }).should.throw()
+    })
+
+    it('when invoked returns a function', () => {
+      partialRenderer({ render: () => {} }, '')
+        .then.should.be.type('function')
+    })
+
+    it('resolves with an error on error', (done) => {
+      const res = {
+        render: (path, locals, callback) => {
+          callback(new Error('nope'))
+        }
+      }
+
+      partialRenderer(res, 'foo')
+        .catch((error) => {
+          error.message.should.eql('nope')
+          done()
+        })
+    })
+
+    it('resolves with an array of partial html on success', (done) => {
+      const templateA = (locals) => `
+        <html>
+          <body>
+            ${locals.name}
+          </body>
+        </html
+      `
+
+      const templateB = (locals) => `
+        <html>
+          <body>
+            ${locals.novels}
+          </body>
+        </html
+      `
+      const res = {
+        render: (path, locals, callback) => {
+          callback(undefined, path(locals))
+        }
+      }
+
+      const locals = {
+        name: 'William Burroughs',
+        novels: 'Nova Express'
+      }
+
+      partialRenderer(res, [templateA, templateB], locals)
+        .then(([a, b]) => {
+          a.should.eql(templateA(locals))
+          b.should.eql(templateB(locals))
+          done()
+        })
+        .catch(done)
+    })
+  })
+
+  describe('#renderPartial', () => {
+    it('throws if a renderer is not provided', () => {
+      (() => {
+        renderPartial()
+      }).should.throw()
+    })
+
+    it('when invoked returns a function', () => {
+      const { render } = renderPartial({ render: () => {} })
+      render.should.be.type('function')
+    })
+
+    it('resolves with an error on error', (done) => {
+      const res = {
+        render: (path, locals, callback) => {
+          callback(new Error('nope'))
+        }
+      }
+
+      renderPartial(res)
+        .render('')
+          .catch((error) => {
+            error.message.should.eql('nope')
+            done()
+          })
+    })
+
+    it('resolves with html on success', (done) => {
+      const template = (locals) => `
+        <html>
+          <body>
+            ${locals.name}
+          </body>
+        </html
+      `
+
+      const res = {
+        render: (path, locals, callback) => {
+          callback(undefined, template(locals))
+        }
+      }
+
+      const locals = {
+        name: 'William Burroughs'
+      }
+
+      renderPartial(res, locals)
+        .render('foo')
+          .then((html) => {
+            html.should.eql(template(locals))
+            done()
+          })
+          .catch(done)
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "express": "^4.13.3",
     "express-ipfilter": "0.2.1",
     "express-limiter": "^1.6.0",
+    "express-react-views": "^0.10.2",
     "factor-bundle": "^2.5.0",
     "forever": "^0.15.3",
     "geoformatter": "git://github.com/dzucconi/geo_formatter.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,7 +913,7 @@ babel-polyfill@^6.23.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-preset-es2015@^6.22.0:
+babel-preset-es2015@^6.22.0, babel-preset-es2015@^6.5.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
   dependencies:
@@ -948,7 +948,7 @@ babel-preset-flow@^6.23.0:
   dependencies:
     babel-plugin-transform-flow-strip-types "^6.22.0"
 
-babel-preset-react@^6.22.0:
+babel-preset-react@^6.22.0, babel-preset-react@^6.5.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-react/-/babel-preset-react-6.24.1.tgz#ba69dfaea45fc3ec639b6a4ecea6e17702c91380"
   dependencies:
@@ -969,7 +969,7 @@ babel-preset-stage-3@^6.17.0:
     babel-plugin-transform-exponentiation-operator "^6.24.1"
     babel-plugin-transform-object-rest-spread "^6.22.0"
 
-babel-register@^6.24.1:
+babel-register@^6.24.1, babel-register@^6.5.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.24.1.tgz#7e10e13a2f71065bdfad5a1787ba45bca6ded75f"
   dependencies:
@@ -1140,7 +1140,7 @@ bluebird-q@^2.1.1:
   dependencies:
     bluebird "^3.4.6"
 
-bluebird@*, bluebird@^3.4.6:
+bluebird@*, bluebird@^3.0.5, bluebird@^3.4.6:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
@@ -1822,6 +1822,13 @@ concurrently@^3.3.0:
     supports-color "^3.2.3"
     tree-kill "^1.1.0"
 
+config-chain@~1.1.5:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.11.tgz#aba09747dfbe4c3e70e766a6e41586e1859fc6f2"
+  dependencies:
+    ini "^1.3.4"
+    proto-list "~1.2.1"
+
 connect-timeout@^1.8.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/connect-timeout/-/connect-timeout-1.9.0.tgz#bc27326b122103714bebfa0d958bab33f6522e3a"
@@ -2455,6 +2462,15 @@ ecdsa-sig-formatter@1.0.9:
     base64url "^2.0.0"
     safe-buffer "^5.0.1"
 
+editorconfig@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.13.2.tgz#8e57926d9ee69ab6cb999f027c2171467acceb35"
+  dependencies:
+    bluebird "^3.0.5"
+    commander "^2.9.0"
+    lru-cache "^3.2.0"
+    sigmund "^1.0.1"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -2967,6 +2983,17 @@ express-ipfilter@0.2.1:
 express-limiter@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/express-limiter/-/express-limiter-1.6.0.tgz#142753588f785b731551603d214415bc79da697a"
+
+express-react-views@^0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/express-react-views/-/express-react-views-0.10.2.tgz#444ed1f2dc7b884541e67f40d7264622f4ba1d4a"
+  dependencies:
+    babel-preset-es2015 "^6.5.0"
+    babel-preset-react "^6.5.0"
+    babel-register "^6.5.1"
+    js-beautify "^1.5.10"
+    lodash.escaperegexp "^4.1.1"
+    object-assign "^4.0.1"
 
 express@*, express@^4.12.3, express@^4.13.3, express@^4.15.2:
   version "4.15.3"
@@ -3801,7 +3828,7 @@ inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
-ini@1.x.x, ini@~1.3.0:
+ini@1.x.x, ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
@@ -4180,6 +4207,15 @@ jquery@>=1.7, jquery@^2.1.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
 
+js-beautify@^1.5.10:
+  version "1.6.14"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.6.14.tgz#d3b8f7322d02b9277d58bd238264c327e58044cd"
+  dependencies:
+    config-chain "~1.1.5"
+    editorconfig "^0.13.2"
+    mkdirp "~0.5.0"
+    nopt "~3.0.1"
+
 js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
@@ -4213,33 +4249,7 @@ jsdom-global@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/jsdom-global/-/jsdom-global-3.0.2.tgz#6bd299c13b0c4626b2da2c0393cd4385d606acb9"
 
-"jsdom@>= 10.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-10.1.0.tgz#7765e00fd5c3567f34985a1c86ff466a61dacc6a"
-  dependencies:
-    abab "^1.0.3"
-    acorn "^4.0.4"
-    acorn-globals "^3.1.0"
-    array-equal "^1.0.0"
-    content-type-parser "^1.0.1"
-    cssom ">= 0.3.2 < 0.4.0"
-    cssstyle ">= 0.2.37 < 0.3.0"
-    escodegen "^1.6.1"
-    html-encoding-sniffer "^1.0.1"
-    nwmatcher ">= 1.3.9 < 2.0.0"
-    parse5 "^1.5.1"
-    pn "^1.0.0"
-    request "^2.79.0"
-    request-promise-native "^1.0.3"
-    sax "^1.2.1"
-    symbol-tree "^3.2.1"
-    tough-cookie "^2.3.2"
-    webidl-conversions "^4.0.0"
-    whatwg-encoding "^1.0.1"
-    whatwg-url "^4.3.0"
-    xml-name-validator "^2.0.1"
-
-jsdom@^11.0.0:
+"jsdom@>= 10.0", jsdom@^11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.0.0.tgz#1ee507cb2c0b16c875002476b1a8557d951353e5"
   dependencies:
@@ -4535,6 +4545,10 @@ lodash.escape@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
 
+lodash.escaperegexp@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
+
 lodash.filter@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
@@ -4635,6 +4649,12 @@ loud-rejection@^1.0.0:
   dependencies:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
+
+lru-cache@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
+  dependencies:
+    pseudomap "^1.0.1"
 
 lsmod@1.0.0:
   version "1.0.0"
@@ -4994,6 +5014,12 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
+nopt@~3.0.1:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
+  dependencies:
+    abbrev "1"
+
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.3.8.tgz#d819eda2a9dedbd1ffa563ea4071d936782295bb"
@@ -5262,10 +5288,6 @@ parse-json@^2.2.0:
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   dependencies:
     error-ex "^1.2.0"
-
-parse5@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
 
 parse5@^3.0.2:
   version "3.0.2"
@@ -5556,6 +5578,10 @@ propagate@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.4.0.tgz#f3fcca0a6fe06736a7ba572966069617c130b481"
 
+proto-list@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
+
 proxy-addr@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.4.tgz#27e545f6960a44a627d9b44467e35c1b6b4ce2f3"
@@ -5574,6 +5600,10 @@ ps-tree@0.0.x:
   resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-0.0.3.tgz#dbf8d752a7fe22fa7d58635689499610e9276ddc"
   dependencies:
     event-stream "~0.5"
+
+pseudomap@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 public-encrypt@^4.0.0:
   version "4.0.0"
@@ -6499,6 +6529,10 @@ shush@^1.0.0:
     caller "~0.0.1"
     strip-json-comments "~0.1.1"
 
+sigmund@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
+
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -6919,7 +6953,7 @@ supertest@^2.0.1:
     methods "1.x"
     superagent "^2.0.0"
 
-supports-color@3.1.2:
+supports-color@3.1.2, supports-color@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -6933,7 +6967,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.2, supports-color@^3.2.3:
+supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:


### PR DESCRIPTION
I've spent a good amount of time thinking about how we can start modernizing our server-side template flow and realized that its simpler than I thought to interpolate the two engines, due to Express providing an `html` callback to `res.render`, e.g.: 

```javascript
res.render('index.jade', { 
  ... 
}, (error, html) => {
  res.render('index.jsx', { 
    html 
  })
})
```

Testing this on `/auctions/:id` it works as you'd expect. This will allow us to incrementally start moving our `jade` fragments over to React without having to throw the whole thing out and start from scratch (unless I'm missing something big).

Additionally, I've created a new helper under `/lib/partial_renderer.js` that exports two functions, `renderPartial` and `renderPartialSet`. They can be used like so in a typical Express route:

```javascript
import partialRenderer from 'lib/partial_renderer'

try {
  // Can be a string or an array of paths
  const [header, footer] = await partialRenderer(res, [ 
    '/path/to/header.jade', 
    '/path/to/footer.jade'
  ])

  // Now pass rendered Jade partial html to React
  res.render('index.jsx', {
    header,
    footer
  })
} catch (error) {
  next()
}
```