### PR TITLE
@sarahscott => Update recently viewed artwork footer to read from cross-platform ids

### DIFF
--- a/src/desktop/lib/global_client_setup.coffee
+++ b/src/desktop/lib/global_client_setup.coffee
@@ -36,7 +36,7 @@ module.exports = ->
 ensureFreshUser = (data) ->
   return unless sd.CURRENT_USER
   for attr in ['id', 'type', 'name', 'email', 'phone', 'lab_features',
-               'default_profile_id', 'has_partner_access', 'collector_level']
+               'default_profile_id', 'has_partner_access', 'collector_level', 'recently_viewed_artwork_ids']
 
     # NOTE:
     # If any of the above props have changed between two routes, and the second

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -161,6 +161,7 @@ export default function(app) {
           'paddle_number',
           'phone',
           'type',
+          'recently_viewed_artwork_ids',
         ],
       })
     )


### PR DESCRIPTION
when available, otherwise use the existing cookie source.