### PR TITLE
@cavvia => Move 'Search for ...' placeholder item to bottom of search results

### DIFF
--- a/src/desktop/components/search_bar/index.styl
+++ b/src/desktop/components/search_bar/index.styl
@@ -92,6 +92,20 @@ search-bar-input-placeholder()
   left 9px
   transform translateY(-50%)
 
+html[data-lab-features*='Spotlight Search']
+  #main-layout-search-bar-container
+    .tt-suggestion
+      &:last-child
+        border-bottom 1px solid gray-lighter-color
+      &.empty-item
+        background-color white
+        font-weight bold
+        &:hover
+        &.tt-cursor
+          background-color black
+          *
+            color white
+
 // Results dropdown
 #main-layout-search-bar-container
   .twitter-typeahead


### PR DESCRIPTION
Chipping away at the comp, this moves the placeholder text/styling to the bottom of the list for the feature:

<img width="864" alt="screen shot 2018-05-09 at 1 57 49 pm" src="https://user-images.githubusercontent.com/1457859/39831035-3665bdaa-5391-11e8-834e-702374f92d8e.png">


When selected:

<img width="866" alt="screen shot 2018-05-09 at 1 58 02 pm" src="https://user-images.githubusercontent.com/1457859/39831042-3acfb332-5391-11e8-8cc5-80f785e182eb.png">


As always, when you select/hit enter on that placeholder item, you go to the search results page.