### PR TITLE
Add a guard against fair profiles without icons

### DIFF
--- a/desktop/apps/fairs/helpers/view_helpers.coffee
+++ b/desktop/apps/fairs/helpers/view_helpers.coffee
@@ -49,7 +49,7 @@ module.exports =
     @isEligible(fair) and @isNotOver(fair)
 
   isEligible: (fair) ->
-    fair.is_published and fair.profile?.is_published
+    fair.is_published and fair.profile?.is_published and fair.profile?.icon?.url
 
   isNotOver: (fair) ->
     Date.parse(fair.end_at) > new Date


### PR DESCRIPTION
### Steps to reproduce

 1. Go to https://admin-fairs.artsy.net
 2. Find an upcoming fair that has a `fair_profile` that doesn't have an `icon` (create a new fair if there isn't any)
 3. Navigate to the Handle and Visibility page by clicking the PROFILE tab and the HANDLE AND VISIBILITY tab underneath
 4. Mark the fair profile as published (here `hidden` could be either)
 5. Save changes
 6. Go to https://www.artsy.net/art-fairs and observe

### Actual

The page displays the 500 error page.

### Expected

 1. On step 4, the admin should not be able to mark a fair profile as published if the profile is missing an `icon`. Or,
 2. The `/art-fairs` (or any page that loads fair profiles) should just work (they should be aware of the fact that a `fair_profile` may not have an `icon`)

This PR implements the 2 as a temporary fix.