### PR TITLE
@yuki24 - restore link when js is not loaded properly

### DIFF
--- a/desktop/apps/search/client/index.coffee
+++ b/desktop/apps/search/client/index.coffee
@@ -68,7 +68,6 @@ module.exports.SearchResultsView = class SearchResultsView extends Backbone.View
         @$(".search-result[data-id='#{result.id}'] .search-result-thumbnail-fallback").html resolvedImage(result: artwork)
 
   trackSelectResult: (e) ->
-    e.preventDefault()
     term = $('#main-layout-search-bar-input').val()
     $searchResult = $(e.currentTarget)
     analyticsHooks.trigger 'search-page:item:click',


### PR DESCRIPTION
@yuki24 and I looked into this for a while and it was quite difficult to determine. We believe that some of the JS analytics files aren't always being loaded correctly. When that occurs the `e.preventDefault()` prohibits the link from working correctly. While removing this restores the link we should figure our why the analytics javascript isn't loading like it should which is represented in https://github.com/artsy/force/issues/1587.