### PR TITLE
Exclude partner articles and classic articles from news sitemap

### DIFF
--- a/src/desktop/apps/sitemaps/routes.coffee
+++ b/src/desktop/apps/sitemaps/routes.coffee
@@ -8,6 +8,7 @@ PartnerFeaturedCities = require '../../collections/partner_featured_cities'
 artsyXapp = require 'artsy-xapp'
 PAGE_SIZE = 100
 { parse } = require 'url'
+sd = require 'sharify'
 httpProxy = require 'http-proxy'
 sitemapProxy = httpProxy.createProxyServer(target: SITEMAP_BASE_URL)
 getFullEditorialHref = require("@artsy/reaction/dist/Components/Publishing/Constants").getFullEditorialHref
@@ -15,6 +16,7 @@ getFullEditorialHref = require("@artsy/reaction/dist/Components/Publishing/Const
 @news = (req, res, next) ->
   new Articles().fetch
     data:
+      channel_id: sd.ARTSY_EDITORIAL_ID
       published: true
       sort: '-published_at'
       exclude_google_news: false
@@ -22,7 +24,7 @@ getFullEditorialHref = require("@artsy/reaction/dist/Components/Publishing/Const
     error: res.backboneError
     success: (articles) ->
       recentArticles = articles.filter (article) ->
-        moment(article.get 'published_at').isAfter(moment().subtract(2, 'days'))
+        moment(article.get 'published_at').isAfter(moment().subtract(2, 'days')) && article.get("layout") != 'classic'
       res.set 'Content-Type', 'text/xml'
       res.render('news', { pretty: true, articles: recentArticles, getFullEditorialHref: getFullEditorialHref })
 

--- a/src/desktop/apps/sitemaps/test/routes.coffee
+++ b/src/desktop/apps/sitemaps/test/routes.coffee
@@ -83,6 +83,7 @@ Sitemap: https://www.artsy.net/sitemap-videos.xml
         results: [
           fabricate('article', { layout: 'standard', published_at: today.toISOString() })
           fabricate('article', { layout: 'news', published_at: oneDayAgo.toISOString() })
+          fabricate('article', { layout: 'classic', published_at: oneDayAgo.toISOString() })
           fabricate('article', { published_at: twoDaysAgo.toISOString() })
         ]
       }


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/GROW-1081

The `ARTSY_EDITORIAL_ID` also needs to be updated before merging this.

 * [x] Update `ARTSY_EDITORIAL_ID` in staging and production