### PR TITLE
[config] Make IP filter disableable in an effort to reduce cost.

### DIFF
--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -73,13 +73,15 @@ export default function(app) {
   app.set("trust proxy", true)
 
   // Denied IPs
-  app.use(
-    ipfilter(IP_DENYLIST.split(","), {
-      allowedHeaders: ["x-forwarded-for"],
-      log: false,
-      mode: "deny",
-    })
-  )
+  if (IP_DENYLIST && IP_DENYLIST.length > 0) {
+    app.use(
+      ipfilter(IP_DENYLIST.split(","), {
+        allowedHeaders: ["x-forwarded-for"],
+        log: false,
+        mode: "deny",
+      })
+    )
+  }
 
   // Timeout middleware
   if (isProduction) {


### PR DESCRIPTION
Part of https://artsyproduct.atlassian.net/browse/PLATFORM-1835

This flamegraph generated by clinic.js _seems_ to suggest that in a prod build of the server code a large amount of time is spent in the `express-ipfilter` middleware. I don’t really feel like I can trust this tool yet, as I'm struggling trying to get things to run without too much noise (e.g. from things like webpack), but figured it was worth a try nonetheless.

After deploying we should remove the `IP_DENYLIST` from production and restart the service.

<img width="2026" alt="Screenshot 2019-10-04 at 22 00 50" src="https://user-images.githubusercontent.com/2320/66236598-2db83880-e6f3-11e9-956a-5fdedee7f3f6.png">
