### PR TITLE
@sweir27 => Remove unneeded analytics code referenced by old artwork page

### DIFF
--- a/src/desktop/analytics/criteo.js
+++ b/src/desktop/analytics/criteo.js
@@ -50,63 +50,6 @@ if (pageType === "auctions") {
       )
     })
   }
-} else if (pageType === "artwork" && !pathSplit[3]) {
-  // https://www.artsy.net/artwork/:artwork_id - (AUCTIONS & ARTWORKS viewItem)
-  //              0          1          2
-  //
-  // We cannot send both ids on product pages, so, send the Auctions account ID
-  // if the artwork is in an auction, otherwise send the Artworks account ID.
-  if (sd.AUCTION && sd.AUCTION.artwork_id) {
-    window.criteo_q.push(
-      { event: "setAccount", account: sd.CRITEO_AUCTIONS_ACCOUNT_NUMBER },
-      { event: "setSiteType", type: "m" },
-      { event: "viewItem", item: sd.AUCTION && sd.AUCTION.artwork_id }
-    )
-  } else {
-    window.criteo_q.push(
-      { event: "setAccount", account: sd.CRITEO_AUCTIONS_ACCOUNT_NUMBER },
-      { event: "setSiteType", type: "d" },
-      { event: "setEmail", email: userEmail },
-      { event: "viewItem", item: sd.COMMERCIAL.artwork._id }
-    )
-  }
-  // ARTWORKS viewBasket
-  analyticsHooks.on("inquiry_questionnaire:modal:opened", function(data) {
-    window.criteo_q.push(
-      { event: "setAccount", account: sd.CRITEO_AUCTIONS_ACCOUNT_NUMBER },
-      { event: "setSiteType", type: "d" },
-      { event: "setEmail", email: userEmail },
-      {
-        event: "viewBasket",
-        item: [
-          {
-            id: sd.COMMERCIAL.artwork._id,
-            price: sd.COMMERCIAL.artwork.price,
-            quantity: 1,
-          },
-        ],
-      }
-    )
-  })
-  // ARTWORKS trackTransaction
-  analyticsHooks.on("inquiry_questionnaire:inquiry:sync", function(data) {
-    window.criteo_q.push(
-      { event: "setAccount", account: sd.CRITEO_AUCTIONS_ACCOUNT_NUMBER },
-      { event: "setSiteType", type: "d" },
-      { event: "setEmail", email: userEmail },
-      {
-        event: "trackTransaction",
-        id: data.inquiry.id,
-        item: [
-          {
-            id: sd.COMMERCIAL.artwork._id,
-            price: sd.COMMERCIAL.artwork.price,
-            quantity: 1,
-          },
-        ],
-      }
-    )
-  })
 } else {
   if (pageType === "collect") {
     // https://www.artsy.net/collect - (ARTWORKS viewHome)

--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -10,25 +10,9 @@ import { reportLoadTimeToVolley } from "lib/volley"
 const pageType = window.sd.PAGE_TYPE || window.location.pathname.split("/")[1]
 var properties = { path: location.pathname }
 
-if (pageType == "artwork") {
-  properties["acquireable"] = sd.ARTWORK.is_acquireable
-  properties["offerable"] = sd.ARTWORK.is_offerable
-  properties["availability"] = sd.ARTWORK.availability
-  properties["price_listed"] = sd.ARTWORK.price && sd.ARTWORK.price.length > 0
-
-  if (sd.ARTWORK.is_acquireable || sd.ARTWORK.is_in_auction) {
-    window.addEventListener("load", function() {
-      // marketing requirement for dynamic retargeting
-      window.analytics.track("Viewed Product", { id: sd.ARTWORK._id })
-    })
-  }
-}
-
 // We exclude these routes from analytics.page calls because they're already
 // taken care of in Reaction.
-// FIXME: When new artwork page is fully rolled out, and goes back to an
-// `artwork` page type, remove `new-artwork` from here.
-const excludedRoutes = ["orders", "new-artwork"]
+const excludedRoutes = ["orders"]
 if (!excludedRoutes.includes(pageType)) {
   analytics.page(properties, { integrations: { Marketo: false } })
 }


### PR DESCRIPTION
There's an open question in Slack about the removal of this Criteo thing.

However, for now, removing it (and unblocking Force deploys) makes sense since it wasn't actually being exercised at all with the new page (so it wasn't actually being used for a while, and thus removing it here doesn't change current production behavior).