### PR TITLE
Handles a deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Want to know more about Artsy tech? Read the [Artsy Engineering Blog](http://art
 * **State:** production
 * **Production:** [https://www.artsy.net](https://www.artsy.net) | [k8s](https://kubernetes.artsy.net/#!/search?q=force&namespace=default)
 * **Staging:** [https://staging.artsy.net](https://staging.artsy.net) | [k8s](https://kubernetes-staging.artsy.net/#!/search?q=force&namespace=default)
-* **Github:** [https://github.com/artsy/force](https://github.com/artsy/force)
+* **GitHub:** [https://github.com/artsy/force](https://github.com/artsy/force)
 * **CI/Deploys:** [CircleCi](https://circleci.com/gh/artsy/force); merged PRs to `artsy/force#master` are automatically deployed to staging; PRs from `staging` to `release` are automatically deployed to production. [Start a deploy...](https://github.com/artsy/force/compare/release...staging?expand=1)
 * **BrowserStack:** For testing applications cross-browser use [BrowserStack](https://browserstack.com). Credentials are located in 1Password.
 * **Point People:** [@damassi](https://github.com/damassi), [@mzikherman](https://github.com/mzikherman)

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,14 @@ cache.setup(() => {
   // if we can't get an xapp token, just exit and let the whole system try
   // again - this prevents a sustained broken state when gravity returns a
   // 502 during force startup.
-  artsyXapp.on('error', process.exit)
+  artsyXapp.on('error', err => {
+    error(`
+Could not start Force because it could not set up the xapp token, this is likely
+due to \`API_URL\`, \`CLIENT_ID\` and \`CLIENT_SECRET\` not being set, but 
+also could be gravity being down.`)
+    error(err)
+    process.exit()
+  })
   // Get an xapp token
   artsyXapp.init({ url: API_URL, id: CLIENT_ID, secret: CLIENT_SECRET }, () => {
     // Start the server

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -270,8 +270,10 @@ export default function(app) {
   }
 
   // Routes for pinging system time and up
-  app.get('/system/time', (req, res) => res.send(200, { time: Date.now() }))
-  app.get('/system/up', (req, res) => res.send(200, { nodejs: true }))
+  app.get('/system/time', (req, res) =>
+    res.status(200).send({ time: Date.now() })
+  )
+  app.get('/system/up', (req, res) => res.status(200).send({ nodejs: true }))
 
   // Ensure CurrentUser is set for Artsy Passport
   // TODO: Investigate race condition b/t reaction's use of AP

--- a/yarn.lock
+++ b/yarn.lock
@@ -9629,7 +9629,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
+react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 


### PR DESCRIPTION


Removes a deprecation warning on launch in staging:

```
~/dev/projects/artsy/js/sites/force master* 1m 36s
❯ hokusai staging logs
yarn run v1.9.4
$ scripts/start.sh
+ '[' production = production ']'
+ node --max_old_space_size=1024 ./src


  [Force] Started on https://staging.artsy.net.

GET / 200 806.322ms 216.218.206.66 "undefined"
Tue, 28 Aug 2018 15:14:13 GMT express deprecated res.send(status, body): Use res.status(status).send(body) instead at src/lib/setup.js:296:16
GET /system/up 200 53.863ms 66.165.229.130 "Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)"
```