### PR TITLE
Scaffold Vanguard route

### DIFF
--- a/src/desktop/apps/article/__tests__/editorial_features.jest.ts
+++ b/src/desktop/apps/article/__tests__/editorial_features.jest.ts
@@ -15,4 +15,9 @@ describe("Editorial Features", () => {
     const customEditorial = isCustomEditorial("5bf306aad8b9430baaf6c6df")
     expect(customEditorial).toBe("EOY_2018_CULTURE")
   })
+
+  it("Can identify VANGUARD_2019", () => {
+    const customEditorial = isCustomEditorial("5d2f8bd0cdc74b00208b7e16")
+    expect(customEditorial).toBe("VANGUARD_2019")
+  })
 })

--- a/src/desktop/apps/article/editorial_features.ts
+++ b/src/desktop/apps/article/editorial_features.ts
@@ -19,6 +19,10 @@ const customEditorialArticles: CustomArticle[] = [
     name: "EOY_2018_CULTURE",
     id: "5bf306aad8b9430baaf6c6df",
   },
+  {
+    name: "VANGUARD_2019",
+    id: "5d2f8bd0cdc74b00208b7e16",
+  },
 ]
 
 /**

--- a/src/desktop/apps/article/queries/relatedArticles.js
+++ b/src/desktop/apps/article/queries/relatedArticles.js
@@ -25,6 +25,7 @@ export const relatedArticles = `
     ${canvasBody}
   }
   relatedArticles {
+    id
     authors {
       name
     }
@@ -35,6 +36,7 @@ export const relatedArticles = `
     title
     slug
     published_at
+    related_article_ids
     media {
       duration
       published


### PR DESCRIPTION
Depends on https://github.com/artsy/reaction/pull/2636
- Routes Artsy Vanguard parent article to reaction's custom editorial templates
- Adds id fields for sub-articles