### PR TITLE
@mzikherman => Bump artsy passport for redirect fix after social signup for bidding

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@artsy/express-reloadable": "^1.2.3",
-    "@artsy/passport": "^1.0.6",
+    "@artsy/passport": "^1.0.7",
     "@artsy/reaction-force": "0.21.0",
     "@artsy/stitch": "^1.3.1",
     "accounting": "^0.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,9 +9,9 @@
     chalk "^2.3.1"
     chokidar "^1.7.0"
 
-"@artsy/passport@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@artsy/passport/-/passport-1.0.6.tgz#6e42df0ad6ad440ae1feaa1b9d5c60394ab164ee"
+"@artsy/passport@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@artsy/passport/-/passport-1.0.7.tgz#429d44c74d5696fee3dba926cc3ec64bbd70cd6c"
   dependencies:
     analytics-node "^2.1.0"
     async "^1.5.0"


### PR DESCRIPTION
cc @erikdstock this fixes the case you found earlier where getting to the login/signup with facebook always redirects you to `/personalize`, even with the custom redirect (the big page) set.