### PR TITLE
Attempt to simplify compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "express-ipfilter": "0.2.1",
     "express-limiter": "^1.6.0",
     "express-request-id": "^1.4.0",
-    "express-static-gzip": "^1.1.3",
     "factor-bundle": "^2.5.0",
     "fastclick": "^1.0.6",
     "flickity": "^2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,7 +96,7 @@
     react-head "^3.0.0"
     react-html-parser "^2.0.2"
     react-lazy-load-image-component "^1.1.1"
-    react-lines-ellipsis "github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a"
+    react-lines-ellipsis xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a
     react-markdown "^2.5.0"
     react-oembed-container "^0.3.0"
     react-overlays "^0.8.3"
@@ -6020,13 +6020,6 @@ express-request-id@^1.4.0:
   integrity sha1-J3ssCUmAPmgQTJ1Fw+aJNPlr9aI=
   dependencies:
     uuid "^3.0.1"
-
-express-static-gzip@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/express-static-gzip/-/express-static-gzip-1.1.3.tgz#345ea02637d9d5865777d6fb57ccc0884abcda65"
-  integrity sha512-k8Q4Dx4PDpzEb8kth4uiPWrBeJWJYSgnWMzNdjQUOsEyXfYKbsyZDkU/uXYKcorRwOie5Vzp4RMEVrJLMfB6rA==
-  dependencies:
-    serve-static "^1.12.3"
 
 express@*:
   version "4.16.4"
@@ -12644,7 +12637,6 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
 
 "react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
   version "0.13.0"
-  uid "0cd517ad9079aeb5e6710178d93dd6faa65b924a"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 
 react-live@^1.12.0:
@@ -14014,7 +14006,7 @@ serve-static@1.12.3:
     parseurl "~1.3.1"
     send "0.15.3"
 
-serve-static@1.13.2, serve-static@^1.12.3:
+serve-static@1.13.2:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.13.2.tgz#095e8472fd5b46237db50ce486a43f4b86c6cec1"
   integrity sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==


### PR DESCRIPTION
Since we're not using `br` compression this removes `express-static-gzip` in favor of default `compression` middleware. 

Also moves `assetMiddleware` down a bit (where bucket assets used to be) because the error 

```
asset is not a function
``` 

seems to be a redherring when artsy.net goes down. Let's see if this fixes it. 