### PR TITLE
@eessex => Smooth scrolling /news

### DIFF
--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment'
 import React, { Component, Fragment } from 'react'
-import { flatten } from 'lodash'
+import { flatten, debounce } from 'lodash'
 import Waypoint from 'react-waypoint'
 import { positronql as _positronql } from 'desktop/lib/positronql'
 import { newsArticlesQuery } from 'desktop/apps/article/queries/articles'
@@ -48,6 +48,8 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
     const date = this.getDateField(article)
     const omit = props.article ? props.article.id : null
     const offset = props.article ? 0 : 6
+
+    this.onDateChange = debounce(this.onDateChange, 200)
 
     this.state = {
       activeArticle: '',
@@ -141,7 +143,7 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
   }
 
   onDateChange = (date) => {
-    const hasNewDate = date !== this.state.date
+    const hasNewDate = !moment(date).isSame(this.state.date, 'day')
     if (hasNewDate) {
       this.setState({ date })
     }

--- a/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.test.js
+++ b/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.test.js
@@ -15,7 +15,7 @@ describe('<InfiniteScrollNewsArticle />', () => {
   let article
   let nextArticle
 
-  before((done) => {
+  before(done => {
     benv.setup(() => {
       benv.expose({ $: benv.require('jquery'), jQuery: benv.require('jquery') })
       sd.APP_URL = 'http://artsy.net'

--- a/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.test.js
+++ b/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.test.js
@@ -14,6 +14,7 @@ describe('<InfiniteScrollNewsArticle />', () => {
   let props
   let article
   let nextArticle
+  let clock
 
   before(done => {
     benv.setup(() => {
@@ -22,11 +23,13 @@ describe('<InfiniteScrollNewsArticle />', () => {
       sd.CURRENT_PATH =
         '/news/artsy-editorial-surprising-reason-men-women-selfies-differently'
       sd.CURRENT_USER = { id: '123' }
+      clock = sinon.useFakeTimers()
       done()
     })
   })
 
   after(() => {
+    clock.restore()
     benv.teardown()
   })
 
@@ -232,8 +235,9 @@ describe('<InfiniteScrollNewsArticle />', () => {
   describe('#onDateChange', () => {
     it('it sets date if it has a new one', () => {
       const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
-      rendered.instance().onDateChange('123')
-      rendered.state('date').should.equal('123')
+      rendered.instance().onDateChange('2018-07-20T17:19:55.909Z')
+      clock.tick(200)
+      rendered.state('date').should.equal('2018-07-20T17:19:55.909Z')
     })
 
     it("it doesn't set date if it hasn't changed", () => {


### PR DESCRIPTION
Debounces the date update and more significantly, fixes a bug where `hasNewDate` was updating no matter what since we were comparing published_at instead of the actual date. 