### PR TITLE
@cavvia => Revert "add support for new homepage rails and update rails order"

### DIFF
--- a/src/desktop/apps/home/queries/initial.coffee
+++ b/src/desktop/apps/home/queries/initial.coffee
@@ -6,14 +6,12 @@ module.exports = """
         max_followed_gene_rails: -1,
         order: [
           ACTIVE_BIDS,
-          RECENTLY_VIEWED_WORKS,
-          SIMILAR_TO_RECENTLY_VIEWED,
-          SAVED_WORKS,
-          SIMILAR_TO_SAVED_WORKS,
-          FOLLOWED_ARTISTS,
-          FOLLOWED_GALLERIES,
+          RECENTLY_VIEWED_WORKS
           RECOMMENDED_WORKS,
+          FOLLOWED_ARTISTS,
           RELATED_ARTISTS,
+          FOLLOWED_GALLERIES,
+          SAVED_WORKS,
           LIVE_AUCTIONS,
           CURRENT_FAIRS,
           FOLLOWED_GENES,


### PR DESCRIPTION
Reverts artsy/force#2528

In prep for MP being rolled back: these new rails `SIMILAR_TO_RECENTLY_VIEWED`, etc. wouldn't exist and MP would throw an error on that. 