### PR TITLE
@xtina-starr => Fixes fair login/signup nav

### DIFF
--- a/src/desktop/components/fair_layout/client/header.coffee
+++ b/src/desktop/components/fair_layout/client/header.coffee
@@ -18,17 +18,26 @@ module.exports = class FairHeaderView extends Backbone.View
   initialize: (options) ->
     { @fair } = options
     @currentUser = CurrentUser.orNull()
+    mediator.on 'open:auth', @openAuth
 
   openAuth: (options) ->
     @modal = new AuthModalView _.extend({ width: '500px' }, options)
 
   signup: (e) ->
     e.preventDefault()
-    mediator.trigger 'open:auth', mode: 'signup'
+    mediator.trigger 'open:auth',
+      mode: 'signup',
+      destination: location.href
+      signupIntent: 'signup'
+      trigger: 'click'
+      contextModule: 'header'
 
   login: (e) ->
     e.preventDefault()
-    mediator.trigger 'open:auth', mode: 'login'
+    mediator.trigger 'open:auth',
+      mode: 'login'
+      trigger: 'click'
+      contextModule: 'header'
 
   logout: (e) ->
     e.preventDefault()

--- a/src/desktop/components/fair_layout/test/client/header.coffee
+++ b/src/desktop/components/fair_layout/test/client/header.coffee
@@ -31,7 +31,7 @@ describe 'HeaderView', ->
       @profile = new Profile fabricate 'fair_profile'
       benv.render resolve(__dirname, '../../templates/header.jade'), {sd: {}, _: _}, =>
         FairHeaderView = benv.require resolve(__dirname, '../../client/header')
-        FairHeaderView.__set__ 'AuthModalView', sinon.stub()
+        FairHeaderView.__set__ 'AuthModalView', @authModalView = sinon.stub()
         FairHeaderView.__set__ 'mediator', @mediator = { trigger: sinon.stub(), on: sinon.stub() }
         @view = new FairHeaderView el: $('.fair-layout-header-right'), model: @profile, fair: @fair
         @$template = $('body')
@@ -40,6 +40,11 @@ describe 'HeaderView', ->
     afterEach ->
       Backbone.sync.restore()
       $.ajax.restore()
+
+    it 'sets up the mediator', ->
+      @mediator.on.args[0][0].should.equal 'open:auth'
+      @mediator.on.args[0][1](mode: 'foo')
+      @authModalView.args[0][0].mode.should.equal 'foo'
 
     describe '#login', ->
       it 'triggers the mediator', ->

--- a/src/desktop/components/light_detector/index.coffee
+++ b/src/desktop/components/light_detector/index.coffee
@@ -1,4 +1,4 @@
-{ BackgroundCheck } = require('background-check/background-check.js')
+BackgroundCheck = require('background-check/background-check.js')
 
 module.exports = ({ targets, backgroundClass, imageUrl }) ->
 


### PR DESCRIPTION
Looks like [this commit](https://github.com/kanaabe/force/commit/e42ecd52998bdf514e33aaefa513b93c2769a445#diff-05fc90c4bdb96b10a0557c46ae6d06f3) first introduced the issue, but anyway we need to do `mediator.on 'open:auth', @openAuth` in order to open the auth modal for Fair pages since those don't use `main_layout/client/header`. Went ahead and added the latest analytics fields to these mediator triggers as well, and a test 😉 