### PR TITLE
@damassi => Fix label for live auctions in preview mode

### DIFF
--- a/desktop/apps/artwork/components/auction_artworks/index.jade
+++ b/desktop/apps/artwork/components/auction_artworks/index.jade
@@ -1,15 +1,16 @@
 if artwork.auction && artwork.auction.artworks && artwork.auction.artworks.length
   - var upcomingLabel = helpers.auction_artworks.upcomingLabel
   - var auction = artwork.auction
-  - var start_at = auction.start_at 
+  - var start_at = auction.start_at
   - var end_at = auction.end_at
+  - var is_closed = auction.is_closed
   - var live_start_at = auction.live_start_at
   - var is_live_open = auction.is_live_open
   - var is_preview = auction.is_preview
   - var totalArtworks = auction.eligible_sale_artworks_count
-  
-  - var auctionLabel = upcomingLabel(start_at, end_at, live_start_at, is_live_open, is_preview)
-  
+
+  - var auctionLabel = upcomingLabel(start_at, end_at, live_start_at, is_closed, is_live_open, is_preview)
+
   section.artwork-section.artwork-auction-artworks( class='js-artwork-auction-artworks' )
     header.artwork-auction-artworks__header
       h3.artwork-auction-artworks__header__name
@@ -17,13 +18,13 @@ if artwork.auction && artwork.auction.artworks && artwork.auction.artworks.lengt
 
       a.artwork-artist-artworks__header__jump( href= auction.href )
         | View All
-        
+
     .artwork-auction-artworks__auction-name
       | #{auction.name} #{auctionLabel}
 
     - var columns = helpers.auction_artworks.masonry(auction.artworks, followed_artist_ids).columns
     include ../../../../components/artwork_masonry_4_column/index
-    
+
     .artwork-auction-artworks__view-all
       .artwork-auction-artworks__view-all__mask
       .artwork-auction-artworks__view-all__button

--- a/desktop/apps/artwork/components/auction_artworks/query.coffee
+++ b/desktop/apps/artwork/components/auction_artworks/query.coffee
@@ -10,6 +10,7 @@ module.exports.auction_artworks = """
         eligible_sale_artworks_count
         end_at
         href
+        is_closed
         is_live_open
         is_preview
         live_start_at

--- a/desktop/apps/artwork/components/auction_artworks/test/index.coffee
+++ b/desktop/apps/artwork/components/auction_artworks/test/index.coffee
@@ -1,0 +1,43 @@
+_ = require 'underscore'
+cheerio = require 'cheerio'
+path = require 'path'
+fs = require 'fs'
+jade = require 'jade'
+moment = require 'moment'
+helpers = require '../helpers'
+sinon = require 'sinon'
+
+render = ->
+  filename = path.resolve __dirname, "../index.jade"
+  jade.compile(
+    fs.readFileSync(filename),
+    { filename: filename }
+  )
+
+describe 'Auction artworks module', ->
+  describe 'when a live sale is in preview', ->
+    it 'should show a sale is opening label', ->
+      artwork = {
+        auction: {
+          is_closed: false,
+          is_live_open: false,
+          is_preview: true,
+          name: 'Phillips Prints'
+          live_start_at: "2017-08-10T16:00:00+00:00",
+          start_at: "2017-08-08T16:00:00+00:00",
+          artworks: [{ title: 'My title' }]
+        }
+      }
+      html = render()(
+        artwork: artwork
+        helpers: {
+          auction_artworks: {
+            upcomingLabel: helpers.upcomingLabel,
+            masonry: () => { columns: [] }
+          }
+        }
+        asset: (->)
+      )
+
+      $ = cheerio.load(html)
+      $('.artwork-auction-artworks__auction-name').html().should.containEql('Phillips Prints Auction opens ')


### PR DESCRIPTION
Noticed this small bug yesterday-- we weren't respecting the entire method signature of the `upcomingLabel` helper method (which is kinda long and accepts timestamps and then a bunch of booleans), which meant that when a LAI sale was in _preview_ mode, the label on the artwork page said `... Auction open for live bidding` instead of `... Auction opens Aug 8, 12:00 PM EDT`.

This fixes up the method call and adds a test.

Note that it is this component on the artwork page that I'm referencing:
![image](https://user-images.githubusercontent.com/2081340/30165815-685e49aa-93af-11e7-82a7-677daa6035ed.png)
