### PR TITLE
Vanguard meta

### DIFF
--- a/src/desktop/apps/article/__tests__/editorial_features.jest.ts
+++ b/src/desktop/apps/article/__tests__/editorial_features.jest.ts
@@ -2,6 +2,7 @@ import {
   isCustomEditorial,
   getCustomEditorialId,
   isVanguardSubArticle,
+  getVanguardSubArticleContent,
 } from "../editorial_features"
 import { StandardArticle } from "@artsy/reaction/dist/Components/Publishing/Fixtures/Articles"
 
@@ -72,6 +73,48 @@ describe("Editorial Features", () => {
       }
       const isSubarticle = isVanguardSubArticle(article)
       expect(isSubarticle).toBeFalsy()
+    })
+  })
+
+  describe("getVanguardSubArticleContent", () => {
+    const article = {
+      ...StandardArticle,
+      relatedArticles: [
+        {
+          title: "Emerging",
+          thumbnail_title: "Emerging Artists to Know",
+          relatedArticles: [
+            {
+              title: "Genesis Belanger",
+              thumbnail_title: "Vanguard 2019: Genesis Belanger",
+            },
+          ],
+        },
+      ],
+    }
+
+    it("returns nothing if path is master series", () => {
+      const subContents = getVanguardSubArticleContent(
+        "series/artsy-vanguard-2019",
+        article
+      )
+      expect(subContents).toBe(undefined)
+    })
+
+    it("returns subArticle data for sub-series if path is not master series", () => {
+      const subContents = getVanguardSubArticleContent(
+        "artsy-vanguard-2019/emerging",
+        article
+      )
+      expect(subContents.title).toBe("Emerging")
+    })
+
+    it("returns subArticle data for artist if path is not master series", () => {
+      const subContents = getVanguardSubArticleContent(
+        "artsy-vanguard-2019/genesis-belanger",
+        article
+      )
+      expect(subContents.title).toBe("Genesis Belanger")
     })
   })
 })

--- a/src/desktop/apps/article/__tests__/routes.jest.ts
+++ b/src/desktop/apps/article/__tests__/routes.jest.ts
@@ -470,15 +470,83 @@ describe("Article Routes", () => {
         seriesArticle: {
           id: "5d3defd1373e39001ff00644",
         },
-        title: "Genesis Balenger",
+        title: "Genesis Belanger",
       }
       positronql.mockReturnValue(Promise.resolve({ article: artistArticle }))
 
       routes.index(req, res, next).then(() => {
         expect(res.redirect).toBeCalledWith(
-          "/series/artsy-vanguard-2019/genesis-balenger"
+          "/series/artsy-vanguard-2019/genesis-belanger"
         )
         done()
+      })
+    })
+
+    describe("Custom meta content", () => {
+      it("sets up custom meta for sub-series", done => {
+        const vanguardArticle = {
+          ...article,
+
+          id: "5d2f8bd0cdc74b00208b7e16",
+          relatedArticles: [
+            {
+              title: "Emerging",
+              thumbnail_title: "The Emerging Artists to Know",
+              relatedArticles: [
+                {
+                  title: "Genesis Belanger",
+                  thumbnail_title: "Vanguard 2019: Genesis Belanger",
+                },
+              ],
+            },
+          ],
+        }
+
+        positronql.mockReturnValue(
+          Promise.resolve({ article: vanguardArticle })
+        )
+
+        req.params = { slug: "emerging" }
+        req.path = "/series/artsy-vanguard-2019/emerging"
+        routes.index(req, res, next).then(() => {
+          expect(res.locals.customMetaContent.thumbnail_title).toBe(
+            "The Emerging Artists to Know"
+          )
+          done()
+        })
+      })
+
+      it("sets up custom meta for artist stub", done => {
+        const vanguardArticle = {
+          ...article,
+
+          id: "5d2f8bd0cdc74b00208b7e16",
+          relatedArticles: [
+            {
+              title: "Emerging",
+              thumbnail_title: "The Emerging Artists to Know",
+              relatedArticles: [
+                {
+                  title: "Genesis Belanger",
+                  thumbnail_title: "Vanguard 2019: Genesis Belanger",
+                },
+              ],
+            },
+          ],
+        }
+
+        positronql.mockReturnValue(
+          Promise.resolve({ article: vanguardArticle })
+        )
+
+        req.params = { slug: "genesis-belanger" }
+        req.path = "/series/artsy-vanguard-2019/genesis-belanger"
+        routes.index(req, res, next).then(() => {
+          expect(res.locals.customMetaContent.thumbnail_title).toBe(
+            "Vanguard 2019: Genesis Belanger"
+          )
+          done()
+        })
       })
     })
   })

--- a/src/desktop/apps/article/editorial_features.ts
+++ b/src/desktop/apps/article/editorial_features.ts
@@ -1,4 +1,5 @@
 import { ArticleData } from "@artsy/reaction/dist/Components/Publishing/Typings"
+import { slugify } from "underscore.string"
 
 interface CustomArticle {
   name: string
@@ -61,4 +62,29 @@ export const isVanguardSubArticle = (article: ArticleData) => {
     (article.seriesArticle.id === getCustomEditorialId("VANGUARD_2019") ||
       VanguardSubSeries.includes(article.seriesArticle.id))
   )
+}
+
+export const getVanguardSubArticleContent = (
+  path: any,
+  article: ArticleData
+) => {
+  let subArticleContent
+  const subArticleSlug = path.split("artsy-vanguard-2019/").pop()
+  const { relatedArticles } = article
+
+  if (!subArticleSlug.includes("artsy-vanguard-2019")) {
+    relatedArticles &&
+      relatedArticles.forEach(series => {
+        if (subArticleSlug === slugify(series.title)) {
+          subArticleContent = series
+        }
+        series.relatedArticles &&
+          series.relatedArticles.map(artist => {
+            if (subArticleSlug === slugify(artist.title)) {
+              subArticleContent = artist
+            }
+          })
+      })
+  }
+  return subArticleContent
 }

--- a/src/desktop/apps/article/queries/seriesRelatedArticles.ts
+++ b/src/desktop/apps/article/queries/seriesRelatedArticles.ts
@@ -40,8 +40,14 @@ export const seriesRelatedArticlesBody = `
   }
   relatedArticles {
     title
+    thumbnail_image
+    thumbnail_title
+    social_description
+    social_image
+    social_title
     layout
     slug
+    description
     seriesArticle {
       id
     }

--- a/src/desktop/apps/article/routes.ts
+++ b/src/desktop/apps/article/routes.ts
@@ -16,6 +16,7 @@ import {
   isCustomEditorial,
   getCustomEditorialId,
   isVanguardSubArticle,
+  getVanguardSubArticleContent,
 } from "./editorial_features"
 import { slugify } from "underscore.string"
 import {
@@ -67,6 +68,18 @@ export const index = async (req, res, next) => {
       return res.redirect(
         `/series/artsy-vanguard-2019/${slugify(article.title)}`
       )
+    }
+
+    let customMetaContent
+    if (customEditorial === "VANGUARD_2019") {
+      customMetaContent = getVanguardSubArticleContent(req.path, article)
+      // Use subArticle content for meta if not master page
+      if (customMetaContent) {
+        res.locals.customMetaContent = {
+          ...article,
+          ...customMetaContent,
+        }
+      }
     }
 
     if (articleId !== article.slug && !customEditorial) {

--- a/src/desktop/apps/article/templates/meta.jade
+++ b/src/desktop/apps/article/templates/meta.jade
@@ -1,4 +1,4 @@
-- article = customMetaContent ? customMetaContent : article
+- article = customMetaContent || article
 - title = article.search_title || article.thumbnail_title || ''
 - titleExtension = article.layout === 'news' ? ' - Artsy News' : ' - Artsy'
 - url = sd.APP_URL + sd.CURRENT_PATH

--- a/src/desktop/apps/article/templates/meta.jade
+++ b/src/desktop/apps/article/templates/meta.jade
@@ -1,3 +1,4 @@
+- article = customMetaContent ? customMetaContent : article
 - title = article.search_title || article.thumbnail_title || ''
 - titleExtension = article.layout === 'news' ? ' - Artsy News' : ' - Artsy'
 - url = sd.APP_URL + sd.CURRENT_PATH


### PR DESCRIPTION
Updates vanguard routing to provide meta content from sub-series and artist pages when loading custom slugs i.e. `/artsy-vanguard-2019/emerging` shows meta-title for the emerging section.