### PR TITLE
Fetch all slugs for related articles

### DIFF
--- a/desktop/apps/article/queries/relatedArticles.js
+++ b/desktop/apps/article/queries/relatedArticles.js
@@ -1,6 +1,7 @@
 export default `
   relatedArticlesPanel {
     slug
+    slugs
     thumbnail_title
     thumbnail_image
     contributing_authors {
@@ -9,6 +10,7 @@ export default `
   }
   relatedArticlesCanvas {
     slug
+    slugs
     thumbnail_title
     thumbnail_image
     contributing_authors {


### PR DESCRIPTION
Related to 
https://waffle.io/artsy/publishing/cards/59fc727221451400241101bf

Not all articles seem to have a slug, causing links in the related articles panel to return null.

![screen shot 2017-11-03 at 11 50 39 am](https://user-images.githubusercontent.com/1497424/32383048-41ba31d2-c08d-11e7-875b-b5eba42b3716.png)
