### PR TITLE
query for is_for_sale so we can evaluate correctly and not always show "Auction Closed"

### DIFF
--- a/src/mobile/apps/artwork/components/related_artworks/queries/index.coffee
+++ b/src/mobile/apps/artwork/components/related_artworks/queries/index.coffee
@@ -33,4 +33,5 @@ module.exports = """
     type
   }
   is_buy_nowable
+  is_for_sale
 """


### PR DESCRIPTION
In [this block](https://github.com/artsy/force/blob/master/src/mobile/components/artwork_columns/artwork.jade#L28-L33), if the artwork has an auction partner, we show `Auction Closed` or `Bid Now` depending on whether or not the artwork is `forsale`. 

This wasn't working as intended because we were never querying for `is_for_sale`. Note that we probably didn't catch it because this particular brand of "related works" only appears if:
- the artwork has an auction-type partner
- the artwork is _not_ in an auction

☝️ that's not a common occurrence except in this case, where we're re-using the auction house partner for an e-commerce work that's not part of an auction.