### PR TITLE
Fix mobile stitch issue

### DIFF
--- a/src/mobile/lib/global_react_modules.js
+++ b/src/mobile/lib/global_react_modules.js
@@ -1,7 +1,1 @@
-export {
-  ArtworkDetailsQueryRenderer as ArtworkDetails,
-} from "reaction/Apps/Artwork/Components/ArtworkDetails"
-
-export {
-  ReactionArtworkArtistInfo as ArtworkArtistInfo,
-} from "desktop/components/react/stitch_components/ReactionArtworkArtistInfo"
+export * from "desktop/components/react/stitch_components"

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,9 +59,9 @@
     underscore.string "^3.2.2"
 
 "@artsy/react-responsive-media@^2.0.0-beta.4":
-  version "2.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@artsy/react-responsive-media/-/react-responsive-media-2.0.0-beta.4.tgz#ed70fbee99f6e2b167ad26f599ce4e5b4ea1f4b0"
-  integrity sha512-w0Aa92ENdshUoHoxRvlsgggAIZ5yOc/jDW141Rbl3IjJZuGe03lgaPUlhVZe+ohqEiB/JHIA+Hjmq8RPHc7WDw==
+  version "2.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@artsy/react-responsive-media/-/react-responsive-media-2.0.0-beta.5.tgz#d61e1a9f215d38d90ec2bb97dc1ff7409d0346fa"
+  integrity sha512-XRYA77v/j3mVInwy5EYb8NtmMkkAD1/XDxDi45BO0oduv4hsljJfjtjK7jN0ziJ6JUm2QTx/t6QwuaT9E7vTuA==
 
 "@artsy/reaction@^8.2.0":
   version "8.2.0"


### PR DESCRIPTION
Fix mobile stitch issue so that mobile matches desktop, since everything is responsive. 

Problem arose after creating new wrapper functionality in Stitch last week so we didn’t have to wrap every stitched component in context and responsive and so on, but didn’t realize that mobile wasn’t using the same components as desktop, and had its own `global_react_modules` file, which didn’t contain that wrapper component and so there was no environment leading to the error.