### PR TITLE
#migration set Node's keepAliveTimeout and update staging ELB configuration - addresses PLATFORM-1102

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -74,7 +74,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: '443'
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: 'true'
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '300'
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '5'
 spec:
   ports:
     - port: 443

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -74,11 +74,11 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: '443'
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: 'true'
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '5'
     service.beta.kubernetes.io/aws-load-balancer-access-log-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: '60'
     service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: 'artsy-elb-logs'
     service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: 'production-force'
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '300'
 spec:
   ports:
     - port: 443

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -75,6 +75,10 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '5'
+    service.beta.kubernetes.io/aws-load-balancer-access-log-enabled: 'true'
+    service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: '60'
+    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: 'artsy-elb-logs'
+    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: 'production-force'
 spec:
   ports:
     - port: 443

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -74,7 +74,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: '443'
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: 'true'
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '300'
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '5'
 spec:
   ports:
     - port: 443

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -25,6 +25,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: KEEPALIVE_TIMEOUT
+              value: '60000'
           envFrom:
             - configMapRef:
                 name: force-environment
@@ -78,7 +80,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: '60'
     service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: 'artsy-elb-logs'
     service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: 'staging-force'
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '300'
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '59'
 spec:
   ports:
     - port: 443

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -75,6 +75,10 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '5'
+    service.beta.kubernetes.io/aws-load-balancer-access-log-enabled: 'true'
+    service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: '60'
+    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: 'artsy-elb-logs'
+    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: 'staging-force'
 spec:
   ports:
     - port: 443

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -74,11 +74,11 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: '443'
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: 'true'
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '5'
     service.beta.kubernetes.io/aws-load-balancer-access-log-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: '60'
     service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: 'artsy-elb-logs'
     service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: 'staging-force'
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '300'
 spec:
   ports:
     - port: 443

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ const {
   CLIENT_SECRET,
   NODE_ENV,
   PORT,
+  KEEPALIVE_TIMEOUT,
   PROFILE_MEMORY,
 } = process.env
 
@@ -50,7 +51,11 @@ also could be gravity being down.`)
           ? `\n\n  [Force] Booting on port ${PORT}... \n`
           : `\n\n  [Force] Started on ${APP_URL}. \n`
 
-      app.listen(PORT, "0.0.0.0", () => console.log(message))
+      const server = app.listen(PORT, "0.0.0.0", () => console.log(message))
+      if (KEEPALIVE_TIMEOUT) {
+        console.log("Setting keepAliveTimeout to " + KEEPALIVE_TIMEOUT + " ms")
+        server.keepAliveTimeout = Number(KEEPALIVE_TIMEOUT)
+      }
     }
   })
 })


### PR DESCRIPTION
Follow-up to https://github.com/artsy/force/pull/3211

Update staging's ELB configuration to set the backend connection idle timeout to 59 seconds, and Node's [server keepalive timeout](https://nodejs.org/api/http.html#http_server_keepalivetimeout) to 60 seconds.

Also enable access logs in the ELBs.

## Migration

1) Merge PR and deploy to staging
2) `hokusai staging update`

Production needs no migration as @dleve123 and I already applied the access log changes manually.