### PR TITLE
@joeyAghion => [Recaptcha] Refactor to avoid race condition

### DIFF
--- a/src/desktop/apps/home/templates/index.jade
+++ b/src/desktop/apps/home/templates/index.jade
@@ -3,23 +3,6 @@ extends ../../../components/main_layout/templates/index
 block head
   include meta
 
-  //- Google reCAPTCHA
-  script( type="text/javascript" ).
-    (function() {
-      function loadGrecaptcha() {
-        if (sd.RECAPTCHA_KEY && !sd.EIGEN) {
-          grecaptcha.execute(sd.RECAPTCHA_KEY, {action: 'homepage'})
-        }
-      }
-      var oldOnLoad = window.onload
-      window.onload = function() {
-        if (typeof oldOnLoad === 'function') {
-          oldOnLoad()
-        }
-        loadGrecaptcha()
-      };
-    })()
-
 append locals
   - assetPackage = 'home'
   - bodyClass = bodyClass + ' body-no-margins body-header-fixed body-transparent-header' + (heroUnits.length && heroUnits[0].mode.match('LIGHT') ? '-white' : '')

--- a/src/desktop/components/main_layout/templates/scripts.jade
+++ b/src/desktop/components/main_layout/templates/scripts.jade
@@ -183,4 +183,10 @@ if sd.ENABLE_INSTANT_PAGE
 
 //- Google reCAPTCHA
 if options.grecaptcha && sd.RECAPTCHA_KEY && !sd.EIGEN
-  script(id="google-recaptcha" src="https://www.google.com/recaptcha/api.js?render=#{sd.RECAPTCHA_KEY}" async defer)
+  script( type="text/javascript" ).
+    var loadGrecaptchaOnHome = function() {
+      if (sd.PAGE_TYPE === 'home') {
+        grecaptcha.execute(sd.RECAPTCHA_KEY, {action: 'homepage'})
+      }
+    }
+  script(id="google-recaptcha" src="https://www.google.com/recaptcha/api.js?onload=loadGrecaptchaOnHome&render=#{sd.RECAPTCHA_KEY}" async defer)


### PR DESCRIPTION
Fixes https://sentry.io/organizations/artsynet/issues/1048199288/?project=28316&query=is%3Aunresolved&statsPeriod=14d

There seems to be some sort of race condition going on where the `onload` is being executed before the script finishes loading with the `async` tag. I believe `window.onload` should wait for those so I'm not 100% sure I can logically trace the race condition, but it seems to be happening a fair bit.

This refactors it slightly to preserve the behavior (which I was wondering- we load the lib on every page but only execute something on the homepage?), but in a way that might be more explicit and avoid a race condition.

I wasn't sure how to test locally that the reCaptcha is actually working, but I was able to verify that the callback was correctly firing after the lib loads.