### PR TITLE
hotfix - bucket-assets requires a short hash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run:
           name: Test
           command: |
-            export commit_hash=`git rev-parse HEAD` && echo $commit_hash
+            export commit_hash=`git rev-parse --short HEAD` && echo $commit_hash
             hokusai test
   build:
     docker:
@@ -40,7 +40,7 @@ jobs:
       - run:
           name: Push
           command: |
-            export commit_hash=`git rev-parse HEAD` && echo $commit_hash
+            export commit_hash=`git rev-parse --short HEAD` && echo $commit_hash
             hokusai registry push --tag $CIRCLE_SHA1 --force --overwrite
   publish_staging_assets:
     docker:


### PR DESCRIPTION
The full hash causes Force to fail to start https://github.com/artsy/bucket-assets/blob/master/index.js#L229