### PR TITLE
[Toolchain] Revert webpack caching on certain loaders

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,26 +48,12 @@ const config = {
       {
         test: /\.coffee$/,
         include: /src/,
-        use: [
-          ...notOnCI({
-            loader: "cache-loader",
-            options: {
-              cacheDirectory: path.join(cacheDirectory, "coffee"),
-            },
-          }),
-          { loader: "coffee-loader" },
-        ],
+        use: [{ loader: "coffee-loader" }],
       },
       {
         test: /\.(jade|pug)$/,
         include: /src/,
         use: [
-          ...notOnCI({
-            loader: "cache-loader",
-            options: {
-              cacheDirectory: path.join(cacheDirectory, "pug"),
-            },
-          }),
           {
             loader: "pug-loader",
             options: {
@@ -81,6 +67,12 @@ const config = {
         test: /(\.(js|ts)x?$)/,
         include: path.resolve("./src"),
         use: [
+          ...notOnCI({
+            loader: "cache-loader",
+            options: {
+              cacheDirectory: path.join(cacheDirectory),
+            },
+          }),
           {
             loader: "babel-loader",
             options: {


### PR DESCRIPTION
This reverts some changes from https://github.com/artsy/force/pull/2916, namely caching on our coffee and jade files, as it led to irregular behavior where changes to certain templates weren't being picked up even after server restarts. 

This is due, I believe, to how caching works vs how a lot of our old coffeescript template code is written: 

```coffeescript
template = -> require('path/to/template') args... 
```

Which means that when a dep is changed down the tree, the initial import site isn't invalided as its hidden behind a closure. (Not sure why template imports are written this way since a normal `template = require('path/...')` works fine and is how its commonly done.) 

(This is me speculating, but reverting to how things were fixes the issue with no observable difference in compiler performance.) 