### PR TITLE
@mzikherman => Dont hide spotlight search if you continue typing it

### DIFF
--- a/src/desktop/components/search_bar/view.coffee
+++ b/src/desktop/components/search_bar/view.coffee
@@ -80,7 +80,18 @@ module.exports = class SearchBarView extends Backbone.View
       @trigger 'search:entered', encodeURIComponent(@$input.val())
 
   maybeHideSpotlight: (e) ->
-    @hideSpotlight() unless e.which is 37 or e.which is 39 # cursor left, right
+    return if e.which is 37 or e.which is 39 # cursor left, right
+
+    letterPressed = String.fromCharCode(e.which).toLowerCase()
+    if letterPressed is @$spotlightRemainingText.text().charAt(0).toLowerCase()
+      return @shiftLetter(letterPressed)
+
+    @hideSpotlight()
+
+  shiftLetter: (letter) ->
+    shiftedInitialText = "#{@$spotlightInitialText.text()}#{letter}"
+    @$spotlightInitialText.text(shiftedInitialText)
+    @$spotlightRemainingText.text(@$spotlightRemainingText.text().slice(1))
 
   hideSpotlight: ->
     @$spotlight.css('z-index', '-1')


### PR DESCRIPTION
![bp](https://user-images.githubusercontent.com/1457859/39789496-26cefcc8-52fe-11e8-86d9-07136d807b2c.gif)

Tweak (thanks @damassi, feels a lot better! ) - if you continue typing the spotlight'ed search, we don't need to hide it.