### PR TITLE
Hide captcha badge

### DIFF
--- a/src/desktop/components/main_layout/stylesheets/index.styl
+++ b/src/desktop/components/main_layout/stylesheets/index.styl
@@ -142,3 +142,6 @@ figure
 #scripts
   width 0
   height 0
+
+.grecaptcha-badge
+  visibility hidden


### PR DESCRIPTION
Didn't see this in production before the deploy, hides a google badge for the reCAPTCHA lib. 

<img width="555" alt="Screen Shot 2019-05-06 at 5 52 13 PM" src="https://user-images.githubusercontent.com/1497424/57257544-c2751800-7027-11e9-9529-6378d757a22b.png">
