### PR TITLE
[SEO Bugfix] Export jQuery as an entrypoint, use that as reference 

### DIFF
--- a/src/desktop/components/main_layout/templates/scripts.jade
+++ b/src/desktop/components/main_layout/templates/scripts.jade
@@ -1,8 +1,10 @@
 - defaultOptions = {stripe: true, sailthru: true, marketo: true, quantcast: true}
 - options = options ? Object.assign({}, defaultOptions, options) : defaultOptions
 
+
 //- Common bundle
 script( src=asset("/assets/common.js") )
+script( src=asset("/assets/jquery.js") )
 
 if options.marketo
   //- Marketo Tracking

--- a/src/desktop/lib/global_client_setup.coffee
+++ b/src/desktop/lib/global_client_setup.coffee
@@ -4,7 +4,6 @@
 # or component.
 #
 
-require '../../lib/global_modules'
 $ = require 'jquery'
 Backbone = require 'backbone'
 Backbone.$ = $

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,9 @@ const config = {
       'webpack-hot-middleware/client?reload=true',
       './src/desktop/apps/webpack/client.js',
     ],
+    // FIXME: Quickfix for PhantomJS / SEO due to jQuery missing in header. See
+    // https://artsy.slack.com/archives/C02BDPZPC/p1520871445000663 for more info.
+    jquery: './node_modules/jquery/dist/jquery.js',
     ...getEntrypoints(),
   },
   output: {
@@ -105,6 +108,7 @@ const config = {
   ],
   resolve: {
     alias: {
+      jquery: 'jquery/dist/jquery.js', // FIXME: Quickfix for PhantomJS / SEO due to jQuery missing in header; see above
       'jquery.ui.widget': 'blueimp-file-upload/js/vendor/jquery.ui.widget.js',
       react: path.resolve('./node_modules/react'),
     },


### PR DESCRIPTION
Now we're getting creative.... Takes a typical jquery import and exports it as an entrypoint, which is then referenced later as the import, circumventing the multiple jquery instance issue (possibly) 