### PR TITLE
Attempt to force gzip on assets

### DIFF
--- a/src/desktop/components/main_layout/templates/scripts.jade
+++ b/src/desktop/components/main_layout/templates/scripts.jade
@@ -2,7 +2,7 @@
 - options = options ? Object.assign({}, defaultOptions, options) : defaultOptions
 
 //- Common bundle
-script( src=asset("/assets/runtimeManifest.js") )
+script( src=asset("/assets/runtime-manifest.js") )
 script( src=asset("/assets/common.js") )
 
 if options.marketo

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -218,6 +218,7 @@ export default function(app) {
       enableBrotli: true,
       orderPreference: ["gzip", "br"], // TODO: Switch order when `br` is suported
       setHeaders: res => {
+        res.setHeader("Accept-Encoding", "gzip")
         res.setHeader("Cache-Control", "public, max-age=31536000")
       },
     })

--- a/src/mobile/components/layout/templates/scaffold.jade
+++ b/src/mobile/components/layout/templates/scaffold.jade
@@ -14,7 +14,7 @@ html( class=htmlClass )
 
     #scripts
       //- Common bundle
-      script( src=asset("/assets/runtimeManifest.js") )
+      script( src=asset("/assets/runtime-manifest.js") )
       script( src=asset("/assets/common.js") )
 
       //- Segment.io

--- a/webpack/envs/base.js
+++ b/webpack/envs/base.js
@@ -94,7 +94,7 @@ export const baseConfig = {
   optimization: {
     // Add Webpack runtime code to the `common` chunk
     runtimeChunk: {
-      name: "runtimeManifest",
+      name: "runtime-manifest",
     },
     splitChunks: {
       cacheGroups: {


### PR DESCRIPTION
We're getting inconsistent `gzip` encoding on our JS files, this attempts to force the header to always return `gzip`. 

Also renamed `runtimeManifest` to `runtime-manifest` so that local devs with case insensitive file systems aren't confused. 