### PR TITLE
@mzikherman: Point mobile hero units to MARTSY

### DIFF
--- a/mobile/apps/home/routes.coffee
+++ b/mobile/apps/home/routes.coffee
@@ -3,7 +3,7 @@ metaphysics = require '../../../lib/metaphysics.coffee'
 query = """
   query {
     home_page {
-      hero_units(platform: MOBILE) {
+      hero_units(platform: MARTSY) {
         mode
         heading
         title


### PR DESCRIPTION
This was just a simple oversight on my part when I refactored hero units to be randomized and use
 GraphQL on mobile—whoops! Pointing to the correct platform enum now. Related to [this thread](https://artsy.slack.com/archives/C0350895E/p1498747973622367).