### PR TITLE
Switches to posts to chill out the logging in positron

### DIFF
--- a/src/desktop/lib/positronql.js
+++ b/src/desktop/lib/positronql.js
@@ -4,7 +4,7 @@ const { POSITRON_URL } = require("sharify").data
 const POSITRON_GRAPHQL_URL = POSITRON_URL + "/api/graphql"
 
 export const positronql = options => {
-  const { method = "get", query, variables, req } = options
+  const { method = "post", query, variables, req } = options
 
   return new Promise((resolve, reject) => {
     const r = request[method](POSITRON_GRAPHQL_URL).set(
@@ -16,7 +16,7 @@ export const positronql = options => {
       r.set("X-Access-Token", req.user.get("accessToken"))
     }
 
-    r.query({
+    r.send({
       query,
       variables: JSON.stringify(variables),
     })


### PR DESCRIPTION
This switches the default implementation of positronQL to use posts instead of gets - this makes logging more reasonable in positron 

<img width="1529" alt="screen shot 2018-10-06 at 10 43 21 am" src="https://user-images.githubusercontent.com/49038/46572490-b1124300-c954-11e8-9ed0-f5c0de0d1634.png">

Tested locally:

<img width="1370" alt="screen shot 2018-10-06 at 10 41 22 am" src="https://user-images.githubusercontent.com/49038/46572493-bbccd800-c954-11e8-89f2-7c139f400720.png">
