### PR TITLE
@cavvia => Link to the partner if possible (underline on hover) in show listings

### DIFF
--- a/desktop/apps/artist/queries/show_fragment.coffee
+++ b/desktop/apps/artist/queries/show_fragment.coffee
@@ -8,6 +8,8 @@ module.exports =
       }
       ... on Partner {
         name
+        is_linkable
+        href
       }
     }
     city

--- a/desktop/apps/artist/stylesheets/sections.styl
+++ b/desktop/apps/artist/stylesheets/sections.styl
@@ -34,6 +34,12 @@
   flex-direction row
   &__text
     margin-left 13px
+    &__partner-name
+      display inline-block
+      a
+        text-decoration none
+        &:hover
+          text-decoration underline
     &__show-name
       display inline-block
       font-style italic

--- a/desktop/apps/artist/templates/sections/cv_item.jade
+++ b/desktop/apps/artist/templates/sections/cv_item.jade
@@ -1,9 +1,17 @@
-mixin showItem(show, trailingText)
+mixin showItem(show)
   .artist-cv-link
     .artist-cv-link__date= showHelpers.date(show.start_at).year()
     .artist-cv-link__text
-      if trailingText
-        = trailingText + ", "
+      if !show.fair && show.partner && show.partner.name
+        .artist-cv-link__text__partner-name
+          if show.partner.is_linkable && show.partner.href
+            a(href= show.partner.href)
+              = show.partner.name
+          else
+            = show.partner.name
+          | ,&nbsp;
+      if showHelpers.showOrFairLocation(show)
+        = showHelpers.showOrFairLocation(show) + ", "
       .artist-cv-link__text__show-name
         if show.href
           a(href= show.href)= show.name

--- a/desktop/apps/artist/templates/sections/exhibition_highlights.jade
+++ b/desktop/apps/artist/templates/sections/exhibition_highlights.jade
@@ -3,7 +3,7 @@ include ./cv_item
 if shows.highlights && shows.highlights.length
   h2 Exhibition Highlights
   each show in shows.highlights
-    +showItem(show, show.fair ? showHelpers.showOrFairLocation(show) : showHelpers.partnerNameAndLocation(show))
+    +showItem(show)
 
   .exibition-highlights-see-more
     button.avant-garde-button-white.is-small

--- a/desktop/apps/artist/templates/sections/show_groupings.jade
+++ b/desktop/apps/artist/templates/sections/show_groupings.jade
@@ -2,16 +2,16 @@ if solo_shows && solo_shows.length
   .bisected-header-cell-section
     h2 Solo Shows
     for show in solo_shows
-      +showItem(show, showHelpers.partnerNameAndLocation(show))
+      +showItem(show)
 
 if group_shows && group_shows.length
   .bisected-header-cell-section
     h2 Group Shows
     for show in group_shows
-      +showItem(show, showHelpers.partnerNameAndLocation(show))
+      +showItem(show)
 
 if fair_booths && fair_booths.length
   .bisected-header-cell-section
     h2 Fair History on Artsy
     for show in fair_booths
-      +showItem(show, showHelpers.showOrFairLocation(show))
+      +showItem(show)

--- a/desktop/apps/artwork/components/artists/index.styl
+++ b/desktop/apps/artwork/components/artists/index.styl
@@ -58,6 +58,12 @@
 
 .artwork-artist__exhibition-highlights__item__text
   margin-left 13px
+  &__partner-name
+    display inline-block
+    a
+      text-decoration none
+      &:hover
+        text-decoration underline
   &__show-name
     display inline-block
     font-style italic

--- a/desktop/apps/artwork/components/artists/query.coffee
+++ b/desktop/apps/artwork/components/artists/query.coffee
@@ -21,9 +21,14 @@ module.exports = """
           }
           ... on Partner {
             name
+            is_linkable
+            href
           }
         }
         city
+        fair {
+          id
+        }
       }
       articles {
         thumbnail_image {

--- a/desktop/apps/artwork/components/artists/templates/exhibition.jade
+++ b/desktop/apps/artwork/components/artists/templates/exhibition.jade
@@ -1,9 +1,17 @@
-mixin showItem(show, trailingText)
+mixin showItem(show)
   .artwork-artist__content__exhibition-highlights__item
     .artwork-artist__content__exhibition-highlights__item__date= helpers.artists.showHelpers.date(show.start_at).year()
     .artwork-artist__exhibition-highlights__item__text
-      if trailingText
-        = trailingText + ", "
+      if !show.fair && show.partner && show.partner.name
+        .artwork-artist__exhibition-highlights__item__text__partner-name
+          if show.partner.is_linkable && show.partner.href
+            a(href= show.partner.href)
+              = show.partner.name
+          else
+            = show.partner.name
+          | ,&nbsp;
+      if helpers.artists.showHelpers.showOrFairLocation(show)
+        = helpers.artists.showHelpers.showOrFairLocation(show) + ", "
       .artwork-artist__exhibition-highlights__item__text__show-name
         if show.href
           a(href= show.href)= show.name
@@ -15,19 +23,19 @@ if shows.solo && shows.solo.length
   .artwork-artist-header-cell-section
     h2 Solo Shows
     for show in helpers.artists.sortExhibitions(shows.solo)
-      +showItem(show, helpers.artists.showHelpers.partnerNameAndLocation(show))
+      +showItem(show)
 
 if shows.group && shows.group.length
   .artwork-artist-header-cell-section
     h2 Group Shows
     for show in helpers.artists.sortExhibitions(shows.group)
-      +showItem(show, helpers.artists.showHelpers.partnerNameAndLocation(show))
+      +showItem(show)
 
 if shows.fair && shows.fair.length
   .artwork-artist-header-cell-section
     h2 Fair History on Artsy
     for show in helpers.artists.sortExhibitions(shows.fair)
-      +showItem(show, helpers.artists.showHelpers.showOrFairLocation(show))
+      +showItem(show)
 
 if artist.exhibition_highlights.length > 15
   a.artwork-artist__content__exhibition-highlights__cv(href=artist.href + '/cv')

--- a/desktop/apps/artwork/components/artists/templates/highlights.jade
+++ b/desktop/apps/artwork/components/artists/templates/highlights.jade
@@ -2,4 +2,4 @@
   h2 Exhibition Highlights
 
   for show in helpers.artists.sortExhibitions(artist.exhibition_highlights.slice(0,5))
-    +showItem(show, helpers.artists.showHelpers.partnerNameAndLocation(show))
+    +showItem(show)


### PR DESCRIPTION
<img width="671" alt="screen shot 2017-08-14 at 3 07 26 pm" src="https://user-images.githubusercontent.com/1457859/29287707-6480ce60-8104-11e7-9454-9365a575a0d5.png">

(had my mouse hovered over the first underlined partner in the pic ^)

This links to the partner (when possible), and adds an underline on hover. Refactored some of the helper code as well.

Last thing for Force in the re-formatting is to maybe hide the year's / organize by section- still waiting confirmation, can be in a later PR. 