### PR TITLE
@oxaudo => Some tweaks to availability display on the artwork page

### DIFF
--- a/desktop/apps/artwork/components/commercial/templates/price.jade
+++ b/desktop/apps/artwork/components/commercial/templates/price.jade
@@ -1,5 +1,7 @@
-- var showPriceLabel = artwork.price && artwork.availability !== 'sold'
-if artwork.sale_message
+- var isPermanentCollection = artwork.availability === 'permanent collection'
+- var isOnLoan = artwork.availability === 'on loan'
+- var showPriceLabel = artwork.price && artwork.availability !== 'sold' && !isOnLoan && !isPermanentCollection
+if artwork.sale_message || isPermanentCollection
   .artwork-commercial__container
     .artwork-commercial__sale-message
       if showPriceLabel
@@ -11,6 +13,8 @@ if artwork.sale_message
             data-message= 'The range is an approximate indication of the work’s price point, and the exact price is quoted upon request.'
             data-anchor= 'bottom-right'
           )
+      else if isPermanentCollection
+        | Permanent collection
       else
         | #{artwork.sale_message}
 

--- a/desktop/apps/artwork/components/commercial/test/template.coffee
+++ b/desktop/apps/artwork/components/commercial/test/template.coffee
@@ -39,4 +39,16 @@ describe 'Commercial template', ->
     $ = cheerio.load(html)
     $('input[name=email]').length.should.eql 1
 
+  it 'correctly displays on loan without pricing info', ->
+    html = renderArtwork { availability: 'on loan', sale_message: 'On loan', price: '$5,000' }
+    $ = cheerio.load(html)
+    $('.artwork-commercial__sale-message').text().should.eql 'On loan'
+    $('.artwork-commercial__shipping-info').length.should.eql 0
+
+  it 'correctly displays permanent collection without pricing info', ->
+    html = renderArtwork { availability: 'permanent collection', price: '$5,000' }
+    $ = cheerio.load(html)
+    $('.artwork-commercial__sale-message').text().should.eql 'Permanent collection'
+    $('.artwork-commercial__shipping-info').length.should.eql 0
+
 


### PR DESCRIPTION
Updates a few things:

- Removes price description/tooltip from `On loan` works, and display `Permanent collection`.

<img width="384" alt="screen shot 2017-11-07 at 11 58 28 am" src="https://user-images.githubusercontent.com/1457859/32508512-94f6d5c0-c3b8-11e7-9783-31fd5ff23071.png">


<img width="382" alt="screen shot 2017-11-07 at 11 58 55 am" src="https://user-images.githubusercontent.com/1457859/32508522-9a9e3982-c3b8-11e7-9cfd-a556990ca8de.png">

Note this depends on https://github.com/artsy/gravity/pull/11392 , being able to have the artwork-level availabilities set on one-edition set works. For now, I just did a `set` in the staging console.
