### PR TITLE
@zephraph => Dont run tests on `release` commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,15 +123,20 @@ workflows:
       - test:
           filters:
             branches:
-              ignore: staging
+              ignore:
+                - staging
+                - release
       - acceptance:
           filters:
             branches:
-              ignore: staging
+              ignore:
+                - staging
+                - release
       - build:
           filters:
             branches:
-              ignore: staging
+              ignore:
+                - staging
           requires:
             - test
             - acceptance

--- a/yarn.lock
+++ b/yarn.lock
@@ -3464,6 +3464,11 @@ class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
   integrity sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
+  dependencies:
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
 
 classnames@^2.2.5:
   version "2.2.5"
@@ -12300,7 +12305,7 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
+react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 


### PR DESCRIPTION
I _think_ this is correct.

What do you think? Basically, tests (+ asset compilation), is insanely slow on Force. It's tracked in a JIRA ticket: https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=37&view=planning&selectedIssue=PLATFORM-599

With tests and assets, Force can take up to half an hour to actually deploy (each step can be up to 15 minutes, and they can't be parallelized since tests run first). There's also a fair amount of spuriousness in both the tests itself, as well as mysterious Docker/Circle issues, that occasionally fail a step (the more steps we have, the more prone we are to spurious CI issues).

So with a CI issue, it can take literally an entire hour to deploy Force, from the time a dev pushes the button. This is super super slow! It doesn't seem like that JIRA ticket is going to be worked on or prioritized, so let's just chip away... cc @joeyAghion 