### PR TITLE
Comment out compression plugin

### DIFF
--- a/webpack/envs/production.js
+++ b/webpack/envs/production.js
@@ -17,9 +17,9 @@ export const productionConfig = {
     filename: "[name].[contenthash].js",
   },
   plugins: [
-    new CompressionWebpackPlugin({
-      test: /(\.(js|ts)x?$)/,
-    }),
+    // new CompressionWebpackPlugin({
+    //   test: /(\.(js|ts)x?$)/,
+    // }),
     new HashedModuleIdsPlugin(),
     new WebpackManifestPlugin({
       fileName: path.resolve(__dirname, "../../manifest.json"),


### PR DESCRIPTION
Lets see what happens if we stick strictly to `Content-Encoding: gzip`, and omit the Compression plugin. 