### PR TITLE
@xtina-starr => Infinite scroll/Display bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@artsy/express-reloadable": "^1.3.1",
     "@artsy/palette": "^2.0.2",
     "@artsy/passport": "^1.0.11",
-    "@artsy/reaction": "^1.20.14",
+    "@artsy/reaction": "^1.20.17",
     "@artsy/stitch": "^1.6.0",
     "@babel/core": "7.0.0-beta.40",
     "@babel/node": "7.0.0-beta.40",

--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -4,12 +4,9 @@ import { flatten, debounce, extend } from 'lodash'
 import Waypoint from 'react-waypoint'
 import { positronql as _positronql } from 'desktop/lib/positronql'
 import { newsArticlesQuery } from 'desktop/apps/article/queries/articles'
-import { RelatedArticlesCanvas } from '@artsy/reaction/dist/Components/Publishing/RelatedArticles/RelatedArticlesCanvas'
 import { ArticleData } from '@artsy/reaction/dist/Components/Publishing/Typings'
 import { NewsNav } from '@artsy/reaction/dist/Components/Publishing/Nav/NewsNav'
 import { setupFollows, setupFollowButtons } from './FollowButton.js'
-import { DisplayCanvas } from '@artsy/reaction/dist/Components/Publishing/Display/Canvas'
-import { Break } from 'desktop/apps/article/components/InfiniteScrollArticle'
 import { LoadingSpinner } from './InfiniteScrollArticle'
 import { NewsArticle } from './NewsArticle'
 import { NewsDateDivider } from '@artsy/reaction/dist/Components/Publishing/News/NewsDateDivider'
@@ -18,7 +15,6 @@ export interface Props {
   article?: ArticleData
   articles: ArticleData[]
   isMobile: boolean
-  marginTop: string
   renderTime?: number
 }
 
@@ -188,6 +184,10 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
         }
         const isTruncated = !this.props.article || i !== 0
         const hasDateDivider = i !== 0 && this.hasNewDate(article, i)
+        const relatedArticlesCanvas = hasMetaContent && related
+        const displayCanvas = hasMetaContent && displayAd
+        const hasRenderTime =
+          hasMetaContent && ((displayAd && displayAd.renderTime) || renderTime)
 
         return (
           <Fragment key={`article-${i}`}>
@@ -201,29 +201,10 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
               nextArticle={articles[i + 1]}
               onActiveArticleChange={id => this.onActiveArticleChange(id)}
               isActive={activeArticle === article.id}
+              relatedArticlesForCanvas={relatedArticlesCanvas as any}
+              display={displayCanvas}
+              renderTime={hasRenderTime}
             />
-            {hasMetaContent &&
-              related && (
-                <Fragment>
-                  <Break />
-                  <RelatedArticlesCanvas
-                    articles={related as any}
-                    isMobile={isMobile}
-                  />
-                  <Break />
-                </Fragment>
-              )}
-            {hasMetaContent &&
-              displayAd && (
-                <Fragment>
-                  <DisplayCanvas
-                    unit={displayAd.canvas}
-                    campaign={displayAd}
-                    renderTime={displayAd.renderTime || renderTime}
-                  />
-                  <Break />
-                </Fragment>
-              )}
           </Fragment>
         )
       })

--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -15,7 +15,7 @@ export interface Props {
   article?: ArticleData
   articles: ArticleData[]
   isMobile: boolean
-  renderTime?: number
+  renderTime?: string
 }
 
 interface State {

--- a/src/desktop/apps/article/components/NewsArticle.tsx
+++ b/src/desktop/apps/article/components/NewsArticle.tsx
@@ -4,6 +4,7 @@ import Waypoint from 'react-waypoint'
 
 interface Props {
   article: any
+  display?: any
   isActive: boolean
   isFirstArticle: boolean
   isMobile: boolean
@@ -11,6 +12,8 @@ interface Props {
   nextArticle: any
   onActiveArticleChange: (id: string) => void
   onDateChange: (date: string) => void
+  relatedArticlesForCanvas?: any
+  renderTime?: any
 }
 
 interface State {
@@ -96,10 +99,13 @@ export class NewsArticle extends Component<Props, State> {
   render() {
     const {
       article,
+      display,
       isActive,
       isMobile,
       isTruncated,
       isFirstArticle,
+      relatedArticlesForCanvas,
+      renderTime,
     } = this.props
     const { bottomOffset } = this.state
     const marginTop = isMobile ? '100px' : '200px'
@@ -120,6 +126,9 @@ export class NewsArticle extends Component<Props, State> {
               marginTop={isFirstArticle ? marginTop : null}
               onExpand={this.onExpand}
               isHovered={isMobile && isActive}
+              relatedArticlesForCanvas={relatedArticlesForCanvas}
+              display={display}
+              renderTime={renderTime}
             />
           </div>
         </Waypoint>

--- a/src/desktop/apps/article/components/NewsArticle.tsx
+++ b/src/desktop/apps/article/components/NewsArticle.tsx
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import { Article } from 'reaction/Components/Publishing/Article'
 import Waypoint from 'react-waypoint'
+import { RelatedArticlesCanvasProps } from 'reaction/Components/Publishing/RelatedArticles/RelatedArticlesCanvas'
 
 interface Props {
   article: any
@@ -12,8 +13,8 @@ interface Props {
   nextArticle: any
   onActiveArticleChange: (id: string) => void
   onDateChange: (date: string) => void
-  relatedArticlesForCanvas?: any
-  renderTime?: any
+  relatedArticlesForCanvas?: RelatedArticlesCanvasProps
+  renderTime?: string
 }
 
 interface State {

--- a/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.test.js
+++ b/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.test.js
@@ -43,10 +43,6 @@ describe('<InfiniteScrollNewsArticle />', () => {
 
   let rewire = require('rewire')('../InfiniteScrollNewsArticle.tsx')
   let { InfiniteScrollNewsArticle } = rewire
-  const { RelatedArticlesCanvas } = require('reaction/Components/Publishing')
-  const {
-    DisplayCanvas,
-  } = require('reaction/Components/Publishing/Display/Canvas')
 
   beforeEach(() => {
     window.history.replaceState = sinon.stub()
@@ -134,7 +130,6 @@ describe('<InfiniteScrollNewsArticle />', () => {
     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
     await rendered.instance().fetchNextArticles()
     rendered.update()
-    rendered.find(DisplayCanvas).length.should.equal(1)
     rendered.html().should.containEql('Sponsored by BMW')
   })
 
@@ -160,7 +155,6 @@ describe('<InfiniteScrollNewsArticle />', () => {
     const rendered = shallow(<InfiniteScrollNewsArticle {...props} />)
     await rendered.instance().fetchNextArticles()
     rendered.update()
-    rendered.find(RelatedArticlesCanvas).length.should.equal(1)
     rendered.html().should.containEql('More from Artsy Editorial')
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,9 +48,9 @@
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
-"@artsy/reaction@^1.20.14":
-  version "1.20.14"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-1.20.14.tgz#dfaba8b4c250b3b934858040f8da1491715ced84"
+"@artsy/reaction@^1.20.17":
+  version "1.20.17"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-1.20.17.tgz#55aa6bc4d0b014ac95bcb31c52bd5dfcc4c92ffa"
   dependencies:
     "@artsy/palette" "^2.3.4"
     cheerio "^1.0.0-rc.2"
@@ -11094,7 +11094,7 @@ styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 
-styled-bootstrap-grid@damassi/styled-bootstrap-grid#respect-padding-in-fluid:
+"styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#respect-padding-in-fluid":
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/f4908956cb3b31ef811c729d3a50784efafe62da"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1061,7 +1061,6 @@ antigravity@artsy/antigravity:
   version "0.1.3"
   resolved "https://codeload.github.com/artsy/antigravity/tar.gz/a4438d2fe9d0cdf71f1c47faba371cd3d004e140"
   dependencies:
-    coffeescript "1.11.1"
     express "*"
 
 any-observable@^0.2.0:


### PR DESCRIPTION
Removes `/news` rendering of `DisplayCanvas` and `RelatedArticlesCanvas` in favor of rendering in Reaction.  Follows up on https://github.com/artsy/reaction/pull/1008.