### PR TITLE
@damassi => update the validation requirements on the submission flow

### DIFF
--- a/desktop/apps/consignments2/client/reducers.js
+++ b/desktop/apps/consignments2/client/reducers.js
@@ -3,7 +3,7 @@ import u from 'updeep'
 import { combineReducers } from 'redux'
 import { composeReducers } from '../../../components/react/utils/compose_reducers'
 import { data as sd } from 'sharify'
-import { contains, last } from 'underscore'
+import { contains } from 'underscore'
 import { reducer as formReducer } from 'redux-form'
 import { responsiveWindowReducer } from '../../../components/react/responsive_window'
 import { routerReducer } from 'react-router-redux'
@@ -191,7 +191,8 @@ function submissionFlow (state = initialState, action) {
     }
     case actions.UNFREEZE_LOCATION_INPUT: {
       return u({
-        locationAutocompleteFrozen: false
+        locationAutocompleteFrozen: false,
+        locationAutocompleteValue: ''
       }, state)
     }
     case actions.UPDATE_ARTIST_AUTOCOMPLETE_VALUE: {

--- a/desktop/apps/consignments2/client/validate.js
+++ b/desktop/apps/consignments2/client/validate.js
@@ -1,0 +1,43 @@
+export const numberWarning = value => value && isNaN(Number(value)) && 'Must be a number'
+
+export const scrollToError = (errors, dispatch) => {
+  const scrollBuffer = 5
+  const firstError = Object.keys(errors)[0]
+  const firstErrorElement = document.getElementsByName(firstError)[0]
+  if (firstErrorElement) {
+    window.scrollTo(0, firstErrorElement.offsetTop - scrollBuffer)
+    firstErrorElement.querySelector('input').focus()
+  }
+}
+
+export function validate (values) {
+  const {
+    depth,
+    edition,
+    edition_number,
+    edition_size,
+    height,
+    location,
+    medium,
+    title,
+    width,
+    year
+  } = values
+  const errors = {}
+
+  // The order of these errors are important, as it determines which field to scroll to
+  // when there is an error on submission.
+  if (!title) errors.title = 'Required'
+  if (!year) errors.year = 'Required'
+  if (!medium) errors.medium = 'Required'
+  if (!height || numberWarning(height)) errors.height = 'Required'
+  if (!width || numberWarning(width)) errors.width = 'Required'
+  if (numberWarning(depth)) errors.depth = 'Required'
+  if (edition) {
+    if (!edition_number) errors.edition_number = 'Required'
+    if (!edition_size || numberWarning(edition_size)) errors.edition_size = 'Required'
+  }
+  if (!location) errors.location = 'Required'
+
+  return errors
+}

--- a/desktop/apps/consignments2/components/describe_work_desktop/index.js
+++ b/desktop/apps/consignments2/components/describe_work_desktop/index.js
@@ -5,44 +5,12 @@ import block from 'bem-cn'
 import { Field, formValueSelector, reduxForm } from 'redux-form'
 import { compose } from 'underscore'
 import { connect } from 'react-redux'
+import { numberWarning, scrollToError, validate } from '../../client/validate'
 import { renderCheckboxInput } from '../checkbox_input'
 import { renderRadioInput } from '../radio_input'
 import { renderSelectInput } from '../select_input'
 import { renderTextInput } from '../text_input'
-import {
-  submitDescribeWork
-} from '../../client/actions'
-
-const numberWarning = value => value && isNaN(Number(value)) && 'Must be a number'
-
-function validate (values, props) {
-  const {
-    depth,
-    edition,
-    edition_number,
-    edition_size,
-    height,
-    medium,
-    title,
-    width,
-    year
-  } = values
-  const errors = {}
-
-  if (!title) errors.title = 'Required'
-  if (!year) errors.year = 'Required'
-  if (!width || numberWarning(width)) errors.width = 'Required'
-  if (!medium) errors.medium = 'Required'
-  if (!height || numberWarning(height)) errors.height = 'Required'
-  if (numberWarning(depth)) errors.depth = 'Required'
-
-  if (edition) {
-    if (!edition_size || numberWarning(edition_size)) errors.edition_size = 'Required'
-    if (!edition_number) errors.edition_number = 'Required'
-  }
-
-  return errors
-}
+import { submitDescribeWork } from '../../client/actions'
 
 export function makeDescribeWorkDesktop (initialValues = {}) {
   function DescribeWorkDesktop (props) {
@@ -53,10 +21,7 @@ export function makeDescribeWorkDesktop (initialValues = {}) {
       loading,
       handleSubmit,
       hasEditionValue,
-      locationAutocompleteFrozen,
-      locationAutocompleteValue,
-      submitDescribeWorkAction,
-      pristine
+      submitDescribeWorkAction
     } = props
 
     const b = block('consignments2-submission-describe-work')
@@ -103,7 +68,6 @@ export function makeDescribeWorkDesktop (initialValues = {}) {
               />
             </div>
           </div>
-
           <div className={b('row')}>
             <div className={b('row-item')}>
               <Field name='height' component={renderTextInput}
@@ -192,12 +156,11 @@ export function makeDescribeWorkDesktop (initialValues = {}) {
           <div className={b('row')}>
             <div className={b('row-item')}>
               <div className={b('instructions')}>What city is the work located in?*</div>
-              <LocationAutocomplete />
+              <Field name='location' component={LocationAutocomplete} />
             </div>
           </div>
           <button
             className={b('next-button').mix('avant-garde-button-black')}
-            disabled={locationAutocompleteValue.length === 0 || !locationAutocompleteFrozen}
             type='submit'
           >
             {
@@ -237,9 +200,6 @@ export function makeDescribeWorkDesktop (initialValues = {}) {
     loading: PropTypes.bool.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     hasEditionValue: PropTypes.bool,
-    locationAutocompleteFrozen: PropTypes.bool.isRequired,
-    locationAutocompleteValue: PropTypes.string,
-    pristine: PropTypes.bool,
     submitDescribeWorkAction: PropTypes.func.isRequired
   }
 
@@ -247,7 +207,8 @@ export function makeDescribeWorkDesktop (initialValues = {}) {
     reduxForm({
       form: 'describeWork', // a unique identifier for this form
       validate,
-      initialValues
+      initialValues,
+      onSubmitFail: scrollToError
     }),
     connect(
       mapStateToProps,

--- a/desktop/apps/consignments2/components/describe_work_mobile/index.js
+++ b/desktop/apps/consignments2/components/describe_work_mobile/index.js
@@ -5,6 +5,8 @@ import block from 'bem-cn'
 import { Field, formValueSelector, reduxForm } from 'redux-form'
 import { compose } from 'underscore'
 import { connect } from 'react-redux'
+import { numberWarning, scrollToError, validate } from '../../client/validate'
+import { renderCheckboxInput } from '../checkbox_input'
 import { renderRadioInput } from '../radio_input'
 import { renderSelectInput } from '../select_input'
 import { renderTextInput } from '../text_input'
@@ -12,31 +14,16 @@ import {
   submitDescribeWork
 } from '../../client/actions'
 
-function validate (values, props) {
-  const {
-    title,
-    year
-  } = values
-  const errors = {}
-
-  if (!title) errors.title = 'Required'
-  if (!year) errors.year = 'Required'
-
-  return errors
-}
-
 export function makeDescribeWorkMobile (initialValues = {}) {
   function DescribeWorkMobile (props) {
     const {
       artistName,
       categoryOptions,
       error,
+      hasEditionValue,
       loading,
       handleSubmit,
-      locationAutocompleteFrozen,
-      locationAutocompleteValue,
-      submitDescribeWorkAction,
-      pristine
+      submitDescribeWorkAction
     } = props
 
     const b = block('consignments2-submission-describe-work-mobile')
@@ -59,6 +46,14 @@ export function makeDescribeWorkMobile (initialValues = {}) {
           </div>
           <div className={b('row')}>
             <div className={b('row-item')}>
+              <Field name='year' component={renderTextInput}
+                item={'year'}
+                label={'Year*'}
+              />
+            </div>
+          </div>
+          <div className={b('row')}>
+            <div className={b('row-item')}>
               <Field name='category' component={renderSelectInput}
                 item={'category'}
                 label={'Category*'}
@@ -68,9 +63,73 @@ export function makeDescribeWorkMobile (initialValues = {}) {
           </div>
           <div className={b('row')}>
             <div className={b('row-item')}>
-              <Field name='year' component={renderTextInput}
-                item={'year'}
-                label={'Year*'}
+              <Field name='medium' component={renderTextInput}
+                item={'medium'}
+                label={'Medium*'}
+              />
+            </div>
+          </div>
+          <div className={b('row')}>
+            <div className={b('row-item')}>
+              <Field name='height' component={renderTextInput}
+                item={'height'}
+                label={'Height*'}
+                warn={numberWarning}
+              />
+            </div>
+            <div className={b('row-item')}>
+              <Field name='width' component={renderTextInput}
+                item={'width'}
+                label={'Width*'}
+                warn={numberWarning}
+              />
+            </div>
+          </div>
+          <div className={b('row')}>
+            <div className={b('row-item')}>
+              <Field name='depth' component={renderTextInput}
+                item={'depth'}
+                label={'Depth'}
+                warn={numberWarning}
+              />
+            </div>
+            <div className={b('row-item')}>
+              <Field name='dimensions_metric' component={renderSelectInput}
+                item={'dimensions_metric'}
+                label={'Units*'}
+                options={['in', 'cm']}
+              />
+            </div>
+          </div>
+          {
+            hasEditionValue && (
+              <div>
+                <div className={b('row')}>
+                  <div className={b('row-item')}>
+                    <Field name='edition_number' component={renderTextInput}
+                      item={'edition_number'}
+                      label={'Edition Number*'}
+                    />
+                  </div>
+                </div>
+                <div className={b('row')}>
+                  <div className={b('row-item')}>
+                    <Field name='edition_size' component={renderTextInput}
+                      item={'edition_size'}
+                      label={'Size of Edition*'}
+                      warn={numberWarning}
+                    />
+                  </div>
+                </div>
+              </div>
+            )
+          }
+          <div className={b('row', {'border-bottom': true})}>
+            <div className={b('row-item')}>
+              <Field name='edition' component={renderCheckboxInput}
+                item={'edition'}
+                label={'This is an edition'}
+                value={false}
               />
             </div>
           </div>
@@ -104,12 +163,11 @@ export function makeDescribeWorkMobile (initialValues = {}) {
           <div className={b('row')}>
             <div className={b('row-item')}>
               <div className={b('instructions')}>What city is the work located in?*</div>
-              <LocationAutocomplete />
+              <Field name='location' component={LocationAutocomplete} />
             </div>
           </div>
           <button
             className={b('next-button').mix('avant-garde-button-black')}
-            disabled={locationAutocompleteValue.length === 0 || !locationAutocompleteFrozen}
             type='submit'
           >
             {
@@ -148,11 +206,9 @@ export function makeDescribeWorkMobile (initialValues = {}) {
     artistName: PropTypes.string.isRequired,
     categoryOptions: PropTypes.array.isRequired,
     error: PropTypes.string,
+    hasEditionValue: PropTypes.bool,
     loading: PropTypes.bool.isRequired,
     handleSubmit: PropTypes.func.isRequired,
-    locationAutocompleteFrozen: PropTypes.bool.isRequired,
-    locationAutocompleteValue: PropTypes.string,
-    pristine: PropTypes.bool,
     submitDescribeWorkAction: PropTypes.func.isRequired
   }
 
@@ -161,6 +217,7 @@ export function makeDescribeWorkMobile (initialValues = {}) {
       form: 'describeWork', // a unique identifier for this form
       validate,
       initialValues,
+      onSubmitFail: scrollToError,
       enableReinitialize: true
     }),
     connect(

--- a/desktop/apps/consignments2/components/location_autocomplete/index.js
+++ b/desktop/apps/consignments2/components/location_autocomplete/index.js
@@ -12,26 +12,19 @@ import {
   updateLocationAutocomplete
 } from '../../client/actions'
 
-function getSuggestionValue (suggestion) {
-  return suggestion.description
-}
-
-function renderSuggestion (suggestion) {
-  return (
-    <div className='autosuggest-suggestion'>
-      <div>{suggestion.description}</div>
-    </div>
-  )
-}
-
 function LocationAutocomplete (props) {
   const {
     chooseLocationAction,
     clearLocationSuggestionsAction,
     fetchLocationSuggestionsAction,
+    input,
     locationAutocompleteFrozen,
     locationAutocompleteSuggestions,
     locationAutocompleteValue,
+    meta: {
+      error,
+      touched
+    },
     unfreezeLocationInputAction,
     updateLocationAutocompleteAction
   } = props
@@ -39,29 +32,55 @@ function LocationAutocomplete (props) {
   const b = block('consignments2-location-input')
 
   const locationAutosuggestInputProps = {
-    value: locationAutocompleteValue,
-    onChange: updateLocationAutocompleteAction
+    disabled: locationAutocompleteFrozen,
+    onChange: updateLocationAutocompleteAction,
+    value: locationAutocompleteValue
   }
 
   const renderInputComponent = inputProps => (
     <div>
       <input {...inputProps} className={b('input').mix('bordered-input')} />
+      {
+        touched && (
+          (error && <div className={b('error')}>{error}</div>)
+        )
+      }
     </div>
   )
 
+  const getSuggestionValue = suggestion => (
+    suggestion.description
+  )
+
+  const renderSuggestion = suggestion => (
+    <div className='autosuggest-suggestion'>
+      <div>{suggestion.description}</div>
+    </div>
+  )
+
+  const chooseLocationOption = (event, { suggestion, suggestionValue, suggestionIndex, sectionIndex, method }) => {
+    chooseLocationAction(suggestion)
+    input.onChange(suggestionValue)
+  }
+
+  const unfreeze = () => {
+    unfreezeLocationInputAction()
+    input.onChange('')
+  }
+
   return (
-    <div className={b({ disabled: locationAutocompleteFrozen })}>
+    <div className={b({ disabled: locationAutocompleteFrozen, error: Boolean(touched && error) })} name={'location'}>
       <Autosuggest
         suggestions={locationAutocompleteSuggestions}
         onSuggestionsFetchRequested={fetchLocationSuggestionsAction}
         onSuggestionsClearRequested={clearLocationSuggestionsAction}
-        onSuggestionSelected={chooseLocationAction}
+        onSuggestionSelected={chooseLocationOption}
         getSuggestionValue={getSuggestionValue}
         renderInputComponent={renderInputComponent}
         renderSuggestion={renderSuggestion}
         inputProps={locationAutosuggestInputProps}
       />
-      { locationAutocompleteFrozen && <div className={b('unfreeze')} onClick={unfreezeLocationInputAction}><Close /></div> }
+      { locationAutocompleteFrozen && <div className={b('unfreeze')} onClick={unfreeze}><Close /></div> }
     </div>
   )
 }
@@ -74,7 +93,7 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    chooseLocationAction (event, { suggestion, suggestionValue }) {
+    chooseLocationAction (suggestion) {
       dispatch(chooseLocation(suggestion))
     },
     clearLocationSuggestionsAction () {
@@ -101,9 +120,11 @@ LocationAutocomplete.propTypes = {
   chooseLocationAction: PropTypes.func.isRequired,
   clearLocationSuggestionsAction: PropTypes.func.isRequired,
   fetchLocationSuggestionsAction: PropTypes.func.isRequired,
+  input: PropTypes.object.isRequired,
   locationAutocompleteFrozen: PropTypes.bool.isRequired,
   locationAutocompleteSuggestions: PropTypes.array,
   locationAutocompleteValue: PropTypes.string,
+  meta: PropTypes.object.isRequired,
   unfreezeLocationInputAction: PropTypes.func.isRequired,
   updateLocationAutocompleteAction: PropTypes.func.isRequired
 }

--- a/desktop/apps/consignments2/components/location_autocomplete/index.styl
+++ b/desktop/apps/consignments2/components/location_autocomplete/index.styl
@@ -5,6 +5,10 @@
     height 40px
     width 100%
 
+  .react-autosuggest__container--open
+    .consignments2-location-input__error
+      display none
+
   .react-autosuggest__suggestion
     min-height 40px
     padding 10px
@@ -23,6 +27,13 @@
       &:focus, &:active
         border-color gray-lighter-color
 
+  &_error
+    .bordered-input
+      border 2px solid red-color
+
+  .bordered-input:disabled
+    border 2px solid gray-lighter-color
+
   &__unfreeze
     position absolute
     right 7px
@@ -34,3 +45,8 @@
     svg
       width 17px
       fill gray-dark-color
+
+  &__error
+    garamond-size('l-caption')
+    color red-color
+    padding-top 5px

--- a/desktop/apps/consignments2/components/step_marker/index.styl
+++ b/desktop/apps/consignments2/components/step_marker/index.styl
@@ -22,10 +22,14 @@
     color purple-color
     position absolute
     text-align center
-    width 90px
+    width 200px
     top 18px
-    left -42px
+    left -93px
     avant-garde-size('s-headline')
+
+    @media (max-width: 960px)
+      width 90px
+      left -42px
 
   &__step
     content ' '

--- a/desktop/apps/consignments2/components/submission_flow/index.js
+++ b/desktop/apps/consignments2/components/submission_flow/index.js
@@ -10,13 +10,10 @@ import {
 
 function SubmissionFlow (props) {
   const b = block('consignments2-submission-flow')
-  const { CurrentStepComponent, isMobile } = props
+  const { CurrentStepComponent } = props
 
   return (
-    <div className={b({mobile: isMobile})}>
-      <div className={b('title')}>
-        Consign your work through Artsy in just a few quick steps
-      </div>
+    <div className={b()}>
       <StepMarker />
       <div className={b('step-form')}>
         <CurrentStepComponent />
@@ -28,14 +25,12 @@ function SubmissionFlow (props) {
 const mapStateToProps = (state) => {
   const {
     submissionFlow: {
-      currentStep,
-      isMobile
+      currentStep
     }
   } = state
 
   return {
-    CurrentStepComponent: stepsConfig[currentStep].component,
-    isMobile
+    CurrentStepComponent: stepsConfig[currentStep].component
   }
 }
 
@@ -49,6 +44,5 @@ export default connect(
 )(SubmissionFlow)
 
 SubmissionFlow.propTypes = {
-  CurrentStepComponent: PropTypes.func.isRequired,
-  isMobile: PropTypes.bool.isRequired
+  CurrentStepComponent: PropTypes.func.isRequired
 }

--- a/desktop/apps/consignments2/components/submission_flow/index.styl
+++ b/desktop/apps/consignments2/components/submission_flow/index.styl
@@ -1,12 +1,3 @@
 .consignments2-submission-flow
   margin-top -20px
   padding-bottom 30px
-
-  &__title
-    text-align center
-    font-size 50px
-    line-height 1.1
-
-  &_mobile
-    .consignments2-submission-flow__title
-      display none

--- a/desktop/apps/consignments2/components/text_input/index.js
+++ b/desktop/apps/consignments2/components/text_input/index.js
@@ -14,10 +14,22 @@ export const renderTextInput = ({ input: { onChange, value }, meta: { error, tou
 )
 
 function TextInput (props) {
-  const { autofocus, error, item, label, instructions, onChange, touched, type, warning, value, ...rest } = props
+  const {
+    autofocus,
+    error,
+    item,
+    label,
+    instructions,
+    onChange,
+    touched,
+    type,
+    warning,
+    value
+  } = props
+
   const b = block('consignments2-submission-text-input')
   return (
-    <div className={b()}>
+    <div className={b({error: Boolean(touched && error)})} name={item}>
       { label && <div className={b('label')}>{ label }</div> }
       { instructions && <div className={b('instructions')}>{ instructions }</div> }
       <input
@@ -40,7 +52,7 @@ function TextInput (props) {
 
 TextInput.propTypes = {
   autofocus: PropTypes.bool,
-  error: PropTypes.bool,
+  error: PropTypes.string,
   item: PropTypes.string.isRequired,
   label: PropTypes.string,
   instructions: PropTypes.string,

--- a/desktop/apps/consignments2/components/text_input/index.styl
+++ b/desktop/apps/consignments2/components/text_input/index.styl
@@ -1,4 +1,8 @@
 .consignments2-submission-text-input
+  &_error
+    .bordered-input
+      border 2px solid red-color
+
   &__label
     avant-garde-size('s-headline')
     margin-bottom 4px

--- a/desktop/apps/consignments2/stylesheets/index.styl
+++ b/desktop/apps/consignments2/stylesheets/index.styl
@@ -36,7 +36,7 @@
     display none
 
   .consignments2-submission
-    min-height calc(100vh \- 210px)
+    min-height calc(100vh \- 230px)
 
     #consignments2-submission__flow
       margin-bottom 50px

--- a/desktop/apps/consignments2/stylesheets/landing/desktop.styl
+++ b/desktop/apps/consignments2/stylesheets/landing/desktop.styl
@@ -119,7 +119,7 @@
         avant-garde-size('body')
 
       &__description
-        margin 10px 0 40px
+        margin 10px 0 20px
         > span
           float left
           margin-right gutter
@@ -131,6 +131,9 @@
 .consignments2-how-consignments-work
   padding-top 60px
   padding-bottom 60px
+
+  .consignments2-section__consign-button
+    margin-top 20px
 
 .consignments2-logos
   background-color gray-lightest-color

--- a/desktop/apps/consignments2/stylesheets/landing/mobile.styl
+++ b/desktop/apps/consignments2/stylesheets/landing/mobile.styl
@@ -31,6 +31,10 @@
     &__steps
       flex-direction column
 
+      &__step
+        &__image
+          width 48px
+
   .consignments2-logos
     padding-bottom 0px
 

--- a/desktop/apps/consignments2/templates/submission_flow.jade
+++ b/desktop/apps/consignments2/templates/submission_flow.jade
@@ -10,7 +10,6 @@ append locals
 block body
   .consignments2-submission.responsive-layout-container
     #consignments2-submission__flow
-    .consignments2-submission__push
   .consignments2-submission__footer
     .consignments2-submission__footer-contents
       .consignments2-submission__footer-contents--title


### PR DESCRIPTION
This PR includes a bunch of minor things:
- Adds _all_ of the fields to the mobile form. Note that the layout is still different enough that I think it warrants having two separate components, but I extracted the `validate` function.
![image](https://user-images.githubusercontent.com/2081340/27357907-2f327b7a-55e2-11e7-8658-a35a89c488f5.png)

- Updates the form to have a more "typical" UX --> the submit button is now enabled by default. Clicking it either submits the form or highlights all of the missing fields in red and scrolls you to the _first_ erroneous field.
![image](https://user-images.githubusercontent.com/2081340/27357835-cbf556e0-55e1-11e7-979d-cc7f8fbc6fb1.png)
![validation](https://user-images.githubusercontent.com/2081340/27357880-06c5a48c-55e2-11e7-8192-c71297bad80b.gif)

- Removes the big `title` from the submission flow and updates the step labels to be on one line for larger breakpoints
![image](https://user-images.githubusercontent.com/2081340/27357875-02a91df2-55e2-11e7-9fdd-9b9a261b431e.png)

- Updates the location input to erase when it is unfrozen (in the gif above)