### PR TITLE
@joeyAghion: Fall through to Force rendering if Reflection fails to respond

### DIFF
--- a/lib/middleware/proxy_to_reflection.coffee
+++ b/lib/middleware/proxy_to_reflection.coffee
@@ -3,11 +3,12 @@
 # https://github.com/artsy/reflection
 #
 httpProxy = require 'http-proxy'
+request = require 'superagent'
 proxy = httpProxy.createProxyServer()
 { REFLECTION_URL } = process.env
 
 module.exports = (req, res, next) ->
-  if req.query._escaped_fragment_?
+  return next() unless req.query._escaped_fragment_?
+  request.head(REFLECTION_URL + req.url).end (err) ->
+    return next() if err
     proxy.web req, res, target: REFLECTION_URL, changeOrigin: true
-  else
-    next()

--- a/test/lib/middleware/proxy_to_reflection.coffee
+++ b/test/lib/middleware/proxy_to_reflection.coffee
@@ -7,11 +7,24 @@ describe 'proxyToReflection', ->
     @req = query: {}
     @res = {}
     @next = sinon.stub()
+    @request = sinon.stub()
+    @request.returns @request
+    @request.head = sinon.stub().returns @request
+    @request.end = sinon.stub().returns @request
+    proxyToReflection.__set__ 'request', @request
     proxyToReflection.__set__ 'proxy', @proxy = web: sinon.stub()
     proxyToReflection.__set__ 'REFLECTION_URL', 'reflection.url'
 
   it 'passes through when there is no escaped fragment query param', ->
     @req.query._escaped_fragment_= null
+    proxyToReflection @req, @res, @next
+    @next.called.should.be.ok()
+    
+  it 'passes through if reflection fails', ->
+    @req.query._escaped_fragment_= null
+    err = new Error "Unauthorized"
+    err.status = 403
+    @request.end.callsArgWith 0, err 
     proxyToReflection @req, @res, @next
     @next.called.should.be.ok()
 
@@ -25,6 +38,7 @@ describe 'proxyToReflection', ->
     for source, dest of paths
       it "proxies #{source} to #{dest}", ->
         @req.query._escaped_fragment_= ''
+        @request.end.callsArg 0
         proxyToReflection @req, @res, @next
         options = @proxy.web.args[0][2]
         options.target.should.equal 'reflection.url'


### PR DESCRIPTION
Addresses https://github.com/artsy/force/issues/1460 by making a HEAD request to the Reflection url first, and if it fails for whatever reason including 403 responses, then it passes control to Force rendering instead of attempting to proxy Reflection.

This extra request is unfortunate overhead as we can't interrupt Node HTTP Proxy [barring this open PR](https://github.com/nodejitsu/node-http-proxy/pull/850), but I'm hoping this is a fine tradeoff as an extra ping to S3 shouldn't be too slow.