### PR TITLE
@craigspaeth => add request id to server-side requests for gene page and auction page

### DIFF
--- a/desktop/apps/auction/actions/artworkBrowser.js
+++ b/desktop/apps/auction/actions/artworkBrowser.js
@@ -58,6 +58,7 @@ export function fetchArtworks () {
     const {
       artworkBrowser: {
         filterParams,
+        requestID,
         user
       }
     } = getState()
@@ -69,7 +70,8 @@ export function fetchArtworks () {
         query: filterQuery,
         variables: filterParams,
         req: {
-          user
+          user,
+          id: requestID
         }
       })
 
@@ -106,6 +108,7 @@ export function fetchArtworksByFollowedArtists () {
         followedArtistRailMax,
         followedArtistRailPage,
         filterParams,
+        requestID,
         user
       }
     } = getState()
@@ -121,7 +124,8 @@ export function fetchArtworksByFollowedArtists () {
         query: worksByFollowedArtists,
         variables: inputVars,
         req: {
-          user
+          user,
+          id: requestID
         }
       })
       if (filter_sale_artworks.hits.length > 0) {

--- a/desktop/apps/auction/reducers/artworkBrowser.js
+++ b/desktop/apps/auction/reducers/artworkBrowser.js
@@ -37,6 +37,7 @@ export const initialState = {
   maxEstimateRangeDisplay: 50000,
   minEstimateRangeDisplay: 0,
   numArtistsYouFollow: 0,
+  requestID: get(sd, 'REQUEST_ID', undefined),
   saleArtworks: [],
   saleArtworksByFollowedArtists: [],
   saleArtworksByFollowedArtistsTotal: 0,

--- a/desktop/apps/auction/routes.js
+++ b/desktop/apps/auction/routes.js
@@ -22,7 +22,8 @@ export async function index (req, res, next) {
 
   try {
     const { sale } = await metaphysics({
-      query: SaleQuery(saleId)
+      query: SaleQuery(saleId),
+      req: req
     })
 
     res.locals.sd.AUCTION = sale
@@ -37,7 +38,8 @@ export async function index (req, res, next) {
 
     try {
       ({ articles } = await metaphysics({
-        query: ArticlesQuery(sale._id)
+        query: ArticlesQuery(sale._id),
+        req: req
       }))
     } catch (error) {
       console.error('(apps/auction/routes.js) Error fetching Articles', error)
@@ -64,6 +66,7 @@ export async function index (req, res, next) {
           sale_id: saleId
         },
         isClosed: sale.is_closed,
+        requestID: req.id,
         user: res.locals.sd.CURRENT_USER
       }, auctionWorksInitialState)
     })
@@ -105,7 +108,7 @@ export async function index (req, res, next) {
 
 export async function redirectLive (req, res, next) {
   try {
-    const { sale } = await metaphysics({ query: SaleQuery(req.params.id) })
+    const { sale } = await metaphysics({ query: SaleQuery(req.params.id), req: req })
     const isLiveOpen = get(sale, 'is_live_open')
 
     if (isLiveOpen) {
@@ -139,7 +142,7 @@ export async function redirectLive (req, res, next) {
 async function fetchUser (req, res) {
   if (req.user) {
     try {
-      const user = await req.user.fetch()
+      const user = await req.user.fetch({ headers: { 'X-Request-Id': req.id } })
       res.locals.sd.CURRENT_USER = {
         ...res.locals.sd.CURRENT_USER,
         ...user

--- a/desktop/apps/gene/client.js
+++ b/desktop/apps/gene/client.js
@@ -42,7 +42,7 @@ function setupGenePage () {
       .html(html)
       .addClass('is-fade-in')
   })
-  gene.fetchArtists('related')
+  gene.fetchArtists('related', { headers: { 'X-Request-Id': sd.REQUEST_ID } })
 
   // Setup user
   const user = CurrentUser.orNull()

--- a/desktop/apps/gene/routes.coffee
+++ b/desktop/apps/gene/routes.coffee
@@ -14,10 +14,13 @@ aggregationParams = require './aggregations.coffee'
   filterData = size: 0, gene_id: req.params.id, aggregations: aggregationParams, include_medium_filter_in_aggregation: true
 
   Q.all [
-    gene.fetch cache: true
+    gene.fetch
+      cache: true,
+      headers: 'X-Request-Id': req.id
     filterArtworks.fetch
       data: filterData
       cache: true
+      headers: 'X-Request-Id': req.id
   ]
 
   .then ->


### PR DESCRIPTION
cc @joeyAghion 

Now that metaphysics passes the `requestID` to gravity for all requests in the new data loader format (hopefully this applies to all requests soon), we can start populating the server-side requests here to give us additional insight into what requests happen on a page load.

I realized another hole is reaction-- I'm hoping there's a way to get the request ID passed to metaphysics from there, but will probably need someone with relay knowledge to help me set that up. 😄 