### PR TITLE
@l2succes: do not initialize marketing modal if there is no slug

### DIFF
--- a/src/desktop/components/marketing_signup_modal/index.coffee
+++ b/src/desktop/components/marketing_signup_modal/index.coffee
@@ -129,6 +129,8 @@ module.exports = class MarketingSignupModal extends Backbone.View
 
     return unless sd.MARKETING_SIGNUP_MODALS?
     modalData = _.findWhere(sd.MARKETING_SIGNUP_MODALS, { slug: slug })
+
+    return unless modalData
     @inner = new MarketingSignupModalInner
       data: modalData
 


### PR DESCRIPTION
 While @anipetrov was QA'ing analytics, she pointed out that the `experiment_viewed` was firing on every page. After looking into this I believe this is happening because of the MarketingSignupModal which gets instantiated globally in the [main_layout client](https://github.com/artsy/force/blob/master/src/desktop/components/main_layout/client.coffee). My proposed fix is to return unless there is a slug present which prevents `splitTest('gdpr_compliance_test').view()` from being executed. The assumption here is that if there is no slug we shouldn't instantiate the marketing modal. @l2succes I know you've also worked in this area so I thought you might be the one to help confirm my assumption.