### PR TITLE
[Trivial] Update newsNav positionTop

### DIFF
--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -279,7 +279,7 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
 
     return (
       <NewsContainer isMobile={isMobile || false} id="article-root">
-        <NewsNav date={date} positionTop={61} />
+        <NewsNav date={date} positionTop={56} />
         {this.renderContent()}
         {this.renderWaypoint()}
       </NewsContainer>


### PR DESCRIPTION
The main menu bar height has changed, updated the `NewsNav` position top to prevent the appearance of a gap between `NewsNav` and main nav.

<img width="885" alt="Screen Shot 2019-03-11 at 5 14 33 PM" src="https://user-images.githubusercontent.com/1497424/54160545-3b8c3080-4426-11e9-838f-90a483252287.png">
