### PR TITLE
[Artist] ensures reflection doesn't index test variants

### DIFF
--- a/src/desktop/apps/artist/client/router.coffee
+++ b/src/desktop/apps/artist/client/router.coffee
@@ -63,7 +63,6 @@ module.exports = class ArtistRouter extends Backbone.Router
 
   overview: ->
     @view = new OverviewView @options
-
     $('body').append @jump.$el
     @view.on 'artist:overview:sync', (artist) =>
       attachCTA new Artist(_.extend({}, artist, @model.attributes))

--- a/src/desktop/apps/artist/client/router.coffee
+++ b/src/desktop/apps/artist/client/router.coffee
@@ -63,6 +63,7 @@ module.exports = class ArtistRouter extends Backbone.Router
 
   overview: ->
     @view = new OverviewView @options
+
     $('body').append @jump.$el
     @view.on 'artist:overview:sync', (artist) =>
       attachCTA new Artist(_.extend({}, artist, @model.attributes))

--- a/src/desktop/apps/artist/client/views/overview.coffee
+++ b/src/desktop/apps/artist/client/views/overview.coffee
@@ -8,6 +8,7 @@ RelatedArticlesView = require '../../../../components/related_articles/view.coff
 RelatedShowsView = require '../../../../components/related_shows/view.coffee'
 ArtworkFilterView = require '../../../../components/artwork_filter_2/view.coffee'
 FollowButton = require '../../../../components/follow_button/view.coffee'
+splitTest = require '../../../../components/split_test/index.coffee'
 viewHelpers = require '../../view_helpers.coffee'
 gradient = require '../../../../components/gradient_blurb/index.coffee'
 template = -> require('../../templates/sections/overview.jade') arguments...

--- a/src/desktop/apps/artist/client/views/overview.coffee
+++ b/src/desktop/apps/artist/client/views/overview.coffee
@@ -23,6 +23,8 @@ module.exports = class OverviewView extends Backbone.View
 
   initialize: ({ @user, @statuses }) ->
     @listenTo this, 'artist:overview:sync', @renderRelated
+    # remove after test closes
+    splitTest('artist_page_variants').view()
 
   fetchRelated: ->
     metaphysics

--- a/src/desktop/apps/artist/client/views/overview.coffee
+++ b/src/desktop/apps/artist/client/views/overview.coffee
@@ -8,7 +8,6 @@ RelatedArticlesView = require '../../../../components/related_articles/view.coff
 RelatedShowsView = require '../../../../components/related_shows/view.coffee'
 ArtworkFilterView = require '../../../../components/artwork_filter_2/view.coffee'
 FollowButton = require '../../../../components/follow_button/view.coffee'
-splitTest = require '../../../../components/split_test/index.coffee'
 viewHelpers = require '../../view_helpers.coffee'
 gradient = require '../../../../components/gradient_blurb/index.coffee'
 template = -> require('../../templates/sections/overview.jade') arguments...
@@ -16,6 +15,7 @@ showHighlightsTemplate = -> require('../../templates/sections/exhibition_highlig
 renderRail = require '../../components/rail/index.coffee'
 metaphysics = require '../../../../../lib/metaphysics.coffee'
 query = require '../../queries/overview.coffee'
+sd = require('sharify').data
 
 module.exports = class OverviewView extends Backbone.View
   subViews: []
@@ -127,10 +127,15 @@ module.exports = class OverviewView extends Backbone.View
 
   render: ->
     # Template expects plain JSON, not a Backbone model.
+    testGroup = sd.ARTIST_PAGE_VARIANTS
+
     @$el.html template
       artist: @model.toJSON()
       viewHelpers: viewHelpers
       statuses: @statuses
+      showSections:
+        header: testGroup is 'control' or testGroup is 'no_info'
+        info: testGroup is 'control' or testGroup is 'no_header'
     _.defer => @postRender()
     this
 

--- a/src/desktop/apps/artist/routes.coffee
+++ b/src/desktop/apps/artist/routes.coffee
@@ -19,13 +19,13 @@ sd = require('sharify').data
 
 @index = (req, res, next) ->
   tab = if req.params.tab? then req.params.tab else ''
-  includeJSONLD = res.locals.sd.REFLECTION
+  isReqFromReflection = res.locals.sd.REFLECTION
   send =
     query: query,
     variables:
       artist_id: req.params.id
       includeBlurb: (tab is '')
-      includeJSONLD: includeJSONLD
+      includeJSONLD: isReqFromReflection
     req: req
 
   return if metaphysics.debug req, res, send
@@ -35,6 +35,9 @@ sd = require('sharify').data
       nav = new Nav artist: artist
 
       return res.redirect(artist.href) unless(_.find nav.sections(), slug: tab) or artist.counts.artworks is 0
+
+      # if request comes from reflection render the control variant of the artist page
+      testGroup = if isReqFromReflection then 'control' else res.locals.sd.ARTIST_PAGE_VARIANTS 
 
       if (req.params.tab? or artist.href is res.locals.sd.CURRENT_PATH)
         currentVeniceFeature(artist)
@@ -52,7 +55,10 @@ sd = require('sharify').data
               tab: tab
               nav: nav
               currentItem: currentItem
-              jsonLD: JSON.stringify helpers.toJSONLD artist if includeJSONLD
+              jsonLD: JSON.stringify helpers.toJSONLD artist if isReqFromReflection
+              showSections:
+                header: testGroup is 'control' or testGroup is 'no_info'
+                info: testGroup is 'control' or testGroup is 'no_header'
 
       else
         res.redirect artist.href

--- a/src/desktop/apps/artist/routes.coffee
+++ b/src/desktop/apps/artist/routes.coffee
@@ -35,10 +35,8 @@ sd = require('sharify').data
       nav = new Nav artist: artist
 
       return res.redirect(artist.href) unless(_.find nav.sections(), slug: tab) or artist.counts.artworks is 0
-      testGroup = res.locals.sd.ARTIST_PAGE_VARIANTS
 
-      # if request comes from reflection render the control variant of the artist page
-      testGroup = if isReqFromReflection then 'control' else res.locals.sd.ARTIST_PAGE_VARIANTS 
+      testGroup = res.locals.sd.ARTIST_PAGE_VARIANTS 
 
       if (req.params.tab? or artist.href is res.locals.sd.CURRENT_PATH)
         currentVeniceFeature(artist)

--- a/src/desktop/apps/artist/routes.coffee
+++ b/src/desktop/apps/artist/routes.coffee
@@ -35,6 +35,7 @@ sd = require('sharify').data
       nav = new Nav artist: artist
 
       return res.redirect(artist.href) unless(_.find nav.sections(), slug: tab) or artist.counts.artworks is 0
+      testGroup = res.locals.sd.ARTIST_PAGE_VARIANTS
 
       # if request comes from reflection render the control variant of the artist page
       testGroup = if isReqFromReflection then 'control' else res.locals.sd.ARTIST_PAGE_VARIANTS 

--- a/src/desktop/apps/artist/templates/index.jade
+++ b/src/desktop/apps/artist/templates/index.jade
@@ -9,7 +9,7 @@ append locals
 
 block body
   - carousel = artist.carousel
-  - hasCarousel = carousel && carousel.images.length >= 4
+  - hasCarousel = carousel && carousel.images.length >= 4 && showSections.header
 
   #artist-page(
     class=(hasCarousel ? 'has-carousel' : 'has-no-carousel')

--- a/src/desktop/apps/artist/templates/sections/overview.jade
+++ b/src/desktop/apps/artist/templates/sections/overview.jade
@@ -10,30 +10,31 @@ mixin rail(title, viewAllUrl, section)
 
         include ../../../../components/merry_go_round/templates/horizontal_navigation
 
-.artist-overview-header
-  .evenly-bisected-header
-    - var artistMeta = viewHelpers.artistMeta(artist)
+if showSections.info
+  .artist-overview-header
+    .evenly-bisected-header
+      - var artistMeta = viewHelpers.artistMeta(artist)
 
-    - var hasMeta = viewHelpers.hasOverviewHeaderMeta(artist)
-    - var hasShows = statuses.shows || statuses.cv
+      - var hasMeta = viewHelpers.hasOverviewHeaderMeta(artist)
+      - var hasShows = statuses.shows || statuses.cv
 
-    .bisected-header-cell.js-artist-overview-header-left
-      if hasMeta
-        .artist-blurb.bisected-header-cell-section
-          h2 Biography
-          if artist.biography_blurb && artist.biography_blurb.text
-            .blurb!= artist.biography_blurb.text
-            if artist.biography_blurb.credit
-              .artist-blurb__credit &mdash; #{artist.biography_blurb.credit}
+      .bisected-header-cell.js-artist-overview-header-left
+        if hasMeta
+          .artist-blurb.bisected-header-cell-section
+            h2 Biography
+            if artist.biography_blurb && artist.biography_blurb.text
+              .blurb!= artist.biography_blurb.text
+              if artist.biography_blurb.credit
+                .artist-blurb__credit &mdash; #{artist.biography_blurb.credit}
+              if artistMeta.length
+                br
             if artistMeta.length
-              br
-          if artistMeta.length
-            .artist-meta-detail!= artistMeta
+              .artist-meta-detail!= artistMeta
 
-    .bisected-header-cell.js-artist-overview-header-right
-      if hasShows
-        .artist-exhibition-highlights.bisected-header-cell-section
-          //- Rendered client-side
+      .bisected-header-cell.js-artist-overview-header-right
+        if hasShows
+          .artist-exhibition-highlights.bisected-header-cell-section
+            //- Rendered client-side
 
 if artist.statuses.artworks
   include ./works

--- a/src/desktop/apps/artist/test/templates.coffee
+++ b/src/desktop/apps/artist/test/templates.coffee
@@ -31,6 +31,9 @@ describe 'Artist header', ->
         artist: @artist
         nav: @nav
         viewHelpers: helpers
+        showSections:
+          header: true
+          info: true
       }, done
 
     it 'should not display the no works message if there is more than 0 artworks', ->
@@ -62,6 +65,9 @@ describe 'Artist header', ->
         artist: @artist
         nav: @nav
         viewHelpers: helpers
+        showSections:
+          header: true
+          info: true
       }, done
 
     it 'should not display the no works message if there is more than 0 artworks', ->
@@ -96,6 +102,9 @@ describe 'Artist header', ->
         artist: @artist
         nav: @nav
         viewHelpers: helpers
+        showSections:
+          header: true
+          info: true
       }, done
 
     it 'should display the no works message if there are no artworks', ->

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -15,10 +15,18 @@
 # module.exports = {}
 
 module.exports = {
- onboarding_test:
-   key: 'onboarding_test'
-   outcomes:
-     control: 50
-     experiment: 50
-   edge: 'experiment'
+  onboarding_test:
+    key: 'onboarding_test'
+    outcomes:
+      control: 50
+      experiment: 50
+    edge: 'experiment'
+  artist_page_variants:
+    key: 'artist_page_variants'
+    outcomes:
+      control: 25
+      no_info: 25
+      no_header: 25
+      no_info_header: 25
+    edge: 'no_info_header'
 }

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -9,6 +9,7 @@
 #   edge: 'new'
 #   dimension: 'dimension1' # Optional GA dimension
 #   scope: 'local' # Optionally disable global initialization
+#   control_group: 'old' #Defaults to `control`
 #
 # Note: if there are no running tests
 # this should export empty Object
@@ -20,6 +21,7 @@ module.exports = {
     outcomes:
       control: 50
       experiment: 50
+    control_group: 'control'
     edge: 'experiment'
   artist_page_variants:
     key: 'artist_page_variants'
@@ -28,5 +30,6 @@ module.exports = {
       no_info: 25
       no_header: 25
       no_info_header: 25
+    control_group: 'control'
     edge: 'no_info_header'
 }

--- a/src/desktop/components/split_test/test/split_test.coffee
+++ b/src/desktop/components/split_test/test/split_test.coffee
@@ -48,3 +48,18 @@ describe 'SplitTest', ->
       adminTest = new @SplitTest key: 'foobar', edge: 'baz', outcomes: baz: 0, qux: 100
       adminTest.admin().should.be.true()
       adminTest.outcome().should.equal 'baz'
+
+  describe 'reflection', ->
+    beforeEach ->
+      @reflectionStub = sinon.stub(@SplitTest::, 'reflection').returns true
+
+    afterEach ->
+      @reflectionStub.restore()
+
+    it 'outcome is set to control group if request comes from Reflection', ->
+      test = new @SplitTest key: 'foobar', edge: 'baz', outcomes: control: 10, qux: 90
+      test.outcome().should.equal 'control'
+    
+    it 'outcome should be set to specified control group key', ->
+      test = new @SplitTest key: 'foobar', edge: 'baz', control_group: 'old', outcomes: old: 10, qux: 90
+      test.outcome().should.equal 'old'


### PR DESCRIPTION
Continuation of https://github.com/artsy/force/pull/2239

This includes a check to ensure reflection don't index one of the experimental variants. 

Here's the analytics call made for this feature when the artist page loads. @anipetrov Is there anything else we'd like to log or track for this test?

```javascript
analytics.track('Experiment Viewed', {
  experiment_id: 'artist_page_variants',
  experiment_name: 'artist_page_variants',
  nonInteraction: 1,
  variation_id: 'no_info_header', // accepted values are 'control', 'no_info', 'no_header', 'no_info_header'
  variation_name: 'no_info_header'
});
```

Raw event from segment
```javascript
{
  "anonymousId": "d4613e2b-4351-4b44-a0f0-5f3efb32a6a0",
  "context": {
    "library": {
      "name": "analytics.js",
      "version": "3.3.0"
    },
    "page": {
      "path": "/artist/kenton-parker",
      "referrer": "http://localhost:5000/artists",
      "search": "",
      "title": "Kenton Parker - 60 Artworks, Bio & Shows on Artsy",
      "url": "http://localhost:5000/artist/kenton-parker"
    },
    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
    "ip": "181.137.96.209"
  },
  "event": "Experiment Viewed",
  "integrations": {},
  "messageId": "ajs-527937ec505aa1a5836693971b4a6fe5",
  "properties": {
    "experiment_id": "artist_page_variants",
    "experiment_name": "artist_page_variants",
    "nonInteraction": 1,
    "variation_id": "no_info_header",
    "variation_name": "no_info_header"
  },
  "receivedAt": "2018-03-05T16:26:50.710Z",
  "sentAt": "2018-03-05T16:26:50.625Z",
  "timestamp": "2018-03-05T16:26:50.708Z",
  "type": "track",
  "userId": null,
  "originalTimestamp": "2018-03-05T16:26:50.623Z"
}
```