### PR TITLE
Make it easier to tap/click the modal close button

### DIFF
--- a/desktop/components/modalize/stylesheets/index.styl
+++ b/desktop/components/modalize/stylesheets/index.styl
@@ -53,8 +53,9 @@
 
 .modalize-close
   position absolute
-  top 25px
-  right 25px
+  top 0
+  right 0
+  padding 25px
   cursor pointer
   transition opacity 0.25s
   opacity 0.15


### PR DESCRIPTION
On mobile, it's a bit hard to tap the "x" close button. using `padding` will expand the tappable area and make it easier to tap it.