### PR TITLE
@yuki24 => Safeguard against possible race condition to load Parsely script

### DIFF
--- a/desktop/analytics/before_ready.js
+++ b/desktop/analytics/before_ready.js
@@ -1,4 +1,0 @@
-/* Analytics code that needs to run before page load and analytics.ready */
-if (!location.pathname.match(/^\/article|^\/2016-year-in-art|^\/venice-biennale/)) {
-  window.PARSELY = {autotrack: false}
-} /* Disable Parsely firing on non-article/section pages */

--- a/desktop/assets/analytics.coffee
+++ b/desktop/assets/analytics.coffee
@@ -8,7 +8,6 @@ mediator.on 'all', (name, data) ->
   analyticsHooks.trigger "mediator:#{name}", data
 
 require '../analytics/main_layout.js'
-require '../analytics/before_ready.js'
 
 $ -> analytics.ready ->
 

--- a/desktop/components/main_layout/templates/scripts.jade
+++ b/desktop/components/main_layout/templates/scripts.jade
@@ -98,6 +98,12 @@ if options.marketo
     }
     }
 
+//- Disable Parsely on non-article pages before loading Segment
+script( type="text/javascript" ).
+  if (!location.pathname.match(/^\/article|^\/2016-year-in-art|^\/venice-biennale/)){
+    window.PARSELY = {autotrack: false}
+  }
+
 //- Segment.io
 script( type="text/javascript" ).
   !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.0.1";


### PR DESCRIPTION
One-line explanation: the contents of the before_ready.js script should run before we download any Segment analytics. Related to: https://github.com/artsy/force/issues/1587

For more detail:
We're supposed to mark pages that shouldn't be tracked with Parsely with:
```
window.PARSELY = {autotrack: false}
```
Currently, this happens in before_ready.js the analytics.coffee file. My guess is there's a race condition between Segment scripts downloading, and this above code that _should_ halt Parsely from initializing things like pInit and heartbeats. 

I can see that on pages where we have {autotrack: false}, those Parsely scripts with pInit and heartbeats are downloading which doesn't make sense. 