### PR TITLE
Update review app docs to cover Reaction canaries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,31 @@ env DEBUG=true yarn start:prod
 
 ## Creating a Review App
 
-If wanting to create a deploy for a WIP feature or for QA, [Hokusai](), supports [Review Apps](https://github.com/artsy/hokusai/blob/master/docs/Review_Apps.md). This can be automated via the [`build_review_app.sh`](https://github.com/artsy/force/blob/master/scripts/build_review_app.sh) script:
+If wanting to create a deploy for a WIP feature or for QA, [Hokusai](), supports [Review Apps](https://github.com/artsy/hokusai/blob/master/docs/Review_Apps.md).
+
+The process for launching the review app differs somewhat depending on whether your unmerged changes are in Reaction or in Force.
+
+### If your unmerged changes are in Reaction
+
+You will first cut a release of Reaction and publish it as a "canary" version to the NPM registry. You will then install this canary release into your copy of Force and launch _that_ as review app.
+
+1. Login to the NPM registry with `npm login`. (You will need to already have an NPM account, and it will need to be associated with the Artsy NPM org — holler on #front-end if you need help with this.)
+1. Update `reaction/package.json` to have a canary version number, e.g. `22.9.8-canary-<your PR number>`
+1. Publish the package under the `canary` tag with `npm publish --tag canary`. (Including the tag is vital to ensuring this release doesn't end up tagged as `latest` — thus triggering a round of auto-update PRs in the various apps that consume Reaction)
+1. Confirm the results of the previous step with `npm dist-tag ls`. You should see something like
+
+   ```
+   canary: 22.9.8-canary-<your PR number>
+   latest: 22.9.7
+   ```
+
+1. Over in Force install the canary with `yarn add @artsy/reaction@canary`
+
+From here on out follow the steps in the next section for launching a Force review app. When you are done with the review process revert your change in step 2 above so that Reaction will resume normal versioning.
+
+### If your unmerged changes are in Force
+
+Launching a Force review app can be automated via the [`build_review_app.sh`](https://github.com/artsy/force/blob/master/scripts/build_review_app.sh) script:
 
 ```sh
 ./scripts/build_review_app.sh review-app-name

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,15 +116,17 @@ This is your Review App url, which should support all of the basic features insi
 
 If you'd like a pretty URL subdomain or need to test full OAuth flows (for, say, login redirects between Gravity and Force for Auction registration) then an additional non-automated step is required via DynDNS:
 
-1. [Login to DynDNS](https://manage.dynect.net/qcke/artsy.net)
-1. Click `Add New Record`
-1. Enter a new subdomain under `Node`
+1. [Login to Cloudflare](https://dash.cloudflare.com/), and navigate to **artsy.net** > **DNS**
+1. Click `+ Add Record`
 1. Change `Type` dropdown to `CNAME`
-1. Paste in URL output by `build_review_app.sh` script into `RData` field, and add a `.` at the end
-1. Scroll to bottom and hit `Save` and then publish changes
+1. Under `Name` enter a new subdomain
+1. Under `Target` paste in URL output by `build_review_app.sh` script
+1. Hit `Save`
 1. DNS will propagate and after a few minutes the review app will be available via `<your-subdomain>.artsy.net`
 
 Read over the [`build_review_app.sh`](https://github.com/artsy/force/blob/master/scripts/build_review_app.sh) script for more info on how this is all done.
+
+😇 After your review app is no longer needed please remember to clean up any CNAMEs you've created, and to de-provision the review app itself with `hokusai review_app delete <review-app-name>`
 
 ## Create a Topic Branch
 

--- a/scripts/build_review_app.sh
+++ b/scripts/build_review_app.sh
@@ -103,7 +103,7 @@ hokusai review_app refresh $NAME
 echo $(kubectl get service force-web --namespace $NAME --context staging -o json \
   | jq .status.loadBalancer.ingress[].hostname)
 #
-# you may do this in the DynDNS interface. Credentials are in 1pass
+# you may do this in the Cloudflare interface. Credentials are in 1pass
 echo "[build_review_app.sh] SUCCESS"
 
 exit 0


### PR DESCRIPTION
This is a follow up to the discussion at https://artsy.slack.com/archives/CP9P4KR35/p1575576740223500

- This updates the **review app** instructions to describe the case where your code changes are in Reaction rather than in Force itself. The steps outlined here allow you to launch a review app for Reaction changes prior to having them merged into Reaction's master branch (which would have the potentially undesirable effect of triggering auto-updates across our various Reaction-consuming apps)

- While I'm in here I'm updating the **DNS** instructions to describe our new dashboard over at Cloudflare, and retiring the old instructions for Dyn.

cc @damassi @artsy/grow