### PR TITLE
@oxaudo => Dont sync current user client side to avoid endless refresh

### DIFF
--- a/src/desktop/lib/global_client_setup.coffee
+++ b/src/desktop/lib/global_client_setup.coffee
@@ -27,7 +27,7 @@ module.exports = ->
   setupErrorReporting()
   setupJquery()
   setupReferrerTracking()
-  syncAuth()
+  # syncAuth()
   listenForInvert()
   listenForBounce()
   confirmation.check()


### PR DESCRIPTION
The same fix that we did here https://github.com/artsy/force/pull/3048 but now in desktop (since new pages are responsive we're seeing users on mobile devices seeing this sometimes).