### PR TITLE
Display personalize flash 'thank you' message after completion of onboarding

### DIFF
--- a/src/desktop/components/main_layout/header/view.coffee
+++ b/src/desktop/components/main_layout/header/view.coffee
@@ -131,8 +131,7 @@ module.exports = class HeaderView extends Backbone.View
     # Sometime '/personalize/' can exist as a redirect parameter in the URL.
     # This causes the flash message to display at unexpected times.
     # This ensures we check for personalize in the pathname.
-    referrerUrl = new URL(document.referrer)
-    if referrerUrl.pathname.match '^/personalize.*'
+    if document.referrer.split('?')[0].match '^/personalize.*'
       new FlashMessage message: 'Thank you for personalizing your profile'
     else if document.referrer.match '/artsy-primer-personalize/'
       new FlashMessage message: 'Thank you. Please expect your personalized portfolio in the next 2 business days.'

--- a/src/desktop/components/main_layout/header/view.coffee
+++ b/src/desktop/components/main_layout/header/view.coffee
@@ -128,7 +128,11 @@ module.exports = class HeaderView extends Backbone.View
         new FlashMessage message: errorMessage
 
   checkForPersonalizeFlash: ->
-    if document.referrer.match '/personalize/'
+    # Sometime '/personalize/' can exist as a redirect parameter in the URL.
+    # This causes the flash message to display at unexpected times.
+    # This ensures we check for personalize in the pathname.
+    referrerUrl = new URL(document.referrer)
+    if referrerUrl.pathname.match '^/personalize.*'
       new FlashMessage message: 'Thank you for personalizing your profile'
     else if document.referrer.match '/artsy-primer-personalize/'
       new FlashMessage message: 'Thank you. Please expect your personalized portfolio in the next 2 business days.'


### PR DESCRIPTION
This address [AR-290](https://artsyproduct.atlassian.net/browse/AR-290). Sometime '/personalize/' can exist as a redirect parameter in the URL. This causes the flash message to display at unexpected times. This ensures we check for personalize in the pathname and disregard the any query string parameters.