### PR TITLE
Revert "[package] Update dd-trace client."

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "cookie-session": "^2.0.0-beta.3",
     "cookies-js": "^1.2.3",
     "cors": "^2.8.3",
-    "dd-trace": "^0.7.3",
+    "dd-trace": "artsy/dd-trace-js#artsy",
     "diacritics": "^1.2.2",
     "dompurify": "^0.8.4",
     "dotenv": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4484,18 +4484,15 @@ date-now@^0.1.4:
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
   integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
-dd-trace@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-0.7.3.tgz#bc028454e2e4a83b13d2ec8346c1a749a3b8ba69"
-  integrity sha512-aIOmLl5Tu1V8C37tsh+esxFot2kq/N/Fuj8zsZaOOrD5C7m6IYJGinkHQINWxep+MN56Q3x95z473zcuqCiFdg==
+dd-trace@artsy/dd-trace-js#artsy:
+  version "0.6.0"
+  resolved "https://codeload.github.com/artsy/dd-trace-js/tar.gz/8331e739b8878eb17600c02b49e7ac55c1de771d"
   dependencies:
     async-hook-jl "^1.7.6"
     int64-buffer "^0.1.9"
     koalas "^1.0.2"
     lodash.kebabcase "^4.1.1"
     lodash.memoize "^4.1.2"
-    lodash.pick "^4.4.0"
-    lodash.truncate "^4.4.2"
     lodash.uniq "^4.5.0"
     methods "^1.1.2"
     msgpack-lite "^0.1.26"
@@ -9800,7 +9797,7 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash.pick@^4.2.1, lodash.pick@^4.4.0:
+lodash.pick@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
@@ -9844,11 +9841,6 @@ lodash.topath@4.5.2:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.topath/-/lodash.topath-4.5.2.tgz#3616351f3bba61994a0931989660bd03254fd009"
   integrity sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=
-
-lodash.truncate@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
-  integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
 lodash.uniq@^4.5.0:
   version "4.5.0"


### PR DESCRIPTION
This reverts commit 1ba4b2d7f6528aba603329f349f62995d7dd6626.

Removing this update from the deploy queue so we can flush the queue, as per https://artsy.slack.com/archives/CA8SANW3W/p1549446975130500?thread_ts=1549396045.087400&cid=CA8SANW3W