### PR TITLE
@kanaabe => Add babel-polyfill

### DIFF
--- a/lib/global_modules.js
+++ b/lib/global_modules.js
@@ -1,3 +1,5 @@
+require('babel-polyfill')
+
 const _ = require('underscore')
 const $ = require('jquery')
 const imagesLoaded = require('imagesloaded')

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-plugin-styled-components": "^1.4.0",
     "babel-plugin-transform-class-properties": "^6.23.0",
     "babel-plugin-transform-runtime": "^6.15.0",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1086,6 +1086,14 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-preset-env@^1.6.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.6.1.tgz#a18b564cc9b9afdf4aae57ae3c1b0d99188e6f48"
@@ -2176,6 +2184,10 @@ core-js@^1.0.0:
 core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
+
+core-js@^2.5.0:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -7021,7 +7033,7 @@ regenerate@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.2.tgz#d1941c67bad437e1be76433add5b385f95b19260"
 
-regenerator-runtime@^0.10.0:
+regenerator-runtime@^0.10.0, regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 


### PR DESCRIPTION
Looks like babel-preset-env was only picking up latest IE Edge releases, and not IE 11 [("last two versions")](https://github.com/artsy/force/blob/master/.babelrc#L5) and so IE 11 was throwing on common ES6 features: 

![screen shot 2018-02-08 at 3 45 12 pm](https://user-images.githubusercontent.com/236943/36005002-57eda23c-0cea-11e8-9486-d05838db69de.png)

This should make things safer for _all_ older browsers, but at some point we should make a call as this adds quite a lot of code to the overall JS that needs to be downloaded. I haven't seen any sentry errors come through so I have to 👏 MS for being rigorous / insistent with their OS update process. 