### PR TITLE
Revert "Make sure not found artists and artworks bubble up as 404s"

### DIFF
--- a/src/desktop/apps/artist/server.tsx
+++ b/src/desktop/apps/artist/server.tsx
@@ -90,13 +90,7 @@ app.get(
       res.status(status).send(layout)
     } catch (error) {
       console.log(error)
-      if (error.message.includes("Artist Not Found")) {
-        const notFoundError: any = new Error("Artist Not Found")
-        notFoundError.status = 404
-        next(notFoundError)
-      } else {
-        next(error)
-      }
+      next(error)
     }
   }
 )

--- a/src/desktop/apps/artwork2/server.tsx
+++ b/src/desktop/apps/artwork2/server.tsx
@@ -65,13 +65,7 @@ app.get(
       res.status(status).send(layout)
     } catch (error) {
       console.log(error)
-      if (error.message.includes("Artwork Not Found")) {
-        const notFoundError: any = new Error("Artwork Not Found")
-        notFoundError.status = 404
-        next(notFoundError)
-      } else {
-        next(error)
-      }
+      next(error)
     }
   }
 )


### PR DESCRIPTION
This reverts commit 2a264f4cd3f245a0bf824ab6aaa2c94d94b668e0.

Related to https://artsyproduct.atlassian.net/browse/DISCO-671.
Depends on https://github.com/artsy/reaction/pull/1855.