### PR TITLE
Fix typo in require

### DIFF
--- a/src/desktop/assets/misc.coffee
+++ b/src/desktop/assets/misc.coffee
@@ -27,7 +27,7 @@ routes =
   '/reset_password': require('../apps/auth/client/index.coffee').init
 
   # TODO: remove 2 after auth2
-  '/reset_password2': requre('../apps/auth2/client/reset_password.coffee').init
+  '/reset_password2': require('../apps/auth2/client/reset_password.coffee').init
 
   '/signup': require('../apps/auth/client/auth.coffee').init
 


### PR DESCRIPTION
# Problem
Delete my account button doesn't work on settings page.

# Cause
there is a typo in reuqire
```
Uncaught ReferenceError: requre is not defined
    at Object.<anonymous> (misc-b9700559.js.jgz:1)
    at Object../src/desktop/assets/misc.coffee (misc-b9700559.js.jgz:1)
    at r (common-20a6894c.js.jgz:1)
    at Object.26 (misc-b9700559.js.jgz:1)
    at r (common-20a6894c.js.jgz:1)
    at window.webpackJsonp (common-20a6894c.js.jgz:1)
    at misc-b9700559.js.jgz:1
```

