### PR TITLE
add ecommerce artwork pageview tracking to mobile web

### DIFF
--- a/src/mobile/analytics/before_ready.js
+++ b/src/mobile/analytics/before_ready.js
@@ -10,11 +10,19 @@ if (!location.pathname.match(/^\/article/)) {
   window.PARSELY = { autotrack: false }
 }
 
+const pageType = window.sd.PAGE_TYPE || window.location.pathname.split("/")[1]
+var properties = { path: location.pathname }
+
+if (pageType == "artwork") {
+  properties["acquireable"] = sd.ARTWORK.is_acquireable
+  properties["availability"] = sd.ARTWORK.availability
+  properties["price_listed"] = sd.ARTWORK.price && sd.ARTWORK.price.length > 0
+}
+
+console.log(properties)
+
 // Track pageview
-analytics.page(
-  { path: location.pathname },
-  { integrations: { Marketo: false } }
-)
+analytics.page(properties, { integrations: { Marketo: false } })
 
 // Track pageload speed
 if (
@@ -23,8 +31,6 @@ if (
   sd.TRACK_PAGELOAD_PATHS
 ) {
   window.addEventListener("load", function() {
-    const pageType =
-      window.sd.PAGE_TYPE || window.location.pathname.split("/")[1]
     if (sd.TRACK_PAGELOAD_PATHS.split("|").includes(pageType)) {
       window.setTimeout(function() {
         const {


### PR DESCRIPTION
This is the same analytics code I pushed for desktop [a couple of weeks back](https://github.com/artsy/force/pull/2909). Soon to be deprecated hopefully as we switch to responsive design on the Artwork page!