### PR TITLE
refactor to fire viewed experiment event from the client

### DIFF
--- a/src/desktop/apps/article/components/App.tsx
+++ b/src/desktop/apps/article/components/App.tsx
@@ -7,6 +7,7 @@ import { EditButton } from "desktop/apps/article/components/EditButton"
 import { ArticleLayout } from "./layouts/Article"
 import { data as sd } from "sharify"
 import { ArticleProps } from "@artsy/reaction/dist/Components/Publishing/Article"
+const splitTest = require("desktop/components/split_test/index.coffee")
 
 export interface AppProps extends ArticleProps {
   templates?: {
@@ -16,6 +17,13 @@ export interface AppProps extends ArticleProps {
 }
 
 export class App extends React.Component<AppProps> {
+  // TODO: Remove after CollectionsRail a/b test
+  componentDidMount() {
+    if (["standard", "feature", "news"].includes(this.props.article.layout)) {
+      splitTest("editorial_collections_rail").view()
+    }
+  }
+
   getArticleLayout = () => {
     const { article } = this.props
 

--- a/src/desktop/apps/article/routes.ts
+++ b/src/desktop/apps/article/routes.ts
@@ -18,8 +18,6 @@ const markdown = require("desktop/components/util/markdown.coffee")
 const { crop, resize } = require("desktop/components/resizer/index.coffee")
 const { stringifyJSONForWeb } = require("desktop/components/util/json.coffee")
 const _Article = require("desktop/models/article.coffee")
-// TODO: update after CollectionsRail a/b test
-const splitTest = require("desktop/components/split_test/index.coffee")
 
 const { SAILTHRU_KEY, SAILTHRU_SECRET } = require("config")
 const sailthru = require("sailthru-client").createSailthruClient(
@@ -146,7 +144,6 @@ export async function index(req, res, next) {
     res.locals.sd.RESPONSIVE_CSS = createMediaStyle()
 
     // CollectionsRail a/b test
-    splitTest("editorial_collections_rail").view()
     const hasCollectionsRail = EDITORIAL_COLLECTIONS_RAIL === "1"
     const showCollectionsRail =
       hasCollectionsRail &&

--- a/src/desktop/apps/articles/components/App.tsx
+++ b/src/desktop/apps/articles/components/App.tsx
@@ -4,13 +4,24 @@ import { ContextProvider } from "reaction/Artsy"
 import { InfiniteScrollNewsArticle } from "desktop/apps/article/components/InfiniteScrollNewsArticle"
 import { data as sd } from "sharify"
 
+// TODO: update after CollectionsRail a/b test
+const splitTest = require("desktop/components/split_test/index.coffee")
+
 export interface Props {
   articles: ArticleData[]
   isMobile: boolean
   marginTop: string
+  isNewsLayout?: boolean
 }
 
 export default class App extends Component<Props, any> {
+  // TODO: Remove after CollectionsRail a/b test
+  componentDidMount() {
+    if (this.props.isNewsLayout) {
+      splitTest("editorial_collections_rail").view()
+    }
+  }
+
   render() {
     return (
       <ContextProvider user={sd.CURRENT_USER}>

--- a/src/desktop/apps/articles/routes.ts
+++ b/src/desktop/apps/articles/routes.ts
@@ -18,9 +18,6 @@ const Articles = require("desktop/collections/articles.coffee")
 const Channel = require("desktop/models/channel.coffee")
 const Section = require("desktop/models/section.coffee")
 
-// TODO: update after CollectionsRail a/b test
-const splitTest = require("desktop/components/split_test/index.coffee")
-
 // FIXME: Rewire
 let positronql = _positronql
 let topParselyArticles = _topParselyArticles
@@ -139,7 +136,7 @@ export async function news(_req, res, next) {
   const renderTime = getCurrentUnixTimestamp()
 
   // CollectionsRail a/b test
-  splitTest("editorial_collections_rail").view()
+  const isNewsLayout = true
 
   // TODO: update after CollectionsRail a/b test
   const showCollectionsRail = res.locals.sd.EDITORIAL_COLLECTIONS_RAIL === "1"
@@ -170,6 +167,7 @@ export async function news(_req, res, next) {
         isMobile,
         renderTime,
         showCollectionsRail,
+        isNewsLayout,
       },
     })
 


### PR DESCRIPTION
Addresses: [GROW-1161](https://artsyproduct.atlassian.net/browse/GROW-1161)

When we launched the editorial collections rail test we were firing the `Experiment Viewed` event from the server when we should be firing this event from the client so that we have access to the global `analytics` object. This PR move that call to the client.

<img width="398" alt="Screen Shot 2019-03-15 at 11 59 56 AM" src="https://user-images.githubusercontent.com/5201004/54444858-f7e14180-4719-11e9-9ff7-f56e695abab0.png">
