### PR TITLE
Fix inquire via phone modal

### DIFF
--- a/desktop/analytics/artwork.js
+++ b/desktop/analytics/artwork.js
@@ -5,7 +5,7 @@
   var $document = $(document)
   $document
     .on('click', '.analytics-artwork-show-phone-number', function () {
-      analytics.track("Clicked 'Show phone number'", $(this).data())
+      analytics.track("Clicked 'Show phone number'", _.omit($(this).data(), 'partner'))
     })
     .on('click', '.analytics-artwork-download', function () {
       analytics.track('Downloaded lo-res image')

--- a/desktop/apps/artwork/components/partner_stub/index.jade
+++ b/desktop/apps/artwork/components/partner_stub/index.jade
@@ -32,6 +32,7 @@ unless artwork.is_in_auction
             class='js-artwork-partner-stub-inquire-via-phone analytics-artwork-show-phone-number garamond-s-body'
             data-partner_id= partner._id
             data-artwork_id= artwork._id
+            data-partner= partner
             data-artist_ids= artistIds
             data-user_id=(sd.CURRENT_USER && sd.CURRENT_USER.id )
             data-context='show phone number'


### PR DESCRIPTION
It turns out https://github.com/artsy/force/pull/1641 broke the Inquire via Phone modal. Instead of removing the partner object entirely from the template, we should just exclude the `partner` key explicitly before sending the data to analytics.