### PR TITLE
Adds Ad Server script to Article pages--DO NOT MERGE

### DIFF
--- a/src/desktop/apps/article/ad_category.ts
+++ b/src/desktop/apps/article/ad_category.ts
@@ -1,0 +1,91 @@
+/**
+ * Parses article metadata to determine correct category type for Google DFP ad placements.
+ */
+
+interface ArticleProperties {
+  layout?: string
+  tracking_tags?: [string]
+  sponsor?: {
+    pixel_tracking_code?: string
+    partner_logo_link?: string
+    partner_light_logo?: string
+    partner_dark_logo?: string
+    partner_condensed_logo?: string
+  }
+}
+
+enum AdCategory {
+  Feature = "feature",
+  Article = "article",
+  NewsLanding = "newslanding",
+  SponsorLanding = "sponsorlanding",
+  SponsorFeature = "sponsorfeature",
+}
+
+const isSponsored = (article: ArticleProperties) => {
+  const { tracking_tags, sponsor } = article
+  if (tracking_tags.includes("sponsored")) {
+    return true
+  }
+
+  // tslint:disable:no-extra-boolean-cast
+  // Check each of the properties of article.sponsor, if any are true then the article is sponsored.
+  if (!!Reflect.get(sponsor, "partner_condensed_logo")) {
+    return true
+  }
+  if (!!Reflect.get(sponsor, "partner_dark_logo")) {
+    return true
+  }
+  if (!!Reflect.get(sponsor, "partner_light_logo")) {
+    return true
+  }
+  if (!!Reflect.get(sponsor, "partner_logo_link")) {
+    return true
+  }
+  if (!!Reflect.get(sponsor, "pixel_tracking_code")) {
+    return true
+  }
+  return false
+}
+
+export const articleAdCategory = (article: ArticleProperties) => {
+  let isNewsLanding = article.layout === "news"
+  if (isNewsLanding) {
+    return AdCategory.NewsLanding
+  }
+
+  let isFeature = article.layout === "feature" && !isSponsored(article)
+  if (isFeature) {
+    return AdCategory.Feature
+  }
+
+  let isSponsoredFeature = article.layout === "feature" && isSponsored(article)
+  if (isSponsoredFeature) {
+    return AdCategory.SponsorFeature
+  }
+
+  let isSponsoredLanding =
+    (article.layout === "series" || article.layout === "video") &&
+    isSponsored(article)
+  if (isSponsoredLanding) {
+    return AdCategory.SponsorLanding
+  }
+
+  return AdCategory.Article
+}
+
+/**
+ * Example Articles
+ *
+ * News Landing: http://localhost:5000/news/artsy-editorial-eternal-beauty-botticelli-s-the-birth-venus-caused-man-heart-attack
+ *
+ * Sponsored Feature: http://localhost:5000/series/artsy-editors-newly-established
+ *
+ * Sponsored Landing (Series):  http://localhost:5000/series/artsy-vanguard
+ *
+ * Sponsored Landing (Video): http://localhost:5000/series/artsy-editors-future-art/artsy-editors-future-art-carrie-mae-weems
+ *
+ * Feature: http://localhost:5000/article/artsy-editorial-rise-fall-internet-art-communities or http://localhost:5000/article/artsy-editorial-inside-new-yorks-remaining-artists-housing
+ *
+ * Article: http://localhost:5000/article/artsy-editorial-malick-sidibephotographs-captured-moments-joy-liberation-mali
+ */

--- a/src/desktop/apps/article/ad_category.ts
+++ b/src/desktop/apps/article/ad_category.ts
@@ -75,17 +75,17 @@ export const articleAdCategory = (article: ArticleProperties) => {
 }
 
 /**
- * Example Articles
+ * Example Article Slugs
  *
- * News Landing: http://localhost:5000/news/artsy-editorial-eternal-beauty-botticelli-s-the-birth-venus-caused-man-heart-attack
+ * News Landing: /news/artsy-editorial-eternal-beauty-botticelli-s-the-birth-venus-caused-man-heart-attack
  *
- * Sponsored Feature: http://localhost:5000/series/artsy-editors-newly-established
+ * Sponsored Feature: /series/artsy-editors-newly-established
  *
- * Sponsored Landing (Series):  http://localhost:5000/series/artsy-vanguard
+ * Sponsored Landing (Series):  /series/artsy-vanguard
  *
- * Sponsored Landing (Video): http://localhost:5000/series/artsy-editors-future-art/artsy-editors-future-art-carrie-mae-weems
+ * Sponsored Landing (Video): /series/artsy-editors-future-art/artsy-editors-future-art-carrie-mae-weems
  *
- * Feature: http://localhost:5000/article/artsy-editorial-rise-fall-internet-art-communities or http://localhost:5000/article/artsy-editorial-inside-new-yorks-remaining-artists-housing
+ * Feature: /article/artsy-editorial-rise-fall-internet-art-communities or /article/artsy-editorial-inside-new-yorks-remaining-artists-housing
  *
- * Article: http://localhost:5000/article/artsy-editorial-malick-sidibephotographs-captured-moments-joy-liberation-mali
+ * Article: /article/artsy-editorial-malick-sidibephotographs-captured-moments-joy-liberation-mali
  */

--- a/src/desktop/apps/article/components/App.tsx
+++ b/src/desktop/apps/article/components/App.tsx
@@ -7,6 +7,8 @@ import { EditButton } from "desktop/apps/article/components/EditButton"
 import { ArticleLayout } from "./layouts/Article"
 import { data as sd } from "sharify"
 import { ArticleProps } from "@artsy/reaction/dist/Components/Publishing/Article"
+import { isProduction } from "lib/environment"
+import { articleAdCategory } from "../ad_category"
 
 export interface AppProps extends ArticleProps {
   templates?: {
@@ -14,8 +16,36 @@ export interface AppProps extends ArticleProps {
     SuperArticleHeader: string
   }
 }
-
+interface HtlbidProps {
+  cmd: any
+  setTargeting?: (a: string, b: string) => any
+}
 export class App extends React.Component<AppProps> {
+  componentDidMount() {
+    this.mountDFPScript()
+  }
+
+  mountDFPScript() {
+    const { article } = this.props
+    let htlbid: HtlbidProps = {
+      cmd: [],
+    }
+    let testingState = isProduction ? "no" : "yes"
+    let pageType = articleAdCategory(article)
+    let postID = article.id
+
+    return `
+      <script src="//htlbid.com/v2/artsy.min.js"></script>
+      <script>
+        ${htlbid["cmd"].push(() => {
+          htlbid.setTargeting("is_testing", testingState)
+          htlbid.setTargeting("page_type", pageType)
+          htlbid.setTargeting("post_id", postID)
+        })}
+      </script>
+    `
+  }
+
   getArticleLayout = () => {
     const { article } = this.props
 


### PR DESCRIPTION
Draft/WIP Commit:
- needs tests/review


This PR maps the article categories created by Hashtag Labs to the various article types we display in Artsy's Editorials, and mounts a script tag to the ad component so ads hosted by HTL's ad server can be injected into the Editorial pages. 