### PR TITLE
@sweir27 => Mobile registration - require users accept conditions of sale

### DIFF
--- a/src/desktop/apps/auction_support/templates/conditions-of-sale-checkbox.jade
+++ b/src/desktop/apps/auction_support/templates/conditions-of-sale-checkbox.jade
@@ -1,0 +1,9 @@
+.registration-form-section.accept-cos
+  .artsy-checkbox
+    .artsy-checkbox--checkbox.registration-form-section__checkbox
+      input( id='accept_cos', name='accept_cos', type='checkbox', value='1' )
+      label( for='accept_cos' )
+    label.artsy-checkbox--label( for='accept_cos' )
+      | Agree to&nbsp;
+      a( href="/conditions-of-sale" target="_blank" ) Conditions of Sale
+      |.

--- a/src/desktop/apps/auction_support/templates/registration-form.jade
+++ b/src/desktop/apps/auction_support/templates/registration-form.jade
@@ -10,12 +10,4 @@
     .registration-form-content
       include ../../../components/credit_card/templates/address
 
-  .registration-form-section.accept-cos
-    .artsy-checkbox
-      .artsy-checkbox--checkbox.registration-form-section__checkbox
-        input( id='accept_cos', name='accept_cos', type='checkbox', value='1' )
-        label( for='accept_cos' )
-      label.artsy-checkbox--label( for='accept_cos' )
-        | Agree to&nbsp;
-        a( href="/conditions-of-sale" target="_blank" ) Conditions of Sale
-        |.
+  include ./conditions-of-sale-checkbox.jade

--- a/src/mobile/apps/auction_support/client/registration_form.coffee
+++ b/src/mobile/apps/auction_support/client/registration_form.coffee
@@ -12,10 +12,13 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
   events:
     'click .registration-form-content .avant-garde-box-button': 'onSubmit'
     'click .bidding-question': 'showBiddingDialog'
+    'change .registration-form-section__checkbox': 'validateAcceptCOS'
+
 
   initialize: (options) ->
     @success = options.success
     @currentUser = CurrentUser.orNull()
+    @$acceptCOS = @$('#accept_cos')
     @$submit = @$('.registration-form-content .avant-garde-box-button')
     @setUpFields()
 
@@ -103,8 +106,19 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
     $element.addClass 'is-loading'
     action().finally => $element.removeClass 'is-loading'
 
+  validateAcceptCOS: (e) ->
+    if @$acceptCOS.prop('checked')
+      @$('.artsy-checkbox').removeClass('error')
+      @$submit.removeClass('is-disabled')
+      true
+    else
+      @$('.artsy-checkbox').addClass('error')
+      @$submit.addClass('is-disabled')
+      false
+
   onSubmit: (event) ->
     event.preventDefault()
+    return unless @validateAcceptCOS()
 
     analyticsHooks.trigger 'registration:submitted-address'
 

--- a/src/mobile/apps/auction_support/stylesheets/index.styl
+++ b/src/mobile/apps/auction_support/stylesheets/index.styl
@@ -5,6 +5,51 @@
 @import '../components/stylus_lib'
 @import '../components/bid_numbers'
 
+checkbox-size = 20px
+
+.artsy-checkbox
+  display inline-block
+  line-height checkbox-size
+  &:hover .artsy-checkbox--checkbox > label:after
+    opacity 0.1
+.artsy-checkbox--checkbox
+  display inline-block
+  width checkbox-size
+  height checkbox-size
+  position relative
+  background gray-lighter-color
+  user-select none
+  > label
+    cursor pointer
+    position absolute
+    top 2px
+    right @top
+    bottom @top
+    left @top
+    background-color white
+    // Check
+    &:after
+      content ''
+      position absolute
+      top 3px
+      right 2px
+      bottom 7px
+      left 2px
+      border 2px solid black
+      border-top none
+      border-right none
+      opacity 0
+      transform rotate(-45deg) translateZ(0)
+      transition opacity 0.25s
+  > input[type='checkbox']
+    visibility hidden
+    &:checked + label:after
+      opacity 1 !important
+.artsy-checkbox--label
+  user-select none
+  margin-left 10px
+  cursor pointer
+
 #auction-registration-page
   margin 20px
   h2
@@ -65,9 +110,40 @@
 
   .avant-garde-box-button
     margin-top 15px
+    &--black
+    &[disabled], &.is-disabled, &.is-disabled
+      &, &:hover
+        border none
+        background-color #c2c2c2
+        cursor default
+        color rgba(white, 0.75)
+        &[data-state='success'], &.is-success
+          background-color green-color
+        &[data-state='error'], &.is-error
+          background-color red-color
 
   .error
     color bad-red-color
+  
+  .registration-form-section.accept-cos
+    margin 30px auto
+    .artsy-checkbox
+      display flex
+      justify-content center
+      align-content center
+      &--label
+      &--label a
+        garamond()
+        color gray-darker-color
+        display inline-block
+        text-transform initial
+        letter-spacing normal
+      &.error
+        .artsy-checkbox--checkbox
+            background bad-red-color
+        .artsy-checkbox--label
+        .artsy-checkbox--label a
+            color bad-red-color
 
 .card-expiration
   width 62%

--- a/src/mobile/apps/auction_support/templates/registration-form.jade
+++ b/src/mobile/apps/auction_support/templates/registration-form.jade
@@ -11,8 +11,12 @@
     .registration-form-content
       include ../../../components/credit_card/templates/address
 
-  .registration-form-section.register
-    p
-      | By bidding, you agree to the&nbsp;
-      a( href="/conditions-of-sale" ) Conditions of Sale
-      | &nbsp;and that all information you provide is true and accurate.
+  .registration-form-section.accept-cos
+    .artsy-checkbox
+      .artsy-checkbox--checkbox.registration-form-section__checkbox
+        input( id='accept_cos', name='accept_cos', type='checkbox', value='1' )
+        label( for='accept_cos' )
+      label.artsy-checkbox--label( for='accept_cos' )
+        | Agree to&nbsp;
+        a( href="/conditions-of-sale" target="_blank" ) Conditions of Sale
+        |.

--- a/src/mobile/apps/auction_support/templates/registration-form.jade
+++ b/src/mobile/apps/auction_support/templates/registration-form.jade
@@ -11,12 +11,4 @@
     .registration-form-content
       include ../../../components/credit_card/templates/address
 
-  .registration-form-section.accept-cos
-    .artsy-checkbox
-      .artsy-checkbox--checkbox.registration-form-section__checkbox
-        input( id='accept_cos', name='accept_cos', type='checkbox', value='1' )
-        label( for='accept_cos' )
-      label.artsy-checkbox--label( for='accept_cos' )
-        | Agree to&nbsp;
-        a( href="/conditions-of-sale" target="_blank" ) Conditions of Sale
-        |.
+  include ../../../../desktop/apps/auction_support/templates/conditions-of-sale-checkbox.jade

--- a/src/mobile/apps/auction_support/templates/registration.jade
+++ b/src/mobile/apps/auction_support/templates/registration.jade
@@ -10,6 +10,6 @@ block content
       .bid-registration-form-contents
         include ./registration-form
       .registration-form-content
-        .avant-garde-box-button.avant-garde-box-button-black
+        .avant-garde-box-button.avant-garde-box-button-black.is-disabled
           | Register
           .loading-spinner

--- a/src/mobile/apps/auction_support/test/client/registration_form.coffee
+++ b/src/mobile/apps/auction_support/test/client/registration_form.coffee
@@ -26,7 +26,7 @@ describe 'RegistrationForm', ->
     benv.teardown()
 
   beforeEach (done) ->
-    sinon.stub(Backbone, 'sync')#.yieldsTo('success')
+    @submitStub = sinon.stub(Backbone, 'sync')#.yieldsTo('success')
 
     @order = new Order()
     @sale = new Sale fabricate 'sale'
@@ -51,6 +51,7 @@ describe 'RegistrationForm', ->
   describe '#submit', ->
 
     beforeEach ->
+      @acceptTerms = => @view.$acceptCOS.prop('checked', true)
       @submitValidForm = =>
         @view.$('input[name="card_name"]').val 'Foo Bar'
         @view.$('select[name="card_expiration_month"]').val '1'
@@ -77,11 +78,12 @@ describe 'RegistrationForm', ->
       @view.on "submitted", =>
         @view.success.called.should.be.ok()
         done()
-
+      @acceptTerms()
       @submitValidForm()
 
     it 'validates the form and displays errors', (done) ->
       @view.$submit.length.should.be.ok()
+      @acceptTerms()
       @view.$submit.click()
 
       @view.on "submitted", =>
@@ -116,7 +118,7 @@ describe 'RegistrationForm', ->
         # Successfully create the bidder
         Backbone.sync.onThirdCall().yieldsTo('success')
 
-
+        @acceptTerms()
         @submitValidForm()
         @view.on "submitted", =>
           @Stripe.card.createToken.args[0][1](200, {})
@@ -141,7 +143,7 @@ describe 'RegistrationForm', ->
       Backbone.sync.onSecondCall().yieldsTo('success')
       # Successfully create the bidder
       Backbone.sync.onThirdCall().yieldsTo('success')
-
+      @acceptTerms()
       @submitValidForm()
 
       @view.on "submitted", =>
@@ -155,3 +157,12 @@ describe 'RegistrationForm', ->
         # Creates the bidder
         Backbone.sync.args[2][1].attributes.sale_id.should.equal @sale.id
         Backbone.sync.args[2][2].url.should.containEql '/api/v1/bidder'
+
+    it 'does not submit the form if Conditions of Sale are not accepted', ->
+      spy = sinon.spy(@submitStub)
+      @submitValidForm()
+      spy.called.should.be.false()
+
+    it 'adds an error class on submit if Conditions of Sale are not accepted', ->
+      @submitValidForm()
+      @view.$('.artsy-checkbox').hasClass('error').should.be.true()


### PR DESCRIPTION
Tracked in https://artsyproduct.atlassian.net/browse/PURCHASE-122

This follows the same pattern as #2470 to add a checkbox for accepting conditions which disables the mobile auction registration form.
I used the same red error color that the rest of the mobile form already used.

![registerform](https://user-images.githubusercontent.com/9088720/39773419-adb5b1dc-52bd-11e8-985e-e7b108a43e10.gif)
