### PR TITLE
@joeyAghion => [BugFix] Drop unneeded interpolation for homepage variables

### DIFF
--- a/src/desktop/apps/home/client/setup_home_page_modules.coffee
+++ b/src/desktop/apps/home/client/setup_home_page_modules.coffee
@@ -61,10 +61,10 @@ module.exports = ->
     metaphysics(
       query: query
       variables:
-        key: "#{module.key}",
-        id: "#{module.params?.id}"
-        related_artist_id: "#{module.params?.related_artist_id}"
-        followed_artist_id: "#{module.params?.followed_artist_id}"
+        key: module.key,
+        id: module.params?.id
+        related_artist_id: module.params?.related_artist_id
+        followed_artist_id: module.params?.followed_artist_id
         timezone: moment.tz.guess()
       req: { user: user }
     ).then ({ home_page: { artwork_module } }) ->


### PR DESCRIPTION
This fix is needed to change `"undefined"` -> `undefined` (and so `if(val)` works, etc.)