### PR TITLE
Do not load stripe script anywhere and opt-in when needed

### DIFF
--- a/src/desktop/apps/auction_support/templates/bid-form.jade
+++ b/src/desktop/apps/auction_support/templates/bid-form.jade
@@ -2,6 +2,7 @@ extends ../../../components/main_layout/templates/minimal_header
 
 append locals
   - assetPackage = 'auctions'
+  - options = {stripe: true}
 
 block body
   #auction-registration-page

--- a/src/desktop/apps/auction_support/templates/registration.jade
+++ b/src/desktop/apps/auction_support/templates/registration.jade
@@ -2,6 +2,7 @@ extends ../../../components/main_layout/templates/minimal_header
 
 append locals
   - assetPackage = 'auctions'
+  - options = {stripe: true}
 
 block body
   #auction-registration-page

--- a/src/desktop/apps/editorial_features/components/venice_2017/templates/index.jade
+++ b/src/desktop/apps/editorial_features/components/venice_2017/templates/index.jade
@@ -3,7 +3,7 @@ extends ../../../../../components/main_layout/templates/blank.jade
 append locals
   - assetPackage = 'editorial_features'
   - section = curation.get('sections')[videoIndex]
-  - options = {stripe: false, marketo: false}
+  - options = {marketo: false}
 
 block head
   include head

--- a/src/desktop/apps/order/templates/checkout.jade
+++ b/src/desktop/apps/order/templates/checkout.jade
@@ -3,6 +3,7 @@ extends ../../../components/main_layout/templates/minimal_header
 append locals
   - assetPackage = 'artists_artworks'
   - bodyClass = 'order-body'
+  - options = {stripe: true}
 
 block body
   #order-page

--- a/src/desktop/apps/user/templates/layout.jade
+++ b/src/desktop/apps/user/templates/layout.jade
@@ -5,6 +5,7 @@ block head
 
 append locals
   - assetPackage = 'misc'
+  - options = {stripe: true}
 
 block body
   .settings-page.responsive-layout-container(

--- a/src/desktop/components/main_layout/templates/blank.jade
+++ b/src/desktop/components/main_layout/templates/blank.jade
@@ -1,6 +1,6 @@
 block locals
   - bodyClass = helpers ? helpers.buildBodyClass(sd) : ''
-  - defaultOptions = {modal: true, flash: true, stripe: true, sailthru: true, marketo: true, quantcast: true}
+  - defaultOptions = {modal: true, flash: true, stripe: false, sailthru: true, marketo: true, quantcast: true}
 - options = options ? Object.assign({}, defaultOptions, options) : defaultOptions
 
 doctype html

--- a/src/desktop/components/main_layout/templates/index.jade
+++ b/src/desktop/components/main_layout/templates/index.jade
@@ -1,7 +1,7 @@
 //- Override any locals with `append locals`
 block locals
   - bodyClass = helpers ? helpers.buildBodyClass(sd, 'body-header-fixed') : '';
-  - defaultOptions = {modal: true, flash: true, stripe: true, sailthru: true, marketo: true, quantcast: true}
+  - defaultOptions = {modal: true, flash: true, stripe: false, sailthru: true, marketo: true, quantcast: true}
   - options = options ? Object.assign({}, defaultOptions, options) : defaultOptions
 
 doctype html

--- a/src/desktop/components/main_layout/templates/minimal_header.jade
+++ b/src/desktop/components/main_layout/templates/minimal_header.jade
@@ -1,7 +1,7 @@
 //- Override any locals with `append locals`
 block locals
   - bodyClass = helpers ? helpers.buildBodyClass(sd, 'body-header-fixed minimal-header') : ''
-  - defaultOptions = {modal: true, flash: true, stripe: true, sailthru: true, marketo: true, quantcast: true}
+  - defaultOptions = {modal: true, flash: true, stripe: false, sailthru: true, marketo: true, quantcast: true}
 - options = options ? Object.assign({}, defaultOptions, options) : defaultOptions
 
 doctype html

--- a/src/desktop/components/main_layout/templates/scripts.jade
+++ b/src/desktop/components/main_layout/templates/scripts.jade
@@ -1,4 +1,4 @@
-- defaultOptions = {stripe: true, sailthru: true, marketo: true, quantcast: true}
+- defaultOptions = {stripe: false, sailthru: true, marketo: true, quantcast: true}
 - options = options ? Object.assign({}, defaultOptions, options) : defaultOptions
 
 //- Adds jQuery


### PR DESCRIPTION
This PR updates the header templates to not load stripe scripts by default. We only have 3 pages that need it, but are loading it everywhere, which adds up extra page load time. Instead, we should opt-in only when necessary rather than loading it on every page.