### PR TITLE
Prompt Googlebot to request pre-rendered page content from Reflection

### DIFF
--- a/desktop/apps/gene/templates/meta.jade
+++ b/desktop/apps/gene/templates/meta.jade
@@ -9,5 +9,4 @@ meta( property="og:image", content=gene.imageUrl('big_and_tall') )
 meta( property="og:type", content=(sd.FACEBOOK_APP_NAMESPACE + ":gene" ) )
 meta( property="twitter:card", content="summary" )
 if sd.INCLUDE_ESCAPED_FRAGMENT
-  if includeMetaFragment
-    meta( name="fragment", content="!" )
+  meta( name="fragment", content="!" )


### PR DESCRIPTION
As discussed (https://github.com/artsy/collector-experience/issues/533), gene pages aren't rendering effectively for Googlebot. We should probably have Reflection pre-render these pages instead. The genes sitemap has already been added to Reflection, so those pages are now being crawled and pre-rendered.

**However** when I checked that Reflection was able to render the page, I noticed apparent problems reaching Metaphysics and the main API. Similar requests work fine from other pages, so I assume there's some low-level difference in how this page functions, or maybe another error interfering. This probably shouldn't be merged until that's addressed (though the pre-rendered pages are no worse than what Googlebot is already seeing):

Blocked on: https://github.com/artsy/reflection/issues/63

Fixes: https://github.com/artsy/collector-experience/issues/533
