### PR TITLE
Add a fade effect to the testimonials

### DIFF
--- a/desktop/apps/gallery_partnerships/stylesheets/index.styl
+++ b/desktop/apps/gallery_partnerships/stylesheets/index.styl
@@ -411,6 +411,30 @@ background-size-cover()
   &__slideshow__item.js-mgr-cell.is-selected
     top 50%
     transform translateY(-50%)
+    position relative
+
+  .js-mgr-cells
+    &:before
+      z-index 1000
+      content ''
+      position absolute
+      top 0
+      left 0
+      width 10px
+      height 100%
+      background -webkit-linear-gradient(to right, #f8f8f8, transparent)
+      background linear-gradient(to right, #f8f8f8, transparent)
+      pointer-events none
+    &:after
+      z-index 1000
+      content ''
+      position absolute
+      top 0
+      right 0
+      width 10px
+      height 100%
+      background linear-gradient(to left, #f8f8f8, transparent)
+      pointer-events none
 
   .mgr-dot
     color #E5E5E5


### PR DESCRIPTION
[As requested here](https://github.com/artsy/collector-experience/issues/447), this PR adds a fade effect to the testimonials:

<img width="1125" alt="screen shot 2017-08-07 at 20 43 31" src="https://user-images.githubusercontent.com/386234/29052048-3b36ba00-7bb5-11e7-8f5a-411d17537c21.png">

