### PR TITLE
[WIP] Add view in room to artwork page v2

### DIFF
--- a/src/desktop/apps/artwork2/client.tsx
+++ b/src/desktop/apps/artwork2/client.tsx
@@ -4,6 +4,7 @@ import { data as sd } from "sharify"
 import React from "react"
 import ReactDOM from "react-dom"
 import { enableIntercom } from "lib/intercom"
+import { openViewInRoom } from "lib/viewInRoom"
 
 const mediator = require("desktop/lib/mediator.coffee")
 const User = require("desktop/models/user.coffee")
@@ -79,4 +80,8 @@ mediator.on("openAuctionBuyerPremium", options => {
 
 mediator.on("enableIntercomForBuyers", options => {
   enableIntercom(options)
+})
+
+mediator.on("openViewInRoom", options => {
+  openViewInRoom(options)
 })

--- a/src/desktop/components/view_in_room/view.coffee
+++ b/src/desktop/components/view_in_room/view.coffee
@@ -22,6 +22,7 @@ module.exports = class ViewInRoom extends Backbone.View
 
   initialize: ({ @$img, @dimensions }) ->
     $(window).on 'resize.view-in-room', _.throttle(@scale, 100)
+    # @$img = [jquery constructor goes here]
     @scrollbar = new Scrollbar
 
   __render__: ->

--- a/src/lib/viewInRoom.ts
+++ b/src/lib/viewInRoom.ts
@@ -4,9 +4,9 @@ const { ViewInRoomView } = require('../desktop/components/view_in_room/view.coff
 export function openViewInRoom({ dimensions, image }) {
 
     // Navigate back to default image if needed
-    // $('.js-artwork-images__pages__page')
-    //   .first()
-    //   .click()
+    $('.js-artwork-images__pages__page')
+      .first()
+      .click()
 
     const view = new ViewInRoomView
       $img: image

--- a/src/lib/viewInRoom.ts
+++ b/src/lib/viewInRoom.ts
@@ -1,0 +1,16 @@
+const { ViewInRoomView } = require('../desktop/components/view_in_room/view.coffee')
+
+// Enable the "view in room" function on artworks with is_hangable === true
+export function openViewInRoom({ dimensions, image }) {
+
+    // Navigate back to default image if needed
+    // $('.js-artwork-images__pages__page')
+    //   .first()
+    //   .click()
+
+    const view = new ViewInRoomView
+      $img: image
+      dimensions: dimensions
+
+    $('body').prepend view.render().$el
+}


### PR DESCRIPTION
This is the sister PR to [this one](https://github.com/artsy/reaction/pull/1928) in Reaction—the final goal is to get the View in Room functionality from the old artwork page to work on the new one with minimal changes.

Still to do on this side: theoretically, if we can pass the data from Reaction in the form expected by ViewInRoomView (mainly an `<img>` tag), we should have very little work to do here. We'd need to resolve some of the jquery weirdness, but we shouldn't have to change the coffeescript file much or at all.

Tracked: [DISCO-465](https://artsyproduct.atlassian.net/browse/DISCO-465)