### PR TITLE
Fixes unwanted dark bars on the new gallery partnerships page

### DIFF
--- a/desktop/apps/gallery_partnerships/stylesheets/index.styl
+++ b/desktop/apps/gallery_partnerships/stylesheets/index.styl
@@ -413,28 +413,28 @@ background-size-cover()
     transform translateY(-50%)
     position relative
 
-  .js-mgr-cells
-    &:before
-      z-index 1000
-      content ''
-      position absolute
-      top 0
-      left 0
-      width 10px
-      height 100%
-      background -webkit-linear-gradient(to right, #f8f8f8, transparent)
-      background linear-gradient(to right, #f8f8f8, transparent)
-      pointer-events none
-    &:after
-      z-index 1000
-      content ''
-      position absolute
-      top 0
-      right 0
-      width 10px
-      height 100%
-      background linear-gradient(to left, #f8f8f8, transparent)
-      pointer-events none
+  @media screen and (min-width: 768px)
+    .js-mgr-cells
+      &:before
+        z-index 1000
+        content ''
+        position absolute
+        top 0
+        left 0
+        width 10px
+        height 100%
+        background linear-gradient(to right, #f8f8f8, transparent)
+        pointer-events none
+      &:after
+        z-index 1000
+        content ''
+        position absolute
+        top 0
+        right 0
+        width 10px
+        height 100%
+        background linear-gradient(to left, #f8f8f8, transparent)
+        pointer-events none
 
   .mgr-dot
     color #E5E5E5

--- a/desktop/apps/gallery_partnerships/stylesheets/index.styl
+++ b/desktop/apps/gallery_partnerships/stylesheets/index.styl
@@ -423,7 +423,7 @@ background-size-cover()
         left 0
         width 10px
         height 100%
-        background linear-gradient(to right, #f8f8f8, transparent)
+        background linear-gradient(to right, rgba(248,248,248,1), rgba(248,248,248,0))
         pointer-events none
       &:after
         z-index 1000
@@ -433,7 +433,7 @@ background-size-cover()
         right 0
         width 10px
         height 100%
-        background linear-gradient(to left, #f8f8f8, transparent)
+        background linear-gradient(to left, rgba(248,248,248,1), rgba(248,248,248,0))
         pointer-events none
 
   .mgr-dot


### PR DESCRIPTION
This PR addresses two issues:

 * removes the fade effects from mobile screens on any browser
 * removes the unwanted dark bars and shows proper fade effects to the testimonial section on safari

closes https://github.com/artsy/collector-experience/issues/467

### Desktop:

![screen shot 2017-08-10 at 6 08 00 pm](https://user-images.githubusercontent.com/386234/29194320-ffbbb0ae-7df6-11e7-9b64-93b7bbe47421.png)

### Mobile:

![screen shot 2017-08-10 at 6 08 14 pm](https://user-images.githubusercontent.com/386234/29194317-fcb7e6fc-7df6-11e7-823f-c69ac6c2a4a9.png)
