### PR TITLE
GALL-1416: Shorten backbone-super-sync cache time on fair overview page

### DIFF
--- a/src/desktop/apps/fair/routes.coffee
+++ b/src/desktop/apps/fair/routes.coffee
@@ -16,6 +16,8 @@ FilterArtworks = require '../../collections/filter_artworks'
 aggregationParams = require './components/browse/aggregations.coffee'
 InfoMenu = require '../../components/info_menu/index.coffee'
 
+DEFAULT_CACHE_TIME = 60
+
 @overview = (req, res, next) ->
   return next() unless res.locals.sd.FAIR
   filterArtworks = new FilterArtworks
@@ -24,8 +26,8 @@ InfoMenu = require '../../components/info_menu/index.coffee'
   filterData = { size: 0, fair_id: fair.id, aggregations: aggregationParams }
   infoMenu = new InfoMenu(fair: fair)
   Q.all([
-    fair.fetch(cache: true)
-    infoMenu.fetch(cache: true)
+    fair.fetch(cache: true, cacheTime: DEFAULT_CACHE_TIME)
+    infoMenu.fetch(cache: true, cacheTime: DEFAULT_CACHE_TIME)
   ]).then () ->
     res.locals.infoMenu = infoMenu.infoMenu
     # TODO: Dependent on attribute of fair
@@ -155,6 +157,7 @@ InfoMenu = require '../../components/info_menu/index.coffee'
 
   fair.fetchPrimarySets
     cache: true
+    cacheTime: DEFAULT_CACHE_TIME
     error: res.backboneError
     success: (primarySets) =>
       res.locals.primarySets = primarySets
@@ -179,6 +182,7 @@ InfoMenu = require '../../components/info_menu/index.coffee'
           error: res.backboneError
           success: (data) ->
             cache.setHash key, data
+            cache.client?.expire key, DEFAULT_CACHE_TIME
             end data
 
 @fetchFairByOrganizerYear = (req, res, next) ->

--- a/src/desktop/collections/ordered_sets.coffee
+++ b/src/desktop/collections/ordered_sets.coffee
@@ -25,20 +25,24 @@ class OrderedSets extends Backbone.Collection
 
     dfd = Q.defer()
 
+    cache = options.cache
+    cacheTime = options.cacheTime
+
     @fetch
       url: "#{sd.API_URL}/api/v1/sets?owner_type=#{ownerType}&owner_id=#{ownerId}&sort=key"
-      cache: options.cache
+      cache: cache
+      cacheTime: cacheTime
       data: options.data
       error: dfd.resolve
       success: =>
-        @fetchSets(cache: options.cache).then dfd.resolve
+        @fetchSets(cache: cache, cacheTime: cacheTime).then dfd.resolve
 
     dfd.promise
 
   fetchSets: (options = {}) ->
     dfd = Q.defer()
     Q.allSettled(@map (model) ->
-      model.fetchItems options?.cache
+      model.fetchItems options.cache, options.cacheTime
     ).then dfd.resolve
     dfd.promise
 

--- a/src/desktop/components/info_menu/index.coffee
+++ b/src/desktop/components/info_menu/index.coffee
@@ -6,6 +6,8 @@ FairEvents = require '../../collections/fair_events'
 Articles = require '../../collections/articles'
 { API_URL } = require('sharify').data
 
+DEFAULT_CACHE_TIME = 60
+
 module.exports = class InfoMenu
   infoMenu: {}
 
@@ -27,6 +29,7 @@ module.exports = class InfoMenu
           .then (menuItems) =>
             @infoMenu = _.extend {}, menuItems...
             cache.setHash @key, @infoMenu
+            cache.client?.expire @key, DEFAULT_CACHE_TIME
             resolve @infoMenu
           .catch reject
           .done()

--- a/src/desktop/models/fair.coffee
+++ b/src/desktop/models/fair.coffee
@@ -15,6 +15,8 @@ deslugify = require '../components/deslugify/index.coffee'
 Relations = require './mixins/relations/fair.coffee'
 MetaOverrides = require './mixins/meta_overrides.coffee'
 
+DEFAULT_CACHE_TIME = 60
+
 module.exports = class Fair extends Backbone.Model
   _.extend @prototype, Relations
   _.extend @prototype, Image(sd.SECURE_IMAGES_URL)
@@ -73,6 +75,7 @@ module.exports = class Fair extends Backbone.Model
       data:
         private_partner: false
       cache: true
+      cacheTime: DEFAULT_CACHE_TIME
       success: ->
         aToZGroup = galleries.groupByAlphaWithColumns 3
         options?.success aToZGroup, galleries
@@ -84,6 +87,7 @@ module.exports = class Fair extends Backbone.Model
     artists.fetchUntilEnd
       url: "#{@url()}/artists"
       cache: true
+      cacheTime: DEFAULT_CACHE_TIME
       success: ->
         aToZGroup = artists.groupByAlphaWithColumns 3
         options.success aToZGroup, artists
@@ -93,12 +97,13 @@ module.exports = class Fair extends Backbone.Model
     sections = new Backbone.Collection
     sections.fetch _.extend options,
       cache: true
+      cacheTime: DEFAULT_CACHE_TIME
       url: "#{@url()}/sections"
 
   fetchPrimarySets: (options) ->
     orderedSets = new OrderedSets
     orderedSets
-      .fetchItemsByOwner('Fair', @get('id'), cache: options.cache)
+      .fetchItemsByOwner('Fair', @get('id'), cache: options.cache, cacheTime: options.cacheTime)
       .done ->
         for set in orderedSets.models
           items = set.get('items').filter (item) ->

--- a/src/desktop/models/ordered_set.coffee
+++ b/src/desktop/models/ordered_set.coffee
@@ -7,12 +7,12 @@ LayoutSyle = require './mixins/layout_style.coffee'
 module.exports = class OrderedSet extends Backbone.Model
   _.extend @prototype, LayoutSyle
 
-  fetchItems: (cache = false) ->
+  fetchItems: (cache = false, cacheTime) ->
     dfd = Q.defer()
     items = new Items null, id: @id, item_type: @get('item_type')
     @set items: items
-    Q.allSettled(items.fetch(cache: cache).then ->
+    Q.allSettled(items.fetch(cache: cache, cacheTime: cacheTime).then ->
       items.map (item) ->
-        if _.isFunction(item.fetchItems) then item.fetchItems(cache) else item
+        if _.isFunction(item.fetchItems) then item.fetchItems(cache, cacheTime) else item
     ).finally dfd.resolve
     dfd.promise

--- a/src/desktop/test/models/ordered_set.coffee
+++ b/src/desktop/test/models/ordered_set.coffee
@@ -6,13 +6,15 @@ Backbone = require 'backbone'
 OrderedSet = rewire '../../models/ordered_set.coffee'
 
 class Items extends Backbone.Model
-  fetch: -> { then: -> sinon.stub() }
 
 OrderedSet.__set__ 'Items', Items
 
 describe 'OrderedSet', ->
   beforeEach ->
     sinon.stub Backbone, 'sync'
+    fetch = -> { then: -> sinon.stub() }
+    @spiedFetch = sinon.spy(fetch)
+    Items.prototype.fetch = @spiedFetch
     @orderedSet = new OrderedSet
 
   afterEach ->
@@ -25,3 +27,8 @@ describe 'OrderedSet', ->
 
     it 'returns a promise', ->
       @orderedSet.fetchItems()
+
+    it 'supports caching', ->
+      @orderedSet.fetchItems(true, 60)
+      @spiedFetch.calledOnce.should.be.ok()
+      @spiedFetch.lastCall.args.should.eql [{cache: true, cacheTime: 60}]


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GALL-1416

The [backbone-super-sync caching](https://github.com/artsy/backbone-super-sync#built-in-request-caching) has been broken for a while and [got fixed](https://artsy.slack.com/archives/C9ZJYFDNF/p1550498674086700) last week. The default 6 hour caching delay doesn't work for fairs team's workflow when tweaking the design of the fair overview page. This PR shortens the caching time to 1 min on the fair overview page.