### PR TITLE
@erikdstock => [Newsfeed QA] Infinite scroll handles articles without published_at 

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@artsy/express-reloadable": "^1.3.0",
     "@artsy/passport": "^1.0.8",
-    "@artsy/reaction": "0.34.3",
+    "@artsy/reaction": "0.34.4",
     "@artsy/stitch": "^1.4.0",
     "@babel/core": "7.0.0-beta.40",
     "@babel/node": "7.0.0-beta.40",

--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -1,3 +1,4 @@
+import moment from 'moment'
 import React, { Component, Fragment } from 'react'
 import { flatten } from 'lodash'
 import Waypoint from 'react-waypoint'
@@ -46,7 +47,8 @@ export class InfiniteScrollNewsArticle extends Component<
   constructor(props) {
     super(props)
 
-    const date = props.articles[0] ? props.articles[0].published_at : null
+    const article = props.articles[0] ? props.articles[0] : {}
+    const date = this.getDateField(article)
     const omit = props.article ? props.article.id : null
     const offset = props.article ? 0 : 6
 
@@ -185,10 +187,16 @@ export class InfiniteScrollNewsArticle extends Component<
     window.history.replaceState({}, article.id, `/news/${article.slug}`)
   }
 
+  getDateField = (article) => {
+    const { published_at, scheduled_publish_at } = article
+    return published_at || scheduled_publish_at || moment().toISOString()
+  }
+
   hasNewDate = (article, i) => {
     const { articles } = this.state
-    const beforeDate = articles[i - 1] && articles[i - 1].published_at.substring(0, 10)
-    const currentDate = article.published_at.substring(0, 10)
+    const beforeArticle = articles[i - 1] ? articles[i - 1] : {}
+    const beforeDate = this.getDateField(beforeArticle).substring(0, 10)
+    const currentDate = this.getDateField(article).substring(0, 10)
 
     return beforeDate !== currentDate
   }
@@ -263,7 +271,10 @@ export class InfiniteScrollNewsArticle extends Component<
 
     return (
       <div id="article-root">
-        <NewsNav date={date} />
+        <NewsNav
+          date={date}
+          positionTop={61}
+        />
         {this.renderContent()}
         {this.renderWaypoint()}
       </div>

--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -194,7 +194,7 @@ export class InfiniteScrollNewsArticle extends Component<
 
   hasNewDate = (article, i) => {
     const { articles } = this.state
-    const beforeArticle = articles[i - 1] ? articles[i - 1] : {}
+    const beforeArticle = articles[i - 1] || {}
     const beforeDate = this.getDateField(beforeArticle).substring(0, 10)
     const currentDate = this.getDateField(article).substring(0, 10)
 

--- a/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.test.js
+++ b/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.test.js
@@ -1,11 +1,12 @@
 import 'jsdom-global/register'
 import _ from 'underscore'
 import benv from 'benv'
-import fixtures from 'desktop/test/helpers/fixtures.coffee'
+import moment from 'moment'
 import sinon from 'sinon'
 import React from 'react'
 import { shallow } from 'enzyme'
 import { data as sd } from 'sharify'
+import fixtures from 'desktop/test/helpers/fixtures.coffee'
 import { UnitCanvasImage } from 'reaction/Components/Publishing/Fixtures/Components'
 import { NewsArticle } from 'reaction/Components/Publishing/Fixtures/Articles'
 
@@ -162,6 +163,37 @@ describe('<InfiniteScrollNewsArticle />', () => {
     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
     const hasNewDate = rendered.instance().hasNewDate(nextArticle, 1)
     hasNewDate.should.equal(true)
+  })
+
+  describe('#getDateField', () => {
+    it('Returns published_at if present', () => {
+      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+      const getDateField = rendered.instance().getDateField(article)
+
+      getDateField.should.equal(article.published_at)
+    })
+    it('Returns scheduled_publish_at if no published_at', () => {
+      const published_at = article.published_at
+      article.scheduled_publish_at = published_at
+      delete article.published_at
+      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+      const getDateField = rendered.instance().getDateField(article)
+
+      getDateField.should.equal(published_at)
+    })
+    it('Returns today for articles with no date field', () => {
+      const today = moment()
+        .toISOString()
+        .substring(0, 10)
+      delete article.published_at
+      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+      const getDateField = rendered
+        .instance()
+        .getDateField(article)
+        .substring(0, 10)
+
+      getDateField.should.equal(today)
+    })
   })
 
   describe('#onEnter', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,9 +28,9 @@
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
-"@artsy/reaction@0.34.3":
-  version "0.34.3"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-0.34.3.tgz#4624c7268c0baa9ee202ba9b4c41d71262167c92"
+"@artsy/reaction@0.34.4":
+  version "0.34.4"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-0.34.4.tgz#e330bd4f106d6c5d0912d3a11f1486c601275abc"
   dependencies:
     formik "^0.11.11"
     history "^4.6.1"


### PR DESCRIPTION
For date headers and infinite scroll, adds `getDateField` method, which returns `scheduled_publish_at` if no `published_at`, and today if no date saved.

Fixes bug of date headers breaking on unpublished articles.