### PR TITLE
Remove schema validation gating production deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,9 +98,6 @@ jobs:
     docker:
       - image: artsy/hokusai:0.4.5
     steps:
-      - run:
-          name: Validated Schemas
-          command: node scripts/validate_schemas.js
       - add_ssh_keys
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
See relevant Slack context [here][0]. We already have some protections
here in Peril/Danger, so there will still be some feedback when service
schemas aren't compatible. 

[0]:https://artsy.slack.com/archives/CA8SANW3W/p1544747822385300