### PR TITLE
Removed defunct link from Jade footer template

### DIFF
--- a/src/desktop/components/main_layout/footer/upper.jade
+++ b/src/desktop/components/main_layout/footer/upper.jade
@@ -4,7 +4,6 @@
     a.mlf-collector-faq( href='/#' ) Buying from Galleries FAQ
     a.mlf-auction-faq( href='/#' ) Buying from Auctions FAQ
     a( href='/consign' ) Consign with Artsy
-    a( href='/professional-buyer' ) Artsy for Professional Buyers
   .mlf-upper-column
     h4 Education
     a( href='/artsy-education' ) Education


### PR DESCRIPTION
Removed link to "Artsy for Professional Buyers"  from Force components.

[See DISCO-289 for info.](https://artsyproduct.atlassian.net/browse/DISCO-289) 

[Related PR Reaction #1290](https://github.com/artsy/reaction/pull/1290)