### PR TITLE
fix: remove minimal header margin whitelisting

### DIFF
--- a/src/desktop/apps/consign/templates/landing.jade
+++ b/src/desktop/apps/consign/templates/landing.jade
@@ -5,7 +5,7 @@ block head
 
 append locals
   - assetPackage = 'misc'
-  - bodyClass = bodyClass + ' body-no-margins body-no-header minimal-header-margin'
+  - bodyClass = bodyClass + ' body-no-margins body-no-header'
   - options = {modal: false, flash: false}
 
 block body

--- a/src/desktop/apps/order2/server.js
+++ b/src/desktop/apps/order2/server.js
@@ -53,7 +53,6 @@ app.get("/order2/:orderID*", async (req, res, next) => {
       locals: {
         ...res.locals,
         assetPackage: "order2",
-        bodyClass: (res.locals.bodyClass || "") + " minimal-header-margin",
         // header logo should link back to originating artwork
         headerLogoHref: res.locals.sd.REFERRER,
         options: {

--- a/src/desktop/components/main_layout/stylesheets/body.styl
+++ b/src/desktop/components/main_layout/stylesheets/body.styl
@@ -74,16 +74,14 @@ html[data-useragent*="iPad"]
     display none
   #main-layout-header-home-logo
     border-right 1px solid gray-lighter-color
-
-// FIXME: Reduce the header margin on whitelisted pages, merge this back into .minimal-header 
-// rule above once other consumers are confirmed.
-.minimal-header.minimal-header-margin
   #main-layout-container
     margin-top 42px !important
 
 // Simply hides the header
 .body-no-header
   #main-layout-header
+    display none
+  #main-layout-minimal-header
     display none
   #main-layout-container
     margin-top 0 !important


### PR DESCRIPTION
Removes a `FIXME` note introduced yesterday now that other pages using the updated minimal header have been validated. Fixes a regression with the updated header not respecting the `.body-no-header` class. See below for screenshots of affected pages.

<img width="1438" alt="screen shot 2018-09-25 at 1 58 33 pm" src="https://user-images.githubusercontent.com/5216744/46033355-084e2300-c0cc-11e8-8582-8efa5615a848.png">
<img width="1440" alt="screen shot 2018-09-25 at 11 54 53 am" src="https://user-images.githubusercontent.com/5216744/46033356-084e2300-c0cc-11e8-9657-0fda75ca223c.png">
<img width="1439" alt="screen shot 2018-09-25 at 11 57 20 am" src="https://user-images.githubusercontent.com/5216744/46033357-084e2300-c0cc-11e8-947d-9ca60b95a0e5.png">
<img width="1438" alt="screen shot 2018-09-25 at 12 09 26 pm" src="https://user-images.githubusercontent.com/5216744/46033358-084e2300-c0cc-11e8-8350-d738c1ece25c.png">
<img width="1434" alt="screen shot 2018-09-25 at 12 50 29 pm" src="https://user-images.githubusercontent.com/5216744/46033359-084e2300-c0cc-11e8-8df3-a99f98db77a2.png">
