### PR TITLE
Don't track any impressions or experiments for homepage entry hub if user is logged in (mobile web)

### DIFF
--- a/src/mobile/apps/home/client/view.coffee
+++ b/src/mobile/apps/home/client/view.coffee
@@ -21,13 +21,15 @@ module.exports = class HomePageView extends PoliteInfiniteScrollView
 
   initialize: ->
     @collection = new ShowsFeed
-    if sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST == "experiment" 
-      analytics.track("Impression", {
-        context_page: "Home",
-        context_module: "HubEntrypoint",
-        subject: "Featured Categories",
-      })
-    splitTest("homepage_collection_hub_entrypoints_test").view()
+    
+    if !sd.CURRENT_USER
+      if sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST == "experiment" 
+        analytics.track("Impression", {
+          context_page: "Home",
+          context_module: "HubEntrypoint",
+          subject: "Featured Categories",
+        })
+      splitTest("homepage_collection_hub_entrypoints_test").view()
 
     @slideshow = new Flickity '#carousel-track',
       cellAlign: 'left'


### PR DESCRIPTION
In #4785, we were tracking experiment viewed & impression for the homepage entry hubs when a user was logged in...which is incorrect, because logged in users _never_ see the homepage entry hubs. This PR removes the tracking for logged in users.