### PR TITLE
[Vanguard] Routing

### DIFF
--- a/src/desktop/apps/article/__tests__/editorial_features.jest.ts
+++ b/src/desktop/apps/article/__tests__/editorial_features.jest.ts
@@ -1,23 +1,37 @@
-import { isCustomEditorial } from "../editorial_features"
+import { isCustomEditorial, getCustomEditorialId } from "../editorial_features"
 
 describe("Editorial Features", () => {
-  it("returns nothing if article ID does not match existing features", () => {
-    const customEditorial = isCustomEditorial("123")
-    expect(customEditorial).toBeFalsy()
+  describe("#isCustomEditoral", () => {
+    it("returns nothing if article ID does not match existing features", () => {
+      const customEditorial = isCustomEditorial("123")
+      expect(customEditorial).toBeFalsy()
+    })
+
+    it("Can identify EOY_2018_ARTISTS", () => {
+      const customEditorial = isCustomEditorial("5bf30690d8b9430baaf6c6de")
+      expect(customEditorial).toBe("EOY_2018_ARTISTS")
+    })
+
+    it("Can identify EOY_2018_CULTURE", () => {
+      const customEditorial = isCustomEditorial("5bf306aad8b9430baaf6c6df")
+      expect(customEditorial).toBe("EOY_2018_CULTURE")
+    })
+
+    it("Can identify VANGUARD_2019", () => {
+      const customEditorial = isCustomEditorial("5d2f8bd0cdc74b00208b7e16")
+      expect(customEditorial).toBe("VANGUARD_2019")
+    })
   })
 
-  it("Can identify EOY_2018_ARTISTS", () => {
-    const customEditorial = isCustomEditorial("5bf30690d8b9430baaf6c6de")
-    expect(customEditorial).toBe("EOY_2018_ARTISTS")
-  })
+  describe("#getCustomEditorialId", () => {
+    it("returns the article id if name is found", () => {
+      const id = getCustomEditorialId("VANGUARD_2019")
+      expect(id).toBe("5d2f8bd0cdc74b00208b7e16")
+    })
 
-  it("Can identify EOY_2018_CULTURE", () => {
-    const customEditorial = isCustomEditorial("5bf306aad8b9430baaf6c6df")
-    expect(customEditorial).toBe("EOY_2018_CULTURE")
-  })
-
-  it("Can identify VANGUARD_2019", () => {
-    const customEditorial = isCustomEditorial("5d2f8bd0cdc74b00208b7e16")
-    expect(customEditorial).toBe("VANGUARD_2019")
+    it("does nothing if name is not found", () => {
+      const id = getCustomEditorialId("VANGUARD_2018")
+      expect(id).toBeUndefined()
+    })
   })
 })

--- a/src/desktop/apps/article/__tests__/routes.jest.ts
+++ b/src/desktop/apps/article/__tests__/routes.jest.ts
@@ -418,4 +418,32 @@ describe("Article Routes", () => {
       expect(res.redirect).toBeCalledWith(301, "/article/foobar")
     })
   })
+
+  describe("Vanguard 2019", () => {
+    it("redirects to /series if shorthand slug", () => {
+      req.params = {}
+      req.path = "/artsy-vanguard-2019"
+      routes.index(req, res, next)
+      expect(res.redirect).toBeCalledWith("/series/artsy-vanguard-2019")
+    })
+
+    it("preserves params when redirects to /series", () => {
+      req.params = { slug: "emerging" }
+      req.path = "/artsy-vanguard-2019"
+      routes.index(req, res, next)
+      expect(res.redirect).toBeCalledWith(
+        "/series/artsy-vanguard-2019/emerging"
+      )
+    })
+
+    it("always fetches master vanguard article if vanguard slug", () => {
+      req.params = { slug: "emerging" }
+      req.path = "/series/artsy-vanguard-2019/emerging"
+      routes.index(req, res, next)
+
+      expect(positronql.mock.calls[0][0].query).toMatch(
+        "5d2f8bd0cdc74b00208b7e16"
+      )
+    })
+  })
 })

--- a/src/desktop/apps/article/editorial_features.ts
+++ b/src/desktop/apps/article/editorial_features.ts
@@ -44,3 +44,10 @@ export const getCustomEditorialId = (name: string) => {
     return customArticle.id
   }
 }
+
+// TODO: redirect sub-series to /artsy-vanguard-2019
+export const VanguardSubSeries = [
+  "5d1d01e03e7eba002037dc4c",
+  "5d3defd1373e39001ff00644",
+  "5d3def6b71e1480020dd7cb9",
+]

--- a/src/desktop/apps/article/editorial_features.ts
+++ b/src/desktop/apps/article/editorial_features.ts
@@ -34,3 +34,13 @@ export const isCustomEditorial = (id: string) => {
     return customArticle.name
   }
 }
+
+/**
+ * Returns the id of specified customEditorialArticle by name
+ */
+export const getCustomEditorialId = (name: string) => {
+  const customArticle = find(customEditorialArticles, { name })
+  if (customArticle) {
+    return customArticle.id
+  }
+}

--- a/src/desktop/apps/article/editorial_features.ts
+++ b/src/desktop/apps/article/editorial_features.ts
@@ -1,5 +1,3 @@
-import { find } from "lodash"
-
 interface CustomArticle {
   name: string
   id: string
@@ -29,7 +27,9 @@ const customEditorialArticles: CustomArticle[] = [
  * Checks if an article._id is included in customEditorialArticles
  */
 export const isCustomEditorial = (id: string) => {
-  const customArticle = find(customEditorialArticles, { id })
+  const customArticle = customEditorialArticles.find(
+    article => article.id === id
+  )
   if (customArticle) {
     return customArticle.name
   }
@@ -39,7 +39,9 @@ export const isCustomEditorial = (id: string) => {
  * Returns the id of specified customEditorialArticle by name
  */
 export const getCustomEditorialId = (name: string) => {
-  const customArticle = find(customEditorialArticles, { name })
+  const customArticle = customEditorialArticles.find(
+    article => article.name === name
+  )
   if (customArticle) {
     return customArticle.id
   }

--- a/src/desktop/apps/article/index.ts
+++ b/src/desktop/apps/article/index.ts
@@ -15,3 +15,7 @@ app.get("/news/:slug/amp", routes.amp)
 app.get("/news/:slug", routes.index)
 app.get("/post/:id", routes.redirectPost)
 app.get("/:id/posts", routes.redirectPost)
+
+// Vanguard 2019 Custom landing page
+app.get("/artsy-vanguard-2019/:slug", routes.index)
+app.get("/artsy-vanguard-2019", routes.index)


### PR DESCRIPTION
Related to https://github.com/artsy/reaction/pull/2701
- Adds route for `/artsy-vanguard-2019`
- Overrides fetching on various vanguard routes to always grab master article data

Public slug structure:
Master article: `/artsy-vanguard-2019`
SubSeries: `/artsy-vanguard-2019/emerging`
Artist stub `/artsy-vanguard-2019/genesis-balenger`

TODO:
- We will need to redirect sub-articles to the parent from their original slugs as well (`/article/artsy-editorial-genesis-balenger` -> `/artsy-vanguard-2019/genesis-balenger`). Will cover this in a separate PR.