### PR TITLE
@craigspaeth => Add ability to import modules via absolute paths

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,9 +5,17 @@
     "stage-3"
   ],
   "plugins": [
+    "babel-plugin-rewire",
     "inline-react-svg",
     "transform-runtime",
-    "transform-class-properties",
-    "babel-plugin-rewire"
+    ["module-resolver", {
+      "root": ["./desktop"],
+      "alias": {
+        "desktop": "./desktop",
+        "mobile": "./mobile",
+        "root": "./"
+      }
+    }],
+    "transform-class-properties"
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -9,12 +9,7 @@
     "inline-react-svg",
     "transform-runtime",
     ["module-resolver", {
-      "root": ["./desktop"],
-      "alias": {
-        "desktop": "./desktop",
-        "mobile": "./mobile",
-        "root": "./"
-      }
+      "root": ["./"]
     }],
     "transform-class-properties"
   ]

--- a/desktop/apps/auction/client/actions.js
+++ b/desktop/apps/auction/client/actions.js
@@ -1,10 +1,10 @@
-import analyticsHooks from 'lib/analytics_hooks.coffee'
-import metaphysics from 'root/lib/metaphysics.coffee'
-import { filterQuery } from 'apps/auction/queries/filter'
-import { worksByFollowedArtists } from 'apps/auction/queries/works_by_followed_artists'
+import analyticsHooks from 'desktop/lib/analytics_hooks.coffee'
+import metaphysics from 'lib/metaphysics.coffee'
+import { filterQuery } from 'desktop/apps/auction/queries/filter'
+import { worksByFollowedArtists } from 'desktop/apps/auction/queries/works_by_followed_artists'
 
 // FIXME: Example test for coffee-script code
-import 'apps/auction/client/test-file.coffee'
+import 'desktop/apps/auction/client/test-file.coffee'
 
 // Action types
 export const DECREMENT_FOLLOWED_ARTISTS_PAGE = 'DECREMENT_FOLLOWED_ARTISTS_PAGE'

--- a/desktop/apps/auction/client/actions.js
+++ b/desktop/apps/auction/client/actions.js
@@ -1,7 +1,10 @@
-import analyticsHooks from '../../../lib/analytics_hooks.coffee'
-import metaphysics from '../../../../lib/metaphysics.coffee'
-import { filterQuery } from '../queries/filter'
-import { worksByFollowedArtists } from '../queries/works_by_followed_artists'
+import analyticsHooks from 'lib/analytics_hooks.coffee'
+import metaphysics from 'root/lib/metaphysics.coffee'
+import { filterQuery } from 'apps/auction/queries/filter'
+import { worksByFollowedArtists } from 'apps/auction/queries/works_by_followed_artists'
+
+// FIXME: Example test for coffee-script code
+import 'apps/auction/client/test-file.coffee'
 
 // Action types
 export const DECREMENT_FOLLOWED_ARTISTS_PAGE = 'DECREMENT_FOLLOWED_ARTISTS_PAGE'

--- a/desktop/apps/auction/client/test-file.coffee
+++ b/desktop/apps/auction/client/test-file.coffee
@@ -1,0 +1,3 @@
+# FIXME: Example for coffee-script code
+actions = require './actions.js'
+console.log actions

--- a/desktop/apps/auction/routes.js
+++ b/desktop/apps/auction/routes.js
@@ -1,11 +1,11 @@
-import Articles from '../../collections/articles.coffee'
-import ArticlesQuery from './queries/articles'
-import Auction from '../../models/auction.coffee'
-import MeQuery from './queries/me'
-import SaleQuery from './queries/sale'
-import footerItems from './footer_items'
-import metaphysics from '../../../lib/metaphysics'
-import { getLiveAuctionUrl } from '../../../utils/domain/auctions/urls'
+import Articles from 'collections/articles.coffee'
+import ArticlesQuery from 'apps/auction/queries/articles'
+import Auction from 'models/auction.coffee'
+import MeQuery from 'apps/auction/queries/me'
+import SaleQuery from 'apps/auction/queries/sale'
+import footerItems from 'apps/auction/footer_items'
+import metaphysics from 'root/lib/metaphysics'
+import { getLiveAuctionUrl } from 'root/utils/domain/auctions/urls'
 
 export const index = async (req, res) => {
   const { me } = await metaphysics({ query: MeQuery(req.params.id), req: req })

--- a/desktop/apps/auction/routes.js
+++ b/desktop/apps/auction/routes.js
@@ -1,11 +1,11 @@
-import Articles from 'collections/articles.coffee'
-import ArticlesQuery from 'apps/auction/queries/articles'
-import Auction from 'models/auction.coffee'
-import MeQuery from 'apps/auction/queries/me'
-import SaleQuery from 'apps/auction/queries/sale'
-import footerItems from 'apps/auction/footer_items'
-import metaphysics from 'root/lib/metaphysics'
-import { getLiveAuctionUrl } from 'root/utils/domain/auctions/urls'
+import Articles from 'desktop/collections/articles.coffee'
+import ArticlesQuery from 'desktop/apps/auction/queries/articles'
+import Auction from 'desktop/models/auction.coffee'
+import MeQuery from 'desktop/apps/auction/queries/me'
+import SaleQuery from 'desktop/apps/auction/queries/sale'
+import footerItems from 'desktop/apps/auction/footer_items'
+import metaphysics from 'lib/metaphysics.coffee'
+import { getLiveAuctionUrl } from 'utils/domain/auctions/urls'
 
 export const index = async (req, res) => {
   const { me } = await metaphysics({ query: MeQuery(req.params.id), req: req })

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-core": "^6.17.0",
     "babel-eslint": "^7.0.0",
     "babel-plugin-inline-react-svg": "^0.2.0",
+    "babel-plugin-module-resolver": "^2.7.1",
     "babel-plugin-rewire": "^1.0.0",
     "babel-plugin-transform-class-properties": "^6.23.0",
     "babel-plugin-transform-runtime": "^6.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -607,6 +607,14 @@ babel-plugin-inline-react-svg@^0.2.0:
     lodash.isplainobject "^4.0.6"
     svgo "^0.7.0"
 
+babel-plugin-module-resolver@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-2.7.1.tgz#18be3c42ddf59f7a456c9e0512cd91394f6e4be1"
+  dependencies:
+    find-babel-config "^1.0.1"
+    glob "^7.1.1"
+    resolve "^1.2.0"
+
 babel-plugin-rewire@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-rewire/-/babel-plugin-rewire-1.1.0.tgz#a6b966d9d8c06c03d95dcda2eec4e2521519549b"
@@ -3147,6 +3155,13 @@ finalhandler@~1.0.3:
     statuses "~1.3.1"
     unpipe "~1.0.0"
 
+find-babel-config@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.1.0.tgz#acc01043a6749fec34429be6b64f542ebb5d6355"
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
+
 find-root@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.0.0.tgz#962ff211aab25c6520feeeb8d6287f8f6e95807a"
@@ -4213,33 +4228,7 @@ jsdom-global@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/jsdom-global/-/jsdom-global-3.0.2.tgz#6bd299c13b0c4626b2da2c0393cd4385d606acb9"
 
-"jsdom@>= 10.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-10.1.0.tgz#7765e00fd5c3567f34985a1c86ff466a61dacc6a"
-  dependencies:
-    abab "^1.0.3"
-    acorn "^4.0.4"
-    acorn-globals "^3.1.0"
-    array-equal "^1.0.0"
-    content-type-parser "^1.0.1"
-    cssom ">= 0.3.2 < 0.4.0"
-    cssstyle ">= 0.2.37 < 0.3.0"
-    escodegen "^1.6.1"
-    html-encoding-sniffer "^1.0.1"
-    nwmatcher ">= 1.3.9 < 2.0.0"
-    parse5 "^1.5.1"
-    pn "^1.0.0"
-    request "^2.79.0"
-    request-promise-native "^1.0.3"
-    sax "^1.2.1"
-    symbol-tree "^3.2.1"
-    tough-cookie "^2.3.2"
-    webidl-conversions "^4.0.0"
-    whatwg-encoding "^1.0.1"
-    whatwg-url "^4.3.0"
-    xml-name-validator "^2.0.1"
-
-jsdom@^11.0.0:
+"jsdom@>= 10.0", jsdom@^11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.0.0.tgz#1ee507cb2c0b16c875002476b1a8557d951353e5"
   dependencies:
@@ -4297,7 +4286,7 @@ json3@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
 
-json5@^0.5.0:
+json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
@@ -5263,10 +5252,6 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-parse5@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
-
 parse5@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.2.tgz#05eff57f0ef4577fb144a79f8b9a967a6cc44510"
@@ -6212,7 +6197,7 @@ resolve@1.1.7, resolve@~1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6:
+resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.2.0:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
@@ -6919,7 +6904,7 @@ supertest@^2.0.1:
     methods "1.x"
     superagent "^2.0.0"
 
-supports-color@3.1.2:
+supports-color@3.1.2, supports-color@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -6933,7 +6918,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.2, supports-color@^3.2.3:
+supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/942.

Since I'm about to do a long stint inside of Force I wanted to sweep back through and follow up on a few things I had started thinking about a while back, with absolute module resolution being no.1 (and server-side React being no.2  😄)

What this PR does is set up [babel-plugin-module-resolver](https://github.com/tleunen/babel-plugin-module-resolver) to take absolute paths encountered in code and remap them to their corresponding file-system location, with aliases set up in `.babelrc`. There is a similar setup in Prediction. When using ES6+, resolution works seamlessly across the server and client and tests, though CoffeeScript code, while importable, must internally resolve paths the old way. I'm sure this can be fixed (but right now is less of a priority).  

Mappings are inside of [`.babelrc`](https://github.com/artsy/force/compare/master...damassi:add-absolute-module-resolution?expand=1#diff-e56633f72ecc521128b3db6586074d2cR11) and point to root of project. Example:

`import foo from 'desktop/apps/foo'`
`import bar from 'mobile/apps/bar'`
`import metaphysics from 'lib/metaphysics.coffee'`
