### PR TITLE
[Supported Browsers] Move safari 10 to unsupported

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "@babel/env",
       {
         "targets": {
-          "browsers": ["last 2 versions", "ie >= 11", "safari >= 10"]
+          "browsers": ["last 2 versions"]
         },
         "useBuiltIns": "usage"
       }

--- a/src/lib/middleware/unsupported_browser.coffee
+++ b/src/lib/middleware/unsupported_browser.coffee
@@ -5,7 +5,7 @@
 uaParser = require 'ua-parser'
 
 isUnsupported = (ua, req) ->
-  not req.cookies.continue_with_bad_browser and ((ua.family is 'IE' and ua.major <=11) or (ua.family is 'Safari' and ua.major < 6))
+  not req.cookies.continue_with_bad_browser and ((ua.family is 'IE' and ua.major <=11) or (ua.family is 'Safari' and ua.major < 10))
 
 getRedirectTo = (req) ->
   req.body['redirect-to'] or req.query['redirect-to'] or req.query['redirect_uri'] or parse(req.get('Referrer') or '').path or '/'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,7 +93,6 @@ const config = {
           compress: {
             warnings: false,
           },
-          safari10: true,
         },
       }),
     ],


### PR DESCRIPTION
Move Safari 10 to unsupported browser list. Additionally fixes recent issue where compiling for an old browser was taking 12s when `yarn link`ing between Force and Reaction. 