### PR TITLE
Adds react-use-dimensions as dev dependency in force

### DIFF
--- a/package.json
+++ b/package.json
@@ -417,6 +417,5 @@
       ".js"
     ],
     "lines": 0
-  },
-  "peerDependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -340,6 +340,7 @@
     "prettier": "1.15.2",
     "pug-loader": "2.4.0",
     "react-test-renderer": "16.8.6",
+    "react-use-dimensions": "^1.2.1",
     "rewire": "2.2.0",
     "s3": "4.4.0",
     "should": "11.2.1",
@@ -416,5 +417,6 @@
       ".js"
     ],
     "lines": 0
-  }
+  },
+  "peerDependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12514,6 +12514,11 @@ react-url-query@^1.1.4:
     prop-types "^15.5.9"
     query-string "^4.2.3"
 
+react-use-dimensions@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-use-dimensions/-/react-use-dimensions-1.2.1.tgz#eb1561db7b06c393209d2bffa449931dd93f7870"
+  integrity sha512-XL+Rup9Hosxx3Ap9xpyQMbVwuUa4BSqiOjfBb2zDuGs4uv2FesFV+m8Z/huRx2BNptMd9ARPqFuSNA62zhCozg==
+
 react-waypoint@8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/react-waypoint/-/react-waypoint-8.0.0.tgz#948748a3160e2ca27ae38b0a9acf8df8284e28e7"


### PR DESCRIPTION
This library needs to be installed as a dependency in Force, otherwise, it throws an error and fails to load components using it.

We technically should not have to do this, but to move the development of Artsy Vanguard work forward, for now, this is a work-around.

Links to this PR in Reaction https://github.com/artsy/reaction/pull/2729