### PR TITLE
@sweir27 => Purchase 106 QA Fixes

### DIFF
--- a/src/desktop/apps/auction_support/client/registration_form.coffee
+++ b/src/desktop/apps/auction_support/client/registration_form.coffee
@@ -121,12 +121,10 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
   validateAcceptCOS: (e) ->
     if @$acceptCOS.prop('checked')
       @$('.artsy-checkbox').removeClass('error')
-      @$('#cos_link').removeClass('conceal-hover-state')
       @$submit.removeClass('is-disabled')
       true
     else
       @$submit.addClass('is-disabled')
-      @$('#cos_link').addClass('conceal-hover-state')
       @$('.artsy-checkbox').addClass('error')
       false
 

--- a/src/desktop/apps/auction_support/client/registration_form.coffee
+++ b/src/desktop/apps/auction_support/client/registration_form.coffee
@@ -121,10 +121,12 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
   validateAcceptCOS: (e) ->
     if @$acceptCOS.prop('checked')
       @$('.artsy-checkbox').removeClass('error')
+      @$('#cos_link').removeClass('conceal-hover-state')
       @$submit.removeClass('is-disabled')
       true
     else
       @$submit.addClass('is-disabled')
+      @$('#cos_link').addClass('conceal-hover-state')
       @$('.artsy-checkbox').addClass('error')
       false
 

--- a/src/desktop/apps/auction_support/stylesheets/index.styl
+++ b/src/desktop/apps/auction_support/stylesheets/index.styl
@@ -42,19 +42,27 @@
       display flex
       justify-content center
       align-content center
-      &--label
-      &--label a
+      &--checkbox
+        margin-right 8px
+      // unset default hover style that encompasses entire wrapper
+      &:hover .artsy-checkbox--checkbox > label:after
+        opacity 0
+      
+      // --label wraps input for this implementation; use it for hover style
+      &--label:hover .artsy-checkbox--checkbox > label:after
+        opacity .1
+      &--label, a
         garamond()
+        font-size 14px
         color gray-darker-color
         display inline-block
         text-transform initial
         letter-spacing normal
       &.error
         .artsy-checkbox--checkbox
-            background red-color
-        .artsy-checkbox--label
-        .artsy-checkbox--label a
-            color red-color
+          background red-color
+        .artsy-checkbox--label, a
+          color red-color
 
   .bid-input-container
     position relative
@@ -177,7 +185,7 @@
 
 .registration-form-content
   .avant-garde-button-black.is-disabled
-    background #c2c2c2
+    background #e5e5e5
 
 @media (max-width: 600px)
   #auction-registration-page

--- a/src/desktop/apps/auction_support/stylesheets/index.styl
+++ b/src/desktop/apps/auction_support/stylesheets/index.styl
@@ -46,6 +46,9 @@
       // unset default hover style that encompasses entire wrapper
       &:hover .artsy-checkbox--checkbox > label:after
         opacity 0
+      // override the checkmark hider if hovering on link while + checked
+      .artsy-checkbox--checkbox input:checked + label
+        z-index 3
       &--label
         position relative
         // common styles for label and <a>
@@ -61,9 +64,10 @@
         // --label wraps input for this implementation; use it for hover style
         &:hover .artsy-checkbox--checkbox > label:after
           opacity .1
-        // Cover up the checkbox hover state if hovering on the window
-        & > a.conceal-hover-state:hover::before
+        // Cover up the checkbox hover state if hovering on a link
+        & > a:hover::before
           content: ''
+          z-index 2
           width 16px
           height 16px
           background white

--- a/src/desktop/apps/auction_support/stylesheets/index.styl
+++ b/src/desktop/apps/auction_support/stylesheets/index.styl
@@ -43,25 +43,33 @@
       justify-content center
       align-content center
       color: gray-darker-color
-      // Alignment for checkbox, label and link (next sibling of the checkbox input)
-      > a, &--label
-        height 20px
-      &--label .artsy-checkbox--checkbox
-          margin-right 8px
-
       // unset default hover style that encompasses entire wrapper
       &:hover .artsy-checkbox--checkbox > label:after
         opacity 0
-      // --label wraps input for this implementation; use it for hover style
-      &--label:hover .artsy-checkbox--checkbox > label:after
-        opacity .1
-      &--label, a
-        garamond()
-        font-size 14px
-        color gray-darker-color
-        display inline-block
-        text-transform initial
-        letter-spacing normal
+      &--label
+        position relative
+        // common styles for label and <a>
+        &, a
+          garamond()
+          font-size 14px
+          color gray-darker-color
+          display inline-block
+          text-transform initial
+          letter-spacing normal
+        .artsy-checkbox--checkbox
+          margin-right 8px
+        // --label wraps input for this implementation; use it for hover style
+        &:hover .artsy-checkbox--checkbox > label:after
+          opacity .1
+        // Cover up the checkbox hover state if hovering on the window
+        & > a.conceal-hover-state:hover::before
+          content: ''
+          width 16px
+          height 16px
+          background white
+          position absolute
+          left 2px
+          top 2px
       &.error
         color red-color
         .artsy-checkbox--checkbox

--- a/src/desktop/apps/auction_support/stylesheets/index.styl
+++ b/src/desktop/apps/auction_support/stylesheets/index.styl
@@ -42,19 +42,16 @@
       display flex
       justify-content center
       align-content center
-      // Vertically align the period.
-      line-height 1.5em
       color: gray-darker-color
+      // Alignment for checkbox, label and link (next sibling of the checkbox input)
+      > a, &--label
+        height 20px
+      &--label .artsy-checkbox--checkbox
+          margin-right 8px
+
       // unset default hover style that encompasses entire wrapper
       &:hover .artsy-checkbox--checkbox > label:after
         opacity 0
-      // Alignment for checkbox, label and link (next sibling of the checkbox input)
-      > a
-        line-height 1.8em
-      &--label
-        margin-right 1px
-        .artsy-checkbox--checkbox
-          margin-right 8px
       // --label wraps input for this implementation; use it for hover style
       &--label:hover .artsy-checkbox--checkbox > label:after
         opacity .1

--- a/src/desktop/apps/auction_support/stylesheets/index.styl
+++ b/src/desktop/apps/auction_support/stylesheets/index.styl
@@ -42,12 +42,19 @@
       display flex
       justify-content center
       align-content center
-      &--checkbox
-        margin-right 8px
+      // Vertically align the period.
+      line-height 1.5em
+      color: gray-darker-color
       // unset default hover style that encompasses entire wrapper
       &:hover .artsy-checkbox--checkbox > label:after
         opacity 0
-      
+      // Alignment for checkbox, label and link (next sibling of the checkbox input)
+      > a
+        line-height 1.8em
+      &--label
+        margin-right 1px
+        .artsy-checkbox--checkbox
+          margin-right 8px
       // --label wraps input for this implementation; use it for hover style
       &--label:hover .artsy-checkbox--checkbox > label:after
         opacity .1
@@ -59,6 +66,7 @@
         text-transform initial
         letter-spacing normal
       &.error
+        color red-color
         .artsy-checkbox--checkbox
           background red-color
         .artsy-checkbox--label, a

--- a/src/desktop/apps/auction_support/templates/conditions-of-sale-checkbox.jade
+++ b/src/desktop/apps/auction_support/templates/conditions-of-sale-checkbox.jade
@@ -5,5 +5,5 @@
         input( id='accept_cos', name='accept_cos', type='checkbox', value='1' )
         label( for='accept_cos' )
       |Agree to&nbsp;
-    a( href="/conditions-of-sale" target="_blank" ) Conditions of Sale
-    |.
+      a.conceal-hover-state( id="cos_link" href="/conditions-of-sale" target="_blank" ) Conditions of Sale
+      |.

--- a/src/desktop/apps/auction_support/templates/conditions-of-sale-checkbox.jade
+++ b/src/desktop/apps/auction_support/templates/conditions-of-sale-checkbox.jade
@@ -1,9 +1,9 @@
 .registration-form-section.accept-cos
   .artsy-checkbox
-    .artsy-checkbox--checkbox.registration-form-section__checkbox
-      input( id='accept_cos', name='accept_cos', type='checkbox', value='1' )
-      label( for='accept_cos' )
     label.artsy-checkbox--label( for='accept_cos' )
-      | Agree to&nbsp;
-      a( href="/conditions-of-sale" target="_blank" ) Conditions of Sale
-      |.
+      .artsy-checkbox--checkbox.registration-form-section__checkbox
+        input( id='accept_cos', name='accept_cos', type='checkbox', value='1' )
+        label( for='accept_cos' )
+      |Agree to&nbsp;
+    a( href="/conditions-of-sale" target="_blank" ) Conditions of Sale
+    |.

--- a/src/desktop/apps/auction_support/templates/conditions-of-sale-checkbox.jade
+++ b/src/desktop/apps/auction_support/templates/conditions-of-sale-checkbox.jade
@@ -5,5 +5,5 @@
         input( id='accept_cos', name='accept_cos', type='checkbox', value='1' )
         label( for='accept_cos' )
       |Agree to&nbsp;
-      a.conceal-hover-state( id="cos_link" href="/conditions-of-sale" target="_blank" ) Conditions of Sale
+      a( id="cos_link" href="/conditions-of-sale" target="_blank" ) Conditions of Sale
       |.

--- a/src/mobile/apps/auction_support/client/registration_form.coffee
+++ b/src/mobile/apps/auction_support/client/registration_form.coffee
@@ -104,18 +104,15 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
   loadingLock: ($element, action) ->
     return if $element.hasClass('is-loading')
     $element.addClass 'is-loading'
-    action().finally => $element.removeClass 'is-loading'
+    action().finally -> $element.removeClass 'is-loading'
 
   validateAcceptCOS: (e) ->
     if @$acceptCOS.prop('checked')
       @$('.artsy-checkbox').removeClass('error')
-      @$('#cos_link').removeClass('conceal-hover-state')
       @$submit.removeClass('is-disabled')
       true
     else
       @$('.artsy-checkbox').addClass('error')
-      @$('#cos_link').addClass('conceal-hover-state')
-
       @$submit.addClass('is-disabled')
       false
 

--- a/src/mobile/apps/auction_support/client/registration_form.coffee
+++ b/src/mobile/apps/auction_support/client/registration_form.coffee
@@ -109,10 +109,13 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
   validateAcceptCOS: (e) ->
     if @$acceptCOS.prop('checked')
       @$('.artsy-checkbox').removeClass('error')
+      @$('#cos_link').removeClass('conceal-hover-state')
       @$submit.removeClass('is-disabled')
       true
     else
       @$('.artsy-checkbox').addClass('error')
+      @$('#cos_link').addClass('conceal-hover-state')
+
       @$submit.addClass('is-disabled')
       false
 

--- a/src/mobile/apps/auction_support/stylesheets/index.styl
+++ b/src/mobile/apps/auction_support/stylesheets/index.styl
@@ -144,25 +144,33 @@ checkbox-size = 20px
     justify-content center
     align-content center
     color: gray-darker-color
-    // Alignment for checkbox, label and link (next sibling of the checkbox input)
-      > a, &--label
-        height 20px
-      &--label .artsy-checkbox--checkbox
-          margin-right 8px
-
     // unset default hover style that encompasses entire wrapper
     &:hover .artsy-checkbox--checkbox > label:after
       opacity 0
-    // --label wraps input for this implementation; use it for hover style
-    &--label:hover .artsy-checkbox--checkbox > label:after
-      opacity .1
-    &--label, a
-      garamond()
-      font-size 14px
-      color gray-darker-color
-      display inline-block
-      text-transform initial
-      letter-spacing normal
+    &--label
+      position relative
+      // common styles for label and <a>
+      &, a
+        garamond()
+        font-size 14px
+        color gray-darker-color
+        display inline-block
+        text-transform initial
+        letter-spacing normal
+      .artsy-checkbox--checkbox
+        margin-right 8px
+      // --label wraps input for this implementation; use it for hover style
+      &:hover .artsy-checkbox--checkbox > label:after
+        opacity .1
+      // Cover up the checkbox hover state if hovering on the window
+      & > a.conceal-hover-state:hover::before
+        content: ''
+        width 16px
+        height 16px
+        background white
+        position absolute
+        left 2px
+        top 2px
     &.error
       color bad-red-color
       .artsy-checkbox--checkbox

--- a/src/mobile/apps/auction_support/stylesheets/index.styl
+++ b/src/mobile/apps/auction_support/stylesheets/index.styl
@@ -143,19 +143,16 @@ checkbox-size = 20px
     display flex
     justify-content center
     align-content center
-    // Vertically align the period.
-    line-height 1.5em
     color: gray-darker-color
+    // Alignment for checkbox, label and link (next sibling of the checkbox input)
+      > a, &--label
+        height 20px
+      &--label .artsy-checkbox--checkbox
+          margin-right 8px
+
     // unset default hover style that encompasses entire wrapper
     &:hover .artsy-checkbox--checkbox > label:after
       opacity 0
-    // Alignment for checkbox, label and link (next sibling of the checkbox input)
-    > a
-      line-height 1.8em
-    &--label
-      margin-right 1px
-      .artsy-checkbox--checkbox
-        margin-right 8px
     // --label wraps input for this implementation; use it for hover style
     &--label:hover .artsy-checkbox--checkbox > label:after
       opacity .1

--- a/src/mobile/apps/auction_support/stylesheets/index.styl
+++ b/src/mobile/apps/auction_support/stylesheets/index.styl
@@ -127,54 +127,55 @@ checkbox-size = 20px
   .error
     color bad-red-color
 
-
-.card-expiration
-  width 62%
-
-#auction-registration-page .card-security-code.credit-card-input-section
-  width 36%
-  display block
-  input
-    padding 10px 0 11px 0
-
-.registration-form-section.accept-cos
-  margin 30px auto !important
-  .artsy-checkbox
-    display flex
-    justify-content center
-    align-content center
-    color: gray-darker-color
-    // unset default hover style that encompasses entire wrapper
-    &:hover .artsy-checkbox--checkbox > label:after
-      opacity 0
-    &--label
-      position relative
-      // common styles for label and <a>
-      &, a
-        garamond()
-        font-size 14px
-        color gray-darker-color
-        display inline-block
-        text-transform initial
-        letter-spacing normal
-      .artsy-checkbox--checkbox
-        margin-right 8px
-      // --label wraps input for this implementation; use it for hover style
+  .registration-form-section.accept-cos
+    margin 30px auto !important
+    .artsy-checkbox
+      display flex
+      justify-content center
+      align-content center
+      color: gray-darker-color
+      // unset default hover style that encompasses entire wrapper
       &:hover .artsy-checkbox--checkbox > label:after
-        opacity .1
-      // Cover up the checkbox hover state if hovering on the window
-      & > a.conceal-hover-state:hover::before
-        content: ''
-        width 16px
-        height 16px
-        background white
-        position absolute
-        left 2px
-        top 2px
-    &.error
-      color bad-red-color
-      .artsy-checkbox--checkbox
-        background bad-red-color
-      .artsy-checkbox--label, a
-          color bad-red-color
+        opacity 0
+      // override the checkmark hider if hovering on link while + checked
+      .artsy-checkbox--checkbox input:checked + label
+        z-index 3
+      &--label
+        position relative
+        // common styles for label and <a>
+        &, a
+          garamond()
+          font-size 14px
+          color gray-darker-color
+          display inline-block
+          text-transform initial
+          letter-spacing normal
+        .artsy-checkbox--checkbox
+          margin-right 8px
+        // --label wraps input for this implementation; use it for hover style
+        &:hover .artsy-checkbox--checkbox > label:after
+          opacity .1
+        // Cover up the checkmark if hovering on a link
+        & > a:hover::before
+          content: ''
+          z-index 2
+          width 16px
+          height 16px
+          background white
+          position absolute
+          left 2px
+          top 2px
+      &.error
+        color bad-red-color
+        .artsy-checkbox--checkbox
+          background bad-red-color
+        .artsy-checkbox--label, a
+            color bad-red-color
+  .card-security-code.credit-card-input-section
+    width 36%
+    display block
+    input
+      padding 10px 0 11px 0
+  .card-expiration
+    width 62%
 

--- a/src/mobile/apps/auction_support/stylesheets/index.styl
+++ b/src/mobile/apps/auction_support/stylesheets/index.styl
@@ -114,7 +114,7 @@ checkbox-size = 20px
     &[disabled], &.is-disabled, &.is-disabled
       &, &:hover
         border none
-        background-color #c2c2c2
+        background-color #e5e5e5
         cursor default
         color rgba(white, 0.75)
         &[data-state='success'], &.is-success

--- a/src/mobile/apps/auction_support/stylesheets/index.styl
+++ b/src/mobile/apps/auction_support/stylesheets/index.styl
@@ -5,8 +5,9 @@
 @import '../components/stylus_lib'
 @import '../components/bid_numbers'
 
+// The default checkbox styling
+// (from /src/desktop/components/main_layout/stylesheets/form_elements.styl)
 checkbox-size = 20px
-
 .artsy-checkbox
   display inline-block
   line-height checkbox-size
@@ -80,10 +81,11 @@ checkbox-size = 20px
     text-transform uppercase
     letter-spacing 2px
 
-  label
-    display block
-    avant-garde()
-    font-size 12px
+  .auction-registration-form
+    label
+      display block
+      avant-garde()
+      font-size 12px
 
   .credit-card-input-section
     margin-top 10px
@@ -124,26 +126,7 @@ checkbox-size = 20px
 
   .error
     color bad-red-color
-  
-  .registration-form-section.accept-cos
-    margin 30px auto
-    .artsy-checkbox
-      display flex
-      justify-content center
-      align-content center
-      &--label
-      &--label a
-        garamond()
-        color gray-darker-color
-        display inline-block
-        text-transform initial
-        letter-spacing normal
-      &.error
-        .artsy-checkbox--checkbox
-            background bad-red-color
-        .artsy-checkbox--label
-        .artsy-checkbox--label a
-            color bad-red-color
+
 
 .card-expiration
   width 62%
@@ -153,3 +136,40 @@ checkbox-size = 20px
   display block
   input
     padding 10px 0 11px 0
+
+.registration-form-section.accept-cos
+  margin 30px auto !important
+  .artsy-checkbox
+    display flex
+    justify-content center
+    align-content center
+    // Vertically align the period.
+    line-height 1.5em
+    color: gray-darker-color
+    // unset default hover style that encompasses entire wrapper
+    &:hover .artsy-checkbox--checkbox > label:after
+      opacity 0
+    // Alignment for checkbox, label and link (next sibling of the checkbox input)
+    > a
+      line-height 1.8em
+    &--label
+      margin-right 1px
+      .artsy-checkbox--checkbox
+        margin-right 8px
+    // --label wraps input for this implementation; use it for hover style
+    &--label:hover .artsy-checkbox--checkbox > label:after
+      opacity .1
+    &--label, a
+      garamond()
+      font-size 14px
+      color gray-darker-color
+      display inline-block
+      text-transform initial
+      letter-spacing normal
+    &.error
+      color bad-red-color
+      .artsy-checkbox--checkbox
+        background bad-red-color
+      .artsy-checkbox--label, a
+          color bad-red-color
+

--- a/src/mobile/apps/auction_support/templates/registration-form.jade
+++ b/src/mobile/apps/auction_support/templates/registration-form.jade
@@ -11,4 +11,4 @@
     .registration-form-content
       include ../../../components/credit_card/templates/address
 
-  include ../../../../desktop/apps/auction_support/templates/conditions-of-sale-checkbox.jade
+include ../../../../desktop/apps/auction_support/templates/conditions-of-sale-checkbox.jade


### PR DESCRIPTION
This PR addresses design feedback from @briansw in PURCHASE-128, -129 AND -130:
https://artsyproduct.atlassian.net/browse/PURCHASE-106

In order to meet PURCHASE-129 (hover on link should not trigger checkbox hover state) I had to unset some of the default `.artsy-checkbox` styling and wrap the input in its text label, then align the link with the text. It appears fine for me in mobile and desktop, but it did take some nudging.

![registerform](https://user-images.githubusercontent.com/9088720/39827606-0e290300-537e-11e8-85a4-854848f48502.gif)

EDIT: Update with new styling that fixes the period issue pointed out by @briansw below. It adds a little extra javascript and an `a::before` pseudoelement to block the hover state when hovering on the link specifically.
![registerform](https://user-images.githubusercontent.com/9088720/39838110-003ff486-539e-11e8-88f8-04e012d69453.gif)

