### PR TITLE
Update all magazine references to editorial

### DIFF
--- a/src/desktop/apps/articles/templates/meta/articles.jade
+++ b/src/desktop/apps/articles/templates/meta/articles.jade
@@ -1,6 +1,6 @@
-title Magazine | Artsy
+title Editorial | Artsy
 - var description = 'Artsy\'s editorial content unpacks the art world through on-the-ground coverage, studio visits, market news, original films, and art-historical explainers.'
-meta( property="og:title", content="Magazine | Artsy" )
+meta( property="og:title", content="Editorial | Artsy" )
 meta( name="description", content= description )
 meta( property="og:description", content= description )
 meta( property="twitter:description", content= description )

--- a/src/desktop/apps/articles/templates/section.jade
+++ b/src/desktop/apps/articles/templates/section.jade
@@ -12,7 +12,7 @@ append locals
 block body
   header.articles-section-header.main-layout-container
     .articles-section-header-left
-      a( href='/posts' ) Magazine
+      a( href='/posts' ) Editorial
       h1= section.get('title')
       p!= section.mdToHtml('description')
     if section.get('partner_logo_url')

--- a/src/desktop/apps/editorial_features/components/eoy/templates/index.jade
+++ b/src/desktop/apps/editorial_features/components/eoy/templates/index.jade
@@ -21,7 +21,7 @@ block body
       .article-sa-plus.icon-close
       a(href= '#{superArticle.get("super_article").partner_logo_link}').ubs-link
         img.article-sa-primary-logo.ubs(src=superArticle.get('super_article').partner_fullscreen_header_logo)
-      a(href='/articles').back-to-magazine Back to Magazine
+      a(href='/articles').back-to-magazine Back to Editorial
     .eoy-feature__content
       include ./scroller.jade
 

--- a/src/desktop/apps/editorial_features/components/gucci/components/nav/__tests__/header.test.js
+++ b/src/desktop/apps/editorial_features/components/gucci/components/nav/__tests__/header.test.js
@@ -17,7 +17,7 @@ xdescribe("Gucci Header", () => {
     component.find(PartnerInline).length.should.eql(1)
     component.html().should.containEql("Artists For Gender Equality")
     component.html().should.containEql('href="/articles"')
-    component.html().should.containEql("Back to Magazine")
+    component.html().should.containEql("Back to Editorial")
   })
 
   xit("Hides the title and menu link if isMobile", () => {
@@ -26,7 +26,7 @@ xdescribe("Gucci Header", () => {
     component.find(PartnerInline).length.should.eql(1)
     component.html().should.not.containEql("Artists For Gender Equality")
     component.html().should.not.containEql('href="/articles"')
-    component.html().should.not.containEql("Back to Magazine")
+    component.html().should.not.containEql("Back to Editorial")
   })
 
   it("Shows a menu icon if isMobile and has onOpenMenu", () => {

--- a/src/desktop/apps/editorial_features/components/gucci/components/nav/header.tsx
+++ b/src/desktop/apps/editorial_features/components/gucci/components/nav/header.tsx
@@ -33,7 +33,7 @@ export const Header: React.SFC<HeaderProps> = props => {
 
       <BackLink size="3" weight="medium">
         <Media greaterThan="sm">
-          <a href="/articles">Back to Magazine</a>
+          <a href="/articles">Back to Editorial</a>
         </Media>
       </BackLink>
 

--- a/src/desktop/apps/editorial_features/components/venice_2017/templates/nav.jade
+++ b/src/desktop/apps/editorial_features/components/venice_2017/templates/nav.jade
@@ -5,4 +5,4 @@
       a(href="https://www.ubs.com/global/en/about_ubs/contemporary-art.html").venice-nav__sticky-ubs-logo
         img(src="https://artsy-media-uploads.s3.amazonaws.com/qp6GUcn5RkvscdYEBmqFXw%2FUBS_White.png")
   .venice-nav__sticky-right
-    a.venice-nav__sticky-magazine(href=sd.APP_URL + '/articles') Back to Magazine
+    a.venice-nav__sticky-magazine(href=sd.APP_URL + '/articles') Back to Editorial

--- a/src/desktop/apps/home/templates/featured_articles.jade
+++ b/src/desktop/apps/home/templates/featured_articles.jade
@@ -1,9 +1,9 @@
 if featuredArticles.length
   #home-featured-articles-section( data-context='featured articles' )
-    h2.home-featured-header Artsy Magazine
+    h2.home-featured-header Artsy Editorial
       .home-browse-all-right
         a( href='/articles' )
-          | Explore the Magazine
+          | Explore Editorial
     ul#home-featured-articles.home-featured-list
       - articles = featuredArticles.take(7)
       for article, i in articles

--- a/src/desktop/components/article/templates/super_article_sticky_header.jade
+++ b/src/desktop/components/article/templates/super_article_sticky_header.jade
@@ -27,7 +27,7 @@ if fullscreenSuperArticle || hasFullscreenHero
       include ../../merry_go_round/templates/horizontal_navigation
       a.article-sa-related__magazine-link(href=sd.APP_URL + '/articles')
         i.icon-chevron-left
-        .article-sa-related__magazine-text Back to the Magazine Homepage
+        .article-sa-related__magazine-text Back to the Editorial
 
   .article-sa-sticky-right
     a.article-sa-magazine-link(href=sd.APP_URL + '/articles') Back to Editorial

--- a/src/desktop/components/main_layout/footer/mobile_footer_menu.jade
+++ b/src/desktop/components/main_layout/footer/mobile_footer_menu.jade
@@ -7,7 +7,7 @@
     a( href='/shows' ) Shows
     a( href='/auctions' ) Auctions
     a( href='/galleries' ) Galleries
-    a( href='/articles' ) Magazine
+    a( href='/articles' ) Editorial
   if user
     .mlf-user-column
       h4= user.get('name')

--- a/src/desktop/components/main_layout/header/templates/more.jade
+++ b/src/desktop/components/main_layout/header/templates/more.jade
@@ -6,7 +6,7 @@ span.mlh-top-nav-link.hover-pulldown( data-mode='hover' )
       a.mlh-pulldown-top-link( href='/auctions', class= activeClass('/auctions') ) Auctions
       a.mlh-pulldown-top-link.galleries( href='/galleries', class= activeClass('/galleries') ) Galleries
       a.mlh-pulldown-top-link.fairs( href='/art-fairs', class= activeClass('/art-fairs') ) Fairs
-      a.mlh-pulldown-top-link.magazine( href='/articles', class= activeClass('/articles') ) Magazine
+      a.mlh-pulldown-top-link.magazine( href='/articles', class= activeClass('/articles') ) Editorial
       a.mlh-pulldown-top-link-persistent( href='/artists', class= activeClass('/artists') ) Artists
       a.mlh-pulldown-top-link-persistent( href='/shows', class= activeClass('/shows') ) Shows
       a.mlh-pulldown-top-link-persistent( href='/institutions', class= activeClass('/institutions') ) Museums

--- a/src/mobile/apps/articles/meta/articles.jade
+++ b/src/mobile/apps/articles/meta/articles.jade
@@ -1,5 +1,5 @@
-title Magazine | Artsy
-meta( property="og:title", content="Magazine | Artsy" )
+title Editorial | Artsy
+meta( property="og:title", content="Editorial | Artsy" )
 meta( name="description", content="Featured Artsy articles." )
 meta( property="og:description", content="Featured Artsy articles." )
 meta( property="twitter:description", content="Featured Artsy articles." )

--- a/src/mobile/apps/articles/templates/section.jade
+++ b/src/mobile/apps/articles/templates/section.jade
@@ -12,7 +12,7 @@ block content
           a(href=featuredSection.get('partner_website_url'))
             img( src=featuredSection.get('partner_logo_url') )
       .articles-section-header__headline
-        a( href='/posts' ) Magazine
+        a( href='/posts' ) Editorial
         h1= featuredSection.get('title')
 
     if (featuredArticles = articles.featured()).length


### PR DESCRIPTION
Follow up to changes in https://github.com/artsy/reaction/pull/2962 and https://github.com/artsy/reaction/pull/2955, updates all magazine references to instead refer to 'editorial'

Related to https://artsyproduct.atlassian.net/browse/PLATFORM-1916