### PR TITLE
@eessex => Bump reaction and next on unpublished media

### DIFF
--- a/desktop/apps/article/__tests__/routes.test.js
+++ b/desktop/apps/article/__tests__/routes.test.js
@@ -80,6 +80,29 @@ describe('Article Routes', () => {
       })
     })
 
+    it('nexts if media is unpublished', (done) => {
+      const data = {
+        article: _.extend({}, fixtures.article, {
+          slug: 'foobar',
+          channel_id: '123',
+          layout: 'video',
+          media: {
+            published: false
+          }
+        })
+      }
+
+      RoutesRewireApi.__Rewire__(
+        'positronql',
+        sinon.stub().returns(Promise.resolve(data))
+      )
+      index(req, res, next)
+      .then(() => {
+        next.callCount.should.equal(1)
+        done()
+      })
+    })
+
     it('redirects to the main slug if an older slug is queried', (done) => {
       const data = {
         article: _.extend({}, fixtures.article, {

--- a/desktop/apps/article/routes.js
+++ b/desktop/apps/article/routes.js
@@ -33,7 +33,11 @@ export async function index (req, res, next) {
       return res.redirect(`/article/${article.slug}`)
     }
 
-    if (article.media && !article.media.published) {
+    if (
+      article.layout === 'video' &&
+      article.media &&
+      !article.media.published
+    ) {
       return next()
     }
 

--- a/desktop/apps/article/routes.js
+++ b/desktop/apps/article/routes.js
@@ -33,6 +33,10 @@ export async function index (req, res, next) {
       return res.redirect(`/article/${article.slug}`)
     }
 
+    if (article.media && !article.media.published) {
+      return next()
+    }
+
     const isSuper = article.is_super_article || article.is_super_sub_article
     const superArticle = new Article()
     const superSubArticles = new Articles()

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@artsy/express-reloadable": "^1.1.0",
-    "@artsy/reaction-force": "0.16.6",
+    "@artsy/reaction-force": "0.16.7",
     "@artsy/stitch": "^1.2.1",
     "accounting": "^0.4.1",
     "analytics-node": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@artsy/express-reloadable": "^1.1.0",
-    "@artsy/reaction-force": "0.16.7",
+    "@artsy/reaction-force": "0.16.9",
     "@artsy/stitch": "^1.2.1",
     "accounting": "^0.4.1",
     "analytics-node": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   dependencies:
     chokidar "^1.7.0"
 
-"@artsy/reaction-force@0.16.7":
-  version "0.16.7"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.16.7.tgz#eafb1abeaba12e387d0007bf00a6950203adada2"
+"@artsy/reaction-force@0.16.9":
+  version "0.16.9"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.16.9.tgz#1c7b796a108c8c35e716c2698ff79a5d199633b6"
   dependencies:
     history "^4.6.1"
     isomorphic-fetch "^2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   dependencies:
     chokidar "^1.7.0"
 
-"@artsy/reaction-force@0.16.6":
-  version "0.16.6"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.16.6.tgz#98c6ba9c97691e5a19d4ab7b16f8dbd87fab60f4"
+"@artsy/reaction-force@0.16.7":
+  version "0.16.7"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.16.7.tgz#eafb1abeaba12e387d0007bf00a6950203adada2"
   dependencies:
     history "^4.6.1"
     isomorphic-fetch "^2.2.1"


### PR DESCRIPTION
If we detect a video article (currently the only one with media), then we should 404 if the media blob is not published. This ensures that the content is not reachable, even though the article itself is published. 

Also bumps reaction to the latest!

