### PR TITLE
Require valid schema to release to production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,3 +114,5 @@ workflows:
           <<: *only_release
       - hokusai/deploy-production:
           <<: *only_release
+          requires:
+            - validate_production_schema


### PR DESCRIPTION
Follow up to #4294, makes valid schema a prerequisite of production deploys.