### PR TITLE
Revert "Promote new reaction-based registration form"

### DIFF
--- a/src/desktop/apps/auction_reaction/server.tsx
+++ b/src/desktop/apps/auction_reaction/server.tsx
@@ -3,5 +3,4 @@ import { bidderRegistration } from "./routes"
 
 export const app = express()
 
-app.get("/auction-registration/:auctionID*", bidderRegistration)
 app.get("/auction-registration2/:auctionID*", bidderRegistration)

--- a/src/desktop/apps/auction_support/index.coffee
+++ b/src/desktop/apps/auction_support/index.coffee
@@ -9,6 +9,7 @@ app = module.exports = express()
 app.set 'views', __dirname + '/templates'
 app.set 'view engine', 'jade'
 
+app.get '/auction-registration/:id', routes.auctionRegistration
 app.get '/auction/:id/bid/:artwork', routes.bid
 app.get '/auction/:id/buyers-premium', routes.buyersPremium
 


### PR DESCRIPTION
Reverts artsy/force#4490

Discovered a bug causing the modal to pop up multiple times:

![ezgif-1-57bf37665c7a](https://user-images.githubusercontent.com/123595/64350290-71216900-cfc6-11e9-9fa5-d69a8ebd224b.gif)

Originally thought this might be due to https://github.com/artsy/force/pull/4484, but I think this is more of a routing issue.