### PR TITLE
@kanaabe => Put back control group

### DIFF
--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -40,6 +40,7 @@ module.exports = {
     weighting: 'equal'
     outcomes: [
       'bio'
+      'control'
       'market'
     ]
   autosuggest_search:


### PR DESCRIPTION
Somehow this line got stripped out when merging changes -- puts control group back for tooltips test