### PR TITLE
Display show as online exclusive if location is not available

### DIFF
--- a/src/desktop/apps/show/templates/metadata/location.jade
+++ b/src/desktop/apps/show/templates/metadata/location.jade
@@ -1,5 +1,5 @@
 .show-location
-  if partner_show.has_location
+  if partner_show.has_location && partner_show.location
     span= ViewHelpers.singleLine(partner_show.location)
     if partner_show.location.coordinates
       a.show-entity-link.js-open-map-modal


### PR DESCRIPTION
Currently one show is online exclusive but returns true for `has_location`. Add some defense around displaying the show so that the page doesn't 500.

https://staging.artsy.net/show/tabla-rasa-gallery-confessions-and-reflections

<img width="951" alt=" 2019-09-06 at 3 37 03 PM" src="https://user-images.githubusercontent.com/1389948/64455775-8082de00-d0bc-11e9-9251-664d85406f38.png">

