### PR TITLE
@damassi => Grasping for straws, delay reloading to allow cookie to be set

### DIFF
--- a/src/mobile/apps/user/routes.coffee
+++ b/src/mobile/apps/user/routes.coffee
@@ -1,6 +1,6 @@
 CurrentUser = require '../../models/current_user'
 
-module.exports.refresh = (req, res) ->
+module.exports.refresh = (req, res, next) ->
   return res.redirect("/") unless req.user
   req.user.fetch
     error: res.backboneError
@@ -11,8 +11,10 @@ module.exports.refresh = (req, res) ->
         else
           # Avoid race condition where this returns _before_
           # session is actually saved, by setting something explicitly.
-          req.session.userRefresh = new Date()
-          res.json req.user.attributes
+          req.session.save()
+            .then ->
+              res.json req.user.attributes
+            .catch next
 
 module.exports.settings = (req, res) ->
   return res.redirect("/log_in?redirect_uri=#{req.url}") unless req.user

--- a/src/mobile/apps/user/routes.coffee
+++ b/src/mobile/apps/user/routes.coffee
@@ -9,12 +9,7 @@ module.exports.refresh = (req, res, next) ->
         if (error)
           next error
         else
-          # Avoid race condition where this returns _before_
-          # session is actually saved, by setting something explicitly.
-          req.session.save()
-            .then ->
-              res.json req.user.attributes
-            .catch next
+          res.json req.user.attributes
 
 module.exports.settings = (req, res) ->
   return res.redirect("/log_in?redirect_uri=#{req.url}") unless req.user

--- a/src/mobile/components/layout/bootstrap.coffee
+++ b/src/mobile/components/layout/bootstrap.coffee
@@ -67,7 +67,8 @@ ensureFreshUser = (data) ->
   for attr in attrs
     if (data[attr] or sd.CURRENT_USER[attr]) and not _.isEqual data[attr], sd.CURRENT_USER[attr]
       RavenClient.captureException("Forced to refresh user", { extra: { attr: attr, session: sd.CURRENT_USER[attr], current: data[attr] } } )
-      $.ajax('/user/refresh').then -> window.location.reload()
+      $.ajax('/user/refresh').then ->
+        setTimeout  (=> window.location.reload()), 500
 
 syncAuth = module.exports.syncAuth = ->
   # Log out of Microgravity if you're not logged in to Gravity


### PR DESCRIPTION
The result of `/user/refresh` (and `req.login`, etc.) is that a new cookie is sent to the client, via a `Set-Cookie` header. This, at least within Force, is synchronous, and so shouldn't be subject to some of the race conditions people were experiencing with asynchronous session saving.

However, that got me thinking, we're expecting the result of `/user/refresh` to contain a new cookie that gets set. We're also immediately...leaving the page (by reloading).

Might that cause the browser to sometimes/race-condition not set the cookie? ie- before setting navigation away occurs and it gets flushed.

This just adds a delay of 500ms around the refresh to allow the browser to 'catch up' and set the cookie properly.