### PR TITLE
@cavvia => Add fragment meta tag to new artist page

### DIFF
--- a/src/desktop/apps/artist2/components/Meta.js
+++ b/src/desktop/apps/artist2/components/Meta.js
@@ -57,6 +57,7 @@ export function Meta(props) {
       {artist.deathyear && (
         <meta property="og:deathyear" content={artist.deathyear} />
       )}
+      <meta property="fragment" content="!" />
       {renderImageMetaTags(artist)}
       {maybeRenderNoIndex(artist)}
     </Fragment>


### PR DESCRIPTION
You brought up in #seo that it seemed as if Google might be crawling some of the new artist pages. What could be happening is: the _initial_ request might be getting the new page, which doesn't include this meta tag. That prevents Google from re-requesting the page w/ the special query param which falls thru to the Reflection version. What we serve to Reflection continues to be the old page, so let's add this tag to the new artist page.

Once we're ready to deploy the new artist page fully (and want Google to index the new one), we'll need to remove this tag again.