### PR TITLE
Allow reaction linking from force

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bundle-report:dev": "NODE_ENV=development ANALYZE_BUNDLE=true yarn build",
     "bundle-report": "NODE_ENV=production ANALYZE_BUNDLE=true yarn build",
     "clean": "rm -rf .cache && rm -f manifest.json && rm -rf public/assets && mkdir -p public/assets && echo '[Force] Cleaned build directory'",
+    "integrate": "./scripts/quicklink-to-project.sh",
     "jest": "JEST_JUNIT_OUTPUT=reports/junit/js-test-results.xml jest --runInBand",
     "mocha": "scripts/mocha.sh",
     "precommit": "lint-staged",

--- a/scripts/quicklink-to-project.sh
+++ b/scripts/quicklink-to-project.sh
@@ -1,0 +1,22 @@
+if [ -z "$1" ] && [ -z "$PROJECT_PATH" ]; then
+  echo "Must supply a project name or set the PROJECT_PATH env"
+fi
+
+PROJECT=${PROJECT_PATH:-../$1}
+
+if [ ! -d "$PROJECT" ]; then
+  echo "$(realpath $PROJECT) doesn't exist, ensure project name is correct or PROJECT_PATH is pointing to a valid directory"
+  exit 1
+fi
+
+cd $PROJECT
+
+# Does package have integrate command?
+cat package.json | jq -e .scripts.integrate &>2
+
+if [ $? -ne 0 ]; then
+  echo "$PROJECT doesn't have integrate npm script, ensure it's valid"
+  exit 1
+fi
+
+yarn integrate force

--- a/scripts/quicklink-to-project.sh
+++ b/scripts/quicklink-to-project.sh
@@ -15,7 +15,7 @@ cd $PROJECT
 cat package.json | jq -e .scripts.integrate &>2
 
 if [ $? -ne 0 ]; then
-  echo "$PROJECT doesn't have integrate npm script, ensure it's valid"
+  echo "$PROJECT doesn't have an `integrate` script in its package.json"
   exit 1
 fi
 

--- a/scripts/quicklink-to-project.sh
+++ b/scripts/quicklink-to-project.sh
@@ -15,6 +15,7 @@ cd $PROJECT
 cat package.json | jq -e .scripts.integrate &>2
 
 if [ $? -ne 0 ]; then
+  # TODO: Reference documentation on the integration process
   echo "$PROJECT doesn't have an `integrate` script in its package.json"
   exit 1
 fi


### PR DESCRIPTION
This is just the other direction from #4475. It does the same thing (links reaction into force), but it allows you do to so _from_ force. 

So you'd run

```
yarn integrate reaction
```

and that'd start up the linking process. I need to add some docs still. 