### PR TITLE
Swap reaction's Grid for palette

### DIFF
--- a/src/desktop/apps/artsy_in_miami/components/MiamiFairWeekPage.js
+++ b/src/desktop/apps/artsy_in_miami/components/MiamiFairWeekPage.js
@@ -2,7 +2,7 @@ import React from "react"
 import styled, { ThemeProvider } from "styled-components"
 
 import colors from "reaction/Assets/Colors"
-import { Row, Col } from "reaction/Components/Grid"
+import { Row, Col } from "@artsy/palette"
 import Text from "reaction/Components/Text"
 import Title from "reaction/Components/Title"
 


### PR DESCRIPTION
Removes last instance of deprecated reaction `Grid` component from Force, in favor of palette.