### PR TITLE
[SSR] Surface remote GraphQL errors.

### DIFF
--- a/patches/react-relay-network-modern+2.5.0.patch
+++ b/patches/react-relay-network-modern+2.5.0.patch
@@ -1,0 +1,21 @@
+patch-package
+--- a/node_modules/react-relay-network-modern/lib/createRequestError.js
++++ b/node_modules/react-relay-network-modern/lib/createRequestError.js
+@@ -104,8 +104,6 @@ function createRequestError(req, res) {
+ 
+   if (!res) {
+     errorReason = 'Server return empty response.';
+-  } else if (!res.json) {
+-    errorReason = (res.text ? res.text : "Server return empty response with Status Code: ".concat(res.status, ".")) + (res ? "\n\n".concat(res.toString()) : '');
+   } else if (res.errors) {
+     if (req instanceof _RelayRequest.default) {
+       errorReason = formatGraphQLErrors(req, res.errors);
+@@ -114,6 +112,8 @@ function createRequestError(req, res) {
+     }
+   } else if (!res.data) {
+     errorReason = 'Server return empty response.data.\n\n' + res.toString();
++  } else if (!res.json) {
++    errorReason = (res.text ? res.text : "Server return empty response with Status Code: ".concat(res.status, ".")) + (res ? "\n\n".concat(res.toString()) : '');
+   }
+ 
+   var error = new RRNLRequestError("Relay request for `".concat(req.getID(), "` failed by the following reasons:\n\n").concat(errorReason));


### PR DESCRIPTION
Related to https://artsyproduct.atlassian.net/browse/BUGS-685

Previously the error message would be:

```
Error Message: Relay request for `routes_CollectAppQuery` failed by the following reasons:

Server return empty response with Status Code: 200.
```

Now the error will look like:

```
Error Message: Relay request for `routes_CollectAppQuery` failed by the following reasons:

1. https://stagingapi.artsy.net/api/v1/filter/artworks?aggregations%5B%5D=total&offset=0&page=1&size=30&sort=-decayed_merch - {"type":"other_error","message":"request timed out","backtrace":[…]}
     artworks: artworks_connection(first: 30, after: "") {
     ^^^
```

----

I'll create a PR for the upstream library. If that ends up being merged before this PR is, then it probably makes sense to replace this patch by the updated library package.