### PR TITLE
Update editorial_collection_rail test name/outcomes

### DIFF
--- a/src/desktop/apps/article/__tests__/routes.test.js
+++ b/src/desktop/apps/article/__tests__/routes.test.js
@@ -426,16 +426,16 @@ describe("Article Routes", () => {
         )
       })
 
-      it("Sets showCollectionsRail when EDITORIAL_COLLECTIONS_RAIL is true", done => {
-        res.locals.sd.EDITORIAL_COLLECTIONS_RAIL = "1"
+      it("Sets showCollectionsRail when EDITORIAL_COLLECTION_RAIL is experiment", done => {
+        res.locals.sd.EDITORIAL_COLLECTION_RAIL = "experiment"
         index(req, res, next).then(() => {
           stitch.args[0][0].data.showCollectionsRail.should.equal(true)
           done()
         })
       })
 
-      it("Sets showCollectionsRail when EDITORIAL_COLLECTIONS_RAIL is false", done => {
-        res.locals.sd.EDITORIAL_COLLECTIONS_RAIL = "0"
+      it("Sets showCollectionsRail when EDITORIAL_COLLECTION_RAIL is not experiment", done => {
+        res.locals.sd.EDITORIAL_COLLECTION_RAIL = "control"
         index(req, res, next).then(() => {
           stitch.args[0][0].data.showCollectionsRail.should.equal(false)
           done()

--- a/src/desktop/apps/article/components/App.tsx
+++ b/src/desktop/apps/article/components/App.tsx
@@ -20,7 +20,7 @@ export class App extends React.Component<AppProps> {
   // TODO: Remove after CollectionsRail a/b test
   componentDidMount() {
     if (["standard", "feature", "news"].includes(this.props.article.layout)) {
-      splitTest("editorial_collections_rail").view()
+      splitTest("editorial_collection_rail").view()
     }
   }
 

--- a/src/desktop/apps/article/routes.ts
+++ b/src/desktop/apps/article/routes.ts
@@ -126,7 +126,7 @@ export async function index(req, res, next) {
 
     const {
       CURRENT_USER,
-      EDITORIAL_COLLECTIONS_RAIL, // TODO: update after CollectionsRail a/b test
+      EDITORIAL_COLLECTION_RAIL, // TODO: update after CollectionsRail a/b test
       IS_MOBILE,
       IS_TABLET,
     } = res.locals.sd
@@ -144,7 +144,7 @@ export async function index(req, res, next) {
     res.locals.sd.RESPONSIVE_CSS = createMediaStyle()
 
     // CollectionsRail a/b test
-    const hasCollectionsRail = EDITORIAL_COLLECTIONS_RAIL === "1"
+    const hasCollectionsRail = EDITORIAL_COLLECTION_RAIL === "experiment"
     const showCollectionsRail =
       hasCollectionsRail &&
       ["standard", "feature", "news"].includes(article.layout)

--- a/src/desktop/apps/articles/components/App.tsx
+++ b/src/desktop/apps/articles/components/App.tsx
@@ -18,7 +18,7 @@ export default class App extends Component<Props, any> {
   // TODO: Remove after CollectionsRail a/b test
   componentDidMount() {
     if (this.props.isNewsLayout) {
-      splitTest("editorial_collections_rail").view()
+      splitTest("editorial_collection_rail").view()
     }
   }
 

--- a/src/desktop/apps/articles/routes.ts
+++ b/src/desktop/apps/articles/routes.ts
@@ -139,7 +139,8 @@ export async function news(_req, res, next) {
   const isNewsLayout = true
 
   // TODO: update after CollectionsRail a/b test
-  const showCollectionsRail = res.locals.sd.EDITORIAL_COLLECTIONS_RAIL === "1"
+  const showCollectionsRail =
+    res.locals.sd.EDITORIAL_COLLECTION_RAIL === "experiment"
 
   try {
     const { articles } = await positronql({

--- a/src/desktop/apps/articles/test/routes.js
+++ b/src/desktop/apps/articles/test/routes.js
@@ -26,7 +26,7 @@ describe("Articles routes", () => {
       render: sinon.stub(),
       locals: {
         sd: {
-          EDITORIAL_COLLECTIONS_RAIL: 1,
+          EDITORIAL_COLLECTION_RAIL: "experiment",
         },
       },
       redirect: sinon.stub(),

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -35,11 +35,11 @@ module.exports = {
     edge: 'v2'
     weighting: 'equal'
 
-  editorial_collections_rail:
-    key: 'editorial_collections_rail'
+  editorial_collection_rail:
+    key: 'editorial_collection_rail'
     outcomes: [
-      0
-      1
+      'control'
+      'experiment'
     ]
     control_group: 0
     edge: 1


### PR DESCRIPTION
- Renames outcomes from boolean 0/1 to control/experiment
- Renames test to `editorial_collection_rail` (no s) to prevent duplicate cookies
