### PR TITLE
Use safe navigation to access partner name

### DIFF
--- a/src/mobile/models/artwork.coffee
+++ b/src/mobile/models/artwork.coffee
@@ -76,7 +76,7 @@ module.exports = class Artwork extends Backbone.Model
     if @hasCollectingInstitution()
       @get('collecting_institution')
     else
-      @get('partner').name
+      @get('partner')?.name
 
   fetchRelatedSales: (options = {}) ->
     new Backbone.Collection(null,


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/BUGS-731
Fixes  https://artsyproduct.atlassian.net/browse/BUGS-723 

This trivial change simply makes use of the Coffeescript extistential operator to safely navigate to an artwork's partner's name on mobile tag pages.

This effectively quiets the client-side JS error and the accompanying Sentry report.

But that's really secondary to the fact that the tag pages (e.g. /tag/koala) are substantially broken on mobile, which is worth a separate ticket. (I'll look for one and create if necessary).
