### PR TITLE
Fixed a style bug in the auction artwork page in IE

### DIFF
--- a/desktop/components/main_layout/stylesheets/utilities.styl
+++ b/desktop/components/main_layout/stylesheets/utilities.styl
@@ -8,6 +8,7 @@
   width 100%
 .vam-outer
   display table
+  table-layout fixed
 .vam-inner
 .vam-cell
   display table-cell


### PR DESCRIPTION
fixes https://github.com/artsy/collector-experience/issues/594

According to [this blog post](1), Chrome incorrectly respects `max-width` for elements in a container with `table-cell`. The fix is to add `table-layout: fixed`, which is a hack but at least it works fine now.

[1]: https://www.carsonshold.com/2014/07/css-display-table-cell-child-width-bug-in-firefox-and-ie/

![screen shot 2017-10-12 at 17 29 32](https://user-images.githubusercontent.com/386234/31486592-ff4bef00-af72-11e7-8eaf-4de2e6c93e72.png)
