### PR TITLE
Fix blurry cover images

### DIFF
--- a/desktop/apps/partner2/components/fixed_cells_count_carousel/articles.jade
+++ b/desktop/apps/partner2/components/fixed_cells_count_carousel/articles.jade
@@ -1,6 +1,6 @@
 - var articles = collection
-- var width = 300
-- var height = 200
+- var width = 403
+- var height = 269
 
 .fcc-carousel.partner2-shows-carousel
 

--- a/desktop/apps/partner2/components/fixed_cells_count_carousel/fair_booths.jade
+++ b/desktop/apps/partner2/components/fixed_cells_count_carousel/fair_booths.jade
@@ -1,6 +1,6 @@
 - var fairBooths = collection
-- var width = 300
-- var height = 200
+- var width = 403
+- var height = 269
 
 .fcc-carousel.partner2-shows-carousel
 


### PR DESCRIPTION
Slack report: https://artsy.slack.com/archives/C03JWJLLH/p1499286765372741

Back in https://github.com/artsy/force/pull/419 we fixed the problem of up-scaled cover images for **shows**.

This simply does the same for **fair booths** and **articles**, all of which appear on partner page overviews/sections.

![403 x 269](https://user-images.githubusercontent.com/140521/27886554-959db9b4-61aa-11e7-86b1-b064b78c6912.png)
