### PR TITLE
Fix galleries A-Z page

### DIFF
--- a/desktop/apps/galleries_institutions/routes.coffee
+++ b/desktop/apps/galleries_institutions/routes.coffee
@@ -85,7 +85,7 @@ fetchPartnerCategories = (type) ->
   partners.fetchUntilEndInParallel
     cache: true
     data:
-      size: 20
+      size: 40
       type: mapTypeClasses[req.params.type]
       sort: 'sortable_id'
       has_full_profile: true


### PR DESCRIPTION
Closes #1800 

Gallery A-Z pages no longer show all partners due to endpoint limitations on how deep we can page.

Complaints about this have become more frequent this week, so this is an expedient fix that simply tweaks the page _size_ in order to get a complete list fetched again.  This is not a _great_ solution, but it will give us some time to figure out if that paging limitation is necessary or not.