### PR TITLE
KSO-10: add collect sitemap to robots.txt #donotmerge

### DIFF
--- a/desktop/apps/sitemaps/index.coffee
+++ b/desktop/apps/sitemaps/index.coffee
@@ -12,6 +12,7 @@ app.get ['/sitemap-artists.xml', '/sitemap-artists-:timestamp.xml'], routes.site
 app.get ['/sitemap-artist-images.xml', '/sitemap-artist-images-:slug.xml'], routes.sitemaps
 app.get ['/sitemap-artworks.xml', '/sitemap-artworks-:timestamp.xml'], routes.sitemaps
 app.get '/sitemap-cities.xml', routes.sitemaps
+app.get '/sitemap-collect.xml', routes.sitemaps
 app.get ['/sitemap-fairs.xml', '/sitemap-fairs-:timestamp.xml'], routes.sitemaps
 app.get ['/sitemap-features.xml', '/sitemap-features-:timestamp.xml'], routes.sitemaps
 app.get '/sitemap-genes.xml', routes.sitemaps

--- a/desktop/apps/sitemaps/routes.coffee
+++ b/desktop/apps/sitemaps/routes.coffee
@@ -50,6 +50,7 @@ sitemapProxy = httpProxy.createProxyServer(target: SITEMAP_BASE_URL)
     Sitemap: #{APP_URL}/sitemap-artist-images.xml
     Sitemap: #{APP_URL}/sitemap-artworks.xml
     Sitemap: #{APP_URL}/sitemap-cities.xml
+    Sitemap: #{APP_URL}/sitemap-collect.xml
     Sitemap: #{APP_URL}/sitemap-fairs.xml
     Sitemap: #{APP_URL}/sitemap-features.xml
     Sitemap: #{APP_URL}/sitemap-genes.xml

--- a/desktop/apps/sitemaps/test/routes.coffee
+++ b/desktop/apps/sitemaps/test/routes.coffee
@@ -51,6 +51,7 @@ Sitemap: https://www.artsy.net/sitemap-artists.xml
 Sitemap: https://www.artsy.net/sitemap-artist-images.xml
 Sitemap: https://www.artsy.net/sitemap-artworks.xml
 Sitemap: https://www.artsy.net/sitemap-cities.xml
+Sitemap: https://www.artsy.net/sitemap-collect.xml
 Sitemap: https://www.artsy.net/sitemap-fairs.xml
 Sitemap: https://www.artsy.net/sitemap-features.xml
 Sitemap: https://www.artsy.net/sitemap-genes.xml


### PR DESCRIPTION
Adds the collect sitemap to our `robots.txt`.

The collect sitemap is now on S3:
http://artsy-sitemaps.s3-website-us-east-1.amazonaws.com/sitemap-collect.xml

For some reason, http://www.artsy.net/sitemap-collect.xml is not proxying correctly... I need to work out why. This also depends on our update for dynamic page titles, so we should wait before merging it in.
