### PR TITLE
Add new search bar to mobile layout

### DIFF
--- a/src/desktop/components/main_layout/header/index.styl
+++ b/src/desktop/components/main_layout/header/index.styl
@@ -37,6 +37,10 @@
   > svg
     height header-logo-icon-size
     width header-logo-icon-size
+
+#main-layout-search-bar
+  padding 10px 0 5px 0
+
 #main-layout-header-center
   padding 0 20px 0 30px
   flex-grow 0

--- a/src/desktop/components/main_layout/header/small_screen_header.styl
+++ b/src/desktop/components/main_layout/header/small_screen_header.styl
@@ -69,6 +69,9 @@
     > svg
       margin-top content-margin-top
 
+  #main-header-search-bar
+    padding 0 70px 0 72px
+
   #main-header-search-box
     position relative
     height logo-size

--- a/src/desktop/components/main_layout/header/small_screen_header.styl
+++ b/src/desktop/components/main_layout/header/small_screen_header.styl
@@ -70,7 +70,7 @@
       margin-top content-margin-top
 
   #main-header-search-bar
-    padding 0 70px 0 72px
+    padding 10px 70px 5px 72px
 
   #main-header-search-box
     position relative

--- a/src/desktop/components/main_layout/header/templates/large_screen_header.jade
+++ b/src/desktop/components/main_layout/header/templates/large_screen_header.jade
@@ -14,7 +14,8 @@ nav.mlh-navbar
         itemscope
         itemtype='http://schema.org/SearchAction'
       )
-        != stitch.components.SearchBar()
+        #main-layout-search-bar
+          != stitch.components.SearchBar()
     else
       include ../../../search_bar/templates/index
   #main-layout-header-center.mlh-navbar-cell

--- a/src/desktop/components/main_layout/header/templates/small_screen_header.jade
+++ b/src/desktop/components/main_layout/header/templates/small_screen_header.jade
@@ -5,7 +5,8 @@ nav.mlh-small-screen#main-header-small-screen
   form#main-header-search-form( action='/search', method='GET' )
     - var lab_features = (sd.CURRENT_USER && sd.CURRENT_USER.lab_features) || []
     if (lab_features.includes('New Search Bar'))
-      != stitch.components.SearchBar()
+      #main-header-search-bar
+        != stitch.components.SearchBar()
     else
       input#main-header-search-box(
         placeholder='Search by artist, gallery, etc.',

--- a/src/desktop/components/main_layout/header/templates/small_screen_header.jade
+++ b/src/desktop/components/main_layout/header/templates/small_screen_header.jade
@@ -3,13 +3,17 @@ nav.mlh-small-screen#main-header-small-screen
     span.screen-reader-text Home
     include ../../public/icons/logo-40.svg
   form#main-header-search-form( action='/search', method='GET' )
-    input#main-header-search-box(
-      placeholder='Search by artist, gallery, etc.',
-      name='term',
-      value=mainHeaderSearchBoxValue,
-      type='search'
-      aria-label='Search'
-    )
+    - var lab_features = (sd.CURRENT_USER && sd.CURRENT_USER.lab_features) || []
+    if (lab_features.includes('New Search Bar'))
+      != stitch.components.SearchBar()
+    else
+      input#main-header-search-box(
+        placeholder='Search by artist, gallery, etc.',
+        name='term',
+        value=mainHeaderSearchBoxValue,
+        type='search'
+        aria-label='Search'
+      )
   button#main-header-search-button.avant-garde-button(form="main-header-search-form") Search
 
   a#main-header-menu-button

--- a/src/desktop/components/react/stitch_components/SearchBar.tsx
+++ b/src/desktop/components/react/stitch_components/SearchBar.tsx
@@ -8,7 +8,7 @@ const SearchBarContainer = styled(Box)`
 `
 
 export const SearchBar = () => (
-  <SearchBarContainer pt={1} pb={0.5}>
+  <SearchBarContainer>
     <SearchBarQueryRenderer />
   </SearchBarContainer>
 )

--- a/src/mobile/components/layout/bootstrap.coffee
+++ b/src/mobile/components/layout/bootstrap.coffee
@@ -20,6 +20,8 @@ doc = window.document
 sharify = require('sharify')
 CurrentUser = require '../../models/current_user.coffee'
 Sentry = require("@sentry/browser")
+globalReactModules = require('../../../desktop/lib/global_react_modules.tsx')
+hydrateStitch = require('@artsy/stitch/dist/internal/hydrate').hydrate
 
 module.exports = ->
   # Add the Gravity XAPP or access token to all ajax requests
@@ -45,6 +47,16 @@ module.exports = ->
 
   # Setup jQuery plugins
   require 'jquery-on-infinite-scroll'
+  mountStitch()
+  
+mountStitch = ->
+  globalReactModules = require('../../../desktop/lib/global_react_modules.tsx')
+  hydrateStitch = require('@artsy/stitch/dist/internal/hydrate').hydrate
+  hydrateStitch({
+    sharifyData: sd
+    modules: globalReactModules
+    wrapper: globalReactModules.StitchWrapper
+  })
 
 syncAuth = module.exports.syncAuth = ->
   # Log out of Microgravity if you're not logged in to Gravity

--- a/src/mobile/components/layout/bootstrap.coffee
+++ b/src/mobile/components/layout/bootstrap.coffee
@@ -47,11 +47,10 @@ module.exports = ->
 
   # Setup jQuery plugins
   require 'jquery-on-infinite-scroll'
-  mountStitch()
+  if sd.stitch?.renderQueue?
+    mountStitch()
   
 mountStitch = ->
-  globalReactModules = require('../../../desktop/lib/global_react_modules.tsx')
-  hydrateStitch = require('@artsy/stitch/dist/internal/hydrate').hydrate
   hydrateStitch({
     sharifyData: sd
     modules: globalReactModules

--- a/src/mobile/components/layout/stylesheets/main_header.styl
+++ b/src/mobile/components/layout/stylesheets/main_header.styl
@@ -17,7 +17,7 @@ header-height = 54px
   border-bottom 1px solid light-gray-border-color
 
 #main-header-search-bar
-  padding 0 64px 0 66px
+  padding 7px 64px 1px 66px
 
 #main-header-search-box
   padding 18px 80px 14px 70px

--- a/src/mobile/components/layout/stylesheets/main_header.styl
+++ b/src/mobile/components/layout/stylesheets/main_header.styl
@@ -16,6 +16,9 @@ header-height = 54px
   background-color white
   border-bottom 1px solid light-gray-border-color
 
+#main-header-search-bar
+  padding 0 64px 0 66px
+
 #main-header-search-box
   padding 18px 80px 14px 70px
   border 0

--- a/src/mobile/components/layout/templates/main.jade
+++ b/src/mobile/components/layout/templates/main.jade
@@ -21,7 +21,8 @@ block body
         form#main-header-search-form( action='/search', method='GET' )
           - var lab_features = (sd.CURRENT_USER && sd.CURRENT_USER.lab_features) || []
           if (lab_features.includes('New Search Bar'))
-            != stitch.components.SearchBar()
+            #main-header-search-bar
+              != stitch.components.SearchBar()
           else
             input#main-header-search-box(
               placeholder='Search',

--- a/src/mobile/components/layout/templates/main.jade
+++ b/src/mobile/components/layout/templates/main.jade
@@ -19,12 +19,16 @@ block body
         a#main-header-menu( href= '#' )
           #main-header-menu-icon
         form#main-header-search-form( action='/search', method='GET' )
-          input#main-header-search-box(
-            placeholder='Search',
-            name='term',
-            value=mainHeaderSearchBoxValue,
-            type='search'
-          )
+          - var lab_features = (sd.CURRENT_USER && sd.CURRENT_USER.lab_features) || []
+          if (lab_features.includes('New Search Bar'))
+            != stitch.components.SearchBar()
+          else
+            input#main-header-search-box(
+              placeholder='Search',
+              name='term',
+              value=mainHeaderSearchBoxValue,
+              type='search'
+            )
           button#main-header-search-button.avant-garde-box-button Search
 
     main

--- a/src/mobile/components/layout/test/layout.coffee
+++ b/src/mobile/components/layout/test/layout.coffee
@@ -22,7 +22,9 @@ describe 'Bootstrapping client-side environment', ->
       sd['ARTSY_XAPP_TOKEN'] = 'xappfoobar'
       sd['CURRENT_USER'] = { accessToken: 'accessfoobar' }
       sd['APP_URL'] = 'http://m.artsy.net'
-      require('../bootstrap')()
+      @bootstrap = rewire '../bootstrap'
+      @bootstrap.__set__('mountStitch', sinon.stub())
+      @bootstrap()
       done()
 
   afterEach ->
@@ -84,6 +86,7 @@ describe 'inquiry cookies', ->
         get: sinon.stub()
       }
       @bootstrap.__set__ 'sd', { APP_URL: 'http://artsy.net' }
+      @bootstrap.__set__('mountStitch', sinon.stub())
       done()
 
   afterEach ->
@@ -123,6 +126,7 @@ describe 'afterSignUpAction', ->
           follow: @follow = sinon.stub()
         })
       }
+      @bootstrap.__set__('mountStitch', sinon.stub())
       done()
 
   afterEach ->


### PR DESCRIPTION
This PR stitches the `<SearchBar>` from reaction into the mobile layout. 

The padding on the stitched `<SearchBar>` is not consistent across the three layouts (large desktop, small desktop, and mobile), so the vertical padding is also moved into the layout stylesheets.

There are still a couple of small visual issues with the search bar on mobile, and we will address those in follow-ups, but this PR gets it hooked up for mobile so that we can start QA'ing it.