### PR TITLE
Restore inquiry auth modal

### DIFF
--- a/src/desktop/components/auth_modal/templates/_gdpr_signup.jade
+++ b/src/desktop/components/auth_modal/templates/_gdpr_signup.jade
@@ -4,21 +4,17 @@
     method='POST'
   )
     .auth-errors
-    - const userName = (user && user.get('name')) ? user.get('name') : ''
     input.bordered-input(
       name='name',
       placeholder='Your full name',
       autofocus=true,
       required
-      value=userName
     )
-    - const email = (user && user.get('email')) ? user.get('email') : ''
     input#js-mailcheck-input-modal.bordered-input(
       name='email',
       type='email',
       placeholder='Your email address',
       required
-      value=email
     )
     input#js-mailcheck-hint-modal.bordered-input(
       name='password',
@@ -42,9 +38,9 @@
     small.gdpr-signup__small
       | By signing up, you agree to our&nbsp;
       br
-      a( href='/terms' ) Terms of Use
+      a( href='/terms' target="_blank" ) Terms of Use
       | &nbsp;and&nbsp;
-      a(href='/privacy') Privacy Policy
+      a(href='/privacy' target="_blank" ) Privacy Policy
 
 
 

--- a/src/desktop/components/inquiry_questionnaire/templates/account/register.jade
+++ b/src/desktop/components/inquiry_questionnaire/templates/account/register.jade
@@ -14,4 +14,43 @@ form.stacked-form
   .iq-form-errors.js-form-errors
     //- Rendered separately
 
-  include ../../../auth_modal/templates/_gdpr_signup
+  label.avant-garde-form-label( for='name' )
+    | Full Name	
+  
+  input.bordered-input(
+    id='name'
+    name='name'
+    type='text'
+    placeholder='Full Name'
+    required
+    value=user.get('name')
+  )
+
+  label.avant-garde-form-label( for='email' )
+    | Email
+
+  input.bordered-input(
+    id='email'
+    name='email'
+    type='email'
+    placeholder='Email'
+    required
+    value=user.get('email')
+  )
+
+  label.avant-garde-form-label( for='password' )
+    | Password
+
+  include ./password
+
+  .iq-top-margin
+    button.avant-garde-button-black.js-form-submit( type='submit' )
+      | Create Account
+
+  .iq-account-sub.iq-account-sub--small
+    span
+      | By signing up, you agree to our&nbsp;
+      a.fine-faux-underline( href='/terms', target='_blank' ) Terms of Use	
+      = ' and '	
+      a.fine-faux-underline( href='/privacy', target='_blank' ) Privacy Policy	
+      | .

--- a/src/desktop/components/inquiry_questionnaire/test/views/account.coffee
+++ b/src/desktop/components/inquiry_questionnaire/test/views/account.coffee
@@ -22,7 +22,7 @@ describe 'Account', setup ->
       @view.$('.iq-headline').text()
         .should.containEql 'Create an account to send your message'
       @view.$('input').map(-> $(this).attr('name')).get()
-        .should.eql ['name', 'email', 'password', '_csrf']
+        .should.eql ['name', 'email', 'password']
 
     it 're-renders when the mode changes', ->
       @view.active.set 'mode', 'forgot'


### PR DESCRIPTION
Per a conversation with @katarinabatina and @junybrum on Friday we discovered that when users created an account with facebook as part of the inquiry flow those inquiries weren't going through. Seeing that we've closed the GDPR test we decided to go ahead and revert back to the old register form.