### PR TITLE
@craigspaeth: Marketing modals

### DIFF
--- a/desktop/components/marketing_signup_modal/index.coffee
+++ b/desktop/components/marketing_signup_modal/index.coffee
@@ -51,6 +51,11 @@ module.exports = class MarketingSignupModal extends Backbone.View
 
   initialize: ->
     slug = qs.parse(location.search.replace /^\?/, '')?['m-id']
+
+    # This is just for the Art Basel Fair campaign and should be removed after
+    # the fair closes.
+    slug = 'ca3' if !slug and sd.CURRENT_PATH is '/art-basel-2017'
+
     modalData = _.findWhere(sd.MARKETING_SIGNUP_MODALS, { slug: slug })
     @inner = new MarketingSignupModalInner
       data: modalData

--- a/desktop/components/marketing_signup_modal/index.jade
+++ b/desktop/components/marketing_signup_modal/index.jade
@@ -1,6 +1,8 @@
 .marketing-signup-modal-left(
   style="background-image: url(#{modal.image})"
 )
+  if modal.photoCredit
+    p.marketing-signup-modal-left__photo-credit= modal.photoCredit
 .marketing-signup-modal-right
   .marketing-signup-modal-right__logo.icon-logotype
   h2.marketing-signup-modal-h2= modal.copy

--- a/desktop/components/marketing_signup_modal/index.styl
+++ b/desktop/components/marketing_signup_modal/index.styl
@@ -22,6 +22,14 @@ divider-height = 40px
     background-position-y calc(100% \+ 1px)
     @media screen and (max-width 768px)
       display none
+  &-left__photo-credit
+    position absolute
+    bottom 10px
+    left 10px
+    color white
+    font-weight bold
+    text-shadow 0 0 5px rgba(0, 0, 0, 1)
+    font-size 13px
   img
     width 100%
 

--- a/desktop/components/marketing_signup_modal/index.styl
+++ b/desktop/components/marketing_signup_modal/index.styl
@@ -24,11 +24,10 @@ divider-height = 40px
       display none
   &-left__photo-credit
     position absolute
-    bottom 10px
-    left 10px
-    color white
+    bottom 8px
+    left 15px
+    color black
     font-weight bold
-    text-shadow 0 0 5px rgba(0, 0, 0, 1)
     font-size 13px
   img
     width 100%

--- a/desktop/config.coffee
+++ b/desktop/config.coffee
@@ -59,7 +59,7 @@ module.exports =
   IP_BLACKLIST: ''
   LINKEDIN_KEY: null
   LINKEDIN_SECRET: null
-  MARKETING_SIGNUP_MODALS: '[{"slug":"ca1","copy":"An art collection for every budget","image":"http://files.artsy.net/images/modal-collect-art.jpg"},{"slug":"ca2","copy":"Buy art from the best galleries and auction houses","image":"http://files.artsy.net/images/modal-collect-art.jpg"},{"slug":"ca3","copy":"Sign Up to Discover and Collect Works from Art Basel","image":"https://d32dm0rphc51dk.cloudfront.net/RzsG8I1uQ957Ky0YCzSo8w/large.jpg","photoCredit":"Image courtesy of Richard Gray Gallery"}]'
+  MARKETING_SIGNUP_MODALS: '[{"slug":"ca1","copy":"An art collection for every budget","image":"http://files.artsy.net/images/modal-collect-art.jpg"},{"slug":"ca2","copy":"Buy art from the best galleries and auction houses","image":"http://files.artsy.net/images/modal-collect-art.jpg"},{"slug":"ca3","copy":"Sign Up to Discover and Collect Works from Art Basel","image":"https://d32dm0rphc51dk.cloudfront.net/SJaRT2vCFzshOvN9PpiiUA/large.jpg","photoCredit":"Image courtesy of Richard Gray Gallery"}]'
   MAX_POLLS_FOR_MAX_BIDS: 20
   MAX_SOCKETS: -1
   METAPHYSICS_ENDPOINT: null

--- a/desktop/config.coffee
+++ b/desktop/config.coffee
@@ -59,7 +59,7 @@ module.exports =
   IP_BLACKLIST: ''
   LINKEDIN_KEY: null
   LINKEDIN_SECRET: null
-  MARKETING_SIGNUP_MODALS: '[{"slug":"ca1","copy":"An art collection for every budget","image":"http://files.artsy.net/images/modal-interior-a-credited.jpg","photoCredit":"Photo by Emily Johnson"},{"slug":"ca2","copy":"Buy art from the best galleries and auction houses","image":"http://files.artsy.net/images/modal-interior-a-credited.jpg","photoCredit":"Photo by Emily Johnson"},{"slug":"ca3","copy":"An art collection for every budget","image":"http://files.artsy.net/images/modal-interior-b-credited.jpg","photoCredit":"Photo by Emily Johnson"},{"slug":"ca4","copy":"Buy art from the best galleries and auction houses","image":"http://files.artsy.net/images/modal-interior-b-credited.jpg","photoCredit":"Photo by Emily Johnson"}]'
+  MARKETING_SIGNUP_MODALS: '[{"slug":"ca1","copy":"An art collection for every budget","image":"http://files.artsy.net/images/modal-collect-art.jpg"},{"slug":"ca2","copy":"Buy art from the best galleries and auction houses","image":"http://files.artsy.net/images/modal-collect-art.jpg"},{"slug":"ca3","copy":"Sign Up to Discover and Collect Works from Art Basel","image":"https://d32dm0rphc51dk.cloudfront.net/RzsG8I1uQ957Ky0YCzSo8w/large.jpg","photoCredit":"Image courtesy of Richard Gray Gallery"}]'
   MAX_POLLS_FOR_MAX_BIDS: 20
   MAX_SOCKETS: -1
   METAPHYSICS_ENDPOINT: null

--- a/mobile/components/marketing_signup_modal/index.jade
+++ b/mobile/components/marketing_signup_modal/index.jade
@@ -12,3 +12,5 @@ section.marketing-signup-modal
       | Continue with Facebook
     p Already have an account?&nbsp;
       a( href='/log_in' ) Log in
+    if modal.photoCredit
+      p.marketing-signup-modal-photo-credit= modal.photoCredit

--- a/mobile/components/marketing_signup_modal/index.styl
+++ b/mobile/components/marketing_signup_modal/index.styl
@@ -45,3 +45,8 @@
 
   a
     color white
+
+  &-photo-credit
+    garamond-size('s-caption')
+    color gray-color
+    margin-top 5px

--- a/mobile/components/marketing_signup_modal/middleware.coffee
+++ b/mobile/components/marketing_signup_modal/middleware.coffee
@@ -3,6 +3,11 @@ _ = require 'underscore'
 module.exports = (req, res, next) ->
   sd = res.locals.sd
   slug = req.query['m-id']
+
+  # This is just for the Art Basel Fair campaign and should be removed after
+  # the fair closes.
+  slug = 'ca3' if !slug and sd.CURRENT_PATH is '/art-basel-2017'
+
   modalData = _.findWhere(sd.MOBILE_MARKETING_SIGNUP_MODALS, { slug: slug })
 
   res.locals.modal = modalData if modalData

--- a/mobile/config.coffee
+++ b/mobile/config.coffee
@@ -33,7 +33,7 @@ module.exports =
   IMAGE_PROXY: 'GEMINI'
   MAILCHIMP_AUCTION_LIST_ID: 'b7b9959ee0'
   MAILCHIMP_KEY: null
-  MOBILE_MARKETING_SIGNUP_MODALS: '[{"slug":"ca1","copy":"An art collection for every budget","image":"http://files.artsy.net/images/modal-collect-art.jpg"},{"slug":"ca2","copy":"Buy art from the best galleries and auction houses","image":"http://files.artsy.net/images/modal-collect-art.jpg"},{"slug":"ca3","copy":"Sign Up to Discover and Collect Works from Art Basel","image":"https://d32dm0rphc51dk.cloudfront.net/RzsG8I1uQ957Ky0YCzSo8w/large.jpg","photoCredit":"Image courtesy of Richard Gray Gallery"}]'
+  MOBILE_MARKETING_SIGNUP_MODALS: '[{"slug":"ca1","copy":"An art collection for every budget","image":"http://files.artsy.net/images/modal-collect-art.jpg"},{"slug":"ca2","copy":"Buy art from the best galleries and auction houses","image":"http://files.artsy.net/images/modal-collect-art.jpg"},{"slug":"ca3","copy":"Sign Up to Discover and Collect Works from Art Basel","image":"https://d32dm0rphc51dk.cloudfront.net/SJaRT2vCFzshOvN9PpiiUA/large.jpg","photoCredit":"Image courtesy of Richard Gray Gallery"}]'
   MAX_POLLS_FOR_MAX_BIDS: 20
   MAX_SOCKETS: -1
   METAPHYSICS_ENDPOINT: 'https://metaphysics-production.artsy.net'

--- a/mobile/config.coffee
+++ b/mobile/config.coffee
@@ -33,7 +33,7 @@ module.exports =
   IMAGE_PROXY: 'GEMINI'
   MAILCHIMP_AUCTION_LIST_ID: 'b7b9959ee0'
   MAILCHIMP_KEY: null
-  MOBILE_MARKETING_SIGNUP_MODALS: '[{"slug":"ca1","copy":"An art collection for every budget","image":"http://files.artsy.net/images/modal-collect-art.jpg"},{"slug":"ca2","copy":"Buy art from the best galleries and auction houses","image":"http://files.artsy.net/images/modal-collect-art.jpg"}]'
+  MOBILE_MARKETING_SIGNUP_MODALS: '[{"slug":"ca1","copy":"An art collection for every budget","image":"http://files.artsy.net/images/modal-collect-art.jpg"},{"slug":"ca2","copy":"Buy art from the best galleries and auction houses","image":"http://files.artsy.net/images/modal-collect-art.jpg"},{"slug":"ca3","copy":"Sign Up to Discover and Collect Works from Art Basel","image":"https://d32dm0rphc51dk.cloudfront.net/RzsG8I1uQ957Ky0YCzSo8w/large.jpg","photoCredit":"Image courtesy of Richard Gray Gallery"}]'
   MAX_POLLS_FOR_MAX_BIDS: 20
   MAX_SOCKETS: -1
   METAPHYSICS_ENDPOINT: 'https://metaphysics-production.artsy.net'


### PR DESCRIPTION
closes: https://github.com/artsy/collector-experience/issues/314

This work updates the marketing modal to add a dedicated modal for the Art Basel 2017 campaign. This modal gets triggered on desktop and mobile web when a user navigates to the Art Basel 2017 Microsite or enters the `m-id=ca3` query param in the url.

*note:* updating the environment variables are pending.

**Desktop version:**
![screen shot 2017-06-07 at 5 57 29 pm](https://user-images.githubusercontent.com/5201004/26903400-fb1911a0-4baa-11e7-8845-17face34e63e.png)


**Mobile version:**
![screen shot 2017-06-07 at 5 58 19 pm](https://user-images.githubusercontent.com/5201004/26903404-ffceab2e-4baa-11e7-8edb-2684fbc98751.png)