### PR TITLE
Disable search results page loading skeleton for mobile clients

### DIFF
--- a/src/desktop/apps/search2/server.tsx
+++ b/src/desktop/apps/search2/server.tsx
@@ -33,6 +33,8 @@ app.get(
       }
     }
 
+    const { IS_MOBILE } = res.locals.sd
+
     try {
       const layout = await stitch({
         basePath: __dirname,
@@ -44,9 +46,11 @@ app.get(
         blocks: {
           loadingComponent: _props => {
             return (
-              <StitchWrapper>
-                <SearchResultsSkeleton />
-              </StitchWrapper>
+              !IS_MOBILE && (
+                <StitchWrapper>
+                  <SearchResultsSkeleton />
+                </StitchWrapper>
+              )
             )
           },
         },


### PR DESCRIPTION
We won't hydrate this react component client-side so much of our media/responsive handling will be ineffective. I think it's simpler to disable the loading skeleton for mobile clients and let the full search results app take over once it hydrates.