### PR TITLE
@craigspaeth => Add additional responsive breakpoints

### DIFF
--- a/desktop/apps/auction2/components/artwork_browser/ArtworkBrowser.styl
+++ b/desktop/apps/auction2/components/artwork_browser/ArtworkBrowser.styl
@@ -1,7 +1,6 @@
 .auction2-ArtworkBrowser
   display flex
   clear both
-  min-width 950px
   margin-top 20px
   border-top 1px solid gray-lighter-color
 

--- a/desktop/apps/auction2/stylesheets/index.styl
+++ b/desktop/apps/auction2/stylesheets/index.styl
@@ -37,6 +37,13 @@
     #main-layout-header
       display block
 
+    #main-layout-footer
+      display block
+
+    #recently-viewed-artworks
+      display none
+
+
 .auction2-page
   clearfix()
 

--- a/desktop/apps/order/stylesheets/mobile.styl
+++ b/desktop/apps/order/stylesheets/mobile.styl
@@ -1,7 +1,7 @@
 default-mobile-width = 400px
 
-@media screen and (max-device-width: 768px)
-  html, body
+.order-body
+  @media screen and (max-device-width: 768px)
     min-height 1024px
     #order-page
       .order-page-content
@@ -14,8 +14,8 @@ default-mobile-width = 400px
       .order-summary
         margin-left 50px
 
-@media screen and (max-device-width: 480px)
-  html, body
+.order-body
+  @media screen and (max-device-width: 480px)
     height 100%
     width 100%
     -webkit-text-size-adjust none

--- a/desktop/apps/order/templates/checkout.jade
+++ b/desktop/apps/order/templates/checkout.jade
@@ -2,6 +2,7 @@ extends ../../../components/main_layout/templates/minimal_header
 
 append locals
   - assetPackage = 'artists_artworks'
+  - bodyClass = 'order-body'
 
 block body
   #order-page

--- a/desktop/apps/order/templates/shipping.jade
+++ b/desktop/apps/order/templates/shipping.jade
@@ -2,6 +2,7 @@ extends ../../../components/main_layout/templates/minimal_header
 
 append locals
   - assetPackage = 'artists_artworks'
+  - bodyClass = 'order-body'
 
 block body
   #order-page

--- a/desktop/components/react/responsive_window/index.js
+++ b/desktop/components/react/responsive_window/index.js
@@ -5,7 +5,9 @@ import { composeReducers } from 'desktop/components/react/utils/composeReducers'
 import { connect } from 'react-redux'
 import { debounce } from 'underscore'
 
-const MOBILE_BREAKPOINT = 640
+// Set responsive-breakpoint width. Must match value found at
+// desktop/components/stylus_lib/index.styl#25 (responsive-mobile-width - 1).
+const MOBILE_BREAKPOINT = 767
 
 // Actions
 const RESIZE_WINDOW = 'RESIZE_WINDOW'

--- a/desktop/components/stylus_lib/index.styl
+++ b/desktop/components/stylus_lib/index.styl
@@ -21,8 +21,8 @@ home-logo-size = 52px
 layout-side-margin = 55px
 main-header-height = 53px
 nav-bar-break = 550px
-responsive-mobile-width = 640px
 welcome-header-height = 85px
+responsive-mobile-width = 768px
 
 // Colors
 json('../../../node_modules/artsy-ezel-components/stylus_lib/colors.json')


### PR DESCRIPTION
This PR accommodates a few different orientations for `/auctions2/id`, namely iPad-like dimensions (which orient as desktop mode) and iPhone portrait / landscape. 

Breakpoints for mobile start at 768px. 

Additionally 
- The route `/orders` has been modified so that its responsive css does not leak into the global scope 
- A footer has been added to the mobile `auctions/:id` view. 

#### iPhone Portrait 

<img width="376" alt="screen shot 2017-08-08 at 4 38 58 pm" src="https://user-images.githubusercontent.com/236943/29099247-0f8381d2-7c59-11e7-897e-0b1227466ca8.png">

---

#### iPhone Landscape

<img width="668" alt="screen shot 2017-08-08 at 4 39 51 pm" src="https://user-images.githubusercontent.com/236943/29099255-1a65e374-7c59-11e7-8f5f-5ee001efcf16.png">

---

### iPad

<img width="1027" alt="screen shot 2017-08-08 at 4 43 01 pm" src="https://user-images.githubusercontent.com/236943/29099258-25a48042-7c59-11e7-9e68-3d9387158e01.png">

---

### Mobile Footer

<img width="582" alt="screen shot 2017-08-08 at 5 15 24 pm" src="https://user-images.githubusercontent.com/236943/29099959-4eb9f2ce-7c5d-11e7-8085-8ea951f55b66.png">

