### PR TITLE
@dblock => Remove alt text from tracking pixel

### DIFF
--- a/desktop/apps/editorial_features/components/gucci/components/App.jsx
+++ b/desktop/apps/editorial_features/components/gucci/components/App.jsx
@@ -88,7 +88,6 @@ export default class App extends Component {
               border='0'
               width='1'
               height='1'
-              alt='Advertisement'
             />
           </a>
 

--- a/desktop/apps/editorial_features/components/gucci/components/App.jsx
+++ b/desktop/apps/editorial_features/components/gucci/components/App.jsx
@@ -85,7 +85,6 @@ export default class App extends Component {
           <a href={`https://ad.doubleclick.net/ddm/jump/N32001.3019648ARTSY/B20483079.208849246;sz=1x1;ord${moment().unix()}=?`}>
             <img
               src={`https://ad.doubleclick.net/ddm/ad/N32001.3019648ARTSY/B20483079.208849246;sz=1x1;ord=${moment().unix()};dc_lat=;dc_rdid=;tag_for_child_directed_treatment=?`}
-              border='0'
               width='1'
               height='1'
             />


### PR DESCRIPTION
Removes the alternative text from the Gucci tracking pixel so we don't see "Advertisement" for some ad blockers. 