### PR TITLE
@sweir27: Fix typography issues on settings page

### DIFF
--- a/desktop/apps/notifications/stylesheets/mobile.styl
+++ b/desktop/apps/notifications/stylesheets/mobile.styl
@@ -41,3 +41,82 @@
     width 20px
     height 20px
     margin-top 1px
+
+// Styles from the Artwork Columns component copy-pasted from the ./mobile side.
+// We're breaking DRY here because in a more responsive future we likely won't
+// be carrying over this component in a significant way.
+#notifications-page
+  .artwork-columns
+    width 100%
+
+  .artwork-columns-double
+    .artwork-columns-column
+      width 50%
+      .artwork-columns-artwork
+        margin 0
+      &:nth-child(1)
+        .artwork-columns-artwork
+          margin-right 10px
+      &:nth-child(2)
+        .artwork-columns-artwork
+          margin-left 10px
+
+  .artwork-columns-triple
+    .artwork-columns-column
+      width 33.33%
+      &:nth-child(1)
+        .artwork-columns-artwork
+          margin 0 10px 0 0
+      &:nth-child(2)
+        .artwork-columns-artwork
+          margin 0 10px
+      &:nth-child(3)
+        .artwork-columns-artwork
+          margin 0 0 0 10px
+
+  .artwork-columns-column
+    max-width 100%
+    display inline-block
+    vertical-align top
+
+  .artwork-columns-artwork img
+    display block
+    width 100%
+
+  .artwork-columns-artwork-details
+    margin 10px 0 20px 0
+    font-size 14px
+    line-height 1.2em
+    color dark-gray-text-color
+    p
+      ellipsis()
+
+  .artwork-columns-artwork-details
+    &__auction-lot-number
+      avant-garde-size('s-headline', true)
+      color black
+    &__buy-now, &__bid
+      color black
+    > a
+      padding-bottom 2px
+      color #666
+      fine-faux-underline()
+
+  .artwork_column__contact-gallery
+    color gray-darker-color
+
+  .artwork-columns-artwork-details__bid-now
+    display flex
+    p.bid-now-link
+      line-height 1.5
+      margin-left -3px
+      text-decoration underline
+    &:before
+      content ''
+      background-image url('/images/paddle.png')
+      background-repeat no-repeat
+      background-position 0 2px
+      background-size 63%
+      padding-right 14px
+      margin-top 1px
+      height 16px

--- a/desktop/assets/misc.styl
+++ b/desktop/assets/misc.styl
@@ -75,7 +75,6 @@
 @require '../apps/notifications/stylesheets'
 @require '../components/artwork_item/stylesheets'
 @require '../components/artwork_columns'
-@require '../../mobile/components/artwork_columns'
 @require '../components/jump'
 
 // user


### PR DESCRIPTION
This fixes that strange issue where `avant-garde-size` was conflicting when I pulled over the mobile component into a desktop app—causing certain pages to render garamond when it should have rendered avant garde. This is another unfortunate case where the global nature of CSS causes maintenance headaches. While we get `@require`s in Stylus, they don't operate like `import`s in a real programming language like JS—they essentially just smartly concatenate files, so we have to be diligent about namespacing even in mixins.

Regardless, after thinking it over I decided it's probably best to just copy-paste over the relevant styles in this case because our goal is to eventually drop ./mobile and importing into ./mobile is only going to make that more difficult to untangle down the line.