### PR TITLE
Configure order router to use beforeUnload event for transitions

### DIFF
--- a/src/desktop/apps/order2/client.js
+++ b/src/desktop/apps/order2/client.js
@@ -33,7 +33,11 @@ mediator.on('openOrdersContactArtsyModal', options => {
   }
 })
 
-buildClientApp({ routes, user: sd.CURRENT_USER })
+buildClientApp({
+  routes,
+  user: sd.CURRENT_USER,
+  historyOptions: { useBeforeUnload: true },
+})
   .then(({ ClientApp }) => {
     ReactDOM.hydrate(
       <Container>


### PR DESCRIPTION
Other part of https://github.com/artsy/reaction/pull/1109. This configures the router to use the beforeunload hook on transitions. 

The above PR will need to be merged and reaction bumped in force before it all works though. 