### PR TITLE
[WIP] Add reCAPTCHA actions to auth2 forms

### DIFF
--- a/src/desktop/apps/auth2/components/AuthStatic.tsx
+++ b/src/desktop/apps/auth2/components/AuthStatic.tsx
@@ -17,8 +17,21 @@ interface Props {
 }
 
 export class AuthStatic extends React.Component<Props> {
+  onHandleSubmit = (values, formikBag) => {
+    const { type, options } = this.props
+    // @ts-ignore
+    grecaptcha.ready(() => {
+      // @ts-ignore
+      grecaptcha.execute(sd.RECAPTCHA_KEY, { action: type })
+      handleSubmit(type as ModalType, options, values, formikBag)
+    })
+  }
+
   render() {
-    const { type, meta: { title } } = this.props
+    const {
+      type,
+      meta: { title },
+    } = this.props
     return (
       <Wrapper>
         <AuthFormContainer>
@@ -27,11 +40,7 @@ export class AuthStatic extends React.Component<Props> {
             {...this.props}
             type={type as ModalType}
             isStatic
-            handleSubmit={handleSubmit.bind(
-              this,
-              this.props.type,
-              this.props.options
-            )}
+            handleSubmit={this.onHandleSubmit}
             submitUrls={{
               login: "/log_in",
               forgot: "/forgot_password",

--- a/src/desktop/apps/auth2/components/MobileAuthStatic.tsx
+++ b/src/desktop/apps/auth2/components/MobileAuthStatic.tsx
@@ -7,6 +7,7 @@ import {
   ModalType,
   ModalOptions,
 } from "reaction/Components/Authentication/Types"
+import { data as sd } from "sharify"
 
 interface Props {
   type: string
@@ -15,8 +16,18 @@ interface Props {
 }
 
 export class MobileAuthStatic extends React.Component<Props> {
+  onHandleSubmit = (values, formikBag) => {
+    const { type, options } = this.props
+    // @ts-ignore
+    grecaptcha.ready(() => {
+      // @ts-ignore
+      grecaptcha.execute(sd.RECAPTCHA_KEY, { action: type })
+      handleSubmit(type as ModalType, options, values, formikBag)
+    })
+  }
+
   render() {
-    const { options } = this.props
+    const { type, options } = this.props
     const submitUrls = {
       login: "/log_in",
       forgot: "/forgot_password",
@@ -30,13 +41,9 @@ export class MobileAuthStatic extends React.Component<Props> {
         <MobileContainer>
           <FormSwitcher
             {...this.props}
-            title={this.props.options.title}
-            type={this.props.type as ModalType}
-            handleSubmit={handleSubmit.bind(
-              this,
-              this.props.type,
-              this.props.options
-            )}
+            title={options.title}
+            type={type as ModalType}
+            handleSubmit={this.onHandleSubmit}
             onBackButtonClicked={() => {
               if (typeof window !== "undefined") {
                 window.location.href = options.redirectTo || "/"

--- a/src/desktop/apps/auth2/components/ModalContainer.tsx
+++ b/src/desktop/apps/auth2/components/ModalContainer.tsx
@@ -11,69 +11,82 @@ import {
 
 const mediator = require("../../../lib/mediator.coffee")
 
-export const ModalContainer: React.SFC<any> = () => {
-  let manager: ModalManager | null
+export class ModalContainer extends React.Component<any> {
+  public manager: ModalManager | null
 
-  mediator.on("open:auth", (options: ModalOptions) => {
+  componentWillMount() {
+    mediator.on("open:auth", this.onOpenAuth)
+    mediator.on("auth:error", this.onAuthError)
+  }
+
+  onHandleSubmit = (type, options, values, formikBag) => {
+    // @ts-ignore
+    grecaptcha.ready(() => {
+      // @ts-ignore
+      grecaptcha.execute(sd.RECAPTCHA_KEY, { action: type })
+      handleSubmit(type as ModalType, options, values, formikBag)
+    })
+  }
+
+  onOpenAuth = (options: ModalOptions) => {
     options.destination = options.destination || location.href
-
-    setCookies(options)
-
     if (options && (options.mode as any) === "register") {
       options.mode = ModalType.signup
     }
 
-    setTimeout(() => {
-      if (manager) {
-        manager.openModal(options)
-      }
-    }, document.readyState === "complete" ? 0 : 500)
-  })
-
-  mediator.on("auth:error", err => {
-    if (manager) {
-      manager.setError(err)
-    }
-  })
-
-  return (
-    <ModalManager
-      ref={ref => (manager = ref)}
-      submitUrls={{
-        login: sd.AP.loginPagePath,
-        signup: sd.AP.signupPagePath,
-        facebook: sd.AP.facebookPath,
-        twitter: sd.AP.twitterPath,
-      }}
-      csrf={sd.CSRF_TOKEN}
-      handleSubmit={handleSubmit as any}
-      onSocialAuthEvent={data => {
-        const analyticsOptions = {
-          action:
-            data.mode === "signup"
-              ? "Created account"
-              : "Successfully logged in",
-          type: data.mode,
-          context_module: data.contextModule,
-          modal_copy: data.copy,
-          trigger: data.trigger || "click",
-          trigger_seconds: data.triggerSeconds,
-          intent: data.intent,
-          auth_redirect: data.redirectTo || data.destination,
-          service: data.service,
+    setCookies(options)
+    setTimeout(
+      () => {
+        if (this.manager) {
+          this.manager.openModal(options)
         }
+      },
+      document.readyState === "complete" ? 0 : 500
+    )
+  }
 
-        Cookies.set(
-          `analytics-${data.mode}`,
-          JSON.stringify(analyticsOptions),
-          {
-            expires: 60 * 60 * 24,
-          }
-        )
-      }}
-      onModalClose={() => {
-        mediator.trigger("modal:closed")
-      }}
-    />
-  )
+  onAuthError = (err: any) => {
+    if (this.manager) {
+      this.manager.setError(err)
+    }
+  }
+
+  onSocialAuthEvent = (data: any) => {
+    const analyticsOptions = {
+      action:
+        data.mode === "signup" ? "Created account" : "Successfully logged in",
+      type: data.mode,
+      context_module: data.contextModule,
+      modal_copy: data.copy,
+      trigger: data.trigger || "click",
+      trigger_seconds: data.triggerSeconds,
+      intent: data.intent,
+      auth_redirect: data.redirectTo || data.destination,
+      service: data.service,
+    }
+
+    Cookies.set(`analytics-${data.mode}`, JSON.stringify(analyticsOptions), {
+      expires: 60 * 60 * 24,
+    })
+  }
+
+  render() {
+    return (
+      <ModalManager
+        ref={ref => (this.manager = ref)}
+        submitUrls={{
+          login: sd.AP.loginPagePath,
+          signup: sd.AP.signupPagePath,
+          facebook: sd.AP.facebookPath,
+          twitter: sd.AP.twitterPath,
+        }}
+        csrf={sd.CSRF_TOKEN}
+        handleSubmit={this.onHandleSubmit}
+        onSocialAuthEvent={this.onSocialAuthEvent}
+        onModalClose={() => {
+          mediator.trigger("modal:closed")
+        }}
+      />
+    )
+  }
 }


### PR DESCRIPTION
Updates all `/auth2` wrappers to fire a `grepcaptcha` action when an auth form is submitted via `handleSubmit`. The action is named for the type of the form: `login`, `signup` or `forgot`.

This implementation will report results to our reCAPTCHA admin panel, but does not block any users. 

On hold pending a few questions--
- How do we incorporate the Google terms/logo into our auth form
- Add some tests to ensure `grecaptcha` events are fired
