### PR TITLE
Implement webpack bundle analyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "start:relay": "yarn relay && concurrently --raw --kill-others 'yarn relay --watch' 'yarn start'",
     "sync-schema": "rm -rf data && mkdir data && graphql-fetch-schema https://metaphysics-staging.artsy.net -o data",
     "test": "sh scripts/test.sh",
-    "webpack": "webpack"
+    "webpack": "webpack",
+    "bundle-report": "NODE_ENV=production ANALYZE_BUNDLE=true webpack"
   },
   "prettier": {
     "bracketSpacing": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,11 +4,12 @@ const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin')
 const ProgressBarPlugin = require('progress-bar-webpack-plugin')
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 const WebpackNotifierPlugin = require('webpack-notifier')
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 const fs = require('fs')
 const path = require('path')
 const webpack = require('webpack')
 
-const { NODE_ENV, PORT, WEBPACK_DEVTOOL } = process.env
+const { NODE_ENV, PORT, WEBPACK_DEVTOOL, ANALYZE_BUNDLE } = process.env
 const isDevelopment = NODE_ENV === 'development'
 const isStaging = NODE_ENV === 'staging'
 const isProduction = NODE_ENV === 'production'
@@ -152,6 +153,10 @@ if (isDevelopment) {
         },
       })
     )
+  }
+
+  if (ANALYZE_BUNDLE) {
+    config.plugins.push(new BundleAnalyzerPlugin())
   }
 }
 


### PR DESCRIPTION
Webpack Bundle Analyzer already exists as a dependency on the project, this just wires it up to be used. 

Bundle analyzer is a tool that gives a detailed visualization of modules included in a webpack build. It can give quick insight into large areas of code duplication or focus areas for optimizations. 

Here's an example output

![image](https://user-images.githubusercontent.com/3087225/40889061-22803abc-672e-11e8-8976-6366ee066993.png)

As a quick demonstration of its value, here we can see part of common.js that actually includes two versions of moment.js

![image](https://user-images.githubusercontent.com/3087225/40889076-5732e3b8-672e-11e8-8416-ae450a46e655.png)
