### PR TITLE
Blocked: Consider api_sign_in_with_redirect when redirecting after authentication.

### DIFF
--- a/src/desktop/apps/authentication/__tests__/helpers.jest.js
+++ b/src/desktop/apps/authentication/__tests__/helpers.jest.js
@@ -242,25 +242,47 @@ describe("Authentication Helpers", () => {
   describe("#getRedirect", () => {
     it("Returns home if type is login and path is login", () => {
       window.history.pushState({}, "", "/login")
-      const redirectTo = getRedirect("login")
+
+      const response = {}
+      const redirectTo = getRedirect("login", response)
+
       expect(redirectTo).toBe("/")
     })
 
     it("Returns home if type is forgot", () => {
       window.history.pushState({}, "", "/forgot")
-      const redirectTo = getRedirect("forgot")
+
+      const response = {}
+      const redirectTo = getRedirect("forgot", response)
+
       expect(redirectTo).toBe("/")
     })
 
     it("Returns /personalize if type is signup", () => {
-      const redirectTo = getRedirect("signup")
+      const response = {}
+      const redirectTo = getRedirect("signup", response)
+
       expect(redirectTo).toBe("/personalize")
     })
 
     it("Returns window.location by default", () => {
-      window.history.pushState({}, "", "/magazine")
-      const redirectTo = getRedirect("login")
+      window.history.pushState({}, "", "/magazine", response)
+
+      const response = {}
+      const redirectTo = getRedirect("login", response)
+
       expect(redirectTo).toBe(window.location)
+    })
+
+    it("returns the redirect_uri in the response if present", () => {
+      const response = {
+        success: true,
+        redirect_uri: "http://some-url.com",
+        user: {},
+      }
+      const redirectTo = getRedirect("anything", response)
+
+      expect(redirectTo).toBe("http://some-url.com")
     })
   })
 })

--- a/src/desktop/apps/authentication/__tests__/helpers.jest.js
+++ b/src/desktop/apps/authentication/__tests__/helpers.jest.js
@@ -136,15 +136,6 @@ describe("Authentication Helpers", () => {
         formikBag
       )
 
-      Backbone.sync.mock.calls[0][2].success()
-      Backbone.sync.mock.calls[1][2].success({
-        success: true,
-        redirect_uri: "testing",
-        user: {
-          id: 123,
-          accessToken: "foobar",
-        },
-      })
       expect(formikBag.setSubmitting.mock.calls[0][0]).toBe(false)
     })
 

--- a/src/desktop/apps/authentication/__tests__/helpers.jest.js
+++ b/src/desktop/apps/authentication/__tests__/helpers.jest.js
@@ -276,7 +276,7 @@ describe("Authentication Helpers", () => {
     it("returns the redirect_uri in the response if present", () => {
       const response = {
         success: true,
-        redirect_uri: "http://some-url.com",
+        api_sign_in_with_redirect: "http://some-url.com",
         user: {},
       }
       const redirectTo = getRedirect("anything", response)

--- a/src/desktop/apps/authentication/__tests__/helpers.jest.js
+++ b/src/desktop/apps/authentication/__tests__/helpers.jest.js
@@ -137,6 +137,14 @@ describe("Authentication Helpers", () => {
       )
 
       Backbone.sync.mock.calls[0][2].success()
+      Backbone.sync.mock.calls[1][2].success({
+        success: true,
+        redirect_uri: "testing",
+        user: {
+          id: 123,
+          accessToken: "foobar",
+        },
+      })
       expect(formikBag.setSubmitting.mock.calls[0][0]).toBe(false)
     })
 

--- a/src/desktop/apps/authentication/helpers.ts
+++ b/src/desktop/apps/authentication/helpers.ts
@@ -74,7 +74,7 @@ export const handleSubmit = (
         analytics.track(action, pickBy(properties, identity))
       }
 
-      const defaultRedirect = getRedirect(type)
+      const defaultRedirect = getRedirect(type, res)
       window.location = modalOptions.redirectTo || (defaultRedirect as any)
     },
     error: (_, res) => {
@@ -112,8 +112,13 @@ export const setCookies = options => {
   }
 }
 
-export const getRedirect = type => {
+export const getRedirect = (type, response) => {
   const { location } = window
+
+  if (response.redirect_uri) {
+    return response.redirect_uri
+  }
+
   switch (type) {
     case "login":
     case "forgot":

--- a/src/desktop/apps/authentication/helpers.ts
+++ b/src/desktop/apps/authentication/helpers.ts
@@ -115,8 +115,8 @@ export const setCookies = options => {
 export const getRedirect = (type, response) => {
   const { location } = window
 
-  if (response.redirect_uri) {
-    return response.redirect_uri
+  if (response.api_sign_in_with_redirect) {
+    return response.api_sign_in_with_redirect
   }
 
   switch (type) {


### PR DESCRIPTION
TODO:

- [x] Add test coverage to the `handleSubmit` function for this change.
- [ ] Bump version of artsy passport after release of https://github.com/artsy/artsy-passport/pull/133
- [x] QA Scenarios:
  - [x] logging in via mobile web on Force (not via ajax) results in a Gravity response and sensible redirect flow
  - [x] logging in via /login on Force results in a Gravity response and a sensible redirect flow (delegated to https://github.com/artsy/force/pull/4357 - no breaking behavior change in this PR)

Problem:

We want to be able to log into Gravity when we log into force. However,
sometimes we login to force via AJAX requests. When we do this, we need
the client to be responsible for redirecting, but the client needs to
know which URL to redirect to.

Solution:

* Patch `handleSubmit` such that it first checks if the response (from
artsy-passport on the server) has a key `api_sign_in_with_redirect`. If it does,
redirect to it.
  + this change is related to https://github.com/artsy/artsy-passport/pull/133
    which exposes a request URI.

Jira: https://artsyproduct.atlassian.net/browse/AUCT-281