### PR TITLE
Remove unused 'onDailyEditorial' flag

### DIFF
--- a/src/desktop/apps/article/routes.js
+++ b/src/desktop/apps/article/routes.js
@@ -127,12 +127,6 @@ export async function index(req, res, next) {
 
     // Email signup
     const isLoggedIn = typeof CURRENT_USER !== "undefined"
-    let onDailyEditorial = false
-    // Only need to check subscription on mobile
-    if (isMobile && CURRENT_USER) {
-      onDailyEditorial = await subscribedToEditorial(CURRENT_USER.email)
-    }
-
     const showTooltips = !isMobile && !isTablet
     const renderTime = getCurrentUnixTimestamp()
 
@@ -159,7 +153,6 @@ export async function index(req, res, next) {
         isLoggedIn,
         isMobile,
         jsonLD,
-        onDailyEditorial,
         renderTime,
         showTooltips,
         superArticle,


### PR DESCRIPTION
This `onDailyEditorial` doesn't seem to be used anywhere in the view: https://github.com/search?q=org%3Aartsy+onDailyEditorial&type=Code

In the route where the other `onDailyEditorial` is used, we map it to `ON_DAILY_EDITORIAL` which is then used in [`src/desktop/components/email/client/editorial_signup.coffee`](https://github.com/artsy/force/blob/4a872b6e8e157c8f5b2d7507a9f85cea247b6e04/src/desktop/components/email/client/editorial_signup.coffee#L30), but in the new Article page we don't even do the same conversion, so I'm confident that we can remove this flag at least in the Article page.