### PR TITLE
Launch homepage collection hubs entry points a/b test

### DIFF
--- a/src/desktop/apps/home/client/index.coffee
+++ b/src/desktop/apps/home/client/index.coffee
@@ -28,7 +28,7 @@ module.exports.HomeView = class HomeView extends Backbone.View
     new HomeAuthRouter
     Backbone.history.start pushState: true
 
-    targetElement = if sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST_QA is "experiment" then ".home-hubs-entry" else ".home-browse-module"
+    targetElement = if sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST is "experiment" then ".home-hubs-entry" else ".home-browse-module"
 
     # Remove after closing the homepage hubs entry points test
     $(targetElement).waypoint(() ->
@@ -39,7 +39,7 @@ module.exports.HomeView = class HomeView extends Backbone.View
         subject: "Featured Categories",
       })
       # Fire experiment viewed event
-      splitTest("homepage_collection_hub_entrypoints_test_qa").view()
+      splitTest("homepage_collection_hub_entrypoints_test").view()
     ,
     {
       triggerOnce: true,

--- a/src/desktop/apps/home/routes.coffee
+++ b/src/desktop/apps/home/routes.coffee
@@ -46,7 +46,7 @@ fetchMetaphysicsData = (req, showHeroUnits, showCollectionsHubs)->
     }
   }
   
-  showCollectionsHubs = res.locals.sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST_QA == "experiment"
+  showCollectionsHubs = res.locals.sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST == "experiment" && !res.locals.sd.CURRENT_USER
   res.locals.sd.PAGE_TYPE = 'home'
   initialFetch = Q
     .allSettled [

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -25,10 +25,10 @@
 # module.exports = {}
 
 module.exports = {
-  homepage_collection_hub_entrypoints_test_qa:
-    key: "homepage_collection_hub_entrypoints_test_qa"
+  homepage_collection_hub_entrypoints_test:
+    key: "homepage_collection_hub_entrypoints_test"
     outcomes:
-      control: 100
-      experiment: 0
+      control: 50
+      experiment: 50
     edge: "experiment"
 }

--- a/src/mobile/apps/home/client/view.coffee
+++ b/src/mobile/apps/home/client/view.coffee
@@ -21,12 +21,13 @@ module.exports = class HomePageView extends PoliteInfiniteScrollView
 
   initialize: ->
     @collection = new ShowsFeed
-    analytics.track("Impression", {
-      context_page: "Home",
-      context_module: "HubEntrypoint",
-      subject: "Featured Categories",
-    })
-    splitTest("homepage_collection_hub_entrypoints_test_qa").view()
+    if sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST == "experiment" 
+      analytics.track("Impression", {
+        context_page: "Home",
+        context_module: "HubEntrypoint",
+        subject: "Featured Categories",
+      })
+    splitTest("homepage_collection_hub_entrypoints_test").view()
 
     @slideshow = new Flickity '#carousel-track',
       cellAlign: 'left'

--- a/src/mobile/apps/home/routes.coffee
+++ b/src/mobile/apps/home/routes.coffee
@@ -26,7 +26,7 @@ query = """
 module.exports.index = (req, res, next) ->
   res.locals.sd.PAGE_TYPE = 'home'
 
-  showCollectionsHubs = res.locals.sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST_QA == "experiment"
+  showCollectionsHubs = res.locals.sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST == "experiment" && !res.locals.sd.CURRENT_USER
 
   metaphysics(query: query, variables: {showCollectionsHubs: showCollectionsHubs})
     .then ({ home_page, marketingHubCollections }) ->

--- a/src/mobile/apps/home/test/client_view.test.coffee
+++ b/src/mobile/apps/home/test/client_view.test.coffee
@@ -22,6 +22,7 @@ describe 'HomePageView', ->
           ['featuredItemsTemplate', 'currentShowsTemplate', 'artworkColumnsTemplate']
         sinon.stub Backbone, 'sync'
         @HomePageView.__set__ 'Flickity', @Flickity = sinon.stub()
+        @HomePageView.__set__ 'sd', {}
         @view = new @HomePageView
         done()
 


### PR DESCRIPTION
Addresses: [GROW-1640](https://artsyproduct.atlassian.net/browse/GROW-1640) & [GROW-1612](https://artsyproduct.atlassian.net/browse/GROW-1612)

**Do not merge yet**
This PR launches the hubs entry points on the homepage a/b test but is blocked by https://github.com/artsy/force/pull/4784 and pending change in reaction to remove the impression analytic event from being fired on page load.