### PR TITLE
Displaying error msg declared in Gravity when a user cannot delete own account

### DIFF
--- a/src/desktop/apps/user/components/delete_my_account/test/view.coffee
+++ b/src/desktop/apps/user/components/delete_my_account/test/view.coffee
@@ -86,11 +86,11 @@ describe 'DeleteMyAccountFormView', ->
         $.ajax
           .onCall 0
           .returns Promise.reject('There was an error')
-
+          .returns Promise.reject(responseJSON: {message: 'Sorry, this account cannot be deleted.'})
       it 'displays the error message', ->
         @view.submit $.Event()
           .then =>
             @view.$('.js-form-errors').text()
               .should.containEql 'There was an error'
             @FlashMessage.args[0][0].message
-              .should.containEql 'An error prevented us from deleting your account through this form.'
+              .should.containEql 'Sorry, this account cannot be deleted.'

--- a/src/desktop/apps/user/components/delete_my_account/view.coffee
+++ b/src/desktop/apps/user/components/delete_my_account/view.coffee
@@ -54,11 +54,7 @@ module.exports = class DeleteMyAccountView extends Backbone.View
         href: '/user/delete'
         autoclose: false
         safe: false
-        message: """
-          An error prevented us from deleting your account through this form.
-          Please <a href='javascript:window.location.reload()'>reload the page and try again</a>.
-          If the problem persists, contact <a href='mailto:support@artsy.net'>support@artsy.net</a>.
-        """
+        message: err.responseJSON.message
 
   render: ->
     @$el.html template()


### PR DESCRIPTION
Gravity has been updated to send an error message in the client response object when a user account cannot be deleted. 

Now one of the following messages displays depending on the reason why a user cannot delete their account:

1. User recently made an order: **'Sorry, this account cannot be deleted at this time because it is associated with a recent order. Please try again after three months from the purchase date.'**

2. User recently had auction activity: **'Sorry, this account cannot be deleted at this time because it is registered to bid in an ongoing or recently closed auction. Please try again after 48 hours.'**

3. User recently contacted a gallery: **'Sorry, this account cannot be deleted at this time because it is connected to a recent inquiry conversation. Please try again after 30 days'**

4. User recent made a BNMO purchase: **'Sorry, this account cannot be deleted at this time because it is connected to a recent purchase. Please try again after three months from the purchase date.'**

5. One or more of the following above reasons: **'Sorry, this account cannot be deleted at this time because it is connected to a recent purchase, inquiry conversation, or registered to bid in an ongoing or recently closed auction. Please try again after 30 days.'**

6. Default error message: **'Sorry, this account cannot be deleted at this time.'**

[See Platform 718 for more context](https://artsyproduct.atlassian.net/browse/PLATFORM-718)