### PR TITLE
@xtina-starr => Analytics.page call when clicking Read More

### DIFF
--- a/src/desktop/assets/analytics.coffee
+++ b/src/desktop/assets/analytics.coffee
@@ -12,8 +12,12 @@ mediator.on 'all', (name, data) ->
 # All Reaction events are sent directly to Segment
 Events.onEvent (data) =>
 
-  # Send Reaction's read more as a Parsely page view
+  # Send Reaction's read more as a page view
   if data.action is 'Clicked read more'
+    analytics.page(
+      { path: location.pathname },
+      { integrations: { Marketo: false }}
+    )
     if window.PARSELY
       window.PARSELY.beacon.trackPageView
         url: location.href,


### PR DESCRIPTION
We noticed that we were only sending PV's to Parsely and ST when clicking read more on all articles in infinite scroll - it appears to have been broken / not fixed since we launched new articles. However since we didn't see a decrease in overall PV's it must mean people don't use this feature a lot. 🤔 