### PR TITLE
@craigspaeth => Adds a page for facebook domain verification

### DIFF
--- a/desktop/apps/dev/index.coffee
+++ b/desktop/apps/dev/index.coffee
@@ -16,3 +16,6 @@ app.get '/dev/blank', (req, res) ->
   res.render 'blank',
     env: NODE_ENV
     view_cache_enabled: app.enabled 'view cache'
+
+app.get '/yeg3dqrlq548zc77ggvfipouil1l1e.html', (req, res) ->
+  res.send 'yeg3dqrlq548zc77ggvfipouil1l1e'


### PR DESCRIPTION
Requested by Mark, to verify artsy.net as our domain for Facebook

Addresses: https://github.com/artsy/publishing/issues/272

Steps for domain verification noted here: https://business.facebook.com/settings/owned-domains/2223608780998302?business_id=10153596186848407