### PR TITLE
[GROW-1513] setup collection hub entrypoints a/b test

### DIFF
--- a/src/desktop/apps/collect/client.js
+++ b/src/desktop/apps/collect/client.js
@@ -10,7 +10,7 @@ buildClientApp({
   context: {
     user: sd.CURRENT_USER,
     mediator,
-    COLLECTION_HUBS: sd.COLLECTION_HUBS,
+    COLLECTION_HUB_ENTRYPOINTS_TEST: sd.COLLECTION_HUB_ENTRYPOINTS_TEST,
   },
 })
   .then(({ ClientApp }) => {

--- a/src/desktop/apps/collect/server.tsx
+++ b/src/desktop/apps/collect/server.tsx
@@ -10,7 +10,7 @@ export const app = express()
 
 const index = async (req, res, next) => {
   try {
-    const { APP_URL, IS_MOBILE, COLLECTION_HUBS } = res.locals.sd
+    const { APP_URL, IS_MOBILE, COLLECTION_HUB_ENTRYPOINTS } = res.locals.sd
 
     const {
       headTags,
@@ -22,9 +22,7 @@ const index = async (req, res, next) => {
       routes: collectRoutes,
       url: req.url,
       userAgent: req.header("User-Agent"),
-      context: buildServerAppContext(req, res, {
-        COLLECTION_HUBS,
-      }),
+      context: buildServerAppContext(req, res, { COLLECTION_HUB_ENTRYPOINTS }),
     })
 
     if (redirect) {

--- a/src/desktop/apps/collect/server.tsx
+++ b/src/desktop/apps/collect/server.tsx
@@ -10,7 +10,11 @@ export const app = express()
 
 const index = async (req, res, next) => {
   try {
-    const { APP_URL, IS_MOBILE, COLLECTION_HUB_ENTRYPOINTS } = res.locals.sd
+    const {
+      APP_URL,
+      IS_MOBILE,
+      COLLECTION_HUB_ENTRYPOINTS_TEST,
+    } = res.locals.sd
 
     const {
       headTags,
@@ -22,7 +26,9 @@ const index = async (req, res, next) => {
       routes: collectRoutes,
       url: req.url,
       userAgent: req.header("User-Agent"),
-      context: buildServerAppContext(req, res, { COLLECTION_HUB_ENTRYPOINTS }),
+      context: buildServerAppContext(req, res, {
+        COLLECTION_HUB_ENTRYPOINTS_TEST,
+      }),
     })
 
     if (redirect) {

--- a/src/desktop/apps/home/routes.coffee
+++ b/src/desktop/apps/home/routes.coffee
@@ -46,7 +46,7 @@ fetchMetaphysicsData = (req, showHeroUnits, showCollectionsHubs)->
     }
   }
   
-  showCollectionsHubs = res.locals.sd.COLLECTION_HUBS == "experiment"
+  showCollectionsHubs = res.locals.sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST_QA == "experiment"
   res.locals.sd.PAGE_TYPE = 'home'
   initialFetch = Q
     .allSettled [

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -25,10 +25,10 @@
 # module.exports = {}
 
 module.exports = {
-  collection_hubs:
-    key: "collection_hubs"
+  collection_hub_entrypoints:
+    key: "collection_hub_entrypoints"
     outcomes:
-      control: 100
-      experiment: 0
+      control: 50
+      experiment: 50
     edge: 'experiment'
 }

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -25,8 +25,8 @@
 # module.exports = {}
 
 module.exports = {
-  collection_hub_entrypoints:
-    key: "collection_hub_entrypoints"
+  collection_hub_entrypoints_test:
+    key: "collection_hub_entrypoints_test"
     outcomes:
       control: 50
       experiment: 50

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -30,5 +30,11 @@ module.exports = {
     outcomes:
       control: 50
       experiment: 50
-    edge: 'experiment'
+    edge: "experiment"
+  homepage_collection_hub_entrypoints_test_qa:
+    key: "homepage_collection_hub_entrypoints_test_qa"
+    outcomes:
+      control: 100
+      experiment: 0
+    edge: "experiment"
 }

--- a/src/mobile/apps/home/routes.coffee
+++ b/src/mobile/apps/home/routes.coffee
@@ -26,7 +26,7 @@ query = """
 module.exports.index = (req, res, next) ->
   res.locals.sd.PAGE_TYPE = 'home'
 
-  showCollectionsHubs = res.locals.sd.COLLECTION_HUBS == "experiment"
+  showCollectionsHubs = res.locals.sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST_QA == "experiment"
 
   metaphysics(query: query, variables: {showCollectionsHubs: showCollectionsHubs})
     .then ({ home_page, marketingHubCollections }) ->


### PR DESCRIPTION
Addresses: [GROW-1513](https://artsyproduct.atlassian.net/browse/GROW-1513)

This renames the Collection Hubs a/b test for launch and breaks the homepage entry points into its own separate test.

Related to https://github.com/artsy/reaction/pull/2844