### PR TITLE
[deploy] Ensure stdin is open when invoking uglifyjs.

### DIFF
--- a/scripts/assets.sh
+++ b/scripts/assets.sh
@@ -13,7 +13,7 @@ NODE_ENV=production browserify \
   -t babelify \
   -t caching-coffeeify \
   -t jadeify \
-  -p [ factor-bundle -o 'uglifyjs -b > public/assets/`basename $FILE .coffee`.js' ] \
+  -p [ factor-bundle -o 'cat | uglifyjs -b > public/assets/`basename $FILE .coffee`.js' ] \
   | uglifyjs -b > public/assets/common.js
 stylus \
   $(find desktop/assets mobile/assets -name '*.styl') \


### PR DESCRIPTION
A naive thought is that `factor-bundle` isn’t opening `stdin` immediately
and uglifyjs isn’t taking that possibility into account, whereas `cat`
does? Not sure, although this does seem to work.