### PR TITLE
Reduce JS bundle sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "resolutions": {
     "babel-core": "^7.0.0-0",
     "graphql": "^0.13.2",
+    "moment": "^2.22.2",
     "babel-plugin-relay": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.5/babel-plugin-relay-1.5.0-artsy.5.tgz",
     "relay-compiler": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.5/relay-compiler-1.5.0-artsy.5.tgz",
     "relay-runtime": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.5/relay-runtime-1.5.0-artsy.5.tgz",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,6 +68,13 @@ const config = {
   plugins: [
     // TODO: Add webpack typechecker
     new ProgressBarPlugin(),
+
+    // Remove moment.js localization files
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+
+    // Don't bundle cheerio with client bundle
+    new webpack.IgnorePlugin(/cheerio/),
+
     new ForkTsCheckerWebpackPlugin({
       formatter: 'codeframe',
       formatterOptions: 'highlightCode',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7811,17 +7811,13 @@ moment-twitter@^0.2.0:
   dependencies:
     moment "~2.4.0"
 
-"moment@>= 2.9.0":
+"moment@>= 2.9.0", moment@^2.11.1, moment@^2.22.2, moment@~2.4.0:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
-moment@^2.11.1, moment@~2.16.0:
+moment@~2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.16.0.tgz#f38f2c97c9889b0ee18fc6cc392e1e443ad2da8e"
-
-moment@~2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.4.0.tgz#06dd8dfbbfdb53a03510080ac788163c9490e75d"
 
 morgan@^1.8.1:
   version "1.8.1"


### PR DESCRIPTION
A start on bundle optimization, this removes the localization file from moment and kills cheerio in the client build. There are seemingly other dependencies that _shouldn't_ be directly included in this. 

@orta pointed out that graphql is being included in our client bundle as well which it probably shouldn't be.... lots more to do here, but I'm just kicking it off. 