### PR TITLE
Don't run bundle report if token isn't available

### DIFF
--- a/webpack/envs/ciConfig.js
+++ b/webpack/envs/ciConfig.js
@@ -39,6 +39,7 @@ export const ciConfig = {
   devtool: false,
   plugins: [
     plugins.duplicatesReport,
-    new BundleAnalyzerPlugin({ token: process.env.BUNDLE_ANALYZER_TOKEN }),
-  ],
+    process.env.BUNDLE_ANALYZER_TOKEN &&
+      new BundleAnalyzerPlugin({ token: process.env.BUNDLE_ANALYZER_TOKEN }),
+  ].filter(p => !!p),
 }


### PR DESCRIPTION
Temporary fix to get us past this failing on forks. 

If the token for bundle analyzer isn't available just don't load it. 