### PR TITLE
Alwys display the marketing modal for the Miami Fair Week on /miami-fair-week

### DIFF
--- a/desktop/apps/miami_fair_week/index.js
+++ b/desktop/apps/miami_fair_week/index.js
@@ -50,11 +50,4 @@ class EditableMiamFairWeekPage extends JSONPage {
   }
 }
 
-// This smells... For some reason 'export default' doesn't work when this file is required by a coffeescript file.
-export default new EditableMiamFairWeekPage({
-  name: SLUG,
-  paths: {
-    show: `/${SLUG}`,
-    edit: `/${SLUG}/edit`
-  }
-}).app
+export default new EditableMiamFairWeekPage({ name: SLUG, paths: { show: `/${SLUG}`, edit: `/${SLUG}/edit` }}).app

--- a/desktop/apps/miami_fair_week/index.js
+++ b/desktop/apps/miami_fair_week/index.js
@@ -7,6 +7,7 @@ import adminOnly from '../../lib/admin_only'
 import JSONPage from '../../components/json_page/es6'
 import MiamiFairWeekPage from './components/MiamiFairWeekPage'
 
+const SLUG = 'miami-fair-week'
 const MARKETING_MODAL_ID = 'ca12'
 
 class EditableMiamFairWeekPage extends JSONPage {
@@ -22,7 +23,7 @@ class EditableMiamFairWeekPage extends JSONPage {
       if (req.query['m-id'] !== MARKETING_MODAL_ID) {
         const queryStringAsString = queryString.stringify(merge({}, req.query, { 'm-id': MARKETING_MODAL_ID }))
 
-        return res.redirect(`/miami-fair-week?${queryStringAsString}`)
+        return res.redirect(`/${SLUG}?${queryStringAsString}`)
       }
 
       const data = await this.jsonPage.get()
@@ -51,9 +52,9 @@ class EditableMiamFairWeekPage extends JSONPage {
 
 // This smells... For some reason 'export default' doesn't work when this file is required by a coffeescript file.
 export default new EditableMiamFairWeekPage({
-  name: 'miami-fair-week',
+  name: SLUG,
   paths: {
-    show: '/miami-fair-week',
-    edit: '/miami-fair-week/edit'
+    show: `/${SLUG}`,
+    edit: `/${SLUG}/edit`
   }
 }).app

--- a/desktop/apps/miami_fair_week/index.js
+++ b/desktop/apps/miami_fair_week/index.js
@@ -1,9 +1,13 @@
 import React from 'react'
+import queryString from 'query-string'
+import merge from 'lodash.merge'
 import { renderLayout } from '@artsy/stitch'
 
 import adminOnly from '../../lib/admin_only'
 import JSONPage from '../../components/json_page/es6'
 import MiamiFairWeekPage from './components/MiamiFairWeekPage'
+
+const MARKETING_MODAL_ID = 'ca12'
 
 class EditableMiamFairWeekPage extends JSONPage {
   registerRoutes() {
@@ -15,6 +19,12 @@ class EditableMiamFairWeekPage extends JSONPage {
 
   async show(req, res, next) {
     try {
+      if (req.query['m-id'] !== MARKETING_MODAL_ID) {
+        const queryStringAsString = queryString.stringify(merge({}, req.query, { 'm-id': MARKETING_MODAL_ID }))
+
+        return res.redirect(`/miami-fair-week?${queryStringAsString}`)
+      }
+
       const data = await this.jsonPage.get()
       const layout = await renderLayout({
         basePath: __dirname,

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "prop-types": "^15.5.8",
     "prundupify": "^1.0.0",
     "qs": "^6.3.0",
+    "query-string": "^5.0.1",
     "raven": "^1.2.1",
     "raven-js": "^3.14.2",
     "rc-slider": "^7.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3291,6 +3291,10 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
 deep-defaults@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/deep-defaults/-/deep-defaults-1.0.4.tgz#1a9762e2b6c8d6a4e9931b8ee7ff8cdcee1d1750"
@@ -7736,6 +7740,14 @@ query-string@^4.1.0, query-string@^4.2.3:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
   dependencies:
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
+query-string@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.0.1.tgz#6e2b86fe0e08aef682ecbe86e85834765402bd88"
+  dependencies:
+    decode-uri-component "^0.2.0"
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 


### PR DESCRIPTION
It seems like it is ok to show the default modal when the login button in the header is clicked, but we still need to show the specialized marketing modal for Miami Fair Week for every request. In order to make sure to always show the modal, the request without the `m-id` key will be redirected to the same path but with the `m-id=ca12` pair (`ca12` is already available both in staging and production). Not sure if there's a better way to achieve this but open to suggestions.