### PR TITLE
@mzikherman => Fix analytics crashers for new artwork page

### DIFF
--- a/src/desktop/analytics/criteo.js
+++ b/src/desktop/analytics/criteo.js
@@ -3,10 +3,11 @@
 //
 window.criteo_q = window.criteo_q || []
 var pathSplit = location.pathname.split("/")
+const pageType = window.sd.PAGE_TYPE || pathSplit[1]
 var userEmail = (function() {
   return sd.CURRENT_USER ? [sd.CURRENT_USER.email] : []
 })()
-if (pathSplit[1] === "auctions") {
+if (pageType === "auctions") {
   // http://www.artsy.net/auctions - (AUCTIONS viewHome)
   //              0          1
   window.criteo_q.push(
@@ -14,7 +15,7 @@ if (pathSplit[1] === "auctions") {
     { event: "setSiteType", type: "d" },
     { event: "viewHome" }
   )
-} else if (pathSplit[1] === "auction") {
+} else if (pageType === "auction") {
   if (!pathSplit[3]) {
     // https://www.artsy.net/auction/:auction_id - (AUCTIONS viewList)
     //              0          1          2
@@ -49,7 +50,7 @@ if (pathSplit[1] === "auctions") {
       )
     })
   }
-} else if (pathSplit[1] === "artwork" && !pathSplit[3]) {
+} else if (pageType === "artwork" && !pathSplit[3]) {
   // https://www.artsy.net/artwork/:artwork_id - (AUCTIONS & ARTWORKS viewItem)
   //              0          1          2
   //
@@ -107,7 +108,7 @@ if (pathSplit[1] === "auctions") {
     )
   })
 } else {
-  if (pathSplit[1] === "collect") {
+  if (pageType === "collect") {
     // https://www.artsy.net/collect - (ARTWORKS viewHome)
     //              0          1
     window.criteo_q.push(

--- a/src/desktop/apps/artwork2/server.tsx
+++ b/src/desktop/apps/artwork2/server.tsx
@@ -37,6 +37,10 @@ app.get(
         margin: auto;
       `
 
+      // While we are rolling out the new page, override the default (`artwork`)
+      // type inferred from the URL, for tracking and comparison purposes.
+      res.locals.sd.PAGE_TYPE = "new-artwork"
+
       const layout = await stitch({
         basePath: __dirname,
         layout: "../../components/main_layout/templates/react_redesign.jade",
@@ -57,10 +61,6 @@ app.get(
           scripts,
         },
       })
-
-      // While we are rolling out the new page, override the default (`artwork`)
-      // type inferred from the URL, for tracking and comparison purposes.
-      res.locals.sd.PAGE_TYPE = "new-artwork"
 
       res.status(status).send(layout)
     } catch (error) {


### PR DESCRIPTION
cc @cavvia this skips a couple of analytics calls that aren't possible in this style, from the new artwork page. The issue is that the calls are triggered from Force and based on bootstrapped data that is no longer present in the new page.

Generally speaking, we've been moving to triggering analytics calls from Reaction these days.