### PR TITLE
@kanaabe => Width bugs

### DIFF
--- a/desktop/components/main_layout/stylesheets/body.styl
+++ b/desktop/components/main_layout/stylesheets/body.styl
@@ -13,10 +13,10 @@ search-bar-input-placeholder()
 
 .screen-reader-text // hide text only for screen-readers
   position absolute
-  left 10000px
-  top auto
-  width 1px
-  height 1px
+  left 0
+  top 0
+  width 0
+  height 0
   overflow hidden
 
 .body-header-fixed


### PR DESCRIPTION
Changes the placement and size of .screen-reader-text to no longer render it offscreen, which led to bugs in width. 

Now text is rendered at 0px height and width, and placed in the top corner of the page.  This still passes Chrome's accessibility audit.