### PR TITLE
[STI-34] Show Online Exclusive label on show page

### DIFF
--- a/desktop/apps/show/routes.coffee
+++ b/desktop/apps/show/routes.coffee
@@ -15,6 +15,7 @@ query = """
       end_at
       name
       displayable
+      is_online_exclusive
       press_release(format: HTML)
       description
       status

--- a/desktop/apps/show/routes.coffee
+++ b/desktop/apps/show/routes.coffee
@@ -15,7 +15,7 @@ query = """
       end_at
       name
       displayable
-      is_online_exclusive
+      has_location
       press_release(format: HTML)
       description
       status

--- a/desktop/apps/show/templates/header.jade
+++ b/desktop/apps/show/templates/header.jade
@@ -31,8 +31,7 @@ header.show-header( class= hasCarousel ? 'has-carousel' : undefined )
       else
         .show-dates
           = ViewHelpers.runningDates(partner_show)
-        if partner_show.location
-          include metadata/location
+        include metadata/location
         if partner_show.events.length > 0
           include metadata/events
 

--- a/desktop/apps/show/templates/metadata/location.jade
+++ b/desktop/apps/show/templates/metadata/location.jade
@@ -1,7 +1,10 @@
 .show-location
-  span= ViewHelpers.singleLine(partner_show.location)
-  if partner_show.location.coordinates
-    a.show-entity-link.js-open-map-modal
-      i.icon-circle-chevron
-      span
-        | Map #{partner_show.location.day_schedules.length > 0 ? '& Full Hours' : ''}
+  if partner_show.is_online_exclusive
+   span= "Online Exclusive"
+  else
+    span= ViewHelpers.singleLine(partner_show.location)
+    if partner_show.location.coordinates
+      a.show-entity-link.js-open-map-modal
+        i.icon-circle-chevron
+        span
+          | Map #{partner_show.location.day_schedules.length > 0 ? '& Full Hours' : ''}

--- a/desktop/apps/show/templates/metadata/location.jade
+++ b/desktop/apps/show/templates/metadata/location.jade
@@ -1,10 +1,10 @@
 .show-location
-  if partner_show.is_online_exclusive
-   span= "Online Exclusive"
-  else
+  if partner_show.has_location
     span= ViewHelpers.singleLine(partner_show.location)
     if partner_show.location.coordinates
       a.show-entity-link.js-open-map-modal
         i.icon-circle-chevron
         span
           | Map #{partner_show.location.day_schedules.length > 0 ? '& Full Hours' : ''}
+  else
+   span= "Online Exclusive"


### PR DESCRIPTION
# Depends On
https://github.com/artsy/metaphysics/pull/927
Make sure ☝️ is merged first.

# Problem
https://artsyproduct.atlassian.net/browse/STI-34
We need to show proper `Online Exclusive` label  for shows without location.

# Solution
Make sure `location.jade` is always included and in there check for newly added `is_online_exculsive` flag that was added to MP in https://github.com/artsy/metaphysics/pull/927 and based on that show `Online Exclusive` or the actual location.