### PR TITLE
Fixes an issue where Safari 10 could not parse assets/common.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,6 +93,7 @@ const config = {
           compress: {
             warnings: false,
           },
+          safari10: true,
         },
       }),
     ],


### PR DESCRIPTION
The `uglifyjs-webpack-plugin` was leaving `let`s and `const`s without transpiling them into 'var's. These days this is usually fine as all the modern browsers support both `let`/`const`, but Safari 10 has [a bug][1] where `let` bindings are incorrectly treated as function-scoped instead of block scoped. This commit updates the options to set [the `safari10` option][2] to `true` so ES6 code will be transpiled down to ES5.

This will possibly affect many other things as this is a big jump.

[1]: https://bugs.webkit.org/show_bug.cgi?id=171041
[2]: https://github.com/mishoo/UglifyJS2/tree/harmony#output-options