### PR TITLE
@damassi: add classes to fix margin issue

### DIFF
--- a/src/desktop/apps/collect2/server.js
+++ b/src/desktop/apps/collect2/server.js
@@ -38,7 +38,7 @@ const index = async (req, res, next) => {
       locals: {
         ...res.locals,
         assetPackage: "collect2",
-        bodyClass: "body-header-fixed body-no-margins",
+        bodyClass: IS_MOBILE ? "body-header-fixed body-no-margins" : null,
       },
     })
 

--- a/src/desktop/apps/collect2/server.js
+++ b/src/desktop/apps/collect2/server.js
@@ -38,6 +38,7 @@ const index = async (req, res, next) => {
       locals: {
         ...res.locals,
         assetPackage: "collect2",
+        bodyClass: "body-header-fixed body-no-margins",
       },
     })
 


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/GROW-963

This fixes the weird extra 10px top margin that appears in the mobile view of the collection page.

**Before**
![screen shot 2018-10-22 at 4 59 59 pm](https://user-images.githubusercontent.com/5201004/47319140-f2287980-d61b-11e8-9556-d7eb5620a6ed.png)

**After**
![screen shot 2018-10-22 at 4 58 33 pm](https://user-images.githubusercontent.com/5201004/47319078-be4d5400-d61b-11e8-9c3c-8f10d5ffe48b.png)

