### PR TITLE
Add acceptance tests for desktop Gallery Profile Pages

### DIFF
--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -6,5 +6,4 @@ mocha \
   --retries 5 \
   --require test.config.js \
   -t 60000 \
-  $@ \
-  dotenv_config_path=.env.test
+  $@

--- a/src/test/acceptance/partner_profile.js
+++ b/src/test/acceptance/partner_profile.js
@@ -3,37 +3,66 @@ import { setup, teardown, stubAuctionReminder } from './helpers'
 import { server as antigravity } from 'antigravity'
 
 describe('Partner profile page', () => {
-  let gravity, browser
+  let gravity, positron, browser
 
   before(async () => {
-    ;({ gravity, browser } = await setup())
+    ;({ gravity, positron, browser } = await setup())
     stubAuctionReminder()
+    gravity.get('/api/v1/shortcut/:id', (req, res) => {
+      res.res.sendStatus(404)
+    })
     gravity.use(antigravity)
-    await browser.useragent('iPhone')
   })
 
   after(teardown)
 
-  it('shows the list of shows', async () => {
-    const $ = await browser.page('/gagosian-gallery/shows')
-    $.html().should.containEql('Upcoming Shows')
+  context('desktop', () => {
+    it('shows the overview', async () => {
+      const $ = await browser.page('/gagosian-gallery')
+      $.html().should.containEql(
+        '<h1 class="partner-name">Gagosian Gallery</h1>'
+      )
+      $.html().should.containEql('<p class="partner-bio">Living the dream as')
+    })
   })
 
-  it('shows partner articles', async () => {
-    const $ = await browser.page('/gagosian-gallery/articles')
-    $.html().should.containEql('Articles')
-  })
+  context('iPhone', () => {
+    before(() => {
+      browser.useragent('iPhone')
+      positron.get('/api/articles', (req, res) => {
+        res.send(require('./fixtures/gravity/home'))
+      })
+    })
 
-  it('does not show contact information for non-active partner', async () => {
-    const $ = await browser.page('/gagosian-gallery/contact')
-    $.html().should.containEql(
-      'Sorry, the page you were looking for doesn&#x2019;t exist at this URL.'
-    )
-  })
+    it('shows the overview', async () => {
+      const $ = await browser.page('/gagosian-gallery?_')
+      $.html().should.containEql(
+        '<h1 class="avant-garde-header">Gagosian Gallery</h1>'
+      )
+      $.html().should.containEql('Living the dream as')
+    })
 
-  it('show contact information for active partner', async () => {
-    const $ = await browser.page('/pace-gallery/contact')
-    $.html().should.containEql('Contact')
-    $.html().should.containEql('New York')
+    it('shows the list of shows', async () => {
+      const $ = await browser.page('/gagosian-gallery/shows')
+      $.html().should.containEql('Upcoming Shows')
+    })
+
+    it('shows partner articles', async () => {
+      const $ = await browser.page('/gagosian-gallery/articles')
+      $.html().should.containEql('Articles')
+    })
+
+    it('does not show contact information for non-active partner', async () => {
+      const $ = await browser.page('/gagosian-gallery/contact')
+      $.html().should.containEql(
+        'Sorry, the page you were looking for doesn&#x2019;t exist at this URL.'
+      )
+    })
+
+    it('show contact information for active partner', async () => {
+      const $ = await browser.page('/pace-gallery/contact')
+      $.html().should.containEql('Contact')
+      $.html().should.containEql('New York')
+    })
   })
 })


### PR DESCRIPTION
Follow up on regression https://github.com/artsy/force/pull/2325#discussion_r179345651.

We actually have some acceptance tests for the GPP, but they are for mobile cases, which is not affected by the change. This PR re-structures the tests and adds a simple test to cover the desktop case. It should help overall coverage.

If we sorted the app mounting order (e.g. revert https://github.com/artsy/force/commit/b4af6d93412832c1245f1dfe7f9128ce8573f610), this new test will reproduce the 404 error we saw in staging.

![screen shot 2018-04-07 at 1 19 29 am](https://user-images.githubusercontent.com/796573/38451649-e3403e64-3a01-11e8-813e-d68a8854f89e.png)
