### PR TITLE
[GDPR] Update styling of Marketo auction partnerships form

### DIFF
--- a/src/desktop/apps/partnerships/stylesheets/marketo.styl
+++ b/src/desktop/apps/partnerships/stylesheets/marketo.styl
@@ -39,7 +39,7 @@
     margin-top 10px
   label
     position absolute !important
-    margin-top -22px !important
+    // margin-top -22px !important
     avant-garde()
     avant-garde-size('s-headline')
     color black
@@ -66,3 +66,36 @@
     text-align center !important
   .mktoAsterix
     display none !important
+  .mktoFormRow:nth-of-type(4n)
+    .mktoFormCol
+      width 100% !important
+      select
+        width 100% !important
+        background-color transparent
+        color gray-darker-color
+        font-size 17px !important
+        transition border-color 0.25s
+
+        appearance none
+        padding 12px !important
+        min-height 44px !important
+        border 2px solid gray-lighter-color
+        border-radius 0
+        background-image: url('/icons/arrow-down.svg')
+        background-repeat no-repeat
+        background-position top 50% right 10px
+        background-size 10px auto
+        &:focus
+        &:active
+        &.is-active
+          border-color purple-color
+          outline none
+          transition border-color 0.5s
+  .mktoFormRow:nth-of-type(9n)
+    .mktoFormCol
+      width 100% !important
+      input[type="checkbox"]
+        width auto !important
+      label
+        position auto
+        padding-left 8px

--- a/src/desktop/apps/partnerships/stylesheets/marketo.styl
+++ b/src/desktop/apps/partnerships/stylesheets/marketo.styl
@@ -48,19 +48,19 @@
   .mktoFormRow
     margin-bottom 10px
   .mktoFormRow:nth-of-type(2n)
-   .mktoFormCol
-     width calc(33.3333% \- 14px) !important
-     margin-right 20px
-     display inline-block
-   .mktoFormCol:nth-of-type(3n)
-     margin-right 0
- .mktoFormRow:nth-of-type(3n)
-   .mktoFormCol
-     width calc(33.3333% \- 14px) !important
-     margin-right 20px
-     display inline-block
-   .mktoFormCol:nth-of-type(3n)
-     margin-right 0
+    .mktoFormCol
+      width calc(33.3333% \- 14px) !important
+      margin-right 20px
+      display inline-block
+    .mktoFormCol:nth-of-type(3n)
+      margin-right 0
+  .mktoFormRow:nth-of-type(3n)
+    .mktoFormCol
+      width calc(33.3333% \- 14px) !important
+      margin-right 20px
+      display inline-block
+    .mktoFormCol:nth-of-type(3n)
+      margin-right 0
   .mktoButtonRow
     width 100%
     text-align center !important


### PR DESCRIPTION
This is a pure CSS change, in order to correctly style the new GDPR form markup that will be activated on the Marketo side. The last two rows in this screen cap represent what's new:

<img width="568" alt="mkto auctions" src="https://user-images.githubusercontent.com/140521/41060899-f590e5ce-699e-11e8-9db3-fc017172a689.png">

The actual markup is not under our control — we go through a lot of hoops to style this based on the selectors they provide.