### PR TITLE
Optimizing moment packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "lodash.isinteger": "^4.0.4",
     "lodash.merge": "^4.6.0",
     "mailcheck": "^1.1.1",
-    "moment": "~2.16.0",
+    "moment": "^2.22.2",
     "moment-timezone": "^0.5.23",
     "moment-twitter": "^0.2.0",
     "nib": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "lodash.merge": "^4.6.0",
     "mailcheck": "^1.1.1",
     "moment": "~2.16.0",
-    "moment-timezone": "^0.5.5",
+    "moment-timezone": "^0.5.23",
     "moment-twitter": "^0.2.0",
     "nib": "^1.1.2",
     "nock": "^9.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10508,13 +10508,6 @@ moment-timezone@^0.5.13, moment-timezone@^0.5.23:
   dependencies:
     moment ">= 2.9.0"
 
-moment-timezone@^0.5.5:
-  version "0.5.13"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.13.tgz#99ce5c7d827262eb0f1f702044177f60745d7b90"
-  integrity sha1-mc5cfYJyYusPH3AgRBd/YHRde5A=
-  dependencies:
-    moment ">= 2.9.0"
-
 moment-twitter@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/moment-twitter/-/moment-twitter-0.2.0.tgz#01f948425a8deb4d300d3ed7592daa699bbb5160"
@@ -12635,7 +12628,7 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-"react-lines-ellipsis@github:xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a":
+react-lines-ellipsis@xiaody/react-lines-ellipsis#0cd517ad9079aeb5e6710178d93dd6faa65b924a:
   version "0.13.0"
   resolved "https://codeload.github.com/xiaody/react-lines-ellipsis/tar.gz/0cd517ad9079aeb5e6710178d93dd6faa65b924a"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10520,11 +10520,6 @@ moment-twitter@^0.2.0:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
   integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
 
-moment@~2.16.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.16.0.tgz#f38f2c97c9889b0ee18fc6cc392e1e443ad2da8e"
-  integrity sha1-848sl8mImw7hj8bMOS4eRDrS2o4=
-
 morgan@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.8.1.tgz#f93023d3887bd27b78dfd6023cea7892ee27a4b1"


### PR DESCRIPTION
Currently, Force's common.js bundle ends up with two versions of moment and two versions of moment-timezone due to mismatched versions in the lockfile. This PR updates both to match with other dependencies+resolutions, saving an estimated 52 KB (after GZIP) on page load.

Tests all passing with the exception of an infiniteScroll test that fails even with the previously declared versions of moment/moment-timezone.