### PR TITLE
Rely on Reaction CSS extraction vs stitch

### DIFF
--- a/src/desktop/apps/artist/server.tsx
+++ b/src/desktop/apps/artist/server.tsx
@@ -21,6 +21,7 @@ app.get(
         redirect,
         status,
         headTags,
+        styleTags,
         scripts,
       } = await buildServerApp({
         routes,
@@ -56,9 +57,6 @@ app.get(
       const layout = await stitch({
         basePath: __dirname,
         layout: "../../components/main_layout/templates/react_redesign.jade",
-        config: {
-          styledComponents: true,
-        },
         blocks: {
           head: () => (
             <>
@@ -72,6 +70,7 @@ app.get(
           ...res.locals,
           assetPackage: "artist",
           scripts,
+          styleTags,
         },
         data: {
           jsonLD,

--- a/src/desktop/apps/artwork2/server.tsx
+++ b/src/desktop/apps/artwork2/server.tsx
@@ -16,6 +16,7 @@ app.get(
         redirect,
         status,
         headTags,
+        styleTags,
         scripts,
       } = await buildServerApp({
         routes,
@@ -36,9 +37,6 @@ app.get(
       const layout = await stitch({
         basePath: __dirname,
         layout: "../../components/main_layout/templates/react_redesign.jade",
-        config: {
-          styledComponents: true,
-        },
         blocks: {
           head: () => <React.Fragment>{headTags}</React.Fragment>,
           body: ServerApp,
@@ -47,6 +45,7 @@ app.get(
           ...res.locals,
           assetPackage: "artwork2",
           scripts,
+          styleTags,
         },
       })
 

--- a/src/desktop/apps/collect/server.tsx
+++ b/src/desktop/apps/collect/server.tsx
@@ -12,7 +12,13 @@ const index = async (req, res, next) => {
   try {
     const { APP_URL, IS_MOBILE } = res.locals.sd
 
-    const { headTags, ServerApp, redirect, scripts } = await buildServerApp({
+    const {
+      headTags,
+      ServerApp,
+      redirect,
+      scripts,
+      styleTags,
+    } = await buildServerApp({
       routes,
       url: req.url,
       userAgent: req.header("User-Agent"),
@@ -28,9 +34,6 @@ const index = async (req, res, next) => {
     const layout = await stitch({
       basePath: __dirname,
       layout: "../../components/main_layout/templates/react_redesign.jade",
-      config: {
-        styledComponents: true,
-      },
       blocks: {
         head: () => <Meta appUrl={APP_URL} headTags={headTags} />,
         body: () => <ServerApp />,
@@ -40,6 +43,7 @@ const index = async (req, res, next) => {
         assetPackage: "collect",
         bodyClass: IS_MOBILE ? "body-header-fixed body-no-margins" : null,
         scripts,
+        styleTags,
       },
     })
 

--- a/src/desktop/apps/collections/server.tsx
+++ b/src/desktop/apps/collections/server.tsx
@@ -11,7 +11,13 @@ app.get("/collections", async (req, res, next) => {
   try {
     const { IS_MOBILE } = res.locals.sd
 
-    const { ServerApp, headTags, redirect, scripts } = await buildServerApp({
+    const {
+      ServerApp,
+      headTags,
+      redirect,
+      scripts,
+      styleTags,
+    } = await buildServerApp({
       routes,
       url: req.url,
       userAgent: req.header("User-Agent"),
@@ -27,9 +33,6 @@ app.get("/collections", async (req, res, next) => {
     const layout = await stitch({
       basePath: __dirname,
       layout: "../../components/main_layout/templates/react_redesign.jade",
-      config: {
-        styledComponents: true,
-      },
       blocks: {
         head: () => <>{headTags}</>,
         body: ServerApp,
@@ -39,6 +42,7 @@ app.get("/collections", async (req, res, next) => {
         assetPackage: "collections",
         bodyClass: IS_MOBILE ? "body-header-fixed body-no-margins" : null,
         scripts,
+        styleTags,
       },
     })
 

--- a/src/desktop/apps/isomorphic-relay-example/server.tsx
+++ b/src/desktop/apps/isomorphic-relay-example/server.tsx
@@ -17,6 +17,7 @@ app.get("/isomorphic-relay-example*", adminOnly, async (req, res, next) => {
       redirect,
       status,
       scripts,
+      styleTags,
     } = await buildServerApp({
       routes: routes as any,
       url: req.url,
@@ -32,9 +33,6 @@ app.get("/isomorphic-relay-example*", adminOnly, async (req, res, next) => {
     const layout = await stitch({
       basePath: __dirname,
       layout: "../../components/main_layout/templates/react_index.jade",
-      config: {
-        styledComponents: true,
-      },
       blocks: {
         head: () => (
           <React.Fragment>
@@ -48,6 +46,7 @@ app.get("/isomorphic-relay-example*", adminOnly, async (req, res, next) => {
         ...res.locals,
         assetPackage: "relay",
         scripts,
+        styleTags,
       },
     })
 

--- a/src/desktop/apps/order2/routes.tsx
+++ b/src/desktop/apps/order2/routes.tsx
@@ -17,6 +17,7 @@ export const checkoutFlow = async (req, res, next) => {
       status,
       headTags,
       scripts,
+      styleTags,
     } = await buildServerApp({
       routes,
       url: req.url,
@@ -36,9 +37,6 @@ export const checkoutFlow = async (req, res, next) => {
       basePath: __dirname,
       layout:
         "../../components/main_layout/templates/react_minimal_header.jade",
-      config: {
-        styledComponents: true,
-      },
       blocks: {
         head: () => headTags,
         body: ServerApp,
@@ -53,6 +51,7 @@ export const checkoutFlow = async (req, res, next) => {
           stripev3: true,
         },
         scripts,
+        styleTags,
       },
     })
 

--- a/src/desktop/components/main_layout/header/templates/user.jade
+++ b/src/desktop/components/main_layout/header/templates/user.jade
@@ -19,7 +19,7 @@
         a( href='/user/edit' )
           | Settings
 
-        a.mlh-logout
+        a( href='#' ).mlh-logout
           | Log out
 
   else

--- a/src/desktop/components/main_layout/templates/react_index.jade
+++ b/src/desktop/components/main_layout/templates/react_index.jade
@@ -7,6 +7,7 @@ append locals
 block head
   != head
   != css
+  != styleTags
 
 block body
   script.

--- a/src/desktop/components/main_layout/templates/react_minimal_header.jade
+++ b/src/desktop/components/main_layout/templates/react_minimal_header.jade
@@ -7,6 +7,7 @@ append locals
 block head
   != head
   != css
+  != styleTags
 
 block body
   #react-root

--- a/src/desktop/components/main_layout/templates/react_redesign.jade
+++ b/src/desktop/components/main_layout/templates/react_redesign.jade
@@ -7,6 +7,7 @@ append locals
 block head
   != head
   != css
+  != styleTags
 
 block body
   #react-root


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/PLATFORM-1184

Back in https://github.com/artsy/reaction/pull/1882 I added the ability to extract styles from Reaction so that we could relay less on stitch for our Styled Components needs. This wasn't wired up at the time  because I was planning on refactoring out stitch style extraction completely from force in one go, and not just in our new SSR apps. Now that we've identified an issue with duplicate style markup this takes on more urgency as a possible solution to the problem. 