### PR TITLE
GALL-1563: Remove the gallery insights blog

### DIFF
--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -127,7 +127,7 @@ module.exports =
   SITEMAP_BASE_URL: 'http://artsy-sitemaps.s3-website-us-east-1.amazonaws.com'
   SHOW_ANALYTICS_CALLS: false
   STRIPE_PUBLISHABLE_KEY: null
-  TEAM_BLOGS: '^\/life-at-artsy$|^\/artsy-education$|^\/gallery-insights$|^\/buying-with-artsy$'
+  TEAM_BLOGS: '^\/life-at-artsy$|^\/artsy-education$|^\/buying-with-artsy$'
   TARGET_CAMPAIGN_URL: '/seattle-art-fair-2017'
   TRACK_PAGELOAD_PATHS: null
   TWILIO_ACCOUNT_SID: null


### PR DESCRIPTION
This is now over on a WordPress blog so we're just killing this route and we've setup a vanity shortcut for it. There's more cleanup to do, but we'll get that in a separate PR once we're sure the redirection is working as expected.