### PR TITLE
@joeyAghion => Pass in option to allow express-filter to block IPs based on intermediates

### DIFF
--- a/src/lib/middleware/error_handler.coffee
+++ b/src/lib/middleware/error_handler.coffee
@@ -1,6 +1,7 @@
 path = require 'path'
 { NODE_ENV } = require '../../config'
 { argv } = require('yargs') # --verbose flag, passed in on boot
+{ IpDeniedError } = require('express-ipfilter')
 
 module.exports = (err, req, res, next) ->
   file = path.resolve(
@@ -10,6 +11,8 @@ module.exports = (err, req, res, next) ->
   isDevelopment = argv.verbose or NODE_ENV is 'development'
   code = 504 if req.timedout
   code ||= err.status || 500
+
+  code = 401 if err instanceof IpDeniedError
 
   if isDevelopment
     message = err.message || err.text || err.toString()

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -80,7 +80,13 @@ export default function(app) {
   app.use(compression())
 
   // Blacklist IPs
-  app.use(ipfilter(IP_BLACKLIST.split(','), { log: false, mode: 'deny' }))
+  app.use(
+    ipfilter(IP_BLACKLIST.split(','), {
+      allowedHeaders: ['x-forwarded-for'],
+      log: false,
+      mode: 'deny',
+    })
+  )
 
   // Rate limiting
   if (OPENREDIS_URL && cache.client) {

--- a/src/test/lib/middleware/error_handler.coffee
+++ b/src/test/lib/middleware/error_handler.coffee
@@ -2,6 +2,7 @@ _ = require 'underscore'
 sinon = require 'sinon'
 rewire = require 'rewire'
 errorHandler = rewire '../../../lib/middleware/error_handler'
+{ IpDeniedError } = require('express-ipfilter')
 
 describe 'errorHandler', ->
   beforeEach ->
@@ -32,3 +33,8 @@ describe 'errorHandler', ->
     _.isUndefined(@renderStub.render.args[0][1].message).should.be.ok()
     @renderStub.render.args[0][1].code.should.equal 420
     _.isUndefined(@renderStub.render.args[0][1].detail).should.be.ok()
+
+  it 'returns a 401 when an IP is blacklisted', ->
+    errorHandler(new IpDeniedError("You've been blocked"), {}, @res, {})
+    @res.status.args[0][0].should.equal 401
+    @renderStub.render.args[0][1].code.should.equal 401


### PR DESCRIPTION
Based on pairing + local testing, this is a required addition (based on our currently used version of this lib) for it to work the way we expect.

This possibly didn't work on Heroku, or the code was lost at some point? Or perhaps Heroku/ELBs were doing something a little differently than present/we expect?

Either way, this works the way we'd like (ie- honoring the first value in the header).

Still to do-
- ~~catch and return a 401 when a block occurs (currently this is thrown and not caught and results in a 500)~~