### PR TITLE
Track clicks to enter live auction from auction + artwork page

### DIFF
--- a/desktop/analytics/artwork.js
+++ b/desktop/analytics/artwork.js
@@ -45,7 +45,7 @@
         label: $(this).text(),
         flow: 'artworks',
         context_module: 'artwork metadata',
-        destination_path: $(this).attr('href')
+        destination_path: $(this).attr('href') // perhaps import sd so we can remove the domain?
       })
     })
 

--- a/desktop/analytics/artwork.js
+++ b/desktop/analytics/artwork.js
@@ -39,6 +39,15 @@
         context_type: context.context_type
       })
     })
+    .on('click', '.artwork-auction__live-button a', function () {
+      analytics.track('click', {
+        type: 'button',
+        label: $(this).text(),
+        flow: 'artworks',
+        context_module: 'artwork metadata',
+        destination_path: $(this).attr('href')
+      })
+    })
 
   analyticsHooks
     .on('artwork:contact-gallery', function (context) {
@@ -54,4 +63,3 @@
       analytics.track("Showed 'Confirm registration on artwork page'", { nonInteraction: 1 })
     })
 })()
-

--- a/desktop/analytics/artwork.js
+++ b/desktop/analytics/artwork.js
@@ -1,3 +1,4 @@
+import { data as sd } from 'sharify'
 (function () {
   'use strict'
 
@@ -45,7 +46,7 @@
         label: $(this).text(),
         flow: 'artworks',
         context_module: 'artwork metadata',
-        destination_path: $(this).attr('href') // perhaps import sd so we can remove the domain?
+        destination_path: $(this).attr('href').replace(sd.PREDICTION_URL, '/')
       })
     })
 

--- a/desktop/apps/auction/components/layout/Banner.js
+++ b/desktop/apps/auction/components/layout/Banner.js
@@ -4,6 +4,7 @@ import React from 'react'
 import block from 'bem-cn'
 import get from 'lodash.get'
 import { connect } from 'react-redux'
+import { data as sd } from 'sharify'
 
 function Banner (props) {
   const {
@@ -15,6 +16,16 @@ function Banner (props) {
     liveAuctionUrl,
     name
   } = props
+
+  const trackEnterLive = () => {
+    window.analytics.track('click', {
+      type: 'button',
+      label: 'enter live auction',
+      flow: 'auctions',
+      context_module: 'auction banner',
+      destination_path: liveAuctionUrl.replace(sd.PREDICTION_URL, '/')
+    })
+  }
 
   const b = block('auction-Banner')
 
@@ -35,7 +46,7 @@ function Banner (props) {
                 Live Bidding Now Open
               </h1>
 
-              <a href={liveAuctionUrl} className='avant-garde-button-white'>
+              <a onClick={trackEnterLive} href={liveAuctionUrl} className='avant-garde-button-white'>
                 Enter live auction
               </a>
             </div>

--- a/desktop/apps/auction/components/layout/__tests__/Banner.test.js
+++ b/desktop/apps/auction/components/layout/__tests__/Banner.test.js
@@ -1,10 +1,25 @@
 import renderTestComponent from 'desktop/apps/auction/__tests__/utils/renderTestComponent'
 import { test } from 'desktop/apps/auction/components/layout/Banner'
-
+import sinon from 'sinon'
 const { Banner } = test
 
 describe('auction/components/layout/Banner.test', () => {
   describe('<Banner />', () => {
+    it('tracks a click on the "Enter Live Auction" button', () => {
+      const liveAuctionUrl = 'live.artsy.net/some-auction-url'
+      const mockTrack = sinon.spy()
+      window.analytics = { track: mockTrack }
+      const { wrapper } = renderTestComponent({
+        Component: Banner,
+        props: {
+          isLiveOpen: true,
+          liveAuctionUrl
+        }
+      })
+
+      wrapper.find('a').simulate('click')
+      mockTrack.calledWithMatch('click').should.be.true()
+    })
     it('renders an Enter Live Auction banner if isLiveOpen', () => {
       const liveAuctionUrl = 'live.artsy.net/some-auction-url'
 


### PR DESCRIPTION

Spec is cases 12 + 13 of https://github.com/artsy/auctions/issues/644

This PR tracks clicks into live auctions on prediction from the artwork and auction pages. On the artwork page I used our standard method of adding handlers and did not add tests (couldn't find any others).

On the Auction page I took a different approach, implementing the tracking code as an `<a onClick={handler}` - this allowed me to quickly test the behavior in the `Button` component (maybe more complicated than the actual implementation though) *and* efficiently chop the domain portion of the url off of the link.

Spreading it around might be a bad approach anyways- we could just keep it all in one place. If folks have thoughts I'd be glad to reconsider. Thanks.