### PR TITLE
hide info in artist page experiment group

### DIFF
--- a/src/desktop/apps/artist/client/views/overview.coffee
+++ b/src/desktop/apps/artist/client/views/overview.coffee
@@ -130,6 +130,8 @@ module.exports = class OverviewView extends Backbone.View
       artist: @model.toJSON()
       viewHelpers: viewHelpers
       statuses: @statuses
+      showSections:
+        info: @testGroup is 'merch_sort' or @testGroup is 'control'
 
     _.defer => @postRender()
     this

--- a/src/desktop/apps/artist/templates/sections/overview.jade
+++ b/src/desktop/apps/artist/templates/sections/overview.jade
@@ -10,24 +10,25 @@ mixin rail(title, viewAllUrl, section)
 
         include ../../../../components/merry_go_round/templates/horizontal_navigation
 
+if showSections.info
+  .artist-overview-header
+    .evenly-bisected-header
+      - var artistMeta = viewHelpers.artistMeta(artist)
 
-.artist-overview-header
-  .evenly-bisected-header
-    - var artistMeta = viewHelpers.artistMeta(artist)
+      - var hasMeta = viewHelpers.hasOverviewHeaderMeta(artist)
+      - var hasShows = statuses.shows || statuses.cv
 
-    - var hasMeta = viewHelpers.hasOverviewHeaderMeta(artist)
-    - var hasShows = statuses.shows || statuses.cv
+      .bisected-header-cell.js-artist-overview-header-left
+        if hasMeta
+          .artist-blurb.bisected-header-cell-section
+            h2 Biography
+            if artist.biography_blurb && artist.biography_blurb.text
+              .blurb!= artist.biography_blurb.text
+              if artist.biography_blurb.credit
+                .artist-blurb__credit &mdash; #{artist.biography_blurb.credit}
+              if artistMeta.length
+                br
 
-    .bisected-header-cell.js-artist-overview-header-left
-      if hasMeta
-        .artist-blurb.bisected-header-cell-section
-          h2 Biography
-          if artist.biography_blurb && artist.biography_blurb.text
-            .blurb!= artist.biography_blurb.text
-            if artist.biography_blurb.credit
-              .artist-blurb__credit &mdash; #{artist.biography_blurb.credit}
-            if artistMeta.length
-              br
           if artistMeta.length
             .artist-meta-detail!= artistMeta
 

--- a/src/desktop/apps/artist/test/templates.coffee
+++ b/src/desktop/apps/artist/test/templates.coffee
@@ -33,6 +33,7 @@ describe 'Artist header', ->
         viewHelpers: helpers
         showSections: 
           header: true
+          info: true
       }, done
 
     it 'should not display the no works message if there is more than 0 artworks', ->
@@ -66,6 +67,7 @@ describe 'Artist header', ->
         viewHelpers: helpers
         showSections: 
           header: true
+          info: true
       }, done
 
     it 'should not display the no works message if there is more than 0 artworks', ->
@@ -102,6 +104,7 @@ describe 'Artist header', ->
         viewHelpers: helpers
         showSections: 
           header: true
+          info: true
       }, done
 
     it 'should display the no works message if there are no artworks', ->


### PR DESCRIPTION
This fixes the AB test on artist pages, which is queued up on Staging, to hide the info section when a user is in the `no_header_merch_sort` group - we should be hiding both the header and info sections for this group.

After this change the experiment group now looks like this:

<img width="1666" alt="screen shot 2018-04-23 at 4 27 10 pm" src="https://user-images.githubusercontent.com/64404/39151448-3f0ce882-4713-11e8-88b6-d116ac55a371.png">
