### PR TITLE
Extract license comments from payloads

### DIFF
--- a/webpack/envs/productionConfig.js
+++ b/webpack/envs/productionConfig.js
@@ -34,6 +34,7 @@ exports.productionConfig = {
         cache: true,
         parallel: true,
         sourceMap: true,
+        extractComments: true,
         uglifyOptions: {
           compress: {
             warnings: false,


### PR DESCRIPTION
This pulls the (potentially many) comments out of our payload files and adds them in an extra `.LICENSE` file. 

For example...

<img width="629" alt="image" src="https://user-images.githubusercontent.com/3087225/55343303-d18d0700-5478-11e9-90ec-507a2092fd16.png">

<img width="594" alt="image" src="https://user-images.githubusercontent.com/3087225/55343335-dea9f600-5478-11e9-9fe6-fd3c2f65cc5b.png">