### PR TITLE
@sweir27 => [Auction] Hide / swap fields if sale

### DIFF
--- a/desktop/apps/artist/client/views/overview.coffee
+++ b/desktop/apps/artist/client/views/overview.coffee
@@ -41,9 +41,9 @@ module.exports = class OverviewView extends Backbone.View
       heightBreakOffset: 20
       onExpand: =>
         if @useNewArtworkFilter
-          @filterView.sticky.rebuild()
+          @filterView.sticky?.rebuild()
         else
-          @sticky.rebuild()
+          @sticky?.rebuild() # FIXME: Is this still needed?
     _.defer =>
       @$('.artist-blurb').addClass('is-fade-in')
       @$('.artist-exhibition-highlights').addClass 'is-fade-in'

--- a/desktop/apps/auction/components/layout/Banner.js
+++ b/desktop/apps/auction/components/layout/Banner.js
@@ -10,6 +10,7 @@ function Banner (props) {
   const {
     auction,
     coverImage,
+    hasEndTime,
     isAuction,
     isClosed,
     isLiveOpen,
@@ -29,6 +30,7 @@ function Banner (props) {
   }
 
   const b = block('auction-Banner')
+  const type = isAuction ? 'Auction' : 'Sale'
 
   return (
     <div
@@ -40,7 +42,7 @@ function Banner (props) {
         style={{ backgroundImage: `url('${coverImage}')` }}
       />
       {(() => {
-        if (isLiveOpen) {
+        if (isLiveOpen && isAuction) {
           return (
             <div className={b('live-details')}>
               <h1>
@@ -56,15 +58,16 @@ function Banner (props) {
           return (
             <div className={b('closed')}>
               <div>
-                Auction Closed
+                {type} Closed
               </div>
             </div>
           )
-        } else {
+        } else if (hasEndTime) {
           return (
             <ClockView
               model={auction}
-              modelName={isAuction ? 'Auction' : 'Sale'}
+              modelName={type}
+              closedText={type + ' Closed'}
             />
           )
         }
@@ -76,6 +79,7 @@ function Banner (props) {
 Banner.propTypes = {
   auction: PropTypes.object.isRequired,
   coverImage: PropTypes.string.isRequired,
+  hasEndTime: PropTypes.bool.isRequired,
   isAuction: PropTypes.bool.isRequired,
   isClosed: PropTypes.bool.isRequired,
   isLiveOpen: PropTypes.bool.isRequired,
@@ -92,12 +96,13 @@ const mapStateToProps = (state) => {
     liveAuctionUrl
   } = state.app
 
-  const { cover_image, is_auction, is_closed, name } = auction.toJSON()
+  const { cover_image, end_at, is_auction, is_closed, name } = auction.toJSON()
   const coverImage = get(cover_image, 'cropped.url', '')
 
   return {
     auction,
     coverImage,
+    hasEndTime: Boolean(end_at),
     isAuction: is_auction,
     isClosed: is_closed,
     isLiveOpen,

--- a/desktop/apps/auction/components/layout/__tests__/Banner.test.js
+++ b/desktop/apps/auction/components/layout/__tests__/Banner.test.js
@@ -1,9 +1,18 @@
+import React from 'react'
 import renderTestComponent from 'desktop/apps/auction/__tests__/utils/renderTestComponent'
-import { test } from 'desktop/apps/auction/components/layout/Banner'
+import BannerWrapper, { test } from 'desktop/apps/auction/components/layout/Banner'
 import sinon from 'sinon'
 const { Banner } = test
 
 describe('auction/components/layout/Banner.test', () => {
+  beforeEach(() => {
+    BannerWrapper.__Rewire__('ClockView', () => <div className='auction-clock' />)
+  })
+
+  afterEach(() => {
+    BannerWrapper.__ResetDependency__('ClockView')
+  })
+
   describe('<Banner />', () => {
     it('tracks a click on the "Enter Live Auction" button', () => {
       const liveAuctionUrl = 'live.artsy.net/some-auction-url'
@@ -12,6 +21,8 @@ describe('auction/components/layout/Banner.test', () => {
       const { wrapper } = renderTestComponent({
         Component: Banner,
         props: {
+          hasEndTime: true,
+          isAuction: true,
           isLiveOpen: true,
           liveAuctionUrl
         }
@@ -20,12 +31,15 @@ describe('auction/components/layout/Banner.test', () => {
       wrapper.find('a').simulate('click')
       mockTrack.calledWithMatch('click').should.be.true()
     })
+
     it('renders an Enter Live Auction banner if isLiveOpen', () => {
       const liveAuctionUrl = 'live.artsy.net/some-auction-url'
 
       const { wrapper } = renderTestComponent({
         Component: Banner,
         props: {
+          isAuction: true,
+          hasEndTime: true,
           isLiveOpen: true,
           liveAuctionUrl
         }
@@ -39,6 +53,7 @@ describe('auction/components/layout/Banner.test', () => {
       const { wrapper } = renderTestComponent({
         Component: Banner,
         props: {
+          hasEndTime: true,
           isLiveOpen: false
         },
         options: {
@@ -47,6 +62,21 @@ describe('auction/components/layout/Banner.test', () => {
       })
 
       wrapper.find('.auction-clock').length.should.eql(1)
+    })
+
+    it('hides clock if no end_at', () => {
+      const { wrapper } = renderTestComponent({
+        Component: Banner,
+        props: {
+          hasEndTime: false,
+          isLiveOpen: false
+        },
+        options: {
+          renderMode: 'render'
+        }
+      })
+
+      wrapper.find('.auction-clock').length.should.eql(0)
     })
   })
 })

--- a/desktop/apps/auction/components/layout/auction_info/AuctionInfo.styl
+++ b/desktop/apps/auction/components/layout/auction_info/AuctionInfo.styl
@@ -1,10 +1,17 @@
 .auction-AuctionInfo
   clearfix()
 
+  +respond-desktop()
+    &__upcomingLabel
+      display inline
+      margin-right 30px
+      position relative
+      top 1px
+
   +respond-mobile()
     &__container
       display flex
-      align-items baseline
+      align-items center
 
     &_expandToFullScreen
       align-items flex-start
@@ -70,9 +77,7 @@
     +respond-mobile()
       cursor pointer
       float none
-      padding-right 6px
-      position: absolute
-      right 13px
+      position: relative
       width inherit
 
       &_expandToFullScreen
@@ -138,11 +143,10 @@
     border-top 1px solid gray-lighter-color
     garamond-size('l-body')
     margin 20px 0
-    padding 15px 0 12px 0
     position relative
 
-    .add-to-calendar
-      margin-left 30px
+    +respond-desktop()
+      padding 10px 0 12px 0
 
     +respond-mobile()
       border-bottom 0
@@ -154,7 +158,7 @@
   &__callout-live-label
     position absolute
     right 0
-    top 15px
+    top 10px
 
     +respond-mobile()
       avant-garde-size('s-headline')

--- a/desktop/apps/auction/components/layout/auction_info/AuctionInfoDesktop.js
+++ b/desktop/apps/auction/components/layout/auction_info/AuctionInfoDesktop.js
@@ -32,13 +32,19 @@ function AuctionInfoDesktop (props) {
         </h1>
 
         <div className={b('callout')}>
-          {upcomingLabel}
+          <div className={b('time')}>
+            { upcomingLabel &&
+              <div className={b('upcomingLabel')}>
+                {upcomingLabel}
+              </div>
+            }
 
-          { showAddToCalendar &&
-            <AddToCalendarView
-              event={event}
-            />
-          }
+            { showAddToCalendar &&
+              <AddToCalendarView
+                event={event}
+              />
+            }
+          </div>
 
           { liveStartAt &&
             <div className={b('callout-live-label')}>

--- a/desktop/apps/auction/components/layout/auction_info/AuctionInfoMobile.js
+++ b/desktop/apps/auction/components/layout/auction_info/AuctionInfoMobile.js
@@ -9,6 +9,7 @@ import { connect } from 'react-redux'
 function AuctionInfoMobile (props) {
   const {
     description,
+    isAuction,
     isAuctionPromo,
     liveStartAt,
     name,
@@ -28,7 +29,7 @@ function AuctionInfoMobile (props) {
           { showInfoWindow &&
             <div className={b('info-window-controls')}>
               <div className={b('info-window-title')}>
-                Auction Information
+                {isAuction ? 'Auction' : 'Sale'} Information
               </div>
               <div
                 onClick={() => showInfoWindowAction(!showInfoWindow)}
@@ -65,20 +66,24 @@ function AuctionInfoMobile (props) {
                 }}
               />
 
-              <div className={b('date-time')}>
-                <div className={b('live-label')}>
-                  Auction Begins
+              { liveStartAt &&
+                <div className={b('date-time')}>
+                  <div className={b('live-label')}>
+                    {isAuction ? 'Auction' : 'Sale'} Begins
+                  </div>
+                  <div>
+                    {upcomingDateTime}
+                  </div>
                 </div>
-                <div>
-                  {upcomingDateTime}
-                </div>
-              </div>
+              }
 
               <div>
                 <div className='chevron-nav-list'>
-                  <a href='/how-auctions-work'>
-                    Auctions FAQ
-                  </a>
+                  { isAuction &&
+                    <a href='/how-auctions-work'>
+                      Auctions FAQ
+                    </a>
+                  }
                   <a href='mailto:specialists@artsy.net'>
                     Contact
                   </a>
@@ -110,6 +115,7 @@ function AuctionInfoMobile (props) {
 
 AuctionInfoMobile.propTypes = {
   description: PropTypes.string.isRequired,
+  isAuction: PropTypes.bool.isRequired,
   isAuctionPromo: PropTypes.bool,
   liveStartAt: PropTypes.string,
   name: PropTypes.string.isRequired,
@@ -124,6 +130,7 @@ const mapStateToProps = (state) => {
 
   return {
     description: auction.mdToHtml('description'),
+    isAuction: auction.isAuction(),
     isAuctionPromo: auction.isAuctionPromo(),
     isMobile,
     liveStartAt: auction.get('live_start_at'),

--- a/desktop/apps/auction/components/layout/auction_info/__tests__/AuctionInfoDesktop.test.js
+++ b/desktop/apps/auction/components/layout/auction_info/__tests__/AuctionInfoDesktop.test.js
@@ -93,5 +93,16 @@ describe('auction/components/layout/auction_info/AuctionInfoDesktop.test', () =>
 
       wrapper.find(Registration).length.should.eql(1)
     })
+
+    it('hides upcomingLabel if empty', () => {
+      const { wrapper } = renderTestComponent({
+        Component: AuctionInfoDesktop,
+        props: {
+          upcomingLabel: ''
+        }
+      })
+
+      wrapper.html().should.not.containEql('AuctionInfoDesktop__upcominigLabel')
+    })
   })
 })

--- a/desktop/apps/auction/components/layout/auction_info/__tests__/AuctionInfoMobile.test.js
+++ b/desktop/apps/auction/components/layout/auction_info/__tests__/AuctionInfoMobile.test.js
@@ -71,10 +71,12 @@ describe('auction/components/layout/auction_info/AuctionInfoMobile.test', () => 
       wrapper.find(Registration).length.should.eql(1)
     })
 
-    it('shows an info window if showInfoWindow is true', () => {
+    it('shows a Auction info window if showInfoWindow is true', () => {
       const { wrapper } = renderTestComponent({
         Component: AuctionInfoMobile,
         props: {
+          isAuction: true,
+          liveStartAt: true,
           showInfoWindow: true,
           description: 'hello description'
         }
@@ -85,6 +87,25 @@ describe('auction/components/layout/auction_info/AuctionInfoMobile.test', () => 
       wrapper.text().should.containEql('Auction Begins')
       wrapper.find('.chevron-nav-list').length.should.eql(1)
       wrapper.text().should.containEql('Auctions FAQ')
+      wrapper.text().should.containEql('Contact')
+    })
+
+    it('shows a Sale info window if showInfoWindow is true', () => {
+      const { wrapper } = renderTestComponent({
+        Component: AuctionInfoMobile,
+        props: {
+          isAuction: false,
+          liveStartAt: true,
+          showInfoWindow: true,
+          description: 'hello description'
+        }
+      })
+
+      wrapper.find(Registration).length.should.eql(1)
+      wrapper.text().should.containEql('hello description')
+      wrapper.text().should.containEql('Sale Begins')
+      wrapper.find('.chevron-nav-list').length.should.eql(1)
+      wrapper.text().should.not.containEql('Auctions FAQ')
       wrapper.text().should.containEql('Contact')
     })
 
@@ -102,5 +123,16 @@ describe('auction/components/layout/auction_info/AuctionInfoMobile.test', () => 
       window.scrollTo.called.should.eql(true)
       wrapper.props().store.getState().app.showInfoWindow.should.eql(true)
     })
+  })
+
+  it('hide upcoming info if missing liveStartAt', () => {
+    const { wrapper } = renderTestComponent({
+      Component: AuctionInfoMobileWrapper,
+      props: {
+        liveStartAt: false,
+        showInfoWindow: false
+      }
+    })
+    wrapper.html().should.not.containEql('AuctionInfoMobile__live-label')
   })
 })

--- a/desktop/components/clock/react.js
+++ b/desktop/components/clock/react.js
@@ -6,7 +6,8 @@ export default class Clock extends Component {
   static propTypes = {
     className: PropTypes.string,
     model: PropTypes.object,
-    modelName: PropTypes.string
+    modelName: PropTypes.string,
+    closedText: PropTypes.string
   }
 
   static defaultProps = {
@@ -22,6 +23,7 @@ export default class Clock extends Component {
     this.$ = require('jquery')
 
     const {
+      closedText,
       model,
       modelName
     } = this.props
@@ -29,6 +31,7 @@ export default class Clock extends Component {
     this.setState(() => {
       this.backboneView = new ClockView({
         el: this.$('.auction-clock'),
+        closedText,
         model,
         modelName
       })

--- a/desktop/components/clock/view.coffee
+++ b/desktop/components/clock/view.coffee
@@ -16,7 +16,7 @@ module.exports = class ClockView extends Backbone.View
   modelName: 'Auction'
 
   initialize: ({ @closedText, @modelName, @stateCallback}) ->
-    @closedText ?= 'Auction Closed'
+    @closedText ?= "Auction Closed"
     @stateCallback = @stateCallback or (-> location.reload())
 
   start: (callback = $.noop) ->

--- a/desktop/models/sale.coffee
+++ b/desktop/models/sale.coffee
@@ -179,7 +179,7 @@ module.exports = class Sale extends Backbone.Model
 
   upcomingLabel: ->
     timeFormat = 'MMM D h:mm A z'
-    if @isClosed()
+    label = if @isClosed()
       "Auction Closed"
     else if @get('live_start_at') and not @isLiveOpen()
       "Live bidding begins #{@zone(@get('live_start_at')).format(timeFormat)}"
@@ -189,8 +189,17 @@ module.exports = class Sale extends Backbone.Model
       "Auction opens #{@zone(@get('start_at')).format(timeFormat)}"
     else if !@get('is_sale')
       "Closes #{@zone(@get('end_at')).format(timeFormat)}"
-    else
+    else if @get('is_auction')
       "Bidding closes #{@zone(@get('end_at')).format(timeFormat)}"
+    else
+      ""
+
+    # Piggyback on common `moment` output to guard against missing / bad data
+    # FIXME: This could perhaps be a bit safer
+    if label.includes('Invalid')
+      ""
+    else
+      label
 
   upcomingDateTime: ->
     timeFormat = 'MMM D h:mm A z'


### PR DESCRIPTION
Addresses a few more things caught in QA desktop / mobile:

- On mobile, the info window pop up needed a swapped 'Sale' title; hidden `Auctions FAQ` button; hidden time if empty or invalid

<img width="251" alt="screen shot 2018-01-30 at 6 03 46 pm" src="https://user-images.githubusercontent.com/236943/35603083-6a071b20-05f0-11e8-9867-30e215167fe7.png">

- Hidden auction time if missing / invalid

<img width="347" alt="screen shot 2018-01-30 at 6 05 02 pm" src="https://user-images.githubusercontent.com/236943/35603112-9a13b1fc-05f0-11e8-941c-4f429ea12b3b.png">

- Hidden clock if no end_at: 

<img width="457" alt="screen shot 2018-01-30 at 7 06 14 pm" src="https://user-images.githubusercontent.com/236943/35603131-aaf253c0-05f0-11e8-8b95-9c6af7323682.png">

- Toggle Clock text on closed 

<img width="324" alt="screen shot 2018-01-30 at 7 38 11 pm" src="https://user-images.githubusercontent.com/236943/35604060-2ced00b0-05f5-11e8-90c4-b8cfbc8cdc95.png">
