### PR TITLE
[WIP] Port optimized yarn install method from reaction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,8 @@ jobs:
       - add_ssh_keys
       - checkout
       - setup_remote_docker
+      - <<: *restore_cache
+      - <<: *verify_dependencies
       - run:
           name: Test
           command: "hokusai test"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,7 @@ workflows:
   version: 2
   default:
     jobs:
+      - update-cache
       - test:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,29 @@
+save_cache: &save_cache
+  save_cache:
+    key: yarn-deps-{{ checksum "yarn.lock" }}
+    paths:
+      - ./node_modules
+
+restore_cache: &restore_cache
+  restore_cache:
+    keys:
+    - yarn-deps-{{ checksum "yarn.lock" }}
+    - yarn-deps-
+      
+verify_dependencies: &verify_dependencies
+  run: yarn --check-files
+
 version: 2.0
 jobs:
+  update-cache:
+    docker:
+      - image: circleci/node:8-stretch-browsers
+    steps:
+      - add_ssh_keys
+      - checkout
+      - <<: *restore_cache
+      - <<: *verify_dependencies
+      - <<: *save_cache
   acceptance:
     docker:
       - image: circleci/node:8-stretch-browsers
@@ -7,9 +31,11 @@ jobs:
     steps:
       - add_ssh_keys
       - checkout
+      - <<: *restore_cache
+      - <<: *verify_dependencies
       - run:
           name: Acceptance Tests
-          command: "yarn install && yarn acceptance src/test/acceptance/*.js"
+          command: "yarn acceptance src/test/acceptance/*.js"
   test:
     docker:
       - image: artsy/hokusai:0.4.5
@@ -45,7 +71,9 @@ jobs:
       - add_ssh_keys
       - checkout
       - setup_remote_docker
-      - run: yarn install && DEPLOY_ENV=staging yarn publish_assets
+      - <<: *restore_cache
+      - <<: *verify_dependencies
+      - run: DEPLOY_ENV=staging yarn publish_assets
       - run: mkdir -p workspace
       - run: cp manifest.json workspace/manifest.json
       - persist_to_workspace:
@@ -59,7 +87,9 @@ jobs:
       - add_ssh_keys
       - checkout
       - setup_remote_docker
-      - run: yarn install && DEPLOY_ENV=release yarn publish_assets
+      - <<: *restore_cache
+      - <<: *verify_dependencies
+      - run: DEPLOY_ENV=release yarn publish_assets
       - run: mkdir -p workspace
       - run: cp manifest.json workspace/manifest.json
       - persist_to_workspace:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM bitnami/node:8
-#FROM circleci/node:8-stretch-browsers
+# FROM bitnami/node:8
+FROM circleci/node:8
 
 RUN install_packages libsecret-1-dev libglib2.0-dev
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1061,6 +1061,7 @@ antigravity@artsy/antigravity:
   version "0.1.3"
   resolved "https://codeload.github.com/artsy/antigravity/tar.gz/a4438d2fe9d0cdf71f1c47faba371cd3d004e140"
   dependencies:
+    coffeescript "1.11.1"
     express "*"
 
 any-observable@^0.2.0:
@@ -9421,7 +9422,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-"react-lines-ellipsis@github:alloy/react-lines-ellipsis#dont-setState-on-unmounted-component":
+react-lines-ellipsis@alloy/react-lines-ellipsis#dont-setState-on-unmounted-component:
   version "0.13.0"
   resolved "https://codeload.github.com/alloy/react-lines-ellipsis/tar.gz/ff6a63a8b4b6b625f46fb753c7acb70a2ccc4541"
 
@@ -11117,7 +11118,7 @@ styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 
-"styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#respect-padding-in-fluid":
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#respect-padding-in-fluid:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/f4908956cb3b31ef811c729d3a50784efafe62da"
 


### PR DESCRIPTION
The yarn install step for force can take around a minute and a half to finish. There's no caching happening currently. This is an attempt to mitigate that by adding the same cache method that reaction uses. 