### PR TITLE
@mzikherman => don't serialize entire req object when redirecting to graphiql

### DIFF
--- a/src/lib/metaphysics.coffee
+++ b/src/lib/metaphysics.coffee
@@ -43,8 +43,7 @@ metaphysics = ({ query, variables, req } = {}) ->
 
 metaphysics.debug = (req, res, send) ->
   if req.query.query?
-    get = extend {}, send,
-      variables: JSON.stringify send.variables
+    get = { query: send.query, variables: JSON.stringify send.variables }
 
     res.redirect "#{METAPHYSICS_ENDPOINT}?#{qs.stringify get}"
 


### PR DESCRIPTION
Sort of performance-related...

We use `metaphysics.debug` as a way to view a page's server-side metaphysics query in graphiql by adding `?query=true` to the end of a force url.

I noticed that when I did this on an artist page, I caused force-staging to run out of memory (and confirmed that locally as well). 😱 

Turns out that the `send` variable here can _also_ include `req` (even though it is also expected to be passed in). This was the case for the artist /index route, which meant that `qs.stringify get` was actually trying to serialize the entire `req` object (along with the query and variables) and stick it into a URL.

This fixes that by explicitly _only_ serializing `query` and `variables` before redirecting to metaphysics.