### PR TITLE
@craigspaeth => [Bugfix] Make related artworks fetch safer

### DIFF
--- a/desktop/apps/artwork/components/related_artists/index.coffee
+++ b/desktop/apps/artwork/components/related_artists/index.coffee
@@ -3,10 +3,11 @@ Backbone = require 'backbone'
 { CLIENT } = require('sharify').data
 initCarousel = require '../../../../components/merry_go_round/horizontal_nav_mgr.coffee'
 { Following, FollowButton } = require '../../../../components/follow_button/index.coffee'
+get = require 'lodash.get'
 CurrentUser = require '../../../../models/current_user.coffee'
 artistsTemplate = -> require('./artists.jade') arguments...
 
-setupFollowButtons = ({ $el, relatedArtists, kind }) =>
+setupFollowButtons = ({ $el, relatedArtists, kind }) ->
   following = new Following(null, kind: kind) if CurrentUser.orNull()
   ids = $el.find('.follow-button').map ->
 
@@ -24,11 +25,11 @@ setupFollowButtons = ({ $el, relatedArtists, kind }) =>
   following?.syncFollows ids
 
 render = ({ relatedArtists, showMore, baseHref}) ->
-  viewAllUrl = sd.CLIENT.artists[0].href + '/related-artists'
+  viewAllUrl = get(sd.CLIENT, 'artists.0.href' + '/related-artists', '')
   artistsTemplate { relatedArtists, showMore, viewAllUrl }
 
 module.exports = ->
-  relatedArtists = sd.CLIENT.artists[0].artists
+  relatedArtists = get(sd.CLIENT, 'artists.0.artists', [])
   showMore = relatedArtists.length > 15
   $el = $('.js-artwork-artist-related-rail__content')
   relatedArtists = _.take(relatedArtists, 15)


### PR DESCRIPTION
Fixes issue where missing related artworks error out:

https://www.artsy.net/artwork/ratnasambhava-the-buddha-of-the-southern-pure-land-tibet 

<img width="422" alt="screen shot 2017-09-29 at 7 05 29 pm" src="https://user-images.githubusercontent.com/236943/31041384-4e88c806-a549-11e7-8924-8c719f8c8c4a.png">
