### PR TITLE
Remove artist insights splitTest experiment

### DIFF
--- a/src/desktop/apps/artist/server.tsx
+++ b/src/desktop/apps/artist/server.tsx
@@ -16,12 +16,10 @@ app.get(
     try {
       const user = req.user && req.user.toJSON()
       const {
-        ARTIST_INSIGHTS,
         ARTIST_COLLECTIONS_RAIL, // TODO: update after Artist Collections Rail a/b test
       } = res.locals.sd
 
       const context = buildServerAppContext(req, res, {
-        ARTIST_INSIGHTS,
         showCollectionsRail: ARTIST_COLLECTIONS_RAIL === "experiment", // TODO: update after Artist Collections Rail a/b test
       })
       const {

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -25,16 +25,6 @@
 # module.exports = {}
 
 module.exports = {
-  artist_insights:
-    key: 'artist_insights'
-    outcomes: [
-      'v1'
-      'v2'
-    ]
-    control_group: 'v1'
-    edge: 'v2'
-    weighting: 'equal'
-
   artist_collections_rail:
     key: 'artist_collections_rail'
     outcomes: [

--- a/src/test/acceptance/artist.js
+++ b/src/test/acceptance/artist.js
@@ -14,18 +14,7 @@ describe("Artist page", () => {
   after(teardown)
 
   it("renders an artist name and some biographical info", async () => {
-    const $ = await browser.page(
-      "/artist/pablo-picasso?split_test[artist_insights]=v1"
-    )
-    $.html().should.containEql("Pablo Picasso")
-    $.html().should.containEql("Spanish")
-    $.html().should.containEql("1881-1973")
-  })
-
-  it("renders an artist name and some biographical info with artist insights v2 enabled", async () => {
-    const $ = await browser.page(
-      "/artist/pablo-picasso?split_test[artist_insights]=v2"
-    )
+    const $ = await browser.page("/artist/pablo-picasso")
     $.html().should.containEql("Pablo Picasso")
     $.html().should.containEql("Spanish")
     $.html().should.containEql("1881-1973")


### PR DESCRIPTION
Artist Insights V2 launched a while ago. This PR follows-up and removes the splitTest experiment.