### PR TITLE
Add toggle to hide staging banner

### DIFF
--- a/src/desktop/components/react/stitch_components/StagingBanner.tsx
+++ b/src/desktop/components/react/stitch_components/StagingBanner.tsx
@@ -1,11 +1,17 @@
-import React from "react"
+import React, { useState } from "react"
 import styled from "styled-components"
 import { Banner, Box } from "@artsy/palette"
 import { data as sd } from "sharify"
 
 export const StagingBanner = () => {
+  const [show, toggleVisible] = useState(true)
+
+  if (!show) {
+    return null
+  }
+
   return (
-    <Container>
+    <Container onClick={() => toggleVisible(false)}>
       <Banner
         backgroundColor="purple100"
         message={sd.APP_URL.replace("https://", "").replace("http://", "")}


### PR DESCRIPTION
We run into issues often where the staging banner gets in the way of QA, because it pushes content down. Added a click to hide. 

Merging so that we can properly test nav bar in morning meeting tomorrow. 