### PR TITLE
@sweir27 => [BUGFIX] Always show bid dropdown

### DIFF
--- a/desktop/apps/artwork/components/auction/templates/bid.jade
+++ b/desktop/apps/artwork/components/auction/templates/bid.jade
@@ -27,12 +27,12 @@ if showAuctionForm
           data-anchor='top-right'
         )
 
-      label.bordered-select.artwork-auction__bid-form__select
-        select( name='bid' required ).js-artwork-auction-max-bid
-          for cents in increments
-            - val = cents / 100
-            - display = accounting.formatMoney(val, sale_artwork.symbol, 0)
-            option( value=val data-display=display )= display
+    label.bordered-select.artwork-auction__bid-form__select
+      select( name='bid' required ).js-artwork-auction-max-bid
+        for cents in increments
+          - val = cents / 100
+          - display = accounting.formatMoney(val, sale_artwork.symbol, 0)
+          option( value=val data-display=display )= display
 
     - bidAmount = 'Bid ' + accounting.formatMoney(firstIncr / 100, sale_artwork.symbol, 0)
 

--- a/desktop/apps/artwork/components/auction/test/view.coffee
+++ b/desktop/apps/artwork/components/auction/test/view.coffee
@@ -171,6 +171,14 @@ describe 'auction', ->
           view.$('.js-artwork-auction-bid').attr('action')
             .should.equal "/artwork/#{@data.artwork.id}"
 
+        it 'renders a bid amount dropdown', ->
+          @data.accounting = accounting
+          @data.me = {}
+          view = new @ArtworkAuctionView data: @data
+          view.render()
+          view.$('.js-artwork-auction-max-bid').length.should.equal 1
+          view.$('.artwork-auction__bid-form__select').length.should.equal 1
+
       describe 'post-bid messages', ->
         beforeEach ->
           @data = Object.assign(@data, {


### PR DESCRIPTION
Fixes regression where the bid dropdown only appears after registration: 

**Before:** 

<img width="380" alt="screen shot 2017-07-12 at 11 44 11 am" src="https://user-images.githubusercontent.com/236943/28134326-8192c2a0-66f7-11e7-9f44-9e193ae5b484.png">

**After:**

<img width="405" alt="screen shot 2017-07-12 at 11 44 58 am" src="https://user-images.githubusercontent.com/236943/28134347-91217d7e-66f7-11e7-80aa-40596b19c90f.png">

