### PR TITLE
@yuki24 => Markdown supported SuperArticle footer

### DIFF
--- a/desktop/apps/article/index.coffee
+++ b/desktop/apps/article/index.coffee
@@ -6,6 +6,7 @@ express = require 'express'
 routes = require './routes'
 { resize, crop } = require '../../components/resizer'
 { toSentence } = require 'underscore.string'
+markdown = require '../../components/util/markdown'
 
 app = module.exports = express()
 app.set 'views', __dirname + '/templates'
@@ -13,6 +14,7 @@ app.set 'view engine', 'jade'
 app.locals.resize = resize
 app.locals.crop = crop
 app.locals.toSentence = toSentence
+app.locals.markdown = markdown
 
 # Permalink routes
 app.get '/post/:id', routes.redirectPost

--- a/desktop/components/article/stylesheets/super_article.styl
+++ b/desktop/components/article/stylesheets/super_article.styl
@@ -72,6 +72,8 @@
 
 .article-sa-footer-blurb
   margin-top 20px
+  a
+    fine-faux-underline()
 .article-sa-cta-container, .article-sa-footer-blurb
   garamond-size('l-body')
 

--- a/desktop/components/article/templates/super_article_footer.jade
+++ b/desktop/components/article/templates/super_article_footer.jade
@@ -3,7 +3,7 @@
     a.article-sa-title( href=superArticle.href() )= superArticle.get('title')
 
     if superArticle.get('super_article').footer_blurb
-      .article-sa-footer-blurb= superArticle.get('super_article').footer_blurb
+      .article-sa-footer-blurb!= markdown(superArticle.get('super_article').footer_blurb)
 
     if superArticle.get('super_article').partner_link_title
       .article-sa-cta-container

--- a/desktop/components/article/test/templates.coffee
+++ b/desktop/components/article/test/templates.coffee
@@ -4,6 +4,7 @@ path = require 'path'
 jade = require 'jade'
 fs = require 'fs'
 moment = require 'moment'
+markdown = require '../../../components/util/markdown'
 Article = require '../../../models/article'
 Articles = require '../../../collections/articles'
 fixtures = require '../../../test/helpers/fixtures.coffee'
@@ -87,6 +88,29 @@ describe 'article show template', ->
     html.should.containEql 'article-sa-sticky-header'
     html.should.containEql '<a href="http://logo.com"><img src="http://fullscreen-logo.jpg"/></a>'
     html.should.not.containEql 'visible no-transition'
+
+  it 'super articles have markdown-supported footers', ->
+    html = render('index')
+      article: new Article
+        title: 'hi'
+        sections: []
+        contributing_authors: []
+        is_super_article: true
+      footerArticles: new Articles
+      superArticle: new Article
+        super_article:
+          partner_logo: 'http://logo.jpg'
+          partner_logo_link: 'http://logo.com'
+          partner_fullscreen_header_logo: 'http://fullscreen-logo.jpg'
+          footer_blurb: 'Article Test [Link](http://artsy.net)'
+      superSubArticles: {models: []}
+      crop: (url) -> url
+      resize: (u) -> u
+      moment: moment
+      sd: {}
+      asset: ->
+      markdown: markdown
+    html.should.containEql '<a href="http://artsy.net">Link</a>'
 
   it 'renders a TOC', ->
     html = render('index')

--- a/desktop/components/article/test/templates.coffee
+++ b/desktop/components/article/test/templates.coffee
@@ -92,7 +92,7 @@ describe 'article show template', ->
   it 'super articles have markdown-supported footers', ->
     html = render('index')
       article: new Article
-        title: 'hi'
+        title: 'Super Article Title'
         sections: []
         contributing_authors: []
         is_super_article: true
@@ -103,9 +103,9 @@ describe 'article show template', ->
           partner_logo_link: 'http://logo.com'
           partner_fullscreen_header_logo: 'http://fullscreen-logo.jpg'
           footer_blurb: 'Article Test [Link](http://artsy.net)'
-      superSubArticles: {models: []}
-      crop: (url) -> url
-      resize: (u) -> u
+      superSubArticles: new Articles
+      crop: ->
+      resize: ->
       moment: moment
       sd: {}
       asset: ->


### PR DESCRIPTION
Related to: https://github.com/artsy/positron/issues/1116 and https://github.com/artsy/positron/pull/1123

We need to add markdown support in the "Super Article" footer for an upcoming sponsorship. [Here's an example of a super article](https://www.artsy.net/article/artsy-editorial-2015-the-year-in-art).

![image](https://user-images.githubusercontent.com/2236794/27357856-eb125f78-55e1-11e7-99f8-f81b4d0e73e0.png)
