### PR TITLE
Log into Gravity after logging into Force

### DIFF
--- a/src/desktop/apps/authentication/__tests__/helpers.jest.js
+++ b/src/desktop/apps/authentication/__tests__/helpers.jest.js
@@ -1,5 +1,10 @@
 import Cookies from "cookies-js"
-import { handleSubmit, setCookies, getRedirect } from "../helpers"
+import {
+  handleSubmit,
+  setCookies,
+  getRedirect,
+  apiAuthWithRedirectUrl,
+} from "../helpers"
 import Backbone from "backbone"
 import $ from "jquery"
 
@@ -7,6 +12,8 @@ jest.mock("cookies-js")
 jest.mock("sharify", () => {
   return {
     data: {
+      API_URL: "https://api.example.com",
+      APP_URL: "https://app.example.com",
       AP: {
         loginPagePath: "foo",
       },
@@ -239,28 +246,140 @@ describe("Authentication Helpers", () => {
       })
     })
   })
+
+  describe("#apiAuthWithRedirectUrl", () => {
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    describe("when there isn't a current user", () => {
+      it("returns the app url, not an api url", async () => {
+        const response = {}
+        const redirectPath = new URL("/any-path", "https://app.example.com")
+
+        const actual = await apiAuthWithRedirectUrl(response, redirectPath)
+
+        expect(actual.toString()).toMatch("https://app.example.com/any-path")
+      })
+    })
+
+    describe("when there is a current user", () => {
+      describe("when we can get a trust token from the api", () => {
+        beforeEach(() => {
+          global.fetch = jest.fn(() =>
+            Promise.resolve({
+              status: 200,
+              ok: true,
+              json: () =>
+                Promise.resolve({
+                  trust_token: "a-trust-token",
+                  issued_at: "some-datetime",
+                  expires_in: "some-datetime",
+                }),
+            })
+          )
+        })
+
+        it("returns an API URL", async () => {
+          const response = { user: { accessToken: "some-access-token" } }
+          const redirectPath = new URL("/any-path", "https://app.example.com")
+
+          const actual = await apiAuthWithRedirectUrl(response, redirectPath)
+
+          expect(actual.toString()).toMatch("https://api.example.com")
+        })
+
+        it("returns with an application URL as the redirect uri", async () => {
+          const response = { user: { accessToken: "some-access-token" } }
+          const redirectPath = new URL("/any-path", "https://app.example.com")
+
+          const actual = await apiAuthWithRedirectUrl(response, redirectPath)
+
+          const expectedRedirectUri = encodeURIComponent(
+            "https://app.example.com/any-path"
+          )
+          expect(actual.toString()).toMatch(
+            `redirect_uri=${expectedRedirectUri}`
+          )
+        })
+
+        it("returns with the trust token from the api", async () => {
+          const response = { user: { accessToken: "some-access-token" } }
+          const redirectPath = new URL("/any-path", "https://app.example.com")
+
+          const actual = await apiAuthWithRedirectUrl(response, redirectPath)
+
+          expect(actual.toString()).toMatch(`trust_token=a-trust-token`)
+        })
+      })
+
+      describe("when we aren't authorized to get a trust token from the api", () => {
+        beforeEach(() => {
+          global.fetch = jest.fn(() =>
+            Promise.resolve({
+              status: 401,
+              ok: false,
+              json: () =>
+                Promise.resolve({
+                  error: "Unauthorized",
+                  text: "The access token is invalid or has expired.",
+                }),
+            })
+          )
+        })
+
+        it("returns the app URL, not the api url", async () => {
+          const response = { user: { accessToken: "some-access-token" } }
+          const redirectPath = new URL("/any-path", "https://app.example.com")
+
+          const actual = await apiAuthWithRedirectUrl(response, redirectPath)
+
+          expect(actual.toString()).toEqual("https://app.example.com/any-path")
+        })
+      })
+
+      describe("when the api is down", () => {
+        beforeEach(() => {
+          global.fetch = jest.fn(() =>
+            Promise.resolve(new Error("gravity is down"))
+          )
+        })
+
+        it("returns the app URL, not the api url", async () => {
+          const response = { user: { accessToken: "some-access-token" } }
+          const redirectPath = new URL("/any-path", "https://app.example.com")
+
+          const actual = await apiAuthWithRedirectUrl(response, redirectPath)
+
+          expect(actual.toString()).toEqual("https://app.example.com/any-path")
+        })
+      })
+    })
+  })
+
   describe("#getRedirect", () => {
     it("Returns home if type is login and path is login", () => {
       window.history.pushState({}, "", "/login")
       const redirectTo = getRedirect("login")
-      expect(redirectTo).toBe("/")
+      expect(redirectTo.toString()).toBe("https://app.example.com/")
     })
 
     it("Returns home if type is forgot", () => {
       window.history.pushState({}, "", "/forgot")
       const redirectTo = getRedirect("forgot")
-      expect(redirectTo).toBe("/")
+      expect(redirectTo.toString()).toBe("https://app.example.com/")
     })
 
     it("Returns /personalize if type is signup", () => {
       const redirectTo = getRedirect("signup")
-      expect(redirectTo).toBe("/personalize")
+      expect(redirectTo.toString()).toBe("https://app.example.com/personalize")
     })
 
     it("Returns window.location by default", () => {
       window.history.pushState({}, "", "/magazine")
       const redirectTo = getRedirect("login")
-      expect(redirectTo).toBe(window.location)
+
+      expect(redirectTo.toString()).toBe(window.location.href)
     })
   })
 })

--- a/src/desktop/apps/authentication/helpers.ts
+++ b/src/desktop/apps/authentication/helpers.ts
@@ -7,6 +7,7 @@ import { data as sd } from "sharify"
 import { pickBy, identity } from "lodash"
 import * as qs from "query-string"
 import { Response } from "express"
+import { captureException } from "@sentry/browser"
 
 const mediator = require("../../lib/mediator.coffee")
 const LoggedOutUser = require("../../models/logged_out_user.coffee")
@@ -151,6 +152,7 @@ export async function apiAuthWithRedirectUrl(
       return appRedirectURL
     }
   } catch (error) {
+    captureException(error)
     return appRedirectURL
   }
 }

--- a/src/desktop/apps/authentication/helpers.ts
+++ b/src/desktop/apps/authentication/helpers.ts
@@ -5,6 +5,7 @@ import {
 } from "reaction/Components/Authentication/Types"
 import { data as sd } from "sharify"
 import { pickBy, identity } from "lodash"
+import * as qs from "query-string"
 
 const mediator = require("../../lib/mediator.coffee")
 const LoggedOutUser = require("../../models/logged_out_user.coffee")
@@ -140,11 +141,11 @@ export async function apiAuthWithRedirectUrl(
       const responseBody = await tokenResponse.json()
       const trustToken = responseBody["trust_token"]
 
-      return new URL(
-        `${
-          sd.API_URL
-        }/users/sign_in?trust_token=${trustToken}&redirect_uri=${appRedirectURL.toString()}`
-      )
+      const queryParams = qs.stringify({
+        trust_token: trustToken,
+        redirect_uri: appRedirectURL.toString(),
+      })
+      return new URL(`${sd.API_URL}/users/sign_in?${queryParams}`)
     } else {
       return appRedirectURL
     }

--- a/src/desktop/apps/authentication/helpers.ts
+++ b/src/desktop/apps/authentication/helpers.ts
@@ -6,6 +6,7 @@ import {
 import { data as sd } from "sharify"
 import { pickBy, identity } from "lodash"
 import * as qs from "query-string"
+import { Response } from "express"
 
 const mediator = require("../../lib/mediator.coffee")
 const LoggedOutUser = require("../../models/logged_out_user.coffee")
@@ -120,11 +121,11 @@ export const setCookies = options => {
 }
 
 export async function apiAuthWithRedirectUrl(
-  response: any,
+  response: Response,
   redirectPath: URL
 ): Promise<URL> {
   const redirectUrl = sd.APP_URL + redirectPath.pathname
-  const accessToken = (response.user || {}).accessToken
+  const accessToken = (response["user"] || {}).accessToken
   const appRedirectURL = new URL(redirectUrl)
 
   // There isn't an access token when we don't have a valid session, for example,

--- a/src/desktop/apps/authentication/helpers.ts
+++ b/src/desktop/apps/authentication/helpers.ts
@@ -150,7 +150,7 @@ export async function apiAuthWithRedirectUrl(
     } else {
       return appRedirectURL
     }
-  } catch {
+  } catch (error) {
     return appRedirectURL
   }
 }


### PR DESCRIPTION
Jira: https://artsyproduct.atlassian.net/browse/AUCT-281
Review app: https://auct-281.artsy.net/

Monitors:
  - [datadog production login monitor](https://app.datadoghq.com/monitors/6233070)
  - [velocity derived counts](https://velocity.artsy.net/graphlot/?width=586&height=308&_salt=1565906540.658&from=-7days&target=summarize(stats.counters.gravity.session.login-failure.count%2C%221h%22)&target=summarize(stats.counters.gravity.session.login-success.count%2C%221h%22))


**Rebase me**

This is the 2nd pass at a solution to synchronize session state before Force and Gravity so that bidders don't need to sign in twice to access an auction.

The previous attempt involved diff to force (https://github.com/artsy/force/pull/4349, https://github.com/artsy/force/pull/4357) and artsy-passport (https://github.com/artsy/artsy-passport/pull/133), but had downsides of:

1. Continuing to leverage artsy-passport (generally a tool that we want to avoid investing in now)
    - this point is mostly my synthesis of [a comment](https://github.com/artsy/artsy-passport/pull/133/files#r309501001) in an [artsy-passport PR](https://github.com/artsy/artsy-passport/pull/133).
2. Not respecting custom redirect locations (see [this comment](https://github.com/artsy/artsy-passport/pull/133#discussion_r309974323) in particular) -- making it a fundamentally less robust solution.

In this solution attempt, replicate much of the logic in artsy-passport in Force by:

1. Creating a trust token in Gravity after auth
2. Using that trust token and a redirect URI to authenticate with Gravity

This is a **high-risk** change as it touches auth, so I've done my best to test against many flows. Below is a running index of videos describing my QA process:

cc @dblandin @erikdstock

---

## QA Step-up Process

* Edit your /etc/hosts file such that localhost can be resolved to local.artsy.net (see [artsy/artsy-passport README](https://github.com/artsy/artsy-passport/blob/1790a27d572a957c409939a3dc27014092430ba1/README.md#contributing))
  - this is required for Gravity to handle the redirect_uri incoming from force.
  - see [Matt's comment below](https://github.com/artsy/force/pull/4379#issuecomment-520935431) for more context.

## Before

### Logging in when viewing any resource

![current-login-behavior-on-staging](https://user-images.githubusercontent.com/1561546/62510323-a1fe5a80-b7dc-11e9-8caa-5eab9d2d2390.gif)

## After

### Logging in from the index

![synced-login-from-root](https://user-images.githubusercontent.com/1561546/62510348-be01fc00-b7dc-11e9-8e05-d7ca3bdff46b.gif)

### Logging in from /login

![synced-login-from-slash-login](https://user-images.githubusercontent.com/1561546/62510369-c9edbe00-b7dc-11e9-8b1b-278335622d46.gif)

### Logging in when viewing any resource

![synced-login-from-any-resource](https://user-images.githubusercontent.com/1561546/62510385-dbcf6100-b7dc-11e9-8a80-38318cabdb4e.gif)
 
### Logging in from auction registration

![synced-login-from-auction-registration](https://user-images.githubusercontent.com/1561546/62510418-f1448b00-b7dc-11e9-9b87-f2cd043dfd4e.gif)

### Logging in from sign up

![synced-login-from-sign-up](https://user-images.githubusercontent.com/1561546/62510497-2bae2800-b7dd-11e9-9522-7bb2eee397c9.gif)
