### PR TITLE
@l2succes => Filter mobile artist articles by in_editorial_feed

### DIFF
--- a/src/mobile/apps/artist/client/view.coffee
+++ b/src/mobile/apps/artist/client/view.coffee
@@ -72,7 +72,7 @@ module.exports = class ArtistPageView extends Backbone.View
 
   renderArticles: ->
     (articles = new Articles).fetch
-      data: artist_id: @model.get('_id'), published: true, limit: 5
+      data: artist_id: @model.get('_id'), in_editorial_feed: true, published: true, limit: 5
       success: =>
         @$('#artist-page-featured-articles').html articles.map((article) ->
           articleFigureTemplate article: article


### PR DESCRIPTION
Missed the mobile app when we made this change a few weeks ago on desktop, filters articles in `/artist` pages by `in_editorial_feed` to exclude news articles.