### PR TITLE
Update unsupported browsers list

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,9 +4,7 @@
       "@babel/env",
       {
         "targets": {
-          "browsers": [
-            "last 2 versions"
-          ]
+          "browsers": ["last 2 versions", "ie >= 11", "safari >= 10"]
         },
         "useBuiltIns": "usage"
       }
@@ -30,15 +28,8 @@
     [
       "module-resolver",
       {
-        "extensions": [
-          ".js",
-          ".jsx",
-          ".ts",
-          ".tsx"
-        ],
-        "root": [
-          "./src"
-        ],
+        "extensions": [".js", ".jsx", ".ts", ".tsx"],
+        "root": ["./src"],
         "alias": {
           "reaction": "@artsy/reaction/dist"
         }
@@ -53,9 +44,7 @@
   ],
   "env": {
     "development": {
-      "plugins": [
-        "react-hot-loader/babel"
-      ]
+      "plugins": ["react-hot-loader/babel"]
     }
   }
 }

--- a/src/desktop/apps/unsupported_browser/template.jade
+++ b/src/desktop/apps/unsupported_browser/template.jade
@@ -17,8 +17,12 @@ html
             | Safari
           a.unsupported-browser-update-first.avant-garde-button-black.settings-submit( href="https://www.mozilla.org/en-US/firefox/new/?utm_source=artsy-net&utm_medium=referral")
             | FireFox
-          a.avant-garde-button-black.settings-submit( href="http://windows.microsoft.com/en-us/internet-explorer/ie-11-worldwide-languages" )
-            | IE 11
+          a.avant-garde-button-black.settings-submit( href="https://www.microsoft.com/en-us/windows/microsoft-edge" )
+            | Microsoft Edge
+
+        br
+        br
+
         form.unsupported-browser-continue( action='', method='post' )
           input( type="hidden", name="redirect-to", value=sd.UNSUPPORTED_BROWSER_REDIRECT || '/' )
           button.avant-garde-button-black.unsupported-browser-submit.is-block Continue with #{sd.BROWSER.family} #{sd.BROWSER.major}

--- a/src/lib/middleware/unsupported_browser.coffee
+++ b/src/lib/middleware/unsupported_browser.coffee
@@ -5,7 +5,7 @@
 uaParser = require 'ua-parser'
 
 isUnsupported = (ua, req) ->
-  not req.cookies.continue_with_bad_browser and ((ua.family is 'IE' and ua.major < 9) or (ua.family is 'Safari' and ua.major < 6))
+  not req.cookies.continue_with_bad_browser and ((ua.family is 'IE' and ua.major <=11) or (ua.family is 'Safari' and ua.major < 6))
 
 getRedirectTo = (req) ->
   req.body['redirect-to'] or req.query['redirect-to'] or req.query['redirect_uri'] or parse(req.get('Referrer') or '').path or '/'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -180,7 +180,7 @@ if (isDevelopment) {
   config.plugins.push(new webpack.HotModuleReplacementPlugin())
   // Staging / Prod
 } else if (isDeploy) {
-  config.devtool = "#source-map"
+  config.devtool = "source-map"
 
   if (ANALYZE_BUNDLE) {
     config.plugins.push(new BundleAnalyzerPlugin())


### PR DESCRIPTION
<img width="656" alt="screen shot 2018-12-18 at 5 53 09 pm" src="https://user-images.githubusercontent.com/236943/50188014-25bb1380-02ee-11e9-9187-0237f41eb8b6.png">

Does fix support for Safari 10 however. 

Main issue blocking IE11 is that there are now libraries that ship `.mjs` files -- modern native JS modules, which conform to modern browser specs -- which Webpack reads in and does not transpile. I tried many things but couldn't get it to work, and so IE 11 would see the `class` keyword and fail. 