### PR TITLE
Update alanytics ctacking for "show phone number"

### DIFF
--- a/desktop/apps/artwork/components/partner_stub/index.jade
+++ b/desktop/apps/artwork/components/partner_stub/index.jade
@@ -33,5 +33,7 @@ unless artwork.is_in_auction
             data-partner_id= partner._id
             data-artwork_id= artwork._id
             data-artist_ids= artistIds
+            data-user_id=(sd.CURRENT_USER && sd.CURRENT_USER.id )
+            data-context='show phone number'
           )
             | Inquire via phone

--- a/desktop/apps/artwork/components/partner_stub/index.jade
+++ b/desktop/apps/artwork/components/partner_stub/index.jade
@@ -32,7 +32,6 @@ unless artwork.is_in_auction
             class='js-artwork-partner-stub-inquire-via-phone analytics-artwork-show-phone-number garamond-s-body'
             data-partner_id= partner._id
             data-artwork_id= artwork._id
-            data-partner= partner
             data-artist_ids= artistIds
           )
             | Inquire via phone


### PR DESCRIPTION
As per [the discussion here](https://github.com/artsy/collector-experience/issues/74#issuecomment-314891645), the current analytics tracking code sends extra information that is unnecessary and doesn't give us enough insights to see drop off rate for sign up from "Inquire via phone" modal. This PR makes the following changes:

 * Do not send unneeded partner information
 * Send `context` and `user_id` so we can track drop off rate for signup