### PR TITLE
Redirect use of search `q=` query param to `term=` query param

### DIFF
--- a/src/desktop/apps/search2/server.tsx
+++ b/src/desktop/apps/search2/server.tsx
@@ -4,6 +4,7 @@ import { routes } from "reaction/Apps/Search/routes"
 import { stitch } from "@artsy/stitch"
 import { buildServerAppContext } from "desktop/lib/buildServerAppContext"
 import express, { Request, Response, NextFunction } from "express"
+import { stringify } from "querystring"
 
 export const app = express()
 
@@ -23,8 +24,14 @@ app.get(
   maybeShowNewPage,
   async (req: Request, res: Response, next: NextFunction) => {
     if (!req.query.term) {
-      res.redirect(302, "/")
-      return
+      if (req.query.q) {
+        const query = stringify({ term: req.query.q })
+        res.redirect(302, `/search?${query}`)
+        return
+      } else {
+        res.redirect(302, "/")
+        return
+      }
     }
 
     try {


### PR DESCRIPTION
The existing search bar redirects to search?q=term while the new search results page expects a `term=` query param. This commit adds a redirect to support both.

ticket: https://artsyproduct.atlassian.net/browse/DISCO-904 :lock: 