### PR TITLE
@kanaabe => Only add .babelrc styled-components lib in development

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,5 +12,14 @@
       "root": ["./"]
     }],
     "transform-class-properties"
-  ]
+  ],
+  "env": {
+    "development": {
+      "plugins": [
+        ["styled-components", {
+          "ssr": true
+        }]
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Fixes issue we were seeing with `NODE_ENV=production` deploys and `styled-components`. 