### PR TITLE
Fix CircleCI builds by increasing the mocha timeout

### DIFF
--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -5,6 +5,6 @@ set -e -x
 mocha \
   --retries 5 \
   --require test.config.js \
-  -t 30000 \
+  -t 60000 \
   $@ \
   dotenv_config_path=.env.test


### PR DESCRIPTION
This fixes the build failure occurring on CircleCI.

Increasing the timeout seems inappropriate, but there's something weird going on in Mocha - The `-t 30000` should configure Mocha so that it'd wait up to 30s for each test, but even with `-t 60000` the `Artwork` test still finishes in around 5.6s, which doesn't explain why it was failing on CircleCI. What this means is that Mocha may be interpreting the `--timeout 30000` option as 3s or there may be something else we aren't aware of yet.

Either way, given the conversation on slack, the direction is probably to incorporate https://www.cypress.io/ at some point, so this should be fine for the time being.
