### PR TITLE
@mzikherman => [ReactionRenderer] Add runtime mode

### DIFF
--- a/src/desktop/apps/artwork/client/index.coffee
+++ b/src/desktop/apps/artwork/client/index.coffee
@@ -1,5 +1,5 @@
 { extend, map, compact } = require 'underscore'
-{ AUCTION, CLIENT } = require('sharify').data
+{ AUCTION, CLIENT, reaction } = require('sharify').data
 { setCookie } = require '../../../components/recently_viewed_artworks/index.coffee'
 { recordArtworkView } = require 'lib/components/record_artwork_view'
 metaphysics = require '../../../../lib/metaphysics.coffee'
@@ -156,6 +156,7 @@ module.exports =
     for key, template of { fold: fold, footer: footer }
       $(".js-artwork-#{key}")
         .html template extend data,
+          reaction: reaction
           helpers: helpers
           user: CurrentUser.orNull()
 
@@ -169,6 +170,7 @@ module.exports =
 
     return unless query? and init?
     variables ?= {}
+
     metaphysics {
       query: query,
       variables: extend { id: CLIENT.id }, variables

--- a/src/desktop/apps/artwork/components/artist_artworks/index.jade
+++ b/src/desktop/apps/artwork/components/artist_artworks/index.jade
@@ -11,6 +11,10 @@ if artwork.artist && artwork.artist.artworks && artwork.artist.artworks.length
     - var columns = helpers.artist_artworks.masonry(artwork.artist.artworks).columns
     include ../../../../components/artwork_masonry/index
 
+    //- TODO: Replace columns above with below
+    //- #test-mount
+    //-   != reaction.artworkGrid({ mountId: 'test-mount'})
+
     .artwork-section__jump
       a.avant-garde-jump-link( href='#{artwork.artist.href}/works' )
         | View all #{artwork.artist.counts.artworks} by #{artwork.artist.name}

--- a/src/desktop/apps/artwork/components/auction_artworks/index.jade
+++ b/src/desktop/apps/artwork/components/auction_artworks/index.jade
@@ -25,6 +25,10 @@ if artwork.auction && artwork.auction.artworks && artwork.auction.artworks.lengt
     - var columns = helpers.auction_artworks.masonry(auction.artworks, followed_artist_ids).columns
     include ../../../../components/artwork_masonry_4_column/index
 
+    //- TODO: Replace columns above with below
+    //- #test-mount
+    //-   != reaction.artworkGrid({ mountId: 'test-mount'})
+
     .artwork-auction-artworks__view-all
       .artwork-auction-artworks__view-all__mask
       .artwork-auction-artworks__view-all__button

--- a/src/desktop/apps/react_example/components/App.js
+++ b/src/desktop/apps/react_example/components/App.js
@@ -14,7 +14,7 @@ export default class App extends Component {
     console.log('Component mounted on client!')
   }
 
-  handleButtonClick = (event) => {
+  handleButtonClick = event => {
     console.warn('React Button clicked!', this.props.description)
   }
 

--- a/src/desktop/apps/react_example/components/clientSideJadeView.jade
+++ b/src/desktop/apps/react_example/components/clientSideJadeView.jade
@@ -1,0 +1,4 @@
+h1
+  | Client-side only template
+
+  #mount-point

--- a/src/desktop/apps/react_example/components/myJadeView.jade
+++ b/src/desktop/apps/react_example/components/myJadeView.jade
@@ -6,6 +6,14 @@ div
 
 br
 
+h1
+  | Reaction Helpers
+
+br
+hr
+br
+
+
 style.
   .reactionArtworkBrick {
     width: 50%;

--- a/src/desktop/apps/react_example/routes.js
+++ b/src/desktop/apps/react_example/routes.js
@@ -19,7 +19,7 @@ export async function index(req, res, next) {
         description: 'hello hi how are you',
       },
       templates: {
-        MyJadeView: 'my_jade_view.jade',
+        MyJadeView: 'myJadeView.jade',
       },
     })
 

--- a/src/desktop/index.js
+++ b/src/desktop/index.js
@@ -5,7 +5,7 @@ const app = (module.exports = require('express')())
 
 // TODO: Move to src/lib/middleware/locals once done developing; this is just so
 // we can get hot module reloading which only works in /desktop and /mobile
-app.use(require('./lib/middleware/renderArtworkBrick').serverRenderer)
+app.use(require('./lib/reactionRenderer').middleware)
 
 // Apps with hardcoded routes or "RESTful" routes
 app.use(require('./apps/home'))

--- a/src/desktop/lib/global_client_setup.coffee
+++ b/src/desktop/lib/global_client_setup.coffee
@@ -20,7 +20,7 @@ setupSplitTests = require '../components/split_test/setup.coffee'
 listenForInvert = require '../components/eggs/invert/index.coffee'
 listenForBounce = require '../components/eggs/bounce/index.coffee'
 confirmation = require '../components/confirmation/index.coffee'
-{ ReactionRenderer } = require './middleware/renderArtworkBrick'
+{ ReactionRenderer } = require './reactionRenderer'
 
 module.exports = ->
   setupErrorReporting()
@@ -101,6 +101,15 @@ mountReactionBlocks = ->
   blocks = uniqBy(sd.reactionBlocks, 'id')
 
   blocks.forEach (block) ->
-    renderer = new ReactionRenderer('client')
+    renderer = new ReactionRenderer({
+      mode: 'client'
+    })
+
     renderer.deserialize(block)
+
+  # Mount renderer for runtime client-side templates. NOTE: must be included
+  # in template when rendering data; e.g., html = myTemplate({ data, reaction })
+  sd.reaction = new ReactionRenderer({
+    mode: 'runtime'
+  })
 

--- a/src/desktop/lib/reactionRenderer.js
+++ b/src/desktop/lib/reactionRenderer.js
@@ -4,6 +4,7 @@ import { Artwork } from 'reaction/Components/Artwork'
 import { ArtworkGrid } from 'reaction/Components/ArtworkGrid'
 import { Fillwidth } from 'reaction/Components/Artwork/Fillwidth'
 import { ServerStyleSheet } from 'styled-components'
+import { data as sd } from 'sharify'
 import { renderToString } from 'react-dom/server'
 import { isFunction, uniqueId } from 'lodash'
 
@@ -14,12 +15,13 @@ export class ReactionRenderer {
   res
   props
 
-  constructor(mode = 'server', res) {
+  constructor({ mode = 'server', res }) {
     this.mode = mode
     this.res = res
   }
 
   artworkBrick(props) {
+    this.props = props
     this.type = this.artworkBrick.name
 
     const html = this.render(props => {
@@ -29,17 +31,23 @@ export class ReactionRenderer {
   }
 
   artworkGrid(props) {
+    this.props = props
     this.type = this.artworkGrid.name
 
     const html = this.render(props => {
       return (
-        <ArtworkGrid columnCount={2} artworks={artworks} useRelay={false} />
+        <ArtworkGrid
+          columnCount={props.columnCount || 3}
+          artworks={artworks}
+          useRelay={false}
+        />
       )
     })
     return html
   }
 
   fillWidth(props) {
+    this.props = props
     this.type = this.fillWidth.name
 
     const html = this.render(props => {
@@ -55,16 +63,23 @@ export class ReactionRenderer {
    */
   addToQueue(block) {
     try {
-      this.res.locals.sharify.data.reactionBlocks.push(block)
+      if (this.mode === 'server') {
+        this.res.locals.sharify.data.reactionBlocks.push(block)
+      } else {
+        if (!sd.reactionBlocks) {
+          sd.reactionBlocks = []
+        }
+
+        sd.reactionBlocks.push(block)
+      }
     } catch (error) {
-      console.error(
-        '(middlware/renderArtworkBrick) Error adding to queue:',
-        error
-      )
+      console.error('(lib/reactionRenderer) Error adding to queue:', error)
     }
   }
 
   serialize() {
+    this.id = this.props.mountId || uniqueId('react-mount-reaction-')
+
     this.addToQueue({
       mode: this.mode,
       id: this.id,
@@ -88,39 +103,45 @@ export class ReactionRenderer {
 
   render(blockType) {
     try {
-      const isServer = this.mode === 'server'
-
-      if (isServer) {
-        this.id = uniqueId('react-mount-reaction-')
+      if (this.mode === 'server') {
         const sheet = new ServerStyleSheet()
         const html = renderToString(sheet.collectStyles(blockType(this.props)))
         const css = sheet.getStyleTags()
-
         this.serialize()
-
         const out = [`<div id=${this.id}></div>`, css, html].join('\n')
         return out
-
-        // Client-side
       } else {
-        ReactDOM.hydrate(
-          blockType(this.props),
-          document.getElementById(this.id)
-        )
+        // Add timeout so that client-side-only templates have a chance to mount
+        // before react attachment / rehydration occurs.
+        setTimeout(() => {
+          if (this.mode === 'runtime') {
+            this.serialize()
+          }
+
+          ReactDOM.hydrate(
+            blockType(this.props),
+            document.getElementById(this.id)
+          )
+        }, 0)
       }
     } catch (error) {
       console.error(
-        '(middleware/renderArtworkBrick) Error rendering server-side: ',
+        `(lib/reactionRenderer) Error rendering ${this.mode}-side:`,
         error
       )
     }
   }
 }
 
-module.exports.serverRenderer = (req, res, next) => {
-  const renderer = new ReactionRenderer('server', res)
+module.exports.middleware = (req, res, next) => {
+  const renderer = new ReactionRenderer({
+    mode: 'server',
+    res,
+  })
+
   res.locals.reaction = renderer
   res.locals.sharify.data.reactionBlocks = []
+
   next()
 }
 
@@ -153,6 +174,150 @@ const artwork = {
 
 const artworks = {
   edges: [
+    {
+      node: {
+        __id: 'QXJ0d29yazpiYW5rc3ktd2UtbG92ZS15b3Utc28tbG92ZS11cw==',
+        image: {
+          aspect_ratio: 1,
+          placeholder: '100%',
+          url:
+            'https://d32dm0rphc51dk.cloudfront.net/hoFocUdpgF4mazPIgekpZA/large.jpg',
+        },
+        href: '/artwork/banksy-we-love-you-so-love-us',
+        title: 'We Love You So Love Us',
+        date: '2000',
+        sale_message: 'Contact For Price',
+        cultural_maker: null,
+        artists: [
+          {
+            __id: 'QXJ0aXN0OmJhbmtzeQ==',
+            href: '/artist/banksy',
+            name: 'Banksy',
+          },
+        ],
+        collecting_institution: null,
+        partner: {
+          name: 'EHC Fine Art',
+          href: '/ehc-fine-art',
+          __id: 'UGFydG5lcjplaGMtZmluZS1hcnQ=',
+          type: 'Gallery',
+        },
+        sale: null,
+        _id: '58e1a19d275b247d353ff0d9',
+        is_inquireable: true,
+        sale_artwork: null,
+        id: 'banksy-we-love-you-so-love-us',
+        is_saved: null,
+      },
+    },
+    {
+      node: {
+        __id: 'QXJ0d29yazpiYW5rc3ktcmFkYXItcmF0LWRpcnR5LWZ1bmtlci1scA==',
+        image: {
+          aspect_ratio: 1,
+          placeholder: '100%',
+          url:
+            'https://d32dm0rphc51dk.cloudfront.net/NQvnb87U8oGDm6kpdJ9jLA/large.jpg',
+        },
+        href: '/artwork/banksy-radar-rat-dirty-funker-lp',
+        title: 'Radar Rat (Dirty Funker LP)',
+        date: '2008',
+        sale_message: '$950',
+        cultural_maker: null,
+        artists: [
+          {
+            __id: 'QXJ0aXN0OmJhbmtzeQ==',
+            href: '/artist/banksy',
+            name: 'Banksy',
+          },
+        ],
+        collecting_institution: null,
+        partner: {
+          name: 'EHC Fine Art',
+          href: '/ehc-fine-art',
+          __id: 'UGFydG5lcjplaGMtZmluZS1hcnQ=',
+          type: 'Gallery',
+        },
+        sale: null,
+        _id: '58e1a19ecd530e4d612cb07f',
+        is_inquireable: true,
+        sale_artwork: null,
+        id: 'banksy-radar-rat-dirty-funker-lp',
+        is_saved: null,
+      },
+    },
+    {
+      node: {
+        __id: 'QXJ0d29yazpiYW5rc3ktZmxvd2VyLWJvbWJlci1ieS1icmFuZGFsaXNt',
+        image: {
+          aspect_ratio: 1.5,
+          placeholder: '66.66666666666666%',
+          url:
+            'https://d32dm0rphc51dk.cloudfront.net/88LaQZxzQdksn76f0LGFoQ/large.jpg',
+        },
+        href: '/artwork/banksy-flower-bomber-by-brandalism',
+        title: 'Flower Bomber (by Brandalism)',
+        date: 'ca. 2017',
+        sale_message: 'Contact For Price',
+        cultural_maker: null,
+        artists: [
+          {
+            __id: 'QXJ0aXN0OmJhbmtzeQ==',
+            href: '/artist/banksy',
+            name: 'Banksy',
+          },
+        ],
+        collecting_institution: null,
+        partner: {
+          name: 'EHC Fine Art',
+          href: '/ehc-fine-art',
+          __id: 'UGFydG5lcjplaGMtZmluZS1hcnQ=',
+          type: 'Gallery',
+        },
+        sale: null,
+        _id: '58e1a19f275b247d353ff0e2',
+        is_inquireable: true,
+        sale_artwork: null,
+        id: 'banksy-flower-bomber-by-brandalism',
+        is_saved: null,
+      },
+    },
+    {
+      node: {
+        __id: 'QXJ0d29yazpiYW5rc3ktZ2lybC13aXRoLWJhbGxvb24tMTQ=',
+        image: {
+          aspect_ratio: 0.75,
+          placeholder: '132.9%',
+          url:
+            'https://d32dm0rphc51dk.cloudfront.net/RRGE9Ild18_IPghZXT6wuQ/large.jpg',
+        },
+        href: '/artwork/banksy-girl-with-balloon-14',
+        title: 'Girl With Balloon',
+        date: '2004',
+        sale_message: 'Contact For Price',
+        cultural_maker: null,
+        artists: [
+          {
+            __id: 'QXJ0aXN0OmJhbmtzeQ==',
+            href: '/artist/banksy',
+            name: 'Banksy',
+          },
+        ],
+        collecting_institution: null,
+        partner: {
+          name: 'Graffik Gallery / Banksy Editions',
+          href: '/graffik-gallery-slash-banksy-editions',
+          __id: 'UGFydG5lcjpncmFmZmlrLWdhbGxlcnktc2xhc2gtYmFua3N5LWVkaXRpb25z',
+          type: 'Gallery',
+        },
+        sale: null,
+        _id: '58e370659c18db774f25ed5b',
+        is_inquireable: true,
+        sale_artwork: null,
+        id: 'banksy-girl-with-balloon-14',
+        is_saved: null,
+      },
+    },
     {
       node: {
         __id: 'QXJ0d29yazpiYW5rc3ktd2UtbG92ZS15b3Utc28tbG92ZS11cw==',

--- a/src/lib/middleware/error_handler.coffee
+++ b/src/lib/middleware/error_handler.coffee
@@ -14,6 +14,8 @@ module.exports = (err, req, res, next) ->
   if isDevelopment
     message = err.message || err.text || err.toString()
     detail = err.stack
-    console.log detail
+
+    if err.status isnt 404
+      console.log detail
 
   res.status(code).render(file, { message, detail, code })


### PR DESCRIPTION
Last piece: For templates that are exclusively rendered client-side we need a way to to mount at runtime. The flow:

- `ReactionRenderer` now has three modes, `server`, `client` and `runtime`
- Runtime represents post-mount `client`, when JS is already executing 
- Runtime mode has two additional requirements: 1) an `#id` to mount to, since that markup isn't available during the server-side render pass; and 2) the `reaction` renderer, which is attached globally to sharify, needs to be passed to the template being rendered client-side since there's no way to inject global helpers into client-side template code. 

Here's an example of a runtime-only page area (artwork in an auction, the "Other auction works" section); this gets mounted once the client is already ready: 

![auctions](https://user-images.githubusercontent.com/236943/39028622-637d0b5c-440c-11e8-889e-5059d645c31c.gif)

#### Todo in a follow up PR 
- Convert to TypeScript 
- Tests 
