### PR TITLE
View in Room: Updates relative scaling so images don't overlap the measurement bar

### DIFF
--- a/src/desktop/components/view_in_room/test/view.coffee
+++ b/src/desktop/components/view_in_room/test/view.coffee
@@ -90,7 +90,7 @@ describe 'ViewInRoomView', ->
         .should.eql ['bottom', 'marginBottom', 'marginLeft', 'transform']
 
       @view.$placeholder.css.args[0][0].bottom
-        .should.equal '868.296px'
+        .should.equal '957.099px'
 
     it 'scales the placeholder and sets it at ground level if the significant dimension is greater than 254', ->
       @view.$placeholder.css = sinon.stub()
@@ -101,4 +101,4 @@ describe 'ViewInRoomView', ->
         .should.eql ['bottom', 'marginLeft', 'transform', 'transformOrigin']
 
       @view.$placeholder.css.args[0][0].bottom
-        .should.equal '624.91px'
+        .should.equal '667.6669999999999px'

--- a/src/desktop/components/view_in_room/view.coffee
+++ b/src/desktop/components/view_in_room/view.coffee
@@ -11,11 +11,14 @@ module.exports = class ViewInRoom extends Backbone.View
 
   # Should be visually at about 57" from interstitial
   eyeLevel: ->
-    0.132 * @roomWidth
+    0.139 * @roomWidth
 
   # Should be visually at about 12" from interstitial
   groundLevel: ->
     0.095 * @roomWidth
+
+  relativeMeasurementHeight: ->
+    0.0065 * @roomWidth
 
   events:
     'click .js-view-in-room-close': 'remove'
@@ -95,23 +98,14 @@ module.exports = class ViewInRoom extends Backbone.View
   scalePlaceholder: ->
     [significantDimension] = @getArtworkDimensions()
 
-    measurementDistanceFromBottom = @$el.height() - @measurementMargin()
-    artworkDistanceFromBottom = (@eyeLevel() - (@$placeholder.height() / 2)) * @artworkScalingFactor()
-    difference = measurementDistanceFromBottom - artworkDistanceFromBottom
-    bottomPx = @eyeLevel()
-
-    # RAISES ARTWORK IF IT OVERLAPS THE MEASUREMENT BAR
-    if measurementDistanceFromBottom > artworkDistanceFromBottom
-      bottomPx = bottomPx + ((difference + 10) * (1 / @artworkScalingFactor()))
-
     options = if significantDimension > 254
-      bottom: "#{@groundLevel()}px"
+      bottom: "#{@groundLevel() + @relativeMeasurementHeight()}px"
       marginLeft: -(@$placeholder.width() / 2)
       transform: "scale(#{@artworkScalingFactor()})"
       transformOrigin: "50% #{@$placeholder.height()}px 0"
 
     else
-      bottom: "#{bottomPx}px"
+      bottom: "#{@eyeLevel() + @relativeMeasurementHeight()}px"
       marginBottom: -(@$placeholder.height() / 2)
       marginLeft: -(@$placeholder.width() / 2)
       transform: "scale(#{@artworkScalingFactor()})"
@@ -123,7 +117,7 @@ module.exports = class ViewInRoom extends Backbone.View
 
   scaleArtwork: ->
     @$artwork.css @getRect(@$placeholder)
-  
+
   scaleMeasurement: ->
     @$measurementBar.css width: "#{@measurementWidth()}"
     @$measurement.css marginTop: "#{@measurementMargin()}px"
@@ -147,8 +141,8 @@ module.exports = class ViewInRoom extends Backbone.View
     factor = Math.round(width * @benchRatio) or 1
     scaling = factor / @$placeholder.width()
     Math.round(scaling * 100) / 100
-  
-  measurementMargin: -> 
+
+  measurementMargin: ->
     @$el.height() / 1.79 - 27
 
   measurementWidth: ->


### PR DESCRIPTION
Woof. Played around with a bunch of scaling options and this one appears to work in most cases... 

The image will overlap the measurement bar if the screen size is super tiny, but I don't think that's a real use-case anyways so am 👍 ignoring.

Some screenshots:
<img width="2560" alt="screen shot 2019-02-28 at 6 06 35 pm" src="https://user-images.githubusercontent.com/2081340/53604842-a6ff1400-3b83-11e9-8281-483060c2401a.png">

<img width="2560" alt="screen shot 2019-02-28 at 6 06 44 pm" src="https://user-images.githubusercontent.com/2081340/53604850-a9616e00-3b83-11e9-826c-95264374aead.png">

Huge image:
<img width="1539" alt="screen shot 2019-02-28 at 6 03 46 pm" src="https://user-images.githubusercontent.com/2081340/53604860-aebeb880-3b83-11e9-9b5e-72a92c7fe610.png">
