### PR TITLE
Upload assets to correct S3 bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - add_ssh_keys
       - checkout
       - setup_remote_docker
-      - run: yarn install && DEPLOY_ENV=release yarn publish_assets
+      - run: yarn install && DEPLOY_ENV=production yarn publish_assets
       - run: mkdir -p workspace
       - run: cp manifest.json workspace/manifest.json
       - persist_to_workspace:


### PR DESCRIPTION
Unless I'm misunderstanding, the previous code would try to upload to a non-existent S3 bucket. The `knox` AWS library unhelpfully returns success when this happens (like [here](https://circleci.com/gh/artsy/force/8043)).
