### PR TITLE
@eessex => Convert EditButton to portal to "fix zindex"

### DIFF
--- a/desktop/apps/article/components/App.js
+++ b/desktop/apps/article/components/App.js
@@ -61,8 +61,7 @@ class EditPortal extends React.Component {
   render () {
     const { article } = this.props
 
-    // Only render on client-side
-    if (typeof window !== 'undefined') {
+    try {
       return ReactDOM.createPortal(
         <EditButton
           channelId={article.channel_id}
@@ -70,7 +69,7 @@ class EditPortal extends React.Component {
         />,
         document.getElementById('react-portal')
       )
-    } else {
+    } catch (e) {
       return false
     }
   }

--- a/desktop/apps/article/components/App.js
+++ b/desktop/apps/article/components/App.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { Fragment } from 'react'
+import ReactDOM from 'react-dom'
 import { Article } from '@artsy/reaction-force/dist/Components/Publishing'
 import ArticleLayout from './layouts/Article'
 import { EditButton } from 'desktop/apps/article/components/EditButton'
@@ -44,14 +45,33 @@ export default class App extends React.Component {
     const { article } = this.props
 
     return (
-      <div>
+      <Fragment>
+        <EditPortal article={article} />
+        {this.getArticleLayout()}
+      </Fragment>
+    )
+  }
+}
+
+class EditPortal extends React.Component {
+  static propTypes = {
+    article: PropTypes.object
+  }
+
+  render () {
+    const { article } = this.props
+
+    // Only render on client-side
+    if (typeof window !== 'undefined') {
+      return ReactDOM.createPortal(
         <EditButton
           channelId={article.channel_id}
           slug={article.slug}
-        />
-
-        {this.getArticleLayout()}
-      </div>
-    )
+        />,
+        document.getElementById('react-portal')
+      )
+    } else {
+      return false
+    }
   }
 }

--- a/desktop/apps/article/components/EditButton.js
+++ b/desktop/apps/article/components/EditButton.js
@@ -12,11 +12,8 @@ export class EditButton extends React.Component {
     slug: PropTypes.string
   }
 
-  constructor (props) {
-    super(props)
-    this.state = {
-      hasButtonState: false
-    }
+  state = {
+    hasButtonState: false
   }
 
   componentDidMount = async () => {

--- a/desktop/apps/article/components/__tests__/App.test.js
+++ b/desktop/apps/article/components/__tests__/App.test.js
@@ -1,8 +1,6 @@
 import 'jsdom-global/register'
-import * as _ from 'underscore'
 import benv from 'benv'
 import React from 'react'
-import fixtures from 'desktop/test/helpers/fixtures.coffee'
 import { mount } from 'enzyme'
 import { data as sd } from 'sharify'
 

--- a/desktop/components/main_layout/templates/react_index.jade
+++ b/desktop/components/main_layout/templates/react_index.jade
@@ -14,6 +14,7 @@ block body
 
   #react-root
     != body
+  #react-portal
 
   if jsonLD
     include ./json_ld


### PR DESCRIPTION
Instead of changing the z-index of the EditButton to fix https://waffle.io/artsy/publishing/cards/5a4e5174c390ea0063e90860, this seemed like a good candidate to try out Portals!

Here is the button in question now visible above a Fullscreen header
![image](https://user-images.githubusercontent.com/2236794/34851776-92f8daec-f6f9-11e7-832e-abca30067925.png)
