### PR TITLE
Ensure signup for home banner triggers onboarding after acct creation

### DIFF
--- a/desktop/apps/home/client/auth_router.coffee
+++ b/desktop/apps/home/client/auth_router.coffee
@@ -45,7 +45,10 @@ module.exports = class HomeAuthRouter extends Backbone.Router
         redirectTo: redirectTo
 
   signup: ->
-    mediator.trigger 'open:auth', mode: 'register'
+    redirectTo = qs.parse(@location.search.replace /^\?/, '')['redirect-to']
+    mediator.trigger 'open:auth',
+      mode: 'register',
+      redirectTo: if redirectTo then redirectTo else null
 
   forgot: ->
     mediator.trigger 'open:auth', mode: 'forgot'

--- a/desktop/apps/home/welcome.coffee
+++ b/desktop/apps/home/welcome.coffee
@@ -2,6 +2,6 @@ module.exports =
   mode: 'WELCOME'
   subtitle: 'Sign up to get updates on your favorite artists'
   heading: 'Learn about and collect art from leading galleries, fairs, and museums'
-  href: '/sign_up'
+  href: '/sign_up?redirect-to=/personalize'
   link_text: 'Sign Up'
   background_image_url: '/images/welcome-hero.jpg'


### PR DESCRIPTION
Addresses [AR-137](https://artsyproduct.atlassian.net/browse/AR-137). This adds a `redirect-to` in the query param and pulls that off in the `signup` method to use that as the redirect url after account creation.