### PR TITLE
Move the marketo script to our CDN

### DIFF
--- a/src/desktop/components/main_layout/templates/scripts.jade
+++ b/src/desktop/components/main_layout/templates/scripts.jade
@@ -6,7 +6,7 @@ script( src=asset("/assets/common.js") )
 
 if options.marketo
   //- Marketo Tracking
-  script(type='text/javascript', src='//du4pg90j806ok.cloudfront.net/js/touch-history/dist/conversionpath-0.3.8.min.js').
+  script(type='text/javascript', src='https://d1s2w0upia4e9w.cloudfront.net/assets/conversionpath-0.3.8.min.js').
     {
     "nolog": true,
     "stageMappings": {


### PR DESCRIPTION
This script was written by our consultant and served from their CDN. It's is not compressed (70KB) and HTTP/2 is not enabled for
their CloudFront endpoint. By compressing and moving this script to our CDN we'll be able to speed up the page load a bit faster (smaller file, HTTP/2 connection).

I initially thought about checking this file in to git so it'll be synced across different S3 buckets automatically, but Webpack doens't like globally scoped Javascript:

![screen shot 2018-03-16 at 4 35 41 pm](https://user-images.githubusercontent.com/386234/37543468-18f7d7cc-2938-11e8-98cb-2d0614889e4f.png)

So I just manually uploaded this file to S3:

 * https://s3.amazonaws.com/artsy-force-production/assets/conversionpath-0.3.8.min.js
 * https://s3.amazonaws.com/artsy-force-production/assets/conversionpath-0.3.8.min.js.gz
 * https://s3.amazonaws.com/artsy-force-staging/assets/conversionpath-0.3.8.min.js
 * https://s3.amazonaws.com/artsy-force-staging/assets/conversionpath-0.3.8.min.js.gz

_(They are all gzipped. The files uploaded to staging are just for parity. I'm open to suggestions as to how we host them (or external dependencies) in the future)_

I understand that this is not even close to ideal, but is the simplest fix that works today. 