### PR TITLE
@zephraph => [Error Handling] No need to explicitly pattern match for 404s from Reaction apps

### DIFF
--- a/src/desktop/apps/artist/server.tsx
+++ b/src/desktop/apps/artist/server.tsx
@@ -77,14 +77,7 @@ app.get(
 
       res.status(status).send(layout)
     } catch (error) {
-      console.log(error)
-      if (error.message.includes("Artist Not Found")) {
-        const notFoundError: any = new Error("Artist Not Found")
-        notFoundError.status = 404
-        next(notFoundError)
-      } else {
-        next(error)
-      }
+      next(error)
     }
   }
 )

--- a/src/desktop/apps/artwork/server.tsx
+++ b/src/desktop/apps/artwork/server.tsx
@@ -86,14 +86,7 @@ app.get(
 
       res.status(status).send(layout)
     } catch (error) {
-      console.log(error)
-      if (error.message.includes("Artwork Not Found")) {
-        const notFoundError: any = new Error("Artwork Not Found")
-        notFoundError.status = 404
-        next(notFoundError)
-      } else {
-        next(error)
-      }
+      next(error)
     }
   }
 )

--- a/src/desktop/apps/order/routes.tsx
+++ b/src/desktop/apps/order/routes.tsx
@@ -57,14 +57,7 @@ export const checkoutFlow = async (req, res, next) => {
 
     res.status(status).send(layout)
   } catch (error) {
-    console.log("(apps/order) Error: ", error)
-    if (error.message.includes("Received status code 404")) {
-      const notFoundError: any = new Error("Order Not Found")
-      notFoundError.status = 404
-      next(notFoundError)
-    } else {
-      next(error)
-    }
+    next(error)
   }
 }
 


### PR DESCRIPTION
Now that:
  - Metaphysics will propagate HTTP status codes from underlying downstream errors
  - Reaction will serve the relevant error page if there is one and only one error w/ status code present

So, we can remove this special-casing. This code isn't even being hit anymore since rather than throwing an error, Reaction is rendering it's own error page anyway.