### PR TITLE
@craigspaeth => Use webfont URL in amp pages

### DIFF
--- a/desktop/apps/article/templates/amp_mixins.jade
+++ b/desktop/apps/article/templates/amp_mixins.jade
@@ -116,7 +116,7 @@ mixin amp_head
   meta(charset='utf-8')
   title= article.get('search_title') || article.get('thumbnail_title')
   link(rel='canonical', href=article.fullHref())
-  link(type="text/css" rel="stylesheet" href="https://fast.fonts.net/cssapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.css")
+  link(type='text/css' rel='stylesheet' href='#{sd.WEBFONT_URL}/force-webfonts.css?a=b')
   meta(name='viewport', content='width=device-width,minimum-scale=1,initial-scale=1')
   script(type='application/ld+json')
     != [jsonLD]


### PR DESCRIPTION
Fixes an issue [noted by Devang today](https://artsy.slack.com/files/U06RJAKV0/F7VUYGG91/screenshot_20171107-011114.jpg) -- AMP pages were not updated with the new WEBFONT_URL var when added a month or so ago.  This lets them access the artsy-icons font for logo and share icons. 
