### PR TITLE
@mzikherman => Save intent for most contexts

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,14 +7,11 @@
       "type": "shell",
       "label": "mocha: watch current file",
       "command": "yarn mocha -- --watch ${fileDirname}/${fileBasename}",
-      "group": {
-        "kind": "build",
-        "isDefault": false
-      }
+      "group": "build"
     },
     {
       "type": "shell",
-      "label": "mocha: test file",
+      "label": "mocha: test current file",
       "command": "yarn mocha -- ${fileDirname}/${fileBasename}",
       "group": {
         "kind": "build",

--- a/src/desktop/apps/auction/components/DOM.js
+++ b/src/desktop/apps/auction/components/DOM.js
@@ -9,7 +9,7 @@ class DOM extends Component {
   static propTypes = {
     auction: PropTypes.object.isRequired,
     children: PropTypes.node.isRequired,
-    user: PropTypes.object
+    user: PropTypes.object,
   }
 
   // Selectors
@@ -17,7 +17,7 @@ class DOM extends Component {
   $body = null
   $registerBtn = null
 
-  componentDidMount () {
+  componentDidMount() {
     const FastClick = require('fastclick')
 
     // removes 300ms delay
@@ -30,18 +30,18 @@ class DOM extends Component {
     this.maybeShowRegistration()
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this.removeEventListeners()
   }
 
-  addEventListeners () {
+  addEventListeners() {
     this.$body = this.$('body')
     this.$body.on('click', '.artsy-checkbox', scrollToTop)
     this.$registerBtn = this.$body.find('.js-register-button')
     this.$registerBtn.on('click', this.handleRegisterBtnClick)
   }
 
-  removeEventListeners () {
+  removeEventListeners() {
     this.$body.off('click')
     this.$registerBtn.off('click', this.handleRegisterBtnClick)
   }
@@ -52,33 +52,32 @@ class DOM extends Component {
 
       mediator.trigger('open:auth', {
         mode: 'register',
-        redirectTo: this.$(event.target).attr('href')
+        redirectTo: this.$(event.target).attr('href'),
+        signupIntent: 'register to bid',
       })
     }
   }
 
-  maybeShowRegistration () {
+  maybeShowRegistration() {
     const { auction, user } = this.props
 
     if (user) {
       if (location.pathname.match('/confirm-registration')) {
         new ConfirmRegistrationModal({
-          auction
+          auction,
         })
       }
     }
   }
 
-  render () {
+  render() {
     return this.props.children
   }
 }
 
 const mapStateToProps = (state) => ({
   auction: state.app.auction,
-  user: state.app.user
+  user: state.app.user,
 })
 
-export default connect(
-  mapStateToProps
-)(DOM)
+export default connect(mapStateToProps)(DOM)

--- a/src/desktop/apps/home/client/hero_unit_view.coffee
+++ b/src/desktop/apps/home/client/hero_unit_view.coffee
@@ -93,4 +93,4 @@ module.exports = class HeroUnitView extends Backbone.View
 
   signUp: (e) ->
     e.preventDefault()
-    mediator.trigger 'open:auth', mode: 'signup'
+    mediator.trigger 'open:auth', mode: 'signup', signupIntent: 'sign up'

--- a/src/desktop/components/artwork_item/save_controls/view.coffee
+++ b/src/desktop/components/artwork_item/save_controls/view.coffee
@@ -37,6 +37,7 @@ module.exports = class SaveControls extends Backbone.View
           action: 'save',
           objectId: @model.id
         }
+        signupIntent: 'save artwork'
       return false
 
     trackedProperties = {

--- a/src/desktop/components/artwork_save/view.coffee
+++ b/src/desktop/components/artwork_save/view.coffee
@@ -33,6 +33,7 @@ module.exports = class ArtworkSaveView extends Backbone.View
           action: 'save',
           objectId: @id
         }
+        signupIntent: 'save artwork'
 
     if @saved
       save = @savedArtworks.get @id

--- a/src/desktop/components/auth_modal/view.coffee
+++ b/src/desktop/components/auth_modal/view.coffee
@@ -39,7 +39,6 @@ module.exports = class AuthModalView extends ModalView
 
   preInitialize: (options = {}) ->
     { @copy, @context, @signupIntent } = options
-    console.log('***', 'signup intent: ' + @signupIntent)
     @user = new LoggedOutUser
     mode = mode: options.mode if options.mode
     @state = new State mode

--- a/src/desktop/components/auth_modal/view.coffee
+++ b/src/desktop/components/auth_modal/view.coffee
@@ -39,6 +39,7 @@ module.exports = class AuthModalView extends ModalView
 
   preInitialize: (options = {}) ->
     { @copy, @context, @signupIntent } = options
+    console.log('***', 'signup intent: ' + @signupIntent)
     @user = new LoggedOutUser
     mode = mode: options.mode if options.mode
     @state = new State mode

--- a/src/desktop/components/follow_button/view.coffee
+++ b/src/desktop/components/follow_button/view.coffee
@@ -62,7 +62,7 @@ module.exports = class FollowButton extends Backbone.View
           action: 'follow'
           objectId: @model.id
         }
-        
+        signupIntent: "follow #{@modelName}"
       return false
 
     # remove null values

--- a/src/desktop/components/main_layout/header/view.coffee
+++ b/src/desktop/components/main_layout/header/view.coffee
@@ -110,11 +110,11 @@ module.exports = class HeaderView extends Backbone.View
 
   signup: (e) ->
     e.preventDefault()
-    mediator.trigger 'open:auth', mode: 'signup'
+    mediator.trigger 'open:auth', mode: 'signup', signupIntent: 'sign up'
 
   login: (e) ->
     e.preventDefault()
-    mediator.trigger 'open:auth', mode: 'login'
+    mediator.trigger 'open:auth', mode: 'login', signupIntent: 'sign up'
 
   logout: (e) ->
     e.preventDefault()

--- a/src/desktop/components/save_button/view.coffee
+++ b/src/desktop/components/save_button/view.coffee
@@ -37,6 +37,7 @@ module.exports = class SaveButton extends Backbone.View
           action: 'save',
           objectId: @model.id
         }
+        signupIntent: 'save artwork'
       return false
 
     trackedProperties = {


### PR DESCRIPTION
This adds intent tracking to the auth modal creation points listed below. There are a few more tricky cases, but most of the work here was finding and checking each case was called correctly. The possible `signupIntent`s are:
```
follow artist
follow profile
follow gene
save artwork
bid
register to bid
sign up
```
These have been added to:

- /artists --> Follow artist
- Artist list view - Follow artist
- Artist view - Follow artist
- Artist view - Related artists - Follow artist
- Artwork view - Follow artist
- Artwork view - Related artists - Follow artist
- Artwork view - Related works - Save work
- Artwork view - Save work
- Auction Sale - Register to bid
- Category view - Follow artist
- Category view - follow gene
- Fair booth view - Follow artist
- Fair booth view - follow profile
- Fair booth view - Save work
- Fair list view - follow profile
- Fair view - follow profile
- Fair view - Save work
- Gallery list view - follow profile
- Gallery view - Artists - Follow artist
- Gallery view - Artists - Save work
- Gallery view - follow profile
- Gallery view - Works - Save work
- Home banner - Sign up
- Home view - Follow artist
- Home view - follow gene
- Log in - Sign up
- Museum list view - follow profile
- Recently viewed works - Save
- Show list view - follow profile
- Show list view - Save work
- Show view - follow profile
- Show view - Save work

