### PR TITLE
Add route for seo artist title sitemap

### DIFF
--- a/src/desktop/apps/sitemaps/index.coffee
+++ b/src/desktop/apps/sitemaps/index.coffee
@@ -10,6 +10,7 @@ app.get '/robots.txt', routes.robots
 app.get ['/sitemap-articles.xml', '/sitemap-articles-:timestamp.xml'], routes.sitemaps
 app.get ['/sitemap-artists.xml', '/sitemap-artists-:timestamp.xml'], routes.sitemaps
 app.get ['/sitemap-artist-images.xml', '/sitemap-artist-images-:slug.xml'], routes.sitemaps
+app.get ['/sitemap-artist-titles.xml'], routes.sitemaps
 app.get ['/sitemap-artworks.xml', '/sitemap-artworks-:timestamp.xml'], routes.sitemaps
 app.get '/sitemap-cities.xml', routes.sitemaps
 app.get '/sitemap-collect.xml', routes.sitemaps

--- a/src/desktop/apps/sitemaps/routes.coffee
+++ b/src/desktop/apps/sitemaps/routes.coffee
@@ -51,6 +51,7 @@ getFullEditorialHref = require("@artsy/reaction/dist/Components/Publishing/Const
     Sitemap: #{APP_URL}/sitemap-articles.xml
     Sitemap: #{APP_URL}/sitemap-artists.xml
     Sitemap: #{APP_URL}/sitemap-artist-images.xml
+    Sitemap: #{APP_URL}/sitemap-artist-titles.xml
     Sitemap: #{APP_URL}/sitemap-artworks.xml
     Sitemap: #{APP_URL}/sitemap-cities.xml
     Sitemap: #{APP_URL}/sitemap-collect.xml

--- a/src/desktop/apps/sitemaps/test/routes.test.coffee
+++ b/src/desktop/apps/sitemaps/test/routes.test.coffee
@@ -49,6 +49,7 @@ Disallow: /search
 Sitemap: https://www.artsy.net/sitemap-articles.xml
 Sitemap: https://www.artsy.net/sitemap-artists.xml
 Sitemap: https://www.artsy.net/sitemap-artist-images.xml
+Sitemap: https://www.artsy.net/sitemap-artist-titles.xml
 Sitemap: https://www.artsy.net/sitemap-artworks.xml
 Sitemap: https://www.artsy.net/sitemap-cities.xml
 Sitemap: https://www.artsy.net/sitemap-collect.xml


### PR DESCRIPTION
This PR handles adding an `https://artsy.net` pre-fixed route for the artist titles uploaded to S3 for SEO title tag test in: [GROW-1373](https://artsyproduct.atlassian.net/browse/GROW-1373).

<img width="705" alt="Screen Shot 2019-10-10 at 4 57 07 PM" src="https://user-images.githubusercontent.com/10385964/66581004-9f730500-eb7f-11e9-9fb9-149cd685c202.png">


