### PR TITLE
Adjusting display to check for profile owner when displaying search result

### DIFF
--- a/src/desktop/apps/search/templates/search_result.jade
+++ b/src/desktop/apps/search/templates/search_result.jade
@@ -1,15 +1,19 @@
-a.search-result( href=result.href(), class=_s.decapitalize(result.get('display_model')), data-id=result.get('id'), data-mongo-id=result.get('_id') )
-  if result.imageUrl() != null && result.get('display_model') != 'Artist'
+- displayModel = result.get('display_model')
+- isFairProfile = displayModel === 'Gallery' && result.get('owner_type') === 'FairOrganizer'
+- displayName =  isFairProfile ? 'fair' : _s.decapitalize(_s.humanize(displayModel))
+
+a.search-result(href=result.href(), class=_s.decapitalize(displayModel), data-id=result.get('id'), data-mongo-id=result.get('_id') )
+  if result.imageUrl() != null && displayModel != 'Artist'
     .search-result-thumbnail
       .search-result-thumbnail-fallback
         include image
   else
     .search-result-no-thumbnail
   .search-result-info
-    if result.get('display_model')
-      .search-result-kind= _s.decapitalize(_s.humanize(result.get('display_model')))
+    if displayModel
+      .search-result-kind= displayName
     .search-result-title= result.resultsPageTitle()
     if result.get('about')
       .search-result-about= result.get('about')
-    if result.get('display_model') == 'Artist' || result.get('display_model') == 'Category'
+    if displayModel == 'Artist' || displayModel == 'Category'
       .search-result-images

--- a/src/desktop/apps/search/templates/search_result.jade
+++ b/src/desktop/apps/search/templates/search_result.jade
@@ -1,6 +1,4 @@
 - displayModel = result.get('display_model')
-- isFairProfile = displayModel === 'Gallery' && result.get('owner_type') === 'FairOrganizer'
-- displayName =  isFairProfile ? 'fair' : _s.decapitalize(_s.humanize(displayModel))
 
 a.search-result(href=result.href(), class=_s.decapitalize(displayModel), data-id=result.get('id'), data-mongo-id=result.get('_id') )
   if result.imageUrl() != null && displayModel != 'Artist'
@@ -11,7 +9,7 @@ a.search-result(href=result.href(), class=_s.decapitalize(displayModel), data-id
     .search-result-no-thumbnail
   .search-result-info
     if displayModel
-      .search-result-kind= displayName
+      .search-result-kind= _s.decapitalize(_s.humanize(displayModel))
     .search-result-title= result.resultsPageTitle()
     if result.get('about')
       .search-result-about= result.get('about')

--- a/src/desktop/models/search_result.coffee
+++ b/src/desktop/models/search_result.coffee
@@ -51,15 +51,22 @@ module.exports = class SearchResult extends Backbone.Model
       "/#{@get('model')}/#{@get('slug')}"
 
   displayModel: ->
-    model =
-      if @get('model') is 'gene'
+    originalModel = @get('model')
+    model = switch originalModel
+      when 'gene'
         'category'
-      else if @get('model') is 'partnershow'
+      when 'partnershow'
         'show'
-      else if @get('model') is 'profile'
+      when 'profile'
         institutionTypes = ['PartnerInstitution', 'PartnerInstitutionalSeller']
-        if @get('owner_type') in institutionTypes then 'institution' else 'gallery'
-      else @get('model')
+        if @get('owner_type') in institutionTypes
+          'institution'
+        else if @get('owner_type') == 'FairOrganizer'
+          'fair'
+        else
+          'gallery'
+      else
+        originalModel
 
     _s.capitalize model
 

--- a/src/desktop/test/models/search_result.coffee
+++ b/src/desktop/test/models/search_result.coffee
@@ -71,6 +71,10 @@ describe 'SearchResult', ->
       it 'has a display_model attribute when it an institution seller profile', ->
         model = new SearchResult(model: 'profile', owner_type: 'PartnerInstitutionalSeller')
         model.get('display_model').should.equal 'Institution'
+      
+      it 'has a display_model attribute when it fair profile', ->
+        model = new SearchResult(model: 'profile', owner_type: 'FairOrganizer')
+        model.get('display_model').should.equal 'Fair'
 
     describe '#imageUrl', ->
       it 'has a image url attribute when it an Artist', ->

--- a/src/mobile/components/search_results/result.jade
+++ b/src/mobile/components/search_results/result.jade
@@ -1,6 +1,4 @@
-- displayModel = result.get('display_model')
-- isFairProfile = displayModel === 'Gallery' && result.get('owner_type') === 'FairOrganizer'
-- displayName =  isFairProfile ? 'fair' : displayModel
+- displayModel = result.get('display_model') 
 
 a.search-result(
   href= result.href()
@@ -20,7 +18,7 @@ a.search-result(
   .search-result-info
     if displayModel
       .search-result-kind
-        = displayName
+        = displayModel
     if result.get('display')
       .search-result-display
         = result.highlightedDisplay ? result.highlightedDisplay(term) : result.get('display')

--- a/src/mobile/components/search_results/result.jade
+++ b/src/mobile/components/search_results/result.jade
@@ -1,3 +1,7 @@
+- displayModel = result.get('display_model')
+- isFairProfile = displayModel === 'Gallery' && result.get('owner_type') === 'FairOrganizer'
+- displayName =  isFairProfile ? 'fair' : displayModel
+
 a.search-result(
   href= result.href()
   class= result.publishedClass && result.publishedClass()
@@ -14,9 +18,9 @@ a.search-result(
       )
 
   .search-result-info
-    if result.get('display_model')
+    if displayModel
       .search-result-kind
-        = result.get('display_model')
+        = displayName
     if result.get('display')
       .search-result-display
         = result.highlightedDisplay ? result.highlightedDisplay(term) : result.get('display')

--- a/src/mobile/models/search_result.coffee
+++ b/src/mobile/models/search_result.coffee
@@ -46,14 +46,21 @@ module.exports = class SearchResult extends Backbone.Model
       "/#{@get('model')}/#{@id}"
 
   displayModel: ->
-    model =
-      if @get('model') is 'gene'
+    originalModel = @get('model')
+    model = switch originalModel
+      when 'gene'
         'category'
-      else if @get('model') is 'partnershow'
+      when 'partnershow'
         'show'
-      else if @get('model') is 'profile'
-        if @get('owner_type') in INSTITUTION_TYPES then 'institution' else 'gallery'
-      else @get('model')
+      when 'profile'
+        if @get('owner_type') in INSTITUTION_TYPES
+          'institution'
+        else if @get('owner_type') == 'FairOrganizer'
+          'fair'
+        else
+          'gallery'
+      else
+        originalModel
 
     _s.capitalize model
 

--- a/src/mobile/test/models/search_result.coffee
+++ b/src/mobile/test/models/search_result.coffee
@@ -59,6 +59,10 @@ describe 'SearchResult', ->
       it 'has a display_model attribute when it an institution seller profile', ->
         model = new SearchResult(model: 'profile', owner_type: 'PartnerInstitutionalSeller')
         model.get('display_model').should.equal 'Institution'
+      
+      it 'has a display_model attribute when it fair profile', ->
+        model = new SearchResult(model: 'profile', owner_type: 'FairOrganizer')
+        model.get('display_model').should.equal 'Fair'
 
   describe '#updateForFair', ->
     it 'modifies location and display model for fair booths', ->


### PR DESCRIPTION
This is a pretty hack fix for https://artsyproduct.atlassian.net/browse/DISCO-537

Let me know if you think it's too smelly to do this very specific check here. The alternative is to figure out where those searchResults are generated and make sure we are assigning the proper display_model for profiles where owner is a fair but I'm not sure if that can affect anything else.

Also there is a very minimal test for this search: https://github.com/artsy/force/blob/master/src/desktop/apps/search/test/client/index.coffee
Could add something that will check that Fair is display when result is a 'Gallery' with ownerType 'Fair' but wanted to make sure this change is legit.