### PR TITLE
Load hero images through Gemini to reduce file size

### DIFF
--- a/src/desktop/apps/home/templates/hero_unit.jade
+++ b/src/desktop/apps/home/templates/hero_unit.jade
@@ -1,6 +1,6 @@
 .home-hero-unit(
   class= 'home-hero-unit' + _s.dasherize(_s.humanize(heroUnit.mode)) + (i == 0 ? ' home-hero-unit-active' : '')
-  style="background-image: url('#{heroUnit.background_image_url}')"
+  style="background-image: url('#{resize(heroUnit.background_image_url, { width: 2000 })}')"
   data-mode=heroUnit.mode
 )
   a.hhu-frame( class='js-homepage-hero-unit', href=heroUnit.href ): .responsive-layout-container: .main-layout-container

--- a/src/desktop/apps/home/test/templates.coffee
+++ b/src/desktop/apps/home/test/templates.coffee
@@ -7,7 +7,8 @@ render = (data) ->
   template = jade.compileFile(require.resolve '../templates/hero_unit.jade')
   template _.extend {}, {
     _s: _s
-    markdown: markdown
+    markdown: markdown,
+    resize: () => {}
   }, data
 
 describe 'Hero unit template', ->


### PR DESCRIPTION
We noticed that the hero images on the home page are not loaded through Gemini. These images are fairly large (2000px by 672px, multi-MB) and take a lot of bandwidth. By loading these images through Gemini's resizing endpoint (with the default quality of `80`) we would be able to reduce approximately 75% of the file size.

## Before

![screen_shot_2018-02-27_at_5_23_46_pm](https://user-images.githubusercontent.com/386234/36758772-5d123dba-1be3-11e8-8923-2cb95c690498.png)

## After

![screen_shot_2018-02-27_at_5_23_12_pm](https://user-images.githubusercontent.com/386234/36758785-641fb2fe-1be3-11e8-9503-3950a27f3ba1.png)

cc @sweir27 