### PR TITLE
@eessex: update article query to include sponsor pixel tracking code

### DIFF
--- a/src/desktop/apps/article/queries/articleBody.js
+++ b/src/desktop/apps/article/queries/articleBody.js
@@ -28,6 +28,7 @@ export const articleBody = `
     partner_light_logo
     partner_condensed_logo
     partner_logo_link
+    pixel_tracking_code
   }
   seriesArticle {
     title
@@ -41,6 +42,7 @@ export const articleBody = `
       partner_light_logo
       partner_condensed_logo
       partner_logo_link
+      pixel_tracking_code
     }
   }
   super_article {


### PR DESCRIPTION
Part of https://artsyproduct.atlassian.net/browse/GROW-772. This adds `pixel_tracking_code` to the article query.