### PR TITLE
[Refactor] Rename unsafe component methods

### DIFF
--- a/src/desktop/apps/articles/components/AuthWrapper.tsx
+++ b/src/desktop/apps/articles/components/AuthWrapper.tsx
@@ -9,7 +9,7 @@ const mediator = require("desktop/lib/mediator.coffee")
 export class AuthWrapper extends React.Component {
   public openModal
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const hasCookie = Cookies.get("editorial-signup-dismissed")
 
     if (

--- a/src/desktop/apps/auction/components/artwork_rail/ArtworkRail.js
+++ b/src/desktop/apps/auction/components/artwork_rail/ArtworkRail.js
@@ -27,7 +27,7 @@ export class ArtworkRail extends Component {
     page: 1,
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.updatePageDisplay()
   }
 

--- a/src/desktop/apps/auction/components/layout/active_bids/MyActiveBids.js
+++ b/src/desktop/apps/auction/components/layout/active_bids/MyActiveBids.js
@@ -20,7 +20,7 @@ class MyActiveBids extends Component {
     lotStandings: [],
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.setState({
       lotStandings: this.props.lotStandings,
     })
@@ -73,16 +73,18 @@ class MyActiveBids extends Component {
       <div className={b()}>
         <h2>Your Active Bids</h2>
 
-        {lotStandings.filter(bid => bid.sale_artwork).map((bid, key) => {
-          return (
-            <ActiveBidItem
-              {...bid.sale_artwork}
-              BidStatus={BidStatus}
-              bid={bid}
-              key={key}
-            />
-          )
-        })}
+        {lotStandings
+          .filter(bid => bid.sale_artwork)
+          .map((bid, key) => {
+            return (
+              <ActiveBidItem
+                {...bid.sale_artwork}
+                BidStatus={BidStatus}
+                bid={bid}
+                key={key}
+              />
+            )
+          })}
       </div>
     )
   }

--- a/src/desktop/apps/authentication/components/ModalContainer.tsx
+++ b/src/desktop/apps/authentication/components/ModalContainer.tsx
@@ -14,7 +14,7 @@ const mediator = require("../../../lib/mediator.coffee")
 export class ModalContainer extends React.Component<any> {
   public manager: ModalManager | null
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     mediator.on("open:auth", this.onOpenAuth)
     mediator.on("auth:error", this.onAuthError)
   }

--- a/src/desktop/components/react/masonry_grid/Reveal.js
+++ b/src/desktop/components/react/masonry_grid/Reveal.js
@@ -21,7 +21,7 @@ export class Reveal extends Component {
     isExpanded: false,
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { isExpanded } = this.props
 
     this.setState({


### PR DESCRIPTION
Addresses some React 16.9 warnings about deprecated component lifecycle methods.