### PR TITLE
Fixed a bug where gene page does not show artworks

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "sh scripts/test.sh"
   },
   "dependencies": {
-    "@artsy/reaction-force": "^0.1.45",
+    "@artsy/reaction-force": "^0.1.47",
     "accounting": "^0.4.1",
     "analytics-node": "^2.4.0",
     "artsy-backbone-mixins": "git://github.com/artsy/artsy-backbone-mixins.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@artsy/reaction-force@^0.1.45":
-  version "0.1.45"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.1.45.tgz#56e7ef1a6f7b0c7ef8f1f1ad32332327367922ad"
+"@artsy/reaction-force@^0.1.47":
+  version "0.1.47"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.1.47.tgz#81e57903f82ac44749bd243c12e353a4fd1ff55f"
   dependencies:
     "@storybook/addon-options" "^3.1.2"
     "@storybook/react" "^3.1.3"
@@ -4958,6 +4958,7 @@ jade@^1.11.0:
     jstransformer "0.0.2"
     mkdirp "~0.5.0"
     transformers "2.1.0"
+    uglify-js "^2.4.19"
     void-elements "~2.0.1"
     with "~4.0.0"
 
@@ -8709,7 +8710,7 @@ uglify-js@2.x.x, uglify-js@^2.8.22:
   optionalDependencies:
     uglify-to-browserify "~1.0.0"
 
-uglify-js@^2.8.29:
+uglify-js@^2.4.19, uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:


### PR DESCRIPTION
`0.1.47` has https://github.com/artsy/reaction/pull/195 and https://github.com/artsy/reaction/pull/194 that should fix the gene page.