### PR TITLE
adding back Artsy for galleries link to navigation menu

### DIFF
--- a/src/desktop/components/main_layout/header/templates/more.jade
+++ b/src/desktop/components/main_layout/header/templates/more.jade
@@ -10,3 +10,6 @@ span.mlh-top-nav-link.hover-pulldown( data-mode='hover' )
       a.mlh-pulldown-top-link-persistent( href='/artists', class= activeClass('/artists') ) Artists
       a.mlh-pulldown-top-link-persistent( href='/shows', class= activeClass('/shows') ) Shows
       a.mlh-pulldown-top-link-persistent( href='/institutions', class= activeClass('/institutions') ) Museums
+    hr.mlh-pulldown-top
+    div.mlh-pulldown-bottom
+      a.mlh-pulldown-bottom-link( href='/gallery-partnerships' ) Artsy for Galleries


### PR DESCRIPTION
Per @katarinabatina request we need to add back `Artsy for Galleries` link into top nav menu. Here it is!

