### PR TITLE
@mzikherman => modal support for faq and inquiries on the order2 page

### DIFF
--- a/src/desktop/apps/order2/client.js
+++ b/src/desktop/apps/order2/client.js
@@ -5,6 +5,33 @@ import mediator from 'desktop/lib/mediator.coffee'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import styled from 'styled-components'
+import openMultiPageModal from 'desktop/components/multi_page_modal/index.coffee'
+import User from 'desktop/models/user.coffee'
+import Artwork from 'desktop/models/artwork.coffee'
+import ArtworkInquiry from 'desktop/models/artwork_inquiry.coffee'
+import openInquiryQuestionnaireFor from 'desktop/components/inquiry_questionnaire/index.coffee'
+
+mediator.on('openOrdersBuyerFAQModal', options => {
+  openMultiPageModal('collector-faqs')
+})
+
+mediator.on('openOrdersContactArtsyModal', options => {
+  const artworkId = options.artworkId
+  if (artworkId) {
+    const user = User.instantiate()
+    const inquiry = new ArtworkInquiry({ notification_delay: 600 })
+    const artwork = new Artwork({ id: artworkId })
+
+    artwork.fetch().then(() => {
+      openInquiryQuestionnaireFor({
+        user,
+        artwork,
+        inquiry,
+        ask_specialist: true,
+      })
+    })
+  }
+})
 
 buildClientApp({ routes, user: sd.CURRENT_USER })
   .then(({ ClientApp }) => {

--- a/src/desktop/assets/order2.styl
+++ b/src/desktop/assets/order2.styl
@@ -1,0 +1,4 @@
+@require '../components/modalize/stylesheets'
+
+.modalize-body
+  padding 30px

--- a/src/desktop/components/inquiry_questionnaire/index.coffee
+++ b/src/desktop/components/inquiry_questionnaire/index.coffee
@@ -10,7 +10,7 @@ openErrorFlash = require './error.coffee'
 sd = require('sharify').data
 { steps, decisions, views } = require './map.coffee'
 
-module.exports = ({ user, artwork, inquiry, bypass, state_attrs }) ->
+module.exports = ({ user, artwork, inquiry, bypass, state_attrs, ask_specialist }) ->
   { collectorProfile } = user.related()
   { userInterests } = collectorProfile.related()
 
@@ -47,6 +47,7 @@ module.exports = ({ user, artwork, inquiry, bypass, state_attrs }) ->
     userInterests: userInterests
     trail: trail
     enableNewInquiryFlow: sd.COMMERCIAL?.enableNewInquiryFlow
+    ask_specialist: ask_specialist
 
   # Attach/teardown analytics events
   analytics.attach state.context

--- a/src/desktop/components/inquiry_questionnaire/map/decisions.coffee
+++ b/src/desktop/components/inquiry_questionnaire/map/decisions.coffee
@@ -7,6 +7,9 @@ decisions =
   is_auction: ({ artwork }) ->
     artwork.get('is_in_auction') is true
 
+  ask_specialist: ({ ask_specialist }) ->
+    ask_specialist
+
   enable_new_inquiry_flow: ({ enableNewInquiryFlow }) -> enableNewInquiryFlow
 
   pre_qualify: ({ artwork, enableNewInquiryFlow }) ->

--- a/src/desktop/components/inquiry_questionnaire/map/decisions.coffee
+++ b/src/desktop/components/inquiry_questionnaire/map/decisions.coffee
@@ -4,11 +4,8 @@ hasSeen = (steps...) -> ({ logger }) -> logger.hasLogged steps...
 hasSeenThisSession = (steps...) -> ({ logger }) -> logger.hasLoggedThisSession steps...
 
 decisions =
-  is_auction: ({ artwork }) ->
-    artwork.get('is_in_auction') is true
-
-  ask_specialist: ({ ask_specialist }) ->
-    ask_specialist
+  ask_specialist: ({ artwork, ask_specialist }) ->
+    artwork.get('is_in_auction') is true || ask_specialist
 
   enable_new_inquiry_flow: ({ enableNewInquiryFlow }) -> enableNewInquiryFlow
 

--- a/src/desktop/components/inquiry_questionnaire/map/decisions.coffee
+++ b/src/desktop/components/inquiry_questionnaire/map/decisions.coffee
@@ -5,7 +5,7 @@ hasSeenThisSession = (steps...) -> ({ logger }) -> logger.hasLoggedThisSession s
 
 decisions =
   ask_specialist: ({ artwork, ask_specialist }) ->
-    artwork.get('is_in_auction') is true || ask_specialist
+    artwork.get('is_in_auction') is true || ask_specialist is true
 
   enable_new_inquiry_flow: ({ enableNewInquiryFlow }) -> enableNewInquiryFlow
 

--- a/src/desktop/components/inquiry_questionnaire/map/steps.coffee
+++ b/src/desktop/components/inquiry_questionnaire/map/steps.coffee
@@ -1,17 +1,10 @@
 module.exports = [
-  is_auction: {
+  ask_specialist: {
     true: [
       'specialist'
       { is_logged_out: true: ['account'] }
     ]
     false: [
-      {
-        ask_specialist: {
-          true: [
-            'specialist'
-          ]
-        }
-      }
       pre_qualify: {
         true: [
           { has_seen_commercial_interest: false: ['commercial_interest'] }

--- a/src/desktop/components/inquiry_questionnaire/map/steps.coffee
+++ b/src/desktop/components/inquiry_questionnaire/map/steps.coffee
@@ -5,6 +5,13 @@ module.exports = [
       { is_logged_out: true: ['account'] }
     ]
     false: [
+      {
+        ask_specialist: {
+          true: [
+            'specialist'
+          ]
+        }
+      }
       pre_qualify: {
         true: [
           { has_seen_commercial_interest: false: ['commercial_interest'] }

--- a/src/desktop/components/inquiry_questionnaire/test/map.coffee
+++ b/src/desktop/components/inquiry_questionnaire/test/map.coffee
@@ -90,6 +90,18 @@ describe 'map', ->
           @state.next().should.equal 'done'
           @state.isEnd().should.be.true()
 
+    describe 'the work should only show the specialist modal', ->
+      beforeEach ->
+        @state.inject ask_specialist: true
+
+      afterEach ->
+        @state.inject ask_specialist: false
+
+      it 'and ends after the specialist step', ->
+        @state.current().should.equal 'specialist'
+        @state.next().should.equal 'done'
+        @state.isEnd().should.be.true()
+
     describe 'A user that has previously seen some steps', ->
       beforeEach ->
         @logger.log 'artists_in_collection'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1061,7 +1061,6 @@ antigravity@artsy/antigravity:
   version "0.1.3"
   resolved "https://codeload.github.com/artsy/antigravity/tar.gz/a4438d2fe9d0cdf71f1c47faba371cd3d004e140"
   dependencies:
-    coffeescript "1.11.1"
     express "*"
 
 any-observable@^0.2.0:
@@ -9419,7 +9418,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
+react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 
@@ -11115,7 +11114,7 @@ styled-bootstrap-grid@damassi/styled-bootstrap-grid#5a115a48a7f4d5608bc73097d52e
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/5a115a48a7f4d5608bc73097d52e14265edc6dd3"
 
-"styled-bootstrap-grid@github:damassi/styled-bootstrap-grid#respect-padding-in-fluid":
+styled-bootstrap-grid@damassi/styled-bootstrap-grid#respect-padding-in-fluid:
   version "1.0.3-2"
   resolved "https://codeload.github.com/damassi/styled-bootstrap-grid/tar.gz/f4908956cb3b31ef811c729d3a50784efafe62da"
 


### PR DESCRIPTION
This PR adds support for two mediator actions being triggered [from reaction](https://github.com/artsy/reaction/blob/master/src/Apps/Order/Components/Summary.tsx#L63-L76).

The first, an FAQ modal, is straightforward.

The second, the "Ask a specialist" modal, is not so straightforward since we previously based whether or not to show the "ask specialist" modal on the `is_auction` flag. This updates that tree/label to be more generic in both cases.

There's not _great_ test coverage for the decision tree stuff, but I can try to add some for this.