### PR TITLE
@damassi => [consignments] always enable log in/sign up buttons

### DIFF
--- a/desktop/apps/consign/client/actions.js
+++ b/desktop/apps/consign/client/actions.js
@@ -321,6 +321,8 @@ export function ignoreRedirectOnAuth () {
 export function logIn (values, accountCreated = false) {
   return async (dispatch, getState) => {
     try {
+      dispatch(startLoading())
+
       const {
         submissionFlow: {
           redirectOnAuth
@@ -342,9 +344,11 @@ export function logIn (values, accountCreated = false) {
       dispatch(updateUser(user.body.user, accountCreated))
       redirectOnAuth && dispatch(push(stepsConfig.chooseArtist.path))
       dispatch(clearError())
+      dispatch(stopLoading())
     } catch (err) {
       const errorMessage = get(err, 'response.body.error', false)
       dispatch(updateError(errorMessage))
+      dispatch(stopLoading())
       console.error(
         '(consignments/client/actions.js @ logIn) Error:', err
       )
@@ -427,6 +431,8 @@ export function showResetPasswordSuccessMessage () {
 export function signUp (values) {
   return async (dispatch, getState) => {
     try {
+      dispatch(startLoading())
+
       const options = {
         email: values.email,
         name: values.name,
@@ -443,6 +449,7 @@ export function signUp (values) {
     } catch (err) {
       const errorMessage = get(err, 'response.body.error', false)
       dispatch(updateError(errorMessage))
+      dispatch(stopLoading())
       console.error(
         '(consignments/client/actions.js @ signUp) Error:', err
       )

--- a/desktop/apps/consign/client/actions.js
+++ b/desktop/apps/consign/client/actions.js
@@ -16,15 +16,15 @@ export const CLEAR_LOCATION_DATA = 'CLEAR_LOCATION_DATA'
 export const CLEAR_LOCATION_SUGGESTIONS = 'CLEAR_LOCATION_SUGGESTIONS'
 export const ERROR_ON_IMAGE = 'ERROR_ON_IMAGE'
 export const FREEZE_LOCATION_INPUT = 'FREEZE_LOCATION_INPUT'
+export const HIDE_LOADER = 'HIDE_LOADER'
 export const HIDE_NOT_CONSIGNING_MESSAGE = 'HIDE_NOT_CONSIGNING_MESSAGE'
 export const IGNORE_REDIRECT_ON_AUTH = 'IGNORE_REDIRECT_ON_AUTH'
 export const REMOVE_ERRORED_IMAGE = 'REMOVE_ERRORED_IMAGE'
 export const REMOVE_UPLOADED_IMAGE = 'REMOVE_UPLOADED_IMAGE'
+export const SHOW_LOADER = 'SHOW_LOADER'
 export const SHOW_NOT_CONSIGNING_MESSAGE = 'SHOW_NOT_CONSIGNING_MESSAGE'
 export const SHOW_RESET_PASSWORD_SUCCESS_MESSAGE = 'SHOW_RESET_PASSWORD_SUCCESS_MESSAGE'
-export const START_LOADING = 'START_LOADING'
 export const START_PROCESSING_IMAGE = 'START_PROCESSING_IMAGE'
-export const STOP_LOADING = 'STOP_LOADING'
 export const STOP_PROCESSING_IMAGE = 'STOP_PROCESSING_IMAGE'
 export const SUBMISSION_CREATED = 'SUBMISSION_CREATED'
 export const SUBMISSION_COMPLETED = 'SUBMISSION_COMPLETED'
@@ -161,10 +161,10 @@ export function completeSubmission () {
 
       dispatch(updateSubmission(submissionResponse.body))
       dispatch(submissionCompleted())
-      dispatch(stopLoading())
+      dispatch(hideLoader())
       dispatch(push(stepsConfig.thankYou.submissionPath.replace(':id', submissionResponse.body.id)))
     } catch (err) {
-      dispatch(stopLoading())
+      dispatch(hideLoader())
       dispatch(submissionError('convection_complete_submission'))
       dispatch(updateError('Unable to submit at this time.'))
       console.error(
@@ -200,11 +200,11 @@ export function createSubmission () {
       }
       dispatch(submissionCreated(submissionBody.body.id))
       dispatch(updateSubmission(submissionBody.body)) // update state to reflect current submission
-      dispatch(stopLoading())
+      dispatch(hideLoader())
       dispatch(push(stepsConfig.describeWork.submissionPath.replace(':id', submissionBody.body.id)))
       dispatch(push(stepsConfig.uploadPhotos.submissionPath.replace(':id', submissionBody.body.id)))
     } catch (err) {
-      dispatch(stopLoading())
+      dispatch(hideLoader())
       dispatch(submissionError('convection_create'))
       dispatch(updateError('Unable to submit at this time.'))
       console.error(
@@ -321,7 +321,7 @@ export function ignoreRedirectOnAuth () {
 export function logIn (values, accountCreated = false) {
   return async (dispatch, getState) => {
     try {
-      dispatch(startLoading())
+      dispatch(showLoader())
 
       const {
         submissionFlow: {
@@ -344,11 +344,11 @@ export function logIn (values, accountCreated = false) {
       dispatch(updateUser(user.body.user, accountCreated))
       redirectOnAuth && dispatch(push(stepsConfig.chooseArtist.path))
       dispatch(clearError())
-      dispatch(stopLoading())
+      dispatch(hideLoader())
     } catch (err) {
       const errorMessage = get(err, 'response.body.error', false)
       dispatch(updateError(errorMessage))
-      dispatch(stopLoading())
+      dispatch(hideLoader())
       console.error(
         '(consignments/client/actions.js @ logIn) Error:', err
       )
@@ -431,7 +431,7 @@ export function showResetPasswordSuccessMessage () {
 export function signUp (values) {
   return async (dispatch, getState) => {
     try {
-      dispatch(startLoading())
+      dispatch(showLoader())
 
       const options = {
         email: values.email,
@@ -449,7 +449,7 @@ export function signUp (values) {
     } catch (err) {
       const errorMessage = get(err, 'response.body.error', false)
       dispatch(updateError(errorMessage))
-      dispatch(stopLoading())
+      dispatch(hideLoader())
       console.error(
         '(consignments/client/actions.js @ signUp) Error:', err
       )
@@ -484,7 +484,7 @@ export function submitArtist () {
 export function submitDescribeWork (values) {
   return (dispatch) => {
     dispatch(clearError())
-    dispatch(startLoading())
+    dispatch(showLoader())
     dispatch(updateInputs(values)) // update the inputs
     dispatch(scrubLocation())
     dispatch(createSubmission()) // create the submission in convection
@@ -497,15 +497,15 @@ export function selectPhoto (file) {
   }
 }
 
-export function startLoading () {
+export function showLoader () {
   return {
-    type: START_LOADING
+    type: SHOW_LOADER
   }
 }
 
-export function stopLoading () {
+export function hideLoader () {
   return {
-    type: STOP_LOADING
+    type: HIDE_LOADER
   }
 }
 
@@ -535,11 +535,11 @@ export function submissionError (errorType) {
 
 export function submitPhoto () {
   return async (dispatch, getState) => {
-    dispatch(startLoading())
+    dispatch(showLoader())
     try {
       dispatch(completeSubmission())
     } catch (err) {
-      dispatch(stopLoading())
+      dispatch(hideLoader())
       dispatch(updateError('Unable to submit at this time.'))
       console.error(
         '(consignments/client/actions.js @ submitPhoto) Error:', err

--- a/desktop/apps/consign/client/reducers.js
+++ b/desktop/apps/consign/client/reducers.js
@@ -60,7 +60,7 @@ const initialState = {
     year: ''
   },
   isMobile: false,
-  loading: false,
+  isLoading: false,
   locationAutocompleteFrozen: false,
   locationAutocompleteSuggestions: [],
   locationAutocompleteValue: '',
@@ -132,6 +132,11 @@ function submissionFlow (state = initialState, action) {
         locationAutocompleteFrozen: true
       }, state)
     }
+    case actions.HIDE_LOADER: {
+      return u({
+        isLoading: false
+      }, state)
+    }
     case actions.HIDE_NOT_CONSIGNING_MESSAGE: {
       return u({
         notConsigningArtist: false
@@ -157,6 +162,11 @@ function submissionFlow (state = initialState, action) {
         uploadedImages: u.reject((ff) => ff.fileName === fileName)
       }, state)
     }
+    case actions.SHOW_LOADER: {
+      return u({
+        isLoading: true
+      }, state)
+    }
     case actions.SHOW_NOT_CONSIGNING_MESSAGE: {
       return u({
         notConsigningArtist: true
@@ -167,11 +177,6 @@ function submissionFlow (state = initialState, action) {
         resetPasswordSuccess: true
       }, state)
     }
-    case actions.START_LOADING: {
-      return u({
-        loading: true
-      }, state)
-    }
     case actions.START_PROCESSING_IMAGE: {
       const fileName = action.payload.fileName
       if (!contains(state.processingImages, fileName)) {
@@ -180,11 +185,6 @@ function submissionFlow (state = initialState, action) {
         }, state)
       }
       return state
-    }
-    case actions.STOP_LOADING: {
-      return u({
-        loading: false
-      }, state)
     }
     case actions.STOP_PROCESSING_IMAGE: {
       const fileName = action.payload.fileName

--- a/desktop/apps/consign/components/describe_work_desktop/index.js
+++ b/desktop/apps/consign/components/describe_work_desktop/index.js
@@ -18,7 +18,7 @@ export function makeDescribeWorkDesktop (initialValues = {}) {
       artistName,
       categoryOptions,
       error,
-      loading,
+      isLoading,
       handleSubmit,
       hasEditionValue,
       submitDescribeWorkAction
@@ -164,7 +164,7 @@ export function makeDescribeWorkDesktop (initialValues = {}) {
             type='submit'
           >
             {
-              loading ? <div className='loading-spinner-white' /> : 'Submit'
+              isLoading ? <div className='loading-spinner-white' /> : 'Submit'
             }
           </button>
           {
@@ -182,7 +182,7 @@ export function makeDescribeWorkDesktop (initialValues = {}) {
       artistName: state.submissionFlow.artistName,
       categoryOptions: state.submissionFlow.categoryOptions,
       error: state.submissionFlow.error,
-      loading: state.submissionFlow.loading,
+      isLoading: state.submissionFlow.isLoading,
       hasEditionValue,
       locationAutocompleteFrozen: state.submissionFlow.locationAutocompleteFrozen,
       locationAutocompleteValue: state.submissionFlow.locationAutocompleteValue
@@ -197,7 +197,7 @@ export function makeDescribeWorkDesktop (initialValues = {}) {
     artistName: PropTypes.string.isRequired,
     categoryOptions: PropTypes.array.isRequired,
     error: PropTypes.string,
-    loading: PropTypes.bool.isRequired,
+    isLoading: PropTypes.bool.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     hasEditionValue: PropTypes.bool,
     submitDescribeWorkAction: PropTypes.func.isRequired

--- a/desktop/apps/consign/components/describe_work_mobile/index.js
+++ b/desktop/apps/consign/components/describe_work_mobile/index.js
@@ -21,7 +21,7 @@ export function makeDescribeWorkMobile (initialValues = {}) {
       categoryOptions,
       error,
       hasEditionValue,
-      loading,
+      isLoading,
       handleSubmit,
       submitDescribeWorkAction
     } = props
@@ -171,7 +171,7 @@ export function makeDescribeWorkMobile (initialValues = {}) {
             type='submit'
           >
             {
-              loading ? <div className='loading-spinner-white' /> : 'Submit'
+              isLoading ? <div className='loading-spinner-white' /> : 'Submit'
             }
           </button>
           {
@@ -191,7 +191,7 @@ export function makeDescribeWorkMobile (initialValues = {}) {
       categoryOptions: state.submissionFlow.categoryOptions,
       error: state.submissionFlow.error,
       isMobile: state.submissionFlow.isMobile,
-      loading: state.submissionFlow.loading,
+      isLoading: state.submissionFlow.isLoading,
       hasEditionValue,
       locationAutocompleteFrozen: state.submissionFlow.locationAutocompleteFrozen,
       locationAutocompleteValue: state.submissionFlow.locationAutocompleteValue
@@ -207,7 +207,7 @@ export function makeDescribeWorkMobile (initialValues = {}) {
     categoryOptions: PropTypes.array.isRequired,
     error: PropTypes.string,
     hasEditionValue: PropTypes.bool,
-    loading: PropTypes.bool.isRequired,
+    isLoading: PropTypes.bool.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     submitDescribeWorkAction: PropTypes.func.isRequired
   }

--- a/desktop/apps/consign/components/log_in/index.js
+++ b/desktop/apps/consign/components/log_in/index.js
@@ -29,9 +29,8 @@ function LogIn (props) {
   const {
     error,
     handleSubmit,
+    loading,
     logInAction,
-    invalid,
-    pristine,
     updateAuthFormStateAndClearErrorAction
   } = props
 
@@ -69,10 +68,11 @@ function LogIn (props) {
         </div>
         <button
           className={b('log-in-button').mix('avant-garde-button-black')}
-          disabled={pristine || invalid}
           type='submit'
         >
-          Log In
+          {
+            loading ? <div className='loading-spinner-white' /> : 'Log In'
+          }
         </button>
         {
           error && <div className={b('error')}>{error}</div>
@@ -94,7 +94,8 @@ function LogIn (props) {
 
 const mapStateToProps = (state) => {
   return {
-    error: state.submissionFlow.error
+    error: state.submissionFlow.error,
+    loading: state.submissionFlow.loading
   }
 }
 
@@ -106,9 +107,8 @@ const mapDispatchToProps = {
 LogIn.propTypes = {
   error: PropTypes.string,
   handleSubmit: PropTypes.func.isRequired,
-  invalid: PropTypes.bool,
+  loading: PropTypes.bool.isRequired,
   logInAction: PropTypes.func.isRequired,
-  pristine: PropTypes.bool,
   updateAuthFormStateAndClearErrorAction: PropTypes.func.isRequired
 }
 

--- a/desktop/apps/consign/components/log_in/index.js
+++ b/desktop/apps/consign/components/log_in/index.js
@@ -29,7 +29,7 @@ function LogIn (props) {
   const {
     error,
     handleSubmit,
-    loading,
+    isLoading,
     logInAction,
     updateAuthFormStateAndClearErrorAction
   } = props
@@ -71,7 +71,7 @@ function LogIn (props) {
           type='submit'
         >
           {
-            loading ? <div className='loading-spinner-white' /> : 'Log In'
+            isLoading ? <div className='loading-spinner-white' /> : 'Log In'
           }
         </button>
         {
@@ -95,7 +95,7 @@ function LogIn (props) {
 const mapStateToProps = (state) => {
   return {
     error: state.submissionFlow.error,
-    loading: state.submissionFlow.loading
+    isLoading: state.submissionFlow.isLoading
   }
 }
 
@@ -107,7 +107,7 @@ const mapDispatchToProps = {
 LogIn.propTypes = {
   error: PropTypes.string,
   handleSubmit: PropTypes.func.isRequired,
-  loading: PropTypes.bool.isRequired,
+  isLoading: PropTypes.bool.isRequired,
   logInAction: PropTypes.func.isRequired,
   updateAuthFormStateAndClearErrorAction: PropTypes.func.isRequired
 }

--- a/desktop/apps/consign/components/log_in/index.styl
+++ b/desktop/apps/consign/components/log_in/index.styl
@@ -42,12 +42,7 @@
     margin-top 0px
     width 100%
     margin-bottom 10px
-
-  &__log-in-button[disabled]
-    pointer-events none
-    background-color white
-    color gray-color
-    border 1px solid gray-color
+    height 45px
 
   &__facebook-button
     display flex

--- a/desktop/apps/consign/components/sign_up/index.js
+++ b/desktop/apps/consign/components/sign_up/index.js
@@ -29,7 +29,7 @@ function SignUp (props) {
   const {
     error,
     handleSubmit,
-    loading,
+    isLoading,
     signUpAction,
     updateAuthFormStateAndClearErrorAction
   } = props
@@ -76,7 +76,7 @@ function SignUp (props) {
           type='submit'
         >
           {
-            loading ? <div className='loading-spinner-white' /> : 'Submit'
+            isLoading ? <div className='loading-spinner-white' /> : 'Submit'
           }
         </button>
         {
@@ -90,7 +90,7 @@ function SignUp (props) {
 const mapStateToProps = (state) => {
   return {
     error: state.submissionFlow.error,
-    loading: state.submissionFlow.loading
+    isLoading: state.submissionFlow.isLoading
   }
 }
 
@@ -102,7 +102,7 @@ const mapDispatchToProps = {
 SignUp.propTypes = {
   error: PropTypes.string,
   handleSubmit: PropTypes.func.isRequired,
-  loading: PropTypes.bool.isRequired,
+  isLoading: PropTypes.bool.isRequired,
   signUpAction: PropTypes.func.isRequired,
   updateAuthFormStateAndClearErrorAction: PropTypes.func.isRequired
 }

--- a/desktop/apps/consign/components/sign_up/index.js
+++ b/desktop/apps/consign/components/sign_up/index.js
@@ -29,9 +29,8 @@ function SignUp (props) {
   const {
     error,
     handleSubmit,
+    loading,
     signUpAction,
-    invalid,
-    pristine,
     updateAuthFormStateAndClearErrorAction
   } = props
 
@@ -74,10 +73,11 @@ function SignUp (props) {
         </div>
         <button
           className={b('sign-up-button').mix('avant-garde-button-black')}
-          disabled={pristine || invalid}
           type='submit'
         >
-          Submit
+          {
+            loading ? <div className='loading-spinner-white' /> : 'Submit'
+          }
         </button>
         {
           error && <div className={b('error')}>{error}</div>
@@ -89,7 +89,8 @@ function SignUp (props) {
 
 const mapStateToProps = (state) => {
   return {
-    error: state.submissionFlow.error
+    error: state.submissionFlow.error,
+    loading: state.submissionFlow.loading
   }
 }
 
@@ -101,9 +102,8 @@ const mapDispatchToProps = {
 SignUp.propTypes = {
   error: PropTypes.string,
   handleSubmit: PropTypes.func.isRequired,
-  invalid: PropTypes.bool,
+  loading: PropTypes.bool.isRequired,
   signUpAction: PropTypes.func.isRequired,
-  pristine: PropTypes.bool,
   updateAuthFormStateAndClearErrorAction: PropTypes.func.isRequired
 }
 

--- a/desktop/apps/consign/components/sign_up/index.styl
+++ b/desktop/apps/consign/components/sign_up/index.styl
@@ -42,9 +42,4 @@
     margin-top 0px
     width 100%
     margin-bottom 10px
-
-  &__sign-up-button[disabled]
-    pointer-events none
-    background-color white
-    color gray-color
-    border 1px solid gray-color
+    height 45px

--- a/desktop/apps/consign/components/upload_photo/index.js
+++ b/desktop/apps/consign/components/upload_photo/index.js
@@ -12,7 +12,7 @@ function UploadPhoto (props) {
     error,
     hideCheckbox,
     isMobile,
-    loading,
+    isLoading,
     processingImages,
     selectPhotoAction,
     skipPhotoSubmission,
@@ -82,7 +82,7 @@ function UploadPhoto (props) {
           disabled={!nextEnabled}
         >
           {
-            loading ? <div className='loading-spinner-white' /> : 'Submit'
+            isLoading ? <div className='loading-spinner-white' /> : 'Submit'
           }
         </div>
         {
@@ -97,7 +97,7 @@ const mapStateToProps = (state) => {
   return {
     error: state.submissionFlow.error,
     isMobile: state.submissionFlow.isMobile,
-    loading: state.submissionFlow.loading,
+    isLoading: state.submissionFlow.isLoading,
     processingImages: state.submissionFlow.processingImages,
     skipPhotoSubmission: state.submissionFlow.skipPhotoSubmission,
     uploadedImages: state.submissionFlow.uploadedImages
@@ -119,7 +119,7 @@ UploadPhoto.propTypes = {
   error: PropTypes.string,
   hideCheckbox: PropTypes.bool,
   isMobile: PropTypes.bool.isRequired,
-  loading: PropTypes.bool.isRequired,
+  isLoading: PropTypes.bool.isRequired,
   processingImages: PropTypes.array.isRequired,
   selectPhotoAction: PropTypes.func.isRequired,
   skipPhotoSubmission: PropTypes.bool.isRequired,

--- a/desktop/apps/consign/test/reducers.js
+++ b/desktop/apps/consign/test/reducers.js
@@ -107,7 +107,7 @@ describe('Reducers', () => {
 
         it('calls the correct actions', () => {
           const expectedActions = [
-            { type: 'START_LOADING' },
+            { type: 'SHOW_LOADER' },
             {
               type: 'UPDATE_USER',
               payload: { user: { id: 'sarah' }, accountCreated: false }
@@ -120,7 +120,7 @@ describe('Reducers', () => {
               }
             },
             { type: 'CLEAR_ERROR' },
-            { type: 'STOP_LOADING' }
+            { type: 'HIDE_LOADER' }
           ]
           store.dispatch(actions.logIn({ email: 'sarah@sarah.com', password: '1234' })).then(() => {
             store.getActions().should.eql(expectedActions)
@@ -134,13 +134,13 @@ describe('Reducers', () => {
             }
           })
           const expectedActions = [
-            { type: 'START_LOADING' },
+            { type: 'SHOW_LOADER' },
             {
               type: 'UPDATE_USER',
               payload: { user: { id: 'sarah' }, accountCreated: false }
             },
             { type: 'CLEAR_ERROR' },
-            { type: 'STOP_LOADING' }
+            { type: 'HIDE_LOADER' }
           ]
           store.dispatch(actions.logIn({ email: 'sarah@sarah.com', password: '1234' })).then(() => {
             store.getActions().should.eql(expectedActions)
@@ -214,8 +214,8 @@ describe('Reducers', () => {
 
         it('calls the correct actions', () => {
           const expectedActions = [
-            { type: 'START_LOADING' },
-            { type: 'START_LOADING' },
+            { type: 'SHOW_LOADER' },
+            { type: 'SHOW_LOADER' },
             {
               type: 'UPDATE_USER',
               payload: { user: { id: 'sarah' }, accountCreated: true }
@@ -228,7 +228,7 @@ describe('Reducers', () => {
               }
             },
             { type: 'CLEAR_ERROR' },
-            { type: 'STOP_LOADING' }
+            { type: 'HIDE_LOADER' }
           ]
           store.dispatch(actions.signUp({ name: 'Sarah', email: 'sarah@sarah.com', password: '1234' })).then(() => {
             store.getActions().should.eql(expectedActions)

--- a/desktop/apps/consign/test/reducers.js
+++ b/desktop/apps/consign/test/reducers.js
@@ -107,6 +107,7 @@ describe('Reducers', () => {
 
         it('calls the correct actions', () => {
           const expectedActions = [
+            { type: 'START_LOADING' },
             {
               type: 'UPDATE_USER',
               payload: { user: { id: 'sarah' }, accountCreated: false }
@@ -118,7 +119,8 @@ describe('Reducers', () => {
                 args: [ '/consign/submission/choose-artist' ]
               }
             },
-            { type: 'CLEAR_ERROR' }
+            { type: 'CLEAR_ERROR' },
+            { type: 'STOP_LOADING' }
           ]
           store.dispatch(actions.logIn({ email: 'sarah@sarah.com', password: '1234' })).then(() => {
             store.getActions().should.eql(expectedActions)
@@ -132,11 +134,13 @@ describe('Reducers', () => {
             }
           })
           const expectedActions = [
+            { type: 'START_LOADING' },
             {
               type: 'UPDATE_USER',
               payload: { user: { id: 'sarah' }, accountCreated: false }
             },
-            { type: 'CLEAR_ERROR' }
+            { type: 'CLEAR_ERROR' },
+            { type: 'STOP_LOADING' }
           ]
           store.dispatch(actions.logIn({ email: 'sarah@sarah.com', password: '1234' })).then(() => {
             store.getActions().should.eql(expectedActions)
@@ -210,6 +214,8 @@ describe('Reducers', () => {
 
         it('calls the correct actions', () => {
           const expectedActions = [
+            { type: 'START_LOADING' },
+            { type: 'START_LOADING' },
             {
               type: 'UPDATE_USER',
               payload: { user: { id: 'sarah' }, accountCreated: true }
@@ -221,7 +227,8 @@ describe('Reducers', () => {
                 args: [ '/consign/submission/choose-artist' ]
               }
             },
-            { type: 'CLEAR_ERROR' }
+            { type: 'CLEAR_ERROR' },
+            { type: 'STOP_LOADING' }
           ]
           store.dispatch(actions.signUp({ name: 'Sarah', email: 'sarah@sarah.com', password: '1234' })).then(() => {
             store.getActions().should.eql(expectedActions)


### PR DESCRIPTION
This PR updates the log in and sign up flows for consignments to _always_ enable the button (as opposed to before when we would only enable the button if you had entered some values for the field). I think there may be some weirdness with redux-form where it doesn't always update the `invalid` and `pristine` values when someone adds something to the form, but it's a little hard to reproduce. We heard reports of users not being able to click the button even after filling in the form, so this should fix that (or make it easier to diagnose).

Note that the form still updates to indicate which fields are `Required` after you click submit, it's just the initial disabling that I'm taking out.

New forms:
![image](https://user-images.githubusercontent.com/2081340/30343483-c584e9b6-97cb-11e7-8a07-c8131af87c26.png)

![image](https://user-images.githubusercontent.com/2081340/30343494-cae3cf9e-97cb-11e7-9a40-90437544d39d.png)
