### PR TITLE
@l2succes: create marketing landing page for frieze week london

### DIFF
--- a/src/desktop/apps/frieze_week_london/client/initializer.js
+++ b/src/desktop/apps/frieze_week_london/client/initializer.js
@@ -1,0 +1,20 @@
+import React from "react"
+import ReactDOM from "react-dom"
+import { BannerPopUp } from "desktop/components/fair_week_marketing/BannerPopUp"
+
+export const init = () => {
+  const bootstrapData = window.__BOOTSTRAP__
+  const {
+    ctaTitle,
+    ctaImageUrl,
+    overlayModalTitle,
+    overlayModalImageUrl,
+  } = bootstrapData.bannerPopUp
+
+  ReactDOM.render(
+    <BannerPopUp
+      {...{ ctaTitle, ctaImageUrl, overlayModalTitle, overlayModalImageUrl }}
+    />,
+    document.getElementById("react-root-for-cta")
+  )
+}

--- a/src/desktop/apps/frieze_week_london/fixture.json
+++ b/src/desktop/apps/frieze_week_london/fixture.json
@@ -1,0 +1,82 @@
+{
+  "bannerPopUp": {
+    "ctaTitle": "A better way to experience Armory Week 2018",
+    "ctaImageUrl":"https://d3vpvtm3t56z1n.cloudfront.net/images/artsyinmiami.jpg",
+    "overlayModalTitle":"Sign up for personalized fair content when our Armory Week coverage begins",
+    "overlayModalImageUrl":"https://d3vpvtm3t56z1n.cloudfront.net/images/artsyinmiami.jpg"
+  },
+  "event": {
+    "banner_image_url": "https://d3vpvtm3t56z1n.cloudfront.net/images/artsyinmiami.jpg",
+    "description": "Collective Structures explores the relationship between individual artists and their mental landscape through a series of spatial installations. It will unfold in multiple chapters, across distinct spaces of the Bath Club, drawing on the historic building. The physical and sensory experiences strive to place viewers at a crossroads between current reality and imagined narrative.",
+    "public_viewing_date": "Public Viewing<br />December 7 12:00pm–6:00pm<br />The Bath Club<br />5937 Collins Ave, Miami Beach",
+    "title": "Artsy in Miami"
+  },
+  "fair_coverage": {
+    "fairs": [
+      {
+        "logo_url": "https://artsy-media-uploads.s3.amazonaws.com/hw-EpvRMNFs4DXrckLIuUw/Art%20Basel%20in%20Miami%20Beach.png",
+        "site_url": "http://www.artsy.net"
+      },
+      {
+        "logo_url": "https://artsy-media-uploads.s3.amazonaws.com/NRvhceHaRT3G3rBBvDP_Mw/Design%20Miami.png",
+        "site_url": null
+      },
+      {
+        "logo_url": "https://artsy-media-uploads.s3.amazonaws.com/F3u0jrSZDe1s6OyNgfHEMA/INK%20Miami.png",
+        "site_url": null
+      },
+      {
+        "logo_url": "https://artsy-media-uploads.s3.amazonaws.com/yCxGbCMOWDQPWrjX8q1srw/Art%20Miami.png",
+        "site_url": null
+      },
+      {
+        "logo_url": "https://artsy-media-uploads.s3.amazonaws.com/Ok6sE6y1--UZjgtCvhY-JQ/CONTEXT%20Miami.png",
+        "site_url": null
+      },
+      {
+        "logo_url": "https://artsy-media-uploads.s3.amazonaws.com/rBIlG3gc12P-N4fzzGWZiA/Aqua%20Miami.png",
+        "site_url": null
+      },
+      {
+        "logo_url": "https://artsy-media-uploads.s3.amazonaws.com/VcPYm77sM-XyX9SpPXSU1g/PULSE%20Miami%20Beach.png",
+        "site_url": null
+      },
+      {
+        "logo_url": "https://artsy-media-uploads.s3.amazonaws.com/-gVCJKQ2POyyKw0x_cd5Bg/NADA.png",
+        "site_url": null
+      }
+    ],
+    "title": "Visit the fairs"
+  },
+  "introduction": {
+    "description": "For one week a year, Miami becomes a global destination for art, design, music and all things visual culture. Each fair brings together the most influential collectors, gallerists, designers, curators and critics from around the world in celebration of design culture and commerce.",
+    "title": "Miami Week<br />Dec 4-10, 2017"
+  },
+  "meta": {
+    "description": "Yo",
+    "title": "Hey"
+  },
+  "prepare_for_fairs": {
+    "articles": [
+      {
+        "article_url": "https://www.artsy.net/article/artsy-editorial-the-20-best-booths-at-art-basel-in-miami-beach",
+        "author": "ANNA LOUIE SUSSMAN",
+        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FlhQti2pXrsXDLlS8jJEIDg%252F_AR_3443.jpg&width=1100&quality=80",
+        "title": "The 20 Best Booths at Art Basel in Miami Beach"
+      },
+      {
+        "article_url": "https://www.artsy.net/article/artsy-editorial-50-must-see-artworks-at-miami-art-week-s-satellite-fairs",
+        "author": "ARTSY EDITORIAL",
+        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FvClMRePyeu9nCashzAgEeA%252F_AR_3326.jpg&width=1100&quality=80",
+        "title": "50 Must-See Artworks at Miami Art Week’s Satellite Fairs"
+      },
+      {
+        "article_url": "https://www.artsy.net/article/artsy-editorial-the-10-best-booths-at-design-miami",
+        "author": "ARTSY EDITORIAL",
+        "image_url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2FOX8QZ5TCXVt8szczr7oWZQ%252Fammann.jpg&width=1100&quality=80",
+        "title": "The 10 Best Booths at Design Miami/"
+      }
+    ],
+    "title": "Stories from Miami"
+  }
+}

--- a/src/desktop/apps/frieze_week_london/index.js
+++ b/src/desktop/apps/frieze_week_london/index.js
@@ -1,0 +1,68 @@
+import { renderLayout as _renderLayout } from "@artsy/stitch"
+import adminOnly from "../../lib/admin_only"
+import JSONPage from "../../components/json_page/es6"
+import { FairWeekPageScaffold } from "desktop/components/fair_week_marketing/PageScaffold"
+import { FairWeekMeta } from "desktop/components/fair_week_marketing/Meta"
+import merge from "lodash.merge"
+import queryString from "query-string"
+
+let renderLayout = _renderLayout
+const SLUG = "london-art-fair-week"
+const MARKETING_MODAL_ID = "ca18"
+
+export class EditableFriezeWeekPage extends JSONPage {
+  registerRoutes() {
+    this.app.get(this.jsonPage.paths.show, adminOnly, this.show.bind(this))
+    this.app.get(this.jsonPage.paths.show + "/data", this.data)
+    this.app.get(this.jsonPage.paths.edit, adminOnly, this.edit)
+    this.app.post(this.jsonPage.paths.edit, adminOnly, this.upload)
+  }
+
+  async show(req, res, next) {
+    try {
+      if (req.query["m-id"] !== MARKETING_MODAL_ID) {
+        const queryStringAsString = queryString.stringify(
+          merge({}, req.query, {
+            "m-id": MARKETING_MODAL_ID,
+          })
+        )
+
+        return res.redirect(`/${SLUG}?${queryStringAsString}`)
+      }
+
+      const data = await this.jsonPage.get()
+      const layout = await renderLayout({
+        basePath: __dirname,
+        layout: "../../components/main_layout/templates/react_index.jade",
+        config: {
+          styledComponents: true,
+        },
+        blocks: {
+          head: FairWeekMeta,
+          body: FairWeekPageScaffold,
+        },
+        locals: {
+          assetPackage: "banner_pop_up",
+        },
+        data: {
+          ...res.locals,
+          ...data,
+          displayStickyFooter: !req.user,
+          data,
+        },
+      })
+
+      res.send(layout)
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+export default new EditableFriezeWeekPage({
+  name: SLUG,
+  paths: {
+    show: `/${SLUG}`,
+    edit: `/${SLUG}/edit`,
+  },
+}).app

--- a/src/desktop/index.js
+++ b/src/desktop/index.js
@@ -69,6 +69,7 @@ app.use(require("./apps/marketing_signup_modals"))
 app.use(require("./apps/artsy_in_miami").default)
 app.use(require("./apps/armory_week").default)
 app.use(require("./apps/frieze_week").default)
+app.use(require("./apps/frieze_week_london").default)
 app.use(require("./apps/basel_week").default)
 
 // Non-profile dynamic vanity url apps


### PR DESCRIPTION
This addresses https://artsyproduct.atlassian.net/browse/GROW-891 and creates the marketing landing page for Frieze Week London under the url `/london-art-fair-week`. This particular landing page should not included an event section so we simply needed to remove the events object from the json.

A few to do items before this page is ready to launch:
- [ ] Upload the json page for this page in production.
- [ ] Remove the `adminOnly` flag in `/london-art-fair-week/index.js` file so that all users can view it.