### PR TITLE
Ensure collections rail displays for /news page

### DIFF
--- a/src/desktop/apps/articles/components/App.tsx
+++ b/src/desktop/apps/articles/components/App.tsx
@@ -1,6 +1,8 @@
 import React, { Component } from "react"
 import { ArticleData } from "reaction/Components/Publishing/Typings"
+import { ContextProvider } from "reaction/Artsy"
 import { InfiniteScrollNewsArticle } from "desktop/apps/article/components/InfiniteScrollNewsArticle"
+import { data as sd } from "sharify"
 
 export interface Props {
   articles: ArticleData[]
@@ -10,6 +12,10 @@ export interface Props {
 
 export default class App extends Component<Props, any> {
   render() {
-    return <InfiniteScrollNewsArticle {...this.props} />
+    return (
+      <ContextProvider user={sd.CURRENT_USER}>
+        <InfiniteScrollNewsArticle {...this.props} />
+      </ContextProvider>
+    )
   }
 }

--- a/src/desktop/apps/articles/routes.js
+++ b/src/desktop/apps/articles/routes.js
@@ -17,6 +17,9 @@ import { PARSELY_KEY, PARSELY_SECRET } from "../../config.coffee"
 import { subscribedToEditorial } from "desktop/apps/article/routes"
 import { data as sd } from "sharify"
 
+// TODO: update after CollectionsRail a/b test
+// const splitTest = require("desktop/components/split_test/index.coffee")
+
 // FIXME: Rewire
 let positronql = _positronql
 let topParselyArticles = _topParselyArticles
@@ -135,6 +138,15 @@ export async function news(req, res, next) {
   const isMobile = res.locals.sd.IS_MOBILE
   const renderTime = getCurrentUnixTimestamp()
 
+  // CollectionsRail a/b test
+  // splitTest("editorial_collections_rail").view()
+
+  // TODO: update after CollectionsRail a/b test
+  const showCollectionsRail =
+    res.locals.sd.EDITORIAL_COLLECTIONS_RAIL_QA === 1 &&
+    req.user &&
+    req.user.isAdmin()
+
   try {
     const { articles } = await positronql({
       query: newsArticlesQuery({ limit: 6 }),
@@ -160,6 +172,7 @@ export async function news(req, res, next) {
         articles,
         isMobile,
         renderTime,
+        showCollectionsRail,
       },
     })
 

--- a/src/desktop/apps/articles/test/routes.js
+++ b/src/desktop/apps/articles/test/routes.js
@@ -5,7 +5,7 @@ import fixtures from "desktop/test/helpers/fixtures.coffee"
 import { extend, cloneDeep } from "lodash"
 
 const rewire = require("rewire")("../routes")
-const { articles, section, teamChannel } = rewire
+const { articles, news, section, teamChannel } = rewire
 
 describe("Articles routes", () => {
   let req
@@ -18,10 +18,17 @@ describe("Articles routes", () => {
     req = {
       params: {},
       query: {},
+      user: {
+        isAdmin: sinon.stub().returns(true),
+      },
     }
     res = {
       render: sinon.stub(),
-      locals: { sd: {} },
+      locals: {
+        sd: {
+          EDITORIAL_COLLECTIONS_RAIL_QA: 1,
+        },
+      },
       redirect: sinon.stub(),
       backboneError: sinon.stub(),
     }
@@ -61,6 +68,20 @@ describe("Articles routes", () => {
     it("requests less than 50 articles", () => {
       articles(req, res, next).then(() => {
         positronql.args[0][0].query.should.containEql("limit: 50")
+      })
+    })
+  })
+
+  describe("#new", () => {
+    it("correctly sets showCollectionsRail", () => {
+      rewire.__set__(
+        "positronql",
+        sinon.stub().returns(Promise.resolve({ articles }))
+      )
+      const stitch = sinon.stub()
+      rewire.__set__("stitch", stitch)
+      news(req, res, next).then(() => {
+        stitch.args[0][0].data.showCollectionsRail.should.equal(true)
       })
     })
   })

--- a/src/desktop/apps/articles/test/routes.js
+++ b/src/desktop/apps/articles/test/routes.js
@@ -72,7 +72,7 @@ describe("Articles routes", () => {
     })
   })
 
-  describe("#new", () => {
+  describe("#news", () => {
     it("correctly sets showCollectionsRail", () => {
       rewire.__set__(
         "positronql",


### PR DESCRIPTION
This PR conditionally adds the `showCollectionsRail` prop to `/news` pages which are different then the`/news/:id` route in the article app. It also wraps the `<InfiniteScrollNewsArticle>` component with a ContextProvider which is need to make the relay query in reaction.

![screen shot 2019-03-06 at 5 29 54 pm](https://user-images.githubusercontent.com/5201004/53918772-defbd080-4035-11e9-901d-5c7d06593d74.png)
