### PR TITLE
Adjust margin for new search bar on pages other than home

### DIFF
--- a/src/desktop/components/main_layout/header/small_screen_header.styl
+++ b/src/desktop/components/main_layout/header/small_screen_header.styl
@@ -71,6 +71,7 @@
 
   #main-header-search-bar
     padding 10px 70px 5px 72px
+    margin-bottom 5px
 
   #main-header-search-box
     position relative


### PR DESCRIPTION
When I submitted #3668, I didn't realize that there were two different templates for the header on mobile. I fixed the one that is used by the home page, but the one used by other pages still looks like this:

<img width="424" alt="sad header" src="https://user-images.githubusercontent.com/1627089/53821676-e470f200-3f33-11e9-8b22-a1d722390338.png">

This PR nudges that gray bar down, and makes it look like this:

<img width="425" alt="happy header" src="https://user-images.githubusercontent.com/1627089/53821797-0ec2af80-3f34-11e9-945b-40d3196cc73b.png">
