### PR TITLE
fix floating point rendering on buyer's premium

### DIFF
--- a/src/desktop/components/buyers_premium/index.coffee
+++ b/src/desktop/components/buyers_premium/index.coffee
@@ -3,6 +3,7 @@ _ = require 'underscore'
 Page = require '../../models/page.coffee'
 
 module.exports = (auction, callback) ->
+  round = (number) -> parseFloat(number.toFixed(2))
   page = new Page id: 'buyers-premium'     # TODO: support multiple concurrent buyer's premiums
   page.fetch
     error: callback
@@ -13,7 +14,7 @@ module.exports = (auction, callback) ->
       if sortedSchedule.length == 1
         buyersPremiumHtml = """
           <div>
-            #{sortedSchedule[0].percent * 100}% on the hammer price
+            #{round(sortedSchedule[0].percent * 100)}% on the hammer price
           </div>
         """
       else
@@ -24,7 +25,7 @@ module.exports = (auction, callback) ->
               <div class='buyers-premium-pre'>
                 On the hammer price up to and including \
                 #{formatMoney(sortedSchedule[idx+1].min_amount_cents / 100, symbol, 0)}:
-                #{sortedSchedule[idx].percent * 100}%
+                #{round(sortedSchedule[idx].percent * 100)}%
               </div>
             </li>
             """
@@ -34,7 +35,7 @@ module.exports = (auction, callback) ->
               <div class='buyers-premium-pre'>
                 On the portion of the hammer price in excess of \
                 #{formatMoney(sortedSchedule[idx].min_amount_cents / 100, symbol, 0)}:
-                #{sortedSchedule[idx].percent * 100}%
+                #{round(sortedSchedule[idx].percent * 100)}%
               </div>
             </li>
             """
@@ -46,7 +47,7 @@ module.exports = (auction, callback) ->
                 #{formatMoney(sortedSchedule[idx].min_amount_cents / 100, symbol, 0)} \
                 up to and including \
                 #{formatMoney(sortedSchedule[idx+1].min_amount_cents / 100, symbol, 0)}: \
-                #{sortedSchedule[idx].percent * 100}%
+                #{round(sortedSchedule[idx].percent * 100)}%
               </div>
             </li>
             """

--- a/src/desktop/components/buyers_premium/index.coffee
+++ b/src/desktop/components/buyers_premium/index.coffee
@@ -3,7 +3,7 @@ _ = require 'underscore'
 Page = require '../../models/page.coffee'
 
 module.exports = (auction, callback) ->
-  round = (number) -> parseFloat(number.toFixed(2))
+  round = (number) -> parseFloat(number.toFixed(5))
   page = new Page id: 'buyers-premium'     # TODO: support multiple concurrent buyer's premiums
   page.fetch
     error: callback

--- a/src/desktop/components/buyers_premium/test/index.coffee
+++ b/src/desktop/components/buyers_premium/test/index.coffee
@@ -25,3 +25,10 @@ describe 'buyersPremium', ->
       html.should.containEql "25% on the hammer price"
       done()
     Backbone.sync.args[0][2].success fabricate 'page'
+ 
+  it 'renders buyers premium nicely that multiplies by 100 poorly', (done) ->
+    sale = fabricate('sale', buyers_premium: { 'schedule': [{ 'min_amount_cents': 0, 'percent': 0.144 }] })
+    buyersPremium new Sale(sale), (err, html) ->
+      html.should.containEql "14.4% on the hammer price"
+      done()
+    Backbone.sync.args[0][2].success fabricate 'page'


### PR DESCRIPTION
Fixes the issue below. Basically, floating point math can lead to weird rounding. I figured we'll probably never need more that 2 places after the decimal point.

<img width="742" alt="image" src="https://user-images.githubusercontent.com/1256382/37133421-4842bb92-2261-11e8-9d2c-835d0059dd31.png">
