### PR TITLE
fixes redirect-to query string

### DIFF
--- a/src/desktop/components/auth_modal/templates/_gdpr_signup.jade
+++ b/src/desktop/components/auth_modal/templates/_gdpr_signup.jade
@@ -1,6 +1,6 @@
 .gdpr-signup
   form.gdpr-signup__form(
-    action=sd.AP.loginPagePath + '?redirect-to' + redirectTo
+    action=sd.AP.loginPagePath + '?redirect-to=' + redirectTo
     method= POST
   )
     .auth-errors

--- a/yarn.lock
+++ b/yarn.lock
@@ -976,7 +976,6 @@ antigravity@artsy/antigravity:
   version "0.1.3"
   resolved "https://codeload.github.com/artsy/antigravity/tar.gz/a4438d2fe9d0cdf71f1c47faba371cd3d004e140"
   dependencies:
-    coffeescript "1.11.1"
     express "*"
 
 any-observable@^0.2.0:


### PR DESCRIPTION
This just fixes the redirect-to query string by adding the `=`.