### PR TITLE
#migration Increase K8s maxSurge for production

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -6,7 +6,7 @@ spec:
   replicas: 3
   strategy:
     rollingUpdate:
-      maxSurge: 1
+      maxSurge: 2
       maxUnavailable: 0
     type: RollingUpdate
   template:


### PR DESCRIPTION
https://artsy.slack.com/archives/C9RK0BLEP/p1535731887000100?thread_ts=1535731055.000100&cid=C9RK0BLEP

Similar to https://github.com/artsy/volt/pull/3129 , Force production deployment took about 7 mins. It's on 3 pods and using the rolling update strategy with `maxSurge` 1 and `maxUnavailable` 0. I'm not super comfortable losing any of the 3 pods during deployment, so I increase maxSurge to 2 and want to see if this speeds up the deployment.

https://circleci.com/gh/artsy/force/9118

### Migration
```
hokusai production update
```