### PR TITLE
[GROW-1685] close homepage entry points test and rollout to 100%

### DIFF
--- a/src/desktop/apps/home/client/index.coffee
+++ b/src/desktop/apps/home/client/index.coffee
@@ -15,7 +15,6 @@ Articles = require '../../../collections/articles'
 Items = require '../../../collections/items'
 featuredArticlesTemplate = -> require('../templates/featured_articles.jade') arguments...
 featuredShowsTemplate = -> require('../templates/featured_shows.jade') arguments...
-splitTest = require '../../../components/split_test/index.coffee'
 { resize } = require '../../../components/resizer/index.coffee'
 sd = require('sharify').data
 _ = require 'underscore'
@@ -27,25 +26,6 @@ module.exports.HomeView = class HomeView extends Backbone.View
     # Set up a router for the /log_in /sign_up and /forgot routes
     new HomeAuthRouter
     Backbone.history.start pushState: true
-
-    if !sd.CURRENT_USER
-      isExperiment = sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST is "experiment"
-      targetElement = if isExperiment then ".home-hubs-entry" else ".home-browse-module"
-      # Remove after closing the homepage hubs entry points test
-      $(targetElement).waypoint(() ->
-        # Fire impression event
-        analytics.track("Impression", {
-          context_page: "Home",
-          context_module: "HubEntrypoint",
-          subject: if isExperiment then "Featured Categories" else "Browse Works for Sale",
-        })
-        # Fire experiment or control viewed event
-        splitTest("homepage_collection_hub_entrypoints_test").view()
-      ,
-      {
-        triggerOnce: true,
-        offset: 500,
-      })
 
     # Render Featured Sections
     @setupHeroUnits()

--- a/src/desktop/apps/home/routes.coffee
+++ b/src/desktop/apps/home/routes.coffee
@@ -46,7 +46,7 @@ fetchMetaphysicsData = (req, showHeroUnits, showCollectionsHubs)->
     }
   }
   
-  showCollectionsHubs = res.locals.sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST == "experiment" && !res.locals.sd.CURRENT_USER
+  showCollectionsHubs = !res.locals.sd.CURRENT_USER
   res.locals.sd.PAGE_TYPE = 'home'
   initialFetch = Q
     .allSettled [

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -25,13 +25,6 @@
 # module.exports = {}
 
 module.exports = {
-  homepage_collection_hub_entrypoints_test:
-    key: "homepage_collection_hub_entrypoints_test"
-    outcomes:
-      control: 50
-      experiment: 50
-    edge: "experiment"
-
   client_side_routing:
     key: "client_side_routing"
     outcomes:

--- a/src/mobile/apps/home/client/view.coffee
+++ b/src/mobile/apps/home/client/view.coffee
@@ -5,7 +5,6 @@ ShowsFeed = require '../../../collections/shows_feed.coffee'
 PoliteInfiniteScrollView = require '../../../components/polite_infinite_scroll/client/view.coffee'
 Flickity = require 'flickity'
 { seeMoreArtworks } = require '../../../components/show_more_works/index.coffee'
-splitTest = require '../../../../desktop/components/split_test/index.coffee'
 
 featuredItemsTemplate = -> require('../../../components/featured_items/template.jade') arguments...
 currentShowsTemplate = -> require('../templates/current_shows.jade') arguments...
@@ -21,15 +20,6 @@ module.exports = class HomePageView extends PoliteInfiniteScrollView
 
   initialize: ->
     @collection = new ShowsFeed
-    
-    if !sd.CURRENT_USER
-      if sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST == "experiment" 
-        analytics.track("Impression", {
-          context_page: "Home",
-          context_module: "HubEntrypoint",
-          subject: "Featured Categories",
-        })
-      splitTest("homepage_collection_hub_entrypoints_test").view()
 
     @slideshow = new Flickity '#carousel-track',
       cellAlign: 'left'

--- a/src/mobile/apps/home/routes.coffee
+++ b/src/mobile/apps/home/routes.coffee
@@ -26,7 +26,7 @@ query = """
 module.exports.index = (req, res, next) ->
   res.locals.sd.PAGE_TYPE = 'home'
 
-  showCollectionsHubs = res.locals.sd.HOMEPAGE_COLLECTION_HUB_ENTRYPOINTS_TEST == "experiment" && !res.locals.sd.CURRENT_USER
+  showCollectionsHubs = !res.locals.sd.CURRENT_USER
 
   metaphysics(query: query, variables: {showCollectionsHubs: showCollectionsHubs})
     .then ({ home_page, marketingHubCollections }) ->


### PR DESCRIPTION
Addresses: [GROW-1685](https://artsyproduct.atlassian.net/browse/GROW-1685)

This PR closes the homepage hubs entry point test and rolls the entry points out to 100% of logged out users.