### PR TITLE
fix background check import

### DIFF
--- a/src/desktop/components/light_detector/index.coffee
+++ b/src/desktop/components/light_detector/index.coffee
@@ -1,4 +1,4 @@
-{ BackgroundCheck } = require('background-check/background-check.js')
+BackgroundCheck = require('background-check/background-check.js')
 
 module.exports = ({ targets, backgroundClass, imageUrl }) ->
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12489,11 +12489,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-"styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3":
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 
-"styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#respect-padding-in-fluid":
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#respect-padding-in-fluid:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/f4908956cb3b31ef811c729d3a50784efafe62da"
 


### PR DESCRIPTION
This turned out to be a red herring in an ongoing incident but did alert us to an improper import that has probably been off for a while. The error we were getting in the console was 'BackgroundCheck is undefined' (at `BackgroundCheck.init`).  We are using a { Named } import  but the export for that BackgroundCheck looks like
```js
  return {
    /*
     * Init and destroy
     */
    init: init,
    destroy: destroy,
...
```
