### PR TITLE
@sweir27 => [Artwork] Reinstate artwork download functionality for admins

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,6 @@
   "[json]": {
     "editor.formatOnSave": false
   },
-  "editor.formatOnSave": true,
   "typescript.tsdk": "./node_modules/typescript/lib",
   "debug.node.autoAttach": "on",
   "cSpell.ignoreWords": [],
@@ -27,5 +26,6 @@
     "typings",
     "**/*.snap",
     "**/*.story.tsx"
-  ]
+  ],
+  "editor.formatOnSave": true
 }

--- a/src/desktop/apps/artwork/__tests__/routes.jest.ts
+++ b/src/desktop/apps/artwork/__tests__/routes.jest.ts
@@ -1,0 +1,70 @@
+import { handleDownload } from "../server"
+
+const Artwork = require("desktop/models/artwork.coffee")
+
+jest.mock("superagent", () => {
+  return {
+    get: () => {
+      return { set: jest.fn() }
+    },
+  }
+})
+
+jest.mock("desktop/models/artwork.coffee")
+
+describe("Request handler for download artwork route", () => {
+  let req
+  let res
+  let next
+  const pipeMock = jest.fn()
+
+  describe("/artwork/:artworkID/download/:filename", () => {
+    beforeEach(() => {
+      req = {
+        params: { artworkID: "percy-painting" },
+        user: { get: () => "token" },
+        pipe: () => {
+          return { pipe: pipeMock }
+        },
+      }
+
+      next = jest.fn()
+    })
+
+    it("serves a 403", done => {
+      Artwork.mockImplementation(() => {
+        return {
+          isDownloadable: () => {
+            return false
+          },
+          fetch: () => jest.fn(),
+        }
+      })
+      handleDownload(req, res, next).then(() => {
+        expect(next).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: "Not authorized to download this image.",
+            status: 403,
+          })
+        )
+        done()
+      })
+    })
+
+    it("pipes the image when the request is authorized", done => {
+      Artwork.mockImplementation(() => {
+        return {
+          isDownloadable: () => {
+            return true
+          },
+          fetch: () => jest.fn(),
+          downloadableUrl: () => jest.fn(),
+        }
+      })
+      handleDownload(req, res, next).then(() => {
+        expect(pipeMock).toHaveBeenCalled()
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
Nice catch that would be lost this functionality when the old artwork app went away.

~~I'm...struggling a little bit with the tests here :(~~ (tests in!) , so this can be merged in the meantime if admins need the functionality back right away.