### PR TITLE
Fix compilation on CI tests

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,17 @@
+FROM node:10.13.0
+
+# The key bits here are making sure we install, libsecret-1-dev libglib2.0-dev
+RUN apt-get update -qq && apt-get install -y \
+  libsecret-1-dev libglib2.0-dev && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ADD . /app
+WORKDIR /app
+
+RUN rm -f /usr/local/bin/yarn && \
+  curl -o- -L https://yarnpkg.com/install.sh | bash && \
+  chmod +x ~/.yarn/bin/yarn && \
+  ln -s ~/.yarn/bin/yarn /usr/local/bin/yarn
+RUN yarn install
+
+CMD yarn start

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -1,6 +1,8 @@
 version: "2"
 services:
   force:
+    build:
+      dockerfile: Dockerfile.test
     command: yarn test
     extends:
       file: common.yml

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,7 +7,7 @@ set -ex
 run () {
   case $CIRCLE_NODE_INDEX in
   0)
-    NODE_ENV=development yarn build
+    NODE_ENV=development yarn webpack
     ;;
   1)
     yarn mocha src/test/lib/*

--- a/webpack/envs/production.js
+++ b/webpack/envs/production.js
@@ -8,7 +8,7 @@ import BrotliWebpackPlugin from "brotli-webpack-plugin"
 import path from "path"
 import { HashedModuleIdsPlugin } from "webpack"
 import { getCSSManifest } from "../utils/getCSSManifest"
-import { NODE_ENV, isCI } from "../../src/lib/environment"
+import { NODE_ENV, isCI, isProduction } from "../../src/lib/environment"
 import { omitIf } from "../utils/omitIf"
 
 export const productionConfig = {
@@ -36,7 +36,7 @@ export const productionConfig = {
     new WebpackManifestPlugin({
       fileName: path.resolve(__dirname, "../../manifest.json"),
       basePath: "/assets/",
-      seed: getCSSManifest(),
+      seed: isProduction ? getCSSManifest() : {},
     }),
 
     ...omitIf(


### PR DESCRIPTION
Don't do production compiles for our assets by pointing at `Dockerfile.test`, and don't show a progress bar on CI.  