### PR TITLE
@eeessex => Use url field for fullscreen hero sections

### DIFF
--- a/desktop/apps/article/templates/amp_mixins.jade
+++ b/desktop/apps/article/templates/amp_mixins.jade
@@ -3,11 +3,11 @@ mixin amp_hero_section(hero)
     when 'image'
       +amp_hero_image(hero.url, hero.caption)
     when 'fullscreen'
-      if hero.background_url
+      if hero.url && hero.url.indexOf('mp4') > -1
         .amp-article__video-container
-          amp-video(src=hero.background_url width="400" height="300" autoplay loop)
+          amp-video(src=hero.url width="400" height="300" autoplay loop)
       else
-        +amp_hero_image(hero.background_image_url, null)
+        +amp_hero_image(hero.url, null)
     when 'video'
       +amp_video(hero)
 

--- a/desktop/apps/article2/queries/article.js
+++ b/desktop/apps/article2/queries/article.js
@@ -21,8 +21,7 @@ export default function ArticleQuery (id) {
           ...on Fullscreen {
             type
             title
-            background_image_url
-            background_url
+            url
           }
         }
         sections {

--- a/desktop/components/article/templates/mixins.jade
+++ b/desktop/components/article/templates/mixins.jade
@@ -24,13 +24,14 @@ mixin video(video)
 
 mixin fullscreen(article)
   figure.article-fullscreen( class= article.get('is_super_article') ? 'article-sa-fullscreen' : '' )
-    if article.get('hero_section').background_url
+    - var url = article.get('hero_section').url
+    if url && url.indexOf('mp4') > -1
       .article-fullscreen__overlay
-      video.article-fullscreen__video-player( src=article.get('hero_section').background_url, autoplay=true, controls=false, loop=true muted playsinline)
-    else if article.get('hero_section').background_image_url
+      video.article-fullscreen__video-player( src=url, autoplay=true, controls=false, loop=true muted playsinline)
+    else
       .article-fullscreen__overlay
       img.article-fullscreen__image(
-        src=resize(article.get('hero_section').background_image_url, { height: 1250, width: 1250 })
+        src=resize(url, { height: 1250, width: 1250 })
       )
 
     .main-layout-container.article-fullscreen__container

--- a/desktop/components/article/test/templates.coffee
+++ b/desktop/components/article/test/templates.coffee
@@ -44,6 +44,7 @@ describe 'article show template', ->
       moment: moment
       sd: {}
       asset: ->
+    html.should.containEql '<video src="http://video.mp4" autoplay="autoplay" loop="loop" muted="muted" playsinline="playsinline" class="article-fullscreen__video-player">'
     html.should.containEql 'article-fullscreen__video-player'
 
   it 'renders fullscreen headers with static image', ->
@@ -61,7 +62,7 @@ describe 'article show template', ->
       moment: moment
       sd: {}
       asset: ->
-    html.should.containEql 'article-fullscreen__image'
+    html.should.containEql '<img src="http://image.jpg" class="article-fullscreen__image"/>'
 
   it 'superSubArticles can render fullscreen header and SA menu with correct classes', ->
     html = render('index')
@@ -71,7 +72,7 @@ describe 'article show template', ->
         contributing_authors: []
         hero_section:
           type: 'fullscreen'
-          background_image_url: 'http://image.jpg'
+          url: 'http://image.jpg'
       footerArticles: new Articles
       superArticle: new Article
         super_article:
@@ -84,7 +85,7 @@ describe 'article show template', ->
       moment: moment
       sd: {}
       asset: ->
-    html.should.containEql 'article-fullscreen__image'
+    html.should.containEql '<img src="http://image.jpg" class="article-fullscreen__image"/>'
     html.should.containEql 'article-sa-sticky-header'
     html.should.containEql '<a href="http://logo.com"><img src="http://fullscreen-logo.jpg"/></a>'
     html.should.not.containEql 'visible no-transition'

--- a/desktop/components/article/test/templates.coffee
+++ b/desktop/components/article/test/templates.coffee
@@ -37,7 +37,7 @@ describe 'article show template', ->
         contributing_authors: []
         hero_section:
           type: 'fullscreen'
-          background_url: 'http://video.mp4'
+          url: 'http://video.mp4'
       footerArticles: new Articles
       crop: (url) -> url
       resize: (u) -> u
@@ -54,7 +54,7 @@ describe 'article show template', ->
         contributing_authors: []
         hero_section:
           type: 'fullscreen'
-          background_image_url: 'http://image.jpg'
+          url: 'http://image.jpg'
       footerArticles: new Articles
       crop: (url) -> url
       resize: (u) -> u


### PR DESCRIPTION
Deprecates `background_image_url` and `background_url` in favor of the simpler, `url` field that is used across hero section types. The `url` is already backfilled.

