### PR TITLE
@erikdstock => dont make users enter credit card again when they try to bid and already have one on file

### DIFF
--- a/src/desktop/apps/auction_support/client/index.coffee
+++ b/src/desktop/apps/auction_support/client/index.coffee
@@ -18,7 +18,7 @@ module.exports.AuctionRouter = class AuctionRouter extends Backbone.Router
     'auction/:id/bid/:artwork': 'bid'
 
   initialize: (options) ->
-    { @sale, @saleArtwork, @registered, @bidderPositions } = options
+    { @sale, @saleArtwork, @registered, @bidderPositions, @hasValidCreditCard } = options
 
   register: ->
     new RegistrationForm
@@ -28,7 +28,7 @@ module.exports.AuctionRouter = class AuctionRouter extends Backbone.Router
         window.location = @sale.registrationSuccessUrl()
 
   bid: ->
-    if @registered
+    if @registered || @hasValidCreditCard
       @initBidForm()
     else
       new RegistrationForm
@@ -52,6 +52,7 @@ module.exports.init = ->
     bidderPositions: new BidderPositions(sd.BIDDER_POSITIONS,
       { sale: sale, saleArtwork: saleArtwork })
     registered: sd.REGISTERED
+    hasValidCreditCard: sd.HAS_VALID_CREDIT_CARD
 
   Backbone.history.start(pushState: true)
 

--- a/src/desktop/apps/auction_support/routes.coffee
+++ b/src/desktop/apps/auction_support/routes.coffee
@@ -112,24 +112,27 @@ registerOrRender = (sale, req, res, next) ->
         success: render
 
   metaphysics
-    query: """ {
-      artwork(id: "#{req.params.artwork}") {
-        sale_artwork {
-          bid_increments
+    query: """
+      query($sale_id: String!, $artwork_id: String!) {
+        artwork(id: $artwork_id) {
+          sale_artwork {
+            bid_increments
+          }
+        }
+        me {
+          has_qualified_credit_cards
+          bidders(sale_id: $sale_id) {
+            id
+          }
         }
       }
-      me {
-        has_qualified_credit_cards
-        bidders(sale_id: "#{sale.get('id')}") {
-          id
-        }
-      }
-    } """
-    req: req
+    """
+    req: req,
+    variables: { sale_id: sale.get('id'), artwork_id: req.params.artwork }
   .catch(next).then ({ artwork, me }) ->
     res.locals.bidIncrements = artwork.sale_artwork.bid_increments
-    res.locals.sd.REGISTERED = Boolean(me && me.bidders && me.bidders.length > 0)
-    res.locals.sd.HAS_VALID_CREDIT_CARD = Boolean(me && me.has_qualified_credit_cards)
+    res.locals.sd.REGISTERED = Boolean(me?.bidders?.length > 0)
+    res.locals.sd.HAS_VALID_CREDIT_CARD = Boolean(me?.has_qualified_credit_cards)
     render()
 
 @buyersPremium = (req, res, next) ->

--- a/src/desktop/apps/auction_support/templates/bid-form.jade
+++ b/src/desktop/apps/auction_support/templates/bid-form.jade
@@ -38,7 +38,7 @@ block body
               )= display
 
           .auction-bid-errors
-        if isRegistered
+        if isRegistered || hasValidCreditCard
           .registration-form-content
             .auction-bid-form-confirm.avant-garde-button-black.is-block Confirm Bid
         else

--- a/src/desktop/apps/auction_support/test/client/registration_form.coffee
+++ b/src/desktop/apps/auction_support/test/client/registration_form.coffee
@@ -9,7 +9,7 @@ Order = require '../../../../models/order'
 Sale = require '../../../../models/sale'
 RegistrationForm = require '../../client/registration_form'
 
-xdescribe 'RegistrationForm', ->
+describe 'RegistrationForm', ->
 
   before (done) ->
     benv.setup =>
@@ -77,7 +77,7 @@ xdescribe 'RegistrationForm', ->
       @view.once 'submitted', =>
         done()
 
-    it 'validates the form and displays errors', (done) ->
+    it 'validates the form and displays errors', ->
       @view.$submit.length.should.be.ok()
       @view.$submit.click()
 
@@ -92,7 +92,6 @@ xdescribe 'RegistrationForm', ->
         html.should.containEql 'Invalid telephone'
         html.should.containEql 'Please review the error(s) above and try again.'
         @view.$submit.hasClass('is-loading').should.be.false()
-        done()
 
     it 'lets the user resubmit a corrected form', ->
       # Submit a bad form

--- a/src/desktop/apps/auction_support/test/routes.coffee
+++ b/src/desktop/apps/auction_support/test/routes.coffee
@@ -166,7 +166,7 @@ describe '#bid', ->
   describe 'when not registered', ->
     beforeEach ->
       metaphysicsStub = sinon.stub()
-      metaphysicsStub.withArgs(sinon.match({ query: sinon.match(/has_qualified_credit_cards/) })).returns(
+      metaphysicsStub.returns(
         Q.resolve(
           me: { has_qualified_credit_cards: true, bidders: null }
           artwork: sale_artwork: bid_increments: [100]

--- a/src/desktop/apps/auction_support/test/routes.coffee
+++ b/src/desktop/apps/auction_support/test/routes.coffee
@@ -128,10 +128,10 @@ describe '#bid', ->
   describe 'with current user', ->
     beforeEach ->
       metaphysicsStub = sinon.stub()
-      metaphysicsStub.withArgs(sinon.match({ query: ' {\n  me {\n    has_qualified_credit_cards\n    bidders(sale_id: "awesome-sale") {\n      id\n    }\n  }\n} ' })).returns(
+      metaphysicsStub.withArgs(sinon.match({ query: sinon.match(/has_qualified_credit_cards/) })).returns(
         Q.resolve(me: { has_qualified_credit_cards: true, bidders: ['foo'] })
       )
-      metaphysicsStub.withArgs(sinon.match({ query: ' {\n  artwork(id: "artwork-id") {\n    sale_artwork {\n      bid_increments\n    }\n  }\n} ' })).returns(
+      metaphysicsStub.withArgs(sinon.match({ query: sinon.match(/bid_increments/) })).returns(
         Q.resolve(artwork: sale_artwork: bid_increments: [100])
       )
       routes.__set__ 'metaphysics', metaphysicsStub
@@ -167,10 +167,10 @@ describe '#bid', ->
   describe 'when not registered', ->
     beforeEach ->
       metaphysicsStub = sinon.stub()
-      metaphysicsStub.withArgs(sinon.match({ query: ' {\n  me {\n    has_qualified_credit_cards\n    bidders(sale_id: "awesome-sale") {\n      id\n    }\n  }\n} ' })).returns(
+      metaphysicsStub.withArgs(sinon.match({ query: sinon.match(/has_qualified_credit_cards/) })).returns(
         Q.resolve(me: { has_qualified_credit_cards: true, bidders: null })
       )
-      metaphysicsStub.withArgs(sinon.match({ query: ' {\n  artwork(id: "artwork-id") {\n    sale_artwork {\n      bid_increments\n    }\n  }\n} ' })).returns(
+      metaphysicsStub.withArgs(sinon.match({ query: sinon.match(/bid_increments/) })).returns(
         Q.resolve(artwork: sale_artwork: bid_increments: [100])
       )
       routes.__set__ 'metaphysics', metaphysicsStub

--- a/src/desktop/apps/auction_support/test/routes.coffee
+++ b/src/desktop/apps/auction_support/test/routes.coffee
@@ -127,12 +127,11 @@ describe '#bid', ->
 
   describe 'with current user', ->
     beforeEach ->
-      metaphysicsStub = sinon.stub()
-      metaphysicsStub.withArgs(sinon.match({ query: sinon.match(/has_qualified_credit_cards/) })).returns(
-        Q.resolve(me: { has_qualified_credit_cards: true, bidders: ['foo'] })
-      )
-      metaphysicsStub.withArgs(sinon.match({ query: sinon.match(/bid_increments/) })).returns(
-        Q.resolve(artwork: sale_artwork: bid_increments: [100])
+      metaphysicsStub = sinon.stub().returns(
+        Q.resolve(
+          me: { has_qualified_credit_cards: true, bidders: ['foo'] }
+          artwork: sale_artwork: bid_increments: [100]
+        )
       )
       routes.__set__ 'metaphysics', metaphysicsStub
 
@@ -168,10 +167,10 @@ describe '#bid', ->
     beforeEach ->
       metaphysicsStub = sinon.stub()
       metaphysicsStub.withArgs(sinon.match({ query: sinon.match(/has_qualified_credit_cards/) })).returns(
-        Q.resolve(me: { has_qualified_credit_cards: true, bidders: null })
-      )
-      metaphysicsStub.withArgs(sinon.match({ query: sinon.match(/bid_increments/) })).returns(
-        Q.resolve(artwork: sale_artwork: bid_increments: [100])
+        Q.resolve(
+          me: { has_qualified_credit_cards: true, bidders: null }
+          artwork: sale_artwork: bid_increments: [100]
+        )
       )
       routes.__set__ 'metaphysics', metaphysicsStub
 

--- a/src/desktop/apps/auction_support/test/templates.coffee
+++ b/src/desktop/apps/auction_support/test/templates.coffee
@@ -54,7 +54,7 @@ describe 'Auction', ->
 
   describe 'bid template', ->
 
-    it 'renders the template for unregistred users without errors', ->
+    it 'renders the template for unregistered users without errors', ->
       template = render('bid-form')
         sd: @sd
         sale: @sale
@@ -63,6 +63,7 @@ describe 'Auction', ->
         bidderPositions: new BidderPositions([fabricate 'bidder_position'],
           { saleArtwork: @saleArtwork, sale: @sale })
         isRegistered: false
+        hasValidCreditCard: false
         maxBid: 1234
         monthRange: @order.getMonthRange()
         yearRange: @order.getYearRange()
@@ -73,7 +74,27 @@ describe 'Auction', ->
       @$template.html().should.not.containEql 'undefined'
       @$template.find('.bid-registration-form-contents').length.should.equal 1
 
-    it 'renders the template for registred users without errors', ->
+    it 'renders the template without a credit card form if hasValidCreditCard is true', ->
+      template = render('bid-form')
+        sd: @sd
+        sale: @sale
+        artwork: @saleArtwork.artwork()
+        saleArtwork: @saleArtwork
+        bidderPositions: new BidderPositions([fabricate 'bidder_position'],
+          { saleArtwork: @saleArtwork, sale: @sale })
+        isRegistered: false
+        hasValidCreditCard: true
+        maxBid: 1234
+        monthRange: @order.getMonthRange()
+        yearRange: @order.getYearRange()
+        accounting: formatMoney: ->
+        bidIncrements: []
+        asset: ->
+      @$template = $(template)
+      @$template.html().should.not.containEql 'undefined'
+      @$template.find('.bid-registration-form-contents').length.should.equal 0
+
+    it 'renders the template for registered users without errors', ->
       template = render('bid-form')
         sd: @sd
         sale: @sale


### PR DESCRIPTION
This PR addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-85

We now return whether or not a user has a valid credit card through the `has_valid_credit_cards` field under `me` (from metaphysics).

I updated the flow slightly to also grab whether or not a user is registered for the sale in the same metaphysics query as above. It's not really any more efficient but it's a little easier to follow this logic than to have to poke through backbone models.

For clarity, here's what the logic does:
- when you click "Bid" on the artwork page, we check to see if you are `isRegistered` and `hasValidCreditCard`.
  - If `isRegistered` is true, then we show you a confirm bid page with no cc form attached
    - when you click "bid" we just create a bidder position via the `me/bidder_positions` endpoint
  - If `isRegistered` is false but `hasValidCreditCard` is true, we show you a confirm bid page with no cc form attached
    - when you click "bid", we also _only_ call the `me/bidder_positions` endpoint which [has logic](https://github.com/artsy/gravity/blob/master/app/api/v1/me_bidder_positions_endpoint.rb#L61-L66) to create a bidder before creating the bidder position
  - If `isRegistered` is false and `hasValidCreditCard` is false, we show you a confirm bid page with a cc form attached
    - when you submit the form, we first call `/bidder` to create a bidder, and then call `me/bidder_positions` to create the position

Leaving this as WIP because as part of my local QA I noticed that for the case where we just call `me/bidder_positions` to both create the bidder _and_ the bidder position, we aren't triggering an [email from pulse](https://github.com/artsy/gravity/blob/master/app/api/v1/bidders_endpoint.rb#L67) as we do from the `/bidder` endpoint. I'll follow up with a gravity PR to do that.

(blocking) gravity PR: https://github.com/artsy/gravity/pull/11702