### PR TITLE
Serve 404 page when order is not found

### DIFF
--- a/src/desktop/apps/order2/__tests__/routes.jest.js
+++ b/src/desktop/apps/order2/__tests__/routes.jest.js
@@ -47,6 +47,7 @@ describe("Request for order", () => {
         done()
       })
     })
+
     it("permits an authenticated user access", done => {
       res.locals.sd.CURRENT_USER = {
         id: "user1234",
@@ -56,6 +57,26 @@ describe("Request for order", () => {
       checkoutFlow(req, res, next).then(() => {
         expect(res.redirect).not.toHaveBeenCalled()
         expect(buildServerApp).toHaveBeenCalled()
+        done()
+      })
+    })
+
+    it("serves a 404 when an order is not found", done => {
+      res.locals.sd.CURRENT_USER = {
+        id: "user1234",
+      }
+      buildServerApp.mockRejectedValue({
+        message: "asdfadsfsda Received status code 404 adsfasd",
+      })
+
+      checkoutFlow(req, res, next).then(() => {
+        expect(buildServerApp).toHaveBeenCalled()
+        expect(next).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: "Order Not Found",
+            status: 404,
+          })
+        )
         done()
       })
     })

--- a/src/desktop/apps/order2/routes.tsx
+++ b/src/desktop/apps/order2/routes.tsx
@@ -58,12 +58,12 @@ export const checkoutFlow = async (req, res, next) => {
 
     res.status(status).send(layout)
   } catch (error) {
+    console.log("(apps/order2) Error: ", error)
     if (error.message.includes("Received status code 404")) {
       const notFoundError: any = new Error("Order Not Found")
       notFoundError.status = 404
       next(notFoundError)
     } else {
-      console.log("(apps/order2) Error: ", error)
       next(error)
     }
   }

--- a/src/desktop/apps/order2/routes.tsx
+++ b/src/desktop/apps/order2/routes.tsx
@@ -58,8 +58,14 @@ export const checkoutFlow = async (req, res, next) => {
 
     res.status(status).send(layout)
   } catch (error) {
-    console.log("(apps/order2) Error: ", error)
-    next(error)
+    if (error.message.includes("Received status code 404")) {
+      const notFoundError: any = new Error("Order Not Found")
+      notFoundError.status = 404
+      next(notFoundError)
+    } else {
+      console.log("(apps/order2) Error: ", error)
+      next(error)
+    }
   }
 }
 


### PR DESCRIPTION
In collaboration with @lilyfromseattle. Addresses [PURCHASE-787](https://artsyproduct.atlassian.net/browse/PURCHASE-787).

This is a temporary fix for serving up a 404 page when an order is not found. It's not an ideal solution - we're going to look into things a bit more and see if we can figure out a better way to emit 404's.

We're also going to talk to @mzikherman as it appears he dealt with this issue for artists/artworks recently, and see if he had any revelations.