### PR TITLE
render auction details on mobile for upcoming auctions

### DIFF
--- a/src/desktop/apps/artwork/routes.coffee
+++ b/src/desktop/apps/artwork/routes.coffee
@@ -90,7 +90,7 @@ bootstrap = ->
       res.locals.jsonLD = stringifyJSONForWeb(convertArtworkToJSONLD(data.artwork))
       res.locals.sd.ARTWORK = data.artwork
 
-      if req.user?
+      if req.user? && sd.INTERCOM_BUYER_APP_SECRET
         res.locals.sd.INTERCOM_BUYER_HASH = crypto.createHmac('sha256', sd.INTERCOM_BUYER_APP_SECRET).update(req.user.get('email')).digest('hex')
 
       # If a saleId is found, then check to see if user has been qualified for

--- a/src/mobile/apps/artwork/components/bid/index.jade
+++ b/src/mobile/apps/artwork/components/bid/index.jade
@@ -2,7 +2,7 @@
 if artwork.auction
   .js-artwork-auction-container
     .artwork-auction-bid-module
-      if artwork.auction.is_open && !artwork.auction.is_live_open && !artwork.is_sold && !helpers.moment().isAfter(artwork.auction.end_at)
+      if artwork.auction.is_preview || artwork.auction.is_open && !artwork.auction.is_live_open && !artwork.is_sold && !helpers.moment().isAfter(artwork.auction.end_at)
         .artwork-auction-bid-module__current-bid
           include ./templates/bid.jade
 


### PR DESCRIPTION
Seems like there are several issues going on in parallel here:

- First, locally we were failing because INTERCOM_BUYER_HASH is set to null by default. I thing there is no harm in checking it before calling it. So should be fine to put the intercom behind if check I believe.

- Second for some reason stitched components are failing locally, but I think that is unrelated to the current change here.

- And finally my change is just renders the current auction item status for upcoming auctions instead of calling them closed. (same as on desktop)
![screen shot 2018-12-03 at 2 59 45 pm](https://user-images.githubusercontent.com/437156/49398714-32941080-f70d-11e8-92af-21af270424b1.png)
