### PR TITLE
@mzikherman => Revert "Update recently viewed artwork footer to read from cross-plat…

### DIFF
--- a/src/desktop/components/recently_viewed_artworks/index.coffee
+++ b/src/desktop/components/recently_viewed_artworks/index.coffee
@@ -15,14 +15,6 @@ template = -> require('./index.jade') arguments...
 cookieValue = ->
   JSON.parse(Cookies.get(COOKIE_NAME) or '[]')
 
-# If the user is logged in and has any recently viewed artworks associated, use that.
-# Otherwise, use the artwork id's stored in the cookie.
-artworkIds = ->
-  if (ids = CurrentUser.orNull()?.get('recently_viewed_artwork_ids'))
-    return ids if ids.length > 0
-
-  return cookieValue()
-
 module.exports =
   setCookie: (artworkId) ->
     uniqueArtworkIds = _.without(cookieValue(), artworkId)
@@ -31,7 +23,7 @@ module.exports =
     Cookies.set COOKIE_NAME, JSON.stringify(artworkIdsToStore), expires: COOKIE_EXPIRY
 
   shouldShowRVARail: ->
-    !blacklist.check() && artworkIds().length > 0 && location.pathname isnt '/'
+    !blacklist.check() && cookieValue().length > 0 && location.pathname isnt '/'
 
   reInitRVARail: ($el) ->
     return unless $el.find('.rva-container').length > 0
@@ -41,7 +33,7 @@ module.exports =
       dontResizeUp: true
 
   setupRail: ($el) ->
-    send = method: 'post', query: query, variables: ids: artworkIds()
+    send = method: 'post', query: query, variables: ids: cookieValue()
     metaphysics send
       .then (data) ->
         $el.html template

--- a/src/desktop/lib/global_client_setup.coffee
+++ b/src/desktop/lib/global_client_setup.coffee
@@ -36,7 +36,7 @@ module.exports = ->
 ensureFreshUser = (data) ->
   return unless sd.CURRENT_USER
   for attr in ['id', 'type', 'name', 'email', 'phone', 'lab_features',
-               'default_profile_id', 'has_partner_access', 'collector_level', 'recently_viewed_artwork_ids']
+               'default_profile_id', 'has_partner_access', 'collector_level']
 
     # NOTE:
     # If any of the above props have changed between two routes, and the second

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -161,7 +161,6 @@ export default function(app) {
           'paddle_number',
           'phone',
           'type',
-          'recently_viewed_artwork_ids',
         ],
       })
     )


### PR DESCRIPTION
I didn't realize the `ensureFreshUser` would force a refresh _every_ time the `recently_viewed_artwork_ids` changed. Not what we want! Didn't notice this in testing/staging.

Since Force is currently in a rolled-back state, this re-enables Force deploys.