### PR TITLE
Configure renovate to update node for force

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "@artsy"
+    "@artsy",
+    "@artsy:node"
   ],
   "assignees": [
     "zephraph",


### PR DESCRIPTION
This is a bit of a test... it updates the renovate config for force to have it update the node version in the Dockerfile. I might have to play around with the configuration a little bit more, we'll see. 