### PR TITLE
@joeyAghion => Be defensive about missing partner in filter results on artist page

### DIFF
--- a/desktop/components/artwork_metadata_stub/templates/didactics.jade
+++ b/desktop/components/artwork_metadata_stub/templates/didactics.jade
@@ -21,7 +21,7 @@ if artwork.collecting_institution
 else if artwork.sale && artwork.sale.is_auction
   a.artwork-metadata-stub__partner.artwork-metadata-stub__line( href= artwork.sale.href )
     = artwork.partner.name
-else
+else if artwork.partner
   a.artwork-metadata-stub__partner.artwork-metadata-stub__line( href= artwork.partner.href )
     = artwork.partner.name
 

--- a/desktop/components/artwork_metadata_stub/test/index.js
+++ b/desktop/components/artwork_metadata_stub/test/index.js
@@ -12,6 +12,22 @@ function render (locals) {
 }
 
 describe('metadata template', () => {
+  describe('without a partner', () => {
+    let partnerlessArtwork
+    beforeEach(() => {
+      partnerlessArtwork = {
+        date: '2018',
+        title: 'A Cat Has No Name',
+        partner: null
+      }
+    })
+
+    it('renders auction closed if the auction is closed', () => {
+      const $ = cheerio.load(render({ artwork: partnerlessArtwork }))
+      $.text().should.containEql('A Cat Has No Name, 2018')
+      $('.artwork-metadata-stub__partner').length.should.eql(0)
+    })
+  })
   describe('auction artwork', () => {
     let auctionArtwork
     beforeEach(() => {


### PR DESCRIPTION
Closes https://github.com/artsy/force/issues/2017

One of the artworks returned (published), lacks a partner. Here's that artwork: www.artsy.net/artwork/mike-pratt-sleeping-moon  (this page and associated Metaphysics query has several issues with it, I'm taking a look at those).

In the meantime, this just makes the template used in the artist page filter a bit more defensive.