### PR TITLE
Fix JSON page resolution

### DIFF
--- a/src/desktop/components/json_page/routes.coffee
+++ b/src/desktop/components/json_page/routes.coffee
@@ -1,3 +1,6 @@
+path = require 'path'
+fs = require 'fs'
+
 module.exports = (page) ->
   data: (req, res, next) ->
     page.get (err, data) ->
@@ -12,7 +15,8 @@ module.exports = (page) ->
       res.locals.sd.PATHS = page.paths
 
       # Render the template irrespective of app/views context
-      template = require('jade').compileFile(require.resolve './templates/index.jade')
+      file = path.resolve(__dirname, './templates/index.jade')
+      template = require('jade').compileFile(file)
       res.write template(res.locals) # Pass locals that were set up in middlewares
       res.end()
 

--- a/src/desktop/components/json_page/update.coffee
+++ b/src/desktop/components/json_page/update.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore'
 fs = require 'fs'
+path = require 'path'
 inquirer = require 'inquirer'
 JSONPage = require './index'
 sd = require('sharify').data
@@ -8,7 +9,7 @@ sd = require('sharify').data
 bucket = sd.S3_BUCKET
 
 try
-  fixture = require.resolve path
+  fixture = path.resolve __dirname, path
 catch
   return console.log 'Cannot find the file you want to update.'
 

--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -135,6 +135,7 @@ module.exports =
   VOLLEY_ENDPOINT: null
   WEBFONT_URL: 'http://webfonts.artsy.net'
   ALLOWED_VANITY_ASSETS: ''
+  VERBOSE_LOGGING: false
 
 # Override any values with env variables if they exist.
 # You can set JSON-y values for env variables as well such as "true" or

--- a/src/lib/middleware/error_handler.coffee
+++ b/src/lib/middleware/error_handler.coffee
@@ -1,5 +1,5 @@
 path = require 'path'
-{ NODE_ENV } = require '../../config'
+{ NODE_ENV, VERBOSE_LOGGING } = require '../../config'
 { argv } = require('yargs') # --verbose flag, passed in on boot
 { IpDeniedError } = require('express-ipfilter')
 
@@ -9,13 +9,13 @@ module.exports = (err, req, res, next) ->
     '../../desktop/components/error_handler/index.jade'
   )
 
-  isDevelopment = argv.verbose or NODE_ENV is 'development'
+  enableLogging = argv.verbose or NODE_ENV is 'development' or VERBOSE_LOGGING is true
   code = 504 if req.timedout
   code ||= err.status || 500
 
   code = 401 if err instanceof IpDeniedError
 
-  if isDevelopment
+  if enableLogging
     message = err.message || err.text || err.toString()
     detail = err.stack
 

--- a/src/lib/middleware/error_handler.coffee
+++ b/src/lib/middleware/error_handler.coffee
@@ -9,7 +9,7 @@ module.exports = (err, req, res, next) ->
     '../../desktop/components/error_handler/index.jade'
   )
 
-  enableLogging = argv.verbose or NODE_ENV is 'development' or VERBOSE_LOGGING is true
+  enableLogging = NODE_ENV is 'development' or argv.verbose or VERBOSE_LOGGING is true
   code = 504 if req.timedout
   code ||= err.status || 500
 


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/BUGS-780.

There was a slight difference between how Webpack handles `require.resolve` and how node handles it, which was leading to an issue where a file lookupID !== an actual file, when running on node. By swapping it out with the more conventional form it fixed the problem.  

Also adds a `VERBOSE_LOGGING` flag that can be toggled on to display errors in our logs and error page outside of `NODE_ENV=development`, vs just posting the status code. 