### PR TITLE
switch to mobile header at 767px

### DIFF
--- a/src/desktop/components/stylus_lib/index.styl
+++ b/src/desktop/components/stylus_lib/index.styl
@@ -19,7 +19,7 @@ gutter = 30px
 home-logo-size = 52px
 layout-side-margin = 55px
 main-header-height = 53px
-nav-bar-break = 550px
+nav-bar-break = 768px
 welcome-header-height = 85px
 responsive-mobile-width = 768px
 


### PR DESCRIPTION
This groundbreaking change addresses https://artsyproduct.atlassian.net/browse/BUY-142

Seems very safe to do because the only other place this variable is used is when changing the background of nav items which is what we desire as well.


The only caveat I noticed that in this small view I don't seem to see any buttons to logIn/logOut. Only the user name and account are shown for logged in user. It is how the current view behaves but we are expanding it to bigger size. 