### PR TITLE
Update max-height on slider in mobile web to not cut off large shows

### DIFF
--- a/src/mobile/components/show_more_works/index.coffee
+++ b/src/mobile/components/show_more_works/index.coffee
@@ -8,6 +8,7 @@ module.exports =
       $(e.currentTarget).find('.circle-border-icon-button').css 'transform', 'none'
     else
       $(e.currentTarget).prev()
-        .animate({'height': $(e.currentTarget).prev().prop('scrollHeight'), 'max-height': 9999}, 1000)
+        .animate({'height': $(e.currentTarget).prev().prop('scrollHeight')}, 1000)
         .addClass 'toggled'
+        .css 'max-height', 'none'
       $(e.currentTarget).find('.circle-border-icon-button').css 'transform', 'rotate(180deg)'


### PR DESCRIPTION
Fixes: https://artsyproduct.atlassian.net/browse/BUGS-664

The actual height of the component necessary to show these works is ~ `18000px` so `9999` just doesn't cut it.

Updated to remove `max-height` completely (as it's set by the un-toggled version of the component). Did a quick pass through the fairs views that re-use this and they seem 👍. 