### PR TITLE
Update /categories3 to consume a graphql connection

### DIFF
--- a/desktop/apps/categories3/__tests__/routes.test.js
+++ b/desktop/apps/categories3/__tests__/routes.test.js
@@ -4,7 +4,7 @@ import {
   index,
   __RewireAPI__ as RoutesRewireApi
 } from 'desktop/apps/categories3/routes'
-import { geneFamiliesFromConnection } from './utils'
+import { geneFamiliesFromConnection } from '../utils'
 
 let req
 let res

--- a/desktop/apps/categories3/__tests__/utils.test.js
+++ b/desktop/apps/categories3/__tests__/utils.test.js
@@ -1,0 +1,106 @@
+import {
+  alphabetizeGenes,
+  featuredGenesForFamily,
+  geneFamiliesFromConnection
+} from '../utils'
+
+describe('#alphabetizeGenes', () => {
+  it('alphabetizes genes by name', () => {
+    const genes = [
+      {
+        id: 'gold',
+        name: 'Gold'
+      },
+      {
+        id: 'copper',
+        name: 'Copper'
+      }
+    ]
+    const result = alphabetizeGenes(genes)
+    result[0].id.should.eql('copper')
+    result[1].id.should.eql('gold')
+  })
+
+  it('it prefers display names when available', () => {
+    const genes = [
+      {
+        id: 'gold',
+        name: 'Gold',
+        display_name: 'Bigly Gold'
+      },
+      {
+        id: 'copper',
+        name: 'Copper'
+      }
+    ]
+
+    const result = alphabetizeGenes(genes)
+
+    result[0].id.should.eql('gold')
+    result[1].id.should.eql('copper')
+  })
+})
+
+describe('#featuredGenesForFamily', () => {
+  it('pulls out featured genes for the given family', () => {
+    const featuredGenesByFamily = [
+      {
+        name: 'Materials',
+        genes: [
+          { id: 'aluminum', href: '/gene/aluminum' },
+          { id: 'gold', href: '/gene/gold' }
+        ]
+      },
+      {
+        name: 'Styles',
+        genes: [
+          { id: 'impressionism', href: '/gene/impressionism' },
+          { id: 'photorealism', href: '/gene/photorealism' }
+        ]
+      }
+    ]
+
+    const result = featuredGenesForFamily('Materials', featuredGenesByFamily)
+    result.should.be.of.type.Object
+    result.name.should.equal('Materials')
+    result.genes[0].id.should.equal('aluminum')
+    result.genes[1].id.should.equal('gold')
+  })
+})
+
+describe('#geneFamiliesFromConnection', () => {
+  it("maps the connection to a simple list of gene families", () => {
+    const dataFromGeneFamilyConnection = {
+      gene_families: {
+        edges: [
+          {
+            node: {
+              id: 'subject-matter',
+              name: 'Subject Matter'
+            }
+          },
+          {
+            node: {
+              id: 'styles-and-movements',
+              name: 'Styles and Movements'
+            }
+          }
+        ]
+      }
+    }
+
+    const expectedFamilies = [
+      {
+        id: 'subject-matter',
+        name: 'Subject Matter'
+      },
+      {
+        id: 'styles-and-movements',
+        name: 'Styles and Movements'
+      }
+    ]
+
+    const result = geneFamiliesFromConnection(dataFromGeneFamilyConnection)
+    result.should.deepEqual(expectedFamilies)
+  })
+})

--- a/desktop/apps/categories3/components/GeneFamilyNav.js
+++ b/desktop/apps/categories3/components/GeneFamilyNav.js
@@ -31,6 +31,8 @@ const GeneFamilyList = styled(Scrollspy)`
   width: inherit;
   max-width: 300px;
   padding-right: 2em;
+  background: white;
+  z-index: 1;
 
   ${primary.style};
   font-size: 13px;

--- a/desktop/apps/categories3/queries/geneFamilies.js
+++ b/desktop/apps/categories3/queries/geneFamilies.js
@@ -1,14 +1,18 @@
-export default function GeneFamiliesQuery() {
+export default function GeneFamiliesQuery () {
   return `
   {
-    gene_families(size: 20) {
-      id
-      name
-      genes {
-        id
-        name
-        display_name
-        is_published
+    gene_families(first: 20) {
+      edges {
+        node {
+          id
+          name
+          genes {
+            id
+            name
+            display_name
+            is_published
+          }
+        }
       }
     }
   }

--- a/desktop/apps/categories3/routes.js
+++ b/desktop/apps/categories3/routes.js
@@ -3,12 +3,15 @@ import GeneFamiliesQuery from './queries/geneFamilies'
 import FeaturedGenesQuery from './queries/featuredGenes'
 import metaphysics from 'lib/metaphysics.coffee'
 import { renderLayout } from '@artsy/stitch'
+import { geneFamiliesFromConnection } from './utils'
 
 export const index = async (req, res, next) => {
   try {
-    const { gene_families: geneFamilies } = await metaphysics({
+    const geneFamilyConnection = await metaphysics({
       query: GeneFamiliesQuery()
     })
+    const geneFamilies = geneFamiliesFromConnection(geneFamilyConnection)
+
     const { gene_families: allFeaturedGenesByFamily } = await metaphysics({
       query: FeaturedGenesQuery()
     })

--- a/desktop/apps/categories3/routes.test.js
+++ b/desktop/apps/categories3/routes.test.js
@@ -4,6 +4,7 @@ import {
   index,
   __RewireAPI__ as RoutesRewireApi
 } from 'desktop/apps/categories3/routes'
+import { geneFamiliesFromConnection } from './utils'
 
 let req
 let res
@@ -19,22 +20,26 @@ describe('#index', () => {
     res = {}
     next = sinon.stub()
     geneFamiliesQuery = {
-      gene_families: [
-        {
-          id: 'materials',
-          name: 'Materials',
-          genes: [
-            {
-              id: 'silver',
-              name: 'Silver'
-            },
-            {
-              id: 'gold',
-              name: 'Gold'
+      gene_families: {
+        edges: [
+          {
+            node: {
+              id: 'materials',
+              name: 'Materials',
+              genes: [
+                {
+                  id: 'silver',
+                  name: 'Silver'
+                },
+                {
+                  id: 'gold',
+                  name: 'Gold'
+                }
+              ]
             }
-          ]
-        }
-      ]
+          }
+        ]
+      }
     }
 
     RoutesRewireApi.__Rewire__(
@@ -60,9 +65,23 @@ describe('#index', () => {
   })
   it('passes the correct variables', () => {
     index(req, res, next).then(() => {
-      renderLayout.args[0][0].data.geneFamilies.should.equal(
-        geneFamiliesQuery.gene_families
-      )
+      const expectedFamilies = [
+        {
+          id: 'materials',
+          name: 'Materials',
+          genes: [
+            {
+              id: 'silver',
+              name: 'Silver'
+            },
+            {
+              id: 'gold',
+              name: 'Gold'
+            }
+          ]
+        }
+      ]
+      renderLayout.args[0][0].data.geneFamilies.should.eql(expectedFamilies)
     })
   })
 })

--- a/desktop/apps/categories3/utils.js
+++ b/desktop/apps/categories3/utils.js
@@ -8,3 +8,6 @@ export const featuredGenesForFamily = (familyName, featuredGenesList) => {
     featuredGenesFamily => featuredGenesFamily.name === familyName
   )
 }
+
+export const geneFamiliesFromConnection = connectionData =>
+  connectionData.gene_families.edges.map(edge => edge.node)


### PR DESCRIPTION
This follows on from https://github.com/artsy/metaphysics/pull/784, in which we updated the `GeneFamilies` schema's pagination to a Relay-style connection

The data fetching code here is updated accordingly. This seems like it might have benefitted from some Relay boilerplate to consume the connection-shaped data properly (I'm guessing — I haven't used Relay at all), but the requirements here are very simple and I think this will do the job.

The relevant diff is just [this commit](https://github.com/anandaroop/force/commit/76479463102f1218a5e3045d1f97b8f567c2c0b6), but I also used this PR to fix a small css issue and re-organize some test files.