### PR TITLE
[Search] Ensure search query persists across client / server

### DIFF
--- a/src/desktop/apps/search2/server.tsx
+++ b/src/desktop/apps/search2/server.tsx
@@ -13,12 +13,15 @@ app.get(
     if (!req.query.term) {
       if (req.query.q) {
         const query = stringify({ term: req.query.q })
+        res.locals.sd.searchQuery = req.query.q
         res.redirect(302, `/search?${query}`)
         return
       } else {
         res.redirect(302, "/")
         return
       }
+    } else {
+      res.locals.sd.searchQuery = req.query.term
     }
     try {
       const layout = await stitch({

--- a/src/desktop/components/main_layout/header/templates/index.jade
+++ b/src/desktop/components/main_layout/header/templates/index.jade
@@ -2,7 +2,7 @@ include ../../../util/activator
 
 if sd.ENABLE_NEW_NAVBAR
   header
-    != stitch.components.NavBar({ user: sd.CURRENT_USER, notificationCount: sd.NOTIFICATION_COUNT })
+    != stitch.components.NavBar({ notificationCount: sd.NOTIFICATION_COUNT, searchQuery: sd.searchQuery, user: sd.CURRENT_USER,  })
 else
   header#main-layout-header( class= sd.HEADER_CLASS ? sd.HEADER_CLASS : '' )
     if sd.APPLICATION_NAME === "force-staging"

--- a/src/desktop/components/react/stitch_components/NavBar.tsx
+++ b/src/desktop/components/react/stitch_components/NavBar.tsx
@@ -22,15 +22,21 @@ const NavBarContainer = styled.div`
 interface NavBarProps {
   user: SystemContextProps["user"]
   notificationCount: number
+  searchQuery?: string
 }
 
-export const NavBar: React.FC<NavBarProps> = ({ notificationCount, user }) => {
+export const NavBar: React.FC<NavBarProps> = ({
+  notificationCount,
+  searchQuery,
+  user,
+}) => {
   const showStagingBanner = sd.APPLICATION_NAME === "force-staging"
 
   return (
     <SystemContextProvider
       mediator={mediator}
       notificationCount={notificationCount}
+      searchQuery={searchQuery}
       user={user}
     >
       <NavBarContainer>


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/DISCO-925

Blocked by companion PR https://github.com/artsy/reaction/pull/2495 

This stores the server-side search query in sharify, and passes it via our SystemContext to reaction where we then pass it into the search bar. 