### PR TITLE
@kanaabe => Use FeatureHeader in queries

### DIFF
--- a/desktop/apps/article2/queries/articleBody.js
+++ b/desktop/apps/article2/queries/articleBody.js
@@ -36,7 +36,7 @@ export default `
   hero_section {
     ...Image
     ...Video
-    ...on Fullscreen {
+    ...on FeatureHeader {
       type
       title
       url


### PR DESCRIPTION
Follow up for https://github.com/artsy/positron/pull/1269: uses 'FeatureHeader' instead of 'Fullscreen' in article queries.