### PR TITLE
Patches flickity

### DIFF
--- a/patches/react-flickity-component+3.2.0.patch
+++ b/patches/react-flickity-component+3.2.0.patch
@@ -1,0 +1,26 @@
+patch-package
+--- a/node_modules/react-flickity-component/lib/index.js
++++ b/node_modules/react-flickity-component/lib/index.js
+@@ -90,13 +90,6 @@ var FlickityComponent = function (_Component) {
+       if (disableImagesLoaded) setFlickityToReady();else (0, _imagesloaded2.default)(carousel, setFlickityToReady);
+       if (flickityRef) flickityRef(this.flkty);
+     }
+-  }, {
+-    key: 'renderPortal',
+-    value: function renderPortal() {
+-      if (!this.carousel) return null;
+-      var mountNode = this.carousel.querySelector('.flickity-slider');
+-      if (mountNode) return (0, _reactDom.createPortal)(this.props.children, mountNode);
+-    }
+   }, {
+     key: 'render',
+     value: function render() {
+@@ -107,7 +100,7 @@ var FlickityComponent = function (_Component) {
+         ref: function ref(c) {
+           _this3.carousel = c;
+         }
+-      }, this.renderPortal());
++      }, this.props.children);
+     }
+   }]);
+ 


### PR DESCRIPTION
- Follow up to https://github.com/artsy/reaction/pull/2388 for Force to remove Flicker from Flickity carousel
- Will also remove this patch once https://github.com/theolampert/react-flickity-component/pull/64 is merged.