### PR TITLE
fixing error when gdpr style leaks into other pages

### DIFF
--- a/src/desktop/components/artist_page_cta/index.styl
+++ b/src/desktop/components/artist_page_cta/index.styl
@@ -219,11 +219,11 @@
     cursor pointer
 
 .gdpr-signup .tos-error
-    color red-color
-    text-align left
-    height 1.23em
-    margin-bottom 8px
-    garamond-size('l-caption')
+  color red-color
+  text-align left
+  height 1.23em
+  margin-bottom 8px
+  garamond-size('l-caption')
 
   .bordered-input
     width 100%

--- a/src/desktop/components/inquiry_questionnaire/stylesheets/desktop.styl
+++ b/src/desktop/components/inquiry_questionnaire/stylesheets/desktop.styl
@@ -149,11 +149,11 @@
   height 150px
 
 .gdpr-signup .tos-error
-    color red-color
-    text-align left
-    height 1.23em
-    margin-bottom 8px
-    garamond-size('l-caption')
+  color red-color
+  text-align left
+  height 1.23em
+  margin-bottom 8px
+  garamond-size('l-caption')
 
   .bordered-input
     width 100%


### PR DESCRIPTION
Fix to: https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=39&projectKey=EV&view=planning&selectedIssue=EV-28

I think what happens here is that when the style was added there it mistakingly had 4 spaces indentation instead of 2. And for some reason stylus completely ignored nesting in this case.

Very strange...