### PR TITLE
@dleve123 => [Sale] Be more defensive about fetching pages > 100 during inf. scroll

### DIFF
--- a/src/desktop/apps/auction/reducers/__tests__/artworkBrowser.test.js
+++ b/src/desktop/apps/auction/reducers/__tests__/artworkBrowser.test.js
@@ -153,6 +153,22 @@ describe("auction/actions/artworkBrowser.test.js", () => {
         ])
         notAllArtworksFetched.artworkBrowser.total.should.eql(10)
       })
+
+      it("updates allFetched to true if the current page exceeds 100", () => {
+        const maxPageResponse = auctions(
+          {
+            artworkBrowser: {
+              total: 1,
+              saleArtworks: [],
+              filterParams: { page: 100 },
+            },
+          },
+          {}
+        )
+        const tooHighPage = auctions(maxPageResponse, actions.updatePage(false))
+        const notAllFetched = auctions(tooHighPage, actions.updateAllFetched())
+        notAllFetched.artworkBrowser.allFetched.should.eql(true)
+      })
     })
 
     describe("#updateArtistId", () => {

--- a/src/desktop/apps/auction/reducers/artworkBrowser.js
+++ b/src/desktop/apps/auction/reducers/artworkBrowser.js
@@ -105,7 +105,8 @@ export default function auctionArtworkFilter(state = initialState, action) {
       )
     }
     case actions.UPDATE_ALL_FETCHED: {
-      if (state.saleArtworks.length === state.total) {
+      const currentPage = state.filterParams.page
+      if (currentPage > 100 || state.saleArtworks.length === state.total) {
         return u(
           {
             allFetched: true,


### PR DESCRIPTION
Re: https://artsy.slack.com/archives/CA8SANW3W/p1571265677276700

It looks like the current code for the auction is a bit brittle with regards to a total count being returned, vs a running count of items fetched. It would keep trying to scroll if they weren't equal.

Since counts _can_ be off in practice, we should be more defensive against a count mismatch.