### PR TITLE
fix issue with search test not showing search button

### DIFF
--- a/src/desktop/components/search_bar/templates/index.jade
+++ b/src/desktop/components/search_bar/templates/index.jade
@@ -24,7 +24,7 @@
 
     a#main-layout-search-bar-icon.icon-search
     
-    if sd.HOME_SEARCH_TEST == 'experiment' && centeredHomepageSearch
+    if testGroup == 'experiment'
       a#main-layout-search-bar-button.avant-garde-button-black Search
 
     #main-layout-search-bar-spinner: .loading-spinner-small


### PR DESCRIPTION
This fixes the search button not showing when in the homepage context. We only pass a `testGroup` through to the template in the home context. I was erroneously using a variable belonging to another object (`centeredHomepageSearch`).