### PR TITLE
@kanaabe => Use meta image tag for news articles

### DIFF
--- a/src/desktop/apps/rss/templates/news.jade
+++ b/src/desktop/apps/rss/templates/news.jade
@@ -20,7 +20,7 @@ rss(version='2.0', xmlns:atom='http://www.w3.org/2005/Atom' xmlns:content='http:
           - media = article.get('media')
           enclosure(url=media.url length=0 type="video/mp4")
         else if article.get('layout') === 'news'
-          enclosure(url="#{sd.APP_URL}/images/og_image.jpg" length=0 type="image/jpeg")
+          meta(property="og:image" content="#{sd.APP_URL}/images/og_image.jpg")
         else if article.get('thumbnail_image')
           - image = article.get('thumbnail_image')
           - extension = image.split('.').pop()

--- a/src/desktop/apps/rss/test/news.coffee
+++ b/src/desktop/apps/rss/test/news.coffee
@@ -73,7 +73,7 @@ describe '/rss', ->
         },
       ]
       rendered = newsTemplate(sd: sd, articles: new Articles(articles), moment: moment)
-      rendered.should.containEql '/images/og_image.jpg" length="0" type="image/jpeg">'
+      rendered.should.containEql '/images/og_image.jpg'
 
     it 'renders enclosures on non-video articles', ->
       articles = [


### PR DESCRIPTION
Tried loading our feed in a few RSS readers, and the default image renders fine as it is-- not sure why Apple News is not able to read the correct image, but taking another stab using the meta `og:image` tag, which is included in their spec [here](https://help.apple.com/newspublisher/icloud/?lang=en#/apdc2c7520ff). 
