### PR TITLE
@xtina-starr => Return early for a Segment call and bump reaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@artsy/express-reloadable": "^1.3.0",
     "@artsy/passport": "^1.0.8",
-    "@artsy/reaction": "^0.40.1",
+    "@artsy/reaction": "^0.40.2",
     "@artsy/stitch": "^1.4.0",
     "@babel/core": "7.0.0-beta.40",
     "@babel/node": "7.0.0-beta.40",

--- a/src/desktop/assets/analytics.coffee
+++ b/src/desktop/assets/analytics.coffee
@@ -11,7 +11,6 @@ mediator.on 'all', (name, data) ->
 
 # All Reaction events are sent directly to Segment
 Events.onEvent (data) =>
-  analytics.track data.action, _.omit data, 'action'
 
   # Send Reaction's read more as a Parsely page view
   if data.action is 'Clicked read more'
@@ -27,6 +26,11 @@ Events.onEvent (data) =>
         track_url: true,
         url: sd.APP_URL + '/' + location.pathname,
         use_stored_tags: true
+
+    # Return early because we don't want to make a Segment call for read more
+    return
+
+  analytics.track data.action, _.omit data, 'action'
 
 require '../analytics/main_layout.js'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,9 +28,9 @@
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
-"@artsy/reaction@^0.40.1":
-  version "0.40.1"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-0.40.1.tgz#a3a8a6f1420ccbb176e93935117e7ba07996b1da"
+"@artsy/reaction@^0.40.2":
+  version "0.40.2"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-0.40.2.tgz#d52b348ba40e99362cbeae6bb1d3b4039680ac9b"
   dependencies:
     formik "^0.11.11"
     history "^4.6.1"


### PR DESCRIPTION
This brings back the tracking call for "Clicked read more" to be able to track a pageview, but it returns early so we don't make an event call in Segment. This is the preferred functionality for #analytics