### PR TITLE
@kanaabe => Bump reaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@artsy/express-reloadable": "^1.3.0",
     "@artsy/passport": "^1.0.8",
-    "@artsy/reaction": "0.31.1",
+    "@artsy/reaction": "0.33.0",
     "@artsy/stitch": "^1.4.0",
     "@babel/core": "7.0.0-beta.40",
     "@babel/node": "7.0.0-beta.40",

--- a/src/desktop/apps/article/components/__tests__/Article.test.js
+++ b/src/desktop/apps/article/components/__tests__/Article.test.js
@@ -46,7 +46,7 @@ describe('<Article />', () => {
       published_at: '2017-05-19T13:09:18.567Z',
       contributing_authors: [{ name: 'Kana' }],
     })
-    const rendered = mount(<ArticleLayout article={article} templates={{}} />)
+    const rendered = shallow(<ArticleLayout article={article} templates={{}} />)
     rendered.find(InfiniteScrollArticle).length.should.equal(1)
     rendered.html().should.containEql('StandardLayout')
   })
@@ -60,7 +60,7 @@ describe('<Article />', () => {
       published_at: '2017-05-19T13:09:18.567Z',
       contributing_authors: [{ name: 'Kana' }],
     })
-    const rendered = mount(<ArticleLayout article={article} templates={{}} />)
+    const rendered = shallow(<ArticleLayout article={article} templates={{}} />)
     rendered.find(InfiniteScrollArticle).length.should.equal(1)
     rendered.html().should.containEql('FeatureLayout')
   })
@@ -74,7 +74,7 @@ describe('<Article />', () => {
       published_at: '2017-05-19T13:09:18.567Z',
       contributing_authors: [{ name: 'Kana' }],
     })
-    const rendered = mount(
+    const rendered = shallow(
       <ArticleLayout article={article} templates={{}} isSuper />
     )
     rendered.find(Article).length.should.equal(1)
@@ -90,7 +90,7 @@ describe('<Article />', () => {
       contributing_authors: [{ name: 'Kana' }],
       relatedArticlesPanel: [fixtures.article],
     })
-    const rendered = mount(<ArticleLayout article={article} />)
+    const rendered = shallow(<ArticleLayout article={article} />)
     const html = rendered.html()
     html.should.containEql('Related Stories')
     html.should.containEql('RelatedArticlesPanel')
@@ -108,7 +108,7 @@ describe('<Article />', () => {
     })
     const SuperArticleView = sinon.stub()
     rewire.__set__('SuperArticleView', SuperArticleView)
-    const rendered = mount(
+    const rendered = shallow(
       <ArticleLayout
         isSuper
         article={article}

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,9 +28,9 @@
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
-"@artsy/reaction@0.31.1":
-  version "0.31.1"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-0.31.1.tgz#79b7f2fb1b9b77d4e249ef802d8695a9baffb945"
+"@artsy/reaction@0.33.0":
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-0.33.0.tgz#50f7848a4c5c7b76185d955acd874a83e6708949"
   dependencies:
     history "^4.6.1"
     isomorphic-fetch "^2.2.1"
@@ -976,7 +976,6 @@ antigravity@artsy/antigravity:
   version "0.1.3"
   resolved "https://codeload.github.com/artsy/antigravity/tar.gz/a4438d2fe9d0cdf71f1c47faba371cd3d004e140"
   dependencies:
-    coffeescript "1.11.1"
     express "*"
 
 any-observable@^0.2.0:


### PR DESCRIPTION
Bumps Reaction to include new content-end strategy.

Shallow tests are to avoid looking for `document` in the Text component, should be fine here since we are only checking to see that children are rendered.