### PR TITLE
Adds new url for old future-of-art page

### DIFF
--- a/desktop/apps/static/index.coffee
+++ b/desktop/apps/static/index.coffee
@@ -14,7 +14,7 @@ app = module.exports = express()
 app.set 'views', __dirname + '/templates'
 app.set 'view engine', 'jade'
 
-app.get '/future-of-art', (req, res) ->
+app.get '/the-future-of-art', (req, res) ->
   new Page(id: 'future-of-art').fetch
     cache: true
     error: res.backboneError


### PR DESCRIPTION
Changes /future-of-art to /the-future-of-art. We need this change to make /future-of-art available as a Vanity url for this article: https://www.artsy.net/article/artsy-editors-future-art