### PR TITLE
@l2succes => add partner image url

### DIFF
--- a/src/desktop/apps/artist2/components/Meta.js
+++ b/src/desktop/apps/artist2/components/Meta.js
@@ -109,6 +109,7 @@ query ArtistMetaQuery($artistID: String!) {
             profile {
               image {
                 small: url(version: "small")
+                large: url(version: "large")
               }
             }
           }
@@ -201,9 +202,12 @@ export const sellerFromPartner = (partner, APP_URL) => {
 
 export const getThumbnailImage = item => {
   const thumbnailUrl = item.image && item.image.small
+  const url = item.image && item.image.large
+
   const image = thumbnailUrl && {
     "@type": "ImageObject",
     thumbnailUrl,
+    url,
   }
   return image
 }

--- a/src/desktop/apps/artist2/components/__tests__/Meta.jest.js
+++ b/src/desktop/apps/artist2/components/__tests__/Meta.jest.js
@@ -47,6 +47,8 @@ describe("Meta", () => {
                 image: {
                   small:
                     "https://d32dm0rphc51dk.cloudfront.net/vIzxQvuBS8gZVPUOKc4tPQ/wide.jpg",
+                  large:
+                    "https://d32dm0rphc51dk.cloudfront.net/vIzxQvuBS8gZVPUOKc4tPQ/wide.jpg",
                 },
               },
             },
@@ -108,6 +110,8 @@ describe("Meta", () => {
                 "@type": "ImageObject",
                 thumbnailUrl:
                   "https://d32dm0rphc51dk.cloudfront.net/vIzxQvuBS8gZVPUOKc4tPQ/wide.jpg",
+                url:
+                  "https://d32dm0rphc51dk.cloudfront.net/vIzxQvuBS8gZVPUOKc4tPQ/wide.jpg",
               },
             },
           },
@@ -153,6 +157,8 @@ describe("Meta", () => {
               "@type": "ImageObject",
               thumbnailUrl:
                 "https://d32dm0rphc51dk.cloudfront.net/vIzxQvuBS8gZVPUOKc4tPQ/wide.jpg",
+              url:
+                "https://d32dm0rphc51dk.cloudfront.net/vIzxQvuBS8gZVPUOKc4tPQ/wide.jpg",
             },
           },
         },
@@ -194,6 +200,8 @@ describe("Meta", () => {
         image: {
           "@type": "ImageObject",
           thumbnailUrl:
+            "https://d32dm0rphc51dk.cloudfront.net/vIzxQvuBS8gZVPUOKc4tPQ/wide.jpg",
+          url:
             "https://d32dm0rphc51dk.cloudfront.net/vIzxQvuBS8gZVPUOKc4tPQ/wide.jpg",
         },
       })


### PR DESCRIPTION
One last item for seller info, seems to run green with the partner image URL in addition to thumbnailUrl.
