### PR TITLE
pass X-Forwarded-For headers to Metaphysics

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "history": "^4.6.1",
     "http-proxy": "^1.11.2",
     "invariant": "^2.2.2",
+    "ip": "^1.1.5",
     "jade": "^1.11.0",
     "jquery": "^2.1.4",
     "jquery-fillwidth-lite": "^1.0.8",

--- a/src/lib/metaphysics.coffee
+++ b/src/lib/metaphysics.coffee
@@ -6,7 +6,7 @@ request = require 'superagent'
 ip = require 'ip'
 
 resolveIPv4 = (ipAddress) ->
-  if ip.isV6Format(ipAddress)? and ~ipAddress.indexOf('::ffff')
+  if ip.isV6Format(ipAddress)? and ipAddress.indexOf('::ffff') >= 0
     return ipAddress.split('::ffff:')[1]
   return ipAddress
 

--- a/src/lib/metaphysics.coffee
+++ b/src/lib/metaphysics.coffee
@@ -3,6 +3,19 @@ qs = require 'qs'
 request = require 'superagent'
 { extend, some } = require 'underscore'
 { METAPHYSICS_ENDPOINT, API_REQUEST_TIMEOUT, REQUEST_ID } = require('sharify').data
+ip = require 'ip'
+
+resolveIPv4 = (ipAddress) ->
+  if ip.isV6Format(ipAddress)? and ~ipAddress.indexOf('::ffff')
+    return ipAddress.split('::ffff:')[1]
+  return ipAddress
+
+resolveProxies = (req) ->
+  ipAddress = resolveIPv4(req.connection.remoteAddress)
+  if req?.headers?["x-forwarded-for"]?
+    return req.headers["x-forwarded-for"] + ", " + ipAddress
+  else
+    return ipAddress
 
 metaphysics = ({ query, variables, req } = {}) ->
   sentRequestId = REQUEST_ID || req?.id || 'implement-me'
@@ -16,6 +29,9 @@ metaphysics = ({ query, variables, req } = {}) ->
     if (token = req?.user?.get?('accessToken') or req?.user?.accessToken)?
       post.set 'X-ACCESS-TOKEN': token
       post.set 'X-USER-ID': req.user.id
+
+    if req?.connection?.remoteAddress?
+      post.set 'X-Forwarded-For', resolveProxies req
 
     post
       .send

--- a/src/test/lib/metaphysics.coffee
+++ b/src/test/lib/metaphysics.coffee
@@ -157,3 +157,16 @@ describe 'metaphysics', ->
               ['Accept', 'application/json']
               ['X-Request-Id', 'foo']
             ]
+
+    describe 'x forwarded for', ->
+      it 'optionally accepts a req object, from which it constructs the x-forwarded-for header if the request has a remote address', ->
+        @request.end.yields null, ok: true, body: data: {}
+
+        metaphysics req: connection: remoteAddress: '::ffff:127.0.0.1'
+          .then =>
+            @request.set.args
+              .should.eql [
+                ['Accept', 'application/json']
+                ['X-Request-Id', 'implement-me']
+                ['X-Forwarded-For', '127.0.0.1']
+              ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -6030,7 +6030,7 @@ ip6@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/ip6/-/ip6-0.0.4.tgz#44c5a9db79e39d405201b4d78d13b3870e48db31"
 
-ip@~1.1.0:
+ip@^1.1.5, ip@~1.1.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
 


### PR DESCRIPTION
We're running Force behind a load balancer, [which sets](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html#x-forwarded-for) the `X-Forwarded-For` header as the IP address of the client - this change makes Force append the IP of the load balancer if the header is provided, or set the header to the client IP if not provided.  Passing it along to Metaphysics, which does the same as of  https://github.com/artsy/metaphysics/pull/1232 and https://github.com/artsy/metaphysics/pull/1264 

With the chain of proxies saved in the `X-Forwarded-For` header, Gravity will be able to resolve the real IP of clients where requests are proxied via Force or MP