### PR TITLE
add readinessProbe to hokusai config for prod and staging

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -32,6 +32,15 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 5000
+          readinessProbe:
+            httpGet:
+              port: 5000
+              path: /system/up
+              httpHeaders:
+                - name: X-FORWARDED-PROTO
+                  value: https
+            initialDelaySeconds: 5
+            periodSeconds: 5
           resources:
             requests:
               cpu: 700m

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -32,6 +32,15 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 5000
+          readinessProbe:
+            httpGet:
+              port: 5000
+              path: /system/up
+              httpHeaders:
+                - name: X-FORWARDED-PROTO
+                  value: https
+            initialDelaySeconds: 5
+            periodSeconds: 5
           resources:
             requests:
               cpu: 700m


### PR DESCRIPTION
As per @joeyAghion's suggestion I modeled this on the way [metaphysics does it](https://github.com/artsy/metaphysics/blob/e27355ffed06e40c4b9ec7bda8d461452647b403/hokusai/staging.yml#L46).

I'm not sure how to test this, though? Do we have some sort of Hokusai mock environment?