### PR TITLE
@mzikherman => Enable saves in stitch Artwork Bricks 

### DIFF
--- a/src/desktop/components/artwork_brick/query.coffee
+++ b/src/desktop/components/artwork_brick/query.coffee
@@ -2,6 +2,7 @@ module.exports = """
   fragment artwork_brick on Artwork {
     __id
     id
+    is_saved
     href
     title
     image {

--- a/src/desktop/components/artwork_filter_2/models/filter.coffee
+++ b/src/desktop/components/artwork_filter_2/models/filter.coffee
@@ -1,4 +1,5 @@
 Backbone = require 'backbone'
+CurrentUser = require '../../../models/current_user.coffee'
 _ = require 'underscore'
 query = require '../queries/filter_artworks.coffee'
 metaphysics = require '../../../../lib/metaphysics.coffee'
@@ -34,7 +35,10 @@ module.exports = class ArtworkFilter extends Backbone.Model
       { @artist_id, @size, @page },
     )
 
-    send = { query, variables }
+    req =
+      user: CurrentUser.orNull()
+
+    send = { query, variables, req }
     @set isLoading: true
     metaphysics send
       .then ({ filter_artworks }) =>

--- a/src/desktop/lib/global_react_modules.js
+++ b/src/desktop/lib/global_react_modules.js
@@ -1,4 +1,3 @@
-import CurrentUser from 'desktop/models/current_user.coffee'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Artwork as ReactionArtwork } from '@artsy/reaction/dist/Components/Artwork'
@@ -6,6 +5,7 @@ import { ArtworkGrid as ReactionArtworkGrid } from '@artsy/reaction/dist/Compone
 import { ContextProvider } from '@artsy/reaction/dist/Components/Artsy'
 import { Help } from '@artsy/reaction/dist/Assets/Icons/Help'
 import { Tooltip } from '@artsy/reaction/dist/Components/Tooltip'
+import { data as sd } from 'sharify'
 
 export const TooltipQuestion = props => {
   return (
@@ -19,8 +19,6 @@ export class ArtworkGrid extends Component {
   static propTypes = {
     artworks: PropTypes.array.isRequired,
   }
-
-  currentUser = null
 
   constructor(props) {
     super(props)
@@ -37,9 +35,6 @@ export class ArtworkGrid extends Component {
     if (props.onAppendArtworks) {
       props.onAppendArtworks(this.appendArtworks)
     }
-
-    const currentUser = CurrentUser.orNull()
-    this.currentUser = currentUser ? currentUser.toJSON() : null
   }
 
   appendArtworks = artworks => {
@@ -52,7 +47,7 @@ export class ArtworkGrid extends Component {
     const artworks = mapToRelayConnection(this.state.artworks)
 
     return (
-      <ContextProvider currentUser={this.currentUser}>
+      <ContextProvider currentUser={sd.CURRENT_USER}>
         <ReactionArtworkGrid
           {...this.props}
           artworks={artworks}
@@ -70,10 +65,9 @@ export const Fillwidth = props => {
     } = require('@artsy/reaction/dist/Components/Artwork/Fillwidth')
 
     const artworks = mapToRelayConnection(props.artworks) // eslint-disable-line
-    const currentUser = CurrentUser.orNull()
 
     return (
-      <ContextProvider currentUser={currentUser ? currentUser.toJSON() : null}>
+      <ContextProvider currentUser={sd.CURRENT_USER}>
         <ReactionFillWidth {...props} artworks={artworks} useRelay={false} />
       </ContextProvider>
     )
@@ -83,10 +77,8 @@ export const Fillwidth = props => {
 }
 
 export const Artwork = props => {
-  const currentUser = CurrentUser.orNull()
-
   return (
-    <ContextProvider currentUser={currentUser ? currentUser.toJSON() : null}>
+    <ContextProvider currentUser={sd.CURRENT_USER}>
       <ReactionArtwork {...props} useRelay={false} />
     </ContextProvider>
   )

--- a/src/desktop/lib/global_react_modules.js
+++ b/src/desktop/lib/global_react_modules.js
@@ -1,9 +1,11 @@
+import CurrentUser from 'desktop/models/current_user.coffee'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Artwork as ReactionArtwork } from '@artsy/reaction/dist/Components/Artwork'
 import { ArtworkGrid as ReactionArtworkGrid } from '@artsy/reaction/dist/Components/ArtworkGrid'
-import { Tooltip } from '@artsy/reaction/dist/Components/Tooltip'
+import { ContextProvider } from '@artsy/reaction/dist/Components/Artsy'
 import { Help } from '@artsy/reaction/dist/Assets/Icons/Help'
+import { Tooltip } from '@artsy/reaction/dist/Components/Tooltip'
 
 export const TooltipQuestion = props => {
   return (
@@ -13,12 +15,12 @@ export const TooltipQuestion = props => {
   )
 }
 
-export const Artwork = props => <ReactionArtwork {...props} useRelay={false} />
-
 export class ArtworkGrid extends Component {
   static propTypes = {
     artworks: PropTypes.array.isRequired,
   }
+
+  currentUser = null
 
   constructor(props) {
     super(props)
@@ -35,6 +37,9 @@ export class ArtworkGrid extends Component {
     if (props.onAppendArtworks) {
       props.onAppendArtworks(this.appendArtworks)
     }
+
+    const currentUser = CurrentUser.orNull()
+    this.currentUser = currentUser ? currentUser.toJSON() : null
   }
 
   appendArtworks = artworks => {
@@ -47,11 +52,13 @@ export class ArtworkGrid extends Component {
     const artworks = mapToRelayConnection(this.state.artworks)
 
     return (
-      <ReactionArtworkGrid
-        {...this.props}
-        artworks={artworks}
-        useRelay={false}
-      />
+      <ContextProvider currentUser={this.currentUser}>
+        <ReactionArtworkGrid
+          {...this.props}
+          artworks={artworks}
+          useRelay={false}
+        />
+      </ContextProvider>
     )
   }
 }
@@ -63,11 +70,26 @@ export const Fillwidth = props => {
     } = require('@artsy/reaction/dist/Components/Artwork/Fillwidth')
 
     const artworks = mapToRelayConnection(props.artworks) // eslint-disable-line
+    const currentUser = CurrentUser.orNull()
 
-    return <ReactionFillWidth {...props} artworks={artworks} useRelay={false} />
+    return (
+      <ContextProvider currentUser={currentUser ? currentUser.toJSON() : null}>
+        <ReactionFillWidth {...props} artworks={artworks} useRelay={false} />
+      </ContextProvider>
+    )
   } else {
     return ''
   }
+}
+
+export const Artwork = props => {
+  const currentUser = CurrentUser.orNull()
+
+  return (
+    <ContextProvider currentUser={currentUser ? currentUser.toJSON() : null}>
+      <ReactionArtwork {...props} useRelay={false} />
+    </ContextProvider>
+  )
 }
 
 // Helpers
@@ -82,321 +104,3 @@ const mapToRelayConnection = artworks => {
     }),
   }
 }
-
-// export const artwork = {
-//   id: 'mikael-olson-some-kind-of-dinosaur',
-//   title: 'Some Kind of Dinosaur',
-//   date: '2015',
-//   sale_message: '$875',
-//   is_in_auction: false,
-//   image: {
-//     placeholder: 200,
-//     // only required prop
-//     url:
-//       'https://d32dm0rphc51dk.cloudfront.net/w6h1rYqIqhhCRE5f0_fxMQ/larger.jpg',
-//     aspect_ratio: 0.74,
-//   },
-//   artists: [
-//     {
-//       __id: 'mikael-olson',
-//       name: 'Mikael Olson',
-//     },
-//   ],
-//   partner: {
-//     name: 'Gallery 1261',
-//   },
-//   href: '/artwork/mikael-olson-some-kind-of-dinosaur',
-// }
-
-// export const artworks = {
-//   edges: [
-//     {
-//       node: {
-//         __id: 'QXJ0d29yazpiYW5rc3ktd2UtbG92ZS15b3Utc28tbG92ZS11cw==',
-//         image: {
-//           aspect_ratio: 1,
-//           placeholder: '100%',
-//           url:
-//             'https://d32dm0rphc51dk.cloudfront.net/hoFocUdpgF4mazPIgekpZA/large.jpg',
-//         },
-//         href: '/artwork/banksy-we-love-you-so-love-us',
-//         title: 'We Love You So Love Us',
-//         date: '2000',
-//         sale_message: 'Contact For Price',
-//         cultural_maker: null,
-//         artists: [
-//           {
-//             __id: 'QXJ0aXN0OmJhbmtzeQ==',
-//             href: '/artist/banksy',
-//             name: 'Banksy',
-//           },
-//         ],
-//         collecting_institution: null,
-//         partner: {
-//           name: 'EHC Fine Art',
-//           href: '/ehc-fine-art',
-//           __id: 'UGFydG5lcjplaGMtZmluZS1hcnQ=',
-//           type: 'Gallery',
-//         },
-//         sale: null,
-//         _id: '58e1a19d275b247d353ff0d9',
-//         is_inquireable: true,
-//         sale_artwork: null,
-//         id: 'banksy-we-love-you-so-love-us',
-//         is_saved: null,
-//       },
-//     },
-//     {
-//       node: {
-//         __id: 'QXJ0d29yazpiYW5rc3ktcmFkYXItcmF0LWRpcnR5LWZ1bmtlci1scA==',
-//         image: {
-//           aspect_ratio: 1,
-//           placeholder: '100%',
-//           url:
-//             'https://d32dm0rphc51dk.cloudfront.net/NQvnb87U8oGDm6kpdJ9jLA/large.jpg',
-//         },
-//         href: '/artwork/banksy-radar-rat-dirty-funker-lp',
-//         title: 'Radar Rat (Dirty Funker LP)',
-//         date: '2008',
-//         sale_message: '$950',
-//         cultural_maker: null,
-//         artists: [
-//           {
-//             __id: 'QXJ0aXN0OmJhbmtzeQ==',
-//             href: '/artist/banksy',
-//             name: 'Banksy',
-//           },
-//         ],
-//         collecting_institution: null,
-//         partner: {
-//           name: 'EHC Fine Art',
-//           href: '/ehc-fine-art',
-//           __id: 'UGFydG5lcjplaGMtZmluZS1hcnQ=',
-//           type: 'Gallery',
-//         },
-//         sale: null,
-//         _id: '58e1a19ecd530e4d612cb07f',
-//         is_inquireable: true,
-//         sale_artwork: null,
-//         id: 'banksy-radar-rat-dirty-funker-lp',
-//         is_saved: null,
-//       },
-//     },
-//     {
-//       node: {
-//         __id: 'QXJ0d29yazpiYW5rc3ktZmxvd2VyLWJvbWJlci1ieS1icmFuZGFsaXNt',
-//         image: {
-//           aspect_ratio: 1.5,
-//           placeholder: '66.66666666666666%',
-//           url:
-//             'https://d32dm0rphc51dk.cloudfront.net/88LaQZxzQdksn76f0LGFoQ/large.jpg',
-//         },
-//         href: '/artwork/banksy-flower-bomber-by-brandalism',
-//         title: 'Flower Bomber (by Brandalism)',
-//         date: 'ca. 2017',
-//         sale_message: 'Contact For Price',
-//         cultural_maker: null,
-//         artists: [
-//           {
-//             __id: 'QXJ0aXN0OmJhbmtzeQ==',
-//             href: '/artist/banksy',
-//             name: 'Banksy',
-//           },
-//         ],
-//         collecting_institution: null,
-//         partner: {
-//           name: 'EHC Fine Art',
-//           href: '/ehc-fine-art',
-//           __id: 'UGFydG5lcjplaGMtZmluZS1hcnQ=',
-//           type: 'Gallery',
-//         },
-//         sale: null,
-//         _id: '58e1a19f275b247d353ff0e2',
-//         is_inquireable: true,
-//         sale_artwork: null,
-//         id: 'banksy-flower-bomber-by-brandalism',
-//         is_saved: null,
-//       },
-//     },
-//     {
-//       node: {
-//         __id: 'QXJ0d29yazpiYW5rc3ktZ2lybC13aXRoLWJhbGxvb24tMTQ=',
-//         image: {
-//           aspect_ratio: 0.75,
-//           placeholder: '132.9%',
-//           url:
-//             'https://d32dm0rphc51dk.cloudfront.net/RRGE9Ild18_IPghZXT6wuQ/large.jpg',
-//         },
-//         href: '/artwork/banksy-girl-with-balloon-14',
-//         title: 'Girl With Balloon',
-//         date: '2004',
-//         sale_message: 'Contact For Price',
-//         cultural_maker: null,
-//         artists: [
-//           {
-//             __id: 'QXJ0aXN0OmJhbmtzeQ==',
-//             href: '/artist/banksy',
-//             name: 'Banksy',
-//           },
-//         ],
-//         collecting_institution: null,
-//         partner: {
-//           name: 'Graffik Gallery / Banksy Editions',
-//           href: '/graffik-gallery-slash-banksy-editions',
-//           __id: 'UGFydG5lcjpncmFmZmlrLWdhbGxlcnktc2xhc2gtYmFua3N5LWVkaXRpb25z',
-//           type: 'Gallery',
-//         },
-//         sale: null,
-//         _id: '58e370659c18db774f25ed5b',
-//         is_inquireable: true,
-//         sale_artwork: null,
-//         id: 'banksy-girl-with-balloon-14',
-//         is_saved: null,
-//       },
-//     },
-//     {
-//       node: {
-//         __id: 'QXJ0d29yazpiYW5rc3ktd2UtbG92ZS15b3Utc28tbG92ZS11cw==',
-//         image: {
-//           aspect_ratio: 1,
-//           placeholder: '100%',
-//           url:
-//             'https://d32dm0rphc51dk.cloudfront.net/hoFocUdpgF4mazPIgekpZA/large.jpg',
-//         },
-//         href: '/artwork/banksy-we-love-you-so-love-us',
-//         title: 'We Love You So Love Us',
-//         date: '2000',
-//         sale_message: 'Contact For Price',
-//         cultural_maker: null,
-//         artists: [
-//           {
-//             __id: 'QXJ0aXN0OmJhbmtzeQ==',
-//             href: '/artist/banksy',
-//             name: 'Banksy',
-//           },
-//         ],
-//         collecting_institution: null,
-//         partner: {
-//           name: 'EHC Fine Art',
-//           href: '/ehc-fine-art',
-//           __id: 'UGFydG5lcjplaGMtZmluZS1hcnQ=',
-//           type: 'Gallery',
-//         },
-//         sale: null,
-//         _id: '58e1a19d275b247d353ff0d9',
-//         is_inquireable: true,
-//         sale_artwork: null,
-//         id: 'banksy-we-love-you-so-love-us',
-//         is_saved: null,
-//       },
-//     },
-//     {
-//       node: {
-//         __id: 'QXJ0d29yazpiYW5rc3ktcmFkYXItcmF0LWRpcnR5LWZ1bmtlci1scA==',
-//         image: {
-//           aspect_ratio: 1,
-//           placeholder: '100%',
-//           url:
-//             'https://d32dm0rphc51dk.cloudfront.net/NQvnb87U8oGDm6kpdJ9jLA/large.jpg',
-//         },
-//         href: '/artwork/banksy-radar-rat-dirty-funker-lp',
-//         title: 'Radar Rat (Dirty Funker LP)',
-//         date: '2008',
-//         sale_message: '$950',
-//         cultural_maker: null,
-//         artists: [
-//           {
-//             __id: 'QXJ0aXN0OmJhbmtzeQ==',
-//             href: '/artist/banksy',
-//             name: 'Banksy',
-//           },
-//         ],
-//         collecting_institution: null,
-//         partner: {
-//           name: 'EHC Fine Art',
-//           href: '/ehc-fine-art',
-//           __id: 'UGFydG5lcjplaGMtZmluZS1hcnQ=',
-//           type: 'Gallery',
-//         },
-//         sale: null,
-//         _id: '58e1a19ecd530e4d612cb07f',
-//         is_inquireable: true,
-//         sale_artwork: null,
-//         id: 'banksy-radar-rat-dirty-funker-lp',
-//         is_saved: null,
-//       },
-//     },
-//     {
-//       node: {
-//         __id: 'QXJ0d29yazpiYW5rc3ktZmxvd2VyLWJvbWJlci1ieS1icmFuZGFsaXNt',
-//         image: {
-//           aspect_ratio: 1.5,
-//           placeholder: '66.66666666666666%',
-//           url:
-//             'https://d32dm0rphc51dk.cloudfront.net/88LaQZxzQdksn76f0LGFoQ/large.jpg',
-//         },
-//         href: '/artwork/banksy-flower-bomber-by-brandalism',
-//         title: 'Flower Bomber (by Brandalism)',
-//         date: 'ca. 2017',
-//         sale_message: 'Contact For Price',
-//         cultural_maker: null,
-//         artists: [
-//           {
-//             __id: 'QXJ0aXN0OmJhbmtzeQ==',
-//             href: '/artist/banksy',
-//             name: 'Banksy',
-//           },
-//         ],
-//         collecting_institution: null,
-//         partner: {
-//           name: 'EHC Fine Art',
-//           href: '/ehc-fine-art',
-//           __id: 'UGFydG5lcjplaGMtZmluZS1hcnQ=',
-//           type: 'Gallery',
-//         },
-//         sale: null,
-//         _id: '58e1a19f275b247d353ff0e2',
-//         is_inquireable: true,
-//         sale_artwork: null,
-//         id: 'banksy-flower-bomber-by-brandalism',
-//         is_saved: null,
-//       },
-//     },
-//     {
-//       node: {
-//         __id: 'QXJ0d29yazpiYW5rc3ktZ2lybC13aXRoLWJhbGxvb24tMTQ=',
-//         image: {
-//           aspect_ratio: 0.75,
-//           placeholder: '132.9%',
-//           url:
-//             'https://d32dm0rphc51dk.cloudfront.net/RRGE9Ild18_IPghZXT6wuQ/large.jpg',
-//         },
-//         href: '/artwork/banksy-girl-with-balloon-14',
-//         title: 'Girl With Balloon',
-//         date: '2004',
-//         sale_message: 'Contact For Price',
-//         cultural_maker: null,
-//         artists: [
-//           {
-//             __id: 'QXJ0aXN0OmJhbmtzeQ==',
-//             href: '/artist/banksy',
-//             name: 'Banksy',
-//           },
-//         ],
-//         collecting_institution: null,
-//         partner: {
-//           name: 'Graffik Gallery / Banksy Editions',
-//           href: '/graffik-gallery-slash-banksy-editions',
-//           __id: 'UGFydG5lcjpncmFmZmlrLWdhbGxlcnktc2xhc2gtYmFua3N5LWVkaXRpb25z',
-//           type: 'Gallery',
-//         },
-//         sale: null,
-//         _id: '58e370659c18db774f25ed5b',
-//         is_inquireable: true,
-//         sale_artwork: null,
-//         id: 'banksy-girl-with-balloon-14',
-//         is_saved: null,
-//       },
-//     },
-//   ],
-// }


### PR DESCRIPTION
To be merged in conjunction with https://github.com/artsy/reaction/pull/683. Wraps stitch grid components in an `Artsy.ContextProvider` so that we can use saves.

- Also updates `/artist/id`

#### Todo in a different PR
- Enable saves for `/artwork/id`, `/collect` and `/shows`