### PR TITLE
@kanaabe => Overflow bug

### DIFF
--- a/desktop/components/main_layout/footer/index.styl
+++ b/desktop/components/main_layout/footer/index.styl
@@ -72,6 +72,8 @@ mlf-upper-column-width = ((100% - mlf-upper-column-aside-width) / 4)
   #main-layout-footer-external
     float right
     display flex
+    position relative
+    overflow hidden
 
   .mlf-social
     display inline-block


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/1749
.screen-reader-text positioning was not acting as expected when inside a floated container, adding position relative kills the bug. 