### PR TITLE
Moves Enabled Ad Feature Flags to server

### DIFF
--- a/src/desktop/apps/article/__tests__/third_party_ads_enabled.jest.ts
+++ b/src/desktop/apps/article/__tests__/third_party_ads_enabled.jest.ts
@@ -1,0 +1,51 @@
+import { areThirdPartyAdsEnabled } from "desktop/apps/article/third_party_ads_enabled"
+import { data as sd } from "sharify"
+
+jest.mock("sharify", () => ({
+  data: {
+    HASHTAG_LAB_ADS_ALLOWLIST: "alloweduser@email.com,alloweduser2@email.com",
+    HASHTAG_LAB_ADS_ENABLED: true,
+    CURRENT_USER: {
+      type: "Non-Admin",
+      email: "someuser@email.com",
+    },
+  },
+}))
+
+describe("feature flag checks when ads should be disabled", () => {
+  it("checks that ads are disabled for non-allowlisted users", () => {
+    const currentUser = sd.CURRENT_USER.email
+    const allowList = sd.HASHTAG_LAB_ADS_ALLOWLIST.split(",").filter(Boolean)
+    const isUserAllowed = allowList.includes(currentUser)
+    const mockResponse = sd.data
+
+    expect(areThirdPartyAdsEnabled(mockResponse)).toBe(false)
+    expect(allowList).toHaveLength(2)
+    expect(isUserAllowed).toBe(false)
+    expect(allowList).toHaveLength(2)
+    expect(allowList).toEqual([
+      "alloweduser@email.com",
+      "alloweduser2@email.com",
+    ])
+  })
+
+  it("checks that ads are disabled for current users", () => {
+    const currentUser = sd.CURRENT_USER.email
+    const allowList = sd.HASHTAG_LAB_ADS_ALLOWLIST.split(",").filter(Boolean)
+    const allowedUsers = allowList.includes(currentUser)
+    const mockResponse = sd.data
+
+    expect(areThirdPartyAdsEnabled(mockResponse)).toBe(false)
+    expect(allowedUsers).not.toContain(currentUser)
+  })
+
+  it("checks that ads are disabled for non-admin users", () => {
+    const adminUser = sd.CURRENT_USER.type
+    const isAdminUser = adminUser === "Admin"
+    const mockResponse = sd.data
+
+    expect(areThirdPartyAdsEnabled(mockResponse)).toBe(false)
+    expect(isAdminUser).toBe(false)
+    expect(adminUser).toEqual("Non-Admin")
+  })
+})

--- a/src/desktop/apps/article/components/InfiniteScrollArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollArticle.tsx
@@ -145,6 +145,7 @@ export class InfiniteScrollArticle extends React.Component<
       showTooltips,
       showCollectionsRail,
       onOpenAuthModal,
+      areHostedAdsEnabled,
     } = this.props
     const { articles, renderTimes } = this.state
 
@@ -165,6 +166,7 @@ export class InfiniteScrollArticle extends React.Component<
               onOpenAuthModal={onOpenAuthModal}
               renderTime={renderTimes[Math.floor(i / 3)]}
               infiniteScrollEntrySlug={slug}
+              areHostedAdsEnabled={areHostedAdsEnabled}
             />
             <Waypoint
               onEnter={waypointData => this.onEnter(article, waypointData)}

--- a/src/desktop/apps/article/components/layouts/Article.tsx
+++ b/src/desktop/apps/article/components/layouts/Article.tsx
@@ -104,6 +104,7 @@ export class ArticleLayout extends React.Component<
       renderTime,
       showTooltips,
       showCollectionsRail,
+      areHostedAdsEnabled,
       templates: { SuperArticleFooter, SuperArticleHeader } = {} as any,
     } = this.props
 
@@ -133,6 +134,7 @@ export class ArticleLayout extends React.Component<
             renderTime={renderTime}
             showTooltips={showTooltips}
             showCollectionsRail={showCollectionsRail}
+            areHostedAdsEnabled={areHostedAdsEnabled}
           />
         ) : (
           <InfiniteScrollArticle
@@ -142,6 +144,7 @@ export class ArticleLayout extends React.Component<
             renderTime={renderTime}
             showTooltips={showTooltips}
             showCollectionsRail={showCollectionsRail}
+            areHostedAdsEnabled={areHostedAdsEnabled}
           />
         )}
 

--- a/src/desktop/apps/article/routes.ts
+++ b/src/desktop/apps/article/routes.ts
@@ -18,6 +18,7 @@ const markdown = require("desktop/components/util/markdown.coffee")
 const { crop, resize } = require("desktop/components/resizer/index.coffee")
 const { stringifyJSONForWeb } = require("desktop/components/util/json.coffee")
 const _Article = require("desktop/models/article.coffee")
+import { areThirdPartyAdsEnabled } from "desktop/apps/article/third_party_ads_enabled"
 
 const { SAILTHRU_KEY, SAILTHRU_SECRET } = require("config")
 const sailthru = require("sailthru-client").createSailthruClient(
@@ -39,6 +40,7 @@ export async function index(req, res, next) {
       query: ArticleQuery(articleId),
       req,
     })
+    const areHostedAdsEnabled = areThirdPartyAdsEnabled(res.locals)
     const article = data.article
     const articleModel = new Article(data.article)
     const search = new URL(sd.APP_URL + req.url).search
@@ -156,6 +158,7 @@ export async function index(req, res, next) {
         markdown,
       },
       data: {
+        areHostedAdsEnabled,
         article,
         customEditorial,
         isSuper,
@@ -192,6 +195,7 @@ export function classic(req, res, _next) {
     id: req.params.slug,
   })
   const accessToken = req.user ? req.user.get("accessToken") : null
+  const areHostedAdsEnabled = areThirdPartyAdsEnabled(res.locals)
 
   article.fetchWithRelated({
     accessToken,
@@ -218,6 +222,7 @@ export function classic(req, res, _next) {
       res.render(
         "article",
         _.extend(data, {
+          areHostedAdsEnabled,
           embed,
           crop,
           resize,
@@ -231,6 +236,7 @@ export function amp(req, res, next) {
   const article = new Article({
     id: req.params.slug,
   })
+  const areHostedAdsEnabled = areThirdPartyAdsEnabled(res.locals)
 
   article.fetchWithRelated({
     error: res.backboneError,
@@ -249,6 +255,7 @@ export function amp(req, res, next) {
       return res.render(
         "amp_article",
         _.extend(data, {
+          areHostedAdsEnabled,
           resize,
           crop,
           embed,

--- a/src/desktop/apps/article/third_party_ads_enabled.ts
+++ b/src/desktop/apps/article/third_party_ads_enabled.ts
@@ -1,0 +1,40 @@
+/**
+ * For now ads, served by Hashtag Labs are only to viewable in the following instances:
+ *  1) When the environment is NOT Production (HASHTAG_LAB_ADS_ENABLED set to false)
+ *  2) When a user is an Admin
+ *  3) When a user has been added to the allowlist set via HASHTAG_LAB_ADS_ALLOWLIST
+ */
+
+export const areThirdPartyAdsEnabled = resp => {
+  const isSharifyGuarded = resp && resp.sd
+  const isUserGuarded = isSharifyGuarded && resp.sd.CURRENT_USER
+  const areThirdPartyAdsEnabled =
+    isSharifyGuarded && resp.sd.HASHTAG_LAB_ADS_ENABLED
+      ? resp.sd.HASHTAG_LAB_ADS_ENABLED
+      : false
+  const allowList =
+    isSharifyGuarded && resp.sd.HASHTAG_LAB_ADS_ALLOWLIST
+      ? resp.sd.HASHTAG_LAB_ADS_ALLOWLIST
+      : ""
+
+  const allowedUsers = allowList.split(",").filter(Boolean)
+  const currentUser =
+    isSharifyGuarded && isUserGuarded && resp.sd.CURRENT_USER.email
+      ? resp.sd.CURRENT_USER.email
+      : null
+  const isAllowedUser = allowedUsers.includes(currentUser)
+  const isAdminUser =
+    (isSharifyGuarded &&
+      isUserGuarded &&
+      resp.sd.CURRENT_USER.type &&
+      resp.sd.CURRENT_USER.type === "Admin") ||
+    false
+
+  if (!areThirdPartyAdsEnabled) {
+    return false
+  }
+  if (isAllowedUser || isAdminUser) {
+    return true
+  }
+  return false
+}


### PR DESCRIPTION
This PR is an update of https://github.com/artsy/reaction/pull/2391. Instead of checking feature flags and en/disabling externally hosted ads client side, we now handle it server side.