### PR TITLE
Fix broken collection acceptance tests by adding more fixture data

### DIFF
--- a/src/test/acceptance/fixtures/metaphysics/collection.json
+++ b/src/test/acceptance/fixtures/metaphysics/collection.json
@@ -3623,7 +3623,8 @@
           ]
         }
       },
-      "__id": "5bcf4e518ef6ac2e05f0eb97"
+      "__id": "5bcf4e518ef6ac2e05f0eb97",
+      "featuredArtistExclusionIds": []
     }
   }
 }


### PR DESCRIPTION
Collaboration with @xtina-starr 

We realized that a [Reaction version bump PR was failing CI](https://github.com/artsy/force/pull/4720), as a result of using incomplete fixture data. This PR adds in the necessary data to successfully run `/collection/:id` acceptance tests.