### PR TITLE
@sweir27 => Require users accept conditions of sale upon registration

### DIFF
--- a/src/desktop/apps/auction_support/client/registration_form.coffee
+++ b/src/desktop/apps/auction_support/client/registration_form.coffee
@@ -13,7 +13,7 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
   events:
     'click .registration-form-content .avant-garde-button-black': 'onSubmit'
     'click .bidding-question': 'showBiddingDialog'
-    'change .registration-form-section__checkbox': 'handleCheckTerms'
+    'change .registration-form-section__checkbox': 'validateAcceptTerms'
 
   initialize: (options) ->
     @result = deferred.promise
@@ -118,21 +118,22 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
     $element.addClass 'is-loading'
     action().finally => $element.removeClass 'is-loading' unless @comboForm
 
-  handleCheckTerms: (e) ->
-    console.log('checking terms')
+  validateAcceptTerms: (e) ->
     if @$acceptTerms.prop('checked')
+      @$('.artsy-checkbox').removeClass('error')
       @enableSubmit()
+      true
     else
+      @$('.artsy-checkbox').addClass('error')
       @disableSubmit()
+      false
   
   disableSubmit: -> @$submit.addClass('is-disabled')
   enableSubmit: -> @$submit.removeClass('is-disabled')
 
   onSubmit: =>
-    # @handleCheckTerms() # Shouldn't be necessary
-    if @$submit.hasClass('is-disabled') or !@$acceptTerms.prop('checked')
-      @disableSubmit()
-      @showError 'You must accept the Conditions of Sale.'
+    # @validateAcceptTerms() # Shouldn't be necessary
+    return unless @validateAcceptTerms()
     else
       analyticsHooks.trigger 'registration:submit-address'
       @loadingLock @$submit, =>

--- a/src/desktop/apps/auction_support/client/registration_form.coffee
+++ b/src/desktop/apps/auction_support/client/registration_form.coffee
@@ -13,12 +13,14 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
   events:
     'click .registration-form-content .avant-garde-button-black': 'onSubmit'
     'click .bidding-question': 'showBiddingDialog'
+    'change .registration-form-section__checkbox': 'handleCheckCOS'
 
   initialize: (options) ->
     @result = deferred.promise
     @success = options.success
     @comboForm = options.comboForm
     @currentUser = CurrentUser.orNull()
+    @acceptedCos = false
     @$submit = @$('.registration-form-content .avant-garde-button-black')
     @setUpFields()
 
@@ -27,6 +29,16 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
     new ModalPageView
       width: '700px'
       pageId: 'auction-info'
+  
+  handleCheckCOS: (e) ->
+    if e.target.checked
+      @enableSubmit()
+    else
+      @disableSubmit()
+  
+  disableSubmit: -> @$submit.addClass('is-disabled')
+  enableSubmit: -> @$submit.removeClass('is-disabled')
+
 
   setUpFields: ->
     @fields =
@@ -40,6 +52,7 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
       city: { el: @$('input.city'), validator: @isPresent, label: 'city' }
       state: { el: @$('input.region'), validator: @isState, label: 'state' }
       zip: { el: @$('input.postal-code'), validator: @isZip }
+      'accept cos': { el: @$('input#accept_cos'), validator: @isChecked }
     @internationalizeFields()
 
   disableForm: ->

--- a/src/desktop/apps/auction_support/client/registration_form.coffee
+++ b/src/desktop/apps/auction_support/client/registration_form.coffee
@@ -132,14 +132,12 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
   enableSubmit: -> @$submit.removeClass('is-disabled')
 
   onSubmit: =>
-    # @validateAcceptTerms() # Shouldn't be necessary
     return unless @validateAcceptTerms()
-    else
-      analyticsHooks.trigger 'registration:submit-address'
-      @loadingLock @$submit, =>
-        (if @validateForm() then Q() else Q.reject('Please review the error(s) above and try again.')).then =>
-          Q.all [@savePhoneNumber(), @tokenizeCard()]
-        .catch (error) =>
-          @showError error
-        .then =>
-          @trigger('submitted')
+    analyticsHooks.trigger 'registration:submit-address'
+    @loadingLock @$submit, =>
+      (if @validateForm() then Q() else Q.reject('Please review the error(s) above and try again.')).then =>
+        Q.all [@savePhoneNumber(), @tokenizeCard()]
+      .catch (error) =>
+        @showError error
+      .then =>
+        @trigger('submitted')

--- a/src/desktop/apps/auction_support/client/registration_form.coffee
+++ b/src/desktop/apps/auction_support/client/registration_form.coffee
@@ -13,14 +13,14 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
   events:
     'click .registration-form-content .avant-garde-button-black': 'onSubmit'
     'click .bidding-question': 'showBiddingDialog'
-    'change .registration-form-section__checkbox': 'validateAcceptTerms'
+    'change .registration-form-section__checkbox': 'validateAcceptCOS'
 
   initialize: (options) ->
     @result = deferred.promise
     @success = options.success
     @comboForm = options.comboForm
     @currentUser = CurrentUser.orNull()
-    @$acceptTerms = @$('#accept_cos')
+    @$acceptCOS = @$('#accept_cos')
     @$submit = @$('.registration-form-content .avant-garde-button-black')
     @setUpFields()
 
@@ -118,21 +118,18 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
     $element.addClass 'is-loading'
     action().finally => $element.removeClass 'is-loading' unless @comboForm
 
-  validateAcceptTerms: (e) ->
-    if @$acceptTerms.prop('checked')
+  validateAcceptCOS: (e) ->
+    if @$acceptCOS.prop('checked')
       @$('.artsy-checkbox').removeClass('error')
-      @enableSubmit()
+      @$submit.removeClass('is-disabled')
       true
     else
+      @$submit.addClass('is-disabled')
       @$('.artsy-checkbox').addClass('error')
-      @disableSubmit()
       false
-  
-  disableSubmit: -> @$submit.addClass('is-disabled')
-  enableSubmit: -> @$submit.removeClass('is-disabled')
 
   onSubmit: =>
-    return unless @validateAcceptTerms()
+    return unless @validateAcceptCOS()
     analyticsHooks.trigger 'registration:submit-address'
     @loadingLock @$submit, =>
       (if @validateForm() then Q() else Q.reject('Please review the error(s) above and try again.')).then =>

--- a/src/desktop/apps/auction_support/stylesheets/index.styl
+++ b/src/desktop/apps/auction_support/stylesheets/index.styl
@@ -42,12 +42,13 @@
       display flex
       justify-content center
       align-content center
-    .artsy-checkbox--label
-    .artsy-checkbox--label a
-      garamond()
-      color gray-darker-color
-      display inline-block
-      text-transform initial
+      &--label
+      &--label a
+        garamond()
+        color gray-darker-color
+        display inline-block
+        text-transform initial
+        letter-spacing normal
 
   .bid-input-container
     position relative
@@ -167,6 +168,10 @@
 
 .auction-bid-form-container .registration-form-content:last-child
   margin-top 30px
+
+.registration-form-content
+  .avant-garde-button-black.is-disabled
+    background #c2c2c2
 
 @media (max-width: 600px)
   #auction-registration-page

--- a/src/desktop/apps/auction_support/stylesheets/index.styl
+++ b/src/desktop/apps/auction_support/stylesheets/index.styl
@@ -49,6 +49,12 @@
         display inline-block
         text-transform initial
         letter-spacing normal
+      &.error
+        .artsy-checkbox--checkbox
+            background red-color
+        .artsy-checkbox--label
+        .artsy-checkbox--label a
+            color red-color
 
   .bid-input-container
     position relative

--- a/src/desktop/apps/auction_support/stylesheets/index.styl
+++ b/src/desktop/apps/auction_support/stylesheets/index.styl
@@ -38,7 +38,10 @@
 
   .registration-form-section.accept-cos
     margin 30px auto
-    width 250px
+    .artsy-checkbox
+      display flex
+      justify-content center
+      align-content center
     .artsy-checkbox--label
     .artsy-checkbox--label a
       garamond()

--- a/src/desktop/apps/auction_support/stylesheets/index.styl
+++ b/src/desktop/apps/auction_support/stylesheets/index.styl
@@ -36,9 +36,15 @@
     margin-top: 9px
     margin-bottom: 18px
 
-  .registration-form-section.register
-    margin-top 10px
-    margin-bottom 10px
+  .registration-form-section.accept-cos
+    margin 30px auto
+    width 250px
+    .artsy-checkbox--label
+    .artsy-checkbox--label a
+      garamond()
+      color gray-darker-color
+      display inline-block
+      text-transform initial
 
   .bid-input-container
     position relative

--- a/src/desktop/apps/auction_support/templates/registration-form.jade
+++ b/src/desktop/apps/auction_support/templates/registration-form.jade
@@ -13,11 +13,10 @@
   .registration-form-section.accept-cos
     .artsy-checkbox
       .artsy-checkbox--checkbox.registration-form-section__checkbox
-        input( id='accept_cos', name='accept_cos', type='checkbox', value='1', checked )
+        input( id='accept_cos', name='accept_cos', type='checkbox', value='1' )
         label( for='accept_cos' )
       label.artsy-checkbox--label( for='accept_cos' )
-        | I agree to the&nbsp;
-        a( href="/conditions-of-sale" target="_blank" ) Conditions of Sale
+        | Agree to&nbsp;
+        a( href="/conditions-of-sale" target="_blank" ) Conditions of Sale.
 
   .registration-form-section.register
-

--- a/src/desktop/apps/auction_support/templates/registration-form.jade
+++ b/src/desktop/apps/auction_support/templates/registration-form.jade
@@ -17,6 +17,7 @@
         label( for='accept_cos' )
       label.artsy-checkbox--label( for='accept_cos' )
         | Agree to&nbsp;
-        a( href="/conditions-of-sale" target="_blank" ) Conditions of Sale.
+        a( href="/conditions-of-sale" target="_blank" ) Conditions of Sale&nbsp;
+        |.
 
   .registration-form-section.register

--- a/src/desktop/apps/auction_support/templates/registration-form.jade
+++ b/src/desktop/apps/auction_support/templates/registration-form.jade
@@ -20,4 +20,4 @@
         a( href="/conditions-of-sale" target="_blank" ) Conditions of Sale
         |.
 
-  .registration-form-section.register
+

--- a/src/desktop/apps/auction_support/templates/registration-form.jade
+++ b/src/desktop/apps/auction_support/templates/registration-form.jade
@@ -17,7 +17,7 @@
         label( for='accept_cos' )
       label.artsy-checkbox--label( for='accept_cos' )
         | Agree to&nbsp;
-        a( href="/conditions-of-sale" target="_blank" ) Conditions of Sale&nbsp;
+        a( href="/conditions-of-sale" target="_blank" ) Conditions of Sale
         |.
 
   .registration-form-section.register

--- a/src/desktop/apps/auction_support/templates/registration-form.jade
+++ b/src/desktop/apps/auction_support/templates/registration-form.jade
@@ -10,8 +10,14 @@
     .registration-form-content
       include ../../../components/credit_card/templates/address
 
+  .registration-form-section.accept-cos
+    .artsy-checkbox
+      .artsy-checkbox--checkbox.registration-form-section__checkbox
+        input( id='accept_cos', name='accept_cos', type='checkbox', value='1', checked )
+        label( for='accept_cos' )
+      label.artsy-checkbox--label( for='accept_cos' )
+        | I agree to the&nbsp;
+        a( href="/conditions-of-sale" target="_blank" ) Conditions of Sale
+
   .registration-form-section.register
-    p
-      | By bidding, you agree to the&nbsp;
-      a( href="/conditions-of-sale" ) Conditions of Sale
-      | &nbsp;and that all information you provide is true and accurate.
+

--- a/src/desktop/apps/auction_support/templates/registration-form.jade
+++ b/src/desktop/apps/auction_support/templates/registration-form.jade
@@ -19,5 +19,3 @@
         | Agree to&nbsp;
         a( href="/conditions-of-sale" target="_blank" ) Conditions of Sale
         |.
-
-

--- a/src/desktop/apps/auction_support/templates/registration.jade
+++ b/src/desktop/apps/auction_support/templates/registration.jade
@@ -14,4 +14,4 @@ block body
       .bid-registration-form-contents
         include ./registration-form
       .registration-form-content
-        .avant-garde-button-black.is-block Register
+        .avant-garde-button-black.is-block.is-disabled Register

--- a/src/desktop/apps/auction_support/test/client/registration_form.coffee
+++ b/src/desktop/apps/auction_support/test/client/registration_form.coffee
@@ -51,7 +51,7 @@ describe 'RegistrationForm', ->
   describe '#submit', ->
 
     beforeEach ->
-      @acceptTerms = => @view.$acceptTerms.prop('checked', true)
+      @acceptTerms = => @view.$acceptCOS.prop('checked', true)
       @submitValidForm = =>
         @view.$('input[name="card_name"]').val 'Foo Bar'
         @view.$('select[name="card_expiration_month"]').val '1'

--- a/src/desktop/apps/auction_support/test/client/registration_form.coffee
+++ b/src/desktop/apps/auction_support/test/client/registration_form.coffee
@@ -52,6 +52,7 @@ describe 'RegistrationForm', ->
 
     beforeEach ->
       @submitValidForm = =>
+        @view.$acceptTerms.prop('checked', true)
         @view.$('input[name="card_name"]').val 'Foo Bar'
         @view.$('select[name="card_expiration_month"]').val '1'
         @view.$('select[name="card_expiration_year"]').val '2024'

--- a/src/desktop/apps/auction_support/test/client/registration_form.coffee
+++ b/src/desktop/apps/auction_support/test/client/registration_form.coffee
@@ -26,7 +26,7 @@ describe 'RegistrationForm', ->
     benv.teardown()
 
   beforeEach (done) ->
-    @submitStub = sinon.stub(Backbone, 'sync')#.yieldsTo('success')
+    @submitStub = sinon.stub(Backbone, 'sync')
 
     @order = new Order()
     @sale = new Sale fabricate 'sale'

--- a/src/mobile/apps/auction_support/stylesheets/index.styl
+++ b/src/mobile/apps/auction_support/stylesheets/index.styl
@@ -5,6 +5,52 @@
 @import '../components/stylus_lib'
 @import '../components/bid_numbers'
 
+// checkbox-size = 20px
+
+// .artsy-checkbox
+//   display inline-block
+//   line-height checkbox-size
+//   &:hover .artsy-checkbox--checkbox > label:after
+//     opacity 0.1
+// .artsy-checkbox--checkbox
+//   display inline-block
+//   width checkbox-size
+//   height checkbox-size
+//   position relative
+//   background gray-lighter-color
+//   user-select none
+//   > label
+//     cursor pointer
+//     position absolute
+//     top 2px
+//     right @top
+//     bottom @top
+//     left @top
+//     background-color white
+//     // Check
+//     &:after
+//       content ''
+//       position absolute
+//       top 3px
+//       right 2px
+//       bottom 7px
+//       left 2px
+//       border 2px solid black
+//       border-top none
+//       border-right none
+//       opacity 0
+//       transform rotate(-45deg) translateZ(0)
+//       transition opacity 0.25s
+//   > input[type='checkbox']
+//     visibility hidden
+//     &:checked + label:after
+//       opacity 1 !important
+// .artsy-checkbox--label
+//   user-select none
+//   margin-left 10px
+//   cursor pointer
+
+
 #auction-registration-page
   margin 20px
   h2

--- a/src/mobile/apps/auction_support/stylesheets/index.styl
+++ b/src/mobile/apps/auction_support/stylesheets/index.styl
@@ -5,52 +5,6 @@
 @import '../components/stylus_lib'
 @import '../components/bid_numbers'
 
-// checkbox-size = 20px
-
-// .artsy-checkbox
-//   display inline-block
-//   line-height checkbox-size
-//   &:hover .artsy-checkbox--checkbox > label:after
-//     opacity 0.1
-// .artsy-checkbox--checkbox
-//   display inline-block
-//   width checkbox-size
-//   height checkbox-size
-//   position relative
-//   background gray-lighter-color
-//   user-select none
-//   > label
-//     cursor pointer
-//     position absolute
-//     top 2px
-//     right @top
-//     bottom @top
-//     left @top
-//     background-color white
-//     // Check
-//     &:after
-//       content ''
-//       position absolute
-//       top 3px
-//       right 2px
-//       bottom 7px
-//       left 2px
-//       border 2px solid black
-//       border-top none
-//       border-right none
-//       opacity 0
-//       transform rotate(-45deg) translateZ(0)
-//       transition opacity 0.25s
-//   > input[type='checkbox']
-//     visibility hidden
-//     &:checked + label:after
-//       opacity 1 !important
-// .artsy-checkbox--label
-//   user-select none
-//   margin-left 10px
-//   cursor pointer
-
-
 #auction-registration-page
   margin 20px
   h2


### PR DESCRIPTION
This PR updates the auction registration form to be disabled until the conditions of sale have been accepted. The link to the conditions opens in a new window. See happy path through error states below:
After talking to @briansw we agreed to the following changes from the new Zeplin mocks for checkboxes and error states:
- Same checkbox as used in artsy-elan
- Red box/text on error
- No error message above the submit button because the input already shows it

![registerform](https://user-images.githubusercontent.com/9088720/39725831-b0825556-5212-11e8-865a-98a09910ac1e.gif)

