### PR TITLE
@saolsen: Allow partners to disable listing represented artists on their profile

### DIFF
--- a/desktop/apps/partner/client/artists.coffee
+++ b/desktop/apps/partner/client/artists.coffee
@@ -20,6 +20,7 @@ module.exports = class PartnerArtistsView extends Backbone.View
   initialize: (options={}) ->
     { @profile, @partner, @artistsListColumnSize, @nextPage, @pageSize, @artistId } =
       _.defaults options, @defaults
+    @distinguishRepresentedArtists = @partner.get('distinguish_represented_artists') != false # default to true
     @cache = options.cache; artists = @cache?.artists
     @collection = if artists? then artists else new PartnerArtists()
     @fetchAllArtists()
@@ -52,6 +53,7 @@ module.exports = class PartnerArtistsView extends Backbone.View
     new ArtistsListView
       collection: @displayables
       el: @$('#artists-list')
+      distinguishRepresentedArtists: @distinguishRepresentedArtists
 
   appendArtist: (partnerArtist, scroll=false, allArtworks=false) ->
     a = partnerArtist.get('artist')

--- a/desktop/apps/partner/client/artists_list.coffee
+++ b/desktop/apps/partner/client/artists_list.coffee
@@ -7,9 +7,10 @@ module.exports = class PartnerArtistsListView extends Backbone.View
   defaults:
     linkToPartnerArtist: true # link to partner artist or artist page
     numberOfColumns: 6
+    distinguishRepresentedArtists: true
 
   initialize: (options={}) ->
-    { @numberOfColumns, @linkToPartnerArtist } = _.defaults options, @defaults
+    { @numberOfColumns, @linkToPartnerArtist, @distinguishRepresentedArtists } = _.defaults options, @defaults
     @render()
 
   render: ->
@@ -25,17 +26,20 @@ module.exports = class PartnerArtistsListView extends Backbone.View
         linkToPartnerArtist: @linkToPartnerArtist
 
   groupArtists: (pas) ->
+    if @distinguishRepresentedArtists
+      groups = _.groupBy pas, (pa) -> pa.get 'represented_by'
+      bigger = label: "represented artists", list: groups.true or []
+      smaller = label: "works available by", list: groups.false or []
+
+      if bigger.list.length < smaller.list.length
+        temp = bigger; bigger = smaller; smaller = temp
+      if smaller.list.length is 0
+        bigger.label = "artists"
+    else
+      bigger = { label: 'artists', list: pas}
+      smaller = { list: [] }
+
     h = Math.ceil pas.length / @numberOfColumns
-
-    groups = _.groupBy pas, (pa) -> pa.get 'represented_by'
-    bigger = label: "represented artists", list: groups.true or []
-    smaller = label: "works available by", list: groups.false or []
-
-    if bigger.list.length < smaller.list.length
-      temp = bigger; bigger = smaller; smaller = temp
-    if smaller.list.length is 0
-      bigger.label = "artists"
-
     smaller.numOfCols = Math.ceil smaller.list.length / h
     bigger.numOfCols = @numberOfColumns - smaller.numOfCols
 

--- a/desktop/apps/partner/client/overview.coffee
+++ b/desktop/apps/partner/client/overview.coffee
@@ -24,7 +24,7 @@ module.exports = class PartnerOverviewView extends Backbone.View
     { @profile, @partner } = _.defaults options, @defaults
     @isPartner = @partner.get('claimed') isnt false
     @showBanner = not @isPartner and not @partner.get 'show_promoted'
-
+    @distinguishRepresentedArtists = @partner.get('distinguish_represented_artists') != false # default to true
     { @numberOfFeatured, @numberOfShows } =
       _.defaults options, if @isPartner then @partnerDefaults else @nonPartnerDefaults
     @$el.html template partner: @partner, showBanner: @showBanner, isPartner: @isPartner
@@ -58,12 +58,15 @@ module.exports = class PartnerOverviewView extends Backbone.View
           @renderArtistsList displayables
 
   renderArtistsGrid: (artists) ->
-    groups = _.groupBy artists, (pa) -> pa.get 'represented_by'
-    represented = label: "represented artists", list: groups.true or []
-    nonrepresented = label: "works available by", list: groups.false or []
+    if @distinguishRepresentedArtists
+      groups = _.groupBy artists, (pa) -> pa.get 'represented_by'
+      represented = label: "represented artists", list: groups.true or []
+      nonrepresented = label: "works available by", list: groups.false or []
 
-    groups = _.filter [represented, nonrepresented], (g) -> g.list.length > 0
-    groups[0].label = "artists" if groups.length is 1
+      groups = _.filter [represented, nonrepresented], (g) -> g.list.length > 0
+      groups[0].label = "artists" if groups.length is 1
+    else
+      groups = [{ label: 'artists', list: artists }]
 
     @$('.partner-overview-artists').html artistsGridTemplate
       partner: @partner
@@ -74,6 +77,7 @@ module.exports = class PartnerOverviewView extends Backbone.View
       collection: artists
       el: @$('.partner-overview-artists')
       linkToPartnerArtist: @isPartner
+      distinguishRepresentedArtists: @distinguishRepresentedArtists
 
   initializeLocations: ->
     return @$('.partner-overview-locations').hide() if @isPartner

--- a/desktop/apps/partner/test/client/artists_list.coffee
+++ b/desktop/apps/partner/test/client/artists_list.coffee
@@ -126,6 +126,25 @@ describe 'PartnerArtistsListView', ->
       groups[0].cols.should.have.lengthOf 1
       groups[0].cols[0].should.have.lengthOf 6
 
+    it 'groups all artists together when partner has distinguish_represented_artists: false', ->
+      pas = new PartnerArtists [
+        fabricate('partner_artist', represented_by: false),
+        fabricate('partner_artist')
+      ]
+      new PartnerArtistsListView
+        collection: pas.models
+        el: $ 'body'
+        numberOfColumns: 4
+        distinguishRepresentedArtists: false
+
+      groups = @template.args[0][0].groups
+      groups.should.have.lengthOf 1
+      groups[0].label.should.equal 'artists'
+      groups[0].cols.should.have.lengthOf 4
+      groups[0].cols[0].should.have.lengthOf 1
+      groups[0].cols[1].should.have.lengthOf 1
+      groups[0].cols[2].should.have.lengthOf 0
+
   describe '#render', ->
 
     beforeEach (done) ->

--- a/desktop/apps/partner2/client/artists.coffee
+++ b/desktop/apps/partner2/client/artists.coffee
@@ -21,7 +21,6 @@ module.exports = class PartnerArtistsView extends Backbone.View
   initialize: (options = {}) ->
     { @profile, @partner, @artistsListColumnSize, @nextPage, @pageSize,
       @artistId, @cache } = _.defaults options, @defaults
-
     # @collection is all displayable partner artists.
     @collection = @cache.artists or new PartnerArtists()
     @startUp()

--- a/desktop/apps/partner2/components/artists_list/test/view.coffee
+++ b/desktop/apps/partner2/components/artists_list/test/view.coffee
@@ -194,6 +194,24 @@ describe 'PartnerArtistsListView', ->
       groups[0].cols.should.have.lengthOf 1
       groups[0].cols[0].should.have.lengthOf 6
 
+    it 'groups all artists together when partner has distinguish_represented_artists: false', ->
+      pas = new PartnerArtists [
+        fabricate('partner_artist', represented_by: false),
+        fabricate('partner_artist')
+      ]
+      @partner.set('distinguish_represented_artists', false)
+      view = new PartnerArtistsListView
+        partner: @partner
+        numberOfColumns: 4
+
+      groups = view.groupArtists pas.models
+      groups.should.have.lengthOf 1
+      groups[0].label.should.equal ""
+      groups[0].cols.should.have.lengthOf 4
+      groups[0].cols[0].should.have.lengthOf 1
+      groups[0].cols[1].should.have.lengthOf 1
+      groups[0].cols[2].should.have.lengthOf 0
+
   describe '#render', ->
     beforeEach ->
       @pas = new PartnerArtists [

--- a/desktop/apps/partner2/components/artists_list/view.coffee
+++ b/desktop/apps/partner2/components/artists_list/view.coffee
@@ -12,6 +12,7 @@ module.exports = class PartnerArtistsListView extends Backbone.View
 
   initialize: (options = {}) ->
     { @partner, @collection, @numberOfColumns, @linkToPartnerArtist } = _.defaults options, @defaults
+    @distinguishRepresentedArtists = @partner.get('distinguish_represented_artists') != false # default true
     @collection ?= new PartnerArtists()
     @collection.url = "#{@partner.url()}/partner_artists?display_on_partner_profile=1"
 
@@ -38,17 +39,20 @@ module.exports = class PartnerArtistsListView extends Backbone.View
       linkToPartnerArtist: @linkToPartnerArtist
 
   groupArtists: (pas) ->
+    if @distinguishRepresentedArtists
+      groups = _.groupBy pas, (pa) -> pa.get 'represented_by'
+      bigger = label: "represented artists", list: groups.true or []
+      smaller = label: "works available by", list: groups.false or []
+
+      if bigger.list.length < smaller.list.length
+        temp = bigger; bigger = smaller; smaller = temp
+      if smaller.list.length is 0
+        bigger.label = ''
+    else
+      bigger = { label: '', list: pas}
+      smaller = { list: [] }
+
     h = Math.ceil pas.length / @numberOfColumns
-
-    groups = _.groupBy pas, (pa) -> pa.get 'represented_by'
-    bigger = label: "represented artists", list: groups.true or []
-    smaller = label: "works available by", list: groups.false or []
-
-    if bigger.list.length < smaller.list.length
-      temp = bigger; bigger = smaller; smaller = temp
-    if smaller.list.length is 0
-      bigger.label = ''
-
     smaller.numOfCols = Math.ceil smaller.list.length / h
     bigger.numOfCols = @numberOfColumns - smaller.numOfCols
 

--- a/mobile/apps/partner_profile/templates/artists.jade
+++ b/mobile/apps/partner_profile/templates/artists.jade
@@ -6,16 +6,21 @@ block content
     nav.slash-breadcrumbs
       a( href='/' + profile.get('id') )= profile.get('owner').name
       span Artists
-    if represented.length
-      h1.avant-garde-header-center.partner-profile-large-header Represented Artists
-      - artists = represented
-      include ../../../components/artist_list/template
-    if unrepresented.length
-      h1.avant-garde-header-center.partner-profile-large-header
-        if profile.get('id').match('gagosian')
-          | Artists
-        else
-          | Works Available By
-      - artists = unrepresented
+    if partner.get('distinguish_represented_artists') !== false
+      if represented.length
+        h1.avant-garde-header-center.partner-profile-large-header Represented Artists
+        - artists = represented
+        include ../../../components/artist_list/template
+      if unrepresented.length
+        h1.avant-garde-header-center.partner-profile-large-header
+          if profile.get('id').match('gagosian')
+            | Artists
+          else
+            | Works Available By
+        - artists = unrepresented
+        include ../../../components/artist_list/template
+    else
+      h1.avant-garde-header-center.partner-profile-large-header Artists
+      - artists = represented.concat(unrepresented)
       include ../../../components/artist_list/template
     a.partner-back-link( href='/' + profile.get('id') ) Go to #{profile.get('owner').name}

--- a/mobile/apps/partner_profile/test/templates.coffee
+++ b/mobile/apps/partner_profile/test/templates.coffee
@@ -25,6 +25,7 @@ describe 'Partner page templates', ->
       represented: []
       unrepresented: new Artists([fabricate 'artist']).models
       sd: {}
+      partner: new Partner fabricate 'partner'
     ).should.not.containEql 'Represented Artists'
 
   it 'changes copy for gagosian', ->
@@ -32,6 +33,17 @@ describe 'Partner page templates', ->
       profile: new Profile fabricate 'profile', id: 'gagosian-gallery'
       represented: new Artists([fabricate 'artist']).models
       unrepresented: new Artists([fabricate 'artist']).models
+      sd: {}
+      partner: new Partner fabricate 'partner'
+    html.should.not.containEql 'Works Available By'
+    html.should.containEql 'Artists'
+
+  it 'renders single list when distinguish_represented_artists is false', ->
+    html = render('artists')
+      profile: new Profile fabricate 'profile'
+      represented: new Artists([fabricate 'artist']).models
+      unrepresented: new Artists([fabricate 'artist']).models
+      partner: new Partner distinguish_represented_artists: false
       sd: {}
     html.should.not.containEql 'Works Available By'
     html.should.containEql 'Artists'


### PR DESCRIPTION
There seem to be dozens of possible partner profile configurations, and we have 3 completely separate code paths responsible for rendering them (`desktop/apps/partner`, `.../partner2`, and `mobile/apps/partner_profile`).

@saolsen and I tried to make the sensible additions in each place to support [STI-6](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=31&projectKey=STI&modal=detail&selectedIssue=STI-6), but this looked slightly different in each location.

The end result is:
* by default, profiles are unchanged from their current appearance
* partners may opt not to display representations on their profiles, in which case artists they represent or don't will appear in a single undifferentiated list
