### PR TITLE
@mzikherman: Skip tests on release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           command: |
             export commit_hash=`git rev-parse --short HEAD` && echo $commit_hash
             hokusai test
-  push:
+  push_staging_image: &push_image
     docker:
       - image: artsy/hokusai:0.4.5
     steps:
@@ -35,6 +35,7 @@ jobs:
           command: |
             export commit_hash=`git rev-parse --short HEAD` && echo $commit_hash
             hokusai registry push --tag $CIRCLE_SHA1 --force --overwrite
+  push_production_image: *push_image
   publish_staging_assets:
     docker:
       - image: circleci/node:10-stretch-browsers
@@ -49,7 +50,7 @@ jobs:
           root: workspace
           paths:
             - manifest.json
-  publish_release_assets:
+  publish_production_assets:
     docker:
       - image: circleci/node:10-stretch-browsers
     steps:
@@ -116,20 +117,26 @@ workflows:
       - test:
           filters:
             branches:
-              ignore: staging
+              ignore:
+                - staging
+                - release
       - acceptance:
           filters:
             branches:
-              ignore: staging
-      - push:
+              ignore:
+                - staging
+                - release
+      - push_staging_image:
           filters:
             branches:
-              only:
-                - master
-                - release
+              only: master
           requires:
             - test
             - acceptance
+      - push_production_image:
+          filters:
+            branches:
+              only: release
       - publish_staging_assets:
           filters:
             branches:
@@ -137,24 +144,21 @@ workflows:
           requires:
             - test
             - acceptance
-      - publish_release_assets:
+      - publish_production_assets:
           filters:
             branches:
               only: release
-          requires:
-            - test
-            - acceptance
       - deploy_hokusai_staging:
           filters:
             branches:
               only: master
           requires:
-            - push
+            - push_staging_image
             - publish_staging_assets
       - deploy_hokusai_production:
           filters:
             branches:
               only: release
           requires:
-            - push
-            - publish_release_assets
+            - push_production_image
+            - publish_production_assets


### PR DESCRIPTION
I _think_ this accomplishes what we discussed, which is that release builds skip `test` and `acceptance` steps and proceed to push the docker image and publish assets, then to perform the actual deploy.

To do this I had to separate the "push" steps so that staging's depends on tests but production's doesn't. [A YAML anchor](https://blog.daemonl.com/2016/02/yaml.html) avoids duplicating the command definition. (There might also be a Circle way to do this.)

I also tried to name the steps with "staging" or "production" instead of "release" for consistency.