### PR TITLE
Use h1 for /auctions page title

### DIFF
--- a/src/desktop/apps/auctions/stylesheets/index.styl
+++ b/src/desktop/apps/auctions/stylesheets/index.styl
@@ -107,7 +107,7 @@
     display table-cell
     vertical-align middle
     padding 20px 0
-  h2
+  h3
     font-style italic
 
 .auction-cta-group .auction-cta-group__left

--- a/src/desktop/apps/auctions/templates/index.jade
+++ b/src/desktop/apps/auctions/templates/index.jade
@@ -15,7 +15,7 @@ block body
       .aggregate-page-items-featured
         if currentAuctions.length
           .aggregate-page-items-featured-set
-            h2.auctions-header Current Auctions
+            h1.auctions-header Current Auctions
             for auction in currentAuctions
               include auction
 

--- a/src/desktop/apps/auctions/templates/index.jade
+++ b/src/desktop/apps/auctions/templates/index.jade
@@ -45,16 +45,16 @@ block body
           .auction-cta-group__left
             img( src="/images/mobile-cta.png" alt="Bid from your phone" )
           .auction-cta-group__right
-            h1 Bid from your phone
-            h2 Download Artsy for iPhone
+            h2 Bid from your phone
+            h3 Download Artsy for iPhone
         a.auction-cta-group(href="/how-auctions-work")
           .auction-cta-group__left
             img( src="/images/kiosk-cta.png" alt="How to Bid on Artsy" )
           .auction-cta-group__right
-            h1 How to Bid on Artsy
+            h2 How to Bid on Artsy
         a.auction-cta-group(href="/auction-partnerships")
           .auction-cta-group__full
-            h1
+            h2
               | Interested in partnering with
               br
               | Artsy for your next auction?


### PR DESCRIPTION
Minor SEO fix noticed while assembling integration tests, use h1 rather than h2 for page title on /auctions route.

<img width="1673" alt="Screen Shot 2019-10-17 at 4 32 10 PM" src="https://user-images.githubusercontent.com/1497424/67045148-b83d6680-f0fb-11e9-85dc-ecad34f722c0.png">
