### PR TITLE
[Scripts] Update create_review_app.sh script

### DIFF
--- a/scripts/build_review_app.sh
+++ b/scripts/build_review_app.sh
@@ -73,8 +73,15 @@ hokusai review_app env copy $NAME --configmap nginx-config --verbose
 # authentication requests won't work!
 hokusai review_app env set $NAME \
   APP_URL="https://$NAME.artsy.net" \
+  APPLICATION_NAME="$NAME" \
   COOKIE_DOMAIN="$NAME.artsy.net" \
   FORCE_URL="https://$NAME.artsy.net"
+
+# Publish Force assets to S3
+hokusai review_app run $NAME 'yarn publish-assets'
+
+# Refresh ENV
+hokusai review_app refresh $NAME
 
 # Now you need to create a CNAME for your review app and wait. This is required
 # as Gravity only allows authentication requests from requests of originating


### PR DESCRIPTION
Updates the review app script with two changes: 
- `hokusai review_app env set $NAME APPLICATION_NAME="$NAME"`: This sets the app name to something other than `force-staging` so that the purple staging banner UI doesn't appear, impacting the QA process
- `hokusai review_app run $NAME 'yarn publish-assets'`, which publish JS / CSS assets to S3