### PR TITLE
Fix display issues with add to cal widget

### DIFF
--- a/desktop/components/add_to_calendar/index.coffee
+++ b/desktop/components/add_to_calendar/index.coffee
@@ -8,8 +8,10 @@ module.exports = class AddToCalendar extends Backbone.View
 
   showCalenderOptions: (e) ->
     e.preventDefault()
+    @$el.find('.add-to-calendar__wrapper').css({height: '205px'})
     $(e.currentTarget).next().show()
 
   hideCalenderOptions: (e) ->
     e.preventDefault()
+    @$el.find('.add-to-calendar__wrapper').css({height: ''})
     $(e.currentTarget).children('.add-to-calendar-event-calendar-wrapper').hide()

--- a/desktop/components/add_to_calendar/index.styl
+++ b/desktop/components/add_to_calendar/index.styl
@@ -5,7 +5,6 @@
   &__wrapper
     position absolute
     width 150px
-    height 205px
     top -18px
 
 .add-to-calendar-event-item-date

--- a/desktop/components/add_to_calendar/react.js
+++ b/desktop/components/add_to_calendar/react.js
@@ -17,8 +17,10 @@ export default class AddToCalendar extends Component {
 
     this.setState(() => {
       this.view = new AddToCalendarView({
-        el: this.props.el || this.$('.auction2-AuctionInfo__callout')
+        el: this.props.el || this.$('.add-to-calendar')
       })
+      console.log("*****", this.view)
+      console.log(this)
 
       return {
         isMounted: true

--- a/desktop/components/add_to_calendar/react.js
+++ b/desktop/components/add_to_calendar/react.js
@@ -19,8 +19,6 @@ export default class AddToCalendar extends Component {
       this.view = new AddToCalendarView({
         el: this.props.el || this.$('.add-to-calendar')
       })
-      console.log("*****", this.view)
-      console.log(this)
 
       return {
         isMounted: true


### PR DESCRIPTION
An auctions team member reported that the [CMA Benefit Auction 2017](https://www.artsy.net/auction/cma-benefit-auction-2017) partner was complaining that its link was unclickable. I looked into it and saw that the calendar wrapper was invisible but blocking the link from being clickable. In addition the hover events were not revealing the calendar bits that belonged there. This is an initial, quick fix that seems to resolve it, but I'm not 💯 on whether this is the best way to go about it or whether it will affect other areas the widget might be used.

Before: Text/link not directly under mouse when they are below the widget, widget hover function not working
![caldiv](https://user-images.githubusercontent.com/9088720/32057071-3dc76cac-ba34-11e7-8310-75356bde590f.gif)

Now: Both are working
![caldiv2](https://user-images.githubusercontent.com/9088720/32057085-44ce560a-ba34-11e7-8883-a21f3aa3caf5.gif)

