### PR TITLE
Interpret a variety of query params for redirects

### DIFF
--- a/src/desktop/apps/authentication/__tests__/routes.jest.ts
+++ b/src/desktop/apps/authentication/__tests__/routes.jest.ts
@@ -18,6 +18,8 @@ describe("Routes", () => {
         path: "/",
         query: {},
         header: () => "referrer",
+        get: jest.fn(),
+        body: {},
       }
       res = {
         locals: {
@@ -282,6 +284,12 @@ describe("Routes", () => {
       req.user = {}
       redirectLoggedInHome(req, res, next)
       expect(res.redirect).toBeCalledWith("/")
+    })
+
+    it("preserves existing redirects for logged out users", () => {
+      req.query = { redirect_uri: "/foo" }
+      expect(next).toBeCalled()
+      expect(req.query.redirect_uri).toBe("/foo")
     })
 
     it("redirects logged in users (with a redirect_uri query param) to redirect location", () => {

--- a/src/desktop/apps/authentication/__tests__/routes.jest.ts
+++ b/src/desktop/apps/authentication/__tests__/routes.jest.ts
@@ -162,6 +162,30 @@ describe("Routes", () => {
         })
       })
 
+      it("can handle old redirect_uri redirect params", done => {
+        req.query = {
+          redirect_uri: "/bar",
+        }
+
+        index(req, res, next).then(() => {
+          const { redirectTo } = stitch.mock.calls[0][0].data.options
+          expect(redirectTo).toBe("/bar")
+          done()
+        })
+      })
+
+      it("can handle old redirect-to redirect params", done => {
+        req.query = {
+          "redirect-to": "/bar",
+        }
+
+        index(req, res, next).then(() => {
+          const { redirectTo } = stitch.mock.calls[0][0].data.options
+          expect(redirectTo).toBe("/bar")
+          done()
+        })
+      })
+
       it("Sets afterSignUpAction cookie if corresponding query params are present", done => {
         req.query = {
           action: "follow",
@@ -284,12 +308,6 @@ describe("Routes", () => {
       req.user = {}
       redirectLoggedInHome(req, res, next)
       expect(res.redirect).toBeCalledWith("/")
-    })
-
-    it("preserves existing redirects for logged out users", () => {
-      req.query = { redirect_uri: "/foo" }
-      expect(next).toBeCalled()
-      expect(req.query.redirect_uri).toBe("/foo")
     })
 
     it("redirects logged in users (with a redirect_uri query param) to redirect location", () => {

--- a/src/desktop/apps/authentication/routes.ts
+++ b/src/desktop/apps/authentication/routes.ts
@@ -141,11 +141,11 @@ export const resetPassword = (req, res) => {
 }
 
 export const redirectLoggedInHome = (req, res, next) => {
-  const pathname = parse(req.url || "").pathname
-  if (["/log_in", "/login", "/sign_up", "/signup"].includes(pathname)) {
-    req.query["redirect-to"] = req.query["redirect-to"] || "/"
-  }
   if (req.user) {
+    const pathname = parse(req.url || "").pathname
+    if (["/log_in", "/login", "/sign_up", "/signup"].includes(pathname)) {
+      req.query["redirect-to"] = req.query["redirect-to"] || "/"
+    }
     res.redirect(getRedirectTo(req))
   } else {
     next()

--- a/src/desktop/apps/authentication/routes.ts
+++ b/src/desktop/apps/authentication/routes.ts
@@ -77,8 +77,8 @@ export const index = async (req, res, next) => {
     res.locals.sd.SET_PASSWORD = req.query.set_password
   }
 
-  const redirectTo = req.query.redirectTo || "/"
-  const signupReferer = req.header("Referer") || req.host
+  const redirectTo = getRedirectTo(req)
+  const signupReferer = req.header("Referer") || req.hostname
 
   if (action) {
     res.cookie("afterSignUpAction", JSON.stringify({ action, objectId, kind }))
@@ -141,10 +141,6 @@ export const resetPassword = (req, res) => {
 }
 
 export const redirectLoggedInHome = (req, res, next) => {
-  const pathname = parse(req.url || "").pathname
-  if (["/log_in", "/login", "/sign_up", "/signup"].includes(pathname)) {
-    req.query["redirect-to"] = "/"
-  }
   if (req.user) {
     res.redirect(getRedirectTo(req))
   } else {
@@ -154,8 +150,8 @@ export const redirectLoggedInHome = (req, res, next) => {
 
 export const getRedirectTo = req => {
   let referrer = parse(req.get("Referrer") || "").path || "/"
-
   return (
+    req.body["redirectTo"] ||
     req.body["redirect-to"] ||
     req.query["redirect-to"] ||
     req.query["redirect_uri"] ||

--- a/src/desktop/apps/authentication/routes.ts
+++ b/src/desktop/apps/authentication/routes.ts
@@ -141,6 +141,10 @@ export const resetPassword = (req, res) => {
 }
 
 export const redirectLoggedInHome = (req, res, next) => {
+  const pathname = parse(req.url || "").pathname
+  if (["/log_in", "/login", "/sign_up", "/signup"].includes(pathname)) {
+    req.query["redirect-to"] = req.query["redirect-to"] || "/"
+  }
   if (req.user) {
     res.redirect(getRedirectTo(req))
   } else {
@@ -151,7 +155,7 @@ export const redirectLoggedInHome = (req, res, next) => {
 export const getRedirectTo = req => {
   let referrer = parse(req.get("Referrer") || "").path || "/"
   return (
-    req.body["redirectTo"] ||
+    req.query["redirectTo"] ||
     req.body["redirect-to"] ||
     req.query["redirect-to"] ||
     req.query["redirect_uri"] ||


### PR DESCRIPTION
Follow up to auth deprecation work, this ensures that all query params referenced in old auth flows are still valid. 