### PR TITLE
@cavvia => Adjust keyword search on /collect to match comps for AB test

### DIFF
--- a/desktop/apps/collect/client.coffee
+++ b/desktop/apps/collect/client.coffee
@@ -35,12 +35,6 @@ module.exports.init = ->
     el: $('.cf-headline')
     params: params
 
-  categoryView = new CategoryFilterView
-    el: $('.cf-categories')
-    params: params
-    aggregations: filter.aggregations
-    categoryMap: sd.CATEGORIES
-
   totalView = new TotalView
     el: $('.cf-total-sort__total')
     filter: filter
@@ -50,19 +44,31 @@ module.exports.init = ->
     el: $('.cf-total-sort__sort')
     params: params
 
-  pillboxView = new PillboxView
-    el: $('.cf-pillboxes')
-    params: params
-    artworks: filter.artworks
-    categoryMap: sd.CATEGORIES
-
-  # Main Artworks view
   if CurrentUser.orNull()?.hasLabFeature('Keyword Search')
+    pillboxView = new PillboxView
+      el: $('.cf-headline-container .cf-pillboxes')
+      params: params
+      artworks: filter.artworks
+      categoryMap: sd.CATEGORIES
+
     keywordView = new KeywordFilterView
       el: $('.cf-keyword')
       params: params
-      aggregations: filter.aggregations
 
+  else
+    categoryView = new CategoryFilterView
+      el: $('.cf-categories')
+      params: params
+      aggregations: filter.aggregations
+      categoryMap: sd.CATEGORIES
+
+    pillboxView = new PillboxView
+      el: $('.cf-right .cf-pillboxes')
+      params: params
+      artworks: filter.artworks
+      categoryMap: sd.CATEGORIES
+
+  # Main Artworks view
   filter.artworks.on 'reset', ->
     artworkView = new ArtworkColumnsView
       collection: filter.artworks

--- a/desktop/apps/collect/templates/index.jade
+++ b/desktop/apps/collect/templates/index.jade
@@ -8,39 +8,30 @@ append locals
 
 block body
   .commercial-filter.main-layout-container
-    .cf-headline
-      //- rendered on the client
+    .cf-headline-container
+      .cf-headline
+      .cf-pillboxes
+
     .cf-sidebar
       .cf-sidebar__filter.cf-sidebar__price
-        //- rendered on the client
       .cf-sidebar__filter.cf-sidebar__followed_artists
       .cf-sidebar__filter.cf-sidebar__mediums
-        //- rendered on the client
       .cf-sidebar__filter.cf-sidebar__size
         .cf-sidebar__size__width
-          //- rendered on the client
         .cf-sidebar__size__height
-          //- rendered on the client
       .cf-sidebar__filter.cf-sidebar__periods
-        //- rendered on the client
       .cf-sidebar__filter.cf-sidebar__locations
-        //- rendered on the client
       .cf-sidebar__filter.cf-sidebar__colors
-        //- rendered on the client
+
     .cf-right
-      .cf-categories
-        //- rendered on the client
+      .cf-keyword
+      .cf-categories        
       .cf-total-sort
         .cf-total-sort__total
-          //- rendered on the client
         .cf-total-sort__sort
-          //- rendered on the client
       .cf-pillboxes
-        //- rendered on the client
-      .cf-keyword
-        //- rendered on the client
       .cf-artworks
-        //- rendered on the client
+
       hr
       .cf-pagination
-        //- rendered on the client
+        

--- a/desktop/components/commercial_filter/filters/keyword/index.jade
+++ b/desktop/components/commercial_filter/filters/keyword/index.jade
@@ -1,13 +1,14 @@
 #keyword-search-bar-container.typeahead
   input#keyword-search-bar-input.bordered-input(
-    placeholder='Search…'
+    placeholder='Filter by style, subject matter, title, artist, gallery, etc.'
     tabindex='1'
     itemprop='query-input'
     type='text'
     name='keyword'
-    value= keyword
     autocomplete="off"
     autocorrect="off"
     autocapitalize="off"
     spellcheck="false"
   )
+
+  a.icon-search

--- a/desktop/components/commercial_filter/filters/keyword/keyword_filter_view.coffee
+++ b/desktop/components/commercial_filter/filters/keyword/keyword_filter_view.coffee
@@ -7,10 +7,9 @@ module.exports = class KeywordFilterView extends Backbone.View
   events:
     "change input#keyword-search-bar-input" : 'setKeyword'
 
-  initialize: ({ @params, aggregations }) ->
+  initialize: ({ @params }) ->
     throw new Error "Requires a params model" unless @params
-    @listenToOnce @params, 'change', @render
-    @listenTo @aggregations, 'reset', @render
+    @listenTo @params, 'change', @render
 
   setKeyword: (e) ->
     if $('input[name=keyword]').val().length > 0
@@ -20,4 +19,3 @@ module.exports = class KeywordFilterView extends Backbone.View
 
   render: ->
     @$el.html template
-      keyword: @params.get('keyword')

--- a/desktop/components/commercial_filter/stylesheets/index.styl
+++ b/desktop/components/commercial_filter/stylesheets/index.styl
@@ -28,6 +28,9 @@ padding-unit = 15px
   hr
     margin (padding-unit * 2) padding-unit
 
+.cf-keyword
+  padding 0 padding-unit
+
 .cf-artworks
   padding 0 padding-unit
   transition opacity 0.25s

--- a/desktop/components/commercial_filter/views/pillbox/index.jade
+++ b/desktop/components/commercial_filter/views/pillbox/index.jade
@@ -1,4 +1,4 @@
-if color || medium || price || width || height || category || majorPeriods || partnerCities
+if color || medium || price || width || height || category || majorPeriods || partnerCities || keyword
   .cf-pillbox__pillboxes
     if category
       .cf-pillbox__pillboxes__category
@@ -34,3 +34,7 @@ if color || medium || price || width || height || category || majorPeriods || pa
         .cf-pillbox__pillboxes__major-period
           span.cf-pillbox__pillboxes_display= displayLocation(partnerCity)
           span.cf-pillbox__pillboxes_clear(data-filter='partner_city' data-value=partnerCity) ×
+    if keyword
+      .cf-pillbox__pillboxes__keyword
+        span.cf-pillbox__pillboxes_display= keyword
+        span.cf-pillbox__pillboxes_clear(data-value='keyword') ×

--- a/desktop/components/commercial_filter/views/pillbox/index.styl
+++ b/desktop/components/commercial_filter/views/pillbox/index.styl
@@ -1,3 +1,9 @@
+html[data-lab-features*='Keyword Search']
+  .cf-pillbox
+    &__pillboxes
+      padding 0
+      padding-bottom 15px
+
 .cf-pillbox
   &__pillboxes
     padding 0 15px 15px 15px

--- a/desktop/components/commercial_filter/views/pillbox/pillbox_view.coffee
+++ b/desktop/components/commercial_filter/views/pillbox/pillbox_view.coffee
@@ -74,3 +74,4 @@ module.exports = class PillboxView extends Backbone.View
       majorPeriods: @params.get('major_periods')
       partnerCities: @params.get('partner_cities')
       displayLocation: @displayLocation
+      keyword: @params.get('keyword')


### PR DESCRIPTION
I thought this was admin-only, but it's actually based on an AB test. Same difference tho!

With lab:

<img width="1225" alt="screen shot 2018-01-18 at 10 46 19 am" src="https://user-images.githubusercontent.com/1457859/35106726-f9d24ca6-fc3c-11e7-92a9-7da388d051d2.png">


Without lab (unchanged):

<img width="1197" alt="screen shot 2018-01-18 at 10 47 36 am" src="https://user-images.githubusercontent.com/1457859/35106749-0ccb661c-fc3d-11e7-911a-1371857d2224.png">


This basically gets it looking like the comp, but keeps it under lab feature.

Still to do:
  - sorting. Since sorting doesn't work, I wasn't sure how we should disable/indicate that the functionality isn't supported when you have a keyword search. (cc @briansw )
  - analytics. Setting up the actual AB test experiment is very straightforward, but we also should be storing all keyword searches, possible via Segment? or something else.