### PR TITLE
@l2succes => Article header/ssr bugs

### DIFF
--- a/src/desktop/apps/article/components/__tests__/Article.test.js
+++ b/src/desktop/apps/article/components/__tests__/Article.test.js
@@ -8,6 +8,7 @@ import { mount } from 'enzyme'
 import { data as sd } from 'sharify'
 import { ContextProvider } from 'reaction/Components/Artsy'
 import { DisplayPanel } from 'reaction/Components/Publishing/Display/DisplayPanel'
+import { FeatureArticle } from '../../../../../../node_modules/@artsy/reaction/dist/Components/Publishing/Fixtures/Articles'
 
 describe('<Article />', () => {
   before(done => {
@@ -17,7 +18,6 @@ describe('<Article />', () => {
       sd.CURRENT_PATH =
         '/article/artsy-editorial-surprising-reason-men-women-selfies-differently'
       sd.CURRENT_USER = { id: '123' }
-      sd.ARTICLE_INFINITE_SCROLL = 'control'
       done()
     })
   })
@@ -244,10 +244,20 @@ describe('<Article /> without infinite scroll', () => {
   })
 
   it('renders a standard article without infinite scroll', () => {
+    props.isExperimentInfiniteScroll = true
     const rendered = getWrapper(props)
 
     rendered.find(InfiniteScrollArticle).length.should.equal(0)
     rendered.html().should.containEql('StandardLayout')
+  })
+
+  it('renders a feature article without infinite scroll', () => {
+    props.isExperimentInfiniteScroll = true
+    props.article = FeatureArticle
+    const rendered = getWrapper(props)
+
+    rendered.find(InfiniteScrollArticle).length.should.equal(0)
+    rendered.html().should.containEql('FeatureLayout')
   })
 
   it('renders a standard article with ads', () => {

--- a/src/desktop/apps/article/components/layouts/Article.js
+++ b/src/desktop/apps/article/components/layouts/Article.js
@@ -61,18 +61,16 @@ export default class ArticleLayout extends React.Component {
   render() {
     const {
       article,
+      isExperimentInfiniteScroll,
       isSuper,
       isMobile,
       renderTime,
       showTooltips,
       templates: { SuperArticleFooter, SuperArticleHeader } = {},
     } = this.props
-
-    const isExperimentInfiniteScroll =
-      sd.ARTICLE_INFINITE_SCROLL === 'experiment'
     const hasNav = isSuper || article.seriesArticle
+    const isStatic = isExperimentInfiniteScroll || hasNav
 
-    const notScrolling = isExperimentInfiniteScroll || hasNav
     return (
       <div>
         {isSuper && (
@@ -83,7 +81,7 @@ export default class ArticleLayout extends React.Component {
           />
         )}
 
-        {notScrolling ? (
+        {isStatic ? (
           <Article
             article={article}
             display={article.display}

--- a/src/desktop/apps/article/routes.js
+++ b/src/desktop/apps/article/routes.js
@@ -119,11 +119,19 @@ export async function index(req, res, next) {
         '../../../components/main_layout/templates/react_blank_index.jade'
     }
 
-    const { CURRENT_USER, IS_MOBILE, IS_TABLET } = res.locals.sd
+    const {
+      ARTICLE_INFINITE_SCROLL,
+      CURRENT_USER,
+      IS_MOBILE,
+      IS_TABLET,
+    } = res.locals.sd
 
     const isMobile = IS_MOBILE
     const isTablet = IS_TABLET
     const jsonLD = stringifyJSONForWeb(articleModel.toJSONLD())
+
+    // Infinite scroll a/b test
+    const isExperimentInfiniteScroll = ARTICLE_INFINITE_SCROLL === 'experiment'
 
     // Email signup
     const isLoggedIn = typeof CURRENT_USER !== 'undefined'
@@ -155,6 +163,7 @@ export async function index(req, res, next) {
       },
       data: {
         article,
+        isExperimentInfiniteScroll,
         isSuper,
         isLoggedIn,
         isMobile,


### PR DESCRIPTION
Turned out the answer to this bug was quite simple. We render different components based on `sd.ARTICLE_INFINITE_SCROLL`, but the value was appearing differently on the server vs client.  By assigning this value at the route and passing as a prop to `renderLayout` inconsistencies are avoided.