### PR TITLE
@damassi => Use in_editorial_feed in news relatedArticlesCanvas query

### DIFF
--- a/src/desktop/apps/article/queries/relatedArticles.js
+++ b/src/desktop/apps/article/queries/relatedArticles.js
@@ -36,7 +36,7 @@ export const relatedArticles = `
 
 export const relatedArticlesNews = (offset, limit) => {
   return `
-    articles(published: true, limit: 4, offset: ${offset}, sort: "-published_at"){
+    articles(published: true, in_editorial_feed: true, limit: 4, offset: ${offset}, sort: "-published_at"){
       ${canvasBody}
     }
   `


### PR DESCRIPTION
Last step for [GROW-426](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-426)

Adds `in_editorial_feed` arg to `relatedArticlesCanvas` query on `/news` articles

![screen shot 2018-03-30 at 3 25 44 pm](https://user-images.githubusercontent.com/1497424/38150911-29cd34e6-342f-11e8-8a0f-ddd4eaa051b4.png)
