### PR TITLE
Grow- 1407 Editorial RSS feed broken

### DIFF
--- a/src/desktop/apps/rss/routes.js
+++ b/src/desktop/apps/rss/routes.js
@@ -13,7 +13,9 @@ let request = _request
 let positronql = _positronql
 
 export const news = (req, res, next) => {
-  const query = { query: newsQuery }
+  const query = {
+    query: newsQuery,
+  }
   return positronql(query)
     .then(async result => {
       try {
@@ -27,7 +29,10 @@ export const news = (req, res, next) => {
           articlesWithoutUnpublishedVideos
         )
         res.set("Content-Type", "application/rss+xml")
-        return res.render("news", { articles, pretty: true })
+        return res.render("news", {
+          articles,
+          pretty: true,
+        })
       } catch (err) {
         console.error(err)
       }
@@ -46,7 +51,10 @@ export const partnerUpdates = (req, res, next) =>
     error: res.backboneError,
     success: articles => {
       res.set("Content-Type", "application/rss+xml")
-      return res.render("partner_updates", { articles, pretty: true })
+      return res.render("partner_updates", {
+        articles,
+        pretty: true,
+      })
     },
   })
 
@@ -80,10 +88,11 @@ export const findSocialEmbeds = article => {
 
 export const maybeFetchSocialEmbed = section => {
   return new Promise((resolve, reject) => {
-    if (section.type !== "social_embed") {
+    const type = section && section.type
+    if (type !== "social_embed") {
       return resolve(section)
     } else {
-      const { url } = section
+      const url = section && section.url
       const service = url.includes("twitter")
         ? "publish.twitter"
         : "api.instagram"

--- a/src/desktop/apps/rss/test/routes.test.js
+++ b/src/desktop/apps/rss/test/routes.test.js
@@ -55,7 +55,9 @@ describe("Routes", () => {
       },
     })
 
-    routes.__set__("sd", { ARTSY_EDITORIAL_CHANNEL: "foo" })
+    routes.__set__("sd", {
+      ARTSY_EDITORIAL_CHANNEL: "foo",
+    })
     routes.__set__("request", request)
     routes.__set__("positronql", sinon.stub().returns(Promise.resolve(results)))
 
@@ -111,7 +113,11 @@ describe("Routes", () => {
 
       routes.__set__(
         "positronql",
-        sinon.stub().returns(Promise.resolve({ articles: articlesWithVideo }))
+        sinon.stub().returns(
+          Promise.resolve({
+            articles: articlesWithVideo,
+          })
+        )
       )
 
       const findArticlesWithEmbedsStub = sinon.stub()
@@ -166,6 +172,13 @@ describe("Routes", () => {
       request.get.args[0][0].should.eql(
         "https://api.instagram.com/oembed?url=https://www.instagram.com/p/Bh-Az5_gaVB/?taken-by=artsy"
       )
+    })
+
+    it("This case is about fetching the undefined data", async () => {
+      section = undefined
+      const newSection = await routes.maybeFetchSocialEmbed(section)
+      const result = newSection === undefined
+      result.should.be.true()
     })
   })
 })


### PR DESCRIPTION
**Address : [Grow - 1407](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-1407) and [Error reprot in the Sentry](https://sentry.io/organizations/artsynet/issues/1048230498/?project=28316&referrer=slack)**

This PR is going to do:

Using the guard operator to prevent us to have an undefined value, 

then there are NO errors that will be reported from the Sentry. 

(The error from Sentry`Cannot read property 'type' of undefined`)

