### PR TITLE
[DO NOT MERGE] Setup rate limiting experiment in prod

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -227,11 +227,11 @@ spec:
             - name: ENABLE_RATE_LIMITING
               value: "true"
             - name: REQUEST_LIMIT
-              value: "100"
+              value: "60"
             - name: REQUEST_EXPIRE
               value: "60"
             - name: REQUEST_PER_INSTANCE_LIMIT
-              value: "120"
+              value: "80"
             - name: REQUEST_PER_INSTANCE_EXPIRE
               value: "300"
           envFrom:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -198,6 +198,92 @@ spec:
                       - foreground
 
 ---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: force-web-canary
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: force
+        layer: application
+        component: web
+      name: force-web-canary
+      namespace: default
+    spec:
+      containers:
+        - name: force-web-canary
+          env:
+            - name: DD_TRACE_AGENT_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: ENABLE_RATE_LIMITING
+              value: "true"
+            - name: REQUEST_LIMIT
+              value: "100"
+            - name: REQUEST_EXPIRE
+              value: "60"
+            - name: REQUEST_PER_INSTANCE_LIMIT
+              value: "120"
+            - name: REQUEST_PER_INSTANCE_EXPIRE
+              value: "300"
+          envFrom:
+            - configMapRef:
+                name: force-environment
+          image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/force:production
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 5000
+          resources:
+            requests:
+              cpu: 700m
+              memory: 1Gi
+            limits:
+              memory: 1.5Gi
+        - name: force-nginx
+          image: artsy/docker-nginx:latest
+          ports:
+            - containerPort: 8080
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/usr/sbin/nginx", "-s", "quit"]
+          env:
+            - name: "NGINX_DEFAULT_CONF"
+              value: >
+                upstream force {
+                    server 127.0.0.1:5000;
+                }
+                server {
+                    listen *:8080;
+                    location / {
+                      proxy_set_header Host $host;
+                      proxy_set_header X-Forwarded-Proto "https";
+                      proxy_redirect off;
+                      proxy_read_timeout 60;
+                      proxy_send_timeout 60;
+                      proxy_pass http://force;
+                    }
+                }
+      dnsPolicy: Default
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                      - foreground
+
+---
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Instead of merging this I might activate it manually just so there's no code change needed for a roll back. 

What this does:

Sets the rate limit to 100 req / min / ip. There's only one force instance involved in this test. 
If 120 requests are made on a single instance, that instance goes into in memory block mode. The block will last for 5 minutes. 