### PR TITLE
@mzikherman => explicitly request tall images for artwork columns on artwork page

### DIFF
--- a/src/mobile/apps/artwork/components/related_artworks/queries/index.coffee
+++ b/src/mobile/apps/artwork/components/related_artworks/queries/index.coffee
@@ -15,7 +15,7 @@ module.exports = """
   }
   image {
     placeholder
-    url
+    url (version: "tall")
     is_default
     thumb: resized(width: 350, version: ["large", "larger"]) {
       url


### PR DESCRIPTION
We noticed that on the artworks view in mobile web, we were requesting images of all sizes to display in the columns below the main artwork view:

![screen shot 2018-02-28 at 4 10 19 pm](https://user-images.githubusercontent.com/2081340/36813357-4a95ee60-1ca2-11e8-8be3-4f01a8b56018.png)

We only need `tall` images (max) for these small views, so this PR updates the metaphysics query that requests the artwork image to explicitly fetch the `tall` version. (Otherwise it just seems to grab the latest image version in the list, which is anything from `large` to `tall` and mostly, `normalized` 😱 .

With this update, we're fetching much less data. (the largest image used to be 4.7 MB for an image that was way down in the related section, vs. 87.4 KB after the change).
![screen shot 2018-02-28 at 4 13 27 pm](https://user-images.githubusercontent.com/2081340/36813443-9aa2725c-1ca2-11e8-9a97-1e8ef9b8187a.png)

