### PR TITLE
[Armory Week] Many UI fixes for the Armory Week landing page

### DIFF
--- a/desktop/apps/armory_week/client/initializer.js
+++ b/desktop/apps/armory_week/client/initializer.js
@@ -2,5 +2,12 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { Cta } from 'desktop/apps/armory_week/components/Cta'
 
-export const init = () =>
-  ReactDOM.hydrate(<Cta {...window.__BOOTSTRAP__} />, document.getElementById('react-root-for-cta'))
+export const init = () => {
+  const bootstrapData = window.__BOOTSTRAP__
+  const { ctaTitle, ctaImageUrl, overlayModalTitle, overlayModalImageUrl } = bootstrapData.bannerPopUp
+
+  ReactDOM.hydrate(
+    <Cta {...{ ctaTitle, ctaImageUrl, overlayModalTitle, overlayModalImageUrl }} />,
+    document.getElementById('react-root-for-cta')
+  )
+}

--- a/desktop/apps/armory_week/components/ArmoryWeekPage.js
+++ b/desktop/apps/armory_week/components/ArmoryWeekPage.js
@@ -11,7 +11,7 @@ const Container = styled.div`
   max-width: 1192px;
   padding-top: 25px;
   @media (max-width: 48em) {
-    padding: 10px 20px 0;
+    padding: 10px 0 0;
   }
 `
 

--- a/desktop/apps/armory_week/components/Cta.js
+++ b/desktop/apps/armory_week/components/Cta.js
@@ -102,10 +102,12 @@ export class Cta extends React.Component {
   }
 
   openModal() {
+    document.querySelector('body').style.overflow = 'hidden'
     this.setState({ isModalOpen: true })
   }
 
   closeModal() {
+    document.querySelector('body').style.overflow = ''
     this.setState({ isModalOpen: false })
   }
 

--- a/desktop/apps/armory_week/components/Cta.js
+++ b/desktop/apps/armory_week/components/Cta.js
@@ -96,6 +96,14 @@ const FooterLink = styled.a`
   text-decoration: underline;
 `
 
+// Use the interface below once https://github.com/artsy/force/pull/2145 is merged:
+// interface CtaProps {
+//   ctaTitle: string
+//   ctaImageUrl: string
+//   ovrlayModalTitle: string
+//   overlayModalImageUrl: string
+// }
+
 export class Cta extends React.Component {
   state = {
     isModalOpen: false,
@@ -112,15 +120,16 @@ export class Cta extends React.Component {
   }
 
   render () {
+    const { ctaTitle, ctaImageUrl, overlayModalTitle, overlayModalImageUrl } = this.props
+
     return (
       <StickyFooter>
         <Container onClick={this.openModal.bind(this)}>
           <FixedCol>
-            <CtaImage
-              src="https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=150&height=149&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FE-k-uLoQADM8AjadsSKHrA%2Fsquare.jpg" />
+            <CtaImage src={ctaImageUrl} />
           </FixedCol>
           <FullWidthCol style={{fontSize: "26px"}}>
-            A better way to experience Armory Week 2018
+            {ctaTitle}
           </FullWidthCol>
           <FixedCol>
             <InvertedButton style={{marginRight: "30px", width: "160px"}}>
@@ -131,13 +140,15 @@ export class Cta extends React.Component {
 
         {this.state.isModalOpen && <OverlayModalContainer>
           <ContentContainer>
-            <Title align="center" titleSize="large" style={{lineHeight: 'normal'}}>
-              Sign up for personalized fair content when our <b>Armory Week</b> coverage begins
-            </Title>
+            <Title
+              align="center"
+              titleSize="large"
+              style={{ lineHeight: 'normal' }}
+              dangerouslySetInnerHTML={{ __html: overlayModalTitle }} />
 
             <Row>
               <Col xs sm md lg>
-                <div style={{background: 'pink', width: '100%', height: '100%', width: '100%' }} />
+                <div style={{ background: `url(${overlayModalImageUrl})`, width: '100%', height: '100%' }} />
               </Col>
               <Col xs sm md lg>
                 <form action="/log_in?modal_id=artist_page_cta" method="POST" className="auth-form" style={{ marginTop: 0 }}>

--- a/desktop/apps/armory_week/components/Cta.js
+++ b/desktop/apps/armory_week/components/Cta.js
@@ -171,7 +171,9 @@ export class Cta extends React.Component {
                   </SeparatorText>
                 </Separator>
 
-                <FacebookButton block />
+                <FacebookButton block>
+                  Continue with Facebook
+                </FacebookButton>
 
                 <footer style={{ marginTop: '10px' }}>
                   <Text align="center" color={colors.graySemibold}

--- a/desktop/apps/armory_week/fixture.json
+++ b/desktop/apps/armory_week/fixture.json
@@ -1,4 +1,10 @@
 {
+  "bannerPopUp": {
+    "ctaTitle": "A better way to experience Armory Week 2018",
+    "ctaImageUrl":"https://d3vpvtm3t56z1n.cloudfront.net/images/artsyinmiami.jpg",
+    "overlayModalTitle":"Sign up for personalized fair content when our Armory Week coverage begins",
+    "overlayModalImageUrl":"https://d3vpvtm3t56z1n.cloudfront.net/images/artsyinmiami.jpg"
+  },
   "event": {
     "banner_image_url": "https://d3vpvtm3t56z1n.cloudfront.net/images/artsyinmiami.jpg",
     "description": "Collective Structures explores the relationship between individual artists and their mental landscape through a series of spatial installations. It will unfold in multiple chapters, across distinct spaces of the Bath Club, drawing on the historic building. The physical and sensory experiences strive to place viewers at a crossroads between current reality and imagined narrative.",


### PR DESCRIPTION
This PR finishes the subtasks below:

 * [AR-114: User shouldn't be able to scroll when the overlay modal is open
](https://artsyproduct.atlassian.net/browse/AR-114)
 * [AR-113: Admin should be able to edit the banner pop up contents](https://artsyproduct.atlassian.net/browse/AR-113)
 * [AR-95: Fix Mobile Margins](https://artsyproduct.atlassian.net/browse/AR-95)
 * [AR-109: Change the `<FacebookButton>` to accept arbitrary button text](https://artsyproduct.atlassian.net/browse/AR-109)