### PR TITLE
@craigspaeth => Deprecate credit_line and credit_url

### DIFF
--- a/desktop/apps/article/queries/articleBody.js
+++ b/desktop/apps/article/queries/articleBody.js
@@ -39,8 +39,6 @@ export default `
   email_metadata {
     headline
     author
-    credit_line
-    credit_url
     image_url
   }
   authors {

--- a/desktop/apps/article/templates/classic_meta.jade
+++ b/desktop/apps/article/templates/classic_meta.jade
@@ -39,10 +39,6 @@ if article.get('published')
       meta( name="sailthru.title", content=article.get('email_metadata').headline)
     if article.get('email_metadata').author
       meta( name="sailthru.author" content=article.get('email_metadata').author)
-    if article.get('email_metadata').credit_url
-      meta( name="sailthru.credit_url" content=article.get('email_metadata').credit_url)
-    if article.get('email_metadata').credit_line
-      meta( name="sailthru.credit_line" content=article.get('email_metadata').credit_line)
     if article.get('email_metadata').image_url
       - var src = article.get('email_metadata').image_url
       meta( name="sailthru.image.full" content=crop(src, { width: 1200, height: 800 } ))

--- a/desktop/apps/article/templates/meta.jade
+++ b/desktop/apps/article/templates/meta.jade
@@ -51,10 +51,6 @@ if article.published && article.email_metadata
     meta( name='sailthru.title', content=email.headline)
   if email.author
     meta( name='sailthru.author' content=email.author)
-  if email.credit_url
-    meta( name='sailthru.credit_url' content=email.credit_url)
-  if email.credit_line
-    meta( name='sailthru.credit_line' content=email.credit_line)
   if email.image_url
     - var src = email.image_url
     meta( name='sailthru.image.full' content=crop(src, { width: 1200, height: 800 } ))

--- a/desktop/apps/editorial_features/components/eoy/templates/head.jade
+++ b/desktop/apps/editorial_features/components/eoy/templates/head.jade
@@ -35,10 +35,6 @@ if article.get('published') && article.get('email_metadata')
     meta( name="sailthru.title", content=article.get('email_metadata').headline)
   if article.get('email_metadata').author
     meta( name="sailthru.author" content=article.get('email_metadata').author)
-  if article.get('email_metadata').credit_url
-    meta( name="sailthru.credit_url" content=article.get('email_metadata').credit_url)
-  if article.get('email_metadata').credit_line
-    meta( name="sailthru.credit_line" content=article.get('email_metadata').credit_line)
   if article.get('email_metadata').image_url
     - var src = article.get('email_metadata').image_url
     meta( name="sailthru.image.full" content=crop(src, { width: 1200, height: 800 } ))


### PR DESCRIPTION
Follows up on https://github.com/artsy/positron/pull/1477

Removes instances of article email metadata fields 'credit_line' and 'credit_url'
