### PR TITLE
Fix circle-ci using wrong versions, loosen engines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   acceptance:
     docker:
-      - image: circleci/node:10.13-stretch-browsers
+      - image: circleci/node:10-stretch-browsers
     parallelism: 1
     steps:
       - add_ssh_keys
@@ -44,7 +44,7 @@ jobs:
             hokusai registry push --tag $CIRCLE_SHA1 --force --overwrite
   publish_staging_assets:
     docker:
-      - image: circleci/node:8-stretch-browsers
+      - image: circleci/node:10-stretch-browsers
     steps:
       - add_ssh_keys
       - checkout
@@ -58,7 +58,7 @@ jobs:
             - manifest.json
   publish_release_assets:
     docker:
-      - image: circleci/node:8-stretch-browsers
+      - image: circleci/node:10-stretch-browsers
     steps:
       - add_ssh_keys
       - checkout

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "10.13.x",
+    "node": "10",
     "yarn": "1.x.x"
   },
   "scripts": {


### PR DESCRIPTION
Missed a spot where some version were out of date in circle. Also loosened the engines to only restrict to the major version. 