### PR TITLE
add mocha watch task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "shell",
+      "label": "mocha: watch current file",
+      "command": "yarn mocha -- --watch ${fileDirname}/${fileBasename}",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a vscode task script to launch the `yarn mocha -- --watch testFile.js` command on whatever file (hopefully a test) is currently active in the editor. It can be launched with `command + shift + B` or whatever task launching flow you prefer.