### PR TITLE
@erikdstock => Add ability to follow an entity after sign up

### DIFF
--- a/src/desktop/apps/artist/client/views/related_artists.coffee
+++ b/src/desktop/apps/artist/client/views/related_artists.coffee
@@ -39,7 +39,6 @@ module.exports = class RelatedArtistsView extends ArtistArtworksView
         model: new Backbone.Model id: id
         modelName: 'artist'
         el: $el
-        href: artist.href
       id
 
     @following?.syncFollows ids

--- a/src/desktop/apps/artist/components/rail/index.coffee
+++ b/src/desktop/apps/artist/components/rail/index.coffee
@@ -21,7 +21,6 @@ setupFollowButtons = ({ $el, items, kind }) =>
       model: new Backbone.Model id: id
       modelName: kind
       el: $el
-      href: _.findWhere(items, id:id).href
     id
 
   following?.syncFollows ids

--- a/src/desktop/apps/artwork/components/related_artists/index.coffee
+++ b/src/desktop/apps/artwork/components/related_artists/index.coffee
@@ -19,7 +19,6 @@ setupFollowButtons = ({ $el, relatedArtists, kind }) ->
       model: new Backbone.Model id: id
       modelName: kind
       el: $el
-      href: _.findWhere(relatedArtists, id:id).href
     id
 
   following?.syncFollows ids

--- a/src/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
+++ b/src/desktop/apps/editorial_features/components/venice_2017/client/index.coffee
@@ -175,7 +175,6 @@ module.exports = class VeniceView extends Backbone.View
         context_page: 'venice_biennale_2017'
         context_module: 'article_artist_follow'
         entity_id: artist.id
-        href: sd.APP_URL + sd.CURRENT_PATH
       new FollowButton
         el: @$(".venice-carousel .artist-follow[data-id='#{artist.id}']")
         following: @following
@@ -184,7 +183,6 @@ module.exports = class VeniceView extends Backbone.View
         context_page: 'venice_biennale_2017'
         context_module: 'article_artist_follow'
         entity_id: artist.id
-        href: sd.APP_URL + sd.CURRENT_PATH
     @following.syncFollows(_.pluck @artists, 'id') if sd.CURRENT_USER?
     @$('.venice-body__follow-item').show()
 

--- a/src/desktop/apps/fair/components/browse/router.coffee
+++ b/src/desktop/apps/fair/components/browse/router.coffee
@@ -47,7 +47,7 @@ module.exports = class BrowseRouter extends Backbone.Router
     mediator.trigger 'open:auth',
       mode: 'register'
       copy: "Sign up to receive updates about #{@fair.nameSansYear()}"
-      redirectTo: "#{@fair.href()}/capture/#{action}"
+      destination: "#{@fair.href()}/capture/#{action}"
 
   capture: (id, action)=>
     signupSuccess fair: @fair, action: action, user: CurrentUser.orNull()

--- a/src/desktop/apps/fairs/client/index.coffee
+++ b/src/desktop/apps/fairs/client/index.coffee
@@ -36,7 +36,6 @@ module.exports.FairsView = class FairsView extends Backbone.View
             modelName: 'profile'
             model: new Profile fair.profile
             label: fair.name
-            href: "#{fair.profile.href}/follow"
             context_page: "Fairs page"
 
           fair.profile.id

--- a/src/desktop/apps/home/components/artists_to_follow/view.coffee
+++ b/src/desktop/apps/home/components/artists_to_follow/view.coffee
@@ -65,7 +65,6 @@ module.exports = class ArtistsToFollowView extends Backbone.View
       modelName: 'artist'
       hideSuggestions: true
       el: $el
-      href: _.findWhere(@results, id: id)?.href
     id
 
   afterFollow: (el, model) =>

--- a/src/desktop/apps/show/components/follow_artists/index.coffee
+++ b/src/desktop/apps/show/components/follow_artists/index.coffee
@@ -14,7 +14,6 @@ module.exports = (artists) ->
       following: following
       modelName: 'artist'
       model: new Backbone.Model artist
-      href: "#{artist.href}/follow"
       context_page: "Show page"
 
     artist.id

--- a/src/desktop/apps/show/components/follow_profile/index.coffee
+++ b/src/desktop/apps/show/components/follow_profile/index.coffee
@@ -14,7 +14,6 @@ module.exports = (profileId) ->
     following: following
     modelName: 'profile'
     model: profile
-    href: "#{profile.href()}/follow"
     context_page: "Show page"
 
   following.syncFollows [profileId] if user

--- a/src/desktop/apps/user/components/categories/view.coffee
+++ b/src/desktop/apps/user/components/categories/view.coffee
@@ -67,7 +67,7 @@ module.exports = class CategoriesView extends QuasiInfiniteView
         view = new FollowButton
           el: @$(".js-entity-follow[data-id='#{category.id}']")
           following: @allFollows
-          modelName: 'category'
+          modelName: 'gene'
           model: category
           context_page: "User setttings page"
 

--- a/src/desktop/components/article/client/image_set.coffee
+++ b/src/desktop/components/article/client/image_set.coffee
@@ -66,5 +66,4 @@ module.exports = class ImageSetView extends Backbone.View
         model: artist
         context_page: "Article page"
         context_module: 'article_image_set'
-        href: sd.APP_URL + sd.CURRENT_PATH
     @following.syncFollows(_.pluck @artists, 'id') if @user?

--- a/src/desktop/components/article/client/view.coffee
+++ b/src/desktop/components/article/client/view.coffee
@@ -85,7 +85,6 @@ module.exports = class ArticleView extends Backbone.View
         model: artist
         context_page: "Article page"
         context_module: 'article_artist_follow'
-        href: sd.APP_URL + sd.CURRENT_PATH
     @following.syncFollows(_.pluck @artists, 'id') if @user?
 
   setupImageSets: ->

--- a/src/desktop/components/auth_modal/view.coffee
+++ b/src/desktop/components/auth_modal/view.coffee
@@ -31,7 +31,6 @@ module.exports = class AuthModalView extends ModalView
 
   initialize: (options) ->
     return if isEigen.checkWith options
-
     { @destination, @successCallback, @afterSignUpAction } = options
     @redirectTo = encodeURIComponent(sanitizeRedirect(options.redirectTo)) if options.redirectTo
     @preInitialize options

--- a/src/desktop/components/eoy_artist_list/index.coffee
+++ b/src/desktop/components/eoy_artist_list/index.coffee
@@ -17,7 +17,6 @@ module.exports = (page = 'EOY 2016') ->
       modelName: 'artist'
       hideSuggestions: true
       el: $(this)
-      href: "/artist/#{$(this).data('id')}/follow"
 
     return $(this).data('id')
 

--- a/src/desktop/components/follow_button/view.coffee
+++ b/src/desktop/components/follow_button/view.coffee
@@ -56,7 +56,13 @@ module.exports = class FollowButton extends Backbone.View
       mediator.trigger 'open:auth',
         mode: 'register'
         copy: "Sign up to follow #{@label}"
-        destination: @href || "#{@model.href()}/follow"
+        destination: @href
+        afterSignUpAction: {
+          kind: @modelName.toLowerCase()
+          action: 'follow'
+          objectId: @model.id
+        }
+        
       return false
 
     # remove null values

--- a/src/desktop/components/main_layout/header/view.coffee
+++ b/src/desktop/components/main_layout/header/view.coffee
@@ -15,6 +15,8 @@ CurrentUser = require '../../../models/current_user.coffee'
 Cookies = require '../../cookies/index.coffee'
 MobileHeaderView = require './mobile_header_view.coffee'
 bundleTemplate = -> require('./templates/bundles.jade') arguments...
+{ Following } = require '../../follow_button/index.coffee'
+
 
 module.exports = class HeaderView extends Backbone.View
   events:
@@ -134,12 +136,16 @@ module.exports = class HeaderView extends Backbone.View
   checkForPostSignupAction: ->
     postSignupAction = Cookies.get 'postSignupAction'
     if postSignupAction
-      Cookies.expire 'postSignupAction'
       return unless @currentUser
-      { action, objectId } = JSON.parse(postSignupAction)
+      { action, objectId, kind } = JSON.parse(postSignupAction)
       if action is 'save'
         @currentUser.initializeDefaultArtworkCollection()
         @currentUser.defaultArtworkCollection().saveArtwork objectId
+      else if action is 'follow' and kind?
+        following = new Following [], kind: kind
+        following.follow objectId
+
+      Cookies.expire 'postSignupAction'
 
   highlightSearch: (e) ->
     if $('#main-layout-search-bar-input').is(':focus')


### PR DESCRIPTION
This adds client-side follows in the same pattern as artwork saves. I tested a bunch of different ones (artist/genes on the home page, fairs, etc.) and all seems to work locally!

The follow button-initiated sign up flow does correctly take you to onboarding (due to that `register` vs `signup` redirect fix the other day), so this removes the `destination` which was the server-side follow routes (which weren't fully implemented) in favor of the client-side follow.

So now, at least for follows, you always go thru onboarding and wind up where you started (and are following the thing).