### PR TITLE
@sweir27: Use staging > release flow instead of master > release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Meta
 * __Production:__ [https://www.artsy.net](https://www.artsy.net) | [Heroku](https://dashboard.heroku.com/apps/force-production/resources)
 * __Staging:__ [https://staging.artsy.net](https://staging.artsy.net) | [Heroku](https://dashboard.heroku.com/apps/force-staging/resources)
 * __Github:__ [https://github.com/artsy/force](https://github.com/artsy/force)
-* __CI/Deploys:__ [CircleCi](https://circleci.com/gh/artsy/force); merged PRs to `artsy/force#master` are automatically deployed to staging; PRs from `master` to `release` are automatically deployed to production. [Start a deploy...](https://github.com/artsy/force/compare/release...master?expand=1)
+* __CI/Deploys:__ [CircleCi](https://circleci.com/gh/artsy/force); merged PRs to `artsy/force#master` are automatically deployed to staging; PRs from `staging` to `release` are automatically deployed to production. [Start a deploy...](https://github.com/artsy/force/compare/release...staging?expand=1)
 * __Point People:__ [@craigspaeth](https://github.com/craigspaeth), [@broskoski](https://github.com/broskoski), [@kanaabe](https://github.com/kanaabe)
 
 [![Build Status](https://circleci.com/gh/artsy/force.svg?style=svg)](https://circleci.com/gh/artsy/force)

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ deployment:
       - chmod 600 ~/.netrc
       - "[[ ! -s \"$(git rev-parse --git-dir)/shallow\" ]] || git fetch --unshallow"
       - DEPLOY_ENV=staging yarn deploy
-      - git push git@github.com:artsy/force.git master:staging
+      - git push git@github.com:artsy/force.git $CIRCLE_SHA1:staging
   production:
     branch: release
     commands:

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,7 @@ deployment:
       - chmod 600 ~/.netrc
       - "[[ ! -s \"$(git rev-parse --git-dir)/shallow\" ]] || git fetch --unshallow"
       - DEPLOY_ENV=staging yarn deploy
+      - git push git@github.com:artsy/force.git master:staging
   production:
     branch: release
     commands:


### PR DESCRIPTION
This adds a push to the staging branch on Force after the deploy to staging build finishes so that we can ensure we don't deploy anything into production that hasn't made it to staging yet. The new workflow is to simply PR from staging to release instead of master to release.