### PR TITLE
Replaces mobile auction clock with desktop #dontmerge

### DIFF
--- a/src/desktop/apps/artwork/components/clock/index.styl
+++ b/src/desktop/apps/artwork/components/clock/index.styl
@@ -1,6 +1,6 @@
 .countdown-clock
   &__label
-    sans('s-headline')
+    sans('s-headline', true)
 
   &__clock
     white-space nowrap
@@ -19,7 +19,7 @@
         position absolute
         top 0
         right 0
-        sans('l-headline')
+        sans('l-headline', true)
 
       &:last-child
         margin-right 0
@@ -31,7 +31,7 @@
         display block
 
       &__value
-        sans('l-headline')
+        sans('l-headline', true)
 
       &__label
         avant-garde()

--- a/src/mobile/apps/artwork/components/bid/index.jade
+++ b/src/mobile/apps/artwork/components/bid/index.jade
@@ -14,7 +14,7 @@ if artwork.auction
             a( href='/how-auctions-work-buyers-premium-taxes-and-fees') buyer's premium
 
         .artwork-auction-bid-module__clock
-          include ../../../../components/auction_clock/template
+          include ../../../../../desktop/apps/artwork/components/clock/index
 
         .artwork-auction-bid-module__auction-links.chevron-nav-list
           a.js-auction-multipage(data-id="auction-faqs") AUCTION FAQ

--- a/src/mobile/apps/artwork/components/bid/index.styl
+++ b/src/mobile/apps/artwork/components/bid/index.styl
@@ -1,3 +1,5 @@
+@import '../../../../../desktop/apps/artwork/components/clock'
+
 .artwork-auction-bid-module__bid-status-title
 .artwork-auction-bid-module__bid-status-amount
   garamond-size('s-body', true)

--- a/src/mobile/apps/artwork/components/bid/view.coffee
+++ b/src/mobile/apps/artwork/components/bid/view.coffee
@@ -3,10 +3,12 @@ Backbone = require 'backbone'
 openMultiPage = require '../../../../components/multi_page/index.coffee'
 ModalView = require '../../../../components/modal/view.coffee'
 Sale = require '../../../../models/sale.coffee'
-AuctionClockView = require '../../../../components/auction_clock/view.coffee'
+ClockView = require '../../../../../desktop/apps/artwork/components/clock/view.coffee'
 Artwork = require '../../../../models/artwork.coffee'
 SaleArtwork = require '../../../../models/sale_artwork.coffee'
 updateCurrentBid = require './index.coffee'
+{ ARTWORK } = require('sharify').data
+{ countdownLabel, countdownTimestamp } = require '../../../../../desktop/apps/artwork/components/banner/helpers.coffee'
 
 module.exports = class ArtworkBidView extends Backbone.View
 
@@ -16,7 +18,7 @@ module.exports = class ArtworkBidView extends Backbone.View
   initialize: ({ @artwork }) ->
     return unless @artwork.auction
     sale = new Sale @artwork.auction
-    @setupAuctionClock(sale)
+    @setupDesktopAuctionClock(sale)
     updateCurrentBid()
 
   openMultiPage: (e) ->
@@ -28,8 +30,11 @@ module.exports = class ArtworkBidView extends Backbone.View
     @$el.append modal.$el
     modal.insertModalContent pages.$el
 
-  setupAuctionClock: (sale) ->
-    @auctionClockView = new AuctionClockView
-      model: sale
-      el: @$('.artwork-auction-bid-module__clock')
-    @auctionClockView.start()
+  setupDesktopAuctionClock: (sale) ->
+    if { start_at, end_at, live_start_at } = ARTWORK.auction
+      clockView = new ClockView
+        label: countdownLabel start_at, live_start_at
+        timestamp: countdownTimestamp start_at, end_at, live_start_at
+      clockView.start()
+    $('.artwork-auction-bid-module__clock')
+      .html clockView.render().$el

--- a/src/mobile/apps/auction/stylesheets/index.styl
+++ b/src/mobile/apps/auction/stylesheets/index.styl
@@ -33,6 +33,7 @@
 
 .auction-title
 .auction-clock
+.countdown-clock
 .auction-description
 .auction-bidding-link
 .auction-info-section
@@ -40,6 +41,9 @@
 .auction-tabs .auction-artwork-list
   margin 20px 0
 
+.countdown-clock
+  text-align: center
+  
 .auction-description
   > h3
     font-weight bold

--- a/src/mobile/apps/feature/client/bid_page.coffee
+++ b/src/mobile/apps/feature/client/bid_page.coffee
@@ -3,7 +3,6 @@ sd = require('sharify').data
 SaleArtwork = require '../../../models/sale_artwork.coffee'
 Backbone = require 'backbone'
 bootstrap = require '../../../components/layout/bootstrap.coffee'
-AuctionClockView = require '../../../components/auction_clock/view.coffee'
 ConditionsOfSale = require '../../../../desktop/apps/auction_support/mixins/conditions_of_sale.js'
 openSpecialistModal = require '../../../components/specialist_modal/index.coffee'
 Auction = require '../../../models/sale.coffee'
@@ -11,6 +10,8 @@ CurrentUser = require '../../../models/current_user.coffee'
 mediator = require '../../../lib/mediator.coffee'
 accounting = require 'accounting'
 analyticsHooks = require '../../../lib/analytics_hooks.coffee'
+ClockView = require '../../../../desktop/apps/artwork/components/clock/view.coffee'
+{ countdownLabel, countdownTimestamp } = require '../../../../desktop/apps/artwork/components/banner/helpers.coffee'
 
 module.exports.BidPageView = class BidPageView extends Backbone.View
   _.extend @prototype, ConditionsOfSale
@@ -124,10 +125,14 @@ module.exports.init = ->
     window: window
     isRegistered: sd.REGISTERED
 
-  new AuctionClockView(
-    model: new Auction sd.AUCTION
-    el: $('.js-auction-clock')
-  ).start()
+  if { start_at, end_at, live_start_at } = sd.AUCTION
+    clockView = new ClockView
+      label: countdownLabel start_at, live_start_at
+      timestamp: countdownTimestamp start_at, end_at, live_start_at
+    clockView.start()
+
+  $('.js-auction-clock')
+    .html clockView.render().$el
 
   mediator.once 'clock:is-almost-over', ->
     $('.js-auction-clock').addClass 'is-almost-over'

--- a/src/mobile/apps/feature/stylesheets/bid.styl
+++ b/src/mobile/apps/feature/stylesheets/bid.styl
@@ -5,6 +5,7 @@
 @import '../components/stylus_lib'
 @import '../components/bid_numbers'
 @import '../../../../desktop/apps/auction_support/stylesheets/conditions_of_sale'
+@import '../../../../desktop/apps/artwork/components/clock'
 
 #feature-bid-page-container
   margin 20px

--- a/src/mobile/apps/feature/templates/bid_page.jade
+++ b/src/mobile/apps/feature/templates/bid_page.jade
@@ -73,4 +73,4 @@ block body
               | Bid #{accounting.formatMoney(next / 100, saleArtwork.get('symbol'), 0)}
               .loading-spinner
     #feature-clock-container.js-auction-clock
-      include ../../../components/auction_clock/template
+      include ../../../../desktop/components/clock/template

--- a/src/mobile/components/stylus_lib/typography.styl
+++ b/src/mobile/components/stylus_lib/typography.styl
@@ -29,6 +29,8 @@ avant-garde-size(size, mixinFont = false)
   if mixinFont
     avant-garde()
 
+sans = avant-garde-size
+
 // Styles
 small-caps()
   text-transform uppercase


### PR DESCRIPTION
An attempt to fix this the intermittent issue with mobile auction page reload loop: https://artsyproduct.atlassian.net/browse/PURCHASE-152

Also documented here: https://trello.com/c/jDdbZkZ9/92-mobile-site-keeps-refereshing

- [x] Replace mobile auction clock with desktop clock
- [ ] Remove mobile auction clock

The cause of refresh hasn't been found out yet but if the cause is a race condition triggering the `location.reload()` [here](https://github.com/artsy/force/blob/316894dc4a2ae6aa4723c730fc9635d897f82884/src/mobile/components/auction_clock/view.coffee#L23), replacing that clock with the stable desktop version will fix the problem.

 (like `clockState` being `undefined` **before** the `onChange` event is bound. `clockState` is initially `undefined` but the `sale.updateState` function is being called **before** the `success` callback witch binds the `onChange` [here](https://github.com/artsy/force/blob/316894dc4a2ae6aa4723c730fc9635d897f82884/src/mobile/models/sale.coffee#L45))

## UI changes:
### Old clock:
<img width="375" alt="screen shot 2018-05-24 at 10 23 48 am" src="https://user-images.githubusercontent.com/687513/40502192-3563102e-5f58-11e8-9f53-18606a8fafd3.png">

### New  clock:
<img width="376" alt="screen shot 2018-05-24 at 10 23 38 am" src="https://user-images.githubusercontent.com/687513/40502206-44bb84f2-5f58-11e8-81c7-ec575b8d333c.png">

It is possible to make the new clock look like the old one with CSS but hasn't done that in favor of making mobile look consistent with the desktop:

<img width="1415" alt="screen shot 2018-05-24 at 1 44 45 pm" src="https://user-images.githubusercontent.com/687513/40502365-bcc4640a-5f58-11e8-9285-cf0cda72c4fe.png">

This is a question for @briansw if we want to keep it this way or make it look the way it was.

