### PR TITLE
bump production resource requests and limits

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -46,10 +46,10 @@ spec:
             timeoutSeconds: 10
           resources:
             requests:
-              cpu: 700m
-              memory: 1Gi
+              cpu: 900m
+              memory: 1536Mi
             limits:
-              memory: 1.5Gi
+              memory: 3Gi
         - name: force-nginx
           image: artsy/docker-nginx:latest
           ports:


### PR DESCRIPTION
Things look stable and hopefully with fewer 500s with these new parameters.  See https://artsy.slack.com/archives/CA8SANW3W/p1571307914301600 for discussion