### PR TITLE
@kana: setup the armory show fair marketing page

### DIFF
--- a/desktop/apps/the_armory_show/components/ArmoryShowFairWeekPage.js
+++ b/desktop/apps/the_armory_show/components/ArmoryShowFairWeekPage.js
@@ -1,0 +1,155 @@
+import React from 'react'
+import styled, { ThemeProvider } from 'styled-components'
+
+import colors from '@artsy/reaction-force/dist/Assets/Colors'
+import { Row, Col } from '@artsy/reaction-force/dist/Components/Grid'
+import Text from '@artsy/reaction-force/dist/Components/Text'
+import Title from '@artsy/reaction-force/dist/Components/Title'
+
+const Container = styled.div`
+  margin: 0 auto;
+  max-width: 1192px;
+  padding-top: 25px;
+  @media (max-width: 48em) {
+    padding: 10px 20px 0;
+  }
+`
+
+const SectionTitle = Title.extend`
+  margin-top: 0;
+  line-height: 1;
+`
+
+const IntroductionText = Text.extend`
+  line-height: 31px;
+  @media (max-width: 24em) {
+    font-size: 20px;
+    line-height: 26px;
+  }
+`
+
+const FairLogo = styled.img`
+  width: 100%;
+  display: inline;
+  @media (min-width: 48em) {
+    max-width: 160px;
+  }
+`
+
+const ReveredColumnOnMobile = styled.div`
+  @media (max-width: 48em) {
+    display: flex;
+    flex-direction: column-reverse;
+    img {
+      margin-left: auto;
+      margin-right: auto;
+    }
+  }
+`
+
+const theme = {
+  flexboxgrid: {
+    breakpoints: {
+      // em, not pixels
+      xs: 0,
+      sm: 24,
+      md: 48,
+      lg: 64
+    }
+  }
+}
+
+export default ({ introduction, fair_coverage, event, prepare_for_fairs }) =>
+  <ThemeProvider theme={theme}>
+    <Container>
+      <Row style={{ paddingBottom: 50 }}>
+        <Col lg={4} md={4} sm={12} xs={12}>
+          <SectionTitle titleSize="large" dangerouslySetInnerHTML={{ __html: introduction.title }} />
+        </Col>
+        <Col lg={8} md={8} sm={12} xs={12}>
+          <ReveredColumnOnMobile>
+            <IntroductionText textSize='xlarge' color={colors.grayDark} style={{ marginBottom: 20 }}>
+              {introduction.description}
+            </IntroductionText>
+            <div>
+              <img style={{ marginTop: 30, marginBottom: 20, maxWidth: '100%' }} src='https://d3vpvtm3t56z1n.cloudfront.net/images/hero.jpg' />
+            </div>
+          </ReveredColumnOnMobile>
+        </Col>
+      </Row>
+
+      <Row style={{ paddingBottom: 50 }}>
+        <Col lg={4} md={4} sm={12} xs={12}>
+          <SectionTitle titleSize="large">
+            {fair_coverage.title}
+          </SectionTitle>
+        </Col>
+        <Col lg={8} md={8} sm={12} xs={12}>
+          <Row style={{ marginBottom: 20 }}>
+            {fair_coverage.fairs.map(fair =>
+              <Col lg={3} md={3} sm={3} xs={6} key={fair.logo_url}>
+                {(fair.site_url && fair.site_url.startsWith('http') ?
+                  <a href={fair.site_url} target='_blank'>
+                    <FairLogo src={fair.logo_url} />
+                  </a>
+                :
+                  <FairLogo src={fair.logo_url} />
+                )}
+              </Col>
+            )}
+          </Row>
+        </Col>
+      </Row>
+
+      <Row style={{ paddingBottom: 45 }}>
+        <Col lg={4} md={4} sm={12} xs={12}>
+          <SectionTitle titleSize="large">
+            {event.title}
+          </SectionTitle>
+        </Col>
+        <Col lg={8} md={8} sm={12} xs={12}>
+          <img style={{ marginBottom: 10, width: '100%' }} src={event.banner_image_url} />
+
+          <Row>
+            <Col lg={7} md={12} sm={12} xs={12} style={{ marginBottom: 25 }}>
+              <Text textSize='medium'>
+                {event.description}
+              </Text>
+            </Col>
+            <Col lg={5} md={12} sm={12} xs={12} style={{ marginBottom: 25 }}>
+              <Text textSize='medium' color={colors.grayDark} dangerouslySetInnerHTML={{ __html: event.public_viewing_date }} />
+            </Col>
+          </Row>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col lg={4} md={4} sm={12} xs={12}>
+          <SectionTitle titleSize="large">
+            {prepare_for_fairs.title}
+          </SectionTitle>
+        </Col>
+        <Col lg={8} md={8} sm={12} xs={12}>
+          {prepare_for_fairs.articles.map(article =>
+            <Row style={{ marginBottom: 25 }} key={article.title}>
+              <Col lg={7} md={7} sm={6} xs={12}>
+                <a href={article.article_url} target='_blank'>
+                  <img style={{ marginBottom: 10, width: '100%' }} src={article.image_url} />
+                </a>
+              </Col>
+              <Col lg={5} md={5} sm={6} xs={12}>
+                <a href={article.article_url} style={{ textDecoration: 'none' }} target='_blank'>
+                  <Title titleSize='small' style={{ margin: '0 0 5px', lineHeight: 1 }}>
+                    {article.title}
+                  </Title>
+                  <Text textStyle='primary' textSize='small'>
+                    {article.author}
+                  </Text>
+                </a>
+              </Col>
+            </Row>
+          )}
+        </Col>
+      </Row>
+    </Container>
+  </ThemeProvider>

--- a/desktop/apps/the_armory_show/fixture.json
+++ b/desktop/apps/the_armory_show/fixture.json
@@ -1,0 +1,76 @@
+{
+  "event": {
+    "banner_image_url": "https://d3vpvtm3t56z1n.cloudfront.net/images/artsyinmiami.jpg",
+    "description": "Collective Structures explores the relationship between individual artists and their mental landscape through a series of spatial installations. It will unfold in multiple chapters, across distinct spaces of the Bath Club, drawing on the historic building. The physical and sensory experiences strive to place viewers at a crossroads between current reality and imagined narrative.",
+    "public_viewing_date": "Public Viewing<br />December 7 12:00pm–6:00pm<br />The Bath Club<br />5937 Collins Ave, Miami Beach",
+    "title": "Artsy in Miami"
+  },
+  "fair_coverage": {
+    "fairs": [
+      {
+        "logo_url": "https://artsy-media-uploads.s3.amazonaws.com/hw-EpvRMNFs4DXrckLIuUw/Art%20Basel%20in%20Miami%20Beach.png",
+        "site_url": "http://www.artsy.net"
+      },
+      {
+        "logo_url": "https://artsy-media-uploads.s3.amazonaws.com/NRvhceHaRT3G3rBBvDP_Mw/Design%20Miami.png",
+        "site_url": null
+      },
+      {
+        "logo_url": "https://artsy-media-uploads.s3.amazonaws.com/F3u0jrSZDe1s6OyNgfHEMA/INK%20Miami.png",
+        "site_url": null
+      },
+      {
+        "logo_url": "https://artsy-media-uploads.s3.amazonaws.com/yCxGbCMOWDQPWrjX8q1srw/Art%20Miami.png",
+        "site_url": null
+      },
+      {
+        "logo_url": "https://artsy-media-uploads.s3.amazonaws.com/Ok6sE6y1--UZjgtCvhY-JQ/CONTEXT%20Miami.png",
+        "site_url": null
+      },
+      {
+        "logo_url": "https://artsy-media-uploads.s3.amazonaws.com/rBIlG3gc12P-N4fzzGWZiA/Aqua%20Miami.png",
+        "site_url": null
+      },
+      {
+        "logo_url": "https://artsy-media-uploads.s3.amazonaws.com/VcPYm77sM-XyX9SpPXSU1g/PULSE%20Miami%20Beach.png",
+        "site_url": null
+      },
+      {
+        "logo_url": "https://artsy-media-uploads.s3.amazonaws.com/-gVCJKQ2POyyKw0x_cd5Bg/NADA.png",
+        "site_url": null
+      }
+    ],
+    "title": "Visit the fairs"
+  },
+  "introduction": {
+    "description": "For one week a year, Miami becomes a global destination for art, design, music and all things visual culture. Each fair brings together the most influential collectors, gallerists, designers, curators and critics from around the world in celebration of design culture and commerce.",
+    "title": "Miami Week<br />Dec 4-10, 2017"
+  },
+  "meta": {
+    "description": "Yo",
+    "title": "Hey"
+  },
+  "prepare_for_fairs": {
+    "articles": [
+      {
+        "article_url": "https://www.artsy.net/article/artsy-editorial-the-20-best-booths-at-art-basel-in-miami-beach",
+        "author": "ANNA LOUIE SUSSMAN",
+        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlhQti2pXrsXDLlS8jJEIDg%252F_AR_3443.jpg&width=1100&quality=95",
+        "title": "The 20 Best Booths at Art Basel in Miami Beach"
+      },
+      {
+        "article_url": "https://www.artsy.net/article/artsy-editorial-50-must-see-artworks-at-miami-art-week-s-satellite-fairs",
+        "author": "ARTSY EDITORIAL",
+        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FvClMRePyeu9nCashzAgEeA%252F_AR_3326.jpg&width=1100&quality=95",
+        "title": "50 Must-See Artworks at Miami Art Week’s Satellite Fairs"
+      },
+      {
+        "article_url": "https://www.artsy.net/article/artsy-editorial-the-10-best-booths-at-design-miami",
+        "author": "ARTSY EDITORIAL",
+        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FOX8QZ5TCXVt8szczr7oWZQ%252Fammann.jpg&width=1100&quality=95",
+        "title": "The 10 Best Booths at Design Miami/"
+      }
+    ],
+    "title": "Stories from Miami"
+  }
+}

--- a/desktop/apps/the_armory_show/index.js
+++ b/desktop/apps/the_armory_show/index.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import queryString from 'query-string'
+import merge from 'lodash.merge'
+import { renderLayout } from '@artsy/stitch'
+
+import adminOnly from '../../lib/admin_only'
+import JSONPage from '../../components/json_page/es6'
+import ArmoryShowFairWeekPage from './components/ArmoryShowFairWeekPage'
+
+const SLUG = 'the-armory-show-fair-week'
+
+class EditableArmoryShowFairWeekPage extends JSONPage {
+  registerRoutes() {
+    this.app.get(this.jsonPage.paths.show, adminOnly, this.show.bind(this))
+    this.app.get(this.jsonPage.paths.show + '/data', adminOnly, this.data)
+    this.app.get(this.jsonPage.paths.edit, adminOnly, this.edit)
+    this.app.post(this.jsonPage.paths.edit, adminOnly, this.upload)
+  }
+
+  async show(req, res, next) {
+    try {
+      const data = await this.jsonPage.get()
+      const layout = await renderLayout({
+        basePath: __dirname,
+        layout: '../../components/main_layout/templates/react_index.jade',
+        config: {
+          styledComponents: true
+        },
+        blocks: {
+          head: './templates/meta.jade',
+          body: ArmoryShowFairWeekPage
+        },
+        data: {
+          ...res.locals,
+          ...data,
+          data
+        }
+      })
+
+      res.send(layout)
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+export default new EditableArmoryShowFairWeekPage({ name: SLUG, paths: { show: `/${SLUG}`, edit: `/${SLUG}/edit` }}).app

--- a/desktop/apps/the_armory_show/templates/meta.jade
+++ b/desktop/apps/the_armory_show/templates/meta.jade
@@ -1,0 +1,5 @@
+title= meta.title
+meta( property="og:title", content=meta.title )
+meta( name="description", content=meta.description )
+meta( name="og:description", content=meta.description )
+meta( property="twitter:description", content=meta.description )

--- a/desktop/index.js
+++ b/desktop/index.js
@@ -50,6 +50,7 @@ app.use(require('./apps/artsy_primer'))
 app.use(require('./apps/gallery_partnerships'))
 app.use(require('./apps/marketing_signup_modals'))
 app.use(require('./apps/artsy_in_miami').default)
+app.use(require('./apps/the_armory_show').default)
 
 // Non-profile dynamic vanity url apps
 app.use(require('./apps/galleries_institutions'))


### PR DESCRIPTION
Once this is merged and deployed to staging it'll be available on https://staging.artsy.net/the-armory-show-fair-week, but this path is subject to change as it's a path we picked out and would like someone on the marketing team to provide a more SEO-friendly path.

![the armory show](https://user-images.githubusercontent.com/5201004/35938687-e89713aa-0c17-11e8-9877-9ab629450db1.gif)


Signed-off-by: Yuki Nishijima <yuki@artsymail.com>