### PR TITLE
Switch editorial CollectionsRail test to admin only and dummy name

### DIFF
--- a/src/desktop/apps/article/__tests__/routes.test.js
+++ b/src/desktop/apps/article/__tests__/routes.test.js
@@ -404,6 +404,9 @@ describe("Article Routes", () => {
 
       beforeEach(() => {
         res.locals.sd.CURRENT_USER = { type: "Admin" }
+        req.user = {
+          isAdmin: sinon.stub().returns(true),
+        }
         data = {
           article: _.extend({}, fixtures.article, {
             slug: "foobar",
@@ -424,7 +427,7 @@ describe("Article Routes", () => {
       })
 
       it("Sets showCollectionsRail when EDITORIAL_COLLECTIONS_RAIL is true", done => {
-        res.locals.sd.EDITORIAL_COLLECTIONS_RAIL = 1
+        res.locals.sd.EDITORIAL_COLLECTIONS_RAIL_QA = 1
         index(req, res, next).then(() => {
           stitch.args[0][0].data.showCollectionsRail.should.equal(true)
           done()
@@ -432,7 +435,7 @@ describe("Article Routes", () => {
       })
 
       it("Sets showCollectionsRail when EDITORIAL_COLLECTIONS_RAIL is false", done => {
-        res.locals.sd.EDITORIAL_COLLECTIONS_RAIL = 0
+        res.locals.sd.EDITORIAL_COLLECTIONS_RAIL_QA = 0
         index(req, res, next).then(() => {
           stitch.args[0][0].data.showCollectionsRail.should.equal(false)
           done()

--- a/src/desktop/apps/article/routes.ts
+++ b/src/desktop/apps/article/routes.ts
@@ -19,7 +19,7 @@ const { crop, resize } = require("desktop/components/resizer/index.coffee")
 const { stringifyJSONForWeb } = require("desktop/components/util/json.coffee")
 const _Article = require("desktop/models/article.coffee")
 // TODO: update after CollectionsRail a/b test
-const splitTest = require("desktop/components/split_test/index.coffee")
+// const splitTest = require("desktop/components/split_test/index.coffee")
 
 const { SAILTHRU_KEY, SAILTHRU_SECRET } = require("config")
 const sailthru = require("sailthru-client").createSailthruClient(
@@ -128,7 +128,7 @@ export async function index(req, res, next) {
 
     const {
       CURRENT_USER,
-      EDITORIAL_COLLECTIONS_RAIL, // TODO: update after CollectionsRail a/b test
+      EDITORIAL_COLLECTIONS_RAIL_QA, // TODO: update after CollectionsRail a/b test
       IS_MOBILE,
       IS_TABLET,
     } = res.locals.sd
@@ -146,8 +146,9 @@ export async function index(req, res, next) {
     res.locals.sd.RESPONSIVE_CSS = createMediaStyle()
 
     // CollectionsRail a/b test
-    splitTest("editorial_collections_rail").view()
-    const hasCollectionsRail = EDITORIAL_COLLECTIONS_RAIL === 1
+    // splitTest("editorial_collections_rail").view()
+    const hasCollectionsRail =
+      EDITORIAL_COLLECTIONS_RAIL_QA === 1 && req.user && req.user.isAdmin()
     const showCollectionsRail =
       hasCollectionsRail &&
       ["standard", "feature", "news"].includes(article.layout)

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -56,8 +56,8 @@ module.exports = {
     edge: 'v2'
     weighting: 'equal'
 
-  editorial_collections_rail:
-    key: 'editorial_collections_rail'
+  editorial_collections_rail_qa:
+    key: 'editorial_collections_rail_qa'
     outcomes: [
       0
       1


### PR DESCRIPTION
Disables `editorial_collections_rail` test by renaming to `editorial_collections_rail_qa`, and removing `splitTest.view()`.  Also limits displaying new rail to admins only. 