### PR TITLE
@saolsen => Dont wait for docker stuff to deploy to heroku on Circle 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,4 +91,4 @@ workflows:
             branches:
               only: master
           requires:
-            - push
+            - test


### PR DESCRIPTION
Currently waiting on a Docker thingie...we can do Heroku deploys right after the test.