### PR TITLE
@sweir27 => a little more obvious validation on the consign flow

### DIFF
--- a/desktop/apps/consignments2/components/describe_work_desktop/index.js
+++ b/desktop/apps/consignments2/components/describe_work_desktop/index.js
@@ -31,13 +31,13 @@ function validate (values, props) {
 
   if (!title) errors.title = 'Required'
   if (!year) errors.year = 'Required'
-  if (!width || numberWarning(width)) errors.width = 'Invalid'
+  if (!width || numberWarning(width)) errors.width = 'Required'
   if (!medium) errors.medium = 'Required'
-  if (!height || numberWarning(height)) errors.height = 'Invalid'
-  if (numberWarning(depth)) errors.depth = 'Invalid'
+  if (!height || numberWarning(height)) errors.height = 'Required'
+  if (numberWarning(depth)) errors.depth = 'Required'
 
   if (edition) {
-    if (!edition_size || numberWarning(edition_size)) errors.edition_size = 'Invalid'
+    if (!edition_size || numberWarning(edition_size)) errors.edition_size = 'Required'
     if (!edition_number) errors.edition_number = 'Required'
   }
 
@@ -56,7 +56,6 @@ export function makeDescribeWorkDesktop (initialValues = {}) {
       locationAutocompleteFrozen,
       locationAutocompleteValue,
       submitDescribeWorkAction,
-      invalid,
       pristine
     } = props
 
@@ -198,7 +197,7 @@ export function makeDescribeWorkDesktop (initialValues = {}) {
           </div>
           <button
             className={b('next-button').mix('avant-garde-button-black')}
-            disabled={invalid || locationAutocompleteValue.length === 0 || !locationAutocompleteFrozen}
+            disabled={pristine || locationAutocompleteValue.length === 0 || !locationAutocompleteFrozen}
             type='submit'
           >
             {
@@ -238,7 +237,6 @@ export function makeDescribeWorkDesktop (initialValues = {}) {
     loading: PropTypes.bool.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     hasEditionValue: PropTypes.bool,
-    invalid: PropTypes.bool,
     locationAutocompleteFrozen: PropTypes.bool.isRequired,
     locationAutocompleteValue: PropTypes.string,
     pristine: PropTypes.bool,

--- a/desktop/apps/consignments2/components/describe_work_mobile/index.js
+++ b/desktop/apps/consignments2/components/describe_work_mobile/index.js
@@ -112,7 +112,7 @@ export function makeDescribeWorkMobile (initialValues = {}) {
           </div>
           <button
             className={b('next-button').mix('avant-garde-button-black')}
-            disabled={pristine || invalid || locationAutocompleteValue.length === 0 || !locationAutocompleteFrozen}
+            disabled={pristine || locationAutocompleteValue.length === 0 || !locationAutocompleteFrozen}
             type='submit'
           >
             {

--- a/desktop/apps/consignments2/components/text_input/index.js
+++ b/desktop/apps/consignments2/components/text_input/index.js
@@ -2,19 +2,20 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import block from 'bem-cn'
 
-export const renderTextInput = ({ input: { onChange, value }, meta: { warning }, ...custom }) => (
+export const renderTextInput = ({ input: { onChange, value }, meta: { error, touched, warning }, ...custom }) => (
   <TextInput
     {...custom}
     value={value}
     onChange={onChange}
     warning={warning}
+    touched={touched}
+    error={error}
   />
 )
 
 function TextInput (props) {
-  const { autofocus, item, label, instructions, onChange, type, warning, value, ...rest } = props
+  const { autofocus, error, item, label, instructions, onChange, touched, type, warning, value, ...rest } = props
   const b = block('consignments2-submission-text-input')
-
   return (
     <div className={b()}>
       { label && <div className={b('label')}>{ label }</div> }
@@ -27,17 +28,24 @@ function TextInput (props) {
         onKeyUp={(e) => onChange(e.target.value)}
         defaultValue={value}
       />
-      {warning && <div className={b('warning')}>{warning}</div>}
+      {
+        touched && (
+          (warning && <div className={b('warning')}>{warning}</div>) ||
+          (error && <div className={b('error')}>{error}</div>)
+        )
+      }
     </div>
   )
 }
 
 TextInput.propTypes = {
   autofocus: PropTypes.bool,
+  error: PropTypes.bool,
   item: PropTypes.string.isRequired,
   label: PropTypes.string,
   instructions: PropTypes.string,
   onChange: PropTypes.func,
+  touched: PropTypes.bool,
   type: PropTypes.string,
   warning: PropTypes.string,
   value: PropTypes.oneOfType([

--- a/desktop/apps/consignments2/components/text_input/index.styl
+++ b/desktop/apps/consignments2/components/text_input/index.styl
@@ -14,3 +14,8 @@
     garamond-size('l-caption')
     color red-color
     padding-top 5px
+
+  &__error
+    garamond-size('l-caption')
+    color red-color
+    padding-top 5px


### PR DESCRIPTION
This PR adds in a little more obvious validation to the form fields-- the use-case is trying to catch a potential issue where the form doesn't register an input leaving the submit button disabled.

![image](https://user-images.githubusercontent.com/2081340/27249647-6ecc97f4-52e8-11e7-9ab3-8d4689043b23.png)

Note that this will only come up if you've attempted to enter a form field (and then backspace out for some reason). The button will be enabled in that case but we'll give you some messaging.