### PR TITLE
@joeyAghion => Add a few granular flags to replace NODE_ENV

### DIFF
--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -55,14 +55,14 @@ setTimeout(function() {
   })
 }, 180000)
 
-// debug tracking calls in development
-if (sd.NODE_ENV !== 'production') {
+// debug tracking calls
+if (sd.SHOW_ANALYTICS_CALLS) {
   analytics.on('track', function() {
     console.info('TRACKED: ', arguments[0], JSON.stringify(arguments[1]))
   })
 }
 
-if (sd.NODE_ENV === 'development') {
+if (sd.SHOW_ANALYTICS_CALLS) {
   analyticsHooks.on('all', function(name, data) {
     console.info('ANALYTICS HOOK: ', name, data)
   })

--- a/src/desktop/apps/sitemaps/routes.coffee
+++ b/src/desktop/apps/sitemaps/routes.coffee
@@ -4,7 +4,7 @@ request = require 'superagent'
 moment = require 'moment'
 async = require 'async'
 PartnerFeaturedCities = require '../../collections/partner_featured_cities'
-{ NODE_ENV, API_URL, POSITRON_URL, APP_URL, ARTSY_EDITORIAL_CHANNEL, SITEMAP_BASE_URL } = require('sharify').data
+{ API_URL, POSITRON_URL, APP_URL, ARTSY_EDITORIAL_CHANNEL, ENABLE_WEB_CRAWLING, SITEMAP_BASE_URL } = require('sharify').data
 artsyXapp = require 'artsy-xapp'
 PAGE_SIZE = 100
 { parse } = require 'url'
@@ -63,8 +63,4 @@ sitemapProxy = httpProxy.createProxyServer(target: SITEMAP_BASE_URL)
     Sitemap: #{APP_URL}/sitemap-videos.xml
 
   """
-  res.send switch NODE_ENV
-    when 'production'
-      robotsText
-    else
-      "User-agent: *\nNoindex: /"
+  res.send if ENABLE_WEB_CRAWLING then robotsText else "User-agent: *\nNoindex: /"

--- a/src/desktop/apps/sitemaps/test/routes.coffee
+++ b/src/desktop/apps/sitemaps/test/routes.coffee
@@ -24,20 +24,19 @@ describe 'Sitemaps', ->
       @res = set: sinon.stub(), send: sinon.stub()
 
     afterEach ->
-      routes.__set__ 'NODE_ENV', 'test'
+      routes.__set__ 'ENABLE_WEB_CRAWLING', false
 
-    it 'renders a noindex in anything but production', ->
-      routes.__set__ 'NODE_ENV', 'staging'
+    it 'renders a noindex when ENABLE_WEB_CRAWLING is false', ->
+      routes.__set__ 'ENABLE_WEB_CRAWLING', false
       routes.robots null, @res
       @res.send.args[0][0]
         .should.equal  'User-agent: *\nNoindex: /'
 
-    describe 'production', ->
+    describe 'when ENABLE_WEB_CRAWLING is true', ->
       beforeEach ->
-        routes.__set__ NODE_ENV: 'production', APP_URL: 'https://www.artsy.net'
+        routes.__set__ ENABLE_WEB_CRAWLING: true, APP_URL: 'https://www.artsy.net'
         routes.robots null, @res
-
-      it 'renders the normal robots with sitemap in production', ->
+      it 'renders robots.txt', ->
         @res.send.args[0][0]
           .should.eql """
 User-agent: *

--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -33,6 +33,7 @@ module.exports =
   EDITORIAL_ADMINS: ''
   EDITORIAL_CTA_BANNER_IMG: 'http://files.artsy.net/images/iphone_email.png'
   ENABLE_EXPERIMENTAL_STITCH_INJECTION: false
+  ENABLE_MEMORY_PROFILING: false
   ENABLE_WEB_CRAWLING: false
   EMAIL_SIGNUP_IMAGES_ID: null
   EMBEDLY_KEY: 'a1f82558d8134f6cbebceb9e67d04980'
@@ -102,6 +103,7 @@ module.exports =
   SESSION_COOKIE_MAX_AGE: 31536000000
   SESSION_SECRET: 'change-me'
   SITEMAP_BASE_URL: 'http://artsy-sitemaps.s3-website-us-east-1.amazonaws.com'
+  SHOW_ANALYTICS_CALLS: false
   STRIPE_PUBLISHABLE_KEY: null
   TEAM_BLOGS: '^\/life-at-artsy$|^\/artsy-education$|^\/gallery-insights$|^\/buying-with-artsy$'
   TARGET_CAMPAIGN_URL: '/seattle-art-fair-2017'

--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -33,6 +33,7 @@ module.exports =
   EDITORIAL_ADMINS: ''
   EDITORIAL_CTA_BANNER_IMG: 'http://files.artsy.net/images/iphone_email.png'
   ENABLE_EXPERIMENTAL_STITCH_INJECTION: false
+  ENABLE_WEB_CRAWLING: false
   EMAIL_SIGNUP_IMAGES_ID: null
   EMBEDLY_KEY: 'a1f82558d8134f6cbebceb9e67d04980'
   EOY_2016_ARTICLE: null

--- a/src/lib/memory_profiler.js
+++ b/src/lib/memory_profiler.js
@@ -8,7 +8,12 @@ const path = require('path')
 const uuid = require('uuid')
 
 const { NODE_ENV } = process.env
-const { S3_KEY, S3_SECRET, S3_BUCKET } = require('../desktop/config')
+const {
+  ENABLE_MEMORY_PROFILING,
+  S3_KEY,
+  S3_SECRET,
+  S3_BUCKET,
+} = require('../desktop/config')
 
 module.exports = () => {
   // Keep track of heap dumps from specific processes.
@@ -68,7 +73,7 @@ module.exports = () => {
   }
 
   log('Enabling memory profiling')
-  if (NODE_ENV !== 'production' && global.gc) {
+  if (ENABLE_MEMORY_PROFILING && global.gc) {
     startLeaking()
   }
 
@@ -97,7 +102,7 @@ module.exports = () => {
         os.tmpdir(),
         `${profileID}-${moment().format('YYYYMMDDHHmmss')}.heapsnapshot`
       )
-      heapdump.writeSnapshot(pathname, (err) => {
+      heapdump.writeSnapshot(pathname, err => {
         if (err) {
           log(`Failed to generate heap dump ${pathname}: ${err.message}`)
           working = false

--- a/src/mobile/analytics/global.js
+++ b/src/mobile/analytics/global.js
@@ -23,13 +23,13 @@ setTimeout(function() {
   })
 }, 180000)
 
-// Debug tracking calls in development
-if (sd.NODE_ENV !== 'production') {
+// Debug tracking calls
+if (sd.SHOW_ANALYTICS_CALLS) {
   analytics.on('track', function() {
     console.debug('TRACKED: ', arguments[0], JSON.stringify(arguments[1]))
   })
 }
-if (sd.NODE_ENV === 'development') {
+if (sd.SHOW_ANALYTICS_CALLS) {
   analyticsHooks.on('all', function(name, data) {
     console.info('ANALYTICS HOOK: ', name, data)
   })

--- a/src/mobile/config.coffee
+++ b/src/mobile/config.coffee
@@ -57,6 +57,7 @@ module.exports =
   SESSION_COOKIE_KEY: 'microgravity-sess'
   SESSION_COOKIE_MAX_AGE: 31536000000
   SESSION_SECRET: 'artsyoss'
+  SHOW_ANALYTICS_CALLS: false
   STRIPE_PUBLISHABLE_KEY: null
   TARGET_CAMPAIGN_URL: '/seattle-art-fair-2017'
   TRACK_PAGELOAD_PATHS: null


### PR DESCRIPTION
While I'm in here, I'll do a sweep for some other places that may need updating to their own flags.

## Migration (after-merge)

On `force-production`:
  Set `ENABLE_WEB_CRAWLING=true`.
  
On `force-staging`:
  Set `SHOW_ANALYTICS_CALLS=true`.
  Set `ENABLE_MEMORY_PROFILING=true`.