### PR TITLE
@pepopowitz => [Bugfix] Honor ?q and ?term query params for mobile/desktop search results

### DIFF
--- a/src/desktop/apps/search/routes.coffee
+++ b/src/desktop/apps/search/routes.coffee
@@ -18,9 +18,10 @@ imageUrl = require './components/image_url'
     .pipe res
 
 @index = (req, res) ->
-  return res.redirect("/") unless req.query.q
+  term = req.query.q || req.query.term
+  return res.redirect("/") unless term
 
-  term = removeDiacritics req.query.q
+  term = removeDiacritics term
   indexes = ['Artwork', 'Artist', 'Article', 'City', 'Fair', 'Tag', 'Gene', 'Feature', 'Page', 'Profile', 'PartnerShow', 'Sale']
   data = { term: term, size: 10 }
   data['indexes[]'] = indexes
@@ -38,7 +39,7 @@ imageUrl = require './components/image_url'
     cache: true
     cacheTime: 60 # 1 minute
     success: (results, response, options) ->
-      totalPages = Math.ceil(parseInt(options.res.headers['x-total-count'] or 0)  / 10)
+      totalPages = Math.ceil(parseInt(options.res?.headers['x-total-count'] or 0)  / 10)
       totalPages = 99 if totalPages > 99
       models = results.models
       res.locals.sd.RESULTS = results.toJSON()

--- a/src/desktop/apps/search/test/routes.coffee
+++ b/src/desktop/apps/search/test/routes.coffee
@@ -38,8 +38,22 @@ describe 'Search routes', ->
       Backbone.sync.args[0][0].should.equal 'read'
       Backbone.sync.args[0][2].data.term.should.equal 'foobAr'
 
-    it 'redirects without query', ->
-      req = { params: {}, query: { } }
-      res = { render: sinon.stub(), redirect: sinon.stub(), locals: { sd: {} } }
+    it 'works with query', ->
+      req = { params: {}, query: { q: "percy" } }
+      res = { render: sinon.stub(), locals: { sd: {} } }
+      routes.index req, res
+      Backbone.sync.args[0][2].success([{}])
+      res.render.called.should.be.ok
+
+    it 'works with term', ->
+      req = { params: {}, query: { term: "percy" } }
+      res = { render: sinon.stub(), locals: { sd: {} } }
+      routes.index req, res
+      Backbone.sync.args[0][2].success([{}])
+      res.render.called.should.be.ok
+
+    it 'redirects without query or term', ->
+      req = { params: {}, query: {} }
+      res = { redirect: sinon.stub(), locals: { sd: {} } }
       routes.index req, res
       res.redirect.args[0][0].should.equal '/'

--- a/src/mobile/apps/search/routes.coffee
+++ b/src/mobile/apps/search/routes.coffee
@@ -2,9 +2,10 @@ SearchResults = require '../../collections/search_results'
 removeDiacritics = require('diacritics').remove
 
 module.exports.index = (req, res, next) ->
-  return res.redirect('/') unless req.query.term
+  term = req.query.q || req.query.term
+  return res.redirect('/') unless term
 
-  term = removeDiacritics req.query.term
+  term = removeDiacritics term
   res.locals.sd.term = term
 
   results = new SearchResults

--- a/src/mobile/apps/search/test/routes.coffee
+++ b/src/mobile/apps/search/test/routes.coffee
@@ -26,8 +26,22 @@ describe 'Search routes', ->
 
         done()
 
-      it 'redirects without query', ->
+      it 'works with query', ->
+        req = { params: {}, query: { q: "percy" } }
+        res = { render: sinon.stub(), locals: { sd: {} } }
+        routes.index req, res
+        Backbone.sync.args[0][2].success([{}])
+        res.render.called.should.be.ok
+
+      it 'works with term', ->
+        req = { params: {}, query: { term: "percy" } }
+        res = { render: sinon.stub(), locals: { sd: {} } }
+        routes.index req, res
+        Backbone.sync.args[0][2].success([{}])
+        res.render.called.should.be.ok
+
+      it 'redirects without query or term', ->
         req = params: {}, query: {}
-        res = render: sinon.stub(), redirect: sinon.stub(), locals: sd: {}
+        res = redirect: sinon.stub(), locals: sd: {}
         routes.index req, res
         res.redirect.args[0][0].should.equal '/'


### PR DESCRIPTION
Nice catch!

We were passing the input as `term` in the desktop XS case: https://github.com/artsy/force/blob/c2f387c62a2a10b0ff2adb99eac6881b3176e2db/src/desktop/components/main_layout/header/templates/small_screen_header.jade#L8 , which sort of makes sense b/c the mobile version of search results uses `term`.

However, that causes an issue w/ XS devices that aren't real devices (which admittedly is an edge case). With responsive pages and us resizing windows we came across it.

This just allows either ?q or ?term to work for search results, they probably should have been the same in the first place.