### PR TITLE
@damassi => Slight rewrite of mobile refresh to avoid operating on `req.user` directly

### DIFF
--- a/src/mobile/apps/user/routes.coffee
+++ b/src/mobile/apps/user/routes.coffee
@@ -1,15 +1,16 @@
 CurrentUser = require '../../models/current_user'
 
-module.exports.refresh = (req, res) ->
-  return res.redirect("/") unless req.user
-  req.user.fetch
-    error: res.backboneError
-    success: ->
-      req.login req.user, (error) ->
-        if (error)
-          next error
-        else
-          res.json req.user.attributes
+module.exports.refresh = (req, res, next) ->
+  user = req.user
+  return res.redirect("/") unless user
+
+  user
+    .fetch()
+    .then ->
+      req.login user, (error) ->
+        return next error if error?
+        res.json user.attributes
+    .catch next
 
 module.exports.settings = (req, res) ->
   return res.redirect("/log_in?redirect_uri=#{req.url}") unless req.user


### PR DESCRIPTION
While attempting to figure out the mobile reload loop, we saw that `req.user` (coming from Passport.js), was being operated on directly (`req.user.fetch`, `return req.user.attributes`).

This _could_ be fine, however, what if _some other_ code is modifying `req.user` while this operation is still happening? That could lead to unexpected behavior. So this is just a teensy rewrite, and it seems innocuous (and sort of unlikely to be an issue), but as we continue investigating, it's possibly worthwhile. 