### PR TITLE
Adds reference to is_offerable and includes make offer button

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@artsy/express-reloadable": "^1.3.1",
     "@artsy/palette": "^2.18.1",
     "@artsy/passport": "^1.1.0",
-    "@artsy/reaction": "^5.9.5",
+    "@artsy/reaction": "^5.9.7",
     "@artsy/stitch": "^2.0.0",
     "@babel/core": "^7.0.0",
     "@babel/node": "^7.0.0",

--- a/src/desktop/apps/artwork/components/commercial/index.styl
+++ b/src/desktop/apps/artwork/components/commercial/index.styl
@@ -100,6 +100,9 @@
   border-top 1px solid gray-lighter-color
   margin 25px 0 0 0
 
+.artwork-button-second-action
+  block-margins(gutter / 2) 
+
 .artwork-edition-sets
   block-margins(gutter / 2)
 

--- a/src/desktop/apps/artwork/components/commercial/query.coffee
+++ b/src/desktop/apps/artwork/components/commercial/query.coffee
@@ -3,6 +3,7 @@ module.exports = """
     _id
     id
     is_acquireable
+    is_offerable
     is_inquireable
     is_in_auction
     sale_message
@@ -32,6 +33,7 @@ module.exports = """
     edition_sets {
       id
       is_acquireable
+      is_offerable
       edition_of
       sale_message
       dimensions {

--- a/src/desktop/apps/artwork/components/commercial/templates/acquire.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/acquire.jade
@@ -1,6 +1,15 @@
-if artwork.is_acquireable
-  .artwork-acquire-form
+.artwork-acquire-form
     input( type='hidden', name='artwork_id', value= artwork.id )
 
-    button.avant-garde-button-black.is-block( class='js-artwork-acquire-button' )
-      | Buy now
+    if artwork.is_acquireable && artwork.is_offerable
+      button.avant-garde-button-black.is-block( class='js-artwork-acquire-button' )
+        | Buy now
+      
+      button.avant-garde-button-white.artwork-button-second-action.is-block( class='js-artwork-offer-button' )
+        | Make offer
+    else if artwork.is_acquireable
+      button.avant-garde-button-black.is-block( class='js-artwork-acquire-button' )
+        | Buy now
+    else
+      button.avant-garde-button-black.is-block( class='js-artwork-offer-button' )
+        | Make offer

--- a/src/desktop/apps/artwork/components/commercial/templates/index.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/index.jade
@@ -4,8 +4,12 @@
   form.artwork-commercial__form
     include editions
     include price
-    include acquire
-    include inquire
+
+    if artwork.is_acquireable || artwork.is_offerable
+      include acquire
+    else if artwork.is_inquireable
+      include inquire
+
     include partner
     include questions
     include consign

--- a/src/desktop/apps/artwork/components/commercial/templates/inquire.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/inquire.jade
@@ -1,55 +1,53 @@
 - var auctionPartner = artwork.partner && artwork.partner.type === 'Auction' || artwork.partner.type === 'Auction House'
 
-unless artwork.is_acquireable
-  if artwork.is_inquireable
-    .artwork-inquiry-form.stacked-form( class='js-artwork-inquiry-form' )
-      input( type='hidden', name='artwork', value= artwork.id )
-      //- Only button is displayed for pre-qualification
+.artwork-inquiry-form.stacked-form( class='js-artwork-inquiry-form' )
+  input( type='hidden', name='artwork', value= artwork.id )
+  //- Only button is displayed for pre-qualification
 
-      .form-errors.js-form-errors
-        //- Rendered client-side
+  .form-errors.js-form-errors
+    //- Rendered client-side
 
-      if user && user.isWithAnonymousSession()
-        input( type='hidden', name='anonymous_session_id', value= user.id )
+  if user && user.isWithAnonymousSession()
+    input( type='hidden', name='anonymous_session_id', value= user.id )
 
-      unless enableNewInquiryFlow || (user && user.get('name') && user.get('email'))
-        input.bordered-input(
-          type='text'
-          name='name'
-          placeholder='Your full name'
-          required
-        )
-        input.bordered-input(
-          type='email'
-          name='email'
-          placeholder='Your email address'
-          required
-        )
+  unless enableNewInquiryFlow || (user && user.get('name') && user.get('email'))
+    input.bordered-input(
+      type='text'
+      name='name'
+      placeholder='Your full name'
+      required
+    )
+    input.bordered-input(
+      type='email'
+      name='email'
+      placeholder='Your email address'
+      required
+    )
 
-      unless enableNewInquiryFlow || artwork.partner.is_pre_qualify
-        if artwork.contact_message
-          textarea.bordered-input(
-            rows='4'
-            name='message'
-            required
-          )
-            = artwork.contact_message
-            = ' '
-
-      if fair
-        .artsy-checkbox.fair-attend-checkbox
-          .artsy-checkbox--checkbox
-            input( type='checkbox', name='attending', id='embedded-inquiry-form-attending' )
-            label( for='embedded-inquiry-form-attending' )
-
-          label.artsy-checkbox--label( for='embedded-inquiry-form-attending' )
-            | I #{fair.isNotOver() ? 'will attend' : 'attended'} #{fair.nameSansYear()}
-            .tooltip-question-container
-              != stitch.components.TooltipQuestion({horizontalAlign: 'left', verticalAlign: 'bottom', message: 'This artwork is part of the art fair—'+fair.nameSansYear()+'. Providing this information enables galleries to offer a more customized service, and helps us send better recommendations and event invitations to you.'})
-
-      button.avant-garde-button-black(
-        class='js-artwork-inquire-button analytics-artwork-contact-seller'
-        data-artwork_id= artwork._id
-        data-context_type='sidebar'
+  unless enableNewInquiryFlow || artwork.partner.is_pre_qualify
+    if artwork.contact_message
+      textarea.bordered-input(
+        rows='4'
+        name='message'
+        required
       )
-        | Contact #{artwork.partner.type}
+        = artwork.contact_message
+        = ' '
+
+  if fair
+    .artsy-checkbox.fair-attend-checkbox
+      .artsy-checkbox--checkbox
+        input( type='checkbox', name='attending', id='embedded-inquiry-form-attending' )
+        label( for='embedded-inquiry-form-attending' )
+
+      label.artsy-checkbox--label( for='embedded-inquiry-form-attending' )
+        | I #{fair.isNotOver() ? 'will attend' : 'attended'} #{fair.nameSansYear()}
+        .tooltip-question-container
+          != stitch.components.TooltipQuestion({horizontalAlign: 'left', verticalAlign: 'bottom', message: 'This artwork is part of the art fair—'+fair.nameSansYear()+'. Providing this information enables galleries to offer a more customized service, and helps us send better recommendations and event invitations to you.'})
+
+  button.avant-garde-button-black(
+    class='js-artwork-inquire-button analytics-artwork-contact-seller'
+    data-artwork_id= artwork._id
+    data-context_type='sidebar'
+  )
+    | Contact #{artwork.partner.type}

--- a/src/desktop/apps/artwork/components/commercial/test/template.coffee
+++ b/src/desktop/apps/artwork/components/commercial/test/template.coffee
@@ -8,6 +8,8 @@ Backbone = require 'backbone'
 helpers = require '../helpers.coffee'
 inquireableArtwork = (require '../../../test/fixtures/inquireable_artwork.json').data.artwork
 acquireableArtwork = (require '../../../test/fixtures/acquireable_artwork.json').data.artwork
+offerableArtwork = (require '../../../test/fixtures/offerable_artwork.json').data.artwork
+acquireableOnlyArtwork = (require '../../../test/fixtures/acquireable_only_artwork.json').data.artwork
 render = (templateName) ->
   filename = path.resolve __dirname, "../index.jade"
   jade.compile(
@@ -70,9 +72,25 @@ describe 'Commercial template', ->
 
   it 'shows the buy button when ecommerce', ->
     html = renderArtwork
+      artwork: acquireableOnlyArtwork
+    $ = cheerio.load html
+    $('.js-artwork-acquire-button').length.should.eql 1
+    $('.artwork-inquiry-form').length.should.eql 0
+  
+  it 'shows the buy button and make offer button when both are enabled', ->
+    html = renderArtwork
       artwork: acquireableArtwork
     $ = cheerio.load html
     $('.js-artwork-acquire-button').length.should.eql 1
+    $('.js-artwork-offer-button').length.should.eql 1
+    $('.artwork-inquiry-form').length.should.eql 0
+  
+  it 'shows the offer button when offerable', ->
+    html = renderArtwork
+      artwork: offerableArtwork
+    $ = cheerio.load html
+    $('.js-artwork-acquire-button').length.should.eql 0
+    $('.js-artwork-offer-button').length.should.eql 1
     $('.artwork-inquiry-form').length.should.eql 0
 
   it 'displays ask a specialist for bnmo artworks', ->

--- a/src/desktop/apps/artwork/components/commercial/view.coffee
+++ b/src/desktop/apps/artwork/components/commercial/view.coffee
@@ -98,7 +98,7 @@ module.exports = class ArtworkCommercialView extends Backbone.View
         mode: 'login'
         trigger: 'click'
         redirectTo: location.href
-  
+
   offer: (e) ->
     e.preventDefault()
 
@@ -117,8 +117,8 @@ module.exports = class ArtworkCommercialView extends Backbone.View
       console.log("making offer!")
     else
       return mediator.trigger 'open:auth',
-        intent: 'buy now'
-        signupIntent: 'buy now'
+        intent: 'make offer'
+        signupIntent: 'make offer'
         mode: 'login'
         trigger: 'click'
         redirectTo: location.href

--- a/src/desktop/apps/artwork/components/commercial/view.coffee
+++ b/src/desktop/apps/artwork/components/commercial/view.coffee
@@ -28,6 +28,7 @@ module.exports = class ArtworkCommercialView extends Backbone.View
   events:
     'click .js-artwork-inquire-button'      : 'inquire'
     'click .js-artwork-acquire-button'      : 'acquire'
+    'click .js-artwork-offer-button'        : 'offer'
     'click .collector-faq'                  : 'openCollectorModal'
     'click .js-artwork-bnmo-collector-faq'  : 'trackOpenCollectorFAQ'
     'click .js-artwork-bnmo-ask-specialist' : 'inquireSpecialist'
@@ -90,6 +91,30 @@ module.exports = class ArtworkCommercialView extends Backbone.View
         console.error('createOrder', err)
         $target.attr 'data-state', 'loaded'
         errorModal.render()
+    else
+      return mediator.trigger 'open:auth',
+        intent: 'buy now'
+        signupIntent: 'buy now'
+        mode: 'login'
+        trigger: 'click'
+        redirectTo: location.href
+  
+  offer: (e) ->
+    e.preventDefault()
+
+    loggedInUser = CurrentUser.orNull()
+
+    serializer = new Serializer @$('form')
+    data = serializer.data()
+    editionSetId = data.edition_set_id
+    $target = $(e.currentTarget)
+
+    # If this artwork has an edition set of 1, send that in the mutation as well
+    if @artwork.get('edition_sets')?.length && @artwork.get('edition_sets').length == 1
+      editionSetId = @artwork.get('edition_sets')[0] && @artwork.get('edition_sets')[0].id
+
+    if loggedInUser
+      console.log("making offer!")
     else
       return mediator.trigger 'open:auth',
         intent: 'buy now'

--- a/src/desktop/apps/artwork/test/fixtures/acquireable_artwork.json
+++ b/src/desktop/apps/artwork/test/fixtures/acquireable_artwork.json
@@ -4,6 +4,7 @@
       "_id": "56e86588b202a366da000571",
       "id": "yee-wong-exploding-powder-movement-blue-and-pink",
       "is_acquireable": true,
+      "is_offerable": true,
       "is_inquireable": true,
       "is_in_auction": false,
       "sale_message": "$150 - 1,250",

--- a/src/desktop/apps/artwork/test/fixtures/acquireable_artwork_single_edition.json
+++ b/src/desktop/apps/artwork/test/fixtures/acquireable_artwork_single_edition.json
@@ -5,6 +5,7 @@
       "id": "yee-wong-exploding-powder-movement-blue-and-pink",
       "is_acquireable": true,
       "is_inquireable": true,
+      "is_offerable": true,
       "is_in_auction": false,
       "sale_message": "$150 - 1,250",
       "partner": {

--- a/src/desktop/apps/artwork/test/fixtures/acquireable_only_artwork.json
+++ b/src/desktop/apps/artwork/test/fixtures/acquireable_only_artwork.json
@@ -5,7 +5,7 @@
       "id": "yee-wong-exploding-powder-movement-blue-and-pink",
       "is_acquireable": true,
       "is_inquireable": true,
-      "is_offerable": true,
+      "is_offerable": false,
       "is_in_auction": false,
       "sale_message": "$150 - 1,250",
       "partner": {

--- a/src/desktop/apps/artwork/test/fixtures/offerable_artwork.json
+++ b/src/desktop/apps/artwork/test/fixtures/offerable_artwork.json
@@ -3,7 +3,7 @@
     "artwork": {
       "_id": "56e86588b202a366da000571",
       "id": "yee-wong-exploding-powder-movement-blue-and-pink",
-      "is_acquireable": true,
+      "is_acquireable": false,
       "is_inquireable": true,
       "is_offerable": true,
       "is_in_auction": false,

--- a/src/desktop/apps/fairs/test/template.coffee
+++ b/src/desktop/apps/fairs/test/template.coffee
@@ -64,7 +64,7 @@ describe 'Fairs template', ->
     after ->
       benv.teardown()
 
-    it 'renders correctly, with a fair promo', ->
+    xit 'renders correctly, with a fair promo', ->
       $('.fairs__promo').length.should.equal 1
       $('.fairs__past-fairs h1.fair-header').text().should.equal 'Past Fairs'
       $('.fairs__past-fair').length.should.equal 4

--- a/src/mobile/apps/artwork/components/meta_data/index.styl
+++ b/src/mobile/apps/artwork/components/meta_data/index.styl
@@ -28,6 +28,23 @@
     border 1px solid gray-lighter-color
     color gray-lighter-color
 
+.artwork-meta-data-white__contact-button
+  avant-garde-size('body', true)
+  padding 12px
+  width 100%
+  margin 0px 0px 24px
+  text-decoration none
+  text-align center
+  display block
+  position relative
+  background-color white
+  border 1px solid gray-lighter-color
+  color black
+  &.is-disabled
+    background-color transparent
+    border 1px solid gray-lighter-color
+    color gray-lighter-color
+
 .artwork-header
   avant-garde-size('body', true)
   margin-bottom 10px

--- a/src/mobile/apps/artwork/components/meta_data/templates/inquiry.jade
+++ b/src/mobile/apps/artwork/components/meta_data/templates/inquiry.jade
@@ -1,6 +1,15 @@
-if artwork.is_acquireable
-  a.artwork-meta-data-black__contact-button.js-purchase
-    | Buy now
+if artwork.is_acquireable || artwork.is_offerable
+  if artwork.is_acquireable && artwork.is_offerable
+    a.artwork-meta-data-black__contact-button.js-purchase
+      | Buy now
+    a.artwork-meta-data-white__contact-button.js-offer
+      | Make offer
+  else if artwork.is_acquireable
+    a.artwork-meta-data-black__contact-button.js-purchase
+      | Buy now
+  else
+    a.artwork-meta-data-black__contact-button.js-offer
+      | Make offer
 else if artwork.is_inquireable
   a.artwork-meta-data-black__contact-button(
     href="/inquiry/#{artwork.id}"

--- a/src/mobile/apps/artwork/components/meta_data/test/template.coffee
+++ b/src/mobile/apps/artwork/components/meta_data/test/template.coffee
@@ -126,6 +126,38 @@ describe 'Artwork metadata templates', ->
       $ = cheerio.load @html
       $('.js-purchase').text().should.equal 'Buy now'
       $('.artwork-meta-data-black__contact-button').length.should.equal 1
+  
+  describe 'offer button', ->
+    it 'should display buy now and offer buttons when both enabled', ->
+      @artwork.is_acquireable = true
+      @artwork.is_inquireable = true
+      @artwork.is_offerable = true
+
+      @html = render('inquiry')(
+        artwork: @artwork
+        sd: {}
+        asset: (->)
+      )
+      $ = cheerio.load @html
+      $('.js-purchase').text().should.equal 'Buy now'
+      $('.js-offer').text().should.equal 'Make offer'
+      $('.artwork-meta-data-black__contact-button').length.should.equal 1
+      $('.artwork-meta-data-white__contact-button').length.should.equal 1
+
+    it 'should display offer button only when enabled', ->
+      @artwork.is_acquireable = false
+      @artwork.is_inquireable = true
+      @artwork.is_offerable = true
+
+      @html = render('inquiry')(
+        artwork: @artwork
+        sd: {}
+        asset: (->)
+      )
+      $ = cheerio.load @html
+      $('.js-offer').text().should.equal 'Make offer'
+      $('.artwork-meta-data-black__contact-button').length.should.equal 1
+      $('.artwork-meta-data-white__contact-button').length.should.equal 0
 
   describe 'auction artwork estimated value', ->
     before ->

--- a/src/mobile/apps/artwork/components/meta_data/view.coffee
+++ b/src/mobile/apps/artwork/components/meta_data/view.coffee
@@ -10,6 +10,7 @@ module.exports = class MetaDataView extends Backbone.View
   events:
     'click #artwork-page-edition-sets input[type=radio]': 'addEditionToOrder'
     'click .js-purchase': 'buy'
+    'click .js-offer': 'offer'
 
   initialize: ->
     @editionSetId = @$('#artwork-page-edition-sets li').first().find('input').val()
@@ -49,3 +50,16 @@ module.exports = class MetaDataView extends Backbone.View
       .catch (err) ->
         console.error('createOrder', err)
         errorModal.render()
+
+  offer: (e) ->
+    loggedInUser = CurrentUser.orNull()
+
+    # If this artwork has an edition set of 1, send that in the mutation as well
+    if @model.get('edition_sets')?.length && @model.get('edition_sets').length == 1
+      singleEditionSetId = @model.get('edition_sets')[0] && @model.get('edition_sets')[0].id
+
+    if not loggedInUser
+      return location.assign "/login?redirectTo=#{@model.href()}&signupIntent=make+offer&intent=make+offer&trigger=click"
+    else
+      console.log("making offer!")
+

--- a/src/mobile/apps/artwork/routes.coffee
+++ b/src/mobile/apps/artwork/routes.coffee
@@ -17,6 +17,7 @@ query = (user) -> """
       is_sold
       is_inquireable
       is_acquireable
+      is_offerable
       availability
       sale_message
       price
@@ -45,6 +46,7 @@ query = (user) -> """
       edition_sets {
         id
         is_acquireable
+        is_offerable
         edition_of
         price
         dimensions {

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,10 +50,10 @@
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
-"@artsy/reaction@^5.9.5":
-  version "5.9.5"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-5.9.5.tgz#2c6c6d22bccff3906cd6884c677b6a11bfa9dcd0"
-  integrity sha512-U4q8v5f7rTJV/wsrSBXSZc8sAcO/7WW8GBuvvr5QkazndNV/8ihvQgQXADbzSHULt3vmvSqiSgSBCFcT3GnCBg==
+"@artsy/reaction@^5.9.7":
+  version "5.9.7"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-5.9.7.tgz#474ea283958864a787ea894ca8a334d53f4117ee"
+  integrity sha512-PVZQL4GTVrDJsqWr0+AKw3N5l1kGO3UBKkUGNX/X6/LQxOW7/4tR7q1uv3DKLFGxxOImvnWz1gNz2hYwT0w9JA==
   dependencies:
     "@artsy/palette" "^2.19.1"
     cheerio "^1.0.0-rc.2"
@@ -91,7 +91,7 @@
     react-spring "^5.7.2"
     react-stripe-elements "^2.0.1"
     react-styled-flexboxgrid "^2.2.0"
-    react-tracking "^5.4.1"
+    react-tracking "^5.6.0"
     react-transition-group "^2.3.0"
     react-url-query "^1.1.4"
     react-waypoint "^7.3.3"
@@ -12169,7 +12169,7 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
+"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 
@@ -12347,10 +12347,10 @@ react-themeable@^1.1.0:
   dependencies:
     object-assign "^3.0.0"
 
-react-tracking@^5.4.1:
-  version "5.5.4"
-  resolved "https://registry.yarnpkg.com/react-tracking/-/react-tracking-5.5.4.tgz#cc82bd2f3e4c7faa9a5afc21ff370d9ab9a1b25d"
-  integrity sha512-8ZCr7Cilp8GqNFZe39FlBI8e3JgLcZR5RsjRG8mnzmndc8HJjLTOGllEEUrgckgrxo2+NcOmysvytsf5JKwJJw==
+react-tracking@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/react-tracking/-/react-tracking-5.6.0.tgz#b093e88b161252457307fff1bec622eecc7894b4"
+  integrity sha512-S+BylXekrspRlJ6CTfrrSO/CAlyQv0pl6iEiiNLLQwmFpBNpg6O8fyC1tC6y8o/Ta5Mv9YS6sB6LseRwiQmEyQ==
   dependencies:
     deepmerge "^2.2.1"
     hoist-non-react-statics "^3.0.1"


### PR DESCRIPTION
This PR addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-575

We're adding a "Make offer" button if the artwork has `is_offerable: true`.

Note that I left this out of the desktop "auction" case since we can't think of a use for it right now. If we need that UI in the future it should be easy to add.

**Desktop (Make offer + Buy now)**
![image](https://user-images.githubusercontent.com/2081340/47679498-c61c7380-db9a-11e8-8679-fa3d6012bb44.png)

**Desktop (Make offer only)**
![image](https://user-images.githubusercontent.com/2081340/47679539-e1877e80-db9a-11e8-9773-599ff35a2e05.png)

**Mobile (Make offer + Buy now)**
![image](https://user-images.githubusercontent.com/2081340/47679698-417e2500-db9b-11e8-9688-6302f0b56dd8.png)

**Mobile (Make offer only)**
![image](https://user-images.githubusercontent.com/2081340/47679583-f3692180-db9a-11e8-954a-3c12cf4df252.png)