### PR TITLE
[Toolchain] Speed up acceptance test time

### DIFF
--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -7,4 +7,3 @@ mocha \
   --require test.config.js \
   -t 30000 \
   $@ \
-  dotenv_config_path=.env.test

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,7 +7,6 @@ trap "exit" INT
 run () {
   case $CIRCLE_NODE_INDEX in
   0)
-    yarn assets
     yarn acceptance test/acceptance/*.js
     ;;
   1)


### PR DESCRIPTION
It turns out we don't need to pre-compile our app before running this, and it has no effect on the tests being run anyways. Should shave a couple min off our overall test-running time.  