### PR TITLE
Add datePublished to JSON-LD metadata for articles

### DIFF
--- a/src/desktop/models/article.coffee
+++ b/src/desktop/models/article.coffee
@@ -257,6 +257,7 @@ module.exports = class Article extends Backbone.Model
       "headline": @get('thumbnail_title')
       "url": @fullHref()
       "thumbnailUrl": @get('thumbnail_image')
+      "datePublished": @get('published_at')
       "dateCreated": @get('published_at')
       "articleSection": @getParselySection()
       "creator": @getAuthorArray()

--- a/src/desktop/test/models/article.test.coffee
+++ b/src/desktop/test/models/article.test.coffee
@@ -218,13 +218,18 @@ describe "Article", ->
       @article.contributingByline().should.equal 'Molly, Kana and Christina'
 
   describe 'toJSONLD', ->
-    it 'Appends the layout, vertical and tracking tags', ->
+    it 'includes the layout, vertical and tracking tags', ->
       @article.set
         tags: ['Venice', 'Technology']
         tracking_tags: ['Evergreen', 'Interviews']
         vertical: { name: 'Culture', id: '123' }
         layout: 'standard'
       @article.toJSONLD().keywords.should.eql [ 'Venice', 'Technology', 'standard', 'Culture', 'Evergreen', 'Interviews' ]
+    it 'includes datestamps', ->
+      @article.set
+        published_at: '2019-04-23T16:31:48.205Z'
+      @article.toJSONLD().dateCreated.should.eql '2019-04-23T16:31:48.205Z'
+      @article.toJSONLD().datePublished.should.eql '2019-04-23T16:31:48.205Z'
 
   describe 'date', ->
     it 'returns NY time for editorial articles', ->


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GROW-1186

This adds a publication date to the standard metadata block that Google considers when deciding what to show as the date next to a search result.

This field was previously identified as missing with Google's [structured data testing tool](https://search.google.com/structured-data/testing-tool/u/0/), but checks out now:

![tool](https://user-images.githubusercontent.com/140521/56696830-02004380-66bb-11e9-9db6-e940d8b70145.png)

Note that there are other fields that are still considered missing, but fixing them would require a deeper dive into the Schema.org requirements for annotating these correctly (as well as probably refactoring the various implementations in Force now — `toJSONLDAmp` vs `toJSONLD`).

So we can create a follow-up ticket if need be (cc @junybrum ).

