### PR TITLE
@mzikherman => Only fetch cta_artists if the user is not logged in

### DIFF
--- a/src/desktop/apps/artist/client/views/overview.coffee
+++ b/src/desktop/apps/artist/client/views/overview.coffee
@@ -35,6 +35,7 @@ module.exports = class OverviewView extends Backbone.View
         artists: @statuses.artists
         articles: @statuses.articles
         shows: @statuses.shows || @statuses.cv
+        loggedOut: !@user
     .then ({ artist }) => @trigger 'artist:overview:sync', artist
 
   setupBlurb: ->

--- a/src/desktop/apps/artist/queries/overview.coffee
+++ b/src/desktop/apps/artist/queries/overview.coffee
@@ -1,6 +1,6 @@
 module.exports =
   """
-  query artist($artist_id: String!, $shows: Boolean!, $artists: Boolean!, $articles: Boolean!) {
+  query artist($artist_id: String!, $shows: Boolean!, $artists: Boolean!, $articles: Boolean!, $loggedOut: Boolean!) {
     artist(id: $artist_id) {
       counts {
         shows: partner_shows
@@ -15,7 +15,7 @@ module.exports =
       artists (size: 15) @include(if: $artists){
         ... artistCell
       }
-      cta_artists: artists(size: 1) {
+      cta_artists: artists(size: 1) @include(if: $loggedOut){
         image {
           thumb: resized(width: 150, version: "square") {
             url

--- a/src/desktop/components/artist_page_cta/templates/overlay.jade
+++ b/src/desktop/components/artist_page_cta/templates/overlay.jade
@@ -16,7 +16,7 @@
                 - var count = 7
                 - var name = artist.get('name')
                 include ./row.jade
-              if artist.get('cta_artists')[0]
+              if artist.get('cta_artists') && artist.get('cta_artists')[0]
                 li
                   - var image = artist.get('cta_artists')[0].image.thumb.url
                   - var count = 3

--- a/src/desktop/components/artist_page_cta/test/template.coffee
+++ b/src/desktop/components/artist_page_cta/test/template.coffee
@@ -1,0 +1,53 @@
+_ = require 'underscore'
+$ = require 'cheerio'
+benv = require 'benv'
+jade = require 'jade'
+{ fabricate } = require 'antigravity'
+Artist = require '../../../models/artist'
+
+templates =
+  overlay: jade.compileFile(require.resolve '../templates/overlay.jade')
+
+describe 'templates', ->
+  before (done) ->
+    benv.setup =>
+      @artist = new Artist fabricate 'artist', name: 'Seth Clark', cta_image: thumb: url: 'http://thumb.jpg'
+      benv.expose
+        sd: AP: 'http://test.test'
+      done()
+
+  after ->
+    benv.teardown()
+
+  describe 'when there are null cta artists', ->
+    beforeEach ->
+      @artist.set cta_artists: null
+      @data = _.extend {}, { artist: @artist }
+
+    it 'renders correctly', ->
+      $template = $(templates.overlay @data)
+      $template.find('.artist-page-cta-overlay__feed__items__row').length.should.equal 1
+      text = $template.find('.artist-page-cta-overlay__headline').text()
+      text.should.equal 'Join Artsy to discover new works by Seth Clark and more artists you love'
+
+  describe 'when there are null cta artists', ->
+    beforeEach ->
+      @artist.set cta_artists: []
+      @data = _.extend {}, { artist: @artist }
+
+    it 'renders correctly', ->
+      $template = $(templates.overlay @data)
+      $template.find('.artist-page-cta-overlay__feed__items__row').length.should.equal 1
+      text = $template.find('.artist-page-cta-overlay__headline').text()
+      text.should.equal 'Join Artsy to discover new works by Seth Clark and more artists you love'
+
+  describe 'when there are some cta artists', ->
+    beforeEach ->
+      @artist.set cta_artists: [{ name: 'Drew Conrad', image: { thumb: { url: 'http://thumb1.jpg' } } }]
+      @data = _.extend {}, { artist: @artist }
+
+    it 'renders correctly', ->
+      $template = $(templates.overlay @data)
+      $template.find('.artist-page-cta-overlay__feed__items__row').length.should.equal 2
+      text = $($template.find('.artist-page-cta-overlay__feed__items__row__artist-info')[1]).text()
+      text.should.equal '3 New WorksTodayDrew Conrad'


### PR DESCRIPTION
Tiny optimization here-- we actually make three separate calls to the `related/artists` endpoint (client-side) on the overview artist page. This PR removes one of those by no longer fetching the `cta_artists` if the user is logged in, since in that case I believe [this variable](https://github.com/artsy/force/blob/master/src/desktop/apps/artist/routes.coffee#L49) will always be false.