### PR TITLE
Revert "@craigspaeth => set request id header in global ajax settings for client-side backbone fetches"

### DIFF
--- a/desktop/apps/gene/client.js
+++ b/desktop/apps/gene/client.js
@@ -42,7 +42,7 @@ function setupGenePage () {
       .html(html)
       .addClass('is-fade-in')
   })
-  gene.fetchArtists('related', { headers: { 'X-Request-Id': sd.REQUEST_ID } })
+  gene.fetchArtists('related')
 
   // Setup user
   const user = CurrentUser.orNull()

--- a/desktop/apps/gene/client.js
+++ b/desktop/apps/gene/client.js
@@ -42,7 +42,7 @@ function setupGenePage () {
       .html(html)
       .addClass('is-fade-in')
   })
-  gene.fetchArtists('related')
+  gene.fetchArtists('related', { headers: { 'X-Request-Id': sd.REQUEST_ID } })
 
   // Setup user
   const user = CurrentUser.orNull()

--- a/desktop/lib/global_client_setup.coffee
+++ b/desktop/lib/global_client_setup.coffee
@@ -86,7 +86,6 @@ setupJquery = ->
   $.ajaxSettings.headers =
     'X-XAPP-TOKEN': sd.ARTSY_XAPP_TOKEN
     'X-ACCESS-TOKEN': sd.CURRENT_USER?.accessToken
-    'X-Request-Id': sd.REQUEST_ID
   window[key] = helper for key, helper of templateModules
 
 setupErrorReporting = ->


### PR DESCRIPTION
Reverts artsy/force#1849

This was returning an error in staging: ```Request header field X-Request-Id is not allowed by Access-Control-Allow-Headers in preflight response.``` for some requests.