### PR TITLE
Move debug-related Webpack plugins to debugConfig

### DIFF
--- a/webpack/envs/base.js
+++ b/webpack/envs/base.js
@@ -4,9 +4,6 @@ import path from "path"
 import webpack from "webpack"
 import { getEntrypoints } from "../utils/getEntrypoints"
 import { NODE_ENV, basePath, isCI } from "../../src/lib/environment"
-import { DuplicatesPlugin } from "inspectpack/plugin"
-import stripAnsi from "strip-ansi"
-import { promises as fs } from "fs"
 
 export const baseConfig = {
   mode: NODE_ENV,
@@ -72,24 +69,6 @@ export const baseConfig = {
       "window.jQuery": "jquery",
       jade: "jade/runtime.js",
       waypoints: "jquery-waypoints/waypoints.js",
-    }),
-    new DuplicatesPlugin({
-      verbose: true,
-      emitHandler(report) {
-        const artifactsPath = path.join(basePath, ".artifacts")
-        fs
-          .mkdir(artifactsPath)
-          .catch(() => Promise.resolve()) // .artifact directory exists, continue...
-          .then(() =>
-            fs.writeFile(
-              path.join(artifactsPath, "duplicates-report"),
-              stripAnsi(report)
-            )
-          )
-          .catch(err => {
-            console.error("[DuplicatesPlugin] Could not write duplicates report", err)
-          })
-      },
     }),
   ],
   resolve: {

--- a/webpack/envs/ci.js
+++ b/webpack/envs/ci.js
@@ -1,8 +1,10 @@
 // @ts-check
 
 import { NODE_ENV } from "../../src/lib/environment"
+import { plugins } from "./debug"
 
 export const ciConfig = {
   mode: NODE_ENV,
   devtool: false,
+  plugins: [plugins.duplicates],
 }

--- a/webpack/envs/debug.js
+++ b/webpack/envs/debug.js
@@ -1,0 +1,37 @@
+import { promises as fs } from "fs"
+import { BundleAnalyzerPlugin } from "webpack-bundle-analyzer"
+import { DuplicatesPlugin } from "inspectpack/plugin"
+import path from "path"
+import stripAnsi from "strip-ansi"
+
+import { NODE_ENV, basePath } from "../../src/lib/environment"
+
+export const plugins = {
+  bundleAnalyzer: new BundleAnalyzerPlugin(),
+  duplicates: new DuplicatesPlugin({
+    verbose: true,
+    emitHandler(report) {
+      const artifactsPath = path.join(basePath, ".artifacts")
+      fs
+        .mkdir(artifactsPath)
+        .catch(() => Promise.resolve()) // .artifact directory exists, continue...
+        .then(() =>
+          fs.writeFile(
+            path.join(artifactsPath, "duplicates-report"),
+            stripAnsi(report)
+          )
+        )
+        .catch(err => {
+          console.error(
+            "[DuplicatesPlugin] Could not write duplicates report",
+            err
+          )
+        })
+    },
+  }),
+}
+
+export const debugConfig = {
+  mode: NODE_ENV,
+  plugins: [plugins.bundleAnalyzer, plugins.duplicates],
+}

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -1,6 +1,5 @@
 import chalk from "chalk"
 import merge from "webpack-merge"
-import { BundleAnalyzerPlugin } from "webpack-bundle-analyzer"
 
 import {
   isDevelopment,
@@ -13,6 +12,7 @@ import {
 import {
   baseConfig,
   ciConfig,
+  debugConfig,
   developmentConfig,
   productionConfig,
 } from "./envs"
@@ -21,6 +21,8 @@ const getConfig = () => {
   console.log(chalk.green(`\n[Force] Building ${NODE_ENV} config...\n`))
 
   switch (true) {
+    case ANALYZE_BUNDLE:
+      return merge.smart(baseConfig, debugConfig)
     case isCI:
       console.log("[Force] CI=true")
       return merge.smart(baseConfig, ciConfig)
@@ -32,9 +34,5 @@ const getConfig = () => {
 }
 
 const config = getConfig()
-
-if (ANALYZE_BUNDLE) {
-  config.plugins.push(new BundleAnalyzerPlugin())
-}
 
 module.exports = config


### PR DESCRIPTION
Noticed that having the webpack `DuplicationPlugin` in the base config was leading to errors when running `yarn link`:
```sh
｢wdm｣: Error: ELOOP: too many symbolic links encountered, open '/Users/cn/Sites/artsy/force/node_modules/@artsy/reaction/node_modules/@artsy/reaction/node_modules/@artsy/reaction/node_modules/@artsy/reaction/node_modules/@artsy/reaction/node_modules/@artsy/reaction/node_modules/@artsy/reaction/node_modules/@artsy/reaction/node_modules/@artsy/reaction/node_modules/@artsy/reaction/node_modules/@artsy/reaction/node_modules/@artsy/reaction/node_modules/@artsy/reaction/node_modules/@artsy/reaction/node_modules/@artsy/reaction/node_modules/@artsy/reaction/node_modules/@artsy/reaction/package.json'
ℹ ｢wdm｣: wait until bundle finished: /
```

This moves things into a `debugConfig`, and also imports it to be used in the `isCI` config