### PR TITLE
@damassi => Add support for recently viewed artwork rail on homepage

### DIFF
--- a/src/desktop/apps/home/queries/initial.coffee
+++ b/src/desktop/apps/home/queries/initial.coffee
@@ -2,9 +2,10 @@ module.exports = """
   query($showHeroUnits: Boolean!) {
     home_page {
       artwork_modules(
-        max_rails: 6,
+        max_rails: 7,
         order: [
           ACTIVE_BIDS,
+          RECENTLY_VIEWED_WORKS
           RECOMMENDED_WORKS,
           FOLLOWED_ARTISTS,
           RELATED_ARTISTS,


### PR DESCRIPTION
depends on https://github.com/artsy/metaphysics/pull/1018 and https://github.com/artsy/gravity/pull/11683 (and creating the site feature in staging).

This is what I was thinking re: https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=40&projectKey=DISCOVER&view=planning&selectedIssue=DISCOVER-56 (surfacing the rail to the top of the homepage)

If the Metaphysics/Grav stuff is done right, this _should_ just work. I suspect Emission has a similar thing going on: https://github.com/artsy/emission/blob/7b91993ee1043fd2a78e279dec4be3f89310229a/src/lib/Scenes/Home/Components/ForYou/index.tsx#L128 (maybe some other places too)

@sarahscott can help out with it!