### PR TITLE
@orta: Avoid re-building staging branch after master build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,8 @@
+general:
+  branches:
+    only:
+      - master
+      - release
 machine:
   node:
     version: 8.4.0


### PR DESCRIPTION
We've run into inconvenient delays a few times because Force's `master` build immediately pushes to the `staging` branch after each successful build and deploy. This starts _another_ build of the same git SHA which occupies 4 Circle containers for ~10 minutes.

I thought we could instead whitelist the `master` and `release` branches. If you like being able to build every branch, I could change this to a blacklist of just the `staging` branch, since that's the main problem.