### PR TITLE
@saolsen: make sure to handle the /reset_password route in new auth flow

### DIFF
--- a/src/desktop/apps/auth2/index.ts
+++ b/src/desktop/apps/auth2/index.ts
@@ -9,5 +9,4 @@ app.set('views', `${__dirname}/templates`)
 app.get('/login', index)
 app.get('/signup', index)
 app.get('/forgot', index)
-// TODO: remove 2 after auth2
-app.get('/reset_password2', resetPassword)
+app.get('/reset_password', resetPassword)


### PR DESCRIPTION
When we switched over to the new auth flow we didn't handle the `/reset_password` route. This came up in insidents because users that are attempting to reset their password are getting a 404 error. For  more context view the [slack conversation](https://artsy.slack.com/archives/C9RK0BLEP/p1531765572000503). 

This PR adds the `/reset_password` to the new auth flow (auth2) but we should follow up to clean up especially when we finish covering the other versions of the auth modal (i.e. marketing auth modal, artist page cta, etc.).


cc: @junybrum 