### PR TITLE
@damassi => Support a standalone page for the Buy Now FAQ

### DIFF
--- a/src/desktop/apps/page/index.coffee
+++ b/src/desktop/apps/page/index.coffee
@@ -24,6 +24,7 @@ app.get '/past-privacy-10-29-12', routes.vanityUrl('past-privacy-10-29-12')
 app.get '/rrf-emerging-curator-competition-official-rules', routes.vanityUrl('rrf-emerging-curator-competition-official-rules')
 app.get '/past-privacy-8-5-13', routes.vanityUrl('past-privacy-8-5-13')
 app.get '/past-terms-9-26-13', routes.vanityUrl('past-terms-9-26-13')
+app.get '/buy-now-feature-faq', routes.vanityUrl('buy-now-feature-faq')
 
 app.get '/page/:id', routes.index
 app.get '/job/:id', routes.index


### PR DESCRIPTION
Just using the old school pages for this. Already added (in staging and prod): https://admin-staging.artsy.net/page/buy-now-feature-faq