### PR TITLE
Never pull in huge normalized image into the carousel

### DIFF
--- a/src/mobile/apps/artwork/routes.coffee
+++ b/src/mobile/apps/artwork/routes.coffee
@@ -62,7 +62,7 @@ query = (user) -> """
         width
       }
       images {
-        url
+        url(version: "large")
         height
         width
         is_default


### PR DESCRIPTION
This fixes https://artsyproduct.atlassian.net/browse/DISCO-440.

During our performance analysis work we noticed that some mobile artwork pages were experiencing really large first meaningful paint times (~40 seconds) due to an image load that was taking ~30 seconds on a regular 3G network. After some investigation I discovered that artworks with multiple images were often pulling in the normalized.jpg rendition of the image which is the largest version of the image that we have stored. This was _significantly_ impacting page performance. 

This update ensures that the `large` image renditions are pulled in instead (which is how the single image setup is already configured). 
