### PR TITLE
Redirect to user from /personalize to /personalize/interests server-side

### DIFF
--- a/src/desktop/apps/personalize/index.coffee
+++ b/src/desktop/apps/personalize/index.coffee
@@ -9,5 +9,5 @@ app = module.exports = express()
 app.set 'views', __dirname
 app.set 'view engine', 'jade'
 
-app.get '/personalize', index
+app.get '/personalize', (_, res) => res.redirect('/personalize/interests')
 app.get '/personalize/:slug', ensureLoggedInUser, index


### PR DESCRIPTION
addresses https://artsyproduct.atlassian.net/browse/GROWTH-367

Currently the redirection from `/personalize` to `/personalize/interests` is handled by [the `<Wizard>` component](https://github.com/artsy/reaction/blob/57547f1572226b973cf31bb21a5d8769bfe8bb29/src/Components/Onboarding/Wizard.tsx#L106-L110), but this design also allowed other Javascript to be running while the component is being mounted. The server-side redirection ensures the consistency of the path sent to Segment since it happens before the browser evaluates Javascript code.