### PR TITLE
@starsirius => Extra guard for hidden availabilities

### DIFF
--- a/desktop/models/artwork.coffee
+++ b/desktop/models/artwork.coffee
@@ -299,6 +299,7 @@ module.exports = class Artwork extends Backbone.Model
     @get 'sale_message'
 
   availabilityMessage: ->
+    return if @get('availability_hidden')
     return if @get('partner')?.type is "Institutional Seller"
     return if @get('availability') is 'for sale' or @get('availability') is 'not for sale' or @get('availability') is 'permanent collection'
     if @get('partner')?.has_limited_fair_partnership


### PR DESCRIPTION
Artwork bricks that use Metaphysics already had this fixed when we worked on the feature, and I updated a `saleMessage` method already, this seems to be a fallback the partner profile page uses /shrug

So, let's update this as well!

I've made the Gravity PR as well: https://github.com/artsy/gravity/pull/11479 , which _should_ make this redundant, but no harm in being defensive.