### PR TITLE
Move the market Insights to be right below artist name on artwork page

### DIFF
--- a/src/desktop/apps/artwork/components/artists/index.jade
+++ b/src/desktop/apps/artwork/components/artists/index.jade
@@ -9,6 +9,9 @@ if artwork.artists.length
         h2.artwork-artist__name
           | About #{artist.name}
 
+        .artwork-artist__market-insights(id="market-insights-container-" + artist._id)        
+          //- Market insights go here
+
         .artwork-artist__content
           .side-tabs( class='js-artwork-artist-tabs' )
             +nav(tabs, helpers.artists.name)

--- a/src/desktop/apps/artwork/components/artists/index.styl
+++ b/src/desktop/apps/artwork/components/artists/index.styl
@@ -2,17 +2,19 @@
 @require '../../../../components/gradient_blurb'
 @require '../../../../components/merry_go_round/index'
 
-.artwork-artists
-  //
-
 .artwork-artist
+  &.artwork-section
+    border-top none
+
   &-header-cell-section
     margin-bottom 20px
-
     h2
       avant-garde-size('body', true)
       margin-bottom 10px
 
+  &__market-insights
+    margin-bottom 30px
+    
   &__name
     serif('headline')
     margin 0 0 distance(gutter) 0

--- a/src/desktop/apps/artwork/components/artists/templates/biography.jade
+++ b/src/desktop/apps/artwork/components/artists/templates/biography.jade
@@ -13,5 +13,3 @@
 
   .artwork-artist__content__short-bio
     p= artist.bio.replace('born', 'b.')
-
-div(id="market-insights-container-" + artist._id)


### PR DESCRIPTION
This needs the updated MarketInsights component from https://github.com/artsy/reaction/pull/706 to look like this:

![screen shot 2018-05-30 at 12 51 53 pm](https://user-images.githubusercontent.com/437156/40755193-4d05d732-644b-11e8-9fa1-29d8e124f049.png)
