### PR TITLE
@damassi => include auction symbol for server-side rendering

### DIFF
--- a/desktop/apps/auction/routes.js
+++ b/desktop/apps/auction/routes.js
@@ -67,6 +67,7 @@ export async function index (req, res, next) {
         },
         isClosed: sale.is_closed,
         requestID: req.id,
+        symbol: sale.symbol,
         user: res.locals.sd.CURRENT_USER
       }, auctionWorksInitialState)
     })


### PR DESCRIPTION
We weren't passing the `symbol` data into our initial store (as the price slider is rendered server-side). This should fix the bug where Veritas (and presumably other sales) don't show the correct currency for this slider.