### PR TITLE
Change partner_category query page size to 50

### DIFF
--- a/src/desktop/apps/galleries_institutions/queries/partner_categories_query.coffee
+++ b/src/desktop/apps/galleries_institutions/queries/partner_categories_query.coffee
@@ -2,7 +2,7 @@ module.exports =
 
   """
   query GalleriesInstitutionsPartnerCategoriesQuery($category_type: CategoryType, $type: [PartnerClassification]){
-    partner_categories(category_type: $category_type, size: 30, internal: false){
+    partner_categories(category_type: $category_type, size: 50, internal: false){
       name
       id
       primary: partners(eligible_for_listing: true, eligible_for_primary_bucket: true, type: $type, sort: RANDOM_SCORE_DESC, default_profile_public: true) {


### PR DESCRIPTION
Was reposted in #incidents https://artsy.slack.com/archives/C9RK0BLEP/p1567172226006600
After investigation with @iskounen and @starsirius  realized recently new categories were added but the query page size was still 30. So had to increase the query page size.

<img width="1127" alt="Screen Shot 2019-08-30 at 10 15 37 AM" src="https://user-images.githubusercontent.com/687513/64027672-32e00180-cb0f-11e9-9561-48b1b909126f.png">
