### PR TITLE
@kanaabe => Add published_at to related query

### DIFF
--- a/desktop/apps/article/queries/relatedArticles.js
+++ b/desktop/apps/article/queries/relatedArticles.js
@@ -11,6 +11,7 @@ export default `
     slug
     thumbnail_title
     thumbnail_image
+    published_at
     contributing_authors {
       name
     }


### PR DESCRIPTION
This was[ added and merged on Friday](https://github.com/artsy/force/pull/1965), however it is no longer in master (not sure if something was reverted?  Can't tell why it disappeared).

