### PR TITLE
Set password

### DIFF
--- a/src/desktop/apps/auth/client/index.coffee
+++ b/src/desktop/apps/auth/client/index.coffee
@@ -2,7 +2,7 @@ _ = require 'underscore'
 qs = require 'querystring'
 Backbone = require 'backbone'
 { parse } = require 'url'
-{ API_URL, REDIRECT_TO } = require('sharify').data
+{ API_URL, RESET_PASWORD_REDIRECT_TO } = require('sharify').data
 Form = require '../../../components/mixins/form.coffee'
 
 module.exports.PasswordResetView = class PasswordResetView extends Backbone.View
@@ -32,7 +32,7 @@ module.exports.PasswordResetView = class PasswordResetView extends Backbone.View
 
     @model.save @serializeForm(),
       success: ->
-        window.location = REDIRECT_TO || '/log_in'
+        window.location = RESET_PASWORD_REDIRECT_TO || '/log_in'
       error: (model, response, options) =>
         @reenableForm()
         @$errors.html @errorMessage(response)

--- a/src/desktop/apps/auth/client/index.coffee
+++ b/src/desktop/apps/auth/client/index.coffee
@@ -2,7 +2,7 @@ _ = require 'underscore'
 qs = require 'querystring'
 Backbone = require 'backbone'
 { parse } = require 'url'
-{ API_URL } = require('sharify').data
+{ API_URL, REDIRECT_TO } = require('sharify').data
 Form = require '../../../components/mixins/form.coffee'
 
 module.exports.PasswordResetView = class PasswordResetView extends Backbone.View
@@ -32,7 +32,7 @@ module.exports.PasswordResetView = class PasswordResetView extends Backbone.View
 
     @model.save @serializeForm(),
       success: ->
-        window.location = '/log_in'
+        window.location = REDIRECT_TO || '/log_in'
       error: (model, response, options) =>
         @reenableForm()
         @$errors.html @errorMessage(response)

--- a/src/desktop/apps/auth/routes.coffee
+++ b/src/desktop/apps/auth/routes.coffee
@@ -8,11 +8,12 @@ sanitizeRedirect = require '@artsy/passport/sanitize-redirect'
 @resetPassword = (req, res) ->
   if req.query.reset_password_token?
     req.session.reset_password_token = req.query.reset_password_token
+    req.session.set_password = req.query.set_password
+    req.session.redirect_to = req.query.redirect_to
     res.redirect '/reset_password'
   else
-    setPassword = req.query.set_password == 'true'
-    redirectTo = req.query.redirect_to
-    res.render 'reset_password', reset_password_token: req.session.reset_password_token, setPassword: setPassword, redirectTo: redirectTo
+    res.locals.sd.REDIRECT_TO = req.session.redirect_to
+    res.render 'reset_password', reset_password_token: req.session.reset_password_token, set_password: req.session.set_password
 
 @twitterLastStep = (req, res) ->
   res.render 'twitter_email'

--- a/src/desktop/apps/auth/routes.coffee
+++ b/src/desktop/apps/auth/routes.coffee
@@ -4,6 +4,7 @@ CurrentUser = require '../../models/current_user.coffee'
 { parse } = require 'url'
 qs = require 'querystring'
 sanitizeRedirect = require '@artsy/passport/sanitize-redirect'
+sd = require('sharify').data
 
 @resetPassword = (req, res) ->
   if req.query.reset_password_token?

--- a/src/desktop/apps/auth/routes.coffee
+++ b/src/desktop/apps/auth/routes.coffee
@@ -10,10 +10,10 @@ sd = require('sharify').data
   if req.query.reset_password_token?
     req.session.reset_password_token = req.query.reset_password_token
     req.session.set_password = req.query.set_password
-    req.session.redirect_to = req.query.redirect_to
+    req.session.reset_password_redirect_to = req.query.reset_password_redirect_to
     res.redirect '/reset_password'
   else
-    res.locals.sd.REDIRECT_TO = req.session.redirect_to
+    res.locals.sd.RESET_PASWORD_REDIRECT_TO = req.session.reset_password_redirect_to
     res.render 'reset_password', reset_password_token: req.session.reset_password_token, set_password: req.session.set_password
 
 @twitterLastStep = (req, res) ->

--- a/src/desktop/apps/auth/routes.coffee
+++ b/src/desktop/apps/auth/routes.coffee
@@ -10,7 +10,9 @@ sanitizeRedirect = require '@artsy/passport/sanitize-redirect'
     req.session.reset_password_token = req.query.reset_password_token
     res.redirect '/reset_password'
   else
-    res.render 'reset_password', reset_password_token: req.session.reset_password_token
+    setPassword = req.query.set_password == 'true'
+    redirectTo = req.query.redirect_to
+    res.render 'reset_password', reset_password_token: req.session.reset_password_token, setPassword: setPassword, redirectTo: redirectTo
 
 @twitterLastStep = (req, res) ->
   res.render 'twitter_email'

--- a/src/desktop/apps/auth/templates/reset_password.jade
+++ b/src/desktop/apps/auth/templates/reset_password.jade
@@ -10,14 +10,13 @@ block body
   #reset-password-page.responsive-layout-container: .main-layout-container
     #auth-artsy-logo.icon-logotype
 
-    - headingText = setPassword ? 'Set your password' : 'Change your password'
+    - headingText = set_password ? 'Set your password' : 'Change your password'
     h1.small-caps= headingText
 
     form.stacked-form#reset-password-form
       .auth-page-error-message
         //- Rendered client-side
       input( type='hidden', name='reset_password_token', value= reset_password_token )
-      input( type='hidden', name='redirect_to', value= redirectTo )
       input.bordered-input(
         name='password'
         placeholder='New Password'
@@ -36,5 +35,5 @@ block body
         required
         data-confirm='password'
       )
-      - buttonText = setPassword ? 'Set my password' : 'Change my password'
+      - buttonText = set_password ? 'Set my password' : 'Change my password'
       button.avant-garde-button-black= buttonText

--- a/src/desktop/apps/auth/templates/reset_password.jade
+++ b/src/desktop/apps/auth/templates/reset_password.jade
@@ -10,12 +10,14 @@ block body
   #reset-password-page.responsive-layout-container: .main-layout-container
     #auth-artsy-logo.icon-logotype
 
-    h1.small-caps Change your password
+    - headingText = setPassword ? 'Set your password' : 'Change your password'
+    h1.small-caps= headingText
 
     form.stacked-form#reset-password-form
       .auth-page-error-message
         //- Rendered client-side
       input( type='hidden', name='reset_password_token', value= reset_password_token )
+      input( type='hidden', name='redirect_to', value= redirectTo )
       input.bordered-input(
         name='password'
         placeholder='New Password'
@@ -34,4 +36,5 @@ block body
         required
         data-confirm='password'
       )
-      button.avant-garde-button-black Change my password
+      - buttonText = setPassword ? 'Set my password' : 'Change my password'
+      button.avant-garde-button-black= buttonText

--- a/src/desktop/apps/auth/test/routes.coffee
+++ b/src/desktop/apps/auth/test/routes.coffee
@@ -17,7 +17,11 @@ describe 'Auth routes', ->
       get: sinon.stub()
       logout: sinon.stub()
       user: new Backbone.Model accessToken: 'secret'
-    @res = render: sinon.stub(), send: sinon.stub(), redirect: sinon.stub()
+    @res =
+      locals: sd: {}
+      redirect: sinon.stub()
+      render: sinon.stub()
+      send: sinon.stub()
     @next = sinon.stub()
 
   describe '#resetPassword', ->

--- a/src/desktop/apps/home/client/auth_router.coffee
+++ b/src/desktop/apps/home/client/auth_router.coffee
@@ -51,4 +51,7 @@ module.exports = class HomeAuthRouter extends Backbone.Router
       redirectTo: if redirectTo then redirectTo else null
 
   forgot: ->
-    mediator.trigger 'open:auth', mode: 'forgot'
+    email = qs.parse(@location.search.replace /^\?/, '').email
+    setPassword = qs.parse(@location.search.replace /^\?/, '').set_password
+    redirectTo = qs.parse(@location.search.replace /^\?/, '').redirect_to
+    mediator.trigger 'open:auth', mode: 'forgot', email: email, setPassword: setPassword, redirectTo: redirectTo

--- a/src/desktop/apps/home/client/auth_router.coffee
+++ b/src/desktop/apps/home/client/auth_router.coffee
@@ -1,7 +1,7 @@
 Backbone = require 'backbone'
 _ = require 'underscore'
 mediator = require '../../../lib/mediator.coffee'
-qs = require 'querystring'
+qs = require 'qs'
 
 module.exports = class HomeAuthRouter extends Backbone.Router
 

--- a/src/desktop/apps/home/client/auth_router.coffee
+++ b/src/desktop/apps/home/client/auth_router.coffee
@@ -54,5 +54,5 @@ module.exports = class HomeAuthRouter extends Backbone.Router
   forgot: ->
     email = @parsedLocation.email
     setPassword = @parsedLocation.set_password
-    redirectTo = @parsedLocation.redirect_to
+    redirectTo = @parsedLocation.reset_password_redirect_to
     mediator.trigger 'open:auth', mode: 'forgot', email: email, setPassword: setPassword, redirectTo: redirectTo

--- a/src/desktop/apps/home/client/auth_router.coffee
+++ b/src/desktop/apps/home/client/auth_router.coffee
@@ -12,14 +12,15 @@ module.exports = class HomeAuthRouter extends Backbone.Router
 
   initialize: ->
     @location = window.location
+    @parsedLocation = qs.parse(window.location.search.replace /^\?/, '')
 
   login: ->
-    error = qs.parse(@location.search.replace /^\?/, '').error
-    redirectTo = qs.parse(@location.search.replace /^\?/, '').redirect_uri or qs.parse(@location.search.replace /^\?/, '')['redirect-to']
+    error = @parsedLocation.error
+    redirectTo = @parsedLocation.redirect_uri or @parsedLocation['redirect-to']
 
     # Handle gravity style account created errors
     unless error
-      error = qs.parse(@location.search.replace /^\?/, '').account_created_email
+      error = @parsedLocation.account_created_email
 
     if error
       msg = switch error
@@ -45,13 +46,13 @@ module.exports = class HomeAuthRouter extends Backbone.Router
         redirectTo: redirectTo
 
   signup: ->
-    redirectTo = qs.parse(@location.search.replace /^\?/, '')['redirect-to']
+    redirectTo = @parsedLocation['redirect-to']
     mediator.trigger 'open:auth',
       mode: 'register',
       redirectTo: if redirectTo then redirectTo else null
 
   forgot: ->
-    email = qs.parse(@location.search.replace /^\?/, '').email
-    setPassword = qs.parse(@location.search.replace /^\?/, '').set_password
-    redirectTo = qs.parse(@location.search.replace /^\?/, '').redirect_to
+    email = @parsedLocation.email
+    setPassword = @parsedLocation.set_password
+    redirectTo = @parsedLocation.redirect_to
     mediator.trigger 'open:auth', mode: 'forgot', email: email, setPassword: setPassword, redirectTo: redirectTo

--- a/src/desktop/apps/home/routes.coffee
+++ b/src/desktop/apps/home/routes.coffee
@@ -69,6 +69,10 @@ fetchMetaphysicsData = (req)->
       res.locals.sd.HERO_UNITS = heroUnits
       res.locals.sd.USER_HOME_PAGE = homePage.artwork_modules
 
+      # for pasing data to client side forgot code
+      res.locals.sd.REDIRECT_TO = req.query.redirect_to
+      res.locals.sd.SET_PASSWORD = req.query.set_password
+
       res.render 'index',
         heroUnits: heroUnits
         modules: homePage.artwork_modules

--- a/src/desktop/apps/home/routes.coffee
+++ b/src/desktop/apps/home/routes.coffee
@@ -70,7 +70,7 @@ fetchMetaphysicsData = (req)->
       res.locals.sd.USER_HOME_PAGE = homePage.artwork_modules
 
       # for pasing data to client side forgot code
-      res.locals.sd.REDIRECT_TO = req.query.redirect_to
+      res.locals.sd.RESET_PASWORD_REDIRECT_TO = req.query.reset_password_redirect_to
       res.locals.sd.SET_PASSWORD = req.query.set_password
 
       res.render 'index',

--- a/src/desktop/components/auth_modal/templates/forgot.jade
+++ b/src/desktop/components/auth_modal/templates/forgot.jade
@@ -6,10 +6,15 @@
       .auth-register
         form.auth-form
           input.bordered-input.is-block(
-            name='email', type='email', placeholder='Email' autofocus= autofocus, required
+            name='email', value=email, type='email', placeholder='Email' autofocus= autofocus, required
           )
-          button#auth-submit.avant-garde-button-black.is-block Send me reset instructions
-          footer.auth-form-options
-            a.auth-toggle( href='/log_in', data-mode='login' ) I remember it!
 
-    include ./_login_footer.jade
+          - buttonText = setPassword ? 'token' : 'reset instructions'
+          button#auth-submit.avant-garde-button-black.is-block Send me #{buttonText}
+
+          - if (!setPassword)
+            footer.auth-form-options
+              a.auth-toggle( href='/log_in', data-mode='login' ) I remember it!
+
+    - if (!setPassword)
+      include ./_login_footer.jade

--- a/src/desktop/components/auth_modal/view.coffee
+++ b/src/desktop/components/auth_modal/view.coffee
@@ -56,6 +56,8 @@ module.exports = class AuthModalView extends ModalView
     @state = new State mode
     @templateData = _.extend {
       context: @context
+      email: options.email
+      setPassword: options.setPassword
       signupIntent: @signupIntent
       copy: @renderCopy(options.copy)
       redirectTo: @currentRedirectTo()

--- a/src/desktop/models/logged_out_user.coffee
+++ b/src/desktop/models/logged_out_user.coffee
@@ -81,7 +81,7 @@ module.exports = class LoggedOutUser extends User
 
   forgot: (options = {}) ->
     attrs = @pick('email')
-    attrs.redirect_to = sd.REDIRECT_TO
+    attrs.reset_password_redirect_to = sd.RESET_PASSWORD_REDIRECT_TO
     attrs.mode = if sd.SET_PASSWORD is 'true' then 'fair_set_password' else null
 
     new Backbone.Model()

--- a/src/desktop/models/logged_out_user.coffee
+++ b/src/desktop/models/logged_out_user.coffee
@@ -80,8 +80,12 @@ module.exports = class LoggedOutUser extends User
   register: @::signup
 
   forgot: (options = {}) ->
+    attrs = @pick('email')
+    attrs.redirect_to = sd.REDIRECT_TO
+    attrs.mode = if sd.SET_PASSWORD is 'true' then 'fair_set_password' else null
+
     new Backbone.Model()
-      .save @pick('email'), _.extend {}, options,
+      .save attrs, _.extend {}, options,
         url: "#{API_URL}/api/v1/users/send_reset_password_instructions"
 
   repossess: (subsequent_user_id, options = {}) ->

--- a/src/desktop/models/logged_out_user.coffee
+++ b/src/desktop/models/logged_out_user.coffee
@@ -81,7 +81,7 @@ module.exports = class LoggedOutUser extends User
 
   forgot: (options = {}) ->
     attrs = @pick('email')
-    attrs.reset_password_redirect_to = sd.RESET_PASSWORD_REDIRECT_TO
+    attrs.reset_password_redirect_to = sd.RESET_PASSWORD_REDIRECT_TO || null
     attrs.mode = if sd.SET_PASSWORD is 'true' then 'fair_set_password' else null
 
     new Backbone.Model()

--- a/src/desktop/test/models/logged_out_user.coffee
+++ b/src/desktop/test/models/logged_out_user.coffee
@@ -83,7 +83,31 @@ describe 'LoggedOutUser', ->
         user.forgot()
         Backbone.sync.args[0][0].should.equal 'create'
         Backbone.sync.args[0][2].url.should.containEql '/api/v1/users/send_reset_password_instructions'
-        Backbone.sync.args[0][1].attributes.should.containEql email: 'foo@bar.com'
+        attributes = Backbone.sync.args[0][1].attributes
+        attributes.should.containEql email: 'foo@bar.com'
+        attributes.should.containEql mode: null
+        attributes.should.containEql reset_password_redirect_to: null
+
+      it 'sends the redirect to in the request', ->
+        LoggedOutUser.__set__ 'sd', RESET_PASSWORD_REDIRECT_TO: 'https://cms.artsy.net'
+        user = new LoggedOutUser email: 'foo@bar.com'
+        user.forgot()
+        attributes = Backbone.sync.args[0][1].attributes
+        attributes.should.containEql reset_password_redirect_to: 'https://cms.artsy.net'
+
+      it 'sends the mode when set password is true', ->
+        LoggedOutUser.__set__ 'sd', SET_PASSWORD: 'true'
+        user = new LoggedOutUser email: 'foo@bar.com'
+        user.forgot()
+        attributes = Backbone.sync.args[0][1].attributes
+        attributes.should.containEql mode: 'fair_set_password'
+
+      it 'ignores other values of SET_PASSWORD', ->
+        LoggedOutUser.__set__ 'sd', SET_PASSWORD: 'invalid'
+        user = new LoggedOutUser email: 'foo@bar.com'
+        user.forgot()
+        attributes = Backbone.sync.args[0][1].attributes
+        attributes.should.containEql mode: null
 
       it 'accepts options and overwrites the default success', (done) ->
         user = new LoggedOutUser email: 'foo@bar.com'


### PR DESCRIPTION
This PR is for this ticket: https://artsyproduct.atlassian.net/browse/SELL-92, which is some fallout from work done to improve security on waves. What I'm trying to do here is modify the forgot password flow so that it's suitable for fair partners that have not yet set their password. The current changes in this PR all pretty much all cosmetic, but you gotta start somewhere!

What I've done is add some additional info from the url so that I can conditionally show and hide content on the forgot password modal and reset password page. I've stopped here to ensure I'm on the right track. The next steps would be:

* take a look at the page after /forgot to ensure the copy lines up
* change the email sent to include the redirect_to param
* take a look at the page after /reset_password to ensure the copy lines up

Basically, I need to make the flow actually work. 😝 