### PR TITLE
@kanaabe => Blockquotes in classic + tweaks

### DIFF
--- a/desktop/components/article/stylesheets/content.styl
+++ b/desktop/components/article/stylesheets/content.styl
@@ -69,7 +69,7 @@ body.body-article
       padding-top 0
     &:last-child
       padding-bottom 0
-  h2
+  h1, h2
     font-size 28px
     line-height 1.2em
     margin-top text-margin-half
@@ -87,10 +87,17 @@ body.body-article
     padding-bottom 3px
   li
     margin-bottom text-margin-half
+    margin-left 1em
   ul li
     list-style disc outside
   ol li
     list-style decimal outside
+  blockquote
+    font-size 40px
+    line-height 1.1em
+    text-align center
+    padding 46px 0
+    margin 0
 
 .article-date
   avant-garde()

--- a/desktop/components/article/templates/mixins.jade
+++ b/desktop/components/article/templates/mixins.jade
@@ -1,9 +1,9 @@
 mixin author-date
   .article-author-date
-    .article-author(class= article.get('contributing_authors').length > 0 ? 'has-contributing-author' : '')
+    .article-author(class= article.get('contributing_authors') && article.get('contributing_authors').length > 0 ? 'has-contributing-author' : '')
       if article.related()
         = article.related().author.get('name')
-    if article.get('contributing_authors').length > 0
+    if article.get('contributing_authors') && article.get('contributing_authors').length > 0
       .article-contributing-author
         = "By " + article.byline()
     .article-date


### PR DESCRIPTION
A few small changes for Edit2 launch in Writer:
- Blockquotes are styled in Classic layouts
- H1 is styled (to match H2) in Classic layouts
- Add a conditional to contributing_authors mixin (was throwing server errors)

Closes https://github.com/artsy/publishing/issues/75
Addresses points in https://github.com/artsy/publishing/issues/84