### PR TITLE
Add RECAPTCHA_KEY to client sd config

### DIFF
--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -93,6 +93,7 @@ module.exports =
   POSITRON_URL: 'http://localhost:3005'
   PREDICTION_URL: 'https://live.artsy.net'
   REFLECTION_URL: 'http://artsy-reflection.s3-website-us-east-1.amazonaws.com/__reflection/forceartsynet'
+  RECAPTCHA_KEY: null,
   BURST_REQUEST_LIMIT: 15,            # Number of requests allowed per BURST_REQUEST_EXPIRE
   BURST_REQUEST_EXPIRE: 1,            # The period in seconds to measure burst requests
   BURST_REQUEST_BLOCK_FOR: 180,       # The number of seconds to block bursts after their limit is reached

--- a/src/mobile/config.coffee
+++ b/src/mobile/config.coffee
@@ -42,6 +42,7 @@ module.exports =
   PORT: 3003
   POSITRON_URL: 'http://writer.artsy.net'
   PREDICTION_URL: 'https://live.artsy.net'
+  RECAPTCHA_KEY: null,
   S3_BUCKET: null
   S3_KEY: null
   S3_SECRET: null


### PR DESCRIPTION
Missed one step in #3993, this makes sure client can access `RECAPTCHA_KEY`.