### PR TITLE
Upgrades Reaction to 3.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@artsy/express-reloadable": "^1.3.1",
     "@artsy/palette": "^2.0.2",
     "@artsy/passport": "^1.0.11",
-    "@artsy/reaction": "^3.1.2",
+    "@artsy/reaction": "^3.1.3",
     "@artsy/stitch": "^1.6.0",
     "@babel/core": "7.0.0-beta.40",
     "@babel/node": "7.0.0-beta.40",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,8 +23,8 @@
     yarn "^1.3.2"
 
 "@artsy/palette@^2.9.3":
-  version "2.9.3"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.9.3.tgz#49b11442460a2949d79417eb8f68f3aac9382324"
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.10.0.tgz#2dda2be953f0258c1ed5fb210ae40480d1a32b85"
   dependencies:
     react "^16.3.2"
     styled-system "^2.2.5"
@@ -48,8 +48,8 @@
     underscore.string "^3.2.2"
 
 "@artsy/reaction@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-3.1.2.tgz#7212f758016ac7d8a6e64bdfc4e7e7b68db4fc25"
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-3.1.3.tgz#2b672f45352c8621812030d424d809f442c55663"
   dependencies:
     "@artsy/palette" "^2.9.3"
     cheerio "^1.0.0-rc.2"
@@ -789,8 +789,8 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
 
 "@types/node@*":
-  version "10.7.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.7.1.tgz#b704d7c259aa40ee052eec678758a68d07132a2e"
+  version "10.9.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.3.tgz#85f288502503ade0b3bfc049fe1777b05d0327d5"
 
 "@types/node@^6.0.46":
   version "6.0.78"
@@ -1069,6 +1069,7 @@ antigravity@artsy/antigravity:
   version "0.1.3"
   resolved "https://codeload.github.com/artsy/antigravity/tar.gz/a4438d2fe9d0cdf71f1c47faba371cd3d004e140"
   dependencies:
+    coffeescript "1.11.1"
     express "*"
 
 any-observable@^0.2.0:
@@ -3512,7 +3513,7 @@ deep-object-diff@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
 
-deepmerge@^2.1.0:
+deepmerge@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.1.1.tgz#e862b4e45ea0555072bf51e7fd0d9845170ae768"
 
@@ -5043,8 +5044,8 @@ forwarded@~0.1.2:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
 
 found-relay@^0.3.0-alpha.13:
-  version "0.3.0-alpha.14"
-  resolved "https://registry.yarnpkg.com/found-relay/-/found-relay-0.3.0-alpha.14.tgz#a0647ff0b4a453d6670baf92bd1b2123a3b67243"
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/found-relay/-/found-relay-0.3.0.tgz#9b58ac52d0f4efc3662bc44a584642b45d25411c"
   dependencies:
     babel-runtime "^6.26.0"
     is-promise "^2.1.0"
@@ -5832,8 +5833,8 @@ iconv-lite@0.4.19:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
 iconv-lite@~0.4.13:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
@@ -7836,9 +7837,9 @@ mime-db@~1.27.0:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
 
-mime-db@~1.35.0:
-  version "1.35.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
+mime-db@~1.36.0:
+  version "1.36.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
 
 mime-types@^2.1.10, mime-types@^2.1.11, mime-types@~2.1.16, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.7:
   version "2.1.18"
@@ -7847,10 +7848,10 @@ mime-types@^2.1.10, mime-types@^2.1.11, mime-types@~2.1.16, mime-types@~2.1.17, 
     mime-db "~1.33.0"
 
 mime-types@^2.1.12:
-  version "2.1.19"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
+  version "2.1.20"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.20.tgz#930cb719d571e903738520f8470911548ca2cc19"
   dependencies:
-    mime-db "~1.35.0"
+    mime-db "~1.36.0"
 
 mime-types@^2.1.3, mime-types@~2.1.11, mime-types@~2.1.15:
   version "2.1.15"
@@ -9619,8 +9620,8 @@ react-is@^16.3.2, react-is@^16.4.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
 
 react-lazy-load-image-component@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-lazy-load-image-component/-/react-lazy-load-image-component-1.1.1.tgz#41e10defa52adf7c0ab9212cf0a94d46899ceff4"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/react-lazy-load-image-component/-/react-lazy-load-image-component-1.1.2.tgz#67253b09a53fb7647306961d3265ee10b871b2d8"
   dependencies:
     lodash.debounce "^4.0.8"
     lodash.throttle "^4.1.1"
@@ -9629,7 +9630,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
+"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 
@@ -9830,11 +9831,11 @@ react-timer-mixin@^0.13.3:
   resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz#75a00c3c94c13abe29b43d63b4c65a88fc8264d3"
 
 react-tracking@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/react-tracking/-/react-tracking-5.3.0.tgz#6107db448084745bc50604d1f3f1f582c0073def"
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/react-tracking/-/react-tracking-5.4.1.tgz#2a85793326aadefa9c3955332181279904fa72c4"
   dependencies:
-    deepmerge "^2.1.0"
-    hoist-non-react-statics "^2.5.0"
+    deepmerge "^2.1.1"
+    hoist-non-react-statics "^3.0.1"
 
 react-transition-group@^2.2.0, react-transition-group@^2.3.0:
   version "2.4.0"
@@ -11392,8 +11393,8 @@ styled-reset@^1.3.4:
   resolved "https://registry.yarnpkg.com/styled-reset/-/styled-reset-1.3.5.tgz#d1da44f93d1c58bec2ac32069e05e001c6637250"
 
 styled-reset@^1.3.5:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/styled-reset/-/styled-reset-1.3.6.tgz#5a964a3d3117b0d9c3d3d7509e8de0a878064146"
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/styled-reset/-/styled-reset-1.3.7.tgz#8c9b6bad083d284eeb7b7916cdc4a7a15d9c85cb"
 
 styled-system@^2.2.5:
   version "2.3.6"


### PR DESCRIPTION
This is required for the BNMO demo meeting shortly, and includes the recent feature work of the Purchase team on the Order app, and necessary metaphysics schema upgrades. 