### PR TITLE
Add acceptance test for /collection/:id

### DIFF
--- a/src/test/acceptance/collection.js
+++ b/src/test/acceptance/collection.js
@@ -1,0 +1,28 @@
+/* eslint-env mocha */
+import { setup, teardown } from "./helpers"
+
+describe("Collection page", () => {
+  let metaphysics, browser
+
+  before(async () => {
+    ;({ metaphysics, browser } = await setup())
+    metaphysics.post("/", (req, res) => {
+      res.send(require("./fixtures/metaphysics/collection"))
+    })
+  })
+
+  after(teardown)
+
+  it("renders a title and header info", async () => {
+    const $ = await browser.page("/collection/kaws-companions")
+    $.html().should.containEql("KAWS: Companions")
+    $.html().should.containEql("Collectible Sculptures")
+    $.html().should.containEql("Brian Donnelly, better known as KAWS")
+  })
+
+  it("renders artwork grid", async () => {
+    const $ = await browser.page("/collection/kaws-companions")
+    $.html().should.containEql("KAWS, Pinocchio, 2018")
+    $.html().should.containEql("IDEA")
+  })
+})

--- a/src/test/acceptance/fixtures/metaphysics/collection.json
+++ b/src/test/acceptance/fixtures/metaphysics/collection.json
@@ -1,0 +1,79 @@
+{
+  "collection": {
+    "id": "5bc89e25ec650e14cf0b4061",
+    "slug": "kaws-companions",
+    "title": "KAWS: Companions",
+    "description":
+      "<p>Brian Donnelly, better known as KAWS, spent the first year of his career as an animator for Disney. After leaving in 1997, KAWS took inspiration from the company&rsquo;s signature cartoon, Mickey Mouse, to create his own set of characters that he named &ldquo;Companions.&rdquo; With gloved hands and X&rsquo;s for eyes, &ldquo;Companions&rdquo; first appeared in KAWS&rsquo;s graffiti works across New York City in the late 1990s. By the end of the decade, the street artist created his first three-dimensional version, and his characters have since taken on a variety of colors, sizes, and poses. In 2017, his four-foot-tall Seated Companion (2011) broke the auction record for the series, selling for over $400,000. However, many of KAWS&rsquo;s &ldquo;Companions&rdquo; are considerably more affordable, such as his vinyl toys produced in collaboration with esteemed manufacturers including Bounty Hunter, Bape, Medicom, and his own brand OriginalFake, which was active between 2006 and 2013.</pheaderI",
+    "headerImage":
+      "https://artsy-vanity-files-production.s3.amazonaws.com/images/kaws2.png",
+    "category": "Collectible Sculptures",
+    "credit": "<p>&copy; KAWS, Medicom Toy 2007.</p>",
+    "query": { "artist_ids": [], "artist_id": null, "gene_id": null, "__id": null },
+    "artworks": {
+      "aggregations": [],
+      "__id": "123"
+    },
+    "filtered_artworks": {
+      "__id":
+        "RmlsdGVyQXJ0d29ya3M6eyJhZ2dyZWdhdGlvbnMiOlsidG90YWwiXSwiYXJ0aXN0X2lkcyI6W10sImdlbmVfaWRzIjpbXSwic2l6ZSI6MCwic29ydCI6Ii1wYXJ0bmVyX3VwZGF0ZWRfYXQiLCJ0YWdfaWQiOiJjb21wYW5pb24ifQ==",
+      "artworks": {
+        "pageInfo": {
+          "hasNextPage": true,
+          "endCursor": "YXJyYXljb25uZWN0aW9uOjI5"
+        },
+        "pageCursors": {
+          "around": [
+            { "cursor": "YXJyYXljb25uZWN0aW9uOi0x", "page": 1, "isCurrent": true }
+          ],
+          "first": null,
+          "last": null,
+          "previous": null
+        },
+        "edges": [
+          {
+            "node": {
+              "__id": "QXJ0d29yazprYXdzLXBpbm9jY2hpby0z",
+              "image": {
+                "aspect_ratio": 0.67,
+                "placeholder": "150%",
+                "url":
+                  "https://d32dm0rphc51dk.cloudfront.net/qu24dwWrXHfw5Z3e6KhXPQ/large.jpg"
+              },
+              "is_biddable": false,
+              "is_acquireable": false,
+              "href": "/artwork/kaws-pinocchio-3",
+              "title": "Pinocchio",
+              "image_title": "KAWS, Pinocchio, 2018",
+              "date": "2018",
+              "sale_message": "Contact For Price",
+              "cultural_maker": null,
+              "artists": [
+                {
+                  "__id": "QXJ0aXN0Omthd3M=",
+                  "href": "/artist/kaws",
+                  "name": "KAWS"
+                }
+              ],
+              "collecting_institution": null,
+              "partner": {
+                "name": "IDEA",
+                "href": "/idea",
+                "__id": "UGFydG5lcjppZGVhLTE=",
+                "type": "Gallery"
+              },
+              "sale": null,
+              "sale_artwork": null,
+              "_id": "5b33f5fa139b2110e3393f17",
+              "is_inquireable": true,
+              "id": "kaws-pinocchio-3",
+              "is_saved": false,
+              "is_offerable": false
+            }
+          }
+        ]
+      }
+    },
+    "__id": "5bc89e25ec650e14cf0b4061"
+  }
+}


### PR DESCRIPTION
Adds a basic acceptance test for `collection/:id` pages

It looks like script for scraping in the acceptance directory is not working as expected, but copied over the fixture used in Reaction for now. 
