### PR TITLE
Render new registration failed modal when bid+register fails

### DIFF
--- a/src/desktop/apps/auction/components/Layout.js
+++ b/src/desktop/apps/auction/components/Layout.js
@@ -29,12 +29,9 @@ function Layout(props) {
 
   const b = block("auction-Layout")
 
-  const Modal =
-    modal === "ConfirmRegistration" ? ConfirmRegistrationModal : null
-
   return (
     <div className={b()}>
-      {Modal && <Modal />}
+      {modal && <ConfirmRegistrationModal />}
       <Banner />
       <div className={b("container", "responsive-layout-container")}>
         <AuctionInfoContainer />

--- a/src/desktop/apps/auction/components/layout/ConfirmRegistrationModal.tsx
+++ b/src/desktop/apps/auction/components/layout/ConfirmRegistrationModal.tsx
@@ -3,7 +3,7 @@ import { Modal } from "reaction/Components/Modal/Modal"
 import { Serif, Button, CheckCircleIcon, Box } from "@artsy/palette"
 import { connect } from "react-redux"
 
-const _ConfirmRegistrationModal = ({ me }) => {
+const _ConfirmRegistrationModal = ({ me, type }) => {
   useEffect(() => {
     const replaceModalTriggerPath = location.pathname.replace(
       "/confirm-registration",
@@ -20,9 +20,13 @@ const _ConfirmRegistrationModal = ({ me }) => {
     setShowModal(false)
   }
 
-  const Content = bidder.qualified_for_bidding
-    ? RegistrationComplete
-    : RegistrationPending
+  let Content
+  if (bidder.qualified_for_bidding) {
+    Content = RegistrationComplete
+  } else {
+    Content =
+      type === "ConfirmBidAndRegistration" ? CantBid : RegistrationPending
+  }
 
   return (
     <Modal show={showModal} onClose={hideModal}>
@@ -30,6 +34,29 @@ const _ConfirmRegistrationModal = ({ me }) => {
         <Content onClick={hideModal} />
       </Box>
     </Modal>
+  )
+}
+
+const CantBid = ({ onClick }) => {
+  return (
+    <>
+      <Serif size="6">Registration pending</Serif>
+      <Serif my={3} size="3t">
+        We're sorry, your bid could not be placed.
+        <br />
+        <br />
+        Artsy is reviewing your registration and you will receive an email when
+        it has been confirmed. Please email specialist@artsy.net with any
+        questions.
+        <br />
+        <br />
+        In the meantime, you can still view works and watch lots you’re
+        interested in.
+      </Serif>
+      <Button width="100%" onClick={onClick}>
+        View works in this sale
+      </Button>
+    </>
   )
 }
 
@@ -46,7 +73,7 @@ const RegistrationPending = ({ onClick }) => {
         interested in.
       </Serif>
       <Button width="100%" onClick={onClick}>
-        Start bidding
+        View works in this sale
       </Button>
     </>
   )
@@ -68,7 +95,7 @@ const RegistrationComplete = ({ onClick }) => {
   )
 }
 
-const mapStateToProps = state => ({ me: state.app.me })
+const mapStateToProps = state => ({ me: state.app.me, type: state.app.modal })
 
 export const ConfirmRegistrationModal = connect(mapStateToProps)(
   _ConfirmRegistrationModal

--- a/src/desktop/apps/auction/components/layout/ConfirmRegistrationModal.tsx
+++ b/src/desktop/apps/auction/components/layout/ConfirmRegistrationModal.tsx
@@ -30,7 +30,7 @@ const _ConfirmRegistrationModal = ({ me, type }) => {
 
   return (
     <Modal show={showModal} onClose={hideModal}>
-      <Box textAlign="center">
+      <Box pt={[3, 0]} textAlign="center">
         <Content onClick={hideModal} />
       </Box>
     </Modal>

--- a/src/desktop/apps/auction/components/layout/__tests__/ConfirmRegistrationModal.jest.tsx
+++ b/src/desktop/apps/auction/components/layout/__tests__/ConfirmRegistrationModal.jest.tsx
@@ -31,7 +31,7 @@ describe("Confirm Registration Modal", () => {
   })
 
   describe("User is not registered for sale", () => {
-    it("does not render the modal", () => {
+    it("does not render the modal if there is no user", () => {
       const { wrapper } = renderTestComponent({
         Component: ConfirmRegistrationModal,
         options: { renderMode: "render" },
@@ -53,6 +53,7 @@ describe("Confirm Registration Modal", () => {
           options: { renderMode: "render" },
           data: {
             app: {
+              modal: "ConfirmRegistration",
               me: {
                 bidders: [
                   {
@@ -70,12 +71,15 @@ describe("Confirm Registration Modal", () => {
     })
 
     describe("User is not qualified for bidding", () => {
-      it("shows a not qualified message", () => {
+      it("shows a bid could not be placed message if the user was trying to bid + register", () => {
         const { wrapper } = renderTestComponent({
           Component: ConfirmRegistrationModal,
+          props: { cantBid: true },
           options: { renderMode: "render" },
           data: {
             app: {
+              modal: "ConfirmBidAndRegistration",
+
               me: {
                 bidders: [
                   {
@@ -86,6 +90,31 @@ describe("Confirm Registration Modal", () => {
             },
           },
         })
+        expect(wrapper.text()).toEqual(
+          expect.stringContaining("We're sorry, your bid could not be placed.")
+        )
+      })
+
+      it("shows a registration pending message if the user was trying to register", () => {
+        const { wrapper } = renderTestComponent({
+          Component: ConfirmRegistrationModal,
+          options: { renderMode: "render" },
+          data: {
+            app: {
+              modal: "ConfirmRegistration",
+              me: {
+                bidders: [
+                  {
+                    qualified_for_bidding: false,
+                  },
+                ],
+              },
+            },
+          },
+        })
+        expect(wrapper.text()).not.toEqual(
+          expect.stringContaining("We're sorry, your bid could not be placed.")
+        )
         expect(wrapper.text()).toEqual(
           expect.stringContaining("Registration pending")
         )

--- a/src/desktop/apps/auction/routes.js
+++ b/src/desktop/apps/auction/routes.js
@@ -84,9 +84,14 @@ export async function index(req, res, next) {
       sort = "-searchable_estimate"
     }
 
-    const modal = req.originalUrl.match("/confirm-registration")
-      ? "ConfirmRegistration"
-      : null
+    let modal
+    if (req.originalUrl.match("/confirm-registration")) {
+      if (req.query.origin === "bid") {
+        modal = "ConfirmBidAndRegistration"
+      } else {
+        modal = "ConfirmRegistration"
+      }
+    }
 
     const store = configureStore(auctionReducer, {
       app: u(

--- a/src/desktop/apps/auction_support/client/bid_form.coffee
+++ b/src/desktop/apps/auction_support/client/bid_form.coffee
@@ -7,7 +7,7 @@ BidderPosition = require '../../../models/bidder_position.coffee'
 CurrentUser = require '../../../models/current_user.coffee'
 ErrorHandlingForm = require '../../../components/credit_card/client/error_handling_form.coffee'
 ConditionsOfSale = require '../mixins/conditions_of_sale.js'
-{ SESSION_ID } = require('sharify').data
+{ SESSION_ID, APP_URL } = require('sharify').data
 { getLiveAuctionUrl } = require '../../../../utils/domain/auctions/urls.js'
 
 module.exports = class BidForm extends ErrorHandlingForm
@@ -65,7 +65,11 @@ module.exports = class BidForm extends ErrorHandlingForm
             @pollForBidderPositionProcessed(model)
           , 1000
         error: (model, response) =>
-          @showError 'Error placing your bid', response
+          if response.responseJSON?.error == "Bidder not qualified to bid on this auction"
+            bidPendingUrl = "#{APP_URL}/auction/#{@model.get('id')}/confirm-registration?origin=bid"
+            window.location = bidPendingUrl
+          else
+            @showError 'Error placing your bid', response
     else
       @showError "Your bid must be higher than #{@bidderPositions.minBid()}"
 

--- a/src/desktop/apps/auction_support/client/bid_form.coffee
+++ b/src/desktop/apps/auction_support/client/bid_form.coffee
@@ -66,6 +66,8 @@ module.exports = class BidForm extends ErrorHandlingForm
           , 1000
         error: (model, response) =>
           if response.responseJSON?.error == "Bidder not qualified to bid on this auction"
+            # Trigger the registration confirmation modal on the auction page
+            #with the 'bid could not be placed' registration pending message
             bidPendingUrl = "#{APP_URL}/auction/#{@model.get('id')}/confirm-registration?origin=bid"
             window.location = bidPendingUrl
           else

--- a/src/mobile/apps/feature/client/bid_page.coffee
+++ b/src/mobile/apps/feature/client/bid_page.coffee
@@ -71,7 +71,7 @@ module.exports.BidPageView = class BidPageView extends Backbone.View
           # with the 'bid could not be placed' registration pending message
 
           bidPendingUrl = "#{sd.APP_URL}/auction/#{@saleArtwork.get('sale').id}/confirm-registration?origin=bid"
-          window.location = bidPendingUrl
+          @window.location = bidPendingUrl
         else
           @onError model, response
 

--- a/src/mobile/apps/feature/client/bid_page.coffee
+++ b/src/mobile/apps/feature/client/bid_page.coffee
@@ -65,7 +65,15 @@ module.exports.BidPageView = class BidPageView extends Backbone.View
           success: =>
             @window.location = "/artwork/#{@saleArtwork.get('artwork').id}#confirm-bid"
           error: @onError
-      error: @onError
+      error: (model, response) =>
+        if response.responseJSON?.error == "Bidder not qualified to bid on this auction"
+          # Trigger the registration confirmation modal on the (desktop) auction page
+          # with the 'bid could not be placed' registration pending message
+
+          bidPendingUrl = "#{sd.APP_URL}/auction/#{@saleArtwork.get('sale').id}/confirm-registration?origin=bid"
+          window.location = bidPendingUrl
+        else
+          @onError model, response
 
   onError: (m, err) =>
     msg = if _.isString(m) then m else JSON.parse(err.responseText).message

--- a/src/mobile/apps/feature/index.coffee
+++ b/src/mobile/apps/feature/index.coffee
@@ -15,14 +15,10 @@ app.get '/feature/:id', routes.index
 app.get '/feature/:id/:queryParams', routes.index
 
 app.get '/auction/:id/bid/:artworkId', routes.bid
+
 # TODO: as of 7/15/19 none of these confirm-registration routes
 # have been called for > 30 days. Investigate removal.
 app.get '/artwork/:id/confirm-registration', routes.confirmRegistration('artwork')
-app.get '/auction/:id/bid/:artworkId/confirm-registration', routes.confirmRegistration('bid')
 
-# Legacy route support for Eigen
-app.get '/feature/:id/bid/:artworkId', routes.bid
-app.get '/feature/:id/bid/:artworkId/confirm-registration', routes.confirmRegistration('bid')
 # Also:
 app.get '/auctions/:id/bid/:artworkId', routes.bid
-app.get '/auctions/:id/bid/:artworkId/confirm-registration', routes.confirmRegistration('bid')

--- a/src/mobile/apps/feature/test/client/bid_page.test.coffee
+++ b/src/mobile/apps/feature/test/client/bid_page.test.coffee
@@ -147,6 +147,14 @@ describe 'BidPageView', ->
       Backbone.sync.args[0][0].should.equal 'create'
       Backbone.sync.args[0][2].url.should.containEql '/api/v1/me/bidder_position'
 
+    it 'gives a could not place your bid message if the bidder is not qualified', () ->
+      Backbone.sync.onFirstCall().yieldsTo('error', responseJSON: { error : "Bidder not qualified to bid on this auction",} )
+      @view.window = { location: "" }
+
+      @acceptConditions()
+      @view.onSubmit(@e)
+      @view.window.location.should.containEql '/confirm-registration?origin=bid'
+
     describe 'polling', ->
       beforeEach ->
         @view.window = {}

--- a/src/mobile/apps/feature/test/routes.test.coffee
+++ b/src/mobile/apps/feature/test/routes.test.coffee
@@ -135,8 +135,7 @@ describe '#confirmRegistration', ->
     routes.confirmRegistration('artwork') @req, @res
     @res.render.args[0][1].href.should.containEql "/artwork/foo-bar"
 
-  it 'points back to the bid page after confirming from an bid page', ->
+  it 'points back to the bid page after confirming from a bid page', ->
     @req.params = id: 'two-x-two', artworkId: 'foo-bar'
     routes.confirmRegistration('bid') @req, @res
     @res.render.args[0][1].href.should.containEql "/auction/two-x-two/bid/foo-bar"
-


### PR DESCRIPTION
Tracked in [AUCT-492](https://artsyproduct.atlassian.net/browse/AUCT-492)
- Fix pending registration button copy
- Redirect failed bids (due to pending registration) to
  /confirm-registration?origin=bid
- Set modal type to identify modal content:
  success | failed (registration) | failed (bid+registration)
- Mobile work is very similar to https://github.com/artsy/force/pull/4305 (+ redirection logic from the desktop portion of this PR)

TODO: 
- [x] Mobile views follow same redirect logic: `"#{APP_URL}/auction/#{sale_id}/confirm-registration?origin=bid"`
- [x] Plans for eventually meeting [original spec](https://app.zeplin.io/project/5c59f1624a2d813589f91e07/screen/5d2de776fe87c963bac178e5)
- [x] Investigate renaming redux `modal` to something more meaningful. _easy win if we want to address this later_
- [x] Refactor Modal content duplication.  _easy win for later (except for warning icon), not necessary now_
- [x] Testing plan

Desktop selfie:
![image](https://user-images.githubusercontent.com/9088720/61415210-15880880-a8be-11e9-8765-509a7d1eb487.png)

Mobile selfie:
![image](https://user-images.githubusercontent.com/9088720/61494159-6dd50e00-a983-11e9-892f-64694c77ac30.png)

Verifying that post bid+register works as expected on mobile:
![image](https://user-images.githubusercontent.com/9088720/61494376-05d2f780-a984-11e9-9009-a1d4b118cbee.png)
