### PR TITLE
@kanaabe: make variations of the checkbox copy consistent

### DIFF
--- a/src/desktop/components/auth_modal/templates/_gdpr_signup.jade
+++ b/src/desktop/components/auth_modal/templates/_gdpr_signup.jade
@@ -34,7 +34,7 @@
             tabindex="0"
           )
           label(for='receive_emails')
-        span Receive our weekly newsletter.
+        span Receive emails from Artsy.
       .gdpr-signup__form__checkbox.gdpr-signup__form__checkbox__accept-terms.artsy-checkbox
         .artsy-checkbox--checkbox
           input(


### PR DESCRIPTION
Small tweak to make the copy consistent for opting into receiving emails on the gdpr form.