### PR TITLE
@damassi => Add heroku prod deploys for Circle 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - run:
           name: Deploy
           command: hokusai staging deploy $CIRCLE_SHA1
-  deploy_heroku:
+  deploy_heroku_staging:
     docker:
       - image: circleci/node:8-stretch-browsers
     steps:
@@ -61,8 +61,21 @@ jobs:
       - setup_remote_docker
       - run: bash .circleci/heroku_setup.sh
       - run:
-          name: Deploy
-          command: "yarn install && bash .circleci/heroku_deploy.sh"
+          name: "Deploy to staging"
+          command: "yarn install && DEPLOY_ENV=staging bash .circleci/heroku_deploy.sh && git push git@github.com:artsy/force.git $CIRCLE_SHA1:staging --force"
+  deploy_heroku_production:
+    docker:
+      - image: circleci/node:8-stretch-browsers
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "1b:84:4f:fe:ad:ef:fc:d1:80:fb:be:ec:0c:03:36:73"
+      - checkout
+      - setup_remote_docker
+      - run: bash .circleci/heroku_setup.sh
+      - run:
+          name: "Deploy to production"
+          command: "yarn install && DEPLOY_ENV=production bash .circleci/heroku_deploy.sh"
         
 
 workflows:
@@ -87,9 +100,15 @@ workflows:
               only: master
           requires:
             - push
-      - deploy_heroku:
+      - deploy_heroku_staging:
           filters:
             branches:
               only: master
+          requires:
+            - test
+      - deploy_heroku_production:
+          filters:
+            branches:
+              only: release
           requires:
             - test

--- a/.circleci/heroku_deploy.sh
+++ b/.circleci/heroku_deploy.sh
@@ -2,10 +2,9 @@
 
 if git remote | grep heroku > /dev/null; then
   git fetch heroku
-  DEPLOY_ENV=staging yarn deploy
-  git push git@github.com:artsy/force.git $CIRCLE_SHA1:staging --force
+  yarn deploy
   heroku restart
-  DEPLOY_ENV=staging yarn sentry
+  yarn sentry
 else
   echo "Heroku is not set up :("
   exit 1

--- a/.circleci/heroku_setup.sh
+++ b/.circleci/heroku_setup.sh
@@ -7,9 +7,9 @@
 # else
 #   exit 0
 # fi
-app_name=force-staging
+# app_name=force-staging
 
-git remote add heroku https://git.heroku.com/$app_name.git
+git remote add heroku https://git.heroku.com/force-$DEPLOY_ENV.git
 wget https://cli-assets.heroku.com/branches/stable/heroku-linux-amd64.tar.gz
 mkdir -p /usr/local/lib /usr/local/bin
 sudo tar -xzf heroku-linux-amd64.tar.gz -C /usr/local/lib


### PR DESCRIPTION
cc @saolsen 

The staging deploy worked, so this tries to generalize a tad and add a production one.