### PR TITLE
@anandaroop => Dedupe location matches in galleries typeahead by slug

### DIFF
--- a/src/desktop/apps/galleries_institutions/components/filter_facet/partner_filter_facet.coffee
+++ b/src/desktop/apps/galleries_institutions/components/filter_facet/partner_filter_facet.coffee
@@ -31,7 +31,7 @@ module.exports = class PartnerFilterFacet extends Backbone.Model
       matches = [@allItemsSuggestion].concat _.select @countItems, ({id}) =>
         id in @emptyStateItemIDs
 
-    callback(matches)
+    callback _.uniq(matches, 'id')
 
   isMatched: (query, string) ->
     escape= (s) ->


### PR DESCRIPTION
I didn't _really_ figure out how/why this was happening to 'Hong Kong', but I think this is a good fix (+ fixes the specific issue)

<img width="467" alt="screen shot 2018-11-13 at 6 35 43 pm" src="https://user-images.githubusercontent.com/1457859/48450131-1ab31780-e773-11e8-96bb-39997e16f5b3.png">

Basically, since we have our own datasource of `{id: slug, name: City/Geo/Country}`, it _should_ be safe to dedupe by `id`. Not sure why HK was matching twice, but logically, we wouldn't ever want a duplicate suggestion to appear (for whatever the reason), so I'm reasonably confident in this little update.