### PR TITLE
Remove unnecessary (maybe?) workflow step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,13 +23,6 @@ jobs:
           command: |
             export commit_hash=`git rev-parse --short HEAD` && echo $commit_hash
             hokusai test
-  build:
-    docker:
-      - image: artsy/hokusai:0.4.5
-    steps:
-      - run:
-          name: "OK"
-          command: "echo All Tests Pass!"
   push:
     docker:
       - image: artsy/hokusai:0.4.5
@@ -128,13 +121,6 @@ workflows:
           filters:
             branches:
               ignore: staging
-      - build:
-          filters:
-            branches:
-              ignore: staging
-          requires:
-            - test
-            - acceptance
       - push:
           filters:
             branches:
@@ -142,19 +128,22 @@ workflows:
                 - master
                 - release
           requires:
-            - build
+            - test
+            - acceptance
       - publish_staging_assets:
           filters:
             branches:
               only: master
           requires:
-            - build
+            - test
+            - acceptance
       - publish_release_assets:
           filters:
             branches:
               only: release
           requires:
-            - build
+            - test
+            - acceptance
       - deploy_hokusai_staging:
           filters:
             branches:


### PR DESCRIPTION
This attempts to remove the `build` workflow step that doesn't seem necessary. If it works as expected, this just simplifies the config slightly so that we can start to complicate it again by skipping tests on release builds.

No rush to merge. In fact, I may want to monitor the build closely so maybe I should just merge and monitor during a low-activity period once any feedback is addressed.