### PR TITLE
Add ability to customize mobile sign up form using query string

### DIFF
--- a/src/desktop/apps/auth2/__tests__/routes.jest.js
+++ b/src/desktop/apps/auth2/__tests__/routes.jest.js
@@ -121,6 +121,7 @@ describe("Routes", () => {
           redirectTo: "/bar",
           signupIntent: "follow artist",
           signupReferer: "referrer",
+          title: "Sign up to follow Andy Warhol",
         }
 
         index(req, res, next).then(() => {
@@ -130,6 +131,7 @@ describe("Routes", () => {
             redirectTo,
             signupIntent,
             signupReferer,
+            title,
           } = stitch.mock.calls[0][0].data.options
 
           expect(afterSignUpAction).toBe(req.query.afterSignUpAction)
@@ -137,6 +139,7 @@ describe("Routes", () => {
           expect(redirectTo).toBe(req.query.redirectTo)
           expect(signupIntent).toBe(req.query.signupIntent)
           expect(signupReferer).toBe(req.query.signupReferer)
+          expect(title).toBe(req.query.title)
           done()
         })
       })

--- a/src/desktop/apps/auth2/components/MobileAuthStatic.tsx
+++ b/src/desktop/apps/auth2/components/MobileAuthStatic.tsx
@@ -30,6 +30,7 @@ export class MobileAuthStatic extends React.Component<Props> {
         <MobileContainer>
           <FormSwitcher
             {...this.props}
+            title={this.props.options.title}
             type={this.props.type as ModalType}
             handleSubmit={handleSubmit.bind(
               this,

--- a/src/desktop/apps/auth2/routes.ts
+++ b/src/desktop/apps/auth2/routes.ts
@@ -23,21 +23,21 @@ export const index = async (req, res, next) => {
       break
   }
 
-  let title = ""
+  let pageTitle = ""
   switch (type) {
     case ModalType.login:
-      title = "Login to Artsy"
+      pageTitle = "Login to Artsy"
       break
     case ModalType.signup:
-      title = "Signup for Artsy"
+      pageTitle = "Signup for Artsy"
       break
     case ModalType.forgot:
-      title = "Forgot Password"
+      pageTitle = "Forgot Password"
       break
   }
   const meta = {
     description: "",
-    title,
+    title: pageTitle,
   }
 
   const {
@@ -51,6 +51,7 @@ export const index = async (req, res, next) => {
     signupIntent,
     intent,
     trigger,
+    title,
   } = req.query
 
   if (type === ModalType.forgot) {
@@ -94,6 +95,7 @@ export const index = async (req, res, next) => {
           signupIntent,
           signupReferer,
           trigger,
+          title,
         },
       },
     })


### PR DESCRIPTION
partially addresses https://artsyproduct.atlassian.net/browse/GROW-1080

This PR adds the ability to change the title of the standalone sign up page. In Reaction we've added the ability to [customize the title at the React level](MobileSignUpForm), and on Force-side we basically pass down the `title` query string to the `<MobileSignUpForm>` component. Once we merge this we'll be able to customize the title by adding `title` to the URL:

```
/sign_up?title=Sign+up+to+follow+artworks&action=follow&...
```

In terms of security, JSX sanitizes any text that goes through it (except for texts assigned to `dangerouslySetInnerHTML`, which we don't use here), so we should be good to go. 