### PR TITLE
@mzikherman => no longer fetch all artworks in auctions or fair booths

### DIFF
--- a/src/mobile/apps/artwork/components/related_artworks/display_related_works.coffee
+++ b/src/mobile/apps/artwork/components/related_artworks/display_related_works.coffee
@@ -17,8 +17,9 @@ module.exports =
         $section = $('.artwork-related-artworks').append template
           title: relatedWorks.title
           type: type
-          isArtist: relatedWorks.isArtist
-          isPartner: relatedWorks.isPartner
+          isRelated: relatedWorks.isRelated
+          href: relatedWorks.href
+          totalCount: relatedWorks.totalCount
 
         $section.find("[data-artworks=#{type}]").html artworks
     )

--- a/src/mobile/apps/artwork/components/related_artworks/index.coffee
+++ b/src/mobile/apps/artwork/components/related_artworks/index.coffee
@@ -6,8 +6,8 @@ metaphysics = require '../../../../../lib/metaphysics.coffee'
 { displayRelatedWorks } = require './display_related_works.coffee'
 
 module.exports = ->
-  isArtist = false
-  isPartner = false
+  isRelated = false
+
   context = ARTWORK.context || {}
   if context.__typename is 'ArtworkContextAuction'
     query = """
@@ -76,12 +76,13 @@ module.exports = ->
       artist_collection = new Artworks _.shuffle artwork.artist?.artworks
       related_collection = new Artworks _.shuffle artwork.layer?.artworks
 
-      relatedWorks = [
-        { collection: auction_collection, title: "Other Works from the Auction", typeName: context.__typename }
-        { collection: artist_collection, title: "Other Works by #{artwork.artist?.name}", typeName: 'artist', isArtist: true }
-        { collection: related_collection, title: "Related Works", typeName: 'related' }
-      ]
-
+      if context.is_open
+        relatedWorks = [{ collection: auction_collection, title: "Other Works from the Auction", typeName: context.__typename, href: artwork.sale.href, totalCount: artwork.sale?.eligible_sale_artworks_count }]
+      else
+        relatedWorks = [
+          { collection: artist_collection, title: "Other Works by #{artwork.artist?.name}", typeName: 'artist', href: ARTWORK.artist?.href, totalCount: ARTWORK.artist?.counts?.artworks }
+          { collection: related_collection, title: "Related Works", typeName: 'related', isRelated: true }
+        ]
       displayRelatedWorks(relatedWorks, context)
     else if context.__typename is 'ArtworkContextFair'
       fair_collection = new Artworks _.shuffle artwork.shows[0]?.artworks
@@ -90,10 +91,10 @@ module.exports = ->
       related_collection = new Artworks _.shuffle artwork.layer?.artworks
 
       relatedWorks = [
-        { collection: fair_collection, title: 'Other Works from the Booth', typeName: context.__typename }
-        { collection: artist_collection, title: "Other Works by #{artwork.artist.name}", typeName: 'artist', isArtist: true }
-        { collection: partner_collection, title: "Other Works by #{artwork.partner?.name}", typeName: context.__typename }
-        { collection: related_collection, title: "Related Works", typeName: 'related' }
+        { collection: fair_collection, title: 'Other Works from the Booth', typeName: context.__typename, href: artwork.shows[0]?.href, totalCount: artwork.shows[0]?.counts?.eligible_artworks }
+        { collection: artist_collection, title: "Other Works by #{artwork.artist?.name}", typeName: 'artist', href: ARTWORK.artist?.href, totalCount: ARTWORK.artist?.counts?.artworks }
+        { collection: partner_collection, title: "Other Works from #{artwork.partner?.name}", typeName: context.__typename, href: ARTWORK.partner?.href, totalCount: ARTWORK.partner?.counts?.artworks }
+        { collection: related_collection, title: "Related Works", typeName: 'related', isRelated: true  }
       ]
 
       displayRelatedWorks(relatedWorks, context)
@@ -103,10 +104,10 @@ module.exports = ->
       partner_collection = new Artworks _.take _.shuffle(artwork.partner?.artworks), 10
       related_collection = new Artworks _.take _.shuffle(artwork.layer?.artworks), 10
       relatedWorks = [
-        { collection: show_collection, title: 'Other Works from the Show', typeName: context.__typename }
-        { collection: artist_collection, title: "Other Works by #{artwork.artist.name}", typeName: 'artist', isArtist: true }
-        { collection: partner_collection, title: "Other Works from #{artwork.partner.name}", typeName: 'gallery', isPartner: true }
-        { collection: related_collection, title: "Related Works", typeName: 'related' }
+        { collection: show_collection, title: 'Other Works from the Show', typeName: context.__typename, href: artwork.shows[0]?.href, totalCount: artwork.shows[0]?.counts?.eligible_artworks }
+        { collection: artist_collection, title: "Other Works by #{artwork.artist.name}", typeName: 'artist', href: ARTWORK.artist?.href, totalCount: ARTWORK.artist?.counts?.artworks }
+        { collection: partner_collection, title: "Other Works from #{artwork.partner.name}", typeName: 'gallery', href: ARTWORK.partner?.href, totalCount: ARTWORK.partner?.counts?.artworks }
+        { collection: related_collection, title: "Related Works", typeName: 'related', isRelated: true  }
       ]
 
       displayRelatedWorks(relatedWorks, context)
@@ -115,9 +116,9 @@ module.exports = ->
       partner_collection = new Artworks _.take _.shuffle(artwork.partner.artworks), 10
       related_collection = new Artworks _.take _.shuffle(artwork.layer?.artworks), 10
       relatedWorks = [
-        { collection: artist_collection, title: "Other Works by #{artwork.artist.name}", typeName: 'artist', isArtist: true }
-        { collection: partner_collection, title: "Other Works from #{artwork.partner.name}", typeName: 'gallery', isPartner: true }
-        { collection: related_collection, title: "Related Works", typeName: 'related' }
+        { collection: artist_collection, title: "Other Works by #{artwork.artist.name}", typeName: 'artist', totalCount: ARTWORK.artist?.counts?.artworks, href: ARTWORK.artist?.href }
+        { collection: partner_collection, title: "Other Works from #{artwork.partner.name}", typeName: 'gallery', href: ARTWORK.partner?.href, totalCount: ARTWORK.partner?.counts?.artworks }
+        { collection: related_collection, title: "Related Works", typeName: 'related', isRelated: true  }
       ]
 
       displayRelatedWorks(relatedWorks, context)

--- a/src/mobile/apps/artwork/components/related_artworks/queries/auction_query.coffee
+++ b/src/mobile/apps/artwork/components/related_artworks/queries/auction_query.coffee
@@ -6,7 +6,8 @@ module.exports = """
       name
       href
       is_open
-      artworks(all: true, size: 50, exclude: [$id]) {
+      eligible_sale_artworks_count
+      artworks(size: 20, exclude: [$id]) {
         sale_artwork {
           lot_label
         }

--- a/src/mobile/apps/artwork/components/related_artworks/queries/fair_query.coffee
+++ b/src/mobile/apps/artwork/components/related_artworks/queries/fair_query.coffee
@@ -4,7 +4,10 @@ module.exports = """
       name
       href
       type
-      artworks(all: true, size: 50, exclude: [$id]) {
+      counts {
+        eligible_artworks
+      }
+      artworks(size: 20, exclude: [$id]) {
         #{require('./index.coffee')}
       }
     }

--- a/src/mobile/apps/artwork/components/related_artworks/queries/show_query.coffee
+++ b/src/mobile/apps/artwork/components/related_artworks/queries/show_query.coffee
@@ -4,7 +4,10 @@ module.exports = """
       name
       href
       kind
-      artworks(all: true, size: 50, exclude: [$id]) {
+      counts {
+        eligible_artworks
+      }
+      artworks(size: 20, exclude: [$id]) {
         #{require('./index.coffee')}
       }
     }

--- a/src/mobile/apps/artwork/components/related_artworks/template.jade
+++ b/src/mobile/apps/artwork/components/related_artworks/template.jade
@@ -9,13 +9,8 @@
           .artwork-related-artworks-module__related-artworks-list(data-artworks=type)
             .loading-spinner
 
-          if isArtist
+          if !isRelated
             .view-all-links-container
-              a.artwork-related-artworks__view-all-link(href=sd.ARTWORK.artist.href)
-                | View All #{sd.ARTWORK.artist.counts.artworks} works
-                .icon
-          if isPartner
-            .view-all-links-container
-              a.artwork-related-artworks__view-all-link(href=sd.ARTWORK.partner.href)
-                | View All #{sd.ARTWORK.partner.counts.artworks} works
+              a.artwork-related-artworks__view-all-link(href=href)
+                | View All #{totalCount} works
                 .icon

--- a/src/mobile/apps/artwork/components/related_artworks/test/display_related_works.coffee
+++ b/src/mobile/apps/artwork/components/related_artworks/test/display_related_works.coffee
@@ -8,7 +8,7 @@ Artworks = require '../../../../../collections/artworks'
 
 describe 'Render Related Artworks', ->
 
-  xdescribe 'displayRelatedWorks', ->
+  describe 'displayRelatedWorks', ->
     beforeEach (done) ->
       benv.setup =>
         benv.expose

--- a/src/mobile/apps/artwork/components/related_artworks/test/index.coffee
+++ b/src/mobile/apps/artwork/components/related_artworks/test/index.coffee
@@ -26,11 +26,20 @@ describe 'Related Artworks', ->
     afterEach ->
       benv.teardown()
 
-    it 'fetches related auction artworks', (done) ->
+    it 'fetches related auction artworks ONLY if the auction is open', (done) ->
       @fetchArtworkBuckets.__set__ 'ARTWORK',
         context:
           __typename: 'ArtworkContextAuction'
           is_open: true
+        artist:
+          href: 'artsy.net/artist/artist1'
+          counts:
+            artworks: 12
+        partner:
+          href: 'artsy.net/partner/partner1'
+          counts:
+            artworks: 56
+
 
       @metaphysics.returns Q.resolve
         artwork:
@@ -42,6 +51,8 @@ describe 'Related Artworks', ->
             ]
           sale:
             is_open: true
+            href: 'artsy.net/auction/sale1'
+            eligible_sale_artworks_count: 40
             artworks: [
               fabricate 'artwork', {
                 sale_artwork: lot_label: '24'
@@ -54,14 +65,28 @@ describe 'Related Artworks', ->
 
       @metaphysics.args[0][0].query.should.containEql 'sale'
       _.defer => _.defer =>
+        @displayRelatedWorks.args[0][0].length.should.equal(1)
+
         @displayRelatedWorks.args[0][0][0].title.should.equal 'Other Works from the Auction'
         @displayRelatedWorks.args[0][0][0].typeName.should.equal 'ArtworkContextAuction'
+        @displayRelatedWorks.args[0][0][0].href.should.equal 'artsy.net/auction/sale1'
+        @displayRelatedWorks.args[0][0][0].totalCount.should.equal 40
         done()
 
-    it 'fetches related fair artworks', (done) ->
+    it 'fetches artist artworks and related artworks if the sale is closed', (done) ->
       @fetchArtworkBuckets.__set__ 'ARTWORK',
         context:
-          __typename: 'ArtworkContextFair'
+          __typename: 'ArtworkContextAuction'
+          is_open: false
+        artist:
+          href: 'artsy.net/artist/artist1'
+          counts:
+            artworks: 12
+        partner:
+          href: 'artsy.net/partner/partner1'
+          counts:
+            artworks: 56
+
 
       @metaphysics.returns Q.resolve
         artwork:
@@ -71,6 +96,55 @@ describe 'Related Artworks', ->
             artworks: [
               fabricate 'artwork'
             ]
+          sale:
+            is_open: true
+            href: 'artsy.net/auction/sale1'
+            eligible_sale_artworks_count: 40
+            artworks: [
+              fabricate 'artwork', {
+                sale_artwork: lot_label: '24'
+                sale: { sale_artwork: lot_label: '24' }
+              }
+            ]
+
+
+      @fetchArtworkBuckets()
+
+      @metaphysics.args[0][0].query.should.containEql 'sale'
+      _.defer => _.defer =>
+        @displayRelatedWorks.args[0][0].length.should.equal(2)
+
+        @displayRelatedWorks.args[0][0][0].title.should.equal 'Other Works by Fela Kuti'
+        @displayRelatedWorks.args[0][0][0].href.should.equal 'artsy.net/artist/artist1'
+        @displayRelatedWorks.args[0][0][0].totalCount.should.equal 12
+
+        @displayRelatedWorks.args[0][0][1].title.should.equal 'Related Works'
+        @displayRelatedWorks.args[0][0][1].isRelated.should.equal true
+        done()
+
+    it 'fetches related fair artworks', (done) ->
+      @fetchArtworkBuckets.__set__ 'ARTWORK',
+        context:
+          __typename: 'ArtworkContextFair'
+        artist:
+          href: 'artsy.net/artist/artist1'
+          counts:
+            artworks: 12
+        partner:
+          href: 'artsy.net/partner/partner1'
+          counts:
+            artworks: 56
+
+      @metaphysics.returns Q.resolve
+        artwork:
+          artist:
+            name: 'Fela Kuti'
+            href: '/fela-kuti'
+            artworks: [
+              fabricate 'artwork'
+            ]
+          partner:
+            name: 'Happy Gallery'
           shows:[
             artworks: [
               fabricate 'artwork', {title: '#BlackLivesMatter'}
@@ -81,8 +155,21 @@ describe 'Related Artworks', ->
 
       @metaphysics.args[0][0].query.should.containEql 'show'
       _.defer => _.defer =>
+        @displayRelatedWorks.args[0][0].length.should.equal(4)
+
         @displayRelatedWorks.args[0][0][0].title.should.equal 'Other Works from the Booth'
         @displayRelatedWorks.args[0][0][0].typeName.should.equal 'ArtworkContextFair'
+
+        @displayRelatedWorks.args[0][0][1].title.should.equal 'Other Works by Fela Kuti'
+        @displayRelatedWorks.args[0][0][1].href.should.equal 'artsy.net/artist/artist1'
+        @displayRelatedWorks.args[0][0][1].totalCount.should.equal 12
+
+        @displayRelatedWorks.args[0][0][2].title.should.equal 'Other Works from Happy Gallery'
+        @displayRelatedWorks.args[0][0][2].href.should.equal 'artsy.net/partner/partner1'
+        @displayRelatedWorks.args[0][0][2].totalCount.should.equal 56
+
+        @displayRelatedWorks.args[0][0][3].title.should.equal 'Related Works'
+        @displayRelatedWorks.args[0][0][3].isRelated.should.equal true
         done()
 
     it 'fetches related show artworks', (done) ->
@@ -90,6 +177,14 @@ describe 'Related Artworks', ->
         context:
           __typename: 'ArtworkContextPartnerShow'
           is_active: true
+        artist:
+          href: 'artsy.net/artist/artist1'
+          counts:
+            artworks: 12
+        partner:
+          href: 'artsy.net/partner/partner1'
+          counts:
+            artworks: 56
 
       @metaphysics.returns Q.resolve
         artwork:
@@ -117,12 +212,33 @@ describe 'Related Artworks', ->
 
       @metaphysics.args[0][0].query.should.containEql 'shows'
       _.defer => _.defer =>
+        @displayRelatedWorks.args[0][0].length.should.equal(4)
+
         @displayRelatedWorks.args[0][0][0].title.should.equal 'Other Works from the Show'
         @displayRelatedWorks.args[0][0][0].typeName.should.equal 'ArtworkContextPartnerShow'
+
+        @displayRelatedWorks.args[0][0][1].title.should.equal 'Other Works by Fela Kuti'
+        @displayRelatedWorks.args[0][0][1].href.should.equal 'artsy.net/artist/artist1'
+        @displayRelatedWorks.args[0][0][1].totalCount.should.equal 12
+
+        @displayRelatedWorks.args[0][0][2].title.should.equal 'Other Works from Pace Gallery'
+        @displayRelatedWorks.args[0][0][2].href.should.equal 'artsy.net/partner/partner1'
+        @displayRelatedWorks.args[0][0][2].totalCount.should.equal 56
+
+        @displayRelatedWorks.args[0][0][3].title.should.equal 'Related Works'
+        @displayRelatedWorks.args[0][0][3].isRelated.should.equal true
         done()
 
-    xit 'fetches related partner and related artworks', (done) ->
-      @fetchArtworkBuckets.__set__ 'ARTWORK', {}
+    it 'fetches related partner and related artworks', (done) ->
+      @fetchArtworkBuckets.__set__ 'ARTWORK',
+        artist:
+          href: 'artsy.net/artist/artist1'
+          counts:
+            artworks: 12
+        partner:
+          href: 'artsy.net/partner/partner1'
+          counts:
+            artworks: 56
 
       @metaphysics.returns Q.resolve
         artwork:
@@ -151,8 +267,16 @@ describe 'Related Artworks', ->
       @metaphysics.args[0][0].query.should.containEql 'partner'
       @metaphysics.args[0][0].query.should.containEql 'layer'
       _.defer => _.defer =>
+        @displayRelatedWorks.args[0][0].length.should.equal(3)
+
+        @displayRelatedWorks.args[0][0][0].title.should.equal 'Other Works by Fela Kuti'
+        @displayRelatedWorks.args[0][0][0].href.should.equal 'artsy.net/artist/artist1'
+        @displayRelatedWorks.args[0][0][0].totalCount.should.equal 12
+
         @displayRelatedWorks.args[0][0][1].title.should.equal 'Other Works from Pace Gallery'
         @displayRelatedWorks.args[0][0][1].typeName.should.equal 'gallery'
+        @displayRelatedWorks.args[0][0][1].totalCount.should.equal 56
+
         @displayRelatedWorks.args[0][0][2].title.should.equal 'Related Works'
         @displayRelatedWorks.args[0][0][2].typeName.should.equal 'related'
         done()


### PR DESCRIPTION
Related to [this discussion](https://github.com/artsy/metaphysics/pull/947#discussion_r171028196) on your previous metaphysics PR, this updates the cases on the mobile web artwork page where we are fetching _all_ artworks for a sale/partner show/fair booth to render underneath the artwork.

This updates to follow the pattern set by the `Related works`, `Artist works` and `Partner works` sections to only fetch 20 works and include a link to the relevant sale/partner show if applicable.

i.e.
![image](https://user-images.githubusercontent.com/2081340/37412911-417475ba-277c-11e8-8962-fc618e2accb5.png)

cc @nicoleyeo 