### PR TITLE
Remove <Container /> component used in new router apps

### DIFF
--- a/src/desktop/apps/artist/client.tsx
+++ b/src/desktop/apps/artist/client.tsx
@@ -3,7 +3,6 @@ import { data as sd } from "sharify"
 import { routes } from "reaction/Apps/Artist/routes"
 import React from "react"
 import ReactDOM from "react-dom"
-import styled from "styled-components"
 import qs from "querystring"
 import { clone, isArray } from "underscore"
 
@@ -18,9 +17,7 @@ buildClientApp({
 })
   .then(({ ClientApp }) => {
     ReactDOM.hydrate(
-      <Container>
-        <ClientApp />
-      </Container>,
+      <ClientApp />,
 
       document.getElementById("react-root")
     )
@@ -56,10 +53,3 @@ const onFilterChange = filters => {
   const fragment = "?" + qs.stringify(params)
   window.history.pushState({}, null, fragment)
 }
-
-// FIXME: Move this to Reaction
-const Container = styled.div`
-  width: 100%;
-  max-width: 1192px;
-  margin: auto;
-`

--- a/src/desktop/apps/artist/server.tsx
+++ b/src/desktop/apps/artist/server.tsx
@@ -3,7 +3,6 @@ import { Meta, query, toJSONLD } from "./components/Meta"
 import { stitch } from "@artsy/stitch"
 import { routes } from "reaction/Apps/Artist/routes"
 import React from "react"
-import styled from "styled-components"
 import { buildServerAppContext } from "desktop/lib/buildServerAppContext"
 import express, { Request, Response, NextFunction } from "express"
 
@@ -38,13 +37,6 @@ app.get(
         return
       }
 
-      // FIXME: Move this to Reaction
-      const Container = styled.div`
-        width: 100%;
-        max-width: 1192px;
-        margin: auto;
-      `
-
       const send = {
         method: "post",
         query,
@@ -74,11 +66,7 @@ app.get(
               <Meta sd={res.locals.sd} artist={artist} />
             </>
           ),
-          body: () => (
-            <Container>
-              <ServerApp />
-            </Container>
-          ),
+          body: ServerApp,
         },
         locals: {
           ...res.locals,

--- a/src/desktop/apps/artwork2/client.tsx
+++ b/src/desktop/apps/artwork2/client.tsx
@@ -3,7 +3,6 @@ import { routes } from "reaction/Apps/Artwork/routes"
 import { data as sd } from "sharify"
 import React from "react"
 import ReactDOM from "react-dom"
-import styled from "styled-components"
 
 const mediator = require("desktop/lib/mediator.coffee")
 const User = require("desktop/models/user.coffee")
@@ -11,13 +10,6 @@ const Artwork = require("desktop/models/artwork.coffee")
 const ArtworkInquiry = require("desktop/models/artwork_inquiry.coffee")
 const openInquiryQuestionnaireFor = require("desktop/components/inquiry_questionnaire/index.coffee")
 const openAuctionBuyerPremium = require("desktop/apps/artwork/components/auction/components/buyers_premium/index.coffee")
-
-// FIXME: Move this to Reaction
-const Container = styled.div`
-  width: 100%;
-  max-width: 1192px;
-  margin: auto;
-`
 
 buildClientApp({
   routes,
@@ -27,12 +19,7 @@ buildClientApp({
   },
 })
   .then(({ ClientApp }) => {
-    ReactDOM.hydrate(
-      <Container>
-        <ClientApp />
-      </Container>,
-      document.getElementById("react-root")
-    )
+    ReactDOM.hydrate(<ClientApp />, document.getElementById("react-root"))
   })
   .catch(error => {
     console.error(error)

--- a/src/desktop/apps/artwork2/server.tsx
+++ b/src/desktop/apps/artwork2/server.tsx
@@ -3,7 +3,6 @@ import { buildServerApp } from "reaction/Artsy/Router/server"
 import { routes } from "reaction/Apps/Artwork/routes"
 import { stitch } from "@artsy/stitch"
 import { buildServerAppContext } from "desktop/lib/buildServerAppContext"
-import styled from "styled-components"
 import express, { Request, Response, NextFunction } from "express"
 
 export const app = express()
@@ -30,13 +29,6 @@ app.get(
         return
       }
 
-      // FIXME: Move this to Reaction
-      const Container = styled.div`
-        width: 100%;
-        max-width: 1192px;
-        margin: auto;
-      `
-
       // While we are rolling out the new page, override the default (`artwork`)
       // type inferred from the URL, for tracking and comparison purposes.
       res.locals.sd.PAGE_TYPE = "new-artwork"
@@ -49,11 +41,7 @@ app.get(
         },
         blocks: {
           head: () => <React.Fragment>{headTags}</React.Fragment>,
-          body: () => (
-            <Container>
-              <ServerApp />
-            </Container>
-          ),
+          body: ServerApp,
         },
         locals: {
           ...res.locals,

--- a/src/desktop/apps/order2/client.js
+++ b/src/desktop/apps/order2/client.js
@@ -67,9 +67,7 @@ buildClientApp({
 })
   .then(({ ClientApp }) => {
     ReactDOM.hydrate(
-      <Container>
-        <ClientApp />
-      </Container>,
+      <ClientApp />,
 
       document.getElementById("react-root")
     )
@@ -81,10 +79,3 @@ buildClientApp({
 if (module.hot) {
   module.hot.accept()
 }
-
-// FIXME: Move this to Reaction
-const Container = styled.div`
-  width: 100%;
-  max-width: 1192px;
-  margin: auto;
-`

--- a/src/desktop/apps/order2/routes.tsx
+++ b/src/desktop/apps/order2/routes.tsx
@@ -1,5 +1,3 @@
-import React from "react"
-import styled from "styled-components"
 import { buildServerApp } from "reaction/Artsy/Router/server"
 import { buildServerAppContext } from "desktop/lib/buildServerAppContext"
 import { routes } from "reaction/Apps/Order/routes"
@@ -31,13 +29,6 @@ export const checkoutFlow = async (req, res, next) => {
       return
     }
 
-    // FIXME: Move this to Reaction
-    const Container = styled.div`
-      width: 100%;
-      max-width: 1192px;
-      margin: auto;
-    `
-
     const headerLogoHref = await getArtworkHref(req)
 
     // Render layout
@@ -50,11 +41,7 @@ export const checkoutFlow = async (req, res, next) => {
       },
       blocks: {
         head: () => headTags,
-        body: () => (
-          <Container>
-            <ServerApp />
-          </Container>
-        ),
+        body: ServerApp,
       },
       locals: {
         ...res.locals,


### PR DESCRIPTION
Once https://github.com/artsy/reaction/pull/1882 is merged and deployed this can be merged.

Moves the `<Container>` component (which constrained the width of the app) over to Reaction. 