### PR TITLE
@eessex: remove adminOnly flag for frieze week london

### DIFF
--- a/src/desktop/apps/frieze_week_london/index.js
+++ b/src/desktop/apps/frieze_week_london/index.js
@@ -12,7 +12,7 @@ const MARKETING_MODAL_ID = "ca18"
 
 export class EditableFriezeWeekPage extends JSONPage {
   registerRoutes() {
-    this.app.get(this.jsonPage.paths.show, adminOnly, this.show.bind(this))
+    this.app.get(this.jsonPage.paths.show, this.show.bind(this))
     this.app.get(this.jsonPage.paths.show + "/data", this.data)
     this.app.get(this.jsonPage.paths.edit, adminOnly, this.edit)
     this.app.post(this.jsonPage.paths.edit, adminOnly, this.upload)


### PR DESCRIPTION
This removes the `adminOnly` flag so the marketing landing for Frieze Week London is visible to all users.
