### PR TITLE
@l2succes: add tracking label for local signup/login

### DIFF
--- a/src/desktop/apps/auth2/__tests__/helpers.jest.js
+++ b/src/desktop/apps/auth2/__tests__/helpers.jest.js
@@ -189,7 +189,7 @@ describe('Authentication Helpers', () => {
           accessToken: 'foobar',
         },
       })
-      expect(window.analytics.track).toBeCalledWith({
+      expect(window.analytics.track).toBeCalledWith('Successfully logged in', {
         action: 'Successfully logged in',
         user_id: 123,
         trigger: 'click',
@@ -224,7 +224,7 @@ describe('Authentication Helpers', () => {
           accessToken: 'foobar',
         },
       })
-      expect(window.analytics.track).toBeCalledWith({
+      expect(window.analytics.track).toBeCalledWith('Created account', {
         action: 'Created account',
         user_id: 123,
         trigger: 'timed',

--- a/src/desktop/apps/auth2/helpers.ts
+++ b/src/desktop/apps/auth2/helpers.ts
@@ -70,7 +70,7 @@ export const handleSubmit = (
           auth_redirect: redirectTo || destination,
           service: 'email',
         }
-        analytics.track(pickBy(properties, identity))
+        analytics.track(action, pickBy(properties, identity))
       }
 
       const defaultRedirect =


### PR DESCRIPTION
Minor: this adds the tracking label for local signup/login. This was overlooked the last bit of analytics work.