### PR TITLE
Auth errors via query render a message

### DIFF
--- a/src/desktop/apps/home/client/auth_router.coffee
+++ b/src/desktop/apps/home/client/auth_router.coffee
@@ -33,7 +33,7 @@ module.exports = class HomeAuthRouter extends Backbone.Router
         when 'account-not-found', 'no-user-access-token', 'no-user'
           "We couldn't find your account. Please sign up."
         else
-          error
+          "An unexpected error occurred."
       mediator.trigger 'open:auth',
         mode: 'login'
         intent: 'login'


### PR DESCRIPTION
Related to https://artsyproduct.atlassian.net/browse/GROW-1179

Stops rendering errors passed via query params, and instead renders a default message. 