### PR TITLE
@damassi => update width of steps and hide auctions section if there are no upcoming auctions

### DIFF
--- a/desktop/apps/consign/stylesheets/landing/desktop.styl
+++ b/desktop/apps/consign/stylesheets/landing/desktop.styl
@@ -109,6 +109,8 @@
 
     &__step
       text-align center
+      max-width 350px
+
       &__image
         max-width 100%
         display inline-block

--- a/desktop/apps/consign/templates/landing.jade
+++ b/desktop/apps/consign/templates/landing.jade
@@ -94,40 +94,40 @@ block body
                 h4.consignments-in-demand__artists__artist__name
                   = artist.get('name')
 
-      //- Upcoming sales, desktop version
-      section.consignments-section.consignments-upcoming-sales.consignments-upcoming-sales--desktop(
-        style='background-image: url(#{sections.upcoming_sales.image.src});'
-      )
-        .consignments-section__content.consignments-upcoming-sales__content
-          .consignments-section__about
-            h3.consignments-section__about__headline
-              = sections.upcoming_sales.headline
-          .consignments-upcoming-sales__sales
-            for sale in sales
-              .consignments-upcoming-sales__sales__sale
-                h5= moment(sale.start_at).format('MMM D')
-                p= sale.name
+      if sales && sales.length > 0
+        //- Upcoming sales, desktop version
+        section.consignments-section.consignments-upcoming-sales.consignments-upcoming-sales--desktop(
+          style='background-image: url(#{sections.upcoming_sales.image.src});'
+        )
+          .consignments-section__content.consignments-upcoming-sales__content
+            .consignments-section__about
+              h3.consignments-section__about__headline
+                = sections.upcoming_sales.headline
+            .consignments-upcoming-sales__sales
+              for sale in sales
+                .consignments-upcoming-sales__sales__sale
+                  h5= moment(sale.start_at).format('MMM D')
+                  p= sale.name
+              .consignments-upcoming-sales__sales__button
+                a.avant-garde-button-black.consignments-section__consign-button( href=submissionPath )
+                    = sections.upcoming_sales.button_cta
+
+        //- Upcoming sales, mobile version
+        section.consignments-section.consignments-upcoming-sales.consignments-upcoming-sales--mobile(
+          style='background-image: url(#{sections.upcoming_sales.mobile_image.src});'
+        )
+          .consignments-section__content.consignments-upcoming-sales__content
+            .consignments-section__about
+              h3.consignments-section__about__headline
+                = sections.upcoming_sales.headline
             .consignments-upcoming-sales__sales__button
               a.avant-garde-button-black.consignments-section__consign-button( href=submissionPath )
-                  = sections.upcoming_sales.button_cta
-
-      //- Upcoming sales, mobile version
-      section.consignments-section.consignments-upcoming-sales.consignments-upcoming-sales--mobile(
-        style='background-image: url(#{sections.upcoming_sales.mobile_image.src});'
-      )
-        .consignments-section__content.consignments-upcoming-sales__content
-          .consignments-section__about
-            h3.consignments-section__about__headline
-              = sections.upcoming_sales.headline
-          .consignments-upcoming-sales__sales__button
-            a.avant-garde-button-black.consignments-section__consign-button( href=submissionPath )
-              = sections.upcoming_sales.button_cta
-          .consignments-upcoming-sales__sales
-            for sale in sales
-              .consignments-upcoming-sales__sales__sale
-                h5= moment(sale.start_at).format('MMM D')
-                p= sale.name
-
+                = sections.upcoming_sales.button_cta
+            .consignments-upcoming-sales__sales
+              for sale in sales
+                .consignments-upcoming-sales__sales__sale
+                  h5= moment(sale.start_at).format('MMM D')
+                  p= sale.name
 
       //- Questions
       section.consignments-section.consignments-section__questions

--- a/desktop/apps/consign/test/routes.js
+++ b/desktop/apps/consign/test/routes.js
@@ -79,4 +79,3 @@ describe('#submissionFlowWithFetch', () => {
     res.locals.sd.SUBMISSION_ARTIST_NAME.should.eql('Andy Warhol')
   })
 })
-

--- a/desktop/apps/consign/test/templates.js
+++ b/desktop/apps/consign/test/templates.js
@@ -1,0 +1,49 @@
+import OrderedSets from '../../../collections/ordered_sets'
+import fs from 'fs'
+import jade from 'jade'
+import jsonData from './fixture.json'
+import moment from 'moment'
+import path from 'path'
+import { extend } from 'underscore'
+
+describe('landing page', () => {
+  let data
+
+  const render = (filename, data) => {
+    const file = `${path.resolve(__dirname, '../')}/templates/${filename}.jade`
+    return jade.compile(
+      fs.readFileSync(file),
+      { filename: file }
+    )(data)
+  }
+
+  before(() => {
+    data = extend(
+      jsonData, {
+        sales: [],
+        sd: {},
+        recentlySold: [],
+        inDemand: new OrderedSets([]),
+        moment,
+        asset: () => {}
+      }
+    )
+  })
+
+  it('hides the upcoming sales section if there are no sales', () => {
+    const html = render('landing', data)
+    html.should.not.containEql('consignments-upcoming-sales__sales__sale')
+  })
+
+  it('hides the upcoming sales section if sales is null', () => {
+    data.sales = null
+    const html = render('landing', data)
+    html.should.not.containEql('consignments-upcoming-sales__sales__sale')
+  })
+
+  it('shows the upcoming sales section if there is a sale', () => {
+    data.sales = [{ name: 'Sarah Evening Sale', start_at: moment.now() }]
+    const html = render('landing', data)
+    html.should.containEql('consignments-upcoming-sales__sales__sale')
+  })
+})


### PR DESCRIPTION
This PR hides the "your work could be in upcoming sales!" section in the case where there are no upcoming sales (probably an edge case at this point since we run so many! but still possible).

It also fixes the spacing on the landing page re https://github.com/artsy/consignments/issues/59:
![image](https://user-images.githubusercontent.com/2081340/29141466-5e59f200-7d1c-11e7-8bcd-ec9a5cc8753a.png)
