### PR TITLE
Backfill fix for auction search result item timezone display

### DIFF
--- a/src/desktop/models/search_result.coffee
+++ b/src/desktop/models/search_result.coffee
@@ -153,8 +153,8 @@ module.exports = class SearchResult extends Backbone.Model
     show.toPageDescription()
 
   formatEventAbout: (title, timezone) ->
-    formattedStartTime = @formatEventTime(@get('start_at'), timezone)
-    formattedEndTime = @formatEventTime(@get('end_at'), timezone)
+    formattedStartTime = @formatEventTime(@get('start_at'), 'MMM Do', timezone)
+    formattedEndTime = @formatEventTime(@get('end_at'), 'MMM Do, YYYY', timezone)
     location = @get('city')
 
     if formattedStartTime and formattedEndTime
@@ -168,7 +168,7 @@ module.exports = class SearchResult extends Backbone.Model
 
     about
 
-  formatEventTime: (timestamp, timezone) ->
+  formatEventTime: (timestamp, format, timezone) ->
     if timestamp
       momentTime = moment(timestamp)
 
@@ -176,9 +176,9 @@ module.exports = class SearchResult extends Backbone.Model
         null
       else if timezone
         momentTime = momentTime.tz(timezone)
-        "#{momentTime.format("MMM Do")} (at #{momentTime.format("h:mma z")})"
+        "#{momentTime.format(format)} (at #{momentTime.format("h:mma z")})"
       else
-        momentTime.format("MMM Do")
+        momentTime.format(format)
 
   href: ->
     @get('location')

--- a/src/mobile/models/search_result.coffee
+++ b/src/mobile/models/search_result.coffee
@@ -156,8 +156,8 @@ module.exports = class SearchResult extends Backbone.Model
     show.toPageDescription()
 
   formatEventAbout: (title, timezone) ->
-    formattedStartTime = @formatEventTime(@get('start_at'), timezone)
-    formattedEndTime = @formatEventTime(@get('end_at'), timezone)
+    formattedStartTime = @formatEventTime(@get('start_at'), 'MMM Do', timezone)
+    formattedEndTime = @formatEventTime(@get('end_at'), 'MMM Do, YYYY', timezone)
     location = @get('city')
 
     if formattedStartTime and formattedEndTime
@@ -171,7 +171,7 @@ module.exports = class SearchResult extends Backbone.Model
 
     about
 
-  formatEventTime: (timestamp, timezone) ->
+  formatEventTime: (timestamp, format, timezone) ->
     if timestamp
       momentTime = moment(timestamp)
 
@@ -179,6 +179,6 @@ module.exports = class SearchResult extends Backbone.Model
         null
       else if timezone
         momentTime = momentTime.tz(timezone)
-        "#{momentTime.format("MMM Do")} (at #{momentTime.format("h:mma z")})"
+        "#{momentTime.format(format)} (at #{momentTime.format("h:mma z")})"
       else
-        momentTime.format("MMM Do")
+        momentTime.format(format)

--- a/src/mobile/models/search_result.coffee
+++ b/src/mobile/models/search_result.coffee
@@ -4,7 +4,7 @@ Backbone = require 'backbone'
 { Image } = require 'artsy-backbone-mixins'
 _s = require 'underscore.string'
 PartnerShow = require './show.coffee'
-moment = require 'moment'
+moment = require 'moment-timezone'
 module.exports = class SearchResult extends Backbone.Model
 
   _.extend @prototype, Image(sd.SECURE_IMAGES_URL)
@@ -80,7 +80,7 @@ module.exports = class SearchResult extends Backbone.Model
     else if @get('display_model') == 'Fair'
       @formatEventAbout('Art fair')
     else if @get('display_model') == 'Sale'
-      @formatEventAbout('Sale')
+      @formatEventAbout('Sale', 'America/New_York')
     else if @get('display_model') in ['Show', 'Booth']
       @formatShowAbout()
     else if @get('display_model') in ['Artwork', 'Feature', 'Gallery']
@@ -155,12 +155,9 @@ module.exports = class SearchResult extends Backbone.Model
 
     show.toPageDescription()
 
-  formatEventAbout: (title) ->
-    if startTime = @get('start_at')
-      formattedStartTime = moment(startTime).format("MMM Do")
-    if endTime = @get('end_at')
-      formattedEndTime = moment(endTime).format("MMM Do, YYYY")
-
+  formatEventAbout: (title, timezone) ->
+    formattedStartTime = @formatEventTime(@get('start_at'), timezone)
+    formattedEndTime = @formatEventTime(@get('end_at'), timezone)
     location = @get('city')
 
     if formattedStartTime and formattedEndTime
@@ -168,7 +165,20 @@ module.exports = class SearchResult extends Backbone.Model
       about += " in #{location}" if location
     else if formattedStartTime
       about = "#{title} opening #{formattedStartTime}"
+      about += " in #{location}" if location
     else
       about = @get('description')
 
     about
+
+  formatEventTime: (timestamp, timezone) ->
+    if timestamp
+      momentTime = moment(timestamp)
+
+      if !momentTime.isValid()
+        null
+      else if timezone
+        momentTime = momentTime.tz(timezone)
+        "#{momentTime.format("MMM Do")} (at #{momentTime.format("h:mma z")})"
+      else
+        momentTime.format("MMM Do")


### PR DESCRIPTION
This commit backfills the fix made to Metaphysics, backing the new search results page, which always displays start/end times for auctions in Eastern Time.