### PR TITLE
@xtina-starr => Fix margins on articles

### DIFF
--- a/desktop/components/article/stylesheets/content.styl
+++ b/desktop/components/article/stylesheets/content.styl
@@ -9,7 +9,7 @@ column-width = 580px
 fixed-share-padding = 89px
 
 body.body-article
-  #main-layout-container
+  #main-layout-container.responsive-layout-container
     margin-left 0px
     margin-right 0px
     max-width 100vw


### PR DESCRIPTION
Retains full width layout for articles list, keeps CTAs at full bleed.
https://github.com/artsy/force/issues/1538

