### PR TITLE
Updates routing to handle /orders as well as /order2

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@artsy/express-reloadable": "^1.3.1",
     "@artsy/palette": "^2.18.1",
     "@artsy/passport": "^1.0.11",
-    "@artsy/reaction": "^5.3.8",
+    "@artsy/reaction": "^5.3.9",
     "@artsy/stitch": "^2.0.0",
     "@babel/core": "^7.0.0",
     "@babel/node": "^7.0.0",

--- a/src/desktop/apps/artwork/components/auction/view.coffee
+++ b/src/desktop/apps/artwork/components/auction/view.coffee
@@ -77,7 +77,7 @@ module.exports = class ArtworkAuctionView extends Backbone.View
         user: loggedInUser
       .then (data) ->
         order = data?.ecommerceCreateOrderWithArtwork?.orderOrError?.order
-        location.assign("/order2/#{order.id}/shipping")
+        location.assign("/orders/#{order.id}/shipping")
 
     # Legacy purchase flow
     else

--- a/src/desktop/apps/artwork/components/commercial/view.coffee
+++ b/src/desktop/apps/artwork/components/commercial/view.coffee
@@ -66,7 +66,7 @@ module.exports = class ArtworkCommercialView extends Backbone.View
         user: loggedInUser
       .then (data) ->
         order = data?.ecommerceCreateOrderWithArtwork?.orderOrError?.order
-        location.assign("/order2/#{order.id}/shipping")
+        location.assign("/orders/#{order.id}/shipping")
 
     else if @artwork.get('partner_type') == "Auction" or @artwork.get('partner_type') == "Auction House"
       order = new PendingOrder

--- a/src/desktop/apps/order2/__tests__/routes.jest.js
+++ b/src/desktop/apps/order2/__tests__/routes.jest.js
@@ -16,11 +16,11 @@ describe("Request for order", () => {
   let next
   const sendMock = jest.fn()
 
-  describe("/order2/:orderID", () => {
+  describe("/orders/:orderID", () => {
     beforeEach(() => {
       req = {
-        path: "/order2/123",
-        originalUrl: "/order2/123",
+        path: "/orders/123",
+        originalUrl: "/orders/123",
         query: {},
         header: () => "referrer",
       }
@@ -42,7 +42,7 @@ describe("Request for order", () => {
     it("redirects an unauthenticated user to log in", done => {
       checkoutFlow(req, res, next).then(() => {
         expect(res.redirect).toHaveBeenCalledWith(
-          "/login?redirectTo=%2Forder2%2F123"
+          "/login?redirectTo=%2Forders%2F123"
         )
         done()
       })

--- a/src/desktop/apps/order2/server.js
+++ b/src/desktop/apps/order2/server.js
@@ -3,6 +3,7 @@ import { checkoutFlow } from "desktop/apps/order2/routes"
 
 const app = (module.exports = express())
 
+app.get("/orders/:orderID*", checkoutFlow)
 app.get("/order2/:orderID*", checkoutFlow)
 
 export default app

--- a/src/mobile/apps/artwork/components/meta_data/view.coffee
+++ b/src/mobile/apps/artwork/components/meta_data/view.coffee
@@ -33,6 +33,6 @@ module.exports = class MetaDataView extends Backbone.View
         user: loggedInUser
       .then (data) ->
         order = data?.ecommerceCreateOrderWithArtwork?.orderOrError?.order
-        location.assign("/order2/#{order.id}/shipping")
+        location.assign("/orders/#{order.id}/shipping")
     else if isAuctionPartner
       acquireArtwork @model, $(e.target), @editionSetId

--- a/yarn.lock
+++ b/yarn.lock
@@ -10137,7 +10137,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
+react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,9 +46,9 @@
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
-"@artsy/reaction@^5.3.8":
-  version "5.3.8"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-5.3.8.tgz#9d217675be32533fcdd6d8f497eb0b95b29fbad3"
+"@artsy/reaction@^5.3.9":
+  version "5.3.9"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-5.3.9.tgz#16c8be35c0b342f2816003ec3b5b9842c82020d0"
   dependencies:
     "@artsy/palette" "^2.19.1"
     cheerio "^1.0.0-rc.2"
@@ -10137,7 +10137,7 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
+"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 


### PR DESCRIPTION
This updates force to both send new orders to the `/orders` route _and_ continue to support the existing `/order2` route until we deprecate it completely.