### PR TITLE
@mzikherman - Allow price to be shown for institutional sellers with price info in artwork item

### DIFF
--- a/desktop/components/artwork_item/templates/artwork.jade
+++ b/desktop/components/artwork_item/templates/artwork.jade
@@ -4,7 +4,7 @@
 - displayPurchase = displayPurchase || false
 - showBlurbs = showBlurbs || false
 - isAuction = isAuction || (set && set.get('type') === 'auction artworks') || false
-- hasInstitutionPartner = artwork.get('partner') && artwork.get('partner').type === 'Institution'
+- hasInstitutionPartner = artwork.get('partner') && artwork.get('partner').type === 'Institution' && !artwork.get('forsale')
 - displayPrice != null ? displayPrice : displayPrice = true
 - saleArtwork = artwork.related().saleArtwork
 - hasAuctionPartner = (artwork.get('partner') && (artwork.get('partner').type === 'Auction' || artwork.get('partner').type === 'Auction House')) || artwork.get('is_biddable')

--- a/desktop/components/artwork_item/templates/partials/price.jade
+++ b/desktop/components/artwork_item/templates/partials/price.jade
@@ -1,4 +1,5 @@
-//- Display price for non-auctions
+//- if the artwork is not owned by an institutional partner and not for sale
+//- and if the artwork is not in an auction
 if !hasInstitutionPartner && !hasAuctionPartner && !isAuction
   if artwork.saleMessage() && displayPrice
     a.faux-underline-hover( href=artwork.href() )

--- a/desktop/components/artwork_item/test/artwork.coffee
+++ b/desktop/components/artwork_item/test/artwork.coffee
@@ -108,6 +108,14 @@ describe 'Artwork Item template', ->
       $('.artwork-item-partner a').text().should.equal @artwork.partnerName()
       $('.artwork-item-partner a').attr('href').should.equal @artwork.partnerLink()
 
+    it 'shows the price if the partner is an institution and the work is forsale', ->
+      @artwork.get('partner').type = 'Institution'
+      @artwork.set sale_message: "$5,200", forsale: true
+      $ = cheerio.load render('artwork')
+        artwork: @artwork
+        sd: {}
+      $('.artwork-item-sale-price').text().should.equal '$5,200'
+
     it 'displays a sale message', ->
       @artwork.set
         sale_message: "$5,200"


### PR DESCRIPTION
Closes #1577

In an ironic twist of fate, my last PR is fixing a bug in the artwork_item template.

Please look carefully at this, there might be something I am missing. The artwork in question: https://api.artsy.net/api/v1/artwork/pacita-abad-feel-the-beat

