### PR TITLE
@mzikherman: KSO-8 reduce filter aggregation overhead on collect

### DIFF
--- a/desktop/apps/collect/client.coffee
+++ b/desktop/apps/collect/client.coffee
@@ -61,6 +61,7 @@ module.exports.init = ->
       params: params
       aggregations: filter.aggregations
       categoryMap: sd.CATEGORIES
+      alwaysEnabled: true
 
     pillboxView = new PillboxView
       el: $('.cf-right .cf-pillboxes')
@@ -86,11 +87,13 @@ module.exports.init = ->
     el: $('.cf-sidebar__mediums')
     params: params
     aggregations: filter.aggregations
+    alwaysEnabled: true    
 
   periodsView = new PeriodFilterView
     el: $('.cf-sidebar__periods')
     params: params
     aggregations: filter.aggregations
+    alwaysEnabled: true    
 
   followedArtistsView = new FollowedArtistFilterView
     el: $('.cf-sidebar__followed_artists')
@@ -101,6 +104,7 @@ module.exports.init = ->
     el: $('.cf-sidebar__locations')
     params: params
     aggregations: filter.aggregations
+    alwaysEnabled: true
 
   priceView = new PriceFilterView
     el: $('.cf-sidebar__price')
@@ -110,6 +114,7 @@ module.exports.init = ->
     el: $('.cf-sidebar__colors')
     params: params
     aggregations: filter.aggregations
+    alwaysEnabled: true
 
   widthView = new SizeFilterView
     el: $('.cf-sidebar__size__width')

--- a/desktop/components/commercial_filter/filters/category/category_filter_view.coffee
+++ b/desktop/components/commercial_filter/filters/category/category_filter_view.coffee
@@ -6,7 +6,7 @@ module.exports = class CategoryFilterView extends Backbone.View
   events:
     'click .cf-categories__category' : 'toggleCategory'
 
-  initialize: ({ @params, @aggregations, @categoryMap }) ->
+  initialize: ({ @params, @aggregations, @categoryMap, @alwaysEnabled }) ->
     throw new Error "Requires a params model" unless @params
     throw new Error "Requires an aggregations collection" unless @aggregations
 
@@ -41,5 +41,5 @@ module.exports = class CategoryFilterView extends Backbone.View
       selectedCategory: @params.get('gene_id')
       hasResults: @hasResults
       counts: @aggregations.get('MEDIUM')?.get('counts')
-
+      alwaysEnabled: @alwaysEnabled
 

--- a/desktop/components/commercial_filter/filters/category/index.jade
+++ b/desktop/components/commercial_filter/filters/category/index.jade
@@ -3,7 +3,7 @@
     .cf-categories__category(
       data-id=category.id
       style="background-image: url(#{category.image})"
-      data-has-results= hasResults && hasResults(counts, category.id) ? "true" : "false"
+      data-has-results= alwaysEnabled || (hasResults && hasResults(counts, category.id)) ? "true" : "false"
       class=(selectedCategory == category.id) ? "is-selected" : ""
     )
       .cf-categories__category__overlay

--- a/desktop/components/commercial_filter/filters/color/color_filter_view.coffee
+++ b/desktop/components/commercial_filter/filters/color/color_filter_view.coffee
@@ -9,7 +9,7 @@ module.exports = class ColorFilterView extends Backbone.View
 
   colors: ['darkblue', 'lightblue', 'darkgreen', 'lightgreen', 'yellow', 'gold', 'orange', 'darkorange', 'red', 'pink', 'darkviolet', 'violet', 'black-and-white']
 
-  initialize: ({ @params, @aggregations }) ->
+  initialize: ({ @params, @aggregations, @alwaysEnabled }) ->
     throw new Error 'Requires a params model' unless @params?
     throw new Error 'Requires an aggregations collection' unless @aggregations?
 
@@ -56,8 +56,9 @@ module.exports = class ColorFilterView extends Backbone.View
       @$checkmark.hide()
 
     # Add empty states
-    respColors = _.pluck @aggregations.get('COLOR')?.get('counts'), 'name'
-    emptyColors = _.difference(@colors, respColors)
-    _.each(emptyColors, (color) ->
-      @$("svg path[data-value='#{color}']").attr('data-empty', true)
-    )
+    if !@alwaysEnabled
+      respColors = _.pluck @aggregations.get('COLOR')?.get('counts')?, 'name'
+      emptyColors = _.difference(@colors, respColors)
+      _.each(emptyColors, (color) ->
+        @$("svg path[data-value='#{color}']").attr('data-empty', true)
+      )

--- a/desktop/components/commercial_filter/filters/location/index.jade
+++ b/desktop/components/commercial_filter/filters/location/index.jade
@@ -5,6 +5,7 @@ include ./all.jade
 each location in locations
   - agg = findAggregation(counts, location)
   - isSelected = _.contains(selected, location)
+  - enabled = alwaysEnabled || findAggregation(counts, location)
 
   include ./location.jade
 

--- a/desktop/components/commercial_filter/filters/location/location.jade
+++ b/desktop/components/commercial_filter/filters/location/location.jade
@@ -1,6 +1,6 @@
-.artsy-checkbox.cf-locations__checkbox(data-has-results=agg ? 'true' : 'false')
+.artsy-checkbox.cf-locations__checkbox(data-has-results=enabled  ? 'true' : 'false')
   .artsy-checkbox--checkbox
-    input( type='checkbox', id=location, checked=isSelected, disabled=!agg )
+    input( type='checkbox', id=location, checked=isSelected )
     label( for=location )
   label.artsy-checkbox--label( for=location ) #{displayLocation(location)}
     if agg

--- a/desktop/components/commercial_filter/filters/location/location_filter_view.coffee
+++ b/desktop/components/commercial_filter/filters/location/location_filter_view.coffee
@@ -15,7 +15,7 @@ module.exports = class LocationFilterView extends Backbone.View
     "change [type='checkbox']" : 'toggleLocation'
     'click .cf-periods__view-all': 'showAll'
 
-  initialize: ({ @params, @aggregations }) ->
+  initialize: ({ @params, @aggregations, @alwaysEnabled }) ->
     throw new Error 'Requires a params model' unless @params?
     throw new Error 'Requires an aggregations collection' unless @aggregations?
 
@@ -83,6 +83,7 @@ module.exports = class LocationFilterView extends Backbone.View
     location.substring(0, commaIndex)
 
   findAggregation: (counts, id) ->
+  if counts?
     _.find counts, (count) -> count.id is id
 
   render: ->
@@ -94,4 +95,5 @@ module.exports = class LocationFilterView extends Backbone.View
       numberFormat: numberFormat
       _: _
       displayLocation: @displayLocation
+      alwaysEnabled: @alwaysEnabled
     @setupTypeahead()

--- a/desktop/components/commercial_filter/filters/medium/index.jade
+++ b/desktop/components/commercial_filter/filters/medium/index.jade
@@ -2,6 +2,6 @@ h1.cf-mediums__option(data-value=false class=selected ? '' : 'is-selected') All
 each name, id in mediums
   h1.cf-mediums__option(
     data-value="#{id}"
-    data-has-results=hasResults(counts, id) ? "true" : "false"
+    data-has-results=alwaysEnabled || hasResults(counts, id) ? "true" : "false"
     class=selected == id ? 'is-selected' : ''
     ) #{name}

--- a/desktop/components/commercial_filter/filters/medium/medium_filter_view.coffee
+++ b/desktop/components/commercial_filter/filters/medium/medium_filter_view.coffee
@@ -9,7 +9,7 @@ module.exports = class MediumFilterView extends Backbone.View
   events:
     'click h1' : 'setMedium'
 
-  initialize: ({ @params, @aggregations }) ->
+  initialize: ({ @params, @aggregations, @alwaysEnabled }) ->
     throw new Error 'Requires a params model' unless @params?
     throw new Error 'Requires an aggregations collection' unless @aggregations?
 
@@ -34,3 +34,4 @@ module.exports = class MediumFilterView extends Backbone.View
       mediums: mediumMap
       selected: @params.get('medium')
       hasResults: @hasResults
+      alwaysEnabled: @alwaysEnabled

--- a/desktop/components/commercial_filter/filters/period/index.jade
+++ b/desktop/components/commercial_filter/filters/period/index.jade
@@ -5,6 +5,7 @@ include ./all.jade
 each majorPeriod in periods
   - agg = findAggregation(counts, majorPeriod)
   - isSelected = _.contains(selected, majorPeriod)
+  - enabled = alwaysEnabled || findAggregation(counts, location)
 
   include ./period.jade
 

--- a/desktop/components/commercial_filter/filters/period/period.jade
+++ b/desktop/components/commercial_filter/filters/period/period.jade
@@ -1,6 +1,6 @@
-.artsy-checkbox.cf-periods__checkbox(data-has-results=agg ? 'true' : 'false')
+.artsy-checkbox.cf-periods__checkbox(data-has-results=enabled ? 'true' : 'false')
   .artsy-checkbox--checkbox
-    input( type='checkbox', id=majorPeriod, checked=isSelected, disabled=!agg )
+    input( type='checkbox', id=majorPeriod, checked=isSelected, disabled=!enabled )
     label( for=majorPeriod )
   label.artsy-checkbox--label( for=majorPeriod ) #{majorPeriod}
     if agg

--- a/desktop/components/commercial_filter/filters/period/period_filter_view.coffee
+++ b/desktop/components/commercial_filter/filters/period/period_filter_view.coffee
@@ -10,7 +10,7 @@ module.exports = class PeriodFilterView extends Backbone.View
     "change [type='checkbox']" : 'togglePeriod'
     'click .cf-periods__view-all': 'showAll'
 
-  initialize: ({ @params, @aggregations }) ->
+  initialize: ({ @params, @aggregations, @alwaysEnabled }) ->
     throw new Error 'Requires a params model' unless @params?
     throw new Error 'Requires an aggregations collection' unless @aggregations?
 
@@ -49,3 +49,4 @@ module.exports = class PeriodFilterView extends Backbone.View
       numberFormat: numberFormat
       _: _
       showAllPeriods: @showAllPeriods
+      alwaysEnabled: @alwaysEnabled

--- a/desktop/components/commercial_filter/models/params.coffee
+++ b/desktop/components/commercial_filter/models/params.coffee
@@ -24,14 +24,14 @@ module.exports = class Params extends Backbone.Model
   UTM = '^utm.*'
 
   defaults:
-    size: 50
+    size: 40
     page: 1
     for_sale: true
     major_periods: []
     partner_cities: []
     gene_ids: []
     artist_ids: []
-    aggregations: ['TOTAL', 'COLOR', 'MEDIUM', 'MAJOR_PERIOD', 'PARTNER_CITY', 'FOLLOWED_ARTISTS']
+    aggregations: ['TOTAL', 'FOLLOWED_ARTISTS']
     ranges:
       price_range:
         min: 50.00

--- a/desktop/components/commercial_filter/test/models/params.coffee
+++ b/desktop/components/commercial_filter/test/models/params.coffee
@@ -19,10 +19,10 @@ describe 'Filter', ->
     it 'returns the defaults if custom defaults are not passed in', ->
       params = new @Params({}, {})
       defaults = params.initialParams()
-      defaults.should.containEql(size: 50, partner_cities: [])
+      defaults.should.containEql(size: 40, partner_cities: [])
 
     it 'returns the custom defaults if they are passed in', ->
       params = new @Params({}, { customDefaults: { size: 20, artist_ids: [] } })
       defaults = params.initialParams()
       defaults.should.eql(size: 20, artist_ids: [])
-      defaults.should.not.containEql(size: 50)
+      defaults.should.not.containEql(size: 40)


### PR DESCRIPTION
In a bid to improve performance on our `/collect` page, this drops medium, period, color, and partner location aggregations from the query. The UX impacts are as follows:

* No period or location counts will display.
* No disabling of period, location, medium or color filters when there are no results available under that filter. All these filters are always enabled. 

This change should only affect the `/collect` page. The hypothesis is that aggregations slow down the query significantly, particularly when multiple filters are set, combined with the assumption that there is almost always content on `/collect` under these filters, as we are filtering on our entire catalogue of for-sale content. I additionally assume the counts, as they are often very large numbers, are not meaningful to users in this context. 

The only time where the assumption that content is available potentially breaks down is when the 'followed artists' filter is selected by a logged in user. I'm not sure if this is a frequently used feature, but i assume the 'works for you' tab is a much more common landing page for browsing works by artists you follow.

I also trim the page size to 40 here in an attempt to cut down on network overhead. That seems more than enough content per page to me.

cc @madeleineb 
