### PR TITLE
@sweir27 => Fix for Contact GalleryBuy display on older artwork bricks

### DIFF
--- a/src/desktop/components/artwork_item/templates/artwork.jade
+++ b/src/desktop/components/artwork_item/templates/artwork.jade
@@ -26,9 +26,9 @@ figure.artwork-item( data-artwork= artwork.get('id') data-id= artwork.get('_id')
     include ./partials/auction_info
     if hasAuctionPartner && !isAuction
       include ./partials/bid_now
-    if showContact && !hasAuctionPartner
-      include ./partials/contact
     if showBuyButton
       include ./partials/buy_button
-    if showBuyLink
+    else if showBuyLink
       include ./partials/buy_link
+    else if showContact && !hasAuctionPartner
+      include ./partials/contact

--- a/src/desktop/components/artwork_item/test/artwork.coffee
+++ b/src/desktop/components/artwork_item/test/artwork.coffee
@@ -188,18 +188,23 @@ describe 'Artwork Item template', ->
 
   describe 'buy button', ->
 
-    it 'renders a buy button if the work is acquirable and purchase is allowed', ->
-      @artwork = new Artwork fabricate 'artwork', { acquireable: true }
+    it 'renders a buy button if the work is acquirable and purchase is allowed, and not a contact CTA', ->
+      # Check that initially we have a contact CTA and no buy button
+      @artwork = new Artwork fabricate 'artwork', { forsale: true }
       $ = cheerio.load render('artwork')
         artwork: @artwork
         sd: {}
       $('.artwork-item-buy').should.have.lengthOf 0
+      $('.artwork-item-contact-seller').text().should.equal 'Contact gallery'
 
+      # Check that now there is a buy button and no contact CTA
+      @artwork.set('acquireable', true)
       $ = cheerio.load render('artwork')
         artwork: @artwork
         displayPurchase: true
         sd: {}
       $('.artwork-item-buy').should.have.lengthOf 1
+      $('.artwork-item-contact-seller').should.have.lengthOf 0
 
   describe 'sold', ->
 


### PR DESCRIPTION
Kind of a weird one.

Old-school bricks (we only update the new Reaction bricks for badges, etc.) still should work, minimally speaking.

<img width="303" alt="screen shot 2018-10-10 at 12 44 52 pm" src="https://user-images.githubusercontent.com/1457859/46752113-5d706400-cc8a-11e8-8529-a103ae70b2f1.png">

We noticed the above ^ on some of the older pages (partner profile, old collect) for acquireable works.

I think this fix makes sense, and checking a couple examples with this fix, looks good.

<img width="523" alt="screen shot 2018-10-10 at 12 43 06 pm" src="https://user-images.githubusercontent.com/1457859/46752149-74af5180-cc8a-11e8-9a0d-2a3c03c9d63e.png">
 