### PR TITLE
@mzikherman => don't resize the "welcome" hero unit

### DIFF
--- a/src/desktop/apps/home/templates/hero_unit.jade
+++ b/src/desktop/apps/home/templates/hero_unit.jade
@@ -1,6 +1,8 @@
+- backgroundImageUrl = (heroUnit.mode === 'WELCOME') ? heroUnit.background_image_url : resize(heroUnit.background_image_url, { width: 2000 })
+
 .home-hero-unit(
   class= 'home-hero-unit' + _s.dasherize(_s.humanize(heroUnit.mode)) + (i == 0 ? ' home-hero-unit-active' : '')
-  style="background-image: url('#{resize(heroUnit.background_image_url, { width: 2000 })}')"
+  style="background-image: url('#{backgroundImageUrl}')"
   data-mode=heroUnit.mode
 )
   a.hhu-frame( class='js-homepage-hero-unit', href=heroUnit.href ): .responsive-layout-container: .main-layout-container

--- a/src/desktop/apps/home/test/templates.coffee
+++ b/src/desktop/apps/home/test/templates.coffee
@@ -8,10 +8,18 @@ render = (data) ->
   template _.extend {}, {
     _s: _s
     markdown: markdown,
-    resize: () => {}
+    resize: (url) => "https://d234.cloudfront.net?resize_to=fit&src=#{url}"
   }, data
 
 describe 'Hero unit template', ->
   it 'renders markdown subtitles', ->
     render heroUnit: subtitle: 'This is a *subtitle*'
       .should.containEql '<em>subtitle</em>'
+
+  it 'resizes the image url if the hero unit comes from metaphysics', ->
+    render heroUnit: subtitle: 'This is a *subtitle*', mode: 'LEFT_DARK', background_image_url: 'd3swk.cloudfront.net/large.jpg'
+      .should.containEql '?resize_to=fit'
+
+  it 'does not resize the image url if the hero unit is the welcome image', ->
+    render heroUnit: subtitle: 'This is a *subtitle*', mode: 'WELCOME'
+      .should.not.containEql '?resize_to=fit'


### PR DESCRIPTION
https://github.com/artsy/force/pull/2227 accidentally broke the "welcome" hero image, which is not loaded through metaphysics (but points to image/data directly in force). 

This PR fixes that to check for the hero unit's `mode`. When loaded through metaphysics, the `mode` will be one of `'LEFT_DARK'`, `'LEFT_LIGHT'`... (all options here: https://github.com/artsy/metaphysics/blob/master/src/schema/home/home_page_hero_units.js#L22-L39), so escaping on `'WELCOME'` seems sufficient.

cc @yuki24 