### PR TITLE
@l2succes => Use system Modal for Auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@artsy/express-reloadable": "^1.3.1",
     "@artsy/palette": "^2.0.2",
     "@artsy/passport": "^1.0.11",
-    "@artsy/reaction": "^1.18.7",
+    "@artsy/reaction": "^1.19.0",
     "@artsy/stitch": "^1.6.0",
     "@babel/core": "7.0.0-beta.40",
     "@babel/node": "7.0.0-beta.40",

--- a/src/desktop/apps/auth2/components/AuthStatic.tsx
+++ b/src/desktop/apps/auth2/components/AuthStatic.tsx
@@ -5,30 +5,29 @@ import {
   ModalType,
   ModalOptions,
 } from '@artsy/reaction/dist/Components/Authentication/Types'
-import { DesktopHeader } from '@artsy/reaction/dist/Components/Authentication/Desktop/Components/DesktopHeader'
+import { ModalHeader } from '@artsy/reaction/dist/Components/Modal/ModalHeader'
 import { handleSubmit } from '../helpers'
 
 interface Props {
   type: string
-  subtitle?: string
+  meta: {
+    title?: string
+  }
   options: ModalOptions
 }
 
 export class AuthStatic extends React.Component<Props> {
   render() {
+    const { type, options, meta: { title } } = this.props
     return (
       <Wrapper>
         <AuthFormContainer>
-          <DesktopHeader subtitle={this.props.subtitle} />
+          <ModalHeader title={title} hasLogo />
           <FormSwitcher
             {...this.props}
-            type={this.props.type as ModalType}
+            type={type as ModalType}
             isStatic
-            handleSubmit={handleSubmit.bind(
-              this,
-              this.props.type,
-              this.props.options
-            )}
+            handleSubmit={handleSubmit.bind(this, type, options)}
           />
         </AuthFormContainer>
       </Wrapper>

--- a/src/desktop/apps/auth2/components/__tests__/AuthStatic.jest.js
+++ b/src/desktop/apps/auth2/components/__tests__/AuthStatic.jest.js
@@ -1,10 +1,10 @@
 import { mount } from 'enzyme'
 import React from 'react'
-// import { DesktopHeader } from '@artsy/reaction/dist/Components/Authentication/Desktop/Components/DesktopHeader'
+import { ModalHeader } from '@artsy/reaction/dist/Components/Modal/ModalHeader'
 import { FormSwitcher } from '@artsy/reaction/dist/Components/Authentication/FormSwitcher'
 import { AuthStatic } from '../AuthStatic'
 
-xdescribe('AuthStatic', () => {
+describe('AuthStatic', () => {
   const getWrapper = props => {
     return mount(<AuthStatic {...props} />)
   }
@@ -13,7 +13,9 @@ xdescribe('AuthStatic', () => {
   beforeEach(() => {
     props = {
       type: 'login',
-      subtitle: 'A sub title',
+      meta: {
+        title: 'A sub title',
+      },
       handleSubmit: jest.fn(),
       options: {},
     }
@@ -26,6 +28,6 @@ xdescribe('AuthStatic', () => {
 
   it('Renders the DesktopHeader', () => {
     const component = getWrapper(props)
-    // expect(component.find(DesktopHeader).text()).toMatch('A sub title')
+    expect(component.find(ModalHeader).text()).toMatch('A sub title')
   })
 })

--- a/src/desktop/apps/auth2/components/__tests__/AuthStatic.jest.js
+++ b/src/desktop/apps/auth2/components/__tests__/AuthStatic.jest.js
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme'
 import React from 'react'
-import { DesktopHeader } from '@artsy/reaction/dist/Components/Authentication/Desktop/Components/DesktopHeader'
+// import { DesktopHeader } from '@artsy/reaction/dist/Components/Authentication/Desktop/Components/DesktopHeader'
 import { FormSwitcher } from '@artsy/reaction/dist/Components/Authentication/FormSwitcher'
 import { AuthStatic } from '../AuthStatic'
 
@@ -26,6 +26,6 @@ xdescribe('AuthStatic', () => {
 
   it('Renders the DesktopHeader', () => {
     const component = getWrapper(props)
-    expect(component.find(DesktopHeader).text()).toMatch('A sub title')
+    // expect(component.find(DesktopHeader).text()).toMatch('A sub title')
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -11092,7 +11092,7 @@ styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 
-"styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#respect-padding-in-fluid":
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#respect-padding-in-fluid:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/f4908956cb3b31ef811c729d3a50784efafe62da"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,9 +49,9 @@
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
-"@artsy/reaction@^1.18.7":
-  version "1.18.7"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-1.18.7.tgz#94626ec266aa7b63c8c12dc6ea16e752eae47ae6"
+"@artsy/reaction@^1.19.0":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-1.19.0.tgz#fff5d5e45a1caf3275886e36e6704aeec85750d1"
   dependencies:
     "@artsy/palette" "^2.3.4"
     cheerio "^1.0.0-rc.2"
@@ -11092,7 +11092,7 @@ styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 
-styled-bootstrap-grid@damassi/styled-bootstrap-grid#respect-padding-in-fluid:
+"styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#respect-padding-in-fluid":
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/f4908956cb3b31ef811c729d3a50784efafe62da"
 


### PR DESCRIPTION
Bumps Reaction to render auth modals using new design system component, replaces use of `DesktopHeader` (now deprecated) with `ModalHeader`.