### PR TITLE
@izakp: Try to avoid timeouts when waiting for rollouts to complete in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,7 @@ jobs:
       - run:
           name: Deploy
           command: hokusai staging deploy $CIRCLE_SHA1
+          no_output_timeout: 20m
 
   deploy_hokusai_production:
     docker:
@@ -105,6 +106,7 @@ jobs:
       - run:
           name: Deploy
           command: hokusai production deploy $CIRCLE_SHA1 --git-remote origin
+          no_output_timeout: 20m
 
 not_staging_or_release: &not_staging_or_release
   filters:


### PR DESCRIPTION
The last dozen or so builds have failed, most timing out after 10 minutes without output. We're not sure if the docker environment is crashing, getting killed, or getting disconnected, or just taking a long time. This doubles the wait time for staging and production deploys.