### PR TITLE
Load health check endpoints before others

### DIFF
--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -240,6 +240,14 @@ export default function(app) {
     })
   }
 
+  // Routes for pinging system time and up
+  app.get("/system/time", (req, res) =>
+    res.status(200).send({ time: Date.now() })
+  )
+  app.get("/system/up", (req, res) => {
+    res.status(200).send({ nodejs: true })
+  })
+
   // Sets up mobile marketing signup modal
   app.use(marketingModals)
 
@@ -278,12 +286,6 @@ export default function(app) {
     })
     app.use(require("../desktop"))
   }
-
-  // Routes for pinging system time and up
-  app.get("/system/time", (req, res) =>
-    res.status(200).send({ time: Date.now() })
-  )
-  app.get("/system/up", (req, res) => res.status(200).send({ nodejs: true }))
 
   // Ensure CurrentUser is set for Artsy Passport
   // TODO: Investigate race condition b/t reaction's use of AP

--- a/src/test/acceptance/partner_profile.js
+++ b/src/test/acceptance/partner_profile.js
@@ -23,6 +23,13 @@ describe("Partner profile page", () => {
       )
       $.html().should.containEql('<p class="partner-bio">Living the dream as')
     })
+
+    it("should not render a page for /system/up healthcheck endpoint", async () => {
+      const $ = await browser.page("/system/up")
+      $.html().should.containEql(
+        '<head></head><body><pre style="word-wrap: break-word; white-space: pre-wrap;">{&quot;nodejs&quot;:true}</pre></body>'
+      )
+    })
   })
 
   context("iPhone", () => {
@@ -62,6 +69,13 @@ describe("Partner profile page", () => {
       const $ = await browser.page("/pace-gallery/contact")
       $.html().should.containEql("Contact")
       $.html().should.containEql("New York")
+    })
+
+    it("should not render a page for /system/up healthcheck endpoint", async () => {
+      const $ = await browser.page("/system/up")
+      $.html().should.containEql(
+        '<head></head><body><pre style="word-wrap: break-word; white-space: pre-wrap;">{&quot;nodejs&quot;:true}</pre></body>'
+      )
     })
   })
 })

--- a/src/test/acceptance/partner_profile.js
+++ b/src/test/acceptance/partner_profile.js
@@ -1,15 +1,18 @@
 /* eslint-env mocha */
 import { setup, teardown } from "./helpers"
 import { server as antigravity } from "antigravity"
+import sinon from "sinon"
 
 describe("Partner profile page", () => {
   let gravity, positron, browser
+  const systemProfileStub = sinon.stub()
 
   before(async () => {
     ;({ gravity, positron, browser } = await setup())
     gravity.get("/api/v1/shortcut/:id", (req, res) => {
       res.res.sendStatus(404)
     })
+    gravity.get("/api/v1/profile/system", systemProfileStub)
     gravity.use(antigravity)
   })
 
@@ -26,9 +29,12 @@ describe("Partner profile page", () => {
 
     it("should not render a page for /system/up healthcheck endpoint", async () => {
       const $ = await browser.page("/system/up")
+
       $.html().should.containEql(
         '<head></head><body><pre style="word-wrap: break-word; white-space: pre-wrap;">{&quot;nodejs&quot;:true}</pre></body>'
       )
+
+      sinon.assert.notCalled(systemProfileStub)
     })
   })
 
@@ -73,9 +79,12 @@ describe("Partner profile page", () => {
 
     it("should not render a page for /system/up healthcheck endpoint", async () => {
       const $ = await browser.page("/system/up")
+
       $.html().should.containEql(
         '<head></head><body><pre style="word-wrap: break-word; white-space: pre-wrap;">{&quot;nodejs&quot;:true}</pre></body>'
       )
+
+      sinon.assert.notCalled(systemProfileStub)
     })
   })
 })


### PR DESCRIPTION
Before this change: the profile app was redirecting
all traffic of that didn’t explicitly match another route to it’s
app. This was resulting in slow health checks that were integrating with
gravity. Considering these health check requests run every 5 seconds,
we’re putting a lot of needless traffic on gravity and other potential
downstream services.

* prettify src/lib/setup.js

Co-authored-by: Christopher Pappas <damassi.pappas@gmail.com>

----

Goal is to ensure that a system healthcheck can never cascade to other systems!

https://app.datadoghq.com/apm/resource/force/express.request/5e3bbf98774abed2?end=1544824820463&env=production&paused=false&spanID=8713293955843515405&start=1544220020463&traceID=891944206827678761

<img width="2392" alt="screen shot 2018-12-14 at 5 02 16 pm" src="https://user-images.githubusercontent.com/1561546/50029805-08223d00-ffc2-11e8-9900-fdeeb3a1234d.png">
