### PR TITLE
@saolsen => Run heroku deploy command properly on Circle 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,12 +52,13 @@ jobs:
           command: hokusai staging deploy $CIRCLE_SHA1
   deploy_heroku:
     docker:
-      - image: circleci/node:8-stretch-browsers
+      - image: artsy/hokusai:0.4.0
     steps:
       - add_ssh_keys:
           fingerprints:
             - "1b:84:4f:fe:ad:ef:fc:d1:80:fb:be:ec:0c:03:36:73"
       - checkout
+      - setup_remote_docker
       - run: bash .circleci/heroku_setup.sh
       - run:
           name: Deploy


### PR DESCRIPTION
The deploy failed since it didn't have the results of `yarn install`, etc. - I changed this to match some of the other steps (which do seem to pick up the `Dockerfile` properly).