### PR TITLE
Fix: Auction registration modal loop

### DIFF
--- a/src/desktop/apps/auction_reaction/routes.jest.ts
+++ b/src/desktop/apps/auction_reaction/routes.jest.ts
@@ -1,13 +1,69 @@
 import { bidderRegistration } from "./routes"
+import { stitch } from "@artsy/stitch"
+
+jest.mock("reaction/Artsy/Router/server", () => {
+  return { buildServerApp: () => ({}) }
+})
+
+jest.mock("@artsy/stitch", () => ({
+  stitch: jest.fn(),
+}))
 
 describe("Reaction Auction app routes", () => {
   describe("bidderRegistration", () => {
-    it("defers handling using next() if the accepted-conditions=true query param is present", () => {
-      const req = { query: { "accepted-conditions": "true" } }
-      const res = {}
-      const next = jest.fn()
-      bidderRegistration(req, res, next)
-      expect(next).toHaveBeenCalledWith()
+    const mockSend = jest.fn()
+    const mockRedirect = jest.fn()
+    const mockNext = jest.fn()
+    const mockStitch = stitch as jest.Mock
+    let req
+    let res
+
+    beforeEach(() => {
+      req = {
+        query: {},
+        header: jest.fn(),
+        originalUrl: "testurl.artsy.net/auction-registration/deluxe-art-sale",
+      }
+      res = {
+        locals: { sd: { CURRENT_USER: { access_token: "1" } } },
+        redirect: mockRedirect,
+        status: () => ({ send: mockSend }),
+      }
+      jest.resetAllMocks()
+    })
+
+    describe("?accepted-conditions=true query param is present", () => {
+      beforeEach(() => {
+        req.query["accepted-conditions"] = "true"
+      })
+
+      it("defers handling using next() if the accepted-conditions=true query param is present", () => {
+        bidderRegistration(req, res, mockNext)
+        expect(mockNext).toHaveBeenCalledWith()
+      })
+    })
+
+    describe("?accepted-conditions=true query param is not present", () => {
+      beforeEach(() => {
+        req.query = {}
+      })
+
+      it("redirects if user is not present", () => {
+        delete res.locals.sd.CURRENT_USER
+        bidderRegistration(req, res, mockNext)
+        expect(mockRedirect).toHaveBeenCalledWith(
+          "/login?redirectTo=testurl.artsy.net%2Fauction-registration%2Fdeluxe-art-sale"
+        )
+      })
+
+      it("does not defer handling", async () => {
+        const layout = "<marquee>Welcome to Artsy</marquee>"
+        const next = jest.fn()
+        mockStitch.mockResolvedValue(layout)
+        await bidderRegistration(req, res, next)
+        expect(next).not.toHaveBeenCalled()
+        expect(mockSend).toHaveBeenCalledWith(layout)
+      })
     })
   })
 })

--- a/src/desktop/apps/auction_reaction/routes.jest.ts
+++ b/src/desktop/apps/auction_reaction/routes.jest.ts
@@ -1,0 +1,13 @@
+import { bidderRegistration } from "./routes"
+
+describe("Reaction Auction app routes", () => {
+  describe("bidderRegistration", () => {
+    it("defers handling using next() if the accepted-conditions=true query param is present", () => {
+      const req = { query: { "accepted-conditions": "true" } }
+      const res = {}
+      const next = jest.fn()
+      bidderRegistration(req, res, next)
+      expect(next).toHaveBeenCalledWith()
+    })
+  })
+})

--- a/src/desktop/apps/auction_reaction/routes.jest.ts
+++ b/src/desktop/apps/auction_reaction/routes.jest.ts
@@ -11,14 +11,16 @@ jest.mock("@artsy/stitch", () => ({
 
 describe("Reaction Auction app routes", () => {
   describe("bidderRegistration", () => {
+    let req
+    let res
     const mockSend = jest.fn()
     const mockRedirect = jest.fn()
     const mockNext = jest.fn()
     const mockStitch = stitch as jest.Mock
-    let req
-    let res
+    const layout = "<marquee>Welcome to Artsy</marquee>"
 
     beforeEach(() => {
+      jest.resetAllMocks()
       req = {
         query: {},
         header: jest.fn(),
@@ -29,7 +31,7 @@ describe("Reaction Auction app routes", () => {
         redirect: mockRedirect,
         status: () => ({ send: mockSend }),
       }
-      jest.resetAllMocks()
+      mockStitch.mockResolvedValue(layout)
     })
 
     describe("?accepted-conditions=true query param is present", () => {
@@ -37,9 +39,10 @@ describe("Reaction Auction app routes", () => {
         req.query["accepted-conditions"] = "true"
       })
 
-      it("defers handling using next() if the accepted-conditions=true query param is present", () => {
-        bidderRegistration(req, res, mockNext)
+      it("defers handling using next() if the accepted-conditions=true query param is present", async () => {
+        await bidderRegistration(req, res, mockNext)
         expect(mockNext).toHaveBeenCalledWith()
+        expect(mockSend).not.toHaveBeenCalled()
       })
     })
 
@@ -48,20 +51,18 @@ describe("Reaction Auction app routes", () => {
         req.query = {}
       })
 
-      it("redirects if user is not present", () => {
+      it("redirects if user is not present", async () => {
         delete res.locals.sd.CURRENT_USER
-        bidderRegistration(req, res, mockNext)
+        await bidderRegistration(req, res, mockNext)
         expect(mockRedirect).toHaveBeenCalledWith(
           "/login?redirectTo=testurl.artsy.net%2Fauction-registration%2Fdeluxe-art-sale"
         )
+        expect(mockSend).not.toHaveBeenCalled()
       })
 
       it("does not defer handling", async () => {
-        const layout = "<marquee>Welcome to Artsy</marquee>"
-        const next = jest.fn()
-        mockStitch.mockResolvedValue(layout)
-        await bidderRegistration(req, res, next)
-        expect(next).not.toHaveBeenCalled()
+        await bidderRegistration(req, res, mockNext)
+        expect(mockNext).not.toHaveBeenCalled()
         expect(mockSend).toHaveBeenCalledWith(layout)
       })
     })

--- a/src/desktop/apps/auction_reaction/routes.tsx
+++ b/src/desktop/apps/auction_reaction/routes.tsx
@@ -4,6 +4,12 @@ import { routes } from "reaction/Apps/Auction/routes"
 import { stitch } from "@artsy/stitch"
 
 export const bidderRegistration = async (req, res, next) => {
+  /* If this request is from a registration modal (trying to create a bidder),
+     defer to the auction_support app router
+  */
+  if (req.query["accepted-conditions"] === "true") {
+    next()
+  }
   if (!res.locals.sd.CURRENT_USER) {
     return res.redirect(
       `/login?redirectTo=${encodeURIComponent(req.originalUrl)}`

--- a/src/desktop/apps/auction_reaction/routes.tsx
+++ b/src/desktop/apps/auction_reaction/routes.tsx
@@ -9,61 +9,61 @@ export const bidderRegistration = async (req, res, next) => {
   */
   if (req.query["accepted-conditions"] === "true") {
     next()
-  }
-  if (!res.locals.sd.CURRENT_USER) {
+  } else if (!res.locals.sd.CURRENT_USER) {
     return res.redirect(
       `/login?redirectTo=${encodeURIComponent(req.originalUrl)}`
     )
-  }
-  try {
-    const {
-      bodyHTML,
-      redirect,
-      status,
-      headTags,
-      scripts,
-      styleTags,
-    } = await buildServerApp({
-      routes,
-      url: req.url,
-      userAgent: req.header("User-Agent"),
-      context: buildServerAppContext(req, res),
-    })
-
-    if (redirect) {
-      res.redirect(302, redirect.url)
-      return
-    }
-
-    // Render layout
-    const layout = await stitch({
-      basePath: __dirname,
-      layout:
-        "../../components/main_layout/templates/react_minimal_header.jade",
-      blocks: {
-        head: () => headTags,
-        body: bodyHTML,
-      },
-      locals: {
-        ...res.locals,
-        assetPackage: "auction_reaction",
-        options: {
-          stripev3: true,
-        },
+  } else {
+    try {
+      const {
+        bodyHTML,
+        redirect,
+        status,
+        headTags,
         scripts,
         styleTags,
-      },
-    })
+      } = await buildServerApp({
+        routes,
+        url: req.url,
+        userAgent: req.header("User-Agent"),
+        context: buildServerAppContext(req, res),
+      })
 
-    res.status(status).send(layout)
-  } catch (error) {
-    console.log("(apps/auction_reaction) Error: ", error)
-    if (error.message.includes("Received status code 404")) {
-      const notFoundError: any = new Error("Sale Not Found")
-      notFoundError.status = 404
-      next(notFoundError)
-    } else {
-      next(error)
+      if (redirect) {
+        res.redirect(302, redirect.url)
+        return
+      }
+
+      // Render layout
+      const layout = await stitch({
+        basePath: __dirname,
+        layout:
+          "../../components/main_layout/templates/react_minimal_header.jade",
+        blocks: {
+          head: () => headTags,
+          body: bodyHTML,
+        },
+        locals: {
+          ...res.locals,
+          assetPackage: "auction_reaction",
+          options: {
+            stripev3: true,
+          },
+          scripts,
+          styleTags,
+        },
+      })
+
+      res.status(status).send(layout)
+    } catch (error) {
+      console.log("(apps/auction_reaction) Error: ", error)
+      if (error.message.includes("Received status code 404")) {
+        const notFoundError: any = new Error("Sale Not Found")
+        notFoundError.status = 404
+        next(notFoundError)
+      } else {
+        next(error)
+      }
     }
   }
 }

--- a/src/desktop/apps/auction_reaction/server.tsx
+++ b/src/desktop/apps/auction_reaction/server.tsx
@@ -3,4 +3,5 @@ import { bidderRegistration } from "./routes"
 
 export const app = express()
 
+app.get("/auction-registration/:auctionID", bidderRegistration)
 app.get("/auction-registration2/:auctionID*", bidderRegistration)


### PR DESCRIPTION
This PR fixes a bug encountered shortly after deploying the new registration form from reaction. It stems from the fact that our `/auction-registration/:slug` route handles multiple cases and redirects; we had QAd this change extensively while the form was sitting at `/auction-registration2/:id` but did not predict the effects of effectively blocking the current `/auction-registration` handler.

in short:
1. new route is in the force `auction_reaction` app, which loads first. It loads the new full-page registration form or redirects to (among other places `/auction/:id/registration-flow` if the user already has a credit card)
2. Old `@auctionRegistration` route lives in the old `auction_support` app. It handles essentially the same redirect logic, and *also the actual bidder creation* if the route _includes_ `?accepted-conditions=true`. So this route has a lot of responsibilities.
3. The *Registration modal* uses this legacy routing for bidder creation, directing the client to `/auction-registration/auction-slug?accepted-conditions=true`, but the newly-defined route from (1) above is catching it first, recognizing the user has a credit card, and sending them back to the /registration-flow route, which pops up the modal again.
4. _The new form is not affected by this because it creates the bidder via a relay mutation._

Initial solution is to manually check for the special query param in our new `auction_reaction` route and, if present, defer to the `auction_support` app using the express `next()` function.