### PR TITLE
@alloy => no longer query for all: true on desktop artwork pages (for shows)

### DIFF
--- a/src/desktop/apps/artwork/client/index.coffee
+++ b/src/desktop/apps/artwork/client/index.coffee
@@ -1,7 +1,7 @@
 { extend, map, compact } = require 'underscore'
 { AUCTION, CLIENT } = require('sharify').data
 { setCookie } = require '../../../components/recently_viewed_artworks/index.coffee'
-{ recordArtworkView } = require 'lib/components/record_artwork_view'
+{ recordArtworkView } = require '../../../../lib/components/record_artwork_view'
 metaphysics = require '../../../../lib/metaphysics.coffee'
 CurrentUser = require '../../../models/current_user.coffee'
 exec = require '../lib/exec.coffee'

--- a/src/desktop/apps/artwork/client/test/index.coffee
+++ b/src/desktop/apps/artwork/client/test/index.coffee
@@ -6,7 +6,6 @@ _ = require 'underscore'
 { resolve } = require 'path'
 { fabricate } = require 'antigravity'
 
-
 describe 'Artwork Client', ->
   before ->
     global.OpenSeadragon = {}
@@ -147,7 +146,7 @@ describe 'Artwork Client', ->
             type: 'Show'
             name: 'Some Show'
             href: '/some-show'
-            counts: { artworks: '2 works' }
+            counts: { eligible_artworks: 100 }
             artworks:  [{ id: 'artwork-4', partner: {}, image: { cell: {}, thumb: { height: 1 }}, title: 'Artwork 4'}]
       $('body').html("""
         <div class="artwork__main__overview__fold js-artwork-fold"></div>
@@ -185,3 +184,4 @@ describe 'Artwork Client', ->
       $('.artwork-section.artwork-show-artworks').html().should.containEql 'Artwork 4'
       $('.artwork-section.artwork-show-artworks').html().should.containEql '/some-show'
       $('.artwork-section.artwork-show-artworks').html().should.containEql 'Other Works from the Show'
+      $('.artwork-section.artwork-show-artworks').html().should.containEql 'View all 100 works'

--- a/src/desktop/apps/artwork/components/fair_artworks/query.coffee
+++ b/src/desktop/apps/artwork/components/fair_artworks/query.coffee
@@ -4,7 +4,10 @@ module.exports = """
       name
       href
       type
-      artworks(all: true, size: 50, exclude: [$id]) {
+      counts {
+        eligible_artworks
+      }
+      artworks(size: 20, exclude: [$id]) {
         ... artwork_brick
       }
     }

--- a/src/desktop/apps/artwork/components/show_artworks/index.jade
+++ b/src/desktop/apps/artwork/components/show_artworks/index.jade
@@ -16,3 +16,8 @@ if artwork.show && artwork.show.artworks.length
     else
       - var columns = helpers.show_artworks.masonry(show.artworks).columns
       include ../../../../components/artwork_masonry/index
+
+    .artwork-section__jump
+      a.avant-garde-jump-link( href='#{artwork.show.href}' )
+        | View all #{artwork.show.counts.eligible_artworks} works
+        i.icon-chevron-small-right

--- a/src/desktop/apps/artwork/components/show_artworks/query.coffee
+++ b/src/desktop/apps/artwork/components/show_artworks/query.coffee
@@ -5,7 +5,10 @@ module.exports = """
         name
         href
         type
-        artworks(all: true, size: 50, exclude: [$id]) {
+        counts {
+          eligible_artworks
+        }
+        artworks(size: 20, exclude: [$id]) {
           ... artwork_brick
         }
       }


### PR DESCRIPTION
Based on recent metaphysics latency/memory issues, this fix is timely.

It's the follow-up from https://github.com/artsy/force/pull/2267 and should remove the remaining cases in force where we're using `all: true` to get all objects via pagination in metaphysics.

I borrowed the logic from the mobile-web side, but we can always revisit with updated language. For now it just says "View all <num artworks> works".

![image](https://user-images.githubusercontent.com/2081340/40361571-c8ea2d36-5d97-11e8-94b0-35ebab3e0ffd.png)
