### PR TITLE
@ashfurrow => Also style clock-months

### DIFF
--- a/src/desktop/components/clock/index.styl
+++ b/src/desktop/components/clock/index.styl
@@ -87,7 +87,7 @@ closed-padding = (((clock-height - closed-font-size) - (closed-border-size * 2))
       font-size 8px
       margin-bottom 2px
 
-  .clock-days, .clock-hours, .clock-minutes, .clock-seconds
+  .clock-months, .clock-days, .clock-hours, .clock-minutes, .clock-seconds
     avant-garde-size('l-headline')
     margin 0 12px
     small

--- a/yarn.lock
+++ b/yarn.lock
@@ -9629,7 +9629,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
+react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-412

Appears this fix was pretty minor! We weren't explicitly styling `.clock-months` here.

Updated view:
![image](https://user-images.githubusercontent.com/2081340/44736749-063d7800-aabe-11e8-9c98-49443f20953b.png)

![image](https://user-images.githubusercontent.com/2081340/44736759-0e95b300-aabe-11e8-9c12-ea8c76737d95.png)
