### PR TITLE
Update artist acceptance fixture to include artist insights

### DIFF
--- a/src/test/acceptance/artist.js
+++ b/src/test/acceptance/artist.js
@@ -14,7 +14,18 @@ describe("Artist page", () => {
   after(teardown)
 
   it("renders an artist name and some biographical info", async () => {
-    const $ = await browser.page("/artist/pablo-picasso")
+    const $ = await browser.page(
+      "/artist/pablo-picasso?split_test[artist_insights]=v1"
+    )
+    $.html().should.containEql("Pablo Picasso")
+    $.html().should.containEql("Spanish")
+    $.html().should.containEql("1881-1973")
+  })
+
+  it("renders an artist name and some biographical info with artist insights v2 enabled", async () => {
+    const $ = await browser.page(
+      "/artist/pablo-picasso?split_test[artist_insights]=v2"
+    )
     $.html().should.containEql("Pablo Picasso")
     $.html().should.containEql("Spanish")
     $.html().should.containEql("1881-1973")

--- a/src/test/acceptance/fixtures/metaphysics/artist.json
+++ b/src/test/acceptance/fixtures/metaphysics/artist.json
@@ -120,6 +120,39 @@
           }
         ]
       },
+      "insights": [
+        {
+          "type": "COLLECTED",
+          "label": "Collected by a major institution",
+          "entities": [
+            "Tate",
+            "Museum of Modern Art (MoMA)",
+            "National Gallery of Art, Washington, D.C.",
+            "Indianapolis Museum of Art at Newfields",
+            "San Francisco Museum of Modern Art (SFMOMA)"
+          ]
+        },
+        {
+          "type": "SOLO_SHOW",
+          "label": "Solo show at a major institution",
+          "entities": ["Tate"]
+        },
+        {
+          "type": "GROUP_SHOW",
+          "label": "Group show at a major institution",
+          "entities": ["Tate"]
+        },
+        {
+          "type": "REVIEWED",
+          "label": "Reviewed by a major art publication",
+          "entities": ["Tate"]
+        },
+        {
+          "type": "BIENNIAL",
+          "label": "Participated in a major biennial",
+          "entities": ["frieze"]
+        }
+      ],
       "related": {
         "genes": {
           "edges": [


### PR DESCRIPTION
Now that we're rendering the artist insights v2 component via an A/B test, the specs need an updated artist fixture including insight data.