### PR TITLE
Update docs to mention  `-f `option

### DIFF
--- a/docs/rolling_back.md
+++ b/docs/rolling_back.md
@@ -2,7 +2,7 @@
 
 So, you're reading this doc, in which case either nothing is on fire and you're simply educating yourself (yay!), or, there's a problem and you need to rollback Force. Take a deep breath, and read on.
 
-1. Run `hokusai registry images`. You'll see output like the below.
+1. Run `hokusai registry images -f production`. This will return list of images that were deployed to production. You'll see output like the below.
 
 ![list of images](images/hokusai_images.png "Hokusai Images")
 


### PR DESCRIPTION
Update docs to mention easier way for finding proper production image.

# Possible Followup
This doc seems pretty generic and applies to all `hokusai` based apps, we can potentially move this to a more common place and point to it from here and possibly other repos.