### PR TITLE
@mzikherman => Be defensive about missing images in masonry grid

### DIFF
--- a/desktop/components/artwork_masonry/index.coffee
+++ b/desktop/components/artwork_masonry/index.coffee
@@ -6,13 +6,12 @@ module.exports = (artworks, heights = [0, 0, 0]) ->
   ]
 
   valid = ({ image }) ->
-    image.thumb.height?
+    image?.thumb?.height?
 
   artworks.map (artwork) ->
     if valid artwork
       i = heights.indexOf min heights
       heights[i] += artwork.image.thumb.height
       columns[i].push artwork
-    else
 
   { columns, heights }


### PR DESCRIPTION
Fixes https://github.com/artsy/collector-experience/issues/509

Basically, artworks with missing images will now be excluded from masonry grouping, vs causing a crash currently. The code was already being defensive about missing dimensions, but we should just be defensive about missing images entirely.