### PR TITLE
@eessex: Verify gdpr auth

### DIFF
--- a/src/desktop/apps/auth2/__tests__/helpers.jest.js
+++ b/src/desktop/apps/auth2/__tests__/helpers.jest.js
@@ -81,16 +81,26 @@ describe('Authentication Helpers', () => {
           intent: 'follow artist',
         },
         {
+          name: 'foo',
           email: 'foo@foo.com',
+          password: 'password',
+          accepted_terms_of_service: true,
         },
         formikBag
       )
+
+      const user = Backbone.sync.mock.calls[0][1]
 
       Backbone.sync.mock.calls[0][2].success()
       Backbone.sync.mock.calls[1][2].success({
         user: { id: 123, accessToken: 'foobar' },
       })
       expect(formikBag.setSubmitting.mock.calls[0][0]).toBe(false)
+      expect(user.get('name')).toBe('foo')
+      expect(user.get('email')).toBe('foo@foo.com')
+      expect(user.get('password')).toBe('password')
+      expect(user.get('accepted_terms_of_service')).toBe(true)
+      expect(user.get('agreed_to_receive_emails')).toBe(true)
     })
 
     it('can handle forgotten passwords', () => {

--- a/src/desktop/apps/auth2/helpers.ts
+++ b/src/desktop/apps/auth2/helpers.ts
@@ -35,6 +35,7 @@ export const handleSubmit = (
     _csrf: sd.CSRF_TOKEN,
     signupIntent: intent,
     signupReferer,
+    agreed_to_receive_emails: values.accepted_terms_of_service,
   })
 
   user.set(userAttributes)

--- a/yarn.lock
+++ b/yarn.lock
@@ -11098,7 +11098,7 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3:
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3, "styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3":
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11098,7 +11098,7 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3, "styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3":
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e14265edc6dd3:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 


### PR DESCRIPTION
This ensures the gdpr properties are passed via email signups (specifically adds `agreed_to_receive_emails`). It also bumps up the version of reaction. 

Payload:
![screen shot 2018-06-26 at 11 13 11 am](https://user-images.githubusercontent.com/5201004/41921929-00c4b48c-7932-11e8-9b49-081a9aa35f69.png)

Gravity db:
![screen shot 2018-06-26 at 11 14 58 am](https://user-images.githubusercontent.com/5201004/41922022-31a9f53a-7932-11e8-9dc4-353e4e10903a.png)
