### PR TITLE
Removes unnecessary tests after deprecating ads on standard articles

### DIFF
--- a/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.jest.tsx
+++ b/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.jest.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import { shallow } from "enzyme"
 import { InfiniteScrollNewsArticle } from "../InfiniteScrollNewsArticle"
 import { NewsArticle } from "reaction/Components/Publishing/Fixtures/Articles"
-import { UnitCanvasImage } from "reaction/Components/Publishing/Fixtures/Components"
 import { extend, times } from "lodash"
 import { data as sd } from "sharify"
 import moment from "moment"
@@ -94,29 +93,6 @@ describe("InfiniteScrollNewsArticle", () => {
     expect(mockPositronql).toBeCalled()
     expect(component.find("#article-root").children().length).toBe(5)
     expect(Object.keys(component.state().display[0])[1]).toBe("renderTime")
-  })
-
-  it("injects a canvas ad after the sixth article", async () => {
-    const data = {
-      articles: times(6, () => {
-        return extend({}, NewsArticle, {
-          slug: "foobar",
-          channel_id: "123",
-          id: "678",
-        })
-      }),
-      display: {
-        name: "BMW",
-        canvas: UnitCanvasImage,
-      },
-    }
-    mockPositronql.mockReturnValue(Promise.resolve(data))
-    const component = getWrapper()
-    const instance = component.instance() as InfiniteScrollNewsArticle
-    await instance.fetchNextArticles()
-    component.update()
-
-    expect(component.html()).toMatch("Sponsored by BMW")
   })
 
   it("injects read more after the sixth article", async () => {

--- a/src/desktop/apps/article/components/layouts/__tests__/Article.jest.tsx
+++ b/src/desktop/apps/article/components/layouts/__tests__/Article.jest.tsx
@@ -12,7 +12,6 @@ import {
 import { clone } from "lodash"
 import { ArticleData } from "@artsy/reaction/dist/Components/Publishing/Typings"
 import { Article } from "@artsy/reaction/dist/Components/Publishing/Article"
-import { Display } from "@artsy/reaction/dist/Components/Publishing/Fixtures/Components"
 import { CollectionsRailContent } from "@artsy/reaction/dist/Components/CollectionsRail"
 
 jest.mock("desktop/components/article/client/super_article.coffee")
@@ -80,21 +79,6 @@ describe("Article Layout", () => {
   it("sets up follow buttons", () => {
     getWrapper()
     expect(mockSetupFollows).toBeCalled()
-  })
-
-  it("renders display components", () => {
-    props.article = clone({
-      ...StandardArticle,
-      display: Display("standard"),
-    } as ArticleData)
-    const component = getWrapper()
-
-    expect(component.html()).toMatch("DisplayPanel")
-    expect(component.html()).toMatch('class="Canvas')
-    expect(component.html()).toMatch("Euismod Inceptos Quam")
-    expect(component.html()).toMatch(
-      "Commodo Risus Pharetra Fermentum Vehicula Adipiscing"
-    )
   })
 
   describe("CollectionsRail", () => {


### PR DESCRIPTION
This PR addresses CI failures caused by https://github.com/artsy/force/pull/4252.
