### PR TITLE
Fix middleware getting stuck in a loop

### DIFF
--- a/src/lib/middleware/rateLimiting.ts
+++ b/src/lib/middleware/rateLimiting.ts
@@ -44,7 +44,7 @@ export const _rateLimiterMiddleware = <
     () =>
       rateLimiter
         .consume(ip)
-        .then(next)
+        .then(() => next())
         .catch(() => res.status(429).send(RATE_LIMIT_MESSAGE)),
     () => res.status(429).send(BURST_LIMIT_MESSAGE)
   )


### PR DESCRIPTION
Remove the closure around this next step, but it looks like doing so throws the middleware into an infinite loop. Not exactly sure _why_, but I was able to replicate locally. This fixed it. 