### PR TITLE
Warn against missing .env file

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -2,4 +2,7 @@
 
 set -e -x
 
+if [ ! -f "./.env" ]; then
+  echo -e "\033[1;31m WARNING: Missing .env file, see CONTRIBUTING.md. \033[0m"
+fi
 forever -c 'node -r dotenv/config --max_old_space_size=1024' .


### PR DESCRIPTION
Seen too many people get snagged on this one because the stack trace is incomprehensible when the server crashes. This adds a simple red warning if trying to start the server without an .env file.