### PR TITLE
Disable a/b test while discover autosuggest test is running

### DIFF
--- a/src/desktop/apps/article/routes.ts
+++ b/src/desktop/apps/article/routes.ts
@@ -126,12 +126,7 @@ export async function index(req, res, next) {
         "../../../components/main_layout/templates/react_blank_index.jade"
     }
 
-    const {
-      CURRENT_USER,
-      // EDITORIAL_COLLECTIONS_RAIL, // TODO: update after CollectionsRail a/b test
-      IS_MOBILE,
-      IS_TABLET,
-    } = res.locals.sd
+    const { CURRENT_USER, IS_MOBILE, IS_TABLET } = res.locals.sd
 
     const isMobile = IS_MOBILE
     const isTablet = IS_TABLET

--- a/src/desktop/apps/article/routes.ts
+++ b/src/desktop/apps/article/routes.ts
@@ -19,7 +19,7 @@ const { crop, resize } = require("desktop/components/resizer/index.coffee")
 const { stringifyJSONForWeb } = require("desktop/components/util/json.coffee")
 const _Article = require("desktop/models/article.coffee")
 // TODO: update after CollectionsRail a/b test
-const splitTest = require("desktop/components/split_test/index.coffee")
+// const splitTest = require("desktop/components/split_test/index.coffee")
 
 const { SAILTHRU_KEY, SAILTHRU_SECRET } = require("config")
 const sailthru = require("sailthru-client").createSailthruClient(
@@ -146,7 +146,7 @@ export async function index(req, res, next) {
     res.locals.sd.RESPONSIVE_CSS = createMediaStyle()
 
     // CollectionsRail a/b test
-    splitTest("editorial_collections_rail").view()
+    // splitTest("editorial_collections_rail").view()
     const hasCollectionsRail = EDITORIAL_COLLECTIONS_RAIL === 1
     const showCollectionsRail =
       hasCollectionsRail &&

--- a/src/desktop/apps/article/routes.ts
+++ b/src/desktop/apps/article/routes.ts
@@ -128,7 +128,7 @@ export async function index(req, res, next) {
 
     const {
       CURRENT_USER,
-      EDITORIAL_COLLECTIONS_RAIL, // TODO: update after CollectionsRail a/b test
+      // EDITORIAL_COLLECTIONS_RAIL, // TODO: update after CollectionsRail a/b test
       IS_MOBILE,
       IS_TABLET,
     } = res.locals.sd
@@ -147,7 +147,9 @@ export async function index(req, res, next) {
 
     // CollectionsRail a/b test
     // splitTest("editorial_collections_rail").view()
-    const hasCollectionsRail = EDITORIAL_COLLECTIONS_RAIL === 1
+    // const hasCollectionsRail = EDITORIAL_COLLECTIONS_RAIL === 1
+    // Set hasCollectionsRail to false to ensure rail is not visable
+    const hasCollectionsRail = false
     const showCollectionsRail =
       hasCollectionsRail &&
       ["standard", "feature", "news"].includes(article.layout)

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -56,13 +56,14 @@ module.exports = {
     edge: 'v2'
     weighting: 'equal'
 
-  editorial_collections_rail:
-    key: 'editorial_collections_rail'
-    outcomes: [
-      0
-      1
-    ]
-    control_group: 0
-    edge: 1
-    weighting: 'equal'
+  # Disable a/b test
+  # editorial_collections_rail:
+  #   key: 'editorial_collections_rail'
+  #   outcomes: [
+  #     0
+  #     1
+  #   ]
+  #   control_group: 0
+  #   edge: 1
+  #   weighting: 'equal'
 }


### PR DESCRIPTION
Per an update from Jun we can't support this test and the autosuggestion test at the same time. We are disabling ours for now.