### PR TITLE
@yuki24 => Enable AB test for market insights on artwork pages

### DIFF
--- a/desktop/analytics/main_layout.js
+++ b/desktop/analytics/main_layout.js
@@ -19,7 +19,7 @@ setTimeout(function () {
 // debug tracking calls in development
 if (sd.NODE_ENV !== 'production') {
   analytics.on('track', function () {
-    console.debug('TRACKED: ', arguments[0], JSON.stringify(arguments[1]))
+    console.info('TRACKED: ', arguments[0], JSON.stringify(arguments[1]))
   })
 }
 if (sd.NODE_ENV === 'development') {

--- a/desktop/apps/artwork/client/index.coffee
+++ b/desktop/apps/artwork/client/index.coffee
@@ -6,6 +6,7 @@ CurrentUser = require '../../../models/current_user.coffee'
 exec = require '../lib/exec.coffee'
 fold = -> require('./fold.jade') arguments...
 footer = -> require('./footer.jade') arguments...
+splitTest = require('../../../components/split_test/index.coffee')
 
 helpers = extend [
   {}
@@ -161,6 +162,7 @@ module.exports =
   init: ->
     setCookie(CLIENT._id)
     exec sharedInit
+    splitTest('artist_market_data').view()
 
     context = CLIENT.context or {}
     { query, init, variables } = setup(context)

--- a/desktop/apps/artwork/components/artists/helpers.coffee
+++ b/desktop/apps/artwork/components/artists/helpers.coffee
@@ -15,13 +15,13 @@ module.exports =
   sortExhibitions: (shows) ->
     sortBy(shows, 'start_at').reverse()
 
-  sections: sections = (artist, isAdmin) ->
+  sections: sections = (artist, hasMarketDataEnabled) ->
     has: (section) ->
       switch section
         when 'biography'
           artist.blurb || artist.bio || artist.biography_blurb?.text != ""
         when 'exhibition_highlights'
-          if isAdmin
+          if hasMarketDataEnabled
             artist.exhibition_highlights? && artist.exhibition_highlights.length > 0
           else
             artist.exhibition_highlights? && artist.exhibition_highlights.length > 15
@@ -30,9 +30,9 @@ module.exports =
         else
           false
 
-  build: (artist, isAdmin) ->
+  build: (artist, hasMarketDataEnabled) ->
     tabs.filter (tab) ->
-      sections artist, isAdmin
+      sections artist, hasMarketDataEnabled
         .has tab
 
   name: (section) ->

--- a/desktop/apps/artwork/components/artists/index.jade
+++ b/desktop/apps/artwork/components/artists/index.jade
@@ -2,7 +2,7 @@ include ../../../../components/side_tabs/mixins
 
 if artwork.artists.length
   for artist in artwork.artists
-    - var tabs = helpers.artists.build(artist, isAdmin)
+    - var tabs = helpers.artists.build(artist, sd.ARTIST_MARKET_DATA === 'experiment')
 
     if tabs.length
       section.artwork-section.artwork-artist(data-artist-id=artist._id)

--- a/desktop/apps/artwork/components/artists/templates/biography.jade
+++ b/desktop/apps/artwork/components/artists/templates/biography.jade
@@ -16,7 +16,7 @@
 
 div(id="market-insights-container-" + artist._id)
 
-unless isAdmin
+unless sd.ARTIST_MARKET_DATA === 'experiment'
   if artist.exhibition_highlights && artist.exhibition_highlights.length <= 15
     include ./exhibition
   else if artist.exhibition_highlights && artist.exhibition_highlights.length > 15

--- a/desktop/apps/artwork/components/artists/test/templates/index.coffee
+++ b/desktop/apps/artwork/components/artists/test/templates/index.coffee
@@ -57,6 +57,7 @@ describe 'Artist Module template', ->
             groupBy: _.groupBy
         }
         asset: (->)
+        sd: {}
       )
 
       @$ = cheerio.load(@html)
@@ -110,6 +111,7 @@ describe 'Artist Module template', ->
             groupBy: _.groupBy
         }
         asset: (->)
+        sd: {}
       )
 
       @$ = cheerio.load(@html)
@@ -152,6 +154,7 @@ describe 'Artist Module template', ->
             groupBy: _.groupBy
         }
         asset: (->)
+        sd: {}
       )
 
       @$ = cheerio.load(@html)

--- a/desktop/apps/artwork/components/meta/index.jade
+++ b/desktop/apps/artwork/components/meta/index.jade
@@ -48,5 +48,5 @@ if sd.INCLUDE_SAILTHRU
     meta( name='image', content=artwork.meta_image.resized.url )
 
 //- Unica Font
-if isAdmin
+if sd.ARTIST_MARKET_DATA === 'experiment'
   link( rel='stylesheet' type='text/css' href="#{sd.WEBFONT_URL + '/unica-webfonts.css'}")

--- a/desktop/apps/artwork/routes.coffee
+++ b/desktop/apps/artwork/routes.coffee
@@ -90,14 +90,14 @@ bootstrap = ->
       # If a saleId is found, then check to see if user has been qualified for
       # bidding so that bid button UI is correct from the server down.
       saleId = get(data, 'artwork.sale.id', false)
-
+      
       if saleId
         fetchMeData(meQuery, req.user, saleId)
           .then (meData) ->
-            res.render 'index', extend data, meData, { isAdmin: res.locals.sd.CURRENT_USER?.type is 'Admin' }
+            res.render 'index', extend data, meData
           .catch next
       else
-        res.render 'index', extend data, { isAdmin: res.locals.sd.CURRENT_USER?.type is 'Admin' }
+        res.render 'index', extend data
     .catch next
 
 @acquire = (req, res, next) ->

--- a/desktop/assets/artists_artworks.coffee
+++ b/desktop/assets/artists_artworks.coffee
@@ -1,5 +1,5 @@
 require('backbone').$ = $
-{ CURRENT_USER } = require('sharify').data
+{ ARTIST_MARKET_DATA } = require('sharify').data
 
 routes =
   '/artist/.*': require('../apps/artist/client/index.coffee').init
@@ -11,7 +11,7 @@ routes =
       require('../apps/artwork_purchase/client/index.coffee').init()
     else
       require('../apps/artwork/client/index.coffee').init()
-      if CURRENT_USER?.type is 'Admin'
+      if ARTIST_MARKET_DATA is 'experiment'
         require('../apps/artwork/components/artists/market_insights.js').default.setupMarketInsights()
 
   '/collect': require('../apps/collect/client.coffee').init

--- a/desktop/components/split_test/running_tests.coffee
+++ b/desktop/components/split_test/running_tests.coffee
@@ -14,4 +14,11 @@
 # this should export empty Object
 # module.exports = {}
 
-module.exports = {}
+module.exports = {
+  artist_market_data:
+    key: 'artist_market_data'
+    outcomes:
+      control: 50
+      experiment: 50
+    edge: 'experiment'
+}


### PR DESCRIPTION
~**Not for merge yet, until we're satisfied with the QA and want to release it**~

This updates the logic, which showed this for logged-in admins, to a proper AB split test, with `experiment` (seeing market insights), and `control`.

You can force a specific branch (which I did to test the tracking), via `?split_test[artist_market_data]=experiment/control` query param.