### PR TITLE
Upgrade to latest Reaction 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@artsy/express-reloadable": "^1.3.1",
     "@artsy/palette": "^2.0.2",
     "@artsy/passport": "^1.0.11",
-    "@artsy/reaction": "^2.2.2",
+    "@artsy/reaction": "^2.3.0",
     "@artsy/stitch": "^1.6.0",
     "@babel/core": "7.0.0-beta.40",
     "@babel/node": "7.0.0-beta.40",

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,9 +47,9 @@
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
-"@artsy/reaction@^2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-2.2.2.tgz#a4aaece80db5b9d195f95b63b0ef82be52ec2b0f"
+"@artsy/reaction@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-2.3.0.tgz#b127f5aad6cdca0af4daed867bfea3fecc9e59b6"
   dependencies:
     "@artsy/palette" "^2.9.1"
     cheerio "^1.0.0-rc.2"
@@ -9419,7 +9419,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
+react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 


### PR DESCRIPTION
This brings in https://github.com/artsy/reaction/pull/1112 I added a few hours ago. I tested the artist page and it seems to be working fine.