### PR TITLE
configure artist collections rail a/b test

### DIFF
--- a/src/desktop/apps/artist/client.tsx
+++ b/src/desktop/apps/artist/client.tsx
@@ -13,7 +13,10 @@ buildClientApp({
   context: {
     user: sd.CURRENT_USER,
     mediator,
-    showCollectionsRail: sd.ARTIST_COLLECTIONS_RAIL_QA === "experiment", // TODO: update after Artist Collections Rail a/b test
+    showCollectionsRail:
+      sd.ARTIST_COLLECTIONS_RAIL_QA === "experiment" &&
+      sd.CURRENT_USER &&
+      sd.CURRENT_USER.type === "Admin", // TODO: update after Artist Collections Rail a/b test
   },
 })
   .then(({ ClientApp }) => {

--- a/src/desktop/apps/artist/client.tsx
+++ b/src/desktop/apps/artist/client.tsx
@@ -13,6 +13,7 @@ buildClientApp({
   context: {
     user: sd.CURRENT_USER,
     mediator,
+    showCollectionsRail: sd.ARTIST_COLLECTIONS_RAIL_QA === "experiment", // TODO: update after Artist Collections Rail a/b test
   },
 })
   .then(({ ClientApp }) => {

--- a/src/desktop/apps/artist/server.tsx
+++ b/src/desktop/apps/artist/server.tsx
@@ -15,7 +15,10 @@ app.get(
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const user = req.user && req.user.toJSON()
-      const { ARTIST_INSIGHTS } = res.locals.sd
+      const {
+        ARTIST_INSIGHTS,
+        ARTIST_COLLECTIONS_RAIL_QA, // TODO: update after Artist Collections Rail a/b test
+      } = res.locals.sd
       const {
         bodyHTML,
         redirect,
@@ -30,6 +33,7 @@ app.get(
         context: {
           ...buildServerAppContext(req, res),
           ARTIST_INSIGHTS,
+          showCollectionsRail: ARTIST_COLLECTIONS_RAIL_QA === "experiment", // TODO: update after Artist Collections Rail a/b test
         },
       })
 

--- a/src/desktop/apps/artist/server.tsx
+++ b/src/desktop/apps/artist/server.tsx
@@ -33,7 +33,10 @@ app.get(
         context: {
           ...buildServerAppContext(req, res),
           ARTIST_INSIGHTS,
-          showCollectionsRail: ARTIST_COLLECTIONS_RAIL_QA === "experiment", // TODO: update after Artist Collections Rail a/b test
+          showCollectionsRail:
+            ARTIST_COLLECTIONS_RAIL_QA === "experiment" &&
+            req.user &&
+            req.user.isAdmin(), // TODO: update after Artist Collections Rail a/b test
         },
       })
 

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -51,7 +51,7 @@ module.exports = {
       'control'
       'experiment'
     ]
-    control_group: 0
-    edge: 1
+    control_group: 'control'
+    edge: 'experiment'
     weighting: 'equal'
 }

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -44,4 +44,14 @@ module.exports = {
     control_group: 0
     edge: 1
     weighting: 'equal'
+
+  artist_collections_rail_qa:
+    key: 'artist_collections_rail_qa'
+    outcomes: [
+      'control'
+      'experiment'
+    ]
+    control_group: 0
+    edge: 1
+    weighting: 'equal'
 }


### PR DESCRIPTION
Addresses: [GROW-1139](https://artsyproduct.atlassian.net/browse/GROW-1139)

Sets up the artist collections rail test in force. This uses showCollectionsRail to determine when to show the rails on the artist page.

Related to https://github.com/artsy/reaction/pull/2172