### PR TITLE
Redefines carousel arrow offset from 30 to 10 pixels

### DIFF
--- a/src/desktop/apps/galleries_institutions/components/primary_carousel/index.styl
+++ b/src/desktop/apps/galleries_institutions/components/primary_carousel/index.styl
@@ -1,7 +1,7 @@
 @require '../../../components/merry_go_round'
 
 carousel-height = 400px
-arrow-offset = 30px
+arrow-offset = 10px
 
 .galleries-institutions-primary-carousel
   position relative


### PR DESCRIPTION
- Brings in carousel arrows to 10px padding instead of 30px so the
- ( https://artsyproduct.atlassian.net/browse/BUGS-713 )

## Before:

![screen shot 2019-01-24 at 11 18 00 am](https://user-images.githubusercontent.com/21182806/51692955-f45bf480-1fcb-11e9-8a67-94345d9ed358.png)

## After: 

![screen shot 2019-01-24 at 11 36 32 am](https://user-images.githubusercontent.com/21182806/51693133-56b4f500-1fcc-11e9-8bd1-401b65ca3db0.png)
