### PR TITLE
Add overlay content to the sticky CTA

### DIFF
--- a/desktop/apps/armory_week/client/initializer.js
+++ b/desktop/apps/armory_week/client/initializer.js
@@ -1,0 +1,6 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { Cta } from 'desktop/apps/armory_week/components/Cta'
+
+export const init = () =>
+  ReactDOM.hydrate(<Cta {...window.__BOOTSTRAP__} />, document.getElementById('react-root-for-cta'))

--- a/desktop/apps/armory_week/components/ArmoryWeekPage.js
+++ b/desktop/apps/armory_week/components/ArmoryWeekPage.js
@@ -6,8 +6,6 @@ import { Row, Col } from '@artsy/reaction-force/dist/Components/Grid'
 import Text from '@artsy/reaction-force/dist/Components/Text'
 import Title from "@artsy/reaction-force/dist/Components/Title"
 
-import { Cta } from './Cta'
-
 const Container = styled.div`
   margin: 0 auto;
   max-width: 1192px;
@@ -61,7 +59,7 @@ const theme = {
   }
 }
 
-export default ({ introduction, fair_coverage, event, prepare_for_fairs }) => (
+export default ({ introduction, fair_coverage, event, prepare_for_fairs }) =>
   <ThemeProvider theme={theme}>
     <Container>
       <Row style={{ paddingBottom: 50 }}>
@@ -119,7 +117,10 @@ export default ({ introduction, fair_coverage, event, prepare_for_fairs }) => (
               </Text>
             </Col>
             <Col lg={5} md={12} sm={12} xs={12} style={{ marginBottom: 25 }}>
-              <Text textSize='medium' color={colors.grayDark} dangerouslySetInnerHTML={{ __html: event.public_viewing_date }} />
+              <Text
+                textSize='medium'
+                color={colors.grayDark}
+                dangerouslySetInnerHTML={{ __html: event.public_viewing_date }} />
             </Col>
           </Row>
         </Col>
@@ -132,26 +133,16 @@ export default ({ introduction, fair_coverage, event, prepare_for_fairs }) => (
           </SectionTitle>
         </Col>
         <Col lg={8} md={8} sm={12} xs={12}>
-          {prepare_for_fairs.articles.map(article => (
+          {prepare_for_fairs.articles.map(article =>
             <Row style={{ marginBottom: 25 }} key={article.title}>
               <Col lg={7} md={7} sm={6} xs={12}>
                 <a href={article.article_url} target="_blank">
-                  <img
-                    style={{ marginBottom: 10, width: "100%" }}
-                    src={article.image_url}
-                  />
+                  <img style={{ marginBottom: 10, width: "100%" }} src={article.image_url} />
                 </a>
               </Col>
               <Col lg={5} md={5} sm={6} xs={12}>
-                <a
-                  href={article.article_url}
-                  style={{ textDecoration: "none" }}
-                  target="_blank"
-                >
-                  <Title
-                    titleSize="small"
-                    style={{ margin: "0 0 5px", lineHeight: 1 }}
-                  >
+                <a href={article.article_url} style={{ textDecoration: "none" }} target="_blank">
+                  <Title titleSize="small" style={{ margin: "0 0 5px", lineHeight: 1 }}>
                     {article.title}
                   </Title>
                   <Text textStyle="primary" textSize="small">
@@ -160,11 +151,10 @@ export default ({ introduction, fair_coverage, event, prepare_for_fairs }) => (
                 </a>
               </Col>
             </Row>
-          ))}
+          )}
         </Col>
       </Row>
 
-      <Cta />
+      <div id="react-root-for-cta" />
     </Container>
   </ThemeProvider>
-);

--- a/desktop/apps/armory_week/components/Cta.js
+++ b/desktop/apps/armory_week/components/Cta.js
@@ -1,11 +1,14 @@
 import React from "react"
 import styled from "styled-components"
 
+import { Row, Col } from '@artsy/reaction-force/dist/Components/Grid'
 import colors from "@artsy/reaction-force/dist/Assets/Colors"
 import InvertedButton from "@artsy/reaction-force/dist/Components/Buttons/Inverted"
+import Text from '@artsy/reaction-force/dist/Components/Text'
+import Title from "@artsy/reaction-force/dist/Components/Title"
+import FacebookButton from "@artsy/reaction-force/dist/Components/Buttons/Facebook"
 
 const StickyFooter = styled.div`
-  cursor: pointer;
   position: fixed;
   right: 0;
   bottom: 0;
@@ -18,6 +21,7 @@ const StickyFooter = styled.div`
 `
 
 const Container = styled.div`
+  cursor: pointer;
   margin: 0 auto;
   max-width: 1192px;
   padding-top: 25px;
@@ -42,26 +46,149 @@ const FullWidthCol = styled.div`
   align-items: center;
 `
 
-const Col = styled.div`
+const FixedCol = styled.div`
   display: flex;
   align-items: center;
 `
 
-export const Cta = () =>
-  <StickyFooter>
-    <Container>
-      <Col>
-        <CtaImage src="https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=150&height=149&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FE-k-uLoQADM8AjadsSKHrA%2Fsquare.jpg" />
-      </Col>
-      <FullWidthCol style={{ fontSize: "26px" }}>
-        A better way to experience Armory Week 2018
-      </FullWidthCol>
-      <Col>
-        <InvertedButton
-          style={{ marginRight: "30px", width: "160px" }}
-        >
-          Sign Up
-        </InvertedButton>
-      </Col>
-    </Container>
-  </StickyFooter>
+const OverlayModalContainer = styled.div`
+  display: flex;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: white;
+  align-items: center;
+  justify-content: center;
+`
+
+const ContentContainer = styled.div`
+  width: 710px;
+`
+const Close = styled.span`
+  position: absolute;
+  top: 10px;
+  right: 20px;
+  font-size: 40px;
+  color: ${colors.grayMedium};
+  cursor: pointer;
+`
+
+const Separator = styled.div`
+  width: 100%;
+  text-align: center;
+  border-bottom: 1px solid #e5e5e5;
+  line-height: .1em;
+  margin: 20px 0 10px;
+`
+
+const SeparatorText = styled(Text)`
+  color: ${colors.graySemibold};
+  background: white;
+  letter-spacing: normal;
+  display: inline;
+  padding: 0 10px;
+`
+
+const FooterLink = styled.a`
+  color: ${colors.graySemibold};
+  text-decoration: underline;
+`
+
+export class Cta extends React.Component {
+  state = {
+    isModalOpen: false,
+  }
+
+  openModal() {
+    this.setState({ isModalOpen: true })
+  }
+
+  closeModal() {
+    this.setState({ isModalOpen: false })
+  }
+
+  render () {
+    return (
+      <StickyFooter>
+        <Container onClick={this.openModal.bind(this)}>
+          <FixedCol>
+            <CtaImage
+              src="https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=150&height=149&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FE-k-uLoQADM8AjadsSKHrA%2Fsquare.jpg" />
+          </FixedCol>
+          <FullWidthCol style={{fontSize: "26px"}}>
+            A better way to experience Armory Week 2018
+          </FullWidthCol>
+          <FixedCol>
+            <InvertedButton style={{marginRight: "30px", width: "160px"}}>
+              Sign Up
+            </InvertedButton>
+          </FixedCol>
+        </Container>
+
+        {this.state.isModalOpen && <OverlayModalContainer>
+          <ContentContainer>
+            <Title align="center" titleSize="large" style={{lineHeight: 'normal'}}>
+              Sign up for personalized fair content when our <b>Armory Week</b> coverage begins
+            </Title>
+
+            <Row>
+              <Col xs sm md lg>
+                <div style={{background: 'pink', width: '100%', height: '100%', width: '100%' }} />
+              </Col>
+              <Col xs sm md lg>
+                <form action="/log_in?modal_id=artist_page_cta" method="POST" className="auth-form" style={{ marginTop: 0 }}>
+                  <div className="auth-errors" />
+                  <input name="name" type="text" placeholder="Your full name" autoFocus required className="bordered-input is-block" style={{ marginTop: 0 }} />
+                  <input id="js-mailcheck-input-modal" name="email" type="email" placeholder="Your email address" required className="bordered-input is-block"/>
+                  <div id="js-mailcheck-hint-modal" />
+                  <input name="password" type="password" placeholder="Create a password" autoComplete="on"
+                         pattern=".{6,}"
+                         title="6 characters minimum" required className="bordered-input is-block"/>
+
+                  <button id="auth-submit" className="avant-garde-button-black is-block">
+                    Sign Up
+                  </button>
+                </form>
+
+                <Separator>
+                  <SeparatorText textStyle='primary' align='center' textSize='xsmall'>
+                    Or
+                  </SeparatorText>
+                </Separator>
+
+                <FacebookButton block />
+
+                <footer style={{ marginTop: '10px' }}>
+                  <Text align="center" color={colors.graySemibold}
+                        style={{fontSize: '13px', marginBottom: '25px', lineHeight: 'normal'}}>
+                    By signing up, you agree to our&nbsp;
+                    <FooterLink href="/terms">
+                      Terms of Use
+                    </FooterLink>
+                    &nbsp;and&nbsp;
+                    <FooterLink href="/privacy">
+                      Privacy Policy
+                    </FooterLink>
+                    .
+                  </Text>
+
+                  <Text textSize="medium" align="center" color={colors.graySemibold} style={{lineHeight: 'normal'}}>
+                    Already have an account?&nbsp;
+                    <FooterLink>
+                      Sign in.
+                    </FooterLink>
+                  </Text>
+                </footer>
+              </Col>
+            </Row>
+          </ContentContainer>
+          <Close onClick={this.closeModal.bind(this)}>
+            ×
+          </Close>
+        </OverlayModalContainer>}
+      </StickyFooter>
+    )
+  }
+}

--- a/desktop/apps/armory_week/index.js
+++ b/desktop/apps/armory_week/index.js
@@ -1,6 +1,4 @@
 import React from 'react'
-import queryString from 'query-string'
-import merge from 'lodash.merge'
 import { renderLayout } from '@artsy/stitch'
 
 import adminOnly from '../../lib/admin_only'
@@ -29,6 +27,9 @@ class EditableArmoryWeekPage extends JSONPage {
         blocks: {
           head: './templates/meta.jade',
           body: ArmoryWeekPage
+        },
+        locals: {
+          assetPackage: 'cta'
         },
         data: {
           ...res.locals,

--- a/desktop/assets/cta.js
+++ b/desktop/assets/cta.js
@@ -1,0 +1,3 @@
+import { $ } from 'backbone'
+
+$(() => require('../apps/armory_week/client/initializer').init())

--- a/desktop/assets/cta.styl
+++ b/desktop/assets/cta.styl
@@ -1,0 +1,1 @@
+// This file was added so that the client-side js doesn't error out due to 404.


### PR DESCRIPTION
This adds a sticky CTA view with an overlay modal:

![2018-02-09 11_48_40](https://user-images.githubusercontent.com/386234/36038997-35c01302-0d8f-11e8-8772-d90aa3955325.gif)

Right now all the contents in the CTA view are static and hard-coded, but [we have a story for making them editable](https://artsyproduct.atlassian.net/browse/AR-113). There are also other related stories to make the page fully functional and we'll address them incrementally:

 * [Change the `<FacebookButton>` to accept arbitrary button text](https://artsyproduct.atlassian.net/browse/AR-109)
 * [User should be able to sign up through the modal](https://artsyproduct.atlassian.net/browse/AR-112)
 * [User shouldn't be able to scroll when the overlay modal is open](https://artsyproduct.atlassian.net/browse/AR-112)