### PR TITLE
Remove Munchkin from page header

### DIFF
--- a/src/desktop/components/main_layout/templates/head.jade
+++ b/src/desktop/components/main_layout/templates/head.jade
@@ -29,28 +29,3 @@ if sd.BROWSER && sd.BROWSER.family != 'Other'
 
 //- Criteo marketing tag... no Segment integration (  ._.)
 script(type='text/javascript', src='//static.criteo.net/js/ld/ld.js', async='true')
-
-//- Marketo munchkin
-if options.marketo
-  script(type='text/javascript').
-    (function() {
-    var didInit = false;
-    function initMunchkin() {
-    if(didInit === false) {
-    didInit = true;
-    Munchkin.init('609-FDY-207', { asyncOnly: true } );
-    }
-    }
-    var s = document.createElement('script');
-    s.type = 'text/javascript';
-    s.async = true;
-    s.src = '//munchkin.marketo.net/munchkin.js';
-    s.cookieAnon = false;
-    s.onreadystatechange = function() {
-    if (this.readyState == 'complete' || this.readyState == 'loaded') {
-    initMunchkin();
-    }
-    };
-    s.onload = initMunchkin;
-    document.getElementsByTagName('head')[0].appendChild(s);
-    })();


### PR DESCRIPTION
This has been broken for a while, directly from their script and is flooding our error logging leading (i suspect) to overages from Sentry since it triggers an error for every user on every page: 

<img width="878" alt="screen shot 2019-01-24 at 12 06 38 pm" src="https://user-images.githubusercontent.com/236943/51706430-3e94a400-1fd3-11e9-8b93-7cc9997414ff.png">
<img width="404" alt="screen shot 2019-01-24 at 12 07 35 pm" src="https://user-images.githubusercontent.com/236943/51706431-3e94a400-1fd3-11e9-93aa-05795a8f7b8c.png">

Spoke with data and they confirmed it was ok to remove for now and are going to follow up. 