### PR TITLE
@eessex => Update jsonLD attribution on article pages

### DIFF
--- a/desktop/apps/article/queries/articleBody.js
+++ b/desktop/apps/article/queries/articleBody.js
@@ -10,6 +10,8 @@ export default `
   thumbnail_title
   social_image
   published_at
+  tags
+  tracking_tags
   slug
   layout
   featured

--- a/desktop/apps/article/routes.js
+++ b/desktop/apps/article/routes.js
@@ -23,6 +23,7 @@ export async function index (req, res, next) {
       req
     })
     const article = data.article
+    const articleModel = new Article(data.article)
 
     if (article.channel_id !== sd.ARTSY_EDITORIAL_CHANNEL) {
       return classic(req, res, next)
@@ -69,6 +70,7 @@ export async function index (req, res, next) {
     }
 
     const isMobile = res.locals.sd.IS_MOBILE
+    const jsonLD = articleModel.toJSONLD()
 
     const layout = await renderLayout({
       basePath: res.app.get('views'),
@@ -89,11 +91,12 @@ export async function index (req, res, next) {
       },
       data: {
         article,
+        isSuper,
+        isMobile,
+        jsonLD,
         subscribed,
         superArticle,
-        superSubArticles,
-        isSuper,
-        isMobile
+        superSubArticles
       },
       templates
     })

--- a/desktop/apps/article/routes.js
+++ b/desktop/apps/article/routes.js
@@ -70,7 +70,7 @@ export async function index (req, res, next) {
     }
 
     const isMobile = res.locals.sd.IS_MOBILE
-    const jsonLD = articleModel.toJSONLD()
+    const jsonLD = stringifyJSONForWeb(articleModel.toJSONLD())
 
     const layout = await renderLayout({
       basePath: res.app.get('views'),

--- a/desktop/apps/article/templates/__tests__/amp.test.js
+++ b/desktop/apps/article/templates/__tests__/amp.test.js
@@ -41,8 +41,9 @@ describe('AMP Templates', () => {
   })
 
   it('includes analytics', () => {
+    const article = new Article(fixtures.article).set({channel_id: null})
     const html = render('amp_article')({
-      article: new Article(fixtures.article),
+      article,
       crop: url => url,
       resize: url => url,
       moment: () => {},

--- a/desktop/apps/partner/test/client/articles.coffee
+++ b/desktop/apps/partner/test/client/articles.coffee
@@ -138,7 +138,10 @@ describe 'ArticlesAdapter', ->
       @view.el.html().should.not.containEql 'articles-grid__more-button'
 
     it 'renders the json-ld', ->
-      Backbone.sync.args[0][2].success fixtures.article
+      article = _.extend {}, fixtures.article,
+        channel_id: null
+        partner_channel_id: '123'        
+      Backbone.sync.args[0][2].success article
       html = @view.el.html()
       html.should.containEql 'json-ld'
-      html.should.containEql 'Other'
+      html.should.containEql 'Partner'

--- a/desktop/apps/partner2/test/client/articles.coffee
+++ b/desktop/apps/partner2/test/client/articles.coffee
@@ -139,7 +139,10 @@ describe 'ArticlesAdapter', ->
       @view.el.html().should.not.containEql 'articles-grid__more-button'
 
     it 'renders the json-ld', ->
-      Backbone.sync.args[0][2].success fixtures.article
+      article = _.extend {}, fixtures.article,
+        channel_id: null
+        partner_channel_id: '123'        
+      Backbone.sync.args[0][2].success article
       html = @view.el.html()
       html.should.containEql 'json-ld'
-      html.should.containEql 'Other'
+      html.should.containEql 'Partner'

--- a/desktop/models/article.coffee
+++ b/desktop/models/article.coffee
@@ -130,7 +130,7 @@ module.exports = class Article extends Backbone.Model
     crop @get(attr), args...
 
   date: (attr) ->
-    if @get('channel_id') is sd.ARTSY_EDITORIAL_CHANNEL
+    if @get('channel_id') is ARTSY_EDITORIAL_CHANNEL
       momentTimezone(@get(attr)).tz('America/New_York')
     else
       moment(@get(attr)).local()

--- a/desktop/models/article.coffee
+++ b/desktop/models/article.coffee
@@ -222,8 +222,8 @@ module.exports = class Article extends Backbone.Model
         success: (article) =>
           superSubArticles.add article
 
-  getParselySection: (channel) ->
-    if @get('channel_id') is sd.ARTSY_EDITORIAL_CHANNEL
+  getParselySection: ->
+    if @get('channel_id') is ARTSY_EDITORIAL_CHANNEL
       'Editorial'
     else if @get('channel_id')
       @get('channel')?.get('name')
@@ -233,7 +233,7 @@ module.exports = class Article extends Backbone.Model
       'Other'
 
   # article metadata tag for parse.ly
-  toJSONLD: (channel) ->
+  toJSONLD: ->
     tags = @get('tags')
     tags = tags.concat @get('vertical').name if @get('vertical')
     tags = tags.concat @get('tracking_tags') if @get('tracking_tags')
@@ -244,12 +244,12 @@ module.exports = class Article extends Backbone.Model
       "url": @fullHref()
       "thumbnailUrl": @get('thumbnail_image')
       "dateCreated": @get('published_at')
-      "articleSection": @getParselySection(channel)
+      "articleSection": @getParselySection()
       "creator": @getAuthorArray()
       "keywords": tags
     }
 
-  toJSONLDAmp: (channel) ->
+  toJSONLDAmp: ->
     compactObject {
       "@context": "http://schema.org"
       "@type": "NewsArticle"

--- a/desktop/test/models/article.coffee
+++ b/desktop/test/models/article.coffee
@@ -12,7 +12,9 @@ momentTimezone = require 'moment-timezone'
 
 describe "Article", ->
   beforeEach ->
-    Article.__set__ 'sd', { EOY_2016_ARTICLE: '1234', ARTSY_EDITORIAL_CHANNEL: '5759e3efb5989e6f98f77993' }
+    Article.__set__ 'sd', {EOY_2016_ARTICLE: '1234'}
+    Article.__set__ 'ARTSY_EDITORIAL_CHANNEL', '5759e3efb5989e6f98f77993'
+    Article.__set__
     sinon.stub Backbone, 'sync'
       .returns Q.defer()
     @article = new Article
@@ -231,23 +233,26 @@ describe "Article", ->
   describe 'getParselySection', ->
 
     it 'returns Editorial', ->
-      @article.set 'channel', new Backbone.Model name: 'Artsy Editorial'
+      @article.set
+        channel_id: '5759e3efb5989e6f98f77993'
       @article.getParselySection().should.equal 'Editorial'
 
     it 'returns channel name', ->
-      @article.set 'channel', new Backbone.Model name: 'Life at Artsy'
+      @article.set
+        channel: new Backbone.Model name: 'Life at Artsy'
+        channel_id: '123'
       @article.getParselySection().should.equal 'Life at Artsy'
 
-    it 'returns Section', ->
-      @article.set 'section', new Backbone.Model title: '56th Venice Biennale'
-      @article.getParselySection().should.equal '56th Venice Biennale'
-
     it 'returns Partner', ->
-      @article.set 'partner', new Backbone.Model
+      @article.set
+        partner_channel_id: '123'
+        channel_id: null
       @article.getParselySection().should.equal 'Partner'
 
     it 'returns Other', ->
-      @article.clear()
+      @article.set
+        partner_channel_id: null
+        channel_id: null
       @article.getParselySection().should.equal 'Other'
 
   describe 'isEOYSubArticle', ->

--- a/desktop/test/models/article.coffee
+++ b/desktop/test/models/article.coffee
@@ -174,28 +174,6 @@ describe "Article", ->
       @article.set 'lead_paragraph', '<p>Existy</p>'
       @article.strip('lead_paragraph').should.equal 'Existy'
 
-  describe '#prepForInstant', ->
-
-    it 'returns the article with empty tags removed', ->
-      @article.set 'sections', [
-        { type: 'text', body: '<p>First Paragraph</p><p></p>' },
-        { type: 'text', body: '<p>Second Paragraph</p><br>'}
-      ]
-      @article.prepForInstant()
-      @article.get('sections')[0].body.should.equal '<p>First Paragraph</p>'
-      @article.get('sections')[1].body.should.equal '<p>Second Paragraph</p>'
-
-    it 'returns the article with captions p tags replaced by h1', ->
-      @article.set 'sections', [
-        { type: 'image', caption: '<p>First Paragraph</p>' },
-        { type: 'image_set', images: [
-          { type: 'image', caption: '<p>A place for credit</p>' }
-        ]}
-      ]
-      @article.prepForInstant()
-      @article.get('sections')[0].caption.should.equal '<h1>First Paragraph</h1>'
-      @article.get('sections')[1].images[0].caption.should.equal '<h1>A place for credit</h1>'
-
   describe 'byline', ->
 
     it 'returns the author when there are no contributing authors', ->


### PR DESCRIPTION
Fixes an issue in Parsely where editorial articles aren't being attributed to the 'Editorial' section