### PR TITLE
@zephraph => Get a working /artwork2 page up

### DIFF
--- a/src/desktop/apps/artwork2/server.js
+++ b/src/desktop/apps/artwork2/server.js
@@ -5,6 +5,8 @@ import { routes } from "reaction/Apps/Artwork/routes"
 import { stitch } from "@artsy/stitch"
 import { Meta } from "./components/Meta"
 import { buildServerAppContext } from "desktop/lib/buildServerAppContext"
+import styled from "styled-components"
+import React from "react"
 
 const app = (module.exports = express())
 
@@ -21,6 +23,12 @@ app.get("/artwork2/:artworkID*", adminOnly, async (req, res, next) => {
       return
     }
 
+    const Container = styled.div`
+      width: 100%;
+      max-width: 1192px;
+      margin: auto;
+    `
+
     const layout = await stitch({
       basePath: __dirname,
       layout: "../../components/main_layout/templates/react_redesign.jade",
@@ -34,12 +42,15 @@ app.get("/artwork2/:artworkID*", adminOnly, async (req, res, next) => {
             <Meta />
           </>
         ),
-        body: ServerApp,
+        body: () => (
+          <Container>
+            <ServerApp />
+          </Container>
+        ),
       },
       locals: {
         ...res.locals,
         assetPackage: "artwork2",
-        styledComponents: true,
       },
     })
 


### PR DESCRIPTION
Along with https://github.com/artsy/reaction/pull/1567 , /artwork2 will load + work (admin-only), but there is an outstanding rehydration issue (though that's likely to be in Reaction and not here).