### PR TITLE
[STI-33] Support online-exclusive shows

### DIFF
--- a/src/desktop/components/featured_shows/metadata/location_with_dates.jade
+++ b/src/desktop/components/featured_shows/metadata/location_with_dates.jade
@@ -1,16 +1,11 @@
 if show.formatCity()
-  = show.formatCity()
+  = show.formatCity() + ", "
+else if show.isOnlineExclusive()
+  = "Online Exclusive, "
 
 if show.upcoming()
-  if show.formatCity()
-    = ', '
   | Opening #{show.dateFormatted('start_at')}
 else if show.isEndingSoon()
-  if show.formatCity()
-    = ', '
   span.fsfs-warning Closing #{show.endingIn()}
 else
-  if show.formatCity()
-    | ,
-    = ' '
   | #{show.date('start_at').format('MMM DD')} – #{show.dateFormatted('end_at')}

--- a/src/desktop/models/partner_show.coffee
+++ b/src/desktop/models/partner_show.coffee
@@ -322,7 +322,7 @@ module.exports = class PartnerShow extends Backbone.Model
     @has 'fair'
 
   isOnlineExclusive: ->
-    !@has('location') && !@has('fair_location') && !@has('partner_location')
+    not @has('location') && not @isFairBooth() && not @has('partner_city')
 
   contextualLabel: (name) ->
     type = if @isFairBooth()

--- a/src/desktop/models/partner_show.coffee
+++ b/src/desktop/models/partner_show.coffee
@@ -321,6 +321,9 @@ module.exports = class PartnerShow extends Backbone.Model
   isFairBooth: ->
     @has 'fair'
 
+  isOnlineExclusive: ->
+    not @has('location') && not @has('fair_location') && not @has('partner_location')
+
   contextualLabel: (name) ->
     type = if @isFairBooth()
       'Fair Booth'

--- a/src/desktop/models/partner_show.coffee
+++ b/src/desktop/models/partner_show.coffee
@@ -322,7 +322,7 @@ module.exports = class PartnerShow extends Backbone.Model
     @has 'fair'
 
   isOnlineExclusive: ->
-    not @has('location') && not @has('fair_location') && not @has('partner_location')
+    !@has('location') && !@has('fair_location') && !@has('partner_location')
 
   contextualLabel: (name) ->
     type = if @isFairBooth()

--- a/src/desktop/test/models/partner_show.coffee
+++ b/src/desktop/test/models/partner_show.coffee
@@ -6,6 +6,7 @@ Backbone = require 'backbone'
 PartnerShow = require '../../models/partner_show'
 PartnerLocation = require '../../models/partner_location'
 FairLocation = require '../../models/partner_location'
+Fair = require '../../models/fair'
 sinon = require 'sinon'
 moment = require 'moment'
 
@@ -89,14 +90,25 @@ describe 'PartnerShow', ->
 
   describe '#isOnlineExclusive', ->
     it 'returns false when there is partner location', ->
-      show = new PartnerShow(fabricate 'show')
+      show = new PartnerShow(fabricate 'show',
+        location: new PartnerLocation(fabricate: 'partner_location'),
+        partner_city: null,
+        fair: null)
       show.isOnlineExclusive().should.be.false()
 
-    it 'returns false when there is fair location', ->
+    it 'returns false when there is a partner_city', ->
       show = new PartnerShow(fabricate 'show',
-        partner_location: null,
-        fair_location:
-          display: 'Booth 1234'
+        location: null,
+        partner_city: 'Tehran',
+        fair: null
+      )
+      show.isOnlineExclusive().should.be.false()
+
+    it 'returns false when its a fair show', ->
+      show = new PartnerShow(fabricate 'show',
+        location: null,
+        fair: new Fair(fabricate: 'fair'),
+        partner_city: null
       )
       show.isOnlineExclusive().should.be.false()
 
@@ -104,7 +116,7 @@ describe 'PartnerShow', ->
       show = new PartnerShow(fabricate 'show',
         location: null,
         partner_location: null,
-        fair_location: null
+        fair: null
       )
       show.isOnlineExclusive().should.be.true()
 

--- a/src/desktop/test/models/partner_show.coffee
+++ b/src/desktop/test/models/partner_show.coffee
@@ -87,6 +87,28 @@ describe 'PartnerShow', ->
       )
       show.location().should.be.instanceOf(FairLocation)
 
+  describe '#isOnlineExclusive', ->
+    it 'returns false when there is partner location', ->
+      show = new PartnerShow(fabricate 'show')
+      show.isOnlineExclusive().should.be.false()
+
+    it 'returns false when there is fair location', ->
+      show = new PartnerShow(fabricate 'show',
+        partner_location: null,
+        fair_location:
+          display: 'Booth 1234'
+      )
+      show.isOnlineExclusive().should.be.false()
+
+    it 'returns true when there is no location', ->
+      show = new PartnerShow(fabricate 'show',
+        location: null,
+        partner_location: null,
+        fair_location: null
+      )
+      show.isOnlineExclusive().should.be.true()
+
+
   describe '#formatShowOrFairCity', ->
 
     it 'returns undefined without location and fair', ->


### PR DESCRIPTION
# Problem
We are now offering _online exclusive_ shows which are shows without any location. We need to update show component (brick?) to properly set the location to `Online Exclusive`.

# Solution
Had to update `PartnerShow` model to include `isOnlineExclusive` method and in `location_with_dates.jade` using it to show proper title.

## Questions:
Do we have i18n support in force?

# Selfie
<img width="858" alt="screen shot 2018-02-14 at 5 36 03 pm" src="https://user-images.githubusercontent.com/1230819/36262260-ee493d6e-1234-11e8-9125-18f7c3f22804.png">


<img width="1262" alt="screen shot 2018-02-15 at 9 44 52 am" src="https://user-images.githubusercontent.com/1230819/36262270-f327064a-1234-11e8-96ef-b21964d18190.png">

cc: @nicoleyeo 

# Followup work
For `show/<id>` page looks like we are using MP for getting the data, will have a separate PR for that one which would be dependent to https://github.com/artsy/metaphysics/pull/927