### PR TITLE
Try adding the hostname specifically to ddTracer

### DIFF
--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -227,7 +227,10 @@ export default function(app) {
     // https://datadog.github.io/dd-trace-js/index.html
     // and we use all the defaults from:
     // https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md#tracer-settings
-    ddTracer.init({})
+    ddTracer.init({
+      hostname: process.env.DD_TRACE_AGENT_HOSTNAME,
+      service: 'force',
+    })
   }
 
   // Sets up mobile marketing signup modal


### PR DESCRIPTION
Well, when I run `hokusai dev start` with this, it will correctly print out the right `process.env.DD_TRACE_AGENT_HOSTNAME` - so perhaps it will do so in staging/prod