### PR TITLE
Fixed bug in article AMP controller (GROW-1071)

### DIFF
--- a/src/desktop/apps/article/routes.js
+++ b/src/desktop/apps/article/routes.js
@@ -228,9 +228,8 @@ export function classic(req, res, next) {
 }
 
 export function amp(req, res, next) {
-  const slug = req.url.split("/")[2]
   const article = new Article({
-    id: slug,
+    id: req.params.slug,
   })
 
   article.fetchWithRelated({

--- a/src/desktop/apps/article/routes.js
+++ b/src/desktop/apps/article/routes.js
@@ -93,7 +93,9 @@ export async function index(req, res, next) {
     if (isSuper && superArticle.get("super_article").related_articles) {
       const related = superArticle.get("super_article").related_articles
       const query = SuperSubArticlesQuery(related)
-      const superSubData = await positronql({ query })
+      const superSubData = await positronql({
+        query,
+      })
       superSubArticles.set(superSubData.articles)
     }
 
@@ -186,7 +188,9 @@ const getBodyClass = article => {
 }
 
 export function classic(req, res, next) {
-  const article = new Article({ id: req.params.slug })
+  const article = new Article({
+    id: req.params.slug,
+  })
   const accessToken = req.user ? req.user.get("accessToken") : null
 
   article.fetchWithRelated({
@@ -224,7 +228,10 @@ export function classic(req, res, next) {
 }
 
 export function amp(req, res, next) {
-  const article = new Article({ id: req.params.slug })
+  const slug = req.url.split("/")[2]
+  const article = new Article({
+    id: slug,
+  })
 
   article.fetchWithRelated({
     error: res.backboneError,

--- a/src/desktop/models/article.coffee
+++ b/src/desktop/models/article.coffee
@@ -64,6 +64,7 @@ module.exports = class Article extends Backbone.Model
       else
          # Check if the article is IN a super article
         dfds.push new Articles().fetch
+          error: options.error
           cache: true
           headers: 'X-Access-Token': options.accessToken or ''
           data:


### PR DESCRIPTION
This ticket addresses [GROW-1071](https://artsyproduct.atlassian.net/browse/GROW-1071) by fixing a mysterious validation error message that was frequently appearing in Positron's logs:

```["super_article_for" needs to be a string of 12 bytes or a string of 24 hex characters]```

This error was mysterious because we knew that it involved a request for a super article, but we could not find its origin. ~After investigation, we discovered that Force was passing an article's slug instead of its ID when it requested articles for AMP.~

~The solution was to change:~

~```const article = new Article({ id: req.params.slug })```~

~to~

~```const article = new Article({ id: req.url.split("/")[2] })```~

~because the request parameters were undefined for a request like `GET /article/:slug/amp`.~

We found that a misspelled or non-existing slug would lead to this error being logged when it was requested through the `/amp` route. However, there were also valid slugs being logged, which cannot be explained. In order to investigate further, we have decided to add some logging to the request for a super article and see what URLs cause this error from Force.