### PR TITLE
#migration Update kubernetes yaml files for up-to-date dns config and shared nginx config

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -62,7 +62,11 @@ spec:
                 configMapKeyRef:
                   name: nginx-config
                   key: force
-      dnsPolicy: Default
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -63,14 +63,17 @@ spec:
                 server {
                     listen *:8080;
                     location / {
-                        proxy_set_header Host staging.artsy.net;
                         proxy_redirect off;
                         proxy_read_timeout 60;
                         proxy_send_timeout 60;
                         proxy_pass http://force;
                     }
                 }
-      dnsPolicy: Default
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -56,19 +56,10 @@ spec:
                 command: ["/usr/sbin/nginx", "-s", "quit"]
           env:
             - name: "NGINX_DEFAULT_CONF"
-              value: >
-                upstream force {
-                    server 127.0.0.1:5000;
-                }
-                server {
-                    listen *:8080;
-                    location / {
-                        proxy_redirect off;
-                        proxy_read_timeout 60;
-                        proxy_send_timeout 60;
-                        proxy_pass http://force;
-                    }
-                }
+              valueFrom:
+                configMapKeyRef:
+                  name: nginx-config
+                  key: force
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:


### PR DESCRIPTION
Updating DNS config for production to Force uses the internal Kubernetes DNS server (we had to work around this in an earlier version of Kubernetes but now all apps should be using this config).  With this set up we can redirect all Force backend -> Metaphysics traffic internally with https://github.com/artsy/metaphysics/pull/1581 and https://github.com/artsy/substance/pull/115 rolled out.

Also I moved the Nginx config to the shared configmap `nginx-config` like we have set up in production

## Migration 

`hokusai production update` 

Staging already applied