### PR TITLE
@mzikherman => [ArtworkBrick] Implement isomorphic reaction block rendering

### DIFF
--- a/src/desktop/apps/react_example/components/my_jade_view.jade
+++ b/src/desktop/apps/react_example/components/my_jade_view.jade
@@ -12,15 +12,21 @@ style.
   }
 
 div(class='reactionArtworkBrick')
-  !=renderArtworkGrid({ title: name })
+  !=reaction.artworkGrid({ title: name })
 
 br
 hr
 br
 
 div(class='reactionArtworkBrick')
-  !=renderArtworkBrick({ title: name })
+  !=reaction.artworkBrick({ title: name })
 
+br
+hr
+br
+
+div
+  !=reaction.fillWidth({ title: name })
 
 br
 

--- a/src/desktop/index.js
+++ b/src/desktop/index.js
@@ -5,7 +5,7 @@ const app = (module.exports = require('express')())
 
 // TODO: Move to src/lib/middleware/locals once done developing; this is just so
 // we can get hot module reloading which only works in /desktop and /mobile
-app.use(require('./lib/middleware/renderArtworkBrick'))
+app.use(require('./lib/middleware/renderArtworkBrick').serverRenderer)
 
 // Apps with hardcoded routes or "RESTful" routes
 app.use(require('./apps/home'))

--- a/src/desktop/lib/global_client_setup.coffee
+++ b/src/desktop/lib/global_client_setup.coffee
@@ -8,6 +8,7 @@ $ = require 'jquery'
 Backbone = require 'backbone'
 Backbone.$ = $
 _ = require 'underscore'
+{ uniqBy } = require 'lodash'
 Cookies = require 'cookies-js'
 imagesLoaded = require 'imagesloaded'
 Raven = require 'raven-js'
@@ -19,6 +20,7 @@ setupSplitTests = require '../components/split_test/setup.coffee'
 listenForInvert = require '../components/eggs/invert/index.coffee'
 listenForBounce = require '../components/eggs/bounce/index.coffee'
 confirmation = require '../components/confirmation/index.coffee'
+{ ReactionRenderer } = require './middleware/renderArtworkBrick'
 
 module.exports = ->
   setupErrorReporting()
@@ -29,6 +31,8 @@ module.exports = ->
   listenForInvert()
   listenForBounce()
   confirmation.check()
+  mountReactionBlocks()
+
 
 ensureFreshUser = (data) ->
   return unless sd.CURRENT_USER
@@ -92,3 +96,11 @@ setupJquery = ->
 setupErrorReporting = ->
   Raven.config(sd.SENTRY_PUBLIC_DSN).install()
   Raven.setUserContext _.pick(user, 'id', 'email') if user = sd.CURRENT_USER
+
+mountReactionBlocks = ->
+  blocks = uniqBy(sd.reactionBlocks, 'id')
+
+  blocks.forEach (block) ->
+    renderer = new ReactionRenderer('client')
+    renderer.deserialize(block)
+


### PR DESCRIPTION
Next step in block odyssey is Isomorphic Rendering to ensure full interactivity between reaction components and Force. Here's the flow: 

1. When a new request is made, append a new `reactionBlocks` array to `sharify`
1. Create a `new ReactionRenderer(mode = 'server')` instance and attach it as a helper to locals under `reaction`
1. Within server-side templates, when a block render is requested from jade  (`reaction.artworkGrid(props)`), serialize the `ReactionRenderer` instance and push it into `reactionBlocks` array
1. On client mount, iterate over all serialized reaction blocks and create a `new ReactionRender(mode = 'client')` instance and then run `deserialize()` which will `ReactDOM.rehydrate` all locations where reaction blocks have been mounted server-side

#### Todo in a different PR
- Rewrite in TypeScript since this is just an in-progress sketch
- Tests once API has settled 
- Fix react html mismatch warning (everything still works tho)