### PR TITLE
Redirect requests for obsolete city guide pages

### DIFF
--- a/src/desktop/apps/articles/templates/meta/section.jade
+++ b/src/desktop/apps/articles/templates/meta/section.jade
@@ -1,9 +1,7 @@
 title= section.get('meta_title')
 meta( property="og:title", content=section.get('meta_title') )
-if sd.CURRENT_PATH == '/city-guides' || '/artsy-education' || '/life-at-artsy'
-  if sd.CURRENT_PATH == '/city-guides'
-    - var description = 'Follow insights from local experts—from the established gallerist to the advisor who never misses a show—for an insider’s guide to some of the art world’s top cites.'
-  else if sd.CURRENT_PATH == '/artsy-education'
+if sd.CURRENT_PATH == '/artsy-education' || '/life-at-artsy'
+  if sd.CURRENT_PATH == '/artsy-education'
     - var description = 'Artsy\'s mission is to make all the world\'s art accessible to anyone with an internet connection. Explore our unique tools for learning about art.'
   else if sd.CURRENT_PATH == '/life-at-artsy'
     - var description = 'From vision and values to people and practices, we’re open-sourcing our company culture and sharing the lessons we learn as Artsy grows.'

--- a/src/desktop/apps/feature/index.coffee
+++ b/src/desktop/apps/feature/index.coffee
@@ -9,5 +9,6 @@ app = module.exports = express()
 app.set 'views', __dirname
 app.set 'view engine', 'jade'
 
+app.get '/feature/city-guide*', routes.redirectCityGuide
 app.get '/feature/:id', routes.index
 app.get '/feature/:id/:tab', routes.index

--- a/src/desktop/apps/feature/routes.coffee
+++ b/src/desktop/apps/feature/routes.coffee
@@ -8,3 +8,7 @@ Feature = require '../../models/feature.coffee'
       res.locals.sd.TAB = req.params.tab
       res.render 'templates/index',
         feature: feature
+
+@redirectCityGuide = (req, res) ->
+  res.redirect 301, 'https://iphone.artsy.net'
+  

--- a/src/desktop/apps/feature/test/routes.coffee
+++ b/src/desktop/apps/feature/test/routes.coffee
@@ -24,3 +24,19 @@ describe '#index', ->
     Backbone.sync.args[0][2].success fabricate 'feature', name: 'Awesome Feature'
     @res.render.args[0][0].should.equal 'templates/index'
     @res.render.args[0][1].feature.get('name').should.equal 'Awesome Feature'
+
+describe '#redirectCityGuide', ->
+
+  beforeEach ->
+    sinon.stub Backbone, 'sync'
+    @req = { params: { id: 'city-guide-foo' } }
+    @res =
+      redirect: sinon.stub()
+
+  afterEach ->
+    Backbone.sync.restore()
+
+  it 'redirects to iphone splash page', ->
+    routes.redirectCityGuide @req, @res
+    @res.redirect.args[0][0].should.eql(301)
+    @res.redirect.args[0][1].should.eql('https://iphone.artsy.net')


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/LD-299

We used to have a number of pages with the name "city guide" in them, unrelated to the new City Guide feature we are launching on iOS.

This PR redirects requests for any of the following deprecated urls —

```
/feature/city-guide
/feature/city-guides
/feature/city-guide-berlin
/feature/city-guide-london
/feature/city-guide-los-angeles
/feature/city-guide-los-angelespar
/feature/city-guide-miami
/feature/city-guide-new-york
/feature/city-guide-paris
/feature/city-guide-rio-de-janeiro
/feature/city-guide-sao-paulo
/feature/city-guide-stockholm
```

Users who end up requesting these urls are probably coming from  organic search results for "artsy city guide" or something similar.

We should send them to the destination on artsy.net that's most closely related to the new City Guide feature, namely the splash page for the iPhone app.
