### PR TITLE
@eessex => Fixes Google AMP errors

### DIFF
--- a/desktop/apps/article/templates/__tests__/amp.test.js
+++ b/desktop/apps/article/templates/__tests__/amp.test.js
@@ -53,4 +53,19 @@ describe('AMP Templates', () => {
     html.should.containEql('"properties.articleSection": "Other"')
     html.should.containEql('<amp-analytics type="segment">')
   })
+
+  it('includes artsy-icon fonts and fonts.com link', () => {
+    const article = new Article(fixtures.article).set({ channel_id: null })
+    const html = render('amp_article')({
+      article,
+      crop: url => url,
+      resize: url => url,
+      moment: () => { },
+      asset: () => { },
+      sd: { WEBFONT_URL: 'https://webfonts.artsy.net' }
+    })
+    html.should.containEql('https://fast.fonts.net/cssapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.css')
+    html.should.containEql('https://webfonts.artsy.net/artsy-icons.eot?uo9ko')
+    html.should.containEql('<style type="text/css" class="amp-custom">')
+  })
 })

--- a/desktop/apps/article/templates/amp_fonts.jade
+++ b/desktop/apps/article/templates/amp_fonts.jade
@@ -1,0 +1,114 @@
+- url = sd.WEBFONT_URL
+<style amp-custom>
+  @font-face {
+    font-family: 'artsy-icons';
+    src: url(url + "artsy-icons.eot?uo9ko");
+    src: url(url + "artsy-icons.eot?#iefixuo9ko") format('embedded-opentype'), url(url + "artsy-icons.woff2?uo9ko") format('woff2'), url(url + "artsy-icons.ttf?uo9ko") format('truetype'), url(url + "artsy-icons.woff?uo9ko") format('woff'), url(url + "artsy-icons.svg?uo9ko#artsy-icons") format('svg');
+    font-weight: normal;
+    font-style: normal;
+  }
+
+  @font-face{
+    font-family:"ITC Avant Garde Gothic W04_B4";
+    src:url(url + "521186fb-1032-4a81-bff4-a67d052d6e5e.eot?#iefix") format("eot")
+  }
+
+  @font-face{
+    font-family:"ITC Avant Garde Gothic W04";
+    src:url(url + "521186fb-1032-4a81-bff4-a67d052d6e5e.eot?#iefix");
+    src:url(url + "521186fb-1032-4a81-bff4-a67d052d6e5e.eot?#iefix") format("eot"),url(url + "cd6106cf-c21e-4d0b-953e-3905a1b9dece.woff2") format("woff2"),url(url + "5f1f53ca-f786-466b-979b-2dc11d2d05e9.woff") format("woff"),url(url + "ac3dc0aa-6281-4d8f-aadb-67c67099ff9c.ttf") format("truetype"),url(url + "0f98417d-ca43-4d3e-b392-21a473e4917a.svg#0f98417d-ca43-4d3e-b392-21a473e4917a") format("svg");
+    font-weight: 400;
+    font-style: Bold;
+  }
+
+  @font-face{
+    font-family:"Adobe Garamond W08_n4";
+    src:url(url + "9b59db8d-790b-448e-901a-83bee80695d7.eot?#iefix") format("eot")
+  }
+
+  @font-face{
+    font-family:"Adobe Garamond W08";
+    src:url(url + "9b59db8d-790b-448e-901a-83bee80695d7.eot?#iefix");
+    src:url(url + "9b59db8d-790b-448e-901a-83bee80695d7.eot?#iefix") format("eot"),url(url + "794c9044-29a1-4d4e-961e-774f21e86764.woff2") format("woff2"),url(url + "b263ec73-3337-45b9-9e86-933d27164f2c.woff") format("woff"),url(url + "9675cf06-4f76-47fb-97df-9b255507e865.ttf") format("truetype"),url(url + "825d51b9-cc7d-4f4d-ba2c-47ffd291aebd.svg#825d51b9-cc7d-4f4d-ba2c-47ffd291aebd") format("svg");
+    font-weight: 400;
+    font-style: normal;
+  }
+
+  @font-face{
+    font-family:"Adobe Garamond W08_i4";
+    src:url(url + "4c83158e-1435-42b3-9577-b2b30ca41519.eot?#iefix") format("eot")
+  }
+
+  @font-face{
+    font-family:"Adobe Garamond W08";
+    src:url(url + "4c83158e-1435-42b3-9577-b2b30ca41519.eot?#iefix");
+    src:url(url + "4c83158e-1435-42b3-9577-b2b30ca41519.eot?#iefix") format("eot"),url(url + "6f903966-2648-436f-8027-84dce5817cbe.woff2") format("woff2"),url(url + "6d0c45bd-b627-4868-942a-91b2f83580f2.woff") format("woff"),url(url + "6334af5a-f301-4a6a-bbe1-2f3f58d3a799.ttf") format("truetype"),url(url + "f00e2b8d-55bd-4f31-b5ae-e6230f2c8481.svg#f00e2b8d-55bd-4f31-b5ae-e6230f2c8481") format("svg");
+    font-weight: 400;
+    font-style: italic;
+  }
+
+  @font-face{
+    font-family:"Adobe Garamond W08_n6";
+    src:url(url + "c8ffd33b-7f59-4efd-ad34-10f0a04b0bde.eot?#iefix") format("eot")
+  }
+
+  @font-face{
+    font-family:"Adobe Garamond W08";
+    src:url(url + "c8ffd33b-7f59-4efd-ad34-10f0a04b0bde.eot?#iefix");
+    src:url(url + "c8ffd33b-7f59-4efd-ad34-10f0a04b0bde.eot?#iefix") format("eot"),url(url + "41e9be24-e4f1-40a2-b51a-fc8f72905b72.woff2") format("woff2"),url(url + "055ac9f4-28a5-49a7-a54e-fd7d20678142.woff") format("woff"),url(url + "a3eeab6f-eb9e-4115-bb38-ab043636fc6d.ttf") format("truetype"),url(url + "bedb1dd5-06ae-4b04-869f-38561a959175.svg#bedb1dd5-06ae-4b04-869f-38561a959175") format("svg");
+    font-weight: 600;
+    font-style: normal;
+  }
+
+  @font-face{
+    font-family:"ITC Avant Garde Gothic W04_B4";
+    src:url(url + "521186fb-1032-4a81-bff4-a67d052d6e5e.eot?#iefix") format("eot")
+  }
+
+  @font-face{
+    font-family:"ITC Avant Garde Gothic W04";
+    src:url(url + "521186fb-1032-4a81-bff4-a67d052d6e5e.eot?#iefix");
+    src:url(url + "521186fb-1032-4a81-bff4-a67d052d6e5e.eot?#iefix") format("eot"),url(url + "cd6106cf-c21e-4d0b-953e-3905a1b9dece.woff2") format("woff2"),url(url + "5f1f53ca-f786-466b-979b-2dc11d2d05e9.woff") format("woff"),url(url + "ac3dc0aa-6281-4d8f-aadb-67c67099ff9c.ttf") format("truetype"),url(url + "0f98417d-ca43-4d3e-b392-21a473e4917a.svg#0f98417d-ca43-4d3e-b392-21a473e4917a") format("svg");
+    font-weight: 400;
+    font-style: Bold;
+  }
+
+  @font-face{
+    font-family:"Adobe Garamond W08_n4";
+    src:url(url + "9b59db8d-790b-448e-901a-83bee80695d7.eot?#iefix") format("eot")
+  }
+
+  @font-face{
+    font-family:"Adobe Garamond W08";
+    src:url(url + "9b59db8d-790b-448e-901a-83bee80695d7.eot?#iefix");
+    src:url(url + "9b59db8d-790b-448e-901a-83bee80695d7.eot?#iefix") format("eot"),url(url + "794c9044-29a1-4d4e-961e-774f21e86764.woff2") format("woff2"),url(url + "b263ec73-3337-45b9-9e86-933d27164f2c.woff") format("woff"),url(url + "9675cf06-4f76-47fb-97df-9b255507e865.ttf") format("truetype"),url(url + "825d51b9-cc7d-4f4d-ba2c-47ffd291aebd.svg#825d51b9-cc7d-4f4d-ba2c-47ffd291aebd") format("svg");
+    font-weight: 400;
+    font-style: normal;
+  }
+
+  @font-face{
+    font-family:"Adobe Garamond W08_i4";
+    src:url(url + "4c83158e-1435-42b3-9577-b2b30ca41519.eot?#iefix") format("eot")
+  }
+
+  @font-face{
+    font-family:"Adobe Garamond W08";
+    src:url("4c83158e-1435-42b3-9577-b2b30ca41519.eot?#iefix");
+    src:url("4c83158e-1435-42b3-9577-b2b30ca41519.eot?#iefix") format("eot"),url("6f903966-2648-436f-8027-84dce5817cbe.woff2") format("woff2"),url("6d0c45bd-b627-4868-942a-91b2f83580f2.woff") format("woff"),url("6334af5a-f301-4a6a-bbe1-2f3f58d3a799.ttf") format("truetype"),url("f00e2b8d-55bd-4f31-b5ae-e6230f2c8481.svg#f00e2b8d-55bd-4f31-b5ae-e6230f2c8481") format("svg");
+    font-weight: 400;
+    font-style: italic;
+  }
+
+  @font-face{
+    font-family:"Adobe Garamond W08_n6";
+    src:url("c8ffd33b-7f59-4efd-ad34-10f0a04b0bde.eot?#iefix") format("eot")
+  }
+
+  @font-face{
+    font-family:"Adobe Garamond W08";
+    src:url("c8ffd33b-7f59-4efd-ad34-10f0a04b0bde.eot?#iefix");
+    src:url("c8ffd33b-7f59-4efd-ad34-10f0a04b0bde.eot?#iefix") format("eot"),url("41e9be24-e4f1-40a2-b51a-fc8f72905b72.woff2") format("woff2"),url("055ac9f4-28a5-49a7-a54e-fd7d20678142.woff") format("woff"),url("a3eeab6f-eb9e-4115-bb38-ab043636fc6d.ttf") format("truetype"),url("bedb1dd5-06ae-4b04-869f-38561a959175.svg#bedb1dd5-06ae-4b04-869f-38561a959175") format("svg");
+    font-weight: 600;
+    font-style: normal;
+  }
+</style>

--- a/desktop/apps/article/templates/amp_fonts.jade
+++ b/desktop/apps/article/templates/amp_fonts.jade
@@ -7,7 +7,7 @@ style.amp-custom(type='text/css').
     font-family: 'artsy-icons';
     src: url("#{url}/artsy-icons.eot?uo9ko");
     src: url("#{url}/artsy-icons.eot?#iefixuo9ko") format('embedded-opentype'),
-      url("#{url}/artsy-icons.woff2?uo9ko"}) format('woff2'),
+      url("#{url}/artsy-icons.woff2?uo9ko") format('woff2'),
       url("#{url}/artsy-icons.ttf?uo9ko") format('truetype'),
       url("#{url}/artsy-icons.woff?uo9ko") format('woff'),
       url("#{url}/artsy-icons.svg?uo9ko#artsy-icons") format('svg');

--- a/desktop/apps/article/templates/amp_fonts.jade
+++ b/desktop/apps/article/templates/amp_fonts.jade
@@ -1,114 +1,16 @@
 - url = sd.WEBFONT_URL
-<style amp-custom>
+
+link(type="text/css" rel="stylesheet" href="https://fast.fonts.net/cssapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.css")
+
+style.amp-custom(type='text/css').
   @font-face {
     font-family: 'artsy-icons';
-    src: url(url + "artsy-icons.eot?uo9ko");
-    src: url(url + "artsy-icons.eot?#iefixuo9ko") format('embedded-opentype'), url(url + "artsy-icons.woff2?uo9ko") format('woff2'), url(url + "artsy-icons.ttf?uo9ko") format('truetype'), url(url + "artsy-icons.woff?uo9ko") format('woff'), url(url + "artsy-icons.svg?uo9ko#artsy-icons") format('svg');
+    src: url("#{url}/artsy-icons.eot?uo9ko");
+    src: url("#{url}/artsy-icons.eot?#iefixuo9ko") format('embedded-opentype'),
+      url("#{url}/artsy-icons.woff2?uo9ko"}) format('woff2'),
+      url("#{url}/artsy-icons.ttf?uo9ko") format('truetype'),
+      url("#{url}/artsy-icons.woff?uo9ko") format('woff'),
+      url("#{url}/artsy-icons.svg?uo9ko#artsy-icons") format('svg');
     font-weight: normal;
     font-style: normal;
   }
-
-  @font-face{
-    font-family:"ITC Avant Garde Gothic W04_B4";
-    src:url(url + "521186fb-1032-4a81-bff4-a67d052d6e5e.eot?#iefix") format("eot")
-  }
-
-  @font-face{
-    font-family:"ITC Avant Garde Gothic W04";
-    src:url(url + "521186fb-1032-4a81-bff4-a67d052d6e5e.eot?#iefix");
-    src:url(url + "521186fb-1032-4a81-bff4-a67d052d6e5e.eot?#iefix") format("eot"),url(url + "cd6106cf-c21e-4d0b-953e-3905a1b9dece.woff2") format("woff2"),url(url + "5f1f53ca-f786-466b-979b-2dc11d2d05e9.woff") format("woff"),url(url + "ac3dc0aa-6281-4d8f-aadb-67c67099ff9c.ttf") format("truetype"),url(url + "0f98417d-ca43-4d3e-b392-21a473e4917a.svg#0f98417d-ca43-4d3e-b392-21a473e4917a") format("svg");
-    font-weight: 400;
-    font-style: Bold;
-  }
-
-  @font-face{
-    font-family:"Adobe Garamond W08_n4";
-    src:url(url + "9b59db8d-790b-448e-901a-83bee80695d7.eot?#iefix") format("eot")
-  }
-
-  @font-face{
-    font-family:"Adobe Garamond W08";
-    src:url(url + "9b59db8d-790b-448e-901a-83bee80695d7.eot?#iefix");
-    src:url(url + "9b59db8d-790b-448e-901a-83bee80695d7.eot?#iefix") format("eot"),url(url + "794c9044-29a1-4d4e-961e-774f21e86764.woff2") format("woff2"),url(url + "b263ec73-3337-45b9-9e86-933d27164f2c.woff") format("woff"),url(url + "9675cf06-4f76-47fb-97df-9b255507e865.ttf") format("truetype"),url(url + "825d51b9-cc7d-4f4d-ba2c-47ffd291aebd.svg#825d51b9-cc7d-4f4d-ba2c-47ffd291aebd") format("svg");
-    font-weight: 400;
-    font-style: normal;
-  }
-
-  @font-face{
-    font-family:"Adobe Garamond W08_i4";
-    src:url(url + "4c83158e-1435-42b3-9577-b2b30ca41519.eot?#iefix") format("eot")
-  }
-
-  @font-face{
-    font-family:"Adobe Garamond W08";
-    src:url(url + "4c83158e-1435-42b3-9577-b2b30ca41519.eot?#iefix");
-    src:url(url + "4c83158e-1435-42b3-9577-b2b30ca41519.eot?#iefix") format("eot"),url(url + "6f903966-2648-436f-8027-84dce5817cbe.woff2") format("woff2"),url(url + "6d0c45bd-b627-4868-942a-91b2f83580f2.woff") format("woff"),url(url + "6334af5a-f301-4a6a-bbe1-2f3f58d3a799.ttf") format("truetype"),url(url + "f00e2b8d-55bd-4f31-b5ae-e6230f2c8481.svg#f00e2b8d-55bd-4f31-b5ae-e6230f2c8481") format("svg");
-    font-weight: 400;
-    font-style: italic;
-  }
-
-  @font-face{
-    font-family:"Adobe Garamond W08_n6";
-    src:url(url + "c8ffd33b-7f59-4efd-ad34-10f0a04b0bde.eot?#iefix") format("eot")
-  }
-
-  @font-face{
-    font-family:"Adobe Garamond W08";
-    src:url(url + "c8ffd33b-7f59-4efd-ad34-10f0a04b0bde.eot?#iefix");
-    src:url(url + "c8ffd33b-7f59-4efd-ad34-10f0a04b0bde.eot?#iefix") format("eot"),url(url + "41e9be24-e4f1-40a2-b51a-fc8f72905b72.woff2") format("woff2"),url(url + "055ac9f4-28a5-49a7-a54e-fd7d20678142.woff") format("woff"),url(url + "a3eeab6f-eb9e-4115-bb38-ab043636fc6d.ttf") format("truetype"),url(url + "bedb1dd5-06ae-4b04-869f-38561a959175.svg#bedb1dd5-06ae-4b04-869f-38561a959175") format("svg");
-    font-weight: 600;
-    font-style: normal;
-  }
-
-  @font-face{
-    font-family:"ITC Avant Garde Gothic W04_B4";
-    src:url(url + "521186fb-1032-4a81-bff4-a67d052d6e5e.eot?#iefix") format("eot")
-  }
-
-  @font-face{
-    font-family:"ITC Avant Garde Gothic W04";
-    src:url(url + "521186fb-1032-4a81-bff4-a67d052d6e5e.eot?#iefix");
-    src:url(url + "521186fb-1032-4a81-bff4-a67d052d6e5e.eot?#iefix") format("eot"),url(url + "cd6106cf-c21e-4d0b-953e-3905a1b9dece.woff2") format("woff2"),url(url + "5f1f53ca-f786-466b-979b-2dc11d2d05e9.woff") format("woff"),url(url + "ac3dc0aa-6281-4d8f-aadb-67c67099ff9c.ttf") format("truetype"),url(url + "0f98417d-ca43-4d3e-b392-21a473e4917a.svg#0f98417d-ca43-4d3e-b392-21a473e4917a") format("svg");
-    font-weight: 400;
-    font-style: Bold;
-  }
-
-  @font-face{
-    font-family:"Adobe Garamond W08_n4";
-    src:url(url + "9b59db8d-790b-448e-901a-83bee80695d7.eot?#iefix") format("eot")
-  }
-
-  @font-face{
-    font-family:"Adobe Garamond W08";
-    src:url(url + "9b59db8d-790b-448e-901a-83bee80695d7.eot?#iefix");
-    src:url(url + "9b59db8d-790b-448e-901a-83bee80695d7.eot?#iefix") format("eot"),url(url + "794c9044-29a1-4d4e-961e-774f21e86764.woff2") format("woff2"),url(url + "b263ec73-3337-45b9-9e86-933d27164f2c.woff") format("woff"),url(url + "9675cf06-4f76-47fb-97df-9b255507e865.ttf") format("truetype"),url(url + "825d51b9-cc7d-4f4d-ba2c-47ffd291aebd.svg#825d51b9-cc7d-4f4d-ba2c-47ffd291aebd") format("svg");
-    font-weight: 400;
-    font-style: normal;
-  }
-
-  @font-face{
-    font-family:"Adobe Garamond W08_i4";
-    src:url(url + "4c83158e-1435-42b3-9577-b2b30ca41519.eot?#iefix") format("eot")
-  }
-
-  @font-face{
-    font-family:"Adobe Garamond W08";
-    src:url("4c83158e-1435-42b3-9577-b2b30ca41519.eot?#iefix");
-    src:url("4c83158e-1435-42b3-9577-b2b30ca41519.eot?#iefix") format("eot"),url("6f903966-2648-436f-8027-84dce5817cbe.woff2") format("woff2"),url("6d0c45bd-b627-4868-942a-91b2f83580f2.woff") format("woff"),url("6334af5a-f301-4a6a-bbe1-2f3f58d3a799.ttf") format("truetype"),url("f00e2b8d-55bd-4f31-b5ae-e6230f2c8481.svg#f00e2b8d-55bd-4f31-b5ae-e6230f2c8481") format("svg");
-    font-weight: 400;
-    font-style: italic;
-  }
-
-  @font-face{
-    font-family:"Adobe Garamond W08_n6";
-    src:url("c8ffd33b-7f59-4efd-ad34-10f0a04b0bde.eot?#iefix") format("eot")
-  }
-
-  @font-face{
-    font-family:"Adobe Garamond W08";
-    src:url("c8ffd33b-7f59-4efd-ad34-10f0a04b0bde.eot?#iefix");
-    src:url("c8ffd33b-7f59-4efd-ad34-10f0a04b0bde.eot?#iefix") format("eot"),url("41e9be24-e4f1-40a2-b51a-fc8f72905b72.woff2") format("woff2"),url("055ac9f4-28a5-49a7-a54e-fd7d20678142.woff") format("woff"),url("a3eeab6f-eb9e-4115-bb38-ab043636fc6d.ttf") format("truetype"),url("bedb1dd5-06ae-4b04-869f-38561a959175.svg#bedb1dd5-06ae-4b04-869f-38561a959175") format("svg");
-    font-weight: 600;
-    font-style: normal;
-  }
-</style>

--- a/desktop/apps/article/templates/amp_mixins.jade
+++ b/desktop/apps/article/templates/amp_mixins.jade
@@ -116,7 +116,6 @@ mixin amp_head
   meta(charset='utf-8')
   title= article.get('search_title') || article.get('thumbnail_title')
   link(rel='canonical', href=article.fullHref())
-  //- link(type='text/css' rel='stylesheet' href='#{sd.WEBFONT_URL}/force-webfonts.css?a=b')
   include ./amp_fonts.jade
   meta(name='viewport', content='width=device-width,minimum-scale=1,initial-scale=1')
   script(type='application/ld+json')

--- a/desktop/apps/article/templates/amp_mixins.jade
+++ b/desktop/apps/article/templates/amp_mixins.jade
@@ -116,7 +116,8 @@ mixin amp_head
   meta(charset='utf-8')
   title= article.get('search_title') || article.get('thumbnail_title')
   link(rel='canonical', href=article.fullHref())
-  link(type='text/css' rel='stylesheet' href='#{sd.WEBFONT_URL}/force-webfonts.css?a=b')
+  //- link(type='text/css' rel='stylesheet' href='#{sd.WEBFONT_URL}/force-webfonts.css?a=b')
+  include ./amp_fonts.jade
   meta(name='viewport', content='width=device-width,minimum-scale=1,initial-scale=1')
   script(type='application/ld+json')
     != [jsonLD]


### PR DESCRIPTION
Addresses: https://waffle.io/artsy/publishing/cards/5a05eb92eddb2a00c9174583

This moves back to using fonts.com for Garamond + Avant Garde, and pulls in`artsy-icons` as a custom font. Unica isn't used in these pages yet but when we do, it should be added in the same way as `artsy-icons`.

This is due to Google AMP whitelisting only a few domains for `<link>`-style imports. All other domains (webfonts.artsy.net) must use their `@font-face` syntax. So many rules 🙄 . [Link](https://www.ampproject.org/docs/guides/responsive/custom_fonts)