### PR TITLE
add health check endpoint under /_health

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "glob": "^7.1.1",
     "graceful-fs": "^4.1.2",
     "graphql": "^0.13.2",
+    "healthcheck-ping": "^2.0.1",
     "heapdump": "^0.3.7",
     "helmet": "^2.3.0",
     "history": "^4.6.1",

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -46,6 +46,7 @@ import splitTestMiddleware from '../desktop/components/split_test/middleware'
 import marketingModals from './middleware/marketing_modals'
 import config from '../config'
 import compression from 'compression'
+import createHealthcheckMiddleware from 'healthcheck-ping'
 
 const {
   API_REQUEST_TIMEOUT,

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -88,6 +88,9 @@ export default function(app) {
     })
   )
 
+  // health check mounted as /_health
+  app.use(createHealthcheckMiddleware())
+
   // Rate limiting
   if (OPENREDIS_URL && cache.client) {
     const limiter = require('express-limiter')(app, cache.client)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5576,6 +5576,12 @@ he@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/he/-/he-0.5.0.tgz#2c05ffaef90b68e860f3fd2b54ef580989277ee2"
 
+healthcheck-ping@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/healthcheck-ping/-/healthcheck-ping-2.0.1.tgz#d3ffed5bd1d05d90a63e81468042d18ff469e36c"
+  dependencies:
+    express "^4.13.3"
+
 heapdump@^0.3.7:
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/heapdump/-/heapdump-0.3.9.tgz#03c74eb0df5d67be0982e83429ba9c9d2b3b7f78"
@@ -9629,7 +9635,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
+react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 


### PR DESCRIPTION
This adds a health check at the `/_health` endpoint. This works locally, when I stand up the server and hit /health I see `{"status":"OK"}`.