### PR TITLE
@l2succes: mobile auth analytics

### DIFF
--- a/src/desktop/apps/auth2/__tests__/helpers.jest.js
+++ b/src/desktop/apps/auth2/__tests__/helpers.jest.js
@@ -197,6 +197,7 @@ describe('Authentication Helpers', () => {
         modal_copy: 'Log in yo',
         auth_redirect: '/',
         service: 'email',
+        type: 'login',
       })
     })
 
@@ -234,6 +235,7 @@ describe('Authentication Helpers', () => {
         auth_redirect: '/articles',
         intent: 'follow artist',
         service: 'email',
+        type: 'signup',
       })
     })
   })

--- a/src/desktop/apps/auth2/helpers.ts
+++ b/src/desktop/apps/auth2/helpers.ts
@@ -65,6 +65,7 @@ export const handleSubmit = (
           trigger,
           trigger_seconds: triggerSeconds,
           intent,
+          type,
           context_module: contextModule,
           modal_copy: copy,
           auth_redirect: redirectTo || destination,

--- a/src/desktop/apps/auth2/routes.ts
+++ b/src/desktop/apps/auth2/routes.ts
@@ -43,11 +43,14 @@ export const index = async (req, res, next) => {
   const {
     action,
     afterSignUpAction,
+    contextModule,
     destination,
     error,
     kind,
     objectId,
     signupIntent,
+    intent,
+    trigger,
   } = req.query
 
   const redirectTo = req.query.redirectTo || '/'
@@ -85,10 +88,13 @@ export const index = async (req, res, next) => {
         error,
         options: {
           afterSignUpAction,
+          contextModule,
           destination,
+          intent,
           redirectTo,
           signupIntent,
           signupReferer,
+          trigger,
         },
       },
     })

--- a/src/mobile/apps/art_fairs/templates/index.jade
+++ b/src/mobile/apps/art_fairs/templates/index.jade
@@ -18,7 +18,7 @@ block content
       if !user
         .art-fairs-content--sign-up-container
           .art-fairs-content--sign-up-container__label Get notified when fair previews open
-          a.avant-garde-box-button.avant-garde-box-button-gray( href='/sign_up' ) Sign up
+          a.avant-garde-box-button.avant-garde-box-button-gray( href="/sign_up?intent=signup&signupIntent=signup&trigger=click&contextModule=Fairs+Page" ) Sign up
 
       include ../../../components/avant_garde_tabs/nav
 

--- a/src/mobile/apps/artwork/components/image/view.coffee
+++ b/src/mobile/apps/artwork/components/image/view.coffee
@@ -37,7 +37,7 @@ module.exports = class ArtworkImageView extends Backbone.View
               'data-state': 'saved'
               'data-action': 'remove'
     else
-      @$('.artwork-header-module__favorites-container a').attr("href", "/sign_up?action=save&objectId=#{@artwork.id}&kind=artwork&redirect-to=#{window.location}")
+      @$('.artwork-header-module__favorites-container a').attr("href", "/sign_up?action=save&objectId=#{@artwork.id}&kind=artwork&redirect-to=#{window.location}&signupIntent=save+artwork&trigger=click&contextModule=Artwork+Page")
       @$('.artwork-header-module__favorites-container').click( (e) ->
         analyticsHooks.trigger 'save:sign-up'
       )

--- a/src/mobile/apps/artwork/components/image/view.coffee
+++ b/src/mobile/apps/artwork/components/image/view.coffee
@@ -37,7 +37,7 @@ module.exports = class ArtworkImageView extends Backbone.View
               'data-state': 'saved'
               'data-action': 'remove'
     else
-      @$('.artwork-header-module__favorites-container a').attr("href", "/sign_up?action=save&objectId=#{@artwork.id}&kind=artwork&redirect-to=#{window.location}&signupIntent=save+artwork&trigger=click&contextModule=Artwork+Page")
+      @$('.artwork-header-module__favorites-container a').attr("href", "/sign_up?action=save&objectId=#{@artwork.id}&kind=artwork&redirect-to=#{window.location}&signupIntent=save+artwork&intent=save+artwork&trigger=click&contextModule=Artwork+Page")
       @$('.artwork-header-module__favorites-container').click( (e) ->
         analyticsHooks.trigger 'save:sign-up'
       )

--- a/src/mobile/apps/auctions/templates/index.jade
+++ b/src/mobile/apps/auctions/templates/index.jade
@@ -19,7 +19,7 @@ block content
       if !user
         .auction-page-content--sign-up-container
           .auction-page-content--sign-up-container__label Get notified when auctions open
-          a.avant-garde-box-button.avant-garde-box-button-gray( href='/sign_up' ) Sign up
+          a.avant-garde-box-button.avant-garde-box-button-gray( href="/sign_up?redirect-to=/auctions&signupIntent=signup&intent=signup&trigger=click&contextModule=Auctions+Header" ) Sign up
 
       include ../../../components/avant_garde_tabs/nav
 

--- a/src/mobile/apps/auth/routes.coffee
+++ b/src/mobile/apps/auth/routes.coffee
@@ -51,6 +51,13 @@ module.exports.resetPassword = (req, res) ->
 module.exports.signUp = (req, res) ->
   locals = _.extend {}, req.query,
     redirectTo: redirectUrl(req)
+    action: req.query.action
+    error: err?.body.error
+    prefill: req.query.prefill
+    intent: req.query.intent
+    signupIntent: req.query.signupIntent
+    trigger: req.query.trigger
+    contextModule: req.query.contextModule
   
   if res.locals.sd.MOBILE_NEW_AUTH_MODAL
     res.redirect "/signup?#{qs.stringify(locals)}"

--- a/src/mobile/apps/auth/test/routes.coffee
+++ b/src/mobile/apps/auth/test/routes.coffee
@@ -187,5 +187,5 @@ describe '#signUp', ->
           MOBILE_NEW_AUTH_MODAL: true
 
     routes.signUp req, res
-    @redirect.args[0][0].should.equal '/signup?redirect-to=%2F&redirectTo=%2F'
+    @redirect.args[0][0].should.containEql '/signup?redirect-to=%2F&redirectTo=%2F'
 

--- a/src/mobile/apps/fair/templates/search_results.jade
+++ b/src/mobile/apps/fair/templates/search_results.jade
@@ -3,7 +3,7 @@ include ../../../components/layout/templates/login-signup
 
 block body
   #content
-    mixin login-signup
+    mixin login-signup("Fair Search Results")
     header#fair-header
       form#fair-header-search-form( action="#{profile.get('id')}/search", method='GET' )
         input#fair-search-input.bordered-input(
@@ -56,4 +56,4 @@ block body
               span#search-term= term
               | &rdquo; 
             | on Artsy
-    mixin login-signup
+    mixin login-signup("Fair Search Results")

--- a/src/mobile/apps/fair_organizer/templates/index.jade
+++ b/src/mobile/apps/fair_organizer/templates/index.jade
@@ -3,7 +3,7 @@ include ../../../components/layout/templates/login-signup
 
 block body
   #content
-    mixin login-signup
+    mixin login-signup("Fair Organizer Profile")
     #fair-organization-page
       if newestFair.imageUrl('large_rectangle')
         .fair-organization-page__header-image
@@ -34,4 +34,4 @@ block body
         .avant-garde-tabs-list#fair-organization__about(data-list="about" class= pastFairs && pastFairs.length ? '' : 'avant-garde-tabs-list--active')
           p!= fairOrg.mdToHtml('about')
 
-    mixin login-signup
+    mixin login-signup("Fair Organizer Profile")

--- a/src/mobile/components/follow_button/view.coffee
+++ b/src/mobile/components/follow_button/view.coffee
@@ -52,6 +52,6 @@ module.exports = class FollowButtonView extends Backbone.View
         setTimeout (=> @$el.removeClass 'is-clicked'), 1500
     else
       analyticsHooks.trigger 'follow:signup'
-      location.href = "/sign_up?action=follow&objectId=#{@followId}&kind=artist&redirect-to=#{window.location}"
+      location.href = "/sign_up?action=follow&objectId=#{@followId}&kind=artist&redirect-to=#{window.location}&signupIntent=follow&trigger=click&contextModule=#{@context_module}"
 
     false

--- a/src/mobile/components/follow_button/view.coffee
+++ b/src/mobile/components/follow_button/view.coffee
@@ -52,6 +52,6 @@ module.exports = class FollowButtonView extends Backbone.View
         setTimeout (=> @$el.removeClass 'is-clicked'), 1500
     else
       analyticsHooks.trigger 'follow:signup'
-      location.href = "/sign_up?action=follow&objectId=#{@followId}&kind=artist&redirect-to=#{window.location}&signupIntent=follow&trigger=click&contextModule=#{@context_module}"
+      location.href = "/sign_up?action=follow&objectId=#{@followId}&kind=artist&redirect-to=#{window.location}&signupIntent=follow+#{@type}&intent=follow+#{@type}&trigger=click&contextModule=#{@context_module}"
 
     false

--- a/src/mobile/components/layout/templates/footer.jade
+++ b/src/mobile/components/layout/templates/footer.jade
@@ -2,7 +2,7 @@ include ./login-signup
 
 footer
   include ../../main_dropdown_menu/template
-  mixin login-signup
+  mixin login-signup("Footer")
   nav.footer__bottom-nav
     a.footer__bottom-nav__link(href="/about") About Artsy
     a.footer__bottom-nav__link(href="/terms") Terms of Use

--- a/src/mobile/components/layout/templates/login-signup.jade
+++ b/src/mobile/components/layout/templates/login-signup.jade
@@ -1,6 +1,6 @@
-mixin login-signup
+mixin login-signup(template)
   .login-signup
     .login-signup-button-container
-      a.avant-garde-box-button.avant-garde-box-button-gray( href='/sign_up' ) Sign up
+      a.avant-garde-box-button.avant-garde-box-button-gray( href="/sign_up?intent=signup&signupIntent=signup&trigger=click&contextModule=#{template}" ) Sign up
     .login-signup-button-container
-      a.avant-garde-box-button.avant-garde-box-button-gray( href='/log_in' ) Log in
+      a.avant-garde-box-button.avant-garde-box-button-gray( href="/log_in?intent=signup&signupIntent=signup&trigger=click&contextModule=#{template}" ) Log in

--- a/src/mobile/components/layout/templates/main.jade
+++ b/src/mobile/components/layout/templates/main.jade
@@ -7,7 +7,7 @@ block body
       if showMarketingSignupModal
         include ../../marketing_signup_modal/index
       else
-        mixin login-signup
+        mixin login-signup("Header")
 
     header#main-header
       nav.main-dropdown-menu.js-main-dropdown-menu


### PR DESCRIPTION
This addresses https://artsyproduct.atlassian.net/browse/GROW-814 by adding the missing properties for analytics to the mobile signup query params.

**Auth Impression:**
<img width="747" alt="screen shot 2018-08-14 at 11 38 21 am" src="https://user-images.githubusercontent.com/5201004/44103257-b9e93624-9fb9-11e8-90f6-14af0559e131.png">

**Created Account (Save Artwork):**
<img width="755" alt="screen shot 2018-08-14 at 11 45 39 am" src="https://user-images.githubusercontent.com/5201004/44103291-cf6244dc-9fb9-11e8-815d-f0f500717a00.png">

**Successfully Logged In (Follow Artist):**
<img width="748" alt="screen shot 2018-08-14 at 12 00 22 pm" src="https://user-images.githubusercontent.com/5201004/44103339-f0d54c5e-9fb9-11e8-8a11-8f08fad2ccea.png">
