### PR TITLE
@joeyAghion => [Session] Restore checking that session is valid client-side on all pageloads

### DIFF
--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -31,41 +31,14 @@ export function globalClientSetup() {
   }
 
   mountStitchComponents()
-}
-
-function ensureFreshUser() {
-  if (!sd.CURRENT_USER) {
-    return
-  }
-
-  for (let attr of [
-    "id",
-    "type",
-    "name",
-    "email",
-    "phone",
-    "lab_features",
-    "default_profile_id",
-    "has_partner_access",
-    "collector_level",
-  ]) {
-    // NOTE:
-    // If any of the above props have changed between two routes, and the second
-    // route fails to mount sd.locals.CURRENT_USER with the latest req.user.fetch()
-    // data, a hard refresh will occur once the client-side mounts as the two
-    // will be out of sync.
-
-    if (!_.isEqual(data[attr], sd.CURRENT_USER[attr])) {
-      $.ajax("/user/refresh").then(() => window.location.reload())
-    }
-  }
+  syncAuth()
 }
 
 export function syncAuth() {
   if (sd.CURRENT_USER) {
     $.ajax({
       url: `${sd.API_URL}/api/v1/me`,
-      success: ensureFreshUser,
+      // success: ensureFreshUser, # this can cause an endless reload
       error() {
         $.ajax({
           method: "DELETE",

--- a/src/mobile/components/layout/bootstrap.coffee
+++ b/src/mobile/components/layout/bootstrap.coffee
@@ -40,38 +40,18 @@ module.exports = ->
 
   setupErrorReporting()
   setupHeaderView()
-  # TODO: Look into why this fails.
-  # syncAuth()
+  syncAuth()
   checkForAfterSignUpAction()
 
   # Setup jQuery plugins
   require 'jquery-on-infinite-scroll'
-
-ensureFreshUser = (data) ->
-  return unless sd.CURRENT_USER
-  attrs = [
-    'id',
-    'type',
-    'name',
-    'email',
-    'phone',
-    'lab_features',
-    'default_profile_id',
-    'has_partner_access',
-    'collector_level'
-  ]
-  for attr in attrs
-    if (data[attr] or sd.CURRENT_USER[attr]) and not _.isEqual data[attr], sd.CURRENT_USER[attr]
-      RavenClient.captureException("Forced to refresh user", { extra: { attr: attr, session: sd.CURRENT_USER[attr], current: data[attr] } } )
-      $.ajax('/user/refresh').then ->
-        setTimeout  (=> window.location.reload()), 500
 
 syncAuth = module.exports.syncAuth = ->
   # Log out of Microgravity if you're not logged in to Gravity
   if sd.CURRENT_USER
     $.ajax
       url: "#{sd.API_URL}/api/v1/me"
-      success: ensureFreshUser
+      # success: ensureFreshUser # this can cause an endless reload
       error: ->
         $.ajax
           method: 'DELETE'


### PR DESCRIPTION
"When the only tool you have is a hammer.....everything looks like a nail"

This restores behavior that was present up until ~6 months ago, which basically calls `/api/v1/me` directly client-side _for every page load_ (this is well cached by Gravity). If there's any error, you are logged out (seems like this error check can be restricted to just 401/403).

Still to check: will this work on pages that wind up 500/404'ing , or will this have no affect on those cases? (which means they would need to navigate to a page that at least returns a 200 to get this to log them out).