### PR TITLE
@damassi => [Middleware] Guard via headersSent in HSTS

### DIFF
--- a/src/lib/middleware/hsts.coffee
+++ b/src/lib/middleware/hsts.coffee
@@ -10,5 +10,5 @@
 module.exports = (req, res, next) ->
   protocol = req.get('X-Forwarded-Proto') or req.protocol
   if protocol is 'https' and parse(APP_URL).protocol is 'https:'
-    res.set('Strict-Transport-Security', 'max-age=31536000')
+    res.set('Strict-Transport-Security', 'max-age=31536000') unless res.headersSent
   next()


### PR DESCRIPTION
After https://github.com/artsy/force/pull/4652/files was deployed, the big flood of errors from the split test middleware have subsided.

A much lower than that (but still pretty high) rate w/ a different stack trace has shown up: https://sentry.io/organizations/artsynet/issues/1079185890/?project=28316&query=is%3Aunresolved. This stack trace mentions `dd-trace` (not sure if that's a red herring).

This adds the `headersSent` guard in one other place in the middleware I noticed.