### PR TITLE
fix issue with dupe search results when items share the same slug

### DIFF
--- a/src/desktop/apps/search/test/client/index.coffee
+++ b/src/desktop/apps/search/test/client/index.coffee
@@ -32,9 +32,7 @@ describe 'SearchResultsView', ->
 
   it 'fills in artwork images', ->
     @view.refreshRenderArtworks(fixture.searchResult)
-
     Backbone.sync.args[1][2].success(fabricate 'artwork', id: 'maya-hayuk-untitled')
-
     @view.$el.html().should.containEql("https://i.embed.ly/1/display/crop?url=%2Flocal%2Fadditional_images%2F4e7cb83e1c80dd00010038e2%2F1%2Fsmall.jpg")
 
 

--- a/src/desktop/models/search_result.coffee
+++ b/src/desktop/models/search_result.coffee
@@ -10,6 +10,11 @@ module.exports = class SearchResult extends Backbone.Model
   _.extend @prototype, Image(sd.SECURE_IMAGES_URL)
 
   initialize: (options) ->
+
+    @set
+      slug: @get('id')
+      id: @get('_id')
+
     @set
       display: @display()
       image_url: @imageUrl()
@@ -33,17 +38,17 @@ module.exports = class SearchResult extends Backbone.Model
     if @get('href')
       @get('href')
     else if @get('model') is 'profile' || @get('model') is 'page'
-      "/#{@get('id')}"
+      "/#{@get('slug')}"
     else if @get('model') is 'fair'
       "/#{@get('profile_id')}"
     else if @get('model') is 'partnershow'
-      "/show/#{@get('id')}"
+      "/show/#{@get('slug')}"
     else if @get('model') is 'sale'
-      "/auction/#{@get('id')}"
+      "/auction/#{@get('slug')}"
     else if @get('model') is 'city'
-      "/shows/#{@get('id')}"
+      "/shows/#{@get('slug')}"
     else
-      "/#{@get('model')}/#{@get('id')}"
+      "/#{@get('model')}/#{@get('slug')}"
 
   displayModel: ->
     model =

--- a/src/desktop/test/helpers/fixtures.coffee
+++ b/src/desktop/test/helpers/fixtures.coffee
@@ -252,6 +252,7 @@ moment = require 'moment'
 @searchResult =
   model: 'artwork'
   id: 'maya-hayuk-untitled'
+  _id: 'maya-hayuk-untitled'
   display: 'Maya Hayuk - 42 Artworks, Bio & Shows on Artsy'
   image_url: 'https://i.embed.ly/1/display/crop?width=70&heig'
   display_model: 'Artwork'

--- a/src/desktop/test/models/search_result.coffee
+++ b/src/desktop/test/models/search_result.coffee
@@ -21,11 +21,11 @@ describe 'SearchResult', ->
 
       it 'has a location attribute when it is an article', ->
         model = new SearchResult(fabricate('article', model: 'article'))
-        model.href().should.containEql '/article/' + model.id
+        model.href().should.containEql '/article/' + model.get('slug')
 
       it 'has a location attribute when it is a page', ->
         model = new SearchResult(fabricate('page', model: 'page'))
-        model.href().should.containEql '/' + model.id
+        model.href().should.containEql '/' + model.get('slug')
 
       it 'has a location attribute when it is a fair', ->
         model = new SearchResult(fabricate('fair', model: 'fair', profile_id: 'foo-profile'))


### PR DESCRIPTION
When two items of different types but with the same slug are returned by our auto-suggest API, Force renders them as the same item, essentially eliminating the other result and displaying a dupe. For example, Code Art Fair and the Code tag share the same slug, `code`, but only the Fair is rendered (twice):

![screen shot 2018-05-30 at 2 54 41 pm](https://user-images.githubusercontent.com/64404/40721304-6a4af99e-6419-11e8-95c8-6d2ebb9e19c6.png)

I fix this by setting the `id` attribute in our result items to the Mongo OID and moving the slug to `slug`. I assume the component is using the `id` attribute to index the items and using a slug for that is invalid since we're dealing with multiple entity types.

Fixes https://artsyproduct.atlassian.net/browse/DISCOVER-120