### PR TITLE
@eessex => [Middleware] Skip AB test middleware in test

### DIFF
--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -216,7 +216,7 @@ export default function(app) {
   app.use(escapedFragmentMiddleware)
   app.use(logger)
   app.use(unsupportedBrowserCheck)
-  app.use(splitTestMiddleware)
+  if (NODE_ENV !== "test") app.use(splitTestMiddleware)
   app.use(addIntercomUserHash)
 
   // Routes for pinging system time and up


### PR DESCRIPTION
This is kind of messy but fixes an issue where based on an AB test, some acceptance specs are failing. Skipping this AB middleware entirely will result in those AB test values not being set, so that would generally result in the control path being used in the UI.

An alternative would be to update our acceptance specs to be able to also stub an AB test value, and then possibly update any fixtures, in order to make the tests deterministic.

I wasn't able to figure out a clean way of stubbing that though, in our existing setup. So went with this for now.