### PR TITLE
@yuki24 => [Onboarding] Support mobile

### DIFF
--- a/desktop/apps/personalize/index.coffee
+++ b/desktop/apps/personalize/index.coffee
@@ -3,7 +3,7 @@
 #
 
 express = require 'express'
-{ index, newOnboarding } = require './routes.js'
+{ index } = require './routes.js'
 adminOnly = require '../../lib/admin_only'
 
 app = module.exports = express()

--- a/mobile/apps/personalize/index.coffee
+++ b/mobile/apps/personalize/index.coffee
@@ -1,5 +1,5 @@
 express = require 'express'
-routes = require './routes'
+{ index } = require './routes.js'
 
 app = module.exports = express()
 
@@ -7,7 +7,7 @@ app.set 'views', __dirname + '/templates'
 app.set 'view engine', 'jade'
 
 app.get '/personalize', (req, res) -> res.redirect '/personalize/collect'
-app.get '/personalize/collect', routes.index
-app.get '/personalize/location', routes.index
-app.get '/personalize/artists', routes.index
-app.get '/personalize/price_range', routes.index
+app.get '/personalize/collect', index
+app.get '/personalize/location', index
+app.get '/personalize/artists', index
+app.get '/personalize/price_range', index

--- a/mobile/apps/personalize/index.coffee
+++ b/mobile/apps/personalize/index.coffee
@@ -6,7 +6,7 @@ app = module.exports = express()
 app.set 'views', __dirname + '/templates'
 app.set 'view engine', 'jade'
 
-app.get '/personalize', (req, res) -> res.redirect '/personalize/collect'
+app.get '/personalize', index
 app.get '/personalize/collect', index
 app.get '/personalize/location', index
 app.get '/personalize/artists', index

--- a/mobile/apps/personalize/routes.coffee
+++ b/mobile/apps/personalize/routes.coffee
@@ -1,5 +1,0 @@
-@index = (req, res, next) ->
-  if req.user?
-    res.render 'index'
-  else
-    res.redirect '/'

--- a/mobile/apps/personalize/routes.js
+++ b/mobile/apps/personalize/routes.js
@@ -2,6 +2,9 @@ export const index = (req, res, next) => {
   if (res.locals.sd.ONBOARDING_TEST === 'experiment') {
     next()
   } else {
+    if (req.path === '/personalize') {
+      return res.redirect('/personalize/collect')
+    }
     if (req.user) {
       res.render('index')
     } else {

--- a/mobile/apps/personalize/routes.js
+++ b/mobile/apps/personalize/routes.js
@@ -1,0 +1,11 @@
+export const index = (req, res, next) => {
+  if (res.locals.sd.ONBOARDING_TEST === 'experiment') {
+    next()
+  } else {
+    if (req.user) {
+      res.render('index')
+    } else {
+      res.redirect('/')
+    }
+  }
+}

--- a/mobile/apps/personalize/test/routes.coffee
+++ b/mobile/apps/personalize/test/routes.coffee
@@ -1,11 +1,24 @@
 sinon = require 'sinon'
-routes = require '../routes'
+{ index } = require '../routes.js'
 
 describe "#index", ->
   it 'should render the index template when a user is present', ->
-    routes.index { user: {} }, { render: renderStub = sinon.stub() }
+    index { user: {} }, {
+      render: renderStub = sinon.stub()
+      locals: sd: ONBOARDING_TEST: 'control'
+    }
     renderStub.args[0][0].should.equal 'index'
 
   it 'should redirect to the root if the user is not present', ->
-    routes.index {}, { redirect: redirectStub = sinon.stub() }
+    index {}, {
+      redirect: redirectStub = sinon.stub()
+      locals: sd: ONBOARDING_TEST: 'control'
+    }
     redirectStub.args[0][0].should.equal '/'
+
+  it 'should next if they are on the experiment of onboarding test', ->
+    index {}, {
+      redirect: redirectStub = sinon.stub()
+      locals: sd: ONBOARDING_TEST: 'experiment'
+    }, next = sinon.stub()
+    next.callCount.should.equal 1


### PR DESCRIPTION
This turned out to be pretty straightforward. When the user gets to a /personalize route on mobile and they have `res.locals.sd.ONBOARDING_TEST === 'experiment'`, we use `next()` to fall through our route handlers to desktop. 