### PR TITLE
@joeyAghion => Make home more resilient

### DIFF
--- a/desktop/apps/home/routes.coffee
+++ b/desktop/apps/home/routes.coffee
@@ -59,7 +59,7 @@ fetchMetaphysicsData = (req)->
   }
 
   Q
-    .all [
+    .allSettled [
       fetchMetaphysicsData req
       featuredLinks.fetch cache: true
       featuredArticles.fetch
@@ -72,21 +72,22 @@ fetchMetaphysicsData = (req)->
       featuredShows.fetch cache: true, cacheTime: timeToCacheInSeconds
     ]
 
-    .then ([{ home_page }]) ->
-      heroUnits = home_page.hero_units
+    .then (results) ->
+      homePage = results[0]?.value.home_page
+      heroUnits = homePage.hero_units
       heroUnits[positionWelcomeHeroMethod(req, res)](welcomeHero) unless req.user?
 
       # always show followed artist rail for logged in users,
       # if we dont get results we will replace with artists TO follow
-      if req.user and not _.findWhere home_page.artwork_modules, { key: 'followed_artists' }
-        home_page.artwork_modules.unshift { key: 'followed_artists' }
+      if req.user and not _.findWhere homePage.artwork_modules, { key: 'followed_artists' }
+        homePage.artwork_modules.unshift { key: 'followed_artists' }
 
       res.locals.sd.HERO_UNITS = heroUnits
-      res.locals.sd.USER_HOME_PAGE = home_page.artwork_modules
+      res.locals.sd.USER_HOME_PAGE = homePage.artwork_modules
 
       res.render 'index',
         heroUnits: heroUnits
-        modules: home_page.artwork_modules
+        modules: homePage.artwork_modules
         featuredLinks: featuredLinks
         featuredArticles: featuredArticles
         featuredShows: featuredShows

--- a/desktop/apps/home/templates/featured_articles.jade
+++ b/desktop/apps/home/templates/featured_articles.jade
@@ -1,13 +1,14 @@
-#home-featured-articles-section( data-context='featured articles' )
-  h2.home-featured-header Artsy Magazine
-    .home-browse-all-right
-      a( href='/articles' )
-        | Explore the Magazine
-  ul#home-featured-articles.home-featured-list
-    - articles = featuredArticles.take(7)
-    for article, i in articles
-      li.home-featured-article-link
-        a( href=article.href() )
-          .home-featured-cover-img( style="background-image: url(" + resize(article.get('thumbnail_image'), { width: 500 }) + ")" )
-          h4= article.get('thumbnail_title')
-          h5= article.byline()
+if featuredArticles.length
+  #home-featured-articles-section( data-context='featured articles' )
+    h2.home-featured-header Artsy Magazine
+      .home-browse-all-right
+        a( href='/articles' )
+          | Explore the Magazine
+    ul#home-featured-articles.home-featured-list
+      - articles = featuredArticles.take(7)
+      for article, i in articles
+        li.home-featured-article-link
+          a( href=article.href() )
+            .home-featured-cover-img( style="background-image: url(" + resize(article.get('thumbnail_image'), { width: 500 }) + ")" )
+            h4= article.get('thumbnail_title')
+            h5= article.byline()

--- a/desktop/apps/home/templates/featured_links.jade
+++ b/desktop/apps/home/templates/featured_links.jade
@@ -1,8 +1,9 @@
-ul#home-top-featured-links( class='js-homepage-featured-links', data-context='under banner' )
-  for link in featuredLinks.models
-    li.home-top-feature-link
-      a.htfl-image-link( href=link.get('href') )
-        .htfl-image: img( src=link.imageUrl('small_rectangle'), alt=link.get('title') )
-        .htfl-details
-          h3= link.get('title')
-          h4= link.get('subtitle')
+if featuredLinks.length
+  ul#home-top-featured-links( class='js-homepage-featured-links', data-context='under banner' )
+    for link in featuredLinks.models
+      li.home-top-feature-link
+        a.htfl-image-link( href=link.get('href') )
+          .htfl-image: img( src=link.imageUrl('small_rectangle'), alt=link.get('title') )
+          .htfl-details
+            h3= link.get('title')
+            h4= link.get('subtitle')

--- a/desktop/apps/home/templates/featured_shows.jade
+++ b/desktop/apps/home/templates/featured_shows.jade
@@ -1,12 +1,13 @@
-#home-featured-shows-section( class='js-homepage-featured-links', data-context='featured shows' )
-  h2.home-featured-header Featured Shows
-    .home-browse-all-right
-      a( href='/shows' )
-        | Explore All Shows
-  ul#home-featured-shows.home-featured-list
-    - allShows = featuredShows.take(8)
-    - displayLocation = true
-    - shows = allShows.slice(0, 2)
-    include ../../../components/featured_shows/large
-    - shows = allShows.slice(2)
-    include ../../../components/featured_shows/small
+if featuredShows.length
+  #home-featured-shows-section( class='js-homepage-featured-links', data-context='featured shows' )
+    h2.home-featured-header Featured Shows
+      .home-browse-all-right
+        a( href='/shows' )
+          | Explore All Shows
+    ul#home-featured-shows.home-featured-list
+      - allShows = featuredShows.take(8)
+      - displayLocation = true
+      - shows = allShows.slice(0, 2)
+      include ../../../components/featured_shows/large
+      - shows = allShows.slice(2)
+      include ../../../components/featured_shows/small

--- a/desktop/apps/home/test/routes.coffee
+++ b/desktop/apps/home/test/routes.coffee
@@ -5,7 +5,7 @@ Backbone = require 'backbone'
 rewire = require 'rewire'
 routes = rewire '../routes'
 Items = require '../../../collections/items'
-Articles = require '../../../collections/articles'
+
 heroUnit =
   "title_image_url": "https://d32dm0rphc51dk.cloudfront.net/o8z4tRzTn3ObRWxvLg3L0g/untouched-png.png",
   "retina_title_image_url": "https://d32dm0rphc51dk.cloudfront.net/o8z4tRzTn3ObRWxvLg3L0g/untouched-png.png",
@@ -55,6 +55,8 @@ describe 'Home routes', ->
           .then =>
             @res.render.args[0][0].should.equal 'index'
             @res.render.args[0][1].featuredArticles.length.should.equal 0
+            @res.render.args[0][1].featuredShows.length.should.equal 1
+            @res.render.args[0][1].featuredLinks.length.should.equal 1
 
       it 'passes empty shows if show fetch fails', ->
         @metaphysics.returns Promise.resolve
@@ -65,13 +67,15 @@ describe 'Home routes', ->
           .onCall 0
           .yieldsTo 'success', [fabricate 'featured_link']
           .onCall 1
-          .yieldsTo 'success', [fabricate 'article']
+          .yieldsTo 'success', new Backbone.Model fabricate 'article'
           .onCall 2
           .yieldsTo 'error'
         routes.index extend({ user: 'existy' }, @req), @res
           .then =>
             @res.render.args[0][0].should.equal 'index'
+            @res.render.args[0][1].featuredArticles.length.should.equal 1
             @res.render.args[0][1].featuredShows.length.should.equal 0
+            @res.render.args[0][1].featuredLinks.length.should.equal 1
 
       it 'passes empty featured links fetch fails', ->
         @metaphysics.returns Promise.resolve
@@ -82,12 +86,14 @@ describe 'Home routes', ->
           .onCall 0
           .yieldsTo 'error'
           .onCall 1
-          .yieldsTo 'success', [fabricate 'article']
+          .yieldsTo 'success', new Backbone.Model fabricate 'article'
           .onCall 2
           .yieldsTo 'success', [fabricate 'show']
         routes.index extend({ user: 'existy' }, @req), @res
           .then =>
             @res.render.args[0][0].should.equal 'index'
+            @res.render.args[0][1].featuredArticles.length.should.equal 1
+            @res.render.args[0][1].featuredShows.length.should.equal 1
             @res.render.args[0][1].featuredLinks.length.should.equal 0
 
     describe 'logged out', ->


### PR DESCRIPTION
Uses Q's `allSettled` instead of `all` which allows us to more manually handle the states (fullfilled/rejected) of the promises instead of going straight to the `catch` block on errors.

Addresses https://github.com/artsy/force/issues/986