### PR TITLE
Fixed download link on artwork page for admins

### DIFF
--- a/src/desktop/apps/artwork/routes.coffee
+++ b/src/desktop/apps/artwork/routes.coffee
@@ -108,7 +108,7 @@ bootstrap = ->
     if artwork.isDownloadable(req.user)
       imageRequest = request.get(artwork.downloadableUrl req.user)
       imageRequest.set('X-ACCESS-TOKEN': req.user.get('accessToken')) if req.user
-      req.pipe(imageRequest).pipe res
+      req.pipe(imageRequest, { end: false }).pipe res
     else
       err = new Error 'Not authorized to download this image.'
       err.status = 403


### PR DESCRIPTION
This PR fixes [BUGS-684](https://artsyproduct.atlassian.net/browse/BUGS-684).

Previously administrators could click on a "Download" link on an artwork page to download its original image file. However, currently this link throws a 500 error with the following message being logged:

`.end() was called twice. This is not supported in superagent`

Upon investigating the endpoint that handles this request, I found that two `.pipe()` calls were being chained, so I added an optional `end: false` flag to the first call to prevent the stream from closing before the second one could execute.

https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options