### PR TITLE
@kanaabe => Add styles and tests to /categories3

### DIFF
--- a/desktop/apps/categories3/components/App.js
+++ b/desktop/apps/categories3/components/App.js
@@ -6,9 +6,9 @@ import GeneFamilyNav from './GeneFamilyNav'
 import TAGPContent from './TAGPContent'
 
 const Layout = styled.div`
-  background: yellow;
   display: flex;
   justify-content: space-between;
+  padding-top: 40px;
 `
 class App extends Component {
   static propTypes = {

--- a/desktop/apps/categories3/components/App.js
+++ b/desktop/apps/categories3/components/App.js
@@ -1,8 +1,15 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
 import GeneFamilyNav from './GeneFamilyNav'
 import TAGPContent from './TAGPContent'
 
+const Layout = styled.div`
+  background: yellow;
+  display: flex;
+  justify-content: space-between;
+`
 class App extends Component {
   static propTypes = {
     geneFamilies: PropTypes.array.isRequired
@@ -11,10 +18,10 @@ class App extends Component {
   render() {
     const { geneFamilies } = this.props
     return (
-      <div>
+      <Layout>
         <GeneFamilyNav geneFamilies={geneFamilies} />
         <TAGPContent geneFamilies={geneFamilies} />
-      </div>
+      </Layout>
     )
   }
 }

--- a/desktop/apps/categories3/components/Gene.js
+++ b/desktop/apps/categories3/components/Gene.js
@@ -1,16 +1,29 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
 
 const propTypes = {
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired
 }
 
+const GeneLI = styled.li`
+  line-height: 2em;
+`
+const GeneA = styled.a`
+  text-decoration: none;
+
+  &:hover {
+    color: purple;
+  }
+`
 const Gene = ({ id, name }) => {
   return (
-    <li>
-      {name}
-    </li>
+    <GeneLI>
+      <GeneA href='#'>
+        {name}
+      </GeneA>
+    </GeneLI>
   )
 }
 

--- a/desktop/apps/categories3/components/Gene.js
+++ b/desktop/apps/categories3/components/Gene.js
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
+import colors from '@artsy/reaction-force/dist/assets/colors'
+
 const propTypes = {
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired
@@ -16,7 +18,7 @@ const GeneLink = styled.a`
   text-decoration: none;
 
   &:hover {
-    color: purple;
+    color: ${colors.purpleRegular};
   }
 `
 const Gene = ({ id, name }) => {

--- a/desktop/apps/categories3/components/Gene.js
+++ b/desktop/apps/categories3/components/Gene.js
@@ -7,10 +7,12 @@ const propTypes = {
   name: PropTypes.string.isRequired
 }
 
-const GeneLI = styled.li`
-  line-height: 2em;
+const GeneItem = styled.li`
+  font-size: 20px;
+  line-height: 1.33em;
+  margin-bottom: 0.66em;
 `
-const GeneA = styled.a`
+const GeneLink = styled.a`
   text-decoration: none;
 
   &:hover {
@@ -19,11 +21,11 @@ const GeneA = styled.a`
 `
 const Gene = ({ id, name }) => {
   return (
-    <GeneLI>
-      <GeneA href='#'>
+    <GeneItem>
+      <GeneLink href={`/gene/${id}`}>
         {name}
-      </GeneA>
-    </GeneLI>
+      </GeneLink>
+    </GeneItem>
   )
 }
 

--- a/desktop/apps/categories3/components/GeneFamily.js
+++ b/desktop/apps/categories3/components/GeneFamily.js
@@ -29,7 +29,7 @@ const GeneList = styled.ul`
 const GeneFamily = ({ id, name, genes }) => {
   const sortedGenes = alphabetizeGenes(genes)
   return (
-    <div>
+    <div id={id}>
       <GeneFamilyName>
         {name}
       </GeneFamilyName>

--- a/desktop/apps/categories3/components/GeneFamily.js
+++ b/desktop/apps/categories3/components/GeneFamily.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import Gene from './Gene'
-import { alphabetizeGenes } from '../helpers/utils.js'
+import alphabetizeGenes from '../helpers/alphabetizeGenes'
 
 const propTypes = {
   id: PropTypes.string.isRequired,

--- a/desktop/apps/categories3/components/GeneFamily.js
+++ b/desktop/apps/categories3/components/GeneFamily.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
 import Gene from './Gene'
 
 const propTypes = {
@@ -8,15 +10,30 @@ const propTypes = {
   genes: PropTypes.array.isRequired
 }
 
+const GeneFamilyName = styled.h2`
+  font-size: 37px;
+  line-height: 1.2em;
+`
+
+const GeneList = styled.ul`
+  margin: 1.5em 0;
+  column-count: 1;
+
+  @media (min-width: 768px) {
+    column-count: 3;
+    column-gap: 2em;
+  }
+`
+
 const GeneFamily = ({ id, name, genes }) => {
   return (
     <div>
-      <h2>
+      <GeneFamilyName>
         {name}
-      </h2>
-      <ul>
+      </GeneFamilyName>
+      <GeneList>
         {genes.map(gene => <Gene key={gene.id} {...gene} />)}
-      </ul>
+      </GeneList>
     </div>
   )
 }

--- a/desktop/apps/categories3/components/GeneFamily.js
+++ b/desktop/apps/categories3/components/GeneFamily.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import Gene from './Gene'
+import { alphabetizeGenes } from '../helpers/utils.js'
 
 const propTypes = {
   id: PropTypes.string.isRequired,
@@ -26,13 +27,14 @@ const GeneList = styled.ul`
 `
 
 const GeneFamily = ({ id, name, genes }) => {
+  const sortedGenes = alphabetizeGenes(genes)
   return (
     <div>
       <GeneFamilyName>
         {name}
       </GeneFamilyName>
       <GeneList>
-        {genes.map(gene => <Gene key={gene.id} {...gene} />)}
+        {sortedGenes.map(gene => <Gene key={gene.id} {...gene} />)}
       </GeneList>
     </div>
   )

--- a/desktop/apps/categories3/components/GeneFamilyNav.js
+++ b/desktop/apps/categories3/components/GeneFamilyNav.js
@@ -6,19 +6,25 @@ const propTypes = {
   geneFamilies: PropTypes.array.isRequired
 }
 
-const Sidebar = styled.aside`
-  width: 24%;
-  background: pink'
+const ResponsiveSidebar = styled.aside`
+  background: pink;
+  display: none;
+
+  @media (min-width: 768px) {
+    display: block;
+    width: 24%;
+    overflow: hidden;
+  }
 `
 
 const GeneFamilyList = styled.ul`
   position: fixed;
   width: inherit;
   padding-right: 2em;
-  `
+`
 const GeneFamilyNav = ({ geneFamilies }) => {
   return (
-    <Sidebar>
+    <ResponsiveSidebar>
       <GeneFamilyList>
         {geneFamilies.map(geneFamily =>
           <li key={geneFamily.id}>
@@ -26,7 +32,7 @@ const GeneFamilyNav = ({ geneFamilies }) => {
           </li>
         )}
       </GeneFamilyList>
-    </Sidebar>
+    </ResponsiveSidebar>
   )
 }
 

--- a/desktop/apps/categories3/components/GeneFamilyNav.js
+++ b/desktop/apps/categories3/components/GeneFamilyNav.js
@@ -1,15 +1,32 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
 
 const propTypes = {
   geneFamilies: PropTypes.array.isRequired
 }
 
+const Sidebar = styled.aside`
+  width: 24%;
+  background: pink'
+`
+
+const GeneFamilyList = styled.ul`
+  position: fixed;
+  width: inherit;
+  padding-right: 2em;
+  `
 const GeneFamilyNav = ({ geneFamilies }) => {
   return (
-    <ul>
-      {geneFamilies.map(geneFamily => <li key={geneFamily.id}>TK</li>)}
-    </ul>
+    <Sidebar>
+      <GeneFamilyList>
+        {geneFamilies.map(geneFamily =>
+          <li key={geneFamily.id}>
+            {geneFamily.name}
+          </li>
+        )}
+      </GeneFamilyList>
+    </Sidebar>
   )
 }
 

--- a/desktop/apps/categories3/components/GeneFamilyNav.js
+++ b/desktop/apps/categories3/components/GeneFamilyNav.js
@@ -2,6 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
+import colors from '@artsy/reaction-force/dist/assets/colors'
+import { primary } from '@artsy/reaction-force/dist/assets/fonts'
+
 const propTypes = {
   geneFamilies: PropTypes.array.isRequired
 }
@@ -22,12 +25,7 @@ const GeneFamilyList = styled.ul`
   width: inherit;
   padding-right: 2em;
 
-  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075',
-    'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
-  font-smoothing: antialiased;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-
+  ${primary.style}
   font-size: 13px;
   line-height: 1.33em;
 `
@@ -39,7 +37,7 @@ const GeneFamilyLink = styled.a`
   text-decoration: none;
 
   &:hover {
-    color: #6e1fff;
+    color: ${colors.purpleRegular};
   }
 `
 

--- a/desktop/apps/categories3/components/GeneFamilyNav.js
+++ b/desktop/apps/categories3/components/GeneFamilyNav.js
@@ -7,7 +7,6 @@ const propTypes = {
 }
 
 const ResponsiveSidebar = styled.aside`
-  background: pink;
   display: none;
 
   @media (min-width: 768px) {
@@ -21,15 +20,37 @@ const GeneFamilyList = styled.ul`
   position: fixed;
   width: inherit;
   padding-right: 2em;
+
+  font-family: 'ITC Avant Garde Gothic W04', 'AvantGardeGothicITCW01D 731075',
+    'AvantGardeGothicITCW01Dm', 'Helvetica', 'sans-serif';
+  font-smoothing: antialiased;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+
+  font-size: 13px;
+  line-height: 1.33em;
 `
+
+const GeneFamilyItem = styled.li`margin-bottom: 1em;`
+
+const GeneFamilyLink = styled.a`
+  transition: color 0.125s;
+
+  &:hover {
+    color: #6e1fff;
+  }
+`
+
 const GeneFamilyNav = ({ geneFamilies }) => {
   return (
     <ResponsiveSidebar>
       <GeneFamilyList>
         {geneFamilies.map(geneFamily =>
-          <li key={geneFamily.id}>
-            {geneFamily.name}
-          </li>
+          <GeneFamilyItem key={geneFamily.id}>
+            <GeneFamilyLink>
+              {geneFamily.name}
+            </GeneFamilyLink>
+          </GeneFamilyItem>
         )}
       </GeneFamilyList>
     </ResponsiveSidebar>

--- a/desktop/apps/categories3/components/GeneFamilyNav.js
+++ b/desktop/apps/categories3/components/GeneFamilyNav.js
@@ -36,6 +36,7 @@ const GeneFamilyItem = styled.li`margin-bottom: 1em;`
 
 const GeneFamilyLink = styled.a`
   transition: color 0.125s;
+  text-decoration: none;
 
   &:hover {
     color: #6e1fff;
@@ -48,7 +49,7 @@ const GeneFamilyNav = ({ geneFamilies }) => {
       <GeneFamilyList>
         {geneFamilies.map(geneFamily =>
           <GeneFamilyItem key={geneFamily.id}>
-            <GeneFamilyLink>
+            <GeneFamilyLink href={`#${geneFamily.id}`}>
               {geneFamily.name}
             </GeneFamilyLink>
           </GeneFamilyItem>

--- a/desktop/apps/categories3/components/GeneFamilyNav.js
+++ b/desktop/apps/categories3/components/GeneFamilyNav.js
@@ -13,6 +13,7 @@ const ResponsiveSidebar = styled.aside`
     display: block;
     width: 24%;
     overflow: hidden;
+    padding-top: 0.5em;
   }
 `
 

--- a/desktop/apps/categories3/components/TAGPContent.js
+++ b/desktop/apps/categories3/components/TAGPContent.js
@@ -5,19 +5,23 @@ import styled from 'styled-components'
 import TAGPIntro from './TAGPIntro'
 import GeneFamilies from './GeneFamilies'
 
-const Main = styled.main`
+const ResponsiveContent = styled.main`
   background: orange;
-  width: 74%;
+  width: 100%;
+
+  @media (min-width: 768px) {
+    width: 74%;
+  }
 `
 const propTypes = {
   geneFamilies: PropTypes.array.isRequired
 }
 const TAGPContent = ({ geneFamilies }) => {
   return (
-    <Main>
+    <ResponsiveContent>
       <TAGPIntro />
       <GeneFamilies geneFamilies={geneFamilies} />
-    </Main>
+    </ResponsiveContent>
   )
 }
 

--- a/desktop/apps/categories3/components/TAGPContent.js
+++ b/desktop/apps/categories3/components/TAGPContent.js
@@ -1,18 +1,23 @@
 import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
 import TAGPIntro from './TAGPIntro'
 import GeneFamilies from './GeneFamilies'
 
-import PropTypes from 'prop-types'
-
+const Main = styled.main`
+  background: orange;
+  width: 74%;
+`
 const propTypes = {
   geneFamilies: PropTypes.array.isRequired
 }
 const TAGPContent = ({ geneFamilies }) => {
   return (
-    <div>
+    <Main>
       <TAGPIntro />
       <GeneFamilies geneFamilies={geneFamilies} />
-    </div>
+    </Main>
   )
 }
 

--- a/desktop/apps/categories3/components/TAGPContent.js
+++ b/desktop/apps/categories3/components/TAGPContent.js
@@ -6,7 +6,6 @@ import TAGPIntro from './TAGPIntro'
 import GeneFamilies from './GeneFamilies'
 
 const ResponsiveContent = styled.main`
-  background: orange;
   width: 100%;
 
   @media (min-width: 768px) {

--- a/desktop/apps/categories3/components/TAGPIntro.js
+++ b/desktop/apps/categories3/components/TAGPIntro.js
@@ -1,14 +1,15 @@
 import React from 'react'
 import styled from 'styled-components'
 
+import { secondary } from '@artsy/reaction-force/dist/assets/fonts'
+
 const Headline = styled.h1`
   font-size: 50px;
   line-height 1em;
 `
 
 const Description = styled.p`
-  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro',
-    'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+  ${secondary.style}
   font-size: 25px;
   line-height: 1.4em;
   margin: 35px 0;

--- a/desktop/apps/categories3/components/TAGPIntro.js
+++ b/desktop/apps/categories3/components/TAGPIntro.js
@@ -1,15 +1,31 @@
 import React from 'react'
+import styled from 'styled-components'
+
+const Headline = styled.h1`
+  font-size: 50px;
+  line-height 1em;
+`
+
+const Description = styled.p`
+  font-family: 'Adobe Garamond W08', 'adobe-garamond-pro',
+    'AGaramondPro-Regular', 'Times New Roman', 'Times', 'serif';
+  font-size: 25px;
+  line-height: 1.4em;
+  margin: 35px 0;
+`
 
 const TAGPIntro = () => {
   return (
     <div>
-      <h1>The Art Genome Project</h1>
-      <p>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Sit, quidem
-        facere doloribus quisquam ducimus alias, consequuntur officia modi
-        dolores ipsam distinctio harum facilis, illum fugit ea? Quo illum esse
-        et!
-      </p>
+      <Headline>The Art Genome Project</Headline>
+      <Description>
+        The Art Genome Project is the classification system and technological
+        framework that powers Artsy. It maps the characteristics (we call them
+        &ldquo;genes&rdquo;) that connect artists, artworks, architecture, and
+        design objects across history. There are currently over 1,000
+        characteristics in The Art Genome Project, including art historical
+        movements, subject matter, and formal qualities.
+      </Description>
     </div>
   )
 }

--- a/desktop/apps/categories3/components/__tests__/App.test.js
+++ b/desktop/apps/categories3/components/__tests__/App.test.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import App from '../App'
+
+describe('Categories App', () => {
+  let app
+  let geneFamilies
+
+  beforeEach(() => {
+    geneFamilies = [
+      {
+        id: 'materials',
+        name: 'Materials',
+        genes: [
+          /* … */
+        ]
+      },
+      {
+        id: 'styles',
+        name: 'Styles',
+        genes: [
+          /* … */
+        ]
+      }
+    ]
+    app = shallow(<App geneFamilies={geneFamilies} />)
+  })
+
+  it('renders navigation', () => {
+    app.find('GeneFamilyNav').length.should.equal(1)
+  })
+
+  it('renders TAGP content', () => {
+    app.find('TAGPContent').length.should.equal(1)
+  })
+})

--- a/desktop/apps/categories3/components/__tests__/Gene.test.js
+++ b/desktop/apps/categories3/components/__tests__/Gene.test.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { render } from 'enzyme'
+import Gene from '../Gene'
+
+describe('Gene', () => {
+  let rendered
+  let gene
+
+  beforeEach(() => {
+    gene = {
+      id: 'gold',
+      name: 'Gold'
+    }
+    rendered = render(<Gene {...gene} />)
+  })
+
+  it('renders a link to the gene', () => {
+    rendered.find('a').text().should.equal('Gold')
+    rendered.find('a').attr('href').should.equal('/gene/gold')
+  })
+})

--- a/desktop/apps/categories3/components/__tests__/GeneFamilies.test.js
+++ b/desktop/apps/categories3/components/__tests__/GeneFamilies.test.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import GeneFamilies from '../GeneFamilies'
+
+describe('GeneFamilies', () => {
+  let component
+  let geneFamilies
+
+  beforeEach(() => {
+    geneFamilies = [
+      {
+        id: 'materials',
+        name: 'Materials',
+        genes: [
+          /* … */
+        ]
+      },
+      {
+        id: 'styles',
+        name: 'Styles',
+        genes: [
+          /* … */
+        ]
+      }
+    ]
+    component = shallow(<GeneFamilies geneFamilies={geneFamilies}/>)
+  })
+
+  it('renders each GeneFamily', () => {
+    component.find('GeneFamily').length.should.equal(geneFamilies.length)
+  })
+})

--- a/desktop/apps/categories3/components/__tests__/GeneFamily.test.js
+++ b/desktop/apps/categories3/components/__tests__/GeneFamily.test.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { render } from 'enzyme'
+import GeneFamily from '../GeneFamily'
+
+describe('GeneFamily', () => {
+  let rendered
+  let geneFamily
+
+  beforeEach(() => {
+    geneFamily = {
+      id: 'materials',
+      name: 'Materials',
+      genes: [
+        {
+          id: 'gold',
+          name: 'Gold'
+        },
+        {
+          id: 'silver',
+          name: 'Silver'
+        },
+        {
+          id: 'bronze',
+          name: 'Bronze'
+        }
+      ]
+    }
+    rendered = render(<GeneFamily {...geneFamily} />)
+  })
+
+  it('renders a family name heading', () => {
+    rendered.find('h2').text().should.equal('Materials')
+  })
+
+  it('renders a list of genes', () => {
+    rendered.find('ul').length.should.equal(1)
+    rendered.find('li').length.should.equal(3)
+  })
+
+  it('alphabetizes the genes', () => {
+    rendered.find('li a').eq(0).text().should.equal('Bronze')
+    rendered.find('li a').eq(1).text().should.equal('Gold')
+    rendered.find('li a').eq(2).text().should.equal('Silver')
+  })
+})

--- a/desktop/apps/categories3/components/__tests__/GeneFamilyNav.test.js
+++ b/desktop/apps/categories3/components/__tests__/GeneFamilyNav.test.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { render } from 'enzyme'
+import GeneFamilyNav from '../GeneFamilyNav'
+
+describe('GeneFamilyNav', () => {
+  let rendered
+  let geneFamilies
+
+  beforeEach(() => {
+    geneFamilies = [
+      {
+        id: 'materials',
+        name: 'Materials',
+        genes: [
+          /* … */
+        ]
+      },
+      {
+        id: 'styles',
+        name: 'Styles',
+        genes: [
+          /* … */
+        ]
+      }
+    ]
+    rendered = render(<GeneFamilyNav geneFamilies={geneFamilies} />)
+  })
+
+  it('renders links for each family', () => {
+    rendered.find('a').length.should.equal(2)
+    rendered.find('a').eq(0).text().should.equal('Materials')
+    rendered.find('a').eq(1).text().should.equal('Styles')
+  })
+})

--- a/desktop/apps/categories3/components/__tests__/TAGPContent.test.js
+++ b/desktop/apps/categories3/components/__tests__/TAGPContent.test.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import TAGPContent from '../TAGPContent'
+
+describe('TAGPContent', () => {
+  let component
+  let geneFamilies
+
+  beforeEach(() => {
+    geneFamilies = [
+      {
+        id: 'materials',
+        name: 'Materials',
+        genes: [
+          /* … */
+        ]
+      },
+      {
+        id: 'styles',
+        name: 'Styles',
+        genes: [
+          /* … */
+        ]
+      }
+    ]
+    component = shallow(<TAGPContent geneFamilies={geneFamilies} />)
+  })
+
+  it('renders the intro to TAGP', () => {
+    component.find('TAGPIntro').length.should.equal(1)
+  })
+
+  it('renders the gene families listing', () => {
+    component.find('GeneFamilies').length.should.equal(1)
+  })
+})

--- a/desktop/apps/categories3/components/__tests__/TAGPIntro.test.js
+++ b/desktop/apps/categories3/components/__tests__/TAGPIntro.test.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render } from 'enzyme'
+import TAGPIntro from '../TAGPIntro'
+
+describe('TAGPIntro', () => {
+  let rendered
+
+  beforeEach(() => {
+    rendered = render(<TAGPIntro />)
+
+  })
+
+  it('includes the description', () => {
+    rendered.text().should.match(/The Art Genome Project/)
+  })
+})

--- a/desktop/apps/categories3/helpers/alphabetizeGenes.js
+++ b/desktop/apps/categories3/helpers/alphabetizeGenes.js
@@ -1,0 +1,3 @@
+import _ from 'underscore'
+
+export default genes => _.sortBy(genes, gene => gene.name)

--- a/desktop/apps/categories3/helpers/utils.js
+++ b/desktop/apps/categories3/helpers/utils.js
@@ -1,0 +1,3 @@
+import _ from 'underscore'
+
+export const alphabetizeGenes = genes => _.sortBy(genes, gene => gene.name)

--- a/desktop/apps/categories3/helpers/utils.js
+++ b/desktop/apps/categories3/helpers/utils.js
@@ -1,3 +1,0 @@
-import _ from 'underscore'
-
-export const alphabetizeGenes = genes => _.sortBy(genes, gene => gene.name)

--- a/desktop/apps/categories3/routes.test.js
+++ b/desktop/apps/categories3/routes.test.js
@@ -9,7 +9,7 @@ let req
 let res
 let next
 let geneFamiliesQuery
-let renderReactLayout
+let renderLayout
 
 describe('#index', () => {
   beforeEach(() => {
@@ -42,8 +42,8 @@ describe('#index', () => {
       sinon.stub().returns(Promise.resolve(geneFamiliesQuery))
     )
 
-    renderReactLayout = sinon.stub()
-    RoutesRewireApi.__Rewire__('renderReactLayout', renderReactLayout)
+    renderLayout = sinon.stub()
+    RoutesRewireApi.__Rewire__('renderLayout', renderLayout)
   })
 
   afterEach(() => {
@@ -52,15 +52,15 @@ describe('#index', () => {
 
   it('renders the categories app', () => {
     index(req, res, next).then(() => {
-      renderReactLayout.args[0][0].blocks.body.should.equal(App)
-      renderReactLayout.args[0][0].locals.assetPackage.should.equal(
+      renderLayout.args[0][0].blocks.body.should.equal(App)
+      renderLayout.args[0][0].locals.assetPackage.should.equal(
         'categories3'
       )
     })
   })
   it('passes the correct variables', () => {
     index(req, res, next).then(() => {
-      renderReactLayout.args[0][0].data.geneFamilies.should.equal(
+      renderLayout.args[0][0].data.geneFamilies.should.equal(
         geneFamiliesQuery.gene_families
       )
     })


### PR DESCRIPTION
This introduces Styled Components to /categories3 in order to specify the broad responsive layout as well as the specific component styles.

![cat3](https://user-images.githubusercontent.com/140521/29688193-db9a0206-88ec-11e7-90ca-cf6f6173516a.gif)


Also adds tests coverage for the React components, with a mix of shallow and static rendering via Enzyme. (The tests are mostly for rendered markup structure, and had me missing Jest snapshots 😿 )