### PR TITLE
add ecommerce property to artwork pageview tracking

### DIFF
--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -3,14 +3,18 @@
 // or any other actions that occur on each page.
 //
 
-import { data as sd } from 'sharify'
-import { reportLoadTimeToVolley } from 'lib/volley'
+import { data as sd } from "sharify"
+import { reportLoadTimeToVolley } from "lib/volley"
 
 // Track pageview
-analytics.page(
-  { path: location.pathname },
-  { integrations: { Marketo: false } }
-)
+const pageType = window.sd.PAGE_TYPE || window.location.pathname.split("/")[1]
+var properties = { path: location.pathname }
+
+if (pageType == "artwork") {
+  properties["ecommerce"] = sd.ARTWORK.is_acquireable
+}
+
+analytics.page(properties, { integrations: { Marketo: false } })
 
 // Track pageload speed
 if (
@@ -18,10 +22,8 @@ if (
   window.performance.timing &&
   sd.TRACK_PAGELOAD_PATHS
 ) {
-  window.addEventListener('load', function() {
-    const pageType =
-      window.sd.PAGE_TYPE || window.location.pathname.split('/')[1]
-    if (sd.TRACK_PAGELOAD_PATHS.split('|').includes(pageType)) {
+  window.addEventListener("load", function() {
+    if (sd.TRACK_PAGELOAD_PATHS.split("|").includes(pageType)) {
       window.setTimeout(function() {
         const {
           requestStart,
@@ -34,7 +36,7 @@ if (
           loadEventEnd,
           domComplete,
           pageType,
-          'desktop'
+          "desktop"
         )
       }, 0)
     }
@@ -43,45 +45,45 @@ if (
 
 // Track 15 second bounce rate
 setTimeout(function() {
-  analytics.track('Time on page', {
-    category: '15 Seconds',
+  analytics.track("Time on page", {
+    category: "15 Seconds",
     message: sd.CURRENT_PATH,
   })
 }, 15000)
 
 // Track 30 second bounce rate
 setTimeout(function() {
-  analytics.track('Time on page', {
-    category: '30 Seconds',
+  analytics.track("Time on page", {
+    category: "30 Seconds",
     message: sd.CURRENT_PATH,
   })
 }, 30000)
 
 // Track 1 min bounce rate
 setTimeout(function() {
-  analytics.track('Time on page', {
-    category: '1 Minute',
+  analytics.track("Time on page", {
+    category: "1 Minute",
     message: sd.CURRENT_PATH,
   })
 }, 60000)
 
 // Track 3 Minute bounce rate
 setTimeout(function() {
-  analytics.track('Time on page', {
-    category: '3 Minutes',
+  analytics.track("Time on page", {
+    category: "3 Minutes",
     message: sd.CURRENT_PATH,
   })
 }, 180000)
 
 // debug tracking calls
 if (sd.SHOW_ANALYTICS_CALLS) {
-  analytics.on('track', function() {
-    console.info('TRACKED: ', arguments[0], JSON.stringify(arguments[1]))
+  analytics.on("track", function() {
+    console.info("TRACKED: ", arguments[0], JSON.stringify(arguments[1]))
   })
 }
 
 if (sd.SHOW_ANALYTICS_CALLS) {
-  analyticsHooks.on('all', function(name, data) {
-    console.info('ANALYTICS HOOK: ', name, data)
+  analyticsHooks.on("all", function(name, data) {
+    console.info("ANALYTICS HOOK: ", name, data)
   })
 }

--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -11,7 +11,9 @@ const pageType = window.sd.PAGE_TYPE || window.location.pathname.split("/")[1]
 var properties = { path: location.pathname }
 
 if (pageType == "artwork") {
-  properties["ecommerce"] = sd.ARTWORK.is_acquireable
+  properties["acquireable"] = sd.ARTWORK.is_acquireable
+  properties["availability"] = sd.ARTWORK.availability
+  properties["price_listed"] = sd.ARTWORK.price && sd.ARTWORK.price.length > 0
 }
 
 analytics.page(properties, { integrations: { Marketo: false } })

--- a/src/desktop/apps/artwork/routes.coffee
+++ b/src/desktop/apps/artwork/routes.coffee
@@ -89,7 +89,7 @@ bootstrap = ->
       res.locals.sd.INCLUDE_SAILTHRU = data.artwork?.fair?
       res.locals.sd.QUERY = req.query
       res.locals.jsonLD = stringifyJSONForWeb(convertArtworkToJSONLD(data.artwork))
-
+      res.locals.sd.ARTWORK = data.artwork
 
       # If a saleId is found, then check to see if user has been qualified for
       # bidding so that bid button UI is correct from the server down.


### PR DESCRIPTION
Adds an `ecommerce` property to our artwork pageview tracking for analytics purposes. I'm using the `is_acquireable` property on the artwork object, which I now share with the client by setting it in `sd.ARTWORK` as we do in some other places. I'm assuming that sharing the Artwork object with the client is not a security or privacy issue - I can't see any sensitive data in it (such as hidden prices).

The difference between `acquireable` and `ecommerce` is worth mentioning. I'm using the latter name in analytics for simplicity, to indicate that the artwork was available for direct purchase at the time of the pageview. If we look at the `acquireable` definition in Gravity it's a little more complicated than simply having the `ecommerce` flag set:

```ruby
def acquireable?
    published? && ecommerce? && has_price_listed? && price_currency == 'USD' && forsale? && inventory.present? && inventory.acquireable?
end
```

However, we don't model any of these other pieces of metadata in our sessions data, so just using `ecommerce` there seemed the most intuitive. There is an argument however, to use `acquireable` in our analytics data too for consistency. Any thoughts on that @anipetrov?

A note for @mikehrom too - We've had the `ecommerce` attribute on the Artwork model in Looker for some time ([here](https://github.com/cavvia/looker/blame/master/artworks.view.lkml#L131)), but we should probably also model out `acquireable` in Looker - it's not a persisted field so we'd need to derive it.