### PR TITLE
Update places and include Koloa on the mobile shows page

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6658,7 +6658,7 @@ pkginfo@0.3.x, pkginfo@0.x.x:
 
 "places@git://github.com/artsy/places.git":
   version "0.0.1"
-  resolved "git://github.com/artsy/places.git#a2859ff2c4df3552e331be9f16c14f229c2bed48"
+  resolved "git://github.com/artsy/places.git#f251a2404bc628fe0d08e9d76df4fda87aa9ee6d"
   dependencies:
     underscore "*"
 


### PR DESCRIPTION
Re: https://artsy.slack.com/archives/C03JWJLLH/p1503416445000079

On the mobile shows page, we are still using the static [places](https://github.com/artsy/places) lib for the list of cities. We still need to migrate to the Gravity generated city list but we might need some design changes on mobile. In the mean time, I'd like to do our partners a favor to [update places](https://github.com/artsy/places/pull/16) and include Koloa on that page. Please don't yell at me. 🙈 

![koloa](https://user-images.githubusercontent.com/796573/30931394-9591c436-a392-11e7-8d29-f706f40f7bca.gif)
