### PR TITLE
bring the current version of ArtworkDetails from reaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@artsy/express-reloadable": "^1.3.1",
     "@artsy/palette": "^2.0.2",
     "@artsy/passport": "^1.0.11",
-    "@artsy/reaction": "^3.7.4",
+    "@artsy/reaction": "^3.9.0",
     "@artsy/stitch": "^1.6.0",
     "@babel/core": "^7.0.0",
     "@babel/node": "^7.0.0",

--- a/src/desktop/apps/artwork/components/additional_info/index.jade
+++ b/src/desktop/apps/artwork/components/additional_info/index.jade
@@ -1,23 +1,22 @@
 include ../../../../components/side_tabs/mixins
 
-- var tabs = helpers.additional_info.build(artwork)
+if user && user.hasLabFeature('New Buy Now Flow')
+  != stitch.components.ArtworkDetails({artworkID: artwork.id})
+else
+  - var tabs = helpers.additional_info.build(artwork)
+  if tabs.length
+    section.artwork-additional-info.artwork-section.side-tabs( class='js-artwork-additional-info' )
+      +nav(tabs, helpers.artists.name)
 
-if tabs.length
-  section.artwork-additional-info.artwork-section.side-tabs( class='js-artwork-additional-info' )
-    +nav(tabs, helpers.artists.name)
-
-    .artwork-additional-info__content.side-tabs__content
-      for tab, i in tabs
-        +tab(tab, i)
-          case tab
-            when 'about_the_work'
-              if user && user.hasLabFeature('New Buy Now Flow')
-                != stitch.components.ArtworkDetails({artworkID: artwork.id})
-              else  
+      .artwork-additional-info__content.side-tabs__content
+        for tab, i in tabs
+          +tab(tab, i)
+            case tab
+              when 'about_the_work'
                 include ./templates/about_the_work
-            when 'exhibition_history'
-              include ./templates/exhibition_history
-            when 'bibliography'
-              include ./templates/bibliography
-            when 'provenance'
-              include ./templates/provenance
+              when 'exhibition_history'
+                include ./templates/exhibition_history
+              when 'bibliography'
+                include ./templates/bibliography
+              when 'provenance'
+                include ./templates/provenance

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,9 +56,9 @@
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
-"@artsy/reaction@^3.7.4":
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-3.8.0.tgz#b02090511b070ac4ac5efad78119c97d3223db0d"
+"@artsy/reaction@^3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-3.9.0.tgz#e457da57ffc04773e09c053ff03cbd040c2ff320"
   dependencies:
     "@artsy/palette" "^2.17.0"
     cheerio "^1.0.0-rc.2"


### PR DESCRIPTION
This still needs a wrap of Boot to make tabs look proper and I need to work on the designs updates that were made recently. But at least all the data should be there and we can start testing the data while I work on updating the looks:

<img width="857" alt="screen shot 2018-09-14 at 12 10 27 pm" src="https://user-images.githubusercontent.com/437156/45562202-acf07b00-b817-11e8-8477-ab172f3ed05f.png">
