### PR TITLE
Scale force staging's pod allocation to minimic production.

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -3,10 +3,10 @@ kind: Deployment
 metadata:
   name: force-web
 spec:
-  replicas: 1
+  replicas: 3
   strategy:
     rollingUpdate:
-      maxSurge: 1
+      maxSurge: 2
       maxUnavailable: 0
     type: RollingUpdate
   template:


### PR DESCRIPTION
We're currently running into issues with immediate 504s when accessing
staging.artsy.net, but aren't sure why. We're hoping that by ensuring
that there are more pods for us to load balance to.