### PR TITLE
fix commercial conversion events tracking #minor

### DIFF
--- a/src/desktop/analytics/bidding.js
+++ b/src/desktop/analytics/bidding.js
@@ -117,13 +117,23 @@ analyticsHooks.on("error", function(message) {
 
 // Confirmed bid on bid page
 analyticsHooks.on("confirm:bid:form:success", function(data) {
+  const price = data.max_bid_amount_cents
+    ? data.max_bid_amount_cents / 100
+    : null
   analytics.track("Confirmed bid on bid page", {
     auction_slug: sd.SALE.id,
     user_id: USER_ID,
     artwork_slug: sd.SALE_ARTWORK.artwork.id,
-    product_id: sd.SALE_ARTWORK.artwork._id,
+    products: [
+      {
+        product_id: sd.SALE_ARTWORK.artwork._id,
+        quantity: 1,
+        price: price,
+      },
+    ],
     bidder_position_id: data.bidder_position_id,
     bidder_id: data.bidder_id,
+    order_id: data.bidder_id,
   })
 })
 

--- a/src/desktop/analytics/inquiry_questionnaire.js
+++ b/src/desktop/analytics/inquiry_questionnaire.js
@@ -177,7 +177,13 @@
   bindOnce("inquiry:sync", function(context) {
     analytics.track("Sent artwork inquiry", {
       artwork_id: context.artwork.get("_id"),
-      product_id: context.artwork.get("_id"),
+      products: [
+        {
+          product_id: context.artwork.get("_id"),
+          quantity: 1,
+          price: context.artwork.get("price") || 6000,
+        },
+      ],
       artwork_slug: context.artwork.id,
       inquiry_id: context.inquiry.id,
     })


### PR DESCRIPTION
Updates the schema for conversion events on bids and inquiries to allow segment to forward on data to Criteo.