### PR TITLE
Add polyfill for object.entries for older browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "dotenv": "^4.0.0",
     "embed-video": "^1.2.0",
     "embedly-view-helpers": "artsy/embedly-view-helpers",
+    "es7-object-polyfill": "^0.0.7",
     "express": "^4.13.3",
     "express-ipfilter": "0.2.1",
     "express-limiter": "^1.6.0",

--- a/src/desktop/lib/global_client_setup.coffee
+++ b/src/desktop/lib/global_client_setup.coffee
@@ -23,6 +23,8 @@ globalReactModules = require('./global_react_modules.tsx')
 hydrateStitch = require('@artsy/stitch/dist/internal/hydrate').hydrate
 { initModalManager } = require('../../desktop/apps/auth2/client/index')
 
+require ('es7-object-polyfill')
+
 module.exports = ->
   setupErrorReporting()
   setupJquery()

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,7 +94,7 @@
     react-head "^3.0.0"
     react-html-parser "^2.0.2"
     react-lazy-load-image-component "^1.1.1"
-    react-lines-ellipsis "github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a"
+    react-lines-ellipsis xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a
     react-markdown "^2.5.0"
     react-oembed-container "^0.3.0"
     react-overlays "^0.8.3"
@@ -5368,6 +5368,13 @@ es6-weak-map@^2.0.1:
     es5-ext "^0.10.14"
     es6-iterator "^2.0.1"
     es6-symbol "^3.1.1"
+
+es7-object-polyfill@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/es7-object-polyfill/-/es7-object-polyfill-0.0.7.tgz#4cc46ab66aebb8db73f5466184d057ee6795713f"
+  integrity sha512-XoD2Grsf1JvpREOmH9yFMd/GHMVjISpxq9sHm1RKZ3XZ+IBXJDIuyqbTu/zegL5GYZnL3hBA9vqJQVGawWIvgQ==
+  dependencies:
+    reflect.ownkeys "^0.2.0"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -12896,6 +12903,11 @@ referrer-policy@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/referrer-policy/-/referrer-policy-1.0.0.tgz#f60eedc92f942b01a6118121ec932d66e8fd7e14"
   integrity sha1-9g7tyS+UKwGmEYEh7JMtZuj9fhQ=
+
+reflect.ownkeys@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz#749aceec7f3fdf8b63f927a04809e90c5c0b3460"
+  integrity sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=
 
 regenerate-unicode-properties@^5.1.1:
   version "5.1.3"


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/BUGS-736

Adds https://github.com/xpl/es7-object-polyfill as a polyfill for older browsers. Not too necessary, but just in case (just a few loc) 