### PR TITLE
@mzikherman => fix issue with validation on the combo bid form

### DIFF
--- a/src/desktop/apps/auction_support/client/bid_form.coffee
+++ b/src/desktop/apps/auction_support/client/bid_form.coffee
@@ -30,10 +30,10 @@ module.exports = class BidForm extends ErrorHandlingForm
   initialize: ({ @saleArtwork, @bidderPositions, @submitImmediately, @isRegistered }) ->
     @user = CurrentUser.orNull()
     @$submit = @$('.registration-form-content .avant-garde-button-black')
-    @placeBid() if @submitImmediately
-    @$('.max-bid').focus() unless @submitImmediately
     @$acceptConditions = @$('#accept_conditions')
     @$conditionsCheckbox = @$('.artsy-checkbox')
+    @placeBid() if @submitImmediately
+    @$('.max-bid').focus() unless @submitImmediately
     @errors = _.defaults @errors, ErrorHandlingForm.prototype.errors
 
   showBiddingDialog: (e) ->

--- a/src/mobile/apps/feature/stylesheets/bid.styl
+++ b/src/mobile/apps/feature/stylesheets/bid.styl
@@ -51,6 +51,7 @@
 
 #feature-bid-page-errors
   color red-color
+  margin-top 15px
   margin-bottom 15px
   display none
   text-align center


### PR DESCRIPTION
Noticed in my QA that the combo bid/registration form would return a weird error when attempting to bid and register in the same go.

Turns out the call to `@validateAcceptConditions()` was failing because after you register, we instantiate the bid form with `@submitImmediately` set to true. Since the `@$acceptConditions` and  `@$conditionsCheckbox` elements didn't exist in that scenario, it was failing. 