### PR TITLE
@mzikherman: reset the artwork grid view when there are no results

### DIFF
--- a/desktop/components/commercial_filter/models/filter.coffee
+++ b/desktop/components/commercial_filter/models/filter.coffee
@@ -112,6 +112,8 @@ module.exports = class Filter extends Backbone.Model
         .then ({ filter_artworks }) =>
           if filter_artworks.hits.length
             @artworks.reset filter_artworks.hits
+          else 
+            @artworks.reset []
           @set loading: false
           @set total: filter_artworks.total
           @set followed_artists_total: filter_artworks.followed_artists_total


### PR DESCRIPTION
Fixes a UI issue which occurs when you narrow down to zero results on `/collect`, either via keyword search or using our standard filters. The artwork grid view does not refresh in these cases, resulting in the 'no results' message appearing above stale results:

<img width="1369" alt="screen shot 2018-01-25 at 5 15 04 pm" src="https://user-images.githubusercontent.com/64404/35401011-a44d7ce4-01f8-11e8-9876-49d2ea8017ee.png">

This resets the grid view (to empty) when there are no results. 