### PR TITLE
@mzikherman => Bump down header sizes and some spacing on homepage

### DIFF
--- a/src/desktop/apps/home/stylesheets/featured_items.styl
+++ b/src/desktop/apps/home/stylesheets/featured_items.styl
@@ -5,7 +5,7 @@ column-gap = 30px
 
 .home-featured-header
   margin (column-gap - 10px) 0 column-gap 0
-  garamond-size('xl-headline')
+  garamond-size('headline')
 
 .home-featured-list
   position relative
@@ -46,6 +46,10 @@ li.grid-item .artwork-item-contact-seller
 
 #home-featured-artists-section
    margin-bottom 0px
+
+#home-featured-shows-section
+  .home-featured-header
+    margin-bottom 0px
 
 // Top featured links
 // ------------------
@@ -91,7 +95,7 @@ li.grid-item .artwork-item-contact-seller
 
 #home-featured-articles-section
   .home-featured-header
-    garamond-size('xl-headline')
+    garamond-size('headline')
 
 .home-featured-article-link
   display inline-block


### PR DESCRIPTION
per @katarinabatina 

Making the titles of 'Artsy magazine', 'Featured shows', and 'Browse Works for Sale' 30px (down from 50px).

Also removing some extra padding around 'Featured shows'