### PR TITLE
Update moment-timezone to reduce payload size

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "mailcheck": "^1.1.1",
     "mocha-lcov-reporter": "^1.3.0",
     "moment": "^2.22.2",
-    "moment-timezone": "^0.5.23",
+    "moment-timezone": "^0.5.25",
     "moment-twitter": "^0.2.0",
     "nib": "^1.1.2",
     "nock": "^9.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9840,13 +9840,6 @@ module-details-from-path@^1.0.3:
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
   integrity sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=
 
-moment-timezone@^0.5.23:
-  version "0.5.23"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.23.tgz#7cbb00db2c14c71b19303cb47b0fb0a6d8651463"
-  integrity sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==
-  dependencies:
-    moment ">= 2.9.0"
-
 moment-timezone@^0.5.25:
   version "0.5.25"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.25.tgz#a11bfa2f74e088327f2cd4c08b3e7bdf55957810"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9847,6 +9847,13 @@ moment-timezone@^0.5.13, moment-timezone@^0.5.23:
   dependencies:
     moment ">= 2.9.0"
 
+moment-timezone@^0.5.25:
+  version "0.5.25"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.25.tgz#a11bfa2f74e088327f2cd4c08b3e7bdf55957810"
+  integrity sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==
+  dependencies:
+    moment ">= 2.9.0"
+
 moment-twitter@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/moment-twitter/-/moment-twitter-0.2.0.tgz#01f948425a8deb4d300d3ed7592daa699bbb5160"


### PR DESCRIPTION
Bumps the version of moment-timezone that's now significantly smaller due to a reduced time-range set in `latest.json`. See https://github.com/moment/moment-timezone/issues/697 for more context. 