### PR TITLE
@zephraph => [Inquiry Auth] Use cookie to immediately open contact modal

### DIFF
--- a/src/desktop/apps/artwork/client.tsx
+++ b/src/desktop/apps/artwork/client.tsx
@@ -15,7 +15,8 @@ const ArtworkInquiry = require("desktop/models/artwork_inquiry.coffee")
 const openInquiryQuestionnaireFor = require("desktop/components/inquiry_questionnaire/index.coffee")
 const openAuctionBuyerPremium = require("desktop/apps/artwork/components/buyers_premium/index.coffee")
 const ViewInRoomView = require("desktop/components/view_in_room/view.coffee")
-// const splitTest = require("desktop/components/split_test/index.coffee")
+const splitTest = require("desktop/components/split_test/index.coffee")
+const Cookies = require("desktop/components/cookies/index.coffee")
 
 buildClientApp({
   routes,
@@ -38,13 +39,24 @@ if (module.hot) {
 const artworkSlug = location.pathname.replace(/\/artwork\//, "")
 recordArtworkView(artworkSlug, sd.CURRENT_USER)
 
-const openInquireableModal = (artworkId: string, { ask_specialist }) => {
+const openInquireableModal = (
+  artworkId: string,
+  { ask_specialist },
+  artworkOptions = {}
+) => {
   if (!artworkId) return
   const user = User.instantiate()
   const inquiry = new ArtworkInquiry({ notification_delay: 600 })
   const artwork = new Artwork({ id: artworkId })
 
+  // TODO: Look into why this is needed.
+  $.ajaxSettings.headers = {
+    "X-XAPP-TOKEN": sd.ARTSY_XAPP_TOKEN,
+    "X-ACCESS-TOKEN":
+      sd.CURRENT_USER != null ? sd.CURRENT_USER.accessToken : undefined,
+  }
   artwork.fetch().then(() => {
+    artwork.set(artworkOptions)
     openInquiryQuestionnaireFor({
       user,
       artwork,
@@ -66,14 +78,47 @@ export const handleOpenAuthModal = options => {
 }
 
 const shouldViewExperiment = () => {
-  return false // TODO: Remove after AB blocker resolved
-  // return sd.INQUIRY_AUTH === "experiment" && !sd.CURRENT_USER
+  return sd.INQUIRY_AUTH_V2 === "experiment" && !sd.CURRENT_USER
 }
 
 const maybeFireTestView = () => {
-  return // TODO: Remove after AB blocker resolved
-  // !sd.CURRENT_USER && splitTest("inquiry_auth").view()
+  !sd.CURRENT_USER && splitTest("inquiry_auth_v2").view()
 }
+
+// If this cookie is set, that means we should immediately launch
+// an inquiry or specialist modal, if the user is signed in.
+// Otherwise, we expire the cookie.
+export const maybeRelaunchInquiryModalAfterAuth = slug => {
+  let cookieValue
+
+  cookieValue = Cookies.get("launchInquiryFlow")
+  if (cookieValue) {
+    sd.CURRENT_USER && openInquireableModal(slug, { ask_specialist: false })
+    Cookies.expire("launchInquiryFlow")
+    return
+  }
+
+  cookieValue = Cookies.get("launchSpecialistFlow")
+  if (cookieValue) {
+    sd.CURRENT_USER && openInquireableModal(slug, { ask_specialist: true })
+    Cookies.expire("launchSpecialistFlow")
+    return
+  }
+
+  cookieValue = Cookies.get("launchAuctionSpecialistFlow")
+  if (cookieValue) {
+    sd.CURRENT_USER &&
+      openInquireableModal(
+        slug,
+        { ask_specialist: true },
+        { is_in_auction: true }
+      )
+    Cookies.expire("launchAuctionSpecialistFlow")
+    return
+  }
+}
+
+maybeRelaunchInquiryModalAfterAuth(artworkSlug)
 
 mediator.on("launchInquiryFlow", options => {
   // TODO: Remove after inquiry a/b test
@@ -85,6 +130,7 @@ mediator.on("launchInquiryFlow", options => {
       modal_copy: "Sign up to contact gallery",
     }
     handleOpenAuthModal(authOptions)
+    Cookies.set("launchInquiryFlow", 1)
   } else {
     openInquireableModal(options.artworkId, { ask_specialist: false })
   }
@@ -100,6 +146,7 @@ mediator.on("openBuyNowAskSpecialistModal", options => {
       modal_copy: "Sign up to ask a specialist",
     }
     handleOpenAuthModal(authOptions)
+    Cookies.set("launchSpecialistFlow", 1)
   } else {
     openInquireableModal(options.artworkId, { ask_specialist: true })
   }
@@ -115,29 +162,15 @@ mediator.on("openAuctionAskSpecialistModal", options => {
       modal_copy: "Sign up to ask a specialist",
     }
     handleOpenAuthModal(authOptions)
+    Cookies.set("launchAuctionSpecialistFlow", 1)
   } else {
-    openAuctionAskSpecialistModal(options)
+    openInquireableModal(
+      options.artworkId,
+      { ask_specialist: true },
+      { is_in_auction: true }
+    )
   }
 })
-
-const openAuctionAskSpecialistModal = options => {
-  const artworkId = options.artworkId
-  if (artworkId) {
-    const user = User.instantiate()
-    const inquiry = new ArtworkInquiry({ notification_delay: 600 })
-    const artwork = new Artwork({ id: artworkId })
-
-    artwork.fetch().then(() => {
-      artwork.set("is_in_auction", true)
-      openInquiryQuestionnaireFor({
-        user,
-        artwork,
-        inquiry,
-        ask_specialist: true,
-      })
-    })
-  }
-}
 
 mediator.on("openViewInRoom", options => {
   try {

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -32,8 +32,8 @@ module.exports = {
       experiment: 0
     edge: 'experiment'
 
-  inquiry_auth:
-    key: 'inquiry_auth'
+  inquiry_auth_v2:
+    key: 'inquiry_auth_v2'
     outcomes: [
       'control'
       'experiment'


### PR DESCRIPTION
Also reenables the AB test, but when this hits staging we should QA with @cavvia 

So, this is sort of a weird one. The desire is that after a successful login/signup occurs (which happens with Reaction modals), the user is immediately brought into the inquiry flow.

However, the inquiry flow is handled via Force modals (this is a legacy component/flow that hasn't been rebuilt in Reaction). Additionally, there's implicit behavior that after a successful login, you get redirected _somewhere_. At the very least we generally reload the page so you get all the 'logged-in' state of things. This is the current behavior.

There winds up being two [reasonable, IMO] ways of proceeding to implement that desired behavior. I'll describe both, although this PR implements the first one.

## Method 1

Use a cookie to track whether a legacy flow should be triggered immediately upon loading the page. When the page is reloaded with a signed-in user, the cookie expires and the flow opens. Otherwise, we just expire the cookie.

This seems to work fine (testing locally). The only quirk is that (at some point in our redesign/shuffling), our 'main' asset file (https://github.com/artsy/force/blob/87f9bbc6c25da9e9a0d356f9cf556d757dcb79d5/src/desktop/components/main_layout/templates/redesign.jade#L43) has started to be evaluated _after_ the JS in the specific app (such as the artwork app), referenced a few lines lower in the layout. So, an `artwork.fetch()` to launch the flow fails with a 401 b/c the [global setup](https://github.com/artsy/force/blob/87f9bbc6c25da9e9a0d356f9cf556d757dcb79d5/src/desktop/lib/global_client_setup.tsx#L104) hasn't happened yet. I left this as a TODO.

## Method 2

Add a new route to the artwork page, `/contact-gallery`. This will immediately open the flow if a user is logged in. Change the redirects during the initial authentication step to redirect to here. The quirk with the fix needed for the `artwork.fetch()` mentioned above would still be needed here.

