### PR TITLE
bump the number of auctions we show on artsy.net

### DIFF
--- a/src/desktop/apps/auctions/routes.coffee
+++ b/src/desktop/apps/auctions/routes.coffee
@@ -19,7 +19,7 @@ setupUser = (user, auction) ->
 
   auctions.fetch(
     cache: true
-    data: published: true, size: 40, sort: '-timely_at,name'
+    data: published: true, size: 100, sort: '-timely_at,name'
   ).then(->
     setupUser(req.user, auctions.next())
   ).then((userData) ->

--- a/src/desktop/apps/auctions/test/routes.coffee
+++ b/src/desktop/apps/auctions/test/routes.coffee
@@ -42,7 +42,7 @@ describe 'Auctions routes', ->
         routes.index {}, @res
 
         Backbone.sync.args[0][1].url.should.containEql '/api/v1/sales'
-        Backbone.sync.args[0][2].data.should.eql published: true, size: 40, sort: '-timely_at,name'
+        Backbone.sync.args[0][2].data.should.eql published: true, size: 100, sort: '-timely_at,name'
         Backbone.sync.args[0][2].success @sales
 
         Backbone.sync.callCount.should.equal 1


### PR DESCRIPTION
[Mobile web](https://github.com/artsy/force/blob/master/src/mobile/apps/auctions/routes.coffee#L16) already fetches 100, as does [emission](https://github.com/artsy/emission/blob/0dd4d4cc479aa6c3c74bb73b63212f7a8bd41747/src/lib/Scenes/Home/Components/Sales/index.tsx#L96). This updates desktop to fetch 100 sales too.