### PR TITLE
@craigspaeth => Fix edit button route

### DIFF
--- a/desktop/apps/article/components/EditButton.js
+++ b/desktop/apps/article/components/EditButton.js
@@ -37,7 +37,7 @@ export default class EditButton extends React.Component {
       return false
     } else {
       return (
-        <StyledEditButton target='_blank' href={`${sd.POSITRON_URL}/articles/${this.props.slug}/edit2`}>
+        <StyledEditButton target='_blank' href={`${sd.POSITRON_URL}/articles/${this.props.slug}/edit`}>
           <i className='icon-with-black-circle icon-edit' />
         </StyledEditButton>
       )

--- a/desktop/apps/article/components/__tests__/EditButton.test.js
+++ b/desktop/apps/article/components/__tests__/EditButton.test.js
@@ -23,7 +23,7 @@ describe('<EditButton />', () => {
     const rendered = mount(<EditButton slug='artsy-editorial-slug' channelId='123' />)
     await promise
     const html = rendered.html()
-    html.should.containEql('/articles/artsy-editorial-slug/edit2')
+    html.should.containEql('/articles/artsy-editorial-slug/edit')
     html.should.containEql('icon-with-black-circle')
   })
 


### PR DESCRIPTION
Hold over from the article2 switch -- switch link to `/edit2` back to `/edit`