### PR TITLE
Fix 500 errors in fair organizers page

### DIFF
--- a/mobile/apps/fair_organizer/templates/fair.jade
+++ b/mobile/apps/fair_organizer/templates/fair.jade
@@ -1,7 +1,7 @@
 .past-fairs--fair-image-grid
   a(href=fair.href())
     .past-fairs--fair-image-grid__inner
-      .fair-large-image-left( style="background-image: url(#{fair.representation.first().imageUrl('large_square')});" )
+      .fair-large-image-left( style="background-image: url(#{fair.imageUrl('large_rectangle')});" )
       .fair-small-images-right
         if fair.representation
           - var representations = fair.representation.slice(1,3)


### PR DESCRIPTION
This fixes 500 errors occurring on e.g. `/design-miami` on mobile devices, reported on Slack and also by Slack. fixes https://sentry.io/artsynet/force-production/issues/346741707/