### PR TITLE
[Lib] Bump styled-components 3.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "sharify": "^0.1.6",
     "standard": "^9.0.0",
     "stickyfill": "^1.1.1",
-    "styled-components": "^2.5.0-1",
+    "styled-components": "^3.2.6",
     "stylus": "^0.54.5",
     "superagent": "^2.3.0",
     "twilio": "^2.5.1",
@@ -280,7 +280,7 @@
       "jsx",
       "ts",
       "tsx"
-    ],   
+    ],
     "testRegex": "/__tests__/.*\\.jest\\.(ts|tsx|js|jsx)$",
     "setupFiles": [
       "<rootDir>/test.config.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,6 +980,7 @@ antigravity@artsy/antigravity:
   version "0.1.3"
   resolved "https://codeload.github.com/artsy/antigravity/tar.gz/a4438d2fe9d0cdf71f1c47faba371cd3d004e140"
   dependencies:
+    coffeescript "1.11.1"
     express "*"
 
 any-observable@^0.2.0:
@@ -8797,6 +8798,10 @@ react-hot-loader@4.0.0-rc.0:
     prop-types "^15.6.0"
     shallowequal "^1.0.2"
 
+react-is@^16.3.1:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
+
 react-lines-ellipsis@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/react-lines-ellipsis/-/react-lines-ellipsis-0.8.0.tgz#922d5a70e8b14260014308389fb47d882225f83f"
@@ -10367,22 +10372,32 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-styled-components@^2.5.0-1:
-  version "2.5.0-1"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-2.5.0-1.tgz#0de96a5a6a07e78f620d6106cdcd10cc932425f7"
+styled-components@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.2.6.tgz#99e6e75a746bdedd295a17e03dd1493055a1cc3b"
   dependencies:
     buffer "^5.0.3"
     css-to-react-native "^2.0.3"
-    fbjs "^0.8.9"
-    hoist-non-react-statics "^1.2.0"
+    fbjs "^0.8.16"
+    hoist-non-react-statics "^2.5.0"
     is-plain-object "^2.0.1"
     prop-types "^15.5.4"
-    stylis "^3.4.0"
+    react-is "^16.3.1"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
     supports-color "^3.2.3"
 
-stylis@^3.0.0, stylis@^3.4.0:
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+
+stylis@^3.0.0:
   version "3.4.8"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.8.tgz#94380babbcd4c75726215794ca985b38ec96d1a3"
+
+stylis@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
 
 stylus@0.54.5, stylus@^0.54.5:
   version "0.54.5"


### PR DESCRIPTION
Upgrade to [3.0 release](https://github.com/styled-components/styled-components/releases/tag/v3.0.1)

Matched in [Reaction](https://github.com/artsy/reaction/pull/643) so that `yarn link` doesn't complain.

Noticed rendering issues related to 3.x upgrades a few months back (`/article` pages wouldn't load) but whatever it was seems to have been fixed. Tested out all around and AOK. This gives us access to the new streaming API. 