### PR TITLE
Set the JPEG image quality to 80

### DIFF
--- a/src/desktop/apps/about/templates/sections/hero_unit.jade
+++ b/src/desktop/apps/about/templates/sections/hero_unit.jade
@@ -17,7 +17,7 @@
   ul.about-hero-unit-bgs
     for image, i in hero.images
       li.about-hero-unit-bg(
-        style="background-image: url(#{crop(image.src, { width: 1500, height: 900, quality: 90 })})"
+        style="background-image: url(#{crop(image.src, { width: 1500, height: 900 })})"
         class=(i === 0 ? 'is-active' : undefined)
       )
         .about-hero-unit-bg-credit: span= image.credit

--- a/src/desktop/apps/armory_week/fixture.json
+++ b/src/desktop/apps/armory_week/fixture.json
@@ -61,19 +61,19 @@
       {
         "article_url": "https://www.artsy.net/article/artsy-editorial-the-20-best-booths-at-art-basel-in-miami-beach",
         "author": "ANNA LOUIE SUSSMAN",
-        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlhQti2pXrsXDLlS8jJEIDg%252F_AR_3443.jpg&width=1100&quality=95",
+        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlhQti2pXrsXDLlS8jJEIDg%252F_AR_3443.jpg&width=1100&quality=80",
         "title": "The 20 Best Booths at Art Basel in Miami Beach"
       },
       {
         "article_url": "https://www.artsy.net/article/artsy-editorial-50-must-see-artworks-at-miami-art-week-s-satellite-fairs",
         "author": "ARTSY EDITORIAL",
-        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FvClMRePyeu9nCashzAgEeA%252F_AR_3326.jpg&width=1100&quality=95",
+        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FvClMRePyeu9nCashzAgEeA%252F_AR_3326.jpg&width=1100&quality=80",
         "title": "50 Must-See Artworks at Miami Art Week’s Satellite Fairs"
       },
       {
         "article_url": "https://www.artsy.net/article/artsy-editorial-the-10-best-booths-at-design-miami",
         "author": "ARTSY EDITORIAL",
-        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FOX8QZ5TCXVt8szczr7oWZQ%252Fammann.jpg&width=1100&quality=95",
+        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FOX8QZ5TCXVt8szczr7oWZQ%252Fammann.jpg&width=1100&quality=80",
         "title": "The 10 Best Booths at Design Miami/"
       }
     ],

--- a/src/desktop/apps/artsy_in_miami/fixture.json
+++ b/src/desktop/apps/artsy_in_miami/fixture.json
@@ -46,19 +46,19 @@
     "title": "Stories from Miami",
     "articles": [
       {
-        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlhQti2pXrsXDLlS8jJEIDg%252F_AR_3443.jpg&width=1100&quality=95",
+        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlhQti2pXrsXDLlS8jJEIDg%252F_AR_3443.jpg&width=1100&quality=80",
         "title": "The 20 Best Booths at Art Basel in Miami Beach",
         "author": "ANNA LOUIE SUSSMAN",
         "article_url": "https://www.artsy.net/article/artsy-editorial-the-20-best-booths-at-art-basel-in-miami-beach"
       },
       {
-        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FvClMRePyeu9nCashzAgEeA%252F_AR_3326.jpg&width=1100&quality=95",
+        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FvClMRePyeu9nCashzAgEeA%252F_AR_3326.jpg&width=1100&quality=80",
         "title": "50 Must-See Artworks at Miami Art Week’s Satellite Fairs",
         "author": "ARTSY EDITORIAL",
         "article_url": "https://www.artsy.net/article/artsy-editorial-50-must-see-artworks-at-miami-art-week-s-satellite-fairs"
       },
       {
-        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FOX8QZ5TCXVt8szczr7oWZQ%252Fammann.jpg&width=1100&quality=95",
+        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FOX8QZ5TCXVt8szczr7oWZQ%252Fammann.jpg&width=1100&quality=80",
         "title": "The 10 Best Booths at Design Miami/",
         "author": "ARTSY EDITORIAL",
         "article_url": "https://www.artsy.net/article/artsy-editorial-the-10-best-booths-at-design-miami"

--- a/src/desktop/apps/artwork/components/related_artists/test/artists_fixture.coffee
+++ b/src/desktop/apps/artwork/components/related_artists/test/artists_fixture.coffee
@@ -45,7 +45,7 @@ module.exports =
         "name": "James Rosenquist",
         "image": {
           "cropped": {
-            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F3VUm07DpKQNQdA_QfCrPcA%2Flarge.jpg"
+            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F3VUm07DpKQNQdA_QfCrPcA%2Flarge.jpg"
           }
         },
         "birthday": "1933",
@@ -62,7 +62,7 @@ module.exports =
         "name": "Tom Wesselmann",
         "image": {
           "cropped": {
-            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F8smV519M1L352CTihrfW7A%2Flarge.jpg"
+            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F8smV519M1L352CTihrfW7A%2Flarge.jpg"
           }
         },
         "birthday": "1931",
@@ -79,7 +79,7 @@ module.exports =
         "name": "Roy Lichtenstein",
         "image": {
           "cropped": {
-            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2For9oKva9F7V4VjrUKKx2iA%2Flarge.jpg"
+            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2For9oKva9F7V4VjrUKKx2iA%2Flarge.jpg"
           }
         },
         "birthday": "1923",
@@ -96,7 +96,7 @@ module.exports =
         "name": "Robert Indiana",
         "image": {
           "cropped": {
-            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FxPV7zLtiKJPPxRVJTEtHIA%2Flarge.jpg"
+            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FxPV7zLtiKJPPxRVJTEtHIA%2Flarge.jpg"
           }
         },
         "birthday": "1928",
@@ -113,7 +113,7 @@ module.exports =
         "name": "Jim Dine",
         "image": {
           "cropped": {
-            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FLl4gMf_OsLMehbgv05H6mw%2Flarge.jpg"
+            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FLl4gMf_OsLMehbgv05H6mw%2Flarge.jpg"
           }
         },
         "birthday": "1935",
@@ -130,7 +130,7 @@ module.exports =
         "name": "Claes Oldenburg & Coosje van Bruggen",
         "image": {
           "cropped": {
-            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FlnJopeqKO7np6fvqpegQpQ%2Flarge.jpg"
+            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FlnJopeqKO7np6fvqpegQpQ%2Flarge.jpg"
           }
         },
         "birthday": "1929 and 1942",
@@ -147,7 +147,7 @@ module.exports =
         "name": "Richard Hamilton",
         "image": {
           "cropped": {
-            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCqLm5-pqOP2wlCcXoxTkhw%2Flarge.jpg"
+            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCqLm5-pqOP2wlCcXoxTkhw%2Flarge.jpg"
           }
         },
         "birthday": "1922",

--- a/src/desktop/apps/auction/__tests__/fixtures/auction.js
+++ b/src/desktop/apps/auction/__tests__/fixtures/auction.js
@@ -1,319 +1,326 @@
 /* eslint-disable */
 
 export default {
-  "app": {
-    "articles": [
-
-    ],
-    "auction": {
-      "_id": "59579ab88b0c145b525ce2eb",
-      "associated_sale": null,
-      "auction_state": "open",
-      "cover_image": {
-        "cropped": {
-          "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=1800&height=600&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F53bAi6FmM1IFOgPOcJorqw%2Fwide.jpg"
-        }
+  app: {
+    articles: [],
+    auction: {
+      _id: '59579ab88b0c145b525ce2eb',
+      associated_sale: null,
+      auction_state: 'open',
+      cover_image: {
+        cropped: {
+          url:
+            'https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=1800&height=600&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F53bAi6FmM1IFOgPOcJorqw%2Fwide.jpg',
+        },
       },
-      "currency": "USD",
-      "description": "Artsy presents **Wright: Art + Design,** featuring works by Greg Lynn, Takashi Murakami, Joan Mir\u00f3, and more. In advance of the auction, browse lots and place max bids before live bidding begins on **July 18th at 12:00pm CT (1:00pm ET).**\r\n\r\nWhen the sale opens, all pre-registered Artsy users can participate and watch the bidding unfold in real time. Registration for the live auction will close on **July 17th at 12:00pm CT (1:00pm ET).**",
-      "eligible_sale_artworks_count": 350,
-      "end_at": null,
-      "id": "wright-art-plus-design-2",
-      "is_auction": true,
-      "is_closed": false,
-      "is_live_open": false,
-      "is_open": true,
-      "live_start_at": "2025-07-18T17:00:00+00:00",
-      "name": "Wright: Art + Design",
-      "registration_ends_at": "2025-07-17T17:00:00+00:00",
-      "start_at": "2017-07-03T18:30:00+00:00",
-      "status": "open",
-      "symbol": "$"
+      currency: 'USD',
+      description:
+        'Artsy presents **Wright: Art + Design,** featuring works by Greg Lynn, Takashi Murakami, Joan Mir\u00f3, and more. In advance of the auction, browse lots and place max bids before live bidding begins on **July 18th at 12:00pm CT (1:00pm ET).**\r\n\r\nWhen the sale opens, all pre-registered Artsy users can participate and watch the bidding unfold in real time. Registration for the live auction will close on **July 17th at 12:00pm CT (1:00pm ET).**',
+      eligible_sale_artworks_count: 350,
+      end_at: null,
+      id: 'wright-art-plus-design-2',
+      is_auction: true,
+      is_closed: false,
+      is_live_open: false,
+      is_open: true,
+      live_start_at: '2025-07-18T17:00:00+00:00',
+      name: 'Wright: Art + Design',
+      registration_ends_at: '2025-07-17T17:00:00+00:00',
+      start_at: '2017-07-03T18:30:00+00:00',
+      status: 'open',
+      symbol: '$',
     },
-    "footerItems": [
+    footerItems: [
       {
-        "href": "https:\/\/app.adjust.com\/v627ct",
-        "target": "_blank",
-        "src": "\/images\/preview-iphone.jpg",
-        "alt": "iPhone",
-        "title": "Bid from your phone",
-        "subtitle": "Download Artsy for iPhone"
-      }
+        href: 'https://app.adjust.com/v627ct',
+        target: '_blank',
+        src: '/images/preview-iphone.jpg',
+        alt: 'iPhone',
+        title: 'Bid from your phone',
+        subtitle: 'Download Artsy for iPhone',
+      },
     ],
-    "isLiveOpen": false,
-    "isMobile": true,
-    "liveAuctionUrl": "https:\/\/live.artsy.net\/wright-art-plus-design-2\/login",
-    "me": {
-      "id": "58828b1e9c18db30f3002fba",
-      "bidders": [
-
-      ],
-      "lot_standings": [
-
-      ]
+    isLiveOpen: false,
+    isMobile: true,
+    liveAuctionUrl: 'https://live.artsy.net/wright-art-plus-design-2/login',
+    me: {
+      id: '58828b1e9c18db30f3002fba',
+      bidders: [],
+      lot_standings: [],
     },
-    "sd": {
-
-    },
-    "showInfoWindow": false
+    sd: {},
+    showInfoWindow: false,
   },
-  "artworkBrowser": {
-    "aggregatedArtists": [
+  artworkBrowser: {
+    aggregatedArtists: [
       {
-        "id": "alvar-aalto",
-        "name": "Alvar Aalto",
-        "count": 1
-      }
-    ],
-    "aggregatedMediums": [
-      {
-        "id": "design",
-        "name": "Design",
-        "count": 189
-      }
-    ],
-    "allFetched": false,
-    "showFollowedArtistsRail": false,
-    "filterParams": {
-      "aggregations": [
-        "ARTIST",
-        "FOLLOWED_ARTISTS",
-        "MEDIUM",
-        "TOTAL"
-      ],
-      "artist_ids": [
-
-      ],
-      "estimate_range": "",
-      "gene_ids": [
-
-      ],
-      "include_artworks_by_followed_artists": false,
-      "page": 1,
-      "sale_id": "wright-art-plus-design-2",
-      "size": 50,
-      "ranges": {
-        "estimate_range": {
-          "min": 0,
-          "max": 50000
-        }
+        id: 'alvar-aalto',
+        name: 'Alvar Aalto',
+        count: 1,
       },
-      "sort": "position"
+    ],
+    aggregatedMediums: [
+      {
+        id: 'design',
+        name: 'Design',
+        count: 189,
+      },
+    ],
+    allFetched: false,
+    showFollowedArtistsRail: false,
+    filterParams: {
+      aggregations: ['ARTIST', 'FOLLOWED_ARTISTS', 'MEDIUM', 'TOTAL'],
+      artist_ids: [],
+      estimate_range: '',
+      gene_ids: [],
+      include_artworks_by_followed_artists: false,
+      page: 1,
+      sale_id: 'wright-art-plus-design-2',
+      size: 50,
+      ranges: {
+        estimate_range: {
+          min: 0,
+          max: 50000,
+        },
+      },
+      sort: 'position',
     },
-    "followedArtistRailMax": 50,
-    "followedArtistRailPage": 1,
-    "followedArtistRailSize": 4,
-    "initialMediumMap": [
+    followedArtistRailMax: 50,
+    followedArtistRailPage: 1,
+    followedArtistRailSize: 4,
+    initialMediumMap: [
       {
-        "id": "design",
-        "name": "Design",
-        "count": 189
+        id: 'design',
+        name: 'Design',
+        count: 189,
       },
       {
-        "id": "prints",
-        "name": "Prints",
-        "count": 51
+        id: 'prints',
+        name: 'Prints',
+        count: 51,
       },
       {
-        "id": "photography",
-        "name": "Photography",
-        "count": 34
+        id: 'photography',
+        name: 'Photography',
+        count: 34,
       },
       {
-        "id": "sculpture",
-        "name": "Sculpture",
-        "count": 30
+        id: 'sculpture',
+        name: 'Sculpture',
+        count: 30,
       },
       {
-        "id": "painting",
-        "name": "Painting",
-        "count": 19
-      }
+        id: 'painting',
+        name: 'Painting',
+        count: 19,
+      },
     ],
-    "isClosed": false,
-    "isFetchingArtworks": false,
-    "isLastFollowedArtistsPage": false,
-    "isListView": false,
-    "maxEstimateRangeDisplay": 50000,
-    "minEstimateRangeDisplay": 0,
-    "numArtistsYouFollow": 0,
-    "saleArtworks": [
+    isClosed: false,
+    isFetchingArtworks: false,
+    isLastFollowedArtistsPage: false,
+    isListView: false,
+    maxEstimateRangeDisplay: 50000,
+    minEstimateRangeDisplay: 0,
+    numArtistsYouFollow: 0,
+    saleArtworks: [
       {
-        "id": "takashi-murakami-oval-peter-norton-christmas-project",
-        "lot_label": "100",
-        "counts": {
-          "bidder_positions": 12
+        id: 'takashi-murakami-oval-peter-norton-christmas-project',
+        lot_label: '100',
+        counts: {
+          bidder_positions: 12,
         },
-        "current_bid": {
-          "display": "$2,400"
+        current_bid: {
+          display: '$2,400',
         },
-        "artwork": {
-          "__id": "QXJ0d29yazp0YWthc2hpLW11cmFrYW1pLW92YWwtcGV0ZXItbm9ydG9uLWNocmlzdG1hcy1wcm9qZWN0",
-          "_id": "595a66178b0c145b525cfc24",
-          "id": "takashi-murakami-oval-peter-norton-christmas-project",
-          "date": "2000",
-          "href": "\/artwork\/takashi-murakami-oval-peter-norton-christmas-project",
-          "title": "Oval (Peter Norton Christmas Project)",
-          "is_sold": false,
-          "image": {
-            "url": "https:\/\/d32dm0rphc51dk.cloudfront.net\/ox6Gfp7QONQMlteR9FO8gw\/normalized.jpg"
+        artwork: {
+          __id:
+            'QXJ0d29yazp0YWthc2hpLW11cmFrYW1pLW92YWwtcGV0ZXItbm9ydG9uLWNocmlzdG1hcy1wcm9qZWN0',
+          _id: '595a66178b0c145b525cfc24',
+          id: 'takashi-murakami-oval-peter-norton-christmas-project',
+          date: '2000',
+          href: '/artwork/takashi-murakami-oval-peter-norton-christmas-project',
+          title: 'Oval (Peter Norton Christmas Project)',
+          is_sold: false,
+          image: {
+            url:
+              'https://d32dm0rphc51dk.cloudfront.net/ox6Gfp7QONQMlteR9FO8gw/normalized.jpg',
           },
-          "images": [
+          images: [
             {
-              "aspect_ratio": 1,
-              "id": "595a66179c18db3d188c9b52",
-              "image_url": "https:\/\/d32dm0rphc51dk.cloudfront.net\/ox6Gfp7QONQMlteR9FO8gw\/large.jpg",
-              "image_large": "https:\/\/d32dm0rphc51dk.cloudfront.net\/ox6Gfp7QONQMlteR9FO8gw\/large.jpg",
-              "image_medium": "https:\/\/d32dm0rphc51dk.cloudfront.net\/ox6Gfp7QONQMlteR9FO8gw\/medium.jpg",
-              "image_versions": [
-                "large_rectangle",
-                "medium_rectangle",
-                "square",
-                "small",
-                "tall",
-                "larger",
-                "large",
-                "medium",
-                "normalized"
+              aspect_ratio: 1,
+              id: '595a66179c18db3d188c9b52',
+              image_url:
+                'https://d32dm0rphc51dk.cloudfront.net/ox6Gfp7QONQMlteR9FO8gw/large.jpg',
+              image_large:
+                'https://d32dm0rphc51dk.cloudfront.net/ox6Gfp7QONQMlteR9FO8gw/large.jpg',
+              image_medium:
+                'https://d32dm0rphc51dk.cloudfront.net/ox6Gfp7QONQMlteR9FO8gw/medium.jpg',
+              image_versions: [
+                'large_rectangle',
+                'medium_rectangle',
+                'square',
+                'small',
+                'tall',
+                'larger',
+                'large',
+                'medium',
+                'normalized',
               ],
-              "placeholder": {
-                "image_url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fox6Gfp7QONQMlteR9FO8gw%2Ftall.jpg"
-              }
+              placeholder: {
+                image_url:
+                  'https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fox6Gfp7QONQMlteR9FO8gw%2Ftall.jpg',
+              },
             },
             {
-              "aspect_ratio": 1,
-              "id": "595a6cd5c9dc2404d2311caf",
-              "image_url": "https:\/\/d32dm0rphc51dk.cloudfront.net\/Z5bu-yvC105gVFbqlwEEKA\/large.jpg",
-              "image_large": "https:\/\/d32dm0rphc51dk.cloudfront.net\/Z5bu-yvC105gVFbqlwEEKA\/large.jpg",
-              "image_medium": "https:\/\/d32dm0rphc51dk.cloudfront.net\/Z5bu-yvC105gVFbqlwEEKA\/medium.jpg",
-              "image_versions": [
-                "square",
-                "large_rectangle",
-                "medium_rectangle",
-                "tall",
-                "small",
-                "large",
-                "medium",
-                "larger",
-                "normalized"
+              aspect_ratio: 1,
+              id: '595a6cd5c9dc2404d2311caf',
+              image_url:
+                'https://d32dm0rphc51dk.cloudfront.net/Z5bu-yvC105gVFbqlwEEKA/large.jpg',
+              image_large:
+                'https://d32dm0rphc51dk.cloudfront.net/Z5bu-yvC105gVFbqlwEEKA/large.jpg',
+              image_medium:
+                'https://d32dm0rphc51dk.cloudfront.net/Z5bu-yvC105gVFbqlwEEKA/medium.jpg',
+              image_versions: [
+                'square',
+                'large_rectangle',
+                'medium_rectangle',
+                'tall',
+                'small',
+                'large',
+                'medium',
+                'larger',
+                'normalized',
               ],
-              "placeholder": {
-                "image_url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FZ5bu-yvC105gVFbqlwEEKA%2Ftall.jpg"
-              }
+              placeholder: {
+                image_url:
+                  'https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FZ5bu-yvC105gVFbqlwEEKA%2Ftall.jpg',
+              },
             },
             {
-              "aspect_ratio": 1,
-              "id": "595a6cd58b3b814fc9d1893e",
-              "image_url": "https:\/\/d32dm0rphc51dk.cloudfront.net\/Yo4NGkesj46MniELKbvWwg\/large.jpg",
-              "image_large": "https:\/\/d32dm0rphc51dk.cloudfront.net\/Yo4NGkesj46MniELKbvWwg\/large.jpg",
-              "image_medium": "https:\/\/d32dm0rphc51dk.cloudfront.net\/Yo4NGkesj46MniELKbvWwg\/medium.jpg",
-              "image_versions": [
-                "square",
-                "large_rectangle",
-                "medium_rectangle",
-                "small",
-                "large",
-                "tall",
-                "medium",
-                "larger",
-                "normalized"
+              aspect_ratio: 1,
+              id: '595a6cd58b3b814fc9d1893e',
+              image_url:
+                'https://d32dm0rphc51dk.cloudfront.net/Yo4NGkesj46MniELKbvWwg/large.jpg',
+              image_large:
+                'https://d32dm0rphc51dk.cloudfront.net/Yo4NGkesj46MniELKbvWwg/large.jpg',
+              image_medium:
+                'https://d32dm0rphc51dk.cloudfront.net/Yo4NGkesj46MniELKbvWwg/medium.jpg',
+              image_versions: [
+                'square',
+                'large_rectangle',
+                'medium_rectangle',
+                'small',
+                'large',
+                'tall',
+                'medium',
+                'larger',
+                'normalized',
               ],
-              "placeholder": {
-                "image_url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fit&width=29&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FYo4NGkesj46MniELKbvWwg%2Ftall.jpg"
-              }
+              placeholder: {
+                image_url:
+                  'https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=29&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FYo4NGkesj46MniELKbvWwg%2Ftall.jpg',
+              },
             },
             {
-              "aspect_ratio": 1,
-              "id": "595a6cd52a893a02c51d7db9",
-              "image_url": "https:\/\/d32dm0rphc51dk.cloudfront.net\/0R8qRiPoDecXg7lIVTljSw\/large.jpg",
-              "image_large": "https:\/\/d32dm0rphc51dk.cloudfront.net\/0R8qRiPoDecXg7lIVTljSw\/large.jpg",
-              "image_medium": "https:\/\/d32dm0rphc51dk.cloudfront.net\/0R8qRiPoDecXg7lIVTljSw\/medium.jpg",
-              "image_versions": [
-                "square",
-                "large_rectangle",
-                "medium_rectangle",
-                "small",
-                "tall",
-                "large",
-                "medium",
-                "larger",
-                "normalized"
+              aspect_ratio: 1,
+              id: '595a6cd52a893a02c51d7db9',
+              image_url:
+                'https://d32dm0rphc51dk.cloudfront.net/0R8qRiPoDecXg7lIVTljSw/large.jpg',
+              image_large:
+                'https://d32dm0rphc51dk.cloudfront.net/0R8qRiPoDecXg7lIVTljSw/large.jpg',
+              image_medium:
+                'https://d32dm0rphc51dk.cloudfront.net/0R8qRiPoDecXg7lIVTljSw/medium.jpg',
+              image_versions: [
+                'square',
+                'large_rectangle',
+                'medium_rectangle',
+                'small',
+                'tall',
+                'large',
+                'medium',
+                'larger',
+                'normalized',
               ],
-              "placeholder": {
-                "image_url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fit&width=29&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F0R8qRiPoDecXg7lIVTljSw%2Ftall.jpg"
-              }
+              placeholder: {
+                image_url:
+                  'https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=29&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F0R8qRiPoDecXg7lIVTljSw%2Ftall.jpg',
+              },
             },
             {
-              "aspect_ratio": 1,
-              "id": "595a6cd5139b2138a48cd004",
-              "image_url": "https:\/\/d32dm0rphc51dk.cloudfront.net\/Du29whk8s42GlJSBrA5nyw\/large.jpg",
-              "image_large": "https:\/\/d32dm0rphc51dk.cloudfront.net\/Du29whk8s42GlJSBrA5nyw\/large.jpg",
-              "image_medium": "https:\/\/d32dm0rphc51dk.cloudfront.net\/Du29whk8s42GlJSBrA5nyw\/medium.jpg",
-              "image_versions": [
-                "square",
-                "large_rectangle",
-                "medium_rectangle",
-                "small",
-                "tall",
-                "large",
-                "medium",
-                "larger",
-                "normalized"
+              aspect_ratio: 1,
+              id: '595a6cd5139b2138a48cd004',
+              image_url:
+                'https://d32dm0rphc51dk.cloudfront.net/Du29whk8s42GlJSBrA5nyw/large.jpg',
+              image_large:
+                'https://d32dm0rphc51dk.cloudfront.net/Du29whk8s42GlJSBrA5nyw/large.jpg',
+              image_medium:
+                'https://d32dm0rphc51dk.cloudfront.net/Du29whk8s42GlJSBrA5nyw/medium.jpg',
+              image_versions: [
+                'square',
+                'large_rectangle',
+                'medium_rectangle',
+                'small',
+                'tall',
+                'large',
+                'medium',
+                'larger',
+                'normalized',
               ],
-              "placeholder": {
-                "image_url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FDu29whk8s42GlJSBrA5nyw%2Ftall.jpg"
-              }
+              placeholder: {
+                image_url:
+                  'https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FDu29whk8s42GlJSBrA5nyw%2Ftall.jpg',
+              },
             },
             {
-              "aspect_ratio": 1,
-              "id": "595a6cd58b3b814fc9d18940",
-              "image_url": "https:\/\/d32dm0rphc51dk.cloudfront.net\/Im67Uwfultpyg4d3CKbxPQ\/large.jpg",
-              "image_large": "https:\/\/d32dm0rphc51dk.cloudfront.net\/Im67Uwfultpyg4d3CKbxPQ\/large.jpg",
-              "image_medium": "https:\/\/d32dm0rphc51dk.cloudfront.net\/Im67Uwfultpyg4d3CKbxPQ\/medium.jpg",
-              "image_versions": [
-                "square",
-                "large_rectangle",
-                "large",
-                "medium_rectangle",
-                "small",
-                "tall",
-                "medium",
-                "larger",
-                "normalized"
+              aspect_ratio: 1,
+              id: '595a6cd58b3b814fc9d18940',
+              image_url:
+                'https://d32dm0rphc51dk.cloudfront.net/Im67Uwfultpyg4d3CKbxPQ/large.jpg',
+              image_large:
+                'https://d32dm0rphc51dk.cloudfront.net/Im67Uwfultpyg4d3CKbxPQ/large.jpg',
+              image_medium:
+                'https://d32dm0rphc51dk.cloudfront.net/Im67Uwfultpyg4d3CKbxPQ/medium.jpg',
+              image_versions: [
+                'square',
+                'large_rectangle',
+                'large',
+                'medium_rectangle',
+                'small',
+                'tall',
+                'medium',
+                'larger',
+                'normalized',
               ],
-              "placeholder": {
-                "image_url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FIm67Uwfultpyg4d3CKbxPQ%2Ftall.jpg"
-              }
-            }
+              placeholder: {
+                image_url:
+                  'https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FIm67Uwfultpyg4d3CKbxPQ%2Ftall.jpg',
+              },
+            },
           ],
-          "artist": {
-            "name": "Takashi Murakami"
+          artist: {
+            name: 'Takashi Murakami',
           },
-          "artists": [
+          artists: [
             {
-              "id": "takashi-murakami",
-              "name": "Takashi Murakami"
-            }
-          ]
-        }
-      }
+              id: 'takashi-murakami',
+              name: 'Takashi Murakami',
+            },
+          ],
+        },
+      },
     ],
-    "saleArtworksByFollowedArtists": [
-
-    ],
-    "saleArtworksByFollowedArtistsTotal": 0,
-    "sortMap": {
-      "position": "Lot Number Asc",
-      "-position": "Lot Number Desc",
-      "-bidder_positions_count": "Most Bids",
-      "bidder_positions_count": "Least Bids",
-      "-searchable_estimate": "Most Expensive",
-      "searchable_estimate": "Least Expensive"
+    saleArtworksByFollowedArtists: [],
+    saleArtworksByFollowedArtistsTotal: 0,
+    sortMap: {
+      position: 'Lot Number Asc',
+      '-position': 'Lot Number Desc',
+      '-bidder_positions_count': 'Most Bids',
+      bidder_positions_count: 'Least Bids',
+      '-searchable_estimate': 'Most Expensive',
+      searchable_estimate: 'Least Expensive',
     },
-    "symbol": "$",
-    "total": 350,
-    "user": {
-
-    }
-  }
+    symbol: '$',
+    total: 350,
+    user: {},
+  },
 }

--- a/src/desktop/apps/auction/components/artwork_browser/__tests__/fixtures/followedArtistSaleArtworks.js
+++ b/src/desktop/apps/auction/components/artwork_browser/__tests__/fixtures/followedArtistSaleArtworks.js
@@ -1,81 +1,118 @@
-export const followedArtistSaleArtworks = [{
-  'id': 'svend-aage-larsen-surrealism',
-  'lot_label': '1',
-  'counts': {
-    'bidder_positions': 0
-  },
-  'current_bid': {
-    'display': 'CHF 550'
-  },
-  'artwork': {
-    'id': 'svend-aage-larsen-surrealism',
-    'title': 'Surrealism',
-    'date': '',
-    'sale_message': 'Contact For Price',
-    'is_in_auction': true,
-    'is_sold': false,
-    'artists': [{
-      'id': 'svend-aage-larsen',
-      'name': 'Svend Aage Larsen'
-    }],
-    'image': {
-      'placeholder': '149.9267935578331%',
-      'url': 'https://d32dm0rphc51dk.cloudfront.net/ItTZn8RMfKx_QAk91cteZg/larger.jpg',
-      'aspect_ratio': 0.67
+export const followedArtistSaleArtworks = [
+  {
+    id: 'svend-aage-larsen-surrealism',
+    lot_label: '1',
+    counts: {
+      bidder_positions: 0,
     },
-    'images': [{
-      'id': '5a5e8a4324f8813f0365d4fc',
-      'image_medium': 'https://d32dm0rphc51dk.cloudfront.net/ItTZn8RMfKx_QAk91cteZg/medium.jpg',
-      'image_versions': ['square', 'large', 'tall', 'small', 'medium_rectangle', 'normalized', 'large_rectangle', 'medium', 'larger'],
-      'placeholder': {
-        'image_url': 'https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=20&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FItTZn8RMfKx_QAk91cteZg%2Ftall.jpg'
-      }
-    }],
-    'partner': {
-      'name': 'Mocktion Demo Partner chris-moction'
+    current_bid: {
+      display: 'CHF 550',
     },
-    'href': '/artwork/svend-aage-larsen-surrealism',
-    'is_purchasable': false,
-    'is_acquireable': false
-  }
-}, {
-  'id': 'emile-gsell-untitled',
-  'lot_label': '2',
-  'counts': {
-    'bidder_positions': 0
+    artwork: {
+      id: 'svend-aage-larsen-surrealism',
+      title: 'Surrealism',
+      date: '',
+      sale_message: 'Contact For Price',
+      is_in_auction: true,
+      is_sold: false,
+      artists: [
+        {
+          id: 'svend-aage-larsen',
+          name: 'Svend Aage Larsen',
+        },
+      ],
+      image: {
+        placeholder: '149.9267935578331%',
+        url:
+          'https://d32dm0rphc51dk.cloudfront.net/ItTZn8RMfKx_QAk91cteZg/larger.jpg',
+        aspect_ratio: 0.67,
+      },
+      images: [
+        {
+          id: '5a5e8a4324f8813f0365d4fc',
+          image_medium:
+            'https://d32dm0rphc51dk.cloudfront.net/ItTZn8RMfKx_QAk91cteZg/medium.jpg',
+          image_versions: [
+            'square',
+            'large',
+            'tall',
+            'small',
+            'medium_rectangle',
+            'normalized',
+            'large_rectangle',
+            'medium',
+            'larger',
+          ],
+          placeholder: {
+            image_url:
+              'https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=20&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FItTZn8RMfKx_QAk91cteZg%2Ftall.jpg',
+          },
+        },
+      ],
+      partner: {
+        name: 'Mocktion Demo Partner chris-moction',
+      },
+      href: '/artwork/svend-aage-larsen-surrealism',
+      is_purchasable: false,
+      is_acquireable: false,
+    },
   },
-  'current_bid': {
-    'display': 'CHF 5,000'
+  {
+    id: 'emile-gsell-untitled',
+    lot_label: '2',
+    counts: {
+      bidder_positions: 0,
+    },
+    current_bid: {
+      display: 'CHF 5,000',
+    },
+    artwork: {
+      id: 'emile-gsell-untitled',
+      title: 'Untitled',
+      date: '',
+      sale_message: 'Contact For Price',
+      is_in_auction: true,
+      is_sold: false,
+      artists: [
+        {
+          id: 'emile-gsell',
+          name: 'Emile Gsell',
+        },
+      ],
+      image: {
+        placeholder: '83.203125%',
+        url:
+          'https://d32dm0rphc51dk.cloudfront.net/V-_SmGFvcwy9c7ZiD1Y-MA/normalized.jpg',
+        aspect_ratio: 1.2,
+      },
+      images: [
+        {
+          id: '5a5e8a4424f8813f0365d508',
+          image_medium:
+            'https://d32dm0rphc51dk.cloudfront.net/V-_SmGFvcwy9c7ZiD1Y-MA/medium.jpg',
+          image_versions: [
+            'square',
+            'large_rectangle',
+            'tall',
+            'small',
+            'large',
+            'medium_rectangle',
+            'larger',
+            'medium',
+            'normalized',
+          ],
+          placeholder: {
+            image_url:
+              'https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FV-_SmGFvcwy9c7ZiD1Y-MA%2Ftall.jpg',
+          },
+        },
+      ],
+      partner: {
+        name: 'Mocktion Demo Partner chris-moction',
+      },
+      href: '/artwork/emile-gsell-untitled',
+      is_purchasable: false,
+      is_acquireable: false,
+    },
   },
-  'artwork': {
-    'id': 'emile-gsell-untitled',
-    'title': 'Untitled',
-    'date': '',
-    'sale_message': 'Contact For Price',
-    'is_in_auction': true,
-    'is_sold': false,
-    'artists': [{
-      'id': 'emile-gsell',
-      'name': 'Emile Gsell'
-    }],
-    'image': {
-      'placeholder': '83.203125%',
-      'url': 'https://d32dm0rphc51dk.cloudfront.net/V-_SmGFvcwy9c7ZiD1Y-MA/normalized.jpg',
-      'aspect_ratio': 1.2
-    },
-    'images': [{
-      'id': '5a5e8a4424f8813f0365d508',
-      'image_medium': 'https://d32dm0rphc51dk.cloudfront.net/V-_SmGFvcwy9c7ZiD1Y-MA/medium.jpg',
-      'image_versions': ['square', 'large_rectangle', 'tall', 'small', 'large', 'medium_rectangle', 'larger', 'medium', 'normalized'],
-      'placeholder': {
-        'image_url': 'https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FV-_SmGFvcwy9c7ZiD1Y-MA%2Ftall.jpg'
-      }
-    }],
-    'partner': {
-      'name': 'Mocktion Demo Partner chris-moction'
-    },
-    'href': '/artwork/emile-gsell-untitled',
-    'is_purchasable': false,
-    'is_acquireable': false
-  }
-}]
+]

--- a/src/desktop/apps/partnerships/templates/hero_unit.jade
+++ b/src/desktop/apps/partnerships/templates/hero_unit.jade
@@ -7,7 +7,7 @@
   ul.partnerships-hero-unit-images
     for image, i in hero.images
       li.partnerships-hero-unit-image(
-        style="background-image: url(#{crop(image.src, { width: 1120, height: 435, quality: 90 })})"
+        style="background-image: url(#{crop(image.src, { width: 1120, height: 435 })})"
         class=(i === 0 ? 'is-active' : undefined)
       )
         .credit= image.credit

--- a/src/desktop/components/article_figure/mixin.jade
+++ b/src/desktop/components/article_figure/mixin.jade
@@ -7,7 +7,7 @@ mixin article-figure(article, width, showDate, showShare)
   if article.get('thumbnail_image') && article.get('thumbnail_image').url
     - var imgUrl = article.get('thumbnail_image').url
   else
-    - var imgUrl = article.cropUrlFor('thumbnail_image', { width: width, height: Math.round(width / 1.5), quality: 95 })
+    - var imgUrl = article.cropUrlFor('thumbnail_image', { width: width, height: Math.round(width / 1.5) })
   figure.article-figure: .article-figure-container
     a.article-figure-img-container( href= article.href() )
       .article-figure-img( style="background-image: url(#{imgUrl})" )

--- a/src/desktop/components/article_figure/parsely_figure.jade
+++ b/src/desktop/components/article_figure/parsely_figure.jade
@@ -2,7 +2,7 @@
 
 - width = width || 300
 
-- var imgUrl = crop(article.image_url, { width: width, height: Math.round(width / 1.5), quality: 95 })
+- var imgUrl = crop(article.image_url, { width: width, height: Math.round(width / 1.5) })
 figure.article-figure: .article-figure-container
   a.article-figure-img-container( href= article.link )
     .article-figure-img( style="background-image: url(#{imgUrl})" )

--- a/src/desktop/components/articles_grid/templates/figure.jade
+++ b/src/desktop/components/articles_grid/templates/figure.jade
@@ -1,5 +1,5 @@
 
-- var imgUrl = article.cropUrlFor('thumbnail_image', { width: 600, height: Math.round(600 / 1.5), quality: 95 })
+- var imgUrl = article.cropUrlFor('thumbnail_image', { width: 600, height: Math.round(600 / 1.5) })
 - var href = articleHref || article.href()
 
 figure.articles-grid__figure.grid-item

--- a/src/desktop/components/auction_reminders/test/view.coffee
+++ b/src/desktop/components/auction_reminders/test/view.coffee
@@ -38,7 +38,7 @@ describe 'AuctionReminderView', ->
           .should.equal 'My Auction'
 
         view.$('img').attr('src')
-          .should.containEql '/crop?url=%2Flarge.jpg&width=80&height=60&quality=95'
+          .should.containEql '/crop?url=%2Flarge.jpg&width=80&height=60&quality=80'
 
   describe '#click', ->
     beforeEach ->

--- a/src/desktop/components/resizer/config.coffee
+++ b/src/desktop/components/resizer/config.coffee
@@ -4,5 +4,5 @@ module.exports =
   enabled: DISABLE_IMAGE_PROXY isnt 'true'
   proxy: IMAGE_PROXY or 'EMBEDLY' # Fallback for specs (sigh)
   defaults:
-    quality: 95
+    quality: 80
     color: 'fff'

--- a/src/desktop/components/resizer/test/index.coffee
+++ b/src/desktop/components/resizer/test/index.coffee
@@ -28,7 +28,7 @@ describe 'resizer', ->
     describe '#resize', ->
       it 'returns the appropriate URL', ->
         resizer.resize @src, width: 32, height: 32
-          .should.equal 'https://i.embed.ly/1/display/resize?url=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&quality=95&key=xxx'
+          .should.equal 'https://i.embed.ly/1/display/resize?url=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&quality=80&key=xxx'
 
       it 'supports options', ->
         resizer.resize @src, width: 300, height: 200, quality: 50
@@ -41,7 +41,7 @@ describe 'resizer', ->
     describe '#crop', ->
       it 'returns the appropriate URL', ->
         resizer.crop @src, width: 32, height: 32
-          .should.equal 'https://i.embed.ly/1/display/crop?url=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&quality=95&key=xxx'
+          .should.equal 'https://i.embed.ly/1/display/crop?url=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&quality=80&key=xxx'
 
       it 'supports options', ->
         resizer.crop @src, width: 300, height: 200, quality: 50
@@ -54,7 +54,7 @@ describe 'resizer', ->
     describe '#fill', ->
       it 'returns the appropriate URL', ->
         resizer.fill @src, width: 32, height: 32
-          .should.equal 'https://i.embed.ly/1/display/fill?url=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&color=fff&quality=95&key=xxx'
+          .should.equal 'https://i.embed.ly/1/display/fill?url=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&color=fff&quality=80&key=xxx'
 
       it 'supports options', ->
         resizer.fill @src, width: 300, height: 200, quality: 50, color: 'ff00cc'
@@ -92,22 +92,22 @@ describe 'resizer', ->
     describe '#resize', ->
       it 'returns the appropriate URL when no width is specified', ->
         resizer.resize @src, height: 300
-          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=height&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&height=300&quality=95'
+          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=height&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&height=300&quality=80'
 
       it 'returns the appropriate URL when no height is specified', ->
         resizer.resize @src, width: 300
-          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=300&quality=95'
+          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=300&quality=80'
 
       it 'returns the appropriate URL when both a height and width are specified', ->
         resizer.resize @src, width: 300, height: 200
-          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=300&height=200&quality=95'
+          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=300&height=200&quality=80'
 
     describe '#crop', ->
       it 'returns the appropriate URL', ->
         resizer.crop @src, width: 32, height: 32
-          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&quality=95'
+          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&quality=80'
 
     describe '#fill', ->
       it 'is not really supported and falls back to crop', ->
         resizer.fill @src, width: 32, height: 32
-          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&quality=95'
+          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&quality=80'

--- a/src/mobile/components/article_figure/index.jade
+++ b/src/mobile/components/article_figure/index.jade
@@ -1,5 +1,5 @@
 - author = article.author
-- imgUrl = crop(article.thumbnail_image, { width: 640, height: Math.round(640 / 1.7), quality: 90 })
+- imgUrl = crop(article.thumbnail_image, { width: 640, height: Math.round(640 / 1.7) })
 
 .article-item
   a.article-item-link( href= '/article/' + article.slug data-id = article.id )

--- a/src/mobile/components/article_figure/template.jade
+++ b/src/mobile/components/article_figure/template.jade
@@ -1,5 +1,5 @@
 - author = article.related().author
-- imgUrl = article.cropUrlFor('thumbnail_image', { width: 640, height: Math.round(640 / 1.7), quality: 90 })
+- imgUrl = article.cropUrlFor('thumbnail_image', { width: 640, height: Math.round(640 / 1.7) })
 
 .article-item
   a.article-item-link( href= article.href() data-id = article.get('id') )

--- a/src/mobile/components/resizer/config.coffee
+++ b/src/mobile/components/resizer/config.coffee
@@ -4,5 +4,5 @@ module.exports =
   enabled: DISABLE_IMAGE_PROXY isnt 'true'
   proxy: IMAGE_PROXY or 'EMBEDLY' # Fallback for specs (sigh)
   defaults:
-    quality: 95
+    quality: 80
     color: 'fff'

--- a/src/mobile/components/resizer/test/index.coffee
+++ b/src/mobile/components/resizer/test/index.coffee
@@ -28,7 +28,7 @@ describe 'resizer', ->
     describe '#resize', ->
       it 'returns the appropriate URL', ->
         resizer.resize @src, width: 32, height: 32
-          .should.equal 'https://i.embed.ly/1/display/resize?url=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&quality=95&key=xxx'
+          .should.equal 'https://i.embed.ly/1/display/resize?url=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&quality=80&key=xxx'
 
       it 'supports options', ->
         resizer.resize @src, width: 300, height: 200, quality: 50
@@ -41,7 +41,7 @@ describe 'resizer', ->
     describe '#crop', ->
       it 'returns the appropriate URL', ->
         resizer.crop @src, width: 32, height: 32
-          .should.equal 'https://i.embed.ly/1/display/crop?url=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&quality=95&key=xxx'
+          .should.equal 'https://i.embed.ly/1/display/crop?url=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&quality=80&key=xxx'
 
       it 'supports options', ->
         resizer.crop @src, width: 300, height: 200, quality: 50
@@ -54,7 +54,7 @@ describe 'resizer', ->
     describe '#fill', ->
       it 'returns the appropriate URL', ->
         resizer.fill @src, width: 32, height: 32
-          .should.equal 'https://i.embed.ly/1/display/fill?url=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&color=fff&quality=95&key=xxx'
+          .should.equal 'https://i.embed.ly/1/display/fill?url=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&color=fff&quality=80&key=xxx'
 
       it 'supports options', ->
         resizer.fill @src, width: 300, height: 200, quality: 50, color: 'ff00cc'
@@ -92,22 +92,22 @@ describe 'resizer', ->
     describe '#resize', ->
       it 'returns the appropriate URL when no width is specified', ->
         resizer.resize @src, height: 300
-          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=height&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&height=300&quality=95'
+          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=height&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&height=300&quality=80'
 
       it 'returns the appropriate URL when no height is specified', ->
         resizer.resize @src, width: 300
-          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=300&quality=95'
+          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=width&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=300&quality=80'
 
       it 'returns the appropriate URL when both a height and width are specified', ->
         resizer.resize @src, width: 300, height: 200
-          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=300&height=200&quality=95'
+          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=300&height=200&quality=80'
 
     describe '#crop', ->
       it 'returns the appropriate URL', ->
         resizer.crop @src, width: 32, height: 32
-          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&quality=95'
+          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&quality=80'
 
     describe '#fill', ->
       it 'is not really supported and falls back to crop', ->
         resizer.fill @src, width: 32, height: 32
-          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&quality=95'
+          .should.equal 'https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRhCPuRWITO6WFW2Zu_u3EQ%2Flarge.jpg&width=32&height=32&quality=80'

--- a/src/test/acceptance/fixtures/metaphysics/artwork.json
+++ b/src/test/acceptance/fixtures/metaphysics/artwork.json
@@ -236,7 +236,7 @@
             {
               "thumbnail_image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=95&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F0coAi_H35Q3Mt4OpemqhQA%252Fkids.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=80&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F0coAi_H35Q3Mt4OpemqhQA%252Fkids.jpg"
                 }
               },
               "href": "\/article\/artsy-editorial-your-kids-will-love-these-children-s-books-illustrated-by-famous-artists",
@@ -248,7 +248,7 @@
             {
               "thumbnail_image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=95&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FNBJyOTneDbTkR38FyEPTmA%252Fwarhol.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=80&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FNBJyOTneDbTkR38FyEPTmA%252Fwarhol.jpg"
                 }
               },
               "href": "\/article\/artsy-editorial-the-7-most-expensive-works-at-next-week-s-new-york-auctions",
@@ -260,7 +260,7 @@
             {
               "thumbnail_image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=95&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlSihpcPq8Hx5bAVVXbXgww%252Fe.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=80&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlSihpcPq8Hx5bAVVXbXgww%252Fe.jpg"
                 }
               },
               "href": "\/article\/artsy-editorial-how-warhol-rauschenberg-and-chamberlain-smuggled-art-onto-the-moon",
@@ -272,7 +272,7 @@
             {
               "thumbnail_image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=95&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FhQpyJMXo2Em3OLy9WGBT_A%252Flarger-29.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=80&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FhQpyJMXo2Em3OLy9WGBT_A%252Flarger-29.jpg"
                 }
               },
               "href": "\/article\/artsy-editorial-from-designers-in-dresses-to-models-off-duty-11-iconic-fashion-photographs-from-the-past-three-decades",
@@ -284,7 +284,7 @@
             {
               "thumbnail_image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=95&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F4JfYD1cUCrfTofIkIyjWvg%252Fliz.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=80&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F4JfYD1cUCrfTofIkIyjWvg%252Fliz.jpg"
                 }
               },
               "href": "\/article\/robin-rile-fine-art-andy-warhol-s-starlets",
@@ -296,7 +296,7 @@
             {
               "thumbnail_image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=95&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F2_qk7N4U5nr_WE2T9o-FPw%252Fbilly.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=80&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F2_qk7N4U5nr_WE2T9o-FPw%252Fbilly.jpg"
                 }
               },
               "href": "\/article\/artsy-editorial-dead-at-76-billy-name-captured-warhol-s-factory-in-its-prime",
@@ -308,7 +308,7 @@
             {
               "thumbnail_image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=95&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FckZNheDgRz_00KLDDWO12w%252Ffrida.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=80&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FckZNheDgRz_00KLDDWO12w%252Ffrida.jpg"
                 }
               },
               "href": "\/article\/editorial-10-masters-of-the-self-portrait-in-their",
@@ -320,7 +320,7 @@
             {
               "thumbnail_image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=95&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FF0HC3bT6juWiktmXohdxUw%252Flarger-22.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=80&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FF0HC3bT6juWiktmXohdxUw%252Flarger-22.jpg"
                 }
               },
               "href": "\/article\/artsy-editorial-what-does-it-take-to-capture-the-perfect-sports-moment",
@@ -332,7 +332,7 @@
             {
               "thumbnail_image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=95&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FI5cHtRJhHafKVvgb73cKhA%252Flarger-31.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=80&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FI5cHtRJhHafKVvgb73cKhA%252Flarger-31.jpg"
                 }
               },
               "href": "\/article\/artsy-editorial-5-things-to-know-about-investing-in-art-right-now",
@@ -344,7 +344,7 @@
             {
               "thumbnail_image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=95&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FqIfus0XKKVelxJPYXuON6w%252Flarger-25.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=100&height=100&quality=80&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FqIfus0XKKVelxJPYXuON6w%252Flarger-25.jpg"
                 }
               },
               "href": "\/article\/artsy-editorial-iconic-artists-and-movements-of-the-1960s",
@@ -360,7 +360,7 @@
               "name": "James Rosenquist",
               "image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F3VUm07DpKQNQdA_QfCrPcA%2Flarge.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F3VUm07DpKQNQdA_QfCrPcA%2Flarge.jpg"
                 }
               },
               "formatted_nationality_and_birthday": "American, b. 1933",
@@ -376,7 +376,7 @@
               "name": "Tom Wesselmann",
               "image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F8smV519M1L352CTihrfW7A%2Flarge.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F8smV519M1L352CTihrfW7A%2Flarge.jpg"
                 }
               },
               "formatted_nationality_and_birthday": "American, 1931\u20132004",
@@ -392,7 +392,7 @@
               "name": "Robert Indiana",
               "image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FxPV7zLtiKJPPxRVJTEtHIA%2Flarge.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FxPV7zLtiKJPPxRVJTEtHIA%2Flarge.jpg"
                 }
               },
               "formatted_nationality_and_birthday": "American, b. 1928",
@@ -408,7 +408,7 @@
               "name": "Roy Lichtenstein",
               "image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2For9oKva9F7V4VjrUKKx2iA%2Flarge.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2For9oKva9F7V4VjrUKKx2iA%2Flarge.jpg"
                 }
               },
               "formatted_nationality_and_birthday": "American, 1923\u20131997",
@@ -424,7 +424,7 @@
               "name": "Claes Oldenburg & Coosje van Bruggen",
               "image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FlnJopeqKO7np6fvqpegQpQ%2Flarge.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FlnJopeqKO7np6fvqpegQpQ%2Flarge.jpg"
                 }
               },
               "formatted_nationality_and_birthday": "American, 1929 and 1942",
@@ -440,7 +440,7 @@
               "name": "Jim Dine",
               "image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FLl4gMf_OsLMehbgv05H6mw%2Flarge.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FLl4gMf_OsLMehbgv05H6mw%2Flarge.jpg"
                 }
               },
               "formatted_nationality_and_birthday": "American, b. 1935",
@@ -456,7 +456,7 @@
               "name": "Mel Ramos",
               "image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FzRIrcfojWmxXOleolo3nNw%2Flarge.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FzRIrcfojWmxXOleolo3nNw%2Flarge.jpg"
                 }
               },
               "formatted_nationality_and_birthday": "American, b. 1935",
@@ -472,7 +472,7 @@
               "name": "Wayne Thiebaud",
               "image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F1bKgwCv09hoThqSvodBiBw%2Flarge.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F1bKgwCv09hoThqSvodBiBw%2Flarge.jpg"
                 }
               },
               "formatted_nationality_and_birthday": "American, b. 1920",
@@ -488,7 +488,7 @@
               "name": "Richard Hamilton",
               "image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCqLm5-pqOP2wlCcXoxTkhw%2Flarge.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCqLm5-pqOP2wlCcXoxTkhw%2Flarge.jpg"
                 }
               },
               "formatted_nationality_and_birthday": "British, 1922\u20132011",
@@ -504,7 +504,7 @@
               "name": "Marjorie Strider",
               "image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FFjy4sK_44VTNf3Q7Yz7VQw%2Flarge.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FFjy4sK_44VTNf3Q7Yz7VQw%2Flarge.jpg"
                 }
               },
               "formatted_nationality_and_birthday": "American, 1934\u20132014",
@@ -520,7 +520,7 @@
               "name": "Claes Oldenburg",
               "image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F6q6LeyKvA_vpT5YzHRSNUA%2Flarge.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F6q6LeyKvA_vpT5YzHRSNUA%2Flarge.jpg"
                 }
               },
               "formatted_nationality_and_birthday": "Swedish, b. 1929",
@@ -536,7 +536,7 @@
               "name": "Jim Nutt",
               "image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F-AIa43HixxWFVBOMx1KbXw%2Flarge.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F-AIa43HixxWFVBOMx1KbXw%2Flarge.jpg"
                 }
               },
               "formatted_nationality_and_birthday": "American, b. 1938",
@@ -552,7 +552,7 @@
               "name": "Richard Phillips",
               "image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FPibzWeSAt4ZHGV_f1dgd1A%2Flarge.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FPibzWeSAt4ZHGV_f1dgd1A%2Flarge.jpg"
                 }
               },
               "formatted_nationality_and_birthday": "American, b. 1962",
@@ -568,7 +568,7 @@
               "name": "Sturtevant",
               "image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FVZ3u45lNAm7SL_0ncPoEag%2Flarge.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FVZ3u45lNAm7SL_0ncPoEag%2Flarge.jpg"
                 }
               },
               "formatted_nationality_and_birthday": "American, 1924\u20132014",
@@ -584,7 +584,7 @@
               "name": "Duane Hanson",
               "image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FvqmGCFGPFerXXKagG7udQA%2Flarge.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FvqmGCFGPFerXXKagG7udQA%2Flarge.jpg"
                 }
               },
               "formatted_nationality_and_birthday": "American, 1925\u20131996",
@@ -600,7 +600,7 @@
               "name": "Dennis Hopper",
               "image": {
                 "cropped": {
-                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FTrFjIT_iogQEQtprbqkvpg%2Flarge.jpg"
+                  "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fill&width=400&height=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FTrFjIT_iogQEQtprbqkvpg%2Flarge.jpg"
                 }
               },
               "formatted_nationality_and_birthday": "American, 1936\u20132013",
@@ -731,7 +731,7 @@
           "id": "4e68f259528702000104c329",
           "url": "https:\/\/d32dm0rphc51dk.cloudfront.net\/vAYXuDl0rYz7QR0Jx4MK2Q\/larger.jpg",
           "placeholder": {
-            "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fit&width=30&height=26&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FvAYXuDl0rYz7QR0Jx4MK2Q%2Fsmall.jpg"
+            "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fit&width=30&height=26&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FvAYXuDl0rYz7QR0Jx4MK2Q%2Fsmall.jpg"
           },
           "is_zoomable": true
         }
@@ -745,7 +745,7 @@
         "resized": {
           "width": 640,
           "height": 560,
-          "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fit&width=640&height=560&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FvAYXuDl0rYz7QR0Jx4MK2Q%2Flarge.jpg"
+          "url": "https:\/\/d7hftxdivxxvm.cloudfront.net\/?resize_to=fit&width=640&height=560&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FvAYXuDl0rYz7QR0Jx4MK2Q%2Flarge.jpg"
         }
       },
       "meta": {

--- a/src/test/acceptance/fixtures/metaphysics/bidding1.json
+++ b/src/test/acceptance/fixtures/metaphysics/bidding1.json
@@ -6,7 +6,7 @@
       "auction_state": "open",
       "cover_image": {
         "cropped": {
-          "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=1800&height=600&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FEdyXwUnVhPOeGGSU4lExzg%2Fwide.jpg"
+          "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=1800&height=600&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FEdyXwUnVhPOeGGSU4lExzg%2Fwide.jpg"
         }
       },
       "currency": "USD",

--- a/src/test/acceptance/fixtures/metaphysics/bidding3.json
+++ b/src/test/acceptance/fixtures/metaphysics/bidding3.json
@@ -660,7 +660,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=26&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FOKJIqI_F0-UOjhbU7dnSbQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=26&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FOKJIqI_F0-UOjhbU7dnSbQ%2Ftall.jpg"
                         }
                      },
                      {
@@ -678,7 +678,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=27&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FC9hlGURBAIoVlT6SfVuoXQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=27&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FC9hlGURBAIoVlT6SfVuoXQ%2Ftall.jpg"
                         }
                      }
                   ],
@@ -722,7 +722,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=22&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F-SAEkdc4riiypgZZdfJ1KQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=22&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F-SAEkdc4riiypgZZdfJ1KQ%2Ftall.jpg"
                         }
                      },
                      {
@@ -740,7 +740,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=25&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FSN_JvQhi180m-munMuZ46w%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=25&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FSN_JvQhi180m-munMuZ46w%2Ftall.jpg"
                         }
                      }
                   ],
@@ -784,7 +784,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=29&height=14&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FKkyKH6j1uxHTcF1Lh9KLrg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=29&height=14&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FKkyKH6j1uxHTcF1Lh9KLrg%2Ftall.jpg"
                         }
                      },
                      {
@@ -802,7 +802,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=22&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F9vp4Z-S7JcqojVovT1MuJw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=22&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F9vp4Z-S7JcqojVovT1MuJw%2Ftall.jpg"
                         }
                      }
                   ],
@@ -846,7 +846,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=24&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FoJm0kWu2g15yfhIctmLVJw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=24&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FoJm0kWu2g15yfhIctmLVJw%2Ftall.jpg"
                         }
                      },
                      {
@@ -864,7 +864,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=25&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FGOtG6VddXuJymAunH8AfNg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=25&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FGOtG6VddXuJymAunH8AfNg%2Ftall.jpg"
                         }
                      }
                   ],
@@ -908,7 +908,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=22&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FoBs6ynhzsg67Wwl8h_gCtg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=22&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FoBs6ynhzsg67Wwl8h_gCtg%2Ftall.jpg"
                         }
                      }
                   ],
@@ -952,7 +952,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=20&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FqQkS6PoTionQ9gWVTv2Znw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=20&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FqQkS6PoTionQ9gWVTv2Znw%2Ftall.jpg"
                         }
                      }
                   ],
@@ -996,7 +996,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=24&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FZgy1avwOqZp5ARQFd43_MA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=24&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FZgy1avwOqZp5ARQFd43_MA%2Ftall.jpg"
                         }
                      },
                      {
@@ -1014,7 +1014,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=26&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F26qlsz0RMQwieoU7LGMnFA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=26&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F26qlsz0RMQwieoU7LGMnFA%2Ftall.jpg"
                         }
                      }
                   ],
@@ -1058,7 +1058,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=24&height=29&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F_zkmhB8pg1IoumbA2Qqw0Q%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=24&height=29&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F_zkmhB8pg1IoumbA2Qqw0Q%2Ftall.jpg"
                         }
                      },
                      {
@@ -1076,7 +1076,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=27&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FBESgItrfMlAS3D4qjtLltw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=27&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FBESgItrfMlAS3D4qjtLltw%2Ftall.jpg"
                         }
                      }
                   ],
@@ -1120,7 +1120,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=11&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FrFUxVigid0JJ8gLZS5n_fA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=11&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FrFUxVigid0JJ8gLZS5n_fA%2Ftall.jpg"
                         }
                      },
                      {
@@ -1138,7 +1138,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=26&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FiWOE-BUkDTZfp52n5rLrwA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=26&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FiWOE-BUkDTZfp52n5rLrwA%2Ftall.jpg"
                         }
                      },
                      {
@@ -1156,7 +1156,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fl1HHWzQmBXqEPK5BG-OHLA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fl1HHWzQmBXqEPK5BG-OHLA%2Ftall.jpg"
                         }
                      },
                      {
@@ -1174,7 +1174,7 @@
                            "large"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=25&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F9K2JXqZf9BJI4GEYaREKxg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=25&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F9K2JXqZf9BJI4GEYaREKxg%2Ftall.jpg"
                         }
                      },
                      {
@@ -1192,7 +1192,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FOLpbJU0bvHkiaOF45hv8VA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FOLpbJU0bvHkiaOF45hv8VA%2Ftall.jpg"
                         }
                      }
                   ],
@@ -1236,7 +1236,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=29&height=29&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fs2ISvCnvPihWe6rhFCN_jw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=29&height=29&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fs2ISvCnvPihWe6rhFCN_jw%2Ftall.jpg"
                         }
                      },
                      {
@@ -1254,7 +1254,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=23&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F9DTnvdXC7yv_MnhSn9gR1w%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=23&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F9DTnvdXC7yv_MnhSn9gR1w%2Ftall.jpg"
                         }
                      }
                   ],
@@ -1298,7 +1298,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FzzQibvS2xflTSSMlM0QvCg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FzzQibvS2xflTSSMlM0QvCg%2Ftall.jpg"
                         }
                      }
                   ],
@@ -1342,7 +1342,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=23&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F4nJ6t-FFj8Ck7K-B9_7mug%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=23&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F4nJ6t-FFj8Ck7K-B9_7mug%2Ftall.jpg"
                         }
                      }
                   ],
@@ -1386,7 +1386,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=24&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FfBjG-DuKGEk9-pUP3WNlRA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=24&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FfBjG-DuKGEk9-pUP3WNlRA%2Ftall.jpg"
                         }
                      }
                   ],
@@ -1430,7 +1430,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=20&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F1NrP-lZiOFznk8afJsQCMg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=20&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F1NrP-lZiOFznk8afJsQCMg%2Ftall.jpg"
                         }
                      },
                      {
@@ -1448,7 +1448,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=22&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FmnXhKifdDP3fqV7OgDRRew%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=22&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FmnXhKifdDP3fqV7OgDRRew%2Ftall.jpg"
                         }
                      }
                   ],
@@ -1492,7 +1492,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=22&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FFuxGcL8pXjuM0NKidDiBFg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=22&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FFuxGcL8pXjuM0NKidDiBFg%2Ftall.jpg"
                         }
                      },
                      {
@@ -1510,7 +1510,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=25&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FdPI5Gocf2ddSRw72_8IZfQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=25&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FdPI5Gocf2ddSRw72_8IZfQ%2Ftall.jpg"
                         }
                      }
                   ],
@@ -1554,7 +1554,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=23&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FSxF_-w3ZgJnFS8-YE8RjTQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=23&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FSxF_-w3ZgJnFS8-YE8RjTQ%2Ftall.jpg"
                         }
                      },
                      {
@@ -1572,7 +1572,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=27&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FuQOhk1RAShxWw68_nXJpRg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=27&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FuQOhk1RAShxWw68_nXJpRg%2Ftall.jpg"
                         }
                      },
                      {
@@ -1590,7 +1590,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=27&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F5D63m3cu-31ZZ4lQ4OWwcw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=27&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F5D63m3cu-31ZZ4lQ4OWwcw%2Ftall.jpg"
                         }
                      }
                   ],
@@ -1634,7 +1634,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=18&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fbtacn-xt0VtLMu5RNBSuPA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=18&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fbtacn-xt0VtLMu5RNBSuPA%2Ftall.jpg"
                         }
                      },
                      {
@@ -1652,7 +1652,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=22&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FVDWJZTtD-jACpEVOIx9Xug%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=22&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FVDWJZTtD-jACpEVOIx9Xug%2Ftall.jpg"
                         }
                      },
                      {
@@ -1670,7 +1670,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=22&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FEfHvYWc7psIVy92J8UsK6w%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=22&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FEfHvYWc7psIVy92J8UsK6w%2Ftall.jpg"
                         }
                      },
                      {
@@ -1688,7 +1688,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=28&height=29&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRIGBtrVFO3KI7T9JOYoWdw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=28&height=29&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRIGBtrVFO3KI7T9JOYoWdw%2Ftall.jpg"
                         }
                      },
                      {
@@ -1706,7 +1706,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=28&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FpizJLsAOSdDwWKWMsZTDcw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=28&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FpizJLsAOSdDwWKWMsZTDcw%2Ftall.jpg"
                         }
                      }
                   ],
@@ -1750,7 +1750,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=21&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FOOajbCykde1iUZtiA_w5Ww%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=21&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FOOajbCykde1iUZtiA_w5Ww%2Ftall.jpg"
                         }
                      },
                      {
@@ -1768,7 +1768,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=23&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F7nPDDiQsglLGfD0grea8MA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=23&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F7nPDDiQsglLGfD0grea8MA%2Ftall.jpg"
                         }
                      }
                   ],
@@ -1812,7 +1812,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=19&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FdB-40bgAnTDW9JYs87w7Nw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=19&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FdB-40bgAnTDW9JYs87w7Nw%2Ftall.jpg"
                         }
                      },
                      {
@@ -1830,7 +1830,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=21&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FpK2Fj8YYqYbmeJhgupLpEQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=21&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FpK2Fj8YYqYbmeJhgupLpEQ%2Ftall.jpg"
                         }
                      }
                   ],
@@ -1874,7 +1874,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=10&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FmzVLN7WINteM0Q2EcEUASA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=10&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FmzVLN7WINteM0Q2EcEUASA%2Ftall.jpg"
                         }
                      },
                      {
@@ -1892,7 +1892,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fv2tMqmiBbOMSQQnqOCB6Tw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fv2tMqmiBbOMSQQnqOCB6Tw%2Ftall.jpg"
                         }
                      },
                      {
@@ -1910,7 +1910,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F37v2sBEr7csv8r3gjHekuQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F37v2sBEr7csv8r3gjHekuQ%2Ftall.jpg"
                         }
                      },
                      {
@@ -1928,7 +1928,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F6oDngrCFU0IL-D4Oh9PiEQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F6oDngrCFU0IL-D4Oh9PiEQ%2Ftall.jpg"
                         }
                      },
                      {
@@ -1946,7 +1946,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F0VLM6_cYexGYWerP5PWFXw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F0VLM6_cYexGYWerP5PWFXw%2Ftall.jpg"
                         }
                      }
                   ],
@@ -1990,7 +1990,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=14&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FTnF8d8jvtziRiQLYgwcgBw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=14&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FTnF8d8jvtziRiQLYgwcgBw%2Ftall.jpg"
                         }
                      }
                   ],
@@ -2034,7 +2034,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=27&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FXypo4AwWIzI-lo1ix8V4TA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=27&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FXypo4AwWIzI-lo1ix8V4TA%2Ftall.jpg"
                         }
                      },
                      {
@@ -2052,7 +2052,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=27&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCN-tGvLDJQ09VThOb_8Q8g%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=27&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCN-tGvLDJQ09VThOb_8Q8g%2Ftall.jpg"
                         }
                      }
                   ],
@@ -2096,7 +2096,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=16&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F7nodX4E_OYK4p6sTuh0tdg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=16&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F7nodX4E_OYK4p6sTuh0tdg%2Ftall.jpg"
                         }
                      },
                      {
@@ -2114,7 +2114,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=19&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F4zOpH7E1oqRqSt9NubWAdw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=19&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F4zOpH7E1oqRqSt9NubWAdw%2Ftall.jpg"
                         }
                      }
                   ],
@@ -2158,7 +2158,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=22&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FUmAojq6hgJ-4RVIOxthRhg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=22&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FUmAojq6hgJ-4RVIOxthRhg%2Ftall.jpg"
                         }
                      },
                      {
@@ -2176,7 +2176,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FGELJIW72MuPYwgxXoKbl6w%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FGELJIW72MuPYwgxXoKbl6w%2Ftall.jpg"
                         }
                      },
                      {
@@ -2194,7 +2194,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=25&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fe5JENnIgerhuOWCAkXaixg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=25&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fe5JENnIgerhuOWCAkXaixg%2Ftall.jpg"
                         }
                      }
                   ],
@@ -2238,7 +2238,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=23&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FmoQfdSoeKPyfunQDcQAfmA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=23&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FmoQfdSoeKPyfunQDcQAfmA%2Ftall.jpg"
                         }
                      },
                      {
@@ -2256,7 +2256,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F0V5P4veYuZDQ97S1wOhx5w%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F0V5P4veYuZDQ97S1wOhx5w%2Ftall.jpg"
                         }
                      },
                      {
@@ -2274,7 +2274,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=25&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F25PhXxSbJXgqYqXaG7cfFw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=25&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F25PhXxSbJXgqYqXaG7cfFw%2Ftall.jpg"
                         }
                      }
                   ],
@@ -2318,7 +2318,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=21&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F6FGHm5-GPyB7Q94an2ToCg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=21&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F6FGHm5-GPyB7Q94an2ToCg%2Ftall.jpg"
                         }
                      },
                      {
@@ -2336,7 +2336,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=25&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FV2PnsKaftY4V1MG12tFc5A%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=25&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FV2PnsKaftY4V1MG12tFc5A%2Ftall.jpg"
                         }
                      }
                   ],
@@ -2380,7 +2380,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=23&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F13sNdgayvV0snSCafdeyzg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=23&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F13sNdgayvV0snSCafdeyzg%2Ftall.jpg"
                         }
                      }
                   ],
@@ -2424,7 +2424,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=10&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F_dTJ-IdDV2UmarCQzmkoAw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=10&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F_dTJ-IdDV2UmarCQzmkoAw%2Ftall.jpg"
                         }
                      }
                   ],
@@ -2468,7 +2468,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=23&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FSReC0pBSL4krwtnb_LIZ_Q%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=23&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FSReC0pBSL4krwtnb_LIZ_Q%2Ftall.jpg"
                         }
                      },
                      {
@@ -2486,7 +2486,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=25&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F8ZxMN5Y4UmZ_SPXtN639aw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=25&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F8ZxMN5Y4UmZ_SPXtN639aw%2Ftall.jpg"
                         }
                      },
                      {
@@ -2504,7 +2504,7 @@
                            "larger"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=25&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FqblZfFI6cGMLJFo9KbszZg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=25&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FqblZfFI6cGMLJFo9KbszZg%2Ftall.jpg"
                         }
                      }
                   ],
@@ -2548,7 +2548,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=21&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fi9FGzSM5ekoR7buFbl4aSg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=21&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fi9FGzSM5ekoR7buFbl4aSg%2Ftall.jpg"
                         }
                      },
                      {
@@ -2566,7 +2566,7 @@
                            "medium_rectangle"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=24&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FB3Zw9aVT4MzJ68qXN8LqoA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=24&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FB3Zw9aVT4MzJ68qXN8LqoA%2Ftall.jpg"
                         }
                      },
                      {
@@ -2584,7 +2584,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=26&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FgzoRGbWUbmZDsp5sxEebIg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=26&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FgzoRGbWUbmZDsp5sxEebIg%2Ftall.jpg"
                         }
                      }
                   ],
@@ -2628,7 +2628,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FpP8SDvr72j5_pHzs_znw0Q%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FpP8SDvr72j5_pHzs_znw0Q%2Ftall.jpg"
                         }
                      },
                      {
@@ -2646,7 +2646,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FpuFOXbEBLHRjFJK4A9IVCA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FpuFOXbEBLHRjFJK4A9IVCA%2Ftall.jpg"
                         }
                      },
                      {
@@ -2664,7 +2664,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FyFOWFmFLsR89cNjjGAdsXw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FyFOWFmFLsR89cNjjGAdsXw%2Ftall.jpg"
                         }
                      },
                      {
@@ -2682,7 +2682,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F0lY5K5N9ieizVtAr9KdC8A%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F0lY5K5N9ieizVtAr9KdC8A%2Ftall.jpg"
                         }
                      }
                   ],
@@ -2726,7 +2726,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FYShEfL8s5-NO8SxD30wRWA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FYShEfL8s5-NO8SxD30wRWA%2Ftall.jpg"
                         }
                      },
                      {
@@ -2744,7 +2744,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FuTzEDMOMWnRVePIT3fxN8g%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FuTzEDMOMWnRVePIT3fxN8g%2Ftall.jpg"
                         }
                      },
                      {
@@ -2762,7 +2762,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F-I0P41773d8gU6T53HrIUQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F-I0P41773d8gU6T53HrIUQ%2Ftall.jpg"
                         }
                      },
                      {
@@ -2780,7 +2780,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FK5UKwuNEbgrmeugnPkL4qw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FK5UKwuNEbgrmeugnPkL4qw%2Ftall.jpg"
                         }
                      }
                   ],
@@ -2824,7 +2824,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FR5OOTfrL2tVEPM5P4X4Asw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FR5OOTfrL2tVEPM5P4X4Asw%2Ftall.jpg"
                         }
                      },
                      {
@@ -2842,7 +2842,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F_O7s5UvG7eePAmL-Z68OTQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F_O7s5UvG7eePAmL-Z68OTQ%2Ftall.jpg"
                         }
                      },
                      {
@@ -2860,7 +2860,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FUBwhfkL5y9xX9Ay0HY30qg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FUBwhfkL5y9xX9Ay0HY30qg%2Ftall.jpg"
                         }
                      },
                      {
@@ -2878,7 +2878,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FVW0lCSUXwI3VA8bY4cwfmg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FVW0lCSUXwI3VA8bY4cwfmg%2Ftall.jpg"
                         }
                      }
                   ],
@@ -2922,7 +2922,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FEgVxpPglwFIvj76Z4G-7Eg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FEgVxpPglwFIvj76Z4G-7Eg%2Ftall.jpg"
                         }
                      },
                      {
@@ -2940,7 +2940,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FkiChuL_fuGWbSR08DmViug%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FkiChuL_fuGWbSR08DmViug%2Ftall.jpg"
                         }
                      },
                      {
@@ -2958,7 +2958,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FNlfLVmk9HziJepbAP9A6Qg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FNlfLVmk9HziJepbAP9A6Qg%2Ftall.jpg"
                         }
                      },
                      {
@@ -2976,7 +2976,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F4-J6hz6gInK7SjoYUxZUkw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F4-J6hz6gInK7SjoYUxZUkw%2Ftall.jpg"
                         }
                      },
                      {
@@ -2994,7 +2994,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F-q1C7NgtUjouiReJiYtuNQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F-q1C7NgtUjouiReJiYtuNQ%2Ftall.jpg"
                         }
                      }
                   ],
@@ -3038,7 +3038,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fz9h_VIhrV94LW5LVXtxG8g%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fz9h_VIhrV94LW5LVXtxG8g%2Ftall.jpg"
                         }
                      },
                      {
@@ -3056,7 +3056,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fbh_m-YfTISmOgvLEXsLZnw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fbh_m-YfTISmOgvLEXsLZnw%2Ftall.jpg"
                         }
                      },
                      {
@@ -3074,7 +3074,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FFLyZH_RUX70qOzn3DlcuFw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FFLyZH_RUX70qOzn3DlcuFw%2Ftall.jpg"
                         }
                      },
                      {
@@ -3092,7 +3092,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FGAjRwzNXwNcWsXLp0x6zwg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FGAjRwzNXwNcWsXLp0x6zwg%2Ftall.jpg"
                         }
                      },
                      {
@@ -3110,7 +3110,7 @@
                            "large"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F92YJXhz2o74S_cjuipfFHw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F92YJXhz2o74S_cjuipfFHw%2Ftall.jpg"
                         }
                      }
                   ],
@@ -3154,7 +3154,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCKYVgyhUozBt11cwYgqhLg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FCKYVgyhUozBt11cwYgqhLg%2Ftall.jpg"
                         }
                      },
                      {
@@ -3172,7 +3172,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=19&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FG7gQw_En4ScFRre09xVV9Q%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=19&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FG7gQw_En4ScFRre09xVV9Q%2Ftall.jpg"
                         }
                      },
                      {
@@ -3190,7 +3190,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=19&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FbtbAqe9IrnSIvLFXYQk9nw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=19&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FbtbAqe9IrnSIvLFXYQk9nw%2Ftall.jpg"
                         }
                      },
                      {
@@ -3208,7 +3208,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=17&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FVHktsizj3ShOmGt5et_G9A%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=17&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FVHktsizj3ShOmGt5et_G9A%2Ftall.jpg"
                         }
                      }
                   ],
@@ -3252,7 +3252,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fb4uO11aKX5Ta3m2eOTjvuw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fb4uO11aKX5Ta3m2eOTjvuw%2Ftall.jpg"
                         }
                      },
                      {
@@ -3270,7 +3270,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FyS-fExMnPsWWsu_r4lEF_w%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FyS-fExMnPsWWsu_r4lEF_w%2Ftall.jpg"
                         }
                      },
                      {
@@ -3288,7 +3288,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FUoROXtc8ie78OYfPiL_ukQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FUoROXtc8ie78OYfPiL_ukQ%2Ftall.jpg"
                         }
                      },
                      {
@@ -3306,7 +3306,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F4Hcx4XuCiRLohYW2R1Basg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F4Hcx4XuCiRLohYW2R1Basg%2Ftall.jpg"
                         }
                      },
                      {
@@ -3324,7 +3324,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Ft_0BG03WI9nTHbAb2fO4wQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Ft_0BG03WI9nTHbAb2fO4wQ%2Ftall.jpg"
                         }
                      },
                      {
@@ -3342,7 +3342,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FfgRYD-UMotltDn63xvZF8Q%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FfgRYD-UMotltDn63xvZF8Q%2Ftall.jpg"
                         }
                      }
                   ],
@@ -3386,7 +3386,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F9P_V97OI_hWBbBwTWJyb_w%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F9P_V97OI_hWBbBwTWJyb_w%2Ftall.jpg"
                         }
                      },
                      {
@@ -3404,7 +3404,7 @@
                            "larger"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F6lEFsz9Esh2MB0FvY6npTw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F6lEFsz9Esh2MB0FvY6npTw%2Ftall.jpg"
                         }
                      },
                      {
@@ -3422,7 +3422,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FAgYO3ug-n-Nyl4ZJXR5r4Q%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FAgYO3ug-n-Nyl4ZJXR5r4Q%2Ftall.jpg"
                         }
                      },
                      {
@@ -3440,7 +3440,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2For-NaQwlA4jeMl0RJosJjQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2For-NaQwlA4jeMl0RJosJjQ%2Ftall.jpg"
                         }
                      },
                      {
@@ -3458,7 +3458,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fh9yHUJ4fVEVXW4-y0n9tQw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fh9yHUJ4fVEVXW4-y0n9tQw%2Ftall.jpg"
                         }
                      },
                      {
@@ -3476,7 +3476,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F9O2q846eeW0lbdge3WAJCA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F9O2q846eeW0lbdge3WAJCA%2Ftall.jpg"
                         }
                      }
                   ],
@@ -3520,7 +3520,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=29&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FtfNT6_7sX14svcIetc1-6Q%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=29&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FtfNT6_7sX14svcIetc1-6Q%2Ftall.jpg"
                         }
                      },
                      {
@@ -3538,7 +3538,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=29&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FjbNGxYu8R3rIIjj7-E7yYw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=29&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FjbNGxYu8R3rIIjj7-E7yYw%2Ftall.jpg"
                         }
                      },
                      {
@@ -3556,7 +3556,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FkLkWl07T2uWyKfPF1yTN2Q%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FkLkWl07T2uWyKfPF1yTN2Q%2Ftall.jpg"
                         }
                      },
                      {
@@ -3574,7 +3574,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F1uKDOTqMd0dH30iPY4aONg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F1uKDOTqMd0dH30iPY4aONg%2Ftall.jpg"
                         }
                      }
                   ],
@@ -3618,7 +3618,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=23&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Feg8KMOLgcGlYe0YzZf-qUg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=23&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Feg8KMOLgcGlYe0YzZf-qUg%2Ftall.jpg"
                         }
                      },
                      {
@@ -3636,7 +3636,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=25&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FIgxLZUv-WVY_XUeuSvgvmw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=25&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FIgxLZUv-WVY_XUeuSvgvmw%2Ftall.jpg"
                         }
                      }
                   ],
@@ -3680,7 +3680,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=22&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F9uEzranjcw-onTkQn0e6EA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=22&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F9uEzranjcw-onTkQn0e6EA%2Ftall.jpg"
                         }
                      },
                      {
@@ -3698,7 +3698,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=23&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fbbyj8q9SzTHgd_sLaKjOzQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=23&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fbbyj8q9SzTHgd_sLaKjOzQ%2Ftall.jpg"
                         }
                      }
                   ],
@@ -3742,7 +3742,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=12&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FPUNxDziVTc0gcUM1r4MEEQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=12&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FPUNxDziVTc0gcUM1r4MEEQ%2Ftall.jpg"
                         }
                      },
                      {
@@ -3760,7 +3760,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=19&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FvCDribfkFE9i5XVLcfSi9g%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=19&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FvCDribfkFE9i5XVLcfSi9g%2Ftall.jpg"
                         }
                      },
                      {
@@ -3778,7 +3778,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=18&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FId7ec9fwXY36JmwfF2b-2Q%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=18&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FId7ec9fwXY36JmwfF2b-2Q%2Ftall.jpg"
                         }
                      }
                   ],
@@ -3822,7 +3822,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=22&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FX08rq0qh-iPKojveRmjRdQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=22&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FX08rq0qh-iPKojveRmjRdQ%2Ftall.jpg"
                         }
                      },
                      {
@@ -3840,7 +3840,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=23&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FrZqIe31eI3n12d8vWaET4A%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=23&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FrZqIe31eI3n12d8vWaET4A%2Ftall.jpg"
                         }
                      },
                      {
@@ -3858,7 +3858,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=22&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fazs33Sj9n5-MavMTlkTnVA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=22&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fazs33Sj9n5-MavMTlkTnVA%2Ftall.jpg"
                         }
                      }
                   ],
@@ -3902,7 +3902,7 @@
                            "medium_rectangle"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=11&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FtvLIlaWktohfiuba1BBbDw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=11&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FtvLIlaWktohfiuba1BBbDw%2Ftall.jpg"
                         }
                      },
                      {
@@ -3920,7 +3920,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=23&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F90w5qELcxWDLyU7Ga4CyuA%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=23&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F90w5qELcxWDLyU7Ga4CyuA%2Ftall.jpg"
                         }
                      },
                      {
@@ -3938,7 +3938,7 @@
                            "medium"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=23&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fv896hEuLJj2dWqcV8972tg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=23&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fv896hEuLJj2dWqcV8972tg%2Ftall.jpg"
                         }
                      }
                   ],
@@ -3982,7 +3982,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=20&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FvV8TZlqKYUfXWyrt978y3A%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=20&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FvV8TZlqKYUfXWyrt978y3A%2Ftall.jpg"
                         }
                      },
                      {
@@ -4000,7 +4000,7 @@
                            "medium_rectangle"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=22&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fzbo9GELD6ltLAGXja_sWrQ%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=22&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fzbo9GELD6ltLAGXja_sWrQ%2Ftall.jpg"
                         }
                      }
                   ],
@@ -4044,7 +4044,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=21&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FQWxlIYKaUYsH4hSqGXUSLg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=21&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FQWxlIYKaUYsH4hSqGXUSLg%2Ftall.jpg"
                         }
                      },
                      {
@@ -4062,7 +4062,7 @@
                            "medium"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=22&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FcycX8AknH8axJ706Q6O8Lg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=22&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FcycX8AknH8axJ706Q6O8Lg%2Ftall.jpg"
                         }
                      }
                   ],
@@ -4106,7 +4106,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=22&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FlaaBxlaw_JonRQD2ue_sgg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=22&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FlaaBxlaw_JonRQD2ue_sgg%2Ftall.jpg"
                         }
                      },
                      {
@@ -4124,7 +4124,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FTHANYIur946AFxHPjgDYZw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FTHANYIur946AFxHPjgDYZw%2Ftall.jpg"
                         }
                      },
                      {
@@ -4142,7 +4142,7 @@
                            "small"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=23&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FNPofjlggLMZ9KFtN4bpUsw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=23&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FNPofjlggLMZ9KFtN4bpUsw%2Ftall.jpg"
                         }
                      }
                   ],
@@ -4186,7 +4186,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=11&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FcIy2ibQgI3SUCaPasC3DJw%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=11&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FcIy2ibQgI3SUCaPasC3DJw%2Ftall.jpg"
                         }
                      },
                      {
@@ -4204,7 +4204,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FfOyYkfP11y3QYGbQ59AC6g%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FfOyYkfP11y3QYGbQ59AC6g%2Ftall.jpg"
                         }
                      },
                      {
@@ -4222,7 +4222,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FJNS3JvtGlr1VyuSJNY3Xyg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=24&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FJNS3JvtGlr1VyuSJNY3Xyg%2Ftall.jpg"
                         }
                      }
                   ],
@@ -4266,7 +4266,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=19&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FxG1wxxmVOexNiv8CPuGXLg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=19&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FxG1wxxmVOexNiv8CPuGXLg%2Ftall.jpg"
                         }
                      },
                      {
@@ -4284,7 +4284,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=21&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FjMLyicwAVOlfRTy72vvvig%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=21&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FjMLyicwAVOlfRTy72vvvig%2Ftall.jpg"
                         }
                      }
                   ],
@@ -4328,7 +4328,7 @@
                            "normalized"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=25&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FF7wbMjkemfcrLcUlnAG4Rg%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=25&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FF7wbMjkemfcrLcUlnAG4Rg%2Ftall.jpg"
                         }
                      },
                      {
@@ -4346,7 +4346,7 @@
                            "medium_rectangle"
                         ],
                         "placeholder":{
-                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=25&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FUUAfE8bw3J9etaeOWbOB8Q%2Ftall.jpg"
+                           "image_url":"https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=30&height=25&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FUUAfE8bw3J9etaeOWbOB8Q%2Ftall.jpg"
                         }
                      }
                   ],

--- a/src/test/acceptance/fixtures/metaphysics/bidding4.json
+++ b/src/test/acceptance/fixtures/metaphysics/bidding4.json
@@ -227,7 +227,7 @@
           "id": "58f7d603c9dc241dad8a593b",
           "url": "https://d32dm0rphc51dk.cloudfront.net/OKJIqI_F0-UOjhbU7dnSbQ/larger.jpg",
           "placeholder": {
-            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=26&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FOKJIqI_F0-UOjhbU7dnSbQ%2Fsmall.jpg"
+            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=26&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FOKJIqI_F0-UOjhbU7dnSbQ%2Fsmall.jpg"
           },
           "is_zoomable": true
         },
@@ -248,7 +248,7 @@
           "id": "58f8d98ca09a6706d5b28a09",
           "url": "https://d32dm0rphc51dk.cloudfront.net/C9hlGURBAIoVlT6SfVuoXQ/larger.jpg",
           "placeholder": {
-            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=27&height=30&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FC9hlGURBAIoVlT6SfVuoXQ%2Fsmall.jpg"
+            "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=27&height=30&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FC9hlGURBAIoVlT6SfVuoXQ%2Fsmall.jpg"
           },
           "is_zoomable": true
         }
@@ -262,7 +262,7 @@
         "resized": {
           "width": 569,
           "height": 640,
-          "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=569&height=640&quality=95&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FOKJIqI_F0-UOjhbU7dnSbQ%2Flarge.jpg"
+          "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=569&height=640&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FOKJIqI_F0-UOjhbU7dnSbQ%2Flarge.jpg"
         }
       },
       "meta": {


### PR DESCRIPTION
This PR changes the image quality of gemini-generated images as it is [suggested by Google](https://developers.google.com/web/tools/lighthouse/audits/optimize-images):

>  To pass the audit, set the compression level of each image to 85 or lower.

This may sound scary, but if you compare two images generated with `quality=95` or `quality=80` side-by-side, you would not be able to see any differences (there is an on-going Slack conversation [here](https://artsy.slack.com/archives/C02BC3HEJ/p1519765865000758) and [there](https://artsy.slack.com/archives/C02BGC5PW/p1519767409000029)).

This would dramatically reduce the file size of an image. In the example below, the size of the image with `quality=95` is 1MB while the other one with `quality=80` is 479KB. Let us know if this is an acceptable change or if we are missing something!

![screen shot 2018-02-23 at 7 01 38 pm](https://user-images.githubusercontent.com/386234/36757806-7e8a40e4-1be0-11e8-96c0-250e831c85f9.png)

cc @sweir27 
