### PR TITLE
@damassi => Dont sync user session on every page load for mobile

### DIFF
--- a/src/mobile/components/layout/bootstrap.coffee
+++ b/src/mobile/components/layout/bootstrap.coffee
@@ -43,7 +43,8 @@ module.exports = ->
 
   setupErrorReporting()
   setupHeaderView()
-  syncAuth()
+  # TODO: Look into why this fails.
+  # syncAuth()
   checkForAfterSignUpAction()
   if globalClientSetup
     globalClientSetup()


### PR DESCRIPTION
This seems to be one of those bugs that's possibly not going to be fully understood, and I'd like to have some benefit from the time spent on it.

So, we just suspend the auth sync for now (since I don't think it's even meaningful).