### PR TITLE
Ensure blacklisting, rate limit happen first

### DIFF
--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -76,17 +76,6 @@ const {
 } = config
 
 export default function(app) {
-  // Timeout middleware
-  if (isProduction) {
-    app.use(timeout(APP_TIMEOUT || "29s"))
-  }
-
-  // Error reporting
-  if (SENTRY_PRIVATE_DSN) {
-    RavenServer.config(SENTRY_PRIVATE_DSN).install()
-    app.use(RavenServer.requestHandler())
-  }
-
   app.set("trust proxy", true)
 
   // Blacklist IPs
@@ -100,6 +89,17 @@ export default function(app) {
 
   // Rate limiting
   app.use(rateLimiterMiddlewareFactory(cache.client))
+
+  // Timeout middleware
+  if (isProduction) {
+    app.use(timeout(APP_TIMEOUT || "29s"))
+  }
+
+  // Error reporting
+  if (SENTRY_PRIVATE_DSN) {
+    RavenServer.config(SENTRY_PRIVATE_DSN).install()
+    app.use(RavenServer.requestHandler())
+  }
 
   app.use(compression())
 


### PR DESCRIPTION
This moves blacklisting and rate limiting to the top of the middleware queue. If the app level rate limiting applies, we want that to happen as early as possible in the middleware chain to hopefully reduce as much load on the node instance as possible. 