### PR TITLE
Do not redirect users back to redirect password on login

### DIFF
--- a/src/desktop/apps/authentication/routes.ts
+++ b/src/desktop/apps/authentication/routes.ts
@@ -154,11 +154,16 @@ export const redirectLoggedInHome = (req, res, next) => {
 
 export const getRedirectTo = req => {
   let referrer = parse(req.get("Referrer") || "").path || "/"
-  return (
+  const redirectTo =
     req.query["redirectTo"] ||
     req.body["redirect-to"] ||
     req.query["redirect-to"] ||
     req.query["redirect_uri"] ||
     referrer
-  )
+
+  if (redirectTo === "/reset_password") {
+    return "/"
+  } else {
+    return redirectTo
+  }
 }

--- a/src/lib/middleware/__tests__/unsupportedBrowser.jest.ts
+++ b/src/lib/middleware/__tests__/unsupportedBrowser.jest.ts
@@ -137,5 +137,10 @@ describe("unsupported browsers", () => {
       req.get.mockReturnValue("/collect")
       expect(getRedirectTo(req)).toBe("/collect")
     })
+
+    it("does not send users back to /reset_password", () => {
+      req.body["redirectTo"] = "/reset_password"
+      expect(getRedirectTo(req)).toBe("/")
+    })
   })
 })


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/PLATFORM-1561

On login we redirect users back to the origin of their login request, but we do not want to do this on reset password because it is confusing to users. This adds a check to the login redirect logic to always send users who reset their password home.