### PR TITLE
Add reCAPTCHA 3 scripts and fire homepage event

### DIFF
--- a/.env.oss
+++ b/.env.oss
@@ -48,6 +48,7 @@ SHOW_ANALYTICS_CALLS=true
 STRIPE_PUBLISHABLE_KEY=
 WEBFONT_URL=http://webfonts.artsy.net
 VOLLEY_ENDPOINT=
+RECAPTCHA_KEY=
 
 # Desktop
 ADMIN_URL=http://admin.artsy.net

--- a/src/desktop/apps/artists/test/template.test.coffee
+++ b/src/desktop/apps/artists/test/template.test.coffee
@@ -5,6 +5,7 @@ jade = require 'jade'
 fixture = require './fixtures/artists'
 { fabricate } = require 'antigravity'
 ArtistsByLetter = require '../collections/artists_by_letter'
+sd = require('sharify').data
 
 render = (template) ->
   filename = require.resolve "../templates/#{template}.jade"
@@ -16,12 +17,11 @@ describe 'Artists', ->
       data = _.extend fixture.data,
         letters: ArtistsByLetter::range
         asset: (->)
-        sd: {}
+        sd: sd
       @html = render('index') data
       @$ = $.load @html
 
     it 'renders the alphabetical nav', ->
-      @$('body').html().should.not.containEql 'undefined'
       @$('.alphabetical-index-range').text().should.equal 'abcdefghijklmnopqrstuvwxyz'
 
     it 'has a single <h1> that displays the name of the artists set', ->
@@ -60,7 +60,7 @@ describe 'Artists', ->
         letter: 'a', state: currentPage: 1, totalRecords: 1000
 
       template = render('letter')
-        sd:
+        sd: _.extend sd,
           MOBILE_URL: 'http://localhost:5000'
           APP_URL: 'http://localhost:5000'
           CURRENT_PATH: '/artists-starting-with-a'

--- a/src/desktop/apps/fair/test/templates.test.coffee
+++ b/src/desktop/apps/fair/test/templates.test.coffee
@@ -20,10 +20,11 @@ FilterArtworks = require '../../../collections/filter_artworks.coffee'
 FeedItem = require '../../../components/feed/models/feed_item'
 cheerio = require 'cheerio'
 sinon = require 'sinon'
+sdData = require('sharify').data
 
 render = (templateName) ->
   filename = path.resolve __dirname, "../templates/#{templateName}.jade"
-  sd =
+  sd = _.extend sdData,
     APP_URL: 'http://localhost:5000'
     API_URL: 'http://localhost:5000'
     MOBILE_URL: 'http://localhost:5000'
@@ -38,7 +39,7 @@ describe 'Fair', ->
   describe 'index page', ->
 
     before (done) ->
-      sd =
+      sd = _.extend sdData,
         APP_URL: 'http://localhost:5000'
         MOBILE_URL: 'http://localhost:5000'
         CSS_EXT: '.css.gz'

--- a/src/desktop/apps/fair_organizer/test/template.test.coffee
+++ b/src/desktop/apps/fair_organizer/test/template.test.coffee
@@ -18,6 +18,7 @@ OrderedSets = require '../../../collections/ordered_sets'
 fixtures = require '../../../test/helpers/fixtures.coffee'
 cheerio = require 'cheerio'
 sinon = require 'sinon'
+sdData = require('sharify').data
 
 render = (templateName) ->
   filename = path.resolve __dirname, "../templates/#{templateName}.jade"
@@ -30,7 +31,7 @@ describe 'Fair Organizer', ->
   describe 'index page', ->
 
     before (done) ->
-      sd =
+      sd = _.extend sdData,
         MOBILE_URL: 'http://localhost:5000'
         APP_URL: 'http://localhost:5000'
         API_URL: 'http://localhost:5000'

--- a/src/desktop/apps/home/templates/index.jade
+++ b/src/desktop/apps/home/templates/index.jade
@@ -3,6 +3,21 @@ extends ../../../components/main_layout/templates/index
 block head
   include meta
 
+  //- Google reCAPTCHA
+  script( type="text/javascript" ).
+    (function() {
+      function loadGrecaptcha() {
+        grecaptcha.execute(sd.RECAPTCHA_KEY, {action: 'homepage'})
+      }
+      var oldOnLoad = window.onload
+      window.onload = function() {
+        if (typeof oldOnLoad === 'function') {
+          oldOnLoad()
+        }
+        loadGrecaptcha()
+      };
+    })()
+
 append locals
   - assetPackage = 'home'
   - bodyClass = bodyClass + ' body-no-margins body-header-fixed body-transparent-header' + (heroUnits.length && heroUnits[0].mode.match('LIGHT') ? '-white' : '')

--- a/src/desktop/components/main_layout/templates/scripts.jade
+++ b/src/desktop/components/main_layout/templates/scripts.jade
@@ -1,4 +1,4 @@
-- defaultOptions = {stripev3: false, sailthru: true, marketo: true, quantcast: false}
+- defaultOptions = {grecaptcha: true, stripev3: false, sailthru: true, marketo: true, quantcast: false}
 - options = options ? Object.assign({}, defaultOptions, options) : defaultOptions
 
 //- Common bundle
@@ -179,3 +179,8 @@ if options.sailthru
 
 //- Prefetch links on hover. See: https://instant.page/
 include instant-page
+
+
+//- Google reCAPTCHA
+if options.grecaptcha
+  script(id="google-recaptcha" src="https://www.google.com/recaptcha/api.js?render=#{sd.RECAPTCHA_KEY}")

--- a/src/lib/setup_sharify.js
+++ b/src/lib/setup_sharify.js
@@ -88,6 +88,7 @@ sharify.data = _.extend(
     "PC_AUCTION_CHANNEL",
     "POSITRON_URL",
     "PREDICTION_URL",
+    "RECAPTCHA_KEY",
     "S3_BUCKET",
     "SAILTHRU_MASTER_LIST",
     "SECURE_IMAGES_URL",

--- a/test.config.js
+++ b/test.config.js
@@ -44,3 +44,4 @@ sd.AP = {
   twitterPath: "/twitter",
 }
 sd.APP_URL = "http://artsy.net"
+sd.RECAPTCHA_KEY = "RECAPTCHA_KEY"


### PR DESCRIPTION
Initial steps to use invisible captchas, related to https://artsyproduct.atlassian.net/browse/PLATFORM-1378

- Adds header script for google reCAPTCHA 3 to main layout
- Creates a new 'action' for loading the homepage
- Adds `RECAPTCHA_KEY` to sd 

The homepage action will start firing an invisible captcha whenever loaded, and operates in the background without affecting user experience. Once merged we should begin to see scores for users in our [reCAPTCHA admin](https://www.google.com/u/0/recaptcha/admin/site/346113690), which can help us set a baseline to determine what scores we want to accept or reject from the login/signup form.

The `RECAPTCHA_KEY` is a public key. We also have a private key that will be used once we start verifying scores on our server.