### PR TITLE
@yuki24 => Hide top banner for ecommerce sales

### DIFF
--- a/src/desktop/apps/artwork/templates/index.jade
+++ b/src/desktop/apps/artwork/templates/index.jade
@@ -8,7 +8,8 @@ block head
 
 block body
   - isAuction = artwork.context && artwork.context.__typename == 'ArtworkContextAuction'
-  
+  - isEcommerceSale = artwork.sale && artwork.sale.is_auction == false
+
   if isAuction
     .artwork-page.main-layout-container
       section.artwork
@@ -19,21 +20,23 @@ block body
             include ../components/actions/index
             include ../components/additional_info/index
             include ../components/artists/index
-            
+
           include ./metadata
-            
+
         .artwork__main__overview__fold( class='js-artwork-fold' )
           include ../client/fold
-        
+
         .artwork__footer( class='js-artwork-footer' )
           include ../client/footer
-  
-  else 
+
+  else
     .artwork-page.main-layout-container
       section.artwork
         .artwork__main
           .artwork__main__overview
-            include ../components/banner/index
+            unless isEcommerceSale
+              include ../components/banner/index
+
             include ../components/images/index
             include ../components/actions/index
             include ../components/additional_info/index


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/BUY-157, which hides the top "explore auction" bar for e-commerce sale artworks.

**Ecommerce sale**
<img width="535" alt="screen shot 2018-04-04 at 4 04 35 pm" src="https://user-images.githubusercontent.com/236943/38339211-fb18d7b2-3821-11e8-9554-ac66e74f1fa3.png">

**Typical Sale**
<img width="542" alt="screen shot 2018-04-04 at 4 06 44 pm" src="https://user-images.githubusercontent.com/236943/38339248-317e4c4c-3822-11e8-989d-ecfd429af408.png">

