### PR TITLE
Use new renovate app config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,6 @@
     "@artsy:app"
   ],
   "assignees": [
-    "zephraph",
+    "zephraph"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,8 @@
 {
   "extends": [
-    "@artsy"
+    "@artsy:app"
   ],
   "assignees": [
     "zephraph",
-    "damassi",
-    "sweir27"
-  ],
-  "automerge": true,
-  "major": {
-    "automerge": false
-  }
+  ]
 }


### PR DESCRIPTION
This updates renovate's config to use the new app preset. Removes assignees (other than myself) to be in line with our new limited assignee workflow, and delete the automerge config (which is already configured via the app preset). 