### PR TITLE
add ArtworkDetails reaction component and display it in About the work tab when user has BNMO feature enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@artsy/express-reloadable": "^1.3.1",
     "@artsy/palette": "^2.0.2",
     "@artsy/passport": "^1.0.11",
-    "@artsy/reaction": "^3.3.1",
+    "@artsy/reaction": "^3.4.1",
     "@artsy/stitch": "^1.6.0",
     "@babel/core": "7.0.0-beta.40",
     "@babel/node": "7.0.0-beta.40",

--- a/src/desktop/apps/artwork/components/additional_info/index.jade
+++ b/src/desktop/apps/artwork/components/additional_info/index.jade
@@ -11,7 +11,10 @@ if tabs.length
         +tab(tab, i)
           case tab
             when 'about_the_work'
-              include ./templates/about_the_work
+              if user && user.hasLabFeature('New Buy Now Flow')
+                != stitch.components.ArtworkDetails({artworkID: artwork.id})
+              else  
+                include ./templates/about_the_work
             when 'exhibition_history'
               include ./templates/exhibition_history
             when 'bibliography'

--- a/src/desktop/components/react/stitch_components/ReactionArtworkDetails.js
+++ b/src/desktop/components/react/stitch_components/ReactionArtworkDetails.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { ContextProvider } from 'reaction/Artsy'
+import { ArtworkDetailsQueryRenderer as Renderer } from 'reaction/Apps/Artwork/Components/ArtworkDetails'
+import { data as sd } from 'sharify'
+
+export const ReactionArtworkDetails = props => {
+  return (
+    <ContextProvider user={sd.CURRENT_USER}>
+      <Renderer artworkID={props.artworkID} />
+    </ContextProvider>
+  )
+}

--- a/src/desktop/components/react/stitch_components/ReactionTooltipQuestion.js
+++ b/src/desktop/components/react/stitch_components/ReactionTooltipQuestion.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { Help } from 'reaction/Assets/Icons/Help'
+import { Tooltip } from 'reaction/Components/Tooltip'
+
+export const ReactionTooltipQuestion = props => {
+  return (
+    <Tooltip {...props}>
+      <Help />
+    </Tooltip>
+  )
+}

--- a/src/desktop/lib/global_react_modules.js
+++ b/src/desktop/lib/global_react_modules.js
@@ -3,17 +3,13 @@ import React, { Component } from 'react'
 import { Artwork as ReactionArtwork } from 'reaction/Components/Artwork'
 import { ArtworkGrid as ReactionArtworkGrid } from 'reaction/Components/ArtworkGrid'
 import { ContextProvider } from 'reaction/Artsy'
-import { Help } from 'reaction/Assets/Icons/Help'
-import { Tooltip } from 'reaction/Components/Tooltip'
 import { data as sd } from 'sharify'
 
-export const TooltipQuestion = props => {
-  return (
-    <Tooltip {...props}>
-      <Help />
-    </Tooltip>
-  )
-}
+import { ReactionTooltipQuestion } from '../components/react/stitch_components/ReactionTooltipQuestion'
+import { ReactionArtworkDetails } from '../components/react/stitch_components/ReactionArtworkDetails'
+
+export const TooltipQuestion = ReactionTooltipQuestion
+export const ArtworkDetails = ReactionArtworkDetails
 
 export class ArtworkGrid extends Component {
   static propTypes = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,9 +54,9 @@
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
-"@artsy/reaction@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-3.3.1.tgz#f63dc4063420f97d18a50433780a03a6019e12d7"
+"@artsy/reaction@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-3.4.1.tgz#6713af061596b75cc9cc4f5bf9be1a6848b9e2fb"
   dependencies:
     "@artsy/palette" "^2.9.3"
     cheerio "^1.0.0-rc.2"
@@ -9647,7 +9647,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
+"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 


### PR DESCRIPTION
This just replaces the content inside `About the work` tab on artwork page. We will decide what actually should go into the whole section and how organize this information in tabs next, but for now that should make it easier to view information side by side and make those decisions.

Example of look:
<img width="1190" alt="screen shot 2018-09-05 at 7 21 48 pm" src="https://user-images.githubusercontent.com/437156/45178414-9b89ec00-b1e3-11e8-9880-c11298f3ec69.png">


And another one:


<img width="1235" alt="screen shot 2018-09-05 at 7 48 32 pm" src="https://user-images.githubusercontent.com/437156/45178421-9f1d7300-b1e3-11e8-9ee2-06000fce1f9d.png">
