### PR TITLE
Update create order mutation (for /order2) to match new shape

### DIFF
--- a/src/desktop/apps/artwork/components/commercial/view.coffee
+++ b/src/desktop/apps/artwork/components/commercial/view.coffee
@@ -7,6 +7,7 @@ CurrentUser = require '../../../../models/current_user.coffee'
 Fair = require '../../../../models/fair.coffee'
 ArtworkInquiry = require '../../../../models/artwork_inquiry.coffee'
 Form = require '../../../../components/form/index.coffee'
+Serializer = require '../../../../components/form/serializer.coffee'
 PendingOrder = require '../../../../models/pending_order.coffee'
 analyticsHooks = require '../../../../lib/analytics_hooks.coffee'
 openMultiPageModal = require '../../../../components/multi_page_modal/index.coffee'
@@ -42,14 +43,16 @@ module.exports = class ArtworkCommercialView extends Backbone.View
     # Show the new buy now flow if you have the lab feature enabled
     loggedInUser = CurrentUser.orNull()
     if loggedInUser?.hasLabFeature('New Buy Now Flow')
+      serializer = new Serializer @$('form')
+      data = serializer.data()
+
       createOrder
-        user: loggedInUser
-        partnerId: @artwork.get('partner_id')
-        currencyCode: "usd"
         artworkId: @artwork.get('_id')
-        priceCents: 500000, quantity: 1
+        editionSetId: data.edition_set_id
+        quantity: 1
+        user: loggedInUser
       .then (data) ->
-        order = data?.createOrder?.result?.order
+        order = data?.createOrderWithArtwork?.result?.order
         location.assign("/order2/#{order.id}/shipping")
 
     else

--- a/src/desktop/components/form/README.md
+++ b/src/desktop/components/form/README.md
@@ -15,7 +15,6 @@ form
   input( name='full_name' )
   input( name='something_else' )
   button
-
 ```
 
 ```coffeescript

--- a/src/lib/components/create_order/index.tsx
+++ b/src/lib/components/create_order/index.tsx
@@ -7,30 +7,21 @@ import query from './mutation'
 let metaphysics = _metaphysics
 
 interface CreateOrderInput {
-  user: any
-  partnerId: string
-  currencyCode: string
   artworkId: string
-  priceCents: number
+  editionSetId: string
   quantity: number
+  user: object
 }
 
 export const createOrder = async (input: CreateOrderInput) => {
-  const {
-    user,
-    partnerId,
-    currencyCode,
-    artworkId,
-    priceCents,
-    quantity,
-  } = input
+  const { artworkId, editionSetId, quantity, user } = input
 
   if (user == null) {
     return
   }
   const send = {
     query,
-    variables: { partnerId, currencyCode, artworkId, priceCents, quantity },
+    variables: { artworkId, editionSetId, quantity },
     req: { user },
   }
 

--- a/src/lib/components/create_order/mutation.js
+++ b/src/lib/components/create_order/mutation.js
@@ -1,21 +1,12 @@
 module.exports = `
-  mutation createOrder($partnerId: String!, $currencyCode: String!, $artworkId: String!, $priceCents: Int!, $quantity: Int!){
-    createOrder(
-      input: {
-        partnerId: $partnerId,
-        currencyCode: $currencyCode,
-        lineItems: [{
-          artworkId: $artworkId,
-          priceCents: $priceCents,
-          quantity: $quantity
-        }]
+mutation createOrder($artworkId: String!, $editionSetId: String, $quantity: Int){
+  createOrderWithArtwork(input: { artworkId: $artworkId, editionSetId: $editionSetId, quantity: $quantity}){
+    result{
+      order{
+        id
       }
-    ) {
-      result {
-        order {
-          id
-        }
-      }
+      errors
     }
+  }
 }
 `

--- a/yarn.lock
+++ b/yarn.lock
@@ -1061,7 +1061,6 @@ antigravity@artsy/antigravity:
   version "0.1.3"
   resolved "https://codeload.github.com/artsy/antigravity/tar.gz/a4438d2fe9d0cdf71f1c47faba371cd3d004e140"
   dependencies:
-    coffeescript "1.11.1"
     express "*"
 
 any-observable@^0.2.0:
@@ -9418,7 +9417,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
+react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 
@@ -11114,7 +11113,7 @@ styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 
-"styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#respect-padding-in-fluid":
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#respect-padding-in-fluid:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/f4908956cb3b31ef811c729d3a50784efafe62da"
 


### PR DESCRIPTION
This PR updates the mutation we use to create an order to follow the new shape of `createOrderWithArtwork`.

It also makes sure to send the `editionSetId` if one is selected (by pulling out the data using `Serializer`).