### PR TITLE
@zephraph => [Performance] Instrument TTI Metric

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "styled-components": "4.3.2",
     "stylus": "0.54.5",
     "superagent": "3.8.3",
+    "tti-polyfill": "^0.2.2",
     "twilio": "2.11.1",
     "typeahead.js": "0.10.5",
     "typescript": "3.7.2",

--- a/src/desktop/components/main_layout/templates/head.jade
+++ b/src/desktop/components/main_layout/templates/head.jade
@@ -31,3 +31,7 @@ script( type="text/javascript" )
 //- Don't include fonts if Reflection is requesting it
 if sd.BROWSER && sd.BROWSER.family != 'Other'
   link( type='text/css', rel='stylesheet', href='#{sd.WEBFONT_URL}/all-webfonts.css')
+
+//- TTI measurement
+script( type="text/javascript" )
+  include ../../../../lib/tti-init.js

--- a/src/lib/__tests__/volley.jest.ts
+++ b/src/lib/__tests__/volley.jest.ts
@@ -41,8 +41,8 @@ describe("Reporting metrics to Volley", () => {
     jest.resetAllMocks()
   })
 
-  it("reports valid metrics", () => {
-    reportLoadTimeToVolley("", "desktop", {
+  it("reports valid metrics", async () => {
+    await reportLoadTimeToVolley("", "desktop", {
       "dom-complete": () => 10,
       "load-event-end": () => 5,
     })
@@ -67,8 +67,8 @@ describe("Reporting metrics to Volley", () => {
     )
   })
 
-  it("reports valid metrics with 'mobile' as the device type when on mobile", () => {
-    reportLoadTimeToVolley("", "mobile", {
+  it("reports valid metrics with 'mobile' as the device type when on mobile", async () => {
+    await reportLoadTimeToVolley("", "mobile", {
       "dom-complete": () => 10,
       "load-event-end": () => 5,
     })
@@ -93,8 +93,8 @@ describe("Reporting metrics to Volley", () => {
     )
   })
 
-  it("reports valid metrics with 'desktop' as the device type when not on mobile", () => {
-    reportLoadTimeToVolley("", "desktop", {
+  it("reports valid metrics with 'desktop' as the device type when not on mobile", async () => {
+    await reportLoadTimeToVolley("", "desktop", {
       "dom-complete": () => 10,
       "load-event-end": () => 5,
     })
@@ -119,8 +119,8 @@ describe("Reporting metrics to Volley", () => {
     )
   })
 
-  it("omits an invalid metric", () => {
-    reportLoadTimeToVolley("", "desktop", {
+  it("omits an invalid metric", async () => {
+    await reportLoadTimeToVolley("", "desktop", {
       "dom-complete": () => 10,
       "load-event-end": () => null,
     })
@@ -139,8 +139,8 @@ describe("Reporting metrics to Volley", () => {
     )
   })
 
-  it("doesn't send anything if called with no valid data", () => {
-    reportLoadTimeToVolley("", "desktop", {})
+  it("doesn't send anything if called with no valid data", async () => {
+    await reportLoadTimeToVolley("", "desktop", {})
     expect(mockSend.mock.calls.length).toBe(0)
   })
 })

--- a/src/lib/tti-init.js
+++ b/src/lib/tti-init.js
@@ -1,0 +1,7 @@
+if ("PerformanceLongTaskTiming" in window) {
+  var g = (window.__tti = { e: [] })
+  g.o = new PerformanceObserver(function(l) {
+    g.e = g.e.concat(l.getEntries())
+  })
+  g.o.observe({ entryTypes: ["longtask"] })
+}

--- a/src/lib/userPerformanceMetrics.ts
+++ b/src/lib/userPerformanceMetrics.ts
@@ -1,5 +1,7 @@
 // Forked and modified from UXM: https://github.com/treosh/uxm
 
+import ttiPolyfill from "tti-polyfill"
+
 declare let PerformancePaintTiming: any
 
 /**
@@ -158,4 +160,9 @@ export function getDomContentLoadedEnd() {
 export function getDomComplete() {
   if (!timingAvailable) return null
   return sanitizedMetrics(perf.timing.requestStart, perf.timing.domComplete)
+}
+
+export async function getTTI() {
+  if (!timingAvailable) return null
+  return Math.round(await ttiPolyfill.getFirstConsistentlyInteractive())
 }

--- a/src/mobile/components/layout/templates/head.jade
+++ b/src/mobile/components/layout/templates/head.jade
@@ -25,3 +25,7 @@ link( rel='preconnect', href='https://www.googleadservices.com' )
 
 link( rel='dns-prefetch', href='https://connect.facebook.net' )
 link( rel='dns-prefetch', href='https://cdn.segment.com' )
+
+//- TTI measurement
+script( type="text/javascript" )
+  include ../../../../lib/tti-init.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -15315,6 +15315,11 @@ tsutils@^3.0.0:
   dependencies:
     tslib "^1.8.1"
 
+tti-polyfill@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/tti-polyfill/-/tti-polyfill-0.2.2.tgz#f7bbf71b13afa9edf60c8bb0d0c05f134e1513b9"
+  integrity sha512-URIoJxvsHThbQEJij29hIBUDHx9UNoBBCQVjy7L8PnzkqY8N6lsAI6h8JrT1Wt2lA0avus/DkuiJxd9qpfCpqw==
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"


### PR DESCRIPTION
cc @eessex 

Based on https://developers.google.com/web/fundamentals/performance/user-centric-performance-metrics , this adds the described metric to volley reporting. I was curious to see the kinds of values that would be reported when playing around locally!

For artist pages, this seemed to range between 4-6 seconds locally.
For artwork pages, it ranged from 1-6 seconds.