### PR TITLE
@sweir27 => [Auction] Fix e-commerce-sale auth issue

### DIFF
--- a/desktop/apps/auction/components/Layout.js
+++ b/desktop/apps/auction/components/Layout.js
@@ -69,7 +69,7 @@ Layout.propTypes = {
 
 const mapStateToProps = (state) => {
   const {
-    app: { articles, auction, me, isMobile, showInfoWindow }
+    app: { articles, auction, me, isEcommerceSale, isMobile, showInfoWindow }
   } = state
 
   const {
@@ -82,7 +82,7 @@ const mapStateToProps = (state) => {
   const showAssociatedAuctions = Boolean(!isMobile && associated_sale)
   const showFilter = Boolean(eligible_sale_artworks_count > 0)
   const showFollowedArtistsRail = Boolean(state.artworkBrowser.showFollowedArtistsRail)
-  const showMyActiveBids = Boolean(me && me.bidders.length && is_open && !is_live_open)
+  const showMyActiveBids = Boolean(!isEcommerceSale && me && me.bidders.length && is_open && !is_live_open)
   const showFooter = Boolean(!isMobile && articles.length || !showFilter)
 
   return {

--- a/desktop/apps/auction/components/__tests__/Layout.test.js
+++ b/desktop/apps/auction/components/__tests__/Layout.test.js
@@ -569,6 +569,16 @@ describe('<Layout />', () => {
         wrapper.html().should.not.containEql('Most Bids')
         wrapper.html().should.not.containEql('Least Bids')
       })
+
+      it('does not show active bids', () => {
+        const { wrapper } = renderTestComponent({
+          Component: Layout,
+          options: { renderMode: 'render' },
+          data
+        })
+
+        wrapper.find('.auction-MyActiveBids').length.should.eql(0)
+      })
     })
 
     describe('mobile', () => {
@@ -606,6 +616,16 @@ describe('<Layout />', () => {
         wrapper.html().should.not.containEql('Lot Number Desc')
         wrapper.html().should.not.containEql('Most Bids')
         wrapper.html().should.not.containEql('Least Bids')
+      })
+
+      it('does not show active bids', () => {
+        const { wrapper } = renderTestComponent({
+          Component: Layout,
+          options: { renderMode: 'render' },
+          data: mobileData
+        })
+
+        wrapper.find('.auction-MyActiveBids').length.should.eql(0)
       })
     })
   })

--- a/desktop/apps/auction/reducers/app.js
+++ b/desktop/apps/auction/reducers/app.js
@@ -5,6 +5,7 @@ export const initialState = {
   articles: [],
   auction: {},
   footerItems: [],
+  isEcommerceSale: undefined,
   isLiveOpen: undefined,
   isMobile: undefined,
   liveAuctionUrl: x => x,


### PR DESCRIPTION
Fixes 500 error that occurs when a user is logged in and attempts to visit an [ecommerce sale](https://staging.artsy.net/auction/chris-ecommerce-sale). This was due to a `me { ... }` query querying for lot standings, but e-commerce sales aren't auctions and don't contain any biddable artworks and is thus return 404.