### PR TITLE
PURCHASE-1365:  Eliminate "Connecting With" function on gallery contact page

### DIFF
--- a/src/desktop/apps/partner/templates/contact_info.jade
+++ b/src/desktop/apps/partner/templates/contact_info.jade
@@ -1,7 +1,3 @@
-if profile.isGallery() && partner.has('email')
-  .purchase
-    p Interested in purchasing works?
-    a.email-gallery( href=partner.getMailTo() ) Contact #{partner.displayName()} via email.
 if partner.has('website')
   .contact-website
     a.partner-website( href=partner.get('website'), target='_blank' )= partner.getSimpleWebsite()

--- a/src/desktop/apps/partner2/templates/contact_info.jade
+++ b/src/desktop/apps/partner2/templates/contact_info.jade
@@ -1,7 +1,3 @@
-if profile.isGallery() && partner.has('email')
-  .purchase
-    p Interested in purchasing works?
-    a.email-gallery( data-partner-id=partner.get('_id'), data-partner-slug=partner.get('id'), href=partner.getMailTo() ) Contact #{partner.displayName()} via email.
 if partner.has('website')
   .contact-website
     a.partner2-website( data-partner-id=partner.get('_id'), data-partner-slug=partner.get('id') href=partner.get('website'), target='_blank' )= partner.getSimpleWebsite()


### PR DESCRIPTION
#[PURCHASE-1365]: Eliminate "Connecting With" function on gallery contact page

What: Gallery contact pages have an option to "Contact XYZ via email" that sends an email from the user's direct inbox to the gallery's designated contact, cc'ing inquiries@.

Pain points:
No way to block suspicious users or artists from sending messages

- ~5 liaisons received complaints from galleries about spam; 7 additional galleries reached out directly to support@ 1 gallery threatened churn

- Over 6 mo period (April—Sept 2018), 274 artists contacted galleries directly about representation

- From a liaison: I think the "connecting with" feature, in my experience at least, has been a nuisance for most galleries

- No way to follow conversations if we're dropped from the thread—sales could be going offline

- 17 conversations on BNMO works occurred through "Connecting with" since launch

- Never heard back on 7 conversations discussing 12 different works, suggesting galleries may have taken conversations offline

- Over 6 mo period (April—Sept 2018), 464 inquiries on artworks occurred offline

- Emails sent via "connecting with" don't appear in the gallery's CMS or come from an "@reply.artsy.net" email, making them hard for partners to track

- No user sign in needed; we lose user data, galleries get no context on inquiry