### PR TITLE
Display featured genes in new categories app

### DIFF
--- a/desktop/apps/categories3/components/App.js
+++ b/desktop/apps/categories3/components/App.js
@@ -12,15 +12,19 @@ const Layout = styled.div`
 `
 class App extends Component {
   static propTypes = {
-    geneFamilies: PropTypes.array.isRequired
+    geneFamilies: PropTypes.array.isRequired,
+    allFeaturedGenesByFamily: PropTypes.array.isRequired
   }
 
-  render() {
-    const { geneFamilies } = this.props
+  render () {
+    const { geneFamilies, allFeaturedGenesByFamily } = this.props
     return (
       <Layout>
         <GeneFamilyNav geneFamilies={geneFamilies} />
-        <TAGPContent geneFamilies={geneFamilies} />
+        <TAGPContent
+          geneFamilies={geneFamilies}
+          allFeaturedGenesByFamily={allFeaturedGenesByFamily}
+        />
       </Layout>
     )
   }

--- a/desktop/apps/categories3/components/FeaturedGene.js
+++ b/desktop/apps/categories3/components/FeaturedGene.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const propTypes = {
+  title: PropTypes.string,
+  href: PropTypes.string,
+  image: PropTypes.object
+}
+
+const FeaturedGene = ({ title, href, image: { url: imageSrc } }) => {
+  return (
+    <div>
+      <a href={href}>
+        {title}
+      </a>
+      <img src={imageSrc} />
+    </div>
+  )
+}
+
+FeaturedGene.propTypes = propTypes
+
+export default FeaturedGene

--- a/desktop/apps/categories3/components/FeaturedGene.js
+++ b/desktop/apps/categories3/components/FeaturedGene.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { primary } from '@artsy/reaction-force/dist/assets/fonts'
 
 const propTypes = {
   title: PropTypes.string,
@@ -7,14 +9,33 @@ const propTypes = {
   image: PropTypes.object
 }
 
+const Container = styled.div`
+  position: relative;
+  overflow: hidden;
+`
+
+const GeneLink = styled.a`
+  position: absolute;
+  left: 1em;
+  bottom: 1em;
+  text-decoration: none;
+
+  color: white;
+  text-shadow: 0 0 10px rgba(0, 0, 0, 0.7);
+
+  ${primary.style} font-size: 13px;
+  line-height: 1.33em;
+  font-weight: bold;
+`
+
+const GeneImage = styled.img`width: 90%;`
+
 const FeaturedGene = ({ title, href, image: { url: imageSrc } }) => {
   return (
-    <div>
-      <a href={href}>
-        {title}
-      </a>
-      <img src={imageSrc} />
-    </div>
+    <Container>
+      <GeneLink href={href}>{title}</GeneLink>
+      <GeneImage src={imageSrc} />
+    </Container>
   )
 }
 

--- a/desktop/apps/categories3/components/FeaturedGenes.js
+++ b/desktop/apps/categories3/components/FeaturedGenes.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
 
 import FeaturedGene from './FeaturedGene'
 
@@ -7,20 +8,27 @@ const propTypes = {
   featuredGenes: PropTypes.object
 }
 
+const Layout = styled.div`
+  padding-top: 1em;
+  column-count: 3;
+  column-gap: 2em;
+`
+
 const FeaturedGenes = ({ featuredGenes }) => {
   return (
-    <div>
+    <Layout>
       {featuredGenes
         ? featuredGenes.genes.length > 0
           ? featuredGenes.genes
               .map(featuredGene => <FeaturedGene key={featuredGene.id} {...featuredGene} />)
+              .slice(0, 3)
           : <p style={{ color: 'orange' }}>
               missing Featured Links?<br />(No featuredGenes.genes list)
             </p>
         : <p style={{ color: 'red' }}>
             missing Set?<br />(No featuredGenes object)
           </p>}
-    </div>
+    </Layout>
   )
 }
 

--- a/desktop/apps/categories3/components/FeaturedGenes.js
+++ b/desktop/apps/categories3/components/FeaturedGenes.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import FeaturedGene from './FeaturedGene'
+
+const propTypes = {
+  featuredGenes: PropTypes.object
+}
+
+const FeaturedGenes = ({ featuredGenes }) => {
+  return (
+    <div>
+      {featuredGenes
+        ? featuredGenes.genes.length > 0
+          ? featuredGenes.genes
+              .map(featuredGene => <FeaturedGene key={featuredGene.id} {...featuredGene} />)
+          : <p style={{ color: 'orange' }}>
+              missing Featured Links?<br />(No featuredGenes.genes list)
+            </p>
+        : <p style={{ color: 'red' }}>
+            missing Set?<br />(No featuredGenes object)
+          </p>}
+    </div>
+  )
+}
+
+FeaturedGenes.propTypes = propTypes
+
+export default FeaturedGenes

--- a/desktop/apps/categories3/components/GeneFamilies.js
+++ b/desktop/apps/categories3/components/GeneFamilies.js
@@ -1,17 +1,24 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+
 import GeneFamily from './GeneFamily'
+import { featuredGenesForFamily } from '../utils.js'
 
 const propTypes = {
-  geneFamilies: PropTypes.array.isRequired
+  geneFamilies: PropTypes.array.isRequired,
+  allFeaturedGenesByFamily: PropTypes.array.isRequired
 }
 
-const GeneFamilies = ({ geneFamilies }) => {
+const GeneFamilies = ({ geneFamilies, allFeaturedGenesByFamily }) => {
   return (
     <div>
-      {geneFamilies.map(geneFamily =>
-        <GeneFamily key={geneFamily.id} {...geneFamily} />
-      )}
+      {geneFamilies.map(geneFamily => {
+        const featuredGenes = featuredGenesForFamily(
+          geneFamily.name,
+          allFeaturedGenesByFamily
+        )
+        return <GeneFamily key={geneFamily.id} featuredGenes={featuredGenes} {...geneFamily} />
+      })}
     </div>
   )
 }

--- a/desktop/apps/categories3/components/GeneFamily.js
+++ b/desktop/apps/categories3/components/GeneFamily.js
@@ -3,12 +3,14 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import Gene from './Gene'
-import alphabetizeGenes from '../helpers/alphabetizeGenes'
+import { alphabetizeGenes } from '../utils.js'
+import FeaturedGenes from './FeaturedGenes'
 
 const propTypes = {
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  genes: PropTypes.array.isRequired
+  genes: PropTypes.array.isRequired,
+  featuredGenes: PropTypes.object
 }
 
 const GeneFamilyName = styled.h2`
@@ -26,13 +28,14 @@ const GeneList = styled.ul`
   }
 `
 
-const GeneFamily = ({ id, name, genes }) => {
+const GeneFamily = ({ id, name, genes, featuredGenes }) => {
   const sortedGenes = alphabetizeGenes(genes)
   return (
     <div id={id}>
       <GeneFamilyName>
         {name}
       </GeneFamilyName>
+      <FeaturedGenes featuredGenes={featuredGenes} />
       <GeneList>
         {sortedGenes.map(gene => <Gene key={gene.id} {...gene} />)}
       </GeneList>

--- a/desktop/apps/categories3/components/TAGPContent.js
+++ b/desktop/apps/categories3/components/TAGPContent.js
@@ -5,6 +5,11 @@ import styled from 'styled-components'
 import TAGPIntro from './TAGPIntro'
 import GeneFamilies from './GeneFamilies'
 
+const propTypes = {
+  geneFamilies: PropTypes.array.isRequired,
+  allFeaturedGenesByFamily: PropTypes.array.isRequired
+}
+
 const ResponsiveContent = styled.main`
   width: 100%;
 
@@ -12,14 +17,11 @@ const ResponsiveContent = styled.main`
     width: 74%;
   }
 `
-const propTypes = {
-  geneFamilies: PropTypes.array.isRequired
-}
-const TAGPContent = ({ geneFamilies }) => {
+const TAGPContent = ({ geneFamilies, allFeaturedGenesByFamily }) => {
   return (
     <ResponsiveContent>
       <TAGPIntro />
-      <GeneFamilies geneFamilies={geneFamilies} />
+      <GeneFamilies geneFamilies={geneFamilies} allFeaturedGenesByFamily={allFeaturedGenesByFamily} />
     </ResponsiveContent>
   )
 }

--- a/desktop/apps/categories3/components/__tests__/App.test.js
+++ b/desktop/apps/categories3/components/__tests__/App.test.js
@@ -5,6 +5,7 @@ import App from '../App'
 describe('Categories App', () => {
   let app
   let geneFamilies
+  let allFeaturedGenesByFamily
 
   beforeEach(() => {
     geneFamilies = [
@@ -23,7 +24,23 @@ describe('Categories App', () => {
         ]
       }
     ]
-    app = shallow(<App geneFamilies={geneFamilies} />)
+
+    allFeaturedGenesByFamily = [
+      {
+        name: 'Materials',
+        genes: [
+          /* … */
+        ]
+      },
+      {
+        name: 'Styles',
+        genes: [
+          /* … */
+        ]
+      }
+    ]
+
+    app = shallow(<App geneFamilies={geneFamilies} allFeaturedGenesByFamily={allFeaturedGenesByFamily} />)
   })
 
   it('renders navigation', () => {

--- a/desktop/apps/categories3/components/__tests__/FeaturedGene.test.js
+++ b/desktop/apps/categories3/components/__tests__/FeaturedGene.test.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { render } from 'enzyme'
+import FeaturedGene from '../FeaturedGene'
+
+describe('FeaturedGene', () => {
+  let rendered
+  let featuredGene
+
+  beforeEach(() => {
+    featuredGene = {
+      title: 'Gold',
+      href: '/gene/gold',
+      image: {
+        url: 'gold.jpg'
+      }
+    }
+
+    rendered = render(<FeaturedGene {...featuredGene} />)
+  })
+
+  it('renders a link to the gene', () => {
+    rendered.find('a').text().should.equal('Gold')
+    rendered.find('a').attr('href').should.equal('/gene/gold')
+  })
+
+  it('renders an image for the gene', () => {
+    rendered.find('img').attr('src').should.equal('gold.jpg')
+  })
+})

--- a/desktop/apps/categories3/components/__tests__/FeaturedGenes.test.js
+++ b/desktop/apps/categories3/components/__tests__/FeaturedGenes.test.js
@@ -1,0 +1,57 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import FeaturedGenes from '../FeaturedGenes'
+import FeaturedGene from '../FeaturedGene'
+
+describe('FeaturedGenes', () => {
+  let component
+  let featuredGenes
+
+  beforeEach(() => {
+    featuredGenes = {
+      name: 'Materials',
+      genes: [
+        {
+          id: 'gold',
+          title: 'Gold',
+          href: '/gene/gold',
+          image: {
+            url: 'gold.jpg'
+          }
+        },
+        {
+          id: 'silver',
+          title: 'Silver',
+          href: '/gene/silver',
+          image: {
+            url: 'silver.jpg'
+          }
+        },
+        {
+          id: 'bronze',
+          title: 'Bronze',
+          href: '/gene/bronze',
+          image: {
+            url: 'bronze.jpg'
+          }
+        },
+        {
+          id: 'wood',
+          title: 'Wood',
+          href: '/gene/wood',
+          image: {
+            url: 'wood.jpg'
+          }
+        }
+      ]
+    }
+
+    component = shallow(<FeaturedGenes featuredGenes={featuredGenes} />)
+  })
+
+  it('renders up to three featured genes', () => {
+    component.find(FeaturedGene).length.should.equal(3)
+    const titleProps = component.find(FeaturedGene).map(fg => fg.props().title)
+    titleProps.should.match(['Gold', 'Silver', 'Bronze'])
+  })
+})

--- a/desktop/apps/categories3/components/__tests__/GeneFamilies.test.js
+++ b/desktop/apps/categories3/components/__tests__/GeneFamilies.test.js
@@ -5,6 +5,7 @@ import GeneFamilies from '../GeneFamilies'
 describe('GeneFamilies', () => {
   let component
   let geneFamilies
+  let allFeaturedGenesByFamily
 
   beforeEach(() => {
     geneFamilies = [
@@ -23,7 +24,22 @@ describe('GeneFamilies', () => {
         ]
       }
     ]
-    component = shallow(<GeneFamilies geneFamilies={geneFamilies}/>)
+
+    allFeaturedGenesByFamily = [
+      {
+        name: 'Materials',
+        genes: [
+          /* … */
+        ]
+      },
+      {
+        name: 'Styles',
+        genes: [
+          /* … */
+        ]
+      }
+    ]
+    component = shallow(<GeneFamilies geneFamilies={geneFamilies} allFeaturedGenesByFamily={allFeaturedGenesByFamily} />)
   })
 
   it('renders each GeneFamily', () => {

--- a/desktop/apps/categories3/components/__tests__/GeneFamily.test.js
+++ b/desktop/apps/categories3/components/__tests__/GeneFamily.test.js
@@ -5,6 +5,7 @@ import GeneFamily from '../GeneFamily'
 describe('GeneFamily', () => {
   let rendered
   let geneFamily
+  let featuredGenes
 
   beforeEach(() => {
     geneFamily = {
@@ -25,11 +26,54 @@ describe('GeneFamily', () => {
         }
       ]
     }
-    rendered = render(<GeneFamily {...geneFamily} />)
+
+    featuredGenes = {
+      name: 'Materials',
+      genes: [
+        {
+          id: 'gold',
+          title: 'Gold',
+          href: '/gene/gold',
+          image: {
+            url: 'gold.jpg'
+          }
+        },
+        {
+          id: 'silver',
+          title: 'Silver',
+          href: '/gene/silver',
+          image: {
+            url: 'silver.jpg'
+          }
+        },
+        {
+          id: 'bronze',
+          title: 'Bronze',
+          href: '/gene/bronze',
+          image: {
+            url: 'bronze.jpg'
+          }
+        },
+        {
+          id: 'wood',
+          title: 'Wood',
+          href: '/gene/wood',
+          image: {
+            url: 'wood.jpg'
+          }
+        }
+      ]
+    }
+
+    rendered = render(<GeneFamily featuredGenes={featuredGenes} {...geneFamily} />)
   })
 
   it('renders a family name heading', () => {
     rendered.find('h2').text().should.equal('Materials')
+  })
+
+  it('renders image links for featured genes', () => {
+    rendered.find('a + img').length.should.equal(3)
   })
 
   it('renders a list of genes', () => {

--- a/desktop/apps/categories3/components/__tests__/TAGPContent.test.js
+++ b/desktop/apps/categories3/components/__tests__/TAGPContent.test.js
@@ -5,6 +5,7 @@ import TAGPContent from '../TAGPContent'
 describe('TAGPContent', () => {
   let component
   let geneFamilies
+  let allFeaturedGenesByFamily
 
   beforeEach(() => {
     geneFamilies = [
@@ -23,7 +24,26 @@ describe('TAGPContent', () => {
         ]
       }
     ]
-    component = shallow(<TAGPContent geneFamilies={geneFamilies} />)
+    allFeaturedGenesByFamily = [
+      {
+        name: 'Materials',
+        genes: [
+          /* … */
+        ]
+      },
+      {
+        name: 'Styles',
+        genes: [
+          /* … */
+        ]
+      }
+    ]
+    component = shallow(
+      <TAGPContent
+        geneFamilies={geneFamilies}
+        allFeaturedGenesByFamily={allFeaturedGenesByFamily}
+      />
+    )
   })
 
   it('renders the intro to TAGP', () => {

--- a/desktop/apps/categories3/helpers/alphabetizeGenes.js
+++ b/desktop/apps/categories3/helpers/alphabetizeGenes.js
@@ -1,3 +1,0 @@
-import _ from 'underscore'
-
-export default genes => _.sortBy(genes, gene => gene.name)

--- a/desktop/apps/categories3/queries/featuredGenes.js
+++ b/desktop/apps/categories3/queries/featuredGenes.js
@@ -1,0 +1,18 @@
+export default function FeaturedGenesQuery() {
+  return `
+  {
+    gene_families: ordered_sets(key: "browse:gene-category") {
+      name
+      genes: items {
+        ... on FeaturedLinkItem {
+          title
+          href
+          image {
+            url(version: "large_rectangle")
+          }
+        }
+      }
+    }
+  }
+  `
+}

--- a/desktop/apps/categories3/queries/featuredGenes.js
+++ b/desktop/apps/categories3/queries/featuredGenes.js
@@ -1,10 +1,11 @@
-export default function FeaturedGenesQuery() {
+export default function FeaturedGenesQuery () {
   return `
   {
     gene_families: ordered_sets(key: "browse:gene-category") {
       name
       genes: items {
         ... on FeaturedLinkItem {
+          id
           title
           href
           image {

--- a/desktop/apps/categories3/routes.js
+++ b/desktop/apps/categories3/routes.js
@@ -1,15 +1,16 @@
 import App from './components/App'
 import GeneFamiliesQuery from './queries/geneFamilies'
-import ReactDOM from 'react-dom/server'
+import FeaturedGenesQuery from './queries/featuredGenes'
 import metaphysics from 'lib/metaphysics.coffee'
-import { ServerStyleSheet } from 'styled-components'
 import { renderLayout } from '@artsy/stitch'
 
 export const index = async (req, res, next) => {
   try {
     const { gene_families: geneFamilies } = await metaphysics({
-      query: GeneFamiliesQuery(),
-      req: req
+      query: GeneFamiliesQuery()
+    })
+    const { gene_families: allFeaturedGenesByFamily } = await metaphysics({
+      query: FeaturedGenesQuery()
     })
 
     const layout = await renderLayout({
@@ -27,7 +28,8 @@ export const index = async (req, res, next) => {
         assetPackage: 'categories3'
       },
       data: {
-        geneFamilies
+        geneFamilies,
+        allFeaturedGenesByFamily
       }
     })
 

--- a/desktop/apps/categories3/utils.js
+++ b/desktop/apps/categories3/utils.js
@@ -1,0 +1,10 @@
+import _ from 'underscore'
+
+export const alphabetizeGenes = genes => _.sortBy(genes, gene => gene.name)
+
+export const featuredGenesForFamily = (familyName, featuredGenesList) => {
+  return _.find(
+    featuredGenesList,
+    featuredGenesFamily => featuredGenesFamily.name === familyName
+  )
+}


### PR DESCRIPTION
This adds the the manually curated **featured genes** for each gene family, i.e. each row of image links in the screencap below:

![feat](https://user-images.githubusercontent.com/140521/29850802-323b32b4-8cfe-11e7-8873-f74706ac1b41.gif)

This relies on the old-school manual curation method in Gravity:
- Each per-family group of featured genes is an `OrderedSet`
- Each featured gene — name + image + link — is a `FeaturedSet`

