### PR TITLE
Old artwork brick incorrectly showed "contact gallery" for bnmo works

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@artsy/express-reloadable": "^1.3.1",
     "@artsy/palette": "^2.18.1",
     "@artsy/passport": "^1.0.11",
-    "@artsy/reaction": "^5.7.2",
+    "@artsy/reaction": "^5.7.3",
     "@artsy/stitch": "^2.0.0",
     "@babel/core": "^7.0.0",
     "@babel/node": "^7.0.0",

--- a/src/desktop/apps/home/client/setup_home_page_modules.coffee
+++ b/src/desktop/apps/home/client/setup_home_page_modules.coffee
@@ -73,7 +73,7 @@ module.exports = ->
       if module.key is 'active_bids'
         $el.find('.abrv-header h1').html(module.title)
         return setupActiveBidsView(module, $el.find('.abrv-content'), user)
-      
+
       return setupFollowedArtistsView(module, $el, user) if module.key is 'followed_artists'
 
       options =

--- a/src/desktop/components/artwork_metadata_stub/templates/contact.jade
+++ b/src/desktop/components/artwork_metadata_stub/templates/contact.jade
@@ -22,7 +22,7 @@ if artwork.sale && artwork.sale.is_auction
           | #{sa.opening_bid.display}
       else if artwork.sale.is_closed
         | Auction closed
-else if artwork.is_inquireable && !(artwork.is_acquireable && auctionPartner)
+else if artwork.is_inquireable && !(artwork.is_acquireable && (auctionPartner || sd.ENABLE_NEW_BUY_NOW_FLOW))
   //- TODO BNMO: Update to hide if the artwork is acquireable
   .artwork-metadata-stub__contact.artwork-metadata-stub__line
     a(

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,10 +50,10 @@
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
-"@artsy/reaction@^5.7.2":
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-5.7.2.tgz#7572b6c0192525699de5224be933b2d3df930b17"
-  integrity sha512-5JmPo+tNkL0a1d8Qo10wnVBG1hl6KASMxGtCoYOuJ3nGlScwl9NjA94rAKDusrvMoNfquoyWSPhvtRuD0NznlA==
+"@artsy/reaction@^5.7.3":
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-5.7.3.tgz#7f127c36436129adee3d4861556f9b426033d5a6"
+  integrity sha512-zHgcA38KDWGoIR5JDBgbVni7bVnQgo4cxrdfLSNFBYsboLNw2QqJGpjNS16uYVssD+8rD7gYkFZBKAIAHqzuXw==
   dependencies:
     "@artsy/palette" "^2.19.1"
     cheerio "^1.0.0-rc.2"
@@ -3137,6 +3137,11 @@ class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
   integrity sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
+  dependencies:
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
 
 classnames@^2.2.5:
   version "2.2.5"
@@ -3706,11 +3711,6 @@ copy-concurrently@^1.0.0:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
     run-queue "^1.0.0"
-
-copy-descriptor@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
-  integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -8453,7 +8453,7 @@ keypress@0.1.x:
   resolved "https://registry.yarnpkg.com/keypress/-/keypress-0.1.0.tgz#4a3188d4291b66b4f65edb99f806aa9ae293592a"
   integrity sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo=
 
-kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
+kind-of@^3.0.2, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
@@ -10033,15 +10033,6 @@ object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
   integrity sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=
-
-object-copy@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
-  integrity sha1-fn2Fi3gb18mRpBupde04EnVOmYw=
-  dependencies:
-    copy-descriptor "^0.1.0"
-    define-property "^0.2.5"
-    kind-of "^3.0.3"
 
 object-inspect@^1.6.0:
   version "1.6.0"
@@ -13353,14 +13344,6 @@ standard@^9.0.0:
     eslint-plugin-react "~6.9.0"
     eslint-plugin-standard "~2.0.1"
     standard-engine "~5.4.0"
-
-static-extend@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
-  integrity sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=
-  dependencies:
-    define-property "^0.2.5"
-    object-copy "^0.1.0"
 
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"


### PR DESCRIPTION
The old artwork brick wasn't handling the "buy now" case behind a feature flag. This fixes that.

The updated rail (with multiple brick-types) looks like this:
![image](https://user-images.githubusercontent.com/2081340/46987824-d5dc8800-d0c3-11e8-826d-6e71d8f7d764.png)

This also bumps reaction.