### PR TITLE
Update identifer of loading container

### DIFF
--- a/src/desktop/apps/search2/client.tsx
+++ b/src/desktop/apps/search2/client.tsx
@@ -15,7 +15,7 @@ buildClientApp({
 })
   .then(({ ClientApp }) => {
     ReactDOM.hydrate(<ClientApp />, document.getElementById("react-root"))
-    document.getElementById("search-results-skeleton").remove()
+    document.getElementById("loading-container").remove()
   })
   .catch(error => {
     console.error(error)


### PR DESCRIPTION
Follow up to https://github.com/artsy/force/pull/3910

The identifier was updated following review feedback, but the client-side callback which removes the loading container still referenced the old value. This commit makes that update.