### PR TITLE
@saolsen => heroku deploys on circle 2.0

### DIFF
--- a/.circleci/heroku_deploy.sh
+++ b/.circleci/heroku_deploy.sh
@@ -1,5 +1,6 @@
 #! /bin/bash -ex
 
+DEPLOY_ENV=staging yarn deploy
 if git remote | grep heroku > /dev/null; then
   git fetch heroku
   git push --force heroku $CIRCLE_SHA1:master
@@ -8,3 +9,4 @@ else
   echo "Heroku is not set up :("
   exit 1
 fi 
+DEPLOY_ENV=staging yarn sentry

--- a/.circleci/heroku_deploy.sh
+++ b/.circleci/heroku_deploy.sh
@@ -1,12 +1,12 @@
 #! /bin/bash -ex
 
-DEPLOY_ENV=staging yarn deploy
 if git remote | grep heroku > /dev/null; then
   git fetch heroku
-  git push --force heroku $CIRCLE_SHA1:master
+  DEPLOY_ENV=staging yarn deploy
+  git push git@github.com:artsy/force.git $CIRCLE_SHA1:staging --force
   heroku restart
+  DEPLOY_ENV=staging yarn sentry
 else
   echo "Heroku is not set up :("
   exit 1
 fi 
-DEPLOY_ENV=staging yarn sentry

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,7 +8,7 @@ gzip -S .jgz $(find public/assets -name '*.js')
 bucket-assets --bucket artsy-force-$DEPLOY_ENV
 heroku config:set ASSET_MANIFEST=$(cat manifest.json) --app=force-$DEPLOY_ENV
 if [ -z "$CIRCLE_SHA1" ]; then
-  git push --force git@heroku.com:force-$DEPLOY_ENV.git master
+  git push --force heroku master
 else
-  git push --force git@heroku.com:force-$DEPLOY_ENV.git $CIRCLE_SHA1:refs/heads/master
+  git push --force heroku $CIRCLE_SHA1:refs/heads/master
 fi


### PR DESCRIPTION
This should hopefully fix the staging deploys to Heroku.

Follow-up: we deploy to production using Circle (PRs to the `release` branch), does that still work with 2.0 or is there a different process?