### PR TITLE
@alloy => Onboarding admin only

### DIFF
--- a/desktop/apps/personalize/client/onboarding.js
+++ b/desktop/apps/personalize/client/onboarding.js
@@ -1,11 +1,9 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import App from 'desktop/apps/personalize/components/App'
-import { rehydrateClient } from 'desktop/components/react/utils/renderReactLayout'
+import { App } from 'desktop/apps/personalize/components/App'
 
 export const init = () => {
-  // Rehydrate data from Server
-  const bootstrapData = rehydrateClient(window.__BOOTSTRAP__)
+  const bootstrapData = window.__BOOTSTRAP__
 
   // Start app
   ReactDOM.hydrate(

--- a/desktop/apps/personalize/client/onboarding.js
+++ b/desktop/apps/personalize/client/onboarding.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import App from 'desktop/apps/personalize/components/App'
+import { rehydrateClient } from 'desktop/components/react/utils/renderReactLayout'
+
+export const init = () => {
+  // Rehydrate data from Server
+  const bootstrapData = rehydrateClient(window.__BOOTSTRAP__)
+
+  // Start app
+  ReactDOM.hydrate(
+    <App {...bootstrapData} />, document.getElementById('react-root')
+  )
+}

--- a/desktop/apps/personalize/components/App.js
+++ b/desktop/apps/personalize/components/App.js
@@ -1,0 +1,19 @@
+// import PropTypes from 'prop-types'
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { ContextProvider } from '@artsy/reaction-force/dist/Components/Artsy'
+import Wizard from '@artsy/reaction-force/dist/Components/Onboarding/Wizard'
+import CollectorIntent from '@artsy/reaction-force/dist/Components/Onboarding/Steps/CollectorIntent'
+import Artists from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Artists'
+import Genes from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Genes'
+import Budget from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Budget'
+const sd = require('sharify').data
+export default class App extends React.Component {
+  render () {
+    return (
+      <ContextProvider currentUser={sd.CURRENT_USER} >
+        <Wizard stepComponents={[CollectorIntent, Artists, Genes, Budget]} />
+      </ContextProvider>
+    )
+  }
+}

--- a/desktop/apps/personalize/components/App.js
+++ b/desktop/apps/personalize/components/App.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import { ContextProvider } from '@artsy/reaction-force/dist/Components/Artsy'
 import Wizard from '@artsy/reaction-force/dist/Components/Onboarding/Wizard'
@@ -5,12 +6,15 @@ import CollectorIntent from '@artsy/reaction-force/dist/Components/Onboarding/St
 import Artists from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Artists'
 import Genes from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Genes'
 import Budget from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Budget'
-const sd = require('sharify').data
 
 export class App extends React.Component {
+  static propTypes = {
+    currentUser: PropTypes.object
+  }
+
   render () {
     return (
-      <ContextProvider currentUser={sd.CURRENT_USER} >
+      <ContextProvider currentUser={this.props.currentUser} >
         <Wizard stepComponents={[CollectorIntent, Artists, Genes, Budget]} />
       </ContextProvider>
     )

--- a/desktop/apps/personalize/components/App.js
+++ b/desktop/apps/personalize/components/App.js
@@ -1,6 +1,4 @@
-// import PropTypes from 'prop-types'
 import React from 'react'
-import ReactDOM from 'react-dom'
 import { ContextProvider } from '@artsy/reaction-force/dist/Components/Artsy'
 import Wizard from '@artsy/reaction-force/dist/Components/Onboarding/Wizard'
 import CollectorIntent from '@artsy/reaction-force/dist/Components/Onboarding/Steps/CollectorIntent'
@@ -8,6 +6,7 @@ import Artists from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Arti
 import Genes from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Genes'
 import Budget from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Budget'
 const sd = require('sharify').data
+
 export default class App extends React.Component {
   render () {
     return (

--- a/desktop/apps/personalize/components/App.js
+++ b/desktop/apps/personalize/components/App.js
@@ -7,7 +7,7 @@ import Genes from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Genes'
 import Budget from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Budget'
 const sd = require('sharify').data
 
-export default class App extends React.Component {
+export class App extends React.Component {
   render () {
     return (
       <ContextProvider currentUser={sd.CURRENT_USER} >

--- a/desktop/apps/personalize/index.coffee
+++ b/desktop/apps/personalize/index.coffee
@@ -3,10 +3,12 @@
 #
 
 express = require 'express'
-routes = require './routes'
+{ index, newOnboarding } = require './routes.js'
+adminOnly = require '../../lib/admin_only'
 
 app = module.exports = express()
 app.set 'views', __dirname
 app.set 'view engine', 'jade'
 
-app.get '/personalize*', routes.index
+app.get '/personalize*', index
+app.get '/onboarding', adminOnly, newOnboarding

--- a/desktop/apps/personalize/onboarding.jade
+++ b/desktop/apps/personalize/onboarding.jade
@@ -1,1 +1,0 @@
-p Hello World!

--- a/desktop/apps/personalize/onboarding.jade
+++ b/desktop/apps/personalize/onboarding.jade
@@ -1,0 +1,1 @@
+p Hello World!

--- a/desktop/apps/personalize/routes.coffee
+++ b/desktop/apps/personalize/routes.coffee
@@ -1,8 +1,0 @@
-_ = require 'underscore'
-
-@index = (req, res) ->
-  req.user.fetch
-    success: (model, response, options) ->
-      res.locals.sd.CURRENT_USER =
-        _.extend(response, res.locals.sd.CURRENT_USER)
-      res.render 'template'

--- a/desktop/apps/personalize/routes.js
+++ b/desktop/apps/personalize/routes.js
@@ -1,6 +1,6 @@
 import * as _ from 'underscore'
 import { renderLayout } from '@artsy/stitch'
-import App from 'desktop/apps/personalize/components/App'
+import { App } from 'desktop/apps/personalize/components/App'
 
 export const index = (req, res) => {
   req.user.fetch({

--- a/desktop/apps/personalize/routes.js
+++ b/desktop/apps/personalize/routes.js
@@ -21,12 +21,11 @@ export async function newOnboarding (req, res, next) {
         },
         layout: '../../components/main_layout/templates/react_blank_index.jade',
         blocks: {
-          // head: 'meta.jade',
           body: App
         },
         locals: {
           ...res.locals,
-          assetPackage: 'misc'
+          assetPackage: 'personalize'
         }
       })
 
@@ -35,7 +34,6 @@ export async function newOnboarding (req, res, next) {
       next(error)
     }
   } else {
-    console.log('index')
-    index(req, res)
+    res.redirect('/personalize')
   }
 }

--- a/desktop/apps/personalize/routes.js
+++ b/desktop/apps/personalize/routes.js
@@ -1,0 +1,41 @@
+import * as _ from 'underscore'
+import { renderLayout } from '@artsy/stitch'
+import App from 'desktop/apps/personalize/components/App'
+
+export const index = (req, res) => {
+  req.user.fetch({
+    success: (model, response, options) => {
+      res.locals.sd.CURRENT_USER = _.extend({}, response, res.locals.sd.CURRENT_USER)
+      res.render('template')
+    }
+  })
+}
+
+export async function newOnboarding (req, res, next) {
+  if (res.locals.sd.ONBOARDING_TEST === 'experiment') {
+    try {
+      const layout = await renderLayout({
+        basePath: req.app.get('views'),
+        config: {
+          styledComponents: true
+        },
+        layout: '../../components/main_layout/templates/react_blank_index.jade',
+        blocks: {
+          // head: 'meta.jade',
+          body: App
+        },
+        locals: {
+          ...res.locals,
+          assetPackage: 'misc'
+        }
+      })
+
+      res.send(layout)
+    } catch (error) {
+      next(error)
+    }
+  } else {
+    console.log('index')
+    index(req, res)
+  }
+}

--- a/desktop/apps/personalize/routes.js
+++ b/desktop/apps/personalize/routes.js
@@ -26,6 +26,9 @@ export async function newOnboarding (req, res, next) {
         locals: {
           ...res.locals,
           assetPackage: 'personalize'
+        },
+        data: {
+          currentUser: res.locals.sd.CURRENT_USER
         }
       })
 

--- a/desktop/apps/personalize/template.jade
+++ b/desktop/apps/personalize/template.jade
@@ -4,7 +4,7 @@ block head
   title Personalize | Artsy
 
 append locals
-  - assetPackage = 'misc'
+  - assetPackage = 'personalize'
 
 block body
   #personalize-page

--- a/desktop/assets/misc.coffee
+++ b/desktop/assets/misc.coffee
@@ -16,6 +16,8 @@ routes =
 
   '/personalize': require('../apps/personalize/client/index.coffee').init
 
+  '/onboarding': require('../apps/personalize/client/onboarding.js').init
+
   '/professional-buyer': require('../apps/pro_buyer/client/index.coffee')
 
   '/style-guide': require('../apps/style_guide/client/index.coffee').init

--- a/desktop/assets/misc.coffee
+++ b/desktop/assets/misc.coffee
@@ -14,10 +14,6 @@ routes =
 
   '/jobs': require('../apps/jobs/client/index.coffee').init
 
-  '/personalize': require('../apps/personalize/client/index.coffee').init
-
-  '/onboarding': require('../apps/personalize/client/onboarding.js').init
-
   '/professional-buyer': require('../apps/pro_buyer/client/index.coffee')
 
   '/style-guide': require('../apps/style_guide/client/index.coffee').init

--- a/desktop/assets/misc.styl
+++ b/desktop/assets/misc.styl
@@ -22,16 +22,6 @@
 // page
 @require '../apps/page'
 
-// personalize
-@require '../components/location_search'
-@require '../components/popover'
-@require '../components/grid'
-@require '../components/user_interests'
-@require '../components/artwork_item/stylesheets'
-@require '../components/artwork_columns'
-@require '../components/partner_profile_cover'
-@require '../apps/personalize/stylesheets'
-
 // press
 @require '../components/chevron_list'
 @require '../apps/press/stylesheets'

--- a/desktop/assets/personalize.coffee
+++ b/desktop/assets/personalize.coffee
@@ -1,0 +1,8 @@
+require('backbone').$ = $
+sd = require('sharify').data
+
+$ ->
+  if location.pathname.match('/personalize*')
+    require('../apps/personalize/client/index.coffee').init()
+  else
+    require('../apps/personalize/client/onboarding.js').init()

--- a/desktop/assets/personalize.styl
+++ b/desktop/assets/personalize.styl
@@ -1,0 +1,8 @@
+@require '../components/location_search'
+@require '../components/popover'
+@require '../components/grid'
+@require '../components/user_interests'
+@require '../components/artwork_item/stylesheets'
+@require '../components/artwork_columns'
+@require '../components/partner_profile_cover'
+@require '../apps/personalize/stylesheets'

--- a/desktop/components/main_layout/header/view.coffee
+++ b/desktop/components/main_layout/header/view.coffee
@@ -106,7 +106,9 @@ module.exports = class HeaderView extends Backbone.View
 
   signup: (e) ->
     e.preventDefault()
-    mediator.trigger 'open:auth', mode: 'signup'
+    mediator.trigger 'open:auth',
+      mode: 'signup'
+      redirectTo: '/personalize'
 
   login: (e) ->
     e.preventDefault()

--- a/desktop/components/split_test/running_tests.coffee
+++ b/desktop/components/split_test/running_tests.coffee
@@ -27,4 +27,10 @@ module.exports = {
       control: 50
       experiment: 50
     edge: 'experiment'
+  onboarding_test:
+    key: 'onboarding_test'
+    outcomes:
+      control: 50
+      experiment: 50
+    edge: 'experiment'
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@artsy/express-reloadable": "^1.2.0",
-    "@artsy/reaction-force": "0.18.12",
+    "@artsy/reaction-force": "0.18.15",
     "@artsy/stitch": "^1.3.1",
     "accounting": "^0.4.1",
     "analytics-node": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   dependencies:
     chokidar "^1.7.0"
 
-"@artsy/reaction-force@0.18.12":
-  version "0.18.12"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.18.12.tgz#bafda2cb4647f92964634a0882d0dd574ca56338"
+"@artsy/reaction-force@0.18.15":
+  version "0.18.15"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.18.15.tgz#c2162d93d955ede17e96c12591bfd6f2e1dc2e6a"
   dependencies:
     history "^4.6.1"
     isomorphic-fetch "^2.2.1"


### PR DESCRIPTION
This PR pulls in the onboarding react root component via server-side rendering using stitch `renderLayout`. It has the initial setup for the A/B test but isn't yet fulling implemented yet. We will also probably have to refactor the tests but are PR'in early to get some eyes on this.

Paired with @xtina-starr on this!

Shows SSR on initial load, then rehydrates after JS is loaded. The SSR doesn't need to fetch any data since the first screen is hardcoded values so subsequent steps are always client-side. 
![onboarding](https://user-images.githubusercontent.com/2236794/35249077-93d3250a-ff9e-11e7-87fb-ceab7d8fb67b.gif)

Check out the test with: `/onboarding?split_test[onboarding_test]=experiment`