### PR TITLE
Remove `json-ld` metadata for shows without location

### DIFF
--- a/src/desktop/apps/show/routes.coffee
+++ b/src/desktop/apps/show/routes.coffee
@@ -147,7 +147,7 @@ query = """
       res.locals.sd.INCLUDE_SAILTHRU = res.locals.sd.PARTNER_SHOW?
       res.locals.ViewHelpers = ViewHelpers
       res.locals.DateHelpers = DateHelpers
-      res.locals.jsonLD = JSON.stringify ViewHelpers.toJSONLD data.partner_show
+      res.locals.jsonLD = JSON.stringify ViewHelpers.toJSONLD data.partner_show if data.partner_show.has_location
       data.artworkColumns = ViewHelpers.groupByColumnsInOrder(data.partner_show.artworks)
       res.render 'index', data
     .catch next

--- a/src/desktop/apps/show/templates/index.jade
+++ b/src/desktop/apps/show/templates/index.jade
@@ -21,4 +21,5 @@ block body
     include columns
     include footer
 
-  include ../../../components/main_layout/templates/json_ld
+  - if (jsonLD)
+    include ../../../components/main_layout/templates/json_ld


### PR DESCRIPTION
Fixes [PURCHASE-1516](https://artsyproduct.atlassian.net/browse/PURCHASE-1516)

`Event` types now have a [required](https://developers.google.com/search/docs/data-types/event#datatypes) `location` field. For shows which don't have location we cannot provide one so removing it altogether

### Questions:
* Is there a problem rendering an empty tag like `<script id="json-ld" type="application/ld+json"></script>` or it needs to be removed when content is empty [here](https://github.com/sepans/force/blob/2b6be957a0127386a965faddb72c67c6cc901dad/src/desktop/components/main_layout/templates/json_ld.jade)
* Is there a change needed for `mobile`? (mobile directory didn't have the corresponding file)
