### PR TITLE
@joeyAghion => Successfully log user off when changing password

### DIFF
--- a/src/desktop/apps/fair/components/capture_signup/test/index.coffee
+++ b/src/desktop/apps/fair/components/capture_signup/test/index.coffee
@@ -22,6 +22,7 @@ describe 'captureSignup', ->
 
   after ->
     benv.teardown()
+    _.delay.restore()
 
   beforeEach =>
     sinon.stub $, 'ajax'

--- a/src/desktop/apps/user/components/password/test/view.coffee
+++ b/src/desktop/apps/user/components/password/test/view.coffee
@@ -1,0 +1,45 @@
+benv = require 'benv'
+sinon = require 'sinon'
+Backbone = require 'backbone'
+_ = require 'underscore'
+{ fabricate } = require 'antigravity'
+CurrentUser = require '../../../../../models/current_user'
+PasswordView = benv.requireWithJadeify require.resolve('../view'), ['template']
+
+describe 'PasswordView', ->
+  before (done) ->
+    benv.setup ->
+      benv.expose $: benv.require('jquery'), jQuery: benv.require('jquery')
+      Backbone.$ = $
+      done()
+
+  after ->
+    benv.teardown()
+
+  beforeEach ->
+    sinon.stub Backbone, 'sync'
+    sinon.stub $, 'ajax'
+    sinon.stub _, 'delay', (cb) -> cb()
+    
+    @user = new CurrentUser fabricate 'user'
+    @view = new PasswordView user: @user
+    @view.render()
+
+  afterEach ->
+    $.ajax.restore()
+    Backbone.sync.restore()
+    _.delay.restore()
+
+  describe '#submit', ->
+    beforeEach ->
+      Backbone.sync
+        .onCall 0
+        .yieldsTo 'success'
+      @view.submit $.Event()
+
+    it 'changes the password', ->
+      Backbone.sync.args[0][1].url.should.match /// api/v1/me/password ///
+
+    it 'logs the user out', ->
+      $.ajax.args[0][0].method.should.equal 'DELETE'
+      $.ajax.args[0][0].url.should.equal '/users/sign_out'

--- a/src/desktop/apps/user/components/password/view.coffee
+++ b/src/desktop/apps/user/components/password/view.coffee
@@ -1,5 +1,5 @@
 { API_URL } = require('sharify').data
-{ extend, delay } = require 'underscore'
+_ = require 'underscore'
 Backbone = require 'backbone'
 GenericFormView = require '../generic_form/view.coffee'
 template = -> require('./index.jade') arguments...
@@ -7,14 +7,14 @@ template = -> require('./index.jade') arguments...
 module.exports = class SettingsPasswordView extends GenericFormView
   className: 'settings-password'
 
-  events: extend GenericFormView::events,
+  events: _.extend GenericFormView::events,
     'click .js-settings-password__toggle': 'toggle'
 
   initialize: ({ @user }) ->
     @model = new Backbone.Model id: 1 # Forces PUT
     @model.url = "#{API_URL}/api/v1/me/password"
 
-    @listenTo @model, 'sync', @redirect
+    @listenTo @model, 'sync', @logoutAndRedirect
 
   toggleable: ->
     @$('.js-settings-password--toggleable')
@@ -25,8 +25,12 @@ module.exports = class SettingsPasswordView extends GenericFormView
 
   # Changing your password logs you out
   # so we redirect to login after changing password
-  redirect: -> delay ->
-    location.assign '/log_in?redirect_uri=/user/edit'
+  logoutAndRedirect: -> _.delay ->
+    $.ajax
+      method: "DELETE"
+      url: "/users/sign_out",
+      complete: ->
+        return location.assign '/log_in?redirect_uri=/user/edit'
   , 300
 
   render: ->

--- a/src/mobile/components/modal/test/view.coffee
+++ b/src/mobile/components/modal/test/view.coffee
@@ -25,6 +25,7 @@ describe 'ModalView', ->
 
   afterEach ->
     benv.teardown()
+    _.delay.restore()
 
   describe '#fadeOut', ->
 


### PR DESCRIPTION
This seems to have been previously working b/c of a side affect.

We used to call https://github.com/artsy/force/blob/0c16b2dd944d17143b8a6c2cd562f6ac5398791a/src/desktop/lib/global_client_setup.tsx#L64-L74 on every page, which had the 'nice' property of logging off and refreshing if _anything_ failed in that `/api/v1/me` call.

This 'change password' form would redirect to you `/log_in?redirect_uri=...`, which would actually do nothing but redirect you to `/` since you were still 'logged in'. Then, the client side check would kick in, and _actually_ log you out and reload the page, leaving you looking at a logged off homepage (and would then need to log in, and would not redirect since the page had _already_ redirected back to `/`).

This solution feels a bit better. It explicitly logs you out and then redirects you to the special `/log_in?redirect_uri=...` link, which will load the homepage _with the login modal triggered_, and will bring you back to settings once you login.