### PR TITLE
adds title query param for artwork and partner sign ups

### DIFF
--- a/src/mobile/apps/artwork/components/image/view.coffee
+++ b/src/mobile/apps/artwork/components/image/view.coffee
@@ -37,7 +37,7 @@ module.exports = class ArtworkImageView extends Backbone.View
               'data-state': 'saved'
               'data-action': 'remove'
     else
-      @$('.artwork-header-module__favorites-container a').attr("href", "/sign_up?action=save&objectId=#{@artwork.id}&kind=artwork&redirect-to=#{window.location}&signupIntent=save+artwork&intent=save+artwork&trigger=click&contextModule=Artwork+Page")
+      @$('.artwork-header-module__favorites-container a').attr("href", "/sign_up?action=save&objectId=#{@artwork.id}&kind=artwork&redirect-to=#{window.location}&signupIntent=save+artwork&intent=save+artwork&trigger=click&contextModule=Artwork+Page&title=Sign+up+to+save+artworks")
       @$('.artwork-header-module__favorites-container').click( (e) ->
         analyticsHooks.trigger 'save:sign-up'
       )

--- a/src/mobile/components/follow_button/view.coffee
+++ b/src/mobile/components/follow_button/view.coffee
@@ -10,6 +10,7 @@ module.exports = class FollowButtonView extends Backbone.View
   initialize: (options) ->
     @validateView options
     { @followId, @isLoggedIn, @type, @_id, @context_module, @context_page } = options
+    console.log('options:', options)
     @listenTo @collection, "add:#{@followId}", @onFollowChange
     @listenTo @collection, "remove:#{@followId}", @onFollowChange
     @onFollowChange()
@@ -52,6 +53,6 @@ module.exports = class FollowButtonView extends Backbone.View
         setTimeout (=> @$el.removeClass 'is-clicked'), 1500
     else
       analyticsHooks.trigger 'follow:signup'
-      location.href = "/sign_up?action=follow&objectId=#{@followId}&kind=artist&redirect-to=#{window.location}&signupIntent=follow+#{@type.toLowerCase()}&intent=follow+#{@type.toLowerCase()}&trigger=click&contextModule=#{@context_module}"
+      location.href = "/sign_up?action=follow&objectId=#{@followId}&kind=artist&redirect-to=#{window.location}&signupIntent=follow+#{@type.toLowerCase()}&intent=follow+#{@type.toLowerCase()}&trigger=click&contextModule=#{@context_module}&title=Sign+up+to+follow+#{@type.toLowerCase()}s"
 
     false


### PR DESCRIPTION
finishes: https://artsyproduct.atlassian.net/browse/GROW-1080

This updates the query parameters to include title so that custom titles can be passed for save and follow actions.

**Save artwork**
<img width="335" alt="screen shot 2019-01-31 at 3 46 50 pm" src="https://user-images.githubusercontent.com/5201004/52084189-7a011680-256f-11e9-826d-36c4db5b5789.png">

**Follow partner**
<img width="338" alt="screen shot 2019-01-31 at 3 46 15 pm" src="https://user-images.githubusercontent.com/5201004/52084239-91d89a80-256f-11e9-9bdc-a105fff54b82.png">

To Do:
- [ ] The follow button for the artist page is handled in [reaction](https://github.com/artsy/reaction/blob/8e5c941bc667a9526f7eb8f9990cdf426a4965e4/src/Apps/Artist/Components/ArtistHeader.tsx#L249-L258) and we will need to pass the custom title there.