### PR TITLE
@xtina-starr => add signupIntent to more auth points

### DIFF
--- a/src/desktop/apps/about/client/view.coffee
+++ b/src/desktop/apps/about/client/view.coffee
@@ -36,7 +36,7 @@ module.exports = class AboutView extends Backbone.View
     e.preventDefault()
     mediator.trigger 'open:auth',
       mode: 'register',
-      signupIntent: 'about page signup cta'
+      signupIntent: 'sign up to save works'
 
   intercept: (e) ->
     e.preventDefault()

--- a/src/desktop/apps/about/client/view.coffee
+++ b/src/desktop/apps/about/client/view.coffee
@@ -34,7 +34,9 @@ module.exports = class AboutView extends Backbone.View
 
   signup: (e) ->
     e.preventDefault()
-    mediator.trigger 'open:auth', mode: 'register'
+    mediator.trigger 'open:auth',
+      mode: 'register',
+      signupIntent: 'about page signup cta'
 
   intercept: (e) ->
     e.preventDefault()

--- a/src/desktop/apps/fairs/client/index.coffee
+++ b/src/desktop/apps/fairs/client/index.coffee
@@ -48,7 +48,7 @@ module.exports.FairsView = class FairsView extends Backbone.View
     mediator.trigger 'open:auth',
       mode: 'register'
       copy: "Sign up to follow fairs"
-      signupIntent: 'fairs page cta'
+      signupIntent: 'sign up to follow fairs'
 
   renderPastFairs: (fairs)->
     @$('#fairs-see-more').removeClass 'is-loading'

--- a/src/desktop/apps/fairs/client/index.coffee
+++ b/src/desktop/apps/fairs/client/index.coffee
@@ -48,6 +48,7 @@ module.exports.FairsView = class FairsView extends Backbone.View
     mediator.trigger 'open:auth',
       mode: 'register'
       copy: "Sign up to follow fairs"
+      signupIntent: 'fairs page cta'
 
   renderPastFairs: (fairs)->
     @$('#fairs-see-more').removeClass 'is-loading'

--- a/src/desktop/components/artist_page_cta/templates/register.jade
+++ b/src/desktop/components/artist_page_cta/templates/register.jade
@@ -27,7 +27,7 @@ div.artist-page-cta-overlay__register
   h2
     span Or
 
-  a.auth-signup-facebook.avant-garde-button-black(href="/users/auth/facebook?skip-onboarding=true&modal_id=artist_page_cta&redirect-to=#{afterAuthPath}", data-context='artist_page_cta')
+  a.auth-signup-facebook.avant-garde-button-black(href="/users/auth/facebook?skip-onboarding=true&modal_id=artist_page_cta&redirect-to=#{afterAuthPath}&signup-intent=#{signupIntent}", data-context='artist_page_cta')
     i.icon-facebook
     | Continue with Facebook
 

--- a/src/desktop/components/artist_page_cta/view.coffee
+++ b/src/desktop/components/artist_page_cta/view.coffee
@@ -43,6 +43,7 @@ module.exports = class ArtistPageCTAView extends Backbone.View
       width: '500px'
       mode: 'login'
       redirectTo: @afterAuthPath
+      signupIntent: 'artist page cta'
 
   currentParams: ->
     qs.parse(location.search.replace(/^\?/, ''))

--- a/src/desktop/components/artist_page_cta/view.coffee
+++ b/src/desktop/components/artist_page_cta/view.coffee
@@ -30,6 +30,7 @@ module.exports = class ArtistPageCTAView extends Backbone.View
     @desiredScrollPosition = @$window.height() * 2
     @alreadyDismissed = false
     @afterAuthPath = "/personalize"
+    @signupIntent = "landing full page modal"
     @$window.on 'scroll', _.throttle(@maybeShowOverlay, 200)
     mediator.on 'clickFollowButton', @fullScreenOverlay
     mediator.on 'clickHeaderAuth', @fullScreenOverlay
@@ -43,7 +44,7 @@ module.exports = class ArtistPageCTAView extends Backbone.View
       width: '500px'
       mode: 'login'
       redirectTo: @afterAuthPath
-      signupIntent: 'artist page cta'
+      signupIntent: @signupIntent
 
   currentParams: ->
     qs.parse(location.search.replace(/^\?/, ''))
@@ -94,6 +95,7 @@ module.exports = class ArtistPageCTAView extends Backbone.View
     @$('button').attr 'data-state', 'loading'
 
     @user.set (data = @serializeForm())
+    @user.set(signupIntent: @signupIntent)
     @user.signup
       success: @onRegisterSuccess
       error: (model, response, options) =>
@@ -111,6 +113,7 @@ module.exports = class ArtistPageCTAView extends Backbone.View
     @$el.html template
       artist: @artist
       afterAuthPath: @afterAuthPath
+      signupIntent: encodeURIComponent(@signupIntent)
     @$banner = @$('.artist-page-cta-banner')
     @$overlay = @$('.artist-page-cta-overlay')
     @

--- a/src/desktop/components/commercial_filter/filters/followed_artists/followed_artist_filter_view.coffee
+++ b/src/desktop/components/commercial_filter/filters/followed_artists/followed_artist_filter_view.coffee
@@ -29,7 +29,10 @@ module.exports = class FollowedArtistsFilterView extends Backbone.View
 
   signup: (e) ->
     e.preventDefault()
-    mediator.trigger 'open:auth', mode: 'register', copy: "Sign up to receive alerts when new works are available by artists you follow."
+    mediator.trigger 'open:auth',
+      mode: 'register',
+      copy: "Sign up to receive alerts when new works are available by artists you follow.",
+      signupIntent: 'commercial filter collect cta'
 
   trackAnalytics: ->
     if @params.get('include_artworks_by_followed_artists')

--- a/src/desktop/components/commercial_filter/filters/followed_artists/followed_artist_filter_view.coffee
+++ b/src/desktop/components/commercial_filter/filters/followed_artists/followed_artist_filter_view.coffee
@@ -32,7 +32,7 @@ module.exports = class FollowedArtistsFilterView extends Backbone.View
     mediator.trigger 'open:auth',
       mode: 'register',
       copy: "Sign up to receive alerts when new works are available by artists you follow.",
-      signupIntent: 'commercial filter collect cta'
+      signupIntent: 'artists you follow filter'
 
   trackAnalytics: ->
     if @params.get('include_artworks_by_followed_artists')

--- a/src/desktop/components/marketing_signup_modal/index.coffee
+++ b/src/desktop/components/marketing_signup_modal/index.coffee
@@ -23,7 +23,9 @@ class MarketingSignupModalInner extends Backbone.View
 
   openLogin: (e) ->
     e.preventDefault()
-    mediator.trigger 'open:auth', mode: 'login'
+    mediator.trigger 'open:auth',
+      mode: 'login'
+      signupIntent: 'marketing cta modal'
     @trigger 'close'
 
   submit: (e) ->

--- a/src/desktop/components/marketing_signup_modal/index.coffee
+++ b/src/desktop/components/marketing_signup_modal/index.coffee
@@ -25,7 +25,7 @@ class MarketingSignupModalInner extends Backbone.View
     e.preventDefault()
     mediator.trigger 'open:auth',
       mode: 'login'
-      signupIntent: 'marketing cta modal'
+      signupIntent: 'marketing modal'
     @trigger 'close'
 
   submit: (e) ->


### PR DESCRIPTION
cc @katarinabatina @mzikherman @anipetrov 
This PR adds signup intent tracking to several CTAs throughout force. I paired with @xtina-starr on this.

_updated- per ani's requests [below]_
```
- fairs list: 'sign up to follow fairs'
- artist page cta from full page sign up modal: 'landing full page modal'
- fair popup modal (marekting_signup_modal): 'marketing modal'
- /collect sign up button cta: 'artists you follow filter'
- about sign up button: 'sign up to save works'
```