### PR TITLE
@xtina-starr => Migrate 'Clicked Gallery Website' event on mobile to 'Click' event

### DIFF
--- a/mobile/analytics/partners.js
+++ b/mobile/analytics/partners.js
@@ -2,16 +2,17 @@
   'use strict'
 
   $('.partner-profile-contact-email a').click(function (e) {
-    analytics.track('Clicked Contact Gallery Via Email', {
+    analytics.track('Click',{
       partner_id: $(e.currentTarget).data('partner-id'),
-      partner_slug: $(e.currentTarget).data('partner-slug')
-    })
+      label: "Contact gallery by email"
+    });
   })
 
   $('.partner-profile-contact-website a').click(function (e) {
-    analytics.track('Clicked Gallery Website', {
+    analytics.track('Click', {
       partner_id: $(e.currentTarget).data('partner-id'),
-      partner_slug: $(e.currentTarget).data('partner-slug')
+      label: "External partner site",
+      destination_path: $(e.currentTarget).attr('href')
     })
   })
 })()


### PR DESCRIPTION
As per the discussion [here](https://artsy.slack.com/archives/C03NF9TKR/p1496249197342826), I'm migrating old event names to new ones. This PR should update the mobile `partner` page to send a `click` event from both mobile web/iOS app (eigen just uses WebView for it).