### PR TITLE
Bump bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "bundlesize": [
     {
       "path": "./public/assets/common.*js",
-      "maxSize": "700 kB"
+      "maxSize": "800 kB"
     },
     {
       "path": "./public/assets/fairs.*js",


### PR DESCRIPTION
Ha. @joeyAghion, you get the last laugh. 

https://github.com/artsy/force/pull/3657 made a change which caused the bundle size to jump by 90 kB and added new duplicates. CI is failing now because of exceeded budget limits. This increases it until we can do the work to fix what was introduced. 