### PR TITLE
Fix the browser back/forward by replacing <Wizard> with react-router

### DIFF
--- a/desktop/apps/personalize/client/onboarding.js
+++ b/desktop/apps/personalize/client/onboarding.js
@@ -1,12 +1,21 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { App } from 'desktop/apps/personalize/components/App'
+import { Router } from 'react-router'
+import createHistory from 'history/createBrowserHistory'
+
+import { ContextProvider } from '@artsy/reaction-force/dist/Components/Artsy'
+import { RoutesWithProgressBar } from '../components/RoutesWithProgressBar'
 
 export const init = () => {
   const bootstrapData = window.__BOOTSTRAP__
 
   // Start app
   ReactDOM.hydrate(
-    <App {...bootstrapData} />, document.getElementById('react-root')
+    <Router history={createHistory()}>
+      <ContextProvider {...bootstrapData}>
+        <RoutesWithProgressBar />
+      </ContextProvider>
+    </Router>,
+    document.getElementById('react-root')
   )
 }

--- a/desktop/apps/personalize/components/App.js
+++ b/desktop/apps/personalize/components/App.js
@@ -1,28 +1,7 @@
-import PropTypes from 'prop-types'
 import React from 'react'
-import { ContextProvider } from '@artsy/reaction-force/dist/Components/Artsy'
-import Wizard from '@artsy/reaction-force/dist/Components/Onboarding/Wizard'
-import CollectorIntent from '@artsy/reaction-force/dist/Components/Onboarding/Steps/CollectorIntent'
-import Artists from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Artists'
-import Genes from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Genes'
-import Budget from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Budget'
 
 export class App extends React.Component {
-  static propTypes = {
-    currentUser: PropTypes.object,
-    redirectTo: PropTypes.string,
-    forceStep: PropTypes.string
-  }
-
   render () {
-    return (
-      <ContextProvider currentUser={this.props.currentUser} >
-        <Wizard
-          stepComponents={[CollectorIntent, Artists, Genes, Budget]}
-          redirectTo={this.props.redirectTo}
-          forceStep={this.props.forceStep}
-        />
-      </ContextProvider>
-    )
+    return <div />
   }
 }

--- a/desktop/apps/personalize/components/RoutesWithProgressBar.js
+++ b/desktop/apps/personalize/components/RoutesWithProgressBar.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import { Route, Redirect } from 'react-router'
+
+import { ProgressIndicator } from '@artsy/reaction-force/dist/Components/Onboarding/ProgressIndicator'
+import CollectorIntent from '@artsy/reaction-force/dist/Components/Onboarding/Steps/CollectorIntent'
+import Artists from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Artists'
+import Genes from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Genes'
+import Budget from '@artsy/reaction-force/dist/Components/Onboarding/Steps/Budget'
+
+const STEPS = [
+  `/personalize/${CollectorIntent.slug}`,
+  `/personalize/${Artists.slug}`,
+  `/personalize/${Genes.slug}`,
+  `/personalize/${Budget.slug}`
+]
+
+export class RoutesWithProgressBar extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      finished: false,
+    }
+  }
+
+  onNextButtonPressed = (increaseBy, history) => {
+    history.push(STEPS[STEPS.indexOf(location.pathname) + increaseBy])
+  }
+
+  onFinish = redirectTo => {
+    this.setState({ finished: true })
+    setTimeout(() => (window.location.href = redirectTo || "/"), 500)
+  }
+
+  render() {
+    return (
+      <div>
+        <Route path='/personalize/*' render={() =>
+          <ProgressIndicator percentComplete={ this.state.finished ? 1 : STEPS.indexOf(location.pathname) / STEPS.length } />
+        } />
+
+        <Route path={`/personalize/${CollectorIntent.slug}`} render={props =>
+          <CollectorIntent {...props} onNextButtonPressed={(increaseBy = 1) => this.onNextButtonPressed(increaseBy, props.history)} />
+        } />
+        <Route path={`/personalize/${Artists.slug}`} render={props =>
+          <Artists {...props} onNextButtonPressed={(increaseBy = 1) => this.onNextButtonPressed(increaseBy, props.history)} />
+        } />
+        <Route path={`/personalize/${Genes.slug}`} render={props =>
+          <Genes {...props} onNextButtonPressed={(increaseBy = 1) => this.onNextButtonPressed(increaseBy, props.history)} />
+        } />
+        <Route path={`/personalize/${Budget.slug}`} render={props =>
+          <Budget {...props} onNextButtonPressed={(increaseBy = 1) => this.onFinish(props.redirectTo, props.history)} />
+        } />
+
+        {new RegExp("/personalize(/*)$").exec(location.pathname) && <Redirect to={`/personalize/${CollectorIntent.slug}`} />}
+      </div>
+    )
+  }
+}


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/AR-110

This PR replaces the <Wizard> component with [`react-router`](https://github.com/ReactTraining/react-router). In the `<Wizard>` component we have a lot of our own hacks to update the page URL. `react-router` provides a simpler way to define routes and also takes care of many edge cases we aren't aware of yet (cross-browser support, SSR, browser back/forward, etc). Instead of maintaining our own wrapper for the History API, we should take advantage of what's already out there.

 * [x] Replace `<Wizard>` with `react-router`
 * [x] disable server-side rendering for now
 * [x] Get the `<ProgressIndicator>`  working again (not updating after a path change in the address bar)
 * [x] ~~Redirect from `/personalize` to `/personalize/interests` on the server-side~~ will address this as a separate PR
 * [x] Fix tests