### PR TITLE
DISCO-927: Block /search/ from robots

### DIFF
--- a/src/desktop/apps/sitemaps/routes.coffee
+++ b/src/desktop/apps/sitemaps/routes.coffee
@@ -47,6 +47,7 @@ getFullEditorialHref = require("@artsy/reaction/dist/Components/Publishing/Const
     Disallow: /*?dns_source=
     Disallow: /*?microsite=
     Disallow: /*?from-show-guide=
+    Disallow: /search/
     Sitemap: #{APP_URL}/sitemap-articles.xml
     Sitemap: #{APP_URL}/sitemap-artists.xml
     Sitemap: #{APP_URL}/sitemap-artist-images.xml

--- a/src/desktop/apps/sitemaps/test/routes.test.coffee
+++ b/src/desktop/apps/sitemaps/test/routes.test.coffee
@@ -45,6 +45,7 @@ Noindex: ?dimension_range=
 Disallow: /*?dns_source=
 Disallow: /*?microsite=
 Disallow: /*?from-show-guide=
+Disallow: /search/
 Sitemap: https://www.artsy.net/sitemap-articles.xml
 Sitemap: https://www.artsy.net/sitemap-artists.xml
 Sitemap: https://www.artsy.net/sitemap-artist-images.xml


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/DISCO-927

We want to prevent bots from indexing pages like https://www.artsy.net/search?term=%EB%B3%B4%EC%A7%80%EA%B1%B8%EC%B2%9C%EC%82%AC%E2%80%BB%20omija.com%20%EC%98%A4%EB%B4%89%EB%84%B7hanging%EB%AA%A8%EC%95%84%EC%A4%98%ED%8B%B0%EB%B9%84%E3%83%A0%ED%88%B0%EC%BD%94%EC%A3%BC%EC%86%8Cnamely%20%ED%95%91%EC%9C%A0%EB%84%B7%E2%88%AA%EC%A7%88%EC%8B%B8%EB%8B%B7%EC%BB%B4h%EB%B9%A0%EA%B5%AC%EB%A6%AC%EB%84%B7%E2%94%AB%E2%92%9F%ED%92%80%EB%B9%B5%EB%8B%B7%EC%BB%B4edge (apparently a URL that is really indexed by Google).