### PR TITLE
@xtina-starr => Add published_at to relatedArticles query

### DIFF
--- a/src/desktop/apps/article/queries/relatedArticles.js
+++ b/src/desktop/apps/article/queries/relatedArticles.js
@@ -26,6 +26,7 @@ export const relatedArticles = `
     thumbnail_image
     title
     slug
+    published_at
     media {
       duration
       published


### PR DESCRIPTION
Fixes [GROW-589](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-589)

RelatedArticles in the Vanguard series were rendering today's date rather than published_at, because we weren't returning the expected field in the query.