### PR TITLE
@kanaabe: restores Created Account analytics event by passing proper selector.

### DIFF
--- a/src/desktop/analytics/account_creation.js
+++ b/src/desktop/analytics/account_creation.js
@@ -37,7 +37,7 @@ const trackAccountCreation = (options) => {
 // Created account (via email)
 $(document).on(
   'submit',
-  '.auth-register form, .marketing-signup-modal form, .artist-page-cta-overlay__register form',
+  '.auth-register form, .marketing-signup-modal form, .artist-page-cta-overlay__register form, .gdpr-signup form',
   function() {
     $(document).one('ajaxComplete', (e, xhr, options) =>
       trackAccountCreation({


### PR DESCRIPTION
We never changed the css selector so we lost the 'Created Account' event. This restores that by passing the proper selector.