### PR TITLE
contact modal can be closed with x button on contact gallery from fair page

### DIFF
--- a/src/desktop/components/contact/show_inquiry_modal.coffee
+++ b/src/desktop/components/contact/show_inquiry_modal.coffee
@@ -90,4 +90,3 @@ module.exports = class ShowInquiryModal extends ContactView
             inquiry: @model
             show: @show
             fair_id: @show.get('fair')?.id
-

--- a/src/desktop/components/contact/view.coffee
+++ b/src/desktop/components/contact/view.coffee
@@ -57,8 +57,6 @@ module.exports = class ContactView extends ModalView
     @renderTemplates()
 
   renderTemplates: ->
-    # Hiding the close button here for now to account for new styling
-    @$('.modal-close').hide()
     @$('#contact-header').html @headerTemplate(@templateData)
     @$('#contact-form').html @formTemplate(@templateData)
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/EV-94

Missed this instance when enabling 'x' on the rest of contact modals.