### PR TITLE
@kanaabe => Article overflow width bug

### DIFF
--- a/desktop/components/article/stylesheets/content.styl
+++ b/desktop/components/article/stylesheets/content.styl
@@ -113,6 +113,8 @@ body.body-article
   text-align center
   padding 10px 0 20px 0
   margin gutter-size auto (gutter-size * 2)
+  position relative
+  overflow hidden
   .article-social__header
     float left
     margin-top 16px
@@ -305,6 +307,7 @@ body.body-article
   max-width 54px
   z-index 10
   float left
+  overflow hidden
   @media screen and (max-width 900px)
     display none
   a


### PR DESCRIPTION
Another bug related to accessible text -- will be sure to take a close look at the previous changes and find more instances with width problems. This bug was raised here: https://artsy.slack.com/archives/C04GGGDCM/p1505920868000296

Adding a position and overflow declaration to the parent of a block including `.screen-reader-text` prevents it from overflowing the page width.  This PR adds this to social buttons in both sticky and footer placements. 