### PR TITLE
[STI-32] Add new Online Exclusive tab

### DIFF
--- a/src/desktop/apps/shows/index.coffee
+++ b/src/desktop/apps/shows/index.coffee
@@ -13,6 +13,7 @@ app.get '/shows', routes.index
 app.get '/shows/:city', routes.city
 app.get '/show', routes.redirectShow
 app.get '/city/:city', routes.redirectFromCity
+app.get '/shows/online', routes.onlineExlusive
 
 # Redirect pre-2015 location routes
 oldRedirects =

--- a/src/desktop/apps/shows/templates/featured_shows.jade
+++ b/src/desktop/apps/shows/templates/featured_shows.jade
@@ -2,4 +2,4 @@
 - shows = allShows.slice(0, 2)
 include ../../../components/featured_shows/large
 - shows = allShows.slice(2)
-include ../../../components/featured_shows/small 
+include ../../../components/featured_shows/small

--- a/src/desktop/apps/shows/templates/location_based.jade
+++ b/src/desktop/apps/shows/templates/location_based.jade
@@ -1,5 +1,5 @@
 extends ../../../components/main_layout/templates/index
-include ../../../../node_modules/artsy-ezel-components/pagination/paginator
+include ../../../../../node_modules/artsy-ezel-components/pagination/paginator
 
 block head
   include meta

--- a/src/desktop/apps/shows/templates/location_based.jade
+++ b/src/desktop/apps/shows/templates/location_based.jade
@@ -1,0 +1,46 @@
+extends ../../../components/main_layout/templates/index
+include ../../../../node_modules/artsy-ezel-components/pagination/paginator
+
+block head
+  include meta
+
+append locals
+  - assetPackage = 'partners'
+  - fromShowGuide = true
+block body
+  - var locationString = onlineExclusive ? "Online Exclusive shows" : "Shows in " + city.name
+  #shows-page.main-layout-container
+    include nav
+
+    //- Only display opening if we are on the first page
+    if opening.length && (current.state.currentPage <= 1)
+      h1.shows-page-header Opening This Week
+      - var shows = opening
+      .shows-page-featured-section: include ../../../components/featured_shows/small
+
+    if current.length
+      h2.shows-page-header
+        | Current #{locationString}
+        if current.state.totalRecords
+          |  (#{current.state.totalRecords})
+      - var shows = current.models
+      .shows-page-featured-section
+        include ../../../components/featured_shows/small
+        +paginate(current.state.currentPage, current.state.totalPages)
+
+    if upcoming.length
+      h1.shows-page-header Upcoming Shows
+      - var shows = upcoming
+      .shows-page-featured-section: include ../../../components/featured_shows/small
+
+    if (opening.length + upcoming.length + current.length) === 0
+      h1.shows-page-header Current #{locationString}
+      .shows-page-featured-empty
+        | There are currently no #{locationString} on Artsy
+
+    if (opening.length + upcoming.length + current.length) < 6 && past.length
+      h2.shows-page-header Past #{locationString}
+      - var shows = past.models
+      .shows-page-featured-section: include ../../../components/featured_shows/small
+
+    include nav

--- a/src/desktop/apps/shows/templates/nav.jade
+++ b/src/desktop/apps/shows/templates/nav.jade
@@ -7,6 +7,10 @@ nav.shows-page-cities-nav.horizontal-list-nav
       href='/shows'
       class= activeClass('/shows')
     ) All
+    a.hln-link.shows-location(
+      href="/shows/online"
+      class= activeClass("/shows/online")
+    )=  "Online Exclusive"
     for city in featuredCities
       a.hln-link.shows-location(
         href="/shows/#{city.slug}"

--- a/src/desktop/apps/shows/test/routes.coffee
+++ b/src/desktop/apps/shows/test/routes.coffee
@@ -38,6 +38,39 @@ describe 'Shows routes', ->
           @res.render.args[0][1].cities[0].should.have.properties 'name', 'slug', 'coords'
           @res.render.args[0][1].featuredCities[0].should.have.properties 'name', 'slug', 'coords'
 
+  describe '#online', ->
+    beforeEach ->
+      @req =
+        params: { }
+        query: { page: 1 }
+      @res = { render: sinon.stub() }
+      @next = sinon.stub()
+
+    it 'fetches the cities & shows and renders the location_based', ->
+      @upcomingShow = new PartnerShow fabricate('show', start_at: moment().add(8, 'days').format(), end_at: moment().add(15, 'days').format())
+      @openingShow = new PartnerShow fabricate('show', start_at: moment().add(1, 'days').format(), end_at: moment().add(10, 'days').format())
+      @currentShow = new PartnerShow fabricate('show', start_at: moment().subtract(5, 'days').format(), end_at: moment().add(5, 'days').format())
+      @pastShow = new PartnerShow fabricate('show', start_at: moment().subtract(15, 'days').format(), end_at: moment().subtract(5, 'days').format())
+      Backbone.sync.onCall(0).yieldsTo 'success', @cities
+      Backbone.sync.onCall(1).yieldsTo 'success', @featuredCities
+      Backbone.sync.onCall(2).yieldsTo 'success', [ @openingShow, @upcomingShow ]
+      Backbone.sync.onCall(3).yieldsTo 'success', [ @currentShow ]
+      Backbone.sync.onCall(4).yieldsTo 'success', [ @pastShow ]
+
+      routes.onlineExlusive @req, @res, @next
+        .then =>
+          Backbone.sync.args[2][2].data.has_location.should.equal false
+          Backbone.sync.args[3][2].data.has_location.should.equal false
+          Backbone.sync.args[4][2].data.has_location.should.equal false
+          @res.render.called.should.be.true()
+          @res.render.getCall(0).args[0].should.equal 'location_based'
+          @res.render.getCall(0).args[1].cities.should.have.length 1
+          @res.render.getCall(0).args[1].featuredCities.should.have.length 1
+          @res.render.getCall(0).args[1].opening.should.have.length 1
+          @res.render.getCall(0).args[1].upcoming.should.have.length 1
+          @res.render.getCall(0).args[1].current.should.have.length 1
+          @res.render.getCall(0).args[1].past.should.have.length 1
+
   describe '#city', ->
     beforeEach ->
       @req =
@@ -55,7 +88,7 @@ describe 'Shows routes', ->
         .then =>
           @next.called.should.be.true()
 
-    it 'fetches the cities & shows and renders the city template', ->
+    it 'fetches the cities & shows and renders the location_based template', ->
       @upcomingShow = new PartnerShow fabricate('show', start_at: moment().add(8, 'days').format(), end_at: moment().add(15, 'days').format())
       @openingShow = new PartnerShow fabricate('show', start_at: moment().add(1, 'days').format(), end_at: moment().add(10, 'days').format())
       @currentShow = new PartnerShow fabricate('show', start_at: moment().subtract(5, 'days').format(), end_at: moment().add(5, 'days').format())
@@ -69,7 +102,7 @@ describe 'Shows routes', ->
       routes.city @req, @res, @next
         .then =>
           @res.render.called.should.be.true()
-          @res.render.getCall(0).args[0].should.equal 'city'
+          @res.render.getCall(0).args[0].should.equal 'location_based'
           @res.render.getCall(0).args[1].city.name.should.equal 'New York'
           @res.render.getCall(0).args[1].cities.should.have.length 1
           @res.render.getCall(0).args[1].featuredCities.should.have.length 1

--- a/src/desktop/apps/shows/test/templates.coffee
+++ b/src/desktop/apps/shows/test/templates.coffee
@@ -6,7 +6,7 @@ benv = require 'benv'
 Show = require '../../../models/partner_show'
 Shows = require '../shows'
 
-describe 'City', ->
+describe 'Location Based', ->
   before (done) ->
     benv.setup =>
       benv.expose $: benv.require('jquery'), jQuery: benv.require('jquery')
@@ -26,7 +26,7 @@ describe 'City', ->
 
     describe 'on the first page', ->
       before (done) ->
-        benv.render resolve(__dirname, '../templates/city.jade'), _.defaults({
+        benv.render resolve(__dirname, '../templates/location_based.jade'), _.defaults({
           opening: [new Show fabricate 'show']
           upcoming: []
           current: new Shows [fabricate 'show'], state: currentPage: 1, pageSize: 1, totalRecords: 1
@@ -40,7 +40,7 @@ describe 'City', ->
 
     describe 'on the second page', ->
       before (done) ->
-        benv.render resolve(__dirname, '../templates/city.jade'), _.defaults({
+        benv.render resolve(__dirname, '../templates/location_based.jade'), _.defaults({
           opening: [new Show fabricate 'show']
           upcoming: []
           current: new Shows _.times(2, -> fabricate 'show'), state: currentPage: 2, pageSize: 1, totalRecords: 2


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/STI-32
We want to add a new `Online Exclusive` tab to shows page which shows similar section as city based tabs except it only shows `Online Exclusive` shows.

# Solution
Added new `online` route to shows routes which basically makes same call as city based tab except instead of passing `near` it passes `has_location` and set it to `false`.
Also renamed `city.jade` to `location_based.jade` for clarity.

# Depends on
Depends on coming gravity PR where we start support  `has_location` for finding shows.
https://github.com/artsy/gravity/pull/11583

# Selfie

![screen shot 2018-02-19 at 10 25 05 am](https://user-images.githubusercontent.com/1230819/36385875-f382fd9e-1561-11e8-95a3-5391a1dae706.png)
