### PR TITLE
Fix lighthouse SEO warnings

### DIFF
--- a/src/desktop/apps/sitemaps/routes.coffee
+++ b/src/desktop/apps/sitemaps/routes.coffee
@@ -42,9 +42,9 @@ sitemapProxy = httpProxy.createProxyServer(target: SITEMAP_BASE_URL)
     User-agent: *
     Noindex: ?sort=
     Noindex: ?dimension_range=
-    Disallow: ?dns_source=
-    Disallow: ?microsite=
-    Disallow: ?from-show-guide=
+    Disallow: /*?dns_source=
+    Disallow: /*?microsite=
+    Disallow: /*?from-show-guide=
     Sitemap: #{APP_URL}/sitemap-articles.xml
     Sitemap: #{APP_URL}/sitemap-artists.xml
     Sitemap: #{APP_URL}/sitemap-artist-images.xml

--- a/src/desktop/apps/sitemaps/test/routes.coffee
+++ b/src/desktop/apps/sitemaps/test/routes.coffee
@@ -42,9 +42,9 @@ describe 'Sitemaps', ->
 User-agent: *
 Noindex: ?sort=
 Noindex: ?dimension_range=
-Disallow: ?dns_source=
-Disallow: ?microsite=
-Disallow: ?from-show-guide=
+Disallow: /*?dns_source=
+Disallow: /*?microsite=
+Disallow: /*?from-show-guide=
 Sitemap: https://www.artsy.net/sitemap-articles.xml
 Sitemap: https://www.artsy.net/sitemap-artists.xml
 Sitemap: https://www.artsy.net/sitemap-artist-images.xml


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/DISCO-441.

Our [robots.txt file](https://artsy.net/robots.txt) has some `Disallow` rules that start with `?`. Lighthouse dings our SEO rating check by 9 points due to this. According to [Google's official docs](https://developers.google.com/search/reference/robots_txt#format-syntax--definition), they expect disallow to start with `/` or `*`. 