### PR TITLE
@sweir27 => Bug fix for fullscreen & non super article

### DIFF
--- a/desktop/components/article/stylesheets/fullscreen_article.styl
+++ b/desktop/components/article/stylesheets/fullscreen_article.styl
@@ -93,7 +93,10 @@ body.body-fullscreen-article
     height 100%
     display flex
     flex-direction column
-    justify-content space-between
+    justify-content flex-end
+  &.article-sa-fullscreen
+    .article-fullscreen__container
+      justify-content space-between
 
   // Logos
   .article-sa-plus-container


### PR DESCRIPTION
The `.article-fullscreen_container` can either have one or two elements as children, so if there are two, we should justify with `space-between`, otherwise `flex-end`. 

Sorry for this last minute bug before your deploy! 