### PR TITLE
Remove comparator on mobile fair collections

### DIFF
--- a/src/mobile/apps/fair_organizer/routes.coffee
+++ b/src/mobile/apps/fair_organizer/routes.coffee
@@ -42,6 +42,7 @@ module.exports.fetchFairOrgData = (req, res, next) ->
   request = fairs.fetch
     data:
       fair_organizer_id: fairOrg.id
+      sort: "-start_at"
     success: (models, response, options)->
       articles = new Articles()
 

--- a/src/mobile/apps/fair_organizer/templates/index.jade
+++ b/src/mobile/apps/fair_organizer/templates/index.jade
@@ -12,7 +12,7 @@ block body
         if profile.hasIcon()
           .fair-organization-page__profile-icon( style="background-image: url(#{profile.iconUrl()})" )
         h1.fair-organization-page__title= fairOrg.get('name')
-        h1.fair-organization-page__subtitle!= newestFair.subtitle()
+        h1.fair-organization-page__subtitle!= newestFair.formatDates()
         h2.fair-organization-page__caption Discover and collect works before the fair opens on Artsy
 
         a.fair-organization-page__notification.avant-garde-box-button.avant-garde-box-button-gray.follow-button( data-state='unfollowed' )

--- a/src/mobile/collections/fairs.coffee
+++ b/src/mobile/collections/fairs.coffee
@@ -12,15 +12,6 @@ module.exports = class Fairs extends Backbone.Collection
 
   model: Fair
 
-  comparator: (fair) ->
-    sizes =
-      'x-large' : 1
-      'large' : 2
-      'medium' : 3
-      'small' : 4
-      'x-small' : 5
-    sizes[fair.get('banner_size')]
-
   url: "#{sd.API_URL}/api/v1/fairs"
 
   # fairs is the array of links to the previous fairs,

--- a/yarn.lock
+++ b/yarn.lock
@@ -978,6 +978,7 @@ antigravity@artsy/antigravity:
   version "0.1.3"
   resolved "https://codeload.github.com/artsy/antigravity/tar.gz/a4438d2fe9d0cdf71f1c47faba371cd3d004e140"
   dependencies:
+    coffeescript "1.11.1"
     express "*"
 
 any-observable@^0.2.0:


### PR DESCRIPTION
Fixes issue where fair dates are occasionally displayed incorrectly on mobile but not on desktop. The root issue is a comparator on the mobile fairs collection that sorts fairs based on banner image size, overriding any other sort order passed to `/fairs`. Incidentally fixes a related issue where fairs in the "Previous Fairs" tab on mobile might show in a jumbled order.

- Removes comparator in mobile fairs collection that sorts 
- Explicitly sorts fairs in chronological order based on `start_at`
- Formats fair dates using `formatDates` instead of `subtitle`
- Includes update to `yarn.lock` setting CoffeeScript version