### PR TITLE
Check for any credit cards [not just qualified] at auction registration

### DIFF
--- a/src/desktop/apps/auction/components/DOM.js
+++ b/src/desktop/apps/auction/components/DOM.js
@@ -64,7 +64,7 @@ class DOM extends Component {
 
       // If the user already has a CC, show accept conditions
       // (which redirects to auction-registration/:slug)
-    } else if (me.has_qualified_credit_cards) {
+    } else if (me.has_credit_cards) {
       this.showAcceptConditions()
 
       // Redirect to credit card registration form

--- a/src/desktop/apps/auction/components/__tests__/DOM.jest.js
+++ b/src/desktop/apps/auction/components/__tests__/DOM.jest.js
@@ -45,7 +45,7 @@ describe('DOM Interactions', () => {
         me: {
           id: 'user',
           bidders: [],
-          has_qualified_credit_cards: true,
+          has_credit_cards: true,
         },
       })
 
@@ -66,7 +66,7 @@ describe('DOM Interactions', () => {
         me: {
           id: 'user',
           bidders: ['SOME BIDDER OBJECT'],
-          has_qualified_credit_cards: true,
+          has_credit_cards: true,
         },
       })
 
@@ -111,7 +111,7 @@ describe('DOM Interactions', () => {
         me: {
           id: 'user',
           bidders: [],
-          has_qualified_credit_cards: false,
+          has_credit_cards: false,
         },
       })
 

--- a/src/desktop/apps/auction/queries/me.js
+++ b/src/desktop/apps/auction/queries/me.js
@@ -2,7 +2,7 @@ export default function MeQuery(sale_id, live = true) {
   return `{
     me {
       id
-      has_qualified_credit_cards
+      has_credit_cards
       bidders(sale_id: "${sale_id}") {
         qualified_for_bidding
       }


### PR DESCRIPTION
Depends on https://github.com/artsy/metaphysics/pull/1093 [merged]

Tracked here:
https://artsyproduct.atlassian.net/browse/PURCHASE-190


This PR makes removes an inconsistency in our checks for the new GDPR auction registration flow. Instead of checking whether a user `has_qualified_credit_cards` we are now just checking for `has_credit_cards` (the metaphyics PR above adds this field & is thus a blocker).

It addresses a bug due to a common issue with cards outside North America failing some checks. 