### PR TITLE
[bundle] Drop cheerio dep from common bundle

### DIFF
--- a/src/desktop/apps/article/__tests__/routes.jest.ts
+++ b/src/desktop/apps/article/__tests__/routes.jest.ts
@@ -385,47 +385,72 @@ describe("Article Routes", () => {
           },
         ],
       })
-      Article.prototype.fetchWithRelated.mockImplementationOnce(options => {
-        options.success({ article: new Article(article) })
-      })
       routes.amp(req, res, next)
       expect(next).toBeCalled()
     })
 
     it("skips if it isnt featured", () => {
       article.featured = false
-      Article.prototype.fetchWithRelated.mockImplementationOnce(options => {
-        options.success({ article: new Article(article) })
-      })
       routes.amp(req, res, next)
       expect(next).toBeCalled()
     })
 
     it("skips if it is series", () => {
       article.layout = "series"
-      Article.prototype.fetchWithRelated.mockImplementationOnce(options => {
-        options.success({ article: new Article(article) })
-      })
       routes.amp(req, res, next)
       expect(next).toBeCalled()
     })
 
     it("skips if it is video", () => {
       article.layout = "video"
-      Article.prototype.fetchWithRelated.mockImplementationOnce(options => {
-        options.success({ article: new Article(article) })
-      })
       routes.amp(req, res, next)
       expect(next).toBeCalled()
     })
 
     it("redirects to the main slug if an older slug is queried", () => {
       article.slug = "zoobar"
-      Article.prototype.fetchWithRelated.mockImplementationOnce(options => {
-        options.success({ article: new Article(article) })
-      })
       routes.amp(req, res, next)
       expect(res.redirect).toBeCalledWith("/article/zoobar/amp")
+    })
+
+    it("preps article for AMP", () => {
+      article.layout = "standard"
+      article.sections = [
+        {
+          type: "text",
+          body:
+            '<a class="jump-link"></a><p>Preparing the article for AMP.</p>',
+        },
+        {
+          type: "image_collection",
+          images: [
+            {
+              type: "image",
+              caption:
+                '<p isrender=true style="background-color:black;">A caption is <i isrender=true>really</i> important</p>',
+            },
+          ],
+        },
+      ]
+      routes.amp(req, res, next)
+      expect(res.render.mock.calls[0][1].article.get("sections"))
+        .toMatchInlineSnapshot(`
+Array [
+  Object {
+    "body": "<p>Preparing the article for AMP.</p>",
+    "type": "text",
+  },
+  Object {
+    "images": Array [
+      Object {
+        "caption": "<p>A caption is <i>really</i> important</p>",
+        "type": "image",
+      },
+    ],
+    "type": "image_collection",
+  },
+]
+`)
     })
   })
 

--- a/src/desktop/apps/articles/test/routes.test.js
+++ b/src/desktop/apps/articles/test/routes.test.js
@@ -146,24 +146,5 @@ describe("Articles routes", () => {
       res.render.args[0][0].should.equal("team_channel")
       res.render.args[0][1].channel.get("name").should.equal(channel.name)
     })
-
-    it.todo("preps article for AMP")
-    // it 'preps article for AMP', ->
-    //   @article.set sections: [
-    //     {
-    //       type: 'text',
-    //       body: '<a class="jump-link"></a><p>Preparing the article for AMP.</p>'
-    //     }
-    //     {
-    //       type: 'image_collection'
-    //       images: [
-    //         type: 'image'
-    //         caption: '<p isrender=true style="background-color:black;">A caption is <i isrender=true>really</i> important</p>'
-    //       ]
-    //     }
-    //   ]
-    //   @article.prepForAMP()
-    //   @article.get('sections')[0].body.should.not.containEql '<a class="jump-link></a>"'
-    //   @article.get('sections')[1].images[0].caption.should.equal '<p>A caption is <i>really</i> important</p>'
   })
 })

--- a/src/desktop/apps/articles/test/routes.test.js
+++ b/src/desktop/apps/articles/test/routes.test.js
@@ -6,12 +6,11 @@ import { extend, cloneDeep } from "lodash"
 import { JSDOM } from "jsdom"
 
 const jsdom = new JSDOM("<!doctype html><html><body></body></html>")
-const { window } = jsdom
-global.Node = window.Node
-global.DOMParser = window.DOMParser
+global.Node = jsdom.window.Node
+global.DOMParser = jsdom.window.DOMParser
 
 const rewire = require("rewire")("../routes")
-const { articles, news, section, teamChannel } = rewire
+const { articles, section, teamChannel } = rewire
 
 describe("Articles routes", () => {
   let req
@@ -147,5 +146,24 @@ describe("Articles routes", () => {
       res.render.args[0][0].should.equal("team_channel")
       res.render.args[0][1].channel.get("name").should.equal(channel.name)
     })
+
+    it.todo("preps article for AMP")
+    // it 'preps article for AMP', ->
+    //   @article.set sections: [
+    //     {
+    //       type: 'text',
+    //       body: '<a class="jump-link"></a><p>Preparing the article for AMP.</p>'
+    //     }
+    //     {
+    //       type: 'image_collection'
+    //       images: [
+    //         type: 'image'
+    //         caption: '<p isrender=true style="background-color:black;">A caption is <i isrender=true>really</i> important</p>'
+    //       ]
+    //     }
+    //   ]
+    //   @article.prepForAMP()
+    //   @article.get('sections')[0].body.should.not.containEql '<a class="jump-link></a>"'
+    //   @article.get('sections')[1].images[0].caption.should.equal '<p>A caption is <i>really</i> important</p>'
   })
 })

--- a/src/desktop/models/article.coffee
+++ b/src/desktop/models/article.coffee
@@ -14,7 +14,6 @@ Channel = require '../models/channel.coffee'
 Relations = require './mixins/relations/article.coffee'
 { stripTags } = require 'underscore.string'
 { compactObject } = require './mixins/compact_object.coffee'
-cheerio = require 'cheerio'
 
 module.exports = class Article extends Backbone.Model
   _.extend @prototype, Relations
@@ -193,31 +192,6 @@ module.exports = class Article extends Backbone.Model
     subArticles.length > 0 and
     not @get('is_super_article') and
     superArticle?.id is sd.EOY_2016_ARTICLE
-
-  prepForAMP: ->
-    sections =  _.map @get('sections'), (section) ->
-      if section.type is 'text'
-        $ = cheerio.load(section.body)
-        $('a:empty').remove()
-        $('p').each ->
-          $(this).removeAttr 'isrender'
-        section.body = $.html()
-        section
-      else if section.type in ['image_set', 'image_collection']
-        section.images = _.map section.images, (image) ->
-          if image.type is 'image' and image.caption
-            $ = cheerio.load(image.caption)
-            $('p, i').each ->
-              $(this).removeAttr 'isrender'
-              $(this).removeAttr 'style'
-            image.caption = $.html()
-            image
-          else
-            image
-        section
-      else
-        section
-    @set 'sections', sections
 
   hasAMP: ->
     isValidLayout = @get('layout') in ['standard', 'feature', 'news']

--- a/src/desktop/test/models/article.test.coffee
+++ b/src/desktop/test/models/article.test.coffee
@@ -9,6 +9,11 @@ sinon = require 'sinon'
 fixtures = require '../helpers/fixtures'
 moment = require 'moment'
 momentTimezone = require 'moment-timezone'
+{ JSDOM } = require 'jsdom'
+
+jsdom = new JSDOM("<!doctype html><html><body></body></html>")
+global.Node = jsdom.window.Node
+global.DOMParser = jsdom.window.DOMParse
 
 describe "Article", ->
   beforeEach ->
@@ -340,7 +345,7 @@ describe "Article", ->
         published: true
         layout: 'series'
       @article.hasAMP().should.be.false()
-    
+
     it 'returns false if article is a video', ->
       @article.set
         sections: [ type: 'text' ]
@@ -348,24 +353,6 @@ describe "Article", ->
         published: true
         layout: 'video'
       @article.hasAMP().should.be.false()
-
-    it 'preps article for AMP', ->
-      @article.set sections: [
-        {
-          type: 'text',
-          body: '<a class="jump-link"></a><p>Preparing the article for AMP.</p>'
-        }
-        {
-          type: 'image_collection'
-          images: [
-            type: 'image'
-            caption: '<p isrender=true style="background-color:black;">A caption is <i isrender=true>really</i> important</p>'
-          ]
-        }
-      ]
-      @article.prepForAMP()
-      @article.get('sections')[0].body.should.not.containEql '<a class="jump-link></a>"'
-      @article.get('sections')[1].images[0].caption.should.equal '<p>A caption is <i>really</i> important</p>'
 
     it 'returns the full AMP href', ->
       @article.ampHref().should.containEql '/amp'

--- a/src/test/acceptance/artist.js
+++ b/src/test/acceptance/artist.js
@@ -1,12 +1,10 @@
 /* eslint-env mocha */
 import { setup, teardown } from "./helpers"
-
 import { JSDOM } from "jsdom"
 
 const jsdom = new JSDOM("<!doctype html><html><body></body></html>")
-const { window } = jsdom
-global.Node = window.Node
-global.DOMParser = window.DOMParser
+global.Node = jsdom.window.Node
+global.DOMParser = jsdom.window.DOMParser
 
 describe("Artist page", () => {
   let metaphysics, browser


### PR DESCRIPTION
Moving some code from a model that’s shared between server and client to just server-side, which is the only place it is used, and with it remove the cheerio dependency from the client-side bundles.

@eessex I didn’t make the test work (yet), because I know little about this area. Let me know if you think this test should be made to work now.

### Before

<img width="501" alt="common-after-removing-parse5" src="https://user-images.githubusercontent.com/2320/66690250-24007900-ec8f-11e9-9494-f2f943e9b120.png">

### After

<img width="503" alt="common-after-removing-cheerio" src="https://user-images.githubusercontent.com/2320/66690213-dbe15680-ec8e-11e9-9797-285279060b1c.png">
