### PR TITLE
Fix DataDog load order; Reenabled server compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ RUN rm -f /usr/local/bin/yarn && \
 RUN yarn install
 
 RUN yarn assets
-
-# FIXME: Reenable for server-side compilation
-# RUN yarn build:server
+RUN yarn build:server
 
 CMD yarn start

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -20,10 +20,7 @@ if [ "$NODE_ENV" != "production" ]; then
     OPT+=(--inspect-brk)
   fi
 
-# FIXME: Reenable for server-side compilation
-#   exec node "${OPT[@]}" ./src
-# else
-#   exec node "${OPT[@]}" ./server.dist.js
+  exec node "${OPT[@]}" ./src
+else
+  exec node "${OPT[@]}" ./server.dist.js
 fi
-
-exec node "${OPT[@]}" ./src

--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -27,7 +27,6 @@ module.exports =
   CONVECTION_GEMINI_APP: 'convection-staging'
   COOKIE_DOMAIN: null
   CRITEO_AUCTIONS_ACCOUNT_NUMBER: '28539'
-  DD_APM_ENABLED: null
   DD_TRACE_AGENT_HOSTNAME: 'localhost'
   DD_SERVICE_NAME: 'force'
   DEFAULT_CACHE_TIME: 3600

--- a/src/index.js
+++ b/src/index.js
@@ -15,20 +15,17 @@ const {
 const chalk = require("chalk")
 console.log(chalk.green(`\n[Force] NODE_ENV=${NODE_ENV}\n`))
 
-// FIXME: Reenable for server-side compilation
-// if (NODE_ENV === "development") {
-//   require("coffeescript/register")
-//   require("@babel/register")({
-//     extensions: [".ts", ".js", ".tsx", ".jsx"],
-//     plugins: ["babel-plugin-dynamic-import-node"],
-//   })
-// }
+if (NODE_ENV === "development") {
+  require("coffeescript/register")
+  require("@babel/register")({
+    extensions: [".ts", ".js", ".tsx", ".jsx"],
+    plugins: ["babel-plugin-dynamic-import-node"],
+  })
+}
 
-require("coffeescript/register")
-require("@babel/register")({
-  extensions: [".ts", ".js", ".tsx", ".jsx"],
-  plugins: ["babel-plugin-dynamic-import-node"],
-})
+// This must come before any other instrumented module.
+// See https://docs.datadoghq.com/tracing/languages/nodejs/ for more info.
+require("./lib/datadog")
 
 global.Promise = require("bluebird")
 

--- a/src/lib/datadog.ts
+++ b/src/lib/datadog.ts
@@ -1,0 +1,17 @@
+import ddTracer from "dd-trace"
+
+if (process.env.DD_APM_ENABLED) {
+  ddTracer.init({
+    hostname: process.env.DD_TRACE_AGENT_HOSTNAME,
+    service: "force",
+    plugins: false,
+  })
+  ddTracer.use("express", {
+    // We want the root spans of MP to be labelled as just `service`
+    service: "force",
+    headers: ["User-Agent"],
+  })
+  ddTracer.use("http", {
+    service: `force.http-client`,
+  })
+}

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -5,7 +5,6 @@
 //
 
 import config from "../config"
-import ddTracer from "dd-trace"
 import _ from "underscore"
 import addRequestId from "express-request-id"
 import artsyPassport from "@artsy/passport"
@@ -72,7 +71,6 @@ const {
   SESSION_COOKIE_KEY,
   SESSION_COOKIE_MAX_AGE,
   SESSION_SECRET,
-  DD_APM_ENABLED,
 } = config
 
 export default function(app) {
@@ -234,22 +232,6 @@ export default function(app) {
       wrapper: globalReactModules.StitchWrapper,
     })
   )
-
-  if (DD_APM_ENABLED) {
-    ddTracer.init({
-      hostname: process.env.DD_TRACE_AGENT_HOSTNAME,
-      service: "force",
-      plugins: false,
-    })
-    ddTracer.use("express", {
-      // We want the root spans of MP to be labelled as just `service`
-      service: "force",
-      headers: ["User-Agent"],
-    })
-    ddTracer.use("http", {
-      service: `force.http-client`,
-    })
-  }
 
   // Routes for pinging system time and up
   app.get("/system/time", (req, res) =>

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -33,9 +33,12 @@ const getConfig = () => {
     case isCI:
       console.log("[Force] CI=true")
       return merge.smart(baseConfig, ciConfig)
+
     case isDevelopment:
       return merge.smart(baseConfig, developmentConfig)
+
     case isProduction:
+      console.log("[Force] Building client-side production code...")
       return merge.smart(baseConfig, productionConfig)
   }
 }

--- a/webpack/utils/getCSSManifest.js
+++ b/webpack/utils/getCSSManifest.js
@@ -17,7 +17,7 @@ function clean() {
 }
 
 function compile() {
-  console.log(chalk.green(`[compileCSS] Compiling...`))
+  console.log(chalk.green(`[Force compileCSS] Compiling...`))
   const files = glob.sync("src/{desktop,mobile}/assets/*.styl", {
     nodir: true,
   })
@@ -38,7 +38,7 @@ function fingerprint(file) {
   try {
     fs.renameSync(file, `${DEST}/${fingerprinted}`)
   } catch (error) {
-    console.error("[compileCSS] Error renaming file:", error)
+    console.error("[Force compileCSS] Error renaming file:", error)
   }
 
   return {
@@ -65,10 +65,10 @@ exports.getCSSManifest = () => {
     clean()
     compile()
     const manifest = createManifest()
-    console.log(chalk.green(`[compileCSS] Complete.`))
+    console.log(chalk.green(`[Force compileCSS] Complete.`))
     return manifest
   } catch (error) {
-    console.error(chalk.red("[compileCSS] Error:", error))
+    console.error(chalk.red("[Force compileCSS] Error:", error))
     process.exit(1)
   }
 }


### PR DESCRIPTION
When deploying server-side compilation we noticed that DataDog logging no longer worked. Reading up on [the docs](https://docs.datadoghq.com/tracing/languages/nodejs/) it states: 

> This library MUST be imported and initialized before any instrumented module. When using a transpiler, you MUST import and initialize the tracer library in an external file and then import that file as a whole when building your application. This prevents hoisting and ensures that the tracer library gets imported and initialized before importing any other instrumented module.

This PR addresses this issue, and re-enables server-side compilation. 
