### PR TITLE
Changed how we install yarn in our image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM bitnami/node:8
 #FROM circleci/node:8-stretch-browsers
 
-#install_packages procps git openssh
+RUN install_packages libsecret-1-dev libglib2.0-dev
 
 #ADD . /home/circleci/project
 ADD . /app
@@ -9,7 +9,10 @@ WORKDIR /app
 
 #WORKDIR /home/circleci/project
 #RUN sudo chown -R circleci:circleci /home/circleci/project
-RUN npm install -g yarn@1.5.1
+RUN rm -f /usr/local/bin/yarn && \
+  curl -o- -L https://yarnpkg.com/install.sh | bash && \
+  chmod +x ~/.yarn/bin/yarn && \
+  ln -s ~/.yarn/bin/yarn /usr/local/bin/yarn
 RUN yarn install
 
 CMD yarn start


### PR DESCRIPTION
# Problem
We are seeing issues with yarn install on docker images
https://circleci.com/gh/artsy/force/6484

# Solution?
Switched to install yarn the _recommended_ way and not use `npm` to install it, while doing that noticed these errors in our log:
```
warning Error running install script for optional dependency: "/app/node_modules/keytar: Command failed.
```
And ended up installing `libsecret-1-dev libglib2.0-dev` on the image to fix it.