### PR TITLE
Upgrade to latest reaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@artsy/express-reloadable": "^1.2.2",
-    "@artsy/reaction-force": "0.19.0",
+    "@artsy/reaction-force": "0.19.1",
     "@artsy/stitch": "^1.3.1",
     "accounting": "^0.4.1",
     "analytics-node": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   dependencies:
     chokidar "^1.7.0"
 
-"@artsy/reaction-force@0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.19.0.tgz#f6ad2aebc3ddd208b058bcae6608d4ddaaeb4d74"
+"@artsy/reaction-force@0.19.1":
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction-force/-/reaction-force-0.19.1.tgz#de13e351ea9655879e1fa82cc49c167861b41207"
   dependencies:
     history "^4.6.1"
     isomorphic-fetch "^2.2.1"


### PR DESCRIPTION
`0.19.1` includes UI fixes for the onboarding components: https://github.com/artsy/reaction/pull/508, https://github.com/artsy/reaction/pull/509