### PR TITLE
Always load in stripe.js

### DIFF
--- a/src/desktop/components/main_layout/templates/scripts.jade
+++ b/src/desktop/components/main_layout/templates/scripts.jade
@@ -121,6 +121,8 @@ if sharify
 //- Stripe
 if options.stripev3
   script(id="stripe-js", src="https://js.stripe.com/v3/")
+else
+  script(id="stripe-js", src="https://js.stripe.com/v3/", async defer)
 
 //- Analytics & common asset package
 if sd.BROWSER && sd.BROWSER.family != 'Other'


### PR DESCRIPTION
Fixes [PURCHASE-1376](https://artsyproduct.atlassian.net/browse/PURCHASE-1376).

On pages where stripe isn't specifically required, it still loads in stripe but with the async and defer tags. 

Here's a good sort of overview of those tags: 
https://flaviocopes.com/javascript-async-defer/#performance-comparison

Essentially it'll be loaded in as a non-blocking resource. We're loading this in, because stripe uses it to enhance the data provided by stripe radar to have a better idea if something is fraud or not. 