### PR TITLE
Skip staging branch on CI; require acceptance tests before deploying to Heroku

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,11 +85,17 @@ workflows:
           filters:
             branches:
               ignore: staging
-      - acceptance
+      - acceptance:
+          filters:
+            branches:
+              ignore: staging
       - build:
+          filters:
+            branches:
+              ignore: staging
           requires:
             - test
-            - acceptance 
+            - acceptance
       - push:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,9 +114,11 @@ workflows:
               only: master
           requires:
             - test
+            - acceptance
       - deploy_heroku_production:
           filters:
             branches:
               only: release
           requires:
             - test
+            - acceptance


### PR DESCRIPTION
Follow up on https://github.com/artsy/force/pull/2490

* Don't kick off builds for [staging branch](https://circleci.com/workflow-run/e3b35227-4ddb-4702-8a7b-1989d9030b49).
* Also require acceptance tests before deploying to Heroku.