### PR TITLE
Style force integration with reaction/search-bar

### DIFF
--- a/src/desktop/components/react/stitch_components/SearchBar.tsx
+++ b/src/desktop/components/react/stitch_components/SearchBar.tsx
@@ -1,16 +1,14 @@
 import React from "react"
 import { Box } from "@artsy/palette"
 import { SearchBarQueryRenderer } from "reaction/Components/Search/SearchBar"
+import styled from "styled-components"
+
+const SearchBarContainer = styled(Box)`
+  z-index: 100;
+`
 
 export const SearchBar = () => (
-  <Box
-    style={{
-      position: "fixed",
-      zIndex: 100,
-      backgroundColor: "white",
-      top: "2px",
-    }}
-  >
+  <SearchBarContainer pt={1} pb={0.5}>
     <SearchBarQueryRenderer />
-  </Box>
+  </SearchBarContainer>
 )


### PR DESCRIPTION
This PR contains a few small styling changes for integration of our new auto-suggest search bar. It makes the search bar look like this:

![image](https://user-images.githubusercontent.com/1627089/53128254-0e84e600-352a-11e9-9410-e1fb3dc266ba.png)

(Ignore the lack of padding on the search suggestion/preview panes - those will be taken care of in reaction!)