### PR TITLE
[script] Enable debug server if ran from vscode terminal.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
     "editor.formatOnSave": false
   },
   "editor.formatOnSave": true,
-  "typescript.tsdk": "./node_modules/typescript/lib"
+  "typescript.tsdk": "./node_modules/typescript/lib",
+  "debug.node.autoAttach": "on"
 }

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -5,11 +5,23 @@ set -ex
 # used for loading correct manifest
 export COMMIT_HASH=`cat COMMIT_HASH.txt`
 
-if [ "$NODE_ENV" = "production" ]; then
-  node --max_old_space_size=4096 ./src
-else
+function version {
+  printf "%03d%03d%03d" $(echo "$1" | tr '.' ' ')
+}
+
+OPT=(--max_old_space_size=4096)
+
+if [ "$NODE_ENV" != "production" ]; then
   if [ ! -f "./.env" ]; then
     echo -e "\033[1;31m WARNING: Missing .env file, see CONTRIBUTING.md. \033[0m"
   fi
-  node -r dotenv/config --max_old_space_size=4096 ./src
+  OPT+=(-r dotenv/config)
+  if [ "$TERM_PROGRAM" == "vscode" ] && \
+     [ ! -z "$TERM_PROGRAM_VERSION" ] && \
+     [ $(version $TERM_PROGRAM_VERSION) -ge $(version "1.22.2") ]
+  then
+    OPT+=(--inspect-brk)
+  fi
 fi
+
+exec node "${OPT[@]}" ./src


### PR DESCRIPTION
Ok, spent a bit more time trying to come up with a good pattern to automatically attach vscode’s debugger in a re-usable way across projects. I’ll comment inline.