### PR TITLE
Fixes missing buy-now artist name

### DIFF
--- a/src/desktop/apps/auction/queries/sale.js
+++ b/src/desktop/apps/auction/queries/sale.js
@@ -1,4 +1,4 @@
-export default function SaleQuery (id) {
+export default function SaleQuery(id) {
   return `{
     sale(id: "${id}") {
       _id
@@ -39,6 +39,8 @@ export default function SaleQuery (id) {
             }
             artists {
               id
+              href
+              name
             }
             partner {
               name


### PR DESCRIPTION
In other tiles artwork metadata comes from [relay](https://github.com/artsy/reaction/blob/master/src/Components/Artwork/Details.tsx#L112-L116
), but in this tile it comes from `SaleQuery` which was missing artist `name` and `href`.

### Before

<img width="450" alt="screen shot 2018-06-18 at 2 19 48 pm" src="https://user-images.githubusercontent.com/687513/41554408-c70dd12c-7302-11e8-8276-83b310d2c98e.png">

### After

<img width="448" alt="screen shot 2018-06-18 at 2 19 12 pm" src="https://user-images.githubusercontent.com/687513/41554411-c9680622-7302-11e8-84ae-b25ea8edaee9.png">
