### PR TITLE
@kanaabe => hide nav for embedded ipad view

### DIFF
--- a/src/desktop/apps/order/stylesheets/index.styl
+++ b/src/desktop/apps/order/stylesheets/index.styl
@@ -84,3 +84,9 @@
   margin-top 20px
   color gray-darkest-color
 
+// Hide nav bar if on ipad
+html[data-useragent*="Artsy-Mobile"]
+  .order-body
+    margin-top -60px
+    #main-layout-header
+      display none


### PR DESCRIPTION
Took me a while to figure out how to hide the nav bar _only_ when this view is embedded in the ipad, but I found this handy guide from @craigspaeth in this old PR. 😄 https://github.com/artsy/microgravity-deprecated/pull/41

The nav bar is [already hidden on the phone](https://github.com/artsy/force/blob/master/src/desktop/apps/order/stylesheets/mobile.styl#L66-L67), so I think it's okay to just use `Artsy-Mobile` here. This adds a little optimization to both cases by bumping the padding back since the header is gone in both (and there was a bunch of extra space).