### PR TITLE
scale out

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: force-web
 spec:
-  replicas: 3
+  replicas: 4
   strategy:
     rollingUpdate:
       maxSurge: 2


### PR DESCRIPTION
Force seems to be getting OOMKilled a lot as it exceeds the 1.5Gi limit.  I tried bumping Force’s memory requests to 1.5Gi and limit to 2Gi but it still seemed to settle at around 1Gi memory consumption… these restarts may be due to traffic spikes… I fear raising the ceiling will put us in the undesirable position of high event loop latency so I want to scale out instead and see if it mitigates these spikes in memory / restarts