### PR TITLE
[GROW-1410] persist analytics data for account creation event

### DIFF
--- a/src/desktop/components/artist_page_cta/view.coffee
+++ b/src/desktop/components/artist_page_cta/view.coffee
@@ -58,12 +58,12 @@ module.exports = class ArtistPageCTAView extends Backbone.View
   fullScreenOverlay: (event) =>
     if event.type != "scroll"
       contextModule = "Footer" if event.currentTarget.className?.includes("artist-page-cta")
-    @eventType = event.type
+    eventType = event.type
     return if @$el.hasClass 'fullscreen'
     @$overlay.fadeIn 300
     @$banner.fadeOut 300
     fragment = qs.stringify @currentParams()
-    @trackImpression(@eventType, contextModule)
+    @trackImpression(eventType, contextModule)
     # This handles the redirect for the new onboarding flow
     @afterAuthPath += "?redirectTo=#{@artist.get('href')}"
     @afterAuthPath += "?#{fragment}" if fragment
@@ -136,16 +136,14 @@ module.exports = class ArtistPageCTAView extends Backbone.View
   onRegisterSuccess: (model, response, options) =>
     hasEmailAndPassword = true if model.get("email") && model.get("password")
     service = if hasEmailAndPassword then "email" else "facebook"
-    accountCreationData = {
+
+    persistedAnalyticsData = JSON.parse(Cookies.get("artist-page-account-creation-data"))
+    Cookies.expire("artist-page-account-creation-data")
+    accountCreationData = _.extend(persistedAnalyticsData, {
       user_id: response.user.id,
-      intent: "signup",
-      modal_copy: "Join Artsy to discover new works by #{@artist.get('name')} and more artists you love",
-      trigger: if @eventType == "scroll" then "scroll" else @eventType,
-      triggerSeconds: 4 if @eventType is "scroll",
-      type: "signup",
-      auth_redirect: location.href
       service: service,
-    }
+    })
+
     mediator.trigger 'artist_cta:account_creation', accountCreationData
     window.location = @afterAuthPath
 
@@ -162,13 +160,17 @@ module.exports = class ArtistPageCTAView extends Backbone.View
     Mailcheck.run('#js-mailcheck-input-modal', '#js-mailcheck-hint-modal', false)
 
   trackImpression:(triggerType, contextModule) =>
-    analytics.track("Auth Impression", {
+    persistData = {
       modal_copy: "Join Artsy to discover new works by #{@artist.get('name')} and more artists you love",
-      onboarding: true,
       trigger: if triggerType == "scroll" then "scroll" else triggerType,
-      triggerSeconds: 4 if triggerType is "scroll",
+      trigger_seconds: 4 if triggerType == "scroll",
       type: "signup",
       intent: "signup",
       context_module: contextModule,
       auth_redirect: location.href
-    })
+    }
+
+    Cookies.set('artist-page-account-creation-data', JSON.stringify(persistData), { expires: 600 })
+
+    analyticsData = _.extend(persistData, { onboarding: true })
+    analytics.track("Auth Impression", analyticsData)

--- a/src/desktop/components/artist_page_cta/view.coffee
+++ b/src/desktop/components/artist_page_cta/view.coffee
@@ -137,9 +137,7 @@ module.exports = class ArtistPageCTAView extends Backbone.View
     hasEmailAndPassword = true if model.get("email") && model.get("password")
     service = if hasEmailAndPassword then "email" else "facebook"
 
-    persistedAnalyticsData = JSON.parse(Cookies.get("artist-page-account-creation-data"))
-    Cookies.expire("artist-page-account-creation-data")
-    accountCreationData = _.extend(persistedAnalyticsData, {
+    accountCreationData = _.extend(_.omit(@analyticsData, "onboarding"), {
       user_id: response.user.id,
       service: service,
     })
@@ -160,17 +158,15 @@ module.exports = class ArtistPageCTAView extends Backbone.View
     Mailcheck.run('#js-mailcheck-input-modal', '#js-mailcheck-hint-modal', false)
 
   trackImpression:(triggerType, contextModule) =>
-    persistData = {
+    @analyticsData = {
       modal_copy: "Join Artsy to discover new works by #{@artist.get('name')} and more artists you love",
       trigger: if triggerType == "scroll" then "scroll" else triggerType,
       trigger_seconds: 4 if triggerType == "scroll",
       type: "signup",
       intent: "signup",
       context_module: contextModule,
-      auth_redirect: location.href
+      auth_redirect: location.href,
+      onboarding: true
     }
-
-    Cookies.set('artist-page-account-creation-data', JSON.stringify(persistData), { expires: 600 })
-
-    analyticsData = _.extend(persistData, { onboarding: true })
-    analytics.track("Auth Impression", analyticsData)
+    
+    analytics.track("Auth Impression", @analyticsData)


### PR DESCRIPTION
Addresses: [GROW-1410](https://artsyproduct.atlassian.net/browse/GROW-1410)

This handles the following analytics QA items:
- Ensure trigger seconds property is consistent for old and new event by using `trigger_seconds`?
- Control, scroll modal -> `created_account`: trigger should be scroll not click. Also, we are missing trigger_seconds
<img width="546" alt="Screen Shot 2019-07-17 at 3 30 07 PM" src="https://user-images.githubusercontent.com/5201004/61406770-845b6680-a8aa-11e9-8547-70991698bfe0.png">

- Control, footer modal -> `created_account`: Missing context_module: Footer
<img width="545" alt="Screen Shot 2019-07-17 at 3 32 58 PM" src="https://user-images.githubusercontent.com/5201004/61406795-8fae9200-a8aa-11e9-8d39-37b63b8c9e71.png">
