### PR TITLE
isSuper is passed down to reaction

### DIFF
--- a/src/desktop/apps/article/components/layouts/Article.tsx
+++ b/src/desktop/apps/article/components/layouts/Article.tsx
@@ -137,6 +137,7 @@ export default class ArticleLayout extends React.Component<
             display={article.display}
             isMobile={isMobile}
             isLoggedIn={isLoggedIn}
+            isSuper={isSuper}
             onOpenAuthModal={this.handleOpenAuthModal}
             relatedArticlesForPanel={article.relatedArticlesPanel}
             relatedArticlesForCanvas={article.relatedArticlesCanvas}


### PR DESCRIPTION
Fixes a small bug where the further reading was incorrectly displaying on superArticles, the `isSuper` prop was not being passed down to reaction.

<img width="1789" alt="screen shot 2019-02-06 at 10 04 43 am" src="https://user-images.githubusercontent.com/1497424/52415577-55e48e80-2ab5-11e9-9015-2664d477cb6c.png">
