### PR TITLE
fix search ranking hack which is causing buggy results

### DIFF
--- a/src/desktop/apps/search/collections/global_search_results.coffee
+++ b/src/desktop/apps/search/collections/global_search_results.coffee
@@ -13,10 +13,3 @@ module.exports = class GlobalSearchResults extends Backbone.Collection
     _.reject response, (item) ->
       # HACK filter out sensitive results (at the artist's request)
       JSON.stringify(item).match(/kippenberger|zoe.*leonard/i)
-
-  moveMatchResultsToTop: (query) ->
-    models = @models
-    for item, index in @models
-      if item.get('display_model') isnt 'show' and item.get('display').toLowerCase() is query.toLowerCase()
-        models.splice(0, 0, models.splice(index, 1)[0])
-    models

--- a/src/desktop/apps/search/routes.coffee
+++ b/src/desktop/apps/search/routes.coffee
@@ -40,7 +40,7 @@ imageUrl = require './components/image_url'
     success: (results, response, options) ->
       totalPages = Math.ceil(parseInt(options.res.headers['x-total-count'] or 0)  / 10)
       totalPages = 99 if totalPages > 99
-      models = results.moveMatchResultsToTop term
+      models = results.models
       res.locals.sd.RESULTS = results.toJSON()
       res.render 'template',
         term: term

--- a/src/desktop/apps/search/test/collections/global_search_results.coffee
+++ b/src/desktop/apps/search/test/collections/global_search_results.coffee
@@ -15,13 +15,3 @@ describe 'GlobalSearchResults', ->
     it 'filters out sensitive results', ->
       results = new GlobalSearchResults @response, parse: true
       results.length.should.equal 1
-
-  describe '#moveMatchResultsToTop', ->
-    it 'moves matching results to the top', ->
-      results = new GlobalSearchResults [
-        { display: 'bar bar', model: 'fair' }
-        { display: 'foo bar', model: 'fair' }
-      ]
-      results.first().get('display').should.equal 'bar bar'
-      results.moveMatchResultsToTop 'foo bar'
-      results.first().get('display').should.equal 'foo bar'


### PR DESCRIPTION
This front-end hack for moving exact matches to the top of the list is causing partner shows named simply after an artist to rank above artist results with exact matches. eg searching for 'Donald Judd' on the site:

<img width="1498" alt="screen shot 2018-04-16 at 12 30 00 pm" src="https://user-images.githubusercontent.com/64404/38822594-ee685cfa-4171-11e8-9081-9cc5ddf6b7b4.png">

There is no longer any need to hack the rankings as we should let Elasticsearch deal with ranking results - it knows how to weight between entities. After the change, the results show correctly:

<img width="1585" alt="screen shot 2018-04-16 at 12 29 52 pm" src="https://user-images.githubusercontent.com/64404/38822604-f3410948-4171-11e8-8bf0-4970b6882d58.png">

This issue was affecting many artists - any that had a `PartnerShow` named after them.

cc @katarinabatina 
