### PR TITLE
[Stitch] Update import path based on TS refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@artsy/palette": "^2.18.1",
     "@artsy/passport": "^1.0.11",
     "@artsy/reaction": "^4.9.0",
-    "@artsy/stitch": "^1.6.0",
+    "@artsy/stitch": "^2.0.0",
     "@babel/core": "^7.0.0",
     "@babel/node": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",

--- a/src/desktop/index.js
+++ b/src/desktop/index.js
@@ -7,7 +7,7 @@ const app = (module.exports = require("express")())
 
 // TODO: Move to src/lib/middleware/locals once done developing; this is just so
 // we can get hot module reloading which only works in /desktop and /mobile
-app.use(require("@artsy/stitch/iso").middleware(modules))
+app.use(require("@artsy/stitch/dist/server").middleware(modules))
 
 // Apps with hardcoded routes or "RESTful" routes
 app.use(require("./apps/home"))

--- a/src/desktop/lib/global_client_setup.coffee
+++ b/src/desktop/lib/global_client_setup.coffee
@@ -20,7 +20,7 @@ listenForInvert = require '../components/eggs/invert/index.coffee'
 listenForBounce = require '../components/eggs/bounce/index.coffee'
 confirmation = require '../components/confirmation/index.coffee'
 globalReactModules = require('./global_react_modules.tsx')
-{ componentRenderer } = require('@artsy/stitch/iso')
+{ componentRenderer } = require('@artsy/stitch/dist/server')
 { initModalManager } = require('../../desktop/apps/auth2/client/index')
 
 module.exports = ->

--- a/src/mobile/index.js
+++ b/src/mobile/index.js
@@ -3,7 +3,7 @@ const app = (module.exports = require("express")())
 
 // TODO: Move to src/lib/middleware/locals once done developing; this is just so
 // we can get hot module reloading which only works in /desktop and /mobile
-app.use(require("@artsy/stitch/iso").middleware(modules))
+app.use(require("@artsy/stitch/dist/server").middleware(modules))
 
 app.use(require("./apps/auth"))
 app.use(require("./apps/page"))

--- a/src/mobile/lib/global_client_setup.coffee
+++ b/src/mobile/lib/global_client_setup.coffee
@@ -4,7 +4,7 @@
 # or component.
 #
 globalReactModules = require('./global_react_modules')
-{ componentRenderer } = require('@artsy/stitch/iso')
+{ componentRenderer } = require('@artsy/stitch/dist/server')
 
 module.exports = ->
   mountStitchBlocks()

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,11 +102,10 @@
     url "^0.11.0"
     yup "^0.24.1"
 
-"@artsy/stitch@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@artsy/stitch/-/stitch-1.6.0.tgz#7b53b51002930653a8044a0b79723a16a2b20aad"
+"@artsy/stitch@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@artsy/stitch/-/stitch-2.0.0.tgz#c0a44186b3eac779bd3c7a6b0030c7ad7acff754"
   dependencies:
-    "@babel/runtime" "^7.0.0-beta.46"
     consolidate "^0.14.5"
     lodash "^4.17.4"
 
@@ -760,13 +759,6 @@
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
   dependencies:
     regenerator-runtime "^0.12.0"
-
-"@babel/runtime@^7.0.0-beta.46":
-  version "7.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.46.tgz#466a9c0498f6d12d054a185981eef742d59d4871"
-  dependencies:
-    core-js "^2.5.3"
-    regenerator-runtime "^0.11.1"
 
 "@babel/template@^7.0.0":
   version "7.0.0"
@@ -3267,10 +3259,6 @@ core-js@^1.0.0:
 core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
-
-core-js@^2.5.3:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@airbnb/node-memwatch@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@airbnb/node-memwatch/-/node-memwatch-1.0.2.tgz#a82e311ae27e05df4fb2cf8e4fbc75caaf7190a4"
-  dependencies:
-    bindings "^1.3.0"
-    nan "^2.9.2"
-
 "@artsy/express-reloadable@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@artsy/express-reloadable/-/express-reloadable-1.3.1.tgz#206adcc56ebcf999aece7efcc34eaf1460cf90a7"
@@ -2172,10 +2165,6 @@ binary-extensions@^1.0.0:
 bindings@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.2.1.tgz#14ad6113812d2d37d72e67b4cacb4bb726505f11"
-
-bindings@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
 
 bl@~1.1.2:
   version "1.1.2"
@@ -8465,10 +8454,6 @@ mute-stream@~0.0.4:
 nan@^2.3.0, nan@^2.3.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
-
-nan@^2.9.2:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
 
 nanomatch@^1.2.5, nanomatch@^1.2.9:
   version "1.2.9"


### PR DESCRIPTION
Blocker: https://github.com/artsy/stitch/pull/13

Fixes import path to our `server` only reference. 