### PR TITLE
Add VAT number display to old version of partner page

### DIFF
--- a/src/desktop/apps/partner/client/contact.coffee
+++ b/src/desktop/apps/partner/client/contact.coffee
@@ -25,4 +25,5 @@ module.exports = class PartnerContactView extends Backbone.View
     @$('.partner-locations').html locationStrings.join("")
 
   renderAdditionalInfo: ->
+    @$('.partner-vat-info').html "VAT ID #: #{@partner.get('vat_number')}" if @partner.get('vat_number')
     @$('.partner-contact-info').html contactTemplate(profile: @profile, partner: @partner)

--- a/src/desktop/apps/partner/stylesheets/contact.styl
+++ b/src/desktop/apps/partner/stylesheets/contact.styl
@@ -27,3 +27,7 @@
       font-size 18px
       line-height 1.25em
       margin 1.4em 0
+  .partner-vat-info
+    unica()
+    color #666666
+    font-size 14px

--- a/src/desktop/apps/partner/templates/contact.jade
+++ b/src/desktop/apps/partner/templates/contact.jade
@@ -3,3 +3,4 @@
     include ./contact_info
   .partner-locations
     .loading-spinner
+  .partner-vat-info

--- a/src/desktop/apps/partner/test/client/contact.test.coffee
+++ b/src/desktop/apps/partner/test/client/contact.test.coffee
@@ -1,0 +1,39 @@
+_ = require 'underscore'
+Backbone = require 'backbone'
+sinon = require 'sinon'
+Partner = require '../../../../models/partner.coffee'
+Profile = require '../../../../models/profile.coffee'
+Contact = require '../../client/contact.coffee'
+benv = require 'benv'
+{ resolve } = require 'path'
+{ fabricate } = require 'antigravity'
+
+describe 'Contact page', ->
+
+  beforeEach (done) ->
+    benv.setup =>
+      benv.expose
+        $: benv.require 'jquery'
+      Backbone.$ = $
+      sinon.stub Backbone, 'sync'
+      benv.render resolve(__dirname, '../../templates/index.jade'), {
+        profile: new Profile fabricate 'partner_profile'
+        sd: { PROFILE: fabricate 'partner_profile' }
+        asset: (->)
+        params: {}
+      }, ->
+        done()
+
+  afterEach ->
+    Backbone.sync.restore()
+    benv.teardown()
+
+  describe '#renderAdditionalInfo', ->
+
+    it 'renders additional info', ->
+      view = new Contact
+        profile: new Profile fabricate 'partner_profile'
+        partner: new Partner fabricate 'partner', vat_number: "ABC123"
+        el: $('body')
+      view.renderAdditionalInfo()
+      $(view.el).html().should.containEql '<div class="partner-vat-info">VAT ID #: ABC123</div>'


### PR DESCRIPTION
More context: this is a followup from Force #4322, which added VAT display to the newer version of the `partner` page, `partner2`. At the time, I believe we thought we didn't need to also implement it on the old version of the page (`partner`). As we were testing with a newly-created partner on staging, we discovered that at least that partner still did use `partner` instead of `partner2`. I would like to follow up by deprecating `partner`, but for now, putting up this patch.