### PR TITLE
@damassi => Consign2 step marker + number validations

### DIFF
--- a/desktop/apps/consignments2/client/reducers.js
+++ b/desktop/apps/consignments2/client/reducers.js
@@ -26,7 +26,7 @@ const stepsMapping = [
   },
   {
     id: 'upload_photos',
-    label: 'Upload Photo',
+    label: 'Upload Photos',
     shortLabel: 'Upload'
   }
 ]

--- a/desktop/apps/consignments2/components/describe_work_desktop/index.js
+++ b/desktop/apps/consignments2/components/describe_work_desktop/index.js
@@ -13,9 +13,12 @@ import {
   submitDescribeWork
 } from '../../client/actions'
 
+const numberWarning = value => value && isNaN(Number(value)) && 'Must be a number'
+
 function validate (values, props) {
   const {
     authenticity_certificate,
+    depth,
     edition,
     edition_number,
     edition_size,
@@ -32,12 +35,13 @@ function validate (values, props) {
   if (!signature) errors.signature = 'Required'
   if (!title) errors.title = 'Required'
   if (!year) errors.year = 'Required'
-  if (!width) errors.width = 'Required'
+  if (!width || numberWarning(width)) errors.width = 'Invalid'
   if (!medium) errors.medium = 'Required'
-  if (!height) errors.height = 'Required'
+  if (!height || numberWarning(height)) errors.height = 'Invalid'
+  if (numberWarning(depth)) errors.depth = 'Invalid'
 
   if (edition) {
-    if (!edition_size) errors.edition_size = 'Required'
+    if (!edition_size || numberWarning(edition_size)) errors.edition_size = 'Invalid'
     if (!edition_number) errors.edition_number = 'Required'
   }
 
@@ -109,18 +113,21 @@ function DescribeWorkDesktop (props) {
             <Field name='height' component={renderTextInput}
               item={'height'}
               label={'Height*'}
+              warn={numberWarning}
             />
           </div>
           <div className={b('row-item')}>
             <Field name='width' component={renderTextInput}
               item={'width'}
               label={'Width*'}
+              warn={numberWarning}
             />
           </div>
           <div className={b('row-item')}>
             <Field name='depth' component={renderTextInput}
               item={'depth'}
               label={'Depth'}
+              warn={numberWarning}
             />
           </div>
           <div className={b('row-item')}>
@@ -144,6 +151,7 @@ function DescribeWorkDesktop (props) {
                 <Field name='edition_size' component={renderTextInput}
                   item={'edition_size'}
                   label={'Size of Edition*'}
+                  warn={numberWarning}
                 />
               </div>
             </div>

--- a/desktop/apps/consignments2/components/step_marker/index.js
+++ b/desktop/apps/consignments2/components/step_marker/index.js
@@ -9,23 +9,11 @@ function StepMarker ({ currentStep, isMobile, steps }) {
   return (
     <div className={b({mobile: isMobile})}>
       <div className={b('steps')}>
-        {/*{
-          steps.map((step, index) => {
-            return (
-              <div className={b('step', { active: index <= currentStep })} key={step.label}>
-                <div className={b('dot')} />
-                <div className={b('label')}>
-                  {isMobile ? step.shortLabel : step.label}
-                </div>
-              </div>
-            )
-          })
-        }*/}
         <ul>
           {
             steps.map((step, index) => {
               return (
-                <li className={b('blah', { active: index === currentStep })} key={step.label}>
+                <li className={b('step', { active: index === currentStep })} key={step.label}>
                   <div className={b('label')}>
                     {isMobile ? step.shortLabel : step.label}
                   </div>

--- a/desktop/apps/consignments2/components/step_marker/index.js
+++ b/desktop/apps/consignments2/components/step_marker/index.js
@@ -9,7 +9,7 @@ function StepMarker ({ currentStep, isMobile, steps }) {
   return (
     <div className={b({mobile: isMobile})}>
       <div className={b('steps')}>
-        {
+        {/*{
           steps.map((step, index) => {
             return (
               <div className={b('step', { active: index <= currentStep })} key={step.label}>
@@ -20,7 +20,20 @@ function StepMarker ({ currentStep, isMobile, steps }) {
               </div>
             )
           })
-        }
+        }*/}
+        <ul>
+          {
+            steps.map((step, index) => {
+              return (
+                <li className={b('blah', { active: index === currentStep })} key={step.label}>
+                  <div className={b('label')}>
+                    {isMobile ? step.shortLabel : step.label}
+                  </div>
+                </li>
+              )
+            })
+          }
+        </ul>
       </div>
     </div>
   )

--- a/desktop/apps/consignments2/components/step_marker/index.styl
+++ b/desktop/apps/consignments2/components/step_marker/index.styl
@@ -7,15 +7,16 @@
   &_mobile
     margin-top 60px
 
-  ul
-    max-width 800px
-    margin 0 auto
-    align-content center
-    align-items center
-    display flex
-    justify-content space-around
+  &__steps
+    ul
+      max-width 750px
+      margin 0 auto
+      align-content center
+      align-items center
+      display flex
+      justify-content space-around
 
-  li
+  &__step
     content ' '
     display flex
     flex-grow 1
@@ -25,30 +26,30 @@
     z-index -1
     border 1px dashed purple-color
 
-  li::before
-    background purple-color
-    border-radius 50%
-    height 12px
-    position absolute
-    text-align center
-    top -6px
-    width 12px
-    left -2px
-    content ' '
+    &::before
+      background purple-color
+      border-radius 50%
+      height 12px
+      position absolute
+      text-align center
+      top -6px
+      width 12px
+      left -2px
+      content ' '
 
-  li:last-child
-    flex-basis 0
-    flex-grow 0
-    flex-shrink 1
+    &:last-child
+      flex-basis 0
+      flex-grow 0
+      flex-shrink 1
 
-  .consignments2-step-marker__blah_active
-    border 1px dashed gray-lighter-color
+    &_active
+      border 1px dashed gray-lighter-color
 
-  .consignments2-step-marker__blah_active ~ li
-    border 1px dashed gray-lighter-color
+    &_active ~ li
+      border 1px dashed gray-lighter-color
 
-  .consignments2-step-marker__blah_active ~ li::before
-    border 1px dashed purple-color
+    &_active ~ li::before
+      border 1px dashed purple-color
 
   &__label
     color purple-color

--- a/desktop/apps/consignments2/components/step_marker/index.styl
+++ b/desktop/apps/consignments2/components/step_marker/index.styl
@@ -1,32 +1,60 @@
 .consignments2-step-marker
   margin-top 80px
+  margin-bottom 100px
+  margin-left 50px
+  margin-right 50px
 
   &_mobile
     margin-top 60px
 
-  &__steps
-    margin 0 auto
+  ul
     max-width 800px
-    display flex
-    justify-content space-between
-
-  &__dot
     margin 0 auto
-    background gray-lighter-color
-    width 10px
-    height 10px
+    align-content center
+    align-items center
+    display flex
+    justify-content space-around
+
+  li
+    content ' '
+    display flex
+    flex-grow 1
+    margin 0
+    position relative
+    text-align right
+    z-index -1
+    border 1px dashed purple-color
+
+  li::before
+    background purple-color
     border-radius 50%
-    margin-bottom 8px
+    height 12px
+    position absolute
+    text-align center
+    top -6px
+    width 12px
+    left -2px
+    content ' '
+
+  li:last-child
+    flex-basis 0
+    flex-grow 0
+    flex-shrink 1
+
+  .consignments2-step-marker__blah_active
+    border 1px dashed gray-lighter-color
+
+  .consignments2-step-marker__blah_active ~ li
+    border 1px dashed gray-lighter-color
+
+  .consignments2-step-marker__blah_active ~ li::before
+    border 1px dashed purple-color
 
   &__label
-    avant-garde-size('s-headline')
-    color gray-lighter-color
-
-  &__step
-    max-width 140px
+    color purple-color
+    position absolute
     text-align center
-    &_active
-      .consignments2-step-marker__label
-        color purple-color
-      .consignments2-step-marker__dot
-        background purple-color
+    width 150px
+    top 18px
+    left -67px
+    avant-garde-size('s-headline')

--- a/desktop/apps/consignments2/components/text_input/index.js
+++ b/desktop/apps/consignments2/components/text_input/index.js
@@ -2,16 +2,17 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import block from 'bem-cn'
 
-export const renderTextInput = ({ input, ...custom }) => (
+export const renderTextInput = ({ input, meta: { warning }, ...custom }) => (
   <TextInput
     {...custom}
     value={input.value}
     onChange={input.onChange}
+    warning={warning}
   />
 )
 
 function TextInput (props) {
-  const { autofocus, item, label, instructions, onChange, type } = props
+  const { autofocus, item, label, instructions, onChange, type, warning } = props
   const b = block('consignments2-submission-text-input')
 
   return (
@@ -25,6 +26,7 @@ function TextInput (props) {
         type={type || 'text'}
         onKeyUp={(e) => onChange(e.target.value)}
       />
+      {warning && <div className={b('warning')}>{warning}</div>}
     </div>
   )
 }
@@ -35,5 +37,6 @@ TextInput.propTypes = {
   label: PropTypes.string,
   instructions: PropTypes.string,
   onChange: PropTypes.func,
-  type: PropTypes.string
+  type: PropTypes.string,
+  warning: PropTypes.string
 }

--- a/desktop/apps/consignments2/components/text_input/index.styl
+++ b/desktop/apps/consignments2/components/text_input/index.styl
@@ -9,3 +9,8 @@
   &__input
     height 40px
     width 100%
+
+  &__warning
+    garamond-size('l-caption')
+    color red-color
+    padding-top 5px

--- a/desktop/apps/consignments2/stylesheets/landing/desktop.styl
+++ b/desktop/apps/consignments2/stylesheets/landing/desktop.styl
@@ -87,9 +87,12 @@
 
       img
         display block
-        max-width 180px
         height auto
-        width 23%
+        width 100%
+
+    &__logo-wrap
+      width 23%
+      max-width 180px
 
 .consignments2-steps
   padding gutter
@@ -151,12 +154,13 @@
 .consignments2-recently-sold
   padding-top 20px
   max-width 1700px
+  margin 0 auto
 
   &__artworks
     display flex
     overflow hidden
     flex-wrap wrap
-    height 540px
+    height 270px
     justify-content center
     padding-top 10px
 

--- a/desktop/apps/consignments2/stylesheets/landing/mobile.styl
+++ b/desktop/apps/consignments2/stylesheets/landing/mobile.styl
@@ -21,9 +21,11 @@
         flex-wrap wrap
 
         img
-          width 50%
-          padding 10px
           padding-bottom 40px
+
+      &__logo-wrap
+        width 50%
+        padding 10px
 
   .consignments2-steps
     &__steps

--- a/desktop/apps/consignments2/templates/landing.jade
+++ b/desktop/apps/consignments2/templates/landing.jade
@@ -47,7 +47,8 @@ block body
                 = sections.placement.headline
             .consignments2-section__images.consignments2-section__images--logos
               for logo in sections.placement.logos
-                img.consignments2-section__images__logo( src= logo.src )
+                .consignments2-section__images__logo-wrap
+                  img.consignments2-section__images__logo( src= logo.src )
 
       //- Top sales
       section.consignments2-section.consignments2-top-sales

--- a/desktop/apps/consignments2/test/components.js
+++ b/desktop/apps/consignments2/test/components.js
@@ -25,7 +25,7 @@ describe('React components', () => {
           <StepMarker store={initialStore} />
         )
         const rendered = wrapper.render()
-        rendered.find('.consignments2-step-marker__dot').length.should.eql(4)
+        rendered.find('.consignments2-step-marker__step').length.should.eql(4)
       })
 
       it('updates the color of step labels', () => {


### PR DESCRIPTION
Just some little UI stuff here. 😄 

Finally got the horizontal step marker lines to work!
![image](https://user-images.githubusercontent.com/2081340/26953772-6546d45c-4c7a-11e7-8fa3-705d7a991d8c.png)

I also added in some client-side validation for the fields (`height`, `width`, `depth`, `edition_size`), that we store as number in the backend, to make sure you input a number here. Will ask for final design help from @katarinabatina on those but it should be fine for now. 😄 
![image](https://user-images.githubusercontent.com/2081340/26954029-c58684ce-4c7b-11e7-8384-db7f566e4a6a.png)
