### PR TITLE
Matches flickity@2.1.2 for Force and Reaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "express-request-id": "1.4.0",
     "factor-bundle": "2.5.0",
     "fastclick": "1.0.6",
-    "flickity": "2.0.6",
+    "flickity": "2.1.2",
     "forever": "0.15.3",
     "gemup": "0.0.2",
     "geoformatter": "dzucconi/geo_formatter",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6160,17 +6160,17 @@ flatiron@~0.4.2:
     optimist "0.6.0"
     prompt "0.2.14"
 
-flickity@2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/flickity/-/flickity-2.0.6.tgz#c623f0417b43cab833a03a5a1a6a23ef08a0a31c"
-  integrity sha1-xiPwQXtDyrgzoDpaGmoj7wigoxw=
+flickity@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/flickity/-/flickity-2.1.2.tgz#f1be68a75c8d8d8d6df68fb2a49f358268279bd0"
+  integrity sha512-6IBJjkfCQ8yG6pah9rA9k4NoA9txuIf9+b3V67y70FdZK0icponlJEqseqLKuram0odKrv9ryjrBHQHgMkFfZA==
   dependencies:
     desandro-matches-selector "^2.0.0"
     ev-emitter "^1.0.2"
     fizzy-ui-utils "^2.0.0"
     get-size "^2.0.0"
     tap-listener "^2.0.0"
-    unidragger "^2.1.0"
+    unidragger "^2.3.0"
 
 flickity@^2.1.2:
   version "2.2.0"
@@ -14875,13 +14875,6 @@ unicode-property-aliases-ecmascript@^1.0.4:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz#5a533f31b4317ea76f17d807fa0d116546111dd0"
   integrity sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==
 
-unidragger@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/unidragger/-/unidragger-2.2.0.tgz#b162f05b8d53b929acc5f5a6e35e09ef69261f30"
-  integrity sha1-sWLwW41TuSmsxfWm414J72kmHzA=
-  dependencies:
-    unipointer "^2.2.0"
-
 unidragger@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/unidragger/-/unidragger-2.3.0.tgz#ab9d9fd62106f3252d88fae5f3a99575e6d31d02"
@@ -14899,14 +14892,7 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^0.4.3"
 
-unipointer@^2.1.0, unipointer@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/unipointer/-/unipointer-2.2.0.tgz#3f6cf997f7d7dc78f75385106a5527efc5d71b61"
-  integrity sha1-P2z5l/fX3Hj3U4UQalUn78XXG2E=
-  dependencies:
-    ev-emitter "^1.0.1"
-
-unipointer@^2.3.0:
+unipointer@^2.1.0, unipointer@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/unipointer/-/unipointer-2.3.0.tgz#ba0dc462ce31c2a88e80810e19c3bae0ce47ed9f"
   integrity sha512-m85sAoELCZhogI1owtJV3Dva7GxkHk2lI7A0otw3o0OwCuC/Q9gi7ehddigEYIAYbhkqNdri+dU1QQkrcBvirQ==


### PR DESCRIPTION
- Updates Flickity version to be the same as the version used in Reaction
- Does not introduce bug introduced in version `2.2.0` mentioned here https://github.com/artsy/force/pull/3985