### PR TITLE
add analytics event when clicking image in artist carousel

### DIFF
--- a/src/desktop/analytics/artist_page.js
+++ b/src/desktop/analytics/artist_page.js
@@ -1,25 +1,29 @@
 if (location.pathname.match('/artist/.*') && sd.ARTIST) {
-  $('#artist-nav-list a, .artist-tabs a').click(function (e) {
+  $('.artist-tabs a').click(function(e) {
     const tab = $(e.target).text()
     analytics.track('Clicked artist page tab', { tab: tab })
   })
 
-  $('.artist-image-module a').click(function (e) {
-    analytics.track('Clicked artwork on artist page image module')
+  $('.artist-carousel a').click(function() {
+    analytics.track('Click', {
+      type: 'thumbnail',
+      destination_path: $(this).attr('href'),
+      context_module: 'carousel',
+    })
   })
 
-  $('.artist-page-content .gradient-blurb-read-more').click(function (e) {
+  $('.artist-page-content .gradient-blurb-read-more').click(function(e) {
     analytics.track('Clicked to expand artist bio header')
   })
 
-  analyticsHooks.on('artist_page:cta:shown', function () {
+  analyticsHooks.on('artist_page:cta:shown', function() {
     analytics.track('Show artist page sign up prompt')
   })
 
-  analyticsHooks.on('artist_page:cta:hidden', function () {
+  analyticsHooks.on('artist_page:cta:hidden', function() {
     analytics.track('Click', {
       context_module: 'artist page signup prompt',
-      type: 'dismiss'
+      type: 'dismiss',
     })
   })
 }


### PR DESCRIPTION
This story: https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=39&projectKey=EV&modal=detail&selectedIssue=EV-100

@wrgoldstein - this also removes couple of events that we I think from the old elements that were deprecated from the page (don't see any usage of `artist-nav-list` or `artist-image-module`). But I might be wrong. Please let me know if events from those elements still relevant somehow.

Also question - should not `context_module: 'carousel'` somehow mention that it's an artist page carousel as opposed to main home page carousel? Or this info can be deducted from other parts of event?