### PR TITLE
Start app in dev mode by default unless NODE_ENV is production

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -2,14 +2,11 @@
 
 set -ex
 
-if [ ! -f "./.env" ]; then
-  echo -e "\033[1;31m WARNING: Missing .env file, see CONTRIBUTING.md. \033[0m"
-fi
-
-export $(cat .env | grep NODE_ENV | xargs)
-
-if [ "$NODE_ENV" = "development" ]; then
-  node -r dotenv/config --max_old_space_size=1024 ./src
-else
+if [ "$NODE_ENV" = "production" ]; then
   node --max_old_space_size=1024 ./src
+else
+  if [ ! -f "./.env" ]; then
+    echo -e "\033[1;31m WARNING: Missing .env file, see CONTRIBUTING.md. \033[0m"
+  fi
+  node -r dotenv/config --max_old_space_size=1024 ./src
 fi


### PR DESCRIPTION
Follow up on https://github.com/artsy/force/pull/2352#discussion_r182159039.

I noticed in our [papertrail log](https://papertrailapp.com/systems/force-staging/events?focus=946681803429867523) we accidentally listed all the exported variables. I believe that was intended for local development when a .env file is present. This PR changes the default mode for running the app to development unless `NODE_ENV` is production, and hope this can simplify the checking.

More details in the commit message (copied below):

Previously we started the app by default in production mode, and only started it in dev mode when `$NODE_ENV` is set to "development". However, this requires us to grep `NODE_ENV` from .env and export it in development before being able to perform the check.

However, in production, lacking the .env file accidentally turns the export statement into just `export` and that means listing all the exported variables. This not only pollutes the logs but also has security concerns.

This commit changes the default to be development and only run the app in production mode when `$NODE_ENV` is set to "production". This simplifes the check because `$NODE_ENV` will be set properly in production.

<img width="1680" alt="screen shot 2018-06-22 at 1 02 31 pm" src="https://user-images.githubusercontent.com/796573/41789362-04c53d9e-761d-11e8-9a56-8902612f3763.png">
