### PR TITLE
@kanaabe  => Remove unnecessary reference to Mixpanel

### DIFF
--- a/desktop/analytics/article_impressions.js
+++ b/desktop/analytics/article_impressions.js
@@ -166,8 +166,7 @@ if (location.pathname.match('/article/') || location.pathname.match('/articles')
   }
 
   var trackImpression = function (item) {
-    analytics.track(item.message, item.context,
-      { integrations: { 'Mixpanel': false } })
+    analytics.track(item.message, item.context)
   }
 
   $(window).on('scroll', _.throttle(trackImpressions, 500))

--- a/desktop/analytics/articles.js
+++ b/desktop/analytics/articles.js
@@ -100,7 +100,7 @@ if (location.pathname.match('/article/') || location.pathname.match('/2016-year-
       destination_path: null,
       impression_type: 'newsletter_signup',
       context_type: options.type
-    }, { integrations: { 'Mixpanel': false } })
+    })
   })
 }
 

--- a/desktop/analytics/impressions.js
+++ b/desktop/analytics/impressions.js
@@ -35,8 +35,6 @@ var trackImpressions = function () {
   if (ids.length > 0) {
     analytics.track('Artwork impressions', {
       ids: ids, nonInteraction: 1
-    }, {
-      integrations: { 'Mixpanel': false }
     })
   }
 }

--- a/desktop/components/split_test/split_test.coffee
+++ b/desktop/components/split_test/split_test.coffee
@@ -64,4 +64,4 @@ module.exports = class SplitTest
       variation_id: outcome = @get()
       variation_name: outcome
       nonInteraction: 1
-    }, Mixpanel: false
+    }

--- a/mobile/analytics/impressions.js
+++ b/mobile/analytics/impressions.js
@@ -27,8 +27,7 @@ var trackImpressions = function() {
   var ids = visibleArtworkIds();
   if (ids.length > 0) {
     analytics.track('Artwork impressions',
-      { ids: ids, nonInteraction: 1 },
-      { integrations: { 'Mixpanel': false }}
+      { ids: ids, nonInteraction: 1 }
     )
   }
 };


### PR DESCRIPTION
We no longer have a subscription to Mixpanel and do not send any events to it, so we no longer have to specifically not send experiment