### PR TITLE
@kanaabe => Add isomorphic React App example 

### DIFF
--- a/desktop/apps/react_example/client.js
+++ b/desktop/apps/react_example/client.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import App from './components/App'
+import { rehydrateClient } from 'desktop/components/react/utils/render_react_layout'
+
+const bootstrapData = rehydrateClient(window.__BOOTSTRAP__)
+
+ReactDOM.render(
+  <App {...bootstrapData} />, document.getElementById('react-root')
+)

--- a/desktop/apps/react_example/components/App.js
+++ b/desktop/apps/react_example/components/App.js
@@ -1,0 +1,52 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+export default class App extends Component {
+  static propTypes = {
+    name: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    templateComponents: PropTypes.object
+  }
+
+  componentDidMount () {
+    console.log('Component mounted on client!')
+  }
+
+  handleButtonClick = (event) => {
+    console.warn('Button clicked!', this.props.description)
+  }
+
+  render () {
+    const {
+      name,
+      description,
+      templateComponents: {
+        MyJadeView
+      }
+    } = this.props
+
+    return (
+      <div>
+        <h1>
+          Hello {name}!
+        </h1>
+
+        <p>
+          {description}
+        </p>
+
+        <button onClick={this.handleButtonClick}>
+          Click me!
+        </button>
+
+        <div>
+          <div>
+            Example Jade view:
+          </div>
+
+          <MyJadeView.Component />
+        </div>
+      </div>
+    )
+  }
+}

--- a/desktop/apps/react_example/components/App.js
+++ b/desktop/apps/react_example/components/App.js
@@ -1,3 +1,4 @@
+import DOM from './DOM'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
@@ -13,7 +14,7 @@ export default class App extends Component {
   }
 
   handleButtonClick = (event) => {
-    console.warn('Button clicked!', this.props.description)
+    console.warn('React Button clicked!', this.props.description)
   }
 
   render () {
@@ -26,27 +27,37 @@ export default class App extends Component {
     } = this.props
 
     return (
-      <div>
-        <h1>
-          Hello {name}!
-        </h1>
+      <DOM>
+        <div>
+          <strong>
+            React
+          </strong>
+          <hr />
 
-        <p>
-          {description}
-        </p>
+          <h1>
+            Hello {name}!
+          </h1>
 
-        <button onClick={this.handleButtonClick}>
-          Click me!
-        </button>
+          <p>
+            {description}
+          </p>
+
+          <button onClick={this.handleButtonClick}>
+            Click me!
+          </button>
+        </div>
+
+        <br />
 
         <div>
-          <div>
-            Example Jade view:
-          </div>
+          <strong>
+            Jade
+          </strong>
+          <hr />
 
           <MyJadeView.Component />
         </div>
-      </div>
+      </DOM>
     )
   }
 }

--- a/desktop/apps/react_example/components/DOM.js
+++ b/desktop/apps/react_example/components/DOM.js
@@ -1,0 +1,45 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import Backbone from 'backbone'
+
+const MyBackboneView = Backbone.View.extend({
+  events: {
+    'click button.js-button': 'handleClick'
+  },
+
+  render: function () {
+    console.log('mounting backbone view!')
+  },
+
+  handleClick: function () {
+    console.warn('Backbone button clicked!')
+  }
+})
+
+export default class DOM extends Component {
+  static propTypes = {
+    children: PropTypes.node
+  }
+
+  componentDidMount () {
+    this.$ = require('jquery')
+
+    this.view = new MyBackboneView({
+      el: document.querySelector('.js-backbone-view')
+    })
+
+    this.view.render()
+  }
+
+  componentWillUnmount () {
+    this.view.remove()
+  }
+
+  render () {
+    return (
+      <div>
+        {this.props.children}
+      </div>
+    )
+  }
+}

--- a/desktop/apps/react_example/components/meta.jade
+++ b/desktop/apps/react_example/components/meta.jade
@@ -1,0 +1,13 @@
+- title = 'React Isomorphic Example'
+- description = 'Hello World!'
+
+title= title
+meta( property='og:title', content= title )
+meta( name='description', content= description )
+meta( property='og:description', content= description )
+meta( property='twitter:description', content= description )
+
+meta( property='og:type', content='website' )
+meta( property='og:event', content='auction' )
+meta( property='twitter:card', content='summary' )
+meta( name='fragment', content='!' )

--- a/desktop/apps/react_example/components/my_jade_view.jade
+++ b/desktop/apps/react_example/components/my_jade_view.jade
@@ -1,0 +1,4 @@
+h1
+  | Hello from MyJadeView 
+div
+  | Data from `data` is available: name: #{name}

--- a/desktop/apps/react_example/components/my_jade_view.jade
+++ b/desktop/apps/react_example/components/my_jade_view.jade
@@ -1,4 +1,21 @@
-h1
+div
   | Hello from MyJadeView 
+  
 div
   | Data from `data` is available: name: #{name}
+    
+br 
+
+div
+  strong
+    | Backbone
+  hr
+    
+  div
+    | Example interaction backbone-code. See components/DOM.js
+    
+    .js-backbone-view
+      button.js-button
+        | Click Me!
+      
+    

--- a/desktop/apps/react_example/index.js
+++ b/desktop/apps/react_example/index.js
@@ -1,0 +1,16 @@
+import 'babel-core/register'
+import express from 'express'
+import reloadable, { isDevelopment } from 'desktop/lib/reloadable'
+
+const app = module.exports = express()
+
+app.set('view engine', 'jade')
+app.set('views', `${__dirname}/components`)
+
+if (isDevelopment) {
+  reloadable(app, (req, res, next) => {
+    require('./server')(req, res, next)
+  })
+} else {
+  app.use(require('./server'))
+}

--- a/desktop/apps/react_example/routes.js
+++ b/desktop/apps/react_example/routes.js
@@ -1,0 +1,25 @@
+import renderReactLayout from 'desktop/components/react/utils/render_react_layout'
+import App from 'desktop/apps/react_example/components/App'
+
+export function index (req, res, next) {
+  const layout = renderReactLayout({
+    basePath: req.app.get('views'),
+    blocks: {
+      head: 'meta.jade',
+      body: App
+    },
+    locals: {
+      ...res.locals,
+      assetPackage: 'react_example'
+    },
+    data: {
+      name: 'Leif',
+      description: 'hello hi how are you'
+    },
+    templates: {
+      MyJadeView: 'my_jade_view.jade'
+    }
+  })
+
+  res.send(layout)
+}

--- a/desktop/apps/react_example/routes.js
+++ b/desktop/apps/react_example/routes.js
@@ -1,5 +1,5 @@
-import renderReactLayout from 'desktop/components/react/utils/render_react_layout'
 import App from 'desktop/apps/react_example/components/App'
+import { renderReactLayout } from 'desktop/components/react/utils/render_react_layout'
 
 export function index (req, res, next) {
   const layout = renderReactLayout({

--- a/desktop/apps/react_example/server.js
+++ b/desktop/apps/react_example/server.js
@@ -1,0 +1,7 @@
+import * as routes from './routes'
+import adminOnly from 'desktop/lib/admin_only.coffee'
+import express from 'express'
+
+const app = module.exports = express.Router()
+
+app.get('/react-example', adminOnly, routes.index)

--- a/desktop/assets/react_example.coffee
+++ b/desktop/assets/react_example.coffee
@@ -1,0 +1,10 @@
+require('backbone').$ = $
+
+routes =
+  '''
+  /react-example/
+  ''': require('../apps/react_example/client.js').default
+
+for paths, init of routes
+  for path in paths.split('\n')
+    $(init) if location.pathname.match path

--- a/desktop/components/main_layout/templates/react_index.jade
+++ b/desktop/components/main_layout/templates/react_index.jade
@@ -6,7 +6,6 @@ append locals
 
 block head
   != header
-
     
 block body
   script.

--- a/desktop/components/react/utils/build_template_component.js
+++ b/desktop/components/react/utils/build_template_component.js
@@ -9,12 +9,12 @@ import renderTemplate from './render_template'
  * @return {Component}
  */
 export default function buildTemplateComponent (template, options = {}) {
-  const TemplateComponent = ({ children }) => {
+  const TemplateComponent = ({ children } = {}) => {
     return (
       <div>
         <div
           dangerouslySetInnerHTML={{
-            __html: renderTemplate(template, options)
+            __html: options.isClient ? template : renderTemplate(template, options)
           }}
         />
         {children}

--- a/desktop/components/react/utils/render_react_layout.js
+++ b/desktop/components/react/utils/render_react_layout.js
@@ -13,6 +13,8 @@ import { renderToString } from 'react-dom/server'
  *
  * // Routes.js
  *
+ * import { renderReactLayout } from 'desktop/components/react/utils/render_react_layout'
+ *
  * export function index (req, res, next) {
  *   const layout = renderReactLayout({
  *     basePath: req.app.get('views'),
@@ -37,7 +39,9 @@ import { renderToString } from 'react-dom/server'
  *
  * // Client.js
  *
- * const bootstrapData = window.__BOOTSTRAP__
+ * import { rehydrateClient } from 'desktop/components/react/utils/render_react_layout'
+ *
+ * const bootstrapData = rehydrateClient(window.__BOOTSTRAP__)
  *
  * ReactDOM.render(
  *   <App {...bootstrapData} />, document.getElementById('react-root')
@@ -46,7 +50,7 @@ import { renderToString } from 'react-dom/server'
  * @param  {Object} options Options configuration object
  * @return {String}         String of html to render
  */
-export default function renderReactLayout (options) {
+export function renderReactLayout (options) {
   /**
    * Configuration
    */

--- a/desktop/components/react/utils/render_react_layout.js
+++ b/desktop/components/react/utils/render_react_layout.js
@@ -4,14 +4,100 @@ import buildTemplateComponent from 'desktop/components/react/utils/build_templat
 import { isFunction, isString } from 'underscore'
 import { renderToString } from 'react-dom/server'
 
+/**
+ * Utility for rendering a React-based isomorphic app. Note that Once html has
+ * been sent over the wire it still needs to be rehydrated on the client. See
+ * apps/react_example/client.js for example.
+ *
+ * @example
+ *
+ * // Routes.js
+ *
+ * export function index (req, res, next) {
+ *   const layout = renderReactLayout({
+ *     basePath: req.app.get('views'),
+ *     blocks: {
+ *       head: 'meta.jade',
+ *       body: AppComponent
+ *     },
+ *     locals: {
+ *       ...res.locals,
+ *       assetPackage: 'react_example',
+ *       bodyClass: 'someCSSClass'
+ *     },
+ *     data: {
+ *       name: 'Leif',
+ *       description: 'hi how are you'
+ *     },
+ *     templates: {
+ *       MyLegacyJadeView: 'some_jade_view.jade'
+ *     }
+ *   })
+ * }
+ *
+ * // Client.js
+ *
+ * const bootstrapData = window.__BOOTSTRAP__
+ *
+ * ReactDOM.render(
+ *   <App {...bootstrapData} />, document.getElementById('react-root')
+ * )
+ *
+ * @param  {Object} options Options configuration object
+ * @return {String}         String of html to render
+ */
 export default function renderReactLayout (options) {
+  /**
+   * Configuration
+   */
   const {
+    /**
+     * Default path to components / templates / views. Typically corresponds to
+     * value set in `app.set('views', `${__dirname}/components`)`
+     */
     basePath = '',
+
+    /**
+     * Blocks to inject into `react_index.jade` layout. Can be either a React
+     * component, a path to a jade template or a string of html
+     */
     blocks: { head, body } = {},
-    locals = {}, // Typically a spread from `res.locals`, or global state
-    data = {},   // Data relevant to components / subapp
+
+    /**
+     * Typically a spread from res.locals, and if mounting a subapp includes
+     * `assetPackage` and `bodyClass` keys
+     */
+    locals = {},
+
+    /**
+     * Data relevant to components / subapp
+     */
+    data = {},
+
+    /**
+     * Legacy .jade templates to render. Keys in object are converted to
+     * components and injected in as props under `props.templateComponents`.
+     */
     templates = {}
   } = options
+
+  const templateComponents = renderTemplateComponents(
+    templates,
+    basePath,
+    data
+  )
+
+  const layout = renderTemplate('desktop/components/main_layout/templates/react_index.jade', {
+    locals: {
+      ...locals,
+      data: {
+        ...data,
+        templateComponents
+      },
+      header: render(head),
+      body: render(body)
+    }
+  })
 
   function render (block) {
     let html = ''
@@ -32,14 +118,10 @@ export default function renderReactLayout (options) {
 
       // Component
     } else if (isReactComponent(block)) {
-      const Component = block // Alias for JSX transpilation
-      const templateComponents = renderTemplateComponents(templates, basePath, data)
+      const Component = block
 
       html = renderToString(
-        <Component
-          {...data}
-          templateComponents={templateComponents}
-        />
+        <Component {...data} templateComponents={templateComponents} />
       )
 
       // String
@@ -60,15 +142,6 @@ export default function renderReactLayout (options) {
     return html
   }
 
-  const layout = renderTemplate('desktop/components/main_layout/templates/react_index.jade', {
-    locals: {
-      ...locals,
-      data,
-      header: render(head),
-      body: render(body)
-    }
-  })
-
   return layout
 }
 
@@ -79,26 +152,61 @@ function isJadeTemplate (fileName) {
 }
 
 function isReactComponent (Component) {
-  if (!isFunction(Component)) {
+  if (isFunction(Component)) {
+    return Component
+  } else {
     throw new Error(
       '(components/reaect/utils/render_react_layout.js) ' +
       'Error rendering layout: Invalid React component'
     )
-  } else {
-    return Component
   }
 }
 
 function renderTemplateComponents (templates, basePath, locals) {
   const templateComponents = Object
     .keys(templates)
-    .reduce((componentMap, key) => ({
-      ...componentMap,
-      [key]: buildTemplateComponent(templates[key], {
+    .reduce((componentMap, key) => {
+      const templateComponent = buildTemplateComponent(templates[key], {
         basePath,
         locals
       })
-    }), {})
+
+      return {
+        ...componentMap,
+        [key]: {
+          Component: templateComponent,
+          html: renderTemplate(templates[key], {
+            basePath,
+            locals
+          })
+        }
+      }
+    }, {})
 
   return templateComponents
+}
+
+export function rehydrateClient (bootstrapData) {
+  if (bootstrapData.templateComponents) {
+    const templates = bootstrapData.templateComponents || {}
+
+    const templateComponents = Object
+      .keys(templates)
+      .reduce((componentMap, key) => {
+        const templateComponent = buildTemplateComponent(templates[key].html, {
+          isClient: true
+        })
+
+        return {
+          ...componentMap,
+          [key]: {
+            Component: templateComponent
+          }
+        }
+      }, {})
+
+    bootstrapData.templateComponents = templateComponents
+  }
+
+  return bootstrapData
 }

--- a/desktop/components/react/utils/test/render_layout_test.js
+++ b/desktop/components/react/utils/test/render_layout_test.js
@@ -1,13 +1,13 @@
 import React from 'react'
-import renderReactLayout from '../render_react_layout'
+import { renderReactLayout, __RewireAPI__ } from '../render_react_layout'
 
 describe('components/react/utils/render_react_layout.js', () => {
   afterEach(() => {
-    renderReactLayout.__ResetDependency__('renderTemplate')
+    __RewireAPI__.__ResetDependency__('renderTemplate')
   })
 
   it('renders jade template blocks', () => {
-    renderReactLayout.__Rewire__('renderTemplate', (options) => {
+    __RewireAPI__.__Rewire__('renderTemplate', (options) => {
       return 'jade'
     })
 
@@ -21,11 +21,11 @@ describe('components/react/utils/render_react_layout.js', () => {
   })
 
   it('renders a stateless functional react component', (done) => {
-    renderReactLayout.__Rewire__('renderTemplate', (options) => {
+    __RewireAPI__.__Rewire__('renderTemplate', (options) => {
       return 'react'
     })
 
-    renderReactLayout.__Rewire__('renderToString', () => {
+    __RewireAPI__.__Rewire__('renderToString', () => {
       done()
     })
 
@@ -47,7 +47,7 @@ describe('components/react/utils/render_react_layout.js', () => {
   })
 
   it('renders a string', () => {
-    renderReactLayout.__Rewire__('renderTemplate', () => {
+    __RewireAPI__.__Rewire__('renderTemplate', () => {
       return 'string'
     })
 

--- a/desktop/index.js
+++ b/desktop/index.js
@@ -68,3 +68,6 @@ app.use(require('./apps/feature'))
 
 // User profiles
 app.use(require('./apps/user'))
+
+// React Serverside Example
+app.use(require('./apps/react_example'))


### PR DESCRIPTION
From our little workshop earlier today! I've also updated the util with some docs for clarity and fixed that bug we saw earlier related to client-side Jade templates. (Will clean up in another PR, but fine for now.)

**To view**: 

```sh
yarn start
open http://localhost:5000/react-example
```

Note that I've broken everything out in three sections so you can see how things interact: 

<img width="557" alt="screen shot 2017-06-27 at 2 08 06 pm" src="https://user-images.githubusercontent.com/236943/27610152-1645a226-5b42-11e7-835c-fa027d2afeae.png">

