### PR TITLE
@sweir => fix double leading slash on analytics

### DIFF
--- a/desktop/analytics/artwork.js
+++ b/desktop/analytics/artwork.js
@@ -46,7 +46,7 @@ import { data as sd } from 'sharify'
         label: $(this).text(),
         flow: 'artworks',
         context_module: 'artwork metadata',
-        destination_path: $(this).attr('href').replace(sd.PREDICTION_URL, '/')
+        destination_path: $(this).attr('href')
       })
     })
 

--- a/desktop/analytics/artwork.js
+++ b/desktop/analytics/artwork.js
@@ -46,7 +46,7 @@ import { data as sd } from 'sharify'
         label: $(this).text(),
         flow: 'artworks',
         context_module: 'artwork metadata',
-        destination_path: $(this).attr('href') // perhaps import sd so we can remove the domain?
+        destination_path: $(this).attr('href').replace(sd.PREDICTION_URL, '/')
       })
     })
 

--- a/desktop/analytics/artwork.js
+++ b/desktop/analytics/artwork.js
@@ -46,7 +46,7 @@ import { data as sd } from 'sharify'
         label: $(this).text(),
         flow: 'artworks',
         context_module: 'artwork metadata',
-        destination_path: $(this).attr('href').replace(sd.PREDICTION_URL, '/')
+        destination_path: $(this).attr('href').replace(sd.PREDICTION_URL, '')
       })
     })
 

--- a/desktop/analytics/artwork.js
+++ b/desktop/analytics/artwork.js
@@ -46,7 +46,7 @@ import { data as sd } from 'sharify'
         label: $(this).text(),
         flow: 'artworks',
         context_module: 'artwork metadata',
-        destination_path: $(this).attr('href')
+        destination_path: $(this).attr('href') // perhaps import sd so we can remove the domain?
       })
     })
 

--- a/desktop/apps/auction/components/layout/Banner.js
+++ b/desktop/apps/auction/components/layout/Banner.js
@@ -23,7 +23,7 @@ function Banner (props) {
       label: 'enter live auction',
       flow: 'auctions',
       context_module: 'auction banner',
-      destination_path: liveAuctionUrl.replace(sd.PREDICTION_URL, '/')
+      destination_path: liveAuctionUrl.replace(sd.PREDICTION_URL, '')
     })
   }
 


### PR DESCRIPTION
This corrects an oversight in my previous PR on this analytics issue (#1992). I noticed that we were tracking the urls in segment (force-staging) with an extra leading slash . This removes it.

Currently tracked in staging:
```
analytics.track('click', {
  context_module: 'auction banner',
  destination_path: '//click-analytics/login',    <<<<<<<<<<<<<
  flow: 'auctions',
  label: 'enter live auction',
  type: 'button'
});
```