### PR TITLE
Fix file exists error when creating .ssh folder for Heroku deployment

### DIFF
--- a/.circleci/heroku_setup.sh
+++ b/.circleci/heroku_setup.sh
@@ -27,5 +27,5 @@ machine git.heroku.com
 EOF
 
 # Add heroku.com to the list of known hosts
-mkdir ~/.ssh/
+mkdir -p ~/.ssh/
 ssh-keyscan -H heroku.com >> ~/.ssh/known_hosts


### PR DESCRIPTION
After https://github.com/artsy/force/pull/2638 and making sure `set -e` worked, the [master build](https://circleci.com/gh/artsy/force/6865) actually caught something and failed 😝. We can compare with a previous master build that had the same error but didn't fail the build.

This PR uses `mkdir -p` to not error when the folder exists.

We can actually go one step further and clean up some scripts, given CircleCI 2.0 now has an easier way to [deploy to Heroku](https://circleci.com/docs/2.0/deployment-integrations/#heroku) ([Volt](https://github.com/artsy/volt/pull/3047) and Induction switched to that). However, Force deployment is more involved and we might just move to K8s at some point, so I decided to leave it for now.

![screen shot 2018-06-21 at 6 00 19 pm](https://user-images.githubusercontent.com/796573/41747733-0d54612e-757d-11e8-8edd-396b066579e1.png)

