### PR TITLE
Do not fire homepage reCAPTCHA event without key

### DIFF
--- a/src/desktop/apps/home/templates/index.jade
+++ b/src/desktop/apps/home/templates/index.jade
@@ -7,7 +7,9 @@ block head
   script( type="text/javascript" ).
     (function() {
       function loadGrecaptcha() {
-        grecaptcha.execute(sd.RECAPTCHA_KEY, {action: 'homepage'})
+        if (sd.RECAPTCHA_KEY) {
+          grecaptcha.execute(sd.RECAPTCHA_KEY, {action: 'homepage'})
+        }
       }
       var oldOnLoad = window.onload
       window.onload = function() {


### PR DESCRIPTION
Missed one spot when updating reCAPTCHA events to fire only when `sd.RECAPTCHA_KEY` is present.