### PR TITLE
@damassi => Minor updates to order2

### DIFF
--- a/src/desktop/apps/articles/index.js
+++ b/src/desktop/apps/articles/index.js
@@ -3,7 +3,7 @@ import * as routes from './routes'
 import { crop, resize } from 'desktop/components/resizer/index.coffee'
 import { toSentence } from 'underscore.string'
 import { data as sd } from 'sharify'
-import adminOnly from 'desktop/lib/admin_only.coffee'
+import adminOnly from 'desktop/lib/admin_only'
 
 const app = (module.exports = express())
 app.set('view engine', 'jade')

--- a/src/desktop/apps/auctions2/index.js
+++ b/src/desktop/apps/auctions2/index.js
@@ -1,5 +1,5 @@
 import * as routes from 'desktop/apps/auctions2/routes'
-import adminOnly from 'desktop/lib/admin_only.coffee'
+import adminOnly from 'desktop/lib/admin_only'
 import express from 'express'
 
 const app = (module.exports = express())

--- a/src/desktop/apps/auctions2/index.js
+++ b/src/desktop/apps/auctions2/index.js
@@ -2,7 +2,7 @@ import * as routes from 'desktop/apps/auctions2/routes'
 import adminOnly from 'desktop/lib/admin_only.coffee'
 import express from 'express'
 
-const app = module.exports = express()
+const app = (module.exports = express())
 
 app.set('view engine', 'jade')
 app.set('views', `${__dirname}/components`)

--- a/src/desktop/apps/order2/index.tsx
+++ b/src/desktop/apps/order2/index.tsx
@@ -1,32 +1,9 @@
-import React from 'react'
+import * as routes from 'desktop/apps/order2/routes'
+import adminOnly from 'desktop/lib/admin_only.coffee'
 import express from 'express'
-import { App } from './Components/App'
-import { renderLayout } from '@artsy/stitch'
 
 const app = (module.exports = express())
 app.set('view engine', 'jade')
 app.set('views', `${__dirname}/Components`)
 
-app.get('/order2', async (_req, res) => {
-  try {
-    const layout = await renderLayout({
-      basePath: __dirname,
-      layout: '../../components/main_layout/templates/react_index.jade',
-      config: {
-        styledComponents: true,
-      },
-      blocks: {
-        head: () => <div>head</div>,
-        body: App,
-      },
-      locals: {
-        assetPackage: 'order2',
-        ...res.locals,
-      },
-    })
-
-    res.send(layout)
-  } catch (error) {
-    console.log('(apps/order2) Error: ', error)
-  }
-})
+app.get('/order2', adminOnly, routes.index)

--- a/src/desktop/apps/order2/index.tsx
+++ b/src/desktop/apps/order2/index.tsx
@@ -1,5 +1,5 @@
 import * as routes from 'desktop/apps/order2/routes'
-import adminOnly from 'desktop/lib/admin_only.coffee'
+import adminOnly from 'desktop/lib/admin_only'
 import express from 'express'
 
 const app = (module.exports = express())

--- a/src/desktop/apps/order2/routes.tsx
+++ b/src/desktop/apps/order2/routes.tsx
@@ -1,0 +1,27 @@
+import { App } from './Components/App'
+import React from 'react'
+import { renderLayout } from '@artsy/stitch'
+
+export async function index(req, res, next) {
+  try {
+    const layout = await renderLayout({
+      basePath: __dirname,
+      layout: '../../components/main_layout/templates/react_index.jade',
+      config: {
+        styledComponents: true,
+      },
+      blocks: {
+        head: () => <div>head</div>,
+        body: App,
+      },
+      locals: {
+        assetPackage: 'order2',
+        ...res.locals,
+      },
+    })
+
+    res.send(layout)
+  } catch (error) {
+    console.log('(apps/order2) Error: ', error)
+  }
+}

--- a/src/desktop/apps/order2/routes.tsx
+++ b/src/desktop/apps/order2/routes.tsx
@@ -2,7 +2,7 @@ import { App } from './Components/App'
 import React from 'react'
 import { renderLayout } from '@artsy/stitch'
 
-export async function index(req, res, next) {
+export async function index(_req, res, _next) {
   try {
     const layout = await renderLayout({
       basePath: __dirname,

--- a/src/desktop/apps/react_example/index.js
+++ b/src/desktop/apps/react_example/index.js
@@ -1,8 +1,8 @@
 import * as routes from './routes'
-import adminOnly from 'desktop/lib/admin_only.coffee'
+import adminOnly from 'desktop/lib/admin_only'
 import express from 'express'
 
-const app = module.exports = express()
+const app = (module.exports = express())
 
 app.set('view engine', 'jade')
 app.set('views', `${__dirname}/components`)

--- a/src/desktop/components/auction_reminders/blacklist.coffee
+++ b/src/desktop/components/auction_reminders/blacklist.coffee
@@ -7,7 +7,6 @@ module.exports =
     '^/artsy-primer'
     '^/collect-art'
     '^/consign'
-    '^/consign2'
     '^/signup'
     '^/login'
     '^/user/edit'
@@ -32,6 +31,8 @@ module.exports =
     '^/video/.*'
     '^/artsy-in-miami'
     '^/armory-week'
+    '^/order'
+    '^/order2'
   ]
 
   check: ->

--- a/src/desktop/lib/admin_only.coffee
+++ b/src/desktop/lib/admin_only.coffee
@@ -1,7 +1,0 @@
-module.exports = (req, res, next) ->
-  if req.user?.get('type') isnt 'Admin'
-    err = new Error 'You must be logged in as an admin'
-    err.status = 403
-    next err
-  else
-    next()

--- a/src/desktop/lib/admin_only.js
+++ b/src/desktop/lib/admin_only.js
@@ -1,0 +1,9 @@
+module.exports = (req, res, next) => {
+  if (!req.user || (req.user && req.user.get('type') !== 'Admin')) {
+    const err = new Error('You must be logged in as an admin')
+    err.status = 403
+    next(err)
+  } else {
+    next()
+  }
+}


### PR DESCRIPTION
This PR addresses https://artsyproduct.atlassian.net/browse/PURCHASE-52 and https://artsyproduct.atlassian.net/browse/PURCHASE-20

- Adds `/order` and `/order2` to the auction_reminders blacklist
- Adds the `adminOnly` flag to the `/order2` page for easier QA in production 

One thing I noticed with this (it's also the case for the `onboarding` app, and potentially others) is that when you supply an `assetPackage` to be rendered in the main_layout, it automatically tries to pull in the corresponding `js` and `css` file. If we're not planning to have css files for the apps that basically just point to reaction, maybe we should create a new base template that only tries to pull in js.