### PR TITLE
@kanaabe: Implement infinite scroll a/b test

### DIFF
--- a/src/desktop/apps/article/components/__tests__/Article.test.js
+++ b/src/desktop/apps/article/components/__tests__/Article.test.js
@@ -7,6 +7,7 @@ import sinon from 'sinon'
 import { mount } from 'enzyme'
 import { data as sd } from 'sharify'
 import { ContextProvider } from 'reaction/Components/Artsy'
+import { DisplayPanel } from 'reaction/Components/Publishing/Display/DisplayPanel'
 
 describe('<Article />', () => {
   before(done => {
@@ -210,8 +211,10 @@ describe('<Article /> without infinite scroll', () => {
   const ArticleLayout = rewire.default
   const InfiniteScrollArticle = require('desktop/apps/article/components/InfiniteScrollArticle')
     .default
-  const { Article } = require('reaction/Components/Publishing')
   const SuperArticleView = sinon.stub()
+  const {
+    DisplayCanvas,
+  } = require('reaction/Components/Publishing/Display/Canvas')
   rewire.__set__('SuperArticleView', SuperArticleView)
   const EditorialSignupView = sinon.stub()
   rewire.__set__('EditorialSignupView', EditorialSignupView)
@@ -268,8 +271,9 @@ describe('<Article /> without infinite scroll', () => {
 
     const html = rendered.html()
     html.should.containEql('DisplayPanel')
-    html.should.containEql('class="Canvas')
+    rendered.find(DisplayPanel).length.should.equal(1)
     html.should.containEql('Campaign 1')
     html.should.containEql('Ad Headline')
+    rendered.find(DisplayCanvas).length.should.equal(1)
   })
 })

--- a/src/desktop/apps/article/components/__tests__/Article.test.js
+++ b/src/desktop/apps/article/components/__tests__/Article.test.js
@@ -180,3 +180,96 @@ describe('<Article />', () => {
     rendered.state().following.length.should.exist
   })
 })
+
+describe('<Article /> without infinite scroll', () => {
+  before(done => {
+    benv.setup(() => {
+      benv.expose({ $: benv.require('jquery'), jQuery: benv.require('jquery') })
+      sd.APP_URL = 'http://artsy.net'
+      sd.CURRENT_PATH =
+        '/article/artsy-editorial-surprising-reason-men-women-selfies-differently'
+      sd.CURRENT_USER = { id: '123' }
+      sd.ARTICLE_INFINITE_SCROLL = 'experiment'
+      done()
+    })
+  })
+
+  after(() => {
+    benv.teardown()
+  })
+
+  window.matchMedia = () => {
+    return {
+      matches: false,
+      addListener: () => {},
+      removeListener: () => {},
+    }
+  }
+
+  const rewire = require('rewire')('../layouts/Article')
+  const ArticleLayout = rewire.default
+  const InfiniteScrollArticle = require('desktop/apps/article/components/InfiniteScrollArticle')
+    .default
+  const { Article } = require('reaction/Components/Publishing')
+  const SuperArticleView = sinon.stub()
+  rewire.__set__('SuperArticleView', SuperArticleView)
+  const EditorialSignupView = sinon.stub()
+  rewire.__set__('EditorialSignupView', EditorialSignupView)
+
+  const getWrapper = props => {
+    return mount(
+      <ContextProvider currentUser={null}>
+        <ArticleLayout {...props} />
+      </ContextProvider>
+    )
+  }
+
+  let props
+  beforeEach(() => {
+    props = {
+      article: _.extend({}, fixtures.article, {
+        layout: 'standard',
+        vertical: {
+          name: 'Art Market',
+        },
+        published_at: '2017-05-19T13:09:18.567Z',
+        contributing_authors: [{ name: 'Kana' }],
+      }),
+      isSuper: false,
+      templates: {},
+    }
+  })
+
+  it('renders a standard article without infinite scroll', () => {
+    const rendered = getWrapper(props)
+
+    rendered.find(InfiniteScrollArticle).length.should.equal(0)
+    rendered.html().should.containEql('StandardLayout')
+  })
+
+  it('renders a standard article with ads', () => {
+    props.article = _.extend({}, props.article, {
+      display: {
+        name: 'Campaign 1',
+        panel: {
+          assets: [{ url: 'http://url.jpg' }],
+          headline: 'Ad Headline',
+          link: { url: 'http://link' },
+        },
+        canvas: {
+          assets: [{ url: 'http://url.jpg' }],
+          headline: 'Ad Headline',
+          link: { url: 'http://link' },
+          layout: 'standard',
+        },
+      },
+    })
+    const rendered = getWrapper(props)
+
+    const html = rendered.html()
+    html.should.containEql('DisplayPanel')
+    html.should.containEql('class="Canvas')
+    html.should.containEql('Campaign 1')
+    html.should.containEql('Ad Headline')
+  })
+})

--- a/src/desktop/apps/article/components/__tests__/Article.test.js
+++ b/src/desktop/apps/article/components/__tests__/Article.test.js
@@ -16,6 +16,7 @@ describe('<Article />', () => {
       sd.CURRENT_PATH =
         '/article/artsy-editorial-surprising-reason-men-women-selfies-differently'
       sd.CURRENT_USER = { id: '123' }
+      sd.ARTICLE_INFINITE_SCROLL = 'control'
       done()
     })
   })

--- a/src/desktop/apps/article/components/layouts/Article.js
+++ b/src/desktop/apps/article/components/layouts/Article.js
@@ -42,6 +42,7 @@ export default class ArticleLayout extends React.Component {
     setupFollowButtons(this.state.following)
     // Track a/b/c test group
     splitTest('article_tooltips').view()
+    splitTest('article_infinite_scroll').view()
 
     if (isSuper) {
       new SuperArticleView({
@@ -75,6 +76,8 @@ export default class ArticleLayout extends React.Component {
     const articleMarginTop = article.layout === 'standard' ? '100px' : '0px'
     const navHeight = isSuper ? '0px' : NAVHEIGHT
     const headerHeight = `calc(100vh - ${navHeight})`
+    const isExperimentInfiniteScroll =
+      sd.ARTICLE_INFINITE_SCROLL === 'experiment'
 
     /**
      * FIXME:
@@ -96,7 +99,11 @@ export default class ArticleLayout extends React.Component {
       )
     }
 
-    if (!isSuper && !article.seriesArticle) {
+    if (
+      !isSuper &&
+      !article.seriesArticle &&
+      sd.ARTICLE_INFINITE_SCROLL === 'control'
+    ) {
       const emailSignupUrl = onDailyEditorial
         ? `${sd.APP_URL}/signup/editorial`
         : ''
@@ -124,6 +131,10 @@ export default class ArticleLayout extends React.Component {
           showTooltips={showTooltips}
           showToolTipMarketData={showToolTipMarketData}
           onOpenAuthModal={this.handleOpenAuthModal}
+          relatedArticlesForCanvas={
+            isExperimentInfiniteScroll && article.relatedArticlesCanvas
+          }
+          display={isExperimentInfiniteScroll && article.display}
         />
       )
     }

--- a/src/desktop/apps/article/components/layouts/Article.js
+++ b/src/desktop/apps/article/components/layouts/Article.js
@@ -42,7 +42,8 @@ export default class ArticleLayout extends React.Component {
     setupFollowButtons(this.state.following)
     // Track a/b/c test group
     splitTest('article_tooltips').view()
-    splitTest('article_infinite_scroll').view()
+    // Comment until we are ready to launch the test
+    // splitTest('article_infinite_scroll').view()
 
     if (isSuper) {
       new SuperArticleView({

--- a/src/desktop/apps/article/components/layouts/Article.js
+++ b/src/desktop/apps/article/components/layouts/Article.js
@@ -99,11 +99,7 @@ export default class ArticleLayout extends React.Component {
       )
     }
 
-    if (
-      !isSuper &&
-      !article.seriesArticle &&
-      sd.ARTICLE_INFINITE_SCROLL === 'control'
-    ) {
+    if (!isSuper && !article.seriesArticle && !isExperimentInfiniteScroll) {
       const emailSignupUrl = onDailyEditorial
         ? `${sd.APP_URL}/signup/editorial`
         : ''

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -43,4 +43,8 @@ module.exports = {
       'control'
       'market'
     ]
+  article_infinite_scroll:
+    key: 'article_infinite_scroll'
+    outcomes:
+      control: 100
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11098,7 +11098,7 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3:
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3, "styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3":
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11098,7 +11098,7 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3, "styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3":
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 


### PR DESCRIPTION
It sets up the test (but puts 100% of users in the control group), conditionally removes the infinite scroll based on the test group, and adds the display panels along with the related articles canvas.

Also there is random `margin-bottom` in the [display canvas](https://artsyproduct.atlassian.net/browse/GROW-739) that causes the ad to scroll which will be addressed in a separate PR.

Signed-off-by: Eve Essex <e.essex@artsymail.com> // cc: @eessex 