### PR TITLE
@sarahscott => Hide hero units and featured section if 'Homepage Search' lab feature enabled

### DIFF
--- a/src/desktop/apps/home/client/index.coffee
+++ b/src/desktop/apps/home/client/index.coffee
@@ -15,6 +15,7 @@ Items = require '../../../collections/items'
 featuredArticlesTemplate = -> require('../templates/featured_articles.jade') arguments...
 featuredShowsTemplate = -> require('../templates/featured_shows.jade') arguments...
 { resize } = require '../../../components/resizer/index.coffee'
+sd = require('sharify').data
 
 module.exports.HomeView = class HomeView extends Backbone.View
   initialize: ->
@@ -23,7 +24,7 @@ module.exports.HomeView = class HomeView extends Backbone.View
     Backbone.history.start pushState: true
 
     # Render Featured Sections
-    @setupHeroUnits()
+    @setupHeroUnits() unless sd.HIDE_HERO_UNITS
     @setupFeaturedShows()
     @setupFeaturedArticles()
 

--- a/src/desktop/apps/home/queries/initial.coffee
+++ b/src/desktop/apps/home/queries/initial.coffee
@@ -1,5 +1,5 @@
 module.exports = """
-  query {
+  query($showHeroUnits: Boolean!) {
     home_page {
       artwork_modules(
         max_rails: 6,
@@ -21,7 +21,7 @@ module.exports = """
           followed_artist_id
         }
       }
-      hero_units(platform: DESKTOP) {
+      hero_units(platform: DESKTOP) @include(if: $showHeroUnits){
         mode
         heading
         title

--- a/src/desktop/apps/home/routes.coffee
+++ b/src/desktop/apps/home/routes.coffee
@@ -53,8 +53,7 @@ fetchMetaphysicsData = (req, showHeroUnits)->
     }
   }
 
-  user = new CurrentUser(req.user) if req.user
-  hideHeroUnits = user.hasLabFeature('Homepage Search') if user
+  hideHeroUnits = req.user?.hasLabFeature('Homepage Search')
   initialFetch = fetchMetaphysicsData req, false if hideHeroUnits
   unless hideHeroUnits
     initialFetch = Q

--- a/src/desktop/apps/home/routes.coffee
+++ b/src/desktop/apps/home/routes.coffee
@@ -10,6 +10,7 @@ viewHelpers = require './view_helpers.coffee'
 welcomeHero = require './welcome'
 browseCategories = require './browse_categories.coffee'
 query = require './queries/initial'
+CurrentUser = require '../../models/current_user.coffee'
 
 getRedirectTo = (req) ->
   req.body['redirect-to'] or
@@ -23,9 +24,10 @@ positionWelcomeHeroMethod = (req, res) ->
   res.cookie 'hide-welcome-hero', '1', expires: new Date(Date.now() + 31536000000)
   method
 
-fetchMetaphysicsData = (req)->
+fetchMetaphysicsData = (req, showHeroUnits)->
   deferred = Q.defer()
-  metaphysics(query: query, req: req)
+
+  metaphysics(query: query, req: req, variables: {showHeroUnits: showHeroUnits})
     .then (data) -> deferred.resolve data
     .catch (err) ->
       deferred.resolve
@@ -51,15 +53,24 @@ fetchMetaphysicsData = (req)->
     }
   }
 
-  Q
-    .allSettled [
-      fetchMetaphysicsData req
-      featuredLinks.fetch cache: true
-    ]
+  user = new CurrentUser(req.user) if req.user
+  hideHeroUnits = user.hasLabFeature('Homepage Search') if user
+  initialFetch = fetchMetaphysicsData req, false if hideHeroUnits
+  unless hideHeroUnits
+    initialFetch = Q
+      .allSettled [
+        fetchMetaphysicsData req, true
+        featuredLinks.fetch cache: true
+      ]
+  initialFetch
     .then (results) ->
-      homePage = results[0]?.value.home_page
-      heroUnits = homePage.hero_units
-      heroUnits[positionWelcomeHeroMethod(req, res)](welcomeHero) unless req.user?
+      if hideHeroUnits
+        homePage = results.home_page
+        heroUnits = []
+      else
+        homePage = results?[0].value.home_page
+        heroUnits = homePage.hero_units
+        heroUnits[positionWelcomeHeroMethod(req, res)](welcomeHero) unless req.user?
 
       # always show followed artist rail for logged in users,
       # if we dont get results we will replace with artists TO follow
@@ -73,6 +84,7 @@ fetchMetaphysicsData = (req)->
       res.locals.sd.RESET_PASSWORD_REDIRECT_TO = req.query.reset_password_redirect_to
       res.locals.sd.SET_PASSWORD = req.query.set_password
 
+      res.locals.sd.HIDE_HERO_UNITS = hideHeroUnits
       res.render 'index',
         heroUnits: heroUnits
         modules: homePage.artwork_modules

--- a/src/desktop/apps/home/stylesheets/index.styl
+++ b/src/desktop/apps/home/stylesheets/index.styl
@@ -13,7 +13,7 @@ hero-units-height = 478px
   margin-top hero-units-height
   padding-bottom 20px
 
-html[data-lab-features*="Homepage Search"]
+html[data-hide-hero-units]
   #home-foreground
     margin-top 0px
     padding-top 20px

--- a/src/desktop/apps/home/stylesheets/index.styl
+++ b/src/desktop/apps/home/stylesheets/index.styl
@@ -13,6 +13,11 @@ hero-units-height = 478px
   margin-top hero-units-height
   padding-bottom 20px
 
+html[data-lab-features*="Homepage Search"]
+  #home-foreground
+    margin-top 0px
+    padding-top 20px
+
 #home-hero-units
   height hero-units-height
   position fixed

--- a/src/desktop/apps/home/templates/index.jade
+++ b/src/desktop/apps/home/templates/index.jade
@@ -8,17 +8,20 @@ append locals
   - bodyClass = bodyClass + ' body-no-margins body-header-fixed body-transparent-header' + (heroUnits.length && heroUnits[0].mode.match('LIGHT') ? '-white' : '')
 
 block body
-  include hero_units
+  unless sd.HIDE_HERO_UNITS
+    include hero_units
 
   #home-foreground
-    #home-hero-units-controls( data-length= heroUnits.length )
-      ul#home-hero-unit-dots
-        for x, i in heroUnits
-          li.hhu-dot( class=(i == 0 ? 'hhud-active' : '') )
+    unless sd.HIDE_HERO_UNITS
+      #home-hero-units-controls( data-length= heroUnits.length )
+        ul#home-hero-unit-dots
+          for x, i in heroUnits
+            li.hhu-dot( class=(i == 0 ? 'hhud-active' : '') )
 
     #home-layout-container.responsive-layout-container
       .main-layout-container: #home-body
-        include featured_links
+        unless sd.HIDE_HERO_UNITS
+          include featured_links
         unless user
           include browse
     include rails

--- a/src/desktop/apps/home/test/routes.coffee
+++ b/src/desktop/apps/home/test/routes.coffee
@@ -34,6 +34,10 @@ describe 'Home routes', ->
       redirect: sinon.stub()
       cookie: @cookieStub = sinon.stub()
 
+    @user = {
+      hasLabFeature: () -> false
+    }
+
   afterEach ->
     Backbone.sync.restore()
 
@@ -47,7 +51,7 @@ describe 'Home routes', ->
         Backbone.sync
           .onCall 0
           .yieldsTo 'error'
-        routes.index extend({ user: 'existy' }, @req), @res
+        routes.index extend(@user, @req), @res
           .then =>
             @res.render.args[0][0].should.equal 'index'
             @res.render.args[0][1].featuredLinks.length.should.equal 0
@@ -87,6 +91,9 @@ describe 'Home routes', ->
                 .should.equal 'Sign up to get updates on your favorite artists'
 
     describe 'logged in', ->
+      beforeEach ->
+        @req.user = @user
+
       it 'renders the homepage without the welcome hero unit', ->
         @metaphysics.returns Promise.resolve
           home_page:
@@ -95,7 +102,7 @@ describe 'Home routes', ->
         Backbone.sync
             .onCall 0
             .yieldsTo 'success', [fabricate 'featured_link']
-        routes.index extend({ user: 'existy' }, @req), @res
+        routes.index @req, @res
           .then =>
             @res.render.args[0][0].should.equal 'index'
             @res.render.args[0][1].modules[0].key.should.equal 'followed_artists'
@@ -103,10 +110,11 @@ describe 'Home routes', ->
               .should.equal 'My hero'
 
       it 'with lab feature, does not fetch hero units or featured links', ->
+        @user.hasLabFeature = () -> true
         @metaphysics.returns Promise.resolve
           home_page:
             artwork_modules: []
-        routes.index extend({ user: { lab_features: ['Homepage Search'] } }, @req), @res
+        routes.index @req, @res
           .then =>
             @res.render.args[0][0].should.equal 'index'
             @res.render.args[0][1].modules[0].key.should.equal 'followed_artists'
@@ -118,7 +126,7 @@ describe 'Home routes', ->
         Backbone.sync
             .onCall 0
             .yieldsTo 'success', [fabricate 'featured_link']
-        routes.index extend({ user: 'existy' }, @req), @res
+        routes.index @req, @res
           .then =>
             @res.render.args[0][0].should.equal 'index'
             @res.render.args[0][1].modules[0].key.should.equal 'followed_artists'

--- a/src/desktop/apps/home/test/routes.coffee
+++ b/src/desktop/apps/home/test/routes.coffee
@@ -102,6 +102,15 @@ describe 'Home routes', ->
             @res.render.args[0][1].heroUnits[0].subtitle
               .should.equal 'My hero'
 
+      it 'with lab feature, does not fetch hero units or featured links', ->
+        @metaphysics.returns Promise.resolve
+          home_page:
+            artwork_modules: []
+        routes.index extend({ user: { lab_features: ['Homepage Search'] } }, @req), @res
+          .then =>
+            @res.render.args[0][0].should.equal 'index'
+            @res.render.args[0][1].modules[0].key.should.equal 'followed_artists'
+
       it 'catches error fetching homepage rails and still renders hero units', ->
         err = new Error 'Failed to get rails'
         err.data = home_page: hero_units: [heroUnit]

--- a/src/desktop/components/main_layout/header/index.styl
+++ b/src/desktop/components/main_layout/header/index.styl
@@ -11,9 +11,10 @@
   z-index zindex-primary-nav
   border-bottom 1px solid gray-lighter-color
 
-html[data-lab-features*="Homepage Search"]
+html[data-hide-hero-units]
   #main-layout-header
     border-bottom none
+    padding 10px 0
 
 .mlh-navbar
   align-items center

--- a/src/desktop/components/main_layout/header/index.styl
+++ b/src/desktop/components/main_layout/header/index.styl
@@ -11,6 +11,10 @@
   z-index zindex-primary-nav
   border-bottom 1px solid gray-lighter-color
 
+html[data-lab-features*="Homepage Search"]
+  #main-layout-header
+    border-bottom none
+
 .mlh-navbar
   align-items center
   display flex

--- a/src/desktop/components/main_layout/header/templates/large_screen_header.jade
+++ b/src/desktop/components/main_layout/header/templates/large_screen_header.jade
@@ -5,7 +5,7 @@ nav.mlh-navbar
   #main-layout-header-left.mlh-navbar-cell
     #main-layout-header-minimal-title
       block minimal-nav-header
-    unless sd.CURRENT_USER && sd.CURRENT_USER.lab_features && sd.CURRENT_USER.lab_features.indexOf('Homepage Search') !== -1
+    unless sd.HIDE_HERO_UNITS
       include ../../../search_bar/templates/index
   #main-layout-header-center.mlh-navbar-cell
     a.mlh-top-nav-link( href='/collect', class= activeClass("/collect") ) Artworks

--- a/src/desktop/components/main_layout/header/templates/large_screen_header.jade
+++ b/src/desktop/components/main_layout/header/templates/large_screen_header.jade
@@ -5,7 +5,8 @@ nav.mlh-navbar
   #main-layout-header-left.mlh-navbar-cell
     #main-layout-header-minimal-title
       block minimal-nav-header
-    include ../../../search_bar/templates/index
+    unless sd.CURRENT_USER && sd.CURRENT_USER.lab_features && sd.CURRENT_USER.lab_features.indexOf('Homepage Search') !== -1
+      include ../../../search_bar/templates/index
   #main-layout-header-center.mlh-navbar-cell
     a.mlh-top-nav-link( href='/collect', class= activeClass("/collect") ) Artworks
     a.mlh-top-nav-link( href='/auctions', class= activeClass('/auctions') ) Auctions

--- a/src/desktop/components/main_layout/header/view.coffee
+++ b/src/desktop/components/main_layout/header/view.coffee
@@ -32,16 +32,17 @@ module.exports = class HeaderView extends Backbone.View
     @checkForNotifications()
     @mobileHeaderView = new MobileHeaderView
       el : @$('#main-header-small-screen')
-    @searchBarView = new SearchBarView
-      el: @$('#main-layout-search-bar-container')
-      $input: @$('#main-layout-search-bar-input')
-      displayEmptyItem: true
-      autoselect: true
-      mode: 'suggest'
-      limit: 7
+    unless @currentUser?.hasLabFeature('Homepage Search')
+      @searchBarView = new SearchBarView
+        el: @$('#main-layout-search-bar-container')
+        $input: @$('#main-layout-search-bar-input')
+        displayEmptyItem: true
+        autoselect: true
+        mode: 'suggest'
+        limit: 7
 
-    @searchBarView.on 'search:entered', (term) -> window.location = "/search?q=#{term}"
-    @searchBarView.on 'search:selected', @searchBarView.selectResult
+      @searchBarView.on 'search:entered', (term) -> window.location = "/search?q=#{term}"
+      @searchBarView.on 'search:selected', @searchBarView.selectResult
 
     mediator.on 'open:auth', @openAuth, @
 

--- a/src/desktop/components/main_layout/header/view.coffee
+++ b/src/desktop/components/main_layout/header/view.coffee
@@ -32,7 +32,7 @@ module.exports = class HeaderView extends Backbone.View
     @checkForNotifications()
     @mobileHeaderView = new MobileHeaderView
       el : @$('#main-header-small-screen')
-    unless @currentUser?.hasLabFeature('Homepage Search')
+    unless sd.HIDE_HERO_UNITS
       @searchBarView = new SearchBarView
         el: @$('#main-layout-search-bar-container')
         $input: @$('#main-layout-search-bar-input')

--- a/src/desktop/components/main_layout/templates/index.jade
+++ b/src/desktop/components/main_layout/templates/index.jade
@@ -9,6 +9,7 @@ html(
   data-useragent=userAgent
   data-user-type=sd.CURRENT_USER && sd.CURRENT_USER.type
   data-lab-features=sd.CURRENT_USER && sd.CURRENT_USER.lab_features && sd.CURRENT_USER.lab_features.join(',')
+  data-hide-hero-units=sd.HIDE_HERO_UNITS
   lang="en"
 )
   head


### PR DESCRIPTION
This starts off our series of PR's with the first plumbing sorta one: hiding hero units and featured links (and not even fetching them), if the lab feature is enabled.