### PR TITLE
Put the existing and new onboarding flows into a single route for running an A/B test

### DIFF
--- a/desktop/apps/personalize/index.coffee
+++ b/desktop/apps/personalize/index.coffee
@@ -11,4 +11,3 @@ app.set 'views', __dirname
 app.set 'view engine', 'jade'
 
 app.get '/personalize*', index
-app.get '/onboarding', adminOnly, newOnboarding

--- a/desktop/apps/personalize/routes.js
+++ b/desktop/apps/personalize/routes.js
@@ -2,41 +2,41 @@ import * as _ from 'underscore'
 import { renderLayout } from '@artsy/stitch'
 import { App } from 'desktop/apps/personalize/components/App'
 
-export const index = (req, res) => {
-  req.user.fetch({
-    success: (model, response, options) => {
-      res.locals.sd.CURRENT_USER = _.extend({}, response, res.locals.sd.CURRENT_USER)
-      res.render('template')
-    }
-  })
+export const index = (req, res, next) => {
+  if (res.locals.sd.ONBOARDING_TEST !== 'experiment') {
+    req.user.fetch({
+      success: (model, response, options) => {
+        res.locals.sd.CURRENT_USER = _.extend({}, response, res.locals.sd.CURRENT_USER)
+        res.render('template')
+      }
+    })
+  } else {
+    newOnboarding(req, res, next)
+  }
 }
 
 export async function newOnboarding (req, res, next) {
-  if (res.locals.sd.ONBOARDING_TEST === 'experiment') {
-    try {
-      const layout = await renderLayout({
-        basePath: req.app.get('views'),
-        config: {
-          styledComponents: true
-        },
-        layout: '../../components/main_layout/templates/react_blank_index.jade',
-        blocks: {
-          body: App
-        },
-        locals: {
-          ...res.locals,
-          assetPackage: 'personalize'
-        },
-        data: {
-          currentUser: res.locals.sd.CURRENT_USER
-        }
-      })
+  try {
+    const layout = await renderLayout({
+      basePath: req.app.get('views'),
+      config: {
+        styledComponents: true
+      },
+      layout: '../../components/main_layout/templates/react_blank_index.jade',
+      blocks: {
+        body: App
+      },
+      locals: {
+        ...res.locals,
+        assetPackage: 'onboarding'
+      },
+      data: {
+        currentUser: res.locals.sd.CURRENT_USER
+      }
+    })
 
-      res.send(layout)
-    } catch (error) {
-      next(error)
-    }
-  } else {
-    res.redirect('/personalize')
+    res.send(layout)
+  } catch (error) {
+    next(error)
   }
 }

--- a/desktop/assets/onboarding.coffee
+++ b/desktop/assets/onboarding.coffee
@@ -1,0 +1,2 @@
+$ ->
+  require('../apps/personalize/client/onboarding.js').init()

--- a/desktop/assets/personalize.coffee
+++ b/desktop/assets/personalize.coffee
@@ -2,7 +2,4 @@ require('backbone').$ = $
 sd = require('sharify').data
 
 $ ->
-  if location.pathname.match('/personalize*')
-    require('../apps/personalize/client/index.coffee').init()
-  else
-    require('../apps/personalize/client/onboarding.js').init()
+  require('../apps/personalize/client/index.coffee').init()

--- a/desktop/components/split_test/running_tests.coffee
+++ b/desktop/components/split_test/running_tests.coffee
@@ -27,10 +27,10 @@ module.exports = {
       control: 50
       experiment: 50
     edge: 'experiment'
-  onboarding_test:
-    key: 'onboarding_test'
-    outcomes:
-      control: 100
-      experiment: 0
-    edge: 'experiment'
+#  onboarding_test:
+#    key: 'onboarding_test'
+#    outcomes:
+#      control: 50
+#      experiment: 50
+#    edge: 'experiment'
 }

--- a/lib/middleware/locals.coffee
+++ b/lib/middleware/locals.coffee
@@ -51,4 +51,9 @@ module.exports = (req, res, next) ->
     (ua.match(/BlackBerry/i))
   )
 
+  if req.query?.onboarding_test
+    res.cookie("onboarding_test", req.query?.onboarding_test, expires: new Date(Date.now() + 31536000000))
+
+  res.locals.sd.ONBOARDING_TEST = req.cookies?["onboarding_test"]
+
   next()


### PR DESCRIPTION
## 🚧  DO NOT MERGE THIS YET 🚧

Christina and I have experimented with single-route onboarding A/B test to see how we could go about actually running the test.

@xtina-starr and I have confirmed that we would be able to run the A/B test with the two flows not affecting each other. However, we need to be careful about rolling this out since the user needs to be logged out in the first place and signs up at some point in the A/B test. This means we can't take advantage of the admin guard middleware. The other thing we could do is that admins should use the query string key `?split_test[onboarding_test]=experiment` for QA, but it'd also allow any user to enter the query string if it's known.

This PR is mergeable as it is, but let's discuss how we go about actually launching it.
