### PR TITLE
@damassi => Allow all the homepage rails!

### DIFF
--- a/src/desktop/apps/home/client/index.coffee
+++ b/src/desktop/apps/home/client/index.coffee
@@ -90,6 +90,7 @@ module.exports.HomeView = class HomeView extends Backbone.View
       @$('#main-layout-header').removeClass('visible')
 
   highlightSearch: (e, onlyOnFocus = true) ->
+    return unless @$input?
     if onlyOnFocus
       @$searchContainer.addClass('focused') if @$input.is(':focus')
     else

--- a/src/desktop/apps/home/queries/initial.coffee
+++ b/src/desktop/apps/home/queries/initial.coffee
@@ -2,7 +2,8 @@ module.exports = """
   query($showHeroUnits: Boolean!) {
     home_page {
       artwork_modules(
-        max_rails: 7,
+        max_rails: -1,
+        max_followed_gene_rails: -1,
         order: [
           ACTIVE_BIDS,
           RECENTLY_VIEWED_WORKS


### PR DESCRIPTION
As per @katarinabatina , since the footer (Magazine + Shows) section on the homepage is de-prioritized, and we're going to be expanding w/ more similarity rails and dropping our 'max' limit, this starts it off doing just that.

Removes cap on max rails and max gene rails (for now in effect this adds a bunch of gene rails towards the bottom of the homepage). As we add the other similarity rails, if we feel that now it's just _too_ many rails, we can cap stuff back. For instance, we could cap _just_ the gene rails w/o limiting anything else.

Currently our limit of 7 means we are actually hiding one of the 'special' rails (recently viewed, 'active bids', etc. - we have > 7 of these now).