### PR TITLE
@craigspaeth => remove excessive artworks fetch on artist page

### DIFF
--- a/desktop/analytics/criteo.js
+++ b/desktop/analytics/criteo.js
@@ -114,14 +114,5 @@ if (pathSplit[1] === 'auctions') {
       { event: 'setEmail', email: userEmail },
       { event: 'viewHome' }
     )
-  } else if (pathSplit[1] === 'artist' && !pathSplit[3]) {
-    // https://www.artsy.net/artist/:artist_id - (ARTWORKS viewList)
-    //              0          1         2
-    window.criteo_q.push(
-      { event: 'setAccount', account: sd.CRITEO_ARTWORKS_ACCOUNT_NUMBER },
-      { event: 'setSiteType', type: 'd' },
-      { event: 'setEmail', email: userEmail },
-      { event: 'viewList', item: _.pluck(sd.ARTIST._artworks, '_id') }
-    )
   }
 }

--- a/desktop/apps/artist/queries/server.coffee
+++ b/desktop/apps/artist/queries/server.coffee
@@ -18,9 +18,6 @@ module.exports = """
         text
         credit
       }
-      _artworks: artworks(size: 50, filter: IS_FOR_SALE) {
-        _id
-      }
       counts {
         follows
         artworks


### PR DESCRIPTION
We were fetching 50 `for_sale` artworks on every artist page reload (from any tab) in order to ping criteo. Since we're not using this feed feature anymore, we can improve our load time a bit by removing.