### PR TITLE
[GROW-1639] close collection hubs entry points a/b test on the collect page

### DIFF
--- a/src/desktop/apps/collect/client.js
+++ b/src/desktop/apps/collect/client.js
@@ -10,7 +10,6 @@ buildClientApp({
   context: {
     user: sd.CURRENT_USER,
     mediator,
-    COLLECTION_HUB_ENTRYPOINTS_TEST: sd.COLLECTION_HUB_ENTRYPOINTS_TEST,
   },
 })
   .then(({ ClientApp }) => {

--- a/src/desktop/apps/collect/server.tsx
+++ b/src/desktop/apps/collect/server.tsx
@@ -10,11 +10,7 @@ export const app = express()
 
 const index = async (req, res, next) => {
   try {
-    const {
-      APP_URL,
-      IS_MOBILE,
-      COLLECTION_HUB_ENTRYPOINTS_TEST,
-    } = res.locals.sd
+    const { APP_URL, IS_MOBILE } = res.locals.sd
 
     const {
       headTags,
@@ -26,9 +22,7 @@ const index = async (req, res, next) => {
       routes: collectRoutes,
       url: req.url,
       userAgent: req.header("User-Agent"),
-      context: buildServerAppContext(req, res, {
-        COLLECTION_HUB_ENTRYPOINTS_TEST,
-      }),
+      context: buildServerAppContext(req, res),
     })
 
     if (redirect) {

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -25,12 +25,6 @@
 # module.exports = {}
 
 module.exports = {
-  collection_hub_entrypoints_test:
-    key: "collection_hub_entrypoints_test"
-    outcomes:
-      control: 50
-      experiment: 50
-    edge: "experiment"
   homepage_collection_hub_entrypoints_test_qa:
     key: "homepage_collection_hub_entrypoints_test_qa"
     outcomes:


### PR DESCRIPTION
Addresses: [GROW-1639](https://artsyproduct.atlassian.net/browse/GROW-1639)

This closes the collection hubs entry points a/b test on the collect page. Related to https://github.com/artsy/reaction/pull/2970.