### PR TITLE
[A/B Test] Add instant.page A/B test #migration

### DIFF
--- a/src/desktop/components/main_layout/templates/instant-page.jade
+++ b/src/desktop/components/main_layout/templates/instant-page.jade
@@ -1,4 +1,4 @@
-if sd.ENABLE_INSTANT_PAGE
+if sd.INSTANT_PAGE_AB_TEST === 'experiment'
   //- Prefetch links on hover. See: https://instant.page/
   script( type="text/javascript" ).
     /*! instant.page v1.2.1 - (C) 2019 Alexandre Dieulot - https://instant.page/license */

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -34,4 +34,14 @@ module.exports = {
     control_group: 'control'
     edge: 'experiment'
     weighting: 'equal'
+
+  instant_page_ab_test:
+    key: 'instant_page_ab_test'
+    outcomes: [
+      'control'
+      'experiment'
+    ]
+    control_group: 'control'
+    edge: 'experiment'
+    weighting: 'equal'
 }

--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -33,7 +33,6 @@ module.exports =
   DISABLE_IMAGE_PROXY: false
   EDITORIAL_ADMINS: ''
   EDITORIAL_CTA_BANNER_IMG: 'http://files.artsy.net/images/iphone_email.png'
-  ENABLE_INSTANT_PAGE: false
   ENABLE_MEMORY_PROFILING: false
   ENABLE_NEW_NAVBAR: false,
   ENABLE_WEB_CRAWLING: false

--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -16,6 +16,7 @@ const templateModules = require("./template_modules.coffee")
 const listenForInvert = require("../components/eggs/invert/index.coffee")
 const listenForBounce = require("../components/eggs/bounce/index.coffee")
 const confirmation = require("../components/confirmation/index.coffee")
+const splitTest = require("desktop/components/split_test/index.coffee")
 
 Backbone.$ = $
 
@@ -37,6 +38,9 @@ export function globalClientSetup() {
 
   syncAuth()
   mediator.on("auth:logout", logoutEventHandler)
+
+  // TODO: Remove A/B test
+  splitTest("instant_page_ab_test").view()
 }
 
 export function syncAuth() {

--- a/src/lib/setup_sharify.js
+++ b/src/lib/setup_sharify.js
@@ -43,7 +43,6 @@ sharify.data = _.extend(
     "EDITORIAL_PATHS",
     "EMAIL_SIGNUP_IMAGES_ID",
     "EMBEDLY_KEY",
-    "ENABLE_INSTANT_PAGE",
     "ENABLE_NEW_NAVBAR",
     "ENABLE_WEB_CRAWLING",
     "EOY_2016_ARTICLE",


### PR DESCRIPTION
Adds a new A/B test around https://instant.page. 

Swaps out the env var `ENABLE_INSTANT_PAGE` for `INSTANT_PAGE_AB_TEST`. 