### PR TITLE
Promote new reaction-based registration form

### DIFF
--- a/src/desktop/apps/auction_reaction/server.tsx
+++ b/src/desktop/apps/auction_reaction/server.tsx
@@ -3,4 +3,5 @@ import { bidderRegistration } from "./routes"
 
 export const app = express()
 
+app.get("/auction-registration/:auctionID*", bidderRegistration)
 app.get("/auction-registration2/:auctionID*", bidderRegistration)

--- a/src/desktop/apps/auction_support/index.coffee
+++ b/src/desktop/apps/auction_support/index.coffee
@@ -9,7 +9,6 @@ app = module.exports = express()
 app.set 'views', __dirname + '/templates'
 app.set 'view engine', 'jade'
 
-app.get '/auction-registration/:id', routes.auctionRegistration
 app.get '/auction/:id/bid/:artwork', routes.bid
 app.get '/auction/:id/buyers-premium', routes.buyersPremium
 


### PR DESCRIPTION
Promotes the new bidder registration form to the primary `auction-registration/:auctionID` route.