### PR TITLE
fix ClockView reload loop

### DIFF
--- a/desktop/apps/artwork/components/clock/test/view.coffee
+++ b/desktop/apps/artwork/components/clock/test/view.coffee
@@ -2,7 +2,6 @@ benv = require 'benv'
 sinon = require 'sinon'
 moment = require 'moment'
 Backbone = require 'backbone'
-ClockView = benv.requireWithJadeify require.resolve('../view'), ['template']
 
 describe 'ClockView', ->
   before (done) ->
@@ -16,23 +15,43 @@ describe 'ClockView', ->
 
   beforeEach ->
     @clock = sinon.useFakeTimers()
+    sinon.spy(location, 'reload')
 
+    # Dynamically import ClockView constructor so that it pulls in the stubbed
+    # setTimeout from sinon.useFakeTimers.
+    @ClockView = benv.requireWithJadeify require.resolve('../view'), ['template']
+    
   afterEach ->
     @clock.restore()
+    location.reload.restore()
+
+  it 'does trigger a reload for a timestamp 1 day away, only after the day passes', ->
+    timestamp = moment().add(1, 'day').format()
+    view = new @ClockView timestamp: timestamp
+    @clock.tick(23 * 60 * 60 * 1000)
+    window.location.reload.called.should.be.false()
+    @clock.tick(60 * 60 * 1000)
+    window.location.reload.called.should.be.true()
+
+  it 'does not trigger an immediate reload for a timestamp 26 days away (past the 24.8 day limit for setTimeout)', ->
+    timestamp = moment().add(26, 'day').format()
+    view = new @ClockView timestamp: timestamp
+    @clock.tick(1000)
+    window.location.reload.called.should.be.false()
 
   it 'renders the clock when there is a timestamp in the future', ->
     timestamp = moment().add(1, 'day').format()
-    view = new ClockView timestamp: timestamp
+    view = new @ClockView timestamp: timestamp
     view.render().$el.text()
       .should.equal '01day00hr00min00sec'
 
   it 'optionally accepts a label', ->
     timestamp = moment().add(1, 'day').format()
-    view = new ClockView label: 'Auction closes in', timestamp: timestamp
+    view = new @ClockView label: 'Auction closes in', timestamp: timestamp
     view.render().$el.text()
       .should.equal 'Auction closes in01day00hr00min00sec'
 
   it 'renders empty if the timestamp has passed', ->
     timestamp = moment().subtract(1, 'day').format()
-    view = new ClockView timestamp: timestamp
+    view = new @ClockView timestamp: timestamp
     view.render().$el.html().should.equal ''

--- a/desktop/apps/artwork/components/clock/view.coffee
+++ b/desktop/apps/artwork/components/clock/view.coffee
@@ -8,6 +8,8 @@ module.exports = class ClockView extends Backbone.View
     endAt = moment.utc(@timestamp)
 
     if endAt.isAfter()
+      # setTimeout fires immediately for any value 2^31 or greater, so prevent
+      # that from happening.
       reloadMs = Math.min(endAt.diff(moment.utc()), 0x7FFFFFFF)
       setTimeout ->
         location.reload()

--- a/desktop/apps/artwork/components/clock/view.coffee
+++ b/desktop/apps/artwork/components/clock/view.coffee
@@ -5,10 +5,13 @@ template = -> require('./index.jade') arguments...
 
 module.exports = class ClockView extends Backbone.View
   initialize: ({ @label, @timestamp }) ->
-    endAt = moment.utc @timestamp
+    endAt = moment.utc(@timestamp)
 
     if endAt.isAfter()
-      setTimeout (-> location.reload()), endAt.diff moment.utc()
+      reloadMs = Math.min(endAt.diff(moment.utc()), 0x7FFFFFFF)
+      setTimeout ->
+        location.reload()
+      , reloadMs
 
   start: ->
     @timer = setInterval @render.bind(this), 1000

--- a/desktop/apps/partnerships/templates/auction_sections.jade
+++ b/desktop/apps/partnerships/templates/auction_sections.jade
@@ -118,10 +118,6 @@ mixin auction_apply(section)
       a( href='/privacy' ) Privacy Policy
       | .
 
-
-    .partnerships-contact Call us: +1 800 589-1350
-
-
 section.partnerships-section( id= sections[0].slug, data-href="/auction-partnerships/#{sections[0].slug}" ): +experience(sections[0])
 section.partnerships-section( id= sections[1].slug, data-href="/auction-partnerships/#{sections[1].slug}" ): +auction_audience(sections[1])
 section.partnerships-section( id= sections[2].slug, data-href="/auction-partnerships/#{sections[2].slug}" ): +access(sections[2])


### PR DESCRIPTION
Fixes #1923, at long last.

Debugging the stubbing of reload and time to work properly was a real headache, and sent me chasing many red herrings. I believe it was importing the view dynamically, so that it would capture the stubbed globals, that finally solved the issues.