### PR TITLE
Enable search results page loading skeleton for mobile devices

### DIFF
--- a/src/desktop/apps/search2/server.tsx
+++ b/src/desktop/apps/search2/server.tsx
@@ -31,9 +31,6 @@ app.get(
         return
       }
     }
-
-    const { IS_MOBILE } = res.locals.sd
-
     try {
       const layout = await stitch({
         basePath: __dirname,
@@ -45,11 +42,9 @@ app.get(
         blocks: {
           loadingComponent: _props => {
             return (
-              !IS_MOBILE && (
-                <StitchWrapper>
-                  <SearchResultsSkeleton />
-                </StitchWrapper>
-              )
+              <StitchWrapper>
+                <SearchResultsSkeleton />
+              </StitchWrapper>
             )
           },
         },


### PR DESCRIPTION
This commit enables server-side rendering of loading skeleton for devices providing a mobile user-agent.

This depends on a corresponding PR (https://github.com/artsy/reaction/pull/2337) which improves styling of the loading skeleton for mobile devices.