### PR TITLE
[NavBar] Address QA items

### DIFF
--- a/src/desktop/components/react/stitch_components/NavBar.tsx
+++ b/src/desktop/components/react/stitch_components/NavBar.tsx
@@ -12,11 +12,14 @@ import { StagingBanner } from "./StagingBanner"
 const mediator = require("desktop/lib/mediator.coffee")
 
 const NavBarContainer = styled.div`
-  position: fixed;
   z-index: 990;
   width: 100%;
   top: 0;
   left: 0;
+
+  /* FIXME: Overwrite main force navbar style. Once main bar is totally removed
+     and no longer controlled by an ENV var we can remove this. */
+  border-bottom: none !important;
 `
 
 interface NavBarProps {
@@ -39,7 +42,7 @@ export const NavBar: React.FC<NavBarProps> = ({
       searchQuery={searchQuery}
       user={user}
     >
-      <NavBarContainer>
+      <NavBarContainer id="main-layout-header">
         {showStagingBanner && <StagingBanner />}
         <ReactionNavBar />
       </NavBarContainer>


### PR DESCRIPTION
Blocked by companion PR: https://github.com/artsy/reaction/pull/2505

Fixes an issue where the top nav bar was consistently fixed, and wouldn't yield control to page-level configuration; e.g., 

![scroll](https://user-images.githubusercontent.com/236943/59000335-dd6db000-87be-11e9-80d8-eb48829bbce3.gif)

^ Also fixed issue where login banner covered the nav: 

<img width="426" alt="Screen Shot 2019-06-05 at 6 33 56 PM" src="https://user-images.githubusercontent.com/236943/59000712-849f1700-87c0-11e9-9c94-5b885233de83.png">

Dodged a bullet with this one 😅