### PR TITLE
@mzikherman => adds tracking for pageload time

### DIFF
--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -3,27 +3,66 @@
 // or any other actions that occur on each page.
 //
 
+import { data as sd } from 'sharify'
+
 // Track pageview
-analytics.page({path: location.pathname}, {integrations: {'Marketo': false}})
+analytics.page(
+  { path: location.pathname },
+  { integrations: { Marketo: false } }
+)
+
+// Track pageload speed
+if (
+  window.performance &&
+  window.performance.timing &&
+  sd.TRACK_PAGELOAD_PATHS
+) {
+  window.addEventListener('load', function() {
+    _.each(sd.TRACK_PAGELOAD_PATHS.split('|'), (path) => {
+      if (window.location.pathname.split('/')[1] === path) {
+        window.setTimeout(function() {
+          const {
+            requestStart,
+            loadEventEnd,
+            domComplete,
+          } = window.performance.timing
+
+          analytics.track('Page load time', {
+            requestStart,
+            loadEventEnd,
+            domComplete,
+          })
+        }, 0)
+      }
+    })
+  })
+}
 
 // Track 15 second bounce rate
-setTimeout(function () {
-  analytics.track('time on page more than 15 seconds', { category: '15 Seconds', message: sd.CURRENT_PATH })
+setTimeout(function() {
+  analytics.track('time on page more than 15 seconds', {
+    category: '15 Seconds',
+    message: sd.CURRENT_PATH,
+  })
 }, 15000)
 
 // Track 3 Minute bounce rate
-setTimeout(function () {
-  analytics.track('time on page more than 3 minutes', { category: '3 Minutes', message: sd.CURRENT_PATH })
+setTimeout(function() {
+  analytics.track('time on page more than 3 minutes', {
+    category: '3 Minutes',
+    message: sd.CURRENT_PATH,
+  })
 }, 180000)
 
 // debug tracking calls in development
 if (sd.NODE_ENV !== 'production') {
-  analytics.on('track', function () {
+  analytics.on('track', function() {
     console.info('TRACKED: ', arguments[0], JSON.stringify(arguments[1]))
   })
 }
+
 if (sd.NODE_ENV === 'development') {
-  analyticsHooks.on('all', function (name, data) {
+  analyticsHooks.on('all', function(name, data) {
     console.info('ANALYTICS HOOK: ', name, data)
   })
 }

--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -105,6 +105,7 @@ module.exports =
   STRIPE_PUBLISHABLE_KEY: null
   TEAM_BLOGS: '^\/life-at-artsy$|^\/artsy-education$|^\/gallery-insights$|^\/buying-with-artsy$'
   TARGET_CAMPAIGN_URL: '/seattle-art-fair-2017'
+  TRACK_PAGELOAD_PATHS: null
   TWILIO_ACCOUNT_SID: null
   TWILIO_AUTH_TOKEN: null
   TWILIO_NUMBER: null

--- a/src/lib/setup_sharify.js
+++ b/src/lib/setup_sharify.js
@@ -89,6 +89,7 @@ sharify.data = _.extend(
     'STRIPE_PUBLISHABLE_KEY',
     'TARGET_CAMPAIGN_URL',
     'TEAM_BLOGS',
+    'TRACK_PAGELOAD_PATHS',
     'VENICE_2015_SECTION',
     'WEBFONT_URL'
   ),

--- a/src/mobile/analytics/before_ready.js
+++ b/src/mobile/analytics/before_ready.js
@@ -2,6 +2,8 @@
 // Analytics code that needs to run before page load and analytics.ready
 //
 
+import { data as sd } from 'sharify'
+
 // Disable Parsely firing on non-article/section pages
 if (!location.pathname.match(/^\/article/)) {
   window.PARSELY = { autotrack: false }
@@ -12,3 +14,30 @@ analytics.page(
   { path: location.pathname },
   { integrations: { Marketo: false } }
 )
+
+// Track pageload speed
+if (
+  window.performance &&
+  window.performance.timing &&
+  sd.TRACK_PAGELOAD_PATHS
+) {
+  window.addEventListener('load', function() {
+    _.each(sd.TRACK_PAGELOAD_PATHS.split('|'), (path) => {
+      if (window.location.pathname.split('/')[1] === path) {
+        window.setTimeout(function() {
+          const {
+            requestStart,
+            loadEventEnd,
+            domComplete,
+          } = window.performance.timing
+
+          analytics.track('Page load time', {
+            requestStart,
+            loadEventEnd,
+            domComplete,
+          })
+        }, 0)
+      }
+    })
+  })
+}

--- a/src/mobile/analytics/global.js
+++ b/src/mobile/analytics/global.js
@@ -2,12 +2,13 @@
 // Analytics that occur globaly on every page. Think if there's a better place
 // before you add to this file.
 //
-analyticsHooks.on('track', function (message, options) {
+
+analyticsHooks.on('track', function(message, options) {
   analytics.track(message, options)
 })
 
 // Track 15 second bounce rate
-setTimeout(function () {
+setTimeout(function() {
   analytics.track('time on page more than 15 seconds', {
     category: '15 Seconds',
     message: sd.CURRENT_PATH,
@@ -15,7 +16,7 @@ setTimeout(function () {
 }, 15000)
 
 // Track 30 second bounce rate
-setTimeout(function () {
+setTimeout(function() {
   analytics.track('time on page more than 30 seconds', {
     category: '30 Seconds',
     message: sd.CURRENT_PATH,
@@ -23,13 +24,13 @@ setTimeout(function () {
 }, 180000)
 
 // Debug tracking calls in development
-if (sd.NODE_ENV != 'production') {
-  analytics.on('track', function () {
+if (sd.NODE_ENV !== 'production') {
+  analytics.on('track', function() {
     console.debug('TRACKED: ', arguments[0], JSON.stringify(arguments[1]))
   })
 }
-if (sd.NODE_ENV == 'development') {
-  analyticsHooks.on('all', function (name, data) {
+if (sd.NODE_ENV === 'development') {
+  analyticsHooks.on('all', function(name, data) {
     console.info('ANALYTICS HOOK: ', name, data)
   })
 }

--- a/src/mobile/config.coffee
+++ b/src/mobile/config.coffee
@@ -59,6 +59,7 @@ module.exports =
   SESSION_SECRET: 'artsyoss'
   STRIPE_PUBLISHABLE_KEY: null
   TARGET_CAMPAIGN_URL: '/seattle-art-fair-2017'
+  TRACK_PAGELOAD_PATHS: null
   TWITTER_CONSUMER_KEY: null
   TWITTER_CONSUMER_SECRET: null
   VENICE_2015_SECTION: null


### PR DESCRIPTION
This PR adds tracking for pageload time (cc @wrgoldstein @yuki24)

The main change is the addition of the `TRACK_PAGELOAD_PATHS` env var, plus the code to actually track the fields we care about _only_ on the pages we are interested in. (we configure the pages that will send this data to avoid overloading segment/costing us too much $$$)

There are also lots of changes due to `prettier` being run on these files for the first time.