### PR TITLE
Hide "coming soon" videos from RSS feed

### DIFF
--- a/src/desktop/apps/rss/routes.js
+++ b/src/desktop/apps/rss/routes.js
@@ -17,7 +17,15 @@ export const news = (req, res, next) => {
   return positronql(query)
     .then(async result => {
       try {
-        const articles = await findArticlesWithEmbeds(result.articles)
+        const articlesWithoutUnpublishedVideos = result.articles.filter(
+          article =>
+            article.layout !== "video" ||
+            (article.media && article.media.published)
+        )
+
+        const articles = await findArticlesWithEmbeds(
+          articlesWithoutUnpublishedVideos
+        )
         res.set("Content-Type", "application/rss+xml")
         return res.render("news", { articles, pretty: true })
       } catch (err) {


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/GROW-956

This PR updates the news RSS to exclude video articles that has `media.published === false`. The GraphQL query already has `media { published }` so we don't have to update that here.