### PR TITLE
Fix wrong item width calc in GPP flickity carousels

### DIFF
--- a/desktop/apps/partner2/stylesheets/overview.styl
+++ b/desktop/apps/partner2/stylesheets/overview.styl
@@ -7,6 +7,7 @@
     margin-bottom 60px
     border-top 1px solid gray-color
     flex 0 1 100%
+    width 100%
     &:empty
       display none
     &[data-module=hero]


### PR DESCRIPTION
Reported in https://artsy.slack.com/archives/C03JWJLLH/p1503332879000518

## Problem
Upon initial load in smaller viewport, some carousels on GPP have overlapping items. Once we resized the window, it's back to normal.

## Solution

![screen shot 2017-08-22 at 12 39 15 pm](https://user-images.githubusercontent.com/796573/29577036-fcb86768-8737-11e7-8e9b-75972a031719.png)

We can simply call `flickity.resize()` immediately after initialization but it's more expensive. It turned out the initial template rendering had wrong width for the overflowing items in a flexbox item, and that caused flickity to calculate wrong item width in it's initialization.

I can reproduce the CSS problem [here](https://jsfiddle.net/uks3rh8b/3/).

_I think_ the issue was that overflowing children in a `flex-basis: 100%` flexbox item have trouble calculating their width based on percentage, and we have to explicitly specify `width: 100%` on the flexbox item again to make it work.