### PR TITLE
@kanaabe => Superarticles with no subArticles

### DIFF
--- a/desktop/components/article/client/view.coffee
+++ b/desktop/components/article/client/view.coffee
@@ -74,7 +74,7 @@ module.exports = class ArticleView extends Backbone.View
     # FS and Super Article setup
     if ($header = @$('.article-fullscreen')).length
       new FullscreenView el: @$el, article: @article, header: $header
-    if sd.SUPER_SUB_ARTICLES?.length > 0
+    if sd.SUPER_SUB_ARTICLES?.length > 0 or @article.get('is_super_article')
       new SuperArticleView el: @$el, article: @article
 
     # Utility

--- a/desktop/components/article/templates/mixins.jade
+++ b/desktop/components/article/templates/mixins.jade
@@ -1,7 +1,8 @@
 mixin author-date
   .article-author-date
     .article-author(class= article.get('contributing_authors').length > 0 ? 'has-contributing-author' : '')
-      = article.related().author.get('name')
+      if article.related()
+        = article.related().author.get('name')
     if article.get('contributing_authors').length > 0
       .article-contributing-author
         = "By " + article.byline()


### PR DESCRIPTION
Closes https://github.com/artsy/positron/issues/1128

Looks like the article.related() was throwing a type error on empty superarticles, adding a conditional lets it render without timing out. 