### PR TITLE
[Minor] Fix margin on magazine page

### DIFF
--- a/desktop/apps/articles/stylesheets/articles.styl
+++ b/desktop/apps/articles/stylesheets/articles.styl
@@ -8,7 +8,7 @@ body.body-articles
     max-width 100%
 
 .articles-articles-page
-  padding 40px 0
+  padding 40px layout-side-margin
   position relative
   width 100%
 


### PR DESCRIPTION
A tiny thing that has bothered me for too long to have gotten to it just now. The magazine page ends up touching the edges of your browser on smaller desktop screens. This adds our standard side margin so it lines up with the search bar/logomark.

![image](https://user-images.githubusercontent.com/555859/33946933-14940f4c-dff1-11e7-944a-8ad0d01e2a47.png)
_after > before_