### PR TITLE
Remove moment.js localizations file

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "resolutions": {
     "babel-core": "^7.0.0-0",
     "graphql": "^0.13.2",
+    "moment": "^2.22.2",
     "babel-plugin-relay": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.5/babel-plugin-relay-1.5.0-artsy.5.tgz",
     "relay-compiler": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.5/relay-compiler-1.5.0-artsy.5.tgz",
     "relay-runtime": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.5/relay-runtime-1.5.0-artsy.5.tgz",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,6 +68,10 @@ const config = {
   plugins: [
     // TODO: Add webpack typechecker
     new ProgressBarPlugin(),
+
+    // Remove moment.js localization files
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+
     new ForkTsCheckerWebpackPlugin({
       formatter: 'codeframe',
       formatterOptions: 'highlightCode',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1061,6 +1061,7 @@ antigravity@artsy/antigravity:
   version "0.1.3"
   resolved "https://codeload.github.com/artsy/antigravity/tar.gz/a4438d2fe9d0cdf71f1c47faba371cd3d004e140"
   dependencies:
+    coffeescript "1.11.1"
     express "*"
 
 any-observable@^0.2.0:
@@ -7828,17 +7829,13 @@ moment-twitter@^0.2.0:
   dependencies:
     moment "~2.4.0"
 
-"moment@>= 2.9.0":
+"moment@>= 2.9.0", moment@^2.11.1, moment@^2.22.2, moment@~2.4.0:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
-moment@^2.11.1, moment@~2.16.0:
+moment@~2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.16.0.tgz#f38f2c97c9889b0ee18fc6cc392e1e443ad2da8e"
-
-moment@~2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.4.0.tgz#06dd8dfbbfdb53a03510080ac788163c9490e75d"
 
 morgan@^1.8.1:
   version "1.8.1"
@@ -9421,7 +9418,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-"react-lines-ellipsis@github:alloy/react-lines-ellipsis#dont-setState-on-unmounted-component":
+react-lines-ellipsis@alloy/react-lines-ellipsis#dont-setState-on-unmounted-component:
   version "0.13.0"
   resolved "https://codeload.github.com/alloy/react-lines-ellipsis/tar.gz/ff6a63a8b4b6b625f46fb753c7acb70a2ccc4541"
 
@@ -11117,7 +11114,7 @@ styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 
-"styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#respect-padding-in-fluid":
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#respect-padding-in-fluid:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/f4908956cb3b31ef811c729d3a50784efafe62da"
 


### PR DESCRIPTION
This brings back only the moment localizations exclusions from #2708. That PR had to be reverted due to the cheerio change. 

## Bundle Reductions

| Asset           |         Old size  |   New size     |   Diff    |  Diff % |
| --- | --- | --- | --- | --- | 
| common.js         |       2.36 MB   | 2 MB   | -366 KB  |  -15.17 % |
 | article.js        |       1.6 MB    | 1.4 MB   | -204 KB  |  -12.45 % |
 | articles.js       |       1.57 MB|    1.37 MB  |  -204 KB  |  -12.70 % |
 | editorial_features.js  |  1.58 MB |   1.38 MB  |  -204 KB  |   -12.59 % |
 | mobile_articles.js   |    811 KB  |  606 KB  |  -204 KB  |  -25.20 % |
 | mobile_all.js       |     606 KB |   536 KB |   -69.2 KB   |  -11.42 % |

## Net Result

| Old size | New size | Diff | Diff % |
| ------- | -- | -- | -- |
| 67.6 MB | 63 MB | -4.62 MB | -6.82 % |

/cc @orta @joeyAghion @ds300 