### PR TITLE
@kanaabe => Static route for /forgot

### DIFF
--- a/src/desktop/apps/auth2/index.ts
+++ b/src/desktop/apps/auth2/index.ts
@@ -1,7 +1,7 @@
 import express from 'express'
+import { data as sd } from 'sharify'
 import { index } from './routes'
 // const { twitterLastStepPath } = require('@artsy/passport').options
-
 const app = (module.exports = express())
 
 app.set('view engine', 'jade')
@@ -9,5 +9,8 @@ app.set('views', `${__dirname}/templates`)
 
 app.get('/login', index)
 app.get('/signup', index)
-app.get('/reset_password', index)
+// TODO: Remove if statement after /auth2 launches
+if (sd.NEW_AUTH_MODAL) {
+  app.get('/forgot', index)
+}
 // app.get(twitterLastStepPath, routes.twitterLastStep)

--- a/src/desktop/apps/auth2/index.ts
+++ b/src/desktop/apps/auth2/index.ts
@@ -1,5 +1,5 @@
 import express from 'express'
-import { data as sd } from 'sharify'
+// import { data as sd } from 'sharify'
 import { index } from './routes'
 // const { twitterLastStepPath } = require('@artsy/passport').options
 const app = (module.exports = express())
@@ -9,8 +9,5 @@ app.set('views', `${__dirname}/templates`)
 
 app.get('/login', index)
 app.get('/signup', index)
-// TODO: Remove if statement after /auth2 launches
-if (sd.NEW_AUTH_MODAL) {
-  app.get('/forgot', index)
-}
+app.get('/forgot', index)
 // app.get(twitterLastStepPath, routes.twitterLastStep)

--- a/src/desktop/apps/auth2/routes.ts
+++ b/src/desktop/apps/auth2/routes.ts
@@ -12,6 +12,7 @@ export const index = async (req, res, next) => {
     case '/signup':
       type = ModalType.signup
       break
+    case '/forgot':
     case '/reset_password':
       type = ModalType.resetPassword
       break

--- a/src/desktop/apps/auth2/routes.ts
+++ b/src/desktop/apps/auth2/routes.ts
@@ -13,7 +13,6 @@ export const index = async (req, res, next) => {
       type = ModalType.signup
       break
     case '/forgot':
-    case '/reset_password':
       type = ModalType.resetPassword
       break
     default:

--- a/src/desktop/apps/home/client/auth_router.coffee
+++ b/src/desktop/apps/home/client/auth_router.coffee
@@ -2,7 +2,6 @@ Backbone = require 'backbone'
 _ = require 'underscore'
 mediator = require '../../../lib/mediator.coffee'
 qs = require 'qs'
-sd = require('sharify').data
 
 module.exports = class HomeAuthRouter extends Backbone.Router
 
@@ -53,8 +52,7 @@ module.exports = class HomeAuthRouter extends Backbone.Router
       redirectTo: if redirectTo then redirectTo else null
 
   forgot: ->
-    mode = if sd.NEW_AUTH_MODAL then 'reset_password' else 'forgot'
     email = @parsedLocation.email
     setPassword = @parsedLocation.set_password
     redirectTo = @parsedLocation.reset_password_redirect_to
-    mediator.trigger 'open:auth', mode: mode, email: email, setPassword: setPassword, redirectTo: redirectTo
+    mediator.trigger 'open:auth', mode: 'forgot', email: email, setPassword: setPassword, redirectTo: redirectTo

--- a/src/desktop/apps/home/client/auth_router.coffee
+++ b/src/desktop/apps/home/client/auth_router.coffee
@@ -2,6 +2,7 @@ Backbone = require 'backbone'
 _ = require 'underscore'
 mediator = require '../../../lib/mediator.coffee'
 qs = require 'qs'
+sd = require('sharify').data
 
 module.exports = class HomeAuthRouter extends Backbone.Router
 
@@ -52,7 +53,8 @@ module.exports = class HomeAuthRouter extends Backbone.Router
       redirectTo: if redirectTo then redirectTo else null
 
   forgot: ->
+    mode = if sd.NEW_AUTH_MODAL then 'reset_password' else 'forgot'
     email = @parsedLocation.email
     setPassword = @parsedLocation.set_password
     redirectTo = @parsedLocation.reset_password_redirect_to
-    mediator.trigger 'open:auth', mode: 'forgot', email: email, setPassword: setPassword, redirectTo: redirectTo
+    mediator.trigger 'open:auth', mode: mode, email: email, setPassword: setPassword, redirectTo: redirectTo

--- a/src/desktop/apps/home/index.coffee
+++ b/src/desktop/apps/home/index.coffee
@@ -6,6 +6,7 @@ express = require 'express'
 routes = require './routes'
 markdown = require '../../components/util/markdown'
 { resize } = require '../../components/resizer'
+sd = require('sharify').data
 
 app = module.exports = express()
 app.set 'views', __dirname + '/templates'
@@ -15,4 +16,6 @@ app.locals.markdown = markdown
 app.get '/', routes.index
 app.get '/log_in', routes.redirectLoggedInHome, routes.index
 app.get '/sign_up', routes.redirectLoggedInHome, routes.index
-app.get '/forgot', routes.index
+# TODO: Remove after /auth2 launches
+if !sd.NEW_AUTH_MODAL
+  app.get '/forgot', routes.index


### PR DESCRIPTION
Addresses [GROW-713](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-713)

If `sd.NEW_AUTH_MODAL`, the `/forgot` route is served by `/auth2` app.  Otherwise, behavior is the same as existing production. 

Static route:
<img width="1337" alt="screen shot 2018-06-14 at 4 22 45 pm" src="https://user-images.githubusercontent.com/1497424/41436645-46a53e86-6ff0-11e8-8b03-8ccce6da1d10.png">

Existing route:
<img width="1337" alt="screen shot 2018-06-14 at 4 24 51 pm" src="https://user-images.githubusercontent.com/1497424/41436660-519be0c4-6ff0-11e8-90c4-6d5005f43072.png">
