### PR TITLE
If artwork has a single edition set, send that edition set ID with the createOrder mutation

### DIFF
--- a/src/desktop/apps/artwork/components/commercial/bootstrap.coffee
+++ b/src/desktop/apps/artwork/components/commercial/bootstrap.coffee
@@ -9,6 +9,7 @@ module.exports = (sd, { artwork, enableNewInquiryFlow }) ->
       is_inquireable: artwork.is_inquireable
       partner_id: artwork.partner._id
       partner_type: artwork.partner?.type
+      edition_sets: artwork.edition_sets
   if artwork.fair?
     sd.COMMERCIAL.artwork.fair =
       id: artwork.fair.id

--- a/src/desktop/apps/artwork/components/commercial/view.coffee
+++ b/src/desktop/apps/artwork/components/commercial/view.coffee
@@ -47,10 +47,15 @@ module.exports = class ArtworkCommercialView extends Backbone.View
 
       serializer = new Serializer @$('form')
       data = serializer.data()
+      editionSetId: data.edition_set_id
+
+      # If this artwork has an edition set of 1, send that in the mutation as well
+      if @artwork.get('edition_sets')?.length && @artwork.get('edition_sets').length == 1
+        editionSetId = @artwork.get('edition_sets')[0] && @artwork.get('edition_sets')[0].id
 
       createOrder
         artworkId: @artwork.get('_id')
-        editionSetId: data.edition_set_id
+        editionSetId: editionSetId
         quantity: 1
         user: loggedInUser
       .then (data) ->

--- a/src/desktop/apps/artwork/test/fixtures/acquireable_artwork_single_edition.json
+++ b/src/desktop/apps/artwork/test/fixtures/acquireable_artwork_single_edition.json
@@ -1,0 +1,33 @@
+{
+  "data": {
+    "artwork": {
+      "_id": "56e86588b202a366da000571",
+      "id": "yee-wong-exploding-powder-movement-blue-and-pink",
+      "is_acquireable": true,
+      "is_inquireable": true,
+      "is_in_auction": false,
+      "sale_message": "$150 - 1,250",
+      "partner": {
+        "id": "artstar",
+        "name": "Artstar",
+        "type": "Gallery",
+        "is_pre_qualify": false,
+        "contact_message":
+          "Hi, I’m interested in purchasing this work. Could you please provide more information about the piece?"
+      },
+      "fair": null,
+      "edition_sets": [
+        {
+          "id": "56e866cd275b241d87000510",
+          "is_acquireable": true,
+          "edition_of": "Edition of 50",
+          "price": "$150",
+          "dimensions": {
+            "in": "11 3/10 × 13 1/2 in",
+            "cm": "28.7 × 34.3 cm"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/mobile/apps/artwork/components/meta_data/view.coffee
+++ b/src/mobile/apps/artwork/components/meta_data/view.coffee
@@ -22,9 +22,13 @@ module.exports = class MetaDataView extends Backbone.View
       @model.get('partner').type == 'Auction House'
 
     if loggedInUser?.hasLabFeature('New Buy Now Flow')
+      # If this artwork has an edition set of 1, send that in the mutation as well
+      if @model.get('edition_sets')?.length && @model.get('edition_sets').length == 1
+        singleEditionSetId = @model.get('edition_sets')[0] && @model.get('edition_sets')[0].id
+
       createOrder
         artworkId: @model.get('_id')
-        editionSetId: @editionSetId
+        editionSetId: @editionSetId || singleEditionSetId
         quantity: 1
         user: loggedInUser
       .then (data) ->

--- a/yarn.lock
+++ b/yarn.lock
@@ -3582,8 +3582,6 @@ dd-trace@artsy/dd-trace-js#artsy:
     semver "^5.5.0"
     shimmer "^1.2.0"
     url-parse "^1.4.3"
-  optionalDependencies:
-    "@airbnb/node-memwatch" "^1.0.2"
 
 debounce@~1.0.0:
   version "1.0.2"
@@ -10158,7 +10156,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
+react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 


### PR DESCRIPTION
Currently, if an artwork has a _single_ edition set, we're not sending an `editionSetId` along with an `artworkId` to exchange. This fixes that issue.

(Note that this functionality was overlooked because gravity [assumes the first](https://github.com/artsy/gravity/blob/master/app/api/v1/me_orders_endpoint.rb#L34-L36) in this scenario).