### PR TITLE
Fix error page mount

### DIFF
--- a/src/desktop/components/error_handler/index.jade
+++ b/src/desktop/components/error_handler/index.jade
@@ -1,4 +1,4 @@
-extends ../main_layout/templates/index
+extends ../main_layout/templates/blank
 
 append locals
   - bodyClass = "error-handler-body"
@@ -41,3 +41,5 @@ block body
 
         .error-handler-return: a( href='/' )
           | Go to Artsy homepage
+
+  include ../main_layout/footer/template


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/PLATFORM-1316

For some reason pointing the main template at `index` fails to load JS. Not sure exactly why, but pointing at the blank page template fixes the problem sufficiently. 

![js](https://user-images.githubusercontent.com/236943/55764825-03c2d980-5a22-11e9-9e53-aea8e5f2b724.gif)
