### PR TITLE
@joeyAghion => Escape user agent string to avoid XSS when inserted into DOM

### DIFF
--- a/lib/middleware/locals.coffee
+++ b/lib/middleware/locals.coffee
@@ -41,7 +41,7 @@ module.exports = (req, res, next) ->
   res.locals.sd.REFLECTION = ua.match('PhantomJS')?
   res.locals.sd.REQUEST_TIMESTAMP = Date.now()
   res.locals.sd.NOTIFICATION_COUNT = req.cookies?['notification-count']
-  res.locals.sd.USER_AGENT = res.locals.userAgent = ua
+  res.locals.sd.USER_AGENT = res.locals.userAgent = escape(ua)
   res.locals.sd.REQUEST_ID = req.id
   res.locals.sd.IS_MOBILE = Boolean(
     (ua.match(/iPhone/i) && !ua.match(/iPad/i)) ||

--- a/test/lib/middleware/locals.coffee
+++ b/test/lib/middleware/locals.coffee
@@ -11,9 +11,9 @@ describe 'locals middleware', ->
     res.locals.sd.SESSION_ID.should.equal req.session.id
 
   it 'adds the user agent', ->
-    middleware req = { url: 'localhost:3000', get: -> 'foobar' },
+    middleware req = { url: 'localhost:3000', get: -> 'foobar<script>omg</script>' },
       res = { locals: { sd: {} } }, ->
-    res.locals.userAgent.should.equal 'foobar'
+    res.locals.userAgent.should.equal 'foobar%3Cscript%3Eomg%3C/script%3E'
 
   it 'current_path does not include query params', ->
     middleware req = { url: 'localhost:3000/foo?bar=baz', get: -> 'foobar' },


### PR DESCRIPTION
I wasn't able to repro the exact offending UA string, but we _were_ directly inserting it into the DOM, so I believe the exploit.

So, we can just `escape` that. The way we currently use the UA in the DOM is thru CSS selectors like `html[data-useragent*="iPad"]`, which should remain unaffected by escaping. There's also some uses of it with code like `USER_AGENT.match('iphone')`, which should also remain unaffected.