### PR TITLE
Undo # from logout link

### DIFF
--- a/src/desktop/components/main_layout/header/templates/user.jade
+++ b/src/desktop/components/main_layout/header/templates/user.jade
@@ -19,7 +19,7 @@
         a( href='/user/edit' )
           | Settings
 
-        a( href='#' ).mlh-logout
+        a.mlh-logout
           | Log out
 
   else


### PR DESCRIPTION
For whatever reason this was leading to a page shell not being refreshed on click. 