### PR TITLE
Track successfully created orders

### DIFF
--- a/src/desktop/apps/artwork/components/commercial/view.coffee
+++ b/src/desktop/apps/artwork/components/commercial/view.coffee
@@ -80,6 +80,7 @@ module.exports = class ArtworkCommercialView extends Backbone.View
       .then (data) ->
         { order, error } = data?.ecommerceCreateOrderWithArtwork?.orderOrError || {}
         if order
+          analytics.track('created_order', { order_id: order.id })
           location.assign("/orders/#{order.id}/shipping")
         else
           console.error('createOrder', error)

--- a/src/mobile/apps/artwork/components/meta_data/test/view.coffee
+++ b/src/mobile/apps/artwork/components/meta_data/test/view.coffee
@@ -16,6 +16,7 @@ describe 'Metadata', ->
   before (done) ->
     benv.setup ->
       benv.expose $: benv.require('jquery'), analytics: track: sinon.stub()
+      analytics: track: sinon.stub()
       Backbone.$ = $
       done()
 
@@ -78,7 +79,7 @@ describe 'Metadata', ->
       location.assign.callCount.should.equal(1)
       location.assign.calledWith('/login?redirectTo=/artwork/peter-alexander-wedge-with-puff&signupIntent=buy+now&intent=buy+now&trigger=click').should.be.ok()
 
-    it 'should reroute to the buy now form', ->
+    it 'should track the successfully created order and reroute to the buy now form', ->
       createOrderStub = sinon.stub().returns(Promise.resolve(ecommerceCreateOrderWithArtwork: orderOrError: order: id: "1234"))
       @MetaDataView.__set__
         createOrder: createOrderStub
@@ -89,6 +90,7 @@ describe 'Metadata', ->
       view.buy(fakeEvent).then ->
         createOrderStub.callCount.should.equal(1)
         location.assign.callCount.should.equal(1)
+        analytics.track.calledWith('created_order', { order_id: '1234' }).should.be.ok()
         location.assign.calledWith('/orders/1234/shipping').should.be.ok()
 
     it 'should show an error modal when buy now mutation fails', ->

--- a/src/mobile/apps/artwork/components/meta_data/view.coffee
+++ b/src/mobile/apps/artwork/components/meta_data/view.coffee
@@ -41,6 +41,7 @@ module.exports = class MetaDataView extends Backbone.View
       .then (data) ->
         { order, error } = data?.ecommerceCreateOrderWithArtwork?.orderOrError || {}
         if order
+          analytics.track('created_order', { order_id: order.id })
           location.assign("/orders/#{order.id}/shipping")
         else
           console.error('createOrder', error)


### PR DESCRIPTION
Tracks successful creation of orders on the client. Resolves [PURCHASE-587](https://artsyproduct.atlassian.net/browse/PURCHASE-587). 

Desktop tests will require a more substantial refactor to be done in a later PR.