### PR TITLE
Add the very basic handling for OpenInRoom mediator call

### DIFF
--- a/src/desktop/apps/artwork2/client.tsx
+++ b/src/desktop/apps/artwork2/client.tsx
@@ -5,12 +5,15 @@ import React from "react"
 import ReactDOM from "react-dom"
 import { enableIntercom } from "lib/intercom"
 
+const $ = require("jquery")
+
 const mediator = require("desktop/lib/mediator.coffee")
 const User = require("desktop/models/user.coffee")
 const Artwork = require("desktop/models/artwork.coffee")
 const ArtworkInquiry = require("desktop/models/artwork_inquiry.coffee")
 const openInquiryQuestionnaireFor = require("desktop/components/inquiry_questionnaire/index.coffee")
 const openAuctionBuyerPremium = require("desktop/apps/artwork/components/auction/components/buyers_premium/index.coffee")
+const ViewInRoomView = require("desktop/components/view_in_room/view.coffee")
 
 buildClientApp({
   routes,
@@ -70,6 +73,23 @@ mediator.on("openAuctionAskSpecialistModal", options => {
         ask_specialist: true,
       })
     })
+  }
+})
+
+mediator.on("openViewInRoom", options => {
+  const url = options.image && options.image.url
+  if (url) {
+    const fakeImg = $('<img src="' + options.image.url + '">').load(function() {
+      // TODO: Give it a position so that it can animate from it.
+      // Or alternatevely figure out how to remove the animation
+    })
+
+    const viewInRoom = new ViewInRoomView({
+      $img: fakeImg,
+      dimensions: options.dimensions && options.dimensions.cm,
+    })
+
+    $("body").prepend(viewInRoom.render().$el)
   }
 })
 

--- a/src/desktop/assets/artwork2.styl
+++ b/src/desktop/assets/artwork2.styl
@@ -1,4 +1,5 @@
 @require '../components/buyers_premium'
+@require '../components/view_in_room'
 
 .modalize-body
   padding 30px


### PR DESCRIPTION
This is my very basic and lame version of view in a room.

The good part about it - it's all very contained on Artwork2 Client file. It does animate funky though and as @zephraph suggested - it might be worth exploring if we want to remove this animation at all as oppose to try to figure out where to animate from.

Also this needs reaction update from here: https://github.com/artsy/reaction/pull/1930 which in turn needs palette update from here: https://github.com/artsy/palette/pull/218

And the current selfie:)
![follow](https://user-images.githubusercontent.com/437156/51638445-549b5980-1f2c-11e9-87f3-4f877f74893a.gif)
