### PR TITLE
improve start.sh

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -22,14 +22,15 @@ if [ "$NODE_ENV" != "production" ]; then
      [ $(version $TERM_PROGRAM_VERSION) -ge $(version "1.22.2") ]
   then
     # Sometimes we have force and metaphysics running at the same time.
-    # in that case we don't want
-    if (node --inspect-brk -e 'console.log()') &> /dev/null; then
-      OPT+=(--inspect-brk)
-    else
+    # in that case we don't want to fail to launch, but simply show a warning
+    # that the debugging won't work.
+    if (nc -z 127.0.0.1 9229) &> /dev/null; then
       echo
       echo "WARNING! You are already debugging another node process!"
       echo
       echo "    force will start without --inspect-brk unless you kill the other process"
+    else
+      OPT+=(--inspect-brk)
     fi
   fi
 


### PR DESCRIPTION
When working with local metaphysics + force I find that they can't run at the same time with the default `yarn start` commands because they both try to start node with `--inspect-brk`. It's not possible to do that because `--inspect-brk` relies on a specific port.

So I often find myself having to alter the `start.sh` script of force, or MP's procfile just to get them both running at the same time. It's minor annoyance. Let's make it go away.

Also made the `-x` flag a production-only thing to avoid dev-time terminal noise.

Before:

![image](https://user-images.githubusercontent.com/1242537/57527689-3e24dc80-7328-11e9-9277-09c01179709b.png)

After:

![image](https://user-images.githubusercontent.com/1242537/57527977-f18dd100-7328-11e9-80f0-62345c2d30bf.png)

