### PR TITLE
Exclude tests from sharify window.alert

### DIFF
--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -147,4 +147,5 @@ for key, val of module.exports
   module.exports[key] = try JSON.parse(val) catch then val
 
 # Warn if this file is included client-side
-alert("WARNING: Do not require config.coffee, please require('sharify').data instead.") if window?
+if process.env.NODE_ENV isnt "test"
+  alert("WARNING: Do not require config.coffee, please require('sharify').data instead.") if window?

--- a/src/mobile/config.coffee
+++ b/src/mobile/config.coffee
@@ -75,4 +75,5 @@ for key, val of module.exports
   module.exports[key] = try JSON.parse(val) catch then val
 
 # Warn if this file is included client-side
-alert("WARNING: Do not require config.coffee, please require('sharify').data instead.") if window?
+if process.env.NODE_ENV isnt "test"
+  alert("WARNING: Do not require config.coffee, please require('sharify').data instead.") if window?


### PR DESCRIPTION
Checks if `NODE_ENV` is test before attempting to fire `window.alert`

This call to alert was causing errors when requiring `sharify` in test files.
