### PR TITLE
@eessex => [Middleware] Add a `return` before redirecting

### DIFF
--- a/src/lib/middleware/unsupportedBrowser.ts
+++ b/src/lib/middleware/unsupportedBrowser.ts
@@ -7,11 +7,12 @@ export const unsupportedBrowserCheck = (req, res, next) => {
     res.locals.sd.BROWSER = ua
   }
   if (
+    req.path !== "/unsupported-browser" &&
     isUnsupported(ua, req) &&
     !/\/unsupported-browser|assets|fonts|images/.test(req.path)
   ) {
     res.locals.sd.UNSUPPORTED_BROWSER_REDIRECT = getRedirectTo(req)
-    res.redirect("/unsupported-browser")
+    return res.redirect("/unsupported-browser")
   }
   next()
 }


### PR DESCRIPTION
This is a tiny improvement in the attempt to fix the `Cannot set headers...` issue.

Basically, in middleware you either want to `next()`, _or_ you want to `return res.render` (or `res.send`, `res.end`, etc.).

This middleware looked like it was subject to both `next()` _and_ a `res.redirect()` being called, which is generally not advised.