### PR TITLE
Works that are inquireable and acquireable should behave correctly

### DIFF
--- a/src/desktop/apps/artwork/components/commercial/templates/inquire.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/inquire.jade
@@ -1,56 +1,57 @@
-- var auctionPartner = artwork.partner.type === 'Auction' || artwork.partner.type === 'Auction House'
+- var auctionPartner = artwork.partner && artwork.partner.type === 'Auction' || artwork.partner.type === 'Auction House'
 - var newBuyNowFlow = user && user.hasLabFeature("New Buy Now Flow")
 
 //- TODO BNMO: Update to hide if the artwork is acquireable
-if artwork.is_inquireable && !((artwork.is_acquireable && auctionPartner) || newBuyNowFlow)
-  .artwork-inquiry-form.stacked-form( class='js-artwork-inquiry-form' )
-    input( type='hidden', name='artwork', value= artwork.id )
-    //- Only button is displayed for pre-qualification
+unless artwork.is_acquireable && (auctionPartner || newBuyNowFlow)
+  if artwork.is_inquireable
+    .artwork-inquiry-form.stacked-form( class='js-artwork-inquiry-form' )
+      input( type='hidden', name='artwork', value= artwork.id )
+      //- Only button is displayed for pre-qualification
 
-    .form-errors.js-form-errors
-      //- Rendered client-side
+      .form-errors.js-form-errors
+        //- Rendered client-side
 
-    if user && user.isWithAnonymousSession()
-      input( type='hidden', name='anonymous_session_id', value= user.id )
+      if user && user.isWithAnonymousSession()
+        input( type='hidden', name='anonymous_session_id', value= user.id )
 
-    unless enableNewInquiryFlow || (user && user.get('name') && user.get('email'))
-      input.bordered-input(
-        type='text'
-        name='name'
-        placeholder='Your full name'
-        required
-      )
-      input.bordered-input(
-        type='email'
-        name='email'
-        placeholder='Your email address'
-        required
-      )
-
-    unless enableNewInquiryFlow || artwork.partner.is_pre_qualify
-      if artwork.contact_message
-        textarea.bordered-input(
-          rows='4'
-          name='message'
+      unless enableNewInquiryFlow || (user && user.get('name') && user.get('email'))
+        input.bordered-input(
+          type='text'
+          name='name'
+          placeholder='Your full name'
           required
         )
-          = artwork.contact_message
-          = ' '
+        input.bordered-input(
+          type='email'
+          name='email'
+          placeholder='Your email address'
+          required
+        )
 
-    if fair
-      .artsy-checkbox.fair-attend-checkbox
-        .artsy-checkbox--checkbox
-          input( type='checkbox', name='attending', id='embedded-inquiry-form-attending' )
-          label( for='embedded-inquiry-form-attending' )
+      unless enableNewInquiryFlow || artwork.partner.is_pre_qualify
+        if artwork.contact_message
+          textarea.bordered-input(
+            rows='4'
+            name='message'
+            required
+          )
+            = artwork.contact_message
+            = ' '
 
-        label.artsy-checkbox--label( for='embedded-inquiry-form-attending' )
-          | I #{fair.isNotOver() ? 'will attend' : 'attended'} #{fair.nameSansYear()}
-          .tooltip-question-container
-            != stitch.components.TooltipQuestion({horizontalAlign: 'left', verticalAlign: 'bottom', message: 'This artwork is part of the art fair—'+fair.nameSansYear()+'. Providing this information enables galleries to offer a more customized service, and helps us send better recommendations and event invitations to you.'})
+      if fair
+        .artsy-checkbox.fair-attend-checkbox
+          .artsy-checkbox--checkbox
+            input( type='checkbox', name='attending', id='embedded-inquiry-form-attending' )
+            label( for='embedded-inquiry-form-attending' )
 
-    button.avant-garde-button-black(
-      class='js-artwork-inquire-button analytics-artwork-contact-seller'
-      data-artwork_id= artwork._id
-      data-context_type='sidebar'
-    )
-      | Contact #{artwork.partner.type}
+          label.artsy-checkbox--label( for='embedded-inquiry-form-attending' )
+            | I #{fair.isNotOver() ? 'will attend' : 'attended'} #{fair.nameSansYear()}
+            .tooltip-question-container
+              != stitch.components.TooltipQuestion({horizontalAlign: 'left', verticalAlign: 'bottom', message: 'This artwork is part of the art fair—'+fair.nameSansYear()+'. Providing this information enables galleries to offer a more customized service, and helps us send better recommendations and event invitations to you.'})
+
+      button.avant-garde-button-black(
+        class='js-artwork-inquire-button analytics-artwork-contact-seller'
+        data-artwork_id= artwork._id
+        data-context_type='sidebar'
+      )
+        | Contact #{artwork.partner.type}

--- a/src/desktop/apps/artwork/components/commercial/templates/inquire.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/inquire.jade
@@ -1,4 +1,8 @@
-if artwork.is_inquireable
+- var auctionPartner = artwork.partner.type === 'Auction' || artwork.partner.type === 'Auction House'
+- var newBuyNowFlow = user && user.hasLabFeature("New Buy Now Flow")
+
+//- TODO BNMO: Update to hide if the artwork is acquireable
+if artwork.is_inquireable && !((artwork.is_acquireable && auctionPartner) || newBuyNowFlow)
   .artwork-inquiry-form.stacked-form( class='js-artwork-inquiry-form' )
     input( type='hidden', name='artwork', value= artwork.id )
     //- Only button is displayed for pre-qualification

--- a/src/desktop/apps/artwork/components/commercial/test/template.coffee
+++ b/src/desktop/apps/artwork/components/commercial/test/template.coffee
@@ -76,12 +76,14 @@ describe 'Commercial template', ->
           hasLabFeature: (feature) -> feature == "New Buy Now Flow"
     $ = cheerio.load html
     $('.js-artwork-acquire-button').length.should.eql 1
+    $('.artwork-inquiry-form').length.should.eql 0
 
   it 'does not show the buy button when the buy now flow lab feature is disabled', ->
     html = renderArtwork
       artwork: acquireableArtwork
     $ = cheerio.load html
     $('.js-artwork-acquire-button').length.should.eql 0
+    $('.artwork-inquiry-form').length.should.eql 1
 
   it 'shows the buy button when ecommerce and the partner is an auction partner', ->
     html = renderArtwork
@@ -91,5 +93,6 @@ describe 'Commercial template', ->
           type: 'Auction'
     $ = cheerio.load html
     $('.js-artwork-acquire-button').length.should.eql 1
+    $('.artwork-inquiry-form').length.should.eql 0
 
 

--- a/src/desktop/apps/artwork/components/partner/index.jade
+++ b/src/desktop/apps/artwork/components/partner/index.jade
@@ -23,6 +23,7 @@ if helpers.partner.isDisplayable(artwork.partner)
           = profile.bio
 
       .artwork-partner__metadata__actions
+         //- TODO BNMO: Update to hide if the artwork is acquireable
         if artwork.is_inquireable
           a.avant-garde-button-black.is-small(
             class='js-artwork-partner-contact analytics-artwork-contact-seller'

--- a/src/desktop/apps/artwork/test/fixtures/acquireable_artwork.json
+++ b/src/desktop/apps/artwork/test/fixtures/acquireable_artwork.json
@@ -4,7 +4,7 @@
       "_id": "56e86588b202a366da000571",
       "id": "yee-wong-exploding-powder-movement-blue-and-pink",
       "is_acquireable": true,
-      "is_inquireable": false,
+      "is_inquireable": true,
       "is_in_auction": false,
       "sale_message": "$150 - 1,250",
       "partner": {

--- a/src/desktop/components/artwork_metadata_stub/queries/contact.coffee
+++ b/src/desktop/components/artwork_metadata_stub/queries/contact.coffee
@@ -3,6 +3,7 @@ module.exports = """
     _id
     href
     is_inquireable
+    is_acquireable
     sale {
       href
       is_auction

--- a/src/desktop/components/artwork_metadata_stub/templates/contact.jade
+++ b/src/desktop/components/artwork_metadata_stub/templates/contact.jade
@@ -1,8 +1,10 @@
+- var auctionPartner = artwork.partner && (artwork.partner.type === 'Auction' || artwork.partner.type === 'Auction House')
+
 if artwork.sale && artwork.sale.is_auction
   if artwork.is_sold
     .artwork-metadata-stub__contact.artwork-metadata-stub__line
       | Sold
-  else 
+  else
     .artwork-metadata-stub__contact.artwork-metadata-stub__line.artwork-metadata-stub__bid-now
       - var sa = artwork.sale_artwork
       if artwork.sale.is_live_open
@@ -20,7 +22,8 @@ if artwork.sale && artwork.sale.is_auction
           | #{sa.opening_bid.display}
       else if artwork.sale.is_closed
         | Auction closed
-else if artwork.is_inquireable
+else if artwork.is_inquireable && !(artwork.is_acquireable && auctionPartner)
+  //- TODO BNMO: Update to hide if the artwork is acquireable
   .artwork-metadata-stub__contact.artwork-metadata-stub__line
     a(
       class='analytics-artwork-contact-seller'

--- a/src/desktop/components/artwork_metadata_stub/test/index.js
+++ b/src/desktop/components/artwork_metadata_stub/test/index.js
@@ -25,6 +25,47 @@ describe('metadata template', () => {
       $('.artwork-metadata-stub__partner').length.should.eql(0)
     })
   })
+
+  describe('gallery work', () => {
+    let artwork
+    beforeEach(() => {
+      artwork = {
+        is_acquireable: false,
+        is_inquireable: true,
+        date: '2007',
+        title: 'My Artwork',
+        partner: { type: 'Gallery', href: '/partner/auction-partner' },
+      }
+    })
+
+    it('shows an inquiry CTA if the artwork is inquireable', () => {
+      const $ = cheerio.load(render({ artwork }))
+      $.text().should.containEql('My Artwork, 2007')
+      $('.artwork-metadata-stub__contact')
+        .text()
+        .should.eql('Contact gallery')
+    })
+  })
+
+  describe('non-auction work by auction partner', () => {
+    let artwork
+    beforeEach(() => {
+      artwork = {
+        is_acquireable: true,
+        is_inquireable: true,
+        date: '2007',
+        title: 'My Artwork',
+        partner: { type: 'Auction House', href: '/partner/auction-partner' },
+      }
+    })
+
+    it('shows an inquiry CTA if the artwork is inquireable', () => {
+      const $ = cheerio.load(render({ artwork }))
+      $.text().should.containEql('My Artwork, 2007')
+      $('.artwork-metadata-stub__contact').length.should.eql(0)
+    })
+  })
+
   describe('auction artwork', () => {
     let auctionArtwork
     beforeEach(() => {

--- a/src/desktop/components/artwork_metadata_stub/test/index.js
+++ b/src/desktop/components/artwork_metadata_stub/test/index.js
@@ -59,7 +59,7 @@ describe('metadata template', () => {
       }
     })
 
-    it('shows an inquiry CTA if the artwork is inquireable', () => {
+    it('does not show an inquiry CTA if the artwork is inquireable', () => {
       const $ = cheerio.load(render({ artwork }))
       $.text().should.containEql('My Artwork, 2007')
       $('.artwork-metadata-stub__contact').length.should.eql(0)

--- a/src/mobile/apps/artwork/components/meta_data/templates/inquiry.jade
+++ b/src/mobile/apps/artwork/components/meta_data/templates/inquiry.jade
@@ -10,7 +10,8 @@ if buyable && (isAuction || newBuyNowFlow || isAuctionPartner)
     else
       | Buy
 
-unless artwork.auction
+ //- TODO BNMO: Update to hide inquiry flow if the artwork is acquireable
+unless (isAuction || newBuyNowFlow || isAuctionPartner)
   if artwork.is_inquireable
     a.artwork-meta-data-black__contact-button(
       href="/inquiry/#{artwork.id}"

--- a/src/mobile/apps/artwork/components/meta_data/templates/inquiry.jade
+++ b/src/mobile/apps/artwork/components/meta_data/templates/inquiry.jade
@@ -9,14 +9,12 @@ if buyable && (isAuction || newBuyNowFlow || isAuctionPartner)
       | Buy Now
     else
       | Buy
-
- //- TODO BNMO: Update to hide inquiry flow if the artwork is acquireable
-unless (isAuction || newBuyNowFlow || isAuctionPartner)
-  if artwork.is_inquireable
-    a.artwork-meta-data-black__contact-button(
-      href="/inquiry/#{artwork.id}"
-    )
-      if artwork.partner && artwork.partner.type == 'Gallery'
-        | Contact Gallery
-      else
-        | Contact Seller
+else if artwork.is_inquireable
+  //- TODO BNMO: Update to hide inquiry flow if the artwork is acquireable
+  a.artwork-meta-data-black__contact-button(
+    href="/inquiry/#{artwork.id}"
+  )
+    if artwork.partner && artwork.partner.type == 'Gallery'
+      | Contact Gallery
+    else
+      | Contact Seller

--- a/src/mobile/apps/artwork/components/meta_data/test/template.coffee
+++ b/src/mobile/apps/artwork/components/meta_data/test/template.coffee
@@ -94,6 +94,7 @@ describe 'Artwork metadata templates', ->
   describe 'buy button', ->
     beforeEach ->
       @artwork.is_acquireable = true
+      @artwork.is_inquireable = true
 
     it 'should not display when new buy now flow lab feature is disabled and is not auction', ->
       @html = render('inquiry')(
@@ -112,8 +113,9 @@ describe 'Artwork metadata templates', ->
       )
       $ = cheerio.load @html
       $('.js-purchase').text().should.equal 'Buy Now'
+      $('.artwork-meta-data-black__contact-button').length.should.equal 1
 
-    it 'should display buy now butten for auction partners', ->
+    it 'should display buy now button for auction partners', ->
       @html = render('inquiry')(
         artwork: _.extend({}, @artwork, { partner: type: 'Auction' })
         sd: {}
@@ -121,6 +123,7 @@ describe 'Artwork metadata templates', ->
       )
       $ = cheerio.load @html
       $('.js-purchase').text().should.equal 'Buy'
+      $('.artwork-meta-data-black__contact-button').length.should.equal 1
 
     it 'should display buy button when ecommerce flag and buy now lab feature enabled', ->
       @html = render('inquiry')(
@@ -131,6 +134,7 @@ describe 'Artwork metadata templates', ->
       )
       $ = cheerio.load @html
       $('.js-purchase').text().should.equal 'Buy'
+      $('.artwork-meta-data-black__contact-button').length.should.equal 1
 
   describe 'for sale works partner header', ->
     describe 'gallery - not for sale', ->


### PR DESCRIPTION
The goal of this PR is to unblock https://github.com/artsy/metaphysics/pull/1249.

Until we launch the BNMO feature, we want (on desktop + mobile web):
- Auction-partner artworks that are `inquireable` _and_ `acquireable` should show the "Buy" button only
- Gallery-partner artworks that are `inquireable` _and_ `acquireable` should show the "Inquire" button _unless_ you have the lab feature, in which case you should see the "Buy" button
- Gallery-partner artworks that are `inquireable` and _not_ `acquireable` should show the "Inquire" button
- Works in an auction that are also `acquireable` should show the bid form + the "Buy" button

When we launch the BNMO flow, we will update this to be simpler:
- Works that are `inquireable` and `acquireable` should _just_ show the buy button (across the board)