### PR TITLE
Revert "[webpack] Drop graphql-js and relay network server from client bundles."

### DIFF
--- a/webpack/envs/baseConfig.js
+++ b/webpack/envs/baseConfig.js
@@ -3,12 +3,7 @@
 const path = require("path")
 const webpack = require("webpack")
 const { getEntrypoints } = require("../utils/getEntrypoints")
-const {
-  BUILD_SERVER,
-  NODE_ENV,
-  basePath,
-  isCI,
-} = require("../../src/lib/environment")
+const { NODE_ENV, basePath, isCI } = require("../../src/lib/environment")
 
 exports.baseConfig = {
   mode: NODE_ENV,
@@ -66,22 +61,7 @@ exports.baseConfig = {
         NODE_ENV: JSON.stringify(NODE_ENV),
       },
     }),
-    // Remove moment.js localization files
-    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
-    // Remove server-only modules from client bundles
-    ...(BUILD_SERVER
-      ? []
-      : [
-          // Remove server side of relay network layer.
-          new webpack.IgnorePlugin(
-            /^react-relay-network-modern-ssr\/node8\/server/
-          ),
-          // No matter what, we don't want the graphql-js package in client
-          // bundles. This /may/ lead to a broken build when e.g. a reaction
-          // module that's used on the client side imports something from
-          // graphql-js, but that's better than silently including this.
-          new webpack.IgnorePlugin(/^graphql(\/.*)?$/),
-        ]),
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/), // Remove moment.js localization files
     new webpack.NamedModulesPlugin(),
     new webpack.ProvidePlugin({
       $: "jquery",


### PR DESCRIPTION
This PR reverts commit 120564b2cbc18e954a394ff04859ea7db50bd026 and partially reverts https://github.com/artsy/force/pull/4696 after seeing some client-side errors in our staging environment.

![gCU7E9B](https://user-images.githubusercontent.com/123595/67027404-7ef2ff80-f0d7-11e9-91be-a9c1578e652b.png)

cc/ @alloy @sweir27 