### PR TITLE
@craigspaeth: comment out launching the seattle art fair sign up modal on seattle a…

### DIFF
--- a/desktop/components/marketing_signup_modal/index.coffee
+++ b/desktop/components/marketing_signup_modal/index.coffee
@@ -54,7 +54,8 @@ module.exports = class MarketingSignupModal extends Backbone.View
 
     # This is just for the Seattle Art Fair campaign and should be removed after
     # the fair closes.
-    slug = 'ca3' if !slug and sd.CURRENT_PATH is '/seattle-art-fair-2017'
+    # (commenting this out for now because the facebook sign up is throwing an error)
+    # slug = 'ca3' if !slug and sd.CURRENT_PATH is '/seattle-art-fair-2017'
 
     modalData = _.findWhere(sd.MARKETING_SIGNUP_MODALS, { slug: slug })
     @inner = new MarketingSignupModalInner

--- a/mobile/components/marketing_signup_modal/middleware.coffee
+++ b/mobile/components/marketing_signup_modal/middleware.coffee
@@ -6,7 +6,8 @@ module.exports = (req, res, next) ->
 
   # This is just for the Seattle Art Fair campaign and should be removed after
   # the fair closes.
-  slug = 'ca3' if !slug and sd.CURRENT_PATH is '/seattle-art-fair-2017'
+  # (commenting this out for now because the facebook sign up is throwing an error)
+  # slug = 'ca3' if !slug and sd.CURRENT_PATH is '/seattle-art-fair-2017'
 
   modalData = _.findWhere(sd.MOBILE_MARKETING_SIGNUP_MODALS, { slug: slug })
 


### PR DESCRIPTION
For context, https://github.com/artsy/collector-experience/issues/432 mentions that the facebook sign up modals are throwing errors. The fair has launched and the modal displays when a user navigates to the fair landing page. To prevent users from seeing the error when trying to sign up via facebook I think it's best to not display the modals until we get the facebook sign up working again. 