### PR TITLE
@kanaabe => New team-blog name

### DIFF
--- a/desktop/config.coffee
+++ b/desktop/config.coffee
@@ -96,7 +96,7 @@ module.exports =
   SESSION_SECRET: 'change-me'
   SITEMAP_BASE_URL: 'http://artsy-sitemaps.s3-website-us-east-1.amazonaws.com'
   STRIPE_PUBLISHABLE_KEY: null
-  TEAM_BLOGS: '^\/life-at-artsy$|^\/artsy-education$|^\/gallery-insights$'
+  TEAM_BLOGS: '^\/life-at-artsy$|^\/artsy-education$|^\/gallery-insights$|^\/buying-with-artsy$'
   TARGET_CAMPAIGN_URL: '/seattle-art-fair-2017'
   TWILIO_ACCOUNT_SID: null
   TWILIO_AUTH_TOKEN: null


### PR DESCRIPTION
Adds 'buying-with-artsy' to the TEAM_BLOGS config setting, re: [this thread](https://artsy.slack.com/archives/C04GGGDCM/p1506088874000385). 