### PR TITLE
merchandisability sort ab test

### DIFF
--- a/src/desktop/apps/collect/client.coffee
+++ b/src/desktop/apps/collect/client.coffee
@@ -18,12 +18,16 @@ SizeFilterView = require '../../components/commercial_filter/filters/size/size_f
 KeywordFilterView = require '../../components/commercial_filter/filters/keyword/keyword_filter_view.coffee'
 PillboxView = require '../../components/commercial_filter/views/pillbox/pillbox_view.coffee'
 ArtworkColumnsView = require '../../components/artwork_columns/view.coffee'
+splitTest = require '../../components/split_test/index.coffee'
 CurrentUser = require '../../models/current_user.coffee'
 scrollFrame = require 'scroll-frame'
 sd = require('sharify').data
 { fullyQualifiedLocations } = require '../../components/commercial_filter/filters/location/location_map.coffee'
 
 module.exports.init = ->
+  # MERCH_SORT_TEST remove after test closes
+  splitTest('merch_sort_test').view()
+  
   # Set initial params from the url params
   paramsFromUrl = qs.parse(location.search.replace(/^\?/, ''))
   params = new Params paramsFromUrl,

--- a/src/desktop/apps/collect/client.coffee
+++ b/src/desktop/apps/collect/client.coffee
@@ -28,7 +28,8 @@ module.exports.init = ->
   paramsFromUrl = qs.parse(location.search.replace(/^\?/, ''))
   params = new Params paramsFromUrl,
     categoryMap: sd.CATEGORIES
-    fullyQualifiedLocations: fullyQualifiedLocations
+    fullyQualifiedLocations: fullyQualifiedLocations,
+    merchTestGroup: sd.MERCH_SORT_TEST
   filter = new Filter params: params
 
   headlineView = new HeadlineView
@@ -44,30 +45,18 @@ module.exports.init = ->
     el: $('.cf-total-sort__sort')
     params: params
 
-  if CurrentUser.orNull()?.hasLabFeature('Keyword Search')
-    pillboxView = new PillboxView
-      el: $('.cf-headline-container .cf-pillboxes')
-      params: params
-      artworks: filter.artworks
-      categoryMap: sd.CATEGORIES
+  categoryView = new CategoryFilterView
+    el: $('.cf-categories')
+    params: params
+    aggregations: filter.aggregations
+    categoryMap: sd.CATEGORIES
+    alwaysEnabled: true
 
-    keywordView = new KeywordFilterView
-      el: $('.cf-keyword')
-      params: params
-
-  else
-    categoryView = new CategoryFilterView
-      el: $('.cf-categories')
-      params: params
-      aggregations: filter.aggregations
-      categoryMap: sd.CATEGORIES
-      alwaysEnabled: true
-
-    pillboxView = new PillboxView
-      el: $('.cf-right .cf-pillboxes')
-      params: params
-      artworks: filter.artworks
-      categoryMap: sd.CATEGORIES
+  pillboxView = new PillboxView
+    el: $('.cf-right .cf-pillboxes')
+    params: params
+    artworks: filter.artworks
+    categoryMap: sd.CATEGORIES
 
   # Main Artworks view
   filter.artworks.on 'reset', ->

--- a/src/desktop/apps/collect/routes.coffee
+++ b/src/desktop/apps/collect/routes.coffee
@@ -7,8 +7,11 @@ page = new JSONPage name: 'browse-categories'
 GeocodedCities = require '../../collections/geocoded_cities'
 { COLLECT_PAGE_TITLES_URL } = require('sharify').data
 getCollectPageTitle = require '../../components/commercial_filter/page_title'
+splitTest = require '../../components/split_test/index.coffee'
 
 @index = (req, res, next) ->
+  # MERCH_SORT_TEST remove after test closes
+  splitTest('merch_sort_test').view()
   geocodedCities = new GeocodedCities()
   collectPageTitleFilters = new Backbone.Collection()
   Q.all([

--- a/src/desktop/apps/collect/routes.coffee
+++ b/src/desktop/apps/collect/routes.coffee
@@ -7,11 +7,8 @@ page = new JSONPage name: 'browse-categories'
 GeocodedCities = require '../../collections/geocoded_cities'
 { COLLECT_PAGE_TITLES_URL } = require('sharify').data
 getCollectPageTitle = require '../../components/commercial_filter/page_title'
-splitTest = require '../../components/split_test/index.coffee'
 
 @index = (req, res, next) ->
-  # MERCH_SORT_TEST remove after test closes
-  splitTest('merch_sort_test').view()
   geocodedCities = new GeocodedCities()
   collectPageTitleFilters = new Backbone.Collection()
   Q.all([

--- a/src/desktop/components/commercial_filter/models/params.coffee
+++ b/src/desktop/components/commercial_filter/models/params.coffee
@@ -43,12 +43,15 @@ module.exports = class Params extends Backbone.Model
         min: 1
         max: 120
 
-  initialize: (attributes, { @categoryMap, @fullyQualifiedLocations, @customDefaults }) ->
+  initialize: (attributes, { @categoryMap, @fullyQualifiedLocations, @merchTestGroup }) ->
 
   initialParams: ->
-    @customDefaults || @defaults
+    @defaults
 
   current: ->
+    if @merchTestGroup is 'experiment' and not @attributes.sort?
+      _.extend @attributes, sort: '-decayed_merch'
+
     if @categoryMap
       categories = @categoryMap[@get('medium') || 'global']
       extra_aggregation_gene_ids = _.pluck categories, 'id'

--- a/src/desktop/components/commercial_filter/test/models/params.coffee
+++ b/src/desktop/components/commercial_filter/test/models/params.coffee
@@ -16,13 +16,7 @@ describe 'Filter', ->
     benv.teardown()
 
   describe '#initialParams', ->
-    it 'returns the defaults if custom defaults are not passed in', ->
+    it 'returns the defaults', ->
       params = new @Params({}, {})
       defaults = params.initialParams()
       defaults.should.containEql(size: 40, partner_cities: [])
-
-    it 'returns the custom defaults if they are passed in', ->
-      params = new @Params({}, { customDefaults: { size: 20, artist_ids: [] } })
-      defaults = params.initialParams()
-      defaults.should.eql(size: 20, artist_ids: [])
-      defaults.should.not.containEql(size: 40)

--- a/src/desktop/components/commercial_filter/views/sort/sort_map.coffee
+++ b/src/desktop/components/commercial_filter/views/sort/sort_map.coffee
@@ -1,4 +1,5 @@
 module.exports =
+  '-decayed_merch': 'Default'
   '-partner_updated_at': "Recently Updated"
   '-prices': "Most Expensive"
   'prices': "Least Expensive"

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -32,4 +32,11 @@ module.exports = {
       no_info_header: 25
     control_group: 'control'
     edge: 'no_info_header'
+  merch_sort_test:
+    key: 'merch_sort_test'
+    outcomes:
+      control: 50
+      experiment: 50
+    control_group: 'control'
+    edge: 'experiment'
 }


### PR DESCRIPTION
This puts a merchandisability A/B test live on `/collect` with two groups. The experiment group gets `-decayed_merch` sort instead of the default `-partner_updated_at`. The merch sort combines our merchandisability scores with freshness and an auction boost.

The merch sort is presented as `Recently Added` in the sort dropdown - @briansw if you have any preferences for language let me know. There is a strong freshness component so I think this language works better than `Relevance` which might raise more questions.

This shouldn't be merged until:

* ~~Gravity is deployed with the latest merch query.~~ DONE
* @wrgoldstein has reviewed and is happy to run this test. One thing to note is that auction lots are boosted in the new sort, so using inquiries as a performance metric won't capture conversions on lots. It might be that artwork pageviews could be enough (as with the last test on `/collect`), though the difference here is that the sort we are testing is explicitly commercial in focus (so inquiries + bids might be more meaningful).

