### PR TITLE
@mzikherman => [Bugfix] Mobile image scroller in /show/:id

### DIFF
--- a/src/mobile/components/artwork_columns/view.coffee
+++ b/src/mobile/components/artwork_columns/view.coffee
@@ -5,10 +5,6 @@ artworkItem = -> require('./artwork.jade') arguments...
 
 module.exports = class ArtworkColumns extends Backbone.View
 
-  initialize: ->
-    unless @$('.artwork-columns-column').length > 0
-      throw "You must render columns before using this view."
-
   # Build up columns of artworks, then append to each existing column
   renderArtworks: (artworkColumns) ->
     return if artworkColumns[0].length is 0


### PR DESCRIPTION
As reported here: https://artsy.slack.com/archives/C02BAQ5K7/p1522956614000692

Looks like a subtle race condition on init. 

![Uploading Screen Shot 2018-04-05 at 12.47.26 PM.png…]()
