### PR TITLE
View-in-room 2.0 - Add measurement dimensions (width) to bench

### DIFF
--- a/src/desktop/components/view_in_room/index.jade
+++ b/src/desktop/components/view_in_room/index.jade
@@ -1,8 +1,6 @@
 .view-in-room__room( class='js-view-in-room-room' )
   img.view-in-room__placeholder( class='js-view-in-room-placeholder' )
-  //- .view-in-room__measurement( class='js-view-in-room-measurement' )
 img.view-in-room__artwork( class='js-view-in-room-artwork' )
-//- .view-in-room__measurement( class='js-view-in-room-measurement' )
 
 a.view-in-room__close( class='js-view-in-room-close' )
   i.icon-close

--- a/src/desktop/components/view_in_room/index.jade
+++ b/src/desktop/components/view_in_room/index.jade
@@ -1,6 +1,14 @@
 .view-in-room__room( class='js-view-in-room-room' )
   img.view-in-room__placeholder( class='js-view-in-room-placeholder' )
+  //- .view-in-room__measurement( class='js-view-in-room-measurement' )
 img.view-in-room__artwork( class='js-view-in-room-artwork' )
+//- .view-in-room__measurement( class='js-view-in-room-measurement' )
 
 a.view-in-room__close( class='js-view-in-room-close' )
   i.icon-close
+
+div.view-in-room__measurement-flex-container
+  div.view-in-room__feet 8 ft
+  div.view-in-room__measurement( class='js-view-in-room-measurement' ) 
+    div.view-in-room__line
+  

--- a/src/desktop/components/view_in_room/index.jade
+++ b/src/desktop/components/view_in_room/index.jade
@@ -7,8 +7,8 @@ img.view-in-room__artwork( class='js-view-in-room-artwork' )
 a.view-in-room__close( class='js-view-in-room-close' )
   i.icon-close
 
-div.view-in-room__measurement-flex-container
-  div.view-in-room__feet 8 ft
-  div.view-in-room__measurement( class='js-view-in-room-measurement' ) 
-    div.view-in-room__line
-  
+.view-in-room__measurement-flex-container
+  .view-in-room__measurement( class='js-view-in-room-measurement' ) 
+    .view-in-room__measurement-feet 8 ft.
+    .view-in-room__measurement-bar( class='js-view-in-room-measurement-bar' ) 
+      .view-in-room__measurement-line

--- a/src/desktop/components/view_in_room/index.styl
+++ b/src/desktop/components/view_in_room/index.styl
@@ -20,6 +20,8 @@ view-in-room = {
       opacity 1
     .view-in-room__artwork
       box-shadow 0 2px 5px rgba(black, 0.4)
+    .view-in-room__measurement
+      opacity 1
 
   &__close
     position absolute
@@ -68,3 +70,25 @@ view-in-room = {
       transition all 0.75s
     &.is-notransition
       transition none
+
+  &__measurement-flex-container
+    display flex
+    justify-content center
+    // align-items center
+    height 100%
+
+  &__measurement
+      transition opacity 0.5s
+      opacity 0
+      height 11px
+      min-width: 140px
+      z-index 1000
+      border-left 1px solid gray-darker-color
+      border-right 1px solid gray-darker-color
+      display flex
+      align-items center
+
+  &__line
+    width 100%
+    height 0px
+    border-top 1px solid gray-darker-color

--- a/src/desktop/components/view_in_room/index.styl
+++ b/src/desktop/components/view_in_room/index.styl
@@ -83,7 +83,6 @@ view-in-room = {
 
   &__measurement-bar
     height 9px
-    min-width 100px
     border-left 1px solid gray-darker-color
     border-right 1px solid gray-darker-color
     display flex

--- a/src/desktop/components/view_in_room/index.styl
+++ b/src/desktop/components/view_in_room/index.styl
@@ -83,7 +83,7 @@ view-in-room = {
 
   &__measurement-bar
     height 9px
-    min-width 140px
+    min-width 100px
     border-left 1px solid gray-darker-color
     border-right 1px solid gray-darker-color
     display flex

--- a/src/desktop/components/view_in_room/index.styl
+++ b/src/desktop/components/view_in_room/index.styl
@@ -74,21 +74,29 @@ view-in-room = {
   &__measurement-flex-container
     display flex
     justify-content center
-    // align-items center
     height 100%
 
   &__measurement
-      transition opacity 0.5s
-      opacity 0
-      height 11px
-      min-width: 140px
-      z-index 1000
-      border-left 1px solid gray-darker-color
-      border-right 1px solid gray-darker-color
-      display flex
-      align-items center
+    transition opacity 0.5s
+    opacity 0
+    z-index 1000
 
-  &__line
+  &__measurement-bar
+    height 9px
+    min-width 140px
+    border-left 1px solid gray-darker-color
+    border-right 1px solid gray-darker-color
+    display flex
+    align-items center
+
+  &__measurement-feet
+    text-align center
+    font-style italic
+    color gray-darker-color
+    height 18px
+    font-size 14px
+
+  &__measurement-line
     width 100%
     height 0px
     border-top 1px solid gray-darker-color

--- a/src/desktop/components/view_in_room/view.coffee
+++ b/src/desktop/components/view_in_room/view.coffee
@@ -39,6 +39,7 @@ module.exports = class ViewInRoom extends Backbone.View
     @$room.imagesLoaded().always =>
       @scaleRoom()
       @scalePlaceholder()
+      @scaleMeasurement()
       @transitionIn()
 
     this
@@ -47,6 +48,7 @@ module.exports = class ViewInRoom extends Backbone.View
     @$artwork = @$('.js-view-in-room-artwork')
     @$placeholder = @$('.js-view-in-room-placeholder')
     @$room = @$('.js-view-in-room-room')
+    @$measurement = @$('.js-view-in-room-measurement')
 
   injectImage: ->
     @$placeholder.add @$artwork
@@ -111,12 +113,17 @@ module.exports = class ViewInRoom extends Backbone.View
 
   scaleArtwork: ->
     @$artwork.css @getRect(@$placeholder)
+  
+  scaleMeasurement: ->
+    @$measurement.css width: "#{@measurementScalingFactor()}"
+    @$measurement.css marginTop: "#{@measurementMargin()}px"
 
   # Called on the throttled window resize event
   scale: =>
     @scaleRoom()
     @scalePlaceholder()
     @scaleArtwork()
+    @scaleMeasurement()
 
   roomScalingFactor: ->
     roomRatio = @$room.width() / @$room.height()
@@ -130,6 +137,20 @@ module.exports = class ViewInRoom extends Backbone.View
     factor = Math.round(width * @benchRatio) or 1
     scaling = factor / @$placeholder.width()
     Math.round(scaling * 100) / 100
+  
+  measurementMargin: -> 
+    value = @$el.height() / 1.83
+    # value = @$el.height() / 9
+    # console.log("MARGIN", value)
+    return value
+
+  measurementScalingFactor: ->
+    value = @$el.height() / 2.42
+    return value
+
+    # console.log("MEASUREMENT HEIGHT", @$measurement.height())
+    # console.log("ROOMWIDTH", @$room.width())
+    # console.log("ROOM SCALING FACTOR", @roomScalingFactor())
 
   # @return [height, width]
   getArtworkDimensions: ->

--- a/src/desktop/components/view_in_room/view.coffee
+++ b/src/desktop/components/view_in_room/view.coffee
@@ -49,6 +49,7 @@ module.exports = class ViewInRoom extends Backbone.View
     @$placeholder = @$('.js-view-in-room-placeholder')
     @$room = @$('.js-view-in-room-room')
     @$measurement = @$('.js-view-in-room-measurement')
+    @$measurementBar = @$('.js-view-in-room-measurement-bar')
 
   injectImage: ->
     @$placeholder.add @$artwork
@@ -115,7 +116,7 @@ module.exports = class ViewInRoom extends Backbone.View
     @$artwork.css @getRect(@$placeholder)
   
   scaleMeasurement: ->
-    @$measurement.css width: "#{@measurementScalingFactor()}"
+    @$measurementBar.css width: "#{@measurementHeight()}"
     @$measurement.css marginTop: "#{@measurementMargin()}px"
 
   # Called on the throttled window resize event
@@ -139,18 +140,10 @@ module.exports = class ViewInRoom extends Backbone.View
     Math.round(scaling * 100) / 100
   
   measurementMargin: -> 
-    value = @$el.height() / 1.83
-    # value = @$el.height() / 9
-    # console.log("MARGIN", value)
-    return value
+    @$el.height() / 1.90
 
-  measurementScalingFactor: ->
-    value = @$el.height() / 2.42
-    return value
-
-    # console.log("MEASUREMENT HEIGHT", @$measurement.height())
-    # console.log("ROOMWIDTH", @$room.width())
-    # console.log("ROOM SCALING FACTOR", @roomScalingFactor())
+  measurementHeight: ->
+    @$el.height() / 2.42
 
   # @return [height, width]
   getArtworkDimensions: ->

--- a/src/desktop/components/view_in_room/view.coffee
+++ b/src/desktop/components/view_in_room/view.coffee
@@ -95,6 +95,15 @@ module.exports = class ViewInRoom extends Backbone.View
   scalePlaceholder: ->
     [significantDimension] = @getArtworkDimensions()
 
+    measurementDistanceFromBottom = @$el.height() - @measurementMargin()
+    artworkDistanceFromBottom = (@eyeLevel() - (@$placeholder.height() / 2)) * @artworkScalingFactor()
+    difference = measurementDistanceFromBottom - artworkDistanceFromBottom
+    bottomPx = @eyeLevel()
+
+    # RAISES ARTWORK IF IT OVERLAPS THE MEASUREMENT BAR
+    if measurementDistanceFromBottom > artworkDistanceFromBottom
+      bottomPx = bottomPx + ((difference + 10) * (1 / @artworkScalingFactor()))
+
     options = if significantDimension > 254
       bottom: "#{@groundLevel()}px"
       marginLeft: -(@$placeholder.width() / 2)
@@ -102,7 +111,7 @@ module.exports = class ViewInRoom extends Backbone.View
       transformOrigin: "50% #{@$placeholder.height()}px 0"
 
     else
-      bottom: "#{@eyeLevel()}px"
+      bottom: "#{bottomPx}px"
       marginBottom: -(@$placeholder.height() / 2)
       marginLeft: -(@$placeholder.width() / 2)
       transform: "scale(#{@artworkScalingFactor()})"

--- a/src/desktop/components/view_in_room/view.coffee
+++ b/src/desktop/components/view_in_room/view.coffee
@@ -116,7 +116,7 @@ module.exports = class ViewInRoom extends Backbone.View
     @$artwork.css @getRect(@$placeholder)
   
   scaleMeasurement: ->
-    @$measurementBar.css width: "#{@measurementHeight()}"
+    @$measurementBar.css width: "#{@measurementWidth()}"
     @$measurement.css marginTop: "#{@measurementMargin()}px"
 
   # Called on the throttled window resize event
@@ -140,9 +140,9 @@ module.exports = class ViewInRoom extends Backbone.View
     Math.round(scaling * 100) / 100
   
   measurementMargin: -> 
-    @$el.height() / 1.90
+    @$el.height() / 1.79 - 27
 
-  measurementHeight: ->
+  measurementWidth: ->
     @$el.height() / 2.42
 
   # @return [height, width]


### PR DESCRIPTION
When using the view-in-room feature, I want the comparable objects to have width measurements (ft) so that I can have a better sense of scale of how the artwork will look when hung up.

Some issues with the width and top margin of the bar but only when the window is resized weirdly. Spent a day trying to fix bit couldn't find a good solution but am open to suggestions. 
<img width="1028" alt="screen shot 2019-02-26 at 9 41 35 am" src="https://user-images.githubusercontent.com/5643895/53420972-cabb3200-39aa-11e9-8eca-d0084864ae0d.png">
<img width="379" alt="screen shot 2019-02-21 at 6 29 17 pm" src="https://user-images.githubusercontent.com/5643895/53421267-6482df00-39ab-11e9-9af0-b15dea3b7cb4.png">
<img width="1184" alt="screen shot 2019-02-21 at 6 29 37 pm" src="https://user-images.githubusercontent.com/5643895/53421332-7795af00-39ab-11e9-9762-c2ef226d5e9d.png">


