### PR TITLE
Fixes an issue where nav dots for testimonials weren't working

### DIFF
--- a/desktop/apps/gallery_partnerships2/client/index.coffee
+++ b/desktop/apps/gallery_partnerships2/client/index.coffee
@@ -1,4 +1,4 @@
-initCarousel = require '../../../components/merry_go_round/index.coffee'
+initCarousel = require '../../../components/merry_go_round/bottom_nav_mgr.coffee'
 sd = require('sharify').data
 
 module.exports.init = ->

--- a/desktop/apps/gallery_partnerships2/stylesheets/index.styl
+++ b/desktop/apps/gallery_partnerships2/stylesheets/index.styl
@@ -371,6 +371,11 @@ background-size-cover()
   padding 40px 0
   height inherit
   garamond-size('l-headline')
+
+  .mgr-arrow-left.icon-chevron-left
+  .mgr-arrow-right.icon-chevron-right
+    display none
+
   @media screen and (max-width: 768px)
     padding 0
     garamond-size('headline')


### PR DESCRIPTION
Right now, the navigation dots for testimonials on http://staging.artsy.net/gallery-partnerships2 are not working. This PR fixes it.