### PR TITLE
Improve force CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           name: Build force assets
           command: yarn build
       - store_artifacts:
-          path: ~/project/force/.artifacts
+          path: ~/project/.artifacts
 
   test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,47 @@
-version: 2.0
+version: 2.1
+
+orbs:
+  yarn: artsy/yarn@0.1.7
+
 jobs:
   acceptance:
     docker:
       - image: circleci/node:10-stretch-browsers
     steps:
-      - add_ssh_keys
-      - checkout
+      - yarn/setup
       - run:
           name: Acceptance Tests
-          command: "yarn install && yarn acceptance src/test/acceptance/*.js"
+          command: yarn acceptance src/test/acceptance/*.js
+
+  validate_staging_schema:
+    docker:
+      - image: circleci/node:10-stretch-browsers
+    steps:
+      - yarn/setup
+      - run:
+          name: Validate Staging Schema
+          command: node scripts/validateSchemas.js staging
+
+  validate_production_schema:
+    docker:
+      - image: circleci/node:10-stretch-browsers
+    steps:
+      - yarn/setup
+      - run:
+          name: Validate Production Schema
+          command: node scripts/validateSchemas.js production
+
+  build:
+    docker:
+      - image: circleci/node:10-stretch-browsers
+    steps:
+      - yarn/setup
+      - run:
+          name: Build force assets
+          command: yarn build
+      - store_artifacts:
+          path: ~/project/force/.artifacts
+
   test:
     docker:
       - image: artsy/hokusai:0.5.2
@@ -21,24 +54,7 @@ jobs:
           name: Test
           command: |
             hokusai test
-  validate_staging_schema:
-    docker:
-      - image: circleci/node:10-stretch-browsers
-    steps:
-      - add_ssh_keys
-      - checkout
-      - run:
-          name: Validate Staging Schema
-          command: "yarn install && node scripts/validateSchemas.js staging"
-  validate_production_schema:
-    docker:
-      - image: circleci/node:10-stretch-browsers
-    steps:
-      - add_ssh_keys
-      - checkout
-      - run:
-          name: Validate Production Schema
-          command: "yarn install && node scripts/validateSchemas.js production"
+
   push_staging_image: &push_image
     docker:
       - image: artsy/hokusai:0.5.2
@@ -51,6 +67,7 @@ jobs:
           command: |
             hokusai registry push --tag $CIRCLE_SHA1 --force --overwrite
   push_production_image: *push_image
+
   deploy_hokusai_staging:
     docker:
       - image: artsy/hokusai:0.5.2
@@ -69,6 +86,7 @@ jobs:
       - run:
           name: Deploy
           command: hokusai staging deploy $CIRCLE_SHA1
+
   deploy_hokusai_production:
     docker:
       - image: artsy/hokusai:0.5.2
@@ -85,55 +103,56 @@ jobs:
           name: Deploy
           command: hokusai production deploy $CIRCLE_SHA1 --git-remote origin
 
+not_staging_or_release: &not_staging_or_release
+  filters:
+    branches:
+      ignore:
+        - staging
+        - release
+
+only_master: &only_master
+  filters:
+    branches:
+      only: master
+
+only_release: &only_release
+  filters:
+    branches:
+      only: release
+
 workflows:
-  version: 2
   default:
     jobs:
+      # Pre-staging
+      - yarn/update-cache:
+          <<: *not_staging_or_release
       - test:
-          filters:
-            branches:
-              ignore:
-                - staging
-                - release
+          <<: *not_staging_or_release
       - acceptance:
-          filters:
-            branches:
-              ignore:
-                - staging
-                - release
+          <<: *not_staging_or_release
       - validate_staging_schema:
-          filters:
-            branches:
-              ignore:
-                - staging
-                - release
-      - validate_production_schema:
-          filters:
-            branches:
-              only: release
+          <<: *not_staging_or_release
+
+      # Staging
       - push_staging_image:
-          filters:
-            branches:
-              only: master
+          <<: *only_master
           requires:
             - test
             - acceptance
             - validate_staging_schema
-      - push_production_image:
-          filters:
-            branches:
-              only: release
-          requires:
-            - validate_production_schema
       - deploy_hokusai_staging:
-          filters:
-            branches:
-              only: master
+          <<: *only_master
           requires:
             - push_staging_image
+
+      # Release
+      - validate_production_schema:
+          <<: *only_release
+      - push_production_image:
+          <<: *only_release
+          requires:
+            - validate_production_schema
       - deploy_hokusai_production:
-          filters:
-            branches:
-              only: release
+          <<: *only_release
           requires:
             - push_production_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,9 @@ workflows:
           <<: *not_staging_or_release
       - validate_staging_schema:
           <<: *not_staging_or_release
+      # Nothing actually relies on this at the moment
+      - build:
+          <<: *not_staging_or_release
 
       # Staging
       - push_staging_image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,7 @@ workflows:
             - test
             - acceptance
             - validate_staging_schema
+            - build
       - deploy_hokusai_staging:
           <<: *only_master
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,16 +44,13 @@ jobs:
 
   test:
     docker:
-      - image: artsy/hokusai:0.5.2
-    parallelism: 4
+      - image: circleci/node:10.13
+    parallelism: 3
     steps:
-      - add_ssh_keys
-      - checkout
-      - setup_remote_docker
+      - yarn/setup
       - run:
           name: Test
-          command: |
-            hokusai test
+          command: yarn test
 
   push_staging_image: &push_image
     docker:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,9 +7,6 @@ set -ex
 run () {
   case $CIRCLE_NODE_INDEX in
   0)
-    NODE_ENV=development yarn webpack
-    ;;
-  1)
     yarn mocha src/test/lib/*
     yarn mocha $(find src/desktop/test -name '*.coffee')
     yarn mocha $(find src/desktop/components/*/test -name '*.coffee')
@@ -18,13 +15,13 @@ run () {
     yarn mocha $(find src/desktop/components/**/*/test -name '*.js')
     yarn mocha $(find src/desktop/components -name '*.test.js')
     ;;
-  2)
+  1)
     yarn mocha $(find src/desktop/apps/*/test -name '*.coffee')
     yarn mocha $(find src/desktop/apps/*/test -name '*.js')
     yarn mocha $(find src/desktop/apps/*/**/*/test -name '*.coffee')
     yarn mocha $(find src/desktop/apps -name '*.test.js')
     ;;
-  3)
+  2)
     yarn mocha $(find src/mobile/test -name '*.coffee')
     yarn mocha $(find src/mobile/components/*/test -name '*.coffee')
     yarn mocha $(find src/mobile/components/**/*/test -name '*.coffee')
@@ -39,7 +36,6 @@ if [ -z "$CIRCLE_NODE_INDEX" ]; then
   CIRCLE_NODE_INDEX=0 run
   CIRCLE_NODE_INDEX=1 run
   CIRCLE_NODE_INDEX=2 run
-  CIRCLE_NODE_INDEX=3 run
 else
   run
 fi


### PR DESCRIPTION
Does (or attempts to do) a few things:

1. Generally speed up force builds (in part by having yarn cache optimization via the yarn orb)
2. Uploads a [duplicate bundle report](https://15960-22887404-gh.circle-artifacts.com/0/home/circleci/project/.artifacts/duplicates-report) from webpack to circle ci's artifact storage for later processing
3. Generally cleans up and dries out the config where it makes sense

For some reason unknown to me, the test script was running webpack in _development_ mode. I can't for the life of me see why it would do that... @damassi or @alloy if either of you happen to know why I'd love to hear more. 