### PR TITLE
Adds tagging to production deploys

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -12,3 +12,8 @@ if [ -z "$CIRCLE_SHA1" ]; then
 else
   git push --force heroku $CIRCLE_SHA1:refs/heads/master
 fi
+
+if [ "$DEPLOY_ENV" = 'production' ]
+  git tag "production-$(date +%Y-%m-%d-%H-%M)"
+  git push -q https://$GITHUB_API_TOKEN@github.com/artsy/force.git --tags
+fi


### PR DESCRIPTION
Adds a tag on a deploy to heroku/hokusai, I think. It's a little hard for me to test this.

I've added an ENV var for @artsyit to deploy it on circle, and referenced that. Whoever makes the next deploy can say whether it worked or not.