### PR TITLE
@damassi => Explicitly save the session to avoid possibly race condition in `req.user`

### DIFF
--- a/src/mobile/apps/user/routes.coffee
+++ b/src/mobile/apps/user/routes.coffee
@@ -9,6 +9,9 @@ module.exports.refresh = (req, res) ->
         if (error)
           next error
         else
+          # Avoid race condition where this returns _before_
+          # session is actually saved, by setting something explicitly.
+          req.session.userRefresh = new Date()
           res.json req.user.attributes
 
 module.exports.settings = (req, res) ->


### PR DESCRIPTION
Using https://github.com/jaredhanson/passport/issues/306#issuecomment-419334330 to work around a potential race condition inside of `req.login` and persisting the session, based on the really old version of Passport.js we are using.

Since currently this is reproable on staging, this might work/hold everything over 🤞 while the more proper task of upgrading that dependency is undertaken, since it's possible this bug was actually a real bug and fixed upstream (...years ago 😐 )