### PR TITLE
@eessex => Fixes caption re-sizing on mobile

### DIFF
--- a/desktop/apps/article/templates/meta.jade
+++ b/desktop/apps/article/templates/meta.jade
@@ -84,7 +84,4 @@ link( rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/l
 link( rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css")
 
 //- Set Viewport scale
-if sd.IS_MOBILE
-  meta( name="viewport", content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" )
-else
-  meta( name="viewport", content="width=device-width, initial-scale=1.0" )
+meta( name="viewport", content="width=device-width, initial-scale=1.0" )

--- a/desktop/apps/article/templates/meta.jade
+++ b/desktop/apps/article/templates/meta.jade
@@ -80,5 +80,8 @@ if !article.indexable
   meta( name='robots', content='noindex' )
 
 //- Slick styles
-<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.min.css" />
-<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css"/>
+link( rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.min.css")
+link( rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css")
+
+//- Set Viewport scale
+meta( name="viewport", content="width=device-width, initial-scale=1.0" )

--- a/desktop/apps/article/templates/meta.jade
+++ b/desktop/apps/article/templates/meta.jade
@@ -84,4 +84,7 @@ link( rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/l
 link( rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css")
 
 //- Set Viewport scale
-meta( name="viewport", content="width=device-width, initial-scale=1.0" )
+if sd.IS_MOBILE
+  meta( name="viewport", content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" )
+else
+  meta( name="viewport", content="width=device-width, initial-scale=1.0" )

--- a/desktop/components/main_layout/stylesheets/body.styl
+++ b/desktop/components/main_layout/stylesheets/body.styl
@@ -180,3 +180,7 @@ html[data-useragent*="iPad"]
 .body-no-padding
   #main-layout-container
     padding 0
+
+@media screen and (max-device-width: 480px)
+  body
+    -webkit-text-size-adjust 100%

--- a/desktop/components/main_layout/stylesheets/body.styl
+++ b/desktop/components/main_layout/stylesheets/body.styl
@@ -180,7 +180,3 @@ html[data-useragent*="iPad"]
 .body-no-padding
   #main-layout-container
     padding 0
-
-@media screen and (max-device-width: 480px)
-  body
-    -webkit-text-size-adjust 100%

--- a/desktop/components/main_layout/stylesheets/index.styl
+++ b/desktop/components/main_layout/stylesheets/index.styl
@@ -56,6 +56,7 @@ body
   font-size default-garamond-font-size
   line-height 1.4em
   text-rendering optimizeLegibility
+  -webkit-text-size-adjust 100%
   -webkit-tap-highlight-color rgba(0, 0, 0, 0);
 a
   color black


### PR DESCRIPTION
Addresses: https://waffle.io/artsy/publishing/cards/5a062bef5304860102841aa7

Problem is that iPhone is resizing text that it thinks is too small --
 https://blog.55minutes.com/2012/04/iphone-text-resizing/. This change prevents the text from growing. It also sets the viewport scale and adjust for mobile (disable zoom)

Note that this change affects `main_layout/stylesheets/index.styl`.
