### PR TITLE
Add yarn start:ssr command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,23 @@ cd force
 yarn link @artsy/reaction && yarn start
 ```
 
+When testing SSR rendering, it's important to only have one copy of styled components in your dependency tree at a given time. This can be achieved by running
+
+```sh
+yarn start:ssr
+```
+
+which under the hood runs
+
+```sh
+cd ../reaction
+rm -rf node_modules/styled-components
+yarn link
+cd ../force
+yarn link @artsy/reaction
+yarn start
+```
+
 ## Running a local copy of Force in Production mode:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "start": "scripts/start.sh",
     "start:prod": "NODE_ENV=production node -r dotenv/config --max_old_space_size=4096 ./src --verbose --debugProd",
     "start:relay": "yarn relay && concurrently --raw --kill-others 'yarn relay --watch' 'yarn start'",
+    "start:ssr": "cd ../reaction && rm -rf node_modules/styled-components && yarn link && cd ../force && yarn link @artsy/reaction && yarn start",
     "sync-schema": "rm -rf data && mkdir data && graphql-fetch-schema https://metaphysics-staging.artsy.net -o data",
     "test": "scripts/test.sh",
     "type-check": "tsc --pretty --noEmit",


### PR DESCRIPTION
Adds a new command `yarn start:ssr` as well as some docs that allows us to get around the `yarn link` issue + styled-components 4. This approach is pretty naive. (If anyone has any suggestions for a better approach please send them over!)