### PR TITLE
Add reset-password styl back

### DIFF
--- a/src/desktop/apps/authentication/reset_password.styl
+++ b/src/desktop/apps/authentication/reset_password.styl
@@ -1,0 +1,8 @@
+@require '../../components/stylus_lib'
+
+#reset-password-page	
+  text-align center	
+  max-width 400px	
+  margin layout-side-margin auto	
+  h1	
+    margin 20px 0

--- a/src/desktop/assets/authentication.styl
+++ b/src/desktop/assets/authentication.styl
@@ -1,1 +1,1 @@
-// This file was added so that the client-side js doesn't error out due to 404.
+@require '../apps/authentication/reset_password.styl'


### PR DESCRIPTION
Although the reset password component was moved to be co-located with the new `/authentication` app, the styles were not, and got removed when `desktop/apps/auth` was removed. 

This PR adds back the styles for the reset password component and addresses https://artsyproduct.atlassian.net/browse/PLATFORM-1472

A follow-up ticket to update these components is here: https://artsyproduct.atlassian.net/browse/GROW-1279
