### PR TITLE
Compile CSS on CI

### DIFF
--- a/webpack/envs/productionConfig.js
+++ b/webpack/envs/productionConfig.js
@@ -10,10 +10,9 @@ const {
   BUILD_SERVER,
   NODE_ENV,
   isProduction,
-  isCI,
 } = require("../../src/lib/environment")
 
-const buildCSS = isProduction && !(isCI || BUILD_SERVER)
+const buildCSS = isProduction && !BUILD_SERVER
 
 exports.productionConfig = {
   mode: NODE_ENV,


### PR DESCRIPTION
Noticed the other day that when running builds on CI it's good to run CSS compilation as well, as we have a lot of complex paths in old code that when modified could break a build on deploy. This adds a bit of time savings to prevent that from occurring. 