### PR TITLE
Add duplicate reports for force webpack builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,15 @@ jobs:
       - store_artifacts:
           path: ~/project/.artifacts
 
+  duplicate-report:
+    docker:
+      - image: circleci/node:10-stretch-browsers
+    steps:
+      - checkout
+      - run:
+          name: Generate webpack duplicates report
+          command: curl "https://artsy-dupe-report.now.sh/now.js?buildNum=$CIRCLE_BUILD_NUM&dryRun=true"
+
   test:
     docker:
       - image: circleci/node:10.13
@@ -132,6 +141,16 @@ workflows:
       # Nothing actually relies on this at the moment
       - build:
           <<: *not_staging_or_release
+
+      - duplicate-report:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore:
+                - staging
+                - release
+                - master
 
       # Staging
       - push_staging_image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,6 @@ jobs:
           command: yarn build
       - store_artifacts:
           path: ~/project/.artifacts
-
-  duplicate-report:
-    docker:
-      - image: circleci/node:10-stretch-browsers
-    steps:
-      - checkout
       - run:
           name: Generate webpack duplicates report
           command: curl "https://artsy-dupe-report.now.sh/now.js?buildNum=$CIRCLE_BUILD_NUM&dryRun=true"
@@ -141,16 +135,6 @@ workflows:
       # Nothing actually relies on this at the moment
       - build:
           <<: *not_staging_or_release
-
-      - duplicate-report:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore:
-                - staging
-                - release
-                - master
 
       # Staging
       - push_staging_image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           path: ~/project/.artifacts
       - run:
           name: Generate webpack duplicates report
-          command: curl "https://artsy-dupe-report.now.sh/now.js?buildNum=$CIRCLE_BUILD_NUM&dryRun=true"
+          command: curl "https://artsy-dupe-report.now.sh/now.js?buildNum=$CIRCLE_BUILD_NUM"
 
   test:
     docker:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3585,12 +3585,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
-  integrity sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0=
-
-classnames@^2.2.6:
+classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==


### PR DESCRIPTION
This integrates with the library [dupe-report](https://github.com/artsy/dupe-report) that builds on top of [inspectpack](https://github.com/FormidableLabs/inspectpack). As a part of every build, force is saving the output of `inspectpack` as a circleci artifact. On a PR, `dupe-report` will download the artifacts from the PR and master and compare them. If they're the same, it bails. If they differ, it'll generate a report like the one below and send a message to the client-infra channel. If the duplicates are cleaned up and the report starts matching master then it'll auto delete itself. 

I've generally tried to put a lot of work into making this legible and useful for folks. It should save us from shipping new duplicates without realizing it. Also, we've now got a list of duplicates to work through to resolve... 

There are probably a few improvements I could make to the header of the message... like how many packages were added or removed. I'm open for input. 

