### PR TITLE
All users should be redirected to the existing personalize flow after signup

### DIFF
--- a/desktop/components/split_test/running_tests.coffee
+++ b/desktop/components/split_test/running_tests.coffee
@@ -30,7 +30,7 @@ module.exports = {
   onboarding_test:
     key: 'onboarding_test'
     outcomes:
-      control: 50
-      experiment: 50
+      control: 100
+      experiment: 0
     edge: 'experiment'
 }


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/AR-68 that is part of https://artsyproduct.atlassian.net/browse/AR-5

We can't take advantage of the admin guard middleware since we are running an A/B test for users who are initially not logged in but attempt to sign up at some point in the experiment. In order to avoid exposing the new flow by accident, we should redirect any user to the existing flow, and admins should use the `?split_test[onboarding_test]=experiment` query string to force-switch to the experiment.

Also, I'm going to remove the admin guard as part of https://artsyproduct.atlassian.net/browse/AR-62 so @katarinabatina can QA as a guest user.