### PR TITLE
close out merch test

### DIFF
--- a/src/desktop/apps/collect/client.coffee
+++ b/src/desktop/apps/collect/client.coffee
@@ -25,15 +25,11 @@ sd = require('sharify').data
 { fullyQualifiedLocations } = require '../../components/commercial_filter/filters/location/location_map.coffee'
 
 module.exports.init = ->
-  # MERCH_SORT_TEST remove after test closes
-  splitTest('merch_sort_test').view()
-  
   # Set initial params from the url params
   paramsFromUrl = qs.parse(location.search.replace(/^\?/, ''))
   params = new Params paramsFromUrl,
     categoryMap: sd.CATEGORIES
-    fullyQualifiedLocations: fullyQualifiedLocations,
-    merchTestGroup: sd.MERCH_SORT_TEST
+    fullyQualifiedLocations: fullyQualifiedLocations
   filter = new Filter params: params
 
   headlineView = new HeadlineView

--- a/src/desktop/components/commercial_filter/models/params.coffee
+++ b/src/desktop/components/commercial_filter/models/params.coffee
@@ -26,6 +26,7 @@ module.exports = class Params extends Backbone.Model
   defaults:
     size: 40
     page: 1
+    sort: '-decayed_merch'
     for_sale: true
     major_periods: []
     partner_cities: []
@@ -43,15 +44,12 @@ module.exports = class Params extends Backbone.Model
         min: 1
         max: 120
 
-  initialize: (attributes, { @categoryMap, @fullyQualifiedLocations, @merchTestGroup }) ->
+  initialize: (attributes, { @categoryMap, @fullyQualifiedLocations }) ->
 
   initialParams: ->
     @defaults
 
   current: ->
-    if @merchTestGroup is 'experiment' and not @attributes.sort?
-      _.extend @attributes, sort: '-decayed_merch'
-
     if @categoryMap
       categories = @categoryMap[@get('medium') || 'global']
       extra_aggregation_gene_ids = _.pluck categories, 'id'

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -25,13 +25,6 @@
 # module.exports = {}
 
 module.exports = {
-  merch_sort_test:
-    key: 'merch_sort_test'
-    outcomes:
-      control: 50
-      experiment: 50
-    control_group: 'control'
-    edge: 'experiment'
   gdpr_compliance_test:
     key: 'gdpr_compliance_test'
     weighting: 'equal'


### PR DESCRIPTION
This closes out the merchandisability test on `/collect` in favour of the experiment, as per the recommendation from analytics. It was found to bump our conversion to artwork pageviews by around 5.5%.