### PR TITLE
@damassi => Alternate specification for react_example asets

### DIFF
--- a/desktop/assets/react_example.coffee
+++ b/desktop/assets/react_example.coffee
@@ -1,10 +1,7 @@
 require('backbone').$ = $
 
 routes =
-  '''
-  /react-example/
-  ''': require('../apps/react_example/client.js').default()
+  '/react-example': require('../apps/react_example/client.js').default()
 
-for paths, init of routes
-  for path in paths.split('\n')
-    $(init) if location.pathname.match path
+for path, init of routes
+  $(init) if location.pathname.match path


### PR DESCRIPTION
Last couple of Force deploys generated empty assets, also saw some errors in the Circle console:

<img width="494" alt="screen shot 2017-08-21 at 4 21 54 pm" src="https://user-images.githubusercontent.com/1457859/29537194-d8573bd2-868e-11e7-8d1e-649943ed7e6c.png">

Just rewrote the file to be a bit clearer, not sure if there's any actual issue here. /shrug