### PR TITLE
@sweir27 => Enable E-Commerce-like "Buy Now" on Mobile 

### DIFF
--- a/desktop/apps/artwork/components/partner_stub/index.jade
+++ b/desktop/apps/artwork/components/partner_stub/index.jade
@@ -8,11 +8,7 @@ unless artwork.is_in_auction
     if artwork.collecting_institution
       .artwork-partner-stub__name
         = artwork.collecting_institution
-
     else
-      if !artwork.is_inquireable
-        hr
-
       //- Default view
       h3.artwork-partner-stub__label
         if artwork.is_for_sale

--- a/mobile/apps/artwork/components/meta_data/templates/index.jade
+++ b/mobile/apps/artwork/components/meta_data/templates/index.jade
@@ -1,12 +1,13 @@
 .artwork-section-separator
 .main-side-margin
   .artwork-meta-data-module
-    if artwork.auction
+    if artwork.auction && artwork.auction.is_auction
       include ../../bid/index.jade
     else
       include ./price.jade
       include ./edition_sets.jade
       include ./inquiry.jade
+
     include ./details.jade
     include ./partner.jade
 

--- a/mobile/apps/artwork/components/meta_data/templates/inquiry.jade
+++ b/mobile/apps/artwork/components/meta_data/templates/inquiry.jade
@@ -1,7 +1,8 @@
-unless artwork.auction 
-  if artwork.is_acquireable
-    a.artwork-meta-data-black__contact-button.js-purchase Buy
-  else if artwork.is_inquireable
+if artwork.is_acquireable
+  a.artwork-meta-data-black__contact-button.js-purchase Buy
+
+unless artwork.auction
+  if artwork.is_inquireable
     a.artwork-meta-data-black__contact-button(
       href="/inquiry/#{artwork.id}"
     )

--- a/mobile/apps/artwork/components/meta_data/templates/price.jade
+++ b/mobile/apps/artwork/components/meta_data/templates/price.jade
@@ -1,4 +1,4 @@
-if artwork.sale_message && !artwork.auction
+if artwork.sale_message
   .artwork-meta-data-price
     if artwork.sale_message
       .sale_message= artwork.sale_message

--- a/mobile/apps/artwork/components/meta_data/test/template.coffee
+++ b/mobile/apps/artwork/components/meta_data/test/template.coffee
@@ -184,6 +184,17 @@ describe 'Artwork metadata templates', ->
         $('.artwork-meta-data__partner .artwork-header').text().should.equal 'Offered by'
         $('.artwork-meta-data__partner .artwork-partner-name').text().should.equal 'Phillips'
 
+    describe 'e-commerce - for sale', ->
+      beforeEach ->
+        @artwork.is_acquireable = true
+
+      it 'should render a "Buy" button', ->
+        html = render('index')(
+          artwork: @artwork
+        )
+
+        html.should.containEql 'Buy'
+
     describe 'collecting institution', ->
       beforeEach ->
         @artwork.is_for_sale = true
@@ -193,8 +204,6 @@ describe 'Artwork metadata templates', ->
       it 'should drop institution header', ->
         html = render('partner')(
           artwork: @artwork
-          sd: {}
-          asset: (->)
         )
 
         $ = cheerio.load(html)
@@ -203,8 +212,6 @@ describe 'Artwork metadata templates', ->
       it 'should display collecting institution as link text', ->
         html = render('partner')(
           artwork: @artwork
-          sd: {}
-          asset: (->)
         )
 
         $ = cheerio.load(html)
@@ -218,8 +225,6 @@ describe 'Artwork metadata templates', ->
 
         @html = render('partner')(
           artwork: @artwork
-          sd: {}
-          asset: (->)
         )
 
       it 'should link to partner\'s page', ->
@@ -234,8 +239,6 @@ describe 'Artwork metadata templates', ->
 
         @html = render('partner')(
           artwork: @artwork
-          sd: {}
-          asset: (->)
         )
 
       it 'should link to partner\'s page', ->
@@ -253,9 +256,10 @@ describe 'Artwork metadata templates', ->
 
       @html = render('index')(
         artwork: @artwork
-        sd: {}
-        asset: (->)
       )
 
     it 'displays estimation', ->
       @html.should.containEql '$7,000-$9,000'
+
+    it 'renders bid module', ->
+      @html.should.containEql('js-artwork-auction-container')


### PR DESCRIPTION
Fixes https://github.com/artsy/auctions/issues/680

This PR addresses an issue we noticed around enabling "Buy Now" on sale artworks that exist in a more general context. Currently this feature is supported _if within an auction_ but on closer inspection all that was needed was to remove the guard and instead rely on a generic `is_aquireable` flag which is returned from the request. 

<img width="200" alt="screen shot 2018-01-09 at 4 27 11 pm" src="https://user-images.githubusercontent.com/236943/34750259-17f2609c-f55b-11e7-84c2-d1d841dbbfa6.png">

Additionally, fixes an issue related to an erroneous `hr` tag in an uncommon code-path. Since there's already a top border this is unneeded: 

**Bad**

<img width="200" alt="screen shot 2018-01-09 at 4 32 17 pm" src="https://user-images.githubusercontent.com/236943/34750284-2f7a305a-f55b-11e7-88f5-dc80608c3760.png">

**Good**

<img width="200" alt="screen shot 2018-01-09 at 4 36 20 pm" src="https://user-images.githubusercontent.com/236943/34750298-45e9e36c-f55b-11e7-8cf9-c20f4ee4cd91.png">
