### PR TITLE
@anandaroop => Display share buttons on partner pages

### DIFF
--- a/desktop/apps/partner2/client/articles.coffee
+++ b/desktop/apps/partner2/client/articles.coffee
@@ -36,7 +36,6 @@ module.exports = class ArticlesAdapter
       success: (article) =>
         @el.html articleTemplate
           article: article
-          hideShare: true
           hideSubscribe: true
           resize: resize
           embed: embed

--- a/desktop/apps/partner2/stylesheets/index.styl
+++ b/desktop/apps/partner2/stylesheets/index.styl
@@ -24,3 +24,7 @@
   .partner2-content
     margin-bottom 50px
     min-height 200px
+  .article-share-fixed
+    position fixed
+    left 0
+    margin-left -100%


### PR DESCRIPTION
This PR follows up on [this Slack convo](https://artsy.slack.com/archives/C3YTM6BTK/p1505919958000787), adding share buttons to partner article pages. Wanted to make sure Partner Success was aware of the change!  

The margin-left looks a little weird, but it allows the elements to sit on the edge of the page when the position changes from fixed to sticky.  

FYI: currently metadata for partner articles is the metadata for the partner's page, rather than the article itself.  This is because the article pages are loaded on the client, and leads to a non-ideal sharing experience.  In the future it would be ideal the change this, but it requires changes to the partner profile page.

Closes https://github.com/artsy/force/issues/1782.