### PR TITLE
@eessex => Mobile auth pages QA

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@artsy/express-reloadable": "^1.3.1",
     "@artsy/palette": "^2.0.2",
     "@artsy/passport": "^1.0.11",
-    "@artsy/reaction": "^1.20.14",
+    "@artsy/reaction": "^1.20.19",
     "@artsy/stitch": "^1.6.0",
     "@babel/core": "7.0.0-beta.40",
     "@babel/node": "7.0.0-beta.40",

--- a/src/desktop/apps/auth2/components/MobileAuthStatic.tsx
+++ b/src/desktop/apps/auth2/components/MobileAuthStatic.tsx
@@ -37,7 +37,9 @@ export class MobileAuthStatic extends React.Component<Props> {
               this.props.options
             )}
             onBackButtonClicked={() => {
-              window.location.href = options.redirectTo || '/'
+              if (typeof window !== 'undefined') {
+                window.location.href = options.redirectTo || '/'
+              }
             }}
             submitUrls={submitUrls}
             isMobile

--- a/src/desktop/apps/auth2/components/MobileAuthStatic.tsx
+++ b/src/desktop/apps/auth2/components/MobileAuthStatic.tsx
@@ -16,6 +16,7 @@ interface Props {
 
 export class MobileAuthStatic extends React.Component<Props> {
   render() {
+    const { options } = this.props
     const submitUrls = {
       login: '/log_in',
       forgot: '/forgot_password',
@@ -23,9 +24,6 @@ export class MobileAuthStatic extends React.Component<Props> {
       facebook: '/users/auth/facebook',
       twitter: '/users/auth/twitter',
     }
-
-    // TODO: pull analytics data
-    const authQueryData = {}
 
     return (
       <AuthFormContainer>
@@ -38,15 +36,8 @@ export class MobileAuthStatic extends React.Component<Props> {
               this.props.type,
               this.props.options
             )}
-            onFacebookLogin={() => {
-              if (typeof window !== 'undefined') {
-                window.location.href = submitUrls.facebook + `?${authQueryData}`
-              }
-            }}
-            onTwitterLogin={() => {
-              if (typeof window !== 'undefined') {
-                window.location.href = submitUrls.twitter + `?${authQueryData}`
-              }
+            onBackButtonClicked={() => {
+              window.location.href = options.redirectTo || '/'
             }}
             submitUrls={submitUrls}
             isMobile

--- a/src/mobile/apps/auth/routes.coffee
+++ b/src/mobile/apps/auth/routes.coffee
@@ -23,8 +23,8 @@ module.exports.login = (req, res) ->
   locals =
     redirectTo: redirectUrl(req)
     action: req.query.action
-  
-  if sd.NEW_AUTH_MODAL
+
+  if res.locals.sd.NEW_AUTH_MODAL
     res.redirect "/login?#{qs.stringify(locals)}"
   else if locals.action
     res.render 'call_to_action', locals
@@ -32,7 +32,7 @@ module.exports.login = (req, res) ->
     res.render 'login', locals
 
 module.exports.forgotPassword = (req, res) ->
-  if sd.NEW_AUTH_MODAL
+  if res.locals.sd.NEW_AUTH_MODAL
     res.redirect '/forgot'
   else
     res.render 'forgot_password'
@@ -56,7 +56,7 @@ module.exports.signUp = (req, res) ->
     error: err?.body.error
     prefill: req.query.prefill
   
-  if sd.NEW_AUTH_MODAL
+  if res.locals.sd.NEW_AUTH_MODAL
     res.redirect "/signup?#{qs.stringify(locals)}"
   else if locals.action
     res.render 'call_to_action', locals

--- a/src/mobile/apps/auth/routes.coffee
+++ b/src/mobile/apps/auth/routes.coffee
@@ -23,14 +23,19 @@ module.exports.login = (req, res) ->
   locals =
     redirectTo: redirectUrl(req)
     action: req.query.action
-
-  if locals.action
+  
+  if sd.NEW_AUTH_MODAL
+    res.redirect "/login?#{qs.stringify(locals)}"
+  else if locals.action
     res.render 'call_to_action', locals
   else
     res.render 'login', locals
 
 module.exports.forgotPassword = (req, res) ->
-  res.render 'forgot_password'
+  if sd.NEW_AUTH_MODAL
+    res.redirect '/forgot'
+  else
+    res.render 'forgot_password'
 
 module.exports.submitForgotPassword = (req, res, next) ->
   new Backbone.Model().save null,
@@ -50,7 +55,10 @@ module.exports.signUp = (req, res) ->
     action: req.query.action
     error: err?.body.error
     prefill: req.query.prefill
-  if locals.action
+  
+  if sd.NEW_AUTH_MODAL
+    res.redirect "/signup?#{qs.stringify(locals)}"
+  else if locals.action
     res.render 'call_to_action', locals
   else if req.query.email
     res.render 'signup_email', locals

--- a/tslint.json
+++ b/tslint.json
@@ -5,6 +5,7 @@
     "tslint-react"
   ],
   "rules": {
+    "jsx-boolean-value": false,
     "jsx-no-lambda": false,
     "jsx-no-multiline-js": false,
     "no-default-export": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,11 +23,10 @@
     yarn "^1.3.2"
 
 "@artsy/palette@^2.3.4":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.5.1.tgz#2437354414cff47c37f510b60ac326aef0e15f00"
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.6.3.tgz#dc2efcd875ab1aaba5bf361d9e305451f4c76b9b"
   dependencies:
     react "^16.3.2"
-    react-primitives "^0.5.0"
     styled-system "^2.2.5"
 
 "@artsy/passport@^1.0.11":
@@ -48,9 +47,9 @@
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
-"@artsy/reaction@^1.20.14":
-  version "1.20.14"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-1.20.14.tgz#dfaba8b4c250b3b934858040f8da1491715ced84"
+"@artsy/reaction@^1.20.19":
+  version "1.20.19"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-1.20.19.tgz#1e29045b153496be9c1bd865466f5b83f47a9971"
   dependencies:
     "@artsy/palette" "^2.3.4"
     cheerio "^1.0.0-rc.2"
@@ -9590,8 +9589,8 @@ react-themeable@^1.1.0:
     object-assign "^3.0.0"
 
 react-timer-mixin@^0.13.3:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.3.tgz#0da8b9f807ec07dc3e854d082c737c65605b3d22"
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz#75a00c3c94c13abe29b43d63b4c65a88fc8264d3"
 
 react-tracking@^4.2.1:
   version "4.2.1"
@@ -11095,7 +11094,7 @@ styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 
-styled-bootstrap-grid@damassi/styled-bootstrap-grid#respect-padding-in-fluid:
+"styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#respect-padding-in-fluid":
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/f4908956cb3b31ef811c729d3a50784efafe62da"
 


### PR DESCRIPTION
Addresses:
 
- [[Mobile Auth QA] Change redirect link for back button for '/login' and '/signup' static route](https://artsyproduct.atlassian.net/browse/GROW-786)
- [Mobile modals - Redirect legacy mobile auth urls to new auth static pages](https://artsyproduct.atlassian.net/browse/GROW-496)

Tasks
- [x] Make the update from /sign_up -> /signup and /log_in -> /login
- [x] Ensure that when updating, we're using proper parameters (ie destination instead of redirectTo for post-onboarding)

Depends on: https://github.com/artsy/reaction/pull/1006