### PR TITLE
[TRIVIAL] Update @artsy/passport

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@airbnb/node-memwatch": "1.0.2",
     "@artsy/express-reloadable": "1.4.6",
     "@artsy/palette": "4.11.9",
-    "@artsy/passport": "1.1.1",
+    "@artsy/passport": "1.1.2",
     "@artsy/reaction": "16.11.19",
     "@artsy/stitch": "6.1.3",
     "@babel/core": "7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,10 +41,10 @@
     styled-system "^3.1.11"
     trunc-html "^1.1.2"
 
-"@artsy/passport@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@artsy/passport/-/passport-1.1.1.tgz#f8aa1ebd405f8bda9b0c7ce7fadebf0e390fe080"
-  integrity sha512-0vnNs1ZK5+BON/TVOlg3br6S/lXULPABFcffPByGLpIKIhiAo1dC7wAFwPPDDk+GrvjJOvNi0923wvbvesdQnA==
+"@artsy/passport@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@artsy/passport/-/passport-1.1.2.tgz#6171558435e48d7cef5d70881070365aba56a0e4"
+  integrity sha512-eNddrCudYX7gf0Sp6nbNL2cSr5+i15M4/tLIyq+EqxjHsdrCD/pd33ItEUmfPbAO988sJmEJffhsp+BwMaizKg==
   dependencies:
     analytics-node "^2.1.0"
     async "^1.5.0"


### PR DESCRIPTION
Bumps to version 1.1.2, includes support for `recaptcha_token`