### PR TITLE
[webpack] Fix bug in our hard-source caching setup.

### DIFF
--- a/patches/hard-source-webpack-plugin+0.12.0.patch
+++ b/patches/hard-source-webpack-plugin+0.12.0.patch
@@ -1,0 +1,17 @@
+patch-package
+--- a/node_modules/hard-source-webpack-plugin/lib/util/serial.js
++++ b/node_modules/hard-source-webpack-plugin/lib/util/serial.js
+@@ -196,7 +196,12 @@ const constructed = (exports.constructed = (Type, args) => ({
+     for (const key in args) {
+       newArgs.push(args[key].thaw(frozen[key], frozen, extra, methods));
+     }
+-    return new Type(...newArgs);
++    if (newArgs.length > 1) {
++      return new Type(...newArgs);
++    } else {
++      const { request, userRequest, rawRequest, loaders, resource, parser } = newArgs[0];
++      return new Type(request, userRequest, rawRequest, loaders, resource, parser);
++    }
+   },
+ }));
+ 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ const isCI = CI === "true"
 
 const cacheDirectory = path.resolve(__dirname, ".cache")
 
-if (!fs.existsSync(cacheDirectory)) {
+if (!isCI && !fs.existsSync(cacheDirectory)) {
   console.log(
     require("chalk").yellow(
       "\n[!] Bugger. No existing `.cache` directory detected, this initial " +


### PR DESCRIPTION
Alright, so, I don’t have a full understanding yet of why this happens, what I know is:

* In webpack v3 this class accepted [a list of params](https://github.com/webpack/webpack/blob/v3.12.0/lib/NormalModule.js#L62), which changed in webpack v4 to be [an object of those params](https://github.com/webpack/webpack/blob/v4.0.0/lib/NormalModule.js#L68-L78). We’re still on webpack v3.
* While it’s probably related to that change in webpack, what’s weird is that one may expect then that this would apply to all modules, but the issue only arises for 2 of our modules:

  - [`src/desktop/apps/editorial_features/components/gucci/components/series/series_footer.jsx`](https://github.com/artsy/force/blob/60be49cb4bde1828e7158880c85d6b2c1dcc42c3/src/desktop/apps/editorial_features/components/gucci/components/series/series_footer.jsx)
  - [`src/desktop/apps/editorial_features/components/gucci/components/section/section_text.jsx`](https://github.com/artsy/force/blob/60be49cb4bde1828e7158880c85d6b2c1dcc42c3/src/desktop/apps/editorial_features/components/gucci/components/section/section_text.jsx)

  Interestingly they both exist in the same part of the codebase, but that may just be a red-herring.

### Reproduction

```
yarn link @artsy/reaction
yarn start
[…]
DONE  Compiled successfully in 117453ms
^C
yarn unlink @artsy/reaction
yarn install --check-files
yarn start
```

![screen shot 2018-10-01 at 1 24 09 pm](https://user-images.githubusercontent.com/2320/46347521-19f37580-c64c-11e8-8e60-7ed39776909f.png)

### Context

Some extra context from my debug session, in case that’s helpful:

<img width="2560" alt="screen shot 2018-10-02 at 13 31 04" src="https://user-images.githubusercontent.com/2320/46346975-39899e80-c64a-11e8-85a5-f2b6af14ff77.png">

<img width="2560" alt="screen shot 2018-10-02 at 13 31 20" src="https://user-images.githubusercontent.com/2320/46346981-3d1d2580-c64a-11e8-8a4c-2f693e80dd5f.png">