### PR TITLE
#migration Update ELB configuration - addresses PLATFORM-1102

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -74,7 +74,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: '443'
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: 'true'
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '300'
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '5'
 spec:
   ports:
     - port: 443

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -75,6 +75,10 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '5'
+    service.beta.kubernetes.io/aws-load-balancer-access-log-enabled: 'true'
+    service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: '60'
+    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: 'artsy-elb-logs'
+    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: 'production-force'
 spec:
   ports:
     - port: 443

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -74,7 +74,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: '443'
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: 'true'
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '300'
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '5'
 spec:
   ports:
     - port: 443

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -75,6 +75,10 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '5'
+    service.beta.kubernetes.io/aws-load-balancer-access-log-enabled: 'true'
+    service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: '60'
+    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: 'artsy-elb-logs'
+    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: 'staging-force'
 spec:
   ports:
     - port: 443


### PR DESCRIPTION
Update ELB configuration to set the backend connection idle timeout to 5 seconds, matching Node's [server keepalive timeout](https://nodejs.org/api/http.html#http_server_keepalivetimeout) and preventing the ELB using connections Node has closed.

Also enable access logs in the ELB.

# Migration

Staging: `hokusai staging update`
Production: `hokusai production update`
