### PR TITLE
Remove mobile auction registration confirmation routes

### DIFF
--- a/src/mobile/apps/feature/index.coffee
+++ b/src/mobile/apps/feature/index.coffee
@@ -15,15 +15,14 @@ app.get '/feature/:id', routes.index
 app.get '/feature/:id/:queryParams', routes.index
 
 app.get '/auction/:id/bid/:artworkId', routes.bid
+# TODO: as of 7/15/19 none of these confirm-registration routes
+# have been called for > 30 days. Investigate removal.
 app.get '/artwork/:id/confirm-registration', routes.confirmRegistration('artwork')
-app.get '/auction/:id/confirm-registration', routes.confirmRegistration('auction')
 app.get '/auction/:id/bid/:artworkId/confirm-registration', routes.confirmRegistration('bid')
 
 # Legacy route support for Eigen
 app.get '/feature/:id/bid/:artworkId', routes.bid
-app.get '/feature/:id/confirm-registration', routes.confirmRegistration('auction')
 app.get '/feature/:id/bid/:artworkId/confirm-registration', routes.confirmRegistration('bid')
 # Also:
 app.get '/auctions/:id/bid/:artworkId', routes.bid
-app.get '/auctions/:id/confirm-registration', routes.confirmRegistration('auction')
 app.get '/auctions/:id/bid/:artworkId/confirm-registration', routes.confirmRegistration('bid')

--- a/src/mobile/apps/feature/routes.coffee
+++ b/src/mobile/apps/feature/routes.coffee
@@ -117,9 +117,6 @@ module.exports.confirmRegistration = (from) ->
       when 'bid'
         href: "/auction/#{req.params.id}/bid/#{req.params.artworkId}"
         buttonCopy: 'Continue Bidding'
-      when 'auction'
-        href: "/auction/#{req.params.id}"
-        buttonCopy: 'Back to Auction'
     locals = _.extend locals,
       h1Copy: 'Registration Complete'
       h2Copy: "We'll notify you when the auction opens."

--- a/src/mobile/apps/feature/test/routes.test.coffee
+++ b/src/mobile/apps/feature/test/routes.test.coffee
@@ -140,7 +140,3 @@ describe '#confirmRegistration', ->
     routes.confirmRegistration('bid') @req, @res
     @res.render.args[0][1].href.should.containEql "/auction/two-x-two/bid/foo-bar"
 
-  it 'points back to the auction page after confirming from an auction page', ->
-    @req.params = id: 'two-x-two'
-    routes.confirmRegistration('auction') @req, @res
-    @res.render.args[0][1].href.should.containEql "/auction/two-x-two"

--- a/src/mobile/assets/mobile_all.coffee
+++ b/src/mobile/assets/mobile_all.coffee
@@ -33,9 +33,6 @@ hash =
   '^/auction/.*/bid/.*': ->
     require('../apps/feature/client/bid_page.coffee').init()
 
-  '^/auction/.*/confirm-registration': ->
-    return
-
   '^/feature/([^/]+)$': ->
     require('../apps/feature/client/index.coffee').init()
 


### PR DESCRIPTION
#4277 replaced a backbone modal with one coming from modern reaction components, but it missed some sneaky hidden route handlers in our mobile app. This PR removes them and makes a note to revisit some other ones that don't seem to be getting called any more.

Importantly, these are not technically modals that cover/obscure other content - they are just basic header + button web pages that link back to the real page.

thanks @xtina-starr for helping me reason about this.

Firefox dev tools showing the new modal:
![image](https://user-images.githubusercontent.com/9088720/61306528-cb6a2e80-a7ba-11e9-9f39-539740b96448.png)

Iphone simulator:
![image](https://user-images.githubusercontent.com/9088720/61307157-d40f3480-a7bb-11e9-8791-2c748121a779.png)
