### PR TITLE
@dblandin => [SearchResults] Match /search2* to make sure sub-tabs are matched

### DIFF
--- a/src/desktop/apps/search2/server.tsx
+++ b/src/desktop/apps/search2/server.tsx
@@ -7,44 +7,47 @@ import express, { Request, Response, NextFunction } from "express"
 
 export const app = express()
 
-app.get("/search2", async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const {
-      bodyHTML,
-      redirect,
-      status,
-      headTags,
-      styleTags,
-      scripts,
-    } = await buildServerApp({
-      routes,
-      url: req.url,
-      userAgent: req.header("User-Agent"),
-      context: buildServerAppContext(req, res),
-    })
-
-    if (redirect) {
-      res.redirect(302, redirect.url)
-      return
-    }
-
-    const layout = await stitch({
-      basePath: __dirname,
-      layout: "../../components/main_layout/templates/react_redesign.jade",
-      blocks: {
-        head: () => <React.Fragment>{headTags}</React.Fragment>,
-        body: bodyHTML,
-      },
-      locals: {
-        ...res.locals,
-        assetPackage: "search2",
-        scripts,
+app.get(
+  "/search2*",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const {
+        bodyHTML,
+        redirect,
+        status,
+        headTags,
         styleTags,
-      },
-    })
+        scripts,
+      } = await buildServerApp({
+        routes,
+        url: req.url,
+        userAgent: req.header("User-Agent"),
+        context: buildServerAppContext(req, res),
+      })
 
-    res.status(status).send(layout)
-  } catch (error) {
-    next(error)
+      if (redirect) {
+        res.redirect(302, redirect.url)
+        return
+      }
+
+      const layout = await stitch({
+        basePath: __dirname,
+        layout: "../../components/main_layout/templates/react_redesign.jade",
+        blocks: {
+          head: () => <React.Fragment>{headTags}</React.Fragment>,
+          body: bodyHTML,
+        },
+        locals: {
+          ...res.locals,
+          assetPackage: "search2",
+          scripts,
+          styleTags,
+        },
+      })
+
+      res.status(status).send(layout)
+    } catch (error) {
+      next(error)
+    }
   }
-})
+)


### PR DESCRIPTION
Currently if you go to https://staging.artsy.net/search2/artists?term=andy directly you get a 404, whereas navigating via tabs (which updates the URL), it's fine.

Just tweaks our matching to make sure we match all `/search2` routes.