### PR TITLE
x problematic tests

### DIFF
--- a/src/desktop/apps/auction/__tests__/routes.jest.js
+++ b/src/desktop/apps/auction/__tests__/routes.jest.js
@@ -1,9 +1,6 @@
 import Backbone from "backbone"
 import metaphysics from "lib/metaphysics.coffee"
 import CurrentUser from "desktop/models/current_user.coffee"
-// import {
-//   fabricate
-// } from 'antigravity'
 import * as routes from "../routes"
 
 jest.mock("backbone")
@@ -21,12 +18,9 @@ jest.mock("desktop/apps/auction/actions/artworkBrowser", () => ({
   }),
 }))
 
-describe("routes", () => {
+xdescribe("routes", () => {
   beforeEach(() => {
     Backbone.sync = jest.fn()
-  })
-  afterEach(() => {
-    // Backbone.sync.restore()
   })
 
   describe("#index", () => {
@@ -86,7 +80,7 @@ describe("routes", () => {
       expect(res.send).toBeCalledWith("<html />")
     })
 
-    it("works even with the Metaphysics module throwing an error", async () => {
+    xit("works even with the Metaphysics module throwing an error", async () => {
       metaphysics
         .mockReturnValueOnce({ sale: { is_auction: true } })
         .mockRejectedValue("oops!")

--- a/src/desktop/apps/auction/components/__tests__/DOM.jest.js
+++ b/src/desktop/apps/auction/components/__tests__/DOM.jest.js
@@ -15,7 +15,7 @@ jest.mock("desktop/lib/mediator.coffee", x => ({
   trigger: jest.fn(),
 }))
 
-describe("DOM Interactions", () => {
+xdescribe("DOM Interactions", () => {
   // spyOn required to restore global mocks' original implementations
   // may not be necessary?
   beforeAll(() => {

--- a/src/desktop/apps/auction/components/__tests__/Layout.test.js
+++ b/src/desktop/apps/auction/components/__tests__/Layout.test.js
@@ -9,7 +9,7 @@ import { promotedSaleArtworks } from "../artwork_browser/__tests__/fixtures/prom
 const rewire = require("rewire")("../Layout")
 const Layout = rewire.default
 
-describe("<Layout />", () => {
+xdescribe("<Layout />", () => {
   let resetRewire
 
   beforeEach(() => {

--- a/src/desktop/apps/auction/components/artwork_browser/header/__tests__/FilterSort.test.js
+++ b/src/desktop/apps/auction/components/artwork_browser/header/__tests__/FilterSort.test.js
@@ -2,7 +2,7 @@ import * as filterActions from "desktop/apps/auction/actions/artworkBrowser"
 import renderTestComponent from "desktop/apps/auction/__tests__/utils/renderTestComponent"
 import FilterSort from "desktop/apps/auction/components/artwork_browser/header/FilterSort"
 
-describe("auction/components/artwork_browser/header/FilterSort.test", () => {
+xdescribe("auction/components/artwork_browser/header/FilterSort.test", () => {
   describe("<FilterSort />", () => {
     it("updates the sort with the current selected sort state", () => {
       const { wrapper } = renderTestComponent({

--- a/src/desktop/apps/auction/components/artwork_browser/header/__tests__/HeaderDesktop.jest.js
+++ b/src/desktop/apps/auction/components/artwork_browser/header/__tests__/HeaderDesktop.jest.js
@@ -2,7 +2,7 @@ import renderTestComponent from "desktop/apps/auction/__tests__/utils/renderTest
 import FilterSort from "desktop/apps/auction/components/artwork_browser/header/FilterSort"
 import HeaderDesktop from "desktop/apps/auction/components/artwork_browser/header/HeaderDesktop"
 
-describe("auction/components/artwork_browser/header/HeaderDesktop.test", () => {
+xdescribe("auction/components/artwork_browser/header/HeaderDesktop.test", () => {
   describe("<HeaderDesktop />", () => {
     it("renders a <FilterSort /> component", () => {
       const { wrapper } = renderTestComponent({

--- a/src/desktop/apps/auction/components/artwork_browser/header/__tests__/HeaderMobile.test.js
+++ b/src/desktop/apps/auction/components/artwork_browser/header/__tests__/HeaderMobile.test.js
@@ -4,7 +4,7 @@ import sinon from "sinon"
 
 const rewire = require("rewire")("../../../../actions/artworkBrowser")
 
-describe("auction/components/artwork_browser/header/HeaderMobile.test", () => {
+xdescribe("auction/components/artwork_browser/header/HeaderMobile.test", () => {
   describe("<HeaderMobile />", () => {
     it("default sort is Default", () => {
       const { wrapper } = renderTestComponent({

--- a/src/desktop/apps/auction/components/artwork_browser/main/artwork/__tests__/BidStatus.test.js
+++ b/src/desktop/apps/auction/components/artwork_browser/main/artwork/__tests__/BidStatus.test.js
@@ -3,7 +3,7 @@ import { test } from "desktop/apps/auction/components/artwork_browser/main/artwo
 
 const { BidStatus } = test
 
-describe("auction/components/artwork_browser/main/artwork/BidStatus.test", () => {
+xdescribe("auction/components/artwork_browser/main/artwork/BidStatus.test", () => {
   describe("<BidStatus />", () => {
     it("renders sold label if artwork is sold", () => {
       const { wrapper } = renderTestComponent({

--- a/src/desktop/apps/auction/components/artwork_browser/main/artwork/__tests__/GridArtwork.test.js
+++ b/src/desktop/apps/auction/components/artwork_browser/main/artwork/__tests__/GridArtwork.test.js
@@ -4,7 +4,7 @@ import renderTestComponent from "desktop/apps/auction/__tests__/utils/renderTest
 const rewire = require("rewire")("../GridArtwork")
 const { GridArtwork } = rewire.test
 
-describe("auction/components/artwork_browser/main/artwork/GridArtwork.test", () => {
+xdescribe("auction/components/artwork_browser/main/artwork/GridArtwork.test", () => {
   describe("<GridArtwork />", () => {
     const BidStatus = () => <div />
 

--- a/src/desktop/apps/auction/components/artwork_browser/main/artwork/__tests__/ListArtwork.test.js
+++ b/src/desktop/apps/auction/components/artwork_browser/main/artwork/__tests__/ListArtwork.test.js
@@ -4,7 +4,7 @@ import renderTestComponent from "desktop/apps/auction/__tests__/utils/renderTest
 const rewire = require("rewire")("../ListArtwork")
 const { ListArtwork } = rewire.test
 
-describe("auction/components/artwork_browser/main/artwork/ListArtwork.test", () => {
+xdescribe("auction/components/artwork_browser/main/artwork/ListArtwork.test", () => {
   describe("<ListArtwork />", () => {
     const BidStatus = () => <div />
 

--- a/src/desktop/apps/auction/components/artwork_browser/main/artwork/__tests__/MasonryArtwork.test.js
+++ b/src/desktop/apps/auction/components/artwork_browser/main/artwork/__tests__/MasonryArtwork.test.js
@@ -4,7 +4,7 @@ import renderTestComponent from "desktop/apps/auction/__tests__/utils/renderTest
 const rewire = require("rewire")("../MasonryArtwork")
 const { MasonryArtwork } = rewire.test
 
-describe("auction/components/artwork_browser/main/artwork/MasonryArtwork.test", () => {
+xdescribe("auction/components/artwork_browser/main/artwork/MasonryArtwork.test", () => {
   describe("<MasonryArtwork />", () => {
     const BidStatus = () => <div />
 

--- a/src/desktop/apps/auction/components/artwork_browser/sidebar/__tests__/ArtistFilter.test.js
+++ b/src/desktop/apps/auction/components/artwork_browser/sidebar/__tests__/ArtistFilter.test.js
@@ -4,7 +4,7 @@ import renderTestComponent from "desktop/apps/auction/__tests__/utils/renderTest
 const rewire = require("rewire")("../ArtistFilter")
 const { ArtistFilter } = rewire.test
 
-describe("auction/components/artwork_browser/sidebar/ArtistFilter.test", () => {
+xdescribe("auction/components/artwork_browser/sidebar/ArtistFilter.test", () => {
   describe("<ArtistFilter />", () => {
     const BasicCheckbox = () => <div />
 

--- a/src/desktop/apps/auction/components/artwork_browser/sidebar/__tests__/BasicCheckbox.jest.js
+++ b/src/desktop/apps/auction/components/artwork_browser/sidebar/__tests__/BasicCheckbox.jest.js
@@ -1,7 +1,7 @@
 import renderTestComponent from "desktop/apps/auction/__tests__/utils/renderTestComponent"
 import BasicCheckbox from "desktop/apps/auction/components/artwork_browser/sidebar/BasicCheckbox"
 
-describe("auction/components/artwork_browser/sidebar/BasicCheckbox.test", () => {
+xdescribe("auction/components/artwork_browser/sidebar/BasicCheckbox.test", () => {
   describe("<FilterSort />", () => {
     it("triggers callback onClick", () => {
       const onClick = jest.fn()

--- a/src/desktop/apps/auction/components/artwork_browser/sidebar/__tests__/MediumFilter.test.js
+++ b/src/desktop/apps/auction/components/artwork_browser/sidebar/__tests__/MediumFilter.test.js
@@ -4,7 +4,7 @@ import renderTestComponent from "desktop/apps/auction/__tests__/utils/renderTest
 const rewire = require("rewire")("../MediumFilter")
 const { MediumFilter } = rewire.test
 
-describe("auction/components/artwork_browser/sidebar/MediumFilter.test", () => {
+xdescribe("auction/components/artwork_browser/sidebar/MediumFilter.test", () => {
   describe("<MediumFilter />", () => {
     const BasicCheckbox = () => <div />
 

--- a/src/desktop/apps/auction/components/artwork_browser/sidebar/__tests__/Sidebar.test.js
+++ b/src/desktop/apps/auction/components/artwork_browser/sidebar/__tests__/Sidebar.test.js
@@ -6,7 +6,7 @@ import { test } from "desktop/apps/auction/components/artwork_browser/sidebar/Si
 
 const { Sidebar } = test
 
-describe("auction/components/artwork_browser/sidebar/Sidebar.test", () => {
+xdescribe("auction/components/artwork_browser/sidebar/Sidebar.test", () => {
   describe("<Sidebar />", () => {
     it("does not render a range slider if sale is closed", () => {
       const { wrapper } = renderTestComponent({

--- a/src/desktop/apps/auction/components/artwork_rail/__tests__/ArtworkRail.test.js
+++ b/src/desktop/apps/auction/components/artwork_rail/__tests__/ArtworkRail.test.js
@@ -3,7 +3,7 @@ import renderTestComponent from "desktop/apps/auction/__tests__/utils/renderTest
 import { ArtworkRail } from "../ArtworkRail"
 import { promotedSaleArtworks } from "../../artwork_browser/__tests__/fixtures/promotedSaleArtworks"
 
-describe("auction/components/artwork_rail/ArtworkRail", () => {
+xdescribe("auction/components/artwork_rail/ArtworkRail", () => {
   const data = {
     app: {
       auction: {

--- a/src/desktop/apps/auction/components/layout/__tests__/Banner.jest.jsx
+++ b/src/desktop/apps/auction/components/layout/__tests__/Banner.jest.jsx
@@ -11,7 +11,7 @@ jest.mock("desktop/components/clock/react", () => ({
   })),
 }))
 
-describe("auction/components/layout/Banner.test", () => {
+xdescribe("auction/components/layout/Banner.test", () => {
   describe("<Banner />", () => {
     it('tracks a click on the "Enter Live Auction" button', () => {
       const liveAuctionUrl = "live.artsy.net/some-auction-url"

--- a/src/desktop/apps/auction/components/layout/__tests__/Footer.test.js
+++ b/src/desktop/apps/auction/components/layout/__tests__/Footer.test.js
@@ -5,7 +5,7 @@ import { test } from "desktop/apps/auction/components/layout/Footer"
 
 const { Footer } = test
 
-describe("auction/components/layout/Footer.test", () => {
+xdescribe("auction/components/layout/Footer.test", () => {
   describe("<Footer />", () => {
     let article
 

--- a/src/desktop/apps/auction/components/layout/active_bids/__tests__/ActiveBidItem.jest.js
+++ b/src/desktop/apps/auction/components/layout/active_bids/__tests__/ActiveBidItem.jest.js
@@ -4,7 +4,7 @@ import { test } from "desktop/apps/auction/components/layout/active_bids/ActiveB
 
 const { ActiveBidItem } = test
 
-describe("auction/components/layout/active_bids/ActiveBidItem.test", () => {
+xdescribe("auction/components/layout/active_bids/ActiveBidItem.test", () => {
   describe("<ActiveBidItem />", () => {
     const bid = {
       active_bid: {

--- a/src/desktop/apps/auction/components/layout/auction_info/__tests__/AuctionInfoContainer.jest.jsx
+++ b/src/desktop/apps/auction/components/layout/auction_info/__tests__/AuctionInfoContainer.jest.jsx
@@ -21,7 +21,7 @@ jest.mock("../AuctionInfoMobile", () => ({
 const AuctionInfoDesktop = require("../AuctionInfoDesktop").default
 const AuctionInfoMobile = require("../AuctionInfoMobile").default
 
-describe("auction/components/layout/auction_info/AuctionInfoContainer.test", () => {
+xdescribe("auction/components/layout/auction_info/AuctionInfoContainer.test", () => {
   beforeEach(() => {
     AuctionInfoDesktop.mockClear()
     AuctionInfoMobile.mockClear()

--- a/src/desktop/apps/auction/components/layout/auction_info/__tests__/Registration.jest.js
+++ b/src/desktop/apps/auction/components/layout/auction_info/__tests__/Registration.jest.js
@@ -3,7 +3,7 @@ import { test } from "desktop/apps/auction/components/layout/auction_info/Regist
 
 const { Registration } = test
 
-describe("auction/components/layout/auction_info/Registration.test", () => {
+xdescribe("auction/components/layout/auction_info/Registration.test", () => {
   describe("<Registration />", () => {
     it("doesnt render when isClosed is true", () => {
       const { wrapper } = renderTestComponent({


### PR DESCRIPTION
Disables tests from `src/desktop/auction` -- these were not run prior to changes in https://github.com/artsy/force/pull/3877, but some were enabled optimistically.  Here all tests in that directory are turned off for the moment, and we can coordinate with the auctions team to enable as priority allows. 

I ran this build 5 times without hitting a timeout, so I believe this should address the flakiness we've experienced since last night.