### PR TITLE
@sweir27 => Buy Now bugfixes

### DIFF
--- a/desktop/apps/auction/components/artwork_browser/PromotedSaleArtworks.js
+++ b/desktop/apps/auction/components/artwork_browser/PromotedSaleArtworks.js
@@ -8,8 +8,8 @@ import { RelayStubProvider } from 'desktop/components/react/RelayStubProvider'
 import { connect } from 'react-redux'
 
 function PromotedSaleArtworks (props) {
-  const { isMobile, promotedSaleArtworks } = props
-  const isRenderable = promotedSaleArtworks && promotedSaleArtworks.length
+  const { isClosed, isMobile, promotedSaleArtworks } = props
+  const isRenderable = Boolean(!isClosed && promotedSaleArtworks && promotedSaleArtworks.length)
 
   if (!isRenderable) {
     return null
@@ -52,6 +52,7 @@ function PromotedSaleArtworks (props) {
 }
 
 PromotedSaleArtworks.propTypes = {
+  isClosed: PropTypes.bool.isRequired,
   isMobile: PropTypes.bool.isRequired,
   promotedSaleArtworks: PropTypes.array.isRequired
 }
@@ -68,9 +69,11 @@ const mapStateToProps = (state) => {
     }
   } = state
 
-  const promotedSaleArtworks = get(auction.toJSON(), 'promoted_sale.sale_artworks', [])
+  const auctionData = auction.toJSON()
+  const promotedSaleArtworks = get(auctionData, 'promoted_sale.sale_artworks', [])
 
   return {
+    isClosed: auctionData.is_closed,
     isMobile,
     promotedSaleArtworks
   }

--- a/desktop/apps/auction/components/artwork_browser/__tests__/PromotedSaleArtworks.test.js
+++ b/desktop/apps/auction/components/artwork_browser/__tests__/PromotedSaleArtworks.test.js
@@ -48,4 +48,35 @@ describe('auction/components/artwork_browser/PromotedSaleArtworks', () => {
     wrapper.html().should.containEql('Buy Now')
     wrapper.find(MasonryGrid).length.should.eql(1)
   })
+
+  it('does not render if sale is closed in desktop', () => {
+    let updatedData = cloneDeep(data)
+    updatedData.app.auction.is_closed = true
+
+    const { wrapper } = renderTestComponent({
+      Component: PromotedSaleArtworks,
+      data: updatedData,
+      props: {
+        promotedSaleArtworks
+      }
+    })
+
+    wrapper.find(ArtworkRail).length.should.eql(0)
+  })
+
+  it('does not render if sale is closed in mobile', () => {
+    let mobileData = cloneDeep(data)
+    mobileData.app.isMobile = true
+    mobileData.app.auction.is_closed = true
+
+    const { wrapper } = renderTestComponent({
+      Component: PromotedSaleArtworks,
+      data: mobileData,
+      props: {
+        promotedSaleArtworks
+      }
+    })
+
+    wrapper.find(MasonryGrid).length.should.eql(0)
+  })
 })

--- a/desktop/apps/auction/components/artwork_browser/main/artwork/GridArtwork.js
+++ b/desktop/apps/auction/components/artwork_browser/main/artwork/GridArtwork.js
@@ -15,6 +15,7 @@ function GridArtwork (props) {
     isAuction,
     isClosed,
     lotLabel,
+    sale_message,
     title
   } = props
 
@@ -32,8 +33,8 @@ function GridArtwork (props) {
         </div>
       </div>
       <div className={b('metadata')}>
-        { isAuction &&
-          <div className={b('lot-information')}>
+        { isAuction
+          ? <div className={b('lot-information')}>
             <div className={b('lot-number')}>
               Lot {lotLabel}
             </div>
@@ -41,6 +42,9 @@ function GridArtwork (props) {
               <BidStatus
                 artworkItem={saleArtwork}
               /> }
+          </div>
+          : <div>
+            {sale_message}
           </div>
         }
         <div className={b('artists')}>
@@ -65,6 +69,7 @@ GridArtwork.propTypes = {
   isClosed: PropTypes.bool.isRequired,
   lotLabel: PropTypes.string, // Not needed for e-commerce sales
   artistDisplay: PropTypes.string.isRequired,
+  sale_message: PropTypes.string, // E-commerce sales only
   title: PropTypes.string.isRequired
 }
 
@@ -78,12 +83,13 @@ const mapStateToProps = (state, props) => {
     : ''
 
   return {
+    artistDisplay,
     date: saleArtwork.artwork.date,
     image,
     isAuction: state.app.auction.get('is_auction'),
     isClosed: state.artworkBrowser.isClosed || state.app.auction.isClosed(),
     lotLabel: saleArtwork.lot_label,
-    artistDisplay,
+    sale_message: saleArtwork.artwork.sale_message,
     title: saleArtwork.artwork.title
   }
 }

--- a/desktop/apps/auction/components/artwork_browser/main/artwork/ListArtwork.js
+++ b/desktop/apps/auction/components/artwork_browser/main/artwork/ListArtwork.js
@@ -17,6 +17,7 @@ function ListArtwork (props) {
     isClosed,
     isMobile,
     lotLabel,
+    sale_message,
     title
   } = props
 
@@ -31,9 +32,12 @@ function ListArtwork (props) {
           </div>
 
           <div className={b('metadata')}>
-            { isAuction &&
-              <div className={b('lot-number')}>
+            { isAuction
+              ? <div className={b('lot-number')}>
                 Lot {lotLabel}
+              </div>
+              : <div>
+                {sale_message}
               </div>
             }
 
@@ -74,9 +78,12 @@ function ListArtwork (props) {
               }}
             />
           </div>
-          { isAuction &&
-            <div className={b('lot-number')}>
+          { isAuction
+            ? <div className={b('lot-number')}>
               Lot {saleArtwork.lot_label}
+            </div>
+            : <div>
+              {sale_message}
             </div>
           }
 
@@ -99,6 +106,7 @@ ListArtwork.propTypes = {
   isMobile: PropTypes.bool.isRequired,
   lotLabel: PropTypes.string.isRequired,
   artistDisplay: PropTypes.string.isRequired,
+  sale_message: PropTypes.string,
   title: PropTypes.string.isRequired
 }
 
@@ -118,6 +126,7 @@ const mapStateToProps = (state, props) => {
     isMobile: state.app.isMobile,
     lotLabel: saleArtwork.lot_label,
     artistDisplay,
+    sale_message: saleArtwork.artwork.sale_message,
     title: saleArtwork.artwork.title
   }
 }

--- a/desktop/apps/auction/components/artwork_browser/main/artwork/MasonryArtwork.js
+++ b/desktop/apps/auction/components/artwork_browser/main/artwork/MasonryArtwork.js
@@ -15,6 +15,7 @@ function MasonryArtwork (props) {
     isAuction,
     isClosed,
     lotLabel,
+    sale_message,
     title
   } = props
 
@@ -26,9 +27,12 @@ function MasonryArtwork (props) {
         <img className={b('image')} src={image} alt={title} />
       </div>
 
-      { isAuction &&
-        <div className={b('lot-number')}>
+      { isAuction
+        ? <div className={b('lot-number')}>
           Lot {lotLabel}
+        </div>
+        : <div className={b('sale-message')}>
+          {sale_message}
         </div>
       }
 
@@ -61,6 +65,7 @@ MasonryArtwork.propTypes = {
   isClosed: PropTypes.bool.isRequired,
   lotLabel: PropTypes.string, // Not needed for e-commerce works
   artistDisplay: PropTypes.string.isRequired,
+  sale_message: PropTypes.string,
   title: PropTypes.string.isRequired
 }
 
@@ -79,6 +84,7 @@ const mapStateToProps = (state, props) => {
     isClosed: state.app.auction.isClosed(),
     lotLabel: saleArtwork.lot_label,
     artistDisplay,
+    sale_message: saleArtwork.artwork.sale_message,
     title: saleArtwork.artwork.title
   }
 }

--- a/desktop/apps/auction/components/artwork_browser/main/artwork/MasonryArtwork.styl
+++ b/desktop/apps/auction/components/artwork_browser/main/artwork/MasonryArtwork.styl
@@ -24,6 +24,9 @@
     position relative
     top -2px
 
+  &__sale-message
+    garamond-size('l-caption')
+
   &__artists, &__title, &__bid-status
     +respond-mobile()
       overflow hidden

--- a/desktop/apps/auction/components/artwork_browser/main/artwork/__tests__/GridArtwork.test.js
+++ b/desktop/apps/auction/components/artwork_browser/main/artwork/__tests__/GridArtwork.test.js
@@ -42,7 +42,7 @@ describe('auction/components/artwork_browser/main/artwork/GridArtwork.test', () 
       wrapper.find(BidStatus).length.should.equal(0)
     })
 
-    it('renders a <BidStatus /> component is not closed', () => {
+    it('renders a <BidStatus /> component if not closed', () => {
       const { wrapper } = renderTestComponent({
         Component: GridArtwork,
         props: {
@@ -53,6 +53,23 @@ describe('auction/components/artwork_browser/main/artwork/GridArtwork.test', () 
       })
 
       wrapper.find(BidStatus).length.should.equal(1)
+    })
+
+    it('renders a sale_message if not an auction', () => {
+      const { wrapper } = renderTestComponent({
+        Component: GridArtwork,
+        props: {
+          sale_message: '$1000',
+          saleArtwork: {
+            _id: 'foo',
+            id: 'bar'
+          },
+          isAuction: false,
+          isClosed: false
+        }
+      })
+
+      wrapper.html().should.containEql('$1000')
     })
   })
 })

--- a/desktop/apps/auction/components/artwork_browser/main/artwork/__tests__/ListArtwork.test.js
+++ b/desktop/apps/auction/components/artwork_browser/main/artwork/__tests__/ListArtwork.test.js
@@ -54,5 +54,19 @@ describe('auction/components/artwork_browser/main/artwork/ListArtwork.test', () 
 
       wrapper.find(BidStatus).length.should.equal(1)
     })
+
+    it('renders a sale_message if not an auction', () => {
+      const { wrapper } = renderTestComponent({
+        Component: ListArtwork,
+        props: {
+          sale_message: '$1000',
+          saleArtwork: { _id: 'foo', id: 'bar' },
+          isAuction: false,
+          isClosed: false
+        }
+      })
+
+      wrapper.html().should.containEql('$1000')
+    })
   })
 })

--- a/desktop/apps/auction/components/artwork_browser/main/artwork/__tests__/MasonryArtwork.test.js
+++ b/desktop/apps/auction/components/artwork_browser/main/artwork/__tests__/MasonryArtwork.test.js
@@ -54,5 +54,19 @@ describe('auction/components/artwork_browser/main/artwork/MasonryArtwork.test', 
 
       wrapper.find(BidStatus).length.should.equal(1)
     })
+
+    it('renders a sale_message if not an auction', () => {
+      const { wrapper } = renderTestComponent({
+        Component: MasonryArtwork,
+        props: {
+          sale_message: '$1000',
+          saleArtwork: { _id: 'foo', id: 'bar' },
+          isAuction: false,
+          isClosed: false
+        }
+      })
+
+      wrapper.html().should.containEql('$1000')
+    })
   })
 })

--- a/desktop/apps/auction/components/layout/Banner.js
+++ b/desktop/apps/auction/components/layout/Banner.js
@@ -10,8 +10,8 @@ function Banner (props) {
   const {
     auction,
     coverImage,
+    isAuction,
     isClosed,
-    isEcommerceSale,
     isLiveOpen,
     isMobile,
     liveAuctionUrl,
@@ -64,6 +64,7 @@ function Banner (props) {
           return (
             <ClockView
               model={auction}
+              modelName={isAuction ? 'Auction' : 'Sale'}
             />
           )
         }
@@ -75,8 +76,8 @@ function Banner (props) {
 Banner.propTypes = {
   auction: PropTypes.object.isRequired,
   coverImage: PropTypes.string.isRequired,
+  isAuction: PropTypes.bool.isRequired,
   isClosed: PropTypes.bool.isRequired,
-  isEcommerceSale: PropTypes.bool.isRequired,
   isLiveOpen: PropTypes.bool.isRequired,
   isMobile: PropTypes.bool.isRequired,
   liveAuctionUrl: PropTypes.string,
@@ -86,20 +87,19 @@ Banner.propTypes = {
 const mapStateToProps = (state) => {
   const {
     auction,
-    isEcommerceSale,
     isLiveOpen,
     isMobile,
     liveAuctionUrl
   } = state.app
 
-  const { cover_image, is_closed, name } = auction.toJSON()
+  const { cover_image, is_auction, is_closed, name } = auction.toJSON()
   const coverImage = get(cover_image, 'cropped.url', '')
 
   return {
     auction,
     coverImage,
+    isAuction: is_auction,
     isClosed: is_closed,
-    isEcommerceSale,
     isLiveOpen,
     isMobile,
     liveAuctionUrl,

--- a/desktop/apps/auction/components/layout/auction_info/AuctionInfo.styl
+++ b/desktop/apps/auction/components/layout/auction_info/AuctionInfo.styl
@@ -13,7 +13,8 @@
       padding-left 20px
       padding-top: 80px
       margin-top: 0px !important // overwrite section spacing when expanded
-      position absolute
+      position fixed
+      overflow-y scroll
       top 0
       z-index 970 // Index required to overwrite top mobile nav ¯\_(ツ)_/¯
       width 100%

--- a/desktop/apps/auction/queries/filter.js
+++ b/desktop/apps/auction/queries/filter.js
@@ -53,6 +53,7 @@ export const filterQuery = `
           image {
             url
           }
+          sale_message
           images {
             aspect_ratio,
             id

--- a/desktop/components/clock/view.coffee
+++ b/desktop/components/clock/view.coffee
@@ -48,6 +48,7 @@ module.exports = class ClockView extends Backbone.View
         mediator.trigger 'clock:is-over'
         @$el.html "<div class='clock-header clock-closed'>#{@closedText}</div>"
         return
+
     @renderClock()
     @interval = setInterval @renderClock, 1000
 

--- a/desktop/components/react/masonry_grid/Reveal.js
+++ b/desktop/components/react/masonry_grid/Reveal.js
@@ -64,7 +64,10 @@ export class Reveal extends Component {
               <Icon
                 name='chevron-down'
                 color='black'
-                fontSize='25px'
+                fontSize='24px'
+                style={{
+                  fontWeight: 'bold'
+                }}
               />
             </Button>
           </Revealer>


### PR DESCRIPTION
**Fixes https://artsyproduct.atlassian.net/projects/BNS/issues/BNS-10 (Arrow not identical to artwork/id arrows)**

(Note that we're using Reaction's new `<Icon />` component so the font weight isn't 100%, but bolded it is very close)

<img width="100" alt="screen shot 2018-01-25 at 5 26 12 pm" src="https://user-images.githubusercontent.com/236943/35421158-717fec86-01f6-11e8-89ab-01a8c68b7f96.png">

**Fixes: https://artsyproduct.atlassian.net/projects/BNS/issues/BNS-7 (Missing price labels)**

<img width="277" alt="screen shot 2018-01-25 at 5 33 25 pm" src="https://user-images.githubusercontent.com/236943/35421175-912f14e4-01f6-11e8-9998-04d62fce0ed9.png">

<img width="204" alt="screen shot 2018-01-25 at 5 33 58 pm" src="https://user-images.githubusercontent.com/236943/35421181-957ea316-01f6-11e8-9c81-bd43d758dd52.png">

**Fixes: https://artsyproduct.atlassian.net/projects/BNS/issues/BNS-6 (remove mention of bidding in timer)**:

<img width="214" alt="screen shot 2018-01-25 at 5 53 17 pm" src="https://user-images.githubusercontent.com/236943/35421560-c095df9a-01f8-11e8-8b8e-3f84e4eef448.png">

**Fixes: https://github.com/artsy/auctions/issues/819 (Auction info full-screen popup did not have `position: fixed`**

![scroll](https://user-images.githubusercontent.com/236943/35421376-c976e812-01f7-11e8-811b-254f5a1e9253.gif)

Also, hides Buy Now rail if the sale is closed. 

