### PR TITLE
[Bugfix] Ensure lot.id is available for modal on /artist/:id

### DIFF
--- a/src/desktop/components/auction_lots/templates/auction_lots_table.jade
+++ b/src/desktop/components/auction_lots/templates/auction_lots_table.jade
@@ -17,6 +17,7 @@ tbody
             a.auction-lot-details-imagelink(
               href= "/artist/#{artist.id}/auction-result/#{lot.id}"
               data-client
+              data-auction-lot-id="#{lot.id}"
             )
               img.auction-lot-image( src= lot.imageUrl('thumbnail'), alt= lot.get('title') )
           else


### PR DESCRIPTION
Found this while digging through old code when clicking the image from a line-item here: https://staging.artsy.net/artist/gerhard-richter/auction-result/260585. 

Restores the modal popup: 

<img width="500" alt="screen shot 2018-05-02 at 12 50 01 pm" src="https://user-images.githubusercontent.com/236943/39545967-b4967b86-4e07-11e8-86eb-db475871423f.png">
