### PR TITLE
@kanaabe : use custom href in search results if one exists

### DIFF
--- a/desktop/models/search_result.coffee
+++ b/desktop/models/search_result.coffee
@@ -30,7 +30,9 @@ module.exports = class SearchResult extends Backbone.Model
     _s.trim(_s.truncate(@get('display'), 75))
 
   location: ->
-    if @get('model') is 'profile' || @get('model') is 'page'
+    if @get('href')
+      @get('href')
+    else if @get('model') is 'profile' || @get('model') is 'page'
       "/#{@get('id')}"
     else if @get('model') is 'fair'
       "/#{@get('profile_id')}"

--- a/desktop/test/models/search_result.coffee
+++ b/desktop/test/models/search_result.coffee
@@ -35,6 +35,10 @@ describe 'SearchResult', ->
         model = new SearchResult({ model: 'city', id: 'gotham' })
         model.href().should.containEql '/shows/gotham'
 
+      it 'has a location attribute when it is a page with a custom href', ->
+        model = new SearchResult({ model: 'page', id: 'blah', href: 'http://example.com' })
+        model.href().should.equal 'http://example.com'
+
     describe '#displayModel', ->
       it 'has a display_model attribute when it is a artwork', ->
         model = new SearchResult(fabricate('artwork', model: 'artwork'))

--- a/mobile/models/search_result.coffee
+++ b/mobile/models/search_result.coffee
@@ -32,7 +32,9 @@ module.exports = class SearchResult extends Backbone.Model
     _s.trim(_s.truncate(@get('display'), 75))
 
   location: ->
-    if @get('model') is 'profile' || @get('model') is 'fair'
+    if @get('href')
+      @get('href')
+    else if @get('model') is 'profile' || @get('model') is 'fair'
       "/#{@id}"
     else if @get('model') is 'partnershow'
       "/show/#{@id}"


### PR DESCRIPTION
this is the follow up to https://github.com/artsy/gravity/pull/11125, which allows us to use custom destination paths for editorial/featured content in search results.