### PR TITLE
Bump the number of shows from premium partners which  we highlight from 3 -> 6

### DIFF
--- a/src/desktop/apps/galleries_institutions/components/primary_carousel/fetch.coffee
+++ b/src/desktop/apps/galleries_institutions/components/primary_carousel/fetch.coffee
@@ -23,7 +23,7 @@ fetchFeaturedSet = (type) ->
 fetchWithParams = (params) ->
   partners = new FilterPartners
   Q(partners.fetch(
-    data: _.extend {}, params, eligible_for_carousel: true, size: 3, sort: '-random_score'
+    data: _.extend {}, params, eligible_for_carousel: true, size: 6, sort: '-random_score'
   ).then (results) ->
     profiles = new Profiles
     Q.all(partners.map (partner) ->


### PR DESCRIPTION
We set this number to three back in 2016 ( https://github.com/artsy/force-private/pull/4357 ), which I think is maybe before we set the idea of premium partners having this as an key part of the selling process. So this bumps the number of premium highlighted shows from 3 -> 6.

It's a quick-fix, an ideal solution is to take the work going on with https://artsyproduct.atlassian.net/browse/GALL-1314 and to make those changes also improve this section too. It could probably do with being an infinite loop.

<img width="1749" alt="screen shot 2019-01-25 at 12 43 49 pm" src="https://user-images.githubusercontent.com/49038/51772295-7ae20600-20a0-11e9-867b-23eb686821a8.png">
