### PR TITLE
NotificationView test update

### DIFF
--- a/src/desktop/apps/notifications/test/client/index.test.coffee
+++ b/src/desktop/apps/notifications/test/client/index.test.coffee
@@ -19,11 +19,7 @@ describe 'NotificationsView', ->
       benv.expose
         $: benv.require 'jquery'
         jQuery: benv.require 'jquery'
-        matchMedia: () ->
-          media: ""
-          matches: false
-          addListener: () => null
-          removeListener: () => null
+
       Backbone.$ = $
       SidebarView = require '../../client/sidebar.coffee'
       done()
@@ -36,6 +32,7 @@ describe 'NotificationsView', ->
     sinon.stub CurrentUser, 'orNull'
     CurrentUser.orNull.returns new CurrentUser fabricate 'user'
     artists = null
+    location.search = ''
     benv.render resolve(__dirname, '../../templates/index.jade'), { sd: {}, asset: (->) , artists: artists }, =>
       { @NotificationsView } = mod = rewire '../../client/index.coffee'
       mod.__set__ 'SidebarView', sinon.stub()
@@ -51,7 +48,6 @@ describe 'NotificationsView', ->
   describe '#initialize', ->
 
     beforeEach ->
-      location.search = ''
       @view = new @NotificationsView el: $('body')
 
     it 'should create a filterState model with defaults', ->


### PR DESCRIPTION
- Removes an unnecessary mock for `window.matchMedia`
- Updates location in beforeEach of all tests

Hoping this will kill:
<img width="634" alt="Screen Shot 2019-06-03 at 6 09 41 PM" src="https://user-images.githubusercontent.com/1497424/58838227-16c1e680-862c-11e9-9ccf-3274427a3dc1.png">
