### PR TITLE
Defer loading of the recaptcha script

### DIFF
--- a/src/desktop/components/main_layout/templates/scripts.jade
+++ b/src/desktop/components/main_layout/templates/scripts.jade
@@ -183,4 +183,4 @@ if sd.ENABLE_INSTANT_PAGE
 
 //- Google reCAPTCHA
 if options.grecaptcha && sd.RECAPTCHA_KEY && !sd.EIGEN
-  script(id="google-recaptcha" src="https://www.google.com/recaptcha/api.js?render=#{sd.RECAPTCHA_KEY}")
+  script(id="google-recaptcha" src="https://www.google.com/recaptcha/api.js?render=#{sd.RECAPTCHA_KEY}" async defer)


### PR DESCRIPTION
I was poking around with lighthouse on the site and I noticed that the recaptcha script was being included in the critical request chain. 

(Third from the bottom)
<img width="615" alt="image" src="https://user-images.githubusercontent.com/3087225/62229857-9f3fd780-b38e-11e9-8a9e-1e2335fd55b7.png"> 

I added the `async` and `defer` tags (which [Google recommends](https://developers.google.com/recaptcha/docs/invisible)) to push it off a bit until the critical requests have had a chance to process. 
