### PR TITLE
Remove unused class from right-click-prevention

### DIFF
--- a/src/desktop/components/prevent_right_click/index.jade
+++ b/src/desktop/components/prevent_right_click/index.jade
@@ -4,8 +4,5 @@ script.
     if (isAdmin) return;
     if (['IMG', 'CANVAS'].indexOf(e.target.nodeName) < 0) return;
     var classes = e.target.className + ' ' + e.target.parentElement.className;
-    if (
-      classes.match('artwork') ||
-      classes.match('seadragon')
-    ) e.preventDefault();
+    if (classes.match('seadragon')) e.preventDefault();
   });


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/DISCO-1063

We used to block users from right-clicking on any artwork images, to discourage them from downloading them. This functionality disappeared from most of the site as pieces were moved from Force to Reaction.

As apps and components have moved to Reaction, semantic CSS class names have turned into name-mangled styled-component class names, and they no longer match [the `classes.match('artwork')` line in this PR](https://github.com/artsy/force/compare/master...pepopowitz:DISCO-1063-clean-up-right-click-prevention#diff-0e9dba180220a48e988eb9df04a46e7dL8).

The `classes.match('seadragon')` line is still needed - it applies right click prevention to the large lightbox image on an artwork page. That image is handled by the OpenSeaDragon library, outside of React....so we can't apply our new `preventRightClick` prop to it.

But the other artwork images that used to be covered by this code are now covered by https://github.com/artsy/reaction/pull/2480. 

---

Note: this does **not** depend on https://github.com/artsy/reaction/pull/2480 getting merged first. The `classes.match('artwork')` line has not applied right-click-prevention to any images on our site in quite some time.