### PR TITLE
@anandaroop => Show fix re: save controls

### DIFF
--- a/src/desktop/apps/show/components/artwork_item_metaphysics/save_controls/view.coffee
+++ b/src/desktop/apps/show/components/artwork_item_metaphysics/save_controls/view.coffee
@@ -19,7 +19,7 @@ module.exports = class SaveControls extends Backbone.View
     @listenTo @artworkCollection, "add:#{@artwork.id}", @onArtworkSaveChange
     @listenTo @artworkCollection, "remove:#{@artwork.id}", @onArtworkSaveChange
 
-    @onArtworkSaveChange()
+    @onArtworkSaveChange() if @artworkCollection
 
   onArtworkSaveChange: ->
     state = if @artworkCollection.isSaved(@artwork) then 'saved' else 'unsaved'


### PR DESCRIPTION
Good catch!

Basically this was crashing since we were trying to set the initial saved state of artworks on the page, which crashes when you're logged out (clearly they're all unsaved in that case). 