### PR TITLE
@anandaroop: Try to remove references to unused related/features?artwork[]=... API

### DIFF
--- a/src/desktop/collections/features.coffee
+++ b/src/desktop/collections/features.coffee
@@ -1,5 +1,0 @@
-Backbone = require 'backbone'
-Feature = require '../models/feature.coffee'
-
-module.exports = class Features extends Backbone.Collection
-  model: Feature

--- a/src/desktop/models/mixins/relations/artwork.coffee
+++ b/src/desktop/models/mixins/relations/artwork.coffee
@@ -11,7 +11,6 @@ module.exports =
     Partner = require '../../partner.coffee'
 
     Sales = require '../../../collections/sales.coffee'
-    Features = require '../../../collections/features.coffee'
     Fairs = require '../../../collections/fairs.coffee'
     Shows = require '../../../collections/partner_shows.coffee'
     Artists = require '../../../collections/artists.coffee'
@@ -24,8 +23,6 @@ module.exports =
 
     sales = new Sales
     sales.url = "#{API_URL}/api/v1/related/sales?artwork[]=#{@id}&active=true&cache_bust=#{Math.random()}"
-    features = new Features
-    features.url = "#{API_URL}/api/v1/related/features?artwork[]=#{@id}&active=true"
     fairs = new Fairs
     fairs.url = "#{API_URL}/api/v1/related/fairs?artwork[]=#{@id}&active=true"
     shows = new Shows
@@ -37,7 +34,6 @@ module.exports =
       partner: partner
       images: images
       sales: sales
-      features: features
       fairs: fairs
       shows: shows
       artists: artists


### PR DESCRIPTION
The `related/features?artwork[]=...` API hasn't been used in years and we removed it in https://github.com/artsy/gravity/pull/11694. I'm just trying to clean up the reference to it and the associated collection here.

There remain many references to the `Feature` model and routes. I think we've largely deprecated these but I can't tell what might still be used. 