### PR TITLE
Deploy: Roll out Artist Insights V2 to all sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@artsy/express-reloadable": "1.4.0",
     "@artsy/palette": "2.33.1",
     "@artsy/passport": "1.1.0",
-    "@artsy/reaction": "11.2.6",
+    "@artsy/reaction": "11.2.7",
     "@artsy/stitch": "4.0.1",
     "@babel/core": "^7.0.0",
     "@babel/node": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@airbnb/node-memwatch": "^1.0.2",
     "@artsy/express-reloadable": "1.4.0",
-    "@artsy/palette": "2.32.2",
+    "@artsy/palette": "2.33.1",
     "@artsy/passport": "1.1.0",
     "@artsy/reaction": "11.2.6",
     "@artsy/stitch": "4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,10 +62,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/react-responsive-media/-/react-responsive-media-2.0.0-beta.5.tgz#d61e1a9f215d38d90ec2bb97dc1ff7409d0346fa"
   integrity sha512-XRYA77v/j3mVInwy5EYb8NtmMkkAD1/XDxDi45BO0oduv4hsljJfjtjK7jN0ziJ6JUm2QTx/t6QwuaT9E7vTuA==
 
-"@artsy/reaction@11.2.6":
-  version "11.2.6"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-11.2.6.tgz#f4e046266ffd542a284ab8396712218093070c47"
-  integrity sha512-u5PHm5eH7u+1bkQzTLq/PWNTduktwHR7xgDSFzWwyczU6ZfQLHxImNB0fzgjteoYD1G/LKnL2euqmDIpmBUDYA==
+"@artsy/reaction@11.2.7":
+  version "11.2.7"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-11.2.7.tgz#9440a4fc372e9cc606689fa247cb5be67e984778"
+  integrity sha512-XtYTmyzfTQx1y4RTr1b7M5v/mxw6fRpBZMNpLQFcaDhGIxJucyxX1oUwTX15NRiqPOI437xNXUV3yNXKB4vpxQ==
   dependencies:
     "@artsy/detect-responsive-traits" "^0.0.1"
     "@artsy/react-responsive-media" "^2.0.0-beta.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,10 +24,10 @@
     chokidar "^1.7.0"
     decache "^4.4.0"
 
-"@artsy/palette@2.32.2":
-  version "2.32.2"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.32.2.tgz#208ce360ac57a6d13d53df48645d52e383349404"
-  integrity sha512-pOeLdgGaOMy1Fp7gI3MHkB9n8RslhzI180IfdHhadONuCHkMilvv25UeMWHveqOdcw6lV4TeAQ7K60byyjG3mA==
+"@artsy/palette@2.33.1":
+  version "2.33.1"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-2.33.1.tgz#6f141afa0c963862729f95723bcae06bef9c8630"
+  integrity sha512-vzDrh5xyf9ffaGmOYmvY7XXwDIJDzE+70D98TkFM1ZKuLOMKws0SVzXAq3hHLpehMQ1O/ONLuFJ7cZXe/CuaMA==
   dependencies:
     moment "^2.23.0"
     moment-timezone "^0.5.23"


### PR DESCRIPTION
This removes the A/B test branching in Reaction to ensure that Artist Insights V2 is enabled for all artist pages.