### PR TITLE
Add more control over rate limit settings

### DIFF
--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -99,9 +99,11 @@ module.exports =
   POSITRON_URL: 'http://localhost:3005'
   PREDICTION_URL: 'https://live.artsy.net'
   REFLECTION_URL: 'http://artsy-reflection.s3-website-us-east-1.amazonaws.com/__reflection/forceartsynet'
-  REQUEST_EXPIRE: 60 # 1 minute
+  REQUEST_EXPIRE: 60
   REQUEST_LIMIT: 300
-  REQUEST_PER_INSTANCE_FALLBACK: 60
+  REQUEST_PER_INSTANCE_FALLBACK: 100
+  REQUEST_PER_INSTANCE_LIMIT: 301
+  REQUEST_PER_INSTANCE_EXPIRE: 60
   ENABLE_RATE_LIMITING: false
   S3_KEY: null
   S3_SECRET: null

--- a/src/lib/middleware/rateLimiting.ts
+++ b/src/lib/middleware/rateLimiting.ts
@@ -6,6 +6,8 @@ const {
   OPENREDIS_URL,
   REQUEST_EXPIRE,
   REQUEST_LIMIT,
+  REQUEST_PER_INSTANCE_EXPIRE,
+  REQUEST_PER_INSTANCE_LIMIT,
   REQUEST_PER_INSTANCE_FALLBACK,
   ENABLE_RATE_LIMITING,
 } = config
@@ -38,8 +40,8 @@ export const rateLimiterMiddlewareFactory = redisClient => {
       storeClient: redisClient,
       points: REQUEST_LIMIT,
       duration: REQUEST_EXPIRE,
-      inmemoryBlockOnConsumed: REQUEST_LIMIT + 1,
-      inmemoryBlockDuration: REQUEST_EXPIRE,
+      inmemoryBlockOnConsumed: REQUEST_PER_INSTANCE_LIMIT,
+      inmemoryBlockDuration: REQUEST_PER_INSTANCE_EXPIRE,
       insuranceLimiter: rateLimiterMemory,
     })
   } else {


### PR DESCRIPTION
This update isn't strictly required, but I thought it'd be good as it'll give us more granular control without having to change code in force. I'm basically just adding a few envs. 

These are the default values too.

```diff
  REQUEST_EXPIRE: 60
  REQUEST_LIMIT: 300
  REQUEST_PER_INSTANCE_FALLBACK: 100
+ REQUEST_PER_INSTANCE_LIMIT: 301
+ REQUEST_PER_INSTANCE_EXPIRE: 60
  ENABLE_RATE_LIMITING: false
```

the `REQUEST_PER_INSTANCE_*` envs are all related to in memory limiters. `FALLBACK` is used as a limit for the in-memory limiter when redis is unavailable (or as an [insurance limiter](https://github.com/animir/node-rate-limiter-flexible/wiki/Insurance-Strategy)). The per request `LIMIT` and `EXPIRE` envs are for the [in memory block](https://github.com/animir/node-rate-limiter-flexible/wiki/In-memory-Block-Strategy). 

Basically how all this works... When using the redis limiter (the default unless something goes awry) the ips that go over rate limit will be communicated to all instances of force and blocked accordingly. That means reads per requests and writes when a limit is hit. As traffic scales beyond the rate limit we've set for the redis limiter, more and more reads are required. At a certain point this may introduce increased latency. To combat that, there's an in-memory blocker which takes over from the redis blocker for the duration of its set period. 

How I have the defaults configured, if any one instance gets 301 requests from an ip in a minute then that instance falls to the in memory rate limiter. It's important to note that it only applies to that single instance though. Up until that point, it'll be using the redis limiter and the request count will be shared among all force instances. Being as we run multiple instances of force, it's more likely that the redis limit for all the instances will be hit before the block limit for any one instance.

Or... err... something like that. 

This PR isn't considered urgent because the rate limiting stuff we have in staging at the moment will suffice. This actually makes the per instance limiting a little more strict though. 
