### PR TITLE
@cavvia => Grouped search results lab feature

### DIFF
--- a/src/desktop/components/main_layout/templates/index.jade
+++ b/src/desktop/components/main_layout/templates/index.jade
@@ -9,7 +9,7 @@ html(
   data-useragent=userAgent
   data-user-type=sd.CURRENT_USER && sd.CURRENT_USER.type
   data-lab-features=sd.CURRENT_USER && sd.CURRENT_USER.lab_features && sd.CURRENT_USER.lab_features.join(',')
-  data-autosuggest-search=sd.AUTOSUGGEST_SEARCH
+  data-autosuggest-search=!(sd.CURRENT_USER && sd.CURRENT_USER.lab_features && sd.CURRENT_USER.lab_features.indexOf('Grouped Search Results') != -1) && sd.AUTOSUGGEST_SEARCH === 'experiment'
   lang="en"
 )
   head

--- a/src/desktop/components/search_bar/collections/search.coffee
+++ b/src/desktop/components/search_bar/collections/search.coffee
@@ -1,4 +1,5 @@
 _ = require 'underscore'
+_s = require 'underscore.string'
 qs = require 'querystring'
 sd = require('sharify').data
 Backbone = require 'backbone'
@@ -10,10 +11,14 @@ class Results extends Backbone.Collection
 module.exports = class Search
   urlRoot: "#{sd.API_URL}/api/v1/match"
 
-  defaults: size: 4
+  defaults:
+    size: 4
+    agg: false
+
+  categories: ['artist', 'sale', 'gallery', 'institution', 'fair']
 
   constructor: (options = {}) ->
-    { @mode, @restrictType, @fairId, @includePrivateResults, @size } =
+    { @mode, @restrictType, @fairId, @includePrivateResults, @size, @agg } =
       _.defaults options, @defaults
     @results = new Results
 
@@ -23,21 +28,51 @@ module.exports = class Search
     "?#{@data()}"
 
   data: ->
-    data = visible_to_public: true, fair_id: @fairId, size: @size
+    data = visible_to_public: true, fair_id: @fairId, size: @size, agg: @agg
     "#{qs.stringify data}&term=%QUERY" # Requires an unencoded percent character
 
-  parseResults: (items) ->
-    if @restrictType?
-      @restrictType = [@restrictType] unless _.isArray @restrictType
-      _.filter items, (item) =>
-        _.contains @restrictType, item?.owner_type
-    else
-      items
-
-  parse: (items, query) ->
-    # HACK filter out sensitive results
-    items = _.reject items, (item) ->
+  filterResults: (items) ->
+    _.reject items, (item) ->
       JSON.stringify(item).match(/kippenberger|zoe.*leonard/i)
-    @results.reset _.map @parseResults(items), (item) =>
+
+  pluralizeAndCapitalize: (word) ->
+    if word.slice(-1) is 'y'
+      "#{_s.capitalize(word.slice(0, -1))}ies"
+    else
+      "#{_s.capitalize(word)}s"
+
+  flattenGrouping: (category, items) ->
+    results = []
+
+    if items?.length > 0
+      firstItem = items.shift()
+      firstItem.displayHeading = true
+      firstItem.category = @pluralizeAndCapitalize(category)
+      results.push(firstItem)
+      results = results.concat(items)
+
+    results
+
+  parseResults: (items, aggregations) ->
+    if aggregations
+      results = []
+      @categories.forEach((category) =>
+        results = results.concat(@flattenGrouping(category, items[category]))
+        delete items[category]
+      )
+      Object.keys(items).forEach((category) =>
+        results = results.concat(@flattenGrouping(category, items[category]))
+      )
+      results
+    else
+      if @restrictType?
+        @restrictType = [@restrictType] unless _.isArray @restrictType
+        _.filter items, (item) =>
+          _.contains @restrictType, item?.owner_type
+      else
+        items
+
+  parse: (items, options = {}) ->
+    @results.reset _.map @filterResults(@parseResults(items, options.aggregations)), (item) =>
       item.model = @mode?.slice(0,-1) unless item.model?
       item

--- a/src/desktop/components/search_bar/index.styl
+++ b/src/desktop/components/search_bar/index.styl
@@ -92,7 +92,7 @@ search-bar-input-placeholder()
   left 9px
   transform translateY(-50%)
 
-html[data-autosuggest-search='experiment']
+html[data-autosuggest-search]
   #main-layout-search-bar-container
     .tt-suggestion
       &:last-child
@@ -105,6 +105,41 @@ html[data-autosuggest-search='experiment']
           background-color black
           *
             color white
+
+html[data-lab-features*='Grouped Search Results']
+  #main-layout-search-bar-container
+    .empty-item
+      line-height suggestion-thumbnail-size
+      height suggestion-height
+      vertical-align top
+      padding-top 10px
+    .mlsb-suggestion
+      display block
+    .tt-suggestions
+      .tt-suggestion
+        border-bottom none
+        &:last-child
+          padding-bottom 10px
+      .tt-suggestion-category
+        &:hover
+          background-color white
+          *
+            color gray-color
+      .tt-cursor
+        .tt-suggestion-category
+          background-color white
+          *
+            color gray-color
+    .tt-suggestion-category
+      color gray-color
+      height 35px
+      line-height 45px
+    .mlsb-suggestion-value, .tt-suggestion-category
+      line-height normal
+      height 25px
+      padding-top 5px
+      padding-left 25px
+      vertical-align top
 
 // Results dropdown
 #main-layout-search-bar-container

--- a/src/desktop/components/search_bar/templates/item.jade
+++ b/src/desktop/components/search_bar/templates/item.jade
@@ -1,12 +1,15 @@
 a.mlsb-suggestion
-  span.mlsb-suggestion-thumbnail
-    span.mlsb-suggestion-fallback
-      img(
-        src= item.imageUrl()
-        width='32'
-        height='32'
-        onerror='this.style.display="none";'
-      )
+  unless enableAggregations
+    span.mlsb-suggestion-thumbnail
+      span.mlsb-suggestion-fallback
+        img(
+          src= item.imageUrl()
+          width='32'
+          height='32'
+          onerror='this.style.display="none";'
+        )
+  if item.get('displayHeading')
+    div.tt-suggestion-category= item.get('category')
   span.mlsb-suggestion-value
     span.mlsb-suggestion-display
       = item.get('display')

--- a/src/desktop/components/search_bar/test/search.coffee
+++ b/src/desktop/components/search_bar/test/search.coffee
@@ -41,3 +41,10 @@ describe 'Search', ->
       search = new Search
       parsed = search.parse(@items)
       parsed.length.should.equal @items.length
+
+    it 'can flatten out aggregations', ->
+      search = new Search
+      items = {auction: @items, artist: @items}
+      parsed = search.parse(items, aggregations: true)
+      parsed[0].get('displayHeading').should.equal true
+      parsed[0].get('category').should.equal 'Artists'


### PR DESCRIPTION
Having this lab feature turned on supersedes the spotlight AB test, and could be safe to merge/deploy in the meantime (while the AB test is running), if we're happy with the approach and want to QA further.

![bp](https://user-images.githubusercontent.com/1457859/40740710-8ac46900-6417-11e8-8aca-a8c00c5a5ab3.gif)


The idea is that we flatten out the hash returned from Gravity, and the _first_ element in each group, gets an additional property which is the category itself. Then, the dynamic template for each item in the dropdown knows to render a top line of category when this is present, which results in quite decent scrolling/selecting behavior.