### PR TITLE
@eessex => SuperArticle footer & infinite scroll bugs

### DIFF
--- a/desktop/apps/article/client/index.coffee
+++ b/desktop/apps/article/client/index.coffee
@@ -45,7 +45,7 @@ module.exports = class ArticleIndexView extends Backbone.View
 
     if sd.SCROLL_ARTICLE is 'infinite'
       @setupInfiniteScroll()
-    else unless sd.SUPER_SUB_ARTICLES.length or @article.get('is_super_article')
+    else unless sd.SUPER_ARTICLE
       @setupFooterArticles()
     if @article.get('channel_id') is sd.PC_ARTSY_CHANNEL or
       @article.get('channel_id') is sd.PC_AUCTION_CHANNEL

--- a/desktop/apps/article/client/index.coffee
+++ b/desktop/apps/article/client/index.coffee
@@ -45,7 +45,7 @@ module.exports = class ArticleIndexView extends Backbone.View
 
     if sd.SCROLL_ARTICLE is 'infinite'
       @setupInfiniteScroll()
-    else unless sd.SUPER_SUB_ARTICLES.length
+    else unless sd.SUPER_SUB_ARTICLES.length or @article.get('is_super_article')
       @setupFooterArticles()
     if @article.get('channel_id') is sd.PC_ARTSY_CHANNEL or
       @article.get('channel_id') is sd.PC_AUCTION_CHANNEL

--- a/desktop/apps/article/routes.coffee
+++ b/desktop/apps/article/routes.coffee
@@ -67,8 +67,10 @@ setupEmailSubscriptions = (user, article, cb) ->
 
 getArticleScrollType = (data) ->
   # Only Artsy Editorial and non super/subsuper articles can have an infinite scroll
-  if data.superSubArticles?.length or data.article.get('channel_id') isnt sd.ARTSY_EDITORIAL_CHANNEL
-    'static'
+  if data.superSubArticles?.length or
+    data.article.get('channel_id') isnt sd.ARTSY_EDITORIAL_CHANNEL or
+    data.article.get('is_super_article')
+      'static'
   else
     'infinite'
 

--- a/desktop/apps/article/routes.coffee
+++ b/desktop/apps/article/routes.coffee
@@ -67,9 +67,8 @@ setupEmailSubscriptions = (user, article, cb) ->
 
 getArticleScrollType = (data) ->
   # Only Artsy Editorial and non super/subsuper articles can have an infinite scroll
-  if data.superSubArticles?.length or
-    data.article.get('channel_id') isnt sd.ARTSY_EDITORIAL_CHANNEL or
-    data.article.get('is_super_article')
+  if data.superArticle or
+    data.article.get('channel_id') isnt sd.ARTSY_EDITORIAL_CHANNEL
       'static'
   else
     'infinite'

--- a/desktop/apps/article/test/routes.coffee
+++ b/desktop/apps/article/test/routes.coffee
@@ -33,7 +33,7 @@ describe 'Article routes', ->
       )
       @res.redirect.args[0][0].should.equal '/article/bar'
 
-   it 'fetches an article, its related content, and renders it', ->
+    it 'fetches an article, its related content, and renders it', ->
       @req.params.slug = 'bar'
       routes.articleItem = new Article
       routes.article @req, @res
@@ -45,6 +45,31 @@ describe 'Article routes', ->
       @res.render.args[0][1].article.get('title').should.equal 'Foo'
       @res.render.args[0][1].superArticles.first().get('title')
         .should.equal 'Super'
+
+    it 'sets the scroll type to infinite', ->
+      @req.params.slug = 'bar'
+      routes.articleItem = new Article
+      routes.article @req, @res
+      routes.__set__ 'sd', {ARTSY_EDITORIAL_CHANNEL: '123'}
+      Article::fetchWithRelated.args[0][0].success(
+        article: new Article(_.extend {}, fixtures.article,
+          title: 'Foo'
+          slug: 'bar'
+          channel_id: '123'
+        )
+        superArticle: null
+      )
+      @res.locals.sd.SCROLL_ARTICLE.should.equal 'infinite'
+
+    it 'sets the scroll type to static', ->
+      @req.params.slug = 'bar'
+      routes.articleItem = new Article
+      routes.article @req, @res
+      Article::fetchWithRelated.args[0][0].success(
+        article: new Article(_.extend {}, fixtures.article, title: 'Foo', slug: 'bar')
+        superArticle: new Article
+      )
+      @res.locals.sd.SCROLL_ARTICLE.should.equal 'static'
 
   describe '#redirectPost', ->
 

--- a/desktop/components/article/stylesheets/super_article.styl
+++ b/desktop/components/article/stylesheets/super_article.styl
@@ -16,6 +16,8 @@
   min-height 300px
 
 .article-sa-footer-left
+  display flex
+  flex-direction column
   position relative
   width 55%
   margin-right 30px
@@ -43,7 +45,6 @@
   align-items center
 
 .article-sa-logos
-  position absolute
   bottom 30px
   &__container
     display flex
@@ -65,6 +66,7 @@
 
 .article-sa-cta-container
   margin-top 20px
+  flex-grow 1
 
 .article-sa-cta
   margin-top 20px
@@ -203,8 +205,9 @@
     .article-sa-footer-left, .article-sa-footer-right
       width 100%
       margin 0px
-    .article-sa-footer-left
-      border-top none
+    .article-sa-footer-right
+      .article-sa-related:last-of-type
+        border-bottom none
     .article-sa-cta-container
       margin-bottom 180px
   @media screen and (max-width: 550px)

--- a/desktop/components/article/templates/super_article_footer.jade
+++ b/desktop/components/article/templates/super_article_footer.jade
@@ -23,8 +23,9 @@
             a( href=superArticle.get('super_article').secondary_logo_link )
               img( src=superArticle.get('super_article').secondary_partner_logo )
 
-  .article-sa-footer-right
-    for subArticle in superSubArticles.models
-      a.article-sa-related( href=subArticle.href() )
-        img.article-sa-related__image(src= crop(subArticle.get('thumbnail_image'), { width: 100, height: 66 }))
-        .article-sa-related__title= subArticle.get('thumbnail_title')
+  if superSubArticles.length
+    .article-sa-footer-right
+      for subArticle in superSubArticles.models
+        a.article-sa-related( href=subArticle.href() )
+          img.article-sa-related__image(src= crop(subArticle.get('thumbnail_image'), { width: 100, height: 66 }))
+          .article-sa-related__title= subArticle.get('thumbnail_title')

--- a/desktop/components/email/client/editorial_signup.coffee
+++ b/desktop/components/email/client/editorial_signup.coffee
@@ -32,7 +32,8 @@ module.exports = class EditorialSignupView extends Backbone.View
   inAEArticlePage: ->
     sd.ARTICLE? and
     sd.ARTICLE.channel_id is sd.ARTSY_EDITORIAL_CHANNEL and
-    not sd.SUPER_SUB_ARTICLES?.length > 0
+    not sd.SUPER_SUB_ARTICLES?.length > 0 and
+    not sd.ARTICLE.is_super_article
 
   inAEMagazinePage: ->
     sd.CURRENT_PATH is '/articles'

--- a/desktop/components/email/client/editorial_signup.coffee
+++ b/desktop/components/email/client/editorial_signup.coffee
@@ -32,8 +32,7 @@ module.exports = class EditorialSignupView extends Backbone.View
   inAEArticlePage: ->
     sd.ARTICLE? and
     sd.ARTICLE.channel_id is sd.ARTSY_EDITORIAL_CHANNEL and
-    not sd.SUPER_SUB_ARTICLES?.length > 0 and
-    not sd.ARTICLE.is_super_article
+    not sd.SUPER_ARTICLE
 
   inAEMagazinePage: ->
     sd.CURRENT_PATH is '/articles'

--- a/desktop/components/email/test/editorial_signup.coffee
+++ b/desktop/components/email/test/editorial_signup.coffee
@@ -33,7 +33,6 @@ describe 'EditorialSignupView', ->
       outcome = { outcome: sinon.stub().returns('old_modal'), view: sinon.stub() }
       @CTABarView::render.returns $el
       @CTABarView::previouslyDismissed.returns false
-      @inAEArticlePage = sinon.spy @EditorialSignupView::, 'inAEArticlePage'
       sinon.stub(@EditorialSignupView::, 'fetchSignupImages').yields()
       sinon.stub @EditorialSignupView::, 'cycleImages'
       @EditorialSignupView.__set__ 'analyticsHooks', trigger: @trigger = sinon.stub()
@@ -66,6 +65,29 @@ describe 'EditorialSignupView', ->
         CURRENT_PATH: '/articles'
       @view.setupAEMagazinePage()
       $(@view.el).find('#modal-container').html().should.not.containEql 'articles-es-cta--banner modal'
+
+  describe '#inAEArticlePage', ->
+
+    it 'returns true if in article page', ->
+      @EditorialSignupView.__set__ 'sd',
+        ARTICLE: channel_id: '123'
+        SUPER_ARTICLE: null
+        ARTSY_EDITORIAL_CHANNEL: '123'
+      @view.inAEArticlePage().should.be.true()
+
+    it 'returns false if super article', ->
+      @EditorialSignupView.__set__ 'sd',
+        ARTICLE: channel_id: '123'
+        SUPER_ARTICLE: {title: 'Super Article'}
+        ARTSY_EDITORIAL_CHANNEL: '123'
+      @view.inAEArticlePage().should.be.false()
+
+    it 'returns false non-editorial article', ->
+      @EditorialSignupView.__set__ 'sd',
+        ARTICLE: channel_id: '123'
+        SUPER_ARTICLE: {title: 'Super Article'}
+        ARTSY_EDITORIAL_CHANNEL: '1233'
+      @view.inAEArticlePage().should.be.false()
 
   describe '#eligibleToSignUp', ->
 


### PR DESCRIPTION
Switches the SA logic to rely on the existence of `sd.SUPER_ARTICLE` instead of `sd.SUPER_SUB_ARTICLES` to support the zero case.

- [x] Removes right footer container when there aren't any sub articles
- [x] Fixes overlapping logos on desktop
- [x] Fixes infinite scroll happening on zero-subarticle SA's