### PR TITLE
Fixes view-in-room transition weirdness

### DIFF
--- a/src/desktop/apps/artwork2/client.tsx
+++ b/src/desktop/apps/artwork2/client.tsx
@@ -92,12 +92,15 @@ mediator.on("openViewInRoom", options => {
       .querySelector("[data-is-default=true]")
       .getBoundingClientRect()
 
-    if (width > height) {
-      newWidth = bounds.width
-      newHeight = height * newWidth / width
-    } else if (height > width) {
+    const imgRatio = newWidth / newHeight
+    const boundsRatio = bounds.width / bounds.height
+
+    if (boundsRatio > imgRatio) {
       newHeight = bounds.height
       newWidth = newHeight * width / height
+    } else if (boundsRatio < imgRatio) {
+      newWidth = bounds.width
+      newHeight = height * newWidth / width
     } else {
       newWidth = bounds.width
       newHeight = newWidth

--- a/src/desktop/components/view_in_room/view.coffee
+++ b/src/desktop/components/view_in_room/view.coffee
@@ -33,7 +33,7 @@ module.exports = class ViewInRoom extends Backbone.View
 
   render: ->
     @__render__()
-    document.body.style.overflowY = 'hidden'
+    @removeScrollbar()
     @cacheSelectors()
     @injectImage()
 
@@ -150,6 +150,27 @@ module.exports = class ViewInRoom extends Backbone.View
   getArtworkDimensions: ->
     @__dimensions__ ?= _.map @dimensions.replace('cm', '').split(' × '), parseFloat
 
+  removeScrollbar: ->
+    $('body').css({
+      'overflow-y': 'hidden',
+      'margin-right': '17px' # to avoid a jump due to scrollbar disappearing
+    })
+
+    $('header').css({
+      'padding-right': '17px'
+    })
+
+  addScrollbar: ->
+    $('body').css({
+      'overflow-y': 'visible',
+      'margin-right': '0px' # to avoid a jump due to scrollbar re-appearing
+    })
+
+    $('header').css({
+      'padding-right': '0px'
+    })
+
+
   remove: ->
     $(window).off 'resize.view-in-room'
     @transitionOut()
@@ -158,6 +179,8 @@ module.exports = class ViewInRoom extends Backbone.View
           @$img.css visibility: 'visible'
         if @$sourceImage
           @$sourceImage.css visibility: 'visible'
-        document.body.style.overflowY = 'visible'
+
+        @addScrollbar()
+
         ViewInRoom.__super__.remove.apply this, arguments
         @trigger 'removed'


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-924

This PR makes a couple of changes to fix weird behavior we were seeing as the image transitions in/out of view in room.
- Updates the logic around whether to constrain the image based on the bounding box width or height (as the viewport changes size, the image can change which side it's "bound" on-- before we were assuming based on the dimensions of the image itself)
- Adds an extra padding to the `body` when we transition in/out to account for a little shift that occurs due to the scrollbar being removed. It appears all browsers have scrollbars that are `17px`, so I went with that.

Before:
![vir-bad](https://user-images.githubusercontent.com/2081340/53897598-79dbb700-4004-11e9-9501-4a115ea2793b.gif)

After:
![vir-good](https://user-images.githubusercontent.com/2081340/53897607-7e07d480-4004-11e9-9405-6ea5ec58fe0e.gif)
