### PR TITLE
@craigspaeth => Self-host webfonts via S3

### DIFF
--- a/desktop/components/main_layout/templates/head.jade
+++ b/desktop/components/main_layout/templates/head.jade
@@ -19,10 +19,6 @@ meta( property="fb:pages" content="342443413406")
 script( type="text/javascript" )
   include ../../../../node_modules/scroll-frame/scroll-frame-head.js
 
-//- Don't include fonts if Reflection is requesting it
-if sd.BROWSER && sd.BROWSER.family != 'PhantomJS'
-  script( type='text/javascript', src='//fast.fonts.net/jsapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.js' )
-
 //- Criteo marketing tag... no Segment integration (  ._.)
 script(type='text/javascript', src='//static.criteo.net/js/ld/ld.js', async='true')
 

--- a/desktop/components/main_layout/templates/index.jade
+++ b/desktop/components/main_layout/templates/index.jade
@@ -17,7 +17,7 @@ html(
       
     //- Don't include fonts if Reflection is requesting it		
     if sd.BROWSER && sd.BROWSER.family != 'PhantomJS'
-      link( type='text/css', rel='stylesheet', href='#{sd.CDN_URL}/fonts/force-webfonts.css')
+      link( type='text/css', rel='stylesheet', href='http://webfonts.artsy.net/force-webfonts.css')
         
     link( type='text/css', rel='stylesheet', href=asset('/assets/main_layout.css') )
       

--- a/desktop/components/main_layout/templates/index.jade
+++ b/desktop/components/main_layout/templates/index.jade
@@ -15,7 +15,12 @@ html(
     include head
     block head
       
+    //- Don't include fonts if Reflection is requesting it		
+    if sd.BROWSER && sd.BROWSER.family != 'PhantomJS'
+      link( type='text/css', rel='stylesheet', href='#{sd.CDN_URL}/fonts/force-webfonts.css')
+        
     link( type='text/css', rel='stylesheet', href=asset('/assets/main_layout.css') )
+      
     if assetPackage
       link( type='text/css', rel='stylesheet', href=asset('/assets/#{assetPackage}.css') )
         


### PR DESCRIPTION
This PR update Force to point to self-hosted webfonts, as opposed to downloading via a font-face CDN. Fonts have been uploaded to S3 and a container CSS file imports them into the app. 

See: https://s3.console.aws.amazon.com/s3/buckets/artsy-webfonts and http://webfonts.artsy.net/ 

Thanks @kanaabe for your S3 help! 

