### PR TITLE
Test new inquiry flow

### DIFF
--- a/src/desktop/apps/artwork/client/index.coffee
+++ b/src/desktop/apps/artwork/client/index.coffee
@@ -162,7 +162,7 @@ module.exports =
   init: ->
     setCookie(CLIENT._id)
     recordArtworkView(CLIENT._id, CurrentUser.orNull())
-    exec sharedInit
+    exec sharedInit, disableZigZagBanner: window.location.search.indexOf("feature-new-inquiry-flow=true") >= 0
 
     context = CLIENT.context or {}
     { query, init, variables } = setup(context)

--- a/src/desktop/apps/artwork/client/index.coffee
+++ b/src/desktop/apps/artwork/client/index.coffee
@@ -162,7 +162,7 @@ module.exports =
   init: ->
     setCookie(CLIENT._id)
     recordArtworkView(CLIENT._id, CurrentUser.orNull())
-    exec sharedInit, disableZigZagBanner: window.location.search.indexOf("feature-new-inquiry-flow=true") >= 0
+    exec sharedInit
 
     context = CLIENT.context or {}
     { query, init, variables } = setup(context)

--- a/src/desktop/apps/artwork/components/commercial/bootstrap.coffee
+++ b/src/desktop/apps/artwork/components/commercial/bootstrap.coffee
@@ -1,5 +1,6 @@
-module.exports = (sd, { artwork }) ->
+module.exports = (sd, { artwork, enableNewInquiryFlow }) ->
   sd.COMMERCIAL =
+    enableNewInquiryFlow: enableNewInquiryFlow
     artwork:
       id: artwork.id
       _id: artwork._id

--- a/src/desktop/apps/artwork/components/commercial/index.coffee
+++ b/src/desktop/apps/artwork/components/commercial/index.coffee
@@ -7,7 +7,7 @@ shouldStick = ->
   COMMERCIAL.artwork.is_acquireable or
   COMMERCIAL.artwork.is_inquireable
 
-module.exports = ->
+module.exports = (options = { disableZigZagBanner: false }) ->
   $el = $('.js-artwork-commercial')
 
   return unless $el.length
@@ -19,7 +19,7 @@ module.exports = ->
   sticky = new Sticky
   sticky.add $el if shouldStick()
 
-  if ($target = $el.find '.js-artwork-inquire-button').length and not COMMERCIAL.artwork.is_acquireable
+  if not options.disableZigZagBanner and ($target = $el.find '.js-artwork-inquire-button').length and not COMMERCIAL.artwork.is_acquireable
     new ZigZagBanner
       $target: $target
       name: 'inquiry'

--- a/src/desktop/apps/artwork/components/commercial/index.coffee
+++ b/src/desktop/apps/artwork/components/commercial/index.coffee
@@ -7,7 +7,7 @@ shouldStick = ->
   COMMERCIAL.artwork.is_acquireable or
   COMMERCIAL.artwork.is_inquireable
 
-module.exports = (options = { disableZigZagBanner: false }) ->
+module.exports = ->
   $el = $('.js-artwork-commercial')
 
   return unless $el.length
@@ -19,7 +19,7 @@ module.exports = (options = { disableZigZagBanner: false }) ->
   sticky = new Sticky
   sticky.add $el if shouldStick()
 
-  if not options.disableZigZagBanner and ($target = $el.find '.js-artwork-inquire-button').length and not COMMERCIAL.artwork.is_acquireable
+  if not COMMERCIAL.enableNewInquiryFlow and ($target = $el.find '.js-artwork-inquire-button').length and not COMMERCIAL.artwork.is_acquireable
     new ZigZagBanner
       $target: $target
       name: 'inquiry'

--- a/src/desktop/apps/artwork/components/commercial/templates/inquire.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/inquire.jade
@@ -9,7 +9,7 @@ if artwork.is_inquireable
     if user && user.isWithAnonymousSession()
       input( type='hidden', name='anonymous_session_id', value= user.id )
 
-    unless user && user.get('name') && user.get('email')
+    unless enableNewInquiryFlow || (user && user.get('name') && user.get('email'))
       input.bordered-input(
         type='text'
         name='name'

--- a/src/desktop/apps/artwork/components/commercial/templates/inquire.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/inquire.jade
@@ -23,7 +23,7 @@ if artwork.is_inquireable
         required
       )
 
-    unless artwork.partner.is_pre_qualify
+    unless enableNewInquiryFlow || artwork.partner.is_pre_qualify
       if artwork.contact_message
         textarea.bordered-input(
           rows='4'

--- a/src/desktop/apps/artwork/routes.coffee
+++ b/src/desktop/apps/artwork/routes.coffee
@@ -82,7 +82,7 @@ bootstrap = ->
     .then (data) ->
       data.fair = new Fair data.artwork.fair if data.artwork.fair
       extend res.locals.helpers, helpers
-      bootstrap res.locals.sd, data
+      bootstrap res.locals.sd, extend data, { enableNewInquiryFlow: req.query["feature-new-inquiry-flow"] is "true" }
       res.locals.sd.PARAMS = req.params
       res.locals.sd.INCLUDE_SAILTHRU = data.artwork?.fair?
       res.locals.sd.QUERY = req.query

--- a/src/desktop/components/auth_modal/view.coffee
+++ b/src/desktop/components/auth_modal/view.coffee
@@ -34,7 +34,7 @@ module.exports = class AuthModalView extends ModalView
 
   initialize: (options) ->
     return if isEigen.checkWith options
-    { @destination, @successCallback, @afterSignUpAction } = options
+    { @destination, @afterSignUpAction } = options
     @redirectTo = encodeURIComponent(sanitizeRedirect(options.redirectTo)) if options.redirectTo
 
     @preInitialize options

--- a/src/desktop/components/inquiry_questionnaire/index.coffee
+++ b/src/desktop/components/inquiry_questionnaire/index.coffee
@@ -7,6 +7,7 @@ Logger = require '../logger/index.coffee'
 Trail = require './trail.coffee'
 analytics = require './analytics.coffee'
 openErrorFlash = require './error.coffee'
+sd = require('sharify').data
 { steps, decisions, views } = require './map.coffee'
 
 module.exports = ({ user, artwork, inquiry, bypass, state_attrs }) ->
@@ -45,6 +46,7 @@ module.exports = ({ user, artwork, inquiry, bypass, state_attrs }) ->
     collectorProfile: collectorProfile
     userInterests: userInterests
     trail: trail
+    enableNewInquiryFlow: sd.COMMERCIAL.enableNewInquiryFlow
 
   # Attach/teardown analytics events
   analytics.attach state.context

--- a/src/desktop/components/inquiry_questionnaire/map/decisions.coffee
+++ b/src/desktop/components/inquiry_questionnaire/map/decisions.coffee
@@ -7,9 +7,11 @@ decisions =
   is_auction: ({ artwork }) ->
     artwork.get('is_in_auction') is true
 
-  pre_qualify: ({ artwork }) ->
-    artwork.related()
-      .partner.get('pre_qualify') is true
+  enable_new_inquiry_flow: ({ enableNewInquiryFlow }) -> enableNewInquiryFlow
+
+  pre_qualify: ({ artwork, enableNewInquiryFlow }) ->
+    not enableNewInquiryFlow and
+      artwork.related().partner.get('pre_qualify') is true
 
   is_collector: ({ user }) ->
     user.isCollector()

--- a/src/desktop/components/inquiry_questionnaire/map/steps.coffee
+++ b/src/desktop/components/inquiry_questionnaire/map/steps.coffee
@@ -50,11 +50,6 @@ module.exports = [
           }
         ]
         false: [
-          {
-            enable_new_inquiry_flow: true: [
-              { is_logged_out: true: ['account'] }
-            ]
-          }
           'inquiry'
           {
             enable_new_inquiry_flow: false: [

--- a/src/desktop/components/inquiry_questionnaire/map/steps.coffee
+++ b/src/desktop/components/inquiry_questionnaire/map/steps.coffee
@@ -50,8 +50,17 @@ module.exports = [
           }
         ]
         false: [
+          {
+            enable_new_inquiry_flow: true: [
+              { is_logged_out: true: ['account'] }
+            ]
+          }
           'inquiry'
-          { is_logged_out: true: ['account'] }
+          {
+            enable_new_inquiry_flow: false: [
+              { is_logged_out: true: ['account'] }
+            ]
+          }
           { has_completed_profile: false: ['confirmation'] }
           { has_seen_commercial_interest: false: ['commercial_interest'] }
           { has_basic_info: false: ['basic_info'] }

--- a/src/desktop/components/inquiry_questionnaire/views/account.coffee
+++ b/src/desktop/components/inquiry_questionnaire/views/account.coffee
@@ -4,6 +4,7 @@ StepView = require './step.coffee'
 Form = require '../../form/index.coffee'
 FormMixin = require '../../mixins/form'
 FormErrorHelpers = require '../../auth_modal/helpers'
+sd = require('sharify').data
 templates =
   register: -> require('../templates/account/register.jade') arguments...
   login: -> require('../templates/account/login.jade') arguments...
@@ -58,11 +59,14 @@ module.exports = class Account extends StepView
         @user.repossess user.id,
           error: form.error.bind form
           success: =>
-            @state.get('inquiry').save {},
-              success: =>
-                @next()
-              error: =>
-                @next()
+            if sd.COMMERCIAL.enableNewInquiryFlow
+              @next()
+            else
+              @state.get('inquiry').save {},
+                success: =>
+                  @next()
+                error: =>
+                  @next()
 
   forgot: (active, mode) ->
     return unless mode is 'forgot'

--- a/src/desktop/components/inquiry_questionnaire/views/inquiry.coffee
+++ b/src/desktop/components/inquiry_questionnaire/views/inquiry.coffee
@@ -6,6 +6,7 @@ defaultMessage = require '../../contact/default_message.coffee'
 ArtworkInquiry = require '../../../models/artwork_inquiry.coffee'
 alertable = require '../../alertable_input/index.coffee'
 hasSeen = require '../../has_seen/index.coffee'
+sd = require('sharify').data
 template = -> require('../templates/inquiry.jade') arguments...
 
 module.exports = class Inquiry extends StepView
@@ -45,14 +46,15 @@ module.exports = class Inquiry extends StepView
 
     form = new Form model: @inquiry, $form: @$('form')
 
-    nudge =
-      $input: @$('textarea')
-      message: 'We recommend personalizing your message to get a faster answer from the gallery.'
-      $submit: @$('button')
-      label: 'Send Anyway?'
+    unless sd.COMMERCIAL.enableNewInquiryFlow
+      nudge =
+        $input: @$('textarea')
+        message: 'We recommend personalizing your message to get a faster answer from the gallery.'
+        $submit: @$('button')
+        label: 'Send Anyway?'
 
-    if not @nudged() and alertable(nudge, ((value) => value is @defaultMessage()))
-      return
+      if not @nudged() and alertable(nudge, ((value) => value is @defaultMessage()))
+        return
 
     return unless form.isReady()
 


### PR DESCRIPTION
Implements the changes for https://artsyproduct.atlassian.net/browse/EV-118 sans the split test.

Test by adding the `?feature-new-inquiry-flow=true` GET parameter.

* Removes purple CTA banner
* Removes pre-filled message form from sidebar
* Removes pre-qualification check (I made Gagosian a pre-qualify partner in staging)
* Remove message personalisation nudge
* Uses full authentication modal and _before_ inquiry modal

Note that there’s no real functionality changes and thus test changes. Once the test has concluded I’ll cleanup and update tests accordingly.