### PR TITLE
@sweir27 => Guard against a failing server-side lot standings call

### DIFF
--- a/src/desktop/apps/auction/__tests__/routes.jest.js
+++ b/src/desktop/apps/auction/__tests__/routes.jest.js
@@ -85,6 +85,16 @@ describe("routes", () => {
       await routes.index(req, res, next)
       expect(res.send).toBeCalledWith("<html />")
     })
+
+    it("works even with the Metaphysics module throwing an error", async () => {
+      metaphysics
+        .mockReturnValueOnce({ sale: { is_auction: true } })
+        .mockRejectedValue("oops!")
+
+      // FIXME: Need to write more robust output test
+      await routes.index(req, res, next)
+      expect(res.send).toBeCalledWith("<html />")
+    })
   })
 
   describe("#redirectLive", async () => {

--- a/src/desktop/apps/auction/routes.js
+++ b/src/desktop/apps/auction/routes.js
@@ -60,10 +60,17 @@ export async function index(req, res, next) {
     let me = {}
 
     if (!isEcommerceSale) {
-      ;({ me } = await metaphysics({
-        query: MeQuery(sale.id),
-        req,
-      }))
+      try {
+        ;({ me } = await metaphysics({
+          query: MeQuery(sale.id),
+          req,
+        }))
+      } catch (error) {
+        console.error(
+          "(apps/auction/routes.js) Error fetching LotStandings",
+          error
+        )
+      }
     }
 
     // If an e-commerce sale, remove all sort options that are Auction related


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/browse/DISCO-436

~~I couldn't actually get the accompanying `routes.test.js` file to work on my computer locally, so I'll push a blind 🙈 spec.~~

EDIT- Figured out my yarn issue, added spec.