### PR TITLE
@xtina-starr => /artist articles limited to "in_editorial_feed"

### DIFF
--- a/src/desktop/apps/artist/queries/articles.coffee
+++ b/src/desktop/apps/artist/queries/articles.coffee
@@ -2,7 +2,7 @@ module.exports =
   """
   query artist($artist_id: String!) {
     artist(id: $artist_id) {
-      articles (limit: 99, sort: PUBLISHED_AT_DESC) {
+      articles (limit: 99, in_editorial_feed: true, sort: PUBLISHED_AT_DESC) {
         href
         thumbnail_title
         thumbnail_teaser


### PR DESCRIPTION
Addresses [GROW-573](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-573), limits articles appearing on `/artist` pages with `in_editorial_feed` query, which excludes the "news" layout.