### PR TITLE
@damassi => Adds SSR for styled-components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,6 +11,9 @@
     ["module-resolver", {
       "root": ["./"]
     }],
-    "transform-class-properties"
+    "transform-class-properties",
+    ["styled-components", {
+      "ssr": true
+    }]
   ]
 }

--- a/desktop/apps/react_example/components/App.js
+++ b/desktop/apps/react_example/components/App.js
@@ -1,6 +1,7 @@
 import DOM from './DOM'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
+import styled from 'styled-components'
 
 export default class App extends Component {
   static propTypes = {
@@ -38,9 +39,9 @@ export default class App extends Component {
             Hello {name}!
           </h1>
 
-          <p>
+          <StyledParagraph>
             {description}
-          </p>
+          </StyledParagraph>
 
           <button onClick={this.handleButtonClick}>
             Click me!
@@ -61,3 +62,7 @@ export default class App extends Component {
     )
   }
 }
+
+const StyledParagraph = styled.p`
+  color: red;
+`

--- a/desktop/components/main_layout/templates/react_index.jade
+++ b/desktop/components/main_layout/templates/react_index.jade
@@ -6,7 +6,8 @@ append locals
 
 block head
   != header
-    
+  != styledComponentCSS
+
 block body
   script.
     var __BOOTSTRAP__ = !{JSON.stringify(data)}

--- a/desktop/components/main_layout/templates/react_index.jade
+++ b/desktop/components/main_layout/templates/react_index.jade
@@ -6,7 +6,7 @@ append locals
 
 block head
   != header
-  != styledComponentCSS
+  != css
 
 block body
   script.

--- a/desktop/components/react/responsive_window/test/responsive_window_spec.js
+++ b/desktop/components/react/responsive_window/test/responsive_window_spec.js
@@ -1,4 +1,5 @@
-import 'jsdom-global/register'
+import jsdom from 'jsdom-global'
+const cleanup = jsdom()
 import React from 'react'
 import ResponsiveWindow, { responsiveWindowAction, responsiveWindowReducer } from '../index'
 import sinon from 'sinon'
@@ -6,6 +7,11 @@ import { createStore } from 'redux'
 import { mount } from 'enzyme'
 
 describe('components/react/responsive_window_spec.js', () => {
+  after((done) => {
+    cleanup()
+    done()
+  })
+
   it('when desktop, isMobile is false', () => {
     const store = createStore(responsiveWindowReducer)
     store.dispatch(responsiveWindowAction(1000))

--- a/desktop/components/react/utils/renderReactLayout.js
+++ b/desktop/components/react/utils/renderReactLayout.js
@@ -121,7 +121,6 @@ export function renderReactLayout (options) {
         )
       }
     }
-
     return { html, styledComponentCSS }
   }
 

--- a/desktop/components/react/utils/renderReactLayout.js
+++ b/desktop/components/react/utils/renderReactLayout.js
@@ -66,7 +66,7 @@ export function renderReactLayout (options) {
     data
   )
 
-  const { bodyHTML, styledComponentCSS } = render(body)
+  const { bodyHTML, css } = render(body)
   const layout = renderTemplate('desktop/components/main_layout/templates/react_index.jade', {
     locals: {
       ...locals,
@@ -76,13 +76,13 @@ export function renderReactLayout (options) {
       },
       header: render(head).html,
       body: bodyHTML,
-      styledComponentCSS
+      css
     }
   })
 
   function render (block) {
     let html = ''
-    let styledComponentCSS = ''
+    let css = ''
 
     if (!block) {
       return html
@@ -105,7 +105,7 @@ export function renderReactLayout (options) {
       html = renderToString(
         sheet.collectStyles(<Component {...data} templateComponents={templateComponents} />)
       )
-      styledComponentCSS = sheet.getStyleTags()
+      css = sheet.getStyleTags()
 
       // String
     } else if (isString(block)) {
@@ -121,7 +121,7 @@ export function renderReactLayout (options) {
         )
       }
     }
-    return { html, styledComponentCSS }
+    return { html, css }
   }
 
   return layout

--- a/desktop/components/react/utils/test/renderLayout.test.js.js
+++ b/desktop/components/react/utils/test/renderLayout.test.js.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { renderReactLayout, __RewireAPI__ } from '../renderReactLayout'
+import styled from 'styled-components'
 
 describe('components/react/utils/renderReactLayout.js', () => {
   afterEach(() => {
@@ -26,6 +27,7 @@ describe('components/react/utils/renderReactLayout.js', () => {
     })
 
     __RewireAPI__.__Rewire__('renderToString', () => {
+      __RewireAPI__.__ResetDependency__('renderToString')
       done()
     })
 
@@ -34,6 +36,23 @@ describe('components/react/utils/renderReactLayout.js', () => {
         body: () => <div />
       }
     })
+  })
+
+  it('injects styled component styles to template head', () => {
+    const StyledDiv = styled.div`
+      color: red;
+    `
+
+    const output = renderReactLayout({
+      blocks: {
+        body: () => <StyledDiv />
+      },
+      locals: {
+        asset: () => {},
+        sd: {}
+      }
+    })
+    output.should.containEql('color: red;')
   })
 
   it('throws if trying to render a class component', () => {

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "annyang": "git://github.com/mzikherman/annyang.git",
     "antigravity": "git://github.com/artsy/antigravity.git",
     "artsy-gemini-upload": "0.0.6",
+    "babel-plugin-styled-components": "^1.1.7",
     "background-check": "git://github.com/kennethcachia/background-check",
     "benv": "^3.3.0",
     "blueimp-file-upload": "9.9.0",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "serve-favicon": "^2.3.0",
     "sharify": "^0.1.6",
     "standard": "^9.0.0",
+    "styled-components": "^2.1.1",
     "stylus": "^0.54.5",
     "superagent": "^2.3.0",
     "twilio": "^2.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -883,6 +883,12 @@ babel-plugin-rewire@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-rewire/-/babel-plugin-rewire-1.1.0.tgz#a6b966d9d8c06c03d95dcda2eec4e2521519549b"
 
+babel-plugin-styled-components@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.1.7.tgz#a92c239779cc80e7838b645c12865c61c4ca71ce"
+  dependencies:
+    stylis "^3.2.1"
+
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,13 +535,7 @@ artsy-passport@^2.0.3:
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
-artsy-xapp@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/artsy-xapp/-/artsy-xapp-1.0.4.tgz#13cc772122d1f8b8aeef6ad6555a792dffa9c3aa"
-  dependencies:
-    superagent "^1.2.0"
-
-"artsy-xapp@git://github.com/artsy/artsy-xapp.git":
+artsy-xapp@^1.0.4, "artsy-xapp@git://github.com/artsy/artsy-xapp.git":
   version "1.0.4"
   resolved "git://github.com/artsy/artsy-xapp.git#cbc3db68469054ab13bfbffe68edda422a0972bb"
   dependencies:
@@ -8304,7 +8298,7 @@ style-loader@^0.17.0:
   dependencies:
     loader-utils "^1.0.2"
 
-styled-components@^2.0.1:
+styled-components@^2.0.1, styled-components@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-2.1.1.tgz#7e9b5bc319ee3963b47aebb74f4658119ea9d484"
   dependencies:


### PR DESCRIPTION
Adds styled-components to Force and extracts the styles in `renderReactLayout.js` 

It looks like we don't need to add the babel-plugin for now -- this works without checksum errors on the react-example and the current version of article2. The checksum error we saw must have come from something I wrote in my other branch.

Thanks @damassi and @alloy for debugging/chatting about this with me!
