### PR TITLE
Adjust bottom margin of mobile search bar

### DIFF
--- a/src/mobile/components/layout/stylesheets/main_header.styl
+++ b/src/mobile/components/layout/stylesheets/main_header.styl
@@ -18,6 +18,7 @@ header-height = 54px
 
 #main-header-search-bar
   padding 7px 64px 1px 66px
+  margin-bottom 5px
 
 #main-header-search-box
   padding 18px 80px 14px 70px


### PR DESCRIPTION
This is a tiny little margin fix for the new search bar on mobile. 

Without this change, the header looks like this:

![image](https://user-images.githubusercontent.com/1627089/53773820-8dc2d400-3eb1-11e9-884a-d899c11ebe48.png)

The gray line is in the wrong place, and makes things look funny.

This change bumps that line down, so it looks much better:

![image](https://user-images.githubusercontent.com/1627089/53773856-b34fdd80-3eb1-11e9-8ff7-ed63da3ca6dc.png)
