### PR TITLE
@cavvia => Launch artwork page sidebar pageviews CTA as an AB test

### DIFF
--- a/src/desktop/apps/artwork/client/index.coffee
+++ b/src/desktop/apps/artwork/client/index.coffee
@@ -7,6 +7,7 @@ CurrentUser = require '../../../models/current_user.coffee'
 exec = require '../lib/exec.coffee'
 fold = -> require('./fold.jade') arguments...
 footer = -> require('./footer.jade') arguments...
+splitTest = require '../../../components/split_test/index.coffee'
 
 helpers = extend [
   {}
@@ -161,6 +162,7 @@ module.exports =
   init: ->
     setCookie(CLIENT._id)
     recordArtworkView(CLIENT._id, CurrentUser.orNull())
+    splitTest('artwork_sidebar_pageviews').view()
     exec sharedInit
 
     context = CLIENT.context or {}

--- a/src/desktop/apps/artwork/components/auction/templates/index.jade
+++ b/src/desktop/apps/artwork/components/auction/templates/index.jade
@@ -1,7 +1,5 @@
 - var auction = artwork.sale
 - var sale_artwork = artwork.sale_artwork
-- var labFeatures = sd && sd.CURRENT_USER && sd.CURRENT_USER.lab_features
-
 if auction.is_auction_promo
   //- Unimplemented
 
@@ -11,7 +9,7 @@ else if auction.is_preview || auction.is_open || auction.is_live_open
   include ./live
   include ./bid
   include ./buy_now
-  if labFeatures && labFeatures.indexOf("Pageviews in Sidebar") > -1
+  if sd && sd.ARTWORK_SIDEBAR_PAGEVIEWS === 'experiment'
     != stitch.components.ArtworkSidebarPageviews({artworkID: artwork.id})
   include ./buyers_premium
   include ./help

--- a/src/desktop/apps/artwork/components/commercial/templates/index.jade
+++ b/src/desktop/apps/artwork/components/commercial/templates/index.jade
@@ -1,7 +1,6 @@
 - var auctionPartner = artwork.partner.type === 'Auction' || artwork.partner.type === 'Auction House'
-- var labFeatures = sd.CURRENT_USER && sd.CURRENT_USER.lab_features
 - var isCommercial = artwork.is_acquireable || artwork.is_offerable || artwork.is_inquireable
-- var hasLabFeature = labFeatures && labFeatures.indexOf("Pageviews in Sidebar") > -1
+- var hasPageviewFeature = sd.ARTWORK_SIDEBAR_PAGEVIEWS === 'experiment'
 
 .artwork-commercial( class='js-artwork-commercial' )
   form.artwork-commercial__form
@@ -13,7 +12,7 @@
     else if artwork.is_inquireable
       include inquire
 
-    if isCommercial && hasLabFeature
+    if isCommercial && hasPageviewFeature
       != stitch.components.ArtworkSidebarPageviews({artworkID: artwork.id})
 
     include partner

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -24,4 +24,14 @@
 # this should export empty Object
 # module.exports = {}
 
-module.exports = {}
+module.exports = {
+  artwork_sidebar_pageviews:
+    key: 'artwork_sidebar_pageviews'
+    outcomes: [
+      'control'
+      'experiment'
+    ]
+    control_group: 'control'
+    edge: 'experiment'
+    weighting: 'equal'
+}


### PR DESCRIPTION
This launches the artwork page sidebar CTA in an AB test (replacing the lab feature).

I don't think we need any custom analytics instrumented here as the widget is just visual, there's no clicking or any other interaction, (besides the usual AB test 'experiment viewed').