### PR TITLE
add lot display to mobile version of artwork

### DIFF
--- a/src/mobile/apps/artwork/components/bid/query.coffee
+++ b/src/mobile/apps/artwork/components/bid/query.coffee
@@ -20,6 +20,7 @@ module.exports = """
       id
       estimate
       reserve_status
+      lot_label
       current_bid {
         amount
       }

--- a/src/mobile/apps/artwork/components/image/index.styl
+++ b/src/mobile/apps/artwork/components/image/index.styl
@@ -54,6 +54,11 @@
 
 .artwork-image-module__artwork-details
   width 100%
+  .lot-number
+    avant-garde()
+    color gray-darker-color
+    font-size 14px
+    margin-bottom 2px
   .artist-name
     garamond()
     display inline-block

--- a/src/mobile/apps/artwork/components/image/templates/index.jade
+++ b/src/mobile/apps/artwork/components/image/templates/index.jade
@@ -15,6 +15,9 @@
             .artwork-header-module__share-button
 
       .artwork-image-module__artwork-details
+        if artwork.auction && artwork.auction.sale_artwork && artwork.auction.sale_artwork.lot_label
+          .lot-number
+            | Lot #{artwork.auction.sale_artwork.lot_label}
         if artists.length
           for artist in artists
             a.artist-name(href=artist.href)= artist.name


### PR DESCRIPTION
Adress https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=57&projectKey=DISCO&modal=detail&selectedIssue=DISCO-349

Judging that this info was not even requested on mobile I doubt it was ever displayed there. But now that is. We just have to make sure we keep it in the artwork page redesign:)