### PR TITLE
[GROW-1463] closes artist page signup a/b test

### DIFF
--- a/src/desktop/apps/artist/components/__tests__/cta.jest.ts
+++ b/src/desktop/apps/artist/components/__tests__/cta.jest.ts
@@ -4,19 +4,12 @@ jest.mock("lib/metaphysics.coffee", () =>
   jest.fn().mockReturnValue(Promise.resolve({}))
 )
 
-jest.mock("desktop/components/split_test/index.coffee", () =>
-  jest.fn().mockReturnValue({
-    view: jest.fn(),
-  })
-)
-
 const mockMetaphysics = require("lib/metaphysics.coffee")
 
 jest.mock("sharify", () => ({
   data: {
     ARTIST_PAGE_CTA_ARTIST_ID: "claes-oldenburg",
     ARTIST_PAGE_CTA_ENABLED: true,
-    ARTIST_PAGE_SIGNUP_MODAL: "experiment",
   },
 }))
 
@@ -65,15 +58,5 @@ describe("CTA", () => {
     await setupArtistSignUpModal()
 
     expect(mockMetaphysics).toBeCalledWith(options)
-  })
-
-  it("should set up a scroll event listener when in the experiment group", async () => {
-    const spy = jest.spyOn(window, "addEventListener")
-    mockMetaphysics.mockReturnValue(Promise.resolve({ artist }))
-    await setupArtistSignUpModal()
-
-    expect(spy).toHaveBeenCalled()
-    expect(spy.mock.calls[0][0]).toBe("scroll")
-    expect(spy.mock.calls[0][2]).toEqual({ once: true })
   })
 })

--- a/src/desktop/apps/artist/components/cta.ts
+++ b/src/desktop/apps/artist/components/cta.ts
@@ -1,12 +1,9 @@
 import * as $ from "jquery"
-import { get } from "lodash"
 import { data as sd } from "sharify"
 
 const metaphysics = require("lib/metaphysics.coffee")
 const Artist = require("desktop/models/artist.coffee")
 const ArtistPageCTAView = require("desktop/components/artist_page_cta/view.coffee")
-const mediator = require("desktop/lib/mediator.coffee")
-const splitTest = require("desktop/components/split_test/index.coffee")
 
 export const query = `
 query ArtistCTAQuery($artistID: String!) {
@@ -26,13 +23,6 @@ query ArtistCTAQuery($artistID: String!) {
       }
       name
     }
-    artworks(size: 1) {
-      image {
-        cropped(width: 390, height: 644) {
-          url
-        }
-      }
-    }
   }
 }
 `
@@ -44,42 +34,14 @@ const send = {
 
 export const setupArtistSignUpModal = () => {
   if (sd.ARTIST_PAGE_CTA_ENABLED && sd.ARTIST_PAGE_CTA_ARTIST_ID) {
-    splitTest("artist_page_signup_modal").view()
     return metaphysics(send).then(({ artist: artistData }) => {
-      const image = get(artistData, "artworks[0].image.cropped.url")
-
-      if (sd.ARTIST_PAGE_SIGNUP_MODAL === "experiment") {
-        if (!sd.CURRENT_USER && !sd.IS_MOBILE) {
-          window.addEventListener(
-            "scroll",
-            () => {
-              setTimeout(() => {
-                mediator.trigger("open:auth", {
-                  copy: `Join Artsy to discover new works by ${
-                    artistData.name
-                  } and more artists you love`,
-                  mode: "signup",
-                  intent: "signup",
-                  signupIntent: "signup",
-                  trigger: "scroll",
-                  triggerSeconds: 4,
-                  destination: location.href,
-                  image,
-                })
-              }, 4000)
-            },
-            { once: true }
-          )
-        }
-      } else {
-        const artist = new Artist(artistData)
-        const view = new ArtistPageCTAView({ artist })
-        $("body").append(view.render().$el)
-        view.initializeMailcheck()
-        setTimeout(() => {
-          view.$el.removeClass("initial")
-        }, 500)
-      }
+      const artist = new Artist(artistData)
+      const view = new ArtistPageCTAView({ artist })
+      $("body").append(view.render().$el)
+      view.initializeMailcheck()
+      setTimeout(() => {
+        view.$el.removeClass("initial")
+      }, 500)
     })
   }
 }

--- a/src/desktop/apps/artist/components/cta.ts
+++ b/src/desktop/apps/artist/components/cta.ts
@@ -35,6 +35,9 @@ const send = {
 export const setupArtistSignUpModal = () => {
   if (sd.ARTIST_PAGE_CTA_ENABLED && sd.ARTIST_PAGE_CTA_ARTIST_ID) {
     return metaphysics(send).then(({ artist: artistData }) => {
+      if (!artistData) {
+        return
+      }
       const artist = new Artist(artistData)
       const view = new ArtistPageCTAView({ artist })
       $("body").append(view.render().$el)

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -25,13 +25,6 @@
 # module.exports = {}
 
 module.exports = {
-  artist_page_signup_modal:
-    key: "artist_page_signup_modal"
-    outcomes:
-      control: 50
-      experiment: 50
-    control_group: "control"
-    edge: "experiment"
   collection_hubs:
     key: "collection_hubs"
     outcomes:


### PR DESCRIPTION
Addresses: [GROW-1463](https://artsyproduct.atlassian.net/browse/GROW-1463)

The grow team is still waiting on a full analysis of the Artist Page Signup A/B Test before we can completely depreciate the Artist Page Signup CTA. This PR closes the signup test so that we can unblock the purchase team who is ready to roll out the inquiry flow test.