### PR TITLE
add google ads tracking to artwork pages

### DIFF
--- a/src/desktop/apps/artwork/components/google/index.jade
+++ b/src/desktop/apps/artwork/components/google/index.jade
@@ -1,0 +1,11 @@
+<!-- Global site tag - AdWords -->
+script(type='text/javascript' async src="https://www.googletagmanager.com/gtag/js?id=#{sd.GOOGLE_ADWORDS_ID}")
+script(type='text/javascript').
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', "#{sd.GOOGLE_ADWORDS_ID}");
+  gtag('event', 'page_view', {
+    'send_to': "#{sd.GOOGLE_ADWORDS_ID}",
+    'dynx_itemid': "#{artwork._id}"
+  });

--- a/src/desktop/apps/artwork/templates/index.jade
+++ b/src/desktop/apps/artwork/templates/index.jade
@@ -6,6 +6,7 @@ append locals
 block head
   include ../components/meta/index
   include ../components/facebook/index
+  include ../components/google/index
 
 block body
   - isAuction = artwork.context && artwork.context.__typename == 'ArtworkContextAuction'

--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -66,6 +66,7 @@ module.exports =
   GENOME_URL: 'https://helix.artsy.net'
   GEODATA_URL: 'http://artsy-geodata.s3-website-us-east-1.amazonaws.com'
   GEOIP_ENDPOINT: 'https://artsy-geoip.herokuapp.com/'
+  GOOGLE_ADWORDS_ID: null
   GOOGLE_MAPS_API_KEY: null
   INTERCOM_APP_ID: null
   INTERCOM_ENABLED: false

--- a/src/lib/setup_sharify.js
+++ b/src/lib/setup_sharify.js
@@ -68,6 +68,7 @@ sharify.data = _.extend(
     "GEODATA_URL",
     "GOOGLE_ANALYTICS_ID",
     "GOOGLE_MAPS_API_KEY",
+    "GOOGLE_ADWORDS_ID",
     "IMAGE_PROXY",
     "INTERCOM_APP_ID",
     "INTERCOM_ENABLED",

--- a/src/mobile/analytics/before_ready.js
+++ b/src/mobile/analytics/before_ready.js
@@ -19,8 +19,6 @@ if (pageType == "artwork") {
   properties["price_listed"] = sd.ARTWORK.price && sd.ARTWORK.price.length > 0
 }
 
-console.log(properties)
-
 // Track pageview
 analytics.page(properties, { integrations: { Marketo: false } })
 
@@ -30,9 +28,9 @@ if (
   window.performance.timing &&
   sd.TRACK_PAGELOAD_PATHS
 ) {
-  window.addEventListener("load", function() {
+  window.addEventListener("load", function () {
     if (sd.TRACK_PAGELOAD_PATHS.split("|").includes(pageType)) {
-      window.setTimeout(function() {
+      window.setTimeout(function () {
         const {
           requestStart,
           loadEventEnd,


### PR DESCRIPTION
As with our FB tracking code, this sends a product ID over to Google Ads when users are visiting artwork pages. This is a requirement for retargeting Buy Now works over the Google Ads display network. This is a high priority request from marketing as we've been banned from Criteo and need to use Google as a marketing channel for Buy Now. It takes 24-48 hours for this to start populating pageviews on the Google Ads side.

No additional user data is sent in the request.

I've added the `GOOGLE_ADWORDS_ID` ENV var to staging and production.