### PR TITLE
Pull inConfirmRegistrationModal from Reaction

### DIFF
--- a/src/desktop/apps/auction/components/layout/ConfirmRegistrationModal.tsx
+++ b/src/desktop/apps/auction/components/layout/ConfirmRegistrationModal.tsx
@@ -1,7 +1,10 @@
-import React, { useEffect, useState } from "react"
-import { Modal } from "reaction/Components/Modal/Modal"
-import { Serif, Button, CheckCircleIcon, Box } from "@artsy/palette"
+import React, { useEffect } from "react"
 import { connect } from "react-redux"
+
+import {
+  ContentKey,
+  PostRegistrationModal,
+} from "reaction/Components/Auction/PostRegistrationModal"
 
 const _ConfirmRegistrationModal = ({ me, modalType, onClose }) => {
   useEffect(() => {
@@ -9,81 +12,27 @@ const _ConfirmRegistrationModal = ({ me, modalType, onClose }) => {
       "/confirm-registration",
       ""
     )
+
     history.replaceState({}, document.title, replaceModalTriggerPath)
   }, [])
-  if (!(me && me.bidders && me.bidders.length)) return null
+
+  if (!(me && me.bidders && me.bidders.length)) {
+    return null
+  }
 
   const bidder = me.bidders[0]
 
-  const [modalVisible, setModalVisible] = useState(true)
-
-  useEffect(
-    () => {
-      if (!modalVisible) {
-        onClose()
-      }
-    },
-    [modalVisible]
-  )
-
-  const hideModal = () => {
-    setModalVisible(false)
-  }
-
-  let Content
+  let contentKey: ContentKey
   if (bidder.qualified_for_bidding) {
-    Content = RegistrationComplete
+    contentKey = "registrationConfirmed"
   } else {
-    Content =
-      modalType === "ConfirmBidAndRegistration" ? CantBid : RegistrationPending
+    contentKey =
+      modalType === "ConfirmBidAndRegistration"
+        ? "bidPending"
+        : "registrationPending"
   }
 
-  return (
-    <Modal show={modalVisible} onClose={hideModal}>
-      <Box pt={[3, 0]} textAlign="center">
-        <Content onClick={hideModal} />
-      </Box>
-    </Modal>
-  )
-}
-
-const CantBid = ({ onClick }) => {
-  return (
-    <>
-      <RegistrationPendingHeader />
-      <Serif my={3} size="3t">
-        We're sorry, your bid could not be placed.
-      </Serif>
-      <ReviewingRegistrationContent />
-      <ViewWorksButton onClick={onClick} />
-    </>
-  )
-}
-
-const RegistrationPending = ({ onClick }) => {
-  return (
-    <>
-      <RegistrationPendingHeader />
-      <ReviewingRegistrationContent />
-      <ViewWorksButton onClick={onClick} />
-    </>
-  )
-}
-const RegistrationComplete = ({ onClick }) => {
-  return (
-    <>
-      <Serif size="6">Registration complete</Serif>
-      <CheckCircleIcon mt={2} height="28px" width="28px" fill="green100" />
-      <Serif mt={2} mb={3} size="3t">
-        Thank you for registering.
-        <br />
-        You’re now eligible to bid on lots in this sale.
-      </Serif>
-      <Button width="100%" onClick={onClick}>
-        Start bidding
-      </Button>
-    </>
-  )
+  return <PostRegistrationModal contentKey={contentKey} onClose={onClose} />
 }
 
 const mapStateToProps = state => ({
@@ -94,28 +43,3 @@ const mapStateToProps = state => ({
 export const ConfirmRegistrationModal = connect(mapStateToProps)(
   _ConfirmRegistrationModal
 )
-
-const ReviewingRegistrationContent = () => {
-  return (
-    <Serif my={3} size="3t">
-      Artsy is reviewing your registration and you will receive an email when it
-      has been confirmed. Please email specialist@artsy.net with any questions.
-      <br />
-      <br />
-      In the meantime, you can still view works and watch lots you’re interested
-      in.
-    </Serif>
-  )
-}
-
-const RegistrationPendingHeader = () => {
-  return <Serif size="6">Registration pending</Serif>
-}
-
-const ViewWorksButton = props => {
-  return (
-    <Button width="100%" onClick={props.onClick}>
-      View works in this sale
-    </Button>
-  )
-}

--- a/src/desktop/apps/auction/components/layout/__tests__/ConfirmRegistrationModal.jest.tsx
+++ b/src/desktop/apps/auction/components/layout/__tests__/ConfirmRegistrationModal.jest.tsx
@@ -76,7 +76,7 @@ describe("Confirm Registration Modal", () => {
       it("shows a qualified message", () => {
         const { wrapper } = renderTestComponent({
           Component: ConfirmRegistrationModal,
-          options: { renderMode: "render" },
+          options: { renderMode: "mount" },
           data: {
             app: {
               modalType: "ConfirmRegistration",
@@ -90,6 +90,7 @@ describe("Confirm Registration Modal", () => {
             },
           },
         })
+
         expect(wrapper.text()).toEqual(
           expect.stringContaining("Registration complete")
         )
@@ -101,7 +102,7 @@ describe("Confirm Registration Modal", () => {
         const { wrapper } = renderTestComponent({
           Component: ConfirmRegistrationModal,
           props: { cantBid: true },
-          options: { renderMode: "render" },
+          options: { renderMode: "mount" },
           data: {
             app: {
               modalType: "ConfirmBidAndRegistration",
@@ -124,7 +125,7 @@ describe("Confirm Registration Modal", () => {
       it("shows a registration pending message if the user was trying to register", () => {
         const { wrapper } = renderTestComponent({
           Component: ConfirmRegistrationModal,
-          options: { renderMode: "render" },
+          options: { renderMode: "mount" },
           data: {
             app: {
               modalType: "ConfirmRegistration",


### PR DESCRIPTION
addresses https://artsyproduct.atlassian.net/browse/AUCT-571

This replaces the duplicate auction registration copies & modals with the one in Reaction.

## Todos

 * [x] self-QA in staging