### PR TITLE
Bring production config up-to-date with temporary measures

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: force-web
 spec:
-  replicas: 6
+  replicas: 14
   strategy:
     rollingUpdate:
       maxSurge: 2

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: force-web
 spec:
-  replicas: 6
+  replicas: 10
   strategy:
     rollingUpdate:
       maxSurge: 2
@@ -68,7 +68,6 @@ spec:
 
                     # Put regexes for undesired referers here
                     "~youtube.com"             1;
-                    "~google.com"              1;
                     "~yahoo.com"               1;
                     "~bing.com"                1;
                 }
@@ -154,13 +153,7 @@ spec:
                         proxy_pass http://force/signup/editorial;
                     }
                     location / {
-                        if ($request_method = POST) {
-                          set $fourohthree POST;
-                        }
                         if ($bad_referer) {
-                          set $fourohthree "${fourohthree}BadReferer";
-                        }
-                        if ($fourohthree = POSTBadReferer) {
                           return 403;
                         }
 

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -155,6 +155,9 @@ spec:
                     location /news/artsy-editorial-belgian-authorities-reportedly-investigating-two-brothers-smuggled-antiquities-syria {
                       deny all;
                     }
+                    location /artwork/xavier-veilhan-light-machine-music {
+                      deny all;
+                    }
                     location / {
                         if ($request_method = POST) {
                           return 403;

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: force-web
 spec:
-  replicas: 10
+  replicas: 6
   strategy:
     rollingUpdate:
       maxSurge: 2
@@ -153,6 +153,9 @@ spec:
                         proxy_pass http://force/signup/editorial;
                     }
                     location / {
+                        if ($request_method = POST) {
+                          return 403;
+                        }
                         if ($bad_referer) {
                           return 403;
                         }

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -88,6 +88,17 @@ spec:
                       proxy_send_timeout 60;
                       proxy_pass http://force/log_in;
                     }
+                    location /sign_up {
+                      if ($bad_referer) {
+                        return 403;
+                      }
+                      proxy_set_header Host $host;
+                      proxy_set_header X-Forwarded-Proto "https";
+                      proxy_redirect off;
+                      proxy_read_timeout 60;
+                      proxy_send_timeout 60;
+                      proxy_pass http://force/sign_up;
+                    }
                     location /about/sms {
                         proxy_set_header Host $host;
                         proxy_set_header X-Forwarded-Proto "https";

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -152,6 +152,9 @@ spec:
                         proxy_send_timeout 60;
                         proxy_pass http://force/signup/editorial;
                     }
+                    location /news/artsy-editorial-belgian-authorities-reportedly-investigating-two-brothers-smuggled-antiquities-syria {
+                      deny all;
+                    }
                     location / {
                         if ($request_method = POST) {
                           return 403;


### PR DESCRIPTION
These were applied previously. This PR brings `master` in sync.