### PR TITLE
Add shipping origin info on artwork

### DIFF
--- a/src/desktop/apps/artwork/components/commercial/query.coffee
+++ b/src/desktop/apps/artwork/components/commercial/query.coffee
@@ -11,6 +11,7 @@ module.exports = """
     is_price_range
     price
     shippingInfo
+    shippingOrigin
     artists {
       name
       is_consignable

--- a/src/desktop/apps/artwork/components/commercial/templates/price.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/price.jade
@@ -14,6 +14,9 @@ if artwork.sale_message || isPermanentCollection
           //- TODO: remove labFeature check once BNMO goes live to everybody
           if user && user.hasLabFeature('New Buy Now Flow')
             | #{artwork.shippingInfo}
+            if artwork.shippingOrigin
+              br
+              | Ships from #{artwork.shippingOrigin}
           else
             | Shipping, tax, and service quoted by seller
       else if isPermanentCollection

--- a/src/mobile/apps/artwork/components/meta_data/templates/price.jade
+++ b/src/mobile/apps/artwork/components/meta_data/templates/price.jade
@@ -7,5 +7,8 @@ if artwork.sale_message
         //- TODO: remove labFeature check once BNMO goes live to everybody
         if user && user.hasLabFeature('New Buy Now Flow')
           | #{artwork.shippingInfo}
+          if artwork.shippingOrigin
+            br
+            | Ships from #{artwork.shippingOrigin}
         else
           | Shipping, tax, and service quoted by seller

--- a/src/mobile/apps/artwork/routes.coffee
+++ b/src/mobile/apps/artwork/routes.coffee
@@ -21,6 +21,7 @@ query = (user) -> """
       sale_message
       price
       shippingInfo
+      shippingOrigin
       is_for_sale
       medium
       edition_of


### PR DESCRIPTION
This requires MP pr (https://github.com/artsy/metaphysics/pull/1215) to be in production before merging.


Looks like that:
<img width="690" alt="screen shot 2018-08-15 at 12 26 38 am" src="https://user-images.githubusercontent.com/437156/44119475-0b98e5ce-a022-11e8-859d-2cec10eb4ebe.png">
