### PR TITLE
Re-organize main nav on desktop

### DIFF
--- a/src/desktop/components/hover_pulldown/index.styl
+++ b/src/desktop/components/hover_pulldown/index.styl
@@ -81,18 +81,14 @@ computed-padding(font-size, target-line-height)
 .mlh-pulldown-top-link
   display none
 
-.mlh-pulldown-top
-  display none
+.mlh-pulldown-top-link-persistent
+  display block
 
-for num in (1..8)
+for num in (1..5)
   delta = (num - 1) * 100
   pixels = 650px + delta
   string_number = "'"+num+"'"
   @media (max-width: pixels)
-    first-break = num==8
-    if first-break
-      .mlh-pulldown-top
-        display block
     [data-priority={string_number}]
       &.mlh-top-nav-link
         display none
@@ -149,6 +145,7 @@ for num in (1..8)
     &:hover
       background-color gray-darkest-color
   .mlh-pulldown-top-link
+  .mlh-pulldown-top-link-persistent
     avant-garde()
     font-size 13px
   > hr

--- a/src/desktop/components/main_layout/footer/upper.jade
+++ b/src/desktop/components/main_layout/footer/upper.jade
@@ -14,7 +14,7 @@
     a( href='/about' ) About
     a( href='https://medium.com/artsy-blog' ) Blog
     a( href='/about/jobs' ) Jobs
-    a( href='http://artsy.github.com/open-source/', target='_blank' ) Open Source
+    a( href='https://artsy.github.com/open-source/', target='_blank' ) Open Source
     a( href='/about/press' ) Press
   .mlf-upper-column
     h4 Partnering with Artsy

--- a/src/desktop/components/main_layout/footer/upper.jade
+++ b/src/desktop/components/main_layout/footer/upper.jade
@@ -12,6 +12,7 @@
   .mlf-upper-column
     h4 About Artsy
     a( href='/about' ) About
+    a( href='https://medium.com/artsy-blog' ) Blog
     a( href='/about/jobs' ) Jobs
     a( href='http://artsy.github.com/open-source/', target='_blank' ) Open Source
     a( href='/about/press' ) Press

--- a/src/desktop/components/main_layout/footer/upper.jade
+++ b/src/desktop/components/main_layout/footer/upper.jade
@@ -8,7 +8,7 @@
   .mlf-upper-column
     h4 Education
     a( href='/artsy-education' ) Education
-    a( href='/about/the-art-genome-project' ) The Art Genome Project
+    a( href='/categories' ) The Art Genome Project
   .mlf-upper-column
     h4 About Artsy
     a( href='/about' ) About

--- a/src/desktop/components/main_layout/header/index.styl
+++ b/src/desktop/components/main_layout/header/index.styl
@@ -37,7 +37,7 @@
     height header-logo-icon-size
     width header-logo-icon-size
 #main-layout-header-center
-  padding 0 20px
+  padding 0 30px
   flex-grow 1
 #main-layout-header-center
 .main-layout-header-user

--- a/src/desktop/components/main_layout/header/templates/large_screen_header.jade
+++ b/src/desktop/components/main_layout/header/templates/large_screen_header.jade
@@ -12,9 +12,6 @@ nav.mlh-navbar
     a.mlh-top-nav-link( data-priority='4' href='/galleries', class= isActive('/galleries') ? activeClass('/galleries') : activeClass('/galleries-a-z') ) Galleries
     a.mlh-top-nav-link( data-priority='5' href='/art-fairs', class= activeClass('/art-fairs') ) Fairs
     a.mlh-top-nav-link( data-priority='3' href='/articles', class= activeClass('/articles') ) Magazine
-    a.mlh-top-nav-link( data-priority='6' href='/artists', class= activeClass('/artists') ) Artists
-    a.mlh-top-nav-link( data-priority='7' href='/shows', class= activeClass('/shows') ) Shows
-    a.mlh-top-nav-link( data-priority='8' href='/institutions', class= isActive('/institutions') ? activeClass('/institutions') : activeClass('/institutions-a-z') ) Museums
 
     include ./more
   include ./user

--- a/src/desktop/components/main_layout/header/templates/large_screen_header.jade
+++ b/src/desktop/components/main_layout/header/templates/large_screen_header.jade
@@ -7,14 +7,14 @@ nav.mlh-navbar
       block minimal-nav-header
     include ../../../search_bar/templates/index
   #main-layout-header-center.mlh-navbar-cell
-    a.mlh-top-nav-link( data-priority='1' href='/artists', class= activeClass('/artists') ) Artists
-    a.mlh-top-nav-link( data-priority='2' href='/collect', class= activeClass("/collect") ) Artworks
-    a.mlh-top-nav-link( data-priority='6' href='/shows', class= activeClass('/shows') ) Shows
-    a.mlh-top-nav-link( data-priority='7' href='/galleries', class= isActive('/galleries') ? activeClass('/galleries') : activeClass('/galleries-a-z') ) Galleries
-    a.mlh-top-nav-link( data-priority='8' href='/institutions', class= isActive('/institutions') ? activeClass('/institutions') : activeClass('/institutions-a-z') ) Museums
+    a.mlh-top-nav-link( data-priority='1' href='/collect', class= activeClass("/collect") ) Artworks
+    a.mlh-top-nav-link( data-priority='2' href='/auctions', class= activeClass('/auctions') ) Auctions
+    a.mlh-top-nav-link( data-priority='4' href='/galleries', class= isActive('/galleries') ? activeClass('/galleries') : activeClass('/galleries-a-z') ) Galleries
     a.mlh-top-nav-link( data-priority='5' href='/art-fairs', class= activeClass('/art-fairs') ) Fairs
-    a.mlh-top-nav-link( data-priority='3' href='/auctions', class= activeClass('/auctions') ) Auctions
-    a.mlh-top-nav-link( data-priority='4' href='/articles', class= activeClass('/articles') ) Magazine
+    a.mlh-top-nav-link( data-priority='3' href='/articles', class= activeClass('/articles') ) Magazine
+    a.mlh-top-nav-link( data-priority='6' href='/artists', class= activeClass('/artists') ) Artists
+    a.mlh-top-nav-link( data-priority='7' href='/shows', class= activeClass('/shows') ) Shows
+    a.mlh-top-nav-link( data-priority='8' href='/institutions', class= isActive('/institutions') ? activeClass('/institutions') : activeClass('/institutions-a-z') ) Museums
 
     include ./more
   include ./user

--- a/src/desktop/components/main_layout/header/templates/more.jade
+++ b/src/desktop/components/main_layout/header/templates/more.jade
@@ -2,14 +2,14 @@ span.mlh-top-nav-link.hover-pulldown( data-mode='hover' )
   | More
   .hover-pulldown-menu
     div.mlh-pulldown-top
-      a.mlh-pulldown-top-link( data-priority='1' href='/artists', class= activeClass('/artists') ) Artists
-      a.mlh-pulldown-top-link( data-priority='2' href='/collect', class= activeClass("/collect") ) Artworks
-      a.mlh-pulldown-top-link( data-priority='6' href='/shows', class= activeClass('/shows') ) Shows
-      a.mlh-pulldown-top-link( data-priority='7' href='/galleries', class= activeClass('/galleries') ) Galleries
-      a.mlh-pulldown-top-link( data-priority='8' href='/institutions', class= activeClass('/institutions') ) Museums
+      a.mlh-pulldown-top-link( data-priority='1' href='/collect', class= activeClass("/collect") ) Artworks
+      a.mlh-pulldown-top-link( data-priority='2' href='/auctions', class= activeClass('/auctions') ) Auctions
+      a.mlh-pulldown-top-link( data-priority='4' href='/galleries', class= activeClass('/galleries') ) Galleries
       a.mlh-pulldown-top-link( data-priority='5' href='/art-fairs', class= activeClass('/art-fairs') ) Fairs
-      a.mlh-pulldown-top-link( data-priority='3' href='/auctions', class= activeClass('/auctions') ) Auctions
-      a.mlh-pulldown-top-link( data-priority='4' href='/articles', class= activeClass('/articles') ) Magazine
+      a.mlh-pulldown-top-link( data-priority='3' href='/articles', class= activeClass('/articles') ) Magazine
+      a.mlh-pulldown-top-link( data-priority='6' href='/artists', class= activeClass('/artists') ) Artists
+      a.mlh-pulldown-top-link( data-priority='7' href='/shows', class= activeClass('/shows') ) Shows
+      a.mlh-pulldown-top-link( data-priority='8' href='/institutions', class= activeClass('/institutions') ) Museums
     hr.mlh-pulldown-top
     div.mlh-pulldown-bottom
       a.mlh-pulldown-bottom-link( href='/about' ) About Artsy

--- a/src/desktop/components/main_layout/header/templates/more.jade
+++ b/src/desktop/components/main_layout/header/templates/more.jade
@@ -13,12 +13,4 @@ span.mlh-top-nav-link.hover-pulldown( data-mode='hover' )
     hr.mlh-pulldown-top
     div.mlh-pulldown-bottom
       a.mlh-pulldown-bottom-link( href='/about' ) About Artsy
-      a.mlh-pulldown-bottom-link( href='/gallery-partnerships' ) Artsy for Galleries
-      a.mlh-pulldown-bottom-link( href='/institution-partnerships' ) Artsy for Museums
-      a.mlh-pulldown-bottom-link( href='/auction-partnerships' ) Artsy for Auctions
-      a.mlh-pulldown-bottom-link( href='/artsy-education' ) Artsy for Education
       a.mlh-pulldown-bottom-link( href='/categories' ) The Art Genome Project
-      a.mlh-pulldown-bottom-link( href='https://medium.com/artsy-blog' ) Artsy Blog
-      a.mlh-pulldown-bottom-link( href='/about/jobs' ) Jobs
-      a.mlh-pulldown-bottom-link( href='/press' ) Press
-      a.mlh-pulldown-bottom-link( href='/contact' ) Contact Artsy

--- a/src/desktop/components/main_layout/header/templates/more.jade
+++ b/src/desktop/components/main_layout/header/templates/more.jade
@@ -7,9 +7,9 @@ span.mlh-top-nav-link.hover-pulldown( data-mode='hover' )
       a.mlh-pulldown-top-link( data-priority='4' href='/galleries', class= activeClass('/galleries') ) Galleries
       a.mlh-pulldown-top-link( data-priority='5' href='/art-fairs', class= activeClass('/art-fairs') ) Fairs
       a.mlh-pulldown-top-link( data-priority='3' href='/articles', class= activeClass('/articles') ) Magazine
-      a.mlh-pulldown-top-link( data-priority='6' href='/artists', class= activeClass('/artists') ) Artists
-      a.mlh-pulldown-top-link( data-priority='7' href='/shows', class= activeClass('/shows') ) Shows
-      a.mlh-pulldown-top-link( data-priority='8' href='/institutions', class= activeClass('/institutions') ) Museums
+      a.mlh-pulldown-top-link-persistent( href='/artists', class= activeClass('/artists') ) Artists
+      a.mlh-pulldown-top-link-persistent( href='/shows', class= activeClass('/shows') ) Shows
+      a.mlh-pulldown-top-link-persistent( href='/institutions', class= activeClass('/institutions') ) Museums
     hr.mlh-pulldown-top
     div.mlh-pulldown-bottom
       a.mlh-pulldown-bottom-link( href='/about' ) About Artsy

--- a/src/desktop/components/main_layout/header/templates/more.jade
+++ b/src/desktop/components/main_layout/header/templates/more.jade
@@ -13,4 +13,3 @@ span.mlh-top-nav-link.hover-pulldown( data-mode='hover' )
     hr.mlh-pulldown-top
     div.mlh-pulldown-bottom
       a.mlh-pulldown-bottom-link( href='/about' ) About Artsy
-      a.mlh-pulldown-bottom-link( href='/categories' ) The Art Genome Project


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/BUY-141
https://artsyproduct.atlassian.net/browse/BUY-143
https://artsyproduct.atlassian.net/browse/BUY-151
https://artsyproduct.atlassian.net/browse/BUY-154

![nav final](https://user-images.githubusercontent.com/140521/38046083-a53a595a-328c-11e8-8aa9-02ffd7e0b72f.gif)

- Re-orders top nav menu items visually
- Re-prioritizes top nav menu items "snapping" into **More** menu
- Removes most items from **More**
- Adds Blog to footer links 
- Updates TAGP footer link to go to /categories