### PR TITLE
Fix /collection/:id integration test

### DIFF
--- a/src/test/acceptance/README.md
+++ b/src/test/acceptance/README.md
@@ -6,7 +6,7 @@ These tests start a set of vanilla Express apps to mock the behavior of dependen
 
 A typical acceptance test will involve setting up these fake servers, running a nightmare instance to browse the website, and asserting the contents of the page using [Nightmare APIs](https://github.com/segmentio/nightmare#extract-from-the-page) or a small helper `$ = await browser.page('.selector')` to provide a convenient jQuery-like interface to the page's contents.
 
-````javascript
+```javascript
 /* eslint-env mocha */
 import { setup, teardown } from './helpers'
 
@@ -28,9 +28,11 @@ describe('', () => {
       $('body').html().should.containEql('These Terms of Use')
     })
   })
-````
+```
 
 ## Fixtures
+
+_**Note:** The description below appears to be obsolete. See [this thread](https://artsy.slack.com/archives/C2TQ4PT8R/p1570211335035500) in the meantime for a workaround for capturing fixtures._
 
 We use fixtures to mock downstream API's JSON responses. These JSON fixtures can be found in the test/acceptance/fixtures folders. You can make these yourself, or more conveniently, you might want to try recording the JSON responses from a given page using [Nock's recording functionality](https://github.com/node-nock/nock#recording). To do so...
 
@@ -45,13 +47,13 @@ $ Writing recordings...
 $ gravity/auction.json: GET stagingapi.artsy.net/api/v1/auction/phillips...
 ```
 
-````javascript
+```javascript
 before(async () => {
-  ({ gravity, browser } = await setup())
-  gravity.get('/api/v1/page/:id', (req, res) => {
-    res.send(require('./fixtures/gravity/auction.json'))
+  ;({ gravity, browser } = await setup())
+  gravity.get("/api/v1/page/:id", (req, res) => {
+    res.send(require("./fixtures/gravity/auction.json"))
   })
 })
-````
+```
 
 **Note:** These fixtures are intended to be a convenient starting point and not an end-all solution. It's encouraged that you modify, create, or delete the fixtures as you see fit for each test to take control of test behavior.

--- a/src/test/acceptance/collection.js
+++ b/src/test/acceptance/collection.js
@@ -13,14 +13,14 @@ describe("Collection page", () => {
 
   after(teardown)
 
-  xit("renders a title and header info", async () => {
+  it("renders a title and header info", async () => {
     const $ = await browser.page("/collection/kaws-companions")
     $.html().should.containEql("KAWS: Companions")
     $.html().should.containEql("Collectible Sculptures")
     $.html().should.containEql("Brian Donnelly, better known as KAWS")
   })
 
-  xit("renders artwork grid", async () => {
+  it("renders artwork grid", async () => {
     const $ = await browser.page("/collection/kaws-companions")
     $.html().should.containEql("Boba Fett Companion")
     $.html().should.containEql("Woodstock")

--- a/src/test/acceptance/fixtures/metaphysics/collection.json
+++ b/src/test/acceptance/fixtures/metaphysics/collection.json
@@ -1,1 +1,3629 @@
-{"data":{"viewer":{"category":"Collectible Sculptures","credit":"<p>&copy; KAWS, Medicom Toy 2007.</p>","description":"<p>Brian Donnelly, better known as KAWS, spent the first year of his career as an animator for Disney. After leaving in 1997, KAWS took inspiration from the company&rsquo;s signature cartoon, Mickey Mouse, to create his own set of characters that he named &ldquo;Companions.&rdquo; With gloved hands and X&rsquo;s for eyes, &ldquo;Companions&rdquo; first appeared in KAWS&rsquo;s graffiti works across New York City in the late 1990s. By the end of the decade, the street artist created his first three-dimensional version, and his characters have since taken on a variety of colors, sizes, and poses. In 2017, his four-foot-tall <i>Seated Companion</i> (2011) broke the auction record for the series, selling for over $400,000. However, many of KAWS&rsquo;s &ldquo;Companions&rdquo; are considerably more affordable, such as his vinyl toys produced in collaboration with esteemed manufacturers including Bounty Hunter, Bape, Medicom, and his own brand OriginalFake, which was active between 2006 and 2013.</p>","headerImage":"https://artsy-vanity-files-production.s3.amazonaws.com/images/kaws2.png","id":"5bcf4e518ef6ac2e05f0eb97","slug":"kaws-companions","title":"KAWS: Companions","query":{"artist_ids":[],"artist_id":null,"gene_id":null,"__id":null},"relatedCollections":[{"headerImage":"http://files.artsy.net/images/pumpkinsbigartistsmallsculpture.png","slug":"collectible-sculptures","title":"Big Artists, Small Sculptures","price_guidance":200,"artworks":{"hits":[{"artist":{"name":"Jeff Koons","__id":"QXJ0aXN0OmplZmYta29vbnM="},"title":"Balloon Rabbit (Red)","image":{"url":"https://d32dm0rphc51dk.cloudfront.net/kH-cSMQl68nfYPGkWqBMqw/small.jpg","__id":"5ae1ee3e139b215b21f42636"},"__id":"QXJ0d29yazpqZWZmLWtvb25zLWJhbGxvb24tcmFiYml0LXJlZC0xNg=="},{"artist":{"name":"Takashi Murakami","__id":"QXJ0aXN0OnRha2FzaGktbXVyYWthbWk="},"title":"Mr. DOB","image":{"url":"https://d32dm0rphc51dk.cloudfront.net/aes0eLUVKs0oksAzap8NNw/small.jpg","__id":"59e928c3cd530e4d86001c4c"},"__id":"QXJ0d29yazp0YWthc2hpLW11cmFrYW1pLW1yLWRvYi00NA=="},{"artist":{"name":"Salvador Dalí","__id":"QXJ0aXN0OnNhbHZhZG9yLWRhbGk="},"title":"CRUCIFIXION (DARK GREY)","image":{"url":"https://d32dm0rphc51dk.cloudfront.net/OR0-pvHkzm0PSBcsuhHsrA/small.jpg","__id":"598dfebca09a677efbc9ec5c"},"__id":"QXJ0d29yazpzYWx2YWRvci1kYWxpLWNydWNpZml4aW9uLWRhcmstZ3JleQ=="}],"__id":"RmlsdGVyQXJ0d29ya3M6eyJhZ2dyZWdhdGlvbnMiOltdLCJhcnRpc3RfaWRzIjpbXSwiZ2VuZV9pZHMiOlsiYmlnLWFydGlzdHMtc21hbGwtc2N1bHB0dXJlcyJdLCJzb3J0IjoiLWRlY2F5ZWRfbWVyY2giLCJrZXl3b3JkX21hdGNoX2V4YWN0IjpmYWxzZX0="},"__id":"5bcf4e518ef6ac2e05f0eb98"},{"headerImage":"https://artsy-vanity-files-production.s3.amazonaws.com/images/kaws2.png","slug":"kaws-toys","title":"KAWS: Toys","price_guidance":450,"artworks":{"hits":[{"artist":{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="},"title":"PINOCCHIO & JIMINY CRICKET","image":{"url":"https://d32dm0rphc51dk.cloudfront.net/oTnxcunE3BROJ3DywuNrOg/small.jpg","__id":"5a7512d29c18db74e1793768"},"__id":"QXJ0d29yazprYXdzLXBpbm9jY2hpby1hbmQtamltaW55LWNyaWNrZXQtNg=="},{"artist":{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="},"title":"Pinocchio and Jiminy Cricket","image":{"url":"https://d32dm0rphc51dk.cloudfront.net/G9SYkdc2PoKdHdJpC-fDew/small.jpg","__id":"5b065181275b24363d0e237d"},"__id":"QXJ0d29yazprYXdzLXBpbm9jY2hpby1hbmQtamltaW55LWNyaWNrZXQtOQ=="},{"artist":{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="},"title":"Pinocchio & Jiminy Cricket","image":{"url":"https://d32dm0rphc51dk.cloudfront.net/sZXRIKbVJkReX4KCHFKpGA/small.jpg","__id":"5bf6d6f903ce8656ceae105a"},"__id":"QXJ0d29yazprYXdzLXBpbm9jY2hpby1hbmQtamltaW55LWNyaWNrZXQtNw=="}],"__id":"RmlsdGVyQXJ0d29ya3M6eyJhZ2dyZWdhdGlvbnMiOltdLCJhcnRpc3RfaWRzIjpbIjRlOTM0MDAyZTM0MGZhMDAwMTAwNTMzNiJdLCJnZW5lX2lkcyI6WyJzY3VscHR1cmUiLCJyZWxhdGVkLXRvLXRveXMiXSwic29ydCI6Ii1kZWNheWVkX21lcmNoIiwia2V5d29yZCI6IkNvbXBhbmlvbiwgQkZGLCBQYXNzaW5nIFRocm91Z2gsIEFzdHJvYm95LCBBc3RybyBCb3ksIFNtYWxsIExpZSwgVG9nZXRoZXIsIEFjY29tcGxpY2UsIFR3aW5zLCBTdG9ybXRyb29wZXIsIEJvYmEgRmV0dCwgRGFydGggVmFkZXIsIFVuZGVyY292ZXIgQmVhciwgVHdlZXR5LCBQaW5vY2NoaW8sIFJlc3RpbmcgUGxhY2UsIEFsb25nIHRoZSBXYXksIEZpbmFsIERheXMsIFpvb3RoLCBUd2VldHksIEpvZSBLYXdzLCBTbm9vcHksIFNlZWluZyBXYXRjaGluZywgUGlub2NjaGlvLCBKaW1pbnkgQ3JpY2tldCwgUGFydG5lcnMsIE1pbG8sIEt1YnJpY2ssIFpvb3RoLCBCb3VudHkgSHVudGVyLCBCZWFyYnJpY2ssIENodW0sIEpQUCwgRmluYWwgRGF5cywgQ2hvbXBlcnMsIENhdCBUZWV0aCBCYW5rLCBCZW5kLCBCbGl0eiwgQmVuZHksIEFjY29tcGxpY2UiLCJrZXl3b3JkX21hdGNoX2V4YWN0Ijp0cnVlfQ=="},"__id":"5beb5aca1338c043ac8ae214"},{"headerImage":"http://files.artsy.net/images/jeffkoonsballoondogs.png","slug":"jeff-koons-balloon-dogs","title":"Jeff Koons: Balloon Dogs","price_guidance":9000,"artworks":{"hits":[{"artist":{"name":"Jeff Koons","__id":"QXJ0aXN0OmplZmYta29vbnM="},"title":"Balloon Rabbit, Balloon Swan, Balloon Monkey","image":{"url":"https://d32dm0rphc51dk.cloudfront.net/dvBjLnQgq3391p-RwIqQVA/small.jpg","__id":"5ac7bb1c275b2434baf3249e"},"__id":"QXJ0d29yazpqZWZmLWtvb25zLWJhbGxvb24tcmFiYml0LWJhbGxvb24tc3dhbi1iYWxsb29uLW1vbmtleQ=="},{"artist":{"name":"Jeff Koons","__id":"QXJ0aXN0OmplZmYta29vbnM="},"title":"Balloon Monkey (Blue)","image":{"url":"https://d32dm0rphc51dk.cloudfront.net/i6QjUwfJu9p_MhoHOiwu3g/small.jpg","__id":"5c59b352c0d46a002cbcf48b"},"__id":"QXJ0d29yazpqZWZmLWtvb25zLWJhbGxvb24tbW9ua2V5LWJsdWUtMjA0NA=="},{"artist":{"name":"Jeff Koons","__id":"QXJ0aXN0OmplZmYta29vbnM="},"title":"Balloon Rabbit, Balloon Swan, and Balloon Monkey ","image":{"url":"https://d32dm0rphc51dk.cloudfront.net/u2OYwWMc4i97fGc7ETRecg/small.jpg","__id":"5c1bb3aa850f997a6dc5445e"},"__id":"QXJ0d29yazpqZWZmLWtvb25zLWJhbGxvb24tcmFiYml0LWJhbGxvb24tc3dhbi1hbmQtYmFsbG9vbi1tb25rZXk="}],"__id":"RmlsdGVyQXJ0d29ya3M6eyJhZ2dyZWdhdGlvbnMiOltdLCJhcnRpc3RfaWRzIjpbIjRkOGI5MmJiNGViNjhhMWIyYzAwMDQ0YSJdLCJnZW5lX2lkcyI6W10sInNvcnQiOiItZGVjYXllZF9tZXJjaCIsImtleXdvcmQiOiJCYWxsb29uIERvZywgQmFsbG9vbiBzd2FuLCBCYWxsb29uIG1vbmtleSwgQmFsbG9vbiBSYWJiaXQiLCJrZXl3b3JkX21hdGNoX2V4YWN0Ijp0cnVlfQ=="},"__id":"5beb5aca1338c043ac8ae218"},{"headerImage":"http://files.artsy.net/images/skateboards.png","slug":"artist-skateboard-decks","title":"Artist Skateboard Decks","price_guidance":200,"artworks":{"hits":[{"artist":{"name":"LA II (Angel Oritz)","__id":"QXJ0aXN0OmxhLWlpLWFuZ2VsLW9yaXR6"},"title":"Loose Change","image":{"url":"https://d32dm0rphc51dk.cloudfront.net/V0FgCLo6f6NmWe8BCJC5wQ/small.jpg","__id":"5babe51cd314d23105273fad"},"__id":"QXJ0d29yazpsYS1paS1hbmdlbC1vcml0ei1sb29zZS1jaGFuZ2U="},{"artist":{"name":"Paul McCarthy","__id":"QXJ0aXN0OnBhdWwtbWNjYXJ0aHk="},"title":"Doll Limited Edition Skate Deck ","image":{"url":"https://d32dm0rphc51dk.cloudfront.net/aJ70KW3JcmLbl_gkZfwXRA/small.jpg","__id":"595ca78e139b21385330d346"},"__id":"QXJ0d29yazpwYXVsLW1jY2FydGh5LWRvbGwtbGltaXRlZC1lZGl0aW9uLXNrYXRlLWRlY2s="},{"artist":{"name":"Jeff Koons","__id":"QXJ0aXN0OmplZmYta29vbnM="},"title":"Skateboard Monkey Train - Blue","image":{"url":"https://d32dm0rphc51dk.cloudfront.net/vC-ocQJ2KKAK7JrlNPwMow/small.jpg","__id":"558ad014726169361c00092c"},"__id":"QXJ0d29yazpqZWZmLWtvb25zLXNrYXRlYm9hcmQtbW9ua2V5LXRyYWluLWJsdWU="}],"__id":"RmlsdGVyQXJ0d29ya3M6eyJhZ2dyZWdhdGlvbnMiOltdLCJhcnRpc3RfaWRzIjpbXSwiZ2VuZV9pZHMiOlsiYXJ0aXN0LXNrYXRlYm9hcmQiXSwic29ydCI6Ii1kZWNheWVkX21lcmNoIiwia2V5d29yZF9tYXRjaF9leGFjdCI6ZmFsc2V9"},"__id":"5beb5acb1338c043ac8ae24f"}],"linkedCollections":[],"artworks":{"hits":[{"href":"/artwork/kaws-kaws-x-be-at-rbrick-dissected-companion-400-percent-and-100-percent-two-works","id":"kaws-kaws-x-be-at-rbrick-dissected-companion-400-percent-and-100-percent-two-works","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=138&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FAqIUxe69SL6dNmFSF7XgDg%2Flarge.jpg","width":138,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=190&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FAqIUxe69SL6dNmFSF7XgDg%2Flarge.jpg","width":190,"height":220},"__id":"5d704fa30f056a000e8546c7"},"__id":"QXJ0d29yazprYXdzLWthd3MteC1iZS1hdC1yYnJpY2stZGlzc2VjdGVkLWNvbXBhbmlvbi00MDAtcGVyY2VudC1hbmQtMTAwLXBlcmNlbnQtdHdvLXdvcmtz"},{"href":"/artwork/kaws-no-future-companion-collaboration-with-hajime-sorayama-black-chrome","id":"kaws-no-future-companion-collaboration-with-hajime-sorayama-black-chrome","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=144&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRFC1iwT6hq1QFwrLevkiEw%2Flarge.jpg","width":144,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=199&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRFC1iwT6hq1QFwrLevkiEw%2Flarge.jpg","width":199,"height":220},"__id":"5acc6297c9dc247dcc317da6"},"__id":"QXJ0d29yazprYXdzLW5vLWZ1dHVyZS1jb21wYW5pb24tY29sbGFib3JhdGlvbi13aXRoLWhhamltZS1zb3JheWFtYS1ibGFjay1jaHJvbWU="},{"href":"/artwork/kaws-small-lie-5","id":"kaws-small-lie-5","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=85&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F9IfyjiZvrCelAnYFjFd2tQ%2Flarge.jpg","width":85,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=117&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F9IfyjiZvrCelAnYFjFd2tQ%2Flarge.jpg","width":117,"height":220},"__id":"5d1274d642f72b000e330313"},"__id":"QXJ0d29yazprYXdzLXNtYWxsLWxpZS01"},{"href":"/artwork/kaws-grey-companion-2016-open-edition","id":"kaws-grey-companion-2016-open-edition","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=106&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FAnNB8gHH4xZnLcJSS4cNpw%2Flarge.jpg","width":106,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=146&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FAnNB8gHH4xZnLcJSS4cNpw%2Flarge.jpg","width":146,"height":220},"__id":"586c13229c18db52e5005c34"},"__id":"QXJ0d29yazprYXdzLWdyZXktY29tcGFuaW9uLTIwMTYtb3Blbi1lZGl0aW9u"},{"href":"/artwork/kaws-boba-fett-companion-10","id":"kaws-boba-fett-companion-10","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=146&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FVh612qcvwJYkw6YTjP9CvQ%2Flarge.jpg","width":146,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=201&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FVh612qcvwJYkw6YTjP9CvQ%2Flarge.jpg","width":201,"height":220},"__id":"5bfec8fbd820902a3aa4c879"},"__id":"QXJ0d29yazprYXdzLWJvYmEtZmV0dC1jb21wYW5pb24tMTA="},{"href":"/artwork/kaws-4-foot-dissected-companion-brown","id":"kaws-4-foot-dissected-companion-brown","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=71&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FU4GBoWFFwPhZ8_65MTUo7g%2Flarge.jpg","width":71,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=98&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FU4GBoWFFwPhZ8_65MTUo7g%2Flarge.jpg","width":98,"height":220},"__id":"5ace9d6eb202a301c8c75de1"},"__id":"QXJ0d29yazprYXdzLTQtZm9vdC1kaXNzZWN0ZWQtY29tcGFuaW9uLWJyb3du"},{"href":"/artwork/kaws-companion-blush-open-edition-set-of-2","id":"kaws-companion-blush-open-edition-set-of-2","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=240&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FXbgSZWPiKVjvNkvgMsUVcg%2Flarge.jpg","width":240,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=330&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FXbgSZWPiKVjvNkvgMsUVcg%2Flarge.jpg","width":330,"height":220},"__id":"59d5c83ec9dc241974970fcd"},"__id":"QXJ0d29yazprYXdzLWNvbXBhbmlvbi1ibHVzaC1vcGVuLWVkaXRpb24tc2V0LW9mLTI="},{"href":"/artwork/kaws-woodstock-8","id":"kaws-woodstock-8","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=126&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F1372C2GWivbxT_jH0Oj-Rg%2Flarge.jpg","width":126,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=173&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F1372C2GWivbxT_jH0Oj-Rg%2Flarge.jpg","width":173,"height":220},"__id":"584ec33ecd530e649e00018a"},"__id":"QXJ0d29yazprYXdzLXdvb2RzdG9jay04"},{"href":"/artwork/kaws-untitled-363","id":"kaws-untitled-363","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=114&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWe2oe6vGSNvM8vMfSfQU3Q%2Flarge.jpg","width":114,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=157&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWe2oe6vGSNvM8vMfSfQU3Q%2Flarge.jpg","width":157,"height":220},"__id":"58f010da8b3b81249ca9a0d9"},"__id":"QXJ0d29yazprYXdzLXVudGl0bGVkLTM2Mw=="},{"href":"/artwork/kaws-kaws-black-companion-2016-open-edition","id":"kaws-kaws-black-companion-2016-open-edition","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=106&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FFJ8SXtPf0cHxfXX9l494rQ%2Flarge.jpg","width":106,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=146&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FFJ8SXtPf0cHxfXX9l494rQ%2Flarge.jpg","width":146,"height":220},"__id":"585acf8cc9dc246107000755"},"__id":"QXJ0d29yazprYXdzLWthd3MtYmxhY2stY29tcGFuaW9uLTIwMTYtb3Blbi1lZGl0aW9u"},{"href":"/artwork/kaws-black-flayed-companion-open-edition-1","id":"kaws-black-flayed-companion-open-edition-1","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=107&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FKXFQf_kDuBKlUjYCFZZNAQ%2Flarge.jpg","width":107,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=147&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FKXFQf_kDuBKlUjYCFZZNAQ%2Flarge.jpg","width":147,"height":220},"__id":"59080a7b139b2141bf630fd1"},"__id":"QXJ0d29yazprYXdzLWJsYWNrLWZsYXllZC1jb21wYW5pb24tb3Blbi1lZGl0aW9uLTE="},{"href":"/artwork/kaws-together-brown-1","id":"kaws-together-brown-1","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=224&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FTTYP_VL_kTPIvKq7c6tKbg%2Flarge.jpg","width":224,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=308&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FTTYP_VL_kTPIvKq7c6tKbg%2Flarge.jpg","width":308,"height":220},"__id":"5b3d88119c18db46dd8a136d"},"__id":"QXJ0d29yazprYXdzLXRvZ2V0aGVyLWJyb3duLTE="},{"href":"/artwork/kaws-small-lie-complete-set-of-three","id":"kaws-small-lie-complete-set-of-three","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=213&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FcNJHHg5fnEUIzYAEWsdJoA%2Flarge.jpg","width":213,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=293&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FcNJHHg5fnEUIzYAEWsdJoA%2Flarge.jpg","width":293,"height":220},"__id":"5b69a938cb6560002339eefe"},"__id":"QXJ0d29yazprYXdzLXNtYWxsLWxpZS1jb21wbGV0ZS1zZXQtb2YtdGhyZWU="},{"href":"/artwork/kaws-kaws-brown-companion-2016","id":"kaws-kaws-brown-companion-2016","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=136&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FAuSruS7cRqAFOVCTtmhEHg%2Flarge.jpg","width":136,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=187&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FAuSruS7cRqAFOVCTtmhEHg%2Flarge.jpg","width":187,"height":220},"__id":"5cf83db3ca30760012f0f6cc"},"__id":"QXJ0d29yazprYXdzLWthd3MtYnJvd24tY29tcGFuaW9uLTIwMTY="},{"href":"/artwork/kaws-pinocchio-3","id":"kaws-pinocchio-3","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=106&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fqu24dwWrXHfw5Z3e6KhXPQ%2Flarge.jpg","width":106,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=146&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fqu24dwWrXHfw5Z3e6KhXPQ%2Flarge.jpg","width":146,"height":220},"__id":"5b33f5fb9c18db46398bfa6c"},"__id":"QXJ0d29yazprYXdzLXBpbm9jY2hpby0z"},{"href":"/artwork/kaws-seeing-watching","id":"kaws-seeing-watching","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=239&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FYmIR6J_b3D7A6JAosmuUgA%2Flarge.jpg","width":239,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=329&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FYmIR6J_b3D7A6JAosmuUgA%2Flarge.jpg","width":329,"height":220},"__id":"5b09630a275b2464ae4b3614"},"__id":"QXJ0d29yazprYXdzLXNlZWluZy13YXRjaGluZw=="},{"href":"/artwork/kaws-4-ft-companion-with-box-and-hologram","id":"kaws-4-ft-companion-with-box-and-hologram","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=160&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FTNrubN2rbSkaRJGxnu4uFA%2Flarge.jpg","width":160,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=220&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FTNrubN2rbSkaRJGxnu4uFA%2Flarge.jpg","width":220,"height":220},"__id":"5ba2f7e5196e630027ffe39c"},"__id":"QXJ0d29yazprYXdzLTQtZnQtY29tcGFuaW9uLXdpdGgtYm94LWFuZC1ob2xvZ3JhbQ=="},{"href":"/artwork/kaws-together-black-1","id":"kaws-together-black-1","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=224&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FPUFz_OjJ-JPaJACdsr1Z7Q%2Flarge.jpg","width":224,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=308&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FPUFz_OjJ-JPaJACdsr1Z7Q%2Flarge.jpg","width":308,"height":220},"__id":"5b21c399a09a674544434a80"},"__id":"QXJ0d29yazprYXdzLXRvZ2V0aGVyLWJsYWNrLTE="},{"href":"/artwork/kaws-boba-fett-companion","id":"kaws-boba-fett-companion","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=103&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FGEJ3-RY2I6rmo8JbuuCQkw%2Flarge.jpg","width":103,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=142&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FGEJ3-RY2I6rmo8JbuuCQkw%2Flarge.jpg","width":142,"height":220},"__id":"575a099b139b216b8a00021a"},"__id":"QXJ0d29yazprYXdzLWJvYmEtZmV0dC1jb21wYW5pb24="},{"href":"/artwork/kaws-holiday-set-of-3-1","id":"kaws-holiday-set-of-3-1","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=224&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FhFd-xFdXhOFF85HBJa0zzw%2Flarge.jpg","width":224,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=308&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FhFd-xFdXhOFF85HBJa0zzw%2Flarge.jpg","width":308,"height":220},"__id":"5cdef8ffd9b0661e37ce52f2"},"__id":"QXJ0d29yazprYXdzLWhvbGlkYXktc2V0LW9mLTMtMQ=="},{"href":"/artwork/kaws-together-grey-1","id":"kaws-together-grey-1","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=224&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FM_SOoP7eBHjuLf866XIu7Q%2Flarge.jpg","width":224,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=308&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FM_SOoP7eBHjuLf866XIu7Q%2Flarge.jpg","width":308,"height":220},"__id":"5b3d85b27622dd1349f706ee"},"__id":"QXJ0d29yazprYXdzLXRvZ2V0aGVyLWdyZXktMQ=="},{"href":"/artwork/kaws-passing-through-grey-1","id":"kaws-passing-through-grey-1","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=115&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FZ84jgLZMNuJxUzO-rgZH1w%2Flarge.jpg","width":115,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=158&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FZ84jgLZMNuJxUzO-rgZH1w%2Flarge.jpg","width":158,"height":220},"__id":"58ebea598b3b8133919f4e50"},"__id":"QXJ0d29yazprYXdzLXBhc3NpbmctdGhyb3VnaC1ncmV5LTE="},{"href":"/artwork/kaws-no-future-companion-silver-chrome-5","id":"kaws-no-future-companion-silver-chrome-5","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=181&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FP0KeZt18ZO1E-vKuOvQUHg%2Flarge.jpg","width":181,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=249&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FP0KeZt18ZO1E-vKuOvQUHg%2Flarge.jpg","width":249,"height":220},"__id":"5acc6298b202a313b86659da"},"__id":"QXJ0d29yazprYXdzLW5vLWZ1dHVyZS1jb21wYW5pb24tc2lsdmVyLWNocm9tZS01"},{"href":"/artwork/kaws-holiday-companion-floating-bed","id":"kaws-holiday-companion-floating-bed","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=217&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Flc2FTCfjWIVizWSfnDDjGg%2Flarge.jpg","width":217,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=298&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Flc2FTCfjWIVizWSfnDDjGg%2Flarge.jpg","width":298,"height":220},"__id":"5b63f597e6b6c466df9491a4"},"__id":"QXJ0d29yazprYXdzLWhvbGlkYXktY29tcGFuaW9uLWZsb2F0aW5nLWJlZA=="},{"href":"/artwork/kaws-grey-flayed-companion-2016-open-edition","id":"kaws-grey-flayed-companion-2016-open-edition","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=106&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FHMKwnB8hZm_c2uI2FxXNXw%2Flarge.jpg","width":106,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=146&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FHMKwnB8hZm_c2uI2FxXNXw%2Flarge.jpg","width":146,"height":220},"__id":"587025b1a09a67566a002edc"},"__id":"QXJ0d29yazprYXdzLWdyZXktZmxheWVkLWNvbXBhbmlvbi0yMDE2LW9wZW4tZWRpdGlvbg=="},{"href":"/artwork/kaws-kaws-companion-open-edition-set-of-6","id":"kaws-kaws-companion-open-edition-set-of-6","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=160&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FGLRzJwHwSZcKEpLREw8uag%2Flarge.jpg","width":160,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=220&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FGLRzJwHwSZcKEpLREw8uag%2Flarge.jpg","width":220,"height":220},"__id":"596f863fc9dc2451b95c38b7"},"__id":"QXJ0d29yazprYXdzLWthd3MtY29tcGFuaW9uLW9wZW4tZWRpdGlvbi1zZXQtb2YtNg=="},{"href":"/artwork/kaws-kaws-along-the-way-complete-set-of-3","id":"kaws-kaws-along-the-way-complete-set-of-3","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=160&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F_WKftu2nTtQsQmd7-VREqQ%2Flarge.jpg","width":160,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=220&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F_WKftu2nTtQsQmd7-VREqQ%2Flarge.jpg","width":220,"height":220},"__id":"5d15c60e02c4fd0011847539"},"__id":"QXJ0d29yazprYXdzLWthd3MtYWxvbmctdGhlLXdheS1jb21wbGV0ZS1zZXQtb2YtMw=="},{"href":"/artwork/kaws-companion-brown-flayed-open-edition","id":"kaws-companion-brown-flayed-open-edition","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=106&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRFWH6hud1-aw2QR5-8a-nA%2Flarge.jpg","width":106,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=146&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRFWH6hud1-aw2QR5-8a-nA%2Flarge.jpg","width":146,"height":220},"__id":"59cdddec2a893a388d5d779d"},"__id":"QXJ0d29yazprYXdzLWNvbXBhbmlvbi1icm93bi1mbGF5ZWQtb3Blbi1lZGl0aW9u"},{"href":"/artwork/kaws-companion-blush-flayed-open-edition","id":"kaws-companion-blush-flayed-open-edition","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=125&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F_ktznsDfwK51vMpo-ZTC2w%2Flarge.jpg","width":125,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=172&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F_ktznsDfwK51vMpo-ZTC2w%2Flarge.jpg","width":172,"height":220},"__id":"59d5c8408b3b81391654d91e"},"__id":"QXJ0d29yazprYXdzLWNvbXBhbmlvbi1ibHVzaC1mbGF5ZWQtb3Blbi1lZGl0aW9u"},{"href":"/artwork/kaws-tweety-1","id":"kaws-tweety-1","image":{"small":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=116&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FBuFOJEBAqGgXabGv8ptFdw%2Flarge.jpg","width":116,"height":160},"large":{"url":"https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=159&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FBuFOJEBAqGgXabGv8ptFdw%2Flarge.jpg","width":159,"height":220},"__id":"59a915978b3b813d7ce3fd6a"},"__id":"QXJ0d29yazprYXdzLXR3ZWV0eS0x"}],"__id":"RmlsdGVyQXJ0d29ya3M6eyJhZ2dyZWdhdGlvbnMiOlsibWVyY2hhbmRpc2FibGVfYXJ0aXN0cyIsIm1lZGl1bSIsIm1ham9yX3BlcmlvZCIsInRvdGFsIl0sImFydGlzdF9pZHMiOltdLCJpbmNsdWRlX21lZGl1bV9maWx0ZXJfaW5fYWdncmVnYXRpb24iOnRydWUsImdlbmVfaWRzIjpbXSwic29ydCI6Ii1kZWNheWVkX21lcmNoIiwidGFnX2lkIjoiY29tcGFuaW9uIiwia2V5d29yZF9tYXRjaF9leGFjdCI6ZmFsc2V9","merchandisable_artists":[{"id":"kaws","_id":"4e934002e340fa0001005336","name":"KAWS","imageUrl":"https://d32dm0rphc51dk.cloudfront.net/WhacjFyMKlMkNVzncPjlRA/square.jpg","birthday":"1974","nationality":"American","__id":"QXJ0aXN0Omthd3M=","is_followed":false,"counts":{"follows":0}},{"id":"robert-lazzarini","_id":"4f5f64c23b555230ac0003ae","name":"Robert Lazzarini","imageUrl":"https://d32dm0rphc51dk.cloudfront.net/1npk1i_Xua5q8Hv0YOq_3g/square.jpg","birthday":"1965","nationality":"American","__id":"QXJ0aXN0OnJvYmVydC1sYXp6YXJpbmk=","is_followed":false,"counts":{"follows":0}},{"id":"hajime-sorayama","_id":"51951ec60cfd96ac75000332","name":"Hajime Sorayama","imageUrl":"https://d32dm0rphc51dk.cloudfront.net/cHtFPMYw7SvCewM-eCrefw/square.jpg","birthday":"1947","nationality":"Japanese","__id":"QXJ0aXN0OmhhamltZS1zb3JheWFtYQ==","is_followed":false,"counts":{"follows":0}},{"id":"medicom","_id":"58fe85ee275b2450a0fd2b51","name":"Medicom","imageUrl":"https://d32dm0rphc51dk.cloudfront.net/jUMOidRmCQ0RyynXM_sFzQ/square.jpg","birthday":"","nationality":"","__id":"QXJ0aXN0Om1lZGljb20=","is_followed":false,"counts":{"follows":0}},{"id":"medicom-toy","_id":"5bd9ff5d1f79d672bb7011d9","name":"Medicom Toy","imageUrl":"https://d32dm0rphc51dk.cloudfront.net/3B9sjaicLbIaO6et-QtUxg/square.jpg","birthday":"","nationality":"","__id":"QXJ0aXN0Om1lZGljb20tdG95","is_followed":false,"counts":{"follows":0}}],"artworks_connection":{"edges":[{"node":{"__id":"QXJ0d29yazprYXdzLWthd3MteC1iZS1hdC1yYnJpY2stZGlzc2VjdGVkLWNvbXBhbmlvbi00MDAtcGVyY2VudC1hbmQtMTAwLXBlcmNlbnQtdHdvLXdvcmtz","availability":"for sale","category":"Sculpture","date":"2010","href":"/artwork/kaws-kaws-x-be-at-rbrick-dissected-companion-400-percent-and-100-percent-two-works","is_acquireable":true,"is_price_range":false,"price":"$4,850","price_currency":"USD","title":"KAWS X BE@RBRICK Dissected Companion 400% and 100% (two works)","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/AqIUxe69SL6dNmFSF7XgDg/larger.jpg","__id":"5d704fa30f056a000e8546c7"},"meta":{"description":"Available for sale from 5ART GALLERY, KAWS, KAWS X BE@RBRICK Dissected Companion 400% and 100% (two works) (2010), Painted cast vinyl"},"partner":{"name":"5ART GALLERY","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/MJOYawSs-Do1tjyKBwTDvA/square.jpg","__id":"5ad82a44a09a6735edc343ae"},"__id":"UHJvZmlsZTo1YXJ0LWdhbGxlcnk="},"locations":[],"__id":"UGFydG5lcjo1YXJ0LWdhbGxlcnk="}}},{"node":{"__id":"QXJ0d29yazprYXdzLW5vLWZ1dHVyZS1jb21wYW5pb24tY29sbGFib3JhdGlvbi13aXRoLWhhamltZS1zb3JheWFtYS1ibGFjay1jaHJvbWU=","availability":"for sale","category":"Sculpture","date":"","href":"/artwork/kaws-no-future-companion-collaboration-with-hajime-sorayama-black-chrome","is_acquireable":false,"is_price_range":false,"price":"","price_currency":"USD","title":"No Future Companion  collaboration with Hajime Sorayama (Black Chrome)","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/RFC1iwT6hq1QFwrLevkiEw/larger.jpg","__id":"5acc6297c9dc247dcc317da6"},"meta":{"description":"Available for sale from MSP Modern, KAWS, No Future Companion  collaboration with Hajime Sorayama (Black Chrome), Polished chrome"},"partner":{"name":"MSP Modern","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/KT0hkz64ZByxq4L8f23Fmw/square.jpg","__id":"58126f672a893a03ec0002cb"},"__id":"UHJvZmlsZTptc3AtbW9kZXJu"},"locations":[],"__id":"UGFydG5lcjptc3AtbW9kZXJu"}}},{"node":{"__id":"QXJ0d29yazprYXdzLXNtYWxsLWxpZS01","availability":"for sale","category":"Sculpture","date":"2017","href":"/artwork/kaws-small-lie-5","is_acquireable":false,"is_price_range":false,"price":"$1,000","price_currency":"USD","title":"SMALL LIE","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/9IfyjiZvrCelAnYFjFd2tQ/larger.jpg","__id":"5d1274d642f72b000e330313"},"meta":{"description":"Available for sale from Silverback Gallery, KAWS, SMALL LIE (2017), Painted Cast Vinyl"},"partner":{"name":"Silverback Gallery","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/JBrYk6IJZwF25xHedI85Iw/large.jpg","__id":"5c450dbce14e710bb73bc2a2"},"__id":"UHJvZmlsZTpzaWx2ZXJiYWNrLWdhbGxlcnk="},"locations":[],"__id":"UGFydG5lcjpzaWx2ZXJiYWNrLWdhbGxlcnk="}}},{"node":{"__id":"QXJ0d29yazprYXdzLWdyZXktY29tcGFuaW9uLTIwMTYtb3Blbi1lZGl0aW9u","availability":"for sale","category":"Sculpture","date":"2016","href":"/artwork/kaws-grey-companion-2016-open-edition","is_acquireable":false,"is_price_range":false,"price":"$1,000","price_currency":"USD","title":"Grey Companion 2016 Open Edition","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/AnNB8gHH4xZnLcJSS4cNpw/larger.jpg","__id":"586c13229c18db52e5005c34"},"meta":{"description":"Available for sale from Black Book Gallery, KAWS, Grey Companion 2016 Open Edition (2016), Plastic/Resin"},"partner":{"name":"Black Book Gallery","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/3hwmKMsYijKVZCtu_Ffcfg/untouched-png.png","__id":"55b7f1177261694002000184"},"__id":"UHJvZmlsZTpibGFja2Jvb2stZ2FsbGVyeQ=="},"locations":[{"address":"3878 S Jason St.","address_2":"","city":"Englewood","state":"CO","country":"US","postal_code":"80110","phone":"303-941-2458","__id":"TG9jYXRpb246NTViN2I4Yjc3MjYxNjkwN2RmMDAwMDZi"}],"__id":"UGFydG5lcjpibGFjay1ib29rLWdhbGxlcnk="}}},{"node":{"__id":"QXJ0d29yazprYXdzLWJvYmEtZmV0dC1jb21wYW5pb24tMTA=","availability":"for sale","category":"Sculpture","date":"2013","href":"/artwork/kaws-boba-fett-companion-10","is_acquireable":true,"is_price_range":false,"price":"£6,325","price_currency":"GBP","title":"Boba Fett Companion","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/Vh612qcvwJYkw6YTjP9CvQ/larger.jpg","__id":"5bfec8fbd820902a3aa4c879"},"meta":{"description":"Available for sale from Lougher Contemporary, KAWS, Boba Fett Companion (2013), Painted cast vinyl"},"partner":{"name":"Lougher Contemporary","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/7ylSt743QGUfBgeXg4_pdg/untouched-png.png","__id":"5d8355d9445543000e3671a6"},"__id":"UHJvZmlsZTpsb3VnaGVyLWNvbnRlbXBvcmFyeQ=="},"locations":[{"address":"Trym Lodge","address_2":"1 Henbury Road","city":"Bristol","state":"","country":"GB","postal_code":"BS9 3HQ","phone":"+44 (0) 117 9596411","__id":"TG9jYXRpb246NWE5NTdkYTQ5YzE4ZGI1MTU3NDNhZDA2"}],"__id":"UGFydG5lcjpsb3VnaGVyLWNvbnRlbXBvcmFyeQ=="}}},{"node":{"__id":"QXJ0d29yazprYXdzLTQtZm9vdC1kaXNzZWN0ZWQtY29tcGFuaW9uLWJyb3du","availability":"for sale","category":"Sculpture","date":"2009","href":"/artwork/kaws-4-foot-dissected-companion-brown","is_acquireable":false,"is_price_range":false,"price":"","price_currency":"USD","title":"4 Foot Dissected Companion (Brown)","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/U4GBoWFFwPhZ8_65MTUo7g/larger.jpg","__id":"5ace9d6eb202a301c8c75de1"},"meta":{"description":"Available for sale from MSP Modern, KAWS, 4 Foot Dissected Companion (Brown) (2009), Cast vinyl resin"},"partner":{"name":"MSP Modern","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/KT0hkz64ZByxq4L8f23Fmw/square.jpg","__id":"58126f672a893a03ec0002cb"},"__id":"UHJvZmlsZTptc3AtbW9kZXJu"},"locations":[],"__id":"UGFydG5lcjptc3AtbW9kZXJu"}}},{"node":{"__id":"QXJ0d29yazprYXdzLWNvbXBhbmlvbi1ibHVzaC1vcGVuLWVkaXRpb24tc2V0LW9mLTI=","availability":"for sale","category":"Sculpture","date":"2017","href":"/artwork/kaws-companion-blush-open-edition-set-of-2","is_acquireable":false,"is_price_range":false,"price":"","price_currency":"USD","title":"COMPANION BLUSH (OPEN EDITION) - SET OF 2","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/XbgSZWPiKVjvNkvgMsUVcg/larger.jpg","__id":"59d5c83ec9dc241974970fcd"},"meta":{"description":"Available for sale from Marcel Katz Art, KAWS, COMPANION BLUSH (OPEN EDITION) - SET OF 2 (2017), Vinyl, paint"},"partner":{"name":"Marcel Katz Art","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/7wl7e01dq5MNOIdUj1i8hA/untouched-png.png","__id":"59ad9783b202a34d72db8c8e"},"__id":"UHJvZmlsZTptYXJjZWwta2F0ei1hcnQ="},"locations":[{"address":"18201 Collins Avenue","address_2":"Unit 1504","city":"Sunny Isles Beach","state":"FL","country":"US","postal_code":"33160","phone":null,"__id":"TG9jYXRpb246NTlhZDk4MDU4YjBjMTQ0OWZlYjM4YzIx"}],"__id":"UGFydG5lcjptYXJjZWwta2F0ei1hcnQ="}}},{"node":{"__id":"QXJ0d29yazprYXdzLXdvb2RzdG9jay04","availability":"for sale","category":"Sculpture","date":"2012","href":"/artwork/kaws-woodstock-8","is_acquireable":false,"is_price_range":false,"price":"","price_currency":"USD","title":"Woodstock","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/1372C2GWivbxT_jH0Oj-Rg/larger.jpg","__id":"584ec33ecd530e649e00018a"},"meta":{"description":"Available for sale from MSP Modern, KAWS, Woodstock (2012), Cast vinyl"},"partner":{"name":"MSP Modern","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/KT0hkz64ZByxq4L8f23Fmw/square.jpg","__id":"58126f672a893a03ec0002cb"},"__id":"UHJvZmlsZTptc3AtbW9kZXJu"},"locations":[],"__id":"UGFydG5lcjptc3AtbW9kZXJu"}}},{"node":{"__id":"QXJ0d29yazprYXdzLXVudGl0bGVkLTM2Mw==","availability":"for sale","category":"Print","date":"1999","href":"/artwork/kaws-untitled-363","is_acquireable":false,"is_price_range":false,"price":"","price_currency":"USD","title":"Untitled ","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/We2oe6vGSNvM8vMfSfQU3Q/larger.jpg","__id":"58f010da8b3b81249ca9a0d9"},"meta":{"description":"Available for sale from EHC Fine Art, KAWS, Untitled  (1999), Offset lithograph"},"partner":{"name":"EHC Fine Art","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/3N0GFFcAzzr0bXa1N_I46A/square140.png","__id":"58e1a524cd530e4d612cb095"},"__id":"UHJvZmlsZTplaGMtZmluZS1hcnQ="},"locations":[],"__id":"UGFydG5lcjplaGMtZmluZS1hcnQ="}}},{"node":{"__id":"QXJ0d29yazprYXdzLWthd3MtYmxhY2stY29tcGFuaW9uLTIwMTYtb3Blbi1lZGl0aW9u","availability":"for sale","category":"Sculpture","date":"2016","href":"/artwork/kaws-kaws-black-companion-2016-open-edition","is_acquireable":false,"is_price_range":false,"price":"$1,000","price_currency":"USD","title":"KAWS \"Black Companion\" 2016 Open Edition","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/FJ8SXtPf0cHxfXX9l494rQ/larger.jpg","__id":"585acf8cc9dc246107000755"},"meta":{"description":"Available for sale from Black Book Gallery, KAWS, KAWS \"Black Companion\" 2016 Open Edition (2016), Plastic/Resin"},"partner":{"name":"Black Book Gallery","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/3hwmKMsYijKVZCtu_Ffcfg/untouched-png.png","__id":"55b7f1177261694002000184"},"__id":"UHJvZmlsZTpibGFja2Jvb2stZ2FsbGVyeQ=="},"locations":[{"address":"3878 S Jason St.","address_2":"","city":"Englewood","state":"CO","country":"US","postal_code":"80110","phone":"303-941-2458","__id":"TG9jYXRpb246NTViN2I4Yjc3MjYxNjkwN2RmMDAwMDZi"}],"__id":"UGFydG5lcjpibGFjay1ib29rLWdhbGxlcnk="}}},{"node":{"__id":"QXJ0d29yazprYXdzLWJsYWNrLWZsYXllZC1jb21wYW5pb24tb3Blbi1lZGl0aW9uLTE=","availability":"for sale","category":"Sculpture","date":"2016","href":"/artwork/kaws-black-flayed-companion-open-edition-1","is_acquireable":false,"is_price_range":false,"price":"$1,350","price_currency":"USD","title":"Black Flayed Companion Open Edition","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/KXFQf_kDuBKlUjYCFZZNAQ/larger.jpg","__id":"59080a7b139b2141bf630fd1"},"meta":{"description":"Available for sale from EHC Fine Art, KAWS, Black Flayed Companion Open Edition (2016), Cast vinyl"},"partner":{"name":"EHC Fine Art","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/3N0GFFcAzzr0bXa1N_I46A/square140.png","__id":"58e1a524cd530e4d612cb095"},"__id":"UHJvZmlsZTplaGMtZmluZS1hcnQ="},"locations":[],"__id":"UGFydG5lcjplaGMtZmluZS1hcnQ="}}},{"node":{"__id":"QXJ0d29yazprYXdzLXRvZ2V0aGVyLWJyb3duLTE=","availability":"for sale","category":"Sculpture","date":"2018","href":"/artwork/kaws-together-brown-1","is_acquireable":false,"is_price_range":false,"price":"$1,290","price_currency":"USD","title":"Together (Brown)","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/TTYP_VL_kTPIvKq7c6tKbg/larger.jpg","__id":"5b3d88119c18db46dd8a136d"},"meta":{"description":"Available for sale from Dope! Gallery, KAWS, Together (Brown) (2018), Vinyl"},"partner":{"name":"Dope! Gallery","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/EmFB4qpTzlURNorf-bxknQ/untouched-png.png","__id":"56124faf7261691a5f000522"},"__id":"UHJvZmlsZTpkb3BlLWdhbGxlcnk="},"locations":[],"__id":"UGFydG5lcjpkb3BlLWdhbGxlcnk="}}},{"node":{"__id":"QXJ0d29yazprYXdzLXNtYWxsLWxpZS1jb21wbGV0ZS1zZXQtb2YtdGhyZWU=","availability":"for sale","category":"Sculpture","date":"2017","href":"/artwork/kaws-small-lie-complete-set-of-three","is_acquireable":false,"is_price_range":false,"price":"Under £1,000","price_currency":"GBP","title":"Small Lie (Complete Set Of Three)","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/cNJHHg5fnEUIzYAEWsdJoA/larger.jpg","__id":"5b69a938cb6560002339eefe"},"meta":{"description":"Available for sale from Lougher Contemporary, KAWS, Small Lie (Complete Set Of Three) (2017), Vinyl and Paint"},"partner":{"name":"Lougher Contemporary","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/7ylSt743QGUfBgeXg4_pdg/untouched-png.png","__id":"5d8355d9445543000e3671a6"},"__id":"UHJvZmlsZTpsb3VnaGVyLWNvbnRlbXBvcmFyeQ=="},"locations":[{"address":"Trym Lodge","address_2":"1 Henbury Road","city":"Bristol","state":"","country":"GB","postal_code":"BS9 3HQ","phone":"+44 (0) 117 9596411","__id":"TG9jYXRpb246NWE5NTdkYTQ5YzE4ZGI1MTU3NDNhZDA2"}],"__id":"UGFydG5lcjpsb3VnaGVyLWNvbnRlbXBvcmFyeQ=="}}},{"node":{"__id":"QXJ0d29yazprYXdzLWthd3MtYnJvd24tY29tcGFuaW9uLTIwMTY=","availability":"for sale","category":"Sculpture","date":"2016","href":"/artwork/kaws-kaws-brown-companion-2016","is_acquireable":true,"is_price_range":false,"price":"$650","price_currency":"USD","title":"Kaws Brown Companion 2016","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/AuSruS7cRqAFOVCTtmhEHg/larger.jpg","__id":"5cf83db3ca30760012f0f6cc"},"meta":{"description":"Available for sale from Lot 180, KAWS, Kaws Brown Companion 2016 (2016), Vinyl Cast Resin"},"partner":{"name":"Lot 180","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/nJUr53gOknXTMjF7QihPtw/untouched-png.png","__id":"5babdac05c4afd7012b214fb"},"__id":"UHJvZmlsZTpsb3QtMTgw"},"locations":[],"__id":"UGFydG5lcjpsb3QtMTgw"}}},{"node":{"__id":"QXJ0d29yazprYXdzLXBpbm9jY2hpby0z","availability":"for sale","category":"Sculpture","date":"2018","href":"/artwork/kaws-pinocchio-3","is_acquireable":false,"is_price_range":false,"price":"","price_currency":"USD","title":"Pinocchio","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/qu24dwWrXHfw5Z3e6KhXPQ/larger.jpg","__id":"5b33f5fb9c18db46398bfa6c"},"meta":{"description":"Available for sale from IDEA, KAWS, Pinocchio (2018), Wood"},"partner":{"name":"IDEA","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/Z_abk4dwgmTK2veWziRYmQ/large.jpg","__id":"58d2ef51cd530e4cb0551916"},"__id":"UHJvZmlsZTppZGVh"},"locations":[],"__id":"UGFydG5lcjppZGVhLTE="}}},{"node":{"__id":"QXJ0d29yazprYXdzLXNlZWluZy13YXRjaGluZw==","availability":"for sale","category":"Sculpture","date":"2018","href":"/artwork/kaws-seeing-watching","is_acquireable":false,"is_price_range":false,"price":"Under $1,000","price_currency":"USD","title":"SEEING WATCHING","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/YmIR6J_b3D7A6JAosmuUgA/larger.jpg","__id":"5b09630a275b2464ae4b3614"},"meta":{"description":"Available for sale from Marcel Katz Art, KAWS, SEEING WATCHING (2018), Plush"},"partner":{"name":"Marcel Katz Art","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/7wl7e01dq5MNOIdUj1i8hA/untouched-png.png","__id":"59ad9783b202a34d72db8c8e"},"__id":"UHJvZmlsZTptYXJjZWwta2F0ei1hcnQ="},"locations":[{"address":"18201 Collins Avenue","address_2":"Unit 1504","city":"Sunny Isles Beach","state":"FL","country":"US","postal_code":"33160","phone":null,"__id":"TG9jYXRpb246NTlhZDk4MDU4YjBjMTQ0OWZlYjM4YzIx"}],"__id":"UGFydG5lcjptYXJjZWwta2F0ei1hcnQ="}}},{"node":{"__id":"QXJ0d29yazprYXdzLTQtZnQtY29tcGFuaW9uLXdpdGgtYm94LWFuZC1ob2xvZ3JhbQ==","availability":"for sale","category":"Sculpture","date":"2007","href":"/artwork/kaws-4-ft-companion-with-box-and-hologram","is_acquireable":false,"is_price_range":false,"price":"","price_currency":"USD","title":"4 Ft Companion (with box and hologram)","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/TNrubN2rbSkaRJGxnu4uFA/larger.jpg","__id":"5ba2f7e5196e630027ffe39c"},"meta":{"description":"Available for sale from MSP Modern, KAWS, 4 Ft Companion (with box and hologram) (2007), Cast vinyl resin"},"partner":{"name":"MSP Modern","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/KT0hkz64ZByxq4L8f23Fmw/square.jpg","__id":"58126f672a893a03ec0002cb"},"__id":"UHJvZmlsZTptc3AtbW9kZXJu"},"locations":[],"__id":"UGFydG5lcjptc3AtbW9kZXJu"}}},{"node":{"__id":"QXJ0d29yazprYXdzLXRvZ2V0aGVyLWJsYWNrLTE=","availability":"for sale","category":"Sculpture","date":"2018","href":"/artwork/kaws-together-black-1","is_acquireable":false,"is_price_range":false,"price":"$1,300","price_currency":"USD","title":"Together Black","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/PUFz_OjJ-JPaJACdsr1Z7Q/larger.jpg","__id":"5b21c399a09a674544434a80"},"meta":{"description":"Available for sale from Marcel Katz Art, KAWS, Together Black (2018), Vinyl"},"partner":{"name":"Marcel Katz Art","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/7wl7e01dq5MNOIdUj1i8hA/untouched-png.png","__id":"59ad9783b202a34d72db8c8e"},"__id":"UHJvZmlsZTptYXJjZWwta2F0ei1hcnQ="},"locations":[{"address":"18201 Collins Avenue","address_2":"Unit 1504","city":"Sunny Isles Beach","state":"FL","country":"US","postal_code":"33160","phone":null,"__id":"TG9jYXRpb246NTlhZDk4MDU4YjBjMTQ0OWZlYjM4YzIx"}],"__id":"UGFydG5lcjptYXJjZWwta2F0ei1hcnQ="}}},{"node":{"__id":"QXJ0d29yazprYXdzLWJvYmEtZmV0dC1jb21wYW5pb24=","availability":"for sale","category":"Sculpture","date":"2013","href":"/artwork/kaws-boba-fett-companion","is_acquireable":false,"is_price_range":false,"price":"","price_currency":"USD","title":"Boba Fett Companion","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/GEJ3-RY2I6rmo8JbuuCQkw/larger.jpg","__id":"575a099b139b216b8a00021a"},"meta":{"description":"Available for sale from Julien's Auctions, KAWS, Boba Fett Companion (2013), Painted cast vinyl"},"partner":{"name":"Julien's Auctions","type":"Auction House","profile":null,"locations":[],"__id":"UGFydG5lcjpqdWxpZW5zLWF1Y3Rpb25z"}}},{"node":{"__id":"QXJ0d29yazprYXdzLWhvbGlkYXktc2V0LW9mLTMtMQ==","availability":"for sale","category":"Textile Arts","date":"2019","href":"/artwork/kaws-holiday-set-of-3-1","is_acquireable":true,"is_price_range":false,"price":"$3,000","price_currency":"USD","title":"Holiday Set of 3","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/hFd-xFdXhOFF85HBJa0zzw/larger.jpg","__id":"5cdef8ffd9b0661e37ce52f2"},"meta":{"description":"Available for sale from New Union Gallery, KAWS, Holiday Set of 3 (2019), Plush"},"partner":{"name":"New Union Gallery","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/KHdGZw0vCfTneDQBZlBDCw/square.jpg","__id":"5c2f06432e7cdf6a4b455c73"},"__id":"UHJvZmlsZTpuZXctdW5pb24tZ2FsbGVyeQ=="},"locations":[],"__id":"UGFydG5lcjpuZXctdW5pb24tZ2FsbGVyeQ=="}}},{"node":{"__id":"QXJ0d29yazprYXdzLXRvZ2V0aGVyLWdyZXktMQ==","availability":"for sale","category":"Sculpture","date":"2018","href":"/artwork/kaws-together-grey-1","is_acquireable":false,"is_price_range":false,"price":"$990","price_currency":"USD","title":"Together (Grey)","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/M_SOoP7eBHjuLf866XIu7Q/larger.jpg","__id":"5b3d85b27622dd1349f706ee"},"meta":{"description":"Available for sale from Dope! Gallery, KAWS, Together (Grey) (2018)"},"partner":{"name":"Dope! Gallery","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/EmFB4qpTzlURNorf-bxknQ/untouched-png.png","__id":"56124faf7261691a5f000522"},"__id":"UHJvZmlsZTpkb3BlLWdhbGxlcnk="},"locations":[],"__id":"UGFydG5lcjpkb3BlLWdhbGxlcnk="}}},{"node":{"__id":"QXJ0d29yazprYXdzLXBhc3NpbmctdGhyb3VnaC1ncmV5LTE=","availability":"for sale","category":"Sculpture","date":"2013","href":"/artwork/kaws-passing-through-grey-1","is_acquireable":false,"is_price_range":false,"price":"$3,400","price_currency":"USD","title":"Passing Through (Grey) ","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/Z84jgLZMNuJxUzO-rgZH1w/larger.jpg","__id":"58ebea598b3b8133919f4e50"},"meta":{"description":"Available for sale from Galerie C.O.A, KAWS, Passing Through (Grey)  (2013), Cast vinyl"},"partner":{"name":"Galerie C.O.A","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/sTZBIuQCT_WNaCi_qHjcXw/square.jpg","__id":"5728fcceb202a321df0003fd"},"__id":"UHJvZmlsZTpnYWxlcmllLWNvYQ=="},"locations":[{"address":"6405 St-Laurent","address_2":"","city":"Montreal","state":"QC","country":"CA","postal_code":"","phone":null,"__id":"TG9jYXRpb246NTcxZjdlZGUyNzViMjQ2ZTRiMDA1NDJm"}],"__id":"UGFydG5lcjpnYWxlcmllLWNvYQ=="}}},{"node":{"__id":"QXJ0d29yazprYXdzLW5vLWZ1dHVyZS1jb21wYW5pb24tc2lsdmVyLWNocm9tZS01","availability":"for sale","category":"Sculpture","date":"2008","href":"/artwork/kaws-no-future-companion-silver-chrome-5","is_acquireable":false,"is_price_range":false,"price":"","price_currency":"USD","title":"No Future Companion (Silver Chrome)","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/P0KeZt18ZO1E-vKuOvQUHg/larger.jpg","__id":"5acc6298b202a313b86659da"},"meta":{"description":"Available for sale from MSP Modern, KAWS, No Future Companion (Silver Chrome) (2008), Polished chrome"},"partner":{"name":"MSP Modern","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/KT0hkz64ZByxq4L8f23Fmw/square.jpg","__id":"58126f672a893a03ec0002cb"},"__id":"UHJvZmlsZTptc3AtbW9kZXJu"},"locations":[],"__id":"UGFydG5lcjptc3AtbW9kZXJu"}}},{"node":{"__id":"QXJ0d29yazprYXdzLWhvbGlkYXktY29tcGFuaW9uLWZsb2F0aW5nLWJlZA==","availability":"for sale","category":"Other","date":"2018","href":"/artwork/kaws-holiday-companion-floating-bed","is_acquireable":false,"is_price_range":false,"price":"$350","price_currency":"USD","title":"Holiday Companion Floating Bed","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/lc2FTCfjWIVizWSfnDDjGg/larger.jpg","__id":"5b63f597e6b6c466df9491a4"},"meta":{"description":"Available for sale from Dope! Gallery, KAWS, Holiday Companion Floating Bed (2018), PVC"},"partner":{"name":"Dope! Gallery","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/EmFB4qpTzlURNorf-bxknQ/untouched-png.png","__id":"56124faf7261691a5f000522"},"__id":"UHJvZmlsZTpkb3BlLWdhbGxlcnk="},"locations":[],"__id":"UGFydG5lcjpkb3BlLWdhbGxlcnk="}}},{"node":{"__id":"QXJ0d29yazprYXdzLWdyZXktZmxheWVkLWNvbXBhbmlvbi0yMDE2LW9wZW4tZWRpdGlvbg==","availability":"for sale","category":"Sculpture","date":"2016","href":"/artwork/kaws-grey-flayed-companion-2016-open-edition","is_acquireable":false,"is_price_range":false,"price":"$1,200","price_currency":"USD","title":"Grey Flayed Companion 2016 Open Edition","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/HMKwnB8hZm_c2uI2FxXNXw/larger.jpg","__id":"587025b1a09a67566a002edc"},"meta":{"description":"Available for sale from Black Book Gallery, KAWS, Grey Flayed Companion 2016 Open Edition (2016), Plastic/Resin"},"partner":{"name":"Black Book Gallery","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/3hwmKMsYijKVZCtu_Ffcfg/untouched-png.png","__id":"55b7f1177261694002000184"},"__id":"UHJvZmlsZTpibGFja2Jvb2stZ2FsbGVyeQ=="},"locations":[{"address":"3878 S Jason St.","address_2":"","city":"Englewood","state":"CO","country":"US","postal_code":"80110","phone":"303-941-2458","__id":"TG9jYXRpb246NTViN2I4Yjc3MjYxNjkwN2RmMDAwMDZi"}],"__id":"UGFydG5lcjpibGFjay1ib29rLWdhbGxlcnk="}}},{"node":{"__id":"QXJ0d29yazprYXdzLWthd3MtY29tcGFuaW9uLW9wZW4tZWRpdGlvbi1zZXQtb2YtNg==","availability":"for sale","category":"Sculpture","date":"2016","href":"/artwork/kaws-kaws-companion-open-edition-set-of-6","is_acquireable":false,"is_price_range":false,"price":"£3,000","price_currency":"GBP","title":"Kaws Companion (Open Edition) - Set of 6","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/GLRzJwHwSZcKEpLREw8uag/larger.jpg","__id":"596f863fc9dc2451b95c38b7"},"meta":{"description":"Available for sale from Reem Gallery, KAWS, Kaws Companion (Open Edition) - Set of 6 (2016), Vinyl figures"},"partner":{"name":"Reem Gallery","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/3eRfTOlDBI3RJ3BtpUHVjw/untouched-png.png","__id":"571f5739139b2127a000499e"},"__id":"UHJvZmlsZTpyZWVtLWdhbGxlcnk="},"locations":[{"address":"4 Mason's Yard","address_2":"St. James's","city":"London","state":"","country":"GB","postal_code":"SW1Y 6JF","phone":null,"__id":"TG9jYXRpb246NWJiZjI5ZTUwNzU3ZWExYjFiMDE2ODBj"}],"__id":"UGFydG5lcjpyZWVtLWdhbGxlcnk="}}},{"node":{"__id":"QXJ0d29yazprYXdzLWthd3MtYWxvbmctdGhlLXdheS1jb21wbGV0ZS1zZXQtb2YtMw==","availability":"for sale","category":"Sculpture","date":"2019","href":"/artwork/kaws-kaws-along-the-way-complete-set-of-3","is_acquireable":true,"is_price_range":false,"price":"$2,800","price_currency":"USD","title":"KAWS Along The Way Complete Set of 3 ","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/_WKftu2nTtQsQmd7-VREqQ/larger.jpg","__id":"5d15c60e02c4fd0011847539"},"meta":{"description":"Available for sale from Lot 180, KAWS, KAWS Along The Way Complete Set of 3  (2019), Cast Resin, Painted Vinyl"},"partner":{"name":"Lot 180","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/nJUr53gOknXTMjF7QihPtw/untouched-png.png","__id":"5babdac05c4afd7012b214fb"},"__id":"UHJvZmlsZTpsb3QtMTgw"},"locations":[],"__id":"UGFydG5lcjpsb3QtMTgw"}}},{"node":{"__id":"QXJ0d29yazprYXdzLWNvbXBhbmlvbi1icm93bi1mbGF5ZWQtb3Blbi1lZGl0aW9u","availability":"for sale","category":"Sculpture","date":"2016","href":"/artwork/kaws-companion-brown-flayed-open-edition","is_acquireable":false,"is_price_range":false,"price":"$650","price_currency":"USD","title":"COMPANION BROWN (FLAYED) (OPEN EDITION)","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/RFWH6hud1-aw2QR5-8a-nA/larger.jpg","__id":"59cdddec2a893a388d5d779d"},"meta":{"description":"Available for sale from Marcel Katz Art, KAWS, COMPANION BROWN (FLAYED) (OPEN EDITION) (2016), Vinyl"},"partner":{"name":"Marcel Katz Art","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/7wl7e01dq5MNOIdUj1i8hA/untouched-png.png","__id":"59ad9783b202a34d72db8c8e"},"__id":"UHJvZmlsZTptYXJjZWwta2F0ei1hcnQ="},"locations":[{"address":"18201 Collins Avenue","address_2":"Unit 1504","city":"Sunny Isles Beach","state":"FL","country":"US","postal_code":"33160","phone":null,"__id":"TG9jYXRpb246NTlhZDk4MDU4YjBjMTQ0OWZlYjM4YzIx"}],"__id":"UGFydG5lcjptYXJjZWwta2F0ei1hcnQ="}}},{"node":{"__id":"QXJ0d29yazprYXdzLWNvbXBhbmlvbi1ibHVzaC1mbGF5ZWQtb3Blbi1lZGl0aW9u","availability":"for sale","category":"Sculpture","date":"2017","href":"/artwork/kaws-companion-blush-flayed-open-edition","is_acquireable":false,"is_price_range":false,"price":"$420","price_currency":"USD","title":"COMPANION BLUSH (FLAYED) (OPEN EDITION)","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/_ktznsDfwK51vMpo-ZTC2w/larger.jpg","__id":"59d5c8408b3b81391654d91e"},"meta":{"description":"Available for sale from Marcel Katz Art, KAWS, COMPANION BLUSH (FLAYED) (OPEN EDITION) (2017), Vinyl, paint"},"partner":{"name":"Marcel Katz Art","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/7wl7e01dq5MNOIdUj1i8hA/untouched-png.png","__id":"59ad9783b202a34d72db8c8e"},"__id":"UHJvZmlsZTptYXJjZWwta2F0ei1hcnQ="},"locations":[{"address":"18201 Collins Avenue","address_2":"Unit 1504","city":"Sunny Isles Beach","state":"FL","country":"US","postal_code":"33160","phone":null,"__id":"TG9jYXRpb246NTlhZDk4MDU4YjBjMTQ0OWZlYjM4YzIx"}],"__id":"UGFydG5lcjptYXJjZWwta2F0ei1hcnQ="}}},{"node":{"__id":"QXJ0d29yazprYXdzLXR3ZWV0eS0x","availability":"for sale","category":"Sculpture","date":"2010","href":"/artwork/kaws-tweety-1","is_acquireable":false,"is_price_range":false,"price":"$2,990","price_currency":"USD","title":"Tweety","artists":[{"name":"KAWS","__id":"QXJ0aXN0Omthd3M="}],"image":{"url":"https://d32dm0rphc51dk.cloudfront.net/BuFOJEBAqGgXabGv8ptFdw/larger.jpg","__id":"59a915978b3b813d7ce3fd6a"},"meta":{"description":"Available for sale from Dope! Gallery, KAWS, Tweety (2010), Vinyl"},"partner":{"name":"Dope! Gallery","type":"Gallery","profile":{"icon":{"url":"https://d32dm0rphc51dk.cloudfront.net/EmFB4qpTzlURNorf-bxknQ/untouched-png.png","__id":"56124faf7261691a5f000522"},"__id":"UHJvZmlsZTpkb3BlLWdhbGxlcnk="},"locations":[],"__id":"UGFydG5lcjpkb3BlLWdhbGxlcnk="}}}]},"aggregations":[{"slice":"MEDIUM","counts":[{"id":"sculpture","name":"Sculpture","count":321,"__id":"QWdncmVnYXRpb25Db3VudDpzY3VscHR1cmU="},{"id":"prints","name":"Prints","count":24,"__id":"QWdncmVnYXRpb25Db3VudDpwcmludHM="},{"id":"design","name":"Design","count":15,"__id":"QWdncmVnYXRpb25Db3VudDpkZXNpZ24="},{"id":"painting","name":"Painting","count":7,"__id":"QWdncmVnYXRpb25Db3VudDpwYWludGluZw=="}]},{"slice":"MAJOR_PERIOD","counts":[{"id":"2010","name":"2010","count":369,"__id":"QWdncmVnYXRpb25Db3VudDoyMDEw"},{"id":"2000","name":"2000","count":164,"__id":"QWdncmVnYXRpb25Db3VudDoyMDAw"},{"id":"1990","name":"1990","count":20,"__id":"QWdncmVnYXRpb25Db3VudDoxOTkw"}]},{"slice":"MERCHANDISABLE_ARTISTS","counts":[{"id":"4e934002e340fa0001005336","name":"KAWS","count":578,"__id":"QWdncmVnYXRpb25Db3VudDo0ZTkzNDAwMmUzNDBmYTAwMDEwMDUzMzY="},{"id":"58fe85ee275b2450a0fd2b51","name":"Medicom","count":3,"__id":"QWdncmVnYXRpb25Db3VudDo1OGZlODVlZTI3NWIyNDUwYTBmZDJiNTE="},{"id":"4f5f64c23b555230ac0003ae","name":"Robert Lazzarini","count":2,"__id":"QWdncmVnYXRpb25Db3VudDo0ZjVmNjRjMjNiNTU1MjMwYWMwMDAzYWU="},{"id":"51951ec60cfd96ac75000332","name":"Hajime Sorayama","count":1,"__id":"QWdncmVnYXRpb25Db3VudDo1MTk1MWVjNjBjZmQ5NmFjNzUwMDAzMzI="},{"id":"5bd9ff5d1f79d672bb7011d9","name":"Medicom Toy","count":1,"__id":"QWdncmVnYXRpb25Db3VudDo1YmQ5ZmY1ZDFmNzlkNjcyYmI3MDExZDk="}]}]},"filtered_artworks":{"__id":"RmlsdGVyQXJ0d29ya3M6eyJhZ2dyZWdhdGlvbnMiOlsibWVyY2hhbmRpc2FibGVfYXJ0aXN0cyIsIm1lZGl1bSIsIm1ham9yX3BlcmlvZCIsInRvdGFsIl0sImFydGlzdF9pZHMiOltdLCJnZW5lX2lkcyI6W10sInNvcnQiOiItZGVjYXllZF9tZXJjaCIsInRhZ19pZCI6ImNvbXBhbmlvbiIsImtleXdvcmRfbWF0Y2hfZXhhY3QiOmZhbHNlfQ==","aggregations":[{"slice":"MEDIUM","counts":[{"id":"sculpture","name":"Sculpture","count":321,"__id":"QWdncmVnYXRpb25Db3VudDpzY3VscHR1cmU="},{"id":"prints","name":"Prints","count":24,"__id":"QWdncmVnYXRpb25Db3VudDpwcmludHM="},{"id":"design","name":"Design","count":15,"__id":"QWdncmVnYXRpb25Db3VudDpkZXNpZ24="},{"id":"painting","name":"Painting","count":7,"__id":"QWdncmVnYXRpb25Db3VudDpwYWludGluZw=="}]},{"slice":"MAJOR_PERIOD","counts":[{"id":"2010","name":"2010","count":369,"__id":"QWdncmVnYXRpb25Db3VudDoyMDEw"},{"id":"2000","name":"2000","count":164,"__id":"QWdncmVnYXRpb25Db3VudDoyMDAw"},{"id":"1990","name":"1990","count":20,"__id":"QWdncmVnYXRpb25Db3VudDoxOTkw"}]},{"slice":"MERCHANDISABLE_ARTISTS","counts":[{"id":"4e934002e340fa0001005336","name":"KAWS","count":578,"__id":"QWdncmVnYXRpb25Db3VudDo0ZTkzNDAwMmUzNDBmYTAwMDEwMDUzMzY="},{"id":"58fe85ee275b2450a0fd2b51","name":"Medicom","count":3,"__id":"QWdncmVnYXRpb25Db3VudDo1OGZlODVlZTI3NWIyNDUwYTBmZDJiNTE="},{"id":"4f5f64c23b555230ac0003ae","name":"Robert Lazzarini","count":2,"__id":"QWdncmVnYXRpb25Db3VudDo0ZjVmNjRjMjNiNTU1MjMwYWMwMDAzYWU="},{"id":"51951ec60cfd96ac75000332","name":"Hajime Sorayama","count":1,"__id":"QWdncmVnYXRpb25Db3VudDo1MTk1MWVjNjBjZmQ5NmFjNzUwMDAzMzI="},{"id":"5bd9ff5d1f79d672bb7011d9","name":"Medicom Toy","count":1,"__id":"QWdncmVnYXRpb25Db3VudDo1YmQ5ZmY1ZDFmNzlkNjcyYmI3MDExZDk="}]}],"artworks":{"pageInfo":{"hasNextPage":true,"endCursor":"YXJyYXljb25uZWN0aW9uOjI5"},"pageCursors":{"around":[{"cursor":"YXJyYXljb25uZWN0aW9uOi0x","page":1,"isCurrent":true},{"cursor":"YXJyYXljb25uZWN0aW9uOjI5","page":2,"isCurrent":false},{"cursor":"YXJyYXljb25uZWN0aW9uOjU5","page":3,"isCurrent":false},{"cursor":"YXJyYXljb25uZWN0aW9uOjg5","page":4,"isCurrent":false}],"first":null,"last":{"cursor":"YXJyYXljb25uZWN0aW9uOjU2OQ==","page":20,"isCurrent":false},"previous":null},"edges":[{"node":{"__id":"QXJ0d29yazprYXdzLWthd3MteC1iZS1hdC1yYnJpY2stZGlzc2VjdGVkLWNvbXBhbmlvbi00MDAtcGVyY2VudC1hbmQtMTAwLXBlcmNlbnQtdHdvLXdvcmtz","id":"kaws-kaws-x-be-at-rbrick-dissected-companion-400-percent-and-100-percent-two-works","href":"/artwork/kaws-kaws-x-be-at-rbrick-dissected-companion-400-percent-and-100-percent-two-works","image":{"aspect_ratio":0.87,"__id":"5d704fa30f056a000e8546c7","placeholder":"115.52346570397111%","url":"https://d32dm0rphc51dk.cloudfront.net/AqIUxe69SL6dNmFSF7XgDg/large.jpg"},"_id":"5d704fa2c637350012dfba67","title":"KAWS X BE@RBRICK Dissected Companion 400% and 100% (two works)","image_title":"KAWS, ‘KAWS X BE@RBRICK Dissected Companion 400% and 100% (two works)’, 2010","date":"2010","sale_message":"$4,850","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"5ART GALLERY","href":"/5art-gallery","__id":"UGFydG5lcjo1YXJ0LWdhbGxlcnk=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":false,"is_saved":false,"is_biddable":false,"is_acquireable":true,"is_offerable":true}},{"node":{"__id":"QXJ0d29yazprYXdzLW5vLWZ1dHVyZS1jb21wYW5pb24tY29sbGFib3JhdGlvbi13aXRoLWhhamltZS1zb3JheWFtYS1ibGFjay1jaHJvbWU=","id":"kaws-no-future-companion-collaboration-with-hajime-sorayama-black-chrome","href":"/artwork/kaws-no-future-companion-collaboration-with-hajime-sorayama-black-chrome","image":{"aspect_ratio":0.91,"__id":"5acc6297c9dc247dcc317da6","placeholder":"110.4253544620517%","url":"https://d32dm0rphc51dk.cloudfront.net/RFC1iwT6hq1QFwrLevkiEw/large.jpg"},"_id":"5acc62968b3b8136f479b13b","title":"No Future Companion  collaboration with Hajime Sorayama (Black Chrome)","image_title":"KAWS, ‘No Future Companion  collaboration with Hajime Sorayama (Black Chrome)’","date":"","sale_message":"Contact For Price","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"MSP Modern","href":"/msp-modern","__id":"UGFydG5lcjptc3AtbW9kZXJu","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLXNtYWxsLWxpZS01","id":"kaws-small-lie-5","href":"/artwork/kaws-small-lie-5","image":{"aspect_ratio":0.53,"__id":"5d1274d642f72b000e330313","placeholder":"187.5%","url":"https://d32dm0rphc51dk.cloudfront.net/9IfyjiZvrCelAnYFjFd2tQ/large.jpg"},"_id":"5cdb55e424b8ea2110aa76a8","title":"SMALL LIE","image_title":"KAWS, ‘SMALL LIE’, 2017","date":"2017","sale_message":"$1,000","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Silverback Gallery","href":"/silverback-gallery","__id":"UGFydG5lcjpzaWx2ZXJiYWNrLWdhbGxlcnk=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":false,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLWdyZXktY29tcGFuaW9uLTIwMTYtb3Blbi1lZGl0aW9u","id":"kaws-grey-companion-2016-open-edition","href":"/artwork/kaws-grey-companion-2016-open-edition","image":{"aspect_ratio":0.67,"__id":"586c13229c18db52e5005c34","placeholder":"149.79195561719834%","url":"https://d32dm0rphc51dk.cloudfront.net/AnNB8gHH4xZnLcJSS4cNpw/large.jpg"},"_id":"586c1321c9dc2445ea00580c","title":"Grey Companion 2016 Open Edition","image_title":"KAWS, ‘Grey Companion 2016 Open Edition’, 2016","date":"2016","sale_message":"$1,000","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Black Book Gallery","href":"/blackbook-gallery","__id":"UGFydG5lcjpibGFjay1ib29rLWdhbGxlcnk=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLWJvYmEtZmV0dC1jb21wYW5pb24tMTA=","id":"kaws-boba-fett-companion-10","href":"/artwork/kaws-boba-fett-companion-10","image":{"aspect_ratio":0.92,"__id":"5bfec8fbd820902a3aa4c879","placeholder":"109.18032786885246%","url":"https://d32dm0rphc51dk.cloudfront.net/Vh612qcvwJYkw6YTjP9CvQ/large.jpg"},"_id":"5a9dcba2cd530e487b0391ae","title":"Boba Fett Companion","image_title":"KAWS, ‘Boba Fett Companion’, 2013","date":"2013","sale_message":"£6,325","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Lougher Contemporary","href":"/lougher-contemporary","__id":"UGFydG5lcjpsb3VnaGVyLWNvbnRlbXBvcmFyeQ==","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":false,"is_saved":false,"is_biddable":false,"is_acquireable":true,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLTQtZm9vdC1kaXNzZWN0ZWQtY29tcGFuaW9uLWJyb3du","id":"kaws-4-foot-dissected-companion-brown","href":"/artwork/kaws-4-foot-dissected-companion-brown","image":{"aspect_ratio":0.45,"__id":"5ace9d6eb202a301c8c75de1","placeholder":"222.6086956521739%","url":"https://d32dm0rphc51dk.cloudfront.net/U4GBoWFFwPhZ8_65MTUo7g/large.jpg"},"_id":"5ace9d6dc9dc2404e5b135a4","title":"4 Foot Dissected Companion (Brown)","image_title":"KAWS, ‘4 Foot Dissected Companion (Brown)’, 2009","date":"2009","sale_message":"Contact For Price","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"MSP Modern","href":"/msp-modern","__id":"UGFydG5lcjptc3AtbW9kZXJu","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLWNvbXBhbmlvbi1ibHVzaC1vcGVuLWVkaXRpb24tc2V0LW9mLTI=","id":"kaws-companion-blush-open-edition-set-of-2","href":"/artwork/kaws-companion-blush-open-edition-set-of-2","image":{"aspect_ratio":1.5,"__id":"59d5c83ec9dc241974970fcd","placeholder":"66.64098613251156%","url":"https://d32dm0rphc51dk.cloudfront.net/XbgSZWPiKVjvNkvgMsUVcg/large.jpg"},"_id":"59d5c83d9c18db0eba89124a","title":"COMPANION BLUSH (OPEN EDITION) - SET OF 2","image_title":"KAWS, ‘COMPANION BLUSH (OPEN EDITION) - SET OF 2’, 2017","date":"2017","sale_message":"Contact For Price","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Marcel Katz Art","href":"/marcel-katz-art","__id":"UGFydG5lcjptYXJjZWwta2F0ei1hcnQ=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLXdvb2RzdG9jay04","id":"kaws-woodstock-8","href":"/artwork/kaws-woodstock-8","image":{"aspect_ratio":0.79,"__id":"584ec33ecd530e649e00018a","placeholder":"126.66666666666666%","url":"https://d32dm0rphc51dk.cloudfront.net/1372C2GWivbxT_jH0Oj-Rg/large.jpg"},"_id":"584ec33ca09a676a9600147e","title":"Woodstock","image_title":"KAWS, ‘Woodstock’, 2012","date":"2012","sale_message":"Contact For Price","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"MSP Modern","href":"/msp-modern","__id":"UGFydG5lcjptc3AtbW9kZXJu","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLXVudGl0bGVkLTM2Mw==","id":"kaws-untitled-363","href":"/artwork/kaws-untitled-363","image":{"aspect_ratio":0.71,"__id":"58f010da8b3b81249ca9a0d9","placeholder":"140.0462962962963%","url":"https://d32dm0rphc51dk.cloudfront.net/We2oe6vGSNvM8vMfSfQU3Q/large.jpg"},"_id":"58f010da139b211274821bb2","title":"Untitled ","image_title":"KAWS, ‘Untitled ’, 1999","date":"1999","sale_message":"Contact For Price","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"EHC Fine Art","href":"/ehc-fine-art","__id":"UGFydG5lcjplaGMtZmluZS1hcnQ=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLWthd3MtYmxhY2stY29tcGFuaW9uLTIwMTYtb3Blbi1lZGl0aW9u","id":"kaws-kaws-black-companion-2016-open-edition","href":"/artwork/kaws-kaws-black-companion-2016-open-edition","image":{"aspect_ratio":0.67,"__id":"585acf8cc9dc246107000755","placeholder":"149.79195561719834%","url":"https://d32dm0rphc51dk.cloudfront.net/FJ8SXtPf0cHxfXX9l494rQ/large.jpg"},"_id":"585acf889c18db6ca20007b4","title":"KAWS \"Black Companion\" 2016 Open Edition","image_title":"KAWS, ‘KAWS \"Black Companion\" 2016 Open Edition’, 2016","date":"2016","sale_message":"$1,000","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Black Book Gallery","href":"/blackbook-gallery","__id":"UGFydG5lcjpibGFjay1ib29rLWdhbGxlcnk=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLWJsYWNrLWZsYXllZC1jb21wYW5pb24tb3Blbi1lZGl0aW9uLTE=","id":"kaws-black-flayed-companion-open-edition-1","href":"/artwork/kaws-black-flayed-companion-open-edition-1","image":{"aspect_ratio":0.67,"__id":"59080a7b139b2141bf630fd1","placeholder":"149.53095684803003%","url":"https://d32dm0rphc51dk.cloudfront.net/KXFQf_kDuBKlUjYCFZZNAQ/large.jpg"},"_id":"59080a7a275b245e99bf7a09","title":"Black Flayed Companion Open Edition","image_title":"KAWS, ‘Black Flayed Companion Open Edition’, 2016","date":"2016","sale_message":"$1,350","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"EHC Fine Art","href":"/ehc-fine-art","__id":"UGFydG5lcjplaGMtZmluZS1hcnQ=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLXRvZ2V0aGVyLWJyb3duLTE=","id":"kaws-together-brown-1","href":"/artwork/kaws-together-brown-1","image":{"aspect_ratio":1.4,"__id":"5b3d88119c18db46dd8a136d","placeholder":"71.42857142857143%","url":"https://d32dm0rphc51dk.cloudfront.net/TTYP_VL_kTPIvKq7c6tKbg/large.jpg"},"_id":"5b3d880dc9dc245c12cd9a7e","title":"Together (Brown)","image_title":"KAWS, ‘Together (Brown)’, 2018","date":"2018","sale_message":"$1,290","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Dope! Gallery","href":"/dope-gallery","__id":"UGFydG5lcjpkb3BlLWdhbGxlcnk=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLXNtYWxsLWxpZS1jb21wbGV0ZS1zZXQtb2YtdGhyZWU=","id":"kaws-small-lie-complete-set-of-three","href":"/artwork/kaws-small-lie-complete-set-of-three","image":{"aspect_ratio":1.33,"__id":"5b69a938cb6560002339eefe","placeholder":"74.94692144373673%","url":"https://d32dm0rphc51dk.cloudfront.net/cNJHHg5fnEUIzYAEWsdJoA/large.jpg"},"_id":"5b69a93794715800225072de","title":"Small Lie (Complete Set Of Three)","image_title":"KAWS, ‘Small Lie (Complete Set Of Three)’, 2017","date":"2017","sale_message":"Under £1,000","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Lougher Contemporary","href":"/lougher-contemporary","__id":"UGFydG5lcjpsb3VnaGVyLWNvbnRlbXBvcmFyeQ==","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLWthd3MtYnJvd24tY29tcGFuaW9uLTIwMTY=","id":"kaws-kaws-brown-companion-2016","href":"/artwork/kaws-kaws-brown-companion-2016","image":{"aspect_ratio":0.85,"__id":"5cf83db3ca30760012f0f6cc","placeholder":"117.50881316098707%","url":"https://d32dm0rphc51dk.cloudfront.net/AuSruS7cRqAFOVCTtmhEHg/large.jpg"},"_id":"5be1ec30b4d1d9002a4dd034","title":"Kaws Brown Companion 2016","image_title":"KAWS, ‘Kaws Brown Companion 2016’, 2016","date":"2016","sale_message":"$650","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Lot 180","href":"/lot-180","__id":"UGFydG5lcjpsb3QtMTgw","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":false,"is_saved":false,"is_biddable":false,"is_acquireable":true,"is_offerable":true}},{"node":{"__id":"QXJ0d29yazprYXdzLXBpbm9jY2hpby0z","id":"kaws-pinocchio-3","href":"/artwork/kaws-pinocchio-3","image":{"aspect_ratio":0.67,"__id":"5b33f5fb9c18db46398bfa6c","placeholder":"150%","url":"https://d32dm0rphc51dk.cloudfront.net/qu24dwWrXHfw5Z3e6KhXPQ/large.jpg"},"_id":"5b33f5fa139b2110e3393f17","title":"Pinocchio","image_title":"KAWS, ‘Pinocchio’, 2018","date":"2018","sale_message":"Contact For Price","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"IDEA","href":"/idea","__id":"UGFydG5lcjppZGVhLTE=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLXNlZWluZy13YXRjaGluZw==","id":"kaws-seeing-watching","href":"/artwork/kaws-seeing-watching","image":{"aspect_ratio":1.5,"__id":"5b09630a275b2464ae4b3614","placeholder":"66.7%","url":"https://d32dm0rphc51dk.cloudfront.net/YmIR6J_b3D7A6JAosmuUgA/large.jpg"},"_id":"5b096309cd530e163f52d60a","title":"SEEING WATCHING","image_title":"KAWS, ‘SEEING WATCHING’, 2018","date":"2018","sale_message":"Under $1,000","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Marcel Katz Art","href":"/marcel-katz-art","__id":"UGFydG5lcjptYXJjZWwta2F0ei1hcnQ=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLTQtZnQtY29tcGFuaW9uLXdpdGgtYm94LWFuZC1ob2xvZ3JhbQ==","id":"kaws-4-ft-companion-with-box-and-hologram","href":"/artwork/kaws-4-ft-companion-with-box-and-hologram","image":{"aspect_ratio":1,"__id":"5ba2f7e5196e630027ffe39c","placeholder":"100%","url":"https://d32dm0rphc51dk.cloudfront.net/TNrubN2rbSkaRJGxnu4uFA/large.jpg"},"_id":"5ba2f7e46b58c8002aed587c","title":"4 Ft Companion (with box and hologram)","image_title":"KAWS, ‘4 Ft Companion (with box and hologram)’, 2007","date":"2007","sale_message":"Contact For Price","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"MSP Modern","href":"/msp-modern","__id":"UGFydG5lcjptc3AtbW9kZXJu","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLXRvZ2V0aGVyLWJsYWNrLTE=","id":"kaws-together-black-1","href":"/artwork/kaws-together-black-1","image":{"aspect_ratio":1.4,"__id":"5b21c399a09a674544434a80","placeholder":"71.42857142857143%","url":"https://d32dm0rphc51dk.cloudfront.net/PUFz_OjJ-JPaJACdsr1Z7Q/large.jpg"},"_id":"5b21c3968b3b813153ef1a15","title":"Together Black","image_title":"KAWS, ‘Together Black’, 2018","date":"2018","sale_message":"$1,300","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Marcel Katz Art","href":"/marcel-katz-art","__id":"UGFydG5lcjptYXJjZWwta2F0ei1hcnQ=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLWJvYmEtZmV0dC1jb21wYW5pb24=","id":"kaws-boba-fett-companion","href":"/artwork/kaws-boba-fett-companion","image":{"aspect_ratio":0.65,"__id":"575a099b139b216b8a00021a","placeholder":"154.63917525773198%","url":"https://d32dm0rphc51dk.cloudfront.net/GEJ3-RY2I6rmo8JbuuCQkw/large.jpg"},"_id":"575a099bb202a32c570001e8","title":"Boba Fett Companion","image_title":"KAWS, ‘Boba Fett Companion’, 2013","date":"2013","sale_message":"Contact For Price","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Julien's Auctions","href":"/auction/juliens-auctions","__id":"UGFydG5lcjpqdWxpZW5zLWF1Y3Rpb25z","type":"Auction House"},"sale":{"is_auction":true,"is_closed":true,"__id":"U2FsZTpqdWxpZW5zLWF1Y3Rpb25zLXN0cmVldC1hcnQtbm93LWlp","is_live_open":false,"is_open":false,"is_preview":false,"display_timely_at":"ends in 3Y"},"sale_artwork":{"counts":{"bidder_positions":6},"highest_bid":{"display":"$3,250","__id":"5769b786ebad64166a000050"},"opening_bid":{"display":"$500"},"__id":"U2FsZUFydHdvcms6a2F3cy1ib2JhLWZldHQtY29tcGFuaW9u"},"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLWhvbGlkYXktc2V0LW9mLTMtMQ==","id":"kaws-holiday-set-of-3-1","href":"/artwork/kaws-holiday-set-of-3-1","image":{"aspect_ratio":1.4,"__id":"5cdef8ffd9b0661e37ce52f2","placeholder":"71.42857142857143%","url":"https://d32dm0rphc51dk.cloudfront.net/hFd-xFdXhOFF85HBJa0zzw/large.jpg"},"_id":"5cdef8feda364a0505e29812","title":"Holiday Set of 3","image_title":"KAWS, ‘Holiday Set of 3’, 2019","date":"2019","sale_message":"$3,000","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"New Union Gallery","href":"/new-union-gallery","__id":"UGFydG5lcjpuZXctdW5pb24tZ2FsbGVyeQ==","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":false,"is_saved":false,"is_biddable":false,"is_acquireable":true,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLXRvZ2V0aGVyLWdyZXktMQ==","id":"kaws-together-grey-1","href":"/artwork/kaws-together-grey-1","image":{"aspect_ratio":1.4,"__id":"5b3d85b27622dd1349f706ee","placeholder":"71.42857142857143%","url":"https://d32dm0rphc51dk.cloudfront.net/M_SOoP7eBHjuLf866XIu7Q/large.jpg"},"_id":"5b39f7cdc9dc24777d10ae48","title":"Together (Grey)","image_title":"KAWS, ‘Together (Grey)’, 2018","date":"2018","sale_message":"$990","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Dope! Gallery","href":"/dope-gallery","__id":"UGFydG5lcjpkb3BlLWdhbGxlcnk=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLXBhc3NpbmctdGhyb3VnaC1ncmV5LTE=","id":"kaws-passing-through-grey-1","href":"/artwork/kaws-passing-through-grey-1","image":{"aspect_ratio":0.72,"__id":"58ebea598b3b8133919f4e50","placeholder":"138.77551020408163%","url":"https://d32dm0rphc51dk.cloudfront.net/Z84jgLZMNuJxUzO-rgZH1w/large.jpg"},"_id":"58ebea58cd530e0770a5aa4c","title":"Passing Through (Grey) ","image_title":"KAWS, ‘Passing Through (Grey) ’, 2013","date":"2013","sale_message":"$3,400","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Galerie C.O.A","href":"/galerie-coa","__id":"UGFydG5lcjpnYWxlcmllLWNvYQ==","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLW5vLWZ1dHVyZS1jb21wYW5pb24tc2lsdmVyLWNocm9tZS01","id":"kaws-no-future-companion-silver-chrome-5","href":"/artwork/kaws-no-future-companion-silver-chrome-5","image":{"aspect_ratio":1.14,"__id":"5acc6298b202a313b86659da","placeholder":"88.1%","url":"https://d32dm0rphc51dk.cloudfront.net/P0KeZt18ZO1E-vKuOvQUHg/large.jpg"},"_id":"5acc6297a09a672192e9e221","title":"No Future Companion (Silver Chrome)","image_title":"KAWS, ‘No Future Companion (Silver Chrome)’, 2008","date":"2008","sale_message":"Contact For Price","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"MSP Modern","href":"/msp-modern","__id":"UGFydG5lcjptc3AtbW9kZXJu","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLWhvbGlkYXktY29tcGFuaW9uLWZsb2F0aW5nLWJlZA==","id":"kaws-holiday-companion-floating-bed","href":"/artwork/kaws-holiday-companion-floating-bed","image":{"aspect_ratio":1.36,"__id":"5b63f597e6b6c466df9491a4","placeholder":"73.6328125%","url":"https://d32dm0rphc51dk.cloudfront.net/lc2FTCfjWIVizWSfnDDjGg/large.jpg"},"_id":"5b63f5944f0ac3504c5d2b1c","title":"Holiday Companion Floating Bed","image_title":"KAWS, ‘Holiday Companion Floating Bed’, 2018","date":"2018","sale_message":"$350","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Dope! Gallery","href":"/dope-gallery","__id":"UGFydG5lcjpkb3BlLWdhbGxlcnk=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLWdyZXktZmxheWVkLWNvbXBhbmlvbi0yMDE2LW9wZW4tZWRpdGlvbg==","id":"kaws-grey-flayed-companion-2016-open-edition","href":"/artwork/kaws-grey-flayed-companion-2016-open-edition","image":{"aspect_ratio":0.67,"__id":"587025b1a09a67566a002edc","placeholder":"149.79195561719834%","url":"https://d32dm0rphc51dk.cloudfront.net/HMKwnB8hZm_c2uI2FxXNXw/large.jpg"},"_id":"587025af9c18db5923002fa5","title":"Grey Flayed Companion 2016 Open Edition","image_title":"KAWS, ‘Grey Flayed Companion 2016 Open Edition’, 2016","date":"2016","sale_message":"$1,200","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Black Book Gallery","href":"/blackbook-gallery","__id":"UGFydG5lcjpibGFjay1ib29rLWdhbGxlcnk=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLWthd3MtY29tcGFuaW9uLW9wZW4tZWRpdGlvbi1zZXQtb2YtNg==","id":"kaws-kaws-companion-open-edition-set-of-6","href":"/artwork/kaws-kaws-companion-open-edition-set-of-6","image":{"aspect_ratio":1,"__id":"596f863fc9dc2451b95c38b7","placeholder":"100%","url":"https://d32dm0rphc51dk.cloudfront.net/GLRzJwHwSZcKEpLREw8uag/large.jpg"},"_id":"596f863dc9dc2450d101c5ad","title":"Kaws Companion (Open Edition) - Set of 6","image_title":"KAWS, ‘Kaws Companion (Open Edition) - Set of 6’, 2016","date":"2016","sale_message":"£3,000","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Reem Gallery","href":"/reem-gallery","__id":"UGFydG5lcjpyZWVtLWdhbGxlcnk=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLWthd3MtYWxvbmctdGhlLXdheS1jb21wbGV0ZS1zZXQtb2YtMw==","id":"kaws-kaws-along-the-way-complete-set-of-3","href":"/artwork/kaws-kaws-along-the-way-complete-set-of-3","image":{"aspect_ratio":1,"__id":"5d15c60e02c4fd0011847539","placeholder":"100%","url":"https://d32dm0rphc51dk.cloudfront.net/_WKftu2nTtQsQmd7-VREqQ/large.jpg"},"_id":"5cc8c54784ba07251416c6e1","title":"KAWS Along The Way Complete Set of 3 ","image_title":"KAWS, ‘KAWS Along The Way Complete Set of 3 ’, 2019","date":"2019","sale_message":"$2,800","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Lot 180","href":"/lot-180","__id":"UGFydG5lcjpsb3QtMTgw","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":false,"is_saved":false,"is_biddable":false,"is_acquireable":true,"is_offerable":true}},{"node":{"__id":"QXJ0d29yazprYXdzLWNvbXBhbmlvbi1icm93bi1mbGF5ZWQtb3Blbi1lZGl0aW9u","id":"kaws-companion-brown-flayed-open-edition","href":"/artwork/kaws-companion-brown-flayed-open-edition","image":{"aspect_ratio":0.67,"__id":"59cdddec2a893a388d5d779d","placeholder":"149.79195561719834%","url":"https://d32dm0rphc51dk.cloudfront.net/RFWH6hud1-aw2QR5-8a-nA/large.jpg"},"_id":"59cddde8a09a6763c63ea6bf","title":"COMPANION BROWN (FLAYED) (OPEN EDITION)","image_title":"KAWS, ‘COMPANION BROWN (FLAYED) (OPEN EDITION)’, 2016","date":"2016","sale_message":"$650","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Marcel Katz Art","href":"/marcel-katz-art","__id":"UGFydG5lcjptYXJjZWwta2F0ei1hcnQ=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLWNvbXBhbmlvbi1ibHVzaC1mbGF5ZWQtb3Blbi1lZGl0aW9u","id":"kaws-companion-blush-flayed-open-edition","href":"/artwork/kaws-companion-blush-flayed-open-edition","image":{"aspect_ratio":0.79,"__id":"59d5c8408b3b81391654d91e","placeholder":"127.35849056603774%","url":"https://d32dm0rphc51dk.cloudfront.net/_ktznsDfwK51vMpo-ZTC2w/large.jpg"},"_id":"59d5c83f275b244ef74b9aad","title":"COMPANION BLUSH (FLAYED) (OPEN EDITION)","image_title":"KAWS, ‘COMPANION BLUSH (FLAYED) (OPEN EDITION)’, 2017","date":"2017","sale_message":"$420","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Marcel Katz Art","href":"/marcel-katz-art","__id":"UGFydG5lcjptYXJjZWwta2F0ei1hcnQ=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}},{"node":{"__id":"QXJ0d29yazprYXdzLXR3ZWV0eS0x","id":"kaws-tweety-1","href":"/artwork/kaws-tweety-1","image":{"aspect_ratio":0.73,"__id":"59a915978b3b813d7ce3fd6a","placeholder":"137.63440860215056%","url":"https://d32dm0rphc51dk.cloudfront.net/BuFOJEBAqGgXabGv8ptFdw/large.jpg"},"_id":"59a915939c18db6bf09cce24","title":"Tweety","image_title":"KAWS, ‘Tweety’, 2010","date":"2010","sale_message":"$2,990","cultural_maker":null,"artists":[{"__id":"QXJ0aXN0Omthd3M=","href":"/artist/kaws","name":"KAWS"}],"collecting_institution":null,"partner":{"name":"Dope! Gallery","href":"/dope-gallery","__id":"UGFydG5lcjpkb3BlLWdhbGxlcnk=","type":"Gallery"},"sale":null,"sale_artwork":null,"is_inquireable":true,"is_saved":false,"is_biddable":false,"is_acquireable":false,"is_offerable":false}}]}},"__id":"5bcf4e518ef6ac2e05f0eb97"}}}
+{
+  "data": {
+    "viewer": {
+      "category": "Collectible Sculptures",
+      "credit": "<p>&copy; KAWS, Medicom Toy 2007.</p>",
+      "description": "<p>Brian Donnelly, better known as KAWS, spent the first year of his career as an animator for Disney. After leaving in 1997, KAWS took inspiration from the company&rsquo;s signature cartoon, Mickey Mouse, to create his own set of characters that he named &ldquo;Companions.&rdquo; With gloved hands and X&rsquo;s for eyes, &ldquo;Companions&rdquo; first appeared in KAWS&rsquo;s graffiti works across New York City in the late 1990s. By the end of the decade, the street artist created his first three-dimensional version, and his characters have since taken on a variety of colors, sizes, and poses. In 2017, his four-foot-tall <i>Seated Companion</i> (2011) broke the auction record for the series, selling for over $400,000. However, many of KAWS&rsquo;s &ldquo;Companions&rdquo; are considerably more affordable, such as his vinyl toys produced in collaboration with esteemed manufacturers including Bounty Hunter, Bape, Medicom, and his own brand OriginalFake, which was active between 2006 and 2013.</p>",
+      "headerImage": "https://artsy-vanity-files-production.s3.amazonaws.com/images/kaws2.png",
+      "id": "5bcf4e518ef6ac2e05f0eb97",
+      "slug": "kaws-companions",
+      "title": "KAWS: Companions",
+      "query": {
+        "artist_ids": [],
+        "artist_id": null,
+        "gene_id": null,
+        "__id": null
+      },
+      "relatedCollections": [
+        {
+          "headerImage": "http://files.artsy.net/images/pumpkinsbigartistsmallsculpture.png",
+          "slug": "collectible-sculptures",
+          "title": "Big Artists, Small Sculptures",
+          "price_guidance": 200,
+          "artworks": {
+            "artworks_connection": {
+              "edges": [
+                {
+                  "node": {
+                    "artist": {
+                      "name": "Jeff Koons",
+                      "__id": "QXJ0aXN0OmplZmYta29vbnM="
+                    },
+                    "title": "Balloon Rabbit (Red)",
+                    "image": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/kH-cSMQl68nfYPGkWqBMqw/small.jpg",
+                      "__id": "5ae1ee3e139b215b21f42636"
+                    },
+                    "__id": "QXJ0d29yazpqZWZmLWtvb25zLWJhbGxvb24tcmFiYml0LXJlZC0xNg=="
+                  }
+                },
+                {
+                  "node": {
+                    "artist": {
+                      "name": "Takashi Murakami",
+                      "__id": "QXJ0aXN0OnRha2FzaGktbXVyYWthbWk="
+                    },
+                    "title": "Mr. DOB",
+                    "image": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/aes0eLUVKs0oksAzap8NNw/small.jpg",
+                      "__id": "59e928c3cd530e4d86001c4c"
+                    },
+                    "__id": "QXJ0d29yazp0YWthc2hpLW11cmFrYW1pLW1yLWRvYi00NA=="
+                  }
+                },
+                {
+                  "node": {
+                    "artist": {
+                      "name": "Salvador Dalí",
+                      "__id": "QXJ0aXN0OnNhbHZhZG9yLWRhbGk="
+                    },
+                    "title": "CRUCIFIXION (DARK GREY)",
+                    "image": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/OR0-pvHkzm0PSBcsuhHsrA/small.jpg",
+                      "__id": "598dfebca09a677efbc9ec5c"
+                    },
+                    "__id": "QXJ0d29yazpzYWx2YWRvci1kYWxpLWNydWNpZml4aW9uLWRhcmstZ3JleQ=="
+                  }
+                }
+              ]
+            },
+            "__id": "RmlsdGVyQXJ0d29ya3M6eyJhZ2dyZWdhdGlvbnMiOlsidG90YWwiXSwiYXJ0aXN0X2lkcyI6W10sImdlbmVfaWRzIjpbImJpZy1hcnRpc3RzLXNtYWxsLXNjdWxwdHVyZXMiXSwic29ydCI6Ii1kZWNheWVkX21lcmNoIiwia2V5d29yZF9tYXRjaF9leGFjdCI6ZmFsc2V9"
+          },
+          "__id": "5bcf4e518ef6ac2e05f0eb98"
+        },
+        {
+          "headerImage": "https://artsy-vanity-files-production.s3.amazonaws.com/images/kaws2.png",
+          "slug": "kaws-toys",
+          "title": "KAWS: Toys",
+          "price_guidance": 450,
+          "artworks": {
+            "artworks_connection": {
+              "edges": [
+                {
+                  "node": {
+                    "artist": {
+                      "name": "KAWS",
+                      "__id": "QXJ0aXN0Omthd3M="
+                    },
+                    "title": "PINOCCHIO & JIMINY CRICKET",
+                    "image": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/oTnxcunE3BROJ3DywuNrOg/small.jpg",
+                      "__id": "5a7512d29c18db74e1793768"
+                    },
+                    "__id": "QXJ0d29yazprYXdzLXBpbm9jY2hpby1hbmQtamltaW55LWNyaWNrZXQtNg=="
+                  }
+                },
+                {
+                  "node": {
+                    "artist": {
+                      "name": "KAWS",
+                      "__id": "QXJ0aXN0Omthd3M="
+                    },
+                    "title": "Pinocchio and Jiminy Cricket",
+                    "image": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/G9SYkdc2PoKdHdJpC-fDew/small.jpg",
+                      "__id": "5b065181275b24363d0e237d"
+                    },
+                    "__id": "QXJ0d29yazprYXdzLXBpbm9jY2hpby1hbmQtamltaW55LWNyaWNrZXQtOQ=="
+                  }
+                },
+                {
+                  "node": {
+                    "artist": {
+                      "name": "KAWS",
+                      "__id": "QXJ0aXN0Omthd3M="
+                    },
+                    "title": "Pinocchio & Jiminy Cricket",
+                    "image": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/sZXRIKbVJkReX4KCHFKpGA/small.jpg",
+                      "__id": "5bf6d6f903ce8656ceae105a"
+                    },
+                    "__id": "QXJ0d29yazprYXdzLXBpbm9jY2hpby1hbmQtamltaW55LWNyaWNrZXQtNw=="
+                  }
+                }
+              ]
+            },
+            "__id": "RmlsdGVyQXJ0d29ya3M6eyJhZ2dyZWdhdGlvbnMiOlsidG90YWwiXSwiYXJ0aXN0X2lkcyI6WyI0ZTkzNDAwMmUzNDBmYTAwMDEwMDUzMzYiXSwiZ2VuZV9pZHMiOlsic2N1bHB0dXJlIiwicmVsYXRlZC10by10b3lzIl0sInNvcnQiOiItZGVjYXllZF9tZXJjaCIsImtleXdvcmQiOiJDb21wYW5pb24sIEJGRiwgUGFzc2luZyBUaHJvdWdoLCBBc3Ryb2JveSwgQXN0cm8gQm95LCBTbWFsbCBMaWUsIFRvZ2V0aGVyLCBBY2NvbXBsaWNlLCBUd2lucywgU3Rvcm10cm9vcGVyLCBCb2JhIEZldHQsIERhcnRoIFZhZGVyLCBVbmRlcmNvdmVyIEJlYXIsIFR3ZWV0eSwgUGlub2NjaGlvLCBSZXN0aW5nIFBsYWNlLCBBbG9uZyB0aGUgV2F5LCBGaW5hbCBEYXlzLCBab290aCwgVHdlZXR5LCBKb2UgS2F3cywgU25vb3B5LCBTZWVpbmcgV2F0Y2hpbmcsIFBpbm9jY2hpbywgSmltaW55IENyaWNrZXQsIFBhcnRuZXJzLCBNaWxvLCBLdWJyaWNrLCBab290aCwgQm91bnR5IEh1bnRlciwgQmVhcmJyaWNrLCBDaHVtLCBKUFAsIEZpbmFsIERheXMsIENob21wZXJzLCBDYXQgVGVldGggQmFuaywgQmVuZCwgQmxpdHosIEJlbmR5LCBBY2NvbXBsaWNlIiwia2V5d29yZF9tYXRjaF9leGFjdCI6dHJ1ZX0="
+          },
+          "__id": "5beb5aca1338c043ac8ae214"
+        },
+        {
+          "headerImage": "http://files.artsy.net/images/jeffkoonsballoondogs.png",
+          "slug": "jeff-koons-balloon-dogs",
+          "title": "Jeff Koons: Balloon Dogs",
+          "price_guidance": 9000,
+          "artworks": {
+            "artworks_connection": {
+              "edges": [
+                {
+                  "node": {
+                    "artist": {
+                      "name": "Jeff Koons",
+                      "__id": "QXJ0aXN0OmplZmYta29vbnM="
+                    },
+                    "title": "Balloon Rabbit, Balloon Swan, Balloon Monkey",
+                    "image": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/dvBjLnQgq3391p-RwIqQVA/small.jpg",
+                      "__id": "5ac7bb1c275b2434baf3249e"
+                    },
+                    "__id": "QXJ0d29yazpqZWZmLWtvb25zLWJhbGxvb24tcmFiYml0LWJhbGxvb24tc3dhbi1iYWxsb29uLW1vbmtleQ=="
+                  }
+                },
+                {
+                  "node": {
+                    "artist": {
+                      "name": "Jeff Koons",
+                      "__id": "QXJ0aXN0OmplZmYta29vbnM="
+                    },
+                    "title": "Balloon Monkey (Blue)",
+                    "image": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/i6QjUwfJu9p_MhoHOiwu3g/small.jpg",
+                      "__id": "5c59b352c0d46a002cbcf48b"
+                    },
+                    "__id": "QXJ0d29yazpqZWZmLWtvb25zLWJhbGxvb24tbW9ua2V5LWJsdWUtMjA0NA=="
+                  }
+                },
+                {
+                  "node": {
+                    "artist": {
+                      "name": "Jeff Koons",
+                      "__id": "QXJ0aXN0OmplZmYta29vbnM="
+                    },
+                    "title": "Balloon Rabbit, Balloon Swan, and Balloon Monkey ",
+                    "image": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/u2OYwWMc4i97fGc7ETRecg/small.jpg",
+                      "__id": "5c1bb3aa850f997a6dc5445e"
+                    },
+                    "__id": "QXJ0d29yazpqZWZmLWtvb25zLWJhbGxvb24tcmFiYml0LWJhbGxvb24tc3dhbi1hbmQtYmFsbG9vbi1tb25rZXk="
+                  }
+                }
+              ]
+            },
+            "__id": "RmlsdGVyQXJ0d29ya3M6eyJhZ2dyZWdhdGlvbnMiOlsidG90YWwiXSwiYXJ0aXN0X2lkcyI6WyI0ZDhiOTJiYjRlYjY4YTFiMmMwMDA0NGEiXSwiZ2VuZV9pZHMiOltdLCJzb3J0IjoiLWRlY2F5ZWRfbWVyY2giLCJrZXl3b3JkIjoiQmFsbG9vbiBEb2csIEJhbGxvb24gc3dhbiwgQmFsbG9vbiBtb25rZXksIEJhbGxvb24gUmFiYml0Iiwia2V5d29yZF9tYXRjaF9leGFjdCI6dHJ1ZX0="
+          },
+          "__id": "5beb5aca1338c043ac8ae218"
+        },
+        {
+          "headerImage": "http://files.artsy.net/images/skateboards.png",
+          "slug": "artist-skateboard-decks",
+          "title": "Artist Skateboard Decks",
+          "price_guidance": 200,
+          "artworks": {
+            "artworks_connection": {
+              "edges": [
+                {
+                  "node": {
+                    "artist": {
+                      "name": "LA II (Angel Oritz)",
+                      "__id": "QXJ0aXN0OmxhLWlpLWFuZ2VsLW9yaXR6"
+                    },
+                    "title": "Loose Change",
+                    "image": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/V0FgCLo6f6NmWe8BCJC5wQ/small.jpg",
+                      "__id": "5babe51cd314d23105273fad"
+                    },
+                    "__id": "QXJ0d29yazpsYS1paS1hbmdlbC1vcml0ei1sb29zZS1jaGFuZ2U="
+                  }
+                },
+                {
+                  "node": {
+                    "artist": {
+                      "name": "Paul McCarthy",
+                      "__id": "QXJ0aXN0OnBhdWwtbWNjYXJ0aHk="
+                    },
+                    "title": "Doll Limited Edition Skate Deck ",
+                    "image": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/aJ70KW3JcmLbl_gkZfwXRA/small.jpg",
+                      "__id": "595ca78e139b21385330d346"
+                    },
+                    "__id": "QXJ0d29yazpwYXVsLW1jY2FydGh5LWRvbGwtbGltaXRlZC1lZGl0aW9uLXNrYXRlLWRlY2s="
+                  }
+                },
+                {
+                  "node": {
+                    "artist": {
+                      "name": "Jeff Koons",
+                      "__id": "QXJ0aXN0OmplZmYta29vbnM="
+                    },
+                    "title": "Skateboard Monkey Train - Blue",
+                    "image": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/vC-ocQJ2KKAK7JrlNPwMow/small.jpg",
+                      "__id": "558ad014726169361c00092c"
+                    },
+                    "__id": "QXJ0d29yazpqZWZmLWtvb25zLXNrYXRlYm9hcmQtbW9ua2V5LXRyYWluLWJsdWU="
+                  }
+                }
+              ]
+            },
+            "__id": "RmlsdGVyQXJ0d29ya3M6eyJhZ2dyZWdhdGlvbnMiOlsidG90YWwiXSwiYXJ0aXN0X2lkcyI6W10sImdlbmVfaWRzIjpbImFydGlzdC1za2F0ZWJvYXJkIl0sInNvcnQiOiItZGVjYXllZF9tZXJjaCIsImtleXdvcmRfbWF0Y2hfZXhhY3QiOmZhbHNlfQ=="
+          },
+          "__id": "5beb5acb1338c043ac8ae24f"
+        }
+      ],
+      "linkedCollections": [],
+      "artworks": {
+        "hits": [
+          {
+            "href": "/artwork/kaws-kaws-x-be-at-rbrick-dissected-companion-400-percent-and-100-percent-two-works",
+            "id": "kaws-kaws-x-be-at-rbrick-dissected-companion-400-percent-and-100-percent-two-works",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=138&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FAqIUxe69SL6dNmFSF7XgDg%2Flarge.jpg",
+                "width": 138,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=190&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FAqIUxe69SL6dNmFSF7XgDg%2Flarge.jpg",
+                "width": 190,
+                "height": 220
+              },
+              "__id": "5d704fa30f056a000e8546c7"
+            },
+            "__id": "QXJ0d29yazprYXdzLWthd3MteC1iZS1hdC1yYnJpY2stZGlzc2VjdGVkLWNvbXBhbmlvbi00MDAtcGVyY2VudC1hbmQtMTAwLXBlcmNlbnQtdHdvLXdvcmtz"
+          },
+          {
+            "href": "/artwork/kaws-no-future-companion-collaboration-with-hajime-sorayama-black-chrome",
+            "id": "kaws-no-future-companion-collaboration-with-hajime-sorayama-black-chrome",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=144&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRFC1iwT6hq1QFwrLevkiEw%2Flarge.jpg",
+                "width": 144,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=199&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRFC1iwT6hq1QFwrLevkiEw%2Flarge.jpg",
+                "width": 199,
+                "height": 220
+              },
+              "__id": "5acc6297c9dc247dcc317da6"
+            },
+            "__id": "QXJ0d29yazprYXdzLW5vLWZ1dHVyZS1jb21wYW5pb24tY29sbGFib3JhdGlvbi13aXRoLWhhamltZS1zb3JheWFtYS1ibGFjay1jaHJvbWU="
+          },
+          {
+            "href": "/artwork/kaws-small-lie-5",
+            "id": "kaws-small-lie-5",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=85&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F9IfyjiZvrCelAnYFjFd2tQ%2Flarge.jpg",
+                "width": 85,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=117&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F9IfyjiZvrCelAnYFjFd2tQ%2Flarge.jpg",
+                "width": 117,
+                "height": 220
+              },
+              "__id": "5d1274d642f72b000e330313"
+            },
+            "__id": "QXJ0d29yazprYXdzLXNtYWxsLWxpZS01"
+          },
+          {
+            "href": "/artwork/kaws-grey-companion-2016-open-edition",
+            "id": "kaws-grey-companion-2016-open-edition",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=106&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FAnNB8gHH4xZnLcJSS4cNpw%2Flarge.jpg",
+                "width": 106,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=146&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FAnNB8gHH4xZnLcJSS4cNpw%2Flarge.jpg",
+                "width": 146,
+                "height": 220
+              },
+              "__id": "586c13229c18db52e5005c34"
+            },
+            "__id": "QXJ0d29yazprYXdzLWdyZXktY29tcGFuaW9uLTIwMTYtb3Blbi1lZGl0aW9u"
+          },
+          {
+            "href": "/artwork/kaws-boba-fett-companion-10",
+            "id": "kaws-boba-fett-companion-10",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=146&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FVh612qcvwJYkw6YTjP9CvQ%2Flarge.jpg",
+                "width": 146,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=201&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FVh612qcvwJYkw6YTjP9CvQ%2Flarge.jpg",
+                "width": 201,
+                "height": 220
+              },
+              "__id": "5bfec8fbd820902a3aa4c879"
+            },
+            "__id": "QXJ0d29yazprYXdzLWJvYmEtZmV0dC1jb21wYW5pb24tMTA="
+          },
+          {
+            "href": "/artwork/kaws-4-foot-dissected-companion-brown",
+            "id": "kaws-4-foot-dissected-companion-brown",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=71&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FU4GBoWFFwPhZ8_65MTUo7g%2Flarge.jpg",
+                "width": 71,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=98&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FU4GBoWFFwPhZ8_65MTUo7g%2Flarge.jpg",
+                "width": 98,
+                "height": 220
+              },
+              "__id": "5ace9d6eb202a301c8c75de1"
+            },
+            "__id": "QXJ0d29yazprYXdzLTQtZm9vdC1kaXNzZWN0ZWQtY29tcGFuaW9uLWJyb3du"
+          },
+          {
+            "href": "/artwork/kaws-companion-blush-open-edition-set-of-2",
+            "id": "kaws-companion-blush-open-edition-set-of-2",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=240&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FXbgSZWPiKVjvNkvgMsUVcg%2Flarge.jpg",
+                "width": 240,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=330&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FXbgSZWPiKVjvNkvgMsUVcg%2Flarge.jpg",
+                "width": 330,
+                "height": 220
+              },
+              "__id": "59d5c83ec9dc241974970fcd"
+            },
+            "__id": "QXJ0d29yazprYXdzLWNvbXBhbmlvbi1ibHVzaC1vcGVuLWVkaXRpb24tc2V0LW9mLTI="
+          },
+          {
+            "href": "/artwork/kaws-woodstock-8",
+            "id": "kaws-woodstock-8",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=126&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F1372C2GWivbxT_jH0Oj-Rg%2Flarge.jpg",
+                "width": 126,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=173&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F1372C2GWivbxT_jH0Oj-Rg%2Flarge.jpg",
+                "width": 173,
+                "height": 220
+              },
+              "__id": "584ec33ecd530e649e00018a"
+            },
+            "__id": "QXJ0d29yazprYXdzLXdvb2RzdG9jay04"
+          },
+          {
+            "href": "/artwork/kaws-untitled-372",
+            "id": "kaws-untitled-372",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=114&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWe2oe6vGSNvM8vMfSfQU3Q%2Flarge.jpg",
+                "width": 114,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=157&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWe2oe6vGSNvM8vMfSfQU3Q%2Flarge.jpg",
+                "width": 157,
+                "height": 220
+              },
+              "__id": "58f010da8b3b81249ca9a0d9"
+            },
+            "__id": "QXJ0d29yazprYXdzLXVudGl0bGVkLTM3Mg=="
+          },
+          {
+            "href": "/artwork/kaws-kaws-black-companion-2016-open-edition",
+            "id": "kaws-kaws-black-companion-2016-open-edition",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=106&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FFJ8SXtPf0cHxfXX9l494rQ%2Flarge.jpg",
+                "width": 106,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=146&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FFJ8SXtPf0cHxfXX9l494rQ%2Flarge.jpg",
+                "width": 146,
+                "height": 220
+              },
+              "__id": "585acf8cc9dc246107000755"
+            },
+            "__id": "QXJ0d29yazprYXdzLWthd3MtYmxhY2stY29tcGFuaW9uLTIwMTYtb3Blbi1lZGl0aW9u"
+          },
+          {
+            "href": "/artwork/kaws-black-flayed-companion-open-edition-1",
+            "id": "kaws-black-flayed-companion-open-edition-1",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=107&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FKXFQf_kDuBKlUjYCFZZNAQ%2Flarge.jpg",
+                "width": 107,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=147&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FKXFQf_kDuBKlUjYCFZZNAQ%2Flarge.jpg",
+                "width": 147,
+                "height": 220
+              },
+              "__id": "59080a7b139b2141bf630fd1"
+            },
+            "__id": "QXJ0d29yazprYXdzLWJsYWNrLWZsYXllZC1jb21wYW5pb24tb3Blbi1lZGl0aW9uLTE="
+          },
+          {
+            "href": "/artwork/kaws-together-brown-1",
+            "id": "kaws-together-brown-1",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=224&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FTTYP_VL_kTPIvKq7c6tKbg%2Flarge.jpg",
+                "width": 224,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=308&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FTTYP_VL_kTPIvKq7c6tKbg%2Flarge.jpg",
+                "width": 308,
+                "height": 220
+              },
+              "__id": "5b3d88119c18db46dd8a136d"
+            },
+            "__id": "QXJ0d29yazprYXdzLXRvZ2V0aGVyLWJyb3duLTE="
+          },
+          {
+            "href": "/artwork/kaws-small-lie-complete-set-of-three",
+            "id": "kaws-small-lie-complete-set-of-three",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=213&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FcNJHHg5fnEUIzYAEWsdJoA%2Flarge.jpg",
+                "width": 213,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=293&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FcNJHHg5fnEUIzYAEWsdJoA%2Flarge.jpg",
+                "width": 293,
+                "height": 220
+              },
+              "__id": "5b69a938cb6560002339eefe"
+            },
+            "__id": "QXJ0d29yazprYXdzLXNtYWxsLWxpZS1jb21wbGV0ZS1zZXQtb2YtdGhyZWU="
+          },
+          {
+            "href": "/artwork/kaws-kaws-brown-companion-2016",
+            "id": "kaws-kaws-brown-companion-2016",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=136&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FAuSruS7cRqAFOVCTtmhEHg%2Flarge.jpg",
+                "width": 136,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=187&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FAuSruS7cRqAFOVCTtmhEHg%2Flarge.jpg",
+                "width": 187,
+                "height": 220
+              },
+              "__id": "5cf83db3ca30760012f0f6cc"
+            },
+            "__id": "QXJ0d29yazprYXdzLWthd3MtYnJvd24tY29tcGFuaW9uLTIwMTY="
+          },
+          {
+            "href": "/artwork/kaws-pinocchio-3",
+            "id": "kaws-pinocchio-3",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=106&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fqu24dwWrXHfw5Z3e6KhXPQ%2Flarge.jpg",
+                "width": 106,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=146&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fqu24dwWrXHfw5Z3e6KhXPQ%2Flarge.jpg",
+                "width": 146,
+                "height": 220
+              },
+              "__id": "5b33f5fb9c18db46398bfa6c"
+            },
+            "__id": "QXJ0d29yazprYXdzLXBpbm9jY2hpby0z"
+          },
+          {
+            "href": "/artwork/kaws-seeing-watching",
+            "id": "kaws-seeing-watching",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=239&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FYmIR6J_b3D7A6JAosmuUgA%2Flarge.jpg",
+                "width": 239,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=329&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FYmIR6J_b3D7A6JAosmuUgA%2Flarge.jpg",
+                "width": 329,
+                "height": 220
+              },
+              "__id": "5b09630a275b2464ae4b3614"
+            },
+            "__id": "QXJ0d29yazprYXdzLXNlZWluZy13YXRjaGluZw=="
+          },
+          {
+            "href": "/artwork/kaws-4-ft-companion-with-box-and-hologram",
+            "id": "kaws-4-ft-companion-with-box-and-hologram",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=160&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FTNrubN2rbSkaRJGxnu4uFA%2Flarge.jpg",
+                "width": 160,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=220&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FTNrubN2rbSkaRJGxnu4uFA%2Flarge.jpg",
+                "width": 220,
+                "height": 220
+              },
+              "__id": "5ba2f7e5196e630027ffe39c"
+            },
+            "__id": "QXJ0d29yazprYXdzLTQtZnQtY29tcGFuaW9uLXdpdGgtYm94LWFuZC1ob2xvZ3JhbQ=="
+          },
+          {
+            "href": "/artwork/kaws-together-black-1",
+            "id": "kaws-together-black-1",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=224&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FPUFz_OjJ-JPaJACdsr1Z7Q%2Flarge.jpg",
+                "width": 224,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=308&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FPUFz_OjJ-JPaJACdsr1Z7Q%2Flarge.jpg",
+                "width": 308,
+                "height": 220
+              },
+              "__id": "5b21c399a09a674544434a80"
+            },
+            "__id": "QXJ0d29yazprYXdzLXRvZ2V0aGVyLWJsYWNrLTE="
+          },
+          {
+            "href": "/artwork/kaws-boba-fett-companion",
+            "id": "kaws-boba-fett-companion",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=103&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FGEJ3-RY2I6rmo8JbuuCQkw%2Flarge.jpg",
+                "width": 103,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=142&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FGEJ3-RY2I6rmo8JbuuCQkw%2Flarge.jpg",
+                "width": 142,
+                "height": 220
+              },
+              "__id": "575a099b139b216b8a00021a"
+            },
+            "__id": "QXJ0d29yazprYXdzLWJvYmEtZmV0dC1jb21wYW5pb24="
+          },
+          {
+            "href": "/artwork/kaws-holiday-set-of-3-1",
+            "id": "kaws-holiday-set-of-3-1",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=224&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FhFd-xFdXhOFF85HBJa0zzw%2Flarge.jpg",
+                "width": 224,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=308&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FhFd-xFdXhOFF85HBJa0zzw%2Flarge.jpg",
+                "width": 308,
+                "height": 220
+              },
+              "__id": "5cdef8ffd9b0661e37ce52f2"
+            },
+            "__id": "QXJ0d29yazprYXdzLWhvbGlkYXktc2V0LW9mLTMtMQ=="
+          },
+          {
+            "href": "/artwork/kaws-together-grey-1",
+            "id": "kaws-together-grey-1",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=224&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FM_SOoP7eBHjuLf866XIu7Q%2Flarge.jpg",
+                "width": 224,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=308&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FM_SOoP7eBHjuLf866XIu7Q%2Flarge.jpg",
+                "width": 308,
+                "height": 220
+              },
+              "__id": "5b3d85b27622dd1349f706ee"
+            },
+            "__id": "QXJ0d29yazprYXdzLXRvZ2V0aGVyLWdyZXktMQ=="
+          },
+          {
+            "href": "/artwork/kaws-passing-through-grey-1",
+            "id": "kaws-passing-through-grey-1",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=115&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FZ84jgLZMNuJxUzO-rgZH1w%2Flarge.jpg",
+                "width": 115,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=158&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FZ84jgLZMNuJxUzO-rgZH1w%2Flarge.jpg",
+                "width": 158,
+                "height": 220
+              },
+              "__id": "58ebea598b3b8133919f4e50"
+            },
+            "__id": "QXJ0d29yazprYXdzLXBhc3NpbmctdGhyb3VnaC1ncmV5LTE="
+          },
+          {
+            "href": "/artwork/kaws-no-future-companion-silver-chrome-5",
+            "id": "kaws-no-future-companion-silver-chrome-5",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=181&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FP0KeZt18ZO1E-vKuOvQUHg%2Flarge.jpg",
+                "width": 181,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=249&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FP0KeZt18ZO1E-vKuOvQUHg%2Flarge.jpg",
+                "width": 249,
+                "height": 220
+              },
+              "__id": "5acc6298b202a313b86659da"
+            },
+            "__id": "QXJ0d29yazprYXdzLW5vLWZ1dHVyZS1jb21wYW5pb24tc2lsdmVyLWNocm9tZS01"
+          },
+          {
+            "href": "/artwork/kaws-holiday-companion-floating-bed",
+            "id": "kaws-holiday-companion-floating-bed",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=217&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Flc2FTCfjWIVizWSfnDDjGg%2Flarge.jpg",
+                "width": 217,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=298&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Flc2FTCfjWIVizWSfnDDjGg%2Flarge.jpg",
+                "width": 298,
+                "height": 220
+              },
+              "__id": "5b63f597e6b6c466df9491a4"
+            },
+            "__id": "QXJ0d29yazprYXdzLWhvbGlkYXktY29tcGFuaW9uLWZsb2F0aW5nLWJlZA=="
+          },
+          {
+            "href": "/artwork/kaws-grey-flayed-companion-2016-open-edition",
+            "id": "kaws-grey-flayed-companion-2016-open-edition",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=106&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FHMKwnB8hZm_c2uI2FxXNXw%2Flarge.jpg",
+                "width": 106,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=146&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FHMKwnB8hZm_c2uI2FxXNXw%2Flarge.jpg",
+                "width": 146,
+                "height": 220
+              },
+              "__id": "587025b1a09a67566a002edc"
+            },
+            "__id": "QXJ0d29yazprYXdzLWdyZXktZmxheWVkLWNvbXBhbmlvbi0yMDE2LW9wZW4tZWRpdGlvbg=="
+          },
+          {
+            "href": "/artwork/kaws-kaws-companion-open-edition-set-of-6",
+            "id": "kaws-kaws-companion-open-edition-set-of-6",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=160&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FGLRzJwHwSZcKEpLREw8uag%2Flarge.jpg",
+                "width": 160,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=220&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FGLRzJwHwSZcKEpLREw8uag%2Flarge.jpg",
+                "width": 220,
+                "height": 220
+              },
+              "__id": "596f863fc9dc2451b95c38b7"
+            },
+            "__id": "QXJ0d29yazprYXdzLWthd3MtY29tcGFuaW9uLW9wZW4tZWRpdGlvbi1zZXQtb2YtNg=="
+          },
+          {
+            "href": "/artwork/kaws-kaws-along-the-way-complete-set-of-3",
+            "id": "kaws-kaws-along-the-way-complete-set-of-3",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=160&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F_WKftu2nTtQsQmd7-VREqQ%2Flarge.jpg",
+                "width": 160,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=220&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F_WKftu2nTtQsQmd7-VREqQ%2Flarge.jpg",
+                "width": 220,
+                "height": 220
+              },
+              "__id": "5d15c60e02c4fd0011847539"
+            },
+            "__id": "QXJ0d29yazprYXdzLWthd3MtYWxvbmctdGhlLXdheS1jb21wbGV0ZS1zZXQtb2YtMw=="
+          },
+          {
+            "href": "/artwork/kaws-companion-brown-flayed-open-edition",
+            "id": "kaws-companion-brown-flayed-open-edition",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=106&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRFWH6hud1-aw2QR5-8a-nA%2Flarge.jpg",
+                "width": 106,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=146&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRFWH6hud1-aw2QR5-8a-nA%2Flarge.jpg",
+                "width": 146,
+                "height": 220
+              },
+              "__id": "59cdddec2a893a388d5d779d"
+            },
+            "__id": "QXJ0d29yazprYXdzLWNvbXBhbmlvbi1icm93bi1mbGF5ZWQtb3Blbi1lZGl0aW9u"
+          },
+          {
+            "href": "/artwork/kaws-companion-blush-flayed-open-edition",
+            "id": "kaws-companion-blush-flayed-open-edition",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=125&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F_ktznsDfwK51vMpo-ZTC2w%2Flarge.jpg",
+                "width": 125,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=172&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F_ktznsDfwK51vMpo-ZTC2w%2Flarge.jpg",
+                "width": 172,
+                "height": 220
+              },
+              "__id": "59d5c8408b3b81391654d91e"
+            },
+            "__id": "QXJ0d29yazprYXdzLWNvbXBhbmlvbi1ibHVzaC1mbGF5ZWQtb3Blbi1lZGl0aW9u"
+          },
+          {
+            "href": "/artwork/kaws-tweety-1",
+            "id": "kaws-tweety-1",
+            "image": {
+              "small": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=116&height=160&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FBuFOJEBAqGgXabGv8ptFdw%2Flarge.jpg",
+                "width": 116,
+                "height": 160
+              },
+              "large": {
+                "url": "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=159&height=220&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FBuFOJEBAqGgXabGv8ptFdw%2Flarge.jpg",
+                "width": 159,
+                "height": 220
+              },
+              "__id": "59a915978b3b813d7ce3fd6a"
+            },
+            "__id": "QXJ0d29yazprYXdzLXR3ZWV0eS0x"
+          }
+        ],
+        "__id": "RmlsdGVyQXJ0d29ya3M6eyJhZ2dyZWdhdGlvbnMiOlsibWVyY2hhbmRpc2FibGVfYXJ0aXN0cyIsIm1lZGl1bSIsIm1ham9yX3BlcmlvZCIsInRvdGFsIl0sImFydGlzdF9pZHMiOltdLCJpbmNsdWRlX21lZGl1bV9maWx0ZXJfaW5fYWdncmVnYXRpb24iOnRydWUsImdlbmVfaWRzIjpbXSwic29ydCI6Ii1kZWNheWVkX21lcmNoIiwidGFnX2lkIjoiY29tcGFuaW9uIiwia2V5d29yZF9tYXRjaF9leGFjdCI6ZmFsc2V9",
+        "merchandisable_artists": [
+          {
+            "id": "kaws",
+            "_id": "4e934002e340fa0001005336",
+            "name": "KAWS",
+            "imageUrl": "https://d32dm0rphc51dk.cloudfront.net/WhacjFyMKlMkNVzncPjlRA/square.jpg",
+            "birthday": "1974",
+            "nationality": "American",
+            "__id": "QXJ0aXN0Omthd3M=",
+            "is_followed": false,
+            "counts": {
+              "follows": 0
+            }
+          },
+          {
+            "id": "robert-lazzarini",
+            "_id": "4f5f64c23b555230ac0003ae",
+            "name": "Robert Lazzarini",
+            "imageUrl": "https://d32dm0rphc51dk.cloudfront.net/1npk1i_Xua5q8Hv0YOq_3g/square.jpg",
+            "birthday": "1965",
+            "nationality": "American",
+            "__id": "QXJ0aXN0OnJvYmVydC1sYXp6YXJpbmk=",
+            "is_followed": false,
+            "counts": {
+              "follows": 0
+            }
+          },
+          {
+            "id": "hajime-sorayama",
+            "_id": "51951ec60cfd96ac75000332",
+            "name": "Hajime Sorayama",
+            "imageUrl": "https://d32dm0rphc51dk.cloudfront.net/cHtFPMYw7SvCewM-eCrefw/square.jpg",
+            "birthday": "1947",
+            "nationality": "Japanese",
+            "__id": "QXJ0aXN0OmhhamltZS1zb3JheWFtYQ==",
+            "is_followed": false,
+            "counts": {
+              "follows": 0
+            }
+          },
+          {
+            "id": "medicom",
+            "_id": "58fe85ee275b2450a0fd2b51",
+            "name": "Medicom",
+            "imageUrl": "https://d32dm0rphc51dk.cloudfront.net/jUMOidRmCQ0RyynXM_sFzQ/square.jpg",
+            "birthday": "",
+            "nationality": "",
+            "__id": "QXJ0aXN0Om1lZGljb20=",
+            "is_followed": false,
+            "counts": {
+              "follows": 0
+            }
+          },
+          {
+            "id": "medicom-toy",
+            "_id": "5bd9ff5d1f79d672bb7011d9",
+            "name": "Medicom Toy",
+            "imageUrl": "https://d32dm0rphc51dk.cloudfront.net/3B9sjaicLbIaO6et-QtUxg/square.jpg",
+            "birthday": "",
+            "nationality": "",
+            "__id": "QXJ0aXN0Om1lZGljb20tdG95",
+            "is_followed": false,
+            "counts": {
+              "follows": 0
+            }
+          }
+        ],
+        "artworks_connection": {
+          "edges": [
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWthd3MteC1iZS1hdC1yYnJpY2stZGlzc2VjdGVkLWNvbXBhbmlvbi00MDAtcGVyY2VudC1hbmQtMTAwLXBlcmNlbnQtdHdvLXdvcmtz",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2010",
+                "href": "/artwork/kaws-kaws-x-be-at-rbrick-dissected-companion-400-percent-and-100-percent-two-works",
+                "is_acquireable": true,
+                "is_price_range": false,
+                "price": "$4,850",
+                "price_currency": "USD",
+                "title": "KAWS X BE@RBRICK Dissected Companion 400% and 100% (two works)",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/AqIUxe69SL6dNmFSF7XgDg/larger.jpg",
+                  "__id": "5d704fa30f056a000e8546c7"
+                },
+                "meta": {
+                  "description": "Available for sale from 5ART GALLERY, KAWS, KAWS X BE@RBRICK Dissected Companion 400% and 100% (two works) (2010), Painted cast vinyl"
+                },
+                "partner": {
+                  "name": "5ART GALLERY",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/MJOYawSs-Do1tjyKBwTDvA/square.jpg",
+                      "__id": "5ad82a44a09a6735edc343ae"
+                    },
+                    "__id": "UHJvZmlsZTo1YXJ0LWdhbGxlcnk="
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjo1YXJ0LWdhbGxlcnk="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLW5vLWZ1dHVyZS1jb21wYW5pb24tY29sbGFib3JhdGlvbi13aXRoLWhhamltZS1zb3JheWFtYS1ibGFjay1jaHJvbWU=",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "",
+                "href": "/artwork/kaws-no-future-companion-collaboration-with-hajime-sorayama-black-chrome",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "",
+                "price_currency": "USD",
+                "title": "No Future Companion  collaboration with Hajime Sorayama (Black Chrome)",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/RFC1iwT6hq1QFwrLevkiEw/larger.jpg",
+                  "__id": "5acc6297c9dc247dcc317da6"
+                },
+                "meta": {
+                  "description": "Available for sale from MSP Modern, KAWS, No Future Companion  collaboration with Hajime Sorayama (Black Chrome), Polished chrome"
+                },
+                "partner": {
+                  "name": "MSP Modern",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/KT0hkz64ZByxq4L8f23Fmw/square.jpg",
+                      "__id": "58126f672a893a03ec0002cb"
+                    },
+                    "__id": "UHJvZmlsZTptc3AtbW9kZXJu"
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjptc3AtbW9kZXJu"
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXNtYWxsLWxpZS01",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2017",
+                "href": "/artwork/kaws-small-lie-5",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "$1,000",
+                "price_currency": "USD",
+                "title": "SMALL LIE",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/9IfyjiZvrCelAnYFjFd2tQ/larger.jpg",
+                  "__id": "5d1274d642f72b000e330313"
+                },
+                "meta": {
+                  "description": "Available for sale from Silverback Gallery, KAWS, SMALL LIE (2017), Painted Cast Vinyl"
+                },
+                "partner": {
+                  "name": "Silverback Gallery",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/JBrYk6IJZwF25xHedI85Iw/large.jpg",
+                      "__id": "5c450dbce14e710bb73bc2a2"
+                    },
+                    "__id": "UHJvZmlsZTpzaWx2ZXJiYWNrLWdhbGxlcnk="
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjpzaWx2ZXJiYWNrLWdhbGxlcnk="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWdyZXktY29tcGFuaW9uLTIwMTYtb3Blbi1lZGl0aW9u",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2016",
+                "href": "/artwork/kaws-grey-companion-2016-open-edition",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "$1,000",
+                "price_currency": "USD",
+                "title": "Grey Companion 2016 Open Edition",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/AnNB8gHH4xZnLcJSS4cNpw/larger.jpg",
+                  "__id": "586c13229c18db52e5005c34"
+                },
+                "meta": {
+                  "description": "Available for sale from Black Book Gallery, KAWS, Grey Companion 2016 Open Edition (2016), Plastic/Resin"
+                },
+                "partner": {
+                  "name": "Black Book Gallery",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/3hwmKMsYijKVZCtu_Ffcfg/untouched-png.png",
+                      "__id": "55b7f1177261694002000184"
+                    },
+                    "__id": "UHJvZmlsZTpibGFja2Jvb2stZ2FsbGVyeQ=="
+                  },
+                  "locations": [
+                    {
+                      "address": "3878 S Jason St.",
+                      "address_2": "",
+                      "city": "Englewood",
+                      "state": "CO",
+                      "country": "US",
+                      "postal_code": "80110",
+                      "phone": "303-941-2458",
+                      "__id": "TG9jYXRpb246NTViN2I4Yjc3MjYxNjkwN2RmMDAwMDZi"
+                    }
+                  ],
+                  "__id": "UGFydG5lcjpibGFjay1ib29rLWdhbGxlcnk="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWJvYmEtZmV0dC1jb21wYW5pb24tMTA=",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2013",
+                "href": "/artwork/kaws-boba-fett-companion-10",
+                "is_acquireable": true,
+                "is_price_range": false,
+                "price": "£6,325",
+                "price_currency": "GBP",
+                "title": "Boba Fett Companion",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/Vh612qcvwJYkw6YTjP9CvQ/larger.jpg",
+                  "__id": "5bfec8fbd820902a3aa4c879"
+                },
+                "meta": {
+                  "description": "Available for sale from Lougher Contemporary, KAWS, Boba Fett Companion (2013), Painted cast vinyl"
+                },
+                "partner": {
+                  "name": "Lougher Contemporary",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/7ylSt743QGUfBgeXg4_pdg/untouched-png.png",
+                      "__id": "5d8355d9445543000e3671a6"
+                    },
+                    "__id": "UHJvZmlsZTpsb3VnaGVyLWNvbnRlbXBvcmFyeQ=="
+                  },
+                  "locations": [
+                    {
+                      "address": "Trym Lodge",
+                      "address_2": "1 Henbury Road",
+                      "city": "Bristol",
+                      "state": "",
+                      "country": "GB",
+                      "postal_code": "BS9 3HQ",
+                      "phone": "+44 (0) 117 9596411",
+                      "__id": "TG9jYXRpb246NWE5NTdkYTQ5YzE4ZGI1MTU3NDNhZDA2"
+                    }
+                  ],
+                  "__id": "UGFydG5lcjpsb3VnaGVyLWNvbnRlbXBvcmFyeQ=="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLTQtZm9vdC1kaXNzZWN0ZWQtY29tcGFuaW9uLWJyb3du",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2009",
+                "href": "/artwork/kaws-4-foot-dissected-companion-brown",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "",
+                "price_currency": "USD",
+                "title": "4 Foot Dissected Companion (Brown)",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/U4GBoWFFwPhZ8_65MTUo7g/larger.jpg",
+                  "__id": "5ace9d6eb202a301c8c75de1"
+                },
+                "meta": {
+                  "description": "Available for sale from MSP Modern, KAWS, 4 Foot Dissected Companion (Brown) (2009), Cast vinyl resin"
+                },
+                "partner": {
+                  "name": "MSP Modern",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/KT0hkz64ZByxq4L8f23Fmw/square.jpg",
+                      "__id": "58126f672a893a03ec0002cb"
+                    },
+                    "__id": "UHJvZmlsZTptc3AtbW9kZXJu"
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjptc3AtbW9kZXJu"
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWNvbXBhbmlvbi1ibHVzaC1vcGVuLWVkaXRpb24tc2V0LW9mLTI=",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2017",
+                "href": "/artwork/kaws-companion-blush-open-edition-set-of-2",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "",
+                "price_currency": "USD",
+                "title": "COMPANION BLUSH (OPEN EDITION) - SET OF 2",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/XbgSZWPiKVjvNkvgMsUVcg/larger.jpg",
+                  "__id": "59d5c83ec9dc241974970fcd"
+                },
+                "meta": {
+                  "description": "Available for sale from Marcel Katz Art, KAWS, COMPANION BLUSH (OPEN EDITION) - SET OF 2 (2017), Vinyl, paint"
+                },
+                "partner": {
+                  "name": "Marcel Katz Art",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/7wl7e01dq5MNOIdUj1i8hA/untouched-png.png",
+                      "__id": "59ad9783b202a34d72db8c8e"
+                    },
+                    "__id": "UHJvZmlsZTptYXJjZWwta2F0ei1hcnQ="
+                  },
+                  "locations": [
+                    {
+                      "address": "18201 Collins Avenue",
+                      "address_2": "Unit 1504",
+                      "city": "Sunny Isles Beach",
+                      "state": "FL",
+                      "country": "US",
+                      "postal_code": "33160",
+                      "phone": null,
+                      "__id": "TG9jYXRpb246NTlhZDk4MDU4YjBjMTQ0OWZlYjM4YzIx"
+                    }
+                  ],
+                  "__id": "UGFydG5lcjptYXJjZWwta2F0ei1hcnQ="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXdvb2RzdG9jay04",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2012",
+                "href": "/artwork/kaws-woodstock-8",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "",
+                "price_currency": "USD",
+                "title": "Woodstock",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/1372C2GWivbxT_jH0Oj-Rg/larger.jpg",
+                  "__id": "584ec33ecd530e649e00018a"
+                },
+                "meta": {
+                  "description": "Available for sale from MSP Modern, KAWS, Woodstock (2012), Cast vinyl"
+                },
+                "partner": {
+                  "name": "MSP Modern",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/KT0hkz64ZByxq4L8f23Fmw/square.jpg",
+                      "__id": "58126f672a893a03ec0002cb"
+                    },
+                    "__id": "UHJvZmlsZTptc3AtbW9kZXJu"
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjptc3AtbW9kZXJu"
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXVudGl0bGVkLTM3Mg==",
+                "availability": "for sale",
+                "category": "Print",
+                "date": "1999",
+                "href": "/artwork/kaws-untitled-372",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "",
+                "price_currency": "USD",
+                "title": "Untitled ",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/We2oe6vGSNvM8vMfSfQU3Q/larger.jpg",
+                  "__id": "58f010da8b3b81249ca9a0d9"
+                },
+                "meta": {
+                  "description": "Available for sale from EHC Fine Art, KAWS, Untitled  (1999), Offset lithograph"
+                },
+                "partner": {
+                  "name": "EHC Fine Art",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/3N0GFFcAzzr0bXa1N_I46A/square140.png",
+                      "__id": "58e1a524cd530e4d612cb095"
+                    },
+                    "__id": "UHJvZmlsZTplaGMtZmluZS1hcnQ="
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjplaGMtZmluZS1hcnQ="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWthd3MtYmxhY2stY29tcGFuaW9uLTIwMTYtb3Blbi1lZGl0aW9u",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2016",
+                "href": "/artwork/kaws-kaws-black-companion-2016-open-edition",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "$1,000",
+                "price_currency": "USD",
+                "title": "KAWS \"Black Companion\" 2016 Open Edition",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/FJ8SXtPf0cHxfXX9l494rQ/larger.jpg",
+                  "__id": "585acf8cc9dc246107000755"
+                },
+                "meta": {
+                  "description": "Available for sale from Black Book Gallery, KAWS, KAWS \"Black Companion\" 2016 Open Edition (2016), Plastic/Resin"
+                },
+                "partner": {
+                  "name": "Black Book Gallery",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/3hwmKMsYijKVZCtu_Ffcfg/untouched-png.png",
+                      "__id": "55b7f1177261694002000184"
+                    },
+                    "__id": "UHJvZmlsZTpibGFja2Jvb2stZ2FsbGVyeQ=="
+                  },
+                  "locations": [
+                    {
+                      "address": "3878 S Jason St.",
+                      "address_2": "",
+                      "city": "Englewood",
+                      "state": "CO",
+                      "country": "US",
+                      "postal_code": "80110",
+                      "phone": "303-941-2458",
+                      "__id": "TG9jYXRpb246NTViN2I4Yjc3MjYxNjkwN2RmMDAwMDZi"
+                    }
+                  ],
+                  "__id": "UGFydG5lcjpibGFjay1ib29rLWdhbGxlcnk="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWJsYWNrLWZsYXllZC1jb21wYW5pb24tb3Blbi1lZGl0aW9uLTE=",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2016",
+                "href": "/artwork/kaws-black-flayed-companion-open-edition-1",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "",
+                "price_currency": "USD",
+                "title": "Black Flayed Companion Open Edition",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/KXFQf_kDuBKlUjYCFZZNAQ/larger.jpg",
+                  "__id": "59080a7b139b2141bf630fd1"
+                },
+                "meta": {
+                  "description": "Available for sale from EHC Fine Art, KAWS, Black Flayed Companion Open Edition (2016), Cast vinyl"
+                },
+                "partner": {
+                  "name": "EHC Fine Art",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/3N0GFFcAzzr0bXa1N_I46A/square140.png",
+                      "__id": "58e1a524cd530e4d612cb095"
+                    },
+                    "__id": "UHJvZmlsZTplaGMtZmluZS1hcnQ="
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjplaGMtZmluZS1hcnQ="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXRvZ2V0aGVyLWJyb3duLTE=",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2018",
+                "href": "/artwork/kaws-together-brown-1",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "$1,290",
+                "price_currency": "USD",
+                "title": "Together (Brown)",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/TTYP_VL_kTPIvKq7c6tKbg/larger.jpg",
+                  "__id": "5b3d88119c18db46dd8a136d"
+                },
+                "meta": {
+                  "description": "Available for sale from Dope! Gallery, KAWS, Together (Brown) (2018), Vinyl"
+                },
+                "partner": {
+                  "name": "Dope! Gallery",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/EmFB4qpTzlURNorf-bxknQ/untouched-png.png",
+                      "__id": "56124faf7261691a5f000522"
+                    },
+                    "__id": "UHJvZmlsZTpkb3BlLWdhbGxlcnk="
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjpkb3BlLWdhbGxlcnk="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXNtYWxsLWxpZS1jb21wbGV0ZS1zZXQtb2YtdGhyZWU=",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2017",
+                "href": "/artwork/kaws-small-lie-complete-set-of-three",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "Under £1,000",
+                "price_currency": "GBP",
+                "title": "Small Lie (Complete Set Of Three)",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/cNJHHg5fnEUIzYAEWsdJoA/larger.jpg",
+                  "__id": "5b69a938cb6560002339eefe"
+                },
+                "meta": {
+                  "description": "Available for sale from Lougher Contemporary, KAWS, Small Lie (Complete Set Of Three) (2017), Vinyl and Paint"
+                },
+                "partner": {
+                  "name": "Lougher Contemporary",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/7ylSt743QGUfBgeXg4_pdg/untouched-png.png",
+                      "__id": "5d8355d9445543000e3671a6"
+                    },
+                    "__id": "UHJvZmlsZTpsb3VnaGVyLWNvbnRlbXBvcmFyeQ=="
+                  },
+                  "locations": [
+                    {
+                      "address": "Trym Lodge",
+                      "address_2": "1 Henbury Road",
+                      "city": "Bristol",
+                      "state": "",
+                      "country": "GB",
+                      "postal_code": "BS9 3HQ",
+                      "phone": "+44 (0) 117 9596411",
+                      "__id": "TG9jYXRpb246NWE5NTdkYTQ5YzE4ZGI1MTU3NDNhZDA2"
+                    }
+                  ],
+                  "__id": "UGFydG5lcjpsb3VnaGVyLWNvbnRlbXBvcmFyeQ=="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWthd3MtYnJvd24tY29tcGFuaW9uLTIwMTY=",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2016",
+                "href": "/artwork/kaws-kaws-brown-companion-2016",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "$650",
+                "price_currency": "USD",
+                "title": "Kaws Brown Companion 2016",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/AuSruS7cRqAFOVCTtmhEHg/larger.jpg",
+                  "__id": "5cf83db3ca30760012f0f6cc"
+                },
+                "meta": {
+                  "description": "Available for sale from Lot 180, KAWS, Kaws Brown Companion 2016 (2016), Vinyl Cast Resin"
+                },
+                "partner": {
+                  "name": "Lot 180",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/nJUr53gOknXTMjF7QihPtw/untouched-png.png",
+                      "__id": "5babdac05c4afd7012b214fb"
+                    },
+                    "__id": "UHJvZmlsZTpsb3QtMTgw"
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjpsb3QtMTgw"
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXBpbm9jY2hpby0z",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2018",
+                "href": "/artwork/kaws-pinocchio-3",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "",
+                "price_currency": "USD",
+                "title": "Pinocchio",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/qu24dwWrXHfw5Z3e6KhXPQ/larger.jpg",
+                  "__id": "5b33f5fb9c18db46398bfa6c"
+                },
+                "meta": {
+                  "description": "Available for sale from IDEA, KAWS, Pinocchio (2018), Wood"
+                },
+                "partner": {
+                  "name": "IDEA",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/Z_abk4dwgmTK2veWziRYmQ/large.jpg",
+                      "__id": "58d2ef51cd530e4cb0551916"
+                    },
+                    "__id": "UHJvZmlsZTppZGVh"
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjppZGVhLTE="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXNlZWluZy13YXRjaGluZw==",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2018",
+                "href": "/artwork/kaws-seeing-watching",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "Under $1,000",
+                "price_currency": "USD",
+                "title": "SEEING WATCHING",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/YmIR6J_b3D7A6JAosmuUgA/larger.jpg",
+                  "__id": "5b09630a275b2464ae4b3614"
+                },
+                "meta": {
+                  "description": "Available for sale from Marcel Katz Art, KAWS, SEEING WATCHING (2018), Plush"
+                },
+                "partner": {
+                  "name": "Marcel Katz Art",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/7wl7e01dq5MNOIdUj1i8hA/untouched-png.png",
+                      "__id": "59ad9783b202a34d72db8c8e"
+                    },
+                    "__id": "UHJvZmlsZTptYXJjZWwta2F0ei1hcnQ="
+                  },
+                  "locations": [
+                    {
+                      "address": "18201 Collins Avenue",
+                      "address_2": "Unit 1504",
+                      "city": "Sunny Isles Beach",
+                      "state": "FL",
+                      "country": "US",
+                      "postal_code": "33160",
+                      "phone": null,
+                      "__id": "TG9jYXRpb246NTlhZDk4MDU4YjBjMTQ0OWZlYjM4YzIx"
+                    }
+                  ],
+                  "__id": "UGFydG5lcjptYXJjZWwta2F0ei1hcnQ="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLTQtZnQtY29tcGFuaW9uLXdpdGgtYm94LWFuZC1ob2xvZ3JhbQ==",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2007",
+                "href": "/artwork/kaws-4-ft-companion-with-box-and-hologram",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "",
+                "price_currency": "USD",
+                "title": "4 Ft Companion (with box and hologram)",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/TNrubN2rbSkaRJGxnu4uFA/larger.jpg",
+                  "__id": "5ba2f7e5196e630027ffe39c"
+                },
+                "meta": {
+                  "description": "Available for sale from MSP Modern, KAWS, 4 Ft Companion (with box and hologram) (2007), Cast vinyl resin"
+                },
+                "partner": {
+                  "name": "MSP Modern",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/KT0hkz64ZByxq4L8f23Fmw/square.jpg",
+                      "__id": "58126f672a893a03ec0002cb"
+                    },
+                    "__id": "UHJvZmlsZTptc3AtbW9kZXJu"
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjptc3AtbW9kZXJu"
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXRvZ2V0aGVyLWJsYWNrLTE=",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2018",
+                "href": "/artwork/kaws-together-black-1",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "$1,300",
+                "price_currency": "USD",
+                "title": "Together Black",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/PUFz_OjJ-JPaJACdsr1Z7Q/larger.jpg",
+                  "__id": "5b21c399a09a674544434a80"
+                },
+                "meta": {
+                  "description": "Available for sale from Marcel Katz Art, KAWS, Together Black (2018), Vinyl"
+                },
+                "partner": {
+                  "name": "Marcel Katz Art",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/7wl7e01dq5MNOIdUj1i8hA/untouched-png.png",
+                      "__id": "59ad9783b202a34d72db8c8e"
+                    },
+                    "__id": "UHJvZmlsZTptYXJjZWwta2F0ei1hcnQ="
+                  },
+                  "locations": [
+                    {
+                      "address": "18201 Collins Avenue",
+                      "address_2": "Unit 1504",
+                      "city": "Sunny Isles Beach",
+                      "state": "FL",
+                      "country": "US",
+                      "postal_code": "33160",
+                      "phone": null,
+                      "__id": "TG9jYXRpb246NTlhZDk4MDU4YjBjMTQ0OWZlYjM4YzIx"
+                    }
+                  ],
+                  "__id": "UGFydG5lcjptYXJjZWwta2F0ei1hcnQ="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWJvYmEtZmV0dC1jb21wYW5pb24=",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2013",
+                "href": "/artwork/kaws-boba-fett-companion",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "",
+                "price_currency": "USD",
+                "title": "Boba Fett Companion",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/GEJ3-RY2I6rmo8JbuuCQkw/larger.jpg",
+                  "__id": "575a099b139b216b8a00021a"
+                },
+                "meta": {
+                  "description": "Available for sale from Julien's Auctions, KAWS, Boba Fett Companion (2013), Painted cast vinyl"
+                },
+                "partner": {
+                  "name": "Julien's Auctions",
+                  "type": "Auction House",
+                  "profile": null,
+                  "locations": [],
+                  "__id": "UGFydG5lcjpqdWxpZW5zLWF1Y3Rpb25z"
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWhvbGlkYXktc2V0LW9mLTMtMQ==",
+                "availability": "for sale",
+                "category": "Textile Arts",
+                "date": "2019",
+                "href": "/artwork/kaws-holiday-set-of-3-1",
+                "is_acquireable": true,
+                "is_price_range": false,
+                "price": "$3,000",
+                "price_currency": "USD",
+                "title": "Holiday Set of 3",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/hFd-xFdXhOFF85HBJa0zzw/larger.jpg",
+                  "__id": "5cdef8ffd9b0661e37ce52f2"
+                },
+                "meta": {
+                  "description": "Available for sale from New Union Gallery, KAWS, Holiday Set of 3 (2019), Plush"
+                },
+                "partner": {
+                  "name": "New Union Gallery",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/KHdGZw0vCfTneDQBZlBDCw/square.jpg",
+                      "__id": "5c2f06432e7cdf6a4b455c73"
+                    },
+                    "__id": "UHJvZmlsZTpuZXctdW5pb24tZ2FsbGVyeQ=="
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjpuZXctdW5pb24tZ2FsbGVyeQ=="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXRvZ2V0aGVyLWdyZXktMQ==",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2018",
+                "href": "/artwork/kaws-together-grey-1",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "$990",
+                "price_currency": "USD",
+                "title": "Together (Grey)",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/M_SOoP7eBHjuLf866XIu7Q/larger.jpg",
+                  "__id": "5b3d85b27622dd1349f706ee"
+                },
+                "meta": {
+                  "description": "Available for sale from Dope! Gallery, KAWS, Together (Grey) (2018)"
+                },
+                "partner": {
+                  "name": "Dope! Gallery",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/EmFB4qpTzlURNorf-bxknQ/untouched-png.png",
+                      "__id": "56124faf7261691a5f000522"
+                    },
+                    "__id": "UHJvZmlsZTpkb3BlLWdhbGxlcnk="
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjpkb3BlLWdhbGxlcnk="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXBhc3NpbmctdGhyb3VnaC1ncmV5LTE=",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2013",
+                "href": "/artwork/kaws-passing-through-grey-1",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "$3,400",
+                "price_currency": "USD",
+                "title": "Passing Through (Grey) ",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/Z84jgLZMNuJxUzO-rgZH1w/larger.jpg",
+                  "__id": "58ebea598b3b8133919f4e50"
+                },
+                "meta": {
+                  "description": "Available for sale from Galerie C.O.A, KAWS, Passing Through (Grey)  (2013), Cast vinyl"
+                },
+                "partner": {
+                  "name": "Galerie C.O.A",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/sTZBIuQCT_WNaCi_qHjcXw/square.jpg",
+                      "__id": "5728fcceb202a321df0003fd"
+                    },
+                    "__id": "UHJvZmlsZTpnYWxlcmllLWNvYQ=="
+                  },
+                  "locations": [
+                    {
+                      "address": "6405 St-Laurent",
+                      "address_2": "",
+                      "city": "Montreal",
+                      "state": "QC",
+                      "country": "CA",
+                      "postal_code": "",
+                      "phone": null,
+                      "__id": "TG9jYXRpb246NTcxZjdlZGUyNzViMjQ2ZTRiMDA1NDJm"
+                    }
+                  ],
+                  "__id": "UGFydG5lcjpnYWxlcmllLWNvYQ=="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLW5vLWZ1dHVyZS1jb21wYW5pb24tc2lsdmVyLWNocm9tZS01",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2008",
+                "href": "/artwork/kaws-no-future-companion-silver-chrome-5",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "",
+                "price_currency": "USD",
+                "title": "No Future Companion (Silver Chrome)",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/P0KeZt18ZO1E-vKuOvQUHg/larger.jpg",
+                  "__id": "5acc6298b202a313b86659da"
+                },
+                "meta": {
+                  "description": "Available for sale from MSP Modern, KAWS, No Future Companion (Silver Chrome) (2008), Polished chrome"
+                },
+                "partner": {
+                  "name": "MSP Modern",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/KT0hkz64ZByxq4L8f23Fmw/square.jpg",
+                      "__id": "58126f672a893a03ec0002cb"
+                    },
+                    "__id": "UHJvZmlsZTptc3AtbW9kZXJu"
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjptc3AtbW9kZXJu"
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWhvbGlkYXktY29tcGFuaW9uLWZsb2F0aW5nLWJlZA==",
+                "availability": "for sale",
+                "category": "Other",
+                "date": "2018",
+                "href": "/artwork/kaws-holiday-companion-floating-bed",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "$350",
+                "price_currency": "USD",
+                "title": "Holiday Companion Floating Bed",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/lc2FTCfjWIVizWSfnDDjGg/larger.jpg",
+                  "__id": "5b63f597e6b6c466df9491a4"
+                },
+                "meta": {
+                  "description": "Available for sale from Dope! Gallery, KAWS, Holiday Companion Floating Bed (2018), PVC"
+                },
+                "partner": {
+                  "name": "Dope! Gallery",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/EmFB4qpTzlURNorf-bxknQ/untouched-png.png",
+                      "__id": "56124faf7261691a5f000522"
+                    },
+                    "__id": "UHJvZmlsZTpkb3BlLWdhbGxlcnk="
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjpkb3BlLWdhbGxlcnk="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWdyZXktZmxheWVkLWNvbXBhbmlvbi0yMDE2LW9wZW4tZWRpdGlvbg==",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2016",
+                "href": "/artwork/kaws-grey-flayed-companion-2016-open-edition",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "$1,200",
+                "price_currency": "USD",
+                "title": "Grey Flayed Companion 2016 Open Edition",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/HMKwnB8hZm_c2uI2FxXNXw/larger.jpg",
+                  "__id": "587025b1a09a67566a002edc"
+                },
+                "meta": {
+                  "description": "Available for sale from Black Book Gallery, KAWS, Grey Flayed Companion 2016 Open Edition (2016), Plastic/Resin"
+                },
+                "partner": {
+                  "name": "Black Book Gallery",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/3hwmKMsYijKVZCtu_Ffcfg/untouched-png.png",
+                      "__id": "55b7f1177261694002000184"
+                    },
+                    "__id": "UHJvZmlsZTpibGFja2Jvb2stZ2FsbGVyeQ=="
+                  },
+                  "locations": [
+                    {
+                      "address": "3878 S Jason St.",
+                      "address_2": "",
+                      "city": "Englewood",
+                      "state": "CO",
+                      "country": "US",
+                      "postal_code": "80110",
+                      "phone": "303-941-2458",
+                      "__id": "TG9jYXRpb246NTViN2I4Yjc3MjYxNjkwN2RmMDAwMDZi"
+                    }
+                  ],
+                  "__id": "UGFydG5lcjpibGFjay1ib29rLWdhbGxlcnk="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWthd3MtY29tcGFuaW9uLW9wZW4tZWRpdGlvbi1zZXQtb2YtNg==",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2016",
+                "href": "/artwork/kaws-kaws-companion-open-edition-set-of-6",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "£3,000",
+                "price_currency": "GBP",
+                "title": "Kaws Companion (Open Edition) - Set of 6",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/GLRzJwHwSZcKEpLREw8uag/larger.jpg",
+                  "__id": "596f863fc9dc2451b95c38b7"
+                },
+                "meta": {
+                  "description": "Available for sale from Reem Gallery, KAWS, Kaws Companion (Open Edition) - Set of 6 (2016), Vinyl figures"
+                },
+                "partner": {
+                  "name": "Reem Gallery",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/3eRfTOlDBI3RJ3BtpUHVjw/untouched-png.png",
+                      "__id": "571f5739139b2127a000499e"
+                    },
+                    "__id": "UHJvZmlsZTpyZWVtLWdhbGxlcnk="
+                  },
+                  "locations": [
+                    {
+                      "address": "4 Mason's Yard",
+                      "address_2": "St. James's",
+                      "city": "London",
+                      "state": "",
+                      "country": "GB",
+                      "postal_code": "SW1Y 6JF",
+                      "phone": null,
+                      "__id": "TG9jYXRpb246NWJiZjI5ZTUwNzU3ZWExYjFiMDE2ODBj"
+                    }
+                  ],
+                  "__id": "UGFydG5lcjpyZWVtLWdhbGxlcnk="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWthd3MtYWxvbmctdGhlLXdheS1jb21wbGV0ZS1zZXQtb2YtMw==",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2019",
+                "href": "/artwork/kaws-kaws-along-the-way-complete-set-of-3",
+                "is_acquireable": true,
+                "is_price_range": false,
+                "price": "$2,800",
+                "price_currency": "USD",
+                "title": "KAWS Along The Way Complete Set of 3 ",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/_WKftu2nTtQsQmd7-VREqQ/larger.jpg",
+                  "__id": "5d15c60e02c4fd0011847539"
+                },
+                "meta": {
+                  "description": "Available for sale from Lot 180, KAWS, KAWS Along The Way Complete Set of 3  (2019), Cast Resin, Painted Vinyl"
+                },
+                "partner": {
+                  "name": "Lot 180",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/nJUr53gOknXTMjF7QihPtw/untouched-png.png",
+                      "__id": "5babdac05c4afd7012b214fb"
+                    },
+                    "__id": "UHJvZmlsZTpsb3QtMTgw"
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjpsb3QtMTgw"
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWNvbXBhbmlvbi1icm93bi1mbGF5ZWQtb3Blbi1lZGl0aW9u",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2016",
+                "href": "/artwork/kaws-companion-brown-flayed-open-edition",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "$650",
+                "price_currency": "USD",
+                "title": "COMPANION BROWN (FLAYED) (OPEN EDITION)",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/RFWH6hud1-aw2QR5-8a-nA/larger.jpg",
+                  "__id": "59cdddec2a893a388d5d779d"
+                },
+                "meta": {
+                  "description": "Available for sale from Marcel Katz Art, KAWS, COMPANION BROWN (FLAYED) (OPEN EDITION) (2016), Vinyl"
+                },
+                "partner": {
+                  "name": "Marcel Katz Art",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/7wl7e01dq5MNOIdUj1i8hA/untouched-png.png",
+                      "__id": "59ad9783b202a34d72db8c8e"
+                    },
+                    "__id": "UHJvZmlsZTptYXJjZWwta2F0ei1hcnQ="
+                  },
+                  "locations": [
+                    {
+                      "address": "18201 Collins Avenue",
+                      "address_2": "Unit 1504",
+                      "city": "Sunny Isles Beach",
+                      "state": "FL",
+                      "country": "US",
+                      "postal_code": "33160",
+                      "phone": null,
+                      "__id": "TG9jYXRpb246NTlhZDk4MDU4YjBjMTQ0OWZlYjM4YzIx"
+                    }
+                  ],
+                  "__id": "UGFydG5lcjptYXJjZWwta2F0ei1hcnQ="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWNvbXBhbmlvbi1ibHVzaC1mbGF5ZWQtb3Blbi1lZGl0aW9u",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2017",
+                "href": "/artwork/kaws-companion-blush-flayed-open-edition",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "$420",
+                "price_currency": "USD",
+                "title": "COMPANION BLUSH (FLAYED) (OPEN EDITION)",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/_ktznsDfwK51vMpo-ZTC2w/larger.jpg",
+                  "__id": "59d5c8408b3b81391654d91e"
+                },
+                "meta": {
+                  "description": "Available for sale from Marcel Katz Art, KAWS, COMPANION BLUSH (FLAYED) (OPEN EDITION) (2017), Vinyl, paint"
+                },
+                "partner": {
+                  "name": "Marcel Katz Art",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/7wl7e01dq5MNOIdUj1i8hA/untouched-png.png",
+                      "__id": "59ad9783b202a34d72db8c8e"
+                    },
+                    "__id": "UHJvZmlsZTptYXJjZWwta2F0ei1hcnQ="
+                  },
+                  "locations": [
+                    {
+                      "address": "18201 Collins Avenue",
+                      "address_2": "Unit 1504",
+                      "city": "Sunny Isles Beach",
+                      "state": "FL",
+                      "country": "US",
+                      "postal_code": "33160",
+                      "phone": null,
+                      "__id": "TG9jYXRpb246NTlhZDk4MDU4YjBjMTQ0OWZlYjM4YzIx"
+                    }
+                  ],
+                  "__id": "UGFydG5lcjptYXJjZWwta2F0ei1hcnQ="
+                }
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXR3ZWV0eS0x",
+                "availability": "for sale",
+                "category": "Sculpture",
+                "date": "2010",
+                "href": "/artwork/kaws-tweety-1",
+                "is_acquireable": false,
+                "is_price_range": false,
+                "price": "$2,990",
+                "price_currency": "USD",
+                "title": "Tweety",
+                "artists": [
+                  {
+                    "name": "KAWS",
+                    "__id": "QXJ0aXN0Omthd3M="
+                  }
+                ],
+                "image": {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/BuFOJEBAqGgXabGv8ptFdw/larger.jpg",
+                  "__id": "59a915978b3b813d7ce3fd6a"
+                },
+                "meta": {
+                  "description": "Available for sale from Dope! Gallery, KAWS, Tweety (2010), Vinyl"
+                },
+                "partner": {
+                  "name": "Dope! Gallery",
+                  "type": "Gallery",
+                  "profile": {
+                    "icon": {
+                      "url": "https://d32dm0rphc51dk.cloudfront.net/EmFB4qpTzlURNorf-bxknQ/untouched-png.png",
+                      "__id": "56124faf7261691a5f000522"
+                    },
+                    "__id": "UHJvZmlsZTpkb3BlLWdhbGxlcnk="
+                  },
+                  "locations": [],
+                  "__id": "UGFydG5lcjpkb3BlLWdhbGxlcnk="
+                }
+              }
+            }
+          ]
+        },
+        "aggregations": [
+          {
+            "slice": "MEDIUM",
+            "counts": [
+              {
+                "id": "sculpture",
+                "name": "Sculpture",
+                "count": 321,
+                "__id": "QWdncmVnYXRpb25Db3VudDpzY3VscHR1cmU="
+              },
+              {
+                "id": "prints",
+                "name": "Prints",
+                "count": 24,
+                "__id": "QWdncmVnYXRpb25Db3VudDpwcmludHM="
+              },
+              {
+                "id": "design",
+                "name": "Design",
+                "count": 15,
+                "__id": "QWdncmVnYXRpb25Db3VudDpkZXNpZ24="
+              },
+              {
+                "id": "painting",
+                "name": "Painting",
+                "count": 7,
+                "__id": "QWdncmVnYXRpb25Db3VudDpwYWludGluZw=="
+              }
+            ]
+          },
+          {
+            "slice": "MAJOR_PERIOD",
+            "counts": [
+              {
+                "id": "2010",
+                "name": "2010",
+                "count": 369,
+                "__id": "QWdncmVnYXRpb25Db3VudDoyMDEw"
+              },
+              {
+                "id": "2000",
+                "name": "2000",
+                "count": 164,
+                "__id": "QWdncmVnYXRpb25Db3VudDoyMDAw"
+              },
+              {
+                "id": "1990",
+                "name": "1990",
+                "count": 20,
+                "__id": "QWdncmVnYXRpb25Db3VudDoxOTkw"
+              }
+            ]
+          },
+          {
+            "slice": "MERCHANDISABLE_ARTISTS",
+            "counts": [
+              {
+                "id": "4e934002e340fa0001005336",
+                "name": "KAWS",
+                "count": 578,
+                "__id": "QWdncmVnYXRpb25Db3VudDo0ZTkzNDAwMmUzNDBmYTAwMDEwMDUzMzY="
+              },
+              {
+                "id": "58fe85ee275b2450a0fd2b51",
+                "name": "Medicom",
+                "count": 3,
+                "__id": "QWdncmVnYXRpb25Db3VudDo1OGZlODVlZTI3NWIyNDUwYTBmZDJiNTE="
+              },
+              {
+                "id": "4f5f64c23b555230ac0003ae",
+                "name": "Robert Lazzarini",
+                "count": 2,
+                "__id": "QWdncmVnYXRpb25Db3VudDo0ZjVmNjRjMjNiNTU1MjMwYWMwMDAzYWU="
+              },
+              {
+                "id": "51951ec60cfd96ac75000332",
+                "name": "Hajime Sorayama",
+                "count": 1,
+                "__id": "QWdncmVnYXRpb25Db3VudDo1MTk1MWVjNjBjZmQ5NmFjNzUwMDAzMzI="
+              },
+              {
+                "id": "5bd9ff5d1f79d672bb7011d9",
+                "name": "Medicom Toy",
+                "count": 1,
+                "__id": "QWdncmVnYXRpb25Db3VudDo1YmQ5ZmY1ZDFmNzlkNjcyYmI3MDExZDk="
+              }
+            ]
+          }
+        ]
+      },
+      "filtered_artworks": {
+        "__id": "RmlsdGVyQXJ0d29ya3M6eyJhZ2dyZWdhdGlvbnMiOlsibWVyY2hhbmRpc2FibGVfYXJ0aXN0cyIsIm1lZGl1bSIsIm1ham9yX3BlcmlvZCIsInRvdGFsIl0sImFydGlzdF9pZHMiOltdLCJnZW5lX2lkcyI6W10sInNvcnQiOiItZGVjYXllZF9tZXJjaCIsInRhZ19pZCI6ImNvbXBhbmlvbiIsImtleXdvcmRfbWF0Y2hfZXhhY3QiOmZhbHNlfQ==",
+        "aggregations": [
+          {
+            "slice": "MEDIUM",
+            "counts": [
+              {
+                "id": "sculpture",
+                "name": "Sculpture",
+                "count": 321,
+                "__id": "QWdncmVnYXRpb25Db3VudDpzY3VscHR1cmU="
+              },
+              {
+                "id": "prints",
+                "name": "Prints",
+                "count": 24,
+                "__id": "QWdncmVnYXRpb25Db3VudDpwcmludHM="
+              },
+              {
+                "id": "design",
+                "name": "Design",
+                "count": 15,
+                "__id": "QWdncmVnYXRpb25Db3VudDpkZXNpZ24="
+              },
+              {
+                "id": "painting",
+                "name": "Painting",
+                "count": 7,
+                "__id": "QWdncmVnYXRpb25Db3VudDpwYWludGluZw=="
+              }
+            ]
+          },
+          {
+            "slice": "MAJOR_PERIOD",
+            "counts": [
+              {
+                "id": "2010",
+                "name": "2010",
+                "count": 369,
+                "__id": "QWdncmVnYXRpb25Db3VudDoyMDEw"
+              },
+              {
+                "id": "2000",
+                "name": "2000",
+                "count": 164,
+                "__id": "QWdncmVnYXRpb25Db3VudDoyMDAw"
+              },
+              {
+                "id": "1990",
+                "name": "1990",
+                "count": 20,
+                "__id": "QWdncmVnYXRpb25Db3VudDoxOTkw"
+              }
+            ]
+          },
+          {
+            "slice": "MERCHANDISABLE_ARTISTS",
+            "counts": [
+              {
+                "id": "4e934002e340fa0001005336",
+                "name": "KAWS",
+                "count": 578,
+                "__id": "QWdncmVnYXRpb25Db3VudDo0ZTkzNDAwMmUzNDBmYTAwMDEwMDUzMzY="
+              },
+              {
+                "id": "58fe85ee275b2450a0fd2b51",
+                "name": "Medicom",
+                "count": 3,
+                "__id": "QWdncmVnYXRpb25Db3VudDo1OGZlODVlZTI3NWIyNDUwYTBmZDJiNTE="
+              },
+              {
+                "id": "4f5f64c23b555230ac0003ae",
+                "name": "Robert Lazzarini",
+                "count": 2,
+                "__id": "QWdncmVnYXRpb25Db3VudDo0ZjVmNjRjMjNiNTU1MjMwYWMwMDAzYWU="
+              },
+              {
+                "id": "51951ec60cfd96ac75000332",
+                "name": "Hajime Sorayama",
+                "count": 1,
+                "__id": "QWdncmVnYXRpb25Db3VudDo1MTk1MWVjNjBjZmQ5NmFjNzUwMDAzMzI="
+              },
+              {
+                "id": "5bd9ff5d1f79d672bb7011d9",
+                "name": "Medicom Toy",
+                "count": 1,
+                "__id": "QWdncmVnYXRpb25Db3VudDo1YmQ5ZmY1ZDFmNzlkNjcyYmI3MDExZDk="
+              }
+            ]
+          }
+        ],
+        "artworks": {
+          "pageInfo": {
+            "hasNextPage": true,
+            "endCursor": "YXJyYXljb25uZWN0aW9uOjI5"
+          },
+          "pageCursors": {
+            "around": [
+              {
+                "cursor": "YXJyYXljb25uZWN0aW9uOi0x",
+                "page": 1,
+                "isCurrent": true
+              },
+              {
+                "cursor": "YXJyYXljb25uZWN0aW9uOjI5",
+                "page": 2,
+                "isCurrent": false
+              },
+              {
+                "cursor": "YXJyYXljb25uZWN0aW9uOjU5",
+                "page": 3,
+                "isCurrent": false
+              },
+              {
+                "cursor": "YXJyYXljb25uZWN0aW9uOjg5",
+                "page": 4,
+                "isCurrent": false
+              }
+            ],
+            "first": null,
+            "last": {
+              "cursor": "YXJyYXljb25uZWN0aW9uOjU2OQ==",
+              "page": 20,
+              "isCurrent": false
+            },
+            "previous": null
+          },
+          "edges": [
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWthd3MteC1iZS1hdC1yYnJpY2stZGlzc2VjdGVkLWNvbXBhbmlvbi00MDAtcGVyY2VudC1hbmQtMTAwLXBlcmNlbnQtdHdvLXdvcmtz",
+                "id": "kaws-kaws-x-be-at-rbrick-dissected-companion-400-percent-and-100-percent-two-works",
+                "href": "/artwork/kaws-kaws-x-be-at-rbrick-dissected-companion-400-percent-and-100-percent-two-works",
+                "image": {
+                  "aspect_ratio": 0.87,
+                  "__id": "5d704fa30f056a000e8546c7",
+                  "placeholder": "115.52346570397111%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/AqIUxe69SL6dNmFSF7XgDg/large.jpg"
+                },
+                "_id": "5d704fa2c637350012dfba67",
+                "title": "KAWS X BE@RBRICK Dissected Companion 400% and 100% (two works)",
+                "image_title": "KAWS, ‘KAWS X BE@RBRICK Dissected Companion 400% and 100% (two works)’, 2010",
+                "date": "2010",
+                "sale_message": "$4,850",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "5ART GALLERY",
+                  "href": "/5art-gallery",
+                  "__id": "UGFydG5lcjo1YXJ0LWdhbGxlcnk=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": false,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": true,
+                "is_offerable": true
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLW5vLWZ1dHVyZS1jb21wYW5pb24tY29sbGFib3JhdGlvbi13aXRoLWhhamltZS1zb3JheWFtYS1ibGFjay1jaHJvbWU=",
+                "id": "kaws-no-future-companion-collaboration-with-hajime-sorayama-black-chrome",
+                "href": "/artwork/kaws-no-future-companion-collaboration-with-hajime-sorayama-black-chrome",
+                "image": {
+                  "aspect_ratio": 0.91,
+                  "__id": "5acc6297c9dc247dcc317da6",
+                  "placeholder": "110.4253544620517%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/RFC1iwT6hq1QFwrLevkiEw/large.jpg"
+                },
+                "_id": "5acc62968b3b8136f479b13b",
+                "title": "No Future Companion  collaboration with Hajime Sorayama (Black Chrome)",
+                "image_title": "KAWS, ‘No Future Companion  collaboration with Hajime Sorayama (Black Chrome)’",
+                "date": "",
+                "sale_message": "Contact For Price",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "MSP Modern",
+                  "href": "/msp-modern",
+                  "__id": "UGFydG5lcjptc3AtbW9kZXJu",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXNtYWxsLWxpZS01",
+                "id": "kaws-small-lie-5",
+                "href": "/artwork/kaws-small-lie-5",
+                "image": {
+                  "aspect_ratio": 0.53,
+                  "__id": "5d1274d642f72b000e330313",
+                  "placeholder": "187.5%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/9IfyjiZvrCelAnYFjFd2tQ/large.jpg"
+                },
+                "_id": "5cdb55e424b8ea2110aa76a8",
+                "title": "SMALL LIE",
+                "image_title": "KAWS, ‘SMALL LIE’, 2017",
+                "date": "2017",
+                "sale_message": "$1,000",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Silverback Gallery",
+                  "href": "/silverback-gallery",
+                  "__id": "UGFydG5lcjpzaWx2ZXJiYWNrLWdhbGxlcnk=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": false,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWdyZXktY29tcGFuaW9uLTIwMTYtb3Blbi1lZGl0aW9u",
+                "id": "kaws-grey-companion-2016-open-edition",
+                "href": "/artwork/kaws-grey-companion-2016-open-edition",
+                "image": {
+                  "aspect_ratio": 0.67,
+                  "__id": "586c13229c18db52e5005c34",
+                  "placeholder": "149.79195561719834%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/AnNB8gHH4xZnLcJSS4cNpw/large.jpg"
+                },
+                "_id": "586c1321c9dc2445ea00580c",
+                "title": "Grey Companion 2016 Open Edition",
+                "image_title": "KAWS, ‘Grey Companion 2016 Open Edition’, 2016",
+                "date": "2016",
+                "sale_message": "$1,000",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Black Book Gallery",
+                  "href": "/blackbook-gallery",
+                  "__id": "UGFydG5lcjpibGFjay1ib29rLWdhbGxlcnk=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWJvYmEtZmV0dC1jb21wYW5pb24tMTA=",
+                "id": "kaws-boba-fett-companion-10",
+                "href": "/artwork/kaws-boba-fett-companion-10",
+                "image": {
+                  "aspect_ratio": 0.92,
+                  "__id": "5bfec8fbd820902a3aa4c879",
+                  "placeholder": "109.18032786885246%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/Vh612qcvwJYkw6YTjP9CvQ/large.jpg"
+                },
+                "_id": "5a9dcba2cd530e487b0391ae",
+                "title": "Boba Fett Companion",
+                "image_title": "KAWS, ‘Boba Fett Companion’, 2013",
+                "date": "2013",
+                "sale_message": "£6,325",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Lougher Contemporary",
+                  "href": "/lougher-contemporary",
+                  "__id": "UGFydG5lcjpsb3VnaGVyLWNvbnRlbXBvcmFyeQ==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": false,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": true,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLTQtZm9vdC1kaXNzZWN0ZWQtY29tcGFuaW9uLWJyb3du",
+                "id": "kaws-4-foot-dissected-companion-brown",
+                "href": "/artwork/kaws-4-foot-dissected-companion-brown",
+                "image": {
+                  "aspect_ratio": 0.45,
+                  "__id": "5ace9d6eb202a301c8c75de1",
+                  "placeholder": "222.6086956521739%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/U4GBoWFFwPhZ8_65MTUo7g/large.jpg"
+                },
+                "_id": "5ace9d6dc9dc2404e5b135a4",
+                "title": "4 Foot Dissected Companion (Brown)",
+                "image_title": "KAWS, ‘4 Foot Dissected Companion (Brown)’, 2009",
+                "date": "2009",
+                "sale_message": "Contact For Price",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "MSP Modern",
+                  "href": "/msp-modern",
+                  "__id": "UGFydG5lcjptc3AtbW9kZXJu",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWNvbXBhbmlvbi1ibHVzaC1vcGVuLWVkaXRpb24tc2V0LW9mLTI=",
+                "id": "kaws-companion-blush-open-edition-set-of-2",
+                "href": "/artwork/kaws-companion-blush-open-edition-set-of-2",
+                "image": {
+                  "aspect_ratio": 1.5,
+                  "__id": "59d5c83ec9dc241974970fcd",
+                  "placeholder": "66.64098613251156%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/XbgSZWPiKVjvNkvgMsUVcg/large.jpg"
+                },
+                "_id": "59d5c83d9c18db0eba89124a",
+                "title": "COMPANION BLUSH (OPEN EDITION) - SET OF 2",
+                "image_title": "KAWS, ‘COMPANION BLUSH (OPEN EDITION) - SET OF 2’, 2017",
+                "date": "2017",
+                "sale_message": "Contact For Price",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Marcel Katz Art",
+                  "href": "/marcel-katz-art",
+                  "__id": "UGFydG5lcjptYXJjZWwta2F0ei1hcnQ=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXdvb2RzdG9jay04",
+                "id": "kaws-woodstock-8",
+                "href": "/artwork/kaws-woodstock-8",
+                "image": {
+                  "aspect_ratio": 0.79,
+                  "__id": "584ec33ecd530e649e00018a",
+                  "placeholder": "126.66666666666666%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/1372C2GWivbxT_jH0Oj-Rg/large.jpg"
+                },
+                "_id": "584ec33ca09a676a9600147e",
+                "title": "Woodstock",
+                "image_title": "KAWS, ‘Woodstock’, 2012",
+                "date": "2012",
+                "sale_message": "Contact For Price",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "MSP Modern",
+                  "href": "/msp-modern",
+                  "__id": "UGFydG5lcjptc3AtbW9kZXJu",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXVudGl0bGVkLTM3Mg==",
+                "id": "kaws-untitled-372",
+                "href": "/artwork/kaws-untitled-372",
+                "image": {
+                  "aspect_ratio": 0.71,
+                  "__id": "58f010da8b3b81249ca9a0d9",
+                  "placeholder": "140.0462962962963%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/We2oe6vGSNvM8vMfSfQU3Q/large.jpg"
+                },
+                "_id": "58f010da139b211274821bb2",
+                "title": "Untitled ",
+                "image_title": "KAWS, ‘Untitled ’, 1999",
+                "date": "1999",
+                "sale_message": "Contact For Price",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "EHC Fine Art",
+                  "href": "/ehc-fine-art",
+                  "__id": "UGFydG5lcjplaGMtZmluZS1hcnQ=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWthd3MtYmxhY2stY29tcGFuaW9uLTIwMTYtb3Blbi1lZGl0aW9u",
+                "id": "kaws-kaws-black-companion-2016-open-edition",
+                "href": "/artwork/kaws-kaws-black-companion-2016-open-edition",
+                "image": {
+                  "aspect_ratio": 0.67,
+                  "__id": "585acf8cc9dc246107000755",
+                  "placeholder": "149.79195561719834%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/FJ8SXtPf0cHxfXX9l494rQ/large.jpg"
+                },
+                "_id": "585acf889c18db6ca20007b4",
+                "title": "KAWS \"Black Companion\" 2016 Open Edition",
+                "image_title": "KAWS, ‘KAWS \"Black Companion\" 2016 Open Edition’, 2016",
+                "date": "2016",
+                "sale_message": "$1,000",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Black Book Gallery",
+                  "href": "/blackbook-gallery",
+                  "__id": "UGFydG5lcjpibGFjay1ib29rLWdhbGxlcnk=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWJsYWNrLWZsYXllZC1jb21wYW5pb24tb3Blbi1lZGl0aW9uLTE=",
+                "id": "kaws-black-flayed-companion-open-edition-1",
+                "href": "/artwork/kaws-black-flayed-companion-open-edition-1",
+                "image": {
+                  "aspect_ratio": 0.67,
+                  "__id": "59080a7b139b2141bf630fd1",
+                  "placeholder": "149.53095684803003%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/KXFQf_kDuBKlUjYCFZZNAQ/large.jpg"
+                },
+                "_id": "59080a7a275b245e99bf7a09",
+                "title": "Black Flayed Companion Open Edition",
+                "image_title": "KAWS, ‘Black Flayed Companion Open Edition’, 2016",
+                "date": "2016",
+                "sale_message": "Contact For Price",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "EHC Fine Art",
+                  "href": "/ehc-fine-art",
+                  "__id": "UGFydG5lcjplaGMtZmluZS1hcnQ=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXRvZ2V0aGVyLWJyb3duLTE=",
+                "id": "kaws-together-brown-1",
+                "href": "/artwork/kaws-together-brown-1",
+                "image": {
+                  "aspect_ratio": 1.4,
+                  "__id": "5b3d88119c18db46dd8a136d",
+                  "placeholder": "71.42857142857143%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/TTYP_VL_kTPIvKq7c6tKbg/large.jpg"
+                },
+                "_id": "5b3d880dc9dc245c12cd9a7e",
+                "title": "Together (Brown)",
+                "image_title": "KAWS, ‘Together (Brown)’, 2018",
+                "date": "2018",
+                "sale_message": "$1,290",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Dope! Gallery",
+                  "href": "/dope-gallery",
+                  "__id": "UGFydG5lcjpkb3BlLWdhbGxlcnk=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXNtYWxsLWxpZS1jb21wbGV0ZS1zZXQtb2YtdGhyZWU=",
+                "id": "kaws-small-lie-complete-set-of-three",
+                "href": "/artwork/kaws-small-lie-complete-set-of-three",
+                "image": {
+                  "aspect_ratio": 1.33,
+                  "__id": "5b69a938cb6560002339eefe",
+                  "placeholder": "74.94692144373673%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/cNJHHg5fnEUIzYAEWsdJoA/large.jpg"
+                },
+                "_id": "5b69a93794715800225072de",
+                "title": "Small Lie (Complete Set Of Three)",
+                "image_title": "KAWS, ‘Small Lie (Complete Set Of Three)’, 2017",
+                "date": "2017",
+                "sale_message": "Under £1,000",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Lougher Contemporary",
+                  "href": "/lougher-contemporary",
+                  "__id": "UGFydG5lcjpsb3VnaGVyLWNvbnRlbXBvcmFyeQ==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWthd3MtYnJvd24tY29tcGFuaW9uLTIwMTY=",
+                "id": "kaws-kaws-brown-companion-2016",
+                "href": "/artwork/kaws-kaws-brown-companion-2016",
+                "image": {
+                  "aspect_ratio": 0.85,
+                  "__id": "5cf83db3ca30760012f0f6cc",
+                  "placeholder": "117.50881316098707%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/AuSruS7cRqAFOVCTtmhEHg/large.jpg"
+                },
+                "_id": "5be1ec30b4d1d9002a4dd034",
+                "title": "Kaws Brown Companion 2016",
+                "image_title": "KAWS, ‘Kaws Brown Companion 2016’, 2016",
+                "date": "2016",
+                "sale_message": "$650",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Lot 180",
+                  "href": "/lot-180",
+                  "__id": "UGFydG5lcjpsb3QtMTgw",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXBpbm9jY2hpby0z",
+                "id": "kaws-pinocchio-3",
+                "href": "/artwork/kaws-pinocchio-3",
+                "image": {
+                  "aspect_ratio": 0.67,
+                  "__id": "5b33f5fb9c18db46398bfa6c",
+                  "placeholder": "150%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/qu24dwWrXHfw5Z3e6KhXPQ/large.jpg"
+                },
+                "_id": "5b33f5fa139b2110e3393f17",
+                "title": "Pinocchio",
+                "image_title": "KAWS, ‘Pinocchio’, 2018",
+                "date": "2018",
+                "sale_message": "Contact For Price",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "IDEA",
+                  "href": "/idea",
+                  "__id": "UGFydG5lcjppZGVhLTE=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXNlZWluZy13YXRjaGluZw==",
+                "id": "kaws-seeing-watching",
+                "href": "/artwork/kaws-seeing-watching",
+                "image": {
+                  "aspect_ratio": 1.5,
+                  "__id": "5b09630a275b2464ae4b3614",
+                  "placeholder": "66.7%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/YmIR6J_b3D7A6JAosmuUgA/large.jpg"
+                },
+                "_id": "5b096309cd530e163f52d60a",
+                "title": "SEEING WATCHING",
+                "image_title": "KAWS, ‘SEEING WATCHING’, 2018",
+                "date": "2018",
+                "sale_message": "Under $1,000",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Marcel Katz Art",
+                  "href": "/marcel-katz-art",
+                  "__id": "UGFydG5lcjptYXJjZWwta2F0ei1hcnQ=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLTQtZnQtY29tcGFuaW9uLXdpdGgtYm94LWFuZC1ob2xvZ3JhbQ==",
+                "id": "kaws-4-ft-companion-with-box-and-hologram",
+                "href": "/artwork/kaws-4-ft-companion-with-box-and-hologram",
+                "image": {
+                  "aspect_ratio": 1,
+                  "__id": "5ba2f7e5196e630027ffe39c",
+                  "placeholder": "100%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/TNrubN2rbSkaRJGxnu4uFA/large.jpg"
+                },
+                "_id": "5ba2f7e46b58c8002aed587c",
+                "title": "4 Ft Companion (with box and hologram)",
+                "image_title": "KAWS, ‘4 Ft Companion (with box and hologram)’, 2007",
+                "date": "2007",
+                "sale_message": "Contact For Price",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "MSP Modern",
+                  "href": "/msp-modern",
+                  "__id": "UGFydG5lcjptc3AtbW9kZXJu",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXRvZ2V0aGVyLWJsYWNrLTE=",
+                "id": "kaws-together-black-1",
+                "href": "/artwork/kaws-together-black-1",
+                "image": {
+                  "aspect_ratio": 1.4,
+                  "__id": "5b21c399a09a674544434a80",
+                  "placeholder": "71.42857142857143%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/PUFz_OjJ-JPaJACdsr1Z7Q/large.jpg"
+                },
+                "_id": "5b21c3968b3b813153ef1a15",
+                "title": "Together Black",
+                "image_title": "KAWS, ‘Together Black’, 2018",
+                "date": "2018",
+                "sale_message": "$1,300",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Marcel Katz Art",
+                  "href": "/marcel-katz-art",
+                  "__id": "UGFydG5lcjptYXJjZWwta2F0ei1hcnQ=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWJvYmEtZmV0dC1jb21wYW5pb24=",
+                "id": "kaws-boba-fett-companion",
+                "href": "/artwork/kaws-boba-fett-companion",
+                "image": {
+                  "aspect_ratio": 0.65,
+                  "__id": "575a099b139b216b8a00021a",
+                  "placeholder": "154.63917525773198%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/GEJ3-RY2I6rmo8JbuuCQkw/large.jpg"
+                },
+                "_id": "575a099bb202a32c570001e8",
+                "title": "Boba Fett Companion",
+                "image_title": "KAWS, ‘Boba Fett Companion’, 2013",
+                "date": "2013",
+                "sale_message": "Contact For Price",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Julien's Auctions",
+                  "href": "/auction/juliens-auctions",
+                  "__id": "UGFydG5lcjpqdWxpZW5zLWF1Y3Rpb25z",
+                  "type": "Auction House"
+                },
+                "sale": {
+                  "is_auction": true,
+                  "is_closed": true,
+                  "__id": "U2FsZTpqdWxpZW5zLWF1Y3Rpb25zLXN0cmVldC1hcnQtbm93LWlp",
+                  "is_live_open": false,
+                  "is_open": false,
+                  "is_preview": false,
+                  "display_timely_at": "ends in 3Y"
+                },
+                "sale_artwork": {
+                  "counts": {
+                    "bidder_positions": 6
+                  },
+                  "highest_bid": {
+                    "display": "$3,250",
+                    "__id": "5769b786ebad64166a000050"
+                  },
+                  "opening_bid": {
+                    "display": "$500"
+                  },
+                  "__id": "U2FsZUFydHdvcms6a2F3cy1ib2JhLWZldHQtY29tcGFuaW9u"
+                },
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWhvbGlkYXktc2V0LW9mLTMtMQ==",
+                "id": "kaws-holiday-set-of-3-1",
+                "href": "/artwork/kaws-holiday-set-of-3-1",
+                "image": {
+                  "aspect_ratio": 1.4,
+                  "__id": "5cdef8ffd9b0661e37ce52f2",
+                  "placeholder": "71.42857142857143%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/hFd-xFdXhOFF85HBJa0zzw/large.jpg"
+                },
+                "_id": "5cdef8feda364a0505e29812",
+                "title": "Holiday Set of 3",
+                "image_title": "KAWS, ‘Holiday Set of 3’, 2019",
+                "date": "2019",
+                "sale_message": "$3,000",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "New Union Gallery",
+                  "href": "/new-union-gallery",
+                  "__id": "UGFydG5lcjpuZXctdW5pb24tZ2FsbGVyeQ==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": false,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": true,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXRvZ2V0aGVyLWdyZXktMQ==",
+                "id": "kaws-together-grey-1",
+                "href": "/artwork/kaws-together-grey-1",
+                "image": {
+                  "aspect_ratio": 1.4,
+                  "__id": "5b3d85b27622dd1349f706ee",
+                  "placeholder": "71.42857142857143%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/M_SOoP7eBHjuLf866XIu7Q/large.jpg"
+                },
+                "_id": "5b39f7cdc9dc24777d10ae48",
+                "title": "Together (Grey)",
+                "image_title": "KAWS, ‘Together (Grey)’, 2018",
+                "date": "2018",
+                "sale_message": "$990",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Dope! Gallery",
+                  "href": "/dope-gallery",
+                  "__id": "UGFydG5lcjpkb3BlLWdhbGxlcnk=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXBhc3NpbmctdGhyb3VnaC1ncmV5LTE=",
+                "id": "kaws-passing-through-grey-1",
+                "href": "/artwork/kaws-passing-through-grey-1",
+                "image": {
+                  "aspect_ratio": 0.72,
+                  "__id": "58ebea598b3b8133919f4e50",
+                  "placeholder": "138.77551020408163%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/Z84jgLZMNuJxUzO-rgZH1w/large.jpg"
+                },
+                "_id": "58ebea58cd530e0770a5aa4c",
+                "title": "Passing Through (Grey) ",
+                "image_title": "KAWS, ‘Passing Through (Grey) ’, 2013",
+                "date": "2013",
+                "sale_message": "$3,400",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Galerie C.O.A",
+                  "href": "/galerie-coa",
+                  "__id": "UGFydG5lcjpnYWxlcmllLWNvYQ==",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLW5vLWZ1dHVyZS1jb21wYW5pb24tc2lsdmVyLWNocm9tZS01",
+                "id": "kaws-no-future-companion-silver-chrome-5",
+                "href": "/artwork/kaws-no-future-companion-silver-chrome-5",
+                "image": {
+                  "aspect_ratio": 1.14,
+                  "__id": "5acc6298b202a313b86659da",
+                  "placeholder": "88.1%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/P0KeZt18ZO1E-vKuOvQUHg/large.jpg"
+                },
+                "_id": "5acc6297a09a672192e9e221",
+                "title": "No Future Companion (Silver Chrome)",
+                "image_title": "KAWS, ‘No Future Companion (Silver Chrome)’, 2008",
+                "date": "2008",
+                "sale_message": "Contact For Price",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "MSP Modern",
+                  "href": "/msp-modern",
+                  "__id": "UGFydG5lcjptc3AtbW9kZXJu",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWhvbGlkYXktY29tcGFuaW9uLWZsb2F0aW5nLWJlZA==",
+                "id": "kaws-holiday-companion-floating-bed",
+                "href": "/artwork/kaws-holiday-companion-floating-bed",
+                "image": {
+                  "aspect_ratio": 1.36,
+                  "__id": "5b63f597e6b6c466df9491a4",
+                  "placeholder": "73.6328125%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/lc2FTCfjWIVizWSfnDDjGg/large.jpg"
+                },
+                "_id": "5b63f5944f0ac3504c5d2b1c",
+                "title": "Holiday Companion Floating Bed",
+                "image_title": "KAWS, ‘Holiday Companion Floating Bed’, 2018",
+                "date": "2018",
+                "sale_message": "$350",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Dope! Gallery",
+                  "href": "/dope-gallery",
+                  "__id": "UGFydG5lcjpkb3BlLWdhbGxlcnk=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWdyZXktZmxheWVkLWNvbXBhbmlvbi0yMDE2LW9wZW4tZWRpdGlvbg==",
+                "id": "kaws-grey-flayed-companion-2016-open-edition",
+                "href": "/artwork/kaws-grey-flayed-companion-2016-open-edition",
+                "image": {
+                  "aspect_ratio": 0.67,
+                  "__id": "587025b1a09a67566a002edc",
+                  "placeholder": "149.79195561719834%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/HMKwnB8hZm_c2uI2FxXNXw/large.jpg"
+                },
+                "_id": "587025af9c18db5923002fa5",
+                "title": "Grey Flayed Companion 2016 Open Edition",
+                "image_title": "KAWS, ‘Grey Flayed Companion 2016 Open Edition’, 2016",
+                "date": "2016",
+                "sale_message": "$1,200",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Black Book Gallery",
+                  "href": "/blackbook-gallery",
+                  "__id": "UGFydG5lcjpibGFjay1ib29rLWdhbGxlcnk=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWthd3MtY29tcGFuaW9uLW9wZW4tZWRpdGlvbi1zZXQtb2YtNg==",
+                "id": "kaws-kaws-companion-open-edition-set-of-6",
+                "href": "/artwork/kaws-kaws-companion-open-edition-set-of-6",
+                "image": {
+                  "aspect_ratio": 1,
+                  "__id": "596f863fc9dc2451b95c38b7",
+                  "placeholder": "100%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/GLRzJwHwSZcKEpLREw8uag/large.jpg"
+                },
+                "_id": "596f863dc9dc2450d101c5ad",
+                "title": "Kaws Companion (Open Edition) - Set of 6",
+                "image_title": "KAWS, ‘Kaws Companion (Open Edition) - Set of 6’, 2016",
+                "date": "2016",
+                "sale_message": "£3,000",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Reem Gallery",
+                  "href": "/reem-gallery",
+                  "__id": "UGFydG5lcjpyZWVtLWdhbGxlcnk=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWthd3MtYWxvbmctdGhlLXdheS1jb21wbGV0ZS1zZXQtb2YtMw==",
+                "id": "kaws-kaws-along-the-way-complete-set-of-3",
+                "href": "/artwork/kaws-kaws-along-the-way-complete-set-of-3",
+                "image": {
+                  "aspect_ratio": 1,
+                  "__id": "5d15c60e02c4fd0011847539",
+                  "placeholder": "100%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/_WKftu2nTtQsQmd7-VREqQ/large.jpg"
+                },
+                "_id": "5cc8c54784ba07251416c6e1",
+                "title": "KAWS Along The Way Complete Set of 3 ",
+                "image_title": "KAWS, ‘KAWS Along The Way Complete Set of 3 ’, 2019",
+                "date": "2019",
+                "sale_message": "$2,800",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Lot 180",
+                  "href": "/lot-180",
+                  "__id": "UGFydG5lcjpsb3QtMTgw",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": false,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": true,
+                "is_offerable": true
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWNvbXBhbmlvbi1icm93bi1mbGF5ZWQtb3Blbi1lZGl0aW9u",
+                "id": "kaws-companion-brown-flayed-open-edition",
+                "href": "/artwork/kaws-companion-brown-flayed-open-edition",
+                "image": {
+                  "aspect_ratio": 0.67,
+                  "__id": "59cdddec2a893a388d5d779d",
+                  "placeholder": "149.79195561719834%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/RFWH6hud1-aw2QR5-8a-nA/large.jpg"
+                },
+                "_id": "59cddde8a09a6763c63ea6bf",
+                "title": "COMPANION BROWN (FLAYED) (OPEN EDITION)",
+                "image_title": "KAWS, ‘COMPANION BROWN (FLAYED) (OPEN EDITION)’, 2016",
+                "date": "2016",
+                "sale_message": "$650",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Marcel Katz Art",
+                  "href": "/marcel-katz-art",
+                  "__id": "UGFydG5lcjptYXJjZWwta2F0ei1hcnQ=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLWNvbXBhbmlvbi1ibHVzaC1mbGF5ZWQtb3Blbi1lZGl0aW9u",
+                "id": "kaws-companion-blush-flayed-open-edition",
+                "href": "/artwork/kaws-companion-blush-flayed-open-edition",
+                "image": {
+                  "aspect_ratio": 0.79,
+                  "__id": "59d5c8408b3b81391654d91e",
+                  "placeholder": "127.35849056603774%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/_ktznsDfwK51vMpo-ZTC2w/large.jpg"
+                },
+                "_id": "59d5c83f275b244ef74b9aad",
+                "title": "COMPANION BLUSH (FLAYED) (OPEN EDITION)",
+                "image_title": "KAWS, ‘COMPANION BLUSH (FLAYED) (OPEN EDITION)’, 2017",
+                "date": "2017",
+                "sale_message": "$420",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Marcel Katz Art",
+                  "href": "/marcel-katz-art",
+                  "__id": "UGFydG5lcjptYXJjZWwta2F0ei1hcnQ=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            },
+            {
+              "node": {
+                "__id": "QXJ0d29yazprYXdzLXR3ZWV0eS0x",
+                "id": "kaws-tweety-1",
+                "href": "/artwork/kaws-tweety-1",
+                "image": {
+                  "aspect_ratio": 0.73,
+                  "__id": "59a915978b3b813d7ce3fd6a",
+                  "placeholder": "137.63440860215056%",
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/BuFOJEBAqGgXabGv8ptFdw/large.jpg"
+                },
+                "_id": "59a915939c18db6bf09cce24",
+                "title": "Tweety",
+                "image_title": "KAWS, ‘Tweety’, 2010",
+                "date": "2010",
+                "sale_message": "$2,990",
+                "cultural_maker": null,
+                "artists": [
+                  {
+                    "__id": "QXJ0aXN0Omthd3M=",
+                    "href": "/artist/kaws",
+                    "name": "KAWS"
+                  }
+                ],
+                "collecting_institution": null,
+                "partner": {
+                  "name": "Dope! Gallery",
+                  "href": "/dope-gallery",
+                  "__id": "UGFydG5lcjpkb3BlLWdhbGxlcnk=",
+                  "type": "Gallery"
+                },
+                "sale": null,
+                "sale_artwork": null,
+                "is_inquireable": true,
+                "is_saved": false,
+                "is_biddable": false,
+                "is_acquireable": false,
+                "is_offerable": false
+              }
+            }
+          ]
+        }
+      },
+      "__id": "5bcf4e518ef6ac2e05f0eb97"
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to https://github.com/artsy/force/pull/4614

This re-enables an integration test which was broken by https://github.com/artsy/reaction/pull/2845

There's interest in moving smoke tests like this over to https://github.com/artsy/integrity, but in the meantime I didn't want to lose coverage about the collection app being wired up correctly.

See further discussion in https://artsy.slack.com/archives/C2TQ4PT8R/p1570211335035500
