### PR TITLE
Add example url for marketing modal

### DIFF
--- a/desktop/apps/marketing_signup_modals/templates/index.jade
+++ b/desktop/apps/marketing_signup_modals/templates/index.jade
@@ -23,7 +23,8 @@ block body
         for modal in modals
           tr
             th= modal["campaignName"]
-            th= modal["slug"]
+            th
+              a(href="https://www.artsy.net/?m-id=#{modal['slug']}", target="_blank")= modal["slug"]
             th= modal["copy"]
             th
               a(href=modal["image"])= modal["image"]

--- a/desktop/apps/marketing_signup_modals/templates/index.jade
+++ b/desktop/apps/marketing_signup_modals/templates/index.jade
@@ -18,6 +18,7 @@ block body
           th Photo Credit
           th Text Color
           th Duration
+          th Text Opacity
       tbody
         for modal in modals
           tr


### PR DESCRIPTION
It took me a while to figure out what the query string key should be to trigger a marketing modal, so it would be nice if the admin page had an example link.

 * Show slugs as a link
 * Also added "Text Opacity" to the title header

![screen_shot_2017-10-26_at_2_11_42_pm](https://user-images.githubusercontent.com/386234/32069649-cb7fa1b8-ba57-11e7-9e26-4b7fe4f63eac.png)
