### PR TITLE
@joeyAghion => [Image Uploading] Drop redundant gemini config, consolidate on @artsy/gemup #migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
   "dependencies": {
     "@airbnb/node-memwatch": "1.0.2",
     "@artsy/express-reloadable": "1.4.6",
+    "@artsy/gemup": "0.0.3",
     "@artsy/palette": "4.12.6",
     "@artsy/passport": "1.1.4",
     "@artsy/reaction": "16.12.21",
@@ -129,7 +130,6 @@
     "artsy-backbone-mixins": "artsy/artsy-backbone-mixins",
     "artsy-eigen-web-association": "artsy/artsy-eigen-web-association",
     "artsy-ezel-components": "artsy/artsy-ezel-components",
-    "artsy-gemini-upload": "0.0.6",
     "artsy-morgan": "artsy/artsy-morgan",
     "artsy-xapp": "artsy/artsy-xapp",
     "babel-eslint": "7.2.3",
@@ -179,7 +179,6 @@
     "fastclick": "1.0.6",
     "flickity": "2.1.2",
     "forever": "0.15.3",
-    "gemup": "0.0.2",
     "geoformatter": "dzucconi/geo_formatter",
     "geolib": "2.0.22",
     "glob": "7.1.3",

--- a/src/desktop/apps/consign/client/actions.js
+++ b/src/desktop/apps/consign/client/actions.js
@@ -1,5 +1,5 @@
 import _request from "superagent"
-import gemup from "gemup"
+import gemup from "@artsy/gemup"
 import { get } from "lodash"
 import stepsConfig from "./steps_config"
 import { data as _sd } from "sharify"
@@ -334,7 +334,6 @@ export function handleImageUpload(file) {
         const options = {
           acl: "private",
           app: sd.CONVECTION_GEMINI_APP,
-          key: sd.GEMINI_S3_ACCESS_KEY,
           fail: _err => {
             dispatch(errorOnImage(file.name))
           },

--- a/src/desktop/components/gemini_form/view.coffee
+++ b/src/desktop/components/gemini_form/view.coffee
@@ -1,6 +1,7 @@
 Backbone = require 'backbone'
 template = -> require('./form.jade') arguments...
 _ = require 'underscore'
+gemup = require '@artsy/gemup'
 
 module.exports = class GeminiForm extends Backbone.View
 
@@ -9,8 +10,11 @@ module.exports = class GeminiForm extends Backbone.View
   initialize: (options) ->
     @$el.html template()
     defaults =
-      geminiApp: sd.GEMINI_APP
       acl: 'public-read'
-      s3Key: sd.GEMINI_S3_ACCESS_KEY
-      geminiKey: sd.GEMINI_ACCOUNT_KEY
-    @$el.geminiUpload _.extend defaults, options
+      app: sd.GEMINI_ACCOUNT_KEY
+    opts = _.extend defaults, options
+
+    geminiUpload = (file) ->
+      gemup(file, opts)
+    @$("input[type='file']").on("change", (e) -> geminiUpload(e.target.files[0]))
+

--- a/src/desktop/components/json_page/client/editor.coffee
+++ b/src/desktop/components/json_page/client/editor.coffee
@@ -71,10 +71,7 @@ module.exports = class JSONPageEditor
 
       new GeminiForm
         el: $form
-        onUploadComplete: (res) =>
-          url = res.url + $form.find('[name=key]').val()
-            .replace('${filename}', encodeURIComponent(res.files[0].name))
-
+        done: (url) =>
           $(this).val(url).trigger 'keyup'
           $(this).prev('img').attr 'src', url
 

--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -59,7 +59,6 @@ module.exports =
   GEMINI_ACCOUNT_KEY: 'force-staging'
   GEMINI_APP: 'http://localhost:3004'
   GEMINI_CLOUDFRONT_URL: 'https://d7hftxdivxxvm.cloudfront.net'
-  GEMINI_S3_ACCESS_KEY: null
   GENOME_URL: 'https://helix.artsy.net'
   GEODATA_URL: 'http://artsy-geodata.s3-website-us-east-1.amazonaws.com'
   GEOIP_ENDPOINT: 'https://artsy-geoip.herokuapp.com/'

--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -96,7 +96,6 @@ function setupJquery() {
   require("jquery-waypoints/shortcuts/sticky-elements/waypoints-sticky.js")
   const loadTouchEvents = require("jquery-touch-events")
   loadTouchEvents($)
-  require("artsy-gemini-upload")($)
 
   // For drop down menus that appear on hover you may want that menu to close
   // once you click it. For these cases do `$el.click -> $(@).hidehover()` and

--- a/src/lib/setup_sharify.js
+++ b/src/lib/setup_sharify.js
@@ -63,7 +63,6 @@ sharify.data = _.extend(
     "GEMINI_ACCOUNT_KEY",
     "GEMINI_APP",
     "GEMINI_CLOUDFRONT_URL",
-    "GEMINI_S3_ACCESS_KEY",
     "GENOME_URL",
     "GEODATA_URL",
     "GOOGLE_ANALYTICS_ID",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,11 @@
     chokidar "^3.0.0"
     decache "^4.4.0"
 
+"@artsy/gemup@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@artsy/gemup/-/gemup-0.0.3.tgz#0397a472bb69432dab3d2d66ca30556815aa96e7"
+  integrity sha512-W///stXDTz3jSQw8UtT0BClVk4DLOsVp7a8v12efsEZvrZNT+85YBqPWq2DP1EX3ILZR1hGZhbKr/Gl5uti56Q==
+
 "@artsy/palette@4.12.6":
   version "4.12.6"
   resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-4.12.6.tgz#26c69b116caa152123b37ba47c1e3c9963e4b19e"
@@ -1894,11 +1899,6 @@ artsy-eigen-web-association@artsy/artsy-eigen-web-association:
 artsy-ezel-components@artsy/artsy-ezel-components:
   version "0.0.6"
   resolved "https://codeload.github.com/artsy/artsy-ezel-components/tar.gz/61983f3758ecc4a0a057aa9c830e3552abcaa50e"
-
-artsy-gemini-upload@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/artsy-gemini-upload/-/artsy-gemini-upload-0.0.6.tgz#ff228ff04a66beb9eb2dd251587c2c3446e26abd"
-  integrity sha1-/yKP8EpmvrnrLdJRWHwsNEbiar0=
 
 artsy-morgan@artsy/artsy-morgan:
   version "1.0.1"
@@ -6641,11 +6641,6 @@ gauge@~2.7.3:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
-
-gemup@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/gemup/-/gemup-0.0.2.tgz#bd9e7bea1957ee0c766924190a9a6222fcc76e28"
-  integrity sha1-vZ576hlX7gx2aSQZCppiIvzHbig=
 
 generate-function@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=64&projectKey=PLATFORM&modal=detail&selectedIssue=PLATFORM-1457

This can unset the `GEMINI_S3_ACCESS_KEY` config post-deploy in the staging and prod environments.

(I tested both editing a JSON page and consignment flow to verify things were still working).