### PR TITLE
@starsirius => Update for new availability states

### DIFF
--- a/desktop/models/artwork.coffee
+++ b/desktop/models/artwork.coffee
@@ -282,8 +282,9 @@ module.exports = class Artwork extends Backbone.Model
     ]).join(", ")
 
   saleMessage: ->
-    return if @get('sale_message') is 'Contact For Price' or @get('availability') is 'not for sale'
-
+    return if @get('availability_hidden')
+    return if @get('sale_message') is 'Contact For Price'
+    return if @get('availability') is 'not for sale' or @get('availability') is 'permanent collection'
     if @get('availability') is 'on hold'
       if @get('price')
         return "#{@get('price')}, on hold"
@@ -292,11 +293,14 @@ module.exports = class Artwork extends Backbone.Model
     if @get('sale_message')?.indexOf('Sold') > - 1
       return 'Sold'
 
+    if (@get('availability') is 'on loan')
+      return 'On loan'
+
     @get 'sale_message'
 
   availabilityMessage: ->
     return if @get('partner')?.type is "Institutional Seller"
-    return if @get('availability') is 'for sale' or @get('availability') is 'not for sale'
+    return if @get('availability') is 'for sale' or @get('availability') is 'not for sale' or @get('availability') is 'permanent collection'
     if @get('partner')?.has_limited_fair_partnership
       'Not inquireable'
     else if @get('availability')?.indexOf('on hold') > - 1

--- a/desktop/test/models/artwork.coffee
+++ b/desktop/test/models/artwork.coffee
@@ -20,15 +20,21 @@ describe 'Artwork', ->
       @artwork.set sale_message: 'Sold'
       @artwork.saleMessage().should.equal 'Sold'
 
+    it 'returns On loan when artwork is on loan', ->
+      @artwork.set availability: 'on loan'
+      @artwork.saleMessage().should.equal 'On loan'
+
     it 'returns the price when on hold', ->
       @artwork.set availability: 'on hold', price: '$420'
       @artwork.saleMessage().should.equal '$420, on hold'
       @artwork.unset 'price'
       @artwork.saleMessage().should.equal 'On hold'
 
-    describe 'sale_message is "Contact for Price" or availability is "not for sale"', ->
+    describe 'sale_message is "Contact for Price" or availability is "not for sale" or "permanent collection"', ->
       it 'returns undefined', ->
-        @artwork.set sale_message: 'Contact For Price', price: '$6,000'
+        @artwork.set availability: 'permanent collection'
+        _.isUndefined(@artwork.saleMessage()).should.be.true()
+        @artwork.set sale_message: 'Contact For Price', price: '$6,000', availability: 'for sale'
         _.isUndefined(@artwork.saleMessage()).should.be.true()
         @artwork.unset 'sale_message', 'price'
         @artwork.set availability: 'not for sale'


### PR DESCRIPTION
Along with https://github.com/artsy/metaphysics/pull/781, this updates the `sale_message` stuff to be consistent with being suppressed as an availability of `permanent collection`, and coming thru as `On loan` in that case. It also supports being suppressed using `availability_hidden` as well.

This _should_ support all these cases, and the existing logic for `price_hidden` will control the `Contact gallery` vs `Contact for price` display (ie- when `price_hidden: true`, the CTA is `Contact for price` and the price itself is hidden, although it _is_ considered in price-based filter results).

The remaining item is to more fully support the `On loan` case thru another partner association, or come to an agreement re: `collecting_institution`, or something else entirely.

Either way, I think this should be fine to merge.