### PR TITLE
Consolidating fonts

### DIFF
--- a/src/desktop/apps/article/templates/meta.jade
+++ b/src/desktop/apps/article/templates/meta.jade
@@ -69,9 +69,6 @@ if article.contributing_authors && article.contributing_authors.length
       if author.name
         meta( name='author', content=author.name )
 
-//- Unica Font
-link( rel='stylesheet' type='text/css' href="#{sd.WEBFONT_URL + '/unica-webfonts.css'}")
-
 //- No Index
 if !article.indexable
   meta( name='robots', content='noindex' )

--- a/src/desktop/apps/articles/templates/meta/articles.jade
+++ b/src/desktop/apps/articles/templates/meta/articles.jade
@@ -10,6 +10,3 @@ meta( property="og:image", content=asset('/images/og_image.jpg') )
 meta( property="og:type", content="website" )
 meta( property="twitter:card", content="summary" )
 link( rel="alternate", type='application/rss+xml' href="#{sd.APP_URL}/rss/news", title='Artsy News' )
-
-//- Unica Font
-link( rel='stylesheet' type='text/css' href="#{sd.WEBFONT_URL + '/unica-webfonts.css'}")

--- a/src/desktop/apps/articles/templates/meta/news.jade
+++ b/src/desktop/apps/articles/templates/meta/news.jade
@@ -10,6 +10,3 @@ meta( property="og:image", content=asset('/images/og_image.jpg') )
 meta( property="og:type", content="website" )
 meta( property="twitter:card", content="summary" )
 link( rel="alternate", type='application/rss+xml' href="#{sd.APP_URL}/rss/news", title='Artsy News' )
-
-//- Unica Font
-link( rel='stylesheet' type='text/css' href="#{sd.WEBFONT_URL + '/unica-webfonts.css'}")

--- a/src/desktop/apps/artwork/components/meta/index.jade
+++ b/src/desktop/apps/artwork/components/meta/index.jade
@@ -46,6 +46,3 @@ if sd.INCLUDE_SAILTHRU
     meta( name='sailthru_credit', content=artwork.image_rights )
   if artwork.meta_image && artwork.meta_image && artwork.meta_image.resized && artwork.meta_image.resized
     meta( name='image', content=artwork.meta_image.resized.url )
-
-//- Unica Font (currently used in Market Insights)
-link( rel='stylesheet' type='text/css' href="#{sd.WEBFONT_URL + '/unica-webfonts.css'}")

--- a/src/desktop/apps/editorial_features/components/gucci/templates/head.jade
+++ b/src/desktop/apps/editorial_features/components/gucci/templates/head.jade
@@ -10,9 +10,6 @@ else
 title= title
 link( rel="canonical", href=url )
 
-//- Unica Font
-link( rel='stylesheet' type='text/css' href="#{sd.WEBFONT_URL + '/unica-webfonts.css'}")
-
 meta(name="description" content=page.description)
 meta(name="keywords" content=page.keywords)
 

--- a/src/desktop/components/fair_layout/templates/index.jade
+++ b/src/desktop/components/fair_layout/templates/index.jade
@@ -8,7 +8,7 @@ html( data-useragent=userAgent )
     block head
     include head
 
-    link( type='text/css', rel='stylesheet', href='#{sd.WEBFONT_URL}/force-webfonts.css?a=b')
+    link( type='text/css', rel='stylesheet', href='#{sd.WEBFONT_URL}/all-webfonts.css')
     link( type='text/css', rel='stylesheet', href=asset('/assets/fairs.css') )
 
     if assetPackage

--- a/src/desktop/components/main_layout/templates/head.jade
+++ b/src/desktop/components/main_layout/templates/head.jade
@@ -21,8 +21,7 @@ script( type="text/javascript" )
 
 //- Don't include fonts if Reflection is requesting it
 if sd.BROWSER && sd.BROWSER.family != 'Other'
-  link( type='text/css', rel='stylesheet', href='#{sd.WEBFONT_URL}/force-webfonts.css?a=b')
-  link( rel='stylesheet' type='text/css' href="#{sd.WEBFONT_URL + '/unica-webfonts.css'}")
+  link( type='text/css', rel='stylesheet', href='#{sd.WEBFONT_URL}/all-webfonts.css')
   link( rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.min.css")
   link( rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css")
 

--- a/src/mobile/apps/articles/meta/articles.jade
+++ b/src/mobile/apps/articles/meta/articles.jade
@@ -8,5 +8,3 @@ meta( property="og:image", content=asset('/images/og_image.jpg') )
 meta( property="og:type", content="website" )
 meta( property="twitter:card", content="summary" )
 
-//- Unica Font
-link( rel='stylesheet' type='text/css' href="#{sd.WEBFONT_URL + '/unica-webfonts.css'}")


### PR DESCRIPTION
Since all of our webfonts can now be found in a single file, [all-webfonts.css](https://webfonts.artsy.net/all-webfonts.css), we can deprecate references to force-webfonts and unica-webfonts