### PR TITLE
[webpack] Drop graphql-js and relay network server from client bundles.

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@artsy/gemup": "0.0.3",
     "@artsy/palette": "4.18.0",
     "@artsy/passport": "1.1.6",
-    "@artsy/reaction": "21.10.0",
+    "@artsy/reaction": "21.10.1",
     "@artsy/stitch": "6.1.6",
     "@babel/core": "7.6.0",
     "@babel/node": "7.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,10 +96,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/react-responsive-media/-/react-responsive-media-2.0.0-beta.5.tgz#d61e1a9f215d38d90ec2bb97dc1ff7409d0346fa"
   integrity sha512-XRYA77v/j3mVInwy5EYb8NtmMkkAD1/XDxDi45BO0oduv4hsljJfjtjK7jN0ziJ6JUm2QTx/t6QwuaT9E7vTuA==
 
-"@artsy/reaction@21.10.0":
-  version "21.10.0"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-21.10.0.tgz#98ed792159eab045a56c7c8a061d492fdcf496c1"
-  integrity sha512-muyFnko1TihMR5JDk5L9z5P3Y350aDCsoVXxnJ79LY7JFZ2k8Q2H6Q4lrqEa+G6iUroTy4sP3ZLaB7J2RQ99eA==
+"@artsy/reaction@21.10.1":
+  version "21.10.1"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-21.10.1.tgz#9b353e4e7adbe37d8de94e16472d8b70479b6377"
+  integrity sha512-y1XTe1L6gePgl1OAkvwYVpIS3bcGKo30oF/h0qkVG3EBjXNR8/XxrKuUTUGex/dVTTFS68XP681CyPuxEIuiUQ==
   dependencies:
     "@artsy/arc" "^1.4.2"
     "@artsy/detect-responsive-traits" "^0.0.5"


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/browse/PLATFORM-1890

Depends on https://github.com/artsy/reaction/pull/2920

⚒ 

### Before

<img width="614" alt="Screenshot 2019-10-17 at 17 01 18" src="https://user-images.githubusercontent.com/2320/67021761-6814d300-f100-11e9-9c6e-3ce3933a440d.png">

### After

<img width="606" alt="Screenshot 2019-10-17 at 16 56 06" src="https://user-images.githubusercontent.com/2320/67021611-2edc6300-f100-11e9-9331-74f38951c455.png">
