### PR TITLE
Remove twitter from user account linking

### DIFF
--- a/src/desktop/apps/user/components/linked_accounts/index.jade
+++ b/src/desktop/apps/user/components/linked_accounts/index.jade
@@ -2,7 +2,7 @@
   if sd.ERROR
     != sd.ERROR
 
-for service in ['Twitter', 'Facebook']
+for service in ['Facebook']
   .settings-linked-accounts__service.settings-split
     .settings-split__left
       .settings-linked-accounts__service__name

--- a/src/desktop/apps/user/components/linked_accounts/index.jade
+++ b/src/desktop/apps/user/components/linked_accounts/index.jade
@@ -2,17 +2,18 @@
   if sd.ERROR
     != sd.ERROR
 
-for service in ['Facebook']
-  .settings-linked-accounts__service.settings-split
-    .settings-split__left
-      .settings-linked-accounts__service__name
-        = service
+- service = 'Facebook'
 
-    .settings-split__right
-      a.settings-linked-accounts__service__toggle.avant-garde-button-white(
-        class='js-settings-linked-accounts__service__toggle'
-        href= sd.AP[service.toLowerCase() + 'Path']
-        data-service= service.toLowerCase()
-        data-connected= user.isLinkedTo(service.toLowerCase()) ? 'connected' : 'disconnected'
-      )
-        i( class='icon-#{service.toLowerCase()}' )
+.settings-linked-accounts__service.settings-split
+  .settings-split__left
+    .settings-linked-accounts__service__name
+      = service
+
+  .settings-split__right
+    a.settings-linked-accounts__service__toggle.avant-garde-button-white(
+      class='js-settings-linked-accounts__service__toggle'
+      href= sd.AP[service.toLowerCase() + 'Path']
+      data-service= service.toLowerCase()
+      data-connected= user.isLinkedTo(service.toLowerCase()) ? 'connected' : 'disconnected'
+    )
+      i( class='icon-#{service.toLowerCase()}' )

--- a/src/desktop/apps/user/components/linked_accounts/test/view.test.coffee
+++ b/src/desktop/apps/user/components/linked_accounts/test/view.test.coffee
@@ -34,28 +34,28 @@ describe 'LinkedAccountsView', ->
       beforeEach ->
         sinon.stub @user, 'isLinkedTo'
           .returns true
-        @view.$('.js-settings-linked-accounts__service__toggle[data-service="twitter"]').click()
+        @view.$('.js-settings-linked-accounts__service__toggle[data-service="facebook"]').click()
 
       afterEach ->
         @user.isLinkedTo.restore()
 
       it 'destroys the authentication', ->
         Backbone.sync.args[0][0].should.equal 'delete'
-        Backbone.sync.args[0][1].url.should.containEql '/api/v1/me/authentications/twitter'
+        Backbone.sync.args[0][1].url.should.containEql '/api/v1/me/authentications/facebook'
 
       describe 'success', ->
         beforeEach ->
           Backbone.sync.yieldsTo 'success'
-          @view.$('.js-settings-linked-accounts__service__toggle[data-service="twitter"]').click()
+          @view.$('.js-settings-linked-accounts__service__toggle[data-service="facebook"]').click()
 
         it 'sets the correct button state', ->
-          @view.$('.js-settings-linked-accounts__service__toggle[data-service="twitter"]')
-            .data().should.eql service: 'twitter', connected: 'disconnected'
+          @view.$('.js-settings-linked-accounts__service__toggle[data-service="facebook"]')
+            .data().should.eql service: 'facebook', connected: 'disconnected'
 
       describe 'error', ->
         beforeEach ->
           Backbone.sync.yieldsTo 'error', responseJSON: error: 'Something bad.'
-          @view.$('.js-settings-linked-accounts__service__toggle[data-service="twitter"]').click()
+          @view.$('.js-settings-linked-accounts__service__toggle[data-service="facebook"]').click()
 
         it 'renders any errors', ->
           @view.$('.js-form-errors').text().should.equal 'Something bad.'


### PR DESCRIPTION
The twitter functionality has been deprecated from Artsy passport and we are removing the env vars for twitter from force. 

This is the last remaining place I'm aware of that allows account linking to twitter.

<img width="876" alt="Screen Shot 2019-09-16 at 11 20 27 AM" src="https://user-images.githubusercontent.com/1497424/64970796-7c9d4b80-d874-11e9-8e0e-988f8a9c3752.png">
