### PR TITLE
@joeyAghion => [CircleCI] Ignore staging branch during deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,12 +81,13 @@ workflows:
   version: 2
   default:
     jobs:
-      - test
-      # - acceptance FIXME: Re enable once circle fixes their browser image.
-      - build:
+      - test:
           filters:
             branches:
               ignore: staging
+
+      # - acceptance FIXME: Re enable once circle fixes their browser image.
+      - build:
           requires:
             - test
             #- acceptance


### PR DESCRIPTION
Realized we need to ignore the `staging` branch during `test` rather than during `build`