### PR TITLE
@craigspaeth => Use NY timezone for editorial articles

### DIFF
--- a/desktop/models/article.coffee
+++ b/desktop/models/article.coffee
@@ -3,6 +3,7 @@ _s = require 'underscore.string'
 Q = require 'bluebird-q'
 Backbone = require 'backbone'
 moment = require 'moment'
+momentTimezone = require 'moment-timezone'
 { POSITRON_URL, APP_URL, ARTSY_EDITORIAL_CHANNEL } = sd = require('sharify').data
 request = require 'superagent'
 Artwork = require '../models/artwork.coffee'
@@ -129,7 +130,10 @@ module.exports = class Article extends Backbone.Model
     crop @get(attr), args...
 
   date: (attr) ->
-    moment(@get(attr)).local()
+    if @get('channel_id') is sd.ARTSY_EDITORIAL_CHANNEL
+      momentTimezone(@get(attr)).tz('America/New_York')
+    else
+      moment(@get(attr)).local()
 
   strip: (attr) ->
     stripTags(@get attr)

--- a/desktop/test/models/article.coffee
+++ b/desktop/test/models/article.coffee
@@ -7,10 +7,12 @@ Article = rewire '../../models/article'
 Articles = require '../../collections/articles'
 sinon = require 'sinon'
 fixtures = require '../helpers/fixtures'
+moment = require 'moment'
+momentTimezone = require 'moment-timezone'
 
 describe "Article", ->
   beforeEach ->
-    Article.__set__ 'sd', { EOY_2016_ARTICLE: '1234' }
+    Article.__set__ 'sd', { EOY_2016_ARTICLE: '1234', ARTSY_EDITORIAL_CHANNEL: '5759e3efb5989e6f98f77993' }
     sinon.stub Backbone, 'sync'
       .returns Q.defer()
     @article = new Article
@@ -237,6 +239,16 @@ describe "Article", ->
       @article.set 'tracking_tags', ['Evergreen', 'Interviews']
       @article.set 'vertical', { name: 'Culture', id: '123' }
       @article.toJSONLD().keywords.should.eql [ 'Venice', 'Technology', 'Culture', 'Evergreen', 'Interviews' ]
+
+  describe 'date', ->
+    it 'returns NY time for editorial articles', ->
+      @article.set 'channel_id', '5759e3efb5989e6f98f77993'
+      @article.set 'date', momentTimezone().tz('America/New_York')
+      @article.date('published_at').format('MMM Do, YYYY h:mm a').should.eql  momentTimezone().tz('America/New_York').format('MMM Do, YYYY h:mm a')
+
+    it 'returns local time for non-editorial articles', ->
+      @article.set 'date', momentTimezone().tz('America/New_York')
+      @article.date('published_at').format('MMM Do, YYYY h:mm a').should.eql  moment().local().format('MMM Do, YYYY h:mm a')
 
   describe 'getParselySection', ->
 


### PR DESCRIPTION
Re: https://artsy.slack.com/archives/C04GGGDCM/p1501252422796212

Updates article model to return date in NY timezone if channel is editorial, otherwise returns local time.