### PR TITLE
@damassi => fix little UI bugs on the consign flow

### DIFF
--- a/desktop/apps/consign/client/actions.js
+++ b/desktop/apps/consign/client/actions.js
@@ -2,7 +2,7 @@ import request from 'superagent'
 import gemup from 'gemup'
 import stepsConfig from './steps_config'
 import { data as sd } from 'sharify'
-import { fetchToken } from '../helpers'
+import { fetchToken, formattedLocation } from '../helpers'
 import { find } from 'underscore'
 import { push } from 'react-router-redux'
 
@@ -55,10 +55,15 @@ export function addImageToUploadedImages (fileName, src) {
   }
 }
 
-export function chooseArtistAndAdvance (value) {
+export function chooseArtist (value) {
   return (dispatch) => {
     dispatch(updateArtistId(value._id))
     dispatch(updateArtistName(value.name))
+  }
+}
+
+export function chooseArtistAdvance () {
+  return (dispatch) => {
     dispatch(push(stepsConfig.describeWork.path))
   }
 }
@@ -139,6 +144,7 @@ export function completeSubmission () {
                           .send({ state: 'submitted' })
 
       dispatch(updateSubmission(submissionResponse.body))
+      dispatch(stopLoading())
       dispatch(push(stepsConfig.thankYou.submissionPath.replace(':id', submissionResponse.body.id)))
     } catch (err) {
       dispatch(stopLoading())
@@ -616,9 +622,9 @@ export function updateLocationFromSubmissionAndFreeze (city, state, country) {
         }
       }
     } = getState()
-    const formattedLocation = [location_city, location_state, location_country].filter((item) => item).join(', ')
+    const location = formattedLocation(location_city, location_state, location_country)
 
-    dispatch(updateLocationAutocompleteValue(formattedLocation))
+    dispatch(updateLocationAutocompleteValue(location))
     dispatch(freezeLocationInput())
   }
 }

--- a/desktop/apps/consign/components/choose_artist/index.js
+++ b/desktop/apps/consign/components/choose_artist/index.js
@@ -6,7 +6,8 @@ import { connect } from 'react-redux'
 import { get } from 'lodash'
 import {
   clearArtistSuggestions,
-  chooseArtistAndAdvance,
+  chooseArtist,
+  chooseArtistAdvance,
   fetchArtistSuggestions,
   showNotConsigningMessage,
   updateArtistAutocompleteValue
@@ -32,7 +33,8 @@ function ChooseArtist (props) {
     artistAutocompleteValue,
     artistName,
     clearArtistSuggestionsAction,
-    chooseArtistAndAdvanceAction,
+    chooseArtistAction,
+    chooseArtistAdvanceAction,
     fetchArtistSuggestionsAction,
     notConsigningArtist,
     showNotConsigningMessageAction,
@@ -66,7 +68,7 @@ function ChooseArtist (props) {
             suggestions={artistAutocompleteSuggestions}
             onSuggestionsFetchRequested={fetchArtistSuggestionsAction}
             onSuggestionsClearRequested={clearArtistSuggestionsAction}
-            onSuggestionSelected={chooseArtistAndAdvanceAction}
+            onSuggestionSelected={chooseArtistAction}
             getSuggestionValue={getSuggestionValue}
             renderInputComponent={renderInputComponent}
             renderSuggestion={renderSuggestion}
@@ -75,7 +77,7 @@ function ChooseArtist (props) {
         </div>
         <div
           className={b('next-button').mix('avant-garde-button-black')}
-          onClick={artistAutocompleteValue === artistName ? chooseArtistAndAdvanceAction : showNotConsigningMessageAction}
+          onClick={artistAutocompleteValue === artistName ? chooseArtistAdvanceAction : showNotConsigningMessageAction}
           disabled={!nextEnabled}
         >
           Next
@@ -95,14 +97,18 @@ const mapStateToProps = (state) => {
   return {
     artistAutocompleteSuggestions: state.submissionFlow.artistAutocompleteSuggestions,
     artistAutocompleteValue: state.submissionFlow.artistAutocompleteValue,
+    artistName: state.submissionFlow.artistName,
     notConsigningArtist: state.submissionFlow.notConsigningArtist
   }
 }
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    chooseArtistAndAdvanceAction (event, { suggestion, suggestionValue }) {
-      dispatch(chooseArtistAndAdvance(suggestion))
+    chooseArtistAction (event, { suggestion, suggestionValue }) {
+      dispatch(chooseArtist(suggestion))
+    },
+    chooseArtistAdvanceAction () {
+      dispatch(chooseArtistAdvance())
     },
     clearArtistSuggestionsAction () {
       dispatch(clearArtistSuggestions())

--- a/desktop/apps/consign/components/describe_work_container/index.js
+++ b/desktop/apps/consign/components/describe_work_container/index.js
@@ -1,13 +1,17 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
+import { formattedLocation } from '../../helpers'
 import { makeDescribeWorkDesktop } from '../describe_work_desktop'
 import { makeDescribeWorkMobile } from '../describe_work_mobile'
 import { isEmpty, pick } from 'underscore'
 
 function DescribeWorkContainer (props) {
   const { isMobile, submission } = props
-  const populatedSubmission = isEmpty(submission) ? { signature: true, authenticity_certificate: true } : submission
+  const location = formattedLocation(submission.location_city, submission.location_state, submission.location_country)
+  const populatedSubmission = isEmpty(submission)
+    ? { signature: true, authenticity_certificate: true }
+    : { ...submission, location }
   const relevantInputs = pick(
     populatedSubmission,
     'artist_id',
@@ -20,6 +24,7 @@ function DescribeWorkContainer (props) {
     'edition_size',
     'height',
     'id',
+    'location',
     'medium',
     'provenance',
     'signature',

--- a/desktop/apps/consign/helpers.js
+++ b/desktop/apps/consign/helpers.js
@@ -12,3 +12,7 @@ export async function fetchToken (accessToken) {
               .send({ client_application_id: sd.CONVECTION_APP_ID })
   return token
 }
+
+export function formattedLocation (city, state, country) {
+  return [city, state, country].filter(Boolean).join(', ')
+}

--- a/desktop/apps/consign/test/helpers.js
+++ b/desktop/apps/consign/test/helpers.js
@@ -1,0 +1,15 @@
+import { formattedLocation } from '../helpers'
+
+describe('helpers', () => {
+  describe('formattedLocation', () => {
+    it('returns the correct string when all fields exist', () => {
+      formattedLocation('Maine', 'New York', 'USA').should.eql('Maine, New York, USA')
+    })
+    it('returns the correct string when some fields exist', () => {
+      formattedLocation('Maine', 'USA').should.eql('Maine, USA')
+    })
+    it('returns the correct string when no fields exist', () => {
+      formattedLocation(null, null, null).should.eql('')
+    })
+  })
+})


### PR DESCRIPTION
This PR fixes 3 little UI bugs, and makes a slight UI adjustment.

Changes:
- Fixes the issue where the spinner would be enabled if you pressed back after uploading a photo
- Fixes the issue where you couldn't re-submit the "describe your work" page because the location would not be validated on rehydration
- **UX adjustment** we used to have it where if you click on an artist from the dropdown, it automatically advances you to the next step. A few bugs cropped up from this behavior, and I remember chatting about how it can be a bit jarring. This PR updates that flow to instead require an explicit click of the "Next" button to advance.
![artist-enter](https://user-images.githubusercontent.com/2081340/28095744-2e54e90e-6672-11e7-9944-d1219843f560.gif)
