### PR TITLE
Make RSS feed resilient to un-fetchable social embed content

### DIFF
--- a/src/desktop/apps/rss/routes.js
+++ b/src/desktop/apps/rss/routes.js
@@ -82,7 +82,7 @@ export const findSocialEmbeds = article => {
       }
     })
   ).then(res => {
-    return res
+    return res.filter(x => !!x)
   })
 }
 

--- a/src/desktop/apps/rss/test/routes.test.js
+++ b/src/desktop/apps/rss/test/routes.test.js
@@ -86,6 +86,16 @@ describe("Routes", () => {
   })
 
   describe("#news", () => {
+    let originalConsoleError = console.error
+
+    beforeEach(() => {
+      console.error = () => {}
+    })
+
+    afterEach(() => {
+      console.error = originalConsoleError
+    })
+
     it("renders the rss feed if #findArticlesWithEmbeds rejects", async () => {
       request.get = sinon.stub().returns({
         end: cb => {

--- a/src/desktop/apps/rss/test/routes.test.js
+++ b/src/desktop/apps/rss/test/routes.test.js
@@ -139,6 +139,17 @@ describe("Routes", () => {
     })
   })
 
+  describe("#findSocialEmbeds", () => {
+    let article = {
+      sections: [{}, undefined],
+    }
+
+    it("filters out undefined sections from an article", async () => {
+      const sections = await routes.findSocialEmbeds(article)
+      sections.length.should.eql(1)
+    })
+  })
+
   describe("#maybeFetchSocialEmbed", () => {
     let section = {}
 


### PR DESCRIPTION
https://artsy.slack.com/archives/C9SATFLUU/p1576679913100400

A deleted Kanye tweet took down our RSS feed, oh yes it did.

It was embedded in [this article](https://www.artsy.net/news/artsy-editorial-kanye-west-will-close-miamis-art-fair-week-premiering-new-opera-vanessa-beecroft), and once it was deleted, the `oembed` content that Force was fetching started 404-ing.

This change makes the RSS feed resilient to un-fetchable embeds by simply filtering out the `undefined` sections that result from them.

If you must know, this was the deleted tweet: https://web.archive.org/web/20191217061445/https://twitter.com/kanyewest/status/1202747255452602368