### PR TITLE
Block a production deploy when there's a unresolved deploy block.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ orbs:
   yarn: artsy/yarn@2.1.1
   hokusai: artsy/hokusai@0.7.0
   node: artsy/node@0.1.0
+  horizon: artsy/release@0.0.1
 
 jobs:
   acceptance:
@@ -77,6 +78,11 @@ only_release: &only_release
 workflows:
   default:
     jobs:
+      - horizon/block:
+          <<: *only_release
+          context: horizon
+          project_id: 11
+
       # Pre-staging
       - yarn/update-cache:
           <<: *not_staging_or_release
@@ -110,4 +116,5 @@ workflows:
       - hokusai/deploy-production:
           <<: *only_release
           requires:
+            - horizon/block
             - validate_production_schema


### PR DESCRIPTION
Problem

Right now, we can and [do][0] create deploy block records for Force,
but currently there's no systematic enforcement of preventing a
unintended deploy when there's an open unresolved deploy block.

Solution

Block a deploy using the Horizon orb. This is similar to [setup in
artsy/currents][1] that has been running production for a while.

[0]:https://releases.artsy.net/admin/deploy_blocks?utf8=%E2%9C%93&q%5Bproject_id_eq%5D=11&commit=Filter&order=id_desc
[1]:https://github.com/artsy/currents/pull/257/files