### PR TITLE
@damassi => Update acceptance tests to handle console errors

### DIFF
--- a/lib/middleware/error_handler.coffee
+++ b/lib/middleware/error_handler.coffee
@@ -6,10 +6,10 @@ module.exports = (err, req, res, next) ->
     __dirname,
     '../../desktop/components/error_handler/index.jade'
   )
-  isNotProduction = NODE_ENV isnt 'production'
-  console.log err if isNotProduction
+  isDevelopment = NODE_ENV is 'development'
+  console.log err if isDevelopment
   code = 504 if req.timedout
   code ||= err.status || 500
-  message = err.message || err.text || err.toString() if isNotProduction
-  detail = err.stack if isNotProduction
+  message = err.message || err.text || err.toString() if isDevelopment
+  detail = err.stack if isDevelopment
   res.status(code).render(file, { message, detail, code })

--- a/test/acceptance/artwork.js
+++ b/test/acceptance/artwork.js
@@ -1,11 +1,12 @@
 /* eslint-env mocha */
-import { setup, teardown } from './helpers'
+import { setup, teardown, stubAuctionReminder } from './helpers'
 
 describe('Artwork page', () => {
   let metaphysics, browser
 
   before(async () => {
     ({ metaphysics, browser } = await setup())
+    stubAuctionReminder()
     metaphysics.post('/', (req, res) => {
       res.send(require('./fixtures/metaphysics/artwork'))
     })

--- a/test/acceptance/auth.js
+++ b/test/acceptance/auth.js
@@ -1,11 +1,12 @@
 /* eslint-env mocha */
-import { setup, teardown } from './helpers'
+import { setup, teardown, stubAuctionReminder } from './helpers'
 
 describe('Authentication', () => {
   let gravity, browser
 
   before(async () => {
     ({ gravity, browser } = await setup())
+    stubAuctionReminder()
     gravity.get('/api/v1/page/terms', (req, res) => {
       res.send(require('./fixtures/gravity/terms.json'))
     })
@@ -13,7 +14,7 @@ describe('Authentication', () => {
 
   after(teardown)
 
-  xit('logs in', async () => {
+  it('logs in', async () => {
     await browser.page('/terms')
     await browser.login()
     const html = await browser.el('.main-layout-header-user')

--- a/test/acceptance/auth.js
+++ b/test/acceptance/auth.js
@@ -14,10 +14,11 @@ describe('Authentication', () => {
 
   after(teardown)
 
-  it('logs in', async () => {
+  it('logs in', async (done) => {
     await browser.page('/terms')
     await browser.login()
     const html = await browser.el('.main-layout-header-user')
     html.should.containEql('Craig Spaeth')
+    done()
   })
 })

--- a/test/acceptance/auth.js
+++ b/test/acceptance/auth.js
@@ -14,7 +14,7 @@ describe('Authentication', () => {
 
   after(teardown)
 
-  it('logs in', async (done) => {
+  xit('logs in', async (done) => {
     await browser.page('/terms')
     await browser.login()
     const html = await browser.el('.main-layout-header-user')

--- a/test/acceptance/bidding.js
+++ b/test/acceptance/bidding.js
@@ -1,11 +1,12 @@
 /* eslint-env mocha */
-import { setup, teardown } from './helpers'
+import { setup, teardown, stubAuctionReminder } from './helpers'
 
 describe('Bidding flow', () => {
   let metaphysics, browser
 
   before(async () => {
     ({ metaphysics, browser } = await setup())
+    stubAuctionReminder()
     metaphysics.post('/', (req, res, next) => {
       if (req.body.query.includes('me {')) {
         res.send(require('./fixtures/metaphysics/bidding.json'))
@@ -25,7 +26,7 @@ describe('Bidding flow', () => {
 
   after(teardown)
 
-  xit('can see the bid dropdown from auction to artwork page', async () => {
+  it('can see the bid dropdown from auction to artwork page', async () => {
     await browser.page('/auction/rago-auctions-19th-slash-20th-c-american-slash-european-art')
     await browser.login()
     await browser.el('[href*="/artwork/jean-dupas-untitled"]')

--- a/test/acceptance/bidding.js
+++ b/test/acceptance/bidding.js
@@ -26,7 +26,7 @@ describe('Bidding flow', () => {
 
   after(teardown)
 
-  it('can see the bid dropdown from auction to artwork page', async () => {
+  xit('can see the bid dropdown from auction to artwork page', async () => {
     await browser.page('/auction/rago-auctions-19th-slash-20th-c-american-slash-european-art')
     await browser.login()
     await browser.el('[href*="/artwork/jean-dupas-untitled"]')

--- a/test/acceptance/helpers/index.js
+++ b/test/acceptance/helpers/index.js
@@ -162,3 +162,8 @@ const startApp = (port) =>
       else resolve(app)
     }))
   })
+
+export const stubAuctionReminder = () =>
+    gravity.get('/api/v1/sales', (req, res) => {
+      res.send([])
+    })

--- a/test/acceptance/home.js
+++ b/test/acceptance/home.js
@@ -1,11 +1,12 @@
 /* eslint-env mocha */
-import { setup, teardown } from './helpers'
+import { setup, teardown, stubAuctionReminder } from './helpers'
 
 describe('Home page', () => {
   let gravity, positron, metaphysics, browser
 
   before(async () => {
     ({ gravity, positron, metaphysics, browser } = await setup())
+    stubAuctionReminder()
     gravity.get('/api/v1/set/529939e2275b245e290004a0/items', (req, res) => {
       res.send(require('./fixtures/gravity/home'))
     })

--- a/test/acceptance/misc.js
+++ b/test/acceptance/misc.js
@@ -1,11 +1,12 @@
 /* eslint-env mocha */
-import { setup, teardown } from './helpers'
+import { setup, teardown, stubAuctionReminder } from './helpers'
 
 describe('Page', () => {
   let gravity, browser
 
   before(async () => {
     ({ gravity, browser } = await setup())
+    stubAuctionReminder()
     gravity.get('/api/v1/page/:id', (req, res) => {
       res.send(require('./fixtures/gravity/page'))
     })

--- a/test/acceptance/partner_profile.js
+++ b/test/acceptance/partner_profile.js
@@ -26,6 +26,8 @@ describe('Partner profile page', () => {
 
   it('does not show contact information for non-active partner', async () => {
     const $ = await browser.page('/gagosian-gallery/contact')
+    
+    
     $.html().should.containEql('Sorry, the page you were looking for doesn&#x2019;t exist at this URL.')
   })
 

--- a/test/acceptance/partner_profile.js
+++ b/test/acceptance/partner_profile.js
@@ -26,8 +26,6 @@ describe('Partner profile page', () => {
 
   it('does not show contact information for non-active partner', async () => {
     const $ = await browser.page('/gagosian-gallery/contact')
-    
-    
     $.html().should.containEql('Sorry, the page you were looking for doesn&#x2019;t exist at this URL.')
   })
 

--- a/test/acceptance/partner_profile.js
+++ b/test/acceptance/partner_profile.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-import { setup, teardown } from './helpers'
+import { setup, teardown, stubAuctionReminder } from './helpers'
 import { server as antigravity } from 'antigravity'
 
 describe('Partner profile page', () => {
@@ -7,6 +7,7 @@ describe('Partner profile page', () => {
 
   before(async () => {
     ({ gravity, browser } = await setup())
+    stubAuctionReminder()
     gravity.use(antigravity)
     await browser.useragent('iPhone')
   })


### PR DESCRIPTION
Related convo here: https://artsy.slack.com/archives/C0350895E/p1501103674430615

WIP because there are two tests still spitting out error messages and I'm still trying to figure out the best place to fix them.

Also, I wanted to stub `app.get('/auctions/reminders')` after [this](https://github.com/artsy/force/blob/master/test/acceptance/helpers/index.js#L110) but because of express finding routes in order, I can't override it. I could recreate the app, but that feels like going down a rabbit hole just to stub one route hence all of the `stubAuctionReminder`s. 

