### PR TITLE
@damassi => Require a phone number when a consignment is submitted

### DIFF
--- a/desktop/apps/auction/routes.js
+++ b/desktop/apps/auction/routes.js
@@ -28,8 +28,6 @@ export async function index (req, res, next) {
     res.locals.sd.AUCTION = sale
     fetchUser(req, res)
 
-    console.log('me query!', MeQuery(sale.id))
-
     const { me } = await metaphysics({
       query: MeQuery(sale.id),
       req: req

--- a/desktop/apps/auction/routes.js
+++ b/desktop/apps/auction/routes.js
@@ -28,6 +28,8 @@ export async function index (req, res, next) {
     res.locals.sd.AUCTION = sale
     fetchUser(req, res)
 
+    console.log('me query!', MeQuery(sale.id))
+
     const { me } = await metaphysics({
       query: MeQuery(sale.id),
       req: req

--- a/desktop/apps/consign/client/actions.js
+++ b/desktop/apps/consign/client/actions.js
@@ -761,11 +761,11 @@ export function updateUser (user, accountCreated) {
   }
 }
 
-export function updateUserPhone (newPhone) {
+export function updateUserPhone (phone) {
   return {
     type: UPDATE_USER_PHONE,
     payload: {
-      newPhone
+      phone
     }
   }
 }

--- a/desktop/apps/consign/client/actions.js
+++ b/desktop/apps/consign/client/actions.js
@@ -49,6 +49,7 @@ export const UPDATE_STEPS_WITH_USER = 'UPDATE_STEPS_WITH_USER'
 export const UPDATE_STEPS_WITHOUT_USER = 'UPDATE_STEPS_WITHOUT_USER'
 export const UPDATE_SUBMISSION = 'UPDATE_SUBMISSION'
 export const UPDATE_USER = 'UPDATE_USER'
+export const UPDATE_USER_PHONE = 'UPDATE_USER_PHONE'
 
 // Action creators
 export function addAssetId (assetId) {
@@ -185,7 +186,6 @@ export function createSubmission () {
         }
       } = getState()
       const token = await fetchToken(user.accessToken)
-
       let submissionBody
       if (submission.id) {
         submissionBody = await request
@@ -198,6 +198,16 @@ export function createSubmission () {
                            .set('Authorization', `Bearer ${token}`)
                            .send(inputs)
       }
+      let userBody
+      // update the user's phone number if it has been changed
+      if (user.phone !== inputs.phone) {
+        userBody = await request
+                           .put(`${sd.API_URL}/api/v1/me`)
+                           .set('X-ACCESS-TOKEN', user.accessToken)
+                           .send({ phone: inputs.phone })
+        dispatch(updateUserPhone(userBody.body.phone))
+      }
+
       dispatch(submissionCreated(submissionBody.body.id))
       dispatch(updateSubmission(submissionBody.body)) // update state to reflect current submission
       dispatch(hideLoader())
@@ -747,6 +757,15 @@ export function updateUser (user, accountCreated) {
     payload: {
       user,
       accountCreated
+    }
+  }
+}
+
+export function updateUserPhone (newPhone) {
+  return {
+    type: UPDATE_USER_PHONE,
+    payload: {
+      newPhone
     }
   }
 }

--- a/desktop/apps/consign/client/reducers.js
+++ b/desktop/apps/consign/client/reducers.js
@@ -53,6 +53,7 @@ const initialState = {
     location_state: '',
     location_country: '',
     medium: '',
+    phone: '',
     provenance: '',
     signature: false,
     title: '',

--- a/desktop/apps/consign/client/reducers.js
+++ b/desktop/apps/consign/client/reducers.js
@@ -312,7 +312,7 @@ function submissionFlow (state = initialState, action) {
     case actions.UPDATE_USER_PHONE: {
       return u({
         user: {
-          phone: action.payload.newPhone
+          phone: action.payload.phone
         }
       }, state)
     }

--- a/desktop/apps/consign/client/reducers.js
+++ b/desktop/apps/consign/client/reducers.js
@@ -309,6 +309,13 @@ function submissionFlow (state = initialState, action) {
         user: action.payload.user
       }, state)
     }
+    case actions.UPDATE_USER_PHONE: {
+      return u({
+        user: {
+          phone: action.payload.newPhone
+        }
+      }, state)
+    }
     default: return state
   }
 }

--- a/desktop/apps/consign/client/validate.js
+++ b/desktop/apps/consign/client/validate.js
@@ -26,6 +26,7 @@ export function validate (values) {
     height,
     location,
     medium,
+    phone,
     title,
     width,
     year
@@ -37,6 +38,7 @@ export function validate (values) {
   if (!title) errors.title = 'Required'
   if (!year) errors.year = 'Required'
   if (!medium) errors.medium = 'Required'
+  if (!phone) errors.phone = 'Required'
   if (!height || numberWarning(height)) errors.height = 'Required'
   if (!width || numberWarning(width)) errors.width = 'Required'
   if (numberWarning(depth)) errors.depth = 'Required'

--- a/desktop/apps/consign/components/describe_work_container/index.js
+++ b/desktop/apps/consign/components/describe_work_container/index.js
@@ -10,8 +10,8 @@ function DescribeWorkContainer (props) {
   const { isMobile, phone, submission } = props
   const location = formattedLocation(submission.location_city, submission.location_state, submission.location_country)
   const populatedSubmission = isEmpty(submission)
-    ? { signature: true, authenticity_certificate: true, phone: phone }
-    : { ...submission, location }
+    ? { signature: true, authenticity_certificate: true, phone }
+    : { ...submission, location, phone }
   const relevantInputs = pick(
     populatedSubmission,
     'artist_id',

--- a/desktop/apps/consign/components/describe_work_container/index.js
+++ b/desktop/apps/consign/components/describe_work_container/index.js
@@ -7,10 +7,10 @@ import { makeDescribeWorkMobile } from '../describe_work_mobile'
 import { isEmpty, pick } from 'underscore'
 
 function DescribeWorkContainer (props) {
-  const { isMobile, submission } = props
+  const { isMobile, phone, submission } = props
   const location = formattedLocation(submission.location_city, submission.location_state, submission.location_country)
   const populatedSubmission = isEmpty(submission)
-    ? { signature: true, authenticity_certificate: true }
+    ? { signature: true, authenticity_certificate: true, phone: phone }
     : { ...submission, location }
   const relevantInputs = pick(
     populatedSubmission,
@@ -26,6 +26,7 @@ function DescribeWorkContainer (props) {
     'id',
     'location',
     'medium',
+    'phone',
     'provenance',
     'signature',
     'title',
@@ -43,6 +44,7 @@ function DescribeWorkContainer (props) {
 const mapStateToProps = (state) => {
   return {
     isMobile: state.submissionFlow.isMobile,
+    phone: state.submissionFlow.user.phone,
     submission: state.submissionFlow.submission
   }
 }
@@ -53,5 +55,6 @@ export default connect(
 
 DescribeWorkContainer.propTypes = {
   isMobile: PropTypes.bool.isRequired,
+  phone: PropTypes.string,
   submission: PropTypes.object
 }

--- a/desktop/apps/consign/components/describe_work_desktop/index.js
+++ b/desktop/apps/consign/components/describe_work_desktop/index.js
@@ -153,7 +153,7 @@ export function makeDescribeWorkDesktop (initialValues = {}) {
               />
             </div>
           </div>
-          <div className={b('row')}>
+          <div className={b('row', {'border-bottom': true})}>
             <div className={b('row-item')}>
               <div className={b('instructions')}>What city is the work located in?*</div>
               <Field name='location' component={LocationAutocomplete} />

--- a/desktop/apps/consign/components/describe_work_desktop/index.js
+++ b/desktop/apps/consign/components/describe_work_desktop/index.js
@@ -159,6 +159,11 @@ export function makeDescribeWorkDesktop (initialValues = {}) {
               <Field name='location' component={LocationAutocomplete} />
             </div>
           </div>
+          <div className={b('row')}>
+            <div className={b('row-item')}>
+              <Field name='phone' component={renderTextInput} label={'Mobile Number*'} item={'phone'} />
+            </div>
+          </div>
           <button
             className={b('next-button').mix('avant-garde-button-black')}
             type='submit'

--- a/desktop/apps/consign/components/describe_work_mobile/index.js
+++ b/desktop/apps/consign/components/describe_work_mobile/index.js
@@ -160,10 +160,15 @@ export function makeDescribeWorkMobile (initialValues = {}) {
               />
             </div>
           </div>
-          <div className={b('row')}>
+          <div className={b('row', {'border-bottom': true})}>
             <div className={b('row-item')}>
               <div className={b('instructions')}>What city is the work located in?*</div>
               <Field name='location' component={LocationAutocomplete} />
+            </div>
+          </div>
+          <div className={b('row')}>
+            <div className={b('row-item')}>
+              <Field name='phone' component={renderTextInput} label={'Mobile Number*'} item={'phone'} />
             </div>
           </div>
           <button

--- a/desktop/apps/consign/routes.js
+++ b/desktop/apps/consign/routes.js
@@ -53,13 +53,15 @@ export const submissionFlowWithId = async (req, res, next) => {
 
 export const submissionFlowWithFetch = async (req, res, next) => {
   try {
-    const token = await fetchToken(req.user.get('accessToken'))
-    const submission = await request
-                              .get(`${res.locals.sd.CONVECTION_APP_URL}/api/submissions/${req.params.id}`)
-                              .set('Authorization', `Bearer ${token}`)
-    const { artist: { name } } = await metaphysics({ query: ArtistQuery(submission.body.artist_id), req })
-    res.locals.sd.SUBMISSION = submission.body
-    res.locals.sd.SUBMISSION_ARTIST_NAME = name
+    if (req.user) {
+      const token = await fetchToken(req.user.get('accessToken'))
+      const submission = await request
+                                .get(`${res.locals.sd.CONVECTION_APP_URL}/api/submissions/${req.params.id}`)
+                                .set('Authorization', `Bearer ${token}`)
+      const { artist: { name } } = await metaphysics({ query: ArtistQuery(submission.body.artist_id), req })
+      res.locals.sd.SUBMISSION = submission.body
+      res.locals.sd.SUBMISSION_ARTIST_NAME = name
+    }
     res.render('submission_flow', { user: req.user })
   } catch (e) {
     next(e)

--- a/desktop/apps/consign/stylesheets/index.styl
+++ b/desktop/apps/consign/stylesheets/index.styl
@@ -26,9 +26,13 @@
 @require '../components/uploaded_image/index'
 
 .consignments-submission-body
+  #main-layout-header
+    overflow hidden
+
   @media (max-width: responsive-mobile-width)
     #main-layout-header
       height 53px
+      overflow hidden
       #main-header-search-form, #main-header-search-button
         display none
 

--- a/desktop/apps/consign/test/reducers.js
+++ b/desktop/apps/consign/test/reducers.js
@@ -165,7 +165,7 @@ describe('Reducers', () => {
           const expectedActions = [
             {
               type: 'UPDATE_USER_PHONE',
-              payload: { newPhone: '6073490948' }
+              payload: { phone: '6073490948' }
             },
             {
               type: 'SUBMISSION_CREATED',

--- a/desktop/apps/consign/test/reducers.js
+++ b/desktop/apps/consign/test/reducers.js
@@ -33,6 +33,22 @@ describe('Reducers', () => {
         })
       })
 
+      describe('#updateUserPhone', () => {
+        it('updates to the new phone number if no phone exists', () => {
+          const withUser = reducers(initialResponse, actions.updateUser({ phone: '' }))
+          const newPhone = '1234567'
+          const updatedPhone = reducers(withUser, actions.updateUserPhone(newPhone))
+          updatedPhone.submissionFlow.user.phone.should.eql(newPhone)
+        })
+
+        it('updates to the new phone number if one already exists', () => {
+          const withUser = reducers(initialResponse, actions.updateUser({ phone: '987654' }))
+          const newPhone = '1234567'
+          const updatedPhone = reducers(withUser, actions.updateUserPhone(newPhone))
+          updatedPhone.submissionFlow.user.phone.should.eql(newPhone)
+        })
+      })
+
       describe('#fetchArtistSuggestions', () => {
         let store
 
@@ -55,7 +71,7 @@ describe('Reducers', () => {
           ActionsRewireApi.__Rewire__('sd', { CURRENT_USER: { accessToken: 'foo' } })
         })
 
-        it('calls the correct actions', () => {
+        it('calls the correct actions', (done) => {
           const expectedActions = [
             {
               type: 'UPDATE_ARTIST_SUGGESTIONS',
@@ -70,7 +86,140 @@ describe('Reducers', () => {
           ]
           store.dispatch(actions.fetchArtistSuggestions()).then(() => {
             store.getActions().should.eql(expectedActions)
+            done()
+          }).catch((err) => done(err))
+        })
+      })
+
+      describe('#createSubmission', () => {
+        let store
+        let request
+
+        beforeEach(() => {
+          benv.setup(() => {
+            sinon.stub(global, 'btoa')
           })
+          const middlewares = [ thunk ]
+          const mockStore = configureMockStore(middlewares)
+
+          store = mockStore({
+            submissionFlow: {
+              user: { accessToken: 'foo', phone: '12345' },
+              submission: {},
+              inputs: { phone: '12345' }
+            }
+          })
+          request = sinon.stub()
+          request.post = sinon.stub().returns(request)
+          request.set = sinon.stub().returns(request)
+          request.send = sinon.stub().returns({ body: { id: 'sub1' } })
+
+          global.window = { btoa: sinon.stub() }
+          ActionsRewireApi.__Rewire__('request', request)
+          ActionsRewireApi.__Rewire__('fetchToken', sinon.stub().returns('fooToken'))
+          ActionsRewireApi.__Rewire__('sd', { CURRENT_USER: { accessToken: 'foo' }, CONVECTION_APP_ID: 'myapp' })
+        })
+
+        afterEach(() => {
+          benv.teardown()
+          global.btoa.restore()
+          ActionsRewireApi.__ResetDependency__('request')
+          ActionsRewireApi.__ResetDependency__('fetchToken')
+          ActionsRewireApi.__ResetDependency__('sd')
+        })
+
+        it('sends the correct actions on success without updating phone', (done) => {
+          const expectedActions = [
+            {
+              type: 'SUBMISSION_CREATED',
+              payload: { submissionId: 'sub1' }
+            },
+            {
+              type: 'UPDATE_SUBMISSION',
+              payload: { submission: { id: 'sub1' } }
+            },
+            { type: 'HIDE_LOADER' },
+            {
+              type: '@@router/CALL_HISTORY_METHOD',
+              payload: {
+                method: 'push',
+                args: [ '/consign/submission/sub1/describe-your-work' ]
+              }
+            },
+            {
+              type: '@@router/CALL_HISTORY_METHOD',
+              payload: {
+                method: 'push',
+                args: [ '/consign/submission/sub1/upload-photos' ]
+              }
+            }
+          ]
+          store.dispatch(actions.createSubmission()).then(() => {
+            store.getActions().should.eql(expectedActions)
+            done()
+          }).catch((err) => done(err))
+        })
+
+        it('sends the correct actions on success while also updating the phone', (done) => {
+          store.dispatch(actions.updateUserPhone('6073490948'))
+          const expectedActions = [
+            {
+              type: 'UPDATE_USER_PHONE',
+              payload: { newPhone: '6073490948' }
+            },
+            {
+              type: 'SUBMISSION_CREATED',
+              payload: { submissionId: 'sub1' }
+            },
+            {
+              type: 'UPDATE_SUBMISSION',
+              payload: { submission: { id: 'sub1' } }
+            },
+            { type: 'HIDE_LOADER' },
+            {
+              type: '@@router/CALL_HISTORY_METHOD',
+              payload: {
+                method: 'push',
+                args: [ '/consign/submission/sub1/describe-your-work' ]
+              }
+            },
+            {
+              type: '@@router/CALL_HISTORY_METHOD',
+              payload: {
+                method: 'push',
+                args: [ '/consign/submission/sub1/upload-photos' ]
+              }
+            }
+          ]
+          store.dispatch(actions.createSubmission()).then(() => {
+            store.getActions().should.eql(expectedActions)
+            done()
+          }).catch((err) => done(err))
+        })
+
+        it('sends the correct actions on error', (done) => {
+          const expectedActions = [
+            {
+              type: 'HIDE_LOADER'
+            },
+            {
+              type: 'SUBMISSION_ERROR',
+              payload: {
+                errorType: 'convection_create'
+              }
+            },
+            {
+              type: 'UPDATE_ERROR',
+              payload: {
+                error: 'Unable to submit at this time.'
+              }
+            }
+          ]
+          request.send = sinon.stub().returns('TypeError')
+          store.dispatch(actions.createSubmission()).then(() => {
+            store.getActions().should.eql(expectedActions)
+            done()
+          }).catch((err) => done(err))
         })
       })
 
@@ -105,7 +254,7 @@ describe('Reducers', () => {
           ActionsRewireApi.__ResetDependency__('sd')
         })
 
-        it('calls the correct actions', () => {
+        it('calls the correct actions', (done) => {
           const expectedActions = [
             { type: 'SHOW_LOADER' },
             {
@@ -124,10 +273,11 @@ describe('Reducers', () => {
           ]
           store.dispatch(actions.logIn({ email: 'sarah@sarah.com', password: '1234' })).then(() => {
             store.getActions().should.eql(expectedActions)
-          })
+            done()
+          }).catch((err) => done(err))
         })
 
-        it('ignores redirect correctly', () => {
+        it('ignores redirect correctly', (done) => {
           store = mockStore({
             submissionFlow: {
               redirectOnAuth: false
@@ -144,7 +294,8 @@ describe('Reducers', () => {
           ]
           store.dispatch(actions.logIn({ email: 'sarah@sarah.com', password: '1234' })).then(() => {
             store.getActions().should.eql(expectedActions)
-          })
+            done()
+          }).catch((err) => done(err))
         })
       })
 
@@ -171,14 +322,15 @@ describe('Reducers', () => {
           ActionsRewireApi.__ResetDependency__('sd')
         })
 
-        it('calls the correct actions', () => {
+        it('calls the correct actions', (done) => {
           const expectedActions = [
             { type: 'CLEAR_ERROR' },
             { type: 'SHOW_RESET_PASSWORD_SUCCESS_MESSAGE' }
           ]
           store.dispatch(actions.resetPassword({ email: 'sarah@sarah.com' })).then(() => {
             store.getActions().should.eql(expectedActions)
-          })
+            done()
+          }).catch((err) => done(err))
         })
       })
 
@@ -212,7 +364,7 @@ describe('Reducers', () => {
           ActionsRewireApi.__ResetDependency__('sd')
         })
 
-        it('calls the correct actions', () => {
+        it('calls the correct actions', (done) => {
           const expectedActions = [
             { type: 'SHOW_LOADER' },
             { type: 'SHOW_LOADER' },
@@ -232,7 +384,8 @@ describe('Reducers', () => {
           ]
           store.dispatch(actions.signUp({ name: 'Sarah', email: 'sarah@sarah.com', password: '1234' })).then(() => {
             store.getActions().should.eql(expectedActions)
-          })
+            done()
+          }).catch((err) => done(err))
         })
       })
 
@@ -440,7 +593,7 @@ describe('Reducers', () => {
           store = mockStore(initialResponse)
         })
 
-        it('errors if the image is not the right type', () => {
+        it('errors if the image is not the right type', (done) => {
           const expectedActions = [
             {
               type: 'ADD_IMAGE_TO_UPLOADED_IMAGES',
@@ -453,7 +606,8 @@ describe('Reducers', () => {
           ]
           store.dispatch(actions.handleImageUpload({ type: 'pdf', name: 'hello.pdf' })).then(() => {
             store.getActions().should.eql(expectedActions)
-          })
+            done()
+          }).catch((err) => done(err))
         })
       })
 
@@ -493,7 +647,7 @@ describe('Reducers', () => {
           ActionsRewireApi.__ResetDependency__('sd')
         })
 
-        it('stops processing the image if it succeeds', () => {
+        it('stops processing the image if it succeeds', (done) => {
           const expectedActions = [
             {
               type: 'STOP_PROCESSING_IMAGE',
@@ -503,10 +657,11 @@ describe('Reducers', () => {
           ]
           store.dispatch(actions.uploadImageToConvection('gemini-token', 'astronaut.jpg')).then(() => {
             store.getActions().should.eql(expectedActions)
-          })
+            done()
+          }).catch((err) => done(err))
         })
 
-        it('updates the error if it does not succeed', () => {
+        it('updates the error if it does not succeed', (done) => {
           request.post = sinon.stub().returns('TypeError')
           const expectedActions = [
             {
@@ -517,7 +672,8 @@ describe('Reducers', () => {
           const filePath = 'http://s3.com/abcdefg%2Fastronaut.jpg'
           store.dispatch(actions.uploadImageToConvection(filePath, 'astronaut.jpg')).then(() => {
             store.getActions().should.eql(expectedActions)
-          })
+            done()
+          }).catch((err) => done(err))
         })
       })
     })


### PR DESCRIPTION
This PR addresses: https://github.com/artsy/consignments/issues/78

We now want to require that users input a `Mobile Number` when they submit a consignment. Filling out that section of the form will send a request to the `/api/v1/me` endpoint to update the phone number on the user profile (so it will be changed artsy-wide, not just on a submission-basis). 

If the user already has a phone number entered on their profile, it will show up here but they have the option to change it.

This field is required in order to submit!

Mobile:
![image](https://user-images.githubusercontent.com/2081340/30614593-07d7f360-9d5a-11e7-9ed5-88ed82ea0334.png)

Desktop:
![image](https://user-images.githubusercontent.com/2081340/30614605-12118a80-9d5a-11e7-832b-6ea79776c865.png)
