### PR TITLE
Remove unnecessary `heroku restart` after deployment

### DIFF
--- a/.circleci/heroku_deploy.sh
+++ b/.circleci/heroku_deploy.sh
@@ -5,7 +5,6 @@ set -ex
 if git remote | grep heroku > /dev/null; then
   git fetch heroku
   yarn deploy
-  heroku restart
   yarn sentry
 else
   echo "Heroku is not set up :("


### PR DESCRIPTION
After https://github.com/artsy/force/pull/2647, I noticed in the [log](https://papertrailapp.com/systems/force-staging/events?focus=946879422122909698) we `npm start` twice after deployment. Heroku will [restart dynos after deployment](https://devcenter.heroku.com/articles/dynos#restarting) so I don't think we need to manually do `heroku restart`.

![screen shot 2018-06-22 at 2 50 18 pm](https://user-images.githubusercontent.com/796573/41794271-d3014cc0-762c-11e8-992d-7531b0ccbf84.png)

