### PR TITLE
add offerable pageview tracking

### DIFF
--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -12,6 +12,7 @@ var properties = { path: location.pathname }
 
 if (pageType == "artwork") {
   properties["acquireable"] = sd.ARTWORK.is_acquireable
+  properties["offerable"] = sd.ARTWORK.is_offerable
   properties["availability"] = sd.ARTWORK.availability
   properties["price_listed"] = sd.ARTWORK.price && sd.ARTWORK.price.length > 0
 


### PR DESCRIPTION
We need to add tracking for `offerable` artwork pageviews as we did for `inquireable` works back when BN launched. This is time sensitive as it needs to be out for MO launch.

This is another piece of metadata which the responsive artwork page needs to be able to send with the segment pageview event.

cc @anipetrov 