### PR TITLE
[Bugfix] Check if headersSent before performing operation

### DIFF
--- a/src/desktop/components/split_test/server_split_test.coffee
+++ b/src/desktop/components/split_test/server_split_test.coffee
@@ -5,7 +5,8 @@ module.exports = class ServerSplitTest extends SplitTest
     super test
 
   set: (outcome) ->
-    @res.cookie @_key(), outcome, expires: new Date(Date.now() + 31536000000)
+    if !@res.headersSent
+      @res.cookie @_key(), outcome, expires: new Date(Date.now() + 31536000000)
     outcome
 
   get: ->

--- a/src/lib/middleware/same_origin.coffee
+++ b/src/lib/middleware/same_origin.coffee
@@ -3,5 +3,7 @@
 #
 
 module.exports = (req, res, next) ->
-  res.set('X-Frame-Options', 'SAMEORIGIN')
+  if !res.headersSent
+    res.set('X-Frame-Options', 'SAMEORIGIN')
+
   next()


### PR DESCRIPTION
Addresses 
- https://sentry.io/organizations/artsynet/issues/1061782931/?project=28316&query=is%3Aunresolved+headers&statsPeriod=14d
- https://sentry.io/organizations/artsynet/issues/912360189/?project=28316&query=is%3Aunresolved+headers&statsPeriod=14d

This adds a guard to check against headers being sent before performing the operation, via express [`res.headersSent`](https://expressjs.com/en/api.html#res.headersSent) property. Curious if there might be a need to check this in the next JS runloop via `setImmediate`, but we should know pretty quickly once the error is closed since it happens so often. 