### PR TITLE
@acjay: Updated size limit on mobile auctions fetch

### DIFF
--- a/mobile/apps/auctions/routes.coffee
+++ b/mobile/apps/auctions/routes.coffee
@@ -13,7 +13,7 @@ module.exports.index = (req, res) ->
   sales = new Sales
   sales.fetch
     cache: true
-    data: is_auction: true, published: true, size: 20, sort: '-timely_at,name'
+    data: is_auction: true, published: true, size: 100, sort: '-timely_at,name'
     success: (collection, response, options) ->
       # Fetch artworks for the sale
       Q.allSettled(sales.map (sale) ->

--- a/mobile/apps/auctions/test/routes.coffee
+++ b/mobile/apps/auctions/test/routes.coffee
@@ -26,7 +26,7 @@ describe 'Auctions routes', ->
     it 'fetches the relevant auction data and renders the index template', (done) ->
       routes.index {}, @res
       Backbone.sync.args[0][1].url.should.containEql '/api/v1/sales'
-      Backbone.sync.args[0][2].data.should.eql is_auction: true, published: true, size: 20, sort: '-timely_at,name'
+      Backbone.sync.args[0][2].data.should.eql is_auction: true, published: true, size: 100, sort: '-timely_at,name'
       Backbone.sync.args[0][2].success(@sales)
       Backbone.sync.callCount.should.equal 5
       Backbone.sync.args[1][1].url().should.containEql '/api/v1/sale/invalid-sale/sale_artworks'
@@ -56,7 +56,7 @@ describe 'Auctions routes', ->
     it 'sorts the open auctions by live_start_at or end_at', (done) ->
       routes.index {}, @res
       Backbone.sync.args[0][1].url.should.containEql '/api/v1/sales'
-      Backbone.sync.args[0][2].data.should.eql is_auction: true, published: true, size: 20, sort: '-timely_at,name'
+      Backbone.sync.args[0][2].data.should.eql is_auction: true, published: true, size: 100, sort: '-timely_at,name'
       Backbone.sync.args[0][2].success(@sales)
       Backbone.sync.callCount.should.equal 5
       Backbone.sync.args[1][1].url().should.containEql '/api/v1/sale/invalid-sale/sale_artworks'


### PR DESCRIPTION
We currently have more than 20 upcoming auctions and the most recent opening auctions are actually being cut off right now. This is a quick fix to the issue [reported in Slack](https://artsy.slack.com/archives/C0C4AJ1PF/p1505657067000028) this morning. @damassi is building a new auctions2 app that will make this code irrelevant going forward.