### PR TITLE
Always use yarn version specified in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "engines": {
     "node": "6.x.x",
-    "npm": "4.x.x"
+    "npm": "4.x.x",
+    "yarn": "0.27.x"
   },
   "scripts": {
     "acceptance": "sh scripts/acceptance.sh",


### PR DESCRIPTION
While I was investigating the FB login issue I realized that heroku uses [a nightly version of `yarn`](https://dashboard.heroku.com/apps/force-staging/activity/builds/b6cfef18-b413-425b-9fa1-3d367454f702) (find `0.28.1`). I installed the same nightly version by [following the steps here](https://yarnpkg.com/en/docs/nightly) and was able to reproduce the same issue locally. It's possible that the nightly yarn solves or loads dependencies differently than the current stable version.

This PR adds `engines.yarn` with the latest stable version [as suggested by a heroku employee](https://github.com/heroku/heroku-buildpack-nodejs/issues/342#issuecomment-267433492).