### PR TITLE
@xtina-starr => Remove admin from `/spring-art-fairs`

### DIFF
--- a/src/desktop/apps/frieze_week/index.js
+++ b/src/desktop/apps/frieze_week/index.js
@@ -13,7 +13,7 @@ const MARKETING_MODAL_ID = 'ca18'
 export class EditableFriezeWeekPage extends JSONPage {
   registerRoutes() {
     this.app.get(this.jsonPage.paths.show, this.show.bind(this))
-    this.app.get(this.jsonPage.paths.show + '/data', adminOnly, this.data)
+    this.app.get(this.jsonPage.paths.show + '/data', this.data)
     this.app.get(this.jsonPage.paths.edit, adminOnly, this.edit)
     this.app.post(this.jsonPage.paths.edit, adminOnly, this.upload)
   }

--- a/src/desktop/components/auction_reminders/blacklist.coffee
+++ b/src/desktop/components/auction_reminders/blacklist.coffee
@@ -28,6 +28,7 @@ module.exports =
     '^/news/.*'
     '^/news'
     '^/series/.*'
+    '^/spring-art-fairs'
     '^/video/.*'
     '^/artsy-in-miami'
     '^/armory-week'


### PR DESCRIPTION
When we're ready, 
- Removes admin flags from Frieze week page
- Adds `/spring-art-fairs` to auction reminder blacklist