### PR TITLE
@kanaabe => bombay footer bug

### DIFF
--- a/desktop/components/article/templates/super_article_footer.jade
+++ b/desktop/components/article/templates/super_article_footer.jade
@@ -5,8 +5,8 @@
     if superArticle.get('super_article').footer_blurb
       .article-sa-footer-blurb!= markdown(superArticle.get('super_article').footer_blurb)
 
-    if superArticle.get('super_article').partner_link_title
-      .article-sa-cta-container
+    .article-sa-cta-container
+      if superArticle.get('super_article').partner_link_title
         a.article-sa-cta.faux-underline( href=superArticle.get('super_article').partner_link )= superArticle.get('super_article').partner_link_title
 
     .article-sa-logos


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/1127 (erroneously in positron)

The cta container in the superArticle footer provides the margin between the description and logo.  Added the div back, and print the link conditionally to preserve formatting. 