### PR TITLE
Stitch collections hubs nav from Reaction into homepage

### DIFF
--- a/src/desktop/apps/home/queries/initial.coffee
+++ b/src/desktop/apps/home/queries/initial.coffee
@@ -1,5 +1,5 @@
 module.exports = """
-  query HomePageQuery($showHeroUnits: Boolean!) {
+  query HomePageQuery($showHeroUnits: Boolean!, $showCollectionsHubs: Boolean!) {
     home_page {
       artwork_modules(
         max_rails: -1,
@@ -37,6 +37,13 @@ module.exports = """
         background_image_url
         credit_line
       }
+    }
+
+    marketingCollections(size: 6) @include(if: $showCollectionsHubs){
+      id
+      slug
+      title
+      thumbnail
     }
   }
 """

--- a/src/desktop/apps/home/queries/initial.coffee
+++ b/src/desktop/apps/home/queries/initial.coffee
@@ -39,7 +39,7 @@ module.exports = """
       }
     }
 
-    marketingCollections(size: 6) @include(if: $showCollectionsHubs){
+    marketingHubCollections @include(if: $showCollectionsHubs){
       id
       slug
       title

--- a/src/desktop/apps/home/routes.coffee
+++ b/src/desktop/apps/home/routes.coffee
@@ -17,10 +17,10 @@ positionWelcomeHeroMethod = (req, res) ->
   res.cookie 'hide-welcome-hero', '1', expires: new Date(Date.now() + 31536000000)
   method
 
-fetchMetaphysicsData = (req, showHeroUnits)->
+fetchMetaphysicsData = (req, showHeroUnits, showCollectionsHubs)->
   deferred = Q.defer()
 
-  metaphysics(query: query, req: req, variables: {showHeroUnits: showHeroUnits})
+  metaphysics(query: query, req: req, variables: {showHeroUnits: showHeroUnits, showCollectionsHubs: showCollectionsHubs})
     .then (data) -> deferred.resolve data
     .catch (err) ->
       deferred.resolve
@@ -45,16 +45,18 @@ fetchMetaphysicsData = (req, showHeroUnits)->
       "query-input": "required name=search_term_string"
     }
   }
-
+  
+  showCollectionsHubs = res.locals.sd.COLLECTION_HUBS == "experiment"
   res.locals.sd.PAGE_TYPE = 'home'
   initialFetch = Q
     .allSettled [
-      fetchMetaphysicsData req, true
+      fetchMetaphysicsData req, true, showCollectionsHubs
       featuredLinks.fetch cache: true
     ]
   initialFetch
     .then (results) ->
       homePage = results?[0].value.home_page
+      collectionsHubs = results?[0].value.marketingCollections
       heroUnits = homePage.hero_units
       heroUnits[positionWelcomeHeroMethod(req, res)](welcomeHero) unless req.user?
 
@@ -72,5 +74,6 @@ fetchMetaphysicsData = (req, showHeroUnits)->
         viewHelpers: viewHelpers
         browseCategories: browseCategories
         jsonLD: JSON.stringify jsonLD
-
+        collectionsHubs: collectionsHubs
+        
     .catch next

--- a/src/desktop/apps/home/routes.coffee
+++ b/src/desktop/apps/home/routes.coffee
@@ -56,7 +56,7 @@ fetchMetaphysicsData = (req, showHeroUnits, showCollectionsHubs)->
   initialFetch
     .then (results) ->
       homePage = results?[0].value.home_page
-      collectionsHubs = results?[0].value.marketingCollections
+      collectionsHubs = results?[0].value.marketingHubCollections
       heroUnits = homePage.hero_units
       heroUnits[positionWelcomeHeroMethod(req, res)](welcomeHero) unless req.user?
 

--- a/src/desktop/apps/home/stylesheets/hubs_entry.styl
+++ b/src/desktop/apps/home/stylesheets/hubs_entry.styl
@@ -1,0 +1,5 @@
+.home-hubs-entry
+  margin-top 20px
+  padding-top 20px
+  border-top 1px solid gray-lighter-color
+  margin-bottom 40px

--- a/src/desktop/apps/home/stylesheets/index.styl
+++ b/src/desktop/apps/home/stylesheets/index.styl
@@ -44,6 +44,7 @@ html[data-useragent*="iPad"]
 @require './explore_sections'
 @require './modules'
 @require './browse'
+@require './hubs_entry'
 @require '../components/followed_artists'
 @require '../components/new_for_you'
 @require '../components/artists_to_follow/stylesheets'

--- a/src/desktop/apps/home/templates/hubs_entry.jade
+++ b/src/desktop/apps/home/templates/hubs_entry.jade
@@ -1,0 +1,3 @@
+.home-hubs-entry
+  h2.home-featured-header Featured categories
+  != stitch.components.CollectionsHubsHomepageNav({collectionsHubs: collectionsHubs})

--- a/src/desktop/apps/home/templates/index.jade
+++ b/src/desktop/apps/home/templates/index.jade
@@ -19,8 +19,18 @@ block body
     #home-layout-container.responsive-layout-container
       .main-layout-container: #home-body
         include featured_links
-        unless user
+
+    if collectionsHubs && collectionsHubs.length
+      #home-layout-container.responsive-layout-container
+        .main-layout-container: #home-body
+          h2.home-featured-header Featured categories
+          != stitch.components.CollectionsHubsHomepageNav({collectionsHubs: collectionsHubs})
+
+    unless user
+      #home-layout-container.responsive-layout-container
+        .main-layout-container: #home-body
           include browse
+
     include rails
     #home-layout-container.responsive-layout-container
       .main-layout-container: #home-body

--- a/src/desktop/apps/home/templates/index.jade
+++ b/src/desktop/apps/home/templates/index.jade
@@ -23,13 +23,12 @@ block body
     if collectionsHubs && collectionsHubs.length
       #home-layout-container.responsive-layout-container
         .main-layout-container: #home-body
-          h2.home-featured-header Featured categories
-          != stitch.components.CollectionsHubsHomepageNav({collectionsHubs: collectionsHubs})
-
-    unless user
-      #home-layout-container.responsive-layout-container
-        .main-layout-container: #home-body
-          include browse
+          include hubs_entry
+    else 
+      unless user
+        #home-layout-container.responsive-layout-container
+          .main-layout-container: #home-body
+            include browse
 
     include rails
     #home-layout-container.responsive-layout-container

--- a/src/desktop/components/react/stitch_components/CollectionsHubsHomepageNav.tsx
+++ b/src/desktop/components/react/stitch_components/CollectionsHubsHomepageNav.tsx
@@ -2,5 +2,11 @@ import React from "react"
 import { CollectionsHubsHomepageNav as ReactionHubsNav } from "reaction/Components/v2/CollectionsHubsHomepageNav"
 
 export const CollectionsHubsHomepageNav = ({ collectionsHubs }) => {
-  return <ReactionHubsNav marketingCollections={collectionsHubs} />
+  return (
+    <ReactionHubsNav
+      marketingHubCollections={
+        collectionsHubs ? collectionsHubs.slice(0, 6) : []
+      }
+    />
+  )
 }

--- a/src/desktop/components/react/stitch_components/CollectionsHubsHomepageNav.tsx
+++ b/src/desktop/components/react/stitch_components/CollectionsHubsHomepageNav.tsx
@@ -1,0 +1,6 @@
+import React from "react"
+import { CollectionsHubsHomepageNav as ReactionHubsNav } from "reaction/Components/v2/CollectionsHubsHomepageNav"
+
+export const CollectionsHubsHomepageNav = ({ collectionsHubs }) => {
+  return <ReactionHubsNav marketingCollections={collectionsHubs} />
+}

--- a/src/desktop/components/react/stitch_components/index.tsx
+++ b/src/desktop/components/react/stitch_components/index.tsx
@@ -3,6 +3,7 @@ export { NavBar } from './NavBar'
 
 export { ReactionArtworkArtistInfo as ArtworkArtistInfo } from "./ReactionArtworkArtistInfo"
 export { ArtworkDetailsQueryRenderer as ArtworkDetails } from "reaction/Apps/Artwork/Components/ArtworkDetails"
+export { CollectionsHubsHomepageNav } from "./CollectionsHubsHomepageNav"
 export { ReactionTooltipQuestion as TooltipQuestion } from "./ReactionTooltipQuestion"
 export { UserSettingsPaymentsQueryRenderer as UserSettingsPayments } from "reaction/Components/Payment/UserSettingsPayments"
 export { StitchWrapper } from './StitchWrapper'

--- a/src/mobile/apps/home/routes.coffee
+++ b/src/mobile/apps/home/routes.coffee
@@ -14,7 +14,7 @@ query = """
       }
     }
 
-    marketingCollections(size: 6) @include(if: $showCollectionsHubs){
+    marketingHubCollections @include(if: $showCollectionsHubs){
       id
       slug
       title
@@ -29,9 +29,9 @@ module.exports.index = (req, res, next) ->
   showCollectionsHubs = res.locals.sd.COLLECTION_HUBS == "experiment"
 
   metaphysics(query: query, variables: {showCollectionsHubs: showCollectionsHubs})
-    .then ({ home_page, marketingCollections }) ->
+    .then ({ home_page, marketingHubCollections }) ->
       res.render 'page', 
         heroUnits: home_page.hero_units, 
         resize: resize, 
-        collectionsHubs: marketingCollections
+        collectionsHubs: marketingHubCollections
     .catch next

--- a/src/mobile/apps/home/routes.coffee
+++ b/src/mobile/apps/home/routes.coffee
@@ -2,7 +2,7 @@
 metaphysics = require '../../../lib/metaphysics.coffee'
 
 query = """
-  query HomePageModulesQuery {
+  query HomePageModulesQuery($showCollectionsHubs:Boolean!) {
     home_page {
       hero_units(platform: MARTSY) {
         mode
@@ -13,12 +13,25 @@ query = """
         background_image_url
       }
     }
+
+    marketingCollections(size: 6) @include(if: $showCollectionsHubs){
+      id
+      slug
+      title
+      thumbnail
+    }
   }
 """
 
 module.exports.index = (req, res, next) ->
   res.locals.sd.PAGE_TYPE = 'home'
-  metaphysics(query: query)
-    .then ({ home_page  }) ->
-      res.render 'page', heroUnits: home_page.hero_units, resize: resize
+
+  showCollectionsHubs = res.locals.sd.COLLECTION_HUBS == "experiment"
+
+  metaphysics(query: query, variables: {showCollectionsHubs: showCollectionsHubs})
+    .then ({ home_page, marketingCollections }) ->
+      res.render 'page', 
+        heroUnits: home_page.hero_units, 
+        resize: resize, 
+        collectionsHubs: marketingCollections
     .catch next

--- a/src/mobile/apps/home/stylesheets/index.styl
+++ b/src/mobile/apps/home/stylesheets/index.styl
@@ -4,6 +4,11 @@
 .home-page-section.main-side-margin
   margin-top 20px
 
+.home-page-section>h2
+  font-size: 22px;
+  margin-bottom: 25px;
+  line-height: 28px;
+  
 #home-page-featured-links
   margin-top 20px
 

--- a/src/mobile/apps/home/templates/page.jade
+++ b/src/mobile/apps/home/templates/page.jade
@@ -18,7 +18,12 @@ block content
                     h2!= heroUnit.subtitle
 
   section.main-side-margin.home-page-section
-    h1.avant-garde-header-center Explore Artsy
+    if collectionsHubs && collectionsHubs.length
+      h2 Featured categories
+      != stitch.components.CollectionsHubsHomepageNav({collectionsHubs: collectionsHubs})
+    else
+      h1.avant-garde-header-center Explore Artsy
+      
     nav#home-page-featured-list.chevron-nav-list
       a#home-page-featured-works( href='/collect' ) Featured Artworks
       a#home-page-featured-articles( href='/articles' ) Featured Articles


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GROW-1486.

This PR stitches the collections hubs nav into the homepage.

- It consumes real hubs data, but that real hubs data is only in staging right now. In addition, [Reaction PR 2765](https://github.com/artsy/reaction/pull/2765) needs to be released & merged into Force before this will all work.
- The hubs only show up after a user has logged in as an admin. 

## On desktop

![homepage-hubs](https://user-images.githubusercontent.com/1627089/64455255-d2266b00-d0b2-11e9-8ab6-61b7195b3181.gif)

## On mobile

![image](https://user-images.githubusercontent.com/1627089/64454487-b4580680-d0b0-11e9-8775-2fb248175b2f.png)
