### PR TITLE
Use feature flag or lab feature for showing bnmo features

### DIFF
--- a/src/desktop/apps/artwork/components/additional_info/index.jade
+++ b/src/desktop/apps/artwork/components/additional_info/index.jade
@@ -1,6 +1,6 @@
 include ../../../../components/side_tabs/mixins
 
-if user && user.hasLabFeature('New Buy Now Flow')
+if sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature('New Buy Now Flow')
   != stitch.components.ArtworkDetails({artworkID: artwork.id})
 else
   - var tabs = helpers.additional_info.build(artwork)

--- a/src/desktop/apps/artwork/components/additional_info/index.jade
+++ b/src/desktop/apps/artwork/components/additional_info/index.jade
@@ -1,6 +1,6 @@
 include ../../../../components/side_tabs/mixins
 
-if sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature('New Buy Now Flow')
+if sd.ENABLE_NEW_BUY_NOW_FLOW || (user && user.hasLabFeature('New Buy Now Flow'))
   != stitch.components.ArtworkDetails({artworkID: artwork.id})
 else
   - var tabs = helpers.additional_info.build(artwork)

--- a/src/desktop/apps/artwork/components/artists/index.jade
+++ b/src/desktop/apps/artwork/components/artists/index.jade
@@ -2,7 +2,7 @@ include ../../../../components/side_tabs/mixins
 
 if artwork.artists.length
   for artist in artwork.artists
-    if user && user.hasLabFeature('New Buy Now Flow')
+    if sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature('New Buy Now Flow')
       != stitch.components.ArtworkArtistInfo({ artistID: artist.id })
     else
       - var tabs = helpers.artists.build(artist)

--- a/src/desktop/apps/artwork/components/artists/index.jade
+++ b/src/desktop/apps/artwork/components/artists/index.jade
@@ -2,7 +2,7 @@ include ../../../../components/side_tabs/mixins
 
 if artwork.artists.length
   for artist in artwork.artists
-    if sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature('New Buy Now Flow')
+    if sd.ENABLE_NEW_BUY_NOW_FLOW || (user && user.hasLabFeature('New Buy Now Flow'))
       != stitch.components.ArtworkArtistInfo({ artistID: artist.id })
     else
       - var tabs = helpers.artists.build(artist)

--- a/src/desktop/apps/artwork/components/auction/view.coffee
+++ b/src/desktop/apps/artwork/components/auction/view.coffee
@@ -1,6 +1,6 @@
 { defer, extend, before, isEqual } = require 'underscore'
 Backbone = require 'backbone'
-{ AUCTION, CURRENT_USER } = require('sharify').data
+{ AUCTION, CURRENT_USER, ENABLE_NEW_BUY_NOW_FLOW } = require('sharify').data
 Form = require '../../../../components/form/index.coffee'
 openMultiPageModal = require '../../../../components/multi_page_modal/index.coffee'
 openBuyersPremiumModal = require './components/buyers_premium/index.coffee'
@@ -70,7 +70,7 @@ module.exports = class ArtworkAuctionView extends Backbone.View
     loggedInUser = CurrentUser.orNull()
 
     # Show the new buy now flow if you have the lab feature enabled
-    if loggedInUser?.hasLabFeature('New Buy Now Flow')
+    if ENABLE_NEW_BUY_NOW_FLOW || loggedInUser?.hasLabFeature('New Buy Now Flow')
       createOrder
         artworkId: AUCTION.artwork_id
         quantity: 1

--- a/src/desktop/apps/artwork/components/commercial/templates/index.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/index.jade
@@ -1,4 +1,4 @@
-- var newBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature("New Buy Now Flow")
+- var newBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW || (user && user.hasLabFeature("New Buy Now Flow"))
 - var auctionPartner = artwork.partner.type === 'Auction' || artwork.partner.type === 'Auction House'
 
 .artwork-commercial( class='js-artwork-commercial' )

--- a/src/desktop/apps/artwork/components/commercial/templates/index.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/index.jade
@@ -1,4 +1,4 @@
-- var newBuyNowFlow = user && user.hasLabFeature("New Buy Now Flow")
+- var newBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature("New Buy Now Flow")
 - var auctionPartner = artwork.partner.type === 'Auction' || artwork.partner.type === 'Auction House'
 
 .artwork-commercial( class='js-artwork-commercial' )

--- a/src/desktop/apps/artwork/components/commercial/templates/inquire.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/inquire.jade
@@ -1,5 +1,5 @@
 - var auctionPartner = artwork.partner && artwork.partner.type === 'Auction' || artwork.partner.type === 'Auction House'
-- var newBuyNowFlow = user && user.hasLabFeature("New Buy Now Flow")
+- var newBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature("New Buy Now Flow")
 
 //- TODO BNMO: Update to hide if the artwork is acquireable
 unless artwork.is_acquireable && (auctionPartner || newBuyNowFlow)

--- a/src/desktop/apps/artwork/components/commercial/templates/inquire.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/inquire.jade
@@ -1,5 +1,5 @@
 - var auctionPartner = artwork.partner && artwork.partner.type === 'Auction' || artwork.partner.type === 'Auction House'
-- var newBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature("New Buy Now Flow")
+- var newBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW || (user && user.hasLabFeature("New Buy Now Flow"))
 
 //- TODO BNMO: Update to hide if the artwork is acquireable
 unless artwork.is_acquireable && (auctionPartner || newBuyNowFlow)

--- a/src/desktop/apps/artwork/components/commercial/templates/price.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/price.jade
@@ -12,7 +12,7 @@ if artwork.sale_message || isPermanentCollection
               != stitch.components.TooltipQuestion({horizontalAlign: 'left', message: 'The range is an approximate indication of the work’s price point, and the exact price is quoted upon request.'})
         .artwork-commercial__shipping-info
           //- TODO: remove labFeature check once BNMO goes live to everybody
-          if sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature('New Buy Now Flow')
+          if sd.ENABLE_NEW_BUY_NOW_FLOW || (user && user.hasLabFeature('New Buy Now Flow'))
             | #{artwork.shippingInfo}
             if artwork.shippingOrigin
               br

--- a/src/desktop/apps/artwork/components/commercial/templates/price.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/price.jade
@@ -12,7 +12,7 @@ if artwork.sale_message || isPermanentCollection
               != stitch.components.TooltipQuestion({horizontalAlign: 'left', message: 'The range is an approximate indication of the work’s price point, and the exact price is quoted upon request.'})
         .artwork-commercial__shipping-info
           //- TODO: remove labFeature check once BNMO goes live to everybody
-          if user && user.hasLabFeature('New Buy Now Flow')
+          if sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature('New Buy Now Flow')
             | #{artwork.shippingInfo}
             if artwork.shippingOrigin
               br

--- a/src/desktop/apps/artwork/components/commercial/view.coffee
+++ b/src/desktop/apps/artwork/components/commercial/view.coffee
@@ -48,8 +48,8 @@ module.exports = class ArtworkCommercialView extends Backbone.View
 
     loggedInUser = CurrentUser.orNull()
 
-    # Show the new buy now flow if you have the lab feature enabled
-    if loggedInUser?.hasLabFeature('New Buy Now Flow')
+    # Show the new buy now flow if you have the lab feature or feature flag enabled
+    if sd.ENABLE_NEW_BUY_NOW_FLOW || loggedInUser?.hasLabFeature('New Buy Now Flow')
 
       serializer = new Serializer @$('form')
       data = serializer.data()

--- a/src/desktop/apps/artwork/components/partner/index.jade
+++ b/src/desktop/apps/artwork/components/partner/index.jade
@@ -1,4 +1,4 @@
-if user && user.hasLabFeature('New Buy Now Flow')
+if sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature('New Buy Now Flow')
   //- Hide old Partner / Gallery info section in favor of ArtworkDetails
 else
   if helpers.partner.isDisplayable(artwork.partner)

--- a/src/desktop/apps/artwork/components/partner/index.jade
+++ b/src/desktop/apps/artwork/components/partner/index.jade
@@ -1,4 +1,4 @@
-if sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature('New Buy Now Flow')
+if sd.ENABLE_NEW_BUY_NOW_FLOW || (user && user.hasLabFeature('New Buy Now Flow'))
   //- Hide old Partner / Gallery info section in favor of ArtworkDetails
 else
   if helpers.partner.isDisplayable(artwork.partner)

--- a/src/mobile/apps/artwork/components/meta_data/templates/description.jade
+++ b/src/mobile/apps/artwork/components/meta_data/templates/description.jade
@@ -1,5 +1,5 @@
 .artwork-meta-data-module__description
-  if user && user.hasLabFeature('New Buy Now Flow')
+  if sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature('New Buy Now Flow')
     != stitch.components.ArtworkDetails({artworkID: artwork.id})
   else if artwork.description || artwork.additional_information || artwork.signature || artwork.manufacturer || artwork.publisher || artwork.series
     h2.artwork-header About the Work

--- a/src/mobile/apps/artwork/components/meta_data/templates/description.jade
+++ b/src/mobile/apps/artwork/components/meta_data/templates/description.jade
@@ -1,5 +1,5 @@
 .artwork-meta-data-module__description
-  if sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature('New Buy Now Flow')
+  if sd.ENABLE_NEW_BUY_NOW_FLOW || (user && user.hasLabFeature('New Buy Now Flow'))
     != stitch.components.ArtworkDetails({artworkID: artwork.id})
   else if artwork.description || artwork.additional_information || artwork.signature || artwork.manufacturer || artwork.publisher || artwork.series
     h2.artwork-header About the Work

--- a/src/mobile/apps/artwork/components/meta_data/templates/inquiry.jade
+++ b/src/mobile/apps/artwork/components/meta_data/templates/inquiry.jade
@@ -1,5 +1,5 @@
 - var isAuction = artwork.auction && artwork.auction.is_auction
-- var newBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature("New Buy Now Flow")
+- var newBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW || (user && user.hasLabFeature("New Buy Now Flow"))
 - var buyable = artwork.is_buy_nowable || artwork.is_acquireable
 - var isAuctionPartner = artwork.partner.type === 'Auction' || artwork.partner.type === 'Auction House'
 

--- a/src/mobile/apps/artwork/components/meta_data/templates/inquiry.jade
+++ b/src/mobile/apps/artwork/components/meta_data/templates/inquiry.jade
@@ -1,5 +1,5 @@
 - var isAuction = artwork.auction && artwork.auction.is_auction
-- var newBuyNowFlow = user && user.hasLabFeature("New Buy Now Flow")
+- var newBuyNowFlow = sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature("New Buy Now Flow")
 - var buyable = artwork.is_buy_nowable || artwork.is_acquireable
 - var isAuctionPartner = artwork.partner.type === 'Auction' || artwork.partner.type === 'Auction House'
 

--- a/src/mobile/apps/artwork/components/meta_data/templates/partner.jade
+++ b/src/mobile/apps/artwork/components/meta_data/templates/partner.jade
@@ -1,6 +1,6 @@
 - var partner = artwork.partner
 
-if !user || !user.hasLabFeature('New Buy Now Flow')
+if !sd.ENABLE_NEW_BUY_NOW_FLOW && !(user && user.hasLabFeature('New Buy Now Flow'))
   .artwork-meta-data__partner
     if partner.type == 'Auction' || partner.type == 'Auction House'
       .artwork-partner-name= partner.name

--- a/src/mobile/apps/artwork/components/meta_data/templates/price.jade
+++ b/src/mobile/apps/artwork/components/meta_data/templates/price.jade
@@ -5,7 +5,7 @@ if artwork.sale_message
     if artwork.price && artwork.availability !== 'sold'
       .shipping-info
         //- TODO: remove labFeature check once BNMO goes live to everybody
-        if sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature('New Buy Now Flow')
+        if sd.ENABLE_NEW_BUY_NOW_FLOW || (user && user.hasLabFeature('New Buy Now Flow'))
           | #{artwork.shippingInfo}
           if artwork.shippingOrigin
             br

--- a/src/mobile/apps/artwork/components/meta_data/templates/price.jade
+++ b/src/mobile/apps/artwork/components/meta_data/templates/price.jade
@@ -5,7 +5,7 @@ if artwork.sale_message
     if artwork.price && artwork.availability !== 'sold'
       .shipping-info
         //- TODO: remove labFeature check once BNMO goes live to everybody
-        if user && user.hasLabFeature('New Buy Now Flow')
+        if sd.ENABLE_NEW_BUY_NOW_FLOW || user && user.hasLabFeature('New Buy Now Flow')
           | #{artwork.shippingInfo}
           if artwork.shippingOrigin
             br

--- a/src/mobile/apps/artwork/components/meta_data/test/template.coffee
+++ b/src/mobile/apps/artwork/components/meta_data/test/template.coffee
@@ -210,6 +210,7 @@ describe 'Artwork metadata templates', ->
       it 'should drop institution header', ->
         html = render('partner')(
           artwork: @artwork
+          sd: {}
         )
 
         $ = cheerio.load(html)
@@ -218,6 +219,7 @@ describe 'Artwork metadata templates', ->
       it 'should display collecting institution as link text', ->
         html = render('partner')(
           artwork: @artwork
+          sd: {}
         )
 
         $ = cheerio.load(html)
@@ -232,6 +234,7 @@ describe 'Artwork metadata templates', ->
 
         @html = render('partner')(
           artwork: @artwork
+          sd: {}
         )
 
       it 'should link to partner\'s page', ->
@@ -249,6 +252,7 @@ describe 'Artwork metadata templates', ->
 
         @html = render('partner')(
           artwork: @artwork
+          sd: {}
         )
 
       it 'should link to partner\'s page', ->
@@ -267,6 +271,7 @@ describe 'Artwork metadata templates', ->
 
       @html = render('index')(
         artwork: @artwork
+        sd: {}
       )
 
     it 'displays estimation', ->

--- a/src/mobile/apps/artwork/components/meta_data/view.coffee
+++ b/src/mobile/apps/artwork/components/meta_data/view.coffee
@@ -21,7 +21,7 @@ module.exports = class MetaDataView extends Backbone.View
       @model.get('partner').type == 'Auction' or
       @model.get('partner').type == 'Auction House'
 
-    if loggedInUser?.hasLabFeature('New Buy Now Flow')
+    if sd.ENABLE_NEW_BUY_NOW_FLOW || loggedInUser?.hasLabFeature('New Buy Now Flow')
       # If this artwork has an edition set of 1, send that in the mutation as well
       if @model.get('edition_sets')?.length && @model.get('edition_sets').length == 1
         singleEditionSetId = @model.get('edition_sets')[0] && @model.get('edition_sets')[0].id

--- a/src/mobile/apps/artwork/components/meta_data/view.coffee
+++ b/src/mobile/apps/artwork/components/meta_data/view.coffee
@@ -2,6 +2,7 @@ Backbone = require 'backbone'
 CurrentUser = require '../../../../models/current_user.coffee'
 { createOrder } = require '../../../../../lib/components/create_order'
 { acquireArtwork } = require('../../../../components/acquire/view.coffee')
+sd = require('sharify').data
 
 module.exports = class MetaDataView extends Backbone.View
 

--- a/src/mobile/apps/artwork/templates/index.jade
+++ b/src/mobile/apps/artwork/templates/index.jade
@@ -7,7 +7,7 @@ block content
 
   include ../components/image/templates/index.jade
   include ../components/meta_data/templates/index.jade
-  if !user || !user.hasLabFeature('New Buy Now Flow')
+  if !sd.ENABLE_NEW_BUY_NOW_FLOW && !(user || user.hasLabFeature('New Buy Now Flow'))
     include ../components/tabs/templates/index.jade
   include ../components/highlights/templates/index.jade
   include ../components/artist/templates/index.jade

--- a/src/mobile/apps/artwork/templates/index.jade
+++ b/src/mobile/apps/artwork/templates/index.jade
@@ -7,7 +7,7 @@ block content
 
   include ../components/image/templates/index.jade
   include ../components/meta_data/templates/index.jade
-  if !sd.ENABLE_NEW_BUY_NOW_FLOW && !(user || user.hasLabFeature('New Buy Now Flow'))
+  if !sd.ENABLE_NEW_BUY_NOW_FLOW && !(user && user.hasLabFeature('New Buy Now Flow'))
     include ../components/tabs/templates/index.jade
   include ../components/highlights/templates/index.jade
   include ../components/artist/templates/index.jade


### PR DESCRIPTION
This PR follows up https://github.com/artsy/force/pull/2958 by adding a check for the `ENABLE_NEW_BUY_NOW_FLOW` feature flag everywhere we are currently checking for the lab feature.

Verified locally (desktop + mobile web) with artworks in the following states:
- Gallery artwork enabled for ecommerce
- Auction Partner artwork enabled for ecommerce
- Artwork in an auction enabled for ecommerce + bidding

Once this is merged, we should set the flag to TRUE on staging. Note that if you are logged out, you won't be able to create an order until https://artsyproduct.atlassian.net/browse/PURCHASE-487 is done.