### PR TITLE
@eessex => Update Read More tracking to use optional pathname

### DIFF
--- a/src/desktop/assets/analytics.coffee
+++ b/src/desktop/assets/analytics.coffee
@@ -14,13 +14,15 @@ Events.onEvent (data) =>
 
   # Send Reaction's read more as a page view
   if data.action is 'Clicked read more'
+    pathname = data.pathname || location.pathname
+    href = sd.APP_URL + '/' + pathname
     analytics.page(
-      { path: location.pathname },
+      { path: pathname },
       { integrations: { Marketo: false }}
     )
     if window.PARSELY
       window.PARSELY.beacon.trackPageView
-        url: location.href,
+        url: href,
         js: 1,
         action_name: 'infinite'
     if window.Sailthru
@@ -28,7 +30,7 @@ Events.onEvent (data) =>
         domain: 'horizon.artsy.net',
         spider: true,
         track_url: true,
-        url: sd.APP_URL + '/' + location.pathname,
+        url: href,
         use_stored_tags: true
 
     # Return early because we don't want to make a Segment call for read more

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,7 +62,7 @@
     yarn "^1.3.2"
     yup "^0.24.1"
 
-"@artsy/stitch@^1.5.0":
+"@artsy/stitch@^1.5.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@artsy/stitch/-/stitch-1.5.1.tgz#09d4bb5e9fb4337a45845de44286686e8e618c5e"
   dependencies:


### PR DESCRIPTION
Follow up to the Expand tracking bug -- this uses the pathname from the event if there is one (avoids a race condition)