### PR TITLE
@l2succes: remove meta tags that have been moved to reaction.

### DIFF
--- a/src/desktop/apps/collect2/meta.tsx
+++ b/src/desktop/apps/collect2/meta.tsx
@@ -8,15 +8,9 @@ interface Props {
 export const Meta = (props: Props) => {
   const { headTags } = props
 
-  const description =
-    "Find artworks by subject matter, style/technique, movement, price, and gallery/institution."
-
   return (
     <Fragment>
       {headTags}
-      <meta name="description" content={description} />
-      <meta property="og:description" content={description} />
-      <meta property="twitter:description" content={description} />
 
       <meta property="og:type" content="website" />
       <meta property="twitter:card" content="summary" />


### PR DESCRIPTION
This cleans up the metadata tags for the collect and collection pages as part of https://artsyproduct.atlassian.net/browse/GROW-904 and https://artsyproduct.atlassian.net/browse/GROW-931. This PR is dependent on https://github.com/artsy/reaction/pull/1496.