### PR TITLE
Updates the anonymous query for show metadata to use a named query

### DIFF
--- a/src/desktop/apps/show/routes.coffee
+++ b/src/desktop/apps/show/routes.coffee
@@ -6,7 +6,7 @@ DateHelpers = require '../../components/util/date_helpers'
 ViewHelpers = require './helpers/view_helpers'
 
 query = """
-  query($id: String!) {
+  query ShowMetadataQuery($id: String!) {
     partner_show(id: $id) {
       _id
       id


### PR DESCRIPTION
From [this trace](https://app.datadoghq.com/apm/resource/metaphysics.graphql/graphql.query/c1dc8c86a146ee60?env=production&paused=false&traceID=4039002158837364791&spanID=8140525992543905883&start=1535732860397&end=1535736460397)