### PR TITLE
Reinstate validate schemas

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ jobs:
   acceptance:
     docker:
       - image: circleci/node:10-stretch-browsers
-    parallelism: 1
     steps:
       - add_ssh_keys
       - checkout
@@ -26,7 +25,6 @@ jobs:
   validate_staging_schema:
     docker:
       - image: circleci/node:10-stretch-browsers
-    parallelism: 1
     steps:
       - add_ssh_keys
       - checkout
@@ -36,7 +34,6 @@ jobs:
   validate_production_schema:
     docker:
       - image: circleci/node:10-stretch-browsers
-    parallelism: 1
     steps:
       - add_ssh_keys
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,26 @@ jobs:
           command: |
             export commit_hash=`git rev-parse --short HEAD` && echo $commit_hash
             hokusai test
+  validate_staging_schema:
+    docker:
+      - image: circleci/node:10-stretch-browsers
+    parallelism: 1
+    steps:
+      - add_ssh_keys
+      - checkout
+      - run:
+          name: Validate Staging Schema
+          command: "yarn install && node scripts/validate_schemas.js staging"
+  validate_production_schema:
+    docker:
+      - image: circleci/node:10-stretch-browsers
+    parallelism: 1
+    steps:
+      - add_ssh_keys
+      - checkout
+      - run:
+          name: Validate Production Schema
+          command: "yarn install && node scripts/validate_schemas.js production"
   push_staging_image: &push_image
     docker:
       - image: artsy/hokusai:0.4.5
@@ -126,6 +146,14 @@ workflows:
               ignore:
                 - staging
                 - release
+      - validate_staging_schema:
+          filters:
+            branches:
+              only: master
+      - validate_production_schema:
+          filters:
+            branches:
+              only: release
       - push_staging_image:
           filters:
             branches:
@@ -133,10 +161,13 @@ workflows:
           requires:
             - test
             - acceptance
+            - validate_staging_schema
       - push_production_image:
           filters:
             branches:
               only: release
+          requires:
+            - validate_production_schema
       - publish_staging_assets:
           filters:
             branches:
@@ -144,10 +175,13 @@ workflows:
           requires:
             - test
             - acceptance
+            - validate_staging_schema
       - publish_production_assets:
           filters:
             branches:
               only: release
+          requires:
+            - validate_production_schema
       - deploy_hokusai_staging:
           filters:
             branches:

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -13,41 +13,4 @@ export default async () => {
       `Please don't include .js files, we want to be using TypeScript found: ${files}.`
     )
   }
-
-  // Breaking change check for Metaphysics production when deploying
-  // also locked against Peril having access to the file
-  if (!peril && danger.github.pr.base.ref === "release") {
-    const { getBreakingChanges } = require("./scripts/validate_schemas")
-    const breakingChanges = await getBreakingChanges()
-    const bc = breakingChanges
-    const typesMissing = bc.filter(b => b.type === "TYPE_REMOVED")
-    const fieldsMissing = bc.filter(b => b.type === "FIELD_REMOVED")
-    const unionOptionsMissing = bc.filter(
-      b => b.type === "TYPE_REMOVED_FROM_UNION"
-    )
-    const fieldChanged = bc.filter(b => b.type === "FIELD_CHANGED_KIND")
-
-    const descriptions = {
-      "Missing types": typesMissing,
-      "Fields missing": fieldsMissing,
-      "Fields changed": fieldChanged,
-      "Union types-mismatch": unionOptionsMissing,
-    }
-
-    if (bc.length) {
-      warn(
-        `Metaphysics production does not have a compatible schema for force's GraphQL usage, please deploy metaphysics to production and re-run Travis CI.`
-      )
-    }
-
-    Object.keys(descriptions).forEach(key => {
-      const breakingChanges: BreakingChange[] = descriptions[key]
-      if (breakingChanges.length) {
-        const fields = breakingChanges.map(
-          b => "`" + b.description.split(" ")[0] + "`"
-        )
-        warn(`${key}: ${danger.utils.sentence(fields)}`)
-      }
-    })
-  }
 }

--- a/scripts/validate_schemas.js
+++ b/scripts/validate_schemas.js
@@ -16,9 +16,8 @@ const {
 } = require("graphql")
 
 const fetch = require("isomorphic-fetch")
-const metaphysicsProd = "https://metaphysics-production.artsy.net/"
 
-const downloadProductionSchema = async endpoint => {
+const downloadMetaphysicsSchema = async endpoint => {
   const postBody = {
     query: introspectionQuery,
     operationName: "IntrospectionQuery",
@@ -46,13 +45,13 @@ const downloadGitHubReaction = async release => {
   return body
 }
 
-const getBreakingChanges = async () => {
+const getBreakingChanges = async (metaphysicsEnv) => {
   const packageJSON = JSON.parse(
     readFileSync(__dirname + "/../package.json", "utf8")
   )
   const reactionVersion = packageJSON["dependencies"]["@artsy/reaction"]
   const reactionSchema = await downloadGitHubReaction(reactionVersion)
-  const metaphyicsSchema = await downloadProductionSchema(metaphysicsProd)
+  const metaphyicsSchema = await downloadMetaphysicsSchema(`https://metaphysics-${metaphysicsEnv}.artsy.net/`)
   return findBreakingChanges(
     buildSchema(metaphyicsSchema),
     buildSchema(reactionSchema)
@@ -66,16 +65,23 @@ module.exports = {
 // @ts-ignore
 if (require.main === module) {
   // When this is being called as a script via `node scripts/validate_schemas.js`
-  getBreakingChanges().then(changes => {
-    if (changes.length) {
-      process.exitCode = 1
-      console.error(
-        "Failing due to breaking changes between Force and Metaphysics Production\n\n"
-      )
-      console.error(changes)
-      console.error(
-        "\n\nYou should deploy metaphysics production, and re-deploy force"
-      )
-    }
-  })
+  if (process.argv.length != 3) {
+    console.log('This script must be called with either "staging" or "production"')
+    process.exitCode = 1
+  } else {
+    getBreakingChanges(process.argv[2]).then(changes => {
+      if (changes.length) {
+        process.exitCode = 1
+        console.error(
+          `Failing due to breaking changes between Force and Metaphysics ${process.argv[2]}\n\n`
+        )
+        console.error(changes)
+        console.error(
+          `\n\nYou should deploy metaphysics ${process.argv[2]}, and re-deploy force`
+        )
+      } else {
+        console.log("No breaking changes found!")
+      }
+    })
+  }
 }

--- a/scripts/validate_schemas.js
+++ b/scripts/validate_schemas.js
@@ -74,11 +74,11 @@ if (require.main === module) {
       if (changes.length) {
         process.exitCode = 1
         console.error(
-          `Failing due to breaking changes between Force and Metaphysics ${env}\n\n`
+          `Metaphysics' ${env} schema is incompatible with this project's expectations:\n\n`
         )
         console.error(changes)
         console.error(
-          `\n\nYou should deploy metaphysics ${env}, and re-deploy force`
+          `\n\nYou should update Metaphysics ${env} before releasing these changes`
         )
       } else {
         console.log("No breaking changes found!")

--- a/scripts/validate_schemas.js
+++ b/scripts/validate_schemas.js
@@ -53,8 +53,8 @@ const getBreakingChanges = async (metaphysicsEnv) => {
   const reactionSchema = await downloadGitHubReaction(reactionVersion)
   const metaphyicsSchema = await downloadMetaphysicsSchema(`https://metaphysics-${metaphysicsEnv}.artsy.net/`)
   return findBreakingChanges(
-    buildSchema(metaphyicsSchema),
-    buildSchema(reactionSchema)
+    buildSchema(reactionSchema),
+    buildSchema(metaphyicsSchema)
   )
 }
 
@@ -69,15 +69,16 @@ if (require.main === module) {
     console.log('This script must be called with either "staging" or "production"')
     process.exitCode = 1
   } else {
-    getBreakingChanges(process.argv[2]).then(changes => {
+    const env = process.argv[2]
+    getBreakingChanges(env).then(changes => {
       if (changes.length) {
         process.exitCode = 1
         console.error(
-          `Failing due to breaking changes between Force and Metaphysics ${process.argv[2]}\n\n`
+          `Failing due to breaking changes between Force and Metaphysics ${env}\n\n`
         )
         console.error(changes)
         console.error(
-          `\n\nYou should deploy metaphysics ${process.argv[2]}, and re-deploy force`
+          `\n\nYou should deploy metaphysics ${env}, and re-deploy force`
         )
       } else {
         console.log("No breaking changes found!")


### PR DESCRIPTION
The validate schemas check was removed in https://github.com/artsy/force/pull/3197 as it was being run via CI in the `hokusai` image which doesn't have node installed.

Generalize scripts/validate_schemas.js to check either staging or production Metaphysics and validate staging on master and production on release

Run validate schema checks on the `circleci/node:10-stretch-browsers` image
