### PR TITLE
[CollectionsHubsNav] Pass COLLECTION_HUBS sharify data to server app

### DIFF
--- a/src/desktop/apps/collect/server.tsx
+++ b/src/desktop/apps/collect/server.tsx
@@ -10,7 +10,7 @@ export const app = express()
 
 const index = async (req, res, next) => {
   try {
-    const { APP_URL, IS_MOBILE } = res.locals.sd
+    const { APP_URL, IS_MOBILE, COLLECTION_HUBS } = res.locals.sd
 
     const {
       headTags,
@@ -22,7 +22,7 @@ const index = async (req, res, next) => {
       routes: collectRoutes,
       url: req.url,
       userAgent: req.header("User-Agent"),
-      context: buildServerAppContext(req, res),
+      context: buildServerAppContext(req, res, { COLLECTION_HUBS }),
     })
 
     if (redirect) {


### PR DESCRIPTION
We added a [split test named COLLECTION_HUBS](https://github.com/artsy/force/blob/e7cf3af91c20caf458581572badc76ddb5f48fd6/src/desktop/components/split_test/running_tests.coffee#L28), but we weren't passing it through to the server app. This was resulting in an SSR hydration mismatch when conditionally displaying elements in Reaction. This PR addresses that.