### PR TITLE
Redirect to home page if /search2 is missing `term=` query param

### DIFF
--- a/src/desktop/apps/search2/server.tsx
+++ b/src/desktop/apps/search2/server.tsx
@@ -10,6 +10,11 @@ export const app = express()
 app.get(
   "/search2*",
   async (req: Request, res: Response, next: NextFunction) => {
+    if (!req.query.term) {
+      res.redirect(302, "/")
+      return
+    }
+
     try {
       const {
         bodyHTML,


### PR DESCRIPTION
This commit ports over the current behavior of /search without a `q=` query param.

ticket: https://artsyproduct.atlassian.net/browse/DISCO-894 :lock: 