### PR TITLE
@mzikherman => Match artist page functionality and launch CTA when there is no ref set

### DIFF
--- a/src/desktop/apps/artist2/server.js
+++ b/src/desktop/apps/artist2/server.js
@@ -39,10 +39,10 @@ app.get('/artist2/:artistID*', async (req, res, next) => {
     }
 
     const { artist } = await metaphysics(send).then(data => data)
-
-    const isExternalReferer =
-      res.locals.sd.REFERRER &&
-      !res.locals.sd.REFERRER.includes(res.locals.sd.APP_URL)
+    const { REFERRER } = res.locals.sd
+    const isExternalReferer = !(
+      REFERRER && REFERRER.includes(res.locals.sd.APP_URL)
+    )
 
     res.locals.sd.ARTIST_PAGE_CTA_ENABLED = !user && isExternalReferer
     res.locals.sd.ARTIST_PAGE_CTA_ARTIST_ID = req.params.artistID


### PR DESCRIPTION
Rather than _only_ launching when there's an external referrer, we should also launch it when there is no referrer set (navigating directly from a new browser, for instance). This matches the existing implementation, not to mention makes it easier to test (in a new signed-out incognito window, visit the artist page). 