### PR TITLE
@saolsen => search result href should include profile_id not fair_id for fairs in mobile web

### DIFF
--- a/src/mobile/models/search_result.coffee
+++ b/src/mobile/models/search_result.coffee
@@ -34,8 +34,10 @@ module.exports = class SearchResult extends Backbone.Model
   location: ->
     if @get('href')
       @get('href')
-    else if @get('model') is 'profile' || @get('model') is 'fair'
+    else if @get('model') is 'profile' || @get('model') is 'page'
       "/#{@id}"
+    else if @get('model') is 'fair'
+      "/#{@get('profile_id')}"
     else if @get('model') is 'partnershow'
       "/show/#{@id}"
     else if @get('model') is 'sale'

--- a/src/mobile/test/models/search_result.coffee
+++ b/src/mobile/test/models/search_result.coffee
@@ -23,6 +23,14 @@ describe 'SearchResult', ->
         model = new SearchResult(fabricate('article', model: 'article'))
         model.href().should.containEql '/article/' + model.id
 
+      it 'has a location attribute when it is a fair', ->
+        model = new SearchResult(fabricate('fair', model: 'fair', profile_id: 'foo-profile'))
+        model.get('location').should.containEql '/foo-profile'
+
+      it 'has a location attribute when it is a page', ->
+        model = new SearchResult(fabricate('page', model: 'page'))
+        model.get('location').should.containEql '/' + model.id
+
     describe '#displayModel', ->
       it 'has a display_model attribute when it is a artwork', ->
         model = new SearchResult(fabricate('artwork', model: 'artwork'))


### PR DESCRIPTION
We discovered that in mobile web, search results were always linking to `/<fair-id>` when the route actually expects a `/<profile-id>`. This works in most cases because the fair slug tends to match the profile slug, but in cases where it doesn't (i.e. aipad fairs), trying to click a result from mobile web search shows a 404 page.

This fixes that and also a likely similar regression related to `page` (which we saw in desktop).

As a side note, I think the search_result models can probably get merged at this point (but this is for an urgent issue so didn't go down that path).