### PR TITLE
Don't use onboarding for inquiry authentication a/b test

### DIFF
--- a/src/desktop/apps/artwork/__tests__/client.jest.ts
+++ b/src/desktop/apps/artwork/__tests__/client.jest.ts
@@ -125,7 +125,6 @@ describe("artwork client", () => {
           contextModule: "Artwork CTA",
           modal_copy: "Sign up to contact gallery",
           redirectTo: "https://artsy.net/",
-          afterSignupAction: expect.anything(),
         })
       })
 
@@ -157,7 +156,6 @@ describe("artwork client", () => {
           contextModule: "Artwork CTA",
           modal_copy: "Sign up to ask a specialist",
           redirectTo: "https://artsy.net/",
-          afterSignupAction: expect.anything(),
         })
       })
 
@@ -189,7 +187,6 @@ describe("artwork client", () => {
           contextModule: "Artwork CTA",
           modal_copy: "Sign up to ask a specialist",
           redirectTo: "https://artsy.net/",
-          afterSignupAction: expect.anything(),
         })
       })
 

--- a/src/desktop/apps/artwork/client.tsx
+++ b/src/desktop/apps/artwork/client.tsx
@@ -81,8 +81,6 @@ mediator.on("launchInquiryFlow", options => {
       intent: "Contact Gallery",
       contextModule: "Artwork CTA",
       modal_copy: "Sign up to contact gallery",
-      afterSignupAction: () =>
-        openInquireableModal(options.artworkId, { ask_specialist: false }),
     }
     handleOpenAuthModal(authOptions)
   } else {
@@ -98,8 +96,6 @@ mediator.on("openBuyNowAskSpecialistModal", options => {
       intent: "Ask a specialist",
       contextModule: "Artwork CTA",
       modal_copy: "Sign up to ask a specialist",
-      afterSignupAction: () =>
-        openInquireableModal(options.artworkId, { ask_specialist: true }),
     }
     handleOpenAuthModal(authOptions)
   } else {
@@ -115,7 +111,6 @@ mediator.on("openAuctionAskSpecialistModal", options => {
       intent: "Ask a specialist",
       contextModule: "Artwork CTA",
       modal_copy: "Sign up to ask a specialist",
-      afterSignupAction: () => openAuctionAskSpecialistModal(options),
     }
     handleOpenAuthModal(authOptions)
   } else {


### PR DESCRIPTION
- replaces `destination` with `redirectTo` to skip onboarding
- re-open dialog after signup via `afterSignupAction`

Related conversation: https://artsy.slack.com/archives/C0KEQD4B0/p1566920083041500