### PR TITLE
[Hold for product approval] => enabled artist market data test and remove lab feature check there

### DIFF
--- a/src/desktop/apps/artist/client/index.coffee
+++ b/src/desktop/apps/artist/client/index.coffee
@@ -11,7 +11,7 @@ testGroup = sd.ARTIST_MARKET_DATA_TEST
 
 module.exports.init = ->
   # TODO: ARTIST_MARKET_DATA_TEST remove after test closes
-  # splitTest('artist_market_data_test').view()
+  splitTest('artist_market_data_test').view()
 
   statuses = ARTIST.statuses
   artist = new Artist ARTIST

--- a/src/desktop/apps/artist/routes.coffee
+++ b/src/desktop/apps/artist/routes.coffee
@@ -36,8 +36,7 @@ sd = require('sharify').data
       return res.redirect(artist.href) unless(_.find nav.sections(), slug: tab) or artist.counts.artworks is 0
 
       # TODO: ARTIST_MARKET_DATA_TEST remove after test closes
-      labFeatureGate = req.user && req.user.hasLabFeature('Artist Market Data Summary')
-      testGroup = if labFeatureGate then res.locals.sd.ARTIST_MARKET_DATA_TEST else 'control'
+      testGroup = res.locals.sd.ARTIST_MARKET_DATA_TEST
   
       if (req.params.tab? or artist.href is res.locals.sd.CURRENT_PATH)
         currentVeniceFeature(artist)


### PR DESCRIPTION
I believe merging this will enable the split test for artist page for all the site users @alloy.

Need to remember to clean up the lab feature on staging and production at some point after this PR is merged and deployed:
```
$ lab_feature = LabFeature.where(name: 'Artist Market Data Summary').first
$ lab_feature.retire!
```