### PR TITLE
@damassi => [Collect] Correctly unset medium from URL when deselected

### DIFF
--- a/src/desktop/apps/collect/client.js
+++ b/src/desktop/apps/collect/client.js
@@ -52,6 +52,8 @@ export const onFilterChange = filters => {
     if (params.medium) {
       route = "/collect" + (params.medium !== "*" ? "/" + params.medium : "")
       delete params.medium
+    } else {
+      route = "/collect"
     }
     fragment = route + "?" + qs.stringify(params)
   }


### PR DESCRIPTION
This whole thing is sort of an anti pattern, this URL thing should just be happening in Reaction (directly using `window.history.pushState`. For now, this fixes the current issue.