### PR TITLE
Disable performance checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,13 +41,7 @@ jobs:
           command: yarn assets
       - store_artifacts:
           path: ~/project/.artifacts
-      - run:
-          name: Generate webpack duplicates report
-          command: curl "https://artsy-dupe-report.now.sh/now.js?buildNum=$CIRCLE_BUILD_NUM"
-      - run:
-          name: Verify bundle sizes
-          command: npx bundlesize
-
+          
   test:
     docker:
       - image: circleci/node:10.13


### PR DESCRIPTION
Remove checks for duplicate bundles and bundle sizes. 