### PR TITLE
@damassi => [Testing] Add a basic integration test for the artist page

### DIFF
--- a/src/test/acceptance/artist.js
+++ b/src/test/acceptance/artist.js
@@ -1,0 +1,22 @@
+/* eslint-env mocha */
+import { setup, teardown } from "./helpers"
+
+describe("Artist page", () => {
+  let metaphysics, browser
+
+  before(async () => {
+    ;({ metaphysics, browser } = await setup())
+    metaphysics.post("/", (req, res) => {
+      res.send(require("./fixtures/metaphysics/artist"))
+    })
+  })
+
+  after(teardown)
+
+  it("renders an artist name and some biographical info", async () => {
+    const $ = await browser.page("/artist/pablo-picasso")
+    $.html().should.containEql("Pablo Picasso")
+    $.html().should.containEql("Spanish")
+    $.html().should.containEql("1881-1973")
+  })
+})

--- a/src/test/acceptance/fixtures/metaphysics/artist.json
+++ b/src/test/acceptance/fixtures/metaphysics/artist.json
@@ -1,0 +1,2724 @@
+{
+  "data": {
+    "artist": {
+      "meta": {
+        "title": "Title",
+        "description": "Description"
+      },
+      "biography_blurb": {
+        "text": "<p>A prolific and tireless innovator of art forms, Pablo Picasso impacted the course of 20th-century art with unparalleled magnitude. Inspired by African and Iberian art and developments in the world around him, Picasso contributed significantly to a number of artistic movements, notably <a href=\"/gene/cubism\">Cubism</a>, <a href=\"/gene/surrealism\">Surrealism</a>, <a href=\"/gene/neoclassicism\">Neoclassicism</a>, and <a href=\"/gene/austrian-and-german-expressionism\">Expressionism</a>. Along with <a href=\"/artist/georges-braque\">Georges Braque</a>, Picasso is best known for pioneering <a href=\"/gene/cubism\">Cubism</a> in an attempt to reconcile three-dimensional space with the two-dimensional picture plane, once asking, “Are we to paint what’s on the face, what’s inside the face, or what’s behind it?” Responding to the Spanish Civil War, he painted his most famous work, <em>Guernica</em> (1937), whose violent images of anguished figures rendered in grisaille made it a definitive work of anti-war art. “Painting is not made to decorate apartments,” he said. “It’s an offensive and defensive weapon against the enemy.” Picasso’s sizable oeuvre includes over 20,000 paintings, prints, drawings, sculptures, ceramics, theater sets, and costume designs.</p>\n",
+        "credit": null
+      },
+      "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+      "currentEvent": {
+        "event": {
+          "__typename": "Sale",
+          "__id": "U2FsZTp3cmlnaHQtZGVzaWduLWluY2x1ZGluZy1wb3N0LXdhci1wbHVzLWNvbnRlbXBvcmFyeQ=="
+        },
+        "image": {
+          "resized": {
+            "url": "https://d7hftxdivxxvm.cloudfront.net?resize_to=width&width=300&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FLTEoWlx9GaHQ_VXbvfaJvg%2Fsource.jpg"
+          }
+        },
+        "name": "Wright: Design including Post War + Contemporary",
+        "status": "Currently at auction",
+        "details": "Live bidding begins Oct 25 1:00 PM EDT",
+        "partner": null,
+        "href": "/auction/wright-design-including-post-war-plus-contemporary"
+      },
+      "_id": "4d8b928b4eb68a1b2c0001f2",
+      "collections": [
+        "Tate",
+        "Museum of Modern Art (MoMA)",
+        "National Gallery of Art, Washington, D.C.",
+        "Indianapolis Museum of Art at Newfields",
+        "San Francisco Museum of Modern Art (SFMOMA) "
+      ],
+      "highlights": {
+        "partners": {
+          "edges": [
+            {
+              "node": {
+                "categories": [
+                  {
+                    "id": "contemporary"
+                  },
+                  {
+                    "id": "established"
+                  },
+                  {
+                    "id": "modern"
+                  },
+                  {
+                    "id": "painting"
+                  },
+                  {
+                    "id": "blue-chip"
+                  }
+                ],
+                "__id": "UGFydG5lcjpnYWdvc2lhbg=="
+              },
+              "__id": "UGFydG5lckFydGlzdEVkZ2U6NTIwNTBlYmMzYjU1NTIzOTNmMDAwMDk0"
+            },
+            {
+              "node": {
+                "categories": [
+                  {
+                    "id": "contemporary"
+                  },
+                  {
+                    "id": "established"
+                  },
+                  {
+                    "id": "painting"
+                  },
+                  {
+                    "id": "blue-chip"
+                  }
+                ],
+                "__id": "UGFydG5lcjpwYWNlLWdhbGxlcnk="
+              },
+              "__id": "UGFydG5lckFydGlzdEVkZ2U6NTZmNTRhYjdjZDUzMGU2NTg3MDAwMWM4"
+            },
+            {
+              "node": {
+                "categories": [
+                  {
+                    "id": "contemporary"
+                  },
+                  {
+                    "id": "established"
+                  },
+                  {
+                    "id": "mid-career"
+                  },
+                  {
+                    "id": "painting"
+                  },
+                  {
+                    "id": "top-established"
+                  }
+                ],
+                "__id": "UGFydG5lcjpiZWNrLWFuZC1lZ2dlbGluZw=="
+              },
+              "__id": "UGFydG5lckFydGlzdEVkZ2U6NTM2YWE5YmVlYmFkNjQ4MzM4MDAwMDk2"
+            }
+          ]
+        }
+      },
+      "auctionResults": {
+        "edges": [
+          {
+            "node": {
+              "price_realized": {
+                "display": "$179m"
+              },
+              "organization": "Christie's",
+              "sale_date": "2015",
+              "__id": "QXVjdGlvblJlc3VsdDozMDU0NA=="
+            }
+          }
+        ]
+      },
+      "related": {
+        "genes": {
+          "edges": [
+            {
+              "node": {
+                "href": "/gene/cubism",
+                "name": "Cubism",
+                "__id": "R2VuZTpjdWJpc20=",
+                "id": "cubism"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/spain",
+                "name": "Spain",
+                "__id": "R2VuZTpzcGFpbg==",
+                "id": "spain"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/pre-world-war-ii-school-of-paris",
+                "name": "Pre-World War II School of Paris",
+                "__id": "R2VuZTpwcmUtd29ybGQtd2FyLWlpLXNjaG9vbC1vZi1wYXJpcw==",
+                "id": "pre-world-war-ii-school-of-paris"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/post-world-war-i-european-classicism",
+                "name": "Post-World War I European Classicism",
+                "__id": "R2VuZTpwb3N0LXdvcmxkLXdhci1pLWV1cm9wZWFuLWNsYXNzaWNpc20=",
+                "id": "post-world-war-i-european-classicism"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/fragmented-geometry",
+                "name": "Fragmented Geometry",
+                "__id": "R2VuZTpmcmFnbWVudGVkLWdlb21ldHJ5",
+                "id": "fragmented-geometry"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/paris-artists",
+                "name": "Paris Artists",
+                "__id": "R2VuZTpwYXJpcy1hcnRpc3Rz",
+                "id": "paris-artists"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/modern-and-impressionist-art",
+                "name": "Modern and Impressionist Art",
+                "__id": "R2VuZTptb2Rlcm4tYW5kLWltcHJlc3Npb25pc3QtYXJ0",
+                "id": "modern-and-impressionist-art"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/france",
+                "name": "France",
+                "__id": "R2VuZTpmcmFuY2U=",
+                "id": "france"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/line-form-and-color",
+                "name": "Line, Form, and Color",
+                "__id": "R2VuZTpsaW5lLWZvcm0tYW5kLWNvbG9y",
+                "id": "line-form-and-color"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/passage",
+                "name": "Passage",
+                "__id": "R2VuZTpwYXNzYWdl",
+                "id": "passage"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/still-life",
+                "name": "Still Life",
+                "__id": "R2VuZTpzdGlsbC1saWZl",
+                "id": "still-life"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/representations-of-everyday-objects",
+                "name": "Representations of Everyday Objects",
+                "__id": "R2VuZTpyZXByZXNlbnRhdGlvbnMtb2YtZXZlcnlkYXktb2JqZWN0cw==",
+                "id": "representations-of-everyday-objects"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/love",
+                "name": "Love",
+                "__id": "R2VuZTpsb3Zl",
+                "id": "love"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/modern-and-impressionist-prints",
+                "name": "Modern and Impressionist Prints",
+                "__id": "R2VuZTptb2Rlcm4tYW5kLWltcHJlc3Npb25pc3QtcHJpbnRz",
+                "id": "modern-and-impressionist-prints"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/collage",
+                "name": "Collage",
+                "__id": "R2VuZTpjb2xsYWdl",
+                "id": "collage"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/painting",
+                "name": "Painting",
+                "__id": "R2VuZTpwYWludGluZw==",
+                "id": "painting"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/individual-portrait",
+                "name": "Individual Portrait",
+                "__id": "R2VuZTppbmRpdmlkdWFsLXBvcnRyYWl0",
+                "id": "individual-portrait"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/group-portrait",
+                "name": "Group Portrait",
+                "__id": "R2VuZTpncm91cC1wb3J0cmFpdA==",
+                "id": "group-portrait"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/ceramic",
+                "name": "Ceramic",
+                "__id": "R2VuZTpjZXJhbWlj",
+                "id": "ceramic"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/engaged-with-european-old-masters",
+                "name": "Engaged with European Old Masters",
+                "__id": "R2VuZTplbmdhZ2VkLXdpdGgtZXVyb3BlYW4tb2xkLW1hc3RlcnM=",
+                "id": "engaged-with-european-old-masters"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/group-of-objects",
+                "name": "Group of Objects",
+                "__id": "R2VuZTpncm91cC1vZi1vYmplY3Rz",
+                "id": "group-of-objects"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/drawing",
+                "name": "Drawing",
+                "__id": "R2VuZTpkcmF3aW5n",
+                "id": "drawing"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/sculpture",
+                "name": "Sculpture",
+                "__id": "R2VuZTpzY3VscHR1cmU=",
+                "id": "sculpture"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/human-figure",
+                "name": "Human Figure",
+                "__id": "R2VuZTpodW1hbi1maWd1cmU=",
+                "id": "human-figure"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/circus-slash-carnival",
+                "name": "Circus/Carnival",
+                "__id": "R2VuZTpjaXJjdXMtc2xhc2gtY2Fybml2YWw=",
+                "id": "circus-slash-carnival"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/political",
+                "name": "Political",
+                "__id": "R2VuZTpwb2xpdGljYWw=",
+                "id": "political"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/personal-histories",
+                "name": "Personal Histories",
+                "__id": "R2VuZTpwZXJzb25hbC1oaXN0b3JpZXM=",
+                "id": "personal-histories"
+              }
+            },
+            {
+              "node": {
+                "href": "/gene/collective-history",
+                "name": "Collective History",
+                "__id": "R2VuZTpjb2xsZWN0aXZlLWhpc3Rvcnk=",
+                "id": "collective-history"
+              }
+            }
+          ]
+        }
+      },
+      "id": "pablo-picasso",
+      "name": "Pablo Picasso",
+      "is_followed": true,
+      "counts": {
+        "for_sale_artworks": 1195,
+        "ecommerce_artworks": 73,
+        "auction_artworks": 1,
+        "artworks": 2645,
+        "follows": 122004,
+        "partner_shows": 320
+      },
+      "filtered_artworks": {
+        "aggregations": [
+          {
+            "slice": "INSTITUTION",
+            "counts": [
+              {
+                "name": "Musée Picasso Paris",
+                "id": "musee-picasso-paris",
+                "__id": "QWdncmVnYXRpb25Db3VudDptdXNlZS1waWNhc3NvLXBhcmlz"
+              },
+              {
+                "name": "Fondation Beyeler",
+                "id": "fondation-beyeler",
+                "__id": "QWdncmVnYXRpb25Db3VudDpmb25kYXRpb24tYmV5ZWxlcg=="
+              },
+              {
+                "name": "Tate Modern",
+                "id": "tate-modern",
+                "__id": "QWdncmVnYXRpb25Db3VudDp0YXRlLW1vZGVybg=="
+              },
+              {
+                "name": "Vancouver Art Gallery",
+                "id": "vancouver-art-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDp2YW5jb3V2ZXItYXJ0LWdhbGxlcnk="
+              },
+              {
+                "name": "The Museum of Modern Art",
+                "id": "the-museum-of-modern-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDp0aGUtbXVzZXVtLW9mLW1vZGVybi1hcnQ="
+              },
+              {
+                "name": "Dallas Museum of Art",
+                "id": "dallas-museum-of-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpkYWxsYXMtbXVzZXVtLW9mLWFydA=="
+              },
+              {
+                "name": "Yale University Art Gallery",
+                "id": "yale-university-art-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDp5YWxlLXVuaXZlcnNpdHktYXJ0LWdhbGxlcnk="
+              },
+              {
+                "name": "ARS/Art Resource",
+                "id": "ars-slash-art-resource",
+                "__id": "QWdncmVnYXRpb25Db3VudDphcnMtc2xhc2gtYXJ0LXJlc291cmNl"
+              },
+              {
+                "name": "Guggenheim Museum Bilbao",
+                "id": "guggenheim-museum-bilbao",
+                "__id": "QWdncmVnYXRpb25Db3VudDpndWdnZW5oZWltLW11c2V1bS1iaWxiYW8="
+              },
+              {
+                "name": "Los Angeles County Museum of Art",
+                "id": "los-angeles-county-museum-of-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpsb3MtYW5nZWxlcy1jb3VudHktbXVzZXVtLW9mLWFydA=="
+              },
+              {
+                "name": "Museo Reina Sofía",
+                "id": "museo-reina-sofia",
+                "__id": "QWdncmVnYXRpb25Db3VudDptdXNlby1yZWluYS1zb2ZpYQ=="
+              },
+              {
+                "name": "Art Institute of Chicago",
+                "id": "art-institute-of-chicago",
+                "__id": "QWdncmVnYXRpb25Db3VudDphcnQtaW5zdGl0dXRlLW9mLWNoaWNhZ28="
+              },
+              {
+                "name": "Museum of Fine Arts, Boston",
+                "id": "museum-of-fine-arts-boston",
+                "__id": "QWdncmVnYXRpb25Db3VudDptdXNldW0tb2YtZmluZS1hcnRzLWJvc3Rvbg=="
+              },
+              {
+                "name": "RMN Grand Palais",
+                "id": "rmn-grand-palais",
+                "__id": "QWdncmVnYXRpb25Db3VudDpybW4tZ3JhbmQtcGFsYWlz"
+              },
+              {
+                "name": "Centre for Fine Arts (BOZAR)",
+                "id": "centre-for-fine-arts-bozar",
+                "__id": "QWdncmVnYXRpb25Db3VudDpjZW50cmUtZm9yLWZpbmUtYXJ0cy1ib3phcg=="
+              },
+              {
+                "name": "Kunstmuseum Bern",
+                "id": "kunstmuseum-bern",
+                "__id": "QWdncmVnYXRpb25Db3VudDprdW5zdG11c2V1bS1iZXJu"
+              },
+              {
+                "name": "Nasher Sculpture Center",
+                "id": "nasher-sculpture-center",
+                "__id": "QWdncmVnYXRpb25Db3VudDpuYXNoZXItc2N1bHB0dXJlLWNlbnRlcg=="
+              },
+              {
+                "name": "San Francisco Museum of Modern Art (SFMOMA) ",
+                "id": "san-francisco-museum-of-modern-art-sfmoma",
+                "__id": "QWdncmVnYXRpb25Db3VudDpzYW4tZnJhbmNpc2NvLW11c2V1bS1vZi1tb2Rlcm4tYXJ0LXNmbW9tYQ=="
+              },
+              {
+                "name": "Belvedere Museum",
+                "id": "belvedere-museum",
+                "__id": "QWdncmVnYXRpb25Db3VudDpiZWx2ZWRlcmUtbXVzZXVt"
+              },
+              {
+                "name": "Blanton Museum of Art",
+                "id": "blanton-museum-of-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpibGFudG9uLW11c2V1bS1vZi1hcnQ="
+              },
+              {
+                "name": "Guggenheim Museum",
+                "id": "guggenheim-museum",
+                "__id": "QWdncmVnYXRpb25Db3VudDpndWdnZW5oZWltLW11c2V1bQ=="
+              },
+              {
+                "name": "ICA Miami",
+                "id": "ica-miami",
+                "__id": "QWdncmVnYXRpb25Db3VudDppY2EtbWlhbWk="
+              },
+              {
+                "name": "Leopold Museum",
+                "id": "leopold-museum",
+                "__id": "QWdncmVnYXRpb25Db3VudDpsZW9wb2xkLW11c2V1bQ=="
+              },
+              {
+                "name": "Modern Art Museum of Fort Worth",
+                "id": "modern-art-museum-of-fort-worth",
+                "__id": "QWdncmVnYXRpb25Db3VudDptb2Rlcm4tYXJ0LW11c2V1bS1vZi1mb3J0LXdvcnRo"
+              },
+              {
+                "name": "Montreal Museum of Fine Arts",
+                "id": "montreal-museum-of-fine-arts",
+                "__id": "QWdncmVnYXRpb25Db3VudDptb250cmVhbC1tdXNldW0tb2YtZmluZS1hcnRz"
+              },
+              {
+                "name": "National Gallery of Art, Washington, D.C.",
+                "id": "national-gallery-of-art-washington-dc",
+                "__id": "QWdncmVnYXRpb25Db3VudDpuYXRpb25hbC1nYWxsZXJ5LW9mLWFydC13YXNoaW5ndG9uLWRj"
+              },
+              {
+                "name": "Philadelphia Museum of Art",
+                "id": "philadelphia-museum-of-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpwaGlsYWRlbHBoaWEtbXVzZXVtLW9mLWFydA=="
+              },
+              {
+                "name": "Saint Louis Art Museum",
+                "id": "saint-louis-art-museum",
+                "__id": "QWdncmVnYXRpb25Db3VudDpzYWludC1sb3Vpcy1hcnQtbXVzZXVt"
+              },
+              {
+                "name": "Statens Museum for Kunst",
+                "id": "statens-museum-for-kunst",
+                "__id": "QWdncmVnYXRpb25Db3VudDpzdGF0ZW5zLW11c2V1bS1mb3Ita3Vuc3Q="
+              },
+              {
+                "name": "The Metropolitan Museum of Art",
+                "id": "the-metropolitan-museum-of-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDp0aGUtbWV0cm9wb2xpdGFuLW11c2V1bS1vZi1hcnQ="
+              }
+            ]
+          },
+          {
+            "slice": "MEDIUM",
+            "counts": [
+              {
+                "name": "Prints",
+                "id": "prints",
+                "__id": "QWdncmVnYXRpb25Db3VudDpwcmludHM="
+              },
+              {
+                "name": "Design",
+                "id": "design",
+                "__id": "QWdncmVnYXRpb25Db3VudDpkZXNpZ24="
+              },
+              {
+                "name": "Sculpture",
+                "id": "sculpture",
+                "__id": "QWdncmVnYXRpb25Db3VudDpzY3VscHR1cmU="
+              },
+              {
+                "name": "Painting",
+                "id": "painting",
+                "__id": "QWdncmVnYXRpb25Db3VudDpwYWludGluZw=="
+              },
+              {
+                "name": "Work on Paper",
+                "id": "work-on-paper",
+                "__id": "QWdncmVnYXRpb25Db3VudDp3b3JrLW9uLXBhcGVy"
+              },
+              {
+                "name": "Drawing",
+                "id": "drawing",
+                "__id": "QWdncmVnYXRpb25Db3VudDpkcmF3aW5n"
+              },
+              {
+                "name": "Photography",
+                "id": "photography",
+                "__id": "QWdncmVnYXRpb25Db3VudDpwaG90b2dyYXBoeQ=="
+              },
+              {
+                "name": "Jewelry",
+                "id": "jewelry",
+                "__id": "QWdncmVnYXRpb25Db3VudDpqZXdlbHJ5"
+              }
+            ]
+          },
+          {
+            "slice": "GALLERY",
+            "counts": [
+              {
+                "name": "ByNewArt",
+                "id": "bynewart",
+                "__id": "QWdncmVnYXRpb25Db3VudDpieW5ld2FydA=="
+              },
+              {
+                "name": "John Szoke",
+                "id": "john-szoke-1",
+                "__id": "QWdncmVnYXRpb25Db3VudDpqb2huLXN6b2tlLTE="
+              },
+              {
+                "name": "Graves International Art",
+                "id": "graves-international-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpncmF2ZXMtaW50ZXJuYXRpb25hbC1hcnQ="
+              },
+              {
+                "name": "RoGallery",
+                "id": "rogallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpyb2dhbGxlcnk="
+              },
+              {
+                "name": "HELENE BAILLY GALLERY",
+                "id": "helene-bailly-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpoZWxlbmUtYmFpbGx5LWdhbGxlcnk="
+              },
+              {
+                "name": "Baterbys Art Gallery",
+                "id": "baterbys-art-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpiYXRlcmJ5cy1hcnQtZ2FsbGVyeQ=="
+              },
+              {
+                "name": "Gallery Art",
+                "id": "gallery-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxsZXJ5LWFydA=="
+              },
+              {
+                "name": "BAILLY GALLERY",
+                "id": "bailly-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpiYWlsbHktZ2FsbGVyeQ=="
+              },
+              {
+                "name": "Fairhead Fine Art Limited",
+                "id": "fairhead-fine-art-limited",
+                "__id": "QWdncmVnYXRpb25Db3VudDpmYWlyaGVhZC1maW5lLWFydC1saW1pdGVk"
+              },
+              {
+                "name": "Leslie Sacks Gallery",
+                "id": "leslie-sacks-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpsZXNsaWUtc2Fja3MtZ2FsbGVyeQ=="
+              },
+              {
+                "name": "Masterworks Fine Art",
+                "id": "masterworks-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDptYXN0ZXJ3b3Jrcy1maW5lLWFydA=="
+              },
+              {
+                "name": "ArtWise",
+                "id": "artwise",
+                "__id": "QWdncmVnYXRpb25Db3VudDphcnR3aXNl"
+              },
+              {
+                "name": "Christopher-Clark Fine Art",
+                "id": "christopher-clark-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpjaHJpc3RvcGhlci1jbGFyay1maW5lLWFydA=="
+              },
+              {
+                "name": "Roshkowska Galleries",
+                "id": "roshkowska-galleries",
+                "__id": "QWdncmVnYXRpb25Db3VudDpyb3Noa293c2thLWdhbGxlcmllcw=="
+              },
+              {
+                "name": "Wallector",
+                "id": "wallector",
+                "__id": "QWdncmVnYXRpb25Db3VudDp3YWxsZWN0b3I="
+              },
+              {
+                "name": "Hirth Fine Art",
+                "id": "hirth-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpoaXJ0aC1maW5lLWFydA=="
+              },
+              {
+                "name": "Alan Cristea Gallery",
+                "id": "alan-cristea-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDphbGFuLWNyaXN0ZWEtZ2FsbGVyeQ=="
+              },
+              {
+                "name": "MSP Modern",
+                "id": "msp-modern",
+                "__id": "QWdncmVnYXRpb25Db3VudDptc3AtbW9kZXJu"
+              },
+              {
+                "name": "Frederick Mulder",
+                "id": "frederick-mulder",
+                "__id": "QWdncmVnYXRpb25Db3VudDpmcmVkZXJpY2stbXVsZGVy"
+              },
+              {
+                "name": "Galerie d'Orsay",
+                "id": "galerie-dorsay",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLWRvcnNheQ=="
+              },
+              {
+                "name": "Gagosian",
+                "id": "gagosian",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWdvc2lhbg=="
+              },
+              {
+                "name": "Odon Wagner Contemporary",
+                "id": "odon-wagner-contemporary",
+                "__id": "QWdncmVnYXRpb25Db3VudDpvZG9uLXdhZ25lci1jb250ZW1wb3Jhcnk="
+              },
+              {
+                "name": "michael lisi / contemporary art",
+                "id": "michael-lisi-slash-contemporary-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDptaWNoYWVsLWxpc2ktc2xhc2gtY29udGVtcG9yYXJ5LWFydA=="
+              },
+              {
+                "name": "R. S. Johnson Fine Art",
+                "id": "r-s-johnson-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpyLXMtam9obnNvbi1maW5lLWFydA=="
+              },
+              {
+                "name": "Artfever",
+                "id": "artfever",
+                "__id": "QWdncmVnYXRpb25Db3VudDphcnRmZXZlcg=="
+              },
+              {
+                "name": "Off the Wall Gallery",
+                "id": "off-the-wall-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpvZmYtdGhlLXdhbGwtZ2FsbGVyeQ=="
+              },
+              {
+                "name": "New River Fine Art",
+                "id": "new-river-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpuZXctcml2ZXItZmluZS1hcnQ="
+              },
+              {
+                "name": "Artsnap",
+                "id": "artsnap",
+                "__id": "QWdncmVnYXRpb25Db3VudDphcnRzbmFw"
+              },
+              {
+                "name": "Emily Friedman Fine Art",
+                "id": "emily-friedman-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDplbWlseS1mcmllZG1hbi1maW5lLWFydA=="
+              },
+              {
+                "name": "Galerie Raphael",
+                "id": "galerie-raphael",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLXJhcGhhZWw="
+              },
+              {
+                "name": "Gilden's Art Gallery",
+                "id": "gildens-art-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnaWxkZW5zLWFydC1nYWxsZXJ5"
+              },
+              {
+                "name": "Marlborough Gallery",
+                "id": "marlborough-gallery-1",
+                "__id": "QWdncmVnYXRpb25Db3VudDptYXJsYm9yb3VnaC1nYWxsZXJ5LTE="
+              },
+              {
+                "name": "Opera Gallery",
+                "id": "opera-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpvcGVyYS1nYWxsZXJ5"
+              },
+              {
+                "name": "Jane Kahan Gallery",
+                "id": "jane-kahan-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpqYW5lLWthaGFuLWdhbGxlcnk="
+              },
+              {
+                "name": "Peter Harrington Gallery",
+                "id": "peter-harrington-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpwZXRlci1oYXJyaW5ndG9uLWdhbGxlcnk="
+              },
+              {
+                "name": "Van der Vorst- Art",
+                "id": "van-der-vorst-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDp2YW4tZGVyLXZvcnN0LWFydA=="
+              },
+              {
+                "name": "Hidden",
+                "id": "hidden",
+                "__id": "QWdncmVnYXRpb25Db3VudDpoaWRkZW4="
+              },
+              {
+                "name": "David Barnett Gallery",
+                "id": "david-barnett-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpkYXZpZC1iYXJuZXR0LWdhbGxlcnk="
+              },
+              {
+                "name": "Art Into Focus",
+                "id": "art-into-focus",
+                "__id": "QWdncmVnYXRpb25Db3VudDphcnQtaW50by1mb2N1cw=="
+              },
+              {
+                "name": "Artware Editions",
+                "id": "artware-editions",
+                "__id": "QWdncmVnYXRpb25Db3VudDphcnR3YXJlLWVkaXRpb25z"
+              },
+              {
+                "name": "Dawson Cole Fine Art",
+                "id": "dawson-cole-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpkYXdzb24tY29sZS1maW5lLWFydA=="
+              },
+              {
+                "name": "Galerie Harter",
+                "id": "galerie-harter",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLWhhcnRlcg=="
+              },
+              {
+                "name": "It Reminds Me of Something",
+                "id": "it-reminds-me-of-something",
+                "__id": "QWdncmVnYXRpb25Db3VudDppdC1yZW1pbmRzLW1lLW9mLXNvbWV0aGluZw=="
+              },
+              {
+                "name": "Thomas French Fine Art",
+                "id": "thomas-french-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDp0aG9tYXMtZnJlbmNoLWZpbmUtYXJ0"
+              },
+              {
+                "name": "Albert Merola Gallery",
+                "id": "albert-merola-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDphbGJlcnQtbWVyb2xhLWdhbGxlcnk="
+              },
+              {
+                "name": "DTR Modern Galleries",
+                "id": "dtr-modern-galleries",
+                "__id": "QWdncmVnYXRpb25Db3VudDpkdHItbW9kZXJuLWdhbGxlcmllcw=="
+              },
+              {
+                "name": "Denis Bloch Fine Art",
+                "id": "denis-bloch-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpkZW5pcy1ibG9jaC1maW5lLWFydA=="
+              },
+              {
+                "name": "Heather James Fine Art",
+                "id": "heather-james-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpoZWF0aGVyLWphbWVzLWZpbmUtYXJ0"
+              },
+              {
+                "name": "Tanya Baxter Contemporary",
+                "id": "tanya-baxter-contemporary",
+                "__id": "QWdncmVnYXRpb25Db3VudDp0YW55YS1iYXh0ZXItY29udGVtcG9yYXJ5"
+              },
+              {
+                "name": "Art Resource Group",
+                "id": "art-resource-group",
+                "__id": "QWdncmVnYXRpb25Db3VudDphcnQtcmVzb3VyY2UtZ3JvdXA="
+              },
+              {
+                "name": "David Benrimon Fine Art",
+                "id": "david-benrimon-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpkYXZpZC1iZW5yaW1vbi1maW5lLWFydA=="
+              },
+              {
+                "name": "Galeria Joan Gaspar",
+                "id": "galeria-joan-gaspar",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmlhLWpvYW4tZ2FzcGFy"
+              },
+              {
+                "name": "Galerie Maximillian",
+                "id": "galerie-maximillian",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLW1heGltaWxsaWFu"
+              },
+              {
+                "name": "MICHALI GALLERY",
+                "id": "michali-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDptaWNoYWxpLWdhbGxlcnk="
+              },
+              {
+                "name": "Nicholas Gallery",
+                "id": "nicholas-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpuaWNob2xhcy1nYWxsZXJ5"
+              },
+              {
+                "name": "Tranter-Sinni Gallery",
+                "id": "tranter-sinni-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDp0cmFudGVyLXNpbm5pLWdhbGxlcnk="
+              },
+              {
+                "name": "F.L. Braswell Fine Art",
+                "id": "fl-braswell-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpmbC1icmFzd2VsbC1maW5lLWFydA=="
+              },
+              {
+                "name": "Galería Guillermo de Osma",
+                "id": "galeria-guillermo-de-osma",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmlhLWd1aWxsZXJtby1kZS1vc21h"
+              },
+              {
+                "name": "Grob Gallery",
+                "id": "grob-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpncm9iLWdhbGxlcnk="
+              },
+              {
+                "name": "HG Contemporary",
+                "id": "hg-contemporary",
+                "__id": "QWdncmVnYXRpb25Db3VudDpoZy1jb250ZW1wb3Jhcnk="
+              },
+              {
+                "name": "Hamilton-Selway Fine Art",
+                "id": "hamilton-selway-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpoYW1pbHRvbi1zZWx3YXktZmluZS1hcnQ="
+              },
+              {
+                "name": "Kreislerart",
+                "id": "kreislerart",
+                "__id": "QWdncmVnYXRpb25Db3VudDprcmVpc2xlcmFydA=="
+              },
+              {
+                "name": "McClain Gallery",
+                "id": "mcclain-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDptY2NsYWluLWdhbGxlcnk="
+              },
+              {
+                "name": "Nazmiyal Collection",
+                "id": "nazmiyal-collection",
+                "__id": "QWdncmVnYXRpb25Db3VudDpuYXptaXlhbC1jb2xsZWN0aW9u"
+              },
+              {
+                "name": "Puccio Fine Art",
+                "id": "puccio-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpwdWNjaW8tZmluZS1hcnQ="
+              },
+              {
+                "name": "The Loft Fine Art",
+                "id": "the-loft-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDp0aGUtbG9mdC1maW5lLWFydA=="
+              },
+              {
+                "name": "Artgráfico ",
+                "id": "artgrafico",
+                "__id": "QWdncmVnYXRpb25Db3VudDphcnRncmFmaWNv"
+              },
+              {
+                "name": "Bogena Galerie",
+                "id": "bogena-galerie",
+                "__id": "QWdncmVnYXRpb25Db3VudDpib2dlbmEtZ2FsZXJpZQ=="
+              },
+              {
+                "name": "Gormleys Fine Art",
+                "id": "gormleys-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnb3JtbGV5cy1maW5lLWFydA=="
+              },
+              {
+                "name": "Larsen Gallery",
+                "id": "larsen-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpsYXJzZW4tZ2FsbGVyeQ=="
+              },
+              {
+                "name": "Long-Sharp Gallery",
+                "id": "long-sharp-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpsb25nLXNoYXJwLWdhbGxlcnk="
+              },
+              {
+                "name": "Martin Lawrence Galleries",
+                "id": "martin-lawrence-galleries",
+                "__id": "QWdncmVnYXRpb25Db3VudDptYXJ0aW4tbGF3cmVuY2UtZ2FsbGVyaWVz"
+              },
+              {
+                "name": "Reem Gallery",
+                "id": "reem-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpyZWVtLWdhbGxlcnk="
+              },
+              {
+                "name": "ACA Galleries",
+                "id": "aca-galleries",
+                "__id": "QWdncmVnYXRpb25Db3VudDphY2EtZ2FsbGVyaWVz"
+              },
+              {
+                "name": "Alessandro Berni Gallery",
+                "id": "alessandro-berni-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDphbGVzc2FuZHJvLWJlcm5pLWdhbGxlcnk="
+              },
+              {
+                "name": "BOCCARA ART",
+                "id": "boccara-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpib2NjYXJhLWFydA=="
+              },
+              {
+                "name": "Cahiers d'Art",
+                "id": "cahiers-dart",
+                "__id": "QWdncmVnYXRpb25Db3VudDpjYWhpZXJzLWRhcnQ="
+              },
+              {
+                "name": "DIE GALERIE",
+                "id": "die-galerie",
+                "__id": "QWdncmVnYXRpb25Db3VudDpkaWUtZ2FsZXJpZQ=="
+              },
+              {
+                "name": "EHC Fine Art",
+                "id": "ehc-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDplaGMtZmluZS1hcnQ="
+              },
+              {
+                "name": "Galerie Boisseree",
+                "id": "galerie-boisseree",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLWJvaXNzZXJlZQ=="
+              },
+              {
+                "name": "Galerie Ostendorff",
+                "id": "galerie-ostendorff",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLW9zdGVuZG9yZmY="
+              },
+              {
+                "name": "Gallery Suiha",
+                "id": "gallery-suiha",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxsZXJ5LXN1aWhh"
+              },
+              {
+                "name": "Harris Schrank Fine Prints",
+                "id": "harris-schrank-fine-prints",
+                "__id": "QWdncmVnYXRpb25Db3VudDpoYXJyaXMtc2NocmFuay1maW5lLXByaW50cw=="
+              },
+              {
+                "name": "LaMantia Fine Art Inc.",
+                "id": "lamantia-fine-art-inc",
+                "__id": "QWdncmVnYXRpb25Db3VudDpsYW1hbnRpYS1maW5lLWFydC1pbmM="
+              },
+              {
+                "name": "MK Fine Art",
+                "id": "mk-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDptay1maW5lLWFydA=="
+              },
+              {
+                "name": "Marcel Katz Art",
+                "id": "marcel-katz-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDptYXJjZWwta2F0ei1hcnQ="
+              },
+              {
+                "name": "Merritt Gallery",
+                "id": "merritt-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDptZXJyaXR0LWdhbGxlcnk="
+              },
+              {
+                "name": "Robin Rile Fine Art",
+                "id": "robin-rile-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpyb2Jpbi1yaWxlLWZpbmUtYXJ0"
+              },
+              {
+                "name": "Ruth Ziegler Fine Arts Ltd.",
+                "id": "ruth-ziegler-fine-arts-ltd",
+                "__id": "QWdncmVnYXRpb25Db3VudDpydXRoLXppZWdsZXItZmluZS1hcnRzLWx0ZA=="
+              },
+              {
+                "name": "Studio Shop Gallery",
+                "id": "studio-shop-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpzdHVkaW8tc2hvcC1nYWxsZXJ5"
+              },
+              {
+                "name": "William Weston Gallery Ltd.",
+                "id": "william-weston-gallery-ltd",
+                "__id": "QWdncmVnYXRpb25Db3VudDp3aWxsaWFtLXdlc3Rvbi1nYWxsZXJ5LWx0ZA=="
+              },
+              {
+                "name": "Winchester Galleries",
+                "id": "winchester-galleries",
+                "__id": "QWdncmVnYXRpb25Db3VudDp3aW5jaGVzdGVyLWdhbGxlcmllcw=="
+              },
+              {
+                "name": " Olsen Irwin",
+                "id": "olsen-irwin",
+                "__id": "QWdncmVnYXRpb25Db3VudDpvbHNlbi1pcndpbg=="
+              },
+              {
+                "name": "Armstrong Fine Art",
+                "id": "armstrong-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDphcm1zdHJvbmctZmluZS1hcnQ="
+              },
+              {
+                "name": "Benjaman Gallery Group",
+                "id": "benjaman-gallery-group",
+                "__id": "QWdncmVnYXRpb25Db3VudDpiZW5qYW1hbi1nYWxsZXJ5LWdyb3Vw"
+              },
+              {
+                "name": "Bode Gallery",
+                "id": "bode-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpib2RlLWdhbGxlcnk="
+              },
+              {
+                "name": "Childs Gallery",
+                "id": "childs-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpjaGlsZHMtZ2FsbGVyeQ=="
+              },
+              {
+                "name": "Contessa Gallery",
+                "id": "contessa-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpjb250ZXNzYS1nYWxsZXJ5"
+              },
+              {
+                "name": "DADA STUDIOS",
+                "id": "dada-studios",
+                "__id": "QWdncmVnYXRpb25Db3VudDpkYWRhLXN0dWRpb3M="
+              },
+              {
+                "name": "Fólio Livraria",
+                "id": "folio-livraria",
+                "__id": "QWdncmVnYXRpb25Db3VudDpmb2xpby1saXZyYXJpYQ=="
+              },
+              {
+                "name": "Galerie Calderone",
+                "id": "galerie-calderone",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLWNhbGRlcm9uZQ=="
+              },
+              {
+                "name": "Galerie Gmurzynska",
+                "id": "galerie-gmurzynska",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLWdtdXJ6eW5za2E="
+              },
+              {
+                "name": "Galerie Jean-François Cazeau",
+                "id": "galerie-jean-francois-cazeau",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLWplYW4tZnJhbmNvaXMtY2F6ZWF1"
+              },
+              {
+                "name": "Galerie Kellermann",
+                "id": "galerie-kellermann",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLWtlbGxlcm1hbm4="
+              },
+              {
+                "name": "Galerie Montmartre ",
+                "id": "galerie-montmartre",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLW1vbnRtYXJ0cmU="
+              },
+              {
+                "name": "Galerie Natalie Seroussi",
+                "id": "galerie-natalie-seroussi",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLW5hdGFsaWUtc2Vyb3Vzc2k="
+              },
+              {
+                "name": "Galerie Philippe David",
+                "id": "galerie-philippe-david",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLXBoaWxpcHBlLWRhdmlk"
+              },
+              {
+                "name": "Galerie Thomas",
+                "id": "galerie-thomas",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLXRob21hcw=="
+              },
+              {
+                "name": "Gallery On The Move",
+                "id": "gallery-on-the-move",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxsZXJ5LW9uLXRoZS1tb3Zl"
+              },
+              {
+                "name": "Gow Langsford Gallery",
+                "id": "gow-langsford-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnb3ctbGFuZ3Nmb3JkLWdhbGxlcnk="
+              },
+              {
+                "name": "Hiram Butler Gallery",
+                "id": "hiram-butler-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpoaXJhbS1idXRsZXItZ2FsbGVyeQ=="
+              },
+              {
+                "name": "Isselbacher Gallery",
+                "id": "isselbacher-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDppc3NlbGJhY2hlci1nYWxsZXJ5"
+              },
+              {
+                "name": "Leviton Fine Art",
+                "id": "leviton-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpsZXZpdG9uLWZpbmUtYXJ0"
+              },
+              {
+                "name": "Mayoral",
+                "id": "mayoral",
+                "__id": "QWdncmVnYXRpb25Db3VudDptYXlvcmFs"
+              },
+              {
+                "name": "Mirat Projects",
+                "id": "mirat-projects",
+                "__id": "QWdncmVnYXRpb25Db3VudDptaXJhdC1wcm9qZWN0cw=="
+              },
+              {
+                "name": "Renata Fine Arts",
+                "id": "renata-fine-arts",
+                "__id": "QWdncmVnYXRpb25Db3VudDpyZW5hdGEtZmluZS1hcnRz"
+              },
+              {
+                "name": "Shaheen Modern and Contemporary Art",
+                "id": "shaheen-modern-and-contemporary-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpzaGFoZWVuLW1vZGVybi1hbmQtY29udGVtcG9yYXJ5LWFydA=="
+              },
+              {
+                "name": "Spalding Nix Fine Art",
+                "id": "spalding-nix-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpzcGFsZGluZy1uaXgtZmluZS1hcnQ="
+              },
+              {
+                "name": "Sylvan Cole Gallery",
+                "id": "sylvan-cole-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpzeWx2YW4tY29sZS1nYWxsZXJ5"
+              },
+              {
+                "name": "Untitled Projects",
+                "id": "untitled-projects",
+                "__id": "QWdncmVnYXRpb25Db3VudDp1bnRpdGxlZC1wcm9qZWN0cw=="
+              },
+              {
+                "name": "VINCE fine arts/ephemera",
+                "id": "vince-fine-arts-slash-ephemera",
+                "__id": "QWdncmVnYXRpb25Db3VudDp2aW5jZS1maW5lLWFydHMtc2xhc2gtZXBoZW1lcmE="
+              },
+              {
+                "name": "Zeit Contemporary Art",
+                "id": "zeit-contemporary-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDp6ZWl0LWNvbnRlbXBvcmFyeS1hcnQ="
+              },
+              {
+                "name": " M.S. Rau Antiques",
+                "id": "ms-rau-antiques",
+                "__id": "QWdncmVnYXRpb25Db3VudDptcy1yYXUtYW50aXF1ZXM="
+              },
+              {
+                "name": "10 Hanover",
+                "id": "10-hanover",
+                "__id": "QWdncmVnYXRpb25Db3VudDoxMC1oYW5vdmVy"
+              },
+              {
+                "name": "ARCHEUS/POST-MODERN",
+                "id": "archeus-slash-post-modern",
+                "__id": "QWdncmVnYXRpb25Db3VudDphcmNoZXVzLXNsYXNoLXBvc3QtbW9kZXJu"
+              },
+              {
+                "name": "AYNAC Gallery",
+                "id": "aynac-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpheW5hYy1nYWxsZXJ5"
+              },
+              {
+                "name": "Anderson Fine Art Gallery",
+                "id": "anderson-fine-art-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDphbmRlcnNvbi1maW5lLWFydC1nYWxsZXJ5"
+              },
+              {
+                "name": "Andipa",
+                "id": "andipa",
+                "__id": "QWdncmVnYXRpb25Db3VudDphbmRpcGE="
+              },
+              {
+                "name": "Art 1900 ",
+                "id": "art-1900",
+                "__id": "QWdncmVnYXRpb25Db3VudDphcnQtMTkwMA=="
+              },
+              {
+                "name": "Art Works Paris Seoul Gallery",
+                "id": "art-works-paris-seoul-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDphcnQtd29ya3MtcGFyaXMtc2VvdWwtZ2FsbGVyeQ=="
+              },
+              {
+                "name": "Artemundi",
+                "id": "artemundi",
+                "__id": "QWdncmVnYXRpb25Db3VudDphcnRlbXVuZGk="
+              },
+              {
+                "name": "Atlas Gallery",
+                "id": "atlas-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDphdGxhcy1nYWxsZXJ5"
+              },
+              {
+                "name": "Beck & Eggeling",
+                "id": "beck-and-eggeling",
+                "__id": "QWdncmVnYXRpb25Db3VudDpiZWNrLWFuZC1lZ2dlbGluZw=="
+              },
+              {
+                "name": "Bill Lowe Gallery",
+                "id": "bill-lowe-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpiaWxsLWxvd2UtZ2FsbGVyeQ=="
+              },
+              {
+                "name": "Christopher West Presents",
+                "id": "christopher-west-presents",
+                "__id": "QWdncmVnYXRpb25Db3VudDpjaHJpc3RvcGhlci13ZXN0LXByZXNlbnRz"
+              },
+              {
+                "name": "DICKINSON",
+                "id": "dickinson",
+                "__id": "QWdncmVnYXRpb25Db3VudDpkaWNraW5zb24="
+              },
+              {
+                "name": "Dellasposa",
+                "id": "dellasposa",
+                "__id": "QWdncmVnYXRpb25Db3VudDpkZWxsYXNwb3Nh"
+              },
+              {
+                "name": "Evelyn Aimis Fine Art",
+                "id": "evelyn-aimis-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpldmVseW4tYWltaXMtZmluZS1hcnQ="
+              },
+              {
+                "name": "Fils Fine Arts",
+                "id": "fils-fine-arts",
+                "__id": "QWdncmVnYXRpb25Db3VudDpmaWxzLWZpbmUtYXJ0cw=="
+              },
+              {
+                "name": "Fromkin Fine Art ",
+                "id": "fromkin-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpmcm9ta2luLWZpbmUtYXJ0"
+              },
+              {
+                "name": "Galerie AM PARK",
+                "id": "galerie-am-park",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLWFtLXBhcms="
+              },
+              {
+                "name": "Galerie Boulakia",
+                "id": "galerie-boulakia",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLWJvdWxha2lh"
+              },
+              {
+                "name": "Galerie Ludwig Kleebolte",
+                "id": "galerie-ludwig-kleebolte",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLWx1ZHdpZy1rbGVlYm9sdGU="
+              },
+              {
+                "name": "Galerie Obrist",
+                "id": "galerie-obrist",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLW9icmlzdA=="
+              },
+              {
+                "name": "Galerie Schwarzer",
+                "id": "galerie-schwarzer",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLXNjaHdhcnplcg=="
+              },
+              {
+                "name": "Galerie Thalberg",
+                "id": "galerie-thalberg",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLXRoYWxiZXJn"
+              },
+              {
+                "name": "Galerie de Souzy",
+                "id": "galerie-de-souzy",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmllLWRlLXNvdXp5"
+              },
+              {
+                "name": "Galería Marita Segovia ",
+                "id": "galeria-marita-segovia",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxlcmlhLW1hcml0YS1zZWdvdmlh"
+              },
+              {
+                "name": "Galleria Tega",
+                "id": "galleria-tega",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxsZXJpYS10ZWdh"
+              },
+              {
+                "name": "Gallery 211",
+                "id": "gallery-211",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYWxsZXJ5LTIxMQ=="
+              },
+              {
+                "name": "Gaudifond Arte",
+                "id": "gaudifond-arte",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnYXVkaWZvbmQtYXJ0ZQ=="
+              },
+              {
+                "name": "Gladwell & Patterson",
+                "id": "gladwell-and-patterson",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnbGFkd2VsbC1hbmQtcGF0dGVyc29u"
+              },
+              {
+                "name": "Glenda Cinquegrana Art Consulting",
+                "id": "glenda-cinquegrana-art-consulting",
+                "__id": "QWdncmVnYXRpb25Db3VudDpnbGVuZGEtY2lucXVlZ3JhbmEtYXJ0LWNvbnN1bHRpbmc="
+              },
+              {
+                "name": "Han Art",
+                "id": "han-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpoYW4tYXJ0"
+              },
+              {
+                "name": "Helly Nahmad Gallery",
+                "id": "helly-nahmad-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpoZWxseS1uYWhtYWQtZ2FsbGVyeQ=="
+              },
+              {
+                "name": "Henning Fine Art",
+                "id": "henning-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpoZW5uaW5nLWZpbmUtYXJ0"
+              },
+              {
+                "name": "Hollis Taggart",
+                "id": "hollis-taggart",
+                "__id": "QWdncmVnYXRpb25Db3VudDpob2xsaXMtdGFnZ2FydA=="
+              },
+              {
+                "name": "Jaime Eguiguren- Art & Antiques",
+                "id": "jaime-eguiguren-art-and-antiques",
+                "__id": "QWdncmVnYXRpb25Db3VudDpqYWltZS1lZ3VpZ3VyZW4tYXJ0LWFuZC1hbnRpcXVlcw=="
+              },
+              {
+                "name": "KM Fine Arts",
+                "id": "km-fine-arts",
+                "__id": "QWdncmVnYXRpb25Db3VudDprbS1maW5lLWFydHM="
+              },
+              {
+                "name": "Kavi Gupta",
+                "id": "kavi-gupta",
+                "__id": "QWdncmVnYXRpb25Db3VudDprYXZpLWd1cHRh"
+              },
+              {
+                "name": "Leandro Navarro",
+                "id": "leandro-navarro",
+                "__id": "QWdncmVnYXRpb25Db3VudDpsZWFuZHJvLW5hdmFycm8="
+              },
+              {
+                "name": "Lebreton",
+                "id": "lebreton",
+                "__id": "QWdncmVnYXRpb25Db3VudDpsZWJyZXRvbg=="
+              },
+              {
+                "name": "Leslie Smith Gallery",
+                "id": "leslie-smith-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpsZXNsaWUtc21pdGgtZ2FsbGVyeQ=="
+              },
+              {
+                "name": "Lions Gallery",
+                "id": "lions-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpsaW9ucy1nYWxsZXJ5"
+              },
+              {
+                "name": "Ludorff",
+                "id": "ludorff",
+                "__id": "QWdncmVnYXRpb25Db3VudDpsdWRvcmZm"
+              },
+              {
+                "name": "Maddox Gallery",
+                "id": "maddox-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDptYWRkb3gtZ2FsbGVyeQ=="
+              },
+              {
+                "name": "Madelyn Jordon Fine Art",
+                "id": "madelyn-jordon-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDptYWRlbHluLWpvcmRvbi1maW5lLWFydA=="
+              },
+              {
+                "name": "Meyerovich Gallery",
+                "id": "meyerovich-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDptZXllcm92aWNoLWdhbGxlcnk="
+              },
+              {
+                "name": "Michael Hoppen Gallery",
+                "id": "michael-hoppen-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDptaWNoYWVsLWhvcHBlbi1nYWxsZXJ5"
+              },
+              {
+                "name": "Najjar",
+                "id": "najjar",
+                "__id": "QWdncmVnYXRpb25Db3VudDpuYWpqYXI="
+              },
+              {
+                "name": "Nikola Rukaj Gallery",
+                "id": "nikola-rukaj-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpuaWtvbGEtcnVrYWotZ2FsbGVyeQ=="
+              },
+              {
+                "name": "Odalys",
+                "id": "odalys",
+                "__id": "QWdncmVnYXRpb25Db3VudDpvZGFseXM="
+              },
+              {
+                "name": "Pinakotheke",
+                "id": "pinakotheke",
+                "__id": "QWdncmVnYXRpb25Db3VudDpwaW5ha290aGVrZQ=="
+              },
+              {
+                "name": "Rachael Cozad Fine Art",
+                "id": "rachael-cozad-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpyYWNoYWVsLWNvemFkLWZpbmUtYXJ0"
+              },
+              {
+                "name": "Reuben Colley Fine Art",
+                "id": "reuben-colley-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpyZXViZW4tY29sbGV5LWZpbmUtYXJ0"
+              },
+              {
+                "name": "Rhodes",
+                "id": "rhodes",
+                "__id": "QWdncmVnYXRpb25Db3VudDpyaG9kZXM="
+              },
+              {
+                "name": "Richard Gray Gallery",
+                "id": "richard-gray-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpyaWNoYXJkLWdyYXktZ2FsbGVyeQ=="
+              },
+              {
+                "name": "Richard Nagy Ltd.",
+                "id": "richard-nagy-ltd",
+                "__id": "QWdncmVnYXRpb25Db3VudDpyaWNoYXJkLW5hZ3ktbHRk"
+              },
+              {
+                "name": "Richard Norton Gallery",
+                "id": "richard-norton-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpyaWNoYXJkLW5vcnRvbi1nYWxsZXJ5"
+              },
+              {
+                "name": "Rosenbaum Contemporary",
+                "id": "rosenbaum-contemporary",
+                "__id": "QWdncmVnYXRpb25Db3VudDpyb3NlbmJhdW0tY29udGVtcG9yYXJ5"
+              },
+              {
+                "name": "Rosenfeld Gallery LLC",
+                "id": "rosenfeld-gallery-llc",
+                "__id": "QWdncmVnYXRpb25Db3VudDpyb3NlbmZlbGQtZ2FsbGVyeS1sbGM="
+              },
+              {
+                "name": "Seraphin Gallery",
+                "id": "seraphin-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDpzZXJhcGhpbi1nYWxsZXJ5"
+              },
+              {
+                "name": "Shoichiro/Projekcts by Projects",
+                "id": "shoichiro-slash-projekcts-by-projects",
+                "__id": "QWdncmVnYXRpb25Db3VudDpzaG9pY2hpcm8tc2xhc2gtcHJvamVrY3RzLWJ5LXByb2plY3Rz"
+              },
+              {
+                "name": "Sigrid Freundorfer Fine Art",
+                "id": "sigrid-freundorfer-fine-art",
+                "__id": "QWdncmVnYXRpb25Db3VudDpzaWdyaWQtZnJldW5kb3JmZXItZmluZS1hcnQ="
+              },
+              {
+                "name": "Stern Pissarro",
+                "id": "stern-pissarro",
+                "__id": "QWdncmVnYXRpb25Db3VudDpzdGVybi1waXNzYXJybw=="
+              },
+              {
+                "name": "TNT Arte",
+                "id": "tnt-arte",
+                "__id": "QWdncmVnYXRpb25Db3VudDp0bnQtYXJ0ZQ=="
+              },
+              {
+                "name": "Taglialatella Galleries",
+                "id": "taglialatella-galleries",
+                "__id": "QWdncmVnYXRpb25Db3VudDp0YWdsaWFsYXRlbGxhLWdhbGxlcmllcw=="
+              },
+              {
+                "name": "Theodore B. Donson Ltd.",
+                "id": "theodore-b-donson-ltd",
+                "__id": "QWdncmVnYXRpb25Db3VudDp0aGVvZG9yZS1iLWRvbnNvbi1sdGQ="
+              },
+              {
+                "name": "Upsilon Gallery",
+                "id": "upsilon-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDp1cHNpbG9uLWdhbGxlcnk="
+              },
+              {
+                "name": "Wada Garou Tokyo",
+                "id": "wada-garou-tokyo",
+                "__id": "QWdncmVnYXRpb25Db3VudDp3YWRhLWdhcm91LXRva3lv"
+              },
+              {
+                "name": "White Porch Gallery",
+                "id": "white-porch-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDp3aGl0ZS1wb3JjaC1nYWxsZXJ5"
+              },
+              {
+                "name": "Willow Gallery",
+                "id": "willow-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDp3aWxsb3ctZ2FsbGVyeQ=="
+              },
+              {
+                "name": "ZQ Art Gallery",
+                "id": "zq-art-gallery",
+                "__id": "QWdncmVnYXRpb25Db3VudDp6cS1hcnQtZ2FsbGVyeQ=="
+              }
+            ]
+          },
+          {
+            "slice": "MAJOR_PERIOD",
+            "counts": [
+              {
+                "name": "Late 19th Century",
+                "id": "Late 19th Century",
+                "__id": "QWdncmVnYXRpb25Db3VudDpMYXRlIDE5dGggQ2VudHVyeQ=="
+              },
+              {
+                "name": "2010",
+                "id": "2010",
+                "__id": "QWdncmVnYXRpb25Db3VudDoyMDEw"
+              },
+              {
+                "name": "2000",
+                "id": "2000",
+                "__id": "QWdncmVnYXRpb25Db3VudDoyMDAw"
+              },
+              {
+                "name": "1990",
+                "id": "1990",
+                "__id": "QWdncmVnYXRpb25Db3VudDoxOTkw"
+              },
+              {
+                "name": "1980",
+                "id": "1980",
+                "__id": "QWdncmVnYXRpb25Db3VudDoxOTgw"
+              },
+              {
+                "name": "1970",
+                "id": "1970",
+                "__id": "QWdncmVnYXRpb25Db3VudDoxOTcw"
+              },
+              {
+                "name": "1960",
+                "id": "1960",
+                "__id": "QWdncmVnYXRpb25Db3VudDoxOTYw"
+              },
+              {
+                "name": "1950",
+                "id": "1950",
+                "__id": "QWdncmVnYXRpb25Db3VudDoxOTUw"
+              },
+              {
+                "name": "1940",
+                "id": "1940",
+                "__id": "QWdncmVnYXRpb25Db3VudDoxOTQw"
+              },
+              {
+                "name": "1930",
+                "id": "1930",
+                "__id": "QWdncmVnYXRpb25Db3VudDoxOTMw"
+              },
+              {
+                "name": "1920",
+                "id": "1920",
+                "__id": "QWdncmVnYXRpb25Db3VudDoxOTIw"
+              },
+              {
+                "name": "1910",
+                "id": "1910",
+                "__id": "QWdncmVnYXRpb25Db3VudDoxOTEw"
+              },
+              {
+                "name": "1900",
+                "id": "1900",
+                "__id": "QWdncmVnYXRpb25Db3VudDoxOTAw"
+              },
+              {
+                "name": "18th Century & Earlier",
+                "id": "18th Century & Earlier",
+                "__id": "QWdncmVnYXRpb25Db3VudDoxOHRoIENlbnR1cnkgJiBFYXJsaWVy"
+              }
+            ]
+          }
+        ],
+        "__id": "RmlsdGVyQXJ0d29ya3M6eyJhZ2dyZWdhdGlvbnMiOlsibWVkaXVtIiwidG90YWwiLCJnYWxsZXJ5IiwiaW5zdGl0dXRpb24iLCJtYWpvcl9wZXJpb2QiXSwic2l6ZSI6MCwiYXJ0aXN0X2lkIjoicGFibG8tcGljYXNzbyJ9"
+      },
+      "grid": {
+        "__id": "RmlsdGVyQXJ0d29ya3M6eyJhZ2dyZWdhdGlvbnMiOlsidG90YWwiXSwibWFqb3JfcGVyaW9kcyI6W10sInNpemUiOjAsInNvcnQiOiItZGVjYXllZF9tZXJjaCIsImFydGlzdF9pZCI6InBhYmxvLXBpY2Fzc28ifQ==",
+        "artworks": {
+          "pageInfo": {
+            "hasNextPage": true,
+            "endCursor": "YXJyYXljb25uZWN0aW9uOjIz"
+          },
+          "pageCursors": {
+            "around": [
+              {
+                "cursor": "YXJyYXljb25uZWN0aW9uOi0x",
+                "page": 1,
+                "isCurrent": true
+              },
+              {
+                "cursor": "YXJyYXljb25uZWN0aW9uOjIz",
+                "page": 2,
+                "isCurrent": false
+              },
+              {
+                "cursor": "YXJyYXljb25uZWN0aW9uOjQ3",
+                "page": 3,
+                "isCurrent": false
+              },
+              {
+                "cursor": "YXJyYXljb25uZWN0aW9uOjcx",
+                "page": 4,
+                "isCurrent": false
+              }
+            ],
+            "first": null,
+            "last": {
+              "cursor": "YXJyYXljb25uZWN0aW9uOjIzNzU=",
+              "page": 100,
+              "isCurrent": false
+            },
+            "previous": null
+          },
+          "edges": [
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLWNob3VldHRvbi10YWJsZS1sYW1w",
+                "image": {
+                  "aspect_ratio": 1,
+                  "placeholder": "100%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/zNcFkEhG_UmCPl7DDWH7hQ/large.jpg"
+                },
+                "is_biddable": true,
+                "is_acquireable": false,
+                "href": "/artwork/pablo-picasso-chouetton-table-lamp",
+                "title": "Chouetton Table Lamp",
+                "date": "1952",
+                "sale_message": "Contact For Price",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Wright",
+                  "href": "/auction/partner-595e69f6a09a671938435977",
+                  "__id": "UGFydG5lcjp3cmlnaHQ=",
+                  "type": "Auction House"
+                },
+                "sale": {
+                  "is_auction": true,
+                  "is_live_open": true,
+                  "is_open": true,
+                  "is_closed": false,
+                  "display_timely_at": "in progress",
+                  "auction_state": "open",
+                  "__id": "U2FsZTp3cmlnaHQtZGVzaWduLWluY2x1ZGluZy1wb3N0LXdhci1wbHVzLWNvbnRlbXBvcmFyeQ=="
+                },
+                "sale_artwork": {
+                  "highest_bid": {
+                    "display": null,
+                    "__id": null
+                  },
+                  "opening_bid": {
+                    "display": "$5,000"
+                  },
+                  "__id": "U2FsZUFydHdvcms6cGFibG8tcGljYXNzby1jaG91ZXR0b24tdGFibGUtbGFtcA==",
+                  "counts": {
+                    "bidder_positions": 0
+                  }
+                },
+                "_id": "5bbfd52052e56e2dad3faa78",
+                "is_inquireable": true,
+                "id": "pablo-picasso-chouetton-table-lamp",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLXNlcmllcy0zNDctYmxvY2gtMTUwMg==",
+                "image": {
+                  "aspect_ratio": 1.23,
+                  "placeholder": "81.13636363636364%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/w97IE7hGxLrmsNJJPnIV2g/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-series-347-bloch-1502",
+                "title": "SERIES 347 (BLOCH 1502)",
+                "date": "1968",
+                "sale_message": "$18,000",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5bbd34b7c1291079f5e37c74",
+                "is_inquireable": true,
+                "id": "pablo-picasso-series-347-bloch-1502",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLW1pbm90YXVyZS12aW9sYW50LXVuZS1mZW1tZS1mcm9tLXRoZS1wb3J0Zm9saW8tbGEtZmx1dGUtZG91Ymxl",
+                "image": {
+                  "aspect_ratio": 1.2,
+                  "placeholder": "83.5416175430323%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/PxpZcuq0pqRrzslyhD1yGQ/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-minotaure-violant-une-femme-from-the-portfolio-la-flute-double",
+                "title": "Minotaure Violant Une Femme from the portfolio \"La Flute Double\"",
+                "date": "1967",
+                "sale_message": "$3,500",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "RoGallery",
+                  "href": "/rogallery",
+                  "__id": "UGFydG5lcjpyb2dhbGxlcnk=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5bbe55de2dd48c4456b9d17c",
+                "is_inquireable": true,
+                "id": "pablo-picasso-minotaure-violant-une-femme-from-the-portfolio-la-flute-double",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLWV0dWRlLXBvdXItbGhvbW1lLWF1LW1vdXRvbi1mcm9tLXRoZS1wb3J0Zm9saW8tbGEtZmx1dGUtZG91Ymxl",
+                "image": {
+                  "aspect_ratio": 0.5,
+                  "placeholder": "198.78286270691333%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/j-CogCFv_rn__dqhMjgDKw/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-etude-pour-lhomme-au-mouton-from-the-portfolio-la-flute-double",
+                "title": "Etude pour l'Homme au Mouton from the portfolio \"La Flute Double\" ",
+                "date": "1967",
+                "sale_message": "$2,850",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "RoGallery",
+                  "href": "/rogallery",
+                  "__id": "UGFydG5lcjpyb2dhbGxlcnk=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5bbe55d06884b7002ce256d2",
+                "is_inquireable": true,
+                "id": "pablo-picasso-etude-pour-lhomme-au-mouton-from-the-portfolio-la-flute-double",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLWZlbW1lLWRhbnMtdW4tZmF1dGV1aWwtMg==",
+                "image": {
+                  "aspect_ratio": 0.74,
+                  "placeholder": "135.20918178452425%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/uy12g9y_vC9tmudzBJQEBg/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-femme-dans-un-fauteuil-2",
+                "title": "FEMME DANS UN FAUTEUIL",
+                "date": "1979-1982",
+                "sale_message": "$1,950",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5bae82f297c8e14c894a06d6",
+                "is_inquireable": true,
+                "id": "pablo-picasso-femme-dans-un-fauteuil-2",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLW5hdHVyZS1tb3J0ZS1hdS12ZXJyZQ==",
+                "image": {
+                  "aspect_ratio": 1.28,
+                  "placeholder": "78.01792303637322%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/qXcTCQeBpPx-Bj_UNvdYSw/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-nature-morte-au-verre",
+                "title": "NATURE MORTE AU VERRE",
+                "date": "1979-1982",
+                "sale_message": "$1,950",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5bae984338d81e2463b34c35",
+                "is_inquireable": true,
+                "id": "pablo-picasso-nature-morte-au-verre",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLWZlbW1lLWNvdWNoZWUtMQ==",
+                "image": {
+                  "aspect_ratio": 1.37,
+                  "placeholder": "73.22461862177802%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/nlZH_HFji8oKO2Os3FZ1cQ/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-femme-couchee-1",
+                "title": "FEMME COUCHEE",
+                "date": "1979-1982",
+                "sale_message": "$3,500",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5bb7ca7cf0c3ef7e2f61c8e5",
+                "is_inquireable": true,
+                "id": "pablo-picasso-femme-couchee-1",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLXBvcnRyYWl0LW9mLW1hcmllLXRoZXJlc2Utd2FsdGVy",
+                "image": {
+                  "aspect_ratio": 0.75,
+                  "placeholder": "133.9941262848752%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/tAIrWd9jfsi0l1EJ2pzPIA/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-portrait-of-marie-therese-walter",
+                "title": "PORTRAIT OF MARIE-THERESE WALTER",
+                "date": "1979-1982",
+                "sale_message": "$2,450",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5baabbbf0b4ac91a10b2682e",
+                "is_inquireable": true,
+                "id": "pablo-picasso-portrait-of-marie-therese-walter",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLWZlbW1lLWF1LWNoYXBlYXUtZ3Jpcw==",
+                "image": {
+                  "aspect_ratio": 0.75,
+                  "placeholder": "132.7716643741403%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/dQSw9eLmqUdJPzzkgqiPHA/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-femme-au-chapeau-gris",
+                "title": "FEMME AU CHAPEAU GRIS",
+                "date": "1979-1982",
+                "sale_message": "$1,950",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5bae9f7fb03bf34d66f6a6b2",
+                "is_inquireable": true,
+                "id": "pablo-picasso-femme-au-chapeau-gris",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLWVuZmFudC1lbi1waWVk",
+                "image": {
+                  "aspect_ratio": 0.74,
+                  "placeholder": "135.43705703678702%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/bycS0hdXsB1L03TNgDixCw/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-enfant-en-pied",
+                "title": "ENFANT EN PIED",
+                "date": "1979-1982",
+                "sale_message": "$1,950",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5bae78c738d81e344ea4ec9a",
+                "is_inquireable": true,
+                "id": "pablo-picasso-enfant-en-pied",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLW1pbm90YXVyZS1hdmV1Z2xlLWNvbmR1aXQtcGFyLXVuZS1wZXRpdGUtZmlsbGU=",
+                "image": {
+                  "aspect_ratio": 1.37,
+                  "placeholder": "73.10924369747899%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/lp3a3bes79gBUf35GI-e6A/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-minotaure-aveugle-conduit-par-une-petite-fille",
+                "title": "MINOTAURE AVEUGLE CONDUIT PAR UNE PETITE FILLE",
+                "date": "1979-1982",
+                "sale_message": "$2,050",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5bae680c552270002a48e5dd",
+                "is_inquireable": true,
+                "id": "pablo-picasso-minotaure-aveugle-conduit-par-une-petite-fille",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLWZlbW1lLWFzc2lzZS1kYW5zLXVuLWZhdGV1aWw=",
+                "image": {
+                  "aspect_ratio": 0.73,
+                  "placeholder": "137.00348432055748%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/3m85LCen83iOqUVzf7HkCw/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-femme-assise-dans-un-fateuil",
+                "title": "FEMME ASSISE DANS UN FATEUIL",
+                "date": "1979-1982",
+                "sale_message": "$1,950",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5baea9ff776b1c4e976950e7",
+                "is_inquireable": true,
+                "id": "pablo-picasso-femme-assise-dans-un-fateuil",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLXBvcnRyYWl0LWVuLWRldXgtcGFydGllcy1ub2lyZS1ldC1ibGFuY2hlLTI2LWQ=",
+                "image": {
+                  "aspect_ratio": 0.71,
+                  "placeholder": "140.62126642771804%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/ES7aRZIXgKDU0BtOri-eHw/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-portrait-en-deux-parties-noire-et-blanche-26-d",
+                "title": "Portrait en Deux Parties Noire et Blanche, 26-D",
+                "date": "1979-1982",
+                "sale_message": "$6,500",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "RoGallery",
+                  "href": "/rogallery",
+                  "__id": "UGFydG5lcjpyb2dhbGxlcnk=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "574f1aca275b2430e80012bc",
+                "is_inquireable": true,
+                "id": "pablo-picasso-portrait-en-deux-parties-noire-et-blanche-26-d",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLXRldGUtZGUtZmVtbWUtMTI=",
+                "image": {
+                  "aspect_ratio": 0.75,
+                  "placeholder": "133.38312173263628%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/QLetYUoU94SVeOH6ZddaLQ/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-tete-de-femme-12",
+                "title": "TETE DE FEMME",
+                "date": "1979 -1982",
+                "sale_message": "$2,450",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5baab1eb5e98ea515adb8747",
+                "is_inquireable": true,
+                "id": "pablo-picasso-tete-de-femme-12",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLW1hcmxib3JvdWdoLWdhbGVyaWUtZGFydC1yb21h",
+                "image": {
+                  "aspect_ratio": 0.68,
+                  "placeholder": "146.13333333333333%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/fqGKyI8dp_yWPespz7mjAg/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-marlborough-galerie-dart-roma",
+                "title": "Marlborough: Galerie d'Art, Roma",
+                "date": "1969",
+                "sale_message": "$4,850",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "RoGallery",
+                  "href": "/rogallery",
+                  "__id": "UGFydG5lcjpyb2dhbGxlcnk=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5bbe55b0aa5513319fc24e92",
+                "is_inquireable": true,
+                "id": "pablo-picasso-marlborough-galerie-dart-roma",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLW5hdHVyZS1tb3J0ZS1hdS1waWNoZXQtcm9zZQ==",
+                "image": {
+                  "aspect_ratio": 1.34,
+                  "placeholder": "74.54202586206897%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/AiusOP0OTNIappG4FGQTqg/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-nature-morte-au-pichet-rose",
+                "title": "NATURE MORTE AU PICHET ROSE",
+                "date": "1979-1982",
+                "sale_message": "$2,450",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5bae566478d5df5308db545d",
+                "is_inquireable": true,
+                "id": "pablo-picasso-nature-morte-au-pichet-rose",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLWl0YWxpZW5uZS1kYXByZXMtdW5lLXBob3RvZ3JhcGhpZQ==",
+                "image": {
+                  "aspect_ratio": 0.78,
+                  "placeholder": "128.26086956521738%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/YyQ1U2EwXK3hOQR4xDsLCQ/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-italienne-dapres-une-photographie",
+                "title": "ITALIENNE D'APRES UNE PHOTOGRAPHIE",
+                "date": "1979-1982",
+                "sale_message": "$4,900",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5baa812f5e98ea1e123e83e2",
+                "is_inquireable": true,
+                "id": "pablo-picasso-italienne-dapres-une-photographie",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLWxlLXZlcnRlLWdhbGFudA==",
+                "image": {
+                  "aspect_ratio": 1.27,
+                  "placeholder": "78.69708631115998%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/yK1KHB7c6vBb6jp_gj09lQ/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-le-verte-galant",
+                "title": "LE VERTE GALANT",
+                "date": "1979-1982",
+                "sale_message": "$2,450",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5bae5417f3953142a386fb8c",
+                "is_inquireable": true,
+                "id": "pablo-picasso-le-verte-galant",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLWZlbW1lLWRlYm91dC0y",
+                "image": {
+                  "aspect_ratio": 0.73,
+                  "placeholder": "136.19676945668135%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/bNQkPpojC6JMKEaj5O584g/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-femme-debout-2",
+                "title": "FEMME DEBOUT",
+                "date": "1979-1982",
+                "sale_message": "$1,950",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5baea2b26c757b5ec293d8ef",
+                "is_inquireable": true,
+                "id": "pablo-picasso-femme-debout-2",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLXRldGUtZGUtbW9ydGUtbGFtcGUtY3J1Y2hlcy1ldC1wb2lyZWF1eA==",
+                "image": {
+                  "aspect_ratio": 1.36,
+                  "placeholder": "73.47938144329898%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/qpuF7Qa2wWP_QgOvrQx5Cw/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-tete-de-morte-lampe-cruches-et-poireaux",
+                "title": "TETE DE MORTE, LAMPE CRUCHES ET POIREAUX",
+                "date": "1979-1982",
+                "sale_message": "$1,950",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5baea1545b421c4760dc69a1",
+                "is_inquireable": true,
+                "id": "pablo-picasso-tete-de-morte-lampe-cruches-et-poireaux",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLXZpc2FnZS1kZS1mZW1tZS1kZS1mYWNl",
+                "image": {
+                  "aspect_ratio": 0.74,
+                  "placeholder": "135.98566308243727%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/Y_nWk3wgt9n12cBZ-x65Zg/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-visage-de-femme-de-face",
+                "title": "VISAGE DE FEMME DE FACE",
+                "date": "1979-1982",
+                "sale_message": "$1,950",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5bae9d53235a5740966a646c",
+                "is_inquireable": true,
+                "id": "pablo-picasso-visage-de-femme-de-face",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLWZlbW1lLWFzc2lzZS1kYW5zLXVuLWZhdXRldWlsLXRyZXNzZQ==",
+                "image": {
+                  "aspect_ratio": 0.75,
+                  "placeholder": "134.20060331825036%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/XOqmjacZ-BGJW0IP4hVGVQ/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-femme-assise-dans-un-fauteuil-tresse",
+                "title": "FEMME ASSISE DANS UN FAUTEUIL TRESSE",
+                "date": "1979-1982",
+                "sale_message": "$2,450",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Gallery Art",
+                  "href": "/gallery-art",
+                  "__id": "UGFydG5lcjpnYWxsZXJ5LWFydA==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5bae581fc60fcc53df98dfcc",
+                "is_inquireable": true,
+                "id": "pablo-picasso-femme-assise-dans-un-fauteuil-tresse",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLWZlbW1lLWEtbGEtbW9udHJl",
+                "image": {
+                  "aspect_ratio": 0.8,
+                  "placeholder": "124.75841386204598%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/6Fth-42H9HowiTOdoVjc7Q/large.jpg"
+                },
+                "is_biddable": false,
+                "is_acquireable": true,
+                "href": "/artwork/pablo-picasso-femme-a-la-montre",
+                "title": "Femme a la Montre",
+                "date": "ca. 1967",
+                "sale_message": "$1,800",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "RoGallery",
+                  "href": "/rogallery",
+                  "__id": "UGFydG5lcjpyb2dhbGxlcnk=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "_id": "5bc10f5a5e5b451476f04587",
+                "is_inquireable": true,
+                "id": "pablo-picasso-femme-a-la-montre",
+                "is_saved": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazpwYWJsby1waWNhc3NvLWdyYW5kLW1hdGVybml0ZS0y",
+                "image": {
+                  "aspect_ratio": 0.7,
+                  "placeholder": "143.02059496567506%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/2_5g8CQsu3oys8soP0XcOw/large.jpg"
+                },
+                "is_biddable": true,
+                "is_acquireable": false,
+                "href": "/artwork/pablo-picasso-grand-maternite-2",
+                "title": "Grand Maternité",
+                "date": "1963",
+                "sale_message": "Contact For Price",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0OnBhYmxvLXBpY2Fzc28=",
+                    "href": "/artist/pablo-picasso",
+                    "name": "Pablo Picasso"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Forum Auctions",
+                  "href": "/auction/forum-auctions",
+                  "__id": "UGFydG5lcjpmb3J1bS1hdWN0aW9ucw==",
+                  "type": "Auction House"
+                },
+                "sale": {
+                  "is_auction": true,
+                  "is_live_open": false,
+                  "is_open": true,
+                  "is_closed": false,
+                  "display_timely_at": "ends in 5d",
+                  "auction_state": "open",
+                  "__id": "U2FsZTpmb3J1bS1hdWN0aW9ucy1tdWx0aXBseQ=="
+                },
+                "sale_artwork": {
+                  "highest_bid": {
+                    "display": null,
+                    "__id": null
+                  },
+                  "opening_bid": {
+                    "display": "£5,500"
+                  },
+                  "__id": "U2FsZUFydHdvcms6cGFibG8tcGljYXNzby1ncmFuZC1tYXRlcm5pdGUtMg==",
+                  "counts": {
+                    "bidder_positions": 0
+                  }
+                },
+                "_id": "5bbfa1601165614621e1db54",
+                "is_inquireable": true,
+                "id": "pablo-picasso-grand-maternite-2",
+                "is_saved": false
+              }
+            }
+          ]
+        }
+      },
+      "exhibition_highlights": [
+        {
+          "partner": {
+            "__typename": "Partner",
+            "name": "Tate Modern",
+            "__id": "UGFydG5lcjp0YXRlLW1vZGVybg=="
+          },
+          "name": "The EY Exhibition: PICASSO 1932 – Love, Fame, Tragedy",
+          "start_at": "2018",
+          "cover_image": {
+            "cropped": {
+              "url": "https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&width=800&height=600&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRKXtbPHeAhlCMj5N9r04SA%2Flarge.jpg"
+            }
+          },
+          "city": "London",
+          "__id": "U2hvdzp0YXRlLW1vZGVybi10aGUtZXktZXhoaWJpdGlvbi1waWNhc3NvLTE5MzItbG92ZS1mYW1lLXRyYWdlZHk="
+        },
+        {
+          "partner": {
+            "__typename": "Partner",
+            "name": "Musée Picasso Paris",
+            "__id": "UGFydG5lcjptdXNlZS1waWNhc3NvLXBhcmlz"
+          },
+          "name": "Picasso 1932. Année érotique",
+          "start_at": "2017",
+          "cover_image": {
+            "cropped": {
+              "url": "https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&width=800&height=600&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FgU16ukVwAAgtHy9mjhIWQw%2Flarge.jpg"
+            }
+          },
+          "city": "Paris",
+          "__id": "U2hvdzptdXNlZS1waWNhc3NvLXBhcmlzLXBpY2Fzc28tMTkzMi1hbm5lZS1lcm90aXF1ZQ=="
+        },
+        {
+          "partner": {
+            "__typename": "Partner",
+            "name": "Musée Picasso Paris",
+            "__id": "UGFydG5lcjptdXNlZS1waWNhc3NvLXBhcmlz"
+          },
+          "name": "Olga Picasso",
+          "start_at": "2017",
+          "cover_image": {
+            "cropped": {
+              "url": "https://d7hftxdivxxvm.cloudfront.net?resize_to=fill&width=800&height=600&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FTSBi03uZrWrng6Wx2dXvbQ%2Flarge.jpg"
+            }
+          },
+          "city": "Paris",
+          "__id": "U2hvdzptdXNlZS1waWNhc3NvLXBhcmlzLW9sZ2EtcGljYXNzbw=="
+        }
+      ],
+      "href": "/artist/pablo-picasso",
+      "is_consignable": true,
+      "artworks_connection": {},
+      "nationality": "Spanish",
+      "years": "1881-1973",
+      "carousel": {
+        "images": [
+          {
+            "href": "/show/bailly-gallery-solo-show-pablo-picasso",
+            "resized": {
+              "url": "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=144&height=200&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FHyc55JQhCdUh1rXQEHFtuw%2Flarge.jpg",
+              "width": 144,
+              "height": 200
+            }
+          },
+          {
+            "href": "/show/tate-modern-the-ey-exhibition-picasso-1932-love-fame-tragedy",
+            "resized": {
+              "url": "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=150&height=200&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FzPgGQ802qxkHR85T7GAEAw%2Flarge.jpg",
+              "width": 150,
+              "height": 200
+            }
+          },
+          {
+            "href": "/artwork/pablo-picasso-portrait-of-art-dealer-ambroise-vollard-1867-1939",
+            "resized": {
+              "url": "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=138&height=200&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRgh7CxrtmPgLgKz2fC8g3Q%2Flarge.jpg",
+              "width": 138,
+              "height": 200
+            }
+          },
+          {
+            "href": "/artwork/pablo-picasso-la-vie-life",
+            "resized": {
+              "url": "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=130&height=200&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FuKQRWPcxmMU_1C7iYBnVcw%2Flarge.jpg",
+              "width": 130,
+              "height": 200
+            }
+          },
+          {
+            "href": "/artwork/pablo-picasso-guernica",
+            "resized": {
+              "url": "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=441&height=200&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fxv2Kv6g8nocq9xATLvS3Vw%2Flarge.jpg",
+              "width": 441,
+              "height": 200
+            }
+          },
+          {
+            "href": "/artwork/pablo-picasso-still-life-with-chair-caning",
+            "resized": {
+              "url": "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=255&height=200&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FiwKcC80o_Ef-dH1Xh0k0Ug%2Flarge.jpg",
+              "width": 255,
+              "height": 200
+            }
+          },
+          {
+            "href": "/artwork/pablo-picasso-daniel-henry-kahnweiler",
+            "resized": {
+              "url": "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=144&height=200&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FrC3xdKws0h2ZlR_fmAK-dQ%2Flarge.jpg",
+              "width": 144,
+              "height": 200
+            }
+          },
+          {
+            "href": "/artwork/pablo-picasso-violin-with-sheet-of-music",
+            "resized": {
+              "url": "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=163&height=200&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F2pn4iPeFtUwJpOSM1EIJWA%2Flarge.jpg",
+              "width": 163,
+              "height": 200
+            }
+          },
+          {
+            "href": "/artwork/pablo-picasso-pichet-tete-carree",
+            "resized": {
+              "url": "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&width=197&height=200&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FjLvJU0z74q-FTVySvhFinA%2Flarge.jpg",
+              "width": 197,
+              "height": 200
+            }
+          }
+        ]
+      },
+      "statuses": {
+        "shows": true,
+        "artists": true,
+        "articles": true,
+        "cv": true,
+        "auction_lots": true
+      }
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13987,7 +13987,7 @@ standard@^9.0.0:
     eslint-plugin-standard "~2.0.1"
     standard-engine "~5.4.0"
 
-static-extend@^0.1.2:
+static-extend@^0.1.1, static-extend@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
   integrity sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=


### PR DESCRIPTION
cc @joeyAghion you were interested in this sort of a test (we have a good amount of Reaction coverage for components, and composing the components properly), so this adds a simple integration test in Force.

This was pretty sketchy running on my computer, but then again all of the existing integration tests were as well, but on CI they _seemed_ stable. This did in fact succeed _once_ on my computer, before succumbing to the same crashers that other tests on `master` had locally, so figured worth a PR and see how Circle likes it.