### PR TITLE
Use the correct URL scheme for news articles

### DIFF
--- a/src/desktop/apps/sitemaps/routes.coffee
+++ b/src/desktop/apps/sitemaps/routes.coffee
@@ -10,11 +10,11 @@ PAGE_SIZE = 100
 { parse } = require 'url'
 httpProxy = require 'http-proxy'
 sitemapProxy = httpProxy.createProxyServer(target: SITEMAP_BASE_URL)
+getFullEditorialHref = require("@artsy/reaction/dist/Components/Publishing/Constants").getFullEditorialHref
 
 @news = (req, res, next) ->
   new Articles().fetch
     data:
-      featured: true
       published: true
       sort: '-published_at'
       exclude_google_news: false
@@ -24,7 +24,7 @@ sitemapProxy = httpProxy.createProxyServer(target: SITEMAP_BASE_URL)
       recentArticles = articles.filter (article) ->
         moment(article.get 'published_at').isAfter(moment().subtract(2, 'days'))
       res.set 'Content-Type', 'text/xml'
-      res.render('news', { pretty: true, articles: recentArticles })
+      res.render('news', { pretty: true, articles: recentArticles, getFullEditorialHref: getFullEditorialHref })
 
 @misc = (req, res, next) ->
   res.set 'Content-Type', 'text/xml'

--- a/src/desktop/apps/sitemaps/templates/news.jade
+++ b/src/desktop/apps/sitemaps/templates/news.jade
@@ -5,7 +5,7 @@ urlset(
 )
     for article in articles
       url
-        loc= 'https://www.artsy.net/article/' + article.get('slug')
+        loc= 'https://www.artsy.net/' + (article.get('layout') == 'news' ?  'news' : 'article') + '/' + article.get('slug')
         news:news
           news:publication
             news:name Artsy

--- a/src/desktop/apps/sitemaps/templates/news.jade
+++ b/src/desktop/apps/sitemaps/templates/news.jade
@@ -5,7 +5,7 @@ urlset(
 )
     for article in articles
       url
-        loc= 'https://www.artsy.net/' + (article.get('layout') == 'news' ?  'news' : 'article') + '/' + article.get('slug')
+        loc= getFullEditorialHref(article.get('layout'), article.get('slug'))
         news:news
           news:publication
             news:name Artsy

--- a/src/desktop/apps/sitemaps/test/routes.coffee
+++ b/src/desktop/apps/sitemaps/test/routes.coffee
@@ -68,23 +68,30 @@ Sitemap: https://www.artsy.net/sitemap-videos.xml
         @res.send.args[0][0].slice(-1).should.eql('\n')
 
   describe '#news', ->
-    it 'displays the sitemap for news that are articles < 2 days old', ->
+    it 'displays the sitemap for articles that are < 2 days old', ->
+      today = new Date()
+      oneDayAgo = new Date()
+      twoDaysAgo = new Date()
+
+      oneDayAgo.setDate(today.getDate() - 1)
+      twoDaysAgo.setDate(today.getDate() - 2)
+
       routes.news(@req, @res)
       Backbone.sync.args[0][2].success {
         total: 16088,
         count: 12,
         results: [
-          fabricate('article', { published_at: new Date().toISOString() })
-          fabricate('article', { published_at: '2015-01-21T22:02:03.808Z' })
+          fabricate('article', { layout: 'standard', published_at: today.toISOString() })
+          fabricate('article', { layout: 'news', published_at: oneDayAgo.toISOString() })
+          fabricate('article', { published_at: twoDaysAgo.toISOString() })
         ]
-
       }
+
       @res.render.args[0][0].should.equal('news')
-      @res.render.args[0][1].articles.length.should.equal(1)
+      @res.render.args[0][1].articles.length.should.equal(2)
 
     it 'fetches with correct news data', ->
       routes.news(@req, @res)
-      Backbone.sync.args[0][2].data.featured.should.be.true()
       Backbone.sync.args[0][2].data.published.should.be.true()
       Backbone.sync.args[0][2].data.sort.should.equal '-published_at'
       Backbone.sync.args[0][2].data.exclude_google_news.should.be.false()

--- a/src/desktop/apps/sitemaps/test/templates.coffee
+++ b/src/desktop/apps/sitemaps/test/templates.coffee
@@ -5,6 +5,7 @@ jade = require 'jade'
 fs = require 'fs'
 moment = require 'moment'
 { fabricate } = require 'antigravity'
+getFullEditorialHref = require("@artsy/reaction/dist/Components/Publishing/Constants").getFullEditorialHref
 Article = require '../../../models/article'
 Articles = require '../../../collections/articles'
 Artwork = require '../../../models/artwork'
@@ -39,9 +40,15 @@ describe 'misc sitemap template', ->
 describe 'news sitemap template', ->
 
   it 'renders article info', ->
-    xml = render('news')
-      articles: [new Article fabricate 'article']
-    xml.should.containEql 'https://www.artsy.net/article/editorial-on-the-heels-of-a-stellar-year'
+    articles = [
+      new Article(fabricate('article', layout: 'standard'))
+      new Article(fabricate('article', layout: 'news', slug: "banksys-half-shredded-painting-will-view-german-museum"))
+    ]
+
+    xml = render('news')(articles: articles, getFullEditorialHref: getFullEditorialHref)
+
+    xml.should.containEql '/article/editorial-on-the-heels-of-a-stellar-year'
+    xml.should.containEql '/news/banksys-half-shredded-painting-will-view-german-museum'
     xml.should.containEql '<news:name>Artsy</news:name>'
     xml.should.containEql '2014-09-24T23:24:54.000Z'
     xml.should.containEql 'On The Heels of A Stellar Year in the West, Sterling Ruby Makes His Vivid Mark on Asia'


### PR DESCRIPTION
Partially addresses https://artsyproduct.atlassian.net/browse/GROW-818

This PR includes two changes:

 * Use the correct URL scheme for news articles (`www.artsy.net/news/article-title`)
 * Update the `sitemap-news.xml` endpoint to include articles that have `exclude_google_news: false`

**Note that even with this PR the `sitemap-news.xml` endpoint only generates the first 100 articles to reduce workloads for Positron since loading literally all articles may affect Positron's performance.** The main purpose of this PR is to make sure we generate the news sitemap in the correct format. Once this is confirmed we should be able to move the entire logic to Cinder so we can cover all articles with no performance penalty.