### PR TITLE
@craigspaeth => Remove unnecessary caching for static city files

### DIFF
--- a/desktop/apps/collect/routes.coffee
+++ b/desktop/apps/collect/routes.coffee
@@ -9,7 +9,7 @@ GeocodedCities = require '../../collections/geocoded_cities'
 @index = (req, res, next) ->
   geocodedCities = new GeocodedCities()
   Q.all([
-    geocodedCities.fetch(cache: true)
+    geocodedCities.fetch()
     page.get()
   ]).spread (geocodedCities, pageData) ->
     res.locals.sd.CATEGORIES = pageData

--- a/desktop/apps/galleries_institutions/routes.coffee
+++ b/desktop/apps/galleries_institutions/routes.coffee
@@ -55,8 +55,8 @@ fetchPartnerCategories = (type) ->
 
   Promise.all([
     fetchPrimaryCarousel(params)
-    partnerCities.fetch(cache: true)
-    partnerFeaturedCities.fetch(cache: true)
+    partnerCities.fetch()
+    partnerFeaturedCities.fetch()
     fetchPartnerCategories(type)
   ])
     .then ([profiles, partnerCities, partnerFeaturedCities, categories]) ->

--- a/desktop/apps/shows/routes.coffee
+++ b/desktop/apps/shows/routes.coffee
@@ -11,8 +11,8 @@ PartnerFeaturedCities = require '../../collections/partner_featured_cities'
   partnerFeaturedCities = new PartnerFeaturedCities()
 
   Q.all([
-    partnerCities.fetch(cache: true)
-    partnerFeaturedCities.fetch(cache: true)
+    partnerCities.fetch()
+    partnerFeaturedCities.fetch()
     shows.fetch(cache: true)
   ]).then ->
     res.render 'index',
@@ -32,8 +32,8 @@ PartnerFeaturedCities = require '../../collections/partner_featured_cities'
   partnerFeaturedCities = new PartnerFeaturedCities()
 
   Q.all([
-    partnerCities.fetch(cache: true)
-    partnerFeaturedCities.fetch(cache: true)
+    partnerCities.fetch()
+    partnerFeaturedCities.fetch()
   ]).then ->
     city = _.findWhere(partnerCities.toJSON(), slug: req.params.city)
     return next() unless city?


### PR DESCRIPTION
Per discussion in #1748 

Force gets some partner city related data from static json files that are generated nightly and posted to S3. These files were ostensibly being cached, but maybe they weren't so much — `ab` benchmarking of Force, running against a local Redis instance, with and without these `cache: true` options shows negligible difference. So a few less of these instances to clean up now.

