### PR TITLE
@mzikherman => Fix for pressing enter quickly on spotlight search

### DIFF
--- a/src/desktop/components/search_bar/view.coffee
+++ b/src/desktop/components/search_bar/view.coffee
@@ -96,7 +96,7 @@ module.exports = class SearchBarView extends Backbone.View
         @hideSpotlight()
         return
       else
-        @emptyItemClick()
+        @emptyItemClick() if @isEmpty()
 
     letterPressed = String.fromCharCode(e.which).toLowerCase()
     if letterPressed is @$spotlightRemainingText.text().charAt(0).toLowerCase()


### PR DESCRIPTION
As reported by @briansw 