### PR TITLE
@damassi => Support artist and artist_id query params to /works-for-you

### DIFF
--- a/src/desktop/assets/misc.coffee
+++ b/src/desktop/assets/misc.coffee
@@ -31,8 +31,8 @@ routes =
 
   '/works-for-you': ->
     require('../apps/notifications/client/index.coffee').init()
-    { artist } = qs.parse(location.search.substring(1))
-    require('../apps/notifications/client/react_grid.js').default.setupReactGrid({artistID: artist})
+    { artist, artist_id } = qs.parse(location.search.substring(1))
+    require('../apps/notifications/client/react_grid.js').default.setupReactGrid({ artistID: (artist || artist_id) })
 
   '/profile/.*': require('../apps/user/client/index.coffee').init
 

--- a/src/desktop/components/commercial_filter/filters/period/period_map.coffee
+++ b/src/desktop/components/commercial_filter/filters/period/period_map.coffee
@@ -15,7 +15,6 @@ module.exports =
     'Late 19th Century',
     'Mid 19th Century',
     'Early 19th Century',
-    '18th Century & Earlier',
   ],
   displayPeriods: [
     '2010',


### PR DESCRIPTION
The old version of `/works-for-you` supported either `artist` or `artist_id` query params (I believe we've used `artist` in emails, and `artist_id` from the bell dropdown).

So this just adds that here.