### PR TITLE
Fixes missing auction artwork detail

### DIFF
--- a/src/mobile/apps/artwork/components/image/templates/index.jade
+++ b/src/mobile/apps/artwork/components/image/templates/index.jade
@@ -21,7 +21,6 @@
         else if artwork.cultural_maker
           .artist-name= artwork.cultural_maker
         
-        unless artwork.auction || (artwork.auction && artwork.auction.is_auction)
-          include ./details.jade
+        include ./details.jade
   
       include ./attribution_class

--- a/src/mobile/apps/artwork/components/meta_data/templates/index.jade
+++ b/src/mobile/apps/artwork/components/meta_data/templates/index.jade
@@ -7,6 +7,7 @@
       include ./edition_sets.jade
       include ./inquiry.jade
 
+    include ../../image/templates/details.jade
     include ./partner.jade
 
     if artwork.auction && artwork.auction.sale_artwork.estimate

--- a/src/mobile/apps/artwork/components/meta_data/templates/index.jade
+++ b/src/mobile/apps/artwork/components/meta_data/templates/index.jade
@@ -7,7 +7,6 @@
       include ./edition_sets.jade
       include ./inquiry.jade
 
-    include ../../image/templates/details.jade
     include ./partner.jade
 
     if artwork.auction && artwork.auction.sale_artwork.estimate


### PR DESCRIPTION
Reported on [#incidents](https://artsy.slack.com/archives/C9RK0BLEP/p1526655623001021) channel.

The file has been changed in [this](https://github.com/artsy/force/commit/0e324a1281d6ce2a07b9ba430bbdc59d51608fd4#diff-ad0338dacfbe0c2a9b1baec49bb7aecf) commit. Merged in [this PR](https://github.com/artsy/force/pull/2420). Still figuring out if it was intentional.

### Before:
<img width="374" alt="screen shot 2018-05-18 at 12 15 51 pm" src="https://user-images.githubusercontent.com/687513/40246091-829466b2-5a95-11e8-95cb-73f5b99b6d3f.png">

### After:

<img width="376" alt="screen shot 2018-05-18 at 12 35 59 pm" src="https://user-images.githubusercontent.com/687513/40246936-a5c557ce-5a98-11e8-82e7-2e87b83c847b.png">

