### PR TITLE
@sweir27 => few more validation improvements

### DIFF
--- a/desktop/apps/consignments2/components/describe_work_desktop/index.js
+++ b/desktop/apps/consignments2/components/describe_work_desktop/index.js
@@ -197,7 +197,7 @@ export function makeDescribeWorkDesktop (initialValues = {}) {
           </div>
           <button
             className={b('next-button').mix('avant-garde-button-black')}
-            disabled={pristine || locationAutocompleteValue.length === 0 || !locationAutocompleteFrozen}
+            disabled={locationAutocompleteValue.length === 0 || !locationAutocompleteFrozen}
             type='submit'
           >
             {

--- a/desktop/apps/consignments2/components/describe_work_mobile/index.js
+++ b/desktop/apps/consignments2/components/describe_work_mobile/index.js
@@ -14,13 +14,11 @@ import {
 
 function validate (values, props) {
   const {
-    location,
     title,
     year
   } = values
   const errors = {}
 
-  if (!location) errors.location = 'Required'
   if (!title) errors.title = 'Required'
   if (!year) errors.year = 'Required'
 
@@ -38,7 +36,6 @@ export function makeDescribeWorkMobile (initialValues = {}) {
       locationAutocompleteFrozen,
       locationAutocompleteValue,
       submitDescribeWorkAction,
-      invalid,
       pristine
     } = props
 
@@ -112,7 +109,7 @@ export function makeDescribeWorkMobile (initialValues = {}) {
           </div>
           <button
             className={b('next-button').mix('avant-garde-button-black')}
-            disabled={pristine || locationAutocompleteValue.length === 0 || !locationAutocompleteFrozen}
+            disabled={locationAutocompleteValue.length === 0 || !locationAutocompleteFrozen}
             type='submit'
           >
             {
@@ -153,7 +150,6 @@ export function makeDescribeWorkMobile (initialValues = {}) {
     error: PropTypes.string,
     loading: PropTypes.bool.isRequired,
     handleSubmit: PropTypes.func.isRequired,
-    invalid: PropTypes.bool,
     locationAutocompleteFrozen: PropTypes.bool.isRequired,
     locationAutocompleteValue: PropTypes.string,
     pristine: PropTypes.bool,


### PR DESCRIPTION
The button will only be _disabled_ if there's no location. Turns out the `pristine` check is not what we want when the page is reloaded with initial values.