### PR TITLE
@l2succes: [HOLD] requires user to click gdpr checkbox before creating an account

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@artsy/express-reloadable": "^1.3.1",
-    "@artsy/passport": "^1.0.10",
+    "@artsy/passport": "^1.0.11",
     "@artsy/reaction": "^1.7.2",
     "@artsy/stitch": "^1.6.0",
     "@babel/core": "7.0.0-beta.40",

--- a/src/mobile/apps/auth/client/signup.coffee
+++ b/src/mobile/apps/auth/client/signup.coffee
@@ -48,9 +48,37 @@ module.exports.SignUpView = class SignUpView extends Backbone.View
       acquisition_initiative: qs.parse(location.search).acquisition_initiative
       redirectTo: @$("input[name='redirect-to']").val()
       _csrf: @$("input[name='_csrf']").val()
+      accepted_terms_of_service: true
+      agreed_to_receive_emails: true
     @signup data
     false
 
+module.exports.SignUpOptionsView = class SignUpOptionsView extends Backbone.View
+  SIGNUP_URLS = {
+    facebook: '/users/auth/facebook',
+    email: '/sign_up?email=1'
+  }
+
+  events:
+    'click #auth-page-signup-social a': 'acceptTermsBeforeSignup'
+
+  acceptTermsBeforeSignup: (e) ->
+    e.preventDefault()
+
+    redirectTo = $(e.currentTarget).data('redirect-to')
+    signupMethod = $(e.currentTarget).data('signup-method')
+    $checkbox = $('.gdpr-signup__form__checkbox__accept-terms input')
+    
+    if $checkbox.is(':checked')
+      $('.gdpr-signup__form__checkbox__accept-terms').removeClass('tos-error')
+      window.location = SIGNUP_URLS[signupMethod] + "&#{redirectTo}"
+    else
+      $('.gdpr-signup__form__checkbox__accept-terms').addClass('tos-error')
+
 module.exports.init = ->
   bootstrap()
-  new SignUpView(el: $("#auth-page")) if window.location.search?.indexOf('email') > -1
+  
+  if window.location.search?.indexOf('email') > -1
+    new SignUpView(el: $("#auth-page"))
+  else
+    new SignUpOptionsView(el: $("#auth-page"))

--- a/src/mobile/apps/auth/stylesheets/index.styl
+++ b/src/mobile/apps/auth/stylesheets/index.styl
@@ -81,3 +81,25 @@
   p
     margin 20px
     text-align center
+
+#gdpr-signup
+  .gdpr-signup__form__checkbox__accept-terms
+    display flex
+    margin-top 30px
+    color dark-gray-text-color
+    a
+      color dark-gray-text-color
+
+    .artsy-checkbox--checkbox
+      margin-right 10px
+
+    span 
+      padding-top 2px
+      max-width 315px
+
+  .gdpr-signup__form__checkbox__accept-terms.tos-error
+    color red-color
+    a
+      color red-color
+    .artsy-checkbox--checkbox
+      background-color red-color

--- a/src/mobile/apps/auth/templates/call_to_action.jade
+++ b/src/mobile/apps/auth/templates/call_to_action.jade
@@ -32,6 +32,5 @@ block body
     ul#auth-call-to-action-forms
       li(class=sd.CURRENT_PATH.includes(sd.AP.signupPagePath) ? 'auth-call-to-action-form-active' : '')
         include signup_buttons
-        include signup_append
       li(class=sd.CURRENT_PATH.includes(sd.AP.loginPagePath) ? 'auth-call-to-action-form-active' : '')
         include login_form

--- a/src/mobile/apps/auth/templates/gdpr_checkbox.jade
+++ b/src/mobile/apps/auth/templates/gdpr_checkbox.jade
@@ -1,0 +1,16 @@
+#gdpr-signup
+  .gdpr-signup__form__checkbox__accept-terms.artsy-checkbox
+    .artsy-checkbox--checkbox
+      input(
+        required,
+        name='accepted_terms_of_service',
+        id='accepted_terms_of_service',
+        type='checkbox',
+        tabindex="0"
+      )
+      label(for='accepted_terms_of_service')
+    span I agree to Artsy’s&nbsp;
+      a( href='/terms', target='_blank' ) Terms of Use
+      | &nbsp;and&nbsp;
+      a(href='/privacy', target='_blank') Privacy Policy,
+      | &nbsp;and to receive emails from Artsy.

--- a/src/mobile/apps/auth/templates/signup.jade
+++ b/src/mobile/apps/auth/templates/signup.jade
@@ -6,6 +6,5 @@ block body
     if error
       .auth-page-error-message= error
     include signup_buttons
-    include signup_append
     p.auth-page-nevermind Already have an account?
       a( href='/log_in' + (redirectTo ? '?redirectTo=#{redirectTo}' : '' )) Log in

--- a/src/mobile/apps/auth/templates/signup_buttons.jade
+++ b/src/mobile/apps/auth/templates/signup_buttons.jade
@@ -1,7 +1,14 @@
 #auth-page-signup-social
   a.auth-page-facebook.avant-garde-box-button.avant-garde-box-button-black(
-    href="/users/auth/facebook?redirect-to=#{redirectTo ? redirectTo : '/personalize/collect'}"
+    href='#'
+    disabled=true
+    data-redirect-to="redirect-to=#{redirectTo ? redirectTo : '/personalize/collect'}"
+    data-signup-method='facebook'
   ) Facebook
   a.avant-garde-box-button.avant-garde-box-button-black(
-    href="/sign_up?email=1&redirect-to=#{redirectTo ? redirectTo : '/personalize/collect'}"
+    href='#'
+    disabled=true
+    data-redirect-to="redirect-to=#{redirectTo ? redirectTo : '/personalize/collect'}"
+    data-signup-method='email'
   ) Your email address
+include gdpr_checkbox

--- a/src/mobile/apps/auth/test/client.coffee
+++ b/src/mobile/apps/auth/test/client.coffee
@@ -125,3 +125,30 @@ describe 'Login view', ->
       @view.serializeForm = -> { email: 'foo', password: 'foo' }
       @view.check { preventDefault: -> }
       $.ajax.restore()
+
+describe 'Require gdpr checkbox', ->
+
+  beforeEach (done) ->
+    benv.setup =>
+      benv.expose {
+        $: benv.require 'jquery'
+        analyticsHooks: { trigger: sinon.stub() }
+      }
+      Backbone.$ = $
+      sinon.stub Backbone, 'sync'
+      benv.render resolve(__dirname, '../templates/signup.jade'), { sd: { AP: {} }, asset: (->) }, =>
+        { SignUpOptionsView } = mod = benv.require resolve(__dirname, '../client/signup')
+        mod.__set__ 'sd', { AP: {} }
+        @view = new SignUpOptionsView el: $('#auth-page')
+        done()
+
+  afterEach ->
+    benv.teardown()
+    Backbone.sync.restore()
+
+  describe 'SignUpOptionsView', ->
+
+      describe '#acceptTermsBeforeSignup', ->
+        it 'adds error class if user does not click gdpr checkbox before creating an account', ->
+          @view.$('#auth-page-signup-social a').first().click()
+          @view.$el.html().should.containEql 'tos-error'

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,9 +10,9 @@
     chokidar "^1.7.0"
     decache "^4.4.0"
 
-"@artsy/passport@^1.0.10":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@artsy/passport/-/passport-1.0.10.tgz#55c6525103b4d3dfdff6e4babecc5f597759efde"
+"@artsy/passport@^1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@artsy/passport/-/passport-1.0.11.tgz#b323f833983bded4202cc3a98ef537740a4bd6fe"
   dependencies:
     analytics-node "^2.1.0"
     async "^1.5.0"


### PR DESCRIPTION
FYI this needs the [update to artsy-passport](https://github.com/artsy/artsy-passport/pull/126) before this gets merged.

This adds the new gdpr checkbox for mobile signups and requires the user to click the checkbox before being able to select one of the signup options (facebook or email).

New Checkbox:
![screen shot 2018-05-16 at 3 53 17 pm](https://user-images.githubusercontent.com/5201004/40140617-61654706-5921-11e8-9c52-53d605faab33.png)

Error State:
![screen shot 2018-05-16 at 3 53 29 pm](https://user-images.githubusercontent.com/5201004/40140616-6147f2fa-5921-11e8-86a0-8d6cf2c522ed.png)

