### PR TITLE
@mzikherman  => resize gene tiles on collect page

### DIFF
--- a/src/desktop/components/commercial_filter/filters/category/category_filter_view.coffee
+++ b/src/desktop/components/commercial_filter/filters/category/category_filter_view.coffee
@@ -1,4 +1,5 @@
 Backbone = require 'backbone'
+{ resize } = require '../../../../components/resizer'
 
 template = -> require('./index.jade') arguments...
 
@@ -42,4 +43,5 @@ module.exports = class CategoryFilterView extends Backbone.View
       hasResults: @hasResults
       counts: @aggregations.get('MEDIUM')?.get('counts')
       alwaysEnabled: @alwaysEnabled
+      resize: resize
 

--- a/src/desktop/components/commercial_filter/filters/category/index.jade
+++ b/src/desktop/components/commercial_filter/filters/category/index.jade
@@ -2,7 +2,7 @@
   each category, id in categories
     .cf-categories__category(
       data-id=category.id
-      style="background-image: url(#{category.image})"
+      style="background-image: url(#{resize(category.image, { width: 250 })})"
       data-has-results= alwaysEnabled || (hasResults && hasResults(counts, category.id)) ? "true" : "false"
       class=(selectedCategory == category.id) ? "is-selected" : ""
     )


### PR DESCRIPTION
We noticed that since the a/b test ended on the collect page (and we're now always showing the gene tiles), the performance of the page took a little dip.

The gene tiles themselves are pretty large:
![screen shot 2018-03-15 at 9 41 11 am](https://user-images.githubusercontent.com/2081340/37467255-126a9910-2836-11e8-82e8-eab5d65429cf.png)


This updates the code to send the images through gemini's resizer, which both reduces the size and the quality... meaning we download much less data! 👏 
![screen shot 2018-03-15 at 9 41 37 am](https://user-images.githubusercontent.com/2081340/37467260-153e2238-2836-11e8-9cc1-3959ab329fc5.png)
