### PR TITLE
@mzikherman: Once again support querystrings in Reflection proxying

### DIFF
--- a/lib/middleware/proxy_to_reflection.coffee
+++ b/lib/middleware/proxy_to_reflection.coffee
@@ -1,14 +1,26 @@
 #
-# When Google requests _escaped_fragement_ proxy to Reflection
+# When Google requests _escaped_fragment_ proxy to Reflection
 # https://github.com/artsy/reflection
 #
 httpProxy = require 'http-proxy'
 request = require 'superagent'
 proxy = httpProxy.createProxyServer()
+{ parse } = require 'url'
 { REFLECTION_URL } = process.env
 
 module.exports = (req, res, next) ->
   return next() unless req.query._escaped_fragment_?
-  request.head(REFLECTION_URL + req.url).end (err) ->
+  proxyUrl = reflectionProxyUrl(req)
+  request.head(proxyUrl).end (err) ->
     return next() if err
-    proxy.web req, res, target: REFLECTION_URL, changeOrigin: true
+    proxy.web req, res,
+      target: proxyUrl
+      ignorePath: true
+      changeOrigin: true
+
+reflectionProxyUrl = (req) ->
+  url = parse(req.url)
+  dest = REFLECTION_URL + url.pathname
+  query = url.query?.replace(/&?_escaped_fragment_=/, '')
+  dest += encodeURIComponent("?" + decodeURIComponent(query)) if query?.length
+  dest

--- a/test/lib/middleware/proxy_to_reflection.coffee
+++ b/test/lib/middleware/proxy_to_reflection.coffee
@@ -37,8 +37,9 @@ describe 'proxyToReflection', ->
 
     for source, dest of paths
       it "proxies #{source} to #{dest}", ->
+        @req.url = source
         @req.query._escaped_fragment_= ''
         @request.end.callsArg 0
         proxyToReflection @req, @res, @next
         options = @proxy.web.args[0][2]
-        options.target.should.equal 'reflection.url'
+        options.target.should.equal "reflection.url#{dest}"


### PR DESCRIPTION
When S3 operates as a web server, it ignores querystring parameters as you'd expect. However, S3 supports characters like `?` and `&` in object paths, so Reflection has no problem crawling sitemapped URLs with querystrings and storing the resulting HTML files at the correspondingly-named locations. It's just important that the intermediate app server escape the desired querystring parameters into the proxied path.

I.e., a googlebot request for `.../collect?gene_id=geometric-abstraction&_escaped_fragment_=` must be proxied to `.../collect%3Fgene_id%3Dgeometric-abstraction`.

This was [encountered](https://github.com/artsy/reflection/pull/25) a long time ago, it's [documented](https://github.com/artsy/reflection#proxy-configuration) and was even implemented in Force (https://github.com/artsy/force/commit/3f353ff0f0240448df8631003d6a8bef2288b9ef#diff-219445cc9f999199f2ec28ad5ec8d214) (with tests!) but was lost in the switch to the `http-proxy` library (https://github.com/artsy/force/pull/1288).