### PR TITLE
@izakp => [Package] Use http-shutdown to gracefully exit

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "helmet": "2.3.0",
     "history": "4.7.2",
     "http-proxy": "1.16.2",
+    "http-shutdown": "^1.2.1",
     "insane": "2.6.1",
     "invariant": "2.2.4",
     "ip": "1.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7827,6 +7827,11 @@ http-proxy@1.16.2:
     eventemitter3 "1.x.x"
     requires-port "1.x.x"
 
+http-shutdown@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/http-shutdown/-/http-shutdown-1.2.1.tgz#f3be43af70d54c32c26ab7aa22d143d737ef761a"
+  integrity sha512-EVttBpDbynTLq1Xz4Y2/AfGv+7HbARU6TmwqtecgUulY3zFvPsgWW3MHMgAU9nwNZeJwgrjCIwk/1g9Be2vVPQ==
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"


### PR DESCRIPTION
Confirmed locally that using `kill` executes the `shutdown` callback properly.