### PR TITLE
send product ids with key transaction events

### DIFF
--- a/src/desktop/analytics/bidding.js
+++ b/src/desktop/analytics/bidding.js
@@ -121,6 +121,7 @@ analyticsHooks.on("confirm:bid:form:success", function(data) {
     auction_slug: sd.SALE.id,
     user_id: USER_ID,
     artwork_slug: sd.SALE_ARTWORK.artwork.id,
+    product_id: sd.SALE_ARTWORK.artwork._id,
     bidder_position_id: data.bidder_position_id,
     bidder_id: data.bidder_id,
   })

--- a/src/desktop/analytics/inquiry_questionnaire.js
+++ b/src/desktop/analytics/inquiry_questionnaire.js
@@ -177,6 +177,7 @@
   bindOnce("inquiry:sync", function(context) {
     analytics.track("Sent artwork inquiry", {
       artwork_id: context.artwork.get("_id"),
+      product_id: context.artwork.get("_id"),
       artwork_slug: context.artwork.id,
       inquiry_id: context.inquiry.id,
     })


### PR DESCRIPTION
this is needed for third party marketing channels to assign the conversion events to specific artworks.