### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM node:10.13-alpine
 
 WORKDIR /app
 
+# Install system dependencies
+# Add deploy user
 RUN apk --no-cache --quiet add \
       bash \
       build-base \
@@ -11,17 +13,23 @@ RUN apk --no-cache --quiet add \
       python && \
       adduser -D -g '' deploy
 
+# Copy files required for installation of application dependencies
 COPY package.json yarn.lock ./
 COPY patches ./patches
 
+# Install application dependencies
 RUN yarn install --frozen-lockfile --quiet
 
+# Copy application code
 COPY . ./
 
+# Build application
+# Update file/directory permissions
 RUN yarn assets && \
     yarn build:server && \
     chown -R deploy:deploy ./
 
+# Switch to less-privileged user
 USER deploy
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,28 @@
 FROM node:10.13-alpine
 
-# Install required libraries
-RUN apk --no-cache add bash curl git \
-  make gcc g++ python \
-  libsecret-dev glib-dev
-
-# Set up deploy user and working directory
-RUN adduser -D -g '' deploy
-RUN mkdir -p /app
-RUN chown deploy:deploy /app
-
-# Set up dumb-init
-ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 /usr/local/bin/dumb-init
-RUN chown deploy:deploy /usr/local/bin/dumb-init
-RUN chmod +x /usr/local/bin/dumb-init
-
-# Copy required libs and files to /app
-ADD . /app
-ADD package.json /app
-ADD yarn.lock /app
 WORKDIR /app
 
-# Set up node_modules
-RUN yarn cache clean && yarn install
+RUN apk --no-cache --quiet add \
+      bash \
+      build-base \
+      curl \
+      dumb-init \
+      git \
+      python && \
+      adduser -D -g '' deploy
 
-# Copy over node_modules
-ADD --chown=deploy:deploy . /app
+COPY package.json yarn.lock ./
+COPY patches ./patches
 
-# Compile assets
-RUN yarn assets
-RUN yarn build:server
+RUN yarn install --frozen-lockfile --quiet
 
-# Switch to deploy user
+COPY . ./
+
+RUN yarn assets && \
+    yarn build:server && \
+    chown -R deploy:deploy ./
+
 USER deploy
-ENV USER deploy
-ENV HOME /home/deploy
 
-ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["yarn", "start"]


### PR DESCRIPTION
This PR contains a few updates to the Dockerfile to simplify instructions, reduce overall layers, and improve layer caching.

- Use `build-base` packages to cover build dependencies.
- Remove `yarn cache clean`
    The docker image should already have an empty cache
- Install `dumb-init` via package manager
- Use --quiet flag for `apk add`
- Copy `package.json`, `yarn.lock` and `packages/` before `yarn install`
- Use `--frozen-lockfile --quiet` flags on `yarn install`
- Copy application files after `yarn install` to cache dependencies
- Give `deploy` user permissions to entire `/app` directory

cc/ @izakp 

This also addresses some permission issues when running `hokusai dev start` locally:

```
force_1        | ERROR in ./src/desktop/apps/auction/client.js
force_1        | Module build failed (from ./node_modules/babel-loader/lib/index.js):
force_1        | Error: EACCES: permission denied, open '/app/.cache/babel/f60447021ef5554c0d521ec258e35618.json.gz'
force_1        | 
force_1        | 
force_1        |  @ ./src/desktop/assets/auctions.coffee 8:99-135
force_1        |  @ multi webpack-hot-middleware/client?reload=true ./src/lib/global_modules ./src/desktop/assets/auctions.coffee
```