### PR TITLE
Set up A/B test for Collection Hubs, admin-only for now

### DIFF
--- a/src/desktop/components/split_test/README.md
+++ b/src/desktop/components/split_test/README.md
@@ -66,6 +66,18 @@ A test is not enabled from the analytics side without a `view` event. This must 
 
 SD variables are made available _on the client-side only_ in Reaction when they are added to [Reaction's Sharify `GlobalData`](https://github.com/artsy/reaction/blob/master/typings/sharify.d.ts).
 
+Once that is done, your Reaction app can access Sharify variables as follows:
+
+```jsx
+import { data as sd } from "sharify"
+
+const MyApp = () => {
+  return (
+    <div>{sd.MY_FEATURE === "new" ? <NewComponent /> : <OldComponent />}</div>
+  )
+}
+```
+
 ### Add link to artist collections rail test!!!
 
 ```javascript

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -27,9 +27,15 @@
 module.exports = {
   artist_page_signup_modal:
     key: "artist_page_signup_modal"
-    outcomes: 
+    outcomes:
       control: 50
       experiment: 50
     control_group: "control"
     edge: "experiment"
+  collection_hubs:
+    key: "collection_hubs"
+    outcomes:
+      control: 100
+      experiment: 0
+    edge: 'experiment'
 }


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GROW-1417

This simply sets up a new A/B test, which we can use as a feature flag to release Collection Hubs features only to admins while they are under development.

Example use of the flag is shown in [this feature branch](https://github.com/artsy/reaction/compare/master...anandaroop:hubs-AB?expand=1).