### PR TITLE
update k8s deployments

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -30,8 +30,10 @@ spec:
           - containerPort: 5000
           resources:
             requests:
-              cpu: "1"
-              memory: "1Gi"
+              cpu: 700m
+              memory: 1Gi
+            limits:
+              memory: 1.5Gi
       dnsPolicy: Default
       affinity:
         nodeAffinity:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -32,6 +32,17 @@ spec:
             requests:
               cpu: "1"
               memory: "1Gi"
+      dnsPolicy: Default
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - foreground
+
 ---
 apiVersion: v1
 kind: Service

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -28,6 +28,12 @@ spec:
           imagePullPolicy: Always
           ports:
           - containerPort: 5000
+          resources:
+            requests:
+              cpu: 700m
+              memory: 1Gi
+            limits:
+              memory: 1.5Gi
       dnsPolicy: Default
       affinity:
         nodeAffinity:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -28,6 +28,17 @@ spec:
           imagePullPolicy: Always
           ports:
           - containerPort: 5000
+      dnsPolicy: Default
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - foreground
+
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
- set `dnsPolicy: Default` to use AWS nameservers (it appears Force is not accessing in-cluster services)
- set `nodeAffinity` so Force are scheduled on the correct node group and do not contend for resources on the `tier: api` node group
- adjust production CPU request and memory limits (our default memory limit is set to 1G [here](https://github.com/artsy/substance/blob/master/services/limits.yml#L10) and seeing Force pods getting OOMKilled