### PR TITLE
@damassi => Bump express-reloadable 1.1.0; watch @artsy/reaction-force

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -209,18 +209,22 @@ export default function (app) {
   // Setup hot-swap loader
   if (NODE_ENV === 'development') {
     const { createReloadable } = require('@artsy/express-reloadable')
-    const reloadAndMount = createReloadable(app, require)
+    const mountAndReload = createReloadable(app, require)
 
     app.use((req, res, next) => {
       if (res.locals.sd.IS_MOBILE) {
-        const mobileApp = reloadAndMount(path.join(__dirname, '..', 'mobile'))
+        const mobileApp = mountAndReload('../mobile')
         mobileApp(req, res, next)
       } else {
         next()
       }
     })
 
-    reloadAndMount(path.join(__dirname, '..', 'desktop'))
+    mountAndReload('../desktop', {
+      additionalModules: [
+        '@artsy/reaction-force'
+      ]
+    })
 
     // In staging or prod, mount routes normally
   } else {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "sh scripts/test.sh"
   },
   "dependencies": {
-    "@artsy/express-reloadable": "^1.0.3",
+    "@artsy/express-reloadable": "^1.1.0",
     "@artsy/reaction-force": "^0.12.0",
     "@artsy/stitch": "^1.2.1",
     "accounting": "^0.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@artsy/express-reloadable@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@artsy/express-reloadable/-/express-reloadable-1.0.3.tgz#ba5ef5160c50dcc25b32ffab078e2a64eecb32a2"
+"@artsy/express-reloadable@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@artsy/express-reloadable/-/express-reloadable-1.1.0.tgz#012a76625df0c069cd05518fe6315baf94f94fcf"
   dependencies:
     chokidar "^1.7.0"
 


### PR DESCRIPTION
Bumps `@artsy/express-reloadable` with new [module-watching ability](https://github.com/artsy/express-reloadable/pull/3). 

**Note:** For now, when pulling changes in via reaction `yarn compile:server` is required. Will follow up with Reaction PR that introduces a new `watch` command that will stream changes over so that dev is as rapid as storybooks. 