### PR TITLE
@xtina-starr => Use mediator to trigger auth modal where possible

### DIFF
--- a/src/desktop/apps/artsy_primer/personalize/client/index.coffee
+++ b/src/desktop/apps/artsy_primer/personalize/client/index.coffee
@@ -7,7 +7,6 @@ PersonalizeState = require './state.coffee'
 mediator = require '../../../../lib/mediator.coffee'
 CurrentUser = require '../../../../models/current_user.coffee'
 Transition = require '../../../../components/mixins/transition.coffee'
-AuthModalView = require '../../../../components/auth_modal/view.coffee'
 analyticsHooks = require '../../../../lib/analytics_hooks.coffee'
 Cookies = require 'cookies-js'
 NextStepView = require './views/next_step.coffee'
@@ -95,9 +94,10 @@ module.exports.init = ->
       # Don't let the user close out by hacking the close points
       $('.modal-close').hide()
       $('.modal-backdrop').click (e) -> e.stopPropagation()
-    new AuthModalView
+
+    mediator.trigger 'open:auth',
       mode: 'register'
-      redirectTo: location.href
+      destination: location.href
       width: 500
 
   # Init the personalize flow

--- a/src/desktop/apps/artwork/components/auction/view.coffee
+++ b/src/desktop/apps/artwork/components/auction/view.coffee
@@ -4,7 +4,7 @@ Backbone = require 'backbone'
 Form = require '../../../../components/form/index.coffee'
 openMultiPageModal = require '../../../../components/multi_page_modal/index.coffee'
 openBuyersPremiumModal = require './components/buyers_premium/index.coffee'
-AuthModalView = require '../../../../components/auth_modal/view.coffee'
+mediator = require '../../../../lib/mediator.coffee'
 inquire = require '../../lib/inquire.coffee'
 acquire = require '../../lib/acquire.coffee'
 helpers = require './helpers.coffee'
@@ -79,7 +79,7 @@ module.exports = class ArtworkAuctionView extends Backbone.View
     form = new Form $form: @$('.js-artwork-auction-bid')
 
     if not CURRENT_USER?
-      return new AuthModalView
+      return mediator.trigger 'open:auth',
         width: '500px',
         signupIntent: 'bid'
         mode: 'register'

--- a/src/desktop/apps/artwork_purchase/client/index.coffee
+++ b/src/desktop/apps/artwork_purchase/client/index.coffee
@@ -6,7 +6,6 @@ CurrentUser = require '../../../models/current_user.coffee'
 PurchaseForm = require './purchase_form.coffee'
 SignupForm = require './purchase_signup_form.coffee'
 successTemplate = ->require('../templates/success.jade') arguments...
-AuthModalView = require '../../../components/auth_modal/view.coffee'
 mediator = require '../../../lib/mediator.coffee'
 Cookies = require '../../../components/cookies/index.coffee'
 Sticky = require '../../../components/sticky/index.coffee'
@@ -56,9 +55,7 @@ class PurchaseView extends Backbone.View
     }, @purchaseForm.serializeForm()
     Cookies.set 'purchase-inquiry', JSON.stringify formData
 
-# Signup
-  # Submit
-
+  # Signup and submit
   submitSignupForm: (form, options) ->
     # Validate both forms before moving on.
     # Call 'forIsSubmitting' on both forms to disable them both while request is in-flight.

--- a/src/desktop/apps/auctions/client/index.coffee
+++ b/src/desktop/apps/auctions/client/index.coffee
@@ -2,7 +2,7 @@
 Auctions = require '../../../collections/auctions.coffee'
 Clock = require '../../../components/clock/view.coffee'
 ModalPageView = require '../../../components/modal/page.coffee'
-AuthModalView = require '../../../components/auth_modal/view.coffee'
+mediator = require '../../../lib/mediator.coffee'
 MyActiveBids = require '../../../components/my_active_bids/view.coffee'
 CurrentUser = require '../../../models/current_user.coffee'
 myActiveBidsTemplate = -> require('../templates/my_active_bids.jade') arguments...
@@ -33,4 +33,6 @@ module.exports.init = ->
 
   $('.js-sign-up-button').click (e) ->
     e.preventDefault()
-    new AuthModalView width: '500px', mode: 'register'
+    mediator.trigger 'open:auth',
+      width: '500px',
+      mode: 'register'

--- a/src/desktop/apps/how_auctions_work/client/index.coffee
+++ b/src/desktop/apps/how_auctions_work/client/index.coffee
@@ -1,5 +1,5 @@
 multiPageView = require '../../../components/multi_page/index.coffee'
-AuthModalView = require '../../../components/auth_modal/view.coffee'
+mediator = require '../../../lib/mediator.coffee'
 
 module.exports.init = ->
   view = multiPageView 'auction-faqs'
@@ -16,7 +16,7 @@ module.exports.init = ->
 
   $('.js-register-button').click (e) ->
     e.preventDefault()
-    new AuthModalView
+    mediator.trigger 'open:auth',
       width: '500px',
       mode: 'register'
       copy: 'Sign up to bid on artworks'

--- a/src/desktop/apps/inquiry/client/routes/development.coffee
+++ b/src/desktop/apps/inquiry/client/routes/development.coffee
@@ -3,7 +3,7 @@ _ = require 'underscore'
 User = require '../../../../models/user.coffee'
 Artwork = require '../../../../models/artwork.coffee'
 ArtworkInquiry = require '../../../../models/artwork_inquiry.coffee'
-AuthModalView = require '../../../../components/auth_modal/view.coffee'
+mediator = require '../../../../lib/mediator.coffee'
 EmbeddedInquiryView = require '../../../../components/embedded_inquiry/view.coffee'
 openInquiryQuestionnaireFor = require '../../../../components/inquiry_questionnaire/index.coffee'
 Logger = require '../../../../components/logger/index.coffee'
@@ -47,7 +47,7 @@ module.exports = ->
   # Handle login/out
   $('.js-login').click (e) ->
     e.preventDefault()
-    new AuthModalView width: '500px', mode: 'login'
+    mediator.trigger 'open:auth', width: '500px', mode: 'login'
   $('.js-logout').click (e) ->
     e.preventDefault()
     $.ajax url: '/users/sign_out', type: 'DELETE', success: -> location.reload()

--- a/src/desktop/apps/pro_buyer/pages/landing/client/view.coffee
+++ b/src/desktop/apps/pro_buyer/pages/landing/client/view.coffee
@@ -3,7 +3,7 @@
 { SHOW_PATH } = require('sharify').data
 Form = require '../../../../../components/form/index.coffee'
 scrollTo = require '../../../../../components/smooth_scroll/index.coffee'
-AuthModalView = require '../../../../../components/auth_modal/view.coffee'
+mediator = require '../../../../../lib/mediator.coffee'
 analyticsHooks = require '../../../../../lib/analytics_hooks.coffee'
 template = -> require('../templates/page.jade') arguments...
 
@@ -61,7 +61,7 @@ module.exports = class ProfessionalBuyerLandingView extends View
         analyticsHooks.trigger 'auth:register'
 
   authenticate: (mode) ->
-    new AuthModalView
+    mediator.trigger 'open:auth',
       mode: mode
       width: '500px'
       copy: 'Artsy Professional Buyer Program'

--- a/src/desktop/components/artist_page_cta/view.coffee
+++ b/src/desktop/components/artist_page_cta/view.coffee
@@ -6,7 +6,6 @@ Form = require '../mixins/form.coffee'
 Mailcheck = require '../mailcheck/index.coffee'
 mediator = require '../../lib/mediator.coffee'
 LoggedOutUser = require '../../models/logged_out_user.coffee'
-AuthModalView = require '../auth_modal/view.coffee'
 template = -> require('./templates/index.jade') arguments...
 overlayTemplate = -> require('./templates/overlay.jade') arguments...
 FormErrorHelpers = require('../auth_modal/helpers')
@@ -44,7 +43,7 @@ module.exports = class ArtistPageCTAView extends Backbone.View
 
   triggerLoginModal: (e) ->
     e.stopPropagation()
-    new AuthModalView
+    mediator.trigger 'open:auth',
       width: '500px'
       mode: 'login'
       redirectTo: @afterAuthPath

--- a/src/desktop/components/artwork_save/view.coffee
+++ b/src/desktop/components/artwork_save/view.coffee
@@ -1,5 +1,5 @@
 Backbone = require 'backbone'
-AuthModalView = require '../auth_modal/view.coffee'
+mediator = require '../../lib/mediator.coffee'
 analyticsHooks = require '../../lib/analytics_hooks.coffee'
 
 module.exports = class ArtworkSaveView extends Backbone.View
@@ -25,7 +25,7 @@ module.exports = class ArtworkSaveView extends Backbone.View
     e.preventDefault()
 
     if not @user.isLoggedIn()
-      return new AuthModalView
+      return mediator.trigger 'open:auth',
         width: '500px',
         mode: 'register'
         copy: 'Sign up to save artworks'

--- a/src/desktop/components/auction_artwork_brick/view.coffee
+++ b/src/desktop/components/auction_artwork_brick/view.coffee
@@ -1,7 +1,7 @@
 { invoke } = require 'underscore'
 Backbone = require 'backbone'
 { CURRENT_USER } = require('sharify').data
-AuthModalView = require '../auth_modal/view.coffee'
+mediator = require '../../lib/mediator.coffee'
 ArtworkSaveView = require '../artwork_save/view.coffee'
 
 module.exports = class AuctionArtworkBrickView extends Backbone.View
@@ -16,7 +16,7 @@ module.exports = class AuctionArtworkBrickView extends Backbone.View
     if not CURRENT_USER?
       e.preventDefault()
 
-      return new AuthModalView
+      return mediator.trigger 'open:auth',
         width: '500px',
         mode: 'register'
         copy: 'Sign up to bid'

--- a/src/desktop/components/auth_modal/view.coffee
+++ b/src/desktop/components/auth_modal/view.coffee
@@ -36,7 +36,7 @@ module.exports = class AuthModalView extends ModalView
     return if isEigen.checkWith options
     { @destination, @successCallback, @afterSignUpAction } = options
     @redirectTo = encodeURIComponent(sanitizeRedirect(options.redirectTo)) if options.redirectTo
-    
+
     @preInitialize options
     super
 
@@ -74,7 +74,7 @@ module.exports = class AuthModalView extends ModalView
     mode = @state.get 'mode'
     if (mode is 'signup' or mode is 'register') and !@destination
       @destination = currentPath unless @redirectTo
-    
+
     switch mode
       when 'login' then postLoginPath
       when 'signup' then postSignupPath

--- a/src/desktop/components/cta_bar/view.coffee
+++ b/src/desktop/components/cta_bar/view.coffee
@@ -1,7 +1,7 @@
 _ = require 'underscore'
 Backbone = require 'backbone'
 Form = require '../mixins/form.coffee'
-AuthModalView = require '../auth_modal/view.coffee'
+mediator = require '../../lib/mediator.coffee'
 Cookies = require '../cookies/index.coffee'
 analyticsHooks = require '../../lib/analytics_hooks.coffee'
 CurrentUser = require '../../models/current_user.coffee'
@@ -68,8 +68,10 @@ module.exports = class CTABarView extends Backbone.View
 
   openModal: (options = {}) ->
     @close()
-    new AuthModalView _.extend {
-      width: '500px', mode: 'register', redirectTo: @linkHref
+    mediator.trigger 'open:auth', _.extend {
+      width: '500px',
+      mode: 'register',
+      redirectTo: @linkHref
     }, @modalOptions, options
 
   render: ->


### PR DESCRIPTION
Consolidates most of the places where we were using AuthModalView directly instead of going through the mediator. 

There are a few places remaining that will have to be refactored as we get the main modal in --
- InquireViaPhoneModalView which extends AuthModalView
- FairHeaderView which does not have the main_layout nav to trigger mediator

Addresses https://artsyproduct.atlassian.net/browse/GROW-587