### PR TITLE
change gallery partnerships url to point to 'https://partners.artsy.net'

### DIFF
--- a/src/desktop/components/main_layout/footer/upper.jade
+++ b/src/desktop/components/main_layout/footer/upper.jade
@@ -17,7 +17,7 @@
     a( href='/about/press' ) Press
   .mlf-upper-column
     h4 Partnering with Artsy
-    a.gallery-partnership-link( data-context='footer' href='/gallery-partnerships' ) Artsy for Galleries
+    a.gallery-partnership-link( data-context='footer' href='https://partners.artsy.net/' ) Artsy for Galleries
     a( href='/institution-partnerships' ) Artsy for Museums
     a( href='/auction-partnerships' ) Artsy for Auctions
   .mlf-upper-column-aside

--- a/src/desktop/components/main_layout/header/templates/more.jade
+++ b/src/desktop/components/main_layout/header/templates/more.jade
@@ -12,4 +12,4 @@ span.mlh-top-nav-link.hover-pulldown( data-mode='hover' )
       a.mlh-pulldown-top-link-persistent( href='/institutions', class= activeClass('/institutions') ) Museums
     hr.mlh-pulldown-top
     div.mlh-pulldown-bottom
-      a.gallery-partnership-link.mlh-pulldown-bottom-link( data-context='global nav dropdown' href='/gallery-partnerships' ) Artsy for Galleries
+      a.gallery-partnership-link.mlh-pulldown-bottom-link( data-context='global nav dropdown' href='https://partners.artsy.net/' ) Artsy for Galleries


### PR DESCRIPTION
This request: https://artsyproduct.atlassian.net/browse/GALL-1479

I believe we have this same link in footer on artwork and artist pages. My guess is that it has to be changed there as well. Will double check with product but that would need to be changed in reaction  either way.

So for now - just header. Also I believe this header is now being rebuilt. Need to make sure that new version points to the correct link.

Also wondering if there is bunch of code in 'gallery-partnerships' that we can clean up. But not sure is it is used anywhere else. So not changing anything but link in this pr:)