### PR TITLE
@damassi => little UX fixes + footer for consign2 page

### DIFF
--- a/desktop/apps/consignments2/client/actions.js
+++ b/desktop/apps/consignments2/client/actions.js
@@ -556,6 +556,11 @@ export function updateCurrentStep (step) {
 }
 
 export function updateInputs (inputs) {
+  if (inputs.edition === false) {
+    inputs.edition_number = ''
+    inputs.edition_size = 0
+  }
+
   return {
     type: UPDATE_INPUTS,
     payload: {

--- a/desktop/apps/consignments2/components/checkbox_input/index.js
+++ b/desktop/apps/consignments2/components/checkbox_input/index.js
@@ -36,6 +36,5 @@ export default function CheckboxInput (props) {
 CheckboxInput.propTypes = {
   item: PropTypes.string.isRequired,
   label: PropTypes.string,
-  onChange: PropTypes.func.isRequired,
-  value: PropTypes.bool
+  onChange: PropTypes.func.isRequired
 }

--- a/desktop/apps/consignments2/components/choose_artist/index.js
+++ b/desktop/apps/consignments2/components/choose_artist/index.js
@@ -30,6 +30,7 @@ function ChooseArtist (props) {
   const {
     artistAutocompleteSuggestions,
     artistAutocompleteValue,
+    artistName,
     clearArtistSuggestionsAction,
     chooseArtistAndAdvanceAction,
     fetchArtistSuggestionsAction,
@@ -74,7 +75,7 @@ function ChooseArtist (props) {
         </div>
         <div
           className={b('next-button').mix('avant-garde-button-black')}
-          onClick={showNotConsigningMessageAction}
+          onClick={artistAutocompleteValue === artistName ? chooseArtistAndAdvanceAction : showNotConsigningMessageAction}
           disabled={!nextEnabled}
         >
           Next
@@ -126,6 +127,7 @@ export default connect(
 ChooseArtist.propTypes = {
   artistAutocompleteSuggestions: PropTypes.array,
   artistAutocompleteValue: PropTypes.string,
+  artistName: PropTypes.string,
   clearArtistSuggestionsAction: PropTypes.func.isRequired,
   chooseArtistAndAdvanceAction: PropTypes.func.isRequired,
   fetchArtistSuggestionsAction: PropTypes.func.isRequired,

--- a/desktop/apps/consignments2/components/step_marker/index.styl
+++ b/desktop/apps/consignments2/components/step_marker/index.styl
@@ -6,6 +6,8 @@
 
   &_mobile
     margin-top 60px
+    margin-left 30px
+    margin-right 30px
 
   &__steps
     ul

--- a/desktop/apps/consignments2/components/submission_flow/index.js
+++ b/desktop/apps/consignments2/components/submission_flow/index.js
@@ -9,7 +9,7 @@ import {
 } from '../../client/actions'
 
 function SubmissionFlow (props) {
-  const b = block('consignments2-submission')
+  const b = block('consignments2-submission-flow')
   const { CurrentStepComponent, isMobile } = props
 
   return (

--- a/desktop/apps/consignments2/components/submission_flow/index.styl
+++ b/desktop/apps/consignments2/components/submission_flow/index.styl
@@ -1,4 +1,4 @@
-.consignments2-submission
+.consignments2-submission-flow
   margin-top -20px
   padding-bottom 30px
 
@@ -8,5 +8,5 @@
     line-height 1.1
 
   &_mobile
-    .consignments2-submission__title
+    .consignments2-submission-flow__title
       display none

--- a/desktop/apps/consignments2/components/upload_photo/index.js
+++ b/desktop/apps/consignments2/components/upload_photo/index.js
@@ -22,7 +22,9 @@ function UploadPhoto (props) {
   } = props
   const b = block('consignments2-submission-upload-photo')
 
-  const nextEnabled = skipPhotoSubmission || (!skipPhotoSubmission && uploadedImages.length > 0 && processingImages.length === 0)
+  const imagesInProgress = uploadedImages.length > 0 && processingImages.length > 0
+  const imagesFinished = uploadedImages.length > 0 && processingImages.length === 0
+  const nextEnabled = (!skipPhotoSubmission && imagesFinished) || (skipPhotoSubmission && !imagesInProgress)
   const uploadCta = isMobile ? 'Click to upload photos' : 'Drag or Click to upload photos'
 
   return (

--- a/desktop/apps/consignments2/stylesheets/index.styl
+++ b/desktop/apps/consignments2/stylesheets/index.styl
@@ -24,3 +24,23 @@
 @require '../components/upload_photo/index'
 @require '../components/upload_photo_landing/index'
 @require '../components/uploaded_image/index'
+
+.consignments2-submission
+  #consignments2-submission__flow
+    margin-bottom 50px
+
+  &__footer
+    position fixed
+    left 0
+    right 0
+    bottom 0
+    background-color white
+
+    @media (max-width: responsive-mobile-width)
+      display none
+
+  &__footer-contents
+    display flex
+    justify-content space-between
+    padding 20px
+    border-top 1px solid gray-lighter-color

--- a/desktop/apps/consignments2/templates/submission_flow.jade
+++ b/desktop/apps/consignments2/templates/submission_flow.jade
@@ -5,8 +5,16 @@ block head
 
 append locals
   - assetPackage = 'misc'
+  - bodyClass = bodyClass + ' consignments2-submission-body'
 
 block body
   .consignments2-submission.responsive-layout-container
     #consignments2-submission__flow
-
+    .consignments2-submission__push
+  .consignments2-submission__footer
+    .consignments2-submission__footer-contents
+      .consignments2-submission__footer-contents--title
+        | Consignments submission
+      .consignments2-submission__footer-contents--contact
+        | If you have any questions feel free to email us at&nbsp;
+        a( href='mailto:consign@artsy.net' ) consign@artsy.net

--- a/desktop/apps/consignments2/test/reducers.js
+++ b/desktop/apps/consignments2/test/reducers.js
@@ -391,6 +391,36 @@ describe('Reducers', () => {
           newInputsStep.submissionFlow.inputs.signature.should.eql(false)
           newInputsStep.submissionFlow.inputs.title.should.eql('My Artwork!')
         })
+
+        it('ignores edition number and size if the checkbox is not checked', () => {
+          initialResponse.submissionFlow.inputs.edition.should.eql(false)
+          initialResponse.submissionFlow.inputs.edition_number.should.eql('')
+          initialResponse.submissionFlow.inputs.edition_size.should.eql(0)
+          const newInputs = {
+            edition: false,
+            edition_number: '12a',
+            edition_size: 120
+          }
+          const newInputsStep = reducers(initialResponse, actions.updateInputs(newInputs))
+          newInputsStep.submissionFlow.inputs.edition.should.eql(false)
+          newInputsStep.submissionFlow.inputs.edition_number.should.eql('')
+          newInputsStep.submissionFlow.inputs.edition_size.should.eql(0)
+        })
+
+        it('keeps edition number and size if the checkbox is checked', () => {
+          initialResponse.submissionFlow.inputs.edition.should.eql(false)
+          initialResponse.submissionFlow.inputs.edition_number.should.eql('')
+          initialResponse.submissionFlow.inputs.edition_size.should.eql(0)
+          const newInputs = {
+            edition: true,
+            edition_number: '12a',
+            edition_size: 120
+          }
+          const newInputsStep = reducers(initialResponse, actions.updateInputs(newInputs))
+          newInputsStep.submissionFlow.inputs.edition.should.eql(true)
+          newInputsStep.submissionFlow.inputs.edition_number.should.eql('12a')
+          newInputsStep.submissionFlow.inputs.edition_size.should.eql(120)
+        })
       })
 
       describe('#handleImageUpload', () => {


### PR DESCRIPTION
This PR fixes a few little UX edge cases:
- If you navigate back to the `/choose-artist` page (still client-side), we now allow you to advance using the `Next` button instead of just by clicking an autocomplete result
- On the Upload photos page, if you check the "No photos available" box while some images are partially processed, we used to enable the submit button. This fixes that.
- If you check the `edition` box on the `/describe-your-work` page and then fill in the `edition_size` and `edition_number` fields but then _uncheck_ the `edition` box (causing those fields to disappear), we now make sure to scrub them from the inputs sent to convection.

It also adds a footer (only in desktop mode).