### PR TITLE
@damassi => Make sure we send the session cookie over with /user/refresh on mobile

### DIFF
--- a/src/mobile/apps/user/routes.coffee
+++ b/src/mobile/apps/user/routes.coffee
@@ -9,6 +9,8 @@ module.exports.refresh = (req, res, next) ->
         if (error)
           next error
         else
+          # Make sure we modify the session to force a `Set-Cooke` header.
+          req.session.userRefresh = new Date()
           res.json req.user.attributes
 
 module.exports.settings = (req, res) ->


### PR DESCRIPTION
We already tried this, but I think it _might_ not have been properly deployed to staging amidst CI flakiness?

Currently, if you make a change in a console and hit https://staging.artsy.net/user/refresh in your desktop Chrome, and inspect:

<img width="832" alt="screen shot 2018-10-30 at 1 48 18 pm" src="https://user-images.githubusercontent.com/1457859/47738876-7bf2cb00-dc4a-11e8-8da7-42310e40f959.png">

This is good! We have the latest and greatest session data from Force's server, being sent to the client in the `Set-Cookie` header.

However, perform the same experiment as above ^, except open your Chrome mobile emulator:

<img width="117" alt="screen shot 2018-10-30 at 1 49 21 pm" src="https://user-images.githubusercontent.com/1457859/47738991-c6744780-dc4a-11e8-80bc-f5bfc87470dd.png">


And voila! There is _no_ `Set-Cookie` header, which is consistent with what the bug reported is...namely, that `/user/refresh` _doesnt_ actually update their session, and so, they are always stale and refreshing.