### PR TITLE
@mzikherman => be defensive about the artist biography page

### DIFF
--- a/mobile/apps/artist/routes.coffee
+++ b/mobile/apps/artist/routes.coffee
@@ -21,7 +21,7 @@ query = """
 shouldDisplayAppBanner = (req) ->
   userAgent = req.headers['user-agent']
   dismissedAppBanner = req.cookies['dismissed-app-banner'] || false
-  
+
   userAgent.match(/iPhone/i) and
     not userAgent.match('Artsy-Mobile') and
     not dismissedAppBanner

--- a/mobile/apps/artist/templates/header.jade
+++ b/mobile/apps/artist/templates/header.jade
@@ -1,11 +1,11 @@
--var hometown = artist.hometown || artist.get('hometown')
--var years = artist.years || artist.get('years')
--var name = artist.name || artist.get('name')
+-var hometown = artist.hometown || (typeof artist.get === 'function' ? artist.get('hometown') : null)
+-var years = artist.years || (typeof artist.get === 'function' ? artist.get('years') : null)
+-var name = artist.name || (typeof artist.get === 'function' ? artist.get('name') : null)
 
 header#artist-page-header
   h1.artist-page-large-header.avant-garde-header-center= name
   h2
     = hometown
     if years && hometown
-      | , 
+      | ,
     = years

--- a/mobile/apps/artist/test/templates.coffee
+++ b/mobile/apps/artist/test/templates.coffee
@@ -65,6 +65,19 @@ describe 'Biography', ->
 
   it 'renders the bio and credit if there is one', ->
     @locals.artist = { hometown: 'Heaven', years: '1995 - 2014', name: 'Bitty', id: 'bitty', biography_blurb: { credit: 'Submitted by Matt', text: 'Bitty was a cat.' } }
-    render('biography')(@locals).should.containEql 'Bitty was a cat.'
-    render('biography')(@locals).should.containEql 'Submitted by Matt'
-  
+    template = render('biography')(@locals)
+    template.should.containEql 'Bitty was a cat.'
+    template.should.containEql 'Submitted by Matt'
+
+describe 'Header', ->
+
+  beforeEach ->
+    @locals = { sd: {}, asset: (->) }
+
+  it 'renders the byline if there is no hometown and no year', ->
+    @locals.artist = { hometown: null, years: null, name: 'Bitty', id: 'bitty', biography_blurb: { credit: 'Submitted by Matt', text: 'Bitty was a cat.' } }
+    render('header')(@locals).should.containEql('Bitty')
+
+  it 'renders the byline if there is no hometown', ->
+    @locals.artist = { hometown: null, years: '1995 - 2014', name: 'Bitty', id: 'bitty', biography_blurb: { credit: 'Submitted by Matt', text: 'Bitty was a cat.' } }
+    render('header')(@locals).should.containEql('1995 - 2014')


### PR DESCRIPTION
Fixes: https://sentry.io/artsynet/force-production/issues/345452571/events/8359706025/

There's a more general issue, which is that we're trying to re-use this header template for an `artist` object that could be a backbone model or a graphql response. Would be great to convert everything to metaphysics-backed data, but I didn't want to jump into that for this bug-fix. Also I've vaguely heard about plans to update the artist page? So hopefully this kind of refactor would be included in that as well.