### PR TITLE
Revert to Node 10.13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.14.1
+FROM node:10.13.0
 ARG commit_hash
 RUN test -n "$commit_hash"
 

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -25,8 +25,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: KEEPALIVE_TIMEOUT
-              value: '60000'
           envFrom:
             - configMapRef:
                 name: force-environment
@@ -80,7 +78,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: '60'
     service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: 'artsy-elb-logs'
     service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: 'staging-force'
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '59'
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '300'
 spec:
   ports:
     - port: 443


### PR DESCRIPTION
Setting `server.keepAliveTimeout` in https://github.com/artsy/force/pull/3232 did not solve 504s on staging.artsy.net - fallback to reverting the Node upgrade that correlates with this behavior

![screen shot 2018-12-20 at 4 56 24 pm](https://user-images.githubusercontent.com/997613/50297058-2aadcd80-047c-11e9-9de3-01a1705d0163.png)
