### PR TITLE
Modifications to tracking of home page hub entrypoint experiment (on desktop)

### DIFF
--- a/src/desktop/apps/home/client/index.coffee
+++ b/src/desktop/apps/home/client/index.coffee
@@ -28,24 +28,24 @@ module.exports.HomeView = class HomeView extends Backbone.View
     new HomeAuthRouter
     Backbone.history.start pushState: true
 
-    targetElement = if sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST is "experiment" then ".home-hubs-entry" else ".home-browse-module"
-
-    # Remove after closing the homepage hubs entry points test
-    $(targetElement).waypoint(() ->
-      # Fire impression event
-      analytics.track("Impression", {
-        context_page: "Home",
-        context_module: "HubEntrypoint",
-        subject: "Featured Categories",
+    if !sd.CURRENT_USER
+      isExperiment = sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST is "experiment"
+      targetElement = if isExperiment then ".home-hubs-entry" else ".home-browse-module"
+      # Remove after closing the homepage hubs entry points test
+      $(targetElement).waypoint(() ->
+        # Fire impression event
+        analytics.track("Impression", {
+          context_page: "Home",
+          context_module: "HubEntrypoint",
+          subject: if isExperiment then "Featured Categories" else "Browse Works for Sale",
+        })
+        # Fire experiment or control viewed event
+        splitTest("homepage_collection_hub_entrypoints_test").view()
+      ,
+      {
+        triggerOnce: true,
+        offset: 500,
       })
-      # Fire experiment viewed event
-      splitTest("homepage_collection_hub_entrypoints_test").view()
-    ,
-    {
-      triggerOnce: true,
-      offset: 500,
-    }
-    )
 
     # Render Featured Sections
     @setupHeroUnits()


### PR DESCRIPTION
This PR addresses feedback from #4785.

1. Don't attempt entry hubs tracking if user is logged in. We weren't actually *tracking* anything if the user was logged in, because neither element that we attach a waypoint to exists in that view, but the code is now more explicit that it shouldn't be attempting to track when the user is logged in.
2. Toggle the impression subject based on control vs experiment. The user is seeing different elements on the page, and the subject will better reflect what they're seeing.