### PR TITLE
 Add intercom handler for mediator call on new artwork page

### DIFF
--- a/src/desktop/apps/artwork2/client.tsx
+++ b/src/desktop/apps/artwork2/client.tsx
@@ -4,6 +4,7 @@ import { data as sd } from "sharify"
 import React from "react"
 import ReactDOM from "react-dom"
 import styled from "styled-components"
+import { enableIntercom } from "lib/intercom"
 
 const mediator = require("desktop/lib/mediator.coffee")
 const User = require("desktop/models/user.coffee")
@@ -87,4 +88,8 @@ mediator.on("openAuctionAskSpecialistModal", options => {
 
 mediator.on("openAuctionBuyerPremium", options => {
   openAuctionBuyerPremium(options.auctionId)
+})
+
+mediator.on("enableIntercomForBuyers", options => {
+  enableIntercom(options)
 })


### PR DESCRIPTION
This handle even dispatched from rendering of the new page here: https://github.com/artsy/reaction/pull/1889

Intercom should be loaded according to the settings that we already have configured to intercom on old artwork page.

I believe once that is merged and on staging - we should be able to see it there:)

https://artsyproduct.atlassian.net/browse/DISCO-675