### PR TITLE
@yuki24: Black-list staging instead of white-listing master/release

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,7 @@
 general:
   branches:
-    only:
-      - master
-      - release
+    ignore:
+      - staging
 machine:
   node:
     version: 8.4.0


### PR DESCRIPTION
...since the latter appears to skip PRs.

Back in https://github.com/artsy/force/pull/2180, I white-listed the `master` and `release` branches because we were wasting Circle container time on rebuilding the `staging` branch immediately after each `master` build. [This Circle discussion](https://discuss.circleci.com/t/build-only-pull-request-to-a-specific-branch/903/2) says "any pull requests affecting those branches will trigger as well," but we observed that PRs no longer get built. Maybe the docs weren't referring to PRs from forks?

