### PR TITLE
@craigspaeth => Hack for creative time :(

### DIFF
--- a/desktop/apps/auction/client/reducers.js
+++ b/desktop/apps/auction/client/reducers.js
@@ -1,31 +1,35 @@
 import * as actions from './actions'
 import { combineReducers } from 'redux'
 import { data as sd } from 'sharify'
-import { contains } from 'underscore'
+import { contains, omit } from 'underscore'
 import u from 'updeep'
+
+const filterParams = {
+  aggregations: ['ARTIST', 'FOLLOWED_ARTISTS', 'MEDIUM', 'TOTAL'],
+  artist_ids: [],
+  estimate_range: '',
+  gene_ids: [],
+  include_artworks_by_followed_artists: false,
+  page: 1,
+  sale_id: sd.AUCTION && sd.AUCTION.id,
+  size: 50,
+  ranges: {
+    estimate_range: {
+      min: 0,
+      max: 50000
+    }
+  },
+  sort: 'position'
+}
+
+const scrubbedParams = omit(filterParams, 'estimate_range')
 
 const initialState = {
   aggregatedArtists: [],
   aggregatedMediums: [],
   allFetched: false,
   displayFollowedArtistsRail: false,
-  filterParams: {
-    aggregations: ['ARTIST', 'FOLLOWED_ARTISTS', 'MEDIUM', 'TOTAL'],
-    artist_ids: [],
-    estimate_range: '',
-    gene_ids: [],
-    include_artworks_by_followed_artists: false,
-    page: 1,
-    sale_id: sd.AUCTION && sd.AUCTION.id,
-    size: 50,
-    ranges: {
-      estimate_range: {
-        min: 0,
-        max: 50000
-      }
-    },
-    sort: 'position'
-  },
+  filterParams: sd.AUCTION._id === '593c3fac8b0c147c16a59381' ? scrubbedParams : filterParams,
   followedArtistRailMax: 50,
   followedArtistRailPage: 1,
   followedArtistRailSize: 4,

--- a/desktop/apps/auction/client/reducers.js
+++ b/desktop/apps/auction/client/reducers.js
@@ -29,7 +29,7 @@ const initialState = {
   aggregatedMediums: [],
   allFetched: false,
   displayFollowedArtistsRail: false,
-  filterParams: sd.AUCTION._id === '593c3fac8b0c147c16a59381' ? scrubbedParams : filterParams,
+  filterParams: sd.AUCTION && sd.AUCTION._id === '593c3fac8b0c147c16a59381' ? scrubbedParams : filterParams,
   followedArtistRailMax: 50,
   followedArtistRailPage: 1,
   followedArtistRailSize: 4,

--- a/desktop/apps/auction/components/sidebar/index.js
+++ b/desktop/apps/auction/components/sidebar/index.js
@@ -7,10 +7,12 @@ import { connect } from 'react-redux'
 import { data as sd } from 'sharify'
 
 function Sidebar ({ isClosed }) {
+  const isCreativeTimeAuction = sd.AUCTION && sd.AUCTION._id === '593c3fac8b0c147c16a59381'
+
   return (
     <div className='auction-artworks-sidebar'>
       <div className='auction-artworks-sidebar__artist-filter'>
-        { !isClosed && sd.AUCTION._id !== '593c3fac8b0c147c16a59381' && <RangeSlider /> }
+        { !isClosed && !isCreativeTimeAuction && <RangeSlider /> }
         <MediumFilter />
         <ArtistFilter />
       </div>

--- a/desktop/apps/auction/components/sidebar/index.js
+++ b/desktop/apps/auction/components/sidebar/index.js
@@ -4,12 +4,13 @@ import PropTypes from 'prop-types'
 import RangeSlider from '../range_slider'
 import React from 'react'
 import { connect } from 'react-redux'
+import { data as sd } from 'sharify'
 
 function Sidebar ({ isClosed }) {
   return (
     <div className='auction-artworks-sidebar'>
       <div className='auction-artworks-sidebar__artist-filter'>
-        { !isClosed && <RangeSlider /> }
+        { !isClosed && sd.AUCTION._id !== '593c3fac8b0c147c16a59381' && <RangeSlider /> }
         <MediumFilter />
         <ArtistFilter />
       </div>


### PR DESCRIPTION
This is a super temporary fix, just so we can launch the creative time auction in an hour or so.

The Creative Time auction is currently not showing any artworks on the auction page because none of the artworks have estimates, which is a field that we're filtering by. For _now_ we can fix this by explicitly not passing the `estimate_range` param in our query (sending `''` or `'0-*` is not sufficient). We also need to hide the price filter box.

I will follow up immediately with the "correct" fixes, which will be to either _also_ filter the price filter by the starting price cents, or to be more forgiving on gravity's side, and have a flag for hiding the price filter on the front end. I'm leaning towards the first option but have to confirm with Devang.