### PR TITLE
Don't cache the gravity response in /auctions

### DIFF
--- a/src/desktop/apps/auctions/routes.coffee
+++ b/src/desktop/apps/auctions/routes.coffee
@@ -18,7 +18,6 @@ setupUser = (user, auction) ->
   auctions.url = "#{API_URL}/api/v1/sales" # Sans is_auction param due to promo sales
 
   auctions.fetch(
-    cache: true
     data: published: true, size: 100, sort: '-timely_at,name'
   ).then(->
     setupUser(req.user, auctions.next())


### PR DESCRIPTION
Slack
context: https://artsy.slack.com/archives/C02BC3HEJ/p1550251913148600

Fixes https://artsyproduct.atlassian.net/browse/AUCT-224

In brief:

- Recently turned on Rate limiting in force
- Previously, caching at /auctions endpoint was broken
- Enabling rate limiting fixed this cache
  + but we don't want to cache auctions response, so remove `cache`
    option in `auctions.fetch`

Some evidence of (undesired) caching going into effect:

- Data Dog trace showing queries to Gravity:
https://app.datadoghq.com/apm/trace/1497793948768870733
  + Note how all traces _in the future_ of this trace respond very quickly,
  and don't integrate with Force's HTTP service or Gravity.