### PR TITLE
Only admins should be able to see marketing modal edit page

### DIFF
--- a/desktop/apps/marketing_signup_modals/index.coffee
+++ b/desktop/apps/marketing_signup_modals/index.coffee
@@ -15,7 +15,7 @@ page = new JSONPage
 
 { data, edit, upload } = require('../../components/json_page/routes')(page)
 
-app.get page.paths.show, routes.index
-app.get page.paths.show + '/data', data
+app.get page.paths.show, adminOnly, routes.index
+app.get page.paths.show + '/data', adminOnly, data
 app.get page.paths.edit, adminOnly, edit
 app.post page.paths.edit, adminOnly, upload


### PR DESCRIPTION
I just noticed https://www.artsy.net/marketing-signup-modals is publicly accessible. It doesn’t look like it hosts any private information right now, but in the future we may add sensitive data to it.