### PR TITLE
@sweir27 => Log out some info for the mysterious endless reload issue

### DIFF
--- a/src/mobile/components/layout/bootstrap.coffee
+++ b/src/mobile/components/layout/bootstrap.coffee
@@ -59,7 +59,8 @@ ensureFreshUser = (data) ->
     'collector_level'
   ]
   for attr in attrs
-    if not _.isEqual data[attr], sd.CURRENT_USER[attr]
+    if (data[attr] or sd.CURRENT_USER[attr]) and not _.isEqual data[attr], sd.CURRENT_USER[attr]
+      RavenClient.captureException("Forced to refresh user", { extra: { attr: attr, session: sd.CURRENT_USER[attr], current: data[attr] } } )
       $.ajax('/user/refresh').then -> window.location.reload()
 
 syncAuth = module.exports.syncAuth = ->


### PR DESCRIPTION
Documented in https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=57&projectKey=DISCO&modal=detail&selectedIssue=DISCO-295 , but this has cropped up / been reported many times, but always hard to reproduce.

This starts logging refreshes to Sentry (which should be grouped together), as well as the 'extra' data so we can see if there's a pattern:

<img width="513" alt="screen shot 2018-09-25 at 5 18 38 pm" src="https://user-images.githubusercontent.com/1457859/46043859-1d847b00-c0e7-11e8-8363-7bdd849051b4.png">

