### PR TITLE
adding usage for domesticShipping and internationalShipping fees for artwork

### DIFF
--- a/src/desktop/apps/artwork/components/commercial/query.coffee
+++ b/src/desktop/apps/artwork/components/commercial/query.coffee
@@ -10,6 +10,8 @@ module.exports = """
     contact_message
     is_price_range
     price
+    domesticShipping
+    internationalShipping
     artists {
       name
       is_consignable

--- a/src/desktop/apps/artwork/components/commercial/query.coffee
+++ b/src/desktop/apps/artwork/components/commercial/query.coffee
@@ -10,8 +10,7 @@ module.exports = """
     contact_message
     is_price_range
     price
-    domesticShipping
-    internationalShipping
+    shippingInfo
     artists {
       name
       is_consignable

--- a/src/desktop/apps/artwork/components/commercial/templates/price.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/price.jade
@@ -17,4 +17,14 @@ if artwork.sale_message || isPermanentCollection
 
     if showPriceLabel
       .artwork-commercial__shipping-info
-        | Shipping, tax, and service quoted by seller
+        - var noShippingInfo = !artwork.domesticShipping && !artwork.internationalShipping
+        - var complimentaryShipping = artwork.domesticShipping == '$0' && artwork.internationalShipping == '$0'
+        - var domesticShippingOnly = artwork.domesticShipping && artwork.domesticShipping != '$0' && !artwork.internationalShipping
+        if noShippingInfo
+          | Shipping, tax, and service quoted by seller
+        else if complimentaryShipping
+          | Free shipping worldwide
+        else if domesticShippingOnly
+          | Shipping: #{artwork.domesticShipping} Continental US only
+        else
+          | Shipping: #{artwork.domesticShipping} Continental US, #{artwork.internationalShipping} rest of the world

--- a/src/desktop/apps/artwork/components/commercial/templates/price.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/price.jade
@@ -10,21 +10,9 @@ if artwork.sale_message || isPermanentCollection
           if artwork.is_price_range
             .tooltip-question-container
               != stitch.components.TooltipQuestion({horizontalAlign: 'left', message: 'The range is an approximate indication of the work’s price point, and the exact price is quoted upon request.'})
+        .artwork-commercial__shipping-info
+          | #{artwork.shippingInfo}
       else if isPermanentCollection
         | Permanent collection
       else
         | #{artwork.sale_message}
-
-    if showPriceLabel
-      .artwork-commercial__shipping-info
-        - var noShippingInfo = !artwork.domesticShipping && !artwork.internationalShipping
-        - var complimentaryShipping = artwork.domesticShipping == '$0' && artwork.internationalShipping == '$0'
-        - var domesticShippingOnly = artwork.domesticShipping && artwork.domesticShipping != '$0' && !artwork.internationalShipping
-        if noShippingInfo
-          | Shipping, tax, and service quoted by seller
-        else if complimentaryShipping
-          | Free shipping worldwide
-        else if domesticShippingOnly
-          | Shipping: #{artwork.domesticShipping} Continental US only
-        else
-          | Shipping: #{artwork.domesticShipping} Continental US, #{artwork.internationalShipping} rest of the world

--- a/src/mobile/apps/artwork/components/meta_data/templates/price.jade
+++ b/src/mobile/apps/artwork/components/meta_data/templates/price.jade
@@ -4,14 +4,4 @@ if artwork.sale_message
       .sale_message= artwork.sale_message
     if artwork.price && artwork.availability !== 'sold'
       .shipping-info
-        - var noShippingInfo = !artwork.domesticShipping && !artwork.internationalShipping
-        - var complimentaryShipping = artwork.domesticShipping == '$0' && artwork.internationalShipping == '$0'
-        - var domesticShippingOnly = artwork.domesticShipping && artwork.domesticShipping != '$0' && !artwork.internationalShipping
-        if noShippingInfo
-          | Shipping, tax, and service quoted by seller
-        else if complimentaryShipping
-          | Free shipping worldwide
-        else if domesticShippingOnly
-          | Shipping: #{artwork.domesticShipping} Continental US only
-        else
-          | Shipping: #{artwork.domesticShipping} Continental US, #{artwork.internationalShipping} rest of the world
+        | #{artwork.shippingInfo}

--- a/src/mobile/apps/artwork/components/meta_data/templates/price.jade
+++ b/src/mobile/apps/artwork/components/meta_data/templates/price.jade
@@ -3,4 +3,15 @@ if artwork.sale_message
     if artwork.sale_message
       .sale_message= artwork.sale_message
     if artwork.price && artwork.availability !== 'sold'
-      .shipping-info Shipping, tax, and services quoted by seller
+      .shipping-info
+        - var noShippingInfo = !artwork.domesticShipping && !artwork.internationalShipping
+        - var complimentaryShipping = artwork.domesticShipping == '$0' && artwork.internationalShipping == '$0'
+        - var domesticShippingOnly = artwork.domesticShipping && artwork.domesticShipping != '$0' && !artwork.internationalShipping
+        if noShippingInfo
+          | Shipping, tax, and service quoted by seller
+        else if complimentaryShipping
+          | Free shipping worldwide
+        else if domesticShippingOnly
+          | Shipping: #{artwork.domesticShipping} Continental US only
+        else
+          | Shipping: #{artwork.domesticShipping} Continental US, #{artwork.internationalShipping} rest of the world

--- a/src/mobile/apps/artwork/routes.coffee
+++ b/src/mobile/apps/artwork/routes.coffee
@@ -20,8 +20,7 @@ query = (user) -> """
       availability
       sale_message
       price
-      domesticShipping
-      internationalShipping
+      shippingInfo
       is_for_sale
       medium
       edition_of

--- a/src/mobile/apps/artwork/routes.coffee
+++ b/src/mobile/apps/artwork/routes.coffee
@@ -20,6 +20,8 @@ query = (user) -> """
       availability
       sale_message
       price
+      domesticShipping
+      internationalShipping
       is_for_sale
       medium
       edition_of


### PR DESCRIPTION
This assumes we can get data introduced here: https://github.com/artsy/metaphysics/pull/1205 and here: https://github.com/artsy/metaphysics/pull/1207

I don't think MP was deployed any time lately but this does seem to not change anything if the data in not available.