### PR TITLE
@dblandin => [Search] Dont render the search results page on the server

### DIFF
--- a/src/desktop/apps/search2/server.tsx
+++ b/src/desktop/apps/search2/server.tsx
@@ -1,12 +1,10 @@
-import React from "react"
-import { buildServerApp } from "reaction/Artsy/Router/server"
-import { routes } from "reaction/Apps/Search/routes"
-import { stitch } from "@artsy/stitch"
-import { buildServerAppContext } from "desktop/lib/buildServerAppContext"
 import express, { Request, Response, NextFunction } from "express"
 import { stringify } from "querystring"
 
 export const app = express()
+
+app.set("views", __dirname + "/templates")
+app.set("view engine", "jade")
 
 const maybeShowNewPage = (req, _res, next) => {
   const shouldShowNewPage =
@@ -22,7 +20,7 @@ const maybeShowNewPage = (req, _res, next) => {
 app.get(
   "/search/:tab?",
   maybeShowNewPage,
-  async (req: Request, res: Response, next: NextFunction) => {
+  async (req: Request, res: Response, _next: NextFunction) => {
     if (!req.query.term) {
       if (req.query.q) {
         const query = stringify({ term: req.query.q })
@@ -34,44 +32,6 @@ app.get(
       }
     }
 
-    try {
-      const {
-        bodyHTML,
-        redirect,
-        status,
-        headTags,
-        styleTags,
-        scripts,
-      } = await buildServerApp({
-        routes,
-        url: req.url,
-        userAgent: req.header("User-Agent"),
-        context: buildServerAppContext(req, res),
-      })
-
-      if (redirect) {
-        res.redirect(302, redirect.url)
-        return
-      }
-
-      const layout = await stitch({
-        basePath: __dirname,
-        layout: "../../components/main_layout/templates/react_redesign.jade",
-        blocks: {
-          head: () => <React.Fragment>{headTags}</React.Fragment>,
-          body: bodyHTML,
-        },
-        locals: {
-          ...res.locals,
-          assetPackage: "search2",
-          scripts,
-          styleTags,
-        },
-      })
-
-      res.status(status).send(layout)
-    } catch (error) {
-      next(error)
-    }
+    res.render("index")
   }
 )

--- a/src/desktop/apps/search2/server.tsx
+++ b/src/desktop/apps/search2/server.tsx
@@ -1,10 +1,8 @@
+import { stitch } from "@artsy/stitch"
 import express, { Request, Response, NextFunction } from "express"
 import { stringify } from "querystring"
 
 export const app = express()
-
-app.set("views", __dirname + "/templates")
-app.set("view engine", "jade")
 
 const maybeShowNewPage = (req, _res, next) => {
   const shouldShowNewPage =
@@ -20,7 +18,7 @@ const maybeShowNewPage = (req, _res, next) => {
 app.get(
   "/search/:tab?",
   maybeShowNewPage,
-  async (req: Request, res: Response, _next: NextFunction) => {
+  async (req: Request, res: Response, next: NextFunction) => {
     if (!req.query.term) {
       if (req.query.q) {
         const query = stringify({ term: req.query.q })
@@ -32,6 +30,19 @@ app.get(
       }
     }
 
-    res.render("index")
+    try {
+      const layout = await stitch({
+        basePath: __dirname,
+        layout: "../../components/main_layout/templates/react_redesign.jade",
+        locals: {
+          ...res.locals,
+          assetPackage: "search2",
+        },
+      })
+
+      res.send(layout)
+    } catch (error) {
+      next(error)
+    }
   }
 )

--- a/src/desktop/apps/search2/templates/index.jade
+++ b/src/desktop/apps/search2/templates/index.jade
@@ -1,7 +1,0 @@
-extends ../../../components/main_layout/templates/redesign
-
-append locals
-  - assetPackage = 'search2'
-
-block body
-  #react-root

--- a/src/desktop/apps/search2/templates/index.jade
+++ b/src/desktop/apps/search2/templates/index.jade
@@ -1,0 +1,7 @@
+extends ../../../components/main_layout/templates/redesign
+
+append locals
+  - assetPackage = 'search2'
+
+block body
+  #react-root


### PR DESCRIPTION
As discussed, we deliberately don't want to render search results on the server. We want the experience to feel as snappy as possible to the user, and are willing to live with SEO ramifications of this change (indeed, a work item is to disallow /search on robots.txt).

So, this just removes all SSR rendering in favor of our blank 'redesign' template (which continues to load the header/NAV and other global client JS, which is essential).

We then let the normal client-side hydration take care of fetching + rendering everything client-side. There doesn't seem to be any warnings/errors doing this and the results looked very promising locally.

A next step could be to iterate on the blank template to include a nice loading state/splash screen (which will get replaced by the client-side rendered data).

cc @damassi as a sanity check too.