### PR TITLE
Fixes ab issue where all medium links on homepage broken (desktop)

### DIFF
--- a/src/desktop/apps/home/templates/browse.jade
+++ b/src/desktop/apps/home/templates/browse.jade
@@ -6,5 +6,5 @@
   .home-browse-module__menu.grid-4-up
     if browseCategories
       each category, id in browseCategories
-        a.home-browse-module__menu__option.grid-item(href="/collect?medium=#{id}")= category
+        a.home-browse-module__menu__option.grid-item(href="/collect/#{id}")= category
       a.home-browse-module__menu__option.grid-item(href="/collect") All Mediums


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/GROW-997

Previously the Collect page was routed to `/collect?medium=#{id}` (e.g. `/collect?medium=painting`) but now it's `/collect/#{id}` (e.g. `/collect/painting`). Because of this the medium links on the homepage for non-logged-in users are broken. This PR updates the paths to fix it.