### PR TITLE
Updates the query to handle the orderOrError union type from Exchange

### DIFF
--- a/src/desktop/apps/artwork/components/commercial/view.coffee
+++ b/src/desktop/apps/artwork/components/commercial/view.coffee
@@ -52,7 +52,7 @@ module.exports = class ArtworkCommercialView extends Backbone.View
         quantity: 1
         user: loggedInUser
       .then (data) ->
-        order = data?.createOrderWithArtwork?.result?.order
+        order = data?.createOrderWithArtwork?.orderOrError?.order
         location.assign("/order2/#{order.id}/shipping")
 
     else

--- a/src/lib/components/create_order/index.tsx
+++ b/src/lib/components/create_order/index.tsx
@@ -1,4 +1,4 @@
-//@ts-ignore
+// @ts-ignore
 import _metaphysics from 'lib/metaphysics.coffee'
 
 import query from './mutation'

--- a/src/lib/components/create_order/mutation.js
+++ b/src/lib/components/create_order/mutation.js
@@ -1,12 +1,28 @@
 module.exports = `
-mutation createOrder($artworkId: String!, $editionSetId: String, $quantity: Int){
-  createOrderWithArtwork(input: { artworkId: $artworkId, editionSetId: $editionSetId, quantity: $quantity}){
-    result{
-      order{
-        id
+  mutation createOrder(
+    $artworkId: String!
+    $editionSetId: String
+    $quantity: Int
+  ) {
+    createOrderWithArtwork(
+      input: {
+        artworkId: $artworkId
+        editionSetId: $editionSetId
+        quantity: $quantity
       }
-      errors
+    ) {
+      orderOrError {
+        ... on OrderWithMutationSuccess {
+          order {
+            id
+          }
+        }
+        ... on OrderWithMutationFailure {
+          error {
+            description
+          }
+        }
+      }
     }
   }
-}
 `

--- a/yarn.lock
+++ b/yarn.lock
@@ -9560,7 +9560,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
+react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 


### PR DESCRIPTION
I didn't run through this with all of the other services running, but it feels like the changes I'd expect - and running `yarn jest` green'd. 