### PR TITLE
Make stitch reloadable

### DIFF
--- a/src/desktop/index.js
+++ b/src/desktop/index.js
@@ -1,6 +1,18 @@
 import { data as sd } from "sharify"
+import { middleware as stitchMiddleware } from "@artsy/stitch/dist/internal/middleware"
+import * as globalReactModules from "desktop/components/react/stitch_components"
 
 const app = (module.exports = require("express")())
+
+// Configure stitch SSR functionality. Mounted here (rather than in setup) so
+// changes to stitched code can be hot reloaded.
+// See: https://github.com/artsy/stitch/tree/master/src/internal for more info.
+app.use(
+  stitchMiddleware({
+    modules: globalReactModules,
+    wrapper: globalReactModules.StitchWrapper,
+  })
+)
 
 // NOTE:
 // App order matters as some apps establish logic that is shared inside of subapps.

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -43,10 +43,7 @@ import CurrentUser from "./current_user"
 import splitTestMiddleware from "../desktop/components/split_test/middleware"
 import marketingModals from "./middleware/marketing_modals"
 import { addIntercomUserHash } from "./middleware/intercom"
-import { middleware as stitchMiddleware } from "@artsy/stitch/dist/internal/middleware"
-import * as globalReactModules from "desktop/components/react/stitch_components"
 import compression from "compression"
-
 import { assetMiddleware } from "./middleware/assetMiddleware"
 import { isDevelopment, isProduction } from "lib/environment"
 
@@ -223,15 +220,6 @@ export default function(app) {
   app.use(unsupportedBrowserCheck)
   app.use(splitTestMiddleware)
   app.use(addIntercomUserHash)
-
-  // Configure stitch SSR functionality. See: https://github.com/artsy/stitch/tree/master/src/internal
-  // for more info.
-  app.use(
-    stitchMiddleware({
-      modules: globalReactModules,
-      wrapper: globalReactModules.StitchWrapper,
-    })
-  )
 
   // Routes for pinging system time and up
   app.get("/system/time", (req, res) =>

--- a/src/mobile/index.js
+++ b/src/mobile/index.js
@@ -1,4 +1,17 @@
+import { middleware as stitchMiddleware } from "@artsy/stitch/dist/internal/middleware"
+import * as globalReactModules from "desktop/components/react/stitch_components"
+
 const app = (module.exports = require("express")())
+
+// Configure stitch SSR functionality. Mounted here (rather than in setup) so
+// changes to stitched code can be hot reloaded.
+// See: https://github.com/artsy/stitch/tree/master/src/internal for more info.
+app.use(
+  stitchMiddleware({
+    modules: globalReactModules,
+    wrapper: globalReactModules.StitchWrapper,
+  })
+)
 
 app.use(require("./apps/auth"))
 app.use(require("./apps/page"))


### PR DESCRIPTION
While stitching in the new nav bar I noticed that changes weren't being reflected until I stopped and restarted the server. This was due to stitch's middleware being mounted with [the rest our middleware](https://github.com/artsy/force/blob/master/src/lib/setup.js), which sits just below [express-reloadable](https://github.com/artsy/express-reloadable)'s hot-swapping boundary -- [`src/desktop`](https://github.com/artsy/force/blob/master/src/lib/setup.js#L263) (and `src/mobile`). 

By mounting inside of `desktop/index` (and `mobile/index`) -- where our application-level express sub-apps are mounted -- it flips on hot-swaps so that changes are immediately reflected without a server restart.  

This  was a regression introduced in https://github.com/artsy/force/pull/3283.