### PR TITLE
@kanaabe => News rss default meta img

### DIFF
--- a/src/desktop/apps/rss/templates/news.jade
+++ b/src/desktop/apps/rss/templates/news.jade
@@ -19,6 +19,8 @@ rss(version='2.0', xmlns:atom='http://www.w3.org/2005/Atom' xmlns:content='http:
         if article.get('layout') === 'video'
           - media = article.get('media')
           enclosure(url=media.url length=0 type="video/mp4")
+        else if article.get('layout') === 'news'
+          enclosure(url="#{sd.APP_URL}/images/og_image.jpg" length=0 type="image/jpeg")
         else if article.get('thumbnail_image')
           - image = article.get('thumbnail_image')
           - extension = image.split('.').pop()

--- a/src/desktop/apps/rss/test/news.coffee
+++ b/src/desktop/apps/rss/test/news.coffee
@@ -65,6 +65,16 @@ describe '/rss', ->
       rendered = newsTemplate(sd: sd, articles: new Articles(article), moment: moment)
       rendered.should.containEql '<enclosure url="https://artsymedia.mp4" length="0" type="video/mp4">'
 
+    it 'renders enclosures on news articles', ->
+      articles = [
+        {
+          layout: 'news',
+          thumbnail_image: 'artsy.net/jpg.jpg'
+        },
+      ]
+      rendered = newsTemplate(sd: sd, articles: new Articles(articles), moment: moment)
+      rendered.should.containEql '/images/og_image.jpg" length="0" type="image/jpeg">'
+
     it 'renders enclosures on non-video articles', ->
       articles = [
         {


### PR DESCRIPTION
Addresses [GROW-585](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-585)

In the RSS feed, uses default meta image for enclosures on 'news' articles rather than `thumbnail_img`.
