### PR TITLE
Resolve rate-limiting issues

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,11 +28,11 @@ if (PROFILE_MEMORY) {
   require(".src/lib/memory_profiler")()
 }
 
-// Add all of the middleware and global setup
-setup(app)
-
 // Connect to Redis
 cache.setup(() => {
+  // Add all of the middleware and global setup
+  setup(app)
+
   // if we can't get an xapp token, just exit and let the whole system try
   // again - this prevents a sustained broken state when gravity returns a
   // 502 during force startup.

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -87,7 +87,7 @@ export default function(app) {
     app.use(RavenServer.requestHandler())
   }
 
-  app.use(compression())
+  app.set("trust proxy", true)
 
   // Blacklist IPs
   app.use(
@@ -98,9 +98,10 @@ export default function(app) {
     })
   )
 
-  app.set("trust proxy", true)
   // Rate limiting
   app.use(rateLimiterMiddlewareFactory(cache.client))
+
+  app.use(compression())
 
   // Blank page used by Eigen for caching web views.
   // See: https://github.com/artsy/microgravity-private/pull/1138


### PR DESCRIPTION
This resolves issues that was causing rate limiting to not work correctly in staging. 

There were several issues.

1. I can't type and writing a file in typescript doesn't help you when importing from coffeescript
2. Add the middleware was being setup before the redis cache was ready. This meant all the things that were supposed to be using the redis cache in the middleware weren't. That explains why the other rate limiting solution wasn't working. 
3. I was confusing myself on `res` and the results of the limiter. I was trying to put the response on something that wasn't a response object. 

I also made a few improvements.

1. I don't check to see if the limiter is enabled on every middleware consumption. That was just wasted cycles. 
2. I moved the `compression` middleware below rate limiting and `trust proxy` above. The `compression` move was just to get as much processing out of the way of rate limiting as possible. If we want to survive a DDOS, we don't want to be wasting cycles. The `trust proxy` move might not've been necessary, but it feels better to set that before it's depended on (like in the api blacklist section via the x-forwarded-for header.

I'm gonna move forward to get this on staging.