### PR TITLE
Explicitly checks for existence of city before searching for city.name

### DIFF
--- a/src/mobile/apps/galleries_institutions/templates/partner.jade
+++ b/src/mobile/apps/galleries_institutions/templates/partner.jade
@@ -9,7 +9,7 @@
     .az-partner-group-cell__name
       = partner.get('name')
     .az-partner-group-cell__location
-      if partner.related().locations.length
+      if partner.related().locations.length && city
         = partner.related().locations.getLocationAddressNearest(city.name)
       else
         | &nbsp;


### PR DESCRIPTION
This caused a bunch of errors on the `/galleries/all` page on mobile web.

Fixes https://artsyproduct.atlassian.net/browse/BUGS-726 (https://sentry.io/artsynet/force-production/issues/856044287/?referrer=alert_email)

Note that a general weird thing about this page is that basically no location names show up. 🤷‍♀️ seems like it could use a bit of a reboot, but for a later time.