### PR TITLE
@mzikherman =>  Hide followed artists module 

### DIFF
--- a/src/desktop/apps/home/routes.coffee
+++ b/src/desktop/apps/home/routes.coffee
@@ -65,16 +65,17 @@ fetchMetaphysicsData = (req, showHeroUnits)->
     .then (results) ->
       if hideHeroUnits
         homePage = results.home_page
+        homePage.artwork_modules = homePage.artwork_modules.filter (module) -> module.key isnt 'followed_artists'
         heroUnits = []
       else
         homePage = results?[0].value.home_page
         heroUnits = homePage.hero_units
         heroUnits[positionWelcomeHeroMethod(req, res)](welcomeHero) unless req.user?
 
-      # always show followed artist rail for logged in users,
-      # if we dont get results we will replace with artists TO follow
-      if req.user and not _.findWhere homePage.artwork_modules, { key: 'followed_artists' }
-        homePage.artwork_modules.unshift { key: 'followed_artists' }
+        # always show followed artist rail for logged in users,
+        # if we dont get results we will replace with artists TO follow
+        if req.user and not _.findWhere homePage.artwork_modules, { key: 'followed_artists' }
+          homePage.artwork_modules.unshift { key: 'followed_artists' }
 
       res.locals.sd.HERO_UNITS = heroUnits
       res.locals.sd.USER_HOME_PAGE = homePage.artwork_modules

--- a/src/desktop/apps/home/test/routes.coffee
+++ b/src/desktop/apps/home/test/routes.coffee
@@ -109,15 +109,15 @@ describe 'Home routes', ->
             @res.render.args[0][1].heroUnits[0].subtitle
               .should.equal 'My hero'
 
-      it 'with lab feature, does not fetch hero units or featured links', ->
+      it 'with lab feature, does not fetch hero units, featured links, or followed artists rail', ->
         @user.hasLabFeature = () -> true
         @metaphysics.returns Promise.resolve
           home_page:
-            artwork_modules: []
+            artwork_modules: [{ key: 'followed_artists' }, { key: 'recommended_works'}]
         routes.index @req, @res
           .then =>
             @res.render.args[0][0].should.equal 'index'
-            @res.render.args[0][1].modules[0].key.should.equal 'followed_artists'
+            @res.render.args[0][1].modules[0].key.should.equal 'recommended_works'
 
       it 'catches error fetching homepage rails and still renders hero units', ->
         err = new Error 'Failed to get rails'


### PR DESCRIPTION
Hides followed_artists module; this could be further optimized by not even including `FOLLOWED_ARTISTS` in the initial metaphysics query, but I think that might be more trouble than it's worth since that initial query is quite small and the real images/data are fetched later.