### PR TITLE
close out artist merch test and launch homepage search test

### DIFF
--- a/src/desktop/apps/artist/client/index.coffee
+++ b/src/desktop/apps/artist/client/index.coffee
@@ -5,14 +5,8 @@ Artist = require '../../../models/artist.coffee'
 CurrentUser = require '../../../models/current_user.coffee'
 ArtistRouter = require './router.coffee'
 FollowedArtistsRailView = require '../../home/components/followed_artists/view.coffee'
-splitTest = require '../../../components/split_test/index.coffee'
 
-testGroup = sd.ARTIST_MERCH_TEST
-
-module.exports.init = ->
-  # ARTIST_MERCH_TEST remove after test closes
-  splitTest('artist_merch_test').view()
-  
+module.exports.init = ->  
   statuses = ARTIST.statuses
   artist = new Artist ARTIST
   user = CurrentUser.orNull()
@@ -21,6 +15,5 @@ module.exports.init = ->
   router = new ArtistRouter
     model: artist,
     statuses: statuses,
-    user: user,
-    testGroup: testGroup
+    user: user
   Backbone.history.start pushState: true

--- a/src/desktop/apps/artist/client/router.coffee
+++ b/src/desktop/apps/artist/client/router.coffee
@@ -32,8 +32,8 @@ module.exports = class ArtistRouter extends Backbone.Router
     'artist/:id/biography': 'biography'
     'artist/:id/auction-results': 'auctionResults'
 
-  initialize: ({ @model, @user, @statuses, @testGroup }) ->
-    @options = model: @model, user: @user, statuses: @statuses, testGroup: @testGroup, el: $('.artist-page-content')
+  initialize: ({ @model, @user, @statuses }) ->
+    @options = model: @model, user: @user, statuses: @statuses, el: $('.artist-page-content')
     @setupUser()
     @setupJump()
     @setupCarousel()
@@ -76,7 +76,6 @@ module.exports = class ArtistRouter extends Backbone.Router
       el: @options.el
       artistID: @model.get('id')
       topOffset: $('.artist-sticky-header-container').height()
-      testGroup: @options.testGroup
 
     $('body').append @jump.$el
 

--- a/src/desktop/apps/artist/client/views/overview.coffee
+++ b/src/desktop/apps/artist/client/views/overview.coffee
@@ -21,7 +21,7 @@ module.exports = class OverviewView extends Backbone.View
   subViews: []
   fetches: []
 
-  initialize: ({ @user, @statuses, @testGroup }) ->
+  initialize: ({ @user, @statuses }) ->
     @listenTo this, 'artist:overview:sync', @renderRelated
 
   fetchRelated: ->
@@ -91,7 +91,6 @@ module.exports = class OverviewView extends Backbone.View
       el: @$('#artwork-section')
       artistID: @model.get('id')
       topOffset: $('.artist-sticky-header-container').height()
-      testGroup: @testGroup
     ).render()
 
     @listenToOnce mediator, 'infinite:scroll:end', =>
@@ -130,8 +129,6 @@ module.exports = class OverviewView extends Backbone.View
       artist: @model.toJSON()
       viewHelpers: viewHelpers
       statuses: @statuses
-      showSections:
-        info: @testGroup is 'merch_sort' or @testGroup is 'control'
 
     _.defer => @postRender()
     this

--- a/src/desktop/apps/artist/routes.coffee
+++ b/src/desktop/apps/artist/routes.coffee
@@ -34,7 +34,6 @@ sd = require('sharify').data
       nav = new Nav artist: artist
 
       return res.redirect(artist.href) unless(_.find nav.sections(), slug: tab) or artist.counts.artworks is 0
-      testGroup = res.locals.sd.ARTIST_MERCH_TEST
 
       if (req.params.tab? or artist.href is res.locals.sd.CURRENT_PATH)
         currentVeniceFeature(artist)
@@ -53,8 +52,6 @@ sd = require('sharify').data
               nav: nav
               currentItem: currentItem
               jsonLD: JSON.stringify helpers.toJSONLD artist if isReqFromReflection
-              showSections:
-                header: testGroup is 'merch_sort' or testGroup is 'control'
 
       else
         res.redirect artist.href

--- a/src/desktop/apps/artist/templates/index.jade
+++ b/src/desktop/apps/artist/templates/index.jade
@@ -9,7 +9,7 @@ append locals
 
 block body
   - carousel = artist.carousel
-  - hasCarousel = carousel && carousel.images.length >= 4 && showSections.header
+  - hasCarousel = carousel && carousel.images.length >= 4
 
   #artist-page(
     class=(hasCarousel ? 'has-carousel' : 'has-no-carousel')

--- a/src/desktop/apps/artist/templates/sections/overview.jade
+++ b/src/desktop/apps/artist/templates/sections/overview.jade
@@ -10,32 +10,31 @@ mixin rail(title, viewAllUrl, section)
 
         include ../../../../components/merry_go_round/templates/horizontal_navigation
 
-if showSections.info
-  .artist-overview-header
-    .evenly-bisected-header
-      - var artistMeta = viewHelpers.artistMeta(artist)
+.artist-overview-header
+  .evenly-bisected-header
+    - var artistMeta = viewHelpers.artistMeta(artist)
 
-      - var hasMeta = viewHelpers.hasOverviewHeaderMeta(artist)
-      - var hasShows = statuses.shows || statuses.cv
+    - var hasMeta = viewHelpers.hasOverviewHeaderMeta(artist)
+    - var hasShows = statuses.shows || statuses.cv
 
-      .bisected-header-cell.js-artist-overview-header-left
-        if hasMeta
-          .artist-blurb.bisected-header-cell-section
-            h2 Biography
-            if artist.biography_blurb && artist.biography_blurb.text
-              .blurb!= artist.biography_blurb.text
-              if artist.biography_blurb.credit
-                .artist-blurb__credit &mdash; #{artist.biography_blurb.credit}
-              if artistMeta.length
-                br
+    .bisected-header-cell.js-artist-overview-header-left
+      if hasMeta
+        .artist-blurb.bisected-header-cell-section
+          h2 Biography
+          if artist.biography_blurb && artist.biography_blurb.text
+            .blurb!= artist.biography_blurb.text
+            if artist.biography_blurb.credit
+              .artist-blurb__credit &mdash; #{artist.biography_blurb.credit}
+            if artistMeta.length
+              br
 
-          if artistMeta.length
-            .artist-meta-detail!= artistMeta
+        if artistMeta.length
+          .artist-meta-detail!= artistMeta
 
-      .bisected-header-cell.js-artist-overview-header-right
-        if hasShows
-          .artist-exhibition-highlights.bisected-header-cell-section
-            //- Rendered client-side
+    .bisected-header-cell.js-artist-overview-header-right
+      if hasShows
+        .artist-exhibition-highlights.bisected-header-cell-section
+          //- Rendered client-side
 
 if artist.statuses.artworks
   include ./works

--- a/src/desktop/apps/home/client/index.coffee
+++ b/src/desktop/apps/home/client/index.coffee
@@ -15,6 +15,7 @@ Articles = require '../../../collections/articles'
 Items = require '../../../collections/items'
 featuredArticlesTemplate = -> require('../templates/featured_articles.jade') arguments...
 featuredShowsTemplate = -> require('../templates/featured_shows.jade') arguments...
+splitTest = require '../../../components/split_test/index.coffee'
 { resize } = require '../../../components/resizer/index.coffee'
 sd = require('sharify').data
 _ = require 'underscore'
@@ -27,13 +28,13 @@ module.exports.HomeView = class HomeView extends Backbone.View
     'blur #main-layout-search-bar-container': 'unhighlightSearch'
     'click #main-layout-search-bar-button': 'performSearch'
 
-  initialize: ->
+  initialize: ({ @testGroup }) ->
     # Set up a router for the /log_in /sign_up and /forgot routes
     new HomeAuthRouter
     Backbone.history.start pushState: true
 
     # Render Featured Sections
-    if sd.HIDE_HERO_UNITS then @setupSearchBar() else @setupHeroUnits()
+    if @testGroup is 'experiment' then @setupSearchBar() else @setupHeroUnits()
     @setupFeaturedShows()
     @setupFeaturedArticles()
 
@@ -72,6 +73,7 @@ module.exports.HomeView = class HomeView extends Backbone.View
       mode: 'suggest'
       limit: 7
       centeredHomepageSearch: true
+      
     @searchBarView.on 'search:entered', (term) -> window.location = "/search?q=#{term}"
     @searchBarView.on 'search:selected', @searchBarView.selectResult
     throttledScroll = _.throttle((=> @onScroll()), 100)
@@ -113,8 +115,8 @@ module.exports.HomeView = class HomeView extends Backbone.View
 
 module.exports.init = ->
   user = CurrentUser.orNull()
-
-  new HomeView el: $('body')
+  splitTest('home_search_test').view()
+  new HomeView el: $('body'), testGroup: sd.HOME_SEARCH_TEST
 
   setupHomePageModules()
   setupArtistsToFollow user

--- a/src/desktop/apps/home/routes.coffee
+++ b/src/desktop/apps/home/routes.coffee
@@ -39,6 +39,9 @@ fetchMetaphysicsData = (req, showHeroUnits)->
 @index = (req, res, next) ->
   return if metaphysics.debug req, res, { method: 'post', query: query }
 
+  hideHeroUnits = res.locals.sd.HOME_SEARCH_TEST is 'experiment'
+  res.locals.sd.HIDE_HERO_UNITS = hideHeroUnits  
+  
   # homepage:featured-sections
   featuredLinks = new Items [], id: '529939e2275b245e290004a0', item_type: 'FeaturedLink'
 
@@ -53,8 +56,8 @@ fetchMetaphysicsData = (req, showHeroUnits)->
     }
   }
 
-  hideHeroUnits = req.user?.hasLabFeature('Homepage Search')
   initialFetch = fetchMetaphysicsData req, false if hideHeroUnits
+
   unless hideHeroUnits
     initialFetch = Q
       .allSettled [
@@ -79,9 +82,9 @@ fetchMetaphysicsData = (req, showHeroUnits)->
       res.locals.sd.RESET_PASSWORD_REDIRECT_TO = req.query.reset_password_redirect_to
       res.locals.sd.SET_PASSWORD = req.query.set_password
 
-      res.locals.sd.HIDE_HERO_UNITS = hideHeroUnits
       res.render 'index',
         heroUnits: heroUnits
+        testGroup: res.locals.sd.HOME_SEARCH_TEST
         modules: homePage.artwork_modules
         featuredLinks: featuredLinks
         viewHelpers: viewHelpers

--- a/src/desktop/apps/home/templates/index.jade
+++ b/src/desktop/apps/home/templates/index.jade
@@ -8,11 +8,11 @@ append locals
   - bodyClass = bodyClass + ' body-no-margins body-header-fixed body-transparent-header' + (heroUnits.length && heroUnits[0].mode.match('LIGHT') ? '-white' : '')
 
 block body
-  unless sd.HIDE_HERO_UNITS
+  unless testGroup == 'experiment'
     include hero_units
 
   #home-foreground
-    if sd.HIDE_HERO_UNITS
+    if testGroup == 'experiment'
       h3= 'Collect art from leading galleries and auction houses.'
       include ../../../components/search_bar/templates/index
     else
@@ -23,7 +23,7 @@ block body
 
     #home-layout-container.responsive-layout-container
       .main-layout-container: #home-body
-        unless sd.HIDE_HERO_UNITS
+        unless testGroup == 'experiment'
           include featured_links
         unless user
           include browse

--- a/src/desktop/components/artwork_filter_2/view.coffee
+++ b/src/desktop/components/artwork_filter_2/view.coffee
@@ -14,14 +14,11 @@ template = -> require('./templates/index.jade') arguments...
 module.exports = class ArtworkFilterView extends Backbone.View
   subviews: []
 
-  initialize: ({ @artistID, @topOffset = 0, @testGroup }) ->
+  initialize: ({ @artistID, @topOffset = 0 }) ->
     @siteHeaderHeight = $('#main-layout-header').outerHeight(true)
     @path = window.location.pathname
     paramsFromUrl = qs.parse(window.location.search.replace(/^\?/, ''))
     @params = new Params paramsFromUrl
-    
-    if not @params.get('sort') and @testGroup != 'control'
-      @params.updateWith 'sort', '-decayed_merch'
 
     @filter = new Filter
       params: @params
@@ -38,7 +35,6 @@ module.exports = class ArtworkFilterView extends Backbone.View
     { @sticky } = new FiltersView _.extend
       el: @$('.artwork-filter-criteria'),
       stickyOffset: @siteHeaderHeight + @topOffset,
-      testGroup: @testGroup,
       { counts, @params }
     @subviews.push new CountView _.extend el: @$('#artwork-filter-right__totals'), { counts, @params }
     @subviews.push new SortsView _.extend el: @$('#artwork-filter-right__sorts-dropdown'), { @params }

--- a/src/desktop/components/artwork_filter_2/views/filters_view.coffee
+++ b/src/desktop/components/artwork_filter_2/views/filters_view.coffee
@@ -15,7 +15,7 @@ module.exports = class ArtworkFiltersView extends Backbone.View
     'click .js-artwork-filter-remove'   : 'filterDeselected'
     'click .js-artwork-filter-view-all' : 'seeAllClicked'
 
-  initialize: ({ @params, @counts, stickyOffset = 0, @testGroup }) ->
+  initialize: ({ @params, @counts, stickyOffset = 0 }) ->
     @sticky = new Sticky
     @sticky.headerHeight = stickyOffset
 
@@ -29,7 +29,7 @@ module.exports = class ArtworkFiltersView extends Backbone.View
 
   render: ->
     forSaleTotal = @counts.get 'for_sale'
-    forSaleFilter = @testGroup == 'control'
+    forSaleFilter = true
     key = if forSale = @params.get 'for_sale' then 'for_sale' else 'all'
     aggregations = @counts.aggregations?[key]
 

--- a/src/desktop/components/search_bar/templates/index.jade
+++ b/src/desktop/components/search_bar/templates/index.jade
@@ -24,7 +24,7 @@
 
     a#main-layout-search-bar-icon.icon-search
     
-    if sd.HIDE_HERO_UNITS
+    if sd.HOME_SEARCH_TEST == 'experiment' && centeredHomepageSearch
       a#main-layout-search-bar-button.avant-garde-button-black Search
 
     #main-layout-search-bar-spinner: .loading-spinner-small

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -25,15 +25,12 @@
 # module.exports = {}
 
 module.exports = {
-  artist_merch_test:
-    key: 'artist_merch_test'
-    weighting: 'equal'
-    outcomes: [
-      'control'
-      'no_header_merch_sort'
-      'merch_sort'
-    ]
+  home_search_test:
+    key: 'home_search_test'
+    outcomes:
+      experiment: 50
+      control: 50
     control_group: 'control'
-    edge: 'merch_sort'
+    edge: 'experiment'
 }
 


### PR DESCRIPTION
This closes out the artist merch test in favour of the control group, and launches a homepage search test (whose key for analytics purposes is `home_search_test`) with two groups `control` and `experiment`.

To test on staging:

http://staging.artsy.net/?split_test[home_search_test]=control
http://staging.artsy.net/?split_test[home_search_test]=experiment

Also worth testing artist pages and checking that the search bar looks as it should on other artsy.net  pages.