### PR TITLE
@damassi => Pass mediator to Reaction apps properly

### DIFF
--- a/src/desktop/apps/artist2/client.js
+++ b/src/desktop/apps/artist2/client.js
@@ -20,12 +20,13 @@ buildClientApp({
   routes,
   context: {
     user: sd.CURRENT_USER,
+    mediator,
   },
 })
   .then(({ ClientApp }) => {
     ReactDOM.hydrate(
       <Container>
-        <ClientApp mediator={mediator} />
+        <ClientApp />
       </Container>,
 
       document.getElementById('react-root')

--- a/src/desktop/apps/collect2/client.js
+++ b/src/desktop/apps/collect2/client.js
@@ -17,12 +17,13 @@ buildClientApp({
   routes,
   context: {
     user: sd.CURRENT_USER,
+    mediator,
   },
 })
   .then(({ ClientApp }) => {
     ReactDOM.hydrate(
       <Container>
-        <ClientApp mediator={mediator} />
+        <ClientApp />
       </Container>,
 
       document.getElementById('react-root')

--- a/src/desktop/apps/order2/client.js
+++ b/src/desktop/apps/order2/client.js
@@ -37,6 +37,7 @@ buildClientApp({
   routes,
   context: {
     user: sd.CURRENT_USER,
+    mediator,
   },
   history: {
     options: {
@@ -47,7 +48,7 @@ buildClientApp({
   .then(({ ClientApp }) => {
     ReactDOM.hydrate(
       <Container>
-        <ClientApp mediator={mediator} />
+        <ClientApp />
       </Container>,
 
       document.getElementById('react-root')


### PR DESCRIPTION
I think this is the way we're supposed to pass these around now. Currently in prod the artist page isn't grabbing the mediator, so it's leading to some bugs (modals, etc.).

Locally this fixes it.