### PR TITLE
add signup modal to news articles

### DIFF
--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -85,7 +85,11 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
       "editorial-signup-dismissed"
     )
 
-    if (!sd.CURRENT_USER && !editorialAuthDismissedCookie) {
+    if (
+      !sd.CURRENT_USER &&
+      !editorialAuthDismissedCookie &&
+      !this.props.isMobile
+    ) {
       this.showAuthModal()
     }
   }
@@ -240,28 +244,26 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
   }
 
   showAuthModal() {
-    if (!sd.CURRENT_USER && !this.props.isMobile) {
-      window.addEventListener(
-        "scroll",
-        once(() => {
-          setTimeout(() => {
-            this.handleOpenAuthModal("register", {
-              mode: ModalType.signup,
-              intent: "Viewed editorial",
-              signupIntent: "signup",
-              trigger: "timed",
-              triggerSeconds: 2,
-              copy: "Sign up for the Best Stories in Art and Visual Culture",
-              destination: location.href,
-              afterSignUpAction: {
-                action: "editorialSignup",
-              },
-            } as any)
-          }, 2000)
-        }),
-        { once: true }
-      )
-    }
+    window.addEventListener(
+      "scroll",
+      once(() => {
+        setTimeout(() => {
+          this.handleOpenAuthModal("register", {
+            mode: ModalType.signup,
+            intent: "Viewed editorial",
+            signupIntent: "signup",
+            trigger: "timed",
+            triggerSeconds: 2,
+            copy: "Sign up for the Best Stories in Art and Visual Culture",
+            destination: location.href,
+            afterSignUpAction: {
+              action: "editorialSignup",
+            },
+          } as any)
+        }, 2000)
+      }),
+      { once: true }
+    )
   }
 
   handleOpenAuthModal = (mode, options: ArticleModalOptions) => {

--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -1,9 +1,14 @@
+import { data as sd } from "sharify"
 import moment from "moment"
 import styled from "styled-components"
 import React, { Component, Fragment } from "react"
-import { flatten, debounce, extend } from "lodash"
+import { flatten, debounce, extend, once } from "lodash"
 import Waypoint from "react-waypoint"
 import { positronql as _positronql } from "desktop/lib/positronql"
+import {
+  ModalOptions,
+  ModalType,
+} from "@artsy/reaction/dist/Components/Authentication/Types"
 import { newsArticlesQuery } from "desktop/apps/article/queries/articles"
 import {
   ArticleData,
@@ -15,6 +20,13 @@ import { setupFollows, setupFollowButtons } from "./FollowButton.js"
 import { LoadingSpinner } from "./InfiniteScrollArticle"
 import { NewsArticle } from "./NewsArticle"
 import { NewsDateDivider } from "reaction/Components/Publishing/News/NewsDateDivider"
+
+const Cookies = require("desktop/components/cookies/index.coffee")
+const mediator = require("desktop/lib/mediator.coffee")
+
+interface ArticleModalOptions extends ModalOptions {
+  signupIntent: string
+}
 
 export interface Props {
   article?: ArticleData
@@ -68,6 +80,18 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
 
   componentDidMount() {
     setupFollowButtons(this.state.following)
+
+    const editorialAuthDismissedCookie = Cookies.get(
+      "editorial-signup-dismissed"
+    )
+
+    if (!sd.CURRENT_USER && !editorialAuthDismissedCookie) {
+      this.showAuthModal()
+    }
+  }
+
+  dismissAuthModal() {
+    Cookies.set("editorial-signup-dismissed", 1, { expires: 864000 })
   }
 
   fetchNextArticles = async () => {
@@ -213,6 +237,38 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
         )
       })
     )
+  }
+
+  showAuthModal() {
+    if (!sd.CURRENT_USER && !this.props.isMobile) {
+      window.addEventListener(
+        "scroll",
+        once(() => {
+          setTimeout(() => {
+            this.handleOpenAuthModal("register", {
+              mode: ModalType.signup,
+              intent: "Viewed editorial",
+              signupIntent: "signup",
+              trigger: "timed",
+              triggerSeconds: 2,
+              copy: "Sign up for the Best Stories in Art and Visual Culture",
+              destination: location.href,
+              afterSignUpAction: {
+                action: "editorialSignup",
+              },
+            } as any)
+          }, 2000)
+        }),
+        { once: true }
+      )
+    }
+  }
+
+  handleOpenAuthModal = (mode, options: ArticleModalOptions) => {
+    mediator.trigger("open:auth", {
+      mode,
+      ...options,
+    })
   }
 
   render() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,7 +100,7 @@
     react-head "^3.0.0"
     react-html-parser "^2.0.2"
     react-lazy-load-image-component "^1.1.1"
-    react-lines-ellipsis "github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a"
+    react-lines-ellipsis xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a
     react-markdown "^2.5.0"
     react-oembed-container "^0.3.0"
     react-overlays "^0.8.3"
@@ -12286,7 +12286,6 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
 
 "react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
   version "0.13.0"
-  uid "0cd517ad9079aeb5e6710178d93dd6faa65b924a"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 
 react-markdown@^2.5.0:


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/GROW-632

This implements a full-user sign-up modals on /news/ pages on desktop.

![screen shot 2018-12-11 at 2 19 01 pm](https://user-images.githubusercontent.com/5201004/49824298-cc803c80-fd4f-11e8-92cd-fc4f1cf0b876.png)
