### PR TITLE
[PageLoader] Set position

### DIFF
--- a/src/desktop/components/main_layout/stylesheets/body.styl
+++ b/src/desktop/components/main_layout/stylesheets/body.styl
@@ -30,7 +30,7 @@ search-bar-input-placeholder()
     &.force-position-absolute
       position absolute
 
-// Adds extra margin for staging banner 
+// Adds extra margin for staging banner
 .body-header-fixed.force-staging
   #main-layout-container
     margin-top (main-header-height + content-margin-top + staging-banner-height)
@@ -186,3 +186,11 @@ html[data-useragent*="iPad"]
 .body-no-padding
   #main-layout-container
     padding 0
+
+// This is where reaction-built apps mount to
+#react-root
+  .reactionPageLoader
+    width: 100%;
+    position: fixed;
+    left: 0;
+    top: 53px !important; // Overwrite storybooks position


### PR DESCRIPTION
Related: https://github.com/artsy/palette/pull/580, https://github.com/artsy/reaction/pull/2785


When working in the `PageLoader` component we need to accommodate the height of the nav bar, while also ensuring that the loader is fixed for users that have scrolled down the page.

![loader](https://user-images.githubusercontent.com/236943/64568789-79eca480-d310-11e9-9dc0-0e9327ffceb1.gif)
