### PR TITLE
[Bugfix] Bump /shows/id image count to max

### DIFF
--- a/src/mobile/apps/show/routes.coffee
+++ b/src/mobile/apps/show/routes.coffee
@@ -25,7 +25,7 @@ module.exports.index = (req, res, next) ->
         show.fetchArtworks
           data:
             page: 1
-            size: 10
+            size: 100
           error: res.backboneError
           success: (artworks) ->
             res.locals.sd.ARTWORKS = artworks


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/BUGS-664

The previous fetch count was only 10; I bumped it to 100, the max. For big shows there could be a request time penalty but the UI supports it, and it seems pretty straightforward. 