### PR TITLE
Only import reloadable when NODE_ENV=development

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -41,7 +41,6 @@ import CurrentUser from './current_user'
 import splitTestMiddleware from '../desktop/components/split_test/middleware'
 import marketingSignupModal from '../mobile/components/marketing_signup_modal/middleware'
 import config from '../config'
-import { createReloadable } from '@artsy/express-reloadable'
 
 const {
   API_REQUEST_TIMEOUT,
@@ -205,6 +204,7 @@ export default function (app) {
 
   // Setup hot-swap loader
   if (NODE_ENV === 'development') {
+    const { createReloadable } = require('@artsy/express-reloadable')
     const reloadAndMount = createReloadable(app, require)
 
     app.use((req, res, next) => {
@@ -228,14 +228,6 @@ export default function (app) {
     })
     app.use(require('../desktop'))
   }
-
-  // Direct mobile devices to the mobile app, otherwise fall through to
-  // the desktop app
-  app.use((req, res, next) => {
-    if (res.locals.sd.IS_MOBILE) require('../mobile')(req, res, next)
-    else next()
-  })
-  app.use(require('../desktop'))
 
   // Routes for pinging system time and up
   app.get('/system/time', (req, res) => res.send(200, { time: Date.now() }))


### PR DESCRIPTION
To make Force a little safer, this PR only `require`'s `@artsy/express-reloadable` when `NODE_ENV=development`. 