### PR TITLE
[WIP] - allow inquiry_questionnaire modals to be closed via x button, click outside or escape

### DIFF
--- a/src/desktop/analytics/inquiry_questionnaire.js
+++ b/src/desktop/analytics/inquiry_questionnaire.js
@@ -1,210 +1,212 @@
-(function () {
+;(function() {
   'use strict'
 
   var namespace, track, bind, bindOnce
 
-  namespace = function (name) {
+  namespace = function(name) {
     return 'inquiry_questionnaire:' + name
   }
 
-  track = function () {
+  track = function() {
     var args
     args = arguments
     args[0] = namespace(' ' + args[0])
     analytics.track.apply(null, args)
   }
 
-  bind = function (name, handler) {
+  bind = function(name, handler) {
     analyticsHooks.on(namespace(name), handler)
   }
 
-  bindOnce = function (name, handler) {
+  bindOnce = function(name, handler) {
     analyticsHooks.once(namespace(name), handler)
   }
 
   // DOM events
   var $document = $(document)
 
-  $document.on('click', '.js-choice', function () {
+  $document.on('click', '.js-choice', function() {
     var choice = $(this).data('value')
     track('Clicked on how_can_we_help option', {
-      choice: choice
+      choice: choice,
     })
   })
 
-  $document.on('click', '.js-nevermind', function (e) {
-    track('Clicked on "Nevermind"', $(e.currentTarget).data())
-  })
-
-  $document.on('click', '.js-iq-collector-level', function (e) {
+  $document.on('click', '.js-iq-collector-level', function(e) {
     track('Clicked "Yes" or "No" button on commercial_interest', {
-      collector_level: e.currentTarget.value
+      collector_level: e.currentTarget.value,
     })
   })
 
-  $document.on('click', '.js-login-email', function () {
+  $document.on('click', '.js-login-email', function() {
     track('Clicked "Log in"')
   })
 
-  $document.on('click', '.js-forgot-password', function () {
+  $document.on('click', '.js-forgot-password', function() {
     track('Clicked "Forgot Password?"')
   })
 
-  $document.on('click', '.js-send-inquiry', function () {
+  $document.on('click', '.js-send-inquiry', function() {
     track('Clicked "Send" on inquiry form')
   })
 
-  $document.one('input', '.js-inquiry-message', function (e) {
+  $document.one('input', '.js-inquiry-message', function(e) {
     track('User changed inquiry message from default')
   })
 
-  $document.on('alert', '.js-inquiry-message', function (e) {
+  $document.on('alert', '.js-inquiry-message', function(e) {
     track('User nudged to change inquiry message from default')
   })
 
-  $document.on('click', '.js-iq-save-skip', function () {
+  $document.on('click', '.js-iq-save-skip', function() {
     track('Clicked on "No thanks don’t save my information"')
   })
 
   // Proxied events
-  bind('modal:opened', function (context) {
+  bind('modal:opened', function(context) {
     track('Opened inquiry flow')
   })
 
-  bind('modal:closed', function (context) {
+  bind('modal:closed', function(context) {
     track('Closed inquiry flow')
   })
 
-  bind('state:completed', function (context) {
+  bind('state:completed', function(context) {
     track('Completed inquiry flow')
   })
 
-  bind('state:aborted', function (context) {
+  bind('state:aborted', function(context) {
     track('Aborted inquiry flow', {
-      current: context.state.current()
+      current: context.state.current(),
     })
   })
 
-  bind('state:next', function (context) {
+  bind('state:next', function(context) {
     track('State changed to ' + context.state.current())
     track('State change', {
-      current: context.state.current()
+      current: context.state.current(),
     })
   })
 
-  bind('user:change:profession', function (context) {
+  bind('user:change:profession', function(context) {
     track('User set profession', {
-      profession: context.user.get('profession')
+      profession: context.user.get('profession'),
     })
   })
 
-  bind('user:change:location', function (context) {
+  bind('user:change:location', function(context) {
     track('User set location', {
-      location: context.user.get('location')
+      location: context.user.get('location'),
     })
   })
 
-  bind('user:change:phone', function (context) {
+  bind('user:change:phone', function(context) {
     track('User set phone', {
-      phone: context.user.get('phone')
+      phone: context.user.get('phone'),
     })
   })
 
-  bind('user:sync', function (context) {
+  bind('user:sync', function(context) {
     track('User data saved')
   })
 
-  bind('collector_profile:sync', function (context) {
+  bind('collector_profile:sync', function(context) {
     track('CollectorProfile data saved')
   })
 
-  bind('user_interests:add', function (context) {
+  bind('user_interests:add', function(context) {
     var userInterest = context.userInterests.last()
     track('User added an interest in artist', {
-      artist_id: userInterest.related().interest.id
+      artist_id: userInterest.related().interest.id,
     })
   })
 
-  bind('user_interests:remove', function (context) {
+  bind('user_interests:remove', function(context) {
     track('User removed an interest in artist')
   })
 
-  bindOnce('inquiry:sync', function (context) {
+  bindOnce('inquiry:sync', function(context) {
     track('Inquiry successfully sent')
   })
 
-  bind('inquiry:error', function (context) {
+  bind('inquiry:error', function(context) {
     track('Problem sending inquiry', context.inquiry.attributes)
   })
 
-  bind('collector_profile:change:affiliated_gallery_ids', function (context) {
+  bind('collector_profile:change:affiliated_gallery_ids', function(context) {
     track('Changed collector_profile:affiliated_gallery_ids', {
-      ids: context.collectorProfile.get('affiliated_gallery_ids')
+      ids: context.collectorProfile.get('affiliated_gallery_ids'),
     })
   })
 
-  bind('collector_profile:change:affiliated_auction_house_ids', function (context) {
+  bind('collector_profile:change:affiliated_auction_house_ids', function(
+    context
+  ) {
     track('Changed collector_profile:affiliated_auction_house_ids', {
-      ids: context.collectorProfile.get('affiliated_auction_house_ids')
+      ids: context.collectorProfile.get('affiliated_auction_house_ids'),
     })
   })
 
-  bind('collector_profile:change:affiliated_fair_ids', function (context) {
+  bind('collector_profile:change:affiliated_fair_ids', function(context) {
     track('Changed collector_profile:affiliated_fair_ids', {
-      ids: context.collectorProfile.get('affiliated_fair_ids')
+      ids: context.collectorProfile.get('affiliated_fair_ids'),
     })
   })
 
-  bind('collector_profile:change:institutional_affiliations', function (context) {
+  bind('collector_profile:change:institutional_affiliations', function(
+    context
+  ) {
     track('Changed collector_profile:institutional_affiliations', {
-      value: context.collectorProfile.get('institutional_affiliations')
+      value: context.collectorProfile.get('institutional_affiliations'),
     })
   })
 
   // Non-namespaced events
-  bind('user:login', function (context) {
+  bind('user:login', function(context) {
     analytics.track('Successfully logged in', {
-      context: 'inquiry_questionnaire'
+      context: 'inquiry_questionnaire',
     })
   })
 
-  bind('user:signup', function (context) {
+  bind('user:signup', function(context) {
     analytics.track('Created account', {
-      context: 'inquiry_questionnaire'
+      context: 'inquiry_questionnaire',
     })
   })
 
-  bindOnce('inquiry:sync', function (context) {
+  bindOnce('inquiry:sync', function(context) {
     analytics.track('Sent artwork inquiry', {
       artwork_id: context.artwork.get('_id'),
       artwork_slug: context.artwork.id,
-      inquiry_id: context.inquiry.id
+      inquiry_id: context.inquiry.id,
     })
   })
 
-  bindOnce('inquiry:show', function (context) {
+  bindOnce('inquiry:show', function(context) {
     analytics.track('Sent show inquiry', {
-      label: context.label
+      label: context.label,
     })
   })
 
-  bindOnce('contact:hover', function (context) {
+  bindOnce('contact:hover', function(context) {
     analytics.track("Hovered over contact form 'Send' button")
   })
 
-  bindOnce('contact:close-x', function (context) {
+  bindOnce('contact:close-x', function(context) {
     analytics.track("Closed the inquiry form via the '×' button")
   })
 
-  bindOnce('contact:close-back', function (context) {
-    analytics.track('Closed the inquiry form by clicking the modal window backdrop')
+  bindOnce('contact:close-back', function(context) {
+    analytics.track(
+      'Closed the inquiry form by clicking the modal window backdrop'
+    )
   })
 
-  bindOnce('contact:submitted', function (context) {
+  bindOnce('contact:submitted', function(context) {
     analytics.track('Contact form submitted', context.attributes)
   })
 
-  bind('inquiry:sent', function (context) {
+  bind('inquiry:sent', function(context) {
     track('Sent artwork inquiry', { label: context.label })
     track('Submit confirm inquiry modal', context.attributes)
     track(context.changed + ' default message')

--- a/src/desktop/apps/inquiry/client/routes/inquiry.coffee
+++ b/src/desktop/apps/inquiry/client/routes/inquiry.coffee
@@ -52,11 +52,6 @@ module.exports = (id, bypass) ->
       logger.log step
       window.scrollTo 0, 0
 
-    # Abort by clicking 'nevermind'
-    .on 'abort', ->
-      logger.reset()
-      location.href = artwork.href()
-
     # End of complete flow
     .on 'done', ->
       if inquiry.send?

--- a/src/desktop/components/contact/confirm_inquiry.coffee
+++ b/src/desktop/components/contact/confirm_inquiry.coffee
@@ -18,7 +18,6 @@ module.exports = class ConfirmInquiryView extends ContactView
 
   events: -> _.extend super,
     'click.handler .modal-backdrop': undefined
-    'click .contact-form-cancel': 'close'
 
   headerTemplate: (locals) =>
     headerTemplate _.extend locals,
@@ -55,7 +54,6 @@ module.exports = class ConfirmInquiryView extends ContactView
       @updatePosition()
       @isLoaded()
       @focusTextareaAfterCopy()
-      @hideCloseButton()
     super
 
   renderLocation: =>
@@ -107,6 +105,3 @@ module.exports = class ConfirmInquiryView extends ContactView
   close: =>
     @exit?()
     super
-
-  hideCloseButton: ->
-    $('.modal-close').hide()

--- a/src/desktop/components/contact/index.styl
+++ b/src/desktop/components/contact/index.styl
@@ -22,10 +22,6 @@
   avant-garde()
   font-size 12px
 
-.contact-form-cancel
-  color gray-darkest-color
-  cursor pointer
-
 #contact-errors
   margin-bottom 10px
 
@@ -57,10 +53,3 @@
   font-size default-garamond-font-size - 1
   &, a
     color gray-darkest-color
-
-a.contact-nevermind
-  text-align left
-  color gray-darker-color
-  text-decoration none
-  margin 20px 30px 30px
-  display block

--- a/src/desktop/components/contact/templates/inquiry_form_confirm.jade
+++ b/src/desktop/components/contact/templates/inquiry_form_confirm.jade
@@ -48,5 +48,3 @@ form.contact-form.stacked-form
 
   button#contact-submit.avant-garde-button-black( href='#', data-state='ok' )
     | Send
-
-  p.contact-form-cancel Nevermind, cancel my inquiry

--- a/src/desktop/components/contact/templates/inquiry_show_form.jade
+++ b/src/desktop/components/contact/templates/inquiry_show_form.jade
@@ -36,6 +36,3 @@ form.contact-form.stacked-form
 
   button#contact-submit.js-send-inquiry.avant-garde-button-black( href='#', data-state='ok' )
     | Send
-
-a.contact-nevermind.js-nevermind(href="#") Nevermind, cancel my inquiry
-

--- a/src/desktop/components/contact/view.coffee
+++ b/src/desktop/components/contact/view.coffee
@@ -29,7 +29,6 @@ module.exports = class ContactView extends ModalView
   events: -> _.extend super,
     'submit form': 'onSubmit'
     'click #contact-submit' : 'onSubmit'
-    'click .contact-nevermind' : 'close'
     'mouseenter #contact-submit' : 'logHover'
 
   initialize: (options = {}) ->

--- a/src/desktop/components/inquiry_questionnaire/index.coffee
+++ b/src/desktop/components/inquiry_questionnaire/index.coffee
@@ -60,12 +60,6 @@ module.exports = ({ user, artwork, inquiry, bypass, state_attrs }) ->
     # Log each step
     .on 'next', log
 
-    # Abort by clicking 'nevermind'
-    .on 'abort', ->
-      modal.close()
-      logger.reset()
-      trail.reset()
-
     # End of complete flow
     .on 'done', ->
 

--- a/src/desktop/components/inquiry_questionnaire/index.coffee
+++ b/src/desktop/components/inquiry_questionnaire/index.coffee
@@ -51,12 +51,6 @@ module.exports = ({ user, artwork, inquiry, bypass, state_attrs }) ->
   modal.view.on 'closed', ->
     analytics.teardown state.context
 
-  # Disable backdrop clicks
-  modal.view.$el.off 'click', '.js-modalize-backdrop'
-
-  # Disable <esc> close
-  $(window).off 'keyup.modalize'
-
   # Log to both the `Logger` and the `Trail`
   log = (step) ->
     trail.log step

--- a/src/desktop/components/inquiry_questionnaire/stylesheets/desktop.styl
+++ b/src/desktop/components/inquiry_questionnaire/stylesheets/desktop.styl
@@ -1,6 +1,4 @@
 .inquiry-questionnaire-modal
-  .modalize-close
-    display none
   .modalize-body
     padding 30px
 

--- a/src/desktop/components/inquiry_questionnaire/stylesheets/desktop.styl
+++ b/src/desktop/components/inquiry_questionnaire/stylesheets/desktop.styl
@@ -73,15 +73,10 @@
     width 100%
 
 .iq-push-down
-.iq-nevermind
   display block
   margin 20px 0 30px 0
   text-decoration none
   garamond-size('s-body')
-
-.iq-nevermind
-  &, a
-    color gray-darker-color
 
 .iq-loadable
   > *

--- a/src/desktop/components/inquiry_questionnaire/templates/account/login.jade
+++ b/src/desktop/components/inquiry_questionnaire/templates/account/login.jade
@@ -37,8 +37,6 @@ form.stacked-form
           | Sign up
 
   .iq-account-sub
-    if user.isWithAccount()
-      include ../partials/nevermind
-    else
+    unless user.isWithAccount()
       a.fine-faux-underline.js-iq-save-skip
         | No thanks don&rsquo;t save my information

--- a/src/desktop/components/inquiry_questionnaire/templates/account/register.jade
+++ b/src/desktop/components/inquiry_questionnaire/templates/account/register.jade
@@ -15,6 +15,3 @@ form.stacked-form
     //- Rendered separately
 
   include ../../../auth_modal/templates/_gdpr_signup
-
-  .iq-push-down
-    include ../partials/nevermind

--- a/src/desktop/components/inquiry_questionnaire/templates/affiliated.jade
+++ b/src/desktop/components/inquiry_questionnaire/templates/affiliated.jade
@@ -17,6 +17,3 @@ form.iq-form.stacked-form
 
   .iq-sticky-bottom
     button.avant-garde-button-black.is-block.iq-next( type='submit' ) Next
-
-    if artwork.related().partner.get('pre_qualify')
-      include ./partials/nevermind

--- a/src/desktop/components/inquiry_questionnaire/templates/artists_in_collection.jade
+++ b/src/desktop/components/inquiry_questionnaire/templates/artists_in_collection.jade
@@ -14,6 +14,3 @@ h1.iq-headline
 
   .iq-sticky-bottom
     button.avant-garde-button-black.is-block.iq-next( type='submit' ) Next
-
-    if artwork.related().partner.get('pre_qualify')
-      include ./partials/nevermind

--- a/src/desktop/components/inquiry_questionnaire/templates/basic_info.jade
+++ b/src/desktop/components/inquiry_questionnaire/templates/basic_info.jade
@@ -55,6 +55,3 @@ form.iq-form.stacked-form
         | Share followed artists, categories, and galleries
 
   button.avant-garde-button-black.iq-next( type='submit' ) Next
-
-if artwork.related().partner.get('pre_qualify')
-  include ./partials/nevermind

--- a/src/desktop/components/inquiry_questionnaire/templates/commercial_interest.jade
+++ b/src/desktop/components/inquiry_questionnaire/templates/commercial_interest.jade
@@ -6,6 +6,3 @@ form.iq-form.stacked-button-menu
     | Yes
   button.avant-garde-button-black.js-iq-collector-level( type='submit', name='collector_level', value='2' )
     | Not yet
-
-if artwork.related().partner.get('pre_qualify')
-  include ./partials/nevermind

--- a/src/desktop/components/inquiry_questionnaire/templates/how_can_we_help.jade
+++ b/src/desktop/components/inquiry_questionnaire/templates/how_can_we_help.jade
@@ -8,6 +8,3 @@ form.stacked-form
     a.js-choice( data-value='student_research_question' ) I&rsquo;m a student/researcher and I have a question
     a.js-choice( data-value='journalist_question' ) I&rsquo;m a journalist and I have a question
     a.js-choice( data-value='other_question' ) Other inquiry
-
-if artwork.related().partner.get('pre_qualify')
-  include ./partials/nevermind

--- a/src/desktop/components/inquiry_questionnaire/templates/inquiry.jade
+++ b/src/desktop/components/inquiry_questionnaire/templates/inquiry.jade
@@ -1,2 +1,1 @@
 include ../../simple_contact/templates/contact_partner
-include ./partials/nevermind

--- a/src/desktop/components/inquiry_questionnaire/templates/institutional_affiliations.jade
+++ b/src/desktop/components/inquiry_questionnaire/templates/institutional_affiliations.jade
@@ -20,6 +20,3 @@ form.iq-form.stacked-form
     = user.related().collectorProfile.get('institutional_affiliations')
 
   button.avant-garde-button-black.is-block.iq-next( type='submit' ) Next
-
-if artwork.related().partner.get('pre_qualify')
-  include ./partials/nevermind

--- a/src/desktop/components/inquiry_questionnaire/templates/partials/nevermind.jade
+++ b/src/desktop/components/inquiry_questionnaire/templates/partials/nevermind.jade
@@ -1,2 +1,0 @@
-a.iq-nevermind.js-nevermind( href='#', data-trail= trail && trail.toString() )
-  | Nevermind, cancel my inquiry

--- a/src/desktop/components/inquiry_questionnaire/templates/specialist.jade
+++ b/src/desktop/components/inquiry_questionnaire/templates/specialist.jade
@@ -1,3 +1,1 @@
 include ../../simple_contact/templates/specialist
-if artwork.related().partner.get('pre_qualify')
-  include ./partials/nevermind

--- a/src/desktop/components/inquiry_questionnaire/templates/test_specialist.jade
+++ b/src/desktop/components/inquiry_questionnaire/templates/test_specialist.jade
@@ -1,3 +1,1 @@
 include ../../simple_contact/templates/specialist
-if artwork.related().partner.get('pre_qualify')
-  include ./partials/nevermind

--- a/src/desktop/components/inquiry_questionnaire/test/index.coffee
+++ b/src/desktop/components/inquiry_questionnaire/test/index.coffee
@@ -48,14 +48,3 @@ describe 'openInquiryQuestionnaireFor', ->
 
   it 'opens the modal', ->
     @modal.opened.should.be.true()
-
-  describe 'abort', ->
-    it 'aborts without error, clearing the logger', (done) ->
-      resetSpy = sinon.spy @Logger::, 'reset'
-
-      @modal.view.once 'closed', -> _.partial(_.delay, _, 2) ->
-        resetSpy.called.should.be.true()
-        resetSpy.restore()
-        done()
-
-      @modal.subView.state.trigger 'abort'

--- a/src/desktop/components/inquiry_questionnaire/test/views/basic_info.coffee
+++ b/src/desktop/components/inquiry_questionnaire/test/views/basic_info.coffee
@@ -22,7 +22,6 @@ describe 'BasicInfo', setup ->
         .should.containEql 'Gagosian Gallery asks for some additional information before placing an inquiry.'
       @view.$('input').map(-> $(this).attr('name')).get()
         .should.eql ['profession', 'phone', 'share_follows']
-      @view.$('.js-nevermind').text().should.equal 'Nevermind, cancel my inquiry' # pre_qualify
 
   describe 'next', ->
     describe 'success', ->

--- a/src/desktop/components/inquiry_questionnaire/views/step.coffee
+++ b/src/desktop/components/inquiry_questionnaire/views/step.coffee
@@ -6,8 +6,7 @@ module.exports = class StepView extends Backbone.View
   __events__: null
 
   events: ->
-    _.extend @__events__,
-      'click .js-nevermind': 'dismiss'
+    @__events__
 
   initialize: ({ @user, @inquiry, @artwork, @state, @trail }) ->
     @__setup__()
@@ -18,10 +17,6 @@ module.exports = class StepView extends Backbone.View
   next: (e) ->
     e?.preventDefault()
     @state.next()
-
-  dismiss: (e) ->
-    e.preventDefault()
-    @state.trigger 'abort'
 
   shouldAutofocus: true
 


### PR DESCRIPTION
This code change adds 'x' button to all inquiry dialogs. And also removes 'nevermind' links from all of those dialogs since this link is now redundant.

![screen shot 2018-04-16 at 10 32 35 am](https://user-images.githubusercontent.com/437156/38815357-bfaa6922-4161-11e8-954d-5f7de5dee28f.png)

This ended up being substantially more code kill than I anticipated. It's a bit tricky now to track who actually worked on all of those files originally since the history only includes move to `src` directory. Would appreciate if maybe @xtina-starr or maybe @damassi can take a look here and flag any potential problems they could see with all this code removals.