### PR TITLE
Fix: Auction registration modal loop (#4495)

### DIFF
--- a/src/desktop/apps/auction_reaction/routes.jest.ts
+++ b/src/desktop/apps/auction_reaction/routes.jest.ts
@@ -1,0 +1,70 @@
+import { bidderRegistration } from "./routes"
+import { stitch } from "@artsy/stitch"
+
+jest.mock("reaction/Artsy/Router/server", () => {
+  return { buildServerApp: () => ({}) }
+})
+
+jest.mock("@artsy/stitch", () => ({
+  stitch: jest.fn(),
+}))
+
+describe("Reaction Auction app routes", () => {
+  describe("bidderRegistration", () => {
+    let req
+    let res
+    const mockSend = jest.fn()
+    const mockRedirect = jest.fn()
+    const mockNext = jest.fn()
+    const mockStitch = stitch as jest.Mock
+    const layout = "<marquee>Welcome to Artsy</marquee>"
+
+    beforeEach(() => {
+      jest.resetAllMocks()
+      req = {
+        query: {},
+        header: jest.fn(),
+        originalUrl: "testurl.artsy.net/auction-registration/deluxe-art-sale",
+      }
+      res = {
+        locals: { sd: { CURRENT_USER: { access_token: "1" } } },
+        redirect: mockRedirect,
+        status: () => ({ send: mockSend }),
+      }
+      mockStitch.mockResolvedValue(layout)
+    })
+
+    describe("?accepted-conditions=true query param is present", () => {
+      beforeEach(() => {
+        req.query["accepted-conditions"] = "true"
+      })
+
+      it("defers handling using next() if the accepted-conditions=true query param is present", async () => {
+        await bidderRegistration(req, res, mockNext)
+        expect(mockNext).toHaveBeenCalledWith()
+        expect(mockSend).not.toHaveBeenCalled()
+      })
+    })
+
+    describe("?accepted-conditions=true query param is not present", () => {
+      beforeEach(() => {
+        req.query = {}
+      })
+
+      it("redirects if user is not present", async () => {
+        delete res.locals.sd.CURRENT_USER
+        await bidderRegistration(req, res, mockNext)
+        expect(mockRedirect).toHaveBeenCalledWith(
+          "/login?redirectTo=testurl.artsy.net%2Fauction-registration%2Fdeluxe-art-sale"
+        )
+        expect(mockSend).not.toHaveBeenCalled()
+      })
+
+      it("does not defer handling", async () => {
+        await bidderRegistration(req, res, mockNext)
+        expect(mockNext).not.toHaveBeenCalled()
+        expect(mockSend).toHaveBeenCalledWith(layout)
+      })
+    })
+  })
+})

--- a/src/desktop/apps/auction_reaction/routes.tsx
+++ b/src/desktop/apps/auction_reaction/routes.tsx
@@ -4,60 +4,66 @@ import { routes } from "reaction/Apps/Auction/routes"
 import { stitch } from "@artsy/stitch"
 
 export const bidderRegistration = async (req, res, next) => {
-  if (!res.locals.sd.CURRENT_USER) {
+  /* If this request is from a registration modal (trying to create a bidder),
+     defer to the auction_support app router
+  */
+  if (req.query["accepted-conditions"] === "true") {
+    next()
+  } else if (!res.locals.sd.CURRENT_USER) {
     return res.redirect(
       `/login?redirectTo=${encodeURIComponent(req.originalUrl)}`
     )
-  }
-  try {
-    const {
-      bodyHTML,
-      redirect,
-      status,
-      headTags,
-      scripts,
-      styleTags,
-    } = await buildServerApp({
-      routes,
-      url: req.url,
-      userAgent: req.header("User-Agent"),
-      context: buildServerAppContext(req, res),
-    })
-
-    if (redirect) {
-      res.redirect(302, redirect.url)
-      return
-    }
-
-    // Render layout
-    const layout = await stitch({
-      basePath: __dirname,
-      layout:
-        "../../components/main_layout/templates/react_minimal_header.jade",
-      blocks: {
-        head: () => headTags,
-        body: bodyHTML,
-      },
-      locals: {
-        ...res.locals,
-        assetPackage: "auction_reaction",
-        options: {
-          stripev3: true,
-        },
+  } else {
+    try {
+      const {
+        bodyHTML,
+        redirect,
+        status,
+        headTags,
         scripts,
         styleTags,
-      },
-    })
+      } = await buildServerApp({
+        routes,
+        url: req.url,
+        userAgent: req.header("User-Agent"),
+        context: buildServerAppContext(req, res),
+      })
 
-    res.status(status).send(layout)
-  } catch (error) {
-    console.log("(apps/auction_reaction) Error: ", error)
-    if (error.message.includes("Received status code 404")) {
-      const notFoundError: any = new Error("Sale Not Found")
-      notFoundError.status = 404
-      next(notFoundError)
-    } else {
-      next(error)
+      if (redirect) {
+        res.redirect(302, redirect.url)
+        return
+      }
+
+      // Render layout
+      const layout = await stitch({
+        basePath: __dirname,
+        layout:
+          "../../components/main_layout/templates/react_minimal_header.jade",
+        blocks: {
+          head: () => headTags,
+          body: bodyHTML,
+        },
+        locals: {
+          ...res.locals,
+          assetPackage: "auction_reaction",
+          options: {
+            stripev3: true,
+          },
+          scripts,
+          styleTags,
+        },
+      })
+
+      res.status(status).send(layout)
+    } catch (error) {
+      console.log("(apps/auction_reaction) Error: ", error)
+      if (error.message.includes("Received status code 404")) {
+        const notFoundError: any = new Error("Sale Not Found")
+        notFoundError.status = 404
+        next(notFoundError)
+      } else {
+        next(error)
+      }
     }
   }
 }

--- a/src/desktop/apps/auction_reaction/server.tsx
+++ b/src/desktop/apps/auction_reaction/server.tsx
@@ -3,4 +3,5 @@ import { bidderRegistration } from "./routes"
 
 export const app = express()
 
+app.get("/auction-registration/:auctionID", bidderRegistration)
 app.get("/auction-registration2/:auctionID*", bidderRegistration)


### PR DESCRIPTION
* Defer route new auction app route handling for legacy bidder creation

add a test and consolidate routing code

* Add auction_reaction app routing tests for redirect + passthrough

* use if/else to ensure route handler halts for next/redirect