### PR TITLE
@xtina-starr => Remove recently viewed works component from home

### DIFF
--- a/src/desktop/components/recently_viewed_artworks/index.coffee
+++ b/src/desktop/components/recently_viewed_artworks/index.coffee
@@ -23,7 +23,7 @@ module.exports =
     Cookies.set COOKIE_NAME, JSON.stringify(artworkIdsToStore), expires: COOKIE_EXPIRY
 
   shouldShowRVARail: ->
-    !blacklist.check() && cookieValue().length > 0
+    !blacklist.check() && cookieValue().length > 0 && location.pathname isnt '/'
 
   reInitRVARail: ($el) ->
     return unless $el.find('.rva-container').length > 0


### PR DESCRIPTION
Now that we have a 'Recently Viewed' artworks rail, this can be removed from the homepage.

Fixes https://artsyproduct.atlassian.net/browse/DISCOVER-81