### PR TITLE
@kanaabe => homepage fix

### DIFF
--- a/src/desktop/apps/home/client/setup_home_page_modules.coffee
+++ b/src/desktop/apps/home/client/setup_home_page_modules.coffee
@@ -1,6 +1,5 @@
 { each } = require 'underscore'
-moment = require 'moment'
-tz = require 'moment-timezone'
+moment = require 'moment-timezone'
 { USER_HOME_PAGE } = require('sharify').data
 User = require '../../../models/user.coffee'
 metaphysics = require '../../../../lib/metaphysics.coffee'


### PR DESCRIPTION
A recent upgrade of moment broke the home page due to a breaking API change. The fix is to import
`moment-timezone` instead of `moment` when we need access to timezone data (e.g. `moment.tz()`). The issue is described here ((https://github.com/moment/moment/issues/4313))

I missed this one import during the update.