### PR TITLE
WIP: Removes Artsy logo from within Eigen for /order2 routes

### DIFF
--- a/src/desktop/apps/order2/server.js
+++ b/src/desktop/apps/order2/server.js
@@ -51,6 +51,7 @@ app.get("/order2/:orderID*", async (req, res, next) => {
         headerLogoHref: res.locals.sd.REFERRER,
         options: {
           stripev3: true,
+          hideLogo: res.locals.sd.EIGEN,
         },
       },
     })

--- a/src/desktop/components/main_layout/header/templates/minimal_header.jade
+++ b/src/desktop/components/main_layout/header/templates/minimal_header.jade
@@ -1,3 +1,4 @@
 nav#main-layout-minimal-header
-  a.logo( href='#{ headerLogoHref || "/" }')
-    include ../../public/icons/logotype.svg
+  unless options.hideLogo
+    a.logo( href='#{ headerLogoHref || "/" }')
+      include ../../public/icons/logotype.svg

--- a/src/desktop/components/main_layout/templates/minimal_header.jade
+++ b/src/desktop/components/main_layout/templates/minimal_header.jade
@@ -1,7 +1,7 @@
 //- Override any locals with `append locals`
 block locals
   - bodyClass = helpers ? helpers.buildBodyClass(sd, 'body-header-fixed minimal-header') : ''
-  - defaultOptions = {modal: true, flash: true, stripe: false, stripev3: false, sailthru: true, marketo: true, quantcast: true}
+  - defaultOptions = {modal: true, flash: true, stripe: false, stripev3: false, sailthru: true, marketo: true, quantcast: true, hideLogo: false}
 - options = options ? Object.assign({}, defaultOptions, options) : defaultOptions
 
 doctype html


### PR DESCRIPTION
This is a PR for [PURCHASE-448](https://artsyproduct.atlassian.net/browse/PURCHASE-448) that removes the back button when the /order2 routes are displayed within Eigen.

This PR is a WIP because it still needs local testing (see PURCHASE-506 and -507) and also because I don't really like the approach. Open to suggestions!