### PR TITLE
Validate Metaphysics' staging schema on pull request builds as well

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,9 @@ workflows:
       - validate_staging_schema:
           filters:
             branches:
-              only: master
+              ignore:
+                - staging
+                - release
       - validate_production_schema:
           filters:
             branches:


### PR DESCRIPTION
I _think_ this will accomplish what we discussed: pull requests should be validated against Metaphysics' staging schema _before_ being merged into `master`.

https://artsyproduct.atlassian.net/browse/PLATFORM-1142

(w/@lilyfromseattle)