### PR TITLE
Remove Sentry client during local development

### DIFF
--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -119,13 +119,15 @@ function setupJquery() {
 }
 
 function setupErrorReporting() {
-  Sentry.init({ dsn: sd.SENTRY_PUBLIC_DSN })
-  const user = sd && sd.CURRENT_USER
+  if (sd.NODE_ENV === "production") {
+    Sentry.init({ dsn: sd.SENTRY_PUBLIC_DSN })
+    const user = sd && sd.CURRENT_USER
 
-  if (sd.CURRENT_USER) {
-    Sentry.configureScope(scope => {
-      scope.setUser(_.pick(user, "id", "email"))
-    })
+    if (sd.CURRENT_USER) {
+      Sentry.configureScope(scope => {
+        scope.setUser(_.pick(user, "id", "email"))
+      })
+    }
   }
 }
 


### PR DESCRIPTION
Noticed that Sentry was consuming local stack traces in dev since everything was piped through sentry's client. Guards so that it's only enabled for staging or prod deploys.