### PR TITLE
Update the dockerfile for Force to use the official node image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
-# The bitnami images are stripped down and offer things like install_packages
-# that avoid crufting up the image with lots of dependencies. 
-# 
-FROM bitnami/node:8.11.3
-#FROM circleci/node:8-stretch-browsers
+FROM node:8.11.3
 
-RUN install_packages libsecret-1-dev libglib2.0-dev
+# The key bits here are making sure we install, libsecret-1-dev libglib2.0-dev
+RUN apt-get update -qq && apt-get install -y \
+  libsecret-1-dev libglib2.0-dev && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-#ADD . /home/circleci/project
 ADD . /app
 WORKDIR /app
 
-#WORKDIR /home/circleci/project
-#RUN sudo chown -R circleci:circleci /home/circleci/project
 RUN rm -f /usr/local/bin/yarn && \
   curl -o- -L https://yarnpkg.com/install.sh | bash && \
   chmod +x ~/.yarn/bin/yarn && \

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -1,4 +1,3 @@
----
 version: '2'
 services:
   force:
@@ -6,17 +5,16 @@ services:
       file: common.yml
       service: force
     environment:
-    - NODE_ENV=development
-    - REDIS_URL=redis://force-redis:6379/0
-    - PORT=5000
-    - S3_KEY
-    - S3_SECRET
-    - DEPLOY_ENV
+      - NODE_ENV=development
+      - REDIS_URL=redis://force-redis:6379/0
+      - PORT=5000
+      - S3_KEY
+      - S3_SECRET
+      - DEPLOY_ENV
     env_file: ../.env
     ports:
-    - 5000:5000
-    command: npm start
+      - 5000:5000
   force-redis:
     image: redis:3.2-alpine
     ports:
-    - 6379:6379
+      - 6379:6379

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -227,7 +227,11 @@ export default function(app) {
     // https://datadog.github.io/dd-trace-js/index.html
     // and we use all the defaults from:
     // https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md#tracer-settings
-    ddTracer.init({})
+    console.log(Object.keys(process.env))
+    ddTracer.init({
+      hostname: process.env.DD_TRACE_AGENT_HOSTNAME,
+      service: 'force',
+    })
   }
 
   // Sets up mobile marketing signup modal


### PR DESCRIPTION
I was trying to get `hokusai dev start` to work to debug the dd-trace stuff, and had @bhoggard come over - he mentioned that we should consider moving off the bitnami image due to https://github.com/artsy/gravity/pull/11858 

So we moved force off, and switched to directly calling apt-get instead.