### PR TITLE
[GROW-1628] Ensure the experiment viewed fires when the first row of entry points

### DIFF
--- a/src/desktop/apps/home/client/index.coffee
+++ b/src/desktop/apps/home/client/index.coffee
@@ -37,7 +37,7 @@ module.exports.HomeView = class HomeView extends Backbone.View
     ,
     {
       triggerOnce: true,
-      offset: 75,
+      offset: 500,
     }
     )
 

--- a/src/desktop/apps/home/client/index.coffee
+++ b/src/desktop/apps/home/client/index.coffee
@@ -32,6 +32,12 @@ module.exports.HomeView = class HomeView extends Backbone.View
 
     # Remove after closing the homepage hubs entry points test
     $(targetElement).waypoint(() ->
+      # Fire impression event
+      analytics.track("Impression", {
+        context_page: "Home",
+        context_module: "HubEntrypoint",
+        subject: "Featured Categories",
+      })
       # Fire experiment viewed event
       splitTest("homepage_collection_hub_entrypoints_test_qa").view()
     ,

--- a/src/mobile/apps/home/client/view.coffee
+++ b/src/mobile/apps/home/client/view.coffee
@@ -21,6 +21,11 @@ module.exports = class HomePageView extends PoliteInfiniteScrollView
 
   initialize: ->
     @collection = new ShowsFeed
+    analytics.track("Impression", {
+      context_page: "Home",
+      context_module: "HubEntrypoint",
+      subject: "Featured Categories",
+    })
     splitTest("homepage_collection_hub_entrypoints_test_qa").view()
 
     @slideshow = new Flickity '#carousel-track',

--- a/src/mobile/apps/home/test/client_view.test.coffee
+++ b/src/mobile/apps/home/test/client_view.test.coffee
@@ -11,8 +11,8 @@ describe 'HomePageView', ->
     benv.setup =>
       benv.expose
         $: benv.require 'jquery'
+        analytics: { track: sinon.stub() }
         Element: window.Element
-
       Backbone.$ = $
       benv.render resolve(__dirname, '../templates/page.jade'), {
         heroUnits: []


### PR DESCRIPTION
Addresses: [GROW-1628](https://artsyproduct.atlassian.net/browse/GROW-1628)

Based on [QA feedback](https://artsy.slack.com/archives/GLZRS5KMH/p1572968252088000?thread_ts=1572965424.079200&cid=GLZRS5KMH) we want to fire the experiment viewed event for the collection hubs entry points when a user see the first row of the entry points. This PR accomplishes that by adjusting the offset options.