### PR TITLE
No longer listen on FAQ modal hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@artsy/express-reloadable": "^1.3.1",
     "@artsy/palette": "^2.18.1",
     "@artsy/passport": "^1.0.11",
-    "@artsy/reaction": "^5.7.4",
+    "@artsy/reaction": "^5.7.5",
     "@artsy/stitch": "^2.0.0",
     "@babel/core": "^7.0.0",
     "@babel/node": "^7.0.0",

--- a/src/desktop/apps/order2/client.js
+++ b/src/desktop/apps/order2/client.js
@@ -5,15 +5,10 @@ import mediator from "desktop/lib/mediator.coffee"
 import React from "react"
 import ReactDOM from "react-dom"
 import styled from "styled-components"
-import openMultiPageModal from "desktop/components/multi_page_modal/index.coffee"
 import User from "desktop/models/user.coffee"
 import Artwork from "desktop/models/artwork.coffee"
 import ArtworkInquiry from "desktop/models/artwork_inquiry.coffee"
 import openInquiryQuestionnaireFor from "desktop/components/inquiry_questionnaire/index.coffee"
-
-mediator.on("openOrdersBuyerFAQModal", options => {
-  openMultiPageModal("collector-faqs")
-})
 
 mediator.on("openOrdersContactArtsyModal", options => {
   const artworkId = options.artworkId

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,10 +50,10 @@
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
-"@artsy/reaction@^5.7.4":
-  version "5.7.4"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-5.7.4.tgz#731d7b000d59c825ae6f43dc2f8f1c79db789817"
-  integrity sha512-svrTP1OZmyaDvk6ucMAxooiaF2EiwfufD/Z4upp4oAb2IkMKGUR9eAYhYaIrZzix4SJZqqWrIdmDuAiuiavQ3w==
+"@artsy/reaction@^5.7.5":
+  version "5.7.5"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-5.7.5.tgz#bc722dbb1dba56c62e9cdd4b2106e09365aa06d8"
+  integrity sha512-o3LZMdmCwsoNSuREiwUV5MssAwS+enC2Ur849KrAC4pbEqWZZhgOp20YaeGBSa4kFVlTuzhQGxAQljLcR0M4uw==
   dependencies:
     "@artsy/palette" "^2.19.1"
     cheerio "^1.0.0-rc.2"


### PR DESCRIPTION
Since https://github.com/artsy/reaction/pull/1419 we don't open the FAQ in a modal anymore, so there's no need to listen on this event.