### PR TITLE
@damassi => guard for presence of artist on artwork in auction ActiveBidItem

### DIFF
--- a/desktop/apps/auction/components/layout/active_bids/ActiveBidItem.js
+++ b/desktop/apps/auction/components/layout/active_bids/ActiveBidItem.js
@@ -3,6 +3,7 @@ import React from 'react'
 import block from 'bem-cn'
 import { connect } from 'react-redux'
 import { getLiveAuctionUrl } from 'utils/domain/auctions/urls'
+import get from 'lodash.get'
 
 function ActiveBidItem (props) {
   const {
@@ -46,7 +47,7 @@ function ActiveBidItem (props) {
           Lot {lot_label}
         </div>
         <h3>
-          {artwork.artist.name}
+          {get(artwork, 'artist.name', '')}
         </h3>
         <div className={b('title')}>
           <em>


### PR DESCRIPTION
 A partner complained that they could not access a sale while logged in. On looking into it I noticed that we assume an active bid artwork to have an artist property. I was able to recreate the problem in staging and fix it by guarding for this on our new auction page. Verified in development.