### PR TITLE
DISCO-856: Exclude another route taken care of in Reaction

### DIFF
--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -12,7 +12,7 @@ var properties = { path: location.pathname }
 
 // We exclude these routes from analytics.page calls because they're already
 // taken care of in Reaction.
-const excludedRoutes = ["orders"]
+const excludedRoutes = ["artwork", "orders"]
 if (!excludedRoutes.includes(pageType)) {
   analytics.page(properties, { integrations: { Marketo: false } })
 }


### PR DESCRIPTION
With 02b5cc41cb149e3a46a2b830b9b80024328a2484 we got artwork page tracking duplicated so this just adds it back to the exclude list.