### PR TITLE
Remove obsolete tracking code

### DIFF
--- a/desktop/analytics/partner.js
+++ b/desktop/analytics/partner.js
@@ -9,20 +9,6 @@
     analytics.track('Non-claimed partner page', _.extend(options, {nonInteraction: 1}))
   })
 
-  $('#partner-contact .email-gallery').click(function (e) {
-    analytics.track('Clicked Contact Gallery Via Email', {
-      partner_id: $(e.currentTarget).data('partner-id'),
-      partner_slug: $(e.currentTarget).data('partner-slug')
-    })
-  })
-
-  $('#partner-contact .partner-website').click(function (e) {
-    analytics.track('Clicked Gallery Website', {
-      partner_id: $(e.currentTarget).data('partner-id'),
-      partner_slug: $(e.currentTarget).data('partner-slug')
-    })
-  })
-
   $('.main-layout-container').on('click', '#partner2-contact .email-gallery', function (e) {
     analytics.track('Click',{
       partner_id: $(e.currentTarget).data('partner-id'),


### PR DESCRIPTION
I confirmed that `'Clicked Contact Gallery Via Email'` and `'Clicked Gallery Website'` are not being sent anymore (segment stats: [email clicks](https://segment.com/artsy-engineering/sources/force-production/schema/tracks/Clicked%2520Contact%2520Gallery%2520Via%2520Email) and [website clicks](https://segment.com/artsy-engineering/sources/force-production/schema/tracks/Clicked%2520Gallery%2520Website)) and safe to remove at this point.