### PR TITLE
@craigspaeth => throw 400-level errors for real

### DIFF
--- a/desktop/apps/artwork/routes.coffee
+++ b/desktop/apps/artwork/routes.coffee
@@ -127,8 +127,9 @@ bootstrap = ->
       imageRequest.set('X-ACCESS-TOKEN': req.user.get('accessToken')) if req.user
       req.pipe(imageRequest).pipe res
     else
-      res.status 403
-      next new Error 'Not authorized to download this image'
+      err = new Error 'Not authorized to download this image.'
+      err.status = 403
+      next err
 
 # Helpers
 fetchMeData = (query, user, saleId) ->

--- a/desktop/apps/artwork/test/routes.coffee
+++ b/desktop/apps/artwork/test/routes.coffee
@@ -54,7 +54,7 @@ describe 'Artwork routes', ->
         it 'nexts with a 403', ->
           routes.download @req, @res, @next
           @next.called.should.be.true()
-          @res.status.args[0][0].should.equal 403
+          @next.args[0][0].status.should.eql 403
 
       describe 'when the image is not downloadable', ->
         beforeEach ->
@@ -66,7 +66,7 @@ describe 'Artwork routes', ->
           routes.download @req, @res, @next
           request.get.called.should.be.false()
           @next.called.should.be.true()
-          @res.status.args[0][0].should.equal 403
+          @next.args[0][0].status.should.eql 403
 
     describe 'as an admin', ->
       describe 'when the image is not downloadable', ->

--- a/desktop/apps/clear_cache/index.coffee
+++ b/desktop/apps/clear_cache/index.coffee
@@ -7,8 +7,9 @@ app.set 'view engine', 'jade'
 
 app.all '/clear-cache', all = (req, res, next) ->
   return next() if req.user?.get('type') is 'Admin'
-  res.status 403
-  next new Error "You must be logged in as an admin to clear the cache."
+  err = new Error 'You must be logged in as an admin to clear the cache.'
+  err.status = 403
+  next err
 app.get '/clear-cache', get = (req, res) ->
   res.render 'index'
 app.post '/clear-cache', post = (req, res, next) ->

--- a/desktop/apps/clear_cache/test/index.coffee
+++ b/desktop/apps/clear_cache/test/index.coffee
@@ -14,3 +14,4 @@ describe 'clear cache app', ->
     app.__get__('all')({ user: new Backbone.Model(type: 'User') }, { status: -> },
       next = sinon.stub())
     next.args[0][0].toString().should.containEql 'must be logged in as an admin'
+    next.args[0][0].status.should.eql 403

--- a/yarn.lock
+++ b/yarn.lock
@@ -5639,6 +5639,7 @@ jade@^1.11.0:
     jstransformer "0.0.2"
     mkdirp "~0.5.0"
     transformers "2.1.0"
+    uglify-js "^2.4.19"
     void-elements "~2.0.1"
     with "~4.0.0"
 
@@ -7962,7 +7963,7 @@ react-komposer@^2.0.0:
     react-stubber "^1.0.0"
     shallowequal "^0.2.2"
 
-"react-lines-ellipsis@github:damassi/react-lines-ellipsis":
+react-lines-ellipsis@damassi/react-lines-ellipsis:
   version "0.7.3"
   resolved "https://codeload.github.com/damassi/react-lines-ellipsis/tar.gz/c7cf3895efbd6eb524af3f4151bba34f481c500b"
 
@@ -9785,7 +9786,7 @@ ua-parser@^0.3.5:
   dependencies:
     yamlparser ">=0.0.2"
 
-uglify-js@2.x.x, uglify-js@^2.4.19, uglify-js@^2.8.29:
+uglify-js@2.x.x, uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:


### PR DESCRIPTION
This fixes a couple of sentry errors we keep seeing for errors that should be 400-level (i.e. not reported).

I believe what's happening in this case is that we weren't setting the `status` on the error object, so it got mistakenly [interpreted as a 500](https://github.com/artsy/force/blob/master/lib/middleware/error_handler.coffee#L12).

This updates those two places to correctly send 403 errors.

Should fix https://sentry.io/artsynet/force-production/issues/275370917/ and https://sentry.io/artsynet/force-production/issues/375324373/