### PR TITLE
Add tracking on buy now checkout flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@artsy/express-reloadable": "^1.3.1",
     "@artsy/palette": "^2.18.1",
     "@artsy/passport": "^1.0.11",
-    "@artsy/reaction": "^5.6.3",
+    "@artsy/reaction": "^5.7.1",
     "@artsy/stitch": "^2.0.0",
     "@babel/core": "^7.0.0",
     "@babel/node": "^7.0.0",

--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -49,37 +49,45 @@ if (
   })
 }
 
-// Track 15 second bounce rate
-setTimeout(function() {
-  analytics.track("Time on page", {
-    category: "15 Seconds",
-    message: sd.CURRENT_PATH,
-  })
-}, 15000)
+class PageTimeTracker {
+  constructor(path, delay, description) {
+    this.path = path
+    this.delay = delay
+    this.description = description
+    this.timer = null
+    this.track()
+  }
 
-// Track 30 second bounce rate
-setTimeout(function() {
-  analytics.track("Time on page", {
-    category: "30 Seconds",
-    message: sd.CURRENT_PATH,
-  })
-}, 30000)
+  setPath(newPath) {
+    this.path = newPath
+  }
 
-// Track 1 min bounce rate
-setTimeout(function() {
-  analytics.track("Time on page", {
-    category: "1 Minute",
-    message: sd.CURRENT_PATH,
-  })
-}, 60000)
+  track() {
+    this.timer = setTimeout(() => {
+      window.analytics.track("Time on page", {
+        category: this.description,
+        message: this.path,
+      })
+    }, this.delay)
+  }
 
-// Track 3 Minute bounce rate
-setTimeout(function() {
-  analytics.track("Time on page", {
-    category: "3 Minutes",
-    message: sd.CURRENT_PATH,
-  })
-}, 180000)
+  clear() {
+    if (this.timer) clearTimeout(this.delay)
+  }
+
+  reset(newPath = null) {
+    this.clear()
+    if (newPath) this.setPath(newPath)
+    this.track()
+  }
+}
+
+window.desktopPageTimeTrackers = [
+  new PageTimeTracker(sd.CURRENT_PATH, 15000, "15 seconds"),
+  new PageTimeTracker(sd.CURRENT_PATH, 30000, "30 seconds"),
+  new PageTimeTracker(sd.CURRENT_PATH, 60000, "1 minute"),
+  new PageTimeTracker(sd.CURRENT_PATH, 180000, "3 minutes"),
+]
 
 // debug tracking calls
 if (sd.SHOW_ANALYTICS_CALLS) {

--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -16,6 +16,10 @@ if (pageType == "artwork") {
   properties["price_listed"] = sd.ARTWORK.price && sd.ARTWORK.price.length > 0
 }
 
+if (pageType === "order2") {
+  properties[""]
+}
+
 analytics.page(properties, { integrations: { Marketo: false } })
 
 // Track pageload speed

--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -16,7 +16,12 @@ if (pageType == "artwork") {
   properties["price_listed"] = sd.ARTWORK.price && sd.ARTWORK.price.length > 0
 }
 
-analytics.page(properties, { integrations: { Marketo: false } })
+// We exclude 'orders' routes from analytics.page calls because they're already
+// taken care of in another place.
+const excludedRoutes = ["orders"]
+if (!excludedRoutes.includes(pageType)) {
+  analytics.page(properties, { integrations: { Marketo: false } })
+}
 
 // Track pageload speed
 if (

--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -68,7 +68,7 @@ class PageTimeTracker {
   }
 
   clear() {
-    if (this.timer) clearTimeout(this.delay)
+    if (this.timer) clearTimeout(this.timer)
   }
 
   reset(newPath = null) {

--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -16,10 +16,6 @@ if (pageType == "artwork") {
   properties["price_listed"] = sd.ARTWORK.price && sd.ARTWORK.price.length > 0
 }
 
-if (pageType === "order2") {
-  properties[""]
-}
-
 analytics.page(properties, { integrations: { Marketo: false } })
 
 // Track pageload speed

--- a/src/desktop/apps/artwork/components/auction/test/view.coffee
+++ b/src/desktop/apps/artwork/components/auction/test/view.coffee
@@ -10,7 +10,7 @@ describe 'auction', ->
   before (done) ->
     sinon.stub global, 'setTimeout'
     benv.setup ->
-      benv.expose $: benv.require('jquery'), jQuery: benv.require('jquery')
+      benv.expose $: benv.require('jquery'), jQuery: benv.require('jquery'), analytics: track: sinon.stub()
       Backbone.$ = $
       done()
 

--- a/src/desktop/apps/artwork/components/auction/view.coffee
+++ b/src/desktop/apps/artwork/components/auction/view.coffee
@@ -71,6 +71,11 @@ module.exports = class ArtworkAuctionView extends Backbone.View
 
     # Show the new buy now flow if you have the lab feature enabled
     if ENABLE_NEW_BUY_NOW_FLOW || loggedInUser?.hasLabFeature('New Buy Now Flow')
+      analytics.track('Click', {
+        subject: 'buy',
+        type: 'button',
+        flow: 'buy now'
+      })
       if loggedInUser
         $target.attr 'data-state', 'loading'
 

--- a/src/desktop/apps/artwork/components/commercial/templates/questions.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/questions.jade
@@ -1,10 +1,11 @@
 - isBuyNowWork = artwork.is_acquireable && (newBuyNowFlow && artwork.partner.type != 'Auction House')
 
 if artwork.is_for_sale
+  - var isBNMOArtwork = artwork.is_acquireable && (newBuyNowFlow && artwork.partner.type != 'Auction House')
   .artwork-commercial__questions
     | Have a question?&nbsp;
     if isBuyNowWork
-      a.collector-faq-buy-now( href='https://www.artsy.net/buy-now-feature-faq' target="_blank" onclick='' ) Read our FAQ
+      a.collector-faq-buy-now( class=isBNMOArtwork ? 'js-artwork-bnmo-collector-faq' : '' href='https://www.artsy.net/buy-now-feature-faq' target="_blank" onclick='' ) Read our FAQ
     else
       a.collector-faq( href='/#' ) Read our FAQ
     if isBuyNowWork

--- a/src/desktop/apps/artwork/components/commercial/test/view.coffee
+++ b/src/desktop/apps/artwork/components/commercial/test/view.coffee
@@ -14,6 +14,7 @@ describe 'ArtworkCommercialView', ->
     benv.setup ->
       benv.expose
         $: benv.require 'jquery'
+        analytics: track: sinon.stub()
         user: user
         sd:
           FORCED_LOGIN_INQUIRY: 'default'

--- a/src/desktop/apps/artwork/components/commercial/view.coffee
+++ b/src/desktop/apps/artwork/components/commercial/view.coffee
@@ -58,9 +58,6 @@ module.exports = class ArtworkCommercialView extends Backbone.View
 
     # Show the new buy now flow if you have the lab feature or feature flag enabled
     if sd.ENABLE_NEW_BUY_NOW_FLOW || loggedInUser?.hasLabFeature('New Buy Now Flow')
-    # Show the new buy now flow if you have the lab feature enabled
-    if loggedInUser?.hasLabFeature('New Buy Now Flow')
-
       analytics.track('Click', {
         subject: 'buy now',
         type: 'button',

--- a/src/desktop/apps/artwork/components/commercial/view.coffee
+++ b/src/desktop/apps/artwork/components/commercial/view.coffee
@@ -43,6 +43,11 @@ module.exports = class ArtworkCommercialView extends Backbone.View
 
   inquireSpecialist: (e) ->
     e.preventDefault()
+    analytics.track('Click', {
+      subject: 'ask a specialist',
+      type: 'button',
+      flow: 'buy now'
+    })
     inquireSpecialist @artwork.get('_id'), ask_specialist: true
 
   acquire: (e) ->

--- a/src/desktop/apps/artwork/components/commercial/view.coffee
+++ b/src/desktop/apps/artwork/components/commercial/view.coffee
@@ -30,6 +30,7 @@ module.exports = class ArtworkCommercialView extends Backbone.View
     'click .js-artwork-inquire-button'      : 'inquire'
     'click .js-artwork-acquire-button'      : 'acquire'
     'click .collector-faq'                  : 'openCollectorModal'
+    'click .js-artwork-bnmo-collector-faq'  : 'trackOpenCollectorModal'
     'click .js-artwork-bnmo-ask-specialist' : 'inquireSpecialist'
 
   initialize: ({ @data }) ->
@@ -160,6 +161,14 @@ module.exports = class ArtworkCommercialView extends Backbone.View
   openCollectorModal: (e) ->
     e.preventDefault()
     openMultiPageModal 'collector-faqs'
+
+  trackOpenCollectorModal: (e) ->
+    e.preventDefault()
+    analytics.track('Click', {
+      subject: 'read faq',
+      type: 'button',
+      flow: 'buy now'
+    })
 
   render: ->
     if @data.artwork.fair

--- a/src/desktop/apps/artwork/components/commercial/view.coffee
+++ b/src/desktop/apps/artwork/components/commercial/view.coffee
@@ -59,9 +59,9 @@ module.exports = class ArtworkCommercialView extends Backbone.View
     # Show the new buy now flow if you have the lab feature or feature flag enabled
     if sd.ENABLE_NEW_BUY_NOW_FLOW || loggedInUser?.hasLabFeature('New Buy Now Flow')
       analytics.track('Click', {
-        subject: 'buy now',
+        subject: 'buy',
         type: 'button',
-        flow: 'buy'
+        flow: 'buy now'
       })
 
       serializer = new Serializer @$('form')

--- a/src/desktop/apps/artwork/components/commercial/view.coffee
+++ b/src/desktop/apps/artwork/components/commercial/view.coffee
@@ -52,6 +52,15 @@ module.exports = class ArtworkCommercialView extends Backbone.View
 
     # Show the new buy now flow if you have the lab feature or feature flag enabled
     if sd.ENABLE_NEW_BUY_NOW_FLOW || loggedInUser?.hasLabFeature('New Buy Now Flow')
+    # Show the new buy now flow if you have the lab feature enabled
+    if loggedInUser?.hasLabFeature('New Buy Now Flow')
+
+      analytics.track('Click', {
+        subject: 'buy now',
+        type: 'button',
+        flow: 'buy'
+      })
+
       serializer = new Serializer @$('form')
       data = serializer.data()
       editionSetId = data.edition_set_id

--- a/src/desktop/apps/order2/client.js
+++ b/src/desktop/apps/order2/client.js
@@ -48,9 +48,11 @@ orderCheckoutFlowEvents.map(eventName => {
     )
     // Reset timers that track time on page since we're tracking each order
     // checkout view as a separate page.
-    window.desktopPageTimeTrackers.forEach(tracker =>
-      tracker.reset(window.location.pathname)
-    )
+    window.desktopPageTimeTrackers.forEach(tracker => {
+      // No need to reset the tracker if we're on the same page.
+      if (window.location.pathname !== tracker.path)
+        tracker.reset(window.location.pathname)
+    })
   })
 })
 

--- a/src/desktop/apps/order2/client.js
+++ b/src/desktop/apps/order2/client.js
@@ -39,6 +39,7 @@ const orderCheckoutFlowEvents = [
   "order:shipping",
   "order:payment",
   "order:review",
+  "order:status",
 ]
 orderCheckoutFlowEvents.map(eventName => {
   mediator.on(eventName, () => {

--- a/src/desktop/apps/order2/client.js
+++ b/src/desktop/apps/order2/client.js
@@ -33,6 +33,22 @@ mediator.on("openOrdersContactArtsyModal", options => {
   }
 })
 
+// Track page views for order checkout flow: shipping, payment and review.
+// These events are triggered from Reaction.
+const orderCheckoutFlowEvents = [
+  "order:shipping",
+  "order:payment",
+  "order:review",
+]
+orderCheckoutFlowEvents.map(eventName => {
+  mediator.on(eventName, () => {
+    window.analytics.page(
+      { path: window.location.pathname },
+      { integrations: { Marketo: false } }
+    )
+  })
+})
+
 buildClientApp({
   routes,
   context: {

--- a/src/desktop/apps/order2/client.js
+++ b/src/desktop/apps/order2/client.js
@@ -46,6 +46,11 @@ orderCheckoutFlowEvents.map(eventName => {
       { path: window.location.pathname },
       { integrations: { Marketo: false } }
     )
+    // Reset timers that track time on page since we're tracking each order
+    // checkout view as a separate page.
+    window.desktopPageTimeTrackers.forEach(tracker =>
+      tracker.reset(window.location.pathname)
+    )
   })
 })
 

--- a/src/mobile/apps/artwork/components/meta_data/test/view.coffee
+++ b/src/mobile/apps/artwork/components/meta_data/test/view.coffee
@@ -15,7 +15,7 @@ describe 'Metadata', ->
 
   before (done) ->
     benv.setup ->
-      benv.expose $: benv.require('jquery')
+      benv.expose $: benv.require('jquery'), analytics: track: sinon.stub()
       Backbone.$ = $
       done()
 

--- a/src/mobile/apps/artwork/components/meta_data/view.coffee
+++ b/src/mobile/apps/artwork/components/meta_data/view.coffee
@@ -25,6 +25,12 @@ module.exports = class MetaDataView extends Backbone.View
       @model.get('partner').type == 'Auction House'
 
     if sd.ENABLE_NEW_BUY_NOW_FLOW || loggedInUser?.hasLabFeature('New Buy Now Flow')
+      analytics.track('Click', {
+        subject: 'buy now',
+        type: 'button',
+        flow: 'buy'
+      })
+
       # If this artwork has an edition set of 1, send that in the mutation as well
       if @model.get('edition_sets')?.length && @model.get('edition_sets').length == 1
         singleEditionSetId = @model.get('edition_sets')[0] && @model.get('edition_sets')[0].id

--- a/src/mobile/apps/artwork/components/meta_data/view.coffee
+++ b/src/mobile/apps/artwork/components/meta_data/view.coffee
@@ -26,9 +26,9 @@ module.exports = class MetaDataView extends Backbone.View
 
     if sd.ENABLE_NEW_BUY_NOW_FLOW || loggedInUser?.hasLabFeature('New Buy Now Flow')
       analytics.track('Click', {
-        subject: 'buy now',
+        subject: 'buy',
         type: 'button',
-        flow: 'buy'
+        flow: 'buy now'
       })
 
       # If this artwork has an edition set of 1, send that in the mutation as well

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,10 +50,10 @@
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
-"@artsy/reaction@^5.6.3":
-  version "5.6.3"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-5.6.3.tgz#e9709a76366577f2e44a875cb5288a174256e686"
-  integrity sha512-MSYgvfh/O1Vr4UJwIVF5DFUiH4BLJhgF4Ha1x3e7lMpJva0T4fJEO9pfxVZV1zsBO0dHFOvkglHhlTSja0iBNQ==
+"@artsy/reaction@^5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-5.7.1.tgz#39ea94d80516e98cd1f37ea0b485c3a4cac7f508"
+  integrity sha512-8OSt3Rpw8kNZxYjR+5UUh4FtmHV5uRHIXrlxFPEPU61rTv+eIxSuhmWv4ogeHRsQhK6AkwCbEEg2FbZZPsszkQ==
   dependencies:
     "@artsy/palette" "^2.19.1"
     cheerio "^1.0.0-rc.2"


### PR DESCRIPTION
This PR adds tracking to the Buy Now checkout flow. See PURCHASE-489 for more details and https://github.com/artsy/reaction/pull/1395 for related work in Reaction.

### What changed
- Added click tracking for "buy now" buttons on artwork page for both desktop and mobile
- Added click tracking for ask a specialist and read FAQ links on artwork page
- Added page view tracking for shipping, payment and review views in buy now checkout flow
- Refactored time on page tracking code into `PageTimeTracker` class