### PR TITLE
Resize hero images on mobile

### DIFF
--- a/src/mobile/apps/home/routes.coffee
+++ b/src/mobile/apps/home/routes.coffee
@@ -1,3 +1,4 @@
+{ resize } = require '../../components/resizer/index.coffee'
 metaphysics = require '../../../lib/metaphysics.coffee'
 
 query = """
@@ -18,5 +19,5 @@ query = """
 module.exports.index = (req, res, next) ->
   metaphysics(query: query)
     .then ({ home_page  }) ->
-      res.render 'page', heroUnits: home_page.hero_units
+      res.render 'page', heroUnits: home_page.hero_units, resize: resize
     .catch next

--- a/src/mobile/apps/home/templates/page.jade
+++ b/src/mobile/apps/home/templates/page.jade
@@ -8,7 +8,7 @@ block content
           for heroUnit in heroUnits
             figure.home-page-hero-unit(
               class= 'home-page-hero-unit' + _s.dasherize(_s.humanize(heroUnit.mode))
-              style="background-image: url(#{heroUnit.background_image_url});"
+              style="background-image: url(#{resize(heroUnit.background_image_url, { width: 635 })});"
             )
               a( href= heroUnit.href )
                 figcaption.home-page-hero-unit-details

--- a/src/mobile/apps/home/test/templates.coffee
+++ b/src/mobile/apps/home/test/templates.coffee
@@ -60,7 +60,7 @@ describe 'Index', ->
       { title: 'Diary of a cat' }
       { title: 'Diary of a dog' }
     ]
-    html = render('page')(heroUnits: heroUnits, sd: {}, _s: _s)
+    html = render('page')(heroUnits: heroUnits, sd: {}, _s: _s, resize: () => {})
     html.should.containEql 'Diary of a cat'
     $ = cheerio.load html
 


### PR DESCRIPTION
This change is similar to #2227 but for mobile.

In addition to reducing the quality (default is now `80`), we found that in some cases even though the hero image that was uploaded is cropped correctly for mobile web, it might still be very large. This should fix that as well.

## Before

![screen_shot_2018-02-28_at_1_32_40_pm](https://user-images.githubusercontent.com/386234/36805906-888713f4-1c8c-11e8-81c0-2b929c9a10fc.png)

## After

![123](https://user-images.githubusercontent.com/386234/36805940-a08eaf3e-1c8c-11e8-8e99-6f02736cfec7.png)
