### PR TITLE
Forgot default value for env var #trivial

### DIFF
--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -13,6 +13,7 @@ module.exports =
   APPLICATION_NAME: 'force-staging'
   APPLY_URL: 'http://apply.artsy.net'
   APP_URL: 'http://localhost:3004'
+  ARTIST_COLLECTIONS_RAIL_IDS: null
   ARTSY_EDITORIAL_CHANNEL: '5759e3efb5989e6f98f77993'
   ARTSY_ID: null
   ARTSY_SECRET: null


### PR DESCRIPTION
#trivial change, I forgot to include the env variable in the config file as well.
As a sidenote we should move away from `./desktop/config` and `./mobile/config`

https://github.com/artsy/force/blob/02f99c674f42a8d82b925e5716657b0a782acd6b/src/config.js#L1-L12