### PR TITLE
@pepopowitz => [Autosuggest] Wrap stitched Reaction component in a <form>

### DIFF
--- a/src/desktop/components/main_layout/header/templates/large_screen_header.jade
+++ b/src/desktop/components/main_layout/header/templates/large_screen_header.jade
@@ -7,7 +7,14 @@ nav.mlh-navbar
       block minimal-nav-header
     - var lab_features = (sd.CURRENT_USER && sd.CURRENT_USER.lab_features) || []
     if (lab_features.includes('New Search Bar'))
-      != stitch.components.SearchBar()
+      form(
+        action='/search'
+        method='GET'
+        itemprop='potentialAction'
+        itemscope
+        itemtype='http://schema.org/SearchAction'
+      )
+        != stitch.components.SearchBar()
     else
       include ../../../search_bar/templates/index
   #main-layout-header-center.mlh-navbar-cell


### PR DESCRIPTION
This lets you just hit 'Enter' after typing in the input and go to the search results page.

For now, this is just copied from: https://github.com/artsy/force/blob/9f129c2ffeb1f8a02d75269e616c9f19d5299abe/src/desktop/components/search_bar/templates/index.jade#L2

As we add this to the mobile and small desktop versions, we can consolidate into a shared layout or something. Tested locally w/ no JS- works!