### PR TITLE
Directly serve gzip .js files

### DIFF
--- a/webpack/envs/production.js
+++ b/webpack/envs/production.js
@@ -17,9 +17,11 @@ export const productionConfig = {
     filename: "[name].[contenthash].js",
   },
   plugins: [
-    // new CompressionWebpackPlugin({
-    //   test: /(\.(js|ts)x?$)/,
-    // }),
+    new CompressionWebpackPlugin({
+      test: /(\.(js|ts)x?$)/,
+      filename: "[path]",
+      // deleteOriginalAssets: false,
+    }),
     new HashedModuleIdsPlugin(),
     new WebpackManifestPlugin({
       fileName: path.resolve(__dirname, "../../manifest.json"),


### PR DESCRIPTION
See what happens when automatic cloudfront gzip is turned off and compressed assets are directly returned. 