### PR TITLE
Get rid of option for stripe v2, now that we no longer use it

### DIFF
--- a/src/desktop/components/main_layout/templates/blank.jade
+++ b/src/desktop/components/main_layout/templates/blank.jade
@@ -1,6 +1,6 @@
 block locals
   - bodyClass = helpers ? helpers.buildBodyClass(sd) : ''
-  - defaultOptions = {modal: true, flash: true, stripe: false, stripev3: false, sailthru: true, marketo: true, quantcast: true}
+  - defaultOptions = {modal: true, flash: true, stripev3: false, sailthru: true, marketo: true, quantcast: true}
 - options = options ? Object.assign({}, defaultOptions, options) : defaultOptions
 
 doctype html

--- a/src/desktop/components/main_layout/templates/index.jade
+++ b/src/desktop/components/main_layout/templates/index.jade
@@ -1,7 +1,7 @@
 //- Override any locals with `append locals`
 block locals
   - bodyClass = helpers ? helpers.buildBodyClass(sd, 'body-header-fixed') : '';
-  - defaultOptions = {modal: true, flash: true, stripe: false, stripev3: false, sailthru: true, marketo: true, quantcast: true}
+  - defaultOptions = {modal: true, flash: true, stripev3: false, sailthru: true, marketo: true, quantcast: true}
   - options = options ? Object.assign({}, defaultOptions, options) : defaultOptions
 
 doctype html

--- a/src/desktop/components/main_layout/templates/minimal_header.jade
+++ b/src/desktop/components/main_layout/templates/minimal_header.jade
@@ -1,7 +1,7 @@
 //- Override any locals with `append locals`
 block locals
   - bodyClass = helpers ? helpers.buildBodyClass(sd, 'body-header-fixed minimal-header') : ''
-  - defaultOptions = {modal: true, flash: true, stripe: false, stripev3: false, sailthru: true, marketo: true, quantcast: true}
+  - defaultOptions = {modal: true, flash: true, stripev3: false, sailthru: true, marketo: true, quantcast: true}
 - options = options ? Object.assign({}, defaultOptions, options) : defaultOptions
 
 doctype html

--- a/src/desktop/components/main_layout/templates/redesign.jade
+++ b/src/desktop/components/main_layout/templates/redesign.jade
@@ -1,7 +1,7 @@
 //- Override any locals with `append locals`
 block locals
   - bodyClass = helpers ? helpers.buildBodyClass(sd, 'body-header-fixed') : '';
-  - defaultOptions = {modal: true, flash: true, stripe: false, stripev3: false, sailthru: true, marketo: true, quantcast: true}
+  - defaultOptions = {modal: true, flash: true, stripev3: false, sailthru: true, marketo: true, quantcast: true}
   - options = options ? Object.assign({}, defaultOptions, options) : defaultOptions
 
 doctype html

--- a/src/desktop/components/main_layout/templates/scripts.jade
+++ b/src/desktop/components/main_layout/templates/scripts.jade
@@ -1,4 +1,4 @@
-- defaultOptions = {stripe: false, stripev3: false, sailthru: true, marketo: true, quantcast: true}
+- defaultOptions = {stripev3: false, sailthru: true, marketo: true, quantcast: true}
 - options = options ? Object.assign({}, defaultOptions, options) : defaultOptions
 
 //- Common bundle
@@ -118,9 +118,6 @@ if sharify
   != sharify.script()
 
 //- Stripe
-if options.stripe
-  script( type="text/javascript", src="https://js.stripe.com/v2/" )
-
 if options.stripev3
   script(id="stripe-js", src="https://js.stripe.com/v3/")
 


### PR DESCRIPTION
Now that we're using `stripev3: true`, everywhere, we don't need to reference stripe v2 anymore.

This just cleans up that option.