### PR TITLE
@kanaabe => Show media publish status & meta

### DIFF
--- a/desktop/apps/article/queries/articleBody.js
+++ b/desktop/apps/article/queries/articleBody.js
@@ -67,7 +67,7 @@ export default `
   hero_section {
     ...Image
     ...Video
-    ...on FeatureHeader {
+    ... on FeatureHeader {
       type
       title
       url

--- a/desktop/apps/article/queries/relatedArticles.js
+++ b/desktop/apps/article/queries/relatedArticles.js
@@ -22,5 +22,10 @@ export default `
     thumbnail_image
     title
     slug
+    media {
+      duration
+      published
+      release_date
+    }
   }
 `


### PR DESCRIPTION
Adds some additional fields to the relatedArticle query to show media duration, publish date, and publish status. 

Resolves first issue in https://github.com/artsy/publishing/issues/280