### PR TITLE
@mzikherman: Disallow crawlers on staging rather than just 'noindex'

### DIFF
--- a/src/desktop/apps/sitemaps/routes.coffee
+++ b/src/desktop/apps/sitemaps/routes.coffee
@@ -63,4 +63,4 @@ sitemapProxy = httpProxy.createProxyServer(target: SITEMAP_BASE_URL)
     Sitemap: #{APP_URL}/sitemap-videos.xml
 
   """
-  res.send if ENABLE_WEB_CRAWLING then robotsText else "User-agent: *\nNoindex: /"
+  res.send if ENABLE_WEB_CRAWLING then robotsText else "User-agent: *\nDisallow: /"

--- a/src/desktop/apps/sitemaps/test/routes.coffee
+++ b/src/desktop/apps/sitemaps/test/routes.coffee
@@ -30,7 +30,7 @@ describe 'Sitemaps', ->
       routes.__set__ 'ENABLE_WEB_CRAWLING', false
       routes.robots null, @res
       @res.send.args[0][0]
-        .should.equal  'User-agent: *\nNoindex: /'
+        .should.equal  'User-agent: *\nDisallow: /'
 
     describe 'when ENABLE_WEB_CRAWLING is true', ->
       beforeEach ->


### PR DESCRIPTION
Staging's `robots.txt` specifies `Noindex: /` but is still constantly getting crawled. (It also _is_ getting indexed--see bing--though perhaps that's based on previously buggy robots.txt contents.)

I think we should use the stronger `Disallow: /` instead. 