### PR TITLE
@oxaudo => Update edition set display on artwork page for availabilities

### DIFF
--- a/desktop/apps/artwork/components/commercial/query.coffee
+++ b/desktop/apps/artwork/components/commercial/query.coffee
@@ -27,10 +27,9 @@ module.exports = """
     }
     edition_sets {
       id
-      is_sold
       is_acquireable
       edition_of
-      price
+      sale_message
       dimensions {
         in
         cm

--- a/desktop/apps/artwork/components/commercial/templates/editions.jade
+++ b/desktop/apps/artwork/components/commercial/templates/editions.jade
@@ -20,7 +20,4 @@ if artwork.edition_sets.length > 1
             = edition_set.edition_of
 
         .artwork-edition-set__price
-          if edition_set.is_sold
-            | #{edition_set.price} - Sold
-          else
-            = edition_set.price
+          = edition_set.sale_message


### PR DESCRIPTION
Currently on staging: 

<img width="368" alt="screen shot 2017-11-21 at 6 29 41 pm" src="https://user-images.githubusercontent.com/1457859/33102268-f66ad89c-cee9-11e7-9c41-45b071e3b338.png">

With using the new field in https://github.com/artsy/metaphysics/pull/825

<img width="420" alt="screen shot 2017-11-21 at 6 21 01 pm" src="https://user-images.githubusercontent.com/1457859/33102280-0519fd14-ceea-11e7-902d-5b3b7fd1d631.png">


Closes https://github.com/artsy/collector-experience/issues/341