### PR TITLE
Artist signup modal analytics

### DIFF
--- a/src/desktop/components/artist_page_cta/view.coffee
+++ b/src/desktop/components/artist_page_cta/view.coffee
@@ -35,12 +35,12 @@ module.exports = class ArtistPageCTAView extends Backbone.View
     @alreadyDismissed = false
     @signupIntent = 'Artist CTA Banner'
     @afterAuthPath = window.location
-    @$window.on 'scroll', _.once(@maybeShowOverlay)
+    @$window.on('scroll', _.once(@maybeShowOverlay))
     mediator.on("artist_cta:account_creation", (options) => analytics.track("Created Account", options))
 
-  maybeShowOverlay: () =>
+  maybeShowOverlay: (event) =>
     if !@alreadyDismissed
-      setTimeout (=> @fullScreenOverlay()), 4000
+      setTimeout (=> @fullScreenOverlay(event)), 4000
 
   triggerLoginModal: (e) ->
     e.stopPropagation()
@@ -55,10 +55,10 @@ module.exports = class ArtistPageCTAView extends Backbone.View
   currentParams: ->
     qs.parse(location.search.replace(/^\?/, ''))
 
-  fullScreenOverlay: (event = "scroll") =>
-    if event != "scroll"
+  fullScreenOverlay: (event) =>
+    if event.type != "scroll"
       contextModule = "Footer" if event.currentTarget.className?.includes("artist-page-cta")
-    @eventType = if event == "scroll" then "scroll" else event.type
+    @eventType = event.type
     return if @$el.hasClass 'fullscreen'
     @$overlay.fadeIn 300
     @$banner.fadeOut 300

--- a/src/desktop/components/artist_page_cta/view.coffee
+++ b/src/desktop/components/artist_page_cta/view.coffee
@@ -36,8 +36,6 @@ module.exports = class ArtistPageCTAView extends Backbone.View
     @signupIntent = 'Artist CTA Banner'
     @afterAuthPath = window.location
     @$window.on 'scroll', _.once(@maybeShowOverlay)
-    mediator.on 'clickFollowButton', @fullScreenOverlay
-    mediator.on 'clickHeaderAuth', @fullScreenOverlay
     mediator.on("artist_cta:account_creation", (options) => analytics.track("Created Account", options))
 
   maybeShowOverlay: () =>


### PR DESCRIPTION
Addresses: [GROW-1294](https://artsyproduct.atlassian.net/browse/GROW-1294)

This PR adds analytics tracking for the existing Artist Page Signup CTA. Specifically we add missing properties for the "Auth Impression Event" (`trigger`, `triggerSeconds` (when applicable), `auth_redirect`, `onboarding`). We also added the "Created Account Event". 

Examples of those analytics events:
![Screen Shot 2019-07-11 at 2 57 00 PM](https://user-images.githubusercontent.com/5201004/61077370-3cd96400-a3ec-11e9-9ab6-a51953b4da72.png)

![Screen Shot 2019-07-11 at 2 56 35 PM](https://user-images.githubusercontent.com/5201004/61077390-46fb6280-a3ec-11e9-920d-32ecec21bb65.png)
