### PR TITLE
Adding contact specialist link to bnmo artwork

### DIFF
--- a/src/desktop/apps/artwork/components/commercial/templates/acquire.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/acquire.jade
@@ -1,5 +1,3 @@
-- var newBuyNowFlow = user && user.hasLabFeature("New Buy Now Flow")
-- var auctionPartner = artwork.partner.type === 'Auction' || artwork.partner.type === 'Auction House'
 if artwork.is_acquireable && (newBuyNowFlow || auctionPartner)
   .artwork-acquire-form
     input( type='hidden', name='artwork_id', value= artwork.id )

--- a/src/desktop/apps/artwork/components/commercial/templates/consign.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/consign.jade
@@ -1,9 +1,9 @@
 if helpers.commercial.isWithConsignableArtists(artwork)
   .artwork-commercial__consignables
-    for artist in artwork.artists
-      .artwork-commercial__consignables__consign
-        | Interested in selling a work by #{artist.name}?
-        = ' '
-        a( href='/consign' )
-          | Consign with Artsy
-        | .
+    .artwork-commercial__consignables__consign
+      - var artistPrompt = (artwork.artists.length === 1) ? artwork.artists[0].name : 'these artists'
+      | Want to sell a work by #{artistPrompt}?
+      = ' '
+      a( href='/consign' )
+        | Learn&nbsp;more
+      | .

--- a/src/desktop/apps/artwork/components/commercial/templates/index.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/index.jade
@@ -1,3 +1,6 @@
+- var newBuyNowFlow = user && user.hasLabFeature("New Buy Now Flow")
+- var auctionPartner = artwork.partner.type === 'Auction' || artwork.partner.type === 'Auction House'
+
 .artwork-commercial( class='js-artwork-commercial' )
   form.artwork-commercial__form
     include editions

--- a/src/desktop/apps/artwork/components/commercial/templates/questions.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/questions.jade
@@ -1,6 +1,9 @@
 if artwork.is_for_sale
   .artwork-commercial__questions
-    | Questions about buying art on Artsy?
-    | Read our&nbsp;
-    a.collector-faq( href='/#' ) Collector FAQ
+    | Have a question?&nbsp;
+    a.collector-faq( href='/#' ) Read our FAQ
+    if (artwork.is_acquireable && (newBuyNowFlow && artwork.partner.type != 'Auction House'))
+      | &nbsp;or&nbsp;
+      a( class='js-artwork-nbmo-ask-specialist' )
+        | ask a specialist
     | .

--- a/src/desktop/apps/artwork/components/commercial/test/template.coffee
+++ b/src/desktop/apps/artwork/components/commercial/test/template.coffee
@@ -95,4 +95,21 @@ describe 'Commercial template', ->
     $('.js-artwork-acquire-button').length.should.eql 1
     $('.artwork-inquiry-form').length.should.eql 0
 
+  it 'displays ask a specialist for bnmo artworks', ->
+    html = renderArtwork
+      artwork: acquireableArtwork
+      artworkOptions:
+        is_for_sale: true
+      templateOptions:
+        user:
+          hasLabFeature: (feature) -> feature == "New Buy Now Flow"
+    $ = cheerio.load html
+    $('.js-artwork-bnmo-ask-specialist').length.should.eql 1
 
+  it 'does not display ask a specialist for non acquireable artwork', ->
+    html = renderArtwork
+      artwork: inquireableArtwork
+      artworkOptions:
+          is_for_sale: true
+    $ = cheerio.load html
+    $('.js-artwork-bnmo-ask-specialist').length.should.eql 0

--- a/src/desktop/apps/artwork/components/commercial/view.coffee
+++ b/src/desktop/apps/artwork/components/commercial/view.coffee
@@ -18,15 +18,17 @@ sd = require('sharify').data
 template = -> require('./templates/index.jade') arguments...
 confirmation = -> require('./templates/confirmation.jade') arguments...
 { createOrder } = require '../../../../../lib/components/create_order'
+inquireSpecialist = require '../../lib/inquire.coffee'
 
 module.exports = class ArtworkCommercialView extends Backbone.View
   tagName: 'form'
   className: 'artwork-commercial'
 
   events:
-    'click .js-artwork-inquire-button'  : 'inquire'
-    'click .js-artwork-acquire-button'  : 'acquire'
-    'click .collector-faq'              : 'openCollectorModal'
+    'click .js-artwork-inquire-button'      : 'inquire'
+    'click .js-artwork-acquire-button'      : 'acquire'
+    'click .collector-faq'                  : 'openCollectorModal'
+    'click .js-artwork-nbmo-ask-specialist' : 'inquireSpecialist'
 
   initialize: ({ @data }) ->
     { artwork } = @data
@@ -36,6 +38,10 @@ module.exports = class ArtworkCommercialView extends Backbone.View
     if CurrentUser.orNull() and
         qs.parse(location.search.substring(1)).inquire is 'true'
       @inquire()
+  
+  inquireSpecialist: (e) ->
+    e.preventDefault()
+    inquireSpecialist @artwork.get('_id')
 
   acquire: (e) ->
     e.preventDefault()

--- a/src/desktop/apps/artwork/components/commercial/view.coffee
+++ b/src/desktop/apps/artwork/components/commercial/view.coffee
@@ -41,7 +41,7 @@ module.exports = class ArtworkCommercialView extends Backbone.View
   
   inquireSpecialist: (e) ->
     e.preventDefault()
-    inquireSpecialist @artwork.get('_id')
+    inquireSpecialist @artwork.get('_id'), ask_specialist: true
 
   acquire: (e) ->
     e.preventDefault()

--- a/src/desktop/apps/artwork/lib/inquire.coffee
+++ b/src/desktop/apps/artwork/lib/inquire.coffee
@@ -4,10 +4,11 @@ Artwork = require '../../../models/artwork.coffee'
 ArtworkInquiry = require '../../../models/artwork_inquiry.coffee'
 openInquiryQuestionnaireFor = require '../../../components/inquiry_questionnaire/index.coffee'
 
-module.exports = (id) ->
+module.exports = (id, options = {}) ->
   user = User.instantiate()
   inquiry = new ArtworkInquiry notification_delay: 600
   artwork = new Artwork id: id
+  ask_specialist = options.ask_specialist || false
 
   Promise artwork.fetch()
     .then ->
@@ -16,4 +17,5 @@ module.exports = (id) ->
       openInquiryQuestionnaireFor
         user: user
         artwork: artwork
-        inquiry: inquiry
+        inquiry: inquiry,
+        ask_specialist: ask_specialist

--- a/src/desktop/components/inquiry_questionnaire/map/decisions.coffee
+++ b/src/desktop/components/inquiry_questionnaire/map/decisions.coffee
@@ -5,7 +5,7 @@ hasSeenThisSession = (steps...) -> ({ logger }) -> logger.hasLoggedThisSession s
 
 decisions =
   ask_specialist: ({ artwork, ask_specialist }) ->
-    artwork.get('is_in_auction') is true || ask_specialist is true || artwork.get('ecommerce') is true
+    artwork.get('is_in_auction') is true || ask_specialist is true
 
   enable_new_inquiry_flow: ({ enableNewInquiryFlow }) -> !!enableNewInquiryFlow
 

--- a/src/desktop/components/inquiry_questionnaire/map/decisions.coffee
+++ b/src/desktop/components/inquiry_questionnaire/map/decisions.coffee
@@ -5,7 +5,7 @@ hasSeenThisSession = (steps...) -> ({ logger }) -> logger.hasLoggedThisSession s
 
 decisions =
   ask_specialist: ({ artwork, ask_specialist }) ->
-    artwork.get('is_in_auction') is true || ask_specialist is true
+    artwork.get('is_in_auction') is true || ask_specialist is true || artwork.get('ecommerce') is true
 
   enable_new_inquiry_flow: ({ enableNewInquiryFlow }) -> !!enableNewInquiryFlow
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10141,7 +10141,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
+react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 


### PR DESCRIPTION
Can't figure out just yet where the email to contact a specialist is set. For now just reusing the logic that we currently have on auction page to contact a specialist. This logic seem to be using inquiry decision tree that is quite complex. Don't feel like I know enough to change any of that though...


The proposed solution seem to do what https://artsyproduct.atlassian.net/browse/DISCO-226 asks for except for not modifying any emails for now. Will try to figure that out next of maybe somebody know right away: @sweir27 or @damassi ?