### PR TITLE
Improve copy when user submits auction registration form without a required field

### DIFF
--- a/src/desktop/apps/auction_support/client/registration_form.coffee
+++ b/src/desktop/apps/auction_support/client/registration_form.coffee
@@ -137,7 +137,7 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
     return unless @validateAcceptConditions()
     analyticsHooks.trigger 'registration:submit-address'
     @loadingLock @$submit, =>
-      (if @validateForm() then Q() else Q.reject('Please review the error(s) above and try again.')).then =>
+      (if @validateForm() then Q() else Q.reject('')).then =>
         Q.all [@savePhoneNumber(), @tokenizeCard()]
       .catch (error) =>
         @showError error

--- a/src/desktop/apps/auction_support/test/client/registration_form.test.coffee
+++ b/src/desktop/apps/auction_support/test/client/registration_form.test.coffee
@@ -89,11 +89,8 @@ describe 'RegistrationForm', ->
         html = @view.$el.html()
         # FIXME: name error not rendered, bluebird hides failure
         # html.should.containEql 'Invalid name on card'
-        html.should.containEql 'Invalid city'
-        html.should.containEql 'Invalid state'
-        html.should.containEql 'Invalid zip'
-        html.should.containEql 'Invalid telephone'
-        html.should.containEql 'Please review the error(s) above and try again.'
+
+        html.should.containEql 'This field is required'
         @view.$submit.hasClass('is-loading').should.be.false()
         done()
 
@@ -106,7 +103,7 @@ describe 'RegistrationForm', ->
 
       @view.once "submitted", =>
         html = @view.$el.html()
-        html.should.containEql 'Please review the error(s) above and try again.'
+        html.should.containEql 'This field is required'
 
         Backbone.sync
           .yieldsTo 'success', {} # savePhoneNumber success

--- a/src/desktop/apps/auction_support/test/client/registration_form.test.coffee
+++ b/src/desktop/apps/auction_support/test/client/registration_form.test.coffee
@@ -87,8 +87,6 @@ describe 'RegistrationForm', ->
 
       @view.once 'submitted', =>
         html = @view.$el.html()
-        # html.should.containEql 'Invalid name on card'
-
         html.should.containEql 'This field is required'
         @view.$submit.hasClass('is-loading').should.be.false()
         done()

--- a/src/desktop/apps/auction_support/test/client/registration_form.test.coffee
+++ b/src/desktop/apps/auction_support/test/client/registration_form.test.coffee
@@ -87,7 +87,6 @@ describe 'RegistrationForm', ->
 
       @view.once 'submitted', =>
         html = @view.$el.html()
-        # FIXME: name error not rendered, bluebird hides failure
         # html.should.containEql 'Invalid name on card'
 
         html.should.containEql 'This field is required'

--- a/src/desktop/components/credit_card/client/error_handling_form.coffee
+++ b/src/desktop/components/credit_card/client/error_handling_form.coffee
@@ -38,7 +38,7 @@ module.exports = class ErrorHandlingForm extends Backbone.View
       continue unless val.el && !val.validator(val.el)
       errors[key] = val.message || "Invalid #{val.label || key}"
       val.el.addClass 'has-error'
-      val.el.last().after "<div class='error'>#{errors[key]}</div>"
+      val.el.last().after "<div class='error'>This field is required</div>"
     _.isEmpty(errors)
 
   filterHtml: ->

--- a/src/desktop/components/credit_card/client/error_handling_form.coffee
+++ b/src/desktop/components/credit_card/client/error_handling_form.coffee
@@ -36,9 +36,9 @@ module.exports = class ErrorHandlingForm extends Backbone.View
     @clearErrors()
     for own key, val of @fields
       continue unless val.el && !val.validator(val.el)
-      errors[key] = val.message || "Invalid #{val.label || key}"
+      errors[key] = val.message || "This field is required"
       val.el.addClass 'has-error'
-      val.el.last().after "<div class='error'>This field is required</div>"
+      val.el.last().after "<div class='error'>#{errors[key]}</div>"
     _.isEmpty(errors)
 
   filterHtml: ->

--- a/src/mobile/apps/auction_support/client/registration_form.coffee
+++ b/src/mobile/apps/auction_support/client/registration_form.coffee
@@ -126,7 +126,7 @@ module.exports = class RegistrationForm extends ErrorHandlingForm
     analyticsHooks.trigger 'registration:submitted-address'
 
     @loadingLock @$submit, =>
-      (if @validateForm() then Q() else Q.reject('Please review the error(s) above and try again.')).then =>
+      (if @validateForm() then Q() else Q.reject('')).then =>
         Q.all [@savePhoneNumber(), @tokenizeCard()]
       .catch (error) =>
         @showError error

--- a/src/mobile/apps/auction_support/test/client/registration_form.test.coffee
+++ b/src/mobile/apps/auction_support/test/client/registration_form.test.coffee
@@ -87,12 +87,7 @@ describe 'RegistrationForm', ->
 
       @view.on "submitted", =>
         html = @view.$el.html()
-        html.should.containEql 'Invalid name on card'
-        html.should.containEql 'Invalid city'
-        html.should.containEql 'Invalid state'
-        html.should.containEql 'Invalid zip'
-        html.should.containEql 'Invalid telephone'
-        html.should.containEql 'Please review the error(s) above and try again.'
+        html.should.containEql 'This field is required'
         done()
 
     it 'lets the user resubmit a corrected form', ->
@@ -103,7 +98,7 @@ describe 'RegistrationForm', ->
       @view.$submit.click()
       @view.once "submitted", =>
         html = @view.$el.html()
-        html.should.containEql 'Please review the error(s) above and try again.'
+        html.should.containEql 'This field is required'
 
         # Now submit a good one
         Backbone.sync

--- a/src/mobile/components/credit_card/client/error_handling_form.coffee
+++ b/src/mobile/components/credit_card/client/error_handling_form.coffee
@@ -30,7 +30,7 @@ module.exports = class ErrorHandlingForm extends Backbone.View
     @clearErrors()
     for own key, val of @fields
       continue unless val.el && !val.validator(val.el)
-      errors[key] = val.message || "Invalid #{val.label || key}"
+      errors[key] = val.message || "This field is required"
       val.el.addClass 'has-error'
       val.el.last().after "<div class='error'>#{errors[key]}</div>"
     _.isEmpty(errors)


### PR DESCRIPTION
If a user has left a required field empty after clicking "Register", they will see "invalid [telephone, city, state]" etc. On the app we currently display "This field is required" which is a much clearer message.

https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=41&view=planning&selectedIssue=PURCHASE-874

__Before:__
<img width="553" alt="Screen Shot 2019-05-06 at 6 01 02 PM" src="https://user-images.githubusercontent.com/5643895/57258070-47acfc80-7029-11e9-8082-53ae11148569.png">

__After:__
<img width="587" alt="Screen Shot 2019-05-06 at 5 58 27 PM" src="https://user-images.githubusercontent.com/5643895/57258082-509dce00-7029-11e9-8288-50f71a4c512c.png">

<img width="384" alt="Screen Shot 2019-05-09 at 1 42 00 PM" src="https://user-images.githubusercontent.com/5643895/57474530-487ba380-7260-11e9-81ae-da43634b50a9.png">
