### PR TITLE
@mzikherman => [CircleCI] Ignore staging branch in prod deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,6 @@ jobs:
       - run:
           name: "Deploy to production"
           command: "yarn install && DEPLOY_ENV=production bash .circleci/heroku_deploy.sh"
-        
 
 workflows:
   version: 2
@@ -85,9 +84,12 @@ workflows:
       - test
       # - acceptance FIXME: Re enable once circle fixes their browser image.
       - build:
+          filters:
+            branches:
+              ignore: staging
           requires:
             - test
-            #- acceptance 
+            #- acceptance
       - push:
           filters:
             branches:


### PR DESCRIPTION
Noticed this was missing with our new deployment pipeline. This follows our [previous config](https://github.com/artsy/force/blob/9f74b2099eb42c11d80fb83caae048697ab8c1d2/circle.yml#L4) but updated to Circle 2