### PR TITLE
@xtina-starr => Editorial auth QA

### DIFF
--- a/src/desktop/apps/article/components/__tests__/App.test.js
+++ b/src/desktop/apps/article/components/__tests__/App.test.js
@@ -34,8 +34,6 @@ describe('<App />', () => {
   }
 
   const ArticleLayoutRewire = rewire('../layouts/Article')
-  const EditorialSignupView = sinon.stub()
-  ArticleLayoutRewire.__set__('EditorialSignupView', EditorialSignupView)
   const ArticleLayout = ArticleLayoutRewire.default
 
   const AppRewire = rewire('../App')

--- a/src/desktop/apps/article/components/__tests__/Article.test.js
+++ b/src/desktop/apps/article/components/__tests__/Article.test.js
@@ -41,8 +41,6 @@ describe('<Article />', () => {
   const { Article } = require('reaction/Components/Publishing')
   const SuperArticleView = sinon.stub()
   rewire.__set__('SuperArticleView', SuperArticleView)
-  const EditorialSignupView = sinon.stub()
-  rewire.__set__('EditorialSignupView', EditorialSignupView)
 
   const getWrapper = props => {
     return mount(
@@ -162,11 +160,6 @@ describe('<Article />', () => {
     html.should.containEql('Ad Headline')
   })
 
-  it('initiates EditorialSignupView for non-super, standard articles', () => {
-    getWrapper(props)
-    EditorialSignupView.called.should.be.true()
-  })
-
   // FIXME: DOES NOT TEST ANTHING
   xit('sets up follow buttons', () => {
     const article = _.extend({}, fixtures.article, {
@@ -216,8 +209,6 @@ describe('<Article /> without infinite scroll', () => {
     DisplayCanvas,
   } = require('reaction/Components/Publishing/Display/Canvas')
   rewire.__set__('SuperArticleView', SuperArticleView)
-  const EditorialSignupView = sinon.stub()
-  rewire.__set__('EditorialSignupView', EditorialSignupView)
 
   const getWrapper = props => {
     return mount(

--- a/src/desktop/apps/article/components/layouts/Article.js
+++ b/src/desktop/apps/article/components/layouts/Article.js
@@ -3,7 +3,6 @@ import InfiniteScrollArticle from '../InfiniteScrollArticle'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Article } from 'reaction/Components/Publishing'
-import _EditorialSignupView from 'desktop/components/email/client/editorial_signup.coffee'
 import _SuperArticleView from 'desktop/components/article/client/super_article.coffee'
 import { setupFollows, setupFollowButtons } from '../FollowButton.js'
 import mediator from 'desktop/lib/mediator.coffee'
@@ -11,7 +10,6 @@ import splitTest from 'desktop/components/split_test/index.coffee'
 
 // FIXME: Rewire
 let SuperArticleView = _SuperArticleView
-let EditorialSignupView = _EditorialSignupView
 
 export default class ArticleLayout extends React.Component {
   constructor(props) {
@@ -41,11 +39,6 @@ export default class ArticleLayout extends React.Component {
       new SuperArticleView({
         el: document.querySelector('body'),
         article: new ArticleModel(article),
-      })
-    }
-    if (!isSuper && article.layout === 'standard') {
-      new EditorialSignupView({
-        el: document.querySelector('body'),
       })
     }
   }

--- a/src/desktop/apps/article/components/layouts/Article.js
+++ b/src/desktop/apps/article/components/layouts/Article.js
@@ -23,6 +23,7 @@ export default class ArticleLayout extends React.Component {
   static propTypes = {
     article: PropTypes.object,
     isMobile: PropTypes.bool,
+    isLoggedIn: PropTypes.bool,
     isSuper: PropTypes.bool,
     templates: PropTypes.object,
     showTooltips: PropTypes.bool,
@@ -61,6 +62,7 @@ export default class ArticleLayout extends React.Component {
       article,
       isExperimentInfiniteScroll,
       isSuper,
+      isLoggedIn,
       isMobile,
       renderTime,
       showTooltips,
@@ -84,6 +86,7 @@ export default class ArticleLayout extends React.Component {
             article={article}
             display={article.display}
             isMobile={isMobile}
+            isLoggedIn={isLoggedIn}
             onOpenAuthModal={this.handleOpenAuthModal}
             relatedArticlesForPanel={article.relatedArticlesPanel}
             relatedArticlesForCanvas={article.relatedArticlesCanvas}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1069,7 +1069,6 @@ antigravity@artsy/antigravity:
   version "0.1.3"
   resolved "https://codeload.github.com/artsy/antigravity/tar.gz/a4438d2fe9d0cdf71f1c47faba371cd3d004e140"
   dependencies:
-    coffeescript "1.11.1"
     express "*"
 
 any-observable@^0.2.0:
@@ -9630,7 +9629,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
+react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GROW-877

- Passes `isLoggedIn` to standard/feature articles
- Stops rendering to-be-deprecated `EditorialSignupView` in `Article` (still used on magazine page)