### PR TITLE
@joeyAghion => [Client Side Routing] Remove AB test calls that moved to Reaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@artsy/gemup": "0.0.3",
     "@artsy/palette": "5.1.11",
     "@artsy/passport": "1.1.6",
-    "@artsy/reaction": "24.0.6",
+    "@artsy/reaction": "^24.0.7",
     "@artsy/stitch": "6.1.6",
     "@babel/core": "7.6.0",
     "@babel/node": "7.6.1",

--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -5,7 +5,6 @@
 
 import { data as sd } from "sharify"
 import { reportLoadTimeToVolley } from "lib/volley"
-const splitTest = require("desktop/components/split_test/index.coffee")
 
 // Track pageview
 const pageType = window.sd.PAGE_TYPE || window.location.pathname.split("/")[1]
@@ -100,9 +99,4 @@ if (sd.SHOW_ANALYTICS_CALLS) {
   analyticsHooks.on("all", function(name, data) {
     console.info("ANALYTICS HOOK: ", name, data)
   })
-}
-
-// TODO: Remove after AB test ends
-if (sd.EXPERIMENTAL_APP_SHELL && sd.CLIENT_SIDE_ROUTING === "control") {
-  splitTest("client_side_routing").view()
 }

--- a/src/desktop/apps/experimental-app-shell/client.tsx
+++ b/src/desktop/apps/experimental-app-shell/client.tsx
@@ -6,7 +6,6 @@ import { data as sd } from "sharify"
 import { client as artworkClient } from "./artwork/client"
 import { client as artistClient } from "./artist/client"
 const mediator = require("desktop/lib/mediator.coffee")
-const splitTest = require("desktop/components/split_test/index.coffee")
 
 buildClientApp({
   routes: getAppRoutes(),
@@ -21,7 +20,6 @@ buildClientApp({
       document.getElementById("react-root"),
       () => {
         const pageType = window.location.pathname.split("/")[1]
-        splitTest("client_side_routing").view()
 
         if (pageType === "search") {
           document.getElementById("loading-container").remove()

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -25,8 +25,8 @@
 # module.exports = {}
 
 module.exports = {
-  client_side_routing:
-    key: "client_side_routing"
+  client_navigation:
+    key: "client_navigation"
     outcomes:
       control: 50
       experiment: 50

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,10 +74,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/react-responsive-media/-/react-responsive-media-2.0.0-beta.5.tgz#d61e1a9f215d38d90ec2bb97dc1ff7409d0346fa"
   integrity sha512-XRYA77v/j3mVInwy5EYb8NtmMkkAD1/XDxDi45BO0oduv4hsljJfjtjK7jN0ziJ6JUm2QTx/t6QwuaT9E7vTuA==
 
-"@artsy/reaction@24.0.6":
-  version "24.0.6"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-24.0.6.tgz#e664b3674183ad51bf9c583052524d22d4614a98"
-  integrity sha512-Cz1rm20OOl/xNeRi9IP8RZiNiqGCeXloo76SMohFbbz2r/XbiG2yhJzMRGa7kG2Mh5jokMlUbtZEbbv+bCw/3w==
+"@artsy/reaction@^24.0.7":
+  version "24.0.7"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-24.0.7.tgz#6530216cb4d8e6cbef9a97cdebdbe733dc600a4d"
+  integrity sha512-2QE4vGfYKSurZNOPzT3X2nHLpWuoNuEtPe31jK1xzLWIYjLZLtu6Ix0uS7uSs51QGnQ1OoiOSxAr37oJlWaPZw==
   dependencies:
     "@artsy/detect-responsive-traits" "^0.0.5"
     "@artsy/react-html-parser" "^3.0.2"
@@ -1952,6 +1952,7 @@ antigravity@artsy/antigravity:
   version "0.1.3"
   resolved "https://codeload.github.com/artsy/antigravity/tar.gz/a4438d2fe9d0cdf71f1c47faba371cd3d004e140"
   dependencies:
+    coffeescript "1.11.1"
     express "*"
 
 any-observable@^0.3.0:


### PR DESCRIPTION
The [Reaction PR](https://github.com/artsy/reaction/pull/3067), once merged, requires these changes to be used in Force.

I usually wind up merging the Reaction PR, and then manually closing the renovate PR that shows up in Force and manually updating the Reaction version and merging this PR.