### PR TITLE
@eessex => Refactor Newsfeed scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@artsy/express-reloadable": "^1.3.0",
     "@artsy/passport": "^1.0.8",
-    "@artsy/reaction": "^0.37.0",
+    "@artsy/reaction": "^0.37.1",
     "@artsy/stitch": "^1.4.0",
     "@babel/core": "7.0.0-beta.40",
     "@babel/node": "7.0.0-beta.40",

--- a/src/desktop/apps/article/components/App.js
+++ b/src/desktop/apps/article/components/App.js
@@ -35,7 +35,6 @@ export default hot(module)(
           )
         }
         case 'news': {
-          article.isTruncated = false
           return (
             <InfiniteScrollNewsArticle articles={[article]} {...this.props} />
           )

--- a/src/desktop/apps/article/components/App.js
+++ b/src/desktop/apps/article/components/App.js
@@ -35,6 +35,7 @@ export default hot(module)(
           )
         }
         case 'news': {
+          article.isTruncated = false
           return (
             <InfiniteScrollNewsArticle articles={[article]} {...this.props} />
           )

--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -8,7 +8,6 @@ import {
   RelatedArticlesCanvas,
 } from '@artsy/reaction/dist/Components/Publishing'
 import { ArticleData } from '@artsy/reaction/dist/Components/Publishing/Typings'
-
 import { NewsNav } from '@artsy/reaction/dist/Components/Publishing/Nav/NewsNav'
 import { setupFollows, setupFollowButtons } from './FollowButton.js'
 import { DisplayCanvas } from '@artsy/reaction/dist/Components/Publishing/Display/Canvas'
@@ -26,15 +25,15 @@ export interface Props {
 
 interface State {
   articles: ArticleData[]
-  date: any
+  date: string
   display: any[]
   error: boolean
-  following: any[]
+  following: object[]
   offset: number
   isEnabled: boolean
   isLoading: boolean
   omit: string
-  relatedArticles: any[]
+  relatedArticles: object[]
 }
 
 // FIXME: Rewire
@@ -44,14 +43,10 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
   constructor(props) {
     super(props)
 
-    const article = props.articles[0] ? props.articles[0] : {}
+    const article = props.articles[0] || {}
     const date = this.getDateField(article)
     const omit = props.article ? props.article.id : null
     const offset = props.article ? 0 : 6
-
-    this.onDateChange = throttle(this.onDateChange, 500, {
-      trailing: true
-    })
 
     this.state = {
       isLoading: false,
@@ -150,13 +145,6 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
     }
   }
 
-  onMetadataChange = (article: any = null) => {
-    const id = article ? article.id : 'news'
-    const path = article ? `/news/${article.slug}` : '/news'
-    document.title = article ? article.thumbnail_title : 'News'
-    window.history.replaceState({}, id, path)
-  }
-
   hasNewDate = (article, i) => {
     const { articles } = this.state
     const beforeArticle = articles[i - 1] || {}
@@ -196,9 +184,7 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
               article={article}
               isTruncated={isTruncated}
               isFirstArticle={i === 0}
-              nextArticle={articles[i + 1]}
               onDateChange={(date) => this.onDateChange(date)}
-              onMetadataChange={this.onMetadataChange}
             />
             {hasMetaContent &&
               related && (

--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -24,17 +24,17 @@ export interface Props {
 }
 
 interface State {
+  activeArticle: string
   articles: ArticleData[]
   date: string
   display: any[]
   error: boolean
   following: object[]
-  offset: number
   isEnabled: boolean
   isLoading: boolean
+  offset: number
   omit: string
   relatedArticles: object[]
-  activeArticle: string
 }
 
 // FIXME: Rewire
@@ -50,17 +50,17 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
     const offset = props.article ? 0 : 6
 
     this.state = {
-      isLoading: false,
+      activeArticle: '',
       articles: props.articles,
       date,
       display: [],
-      offset,
-      omit,
       error: false,
       following: setupFollows() || null,
       isEnabled: true,
-      relatedArticles: [],
-      activeArticle: ''
+      isLoading: false,
+      offset,
+      omit,
+      relatedArticles: []
     }
   }
 

--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -39,8 +39,6 @@ interface State {
 // FIXME: Rewire
 let positronql = _positronql
 
-const TOP_OFFSET = '50%'
-
 export class InfiniteScrollNewsArticle extends Component<Props, State> {
   constructor(props) {
     super(props)
@@ -152,8 +150,10 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
       if (hasNewDate) {
         this.setState({ date: article.published_at })
       }
-      if (i === 0 || article.isTruncated === false) {
+      if (article.isTruncated === false) {
         this.setMetadata(article)
+      } else {
+        this.setMetadata()
       }
     }
   }
@@ -239,6 +239,11 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
               marginTop={i === 0 ? marginTop : null}
               onExpand={() => this.onExpand(i)}
             />
+            <Waypoint
+              onEnter={(waypointData) => this.onEnter(i, waypointData)}
+              onLeave={(waypointData) => this.onLeave(i, waypointData)}
+              topOffset="200px"
+            />
             {hasMetaContent &&
               related && (
                 <Fragment>
@@ -257,11 +262,6 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
                   <Break />
                 </Fragment>
               )}
-            <Waypoint
-              onEnter={(waypointData) => this.onEnter(i, waypointData)}
-              onLeave={(waypointData) => this.onLeave(i, waypointData)}
-              topOffset={TOP_OFFSET}
-            />
           </Fragment>
         )
       })

--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment'
 import React, { Component, Fragment } from 'react'
-import { flatten, throttle } from 'lodash'
+import { flatten } from 'lodash'
 import Waypoint from 'react-waypoint'
 import { positronql as _positronql } from 'desktop/lib/positronql'
 import { newsArticlesQuery } from 'desktop/apps/article/queries/articles'
@@ -34,6 +34,7 @@ interface State {
   isLoading: boolean
   omit: string
   relatedArticles: object[]
+  activeArticle: string
 }
 
 // FIXME: Rewire
@@ -48,10 +49,6 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
     const omit = props.article ? props.article.id : null
     const offset = props.article ? 0 : 6
 
-    this.onDateChange = throttle(this.onDateChange, 500, {
-      trailing: true
-    })
-
     this.state = {
       isLoading: false,
       articles: props.articles,
@@ -63,6 +60,7 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
       following: setupFollows() || null,
       isEnabled: true,
       relatedArticles: [],
+      activeArticle: ''
     }
   }
 
@@ -149,6 +147,10 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
     }
   }
 
+  onActiveArticleChange = (id) => {
+    this.setState({ activeArticle: id })
+  }
+
   hasNewDate = (article, i) => {
     const { articles } = this.state
     const beforeArticle = articles[i - 1] || {}
@@ -164,7 +166,7 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
   }
 
   renderContent = () => {
-    const { articles, display, relatedArticles } = this.state
+    const { activeArticle, articles, display, relatedArticles } = this.state
     const { isMobile } = this.props
 
     let counter = 0
@@ -190,6 +192,8 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
               isFirstArticle={i === 0}
               onDateChange={(date) => this.onDateChange(date)}
               nextArticle={articles[i + 1]}
+              onActiveArticleChange={(id) => this.onActiveArticleChange(id)}
+              isActive={activeArticle === article.id}
             />
             {hasMetaContent &&
               related && (

--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -48,6 +48,10 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
     const omit = props.article ? props.article.id : null
     const offset = props.article ? 0 : 6
 
+    this.onDateChange = throttle(this.onDateChange, 500, {
+      trailing: true
+    })
+
     this.state = {
       isLoading: false,
       articles: props.articles,
@@ -185,6 +189,7 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
               isTruncated={isTruncated}
               isFirstArticle={i === 0}
               onDateChange={(date) => this.onDateChange(date)}
+              nextArticle={articles[i + 1]}
             />
             {hasMetaContent &&
               related && (

--- a/src/desktop/apps/article/components/NewsArticle.tsx
+++ b/src/desktop/apps/article/components/NewsArticle.tsx
@@ -1,0 +1,102 @@
+import React, { Component, Fragment } from 'react'
+import { Article } from '@artsy/reaction/dist/Components/Publishing'
+import Waypoint from 'react-waypoint'
+
+interface Props {
+  article: any
+  isMobile: boolean
+  isTruncated: boolean
+  isFirstArticle: boolean
+  nextArticle: any
+  onDateChange: any
+  onMetadataChange: any
+}
+
+interface State {
+  isTruncated: boolean
+}
+
+export class NewsArticle extends Component<Props, State> {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      isTruncated: props.isTruncated || false
+    }
+  }
+
+  onExpand = () => {
+    this.setState({
+      isTruncated: false
+    })
+  }
+
+  onEnter = ({ previousPosition, currentPosition }) => {
+    const {
+      article,
+      onDateChange,
+      onMetadataChange
+    } = this.props
+    const { isTruncated } = this.state
+    const enteredArticle =
+      previousPosition === 'above' && currentPosition === 'inside'
+
+    if (enteredArticle) {
+      onDateChange(article.published_at)
+
+      if (!isTruncated) {
+        onMetadataChange(article)
+      } else {
+        onMetadataChange()
+      }
+    }
+  }
+
+  onLeave = ({ previousPosition, currentPosition }) => {
+    const {
+      nextArticle,
+      onDateChange,
+      onMetadataChange
+    } = this.props
+
+    if (
+      nextArticle &&
+      previousPosition === 'inside' &&
+      currentPosition === 'above'
+    ) {
+      onDateChange(nextArticle.published_at)
+      if (nextArticle.isTruncated === false) {
+        onMetadataChange(nextArticle)
+      } else {
+        onMetadataChange()
+      }
+    }
+  }
+
+  render() {
+    const {
+      article,
+      isMobile,
+      isTruncated,
+      isFirstArticle
+    } = this.props
+    const marginTop = isMobile ? '100px' : '200px'
+
+    return (
+      <Fragment>
+        <Article
+          article={article}
+          isTruncated={isTruncated}
+          isMobile={isMobile}
+          marginTop={isFirstArticle ? marginTop : null}
+          onExpand={this.onExpand}
+        />
+        <Waypoint
+          onEnter={(waypointData) => this.onEnter(waypointData)}
+          onLeave={(waypointData) => this.onLeave(waypointData)}
+          topOffset="30px"
+        />
+      </Fragment>
+    )
+  }
+}

--- a/src/desktop/apps/article/components/NewsArticle.tsx
+++ b/src/desktop/apps/article/components/NewsArticle.tsx
@@ -5,9 +5,9 @@ import Waypoint from 'react-waypoint'
 interface Props {
   article: any
   isActive: boolean
+  isFirstArticle: boolean
   isMobile: boolean
   isTruncated: boolean
-  isFirstArticle: boolean
   nextArticle: any
   onActiveArticleChange: (id: string) => void
   onDateChange: (date: string) => void
@@ -64,7 +64,6 @@ export class NewsArticle extends Component<Props, State> {
       if (isMobile) {
         onActiveArticleChange(article.id)
       }
-
     }
   }
 

--- a/src/desktop/apps/article/components/NewsArticle.tsx
+++ b/src/desktop/apps/article/components/NewsArticle.tsx
@@ -7,9 +7,7 @@ interface Props {
   isMobile: boolean
   isTruncated: boolean
   isFirstArticle: boolean
-  nextArticle: any
-  onDateChange: any
-  onMetadataChange: any
+  onDateChange: (date: string) => void
 }
 
 interface State {
@@ -26,49 +24,34 @@ export class NewsArticle extends Component<Props, State> {
   }
 
   onExpand = () => {
+    const { article } = this.props
+    this.setMetadata(article)
     this.setState({
       isTruncated: false
     })
   }
 
-  onEnter = ({ previousPosition, currentPosition }) => {
+  setMetadata = (article: any = null) => {
+    const id = article ? article.id : 'news'
+    const path = article ? `/news/${article.slug}` : '/news'
+    document.title = article ? article.thumbnail_title : 'News'
+    window.history.replaceState({}, id, path)
+  }
+
+  onEnter = ({ currentPosition }) => {
     const {
       article,
-      onDateChange,
-      onMetadataChange
+      onDateChange
     } = this.props
     const { isTruncated } = this.state
-    const enteredArticle =
-      previousPosition === 'above' && currentPosition === 'inside'
 
-    if (enteredArticle) {
+    if (currentPosition === 'inside') {
       onDateChange(article.published_at)
 
       if (!isTruncated) {
-        onMetadataChange(article)
+        this.setMetadata(article)
       } else {
-        onMetadataChange()
-      }
-    }
-  }
-
-  onLeave = ({ previousPosition, currentPosition }) => {
-    const {
-      nextArticle,
-      onDateChange,
-      onMetadataChange
-    } = this.props
-
-    if (
-      nextArticle &&
-      previousPosition === 'inside' &&
-      currentPosition === 'above'
-    ) {
-      onDateChange(nextArticle.published_at)
-      if (nextArticle.isTruncated === false) {
-        onMetadataChange(nextArticle)
-      } else {
-        onMetadataChange()
+        this.setMetadata()
       }
     }
   }
@@ -84,18 +67,20 @@ export class NewsArticle extends Component<Props, State> {
 
     return (
       <Fragment>
-        <Article
-          article={article}
-          isTruncated={isTruncated}
-          isMobile={isMobile}
-          marginTop={isFirstArticle ? marginTop : null}
-          onExpand={this.onExpand}
-        />
         <Waypoint
           onEnter={(waypointData) => this.onEnter(waypointData)}
-          onLeave={(waypointData) => this.onLeave(waypointData)}
           topOffset="30px"
-        />
+        >
+          <div>
+            <Article
+              article={article}
+              isTruncated={isTruncated}
+              isMobile={isMobile}
+              marginTop={isFirstArticle ? marginTop : null}
+              onExpand={this.onExpand}
+            />
+          </div>
+        </Waypoint>
       </Fragment>
     )
   }

--- a/src/desktop/apps/article/components/NewsArticle.tsx
+++ b/src/desktop/apps/article/components/NewsArticle.tsx
@@ -7,6 +7,7 @@ interface Props {
   isMobile: boolean
   isTruncated: boolean
   isFirstArticle: boolean
+  nextArticle: any
   onDateChange: (date: string) => void
 }
 
@@ -38,7 +39,7 @@ export class NewsArticle extends Component<Props, State> {
     window.history.replaceState({}, id, path)
   }
 
-  onEnter = ({ currentPosition }) => {
+  onEnter = ({ previousPosition, currentPosition }) => {
     const {
       article,
       onDateChange
@@ -46,12 +47,27 @@ export class NewsArticle extends Component<Props, State> {
     const { isTruncated } = this.state
 
     if (currentPosition === 'inside') {
-      onDateChange(article.published_at)
+      if (previousPosition === 'above') {
+        onDateChange(article.published_at)
+      }
 
       if (!isTruncated) {
         this.setMetadata(article)
       } else {
         this.setMetadata()
+      }
+    }
+  }
+
+  onLeave = ({ previousPosition, currentPosition }) => {
+    const {
+      nextArticle,
+      onDateChange
+    } = this.props
+
+    if (currentPosition === 'inside' && previousPosition === 'below') {
+      if (nextArticle) {
+        onDateChange(nextArticle.published_at)
       }
     }
   }

--- a/src/desktop/apps/article/components/NewsArticle.tsx
+++ b/src/desktop/apps/article/components/NewsArticle.tsx
@@ -15,6 +15,7 @@ interface Props {
 
 interface State {
   isTruncated: boolean
+  bottomOffset: string
 }
 
 export class NewsArticle extends Component<Props, State> {
@@ -22,8 +23,15 @@ export class NewsArticle extends Component<Props, State> {
     super(props)
 
     this.state = {
-      isTruncated: props.isTruncated || false
+      isTruncated: props.isTruncated || false,
+      bottomOffset: "200px"
     }
+  }
+
+  componentDidMount() {
+    this.setState({
+      bottomOffset: `${window.innerHeight / 2}px`
+    })
   }
 
   onExpand = () => {
@@ -93,8 +101,8 @@ export class NewsArticle extends Component<Props, State> {
       isTruncated,
       isFirstArticle
     } = this.props
+    const { bottomOffset } = this.state
     const marginTop = isMobile ? '100px' : '200px'
-    const bottomOffset = window ? `${window.innerHeight / 2}px` : '200px'
 
     return (
       <Fragment>

--- a/src/desktop/apps/article/components/NewsArticle.tsx
+++ b/src/desktop/apps/article/components/NewsArticle.tsx
@@ -4,10 +4,12 @@ import Waypoint from 'react-waypoint'
 
 interface Props {
   article: any
+  isActive: boolean
   isMobile: boolean
   isTruncated: boolean
   isFirstArticle: boolean
   nextArticle: any
+  onActiveArticleChange: (id: string) => void
   onDateChange: (date: string) => void
 }
 
@@ -42,7 +44,9 @@ export class NewsArticle extends Component<Props, State> {
   onEnter = ({ previousPosition, currentPosition }) => {
     const {
       article,
-      onDateChange
+      onActiveArticleChange,
+      onDateChange,
+      isMobile
     } = this.props
     const { isTruncated } = this.state
 
@@ -56,18 +60,28 @@ export class NewsArticle extends Component<Props, State> {
       } else {
         this.setMetadata()
       }
+
+      if (isMobile) {
+        onActiveArticleChange(article.id)
+      }
+
     }
   }
 
   onLeave = ({ previousPosition, currentPosition }) => {
     const {
       nextArticle,
-      onDateChange
+      onDateChange,
+      isMobile,
+      onActiveArticleChange
     } = this.props
 
-    if (currentPosition === 'inside' && previousPosition === 'below') {
+    if (currentPosition === 'above' && previousPosition === 'inside') {
       if (nextArticle) {
         onDateChange(nextArticle.published_at)
+        if (isMobile) {
+          onActiveArticleChange(nextArticle.id)
+        }
       }
     }
   }
@@ -75,17 +89,21 @@ export class NewsArticle extends Component<Props, State> {
   render() {
     const {
       article,
+      isActive,
       isMobile,
       isTruncated,
       isFirstArticle
     } = this.props
     const marginTop = isMobile ? '100px' : '200px'
+    const bottomOffset = window ? `${window.innerHeight / 2}px` : '200px'
 
     return (
       <Fragment>
         <Waypoint
           onEnter={(waypointData) => this.onEnter(waypointData)}
-          topOffset="30px"
+          onLeave={(waypointData) => this.onLeave(waypointData)}
+          topOffset="-10px"
+          bottomOffset={bottomOffset}
         >
           <div>
             <Article
@@ -94,6 +112,7 @@ export class NewsArticle extends Component<Props, State> {
               isMobile={isMobile}
               marginTop={isFirstArticle ? marginTop : null}
               onExpand={this.onExpand}
+              isHovered={isMobile && isActive}
             />
           </div>
         </Waypoint>

--- a/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.test.js
+++ b/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.test.js
@@ -8,7 +8,7 @@ import { shallow } from 'enzyme'
 import { data as sd } from 'sharify'
 import fixtures from 'desktop/test/helpers/fixtures.coffee'
 import { UnitCanvasImage } from 'reaction/Components/Publishing/Fixtures/Components'
-import { NewsArticle } from 'reaction/Components/Publishing/Fixtures/Articles'
+// import { NewsArticle } from 'reaction/Components/Publishing/Fixtures/Articles'
 
 describe('<InfiniteScrollNewsArticle />', () => {
   let props
@@ -40,13 +40,11 @@ describe('<InfiniteScrollNewsArticle />', () => {
 
   let rewire = require('rewire')('../InfiniteScrollNewsArticle.tsx')
   let { InfiniteScrollNewsArticle } = rewire
-  const {
-    Article,
-    RelatedArticlesCanvas,
-  } = require('reaction/Components/Publishing')
+  const { RelatedArticlesCanvas } = require('reaction/Components/Publishing')
   const {
     DisplayCanvas,
   } = require('reaction/Components/Publishing/Display/Canvas')
+  const { NewsArticle } = require('../NewsArticle.tsx')
 
   beforeEach(() => {
     window.history.replaceState = sinon.stub()
@@ -69,6 +67,7 @@ describe('<InfiniteScrollNewsArticle />', () => {
       article,
       articles: [article],
       marginTop: '50px',
+      isMobile: false,
     }
   })
 
@@ -90,22 +89,12 @@ describe('<InfiniteScrollNewsArticle />', () => {
     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
     await rendered.instance().fetchNextArticles()
     rendered.update()
-    rendered.find(Article).length.should.equal(2)
+    rendered.find(NewsArticle).length.should.equal(2)
   })
 
   it('sets up follow buttons', () => {
     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
     rendered.state().following.length.should.exist
-  })
-
-  it('#onExpand pushes article url to browser and updates articles state', () => {
-    const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-    rendered.instance().onExpand(0)
-
-    rendered.state('articles')[0].isTruncated.should.be.false()
-    window.history.replaceState.args[0][2].should.containEql(
-      '/news/news-article'
-    )
   })
 
   it('#hasNewDate returns true if article date is different from previous article', () => {
@@ -131,202 +120,183 @@ describe('<InfiniteScrollNewsArticle />', () => {
     }
     rewire.__set__('positronql', sinon.stub().returns(Promise.resolve(data)))
     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-    await rendered.instance().fetchNextArticles()
-    rendered.update()
-    rendered.find(DisplayCanvas).length.should.equal(1)
-    rendered.html().should.containEql('Sponsored by BMW')
+    // await rendered.instance().fetchNextArticles()
+    // rendered.update()
+    console.log(rendered.html())
+    // rendered.find(DisplayCanvas).length.should.equal(1)
+    // rendered.html().should.containEql('Sponsored by BMW')
   })
 
-  it('injects read more after the sixth article', async () => {
-    const data = {
-      articles: _.times(6, () => {
-        return _.extend({}, fixtures.article, {
-          slug: 'foobar',
-          channel_id: '123',
-          id: '678',
-        })
-      }),
-      relatedArticlesCanvas: _.times(4, () => {
-        return _.extend({}, fixtures.article, {
-          slug: 'related-article',
-          channel_id: '123',
-          id: '456',
-        })
-      }),
-    }
-    rewire.__set__('positronql', sinon.stub().returns(Promise.resolve(data)))
-    const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-    await rendered.instance().fetchNextArticles()
-    rendered.update()
-    rendered.find(RelatedArticlesCanvas).length.should.equal(1)
-    rendered.html().should.containEql('More from Artsy Editorial')
-  })
+  // it('injects read more after the sixth article', async () => {
+  //   const data = {
+  //     articles: _.times(6, () => {
+  //       return _.extend({}, fixtures.article, {
+  //         slug: 'foobar',
+  //         channel_id: '123',
+  //         id: '678',
+  //       })
+  //     }),
+  //     relatedArticlesCanvas: _.times(4, () => {
+  //       return _.extend({}, fixtures.article, {
+  //         slug: 'related-article',
+  //         channel_id: '123',
+  //         id: '456',
+  //       })
+  //     }),
+  //   }
+  //   rewire.__set__('positronql', sinon.stub().returns(Promise.resolve(data)))
+  //   const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+  //   await rendered.instance().fetchNextArticles()
+  //   rendered.update()
+  //   rendered.find(RelatedArticlesCanvas).length.should.equal(1)
+  //   rendered.html().should.containEql('More from Artsy Editorial')
+  // })
 
-  describe('/news - news index', () => {
-    beforeEach(() => {
-      delete props.article
-    })
+  // describe('/news - news index', () => {
+  //   beforeEach(() => {
+  //     delete props.article
+  //   })
 
-    it('renders list', () => {
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      rendered.find(Article).length.should.equal(1)
-      rendered.html().should.containEql('NewsLayout')
-    })
+  //   it('renders list', () => {
+  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+  //     rendered.find(Article).length.should.equal(1)
+  //     rendered.html().should.containEql('NewsLayout')
+  //   })
 
-    it('sets up state without props.article', () => {
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      rendered.state().offset.should.eql(6)
-      rendered.state().date.should.eql(props.articles[0].published_at)
-    })
-  })
+  //   it('sets up state without props.article', () => {
+  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+  //     rendered.state().offset.should.eql(6)
+  //     rendered.state().date.should.eql(props.articles[0].published_at)
+  //   })
+  // })
 
-  describe('/news/:id - single news article', () => {
-    it('renders the initial article', () => {
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      rendered.find(Article).length.should.equal(1)
-      rendered.html().should.containEql('NewsLayout')
-    })
+  // describe('/news/:id - single news article', () => {
+  //   it('renders the initial article', () => {
+  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+  //     rendered.find(Article).length.should.equal(1)
+  //     rendered.html().should.containEql('NewsLayout')
+  //   })
 
-    it('sets up state for a single article', () => {
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      rendered.state().offset.should.eql(0)
-      rendered.state().omit.should.eql(props.article.id)
-      rendered.state().date.should.eql(props.article.published_at)
-    })
-  })
+  //   it('sets up state for a single article', () => {
+  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+  //     rendered.state().offset.should.eql(0)
+  //     rendered.state().omit.should.eql(props.article.id)
+  //     rendered.state().date.should.eql(props.article.published_at)
+  //   })
+  // })
 
-  describe('#getDateField', () => {
-    it('Returns published_at if present', () => {
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      const getDateField = rendered.instance().getDateField(article)
+  // describe('#getDateField', () => {
+  //   it('Returns published_at if present', () => {
+  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+  //     const getDateField = rendered.instance().getDateField(article)
 
-      getDateField.should.equal(article.published_at)
-    })
-    it('Returns scheduled_publish_at if no published_at', () => {
-      const published_at = article.published_at
-      article.scheduled_publish_at = published_at
-      delete article.published_at
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      const getDateField = rendered.instance().getDateField(article)
+  //     getDateField.should.equal(article.published_at)
+  //   })
+  //   it('Returns scheduled_publish_at if no published_at', () => {
+  //     const published_at = article.published_at
+  //     article.scheduled_publish_at = published_at
+  //     delete article.published_at
+  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+  //     const getDateField = rendered.instance().getDateField(article)
 
-      getDateField.should.equal(published_at)
-    })
-    it('Returns today for articles with no date field', () => {
-      const today = moment()
-        .toISOString()
-        .substring(0, 10)
-      delete article.published_at
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      const getDateField = rendered
-        .instance()
-        .getDateField(article)
-        .substring(0, 10)
+  //     getDateField.should.equal(published_at)
+  //   })
+  //   it('Returns today for articles with no date field', () => {
+  //     const today = moment()
+  //       .toISOString()
+  //       .substring(0, 10)
+  //     delete article.published_at
+  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+  //     const getDateField = rendered
+  //       .instance()
+  //       .getDateField(article)
+  //       .substring(0, 10)
 
-      getDateField.should.equal(today)
-    })
-  })
+  //     getDateField.should.equal(today)
+  //   })
+  // })
 
-  describe('#onEnter', () => {
-    it('does not push url to browser if it is not scrolling upwards into an article', () => {
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      rendered.instance().onEnter(0, {})
+  // describe('#onEnter', () => {
+  //   it('does not push url to browser if it is not scrolling upwards into an article', () => {
+  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+  //     rendered.instance().onEnter(0, {})
 
-      window.history.replaceState.args.length.should.equal(0)
-    })
+  //     window.history.replaceState.args.length.should.equal(0)
+  //   })
 
-    it('sets state.date if entered and article date is different from existing state', () => {
-      props.articles.push(nextArticle)
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      rendered.instance().setState = sinon.stub()
-      rendered.update()
-      rendered.instance().onEnter(1, {
-        previousPosition: 'above',
-        currentPosition: 'inside',
-      })
-      rendered
-        .instance()
-        .setState.args[0][0].date.should.equal(nextArticle.published_at)
-    })
+  //   it('sets state.date if entered and article date is different from existing state', () => {
+  //     props.articles.push(nextArticle)
+  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+  //     rendered.instance().setState = sinon.stub()
+  //     rendered.update()
+  //     rendered.instance().onEnter(1, {
+  //       previousPosition: 'above',
+  //       currentPosition: 'inside',
+  //     })
+  //     rendered
+  //       .instance()
+  //       .setState.args[0][0].date.should.equal(nextArticle.published_at)
+  //   })
 
-    it('pushes article url to browser if it is scrolling upwards into props.article', () => {
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      rendered.instance().onEnter(0, {
-        previousPosition: 'above',
-        currentPosition: 'inside',
-      })
-      window.history.replaceState.args[0][2].should.containEql(
-        '/news/news-article'
-      )
-    })
+  //   it('pushes article url to browser if it is scrolling upwards into props.article', () => {
+  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+  //     rendered.instance().onEnter(0, {
+  //       previousPosition: 'above',
+  //       currentPosition: 'inside',
+  //     })
+  //     window.history.replaceState.args[0][2].should.containEql(
+  //       '/news/news-article'
+  //     )
+  //   })
 
-    it('pushes /news to browser if it is scrolling upwards into a truncated news article', () => {
-      props.articles.push(nextArticle)
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      rendered.instance().onEnter(1, {
-        previousPosition: 'above',
-        currentPosition: 'inside',
-      })
-      window.history.replaceState.args[0][2].should.containEql('/news')
-    })
+  //   it('pushes /news to browser if it is scrolling upwards into a truncated news article', () => {
+  //     props.articles.push(nextArticle)
+  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+  //     rendered.instance().onEnter(1, {
+  //       previousPosition: 'above',
+  //       currentPosition: 'inside',
+  //     })
+  //     window.history.replaceState.args[0][2].should.containEql('/news')
+  //   })
 
-    it('does not push url to browser if it is not scrolling upwards into an article', () => {
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      rendered.instance().onEnter(0, {})
+  //   it('does not push url to browser if it is not scrolling upwards into an article', () => {
+  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+  //     rendered.instance().onEnter(0, {})
 
-      window.history.replaceState.args.length.should.equal(0)
-    })
-  })
+  //     window.history.replaceState.args.length.should.equal(0)
+  //   })
+  // })
 
-  describe('#onLeave', () => {
-    it('does not push url to browser if it is not scrolling downwards into the next article', () => {
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      rendered.instance().onLeave(0, {})
+  // describe('#onLeave', () => {
+  //   it('does not push url to browser if it is not scrolling downwards into the next article', () => {
+  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+  //     rendered.instance().onLeave(0, {})
 
-      window.history.replaceState.args.length.should.equal(0)
-    })
+  //     window.history.replaceState.args.length.should.equal(0)
+  //   })
 
-    it('pushes "/news" to browser if it is scrolling downwards into the next article', () => {
-      props.articles.push(nextArticle)
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      rendered.instance().onLeave(0, {
-        previousPosition: 'inside',
-        currentPosition: 'above',
-      })
-      window.history.replaceState.args[0][2].should.containEql('/news')
-    })
+  //   it('pushes "/news" to browser if it is scrolling downwards into the next article', () => {
+  //     props.articles.push(nextArticle)
+  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+  //     rendered.instance().onLeave(0, {
+  //       previousPosition: 'inside',
+  //       currentPosition: 'above',
+  //     })
+  //     window.history.replaceState.args[0][2].should.containEql('/news')
+  //   })
 
-    it('sets state.date if has left and article date is different from existing state', () => {
-      props.articles.push(nextArticle)
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      rendered.instance().setState = sinon.stub()
-      rendered.update()
-      rendered.instance().onLeave(0, {
-        previousPosition: 'inside',
-        currentPosition: 'above',
-      })
-      rendered
-        .instance()
-        .setState.args[0][0].date.should.equal(nextArticle.published_at)
-    })
-  })
-
-  describe('#setMetadata', () => {
-    it('sets default news metadata', () => {
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      rendered.instance().setMetadata()
-      window.history.replaceState.args[0][2].should.containEql('/news')
-    })
-
-    it('#sets article metadata', () => {
-      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      rendered.instance().setMetadata({
-        slug: 'some-slug',
-        thumbnail_title: 'Some title',
-        id: '123',
-      })
-      window.history.replaceState.args[0][2].should.containEql(
-        '/news/some-slug'
-      )
-    })
-  })
+  //   it('sets state.date if has left and article date is different from existing state', () => {
+  //     props.articles.push(nextArticle)
+  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+  //     rendered.instance().setState = sinon.stub()
+  //     rendered.update()
+  //     rendered.instance().onLeave(0, {
+  //       previousPosition: 'inside',
+  //       currentPosition: 'above',
+  //     })
+  //     rendered
+  //       .instance()
+  //       .setState.args[0][0].date.should.equal(nextArticle.published_at)
+  //   })
+  // })
 })

--- a/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.test.js
+++ b/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.test.js
@@ -8,7 +8,7 @@ import { shallow } from 'enzyme'
 import { data as sd } from 'sharify'
 import fixtures from 'desktop/test/helpers/fixtures.coffee'
 import { UnitCanvasImage } from 'reaction/Components/Publishing/Fixtures/Components'
-// import { NewsArticle } from 'reaction/Components/Publishing/Fixtures/Articles'
+import { NewsArticle } from 'reaction/Components/Publishing/Fixtures/Articles'
 
 describe('<InfiniteScrollNewsArticle />', () => {
   let props
@@ -44,7 +44,6 @@ describe('<InfiniteScrollNewsArticle />', () => {
   const {
     DisplayCanvas,
   } = require('reaction/Components/Publishing/Display/Canvas')
-  const { NewsArticle } = require('../NewsArticle.tsx')
 
   beforeEach(() => {
     window.history.replaceState = sinon.stub()
@@ -89,7 +88,10 @@ describe('<InfiniteScrollNewsArticle />', () => {
     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
     await rendered.instance().fetchNextArticles()
     rendered.update()
-    rendered.find(NewsArticle).length.should.equal(2)
+    rendered
+      .find('#article-root')
+      .children()
+      .length.should.equal(4)
   })
 
   it('sets up follow buttons', () => {
@@ -107,7 +109,7 @@ describe('<InfiniteScrollNewsArticle />', () => {
   it('injects a canvas ad after the sixth article', async () => {
     const data = {
       articles: _.times(6, () => {
-        return _.extend({}, fixtures.article, {
+        return _.extend({}, NewsArticle, {
           slug: 'foobar',
           channel_id: '123',
           id: '678',
@@ -120,183 +122,113 @@ describe('<InfiniteScrollNewsArticle />', () => {
     }
     rewire.__set__('positronql', sinon.stub().returns(Promise.resolve(data)))
     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-    // await rendered.instance().fetchNextArticles()
-    // rendered.update()
-    console.log(rendered.html())
-    // rendered.find(DisplayCanvas).length.should.equal(1)
-    // rendered.html().should.containEql('Sponsored by BMW')
+    await rendered.instance().fetchNextArticles()
+    rendered.update()
+    rendered.find(DisplayCanvas).length.should.equal(1)
+    rendered.html().should.containEql('Sponsored by BMW')
   })
 
-  // it('injects read more after the sixth article', async () => {
-  //   const data = {
-  //     articles: _.times(6, () => {
-  //       return _.extend({}, fixtures.article, {
-  //         slug: 'foobar',
-  //         channel_id: '123',
-  //         id: '678',
-  //       })
-  //     }),
-  //     relatedArticlesCanvas: _.times(4, () => {
-  //       return _.extend({}, fixtures.article, {
-  //         slug: 'related-article',
-  //         channel_id: '123',
-  //         id: '456',
-  //       })
-  //     }),
-  //   }
-  //   rewire.__set__('positronql', sinon.stub().returns(Promise.resolve(data)))
-  //   const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //   await rendered.instance().fetchNextArticles()
-  //   rendered.update()
-  //   rendered.find(RelatedArticlesCanvas).length.should.equal(1)
-  //   rendered.html().should.containEql('More from Artsy Editorial')
-  // })
+  it('injects read more after the sixth article', async () => {
+    const data = {
+      articles: _.times(6, () => {
+        return _.extend({}, fixtures.article, {
+          slug: 'foobar',
+          channel_id: '123',
+          id: '678',
+        })
+      }),
+      relatedArticlesCanvas: _.times(4, () => {
+        return _.extend({}, fixtures.article, {
+          slug: 'related-article',
+          channel_id: '123',
+          id: '456',
+        })
+      }),
+    }
+    rewire.__set__('positronql', sinon.stub().returns(Promise.resolve(data)))
+    const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+    await rendered.instance().fetchNextArticles()
+    rendered.update()
+    rendered.find(RelatedArticlesCanvas).length.should.equal(1)
+    rendered.html().should.containEql('More from Artsy Editorial')
+  })
 
-  // describe('/news - news index', () => {
-  //   beforeEach(() => {
-  //     delete props.article
-  //   })
+  describe('/news - news index', () => {
+    beforeEach(() => {
+      delete props.article
+    })
 
-  //   it('renders list', () => {
+    it('renders list', () => {
+      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+      rendered
+        .find('#article-root')
+        .children()
+        .length.should.equal(3)
+      rendered.html().should.containEql('NewsLayout')
+    })
+
+    it('sets up state without props.article', () => {
+      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+      rendered.state().offset.should.eql(6)
+      rendered.state().date.should.eql(props.articles[0].published_at)
+    })
+  })
+
+  describe('/news/:id - single news article', () => {
+    it('renders the initial article', () => {
+      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+      rendered
+        .find('#article-root')
+        .children()
+        .length.should.equal(3)
+      rendered.html().should.containEql('NewsLayout')
+    })
+
+    it('sets up state for a single article', () => {
+      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+      rendered.state().offset.should.eql(0)
+      rendered.state().omit.should.eql(props.article.id)
+      rendered.state().date.should.eql(props.article.published_at)
+    })
+  })
+
+  describe('#getDateField', () => {
+    it('Returns published_at if present', () => {
+      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+      const getDateField = rendered.instance().getDateField(article)
+
+      getDateField.should.equal(article.published_at)
+    })
+    it('Returns scheduled_publish_at if no published_at', () => {
+      const published_at = article.published_at
+      article.scheduled_publish_at = published_at
+      delete article.published_at
+      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+      const getDateField = rendered.instance().getDateField(article)
+
+      getDateField.should.equal(published_at)
+    })
+    it('Returns today for articles with no date field', () => {
+      const today = moment()
+        .toISOString()
+        .substring(0, 10)
+      delete article.published_at
+      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+      const getDateField = rendered
+        .instance()
+        .getDateField(article)
+        .substring(0, 10)
+
+      getDateField.should.equal(today)
+    })
+  })
+
+  // describe('#onDateChange', () => {
+  //   it('is throttled', () => {
   //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //     rendered.find(Article).length.should.equal(1)
-  //     rendered.html().should.containEql('NewsLayout')
-  //   })
+  //     rendered.instance().onDateChange('123')
+  //     console.log(rendered.state('date'))
 
-  //   it('sets up state without props.article', () => {
-  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //     rendered.state().offset.should.eql(6)
-  //     rendered.state().date.should.eql(props.articles[0].published_at)
-  //   })
-  // })
-
-  // describe('/news/:id - single news article', () => {
-  //   it('renders the initial article', () => {
-  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //     rendered.find(Article).length.should.equal(1)
-  //     rendered.html().should.containEql('NewsLayout')
-  //   })
-
-  //   it('sets up state for a single article', () => {
-  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //     rendered.state().offset.should.eql(0)
-  //     rendered.state().omit.should.eql(props.article.id)
-  //     rendered.state().date.should.eql(props.article.published_at)
-  //   })
-  // })
-
-  // describe('#getDateField', () => {
-  //   it('Returns published_at if present', () => {
-  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //     const getDateField = rendered.instance().getDateField(article)
-
-  //     getDateField.should.equal(article.published_at)
-  //   })
-  //   it('Returns scheduled_publish_at if no published_at', () => {
-  //     const published_at = article.published_at
-  //     article.scheduled_publish_at = published_at
-  //     delete article.published_at
-  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //     const getDateField = rendered.instance().getDateField(article)
-
-  //     getDateField.should.equal(published_at)
-  //   })
-  //   it('Returns today for articles with no date field', () => {
-  //     const today = moment()
-  //       .toISOString()
-  //       .substring(0, 10)
-  //     delete article.published_at
-  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //     const getDateField = rendered
-  //       .instance()
-  //       .getDateField(article)
-  //       .substring(0, 10)
-
-  //     getDateField.should.equal(today)
-  //   })
-  // })
-
-  // describe('#onEnter', () => {
-  //   it('does not push url to browser if it is not scrolling upwards into an article', () => {
-  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //     rendered.instance().onEnter(0, {})
-
-  //     window.history.replaceState.args.length.should.equal(0)
-  //   })
-
-  //   it('sets state.date if entered and article date is different from existing state', () => {
-  //     props.articles.push(nextArticle)
-  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //     rendered.instance().setState = sinon.stub()
-  //     rendered.update()
-  //     rendered.instance().onEnter(1, {
-  //       previousPosition: 'above',
-  //       currentPosition: 'inside',
-  //     })
-  //     rendered
-  //       .instance()
-  //       .setState.args[0][0].date.should.equal(nextArticle.published_at)
-  //   })
-
-  //   it('pushes article url to browser if it is scrolling upwards into props.article', () => {
-  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //     rendered.instance().onEnter(0, {
-  //       previousPosition: 'above',
-  //       currentPosition: 'inside',
-  //     })
-  //     window.history.replaceState.args[0][2].should.containEql(
-  //       '/news/news-article'
-  //     )
-  //   })
-
-  //   it('pushes /news to browser if it is scrolling upwards into a truncated news article', () => {
-  //     props.articles.push(nextArticle)
-  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //     rendered.instance().onEnter(1, {
-  //       previousPosition: 'above',
-  //       currentPosition: 'inside',
-  //     })
-  //     window.history.replaceState.args[0][2].should.containEql('/news')
-  //   })
-
-  //   it('does not push url to browser if it is not scrolling upwards into an article', () => {
-  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //     rendered.instance().onEnter(0, {})
-
-  //     window.history.replaceState.args.length.should.equal(0)
-  //   })
-  // })
-
-  // describe('#onLeave', () => {
-  //   it('does not push url to browser if it is not scrolling downwards into the next article', () => {
-  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //     rendered.instance().onLeave(0, {})
-
-  //     window.history.replaceState.args.length.should.equal(0)
-  //   })
-
-  //   it('pushes "/news" to browser if it is scrolling downwards into the next article', () => {
-  //     props.articles.push(nextArticle)
-  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //     rendered.instance().onLeave(0, {
-  //       previousPosition: 'inside',
-  //       currentPosition: 'above',
-  //     })
-  //     window.history.replaceState.args[0][2].should.containEql('/news')
-  //   })
-
-  //   it('sets state.date if has left and article date is different from existing state', () => {
-  //     props.articles.push(nextArticle)
-  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //     rendered.instance().setState = sinon.stub()
-  //     rendered.update()
-  //     rendered.instance().onLeave(0, {
-  //       previousPosition: 'inside',
-  //       currentPosition: 'above',
-  //     })
-  //     rendered
-  //       .instance()
-  //       .setState.args[0][0].date.should.equal(nextArticle.published_at)
   //   })
   // })
 })

--- a/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.test.js
+++ b/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.test.js
@@ -96,7 +96,7 @@ describe('<InfiniteScrollNewsArticle />', () => {
 
   it('sets up follow buttons', () => {
     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-    rendered.state().following.length.should.exist
+    rendered.state('following').length.should.exist
   })
 
   it('#hasNewDate returns true if article date is different from previous article', () => {
@@ -151,6 +151,12 @@ describe('<InfiniteScrollNewsArticle />', () => {
     rendered.update()
     rendered.find(RelatedArticlesCanvas).length.should.equal(1)
     rendered.html().should.containEql('More from Artsy Editorial')
+  })
+
+  it('#onActiveArticleChange sets the activeArticle', () => {
+    const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+    rendered.instance().onActiveArticleChange('1234')
+    rendered.state('activeArticle').should.equal('1234')
   })
 
   describe('/news - news index', () => {
@@ -223,12 +229,18 @@ describe('<InfiniteScrollNewsArticle />', () => {
     })
   })
 
-  // describe('#onDateChange', () => {
-  //   it('is throttled', () => {
-  //     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-  //     rendered.instance().onDateChange('123')
-  //     console.log(rendered.state('date'))
+  describe('#onDateChange', () => {
+    it('it sets date if it has a new one', () => {
+      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+      rendered.instance().onDateChange('123')
+      rendered.state('date').should.equal('123')
+    })
 
-  //   })
-  // })
+    it("it doesn't set date if it hasn't changed", () => {
+      const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
+      rendered.setState = sinon.stub()
+      rendered.instance().onDateChange('2018-07-19T17:19:55.909Z')
+      rendered.setState.callCount.should.equal(0)
+    })
+  })
 })

--- a/src/desktop/apps/article/components/__tests__/NewsArticle.test.js
+++ b/src/desktop/apps/article/components/__tests__/NewsArticle.test.js
@@ -1,0 +1,130 @@
+import 'jsdom-global/register'
+import _ from 'underscore'
+import benv from 'benv'
+import sinon from 'sinon'
+import React from 'react'
+import { mount, shallow } from 'enzyme'
+import { data as sd } from 'sharify'
+import { NewsArticle as NewsArticleFixture } from 'reaction/Components/Publishing/Fixtures/Articles'
+
+describe('<NewsArticle />', () => {
+  let props
+  let article
+
+  before((done) => {
+    benv.setup(() => {
+      benv.expose({ $: benv.require('jquery'), jQuery: benv.require('jquery') })
+      sd.APP_URL = 'http://artsy.net'
+      sd.CURRENT_PATH =
+        '/news/artsy-editorial-surprising-reason-men-women-selfies-differently'
+      sd.CURRENT_USER = { id: '123' }
+      done()
+    })
+  })
+
+  after(() => {
+    benv.teardown()
+  })
+
+  window.matchMedia = () => {
+    return {
+      matches: false,
+      addListener: () => {},
+      removeListener: () => {},
+    }
+  }
+
+  let rewire = require('rewire')('../NewsArticle.tsx')
+  let { NewsArticle } = rewire
+
+  beforeEach(() => {
+    window.history.replaceState = sinon.stub()
+    article = _.extend({ slug: 'news-article' }, NewsArticleFixture)
+
+    props = {
+      article,
+      isMobile: true,
+      isTruncated: true,
+      isFirstArticle: true,
+      onDateChange: sinon.stub(),
+    }
+  })
+
+  afterEach(() => {
+    window.history.replaceState.reset()
+  })
+
+  it('renders the article', () => {
+    const rendered = mount(<NewsArticle {...props} />)
+    rendered.html().should.containEql('NewsLayout')
+  })
+
+  it('#onExpand pushes article url to browser and updates articles state', () => {
+    const rendered = mount(<NewsArticle {...props} />)
+    rendered.instance().onExpand()
+
+    rendered.state('isTruncated').should.be.false()
+    window.history.replaceState.args[0][2].should.containEql(
+      '/news/news-article'
+    )
+  })
+
+  describe('#setMetadata', () => {
+    it('sets default news metadata', () => {
+      const rendered = mount(<NewsArticle {...props} />)
+      rendered.instance().setMetadata()
+      window.history.replaceState.args[0][2].should.containEql('/news')
+    })
+
+    it('#sets article metadata', () => {
+      const rendered = mount(<NewsArticle {...props} />)
+      rendered.instance().setMetadata({
+        slug: 'some-slug',
+        thumbnail_title: 'Some title',
+        id: '123',
+      })
+      window.history.replaceState.args[0][2].should.containEql(
+        '/news/some-slug'
+      )
+    })
+  })
+
+  describe('#onEnter', () => {
+    it('does not push url to browser if it is not scrolling into an article', () => {
+      const rendered = mount(<NewsArticle {...props} />)
+      rendered.instance().onEnter({
+        currentPosition: 'outside',
+      })
+
+      window.history.replaceState.args.length.should.equal(0)
+    })
+
+    it('calls onDateChange if waypoint is triggered inside', () => {
+      const rendered = mount(<NewsArticle {...props} />)
+      rendered.instance().onEnter({
+        currentPosition: 'inside',
+      })
+
+      props.onDateChange.args[0][0].should.equal(article.published_at)
+    })
+
+    it('pushes /news to browser if it is scrolling into a truncated article', () => {
+      const rendered = mount(<NewsArticle {...props} />)
+      rendered.instance().onEnter({
+        currentPosition: 'inside',
+      })
+      window.history.replaceState.args[0][2].should.containEql('/news')
+    })
+
+    it('pushes the article if it is scrolling into a non-truncated article', () => {
+      props.isTruncated = false
+      const rendered = mount(<NewsArticle {...props} />)
+      rendered.instance().onEnter({
+        currentPosition: 'inside',
+      })
+      window.history.replaceState.args[0][2].should.containEql(
+        '/news/news-article'
+      )
+    })
+  })
+})

--- a/src/desktop/apps/article/components/__tests__/NewsArticle.test.js
+++ b/src/desktop/apps/article/components/__tests__/NewsArticle.test.js
@@ -46,7 +46,12 @@ describe('<NewsArticle />', () => {
       isMobile: true,
       isTruncated: true,
       isFirstArticle: true,
+      nextArticle: {
+        id: '1234',
+        published_at: '5678',
+      },
       onDateChange: sinon.stub(),
+      onActiveArticleChange: sinon.stub(),
     }
   })
 
@@ -103,6 +108,7 @@ describe('<NewsArticle />', () => {
       const rendered = mount(<NewsArticle {...props} />)
       rendered.instance().onEnter({
         currentPosition: 'inside',
+        previousPosition: 'above',
       })
 
       props.onDateChange.args[0][0].should.equal(article.published_at)
@@ -125,6 +131,35 @@ describe('<NewsArticle />', () => {
       window.history.replaceState.args[0][2].should.containEql(
         '/news/news-article'
       )
+    })
+
+    it('calls #onActiveArticleChange if it is mobile', () => {
+      props.isMobile = true
+      const rendered = mount(<NewsArticle {...props} />)
+      rendered.instance().onEnter({
+        currentPosition: 'inside',
+      })
+      props.onActiveArticleChange.callCount.should.equal(1)
+    })
+  })
+
+  describe('#onLeave', () => {
+    it('changes the date if there is a next article on leave', () => {
+      const rendered = mount(<NewsArticle {...props} />)
+      rendered.instance().onLeave({
+        currentPosition: 'above',
+        previousPosition: 'inside',
+      })
+      props.onDateChange.args[0][0].should.equal('5678')
+    })
+
+    it('calls #onActiveArticleChange if it is mobile', () => {
+      const rendered = mount(<NewsArticle {...props} />)
+      rendered.instance().onLeave({
+        currentPosition: 'above',
+        previousPosition: 'inside',
+      })
+      props.onActiveArticleChange.args[0][0].should.equal('1234')
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,9 +28,9 @@
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
-"@artsy/reaction@^0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-0.37.0.tgz#41a66acdefe70c37378c77962f3c4e72b44b71a4"
+"@artsy/reaction@^0.37.1":
+  version "0.37.1"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-0.37.1.tgz#a09c35f30945620422b3cb03ad250882e985c339"
   dependencies:
     formik "^0.11.11"
     history "^4.6.1"


### PR DESCRIPTION
Separates out NewsArticle into a subcomponent to better handle scrolling and url handling. The main change is that waypoint handling is no longer tied to the main app and each article is now responsible for its own changes. We make use of [waypoints with children](https://github.com/brigade/react-waypoint#children) to handle the top and bottom of the article. 

Addresses
https://artsyproduct.atlassian.net/browse/GROW-444
https://artsyproduct.atlassian.net/browse/GROW-177

![news-scroll](https://user-images.githubusercontent.com/2236794/38693439-daba7d7a-3e54-11e8-8588-c53c5cc71c08.gif)
![news-scroll-2](https://user-images.githubusercontent.com/2236794/38693452-e3bcdd3c-3e54-11e8-8a06-00e7659eef7c.gif)
