### PR TITLE
Remove criteo from our preconnects

### DIFF
--- a/src/desktop/components/main_layout/templates/head.jade
+++ b/src/desktop/components/main_layout/templates/head.jade
@@ -10,7 +10,6 @@ link( rel='search', type='application/opensearchdescription+xml', href=asset('/i
 link( rel='preconnect', href='https://www.google-analytics.com' )
 link( rel='preconnect', href='https://googleads.g.doubleclick.net' )
 link( rel='preconnect', href='https://www.googleadservices.com' )
-link( rel='preconnect', href='https://gum.criteo.com' )
 
 link( rel='dns-prefetch', href='https://connect.facebook.net' )
 link( rel='dns-prefetch', href='https://cdn.segment.com' )

--- a/src/mobile/components/layout/templates/head.jade
+++ b/src/mobile/components/layout/templates/head.jade
@@ -22,7 +22,6 @@ link( type='text/css', rel='stylesheet', href=asset('/assets/' + assetPackage + 
 link( rel='preconnect', href='https://www.google-analytics.com' )
 link( rel='preconnect', href='https://googleads.g.doubleclick.net' )
 link( rel='preconnect', href='https://www.googleadservices.com' )
-link( rel='preconnect', href='https://gum.criteo.com' )
 
 link( rel='dns-prefetch', href='https://connect.facebook.net' )
 link( rel='dns-prefetch', href='https://cdn.segment.com' )


### PR DESCRIPTION
Noticed a warning reported by lighthouse that we were including criteo in our preconnect list when it wasn't on the page. 

I've just removed it for now. 