### PR TITLE
#migration set KEEPALIVE_TIMEOUT to 60 seconds and elb connection idle timeout to 59 seconds on prod

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -25,6 +25,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: KEEPALIVE_TIMEOUT
+              value: '60000'
           envFrom:
             - configMapRef:
                 name: force-environment
@@ -78,7 +80,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: '60'
     service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: 'artsy-elb-logs'
     service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: 'production-force'
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '300'
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '59'
 spec:
   ports:
     - port: 443


### PR DESCRIPTION
Follow-up to https://github.com/artsy/force/pull/3224

## Migration

Once 6c87527d14082b267a8bdb32c5d1f96ac21206a1 makes it to production, run `hokusai production update`
