### PR TITLE
@damassi => remove the partner link for auction artworks

### DIFF
--- a/mobile/apps/artwork/components/meta_data/templates/partner.jade
+++ b/mobile/apps/artwork/components/meta_data/templates/partner.jade
@@ -3,8 +3,8 @@
     //- Drop Header
   else
     h2.artwork-header= artwork.is_for_sale ? 'Offered by' : artwork.partner.type.replace('Institutional Seller', 'Institution')
-  if artwork.partner.type == 'Auction'
-    a.artwork-partner-link.chevron-arrow-button( href='/auction' + artwork.partner.href )= artwork.partner.name
+  if artwork.partner.type == 'Auction' || artwork.partner.type == 'Auction House'
+    .artwork-partner-name= artwork.partner.name
   else if artwork.collecting_institution && artwork.partner.type == 'Institution'
     a.artwork-partner-link.chevron-arrow-button( href=artwork.partner.href )= artwork.collecting_institution
   else

--- a/mobile/apps/artwork/components/meta_data/test/template.coffee
+++ b/mobile/apps/artwork/components/meta_data/test/template.coffee
@@ -150,6 +150,40 @@ describe 'Artwork metadata templates', ->
         $ = cheerio.load(html)
         $('.artwork-meta-data__partner .artwork-header').text().should.equal 'Offered by'
 
+    describe 'auction house - not for sale', ->
+      beforeEach ->
+        @artwork.is_for_sale = false
+        @artwork.partner.type = 'Auction House'
+        @artwork.partner.name = 'Phillips'
+
+      it 'should display Gallery header', ->
+        html = render('partner')(
+          artwork: @artwork
+          sd: {}
+          asset: (->)
+        )
+
+        $ = cheerio.load(html)
+        $('.artwork-meta-data__partner .artwork-header').text().should.equal 'Auction House'
+        $('.artwork-meta-data__partner .artwork-partner-name').text().should.equal 'Phillips'
+
+    describe 'auction house - for sale', ->
+      beforeEach ->
+        @artwork.is_for_sale = true
+        @artwork.partner.type = 'Auction House'
+        @artwork.partner.name = 'Phillips'
+
+      it 'should display Offered by when work is for sale', ->
+        html = render('partner')(
+          artwork: @artwork
+          sd: {}
+          asset: (->)
+        )
+
+        $ = cheerio.load(html)
+        $('.artwork-meta-data__partner .artwork-header').text().should.equal 'Offered by'
+        $('.artwork-meta-data__partner .artwork-partner-name').text().should.equal 'Phillips'
+
     describe 'collecting institution', ->
       beforeEach ->
         @artwork.is_for_sale = true
@@ -207,21 +241,6 @@ describe 'Artwork metadata templates', ->
       it 'should link to partner\'s page', ->
         $ = cheerio.load(@html)
         $('.artwork-meta-data__partner .artwork-header').text().should.equal 'Institution'
-
-    describe 'auction - partner', ->
-      before ->
-        @artwork.partner.type = 'Auction'
-        @artwork.partner.href = '/spring-slash-break-benefit-auction-2016'
-
-        @html = render('partner')(
-          artwork: @artwork
-          sd: {}
-          asset: (->)
-        )
-
-      it 'should include auction in the url', ->
-        $ = cheerio.load(@html)
-        $('.artwork-partner-link').attr('href').should.equal '/auction/spring-slash-break-benefit-auction-2016'
 
   describe 'auction artwork estimated value', ->
     before ->


### PR DESCRIPTION
This fixes the issue where partner names were linking to non-existent urls for auction lots. It seems like the template was assuming that partner slugs would be the same as sale slugs, so was constructing a url like `/auction/#{default_profile_id}`. This may have been valid in _some_ cases but it would have been a happy accident. 

Once we have partner profile pages for auction houses we will be able to link to those, but for now I'm removing the `a` tag per discussion with @devangt so they at least don't lead to a 404.

![image](https://user-images.githubusercontent.com/2081340/28172994-203b62cc-67bb-11e7-86ee-4a5a56cc2c19.png)
