### PR TITLE
[PURCHASE-1647] Adds json-ld to show mobile page

### DIFF
--- a/src/desktop/apps/show/templates/index.jade
+++ b/src/desktop/apps/show/templates/index.jade
@@ -21,5 +21,5 @@ block body
     include columns
     include footer
 
-  - if (jsonLD)
+  if jsonLD
     include ../../../components/main_layout/templates/json_ld

--- a/src/mobile/apps/show/helpers/view_helpers.coffee
+++ b/src/mobile/apps/show/helpers/view_helpers.coffee
@@ -16,10 +16,10 @@ module.exports =
       endDate: (new Date(show.get('end_at'))).toISOString()
       location: @toJSONLDLocation(show.location()) if show.location()
       performer: @performers(show)
-    }
+    } if show.location()?
 
   performers: (show) ->
-    @toJSONLDShortArtist(artist) for artist in show.get('artists')
+    @toJSONLDShortArtist(artist) for artist in show.get('artists') if show.get('artists')?
 
   toJSONLDShortArtist: (artist) ->
     compactObject {

--- a/src/mobile/apps/show/helpers/view_helpers.coffee
+++ b/src/mobile/apps/show/helpers/view_helpers.coffee
@@ -1,0 +1,45 @@
+_ = require 'underscore'
+{ slugify } = require 'underscore.string'
+{ compactObject } = require '../../../models/mixins/compact_object.coffee'
+sd = require('sharify').data
+
+module.exports =
+
+  toJSONLD: (show) ->
+    compactObject {
+      "@context": "http://schema.org"
+      "@type": "Event"
+      name: show.get('name')
+      image: show.get('image_url')
+      url: "#{sd.APP_URL}/show/#{show.get('id')}"
+      startDate: (new Date(show.get('start_at'))).toISOString()
+      endDate: (new Date(show.get('end_at'))).toISOString()
+      location: @toJSONLDLocation(show.location()) if show.location()
+      performer: @performers(show)
+    }
+
+  performers: (show) ->
+    @toJSONLDShortArtist(artist) for artist in show.get('artists')
+
+  toJSONLDShortArtist: (artist) ->
+    compactObject {
+      "@type": "Person"
+      image: artist.image_url
+      name: artist.name
+      sameAs: "#{sd.APP_URL}/artist/#{artist.sortable_id}"
+    }
+
+  toJSONLDLocation: (location) ->
+    address = [location.get('address') or '', location.get('address_2') or ''].join('')
+    compactObject {
+      "@type": "Place"
+      name: location.get('name')
+      address: compactObject {
+        "@type": "PostalAddress"
+        streetAddress: address
+        addressLocality: location.get('city')
+        addressRegion: location.get('state')
+        postalCode: location.get('postal_code')
+        addressCountry: if location.get('country')?.length > 0 then location.get('country')
+      }
+    }

--- a/src/mobile/apps/show/routes.coffee
+++ b/src/mobile/apps/show/routes.coffee
@@ -40,7 +40,7 @@ module.exports.index = (req, res, next) ->
 
     res.locals.sd.SHOW = show
     res.locals.sd.INSTALL_SHOTS = show.related().installShots
-    res.locals.jsonLD = JSON.stringify ViewHelpers.toJSONLD show if show.location()
+    res.locals.jsonLD = JSON.stringify ViewHelpers.toJSONLD show
     res.render 'index',
       show: show
       fair: show.related().fair

--- a/src/mobile/apps/show/routes.coffee
+++ b/src/mobile/apps/show/routes.coffee
@@ -3,6 +3,7 @@ Q = require 'bluebird-q'
 moment = require 'moment'
 Show = require '../../models/show.coffee'
 Location = require '../../models/location.coffee'
+ViewHelpers = require '../../apps/show/helpers/view_helpers'
 
 
 module.exports.index = (req, res, next) ->
@@ -39,7 +40,7 @@ module.exports.index = (req, res, next) ->
 
     res.locals.sd.SHOW = show
     res.locals.sd.INSTALL_SHOTS = show.related().installShots
-
+    res.locals.jsonLD = JSON.stringify ViewHelpers.toJSONLD show if show.location()
     res.render 'index',
       show: show
       fair: show.related().fair

--- a/src/mobile/apps/show/templates/index.jade
+++ b/src/mobile/apps/show/templates/index.jade
@@ -38,5 +38,5 @@ block content
     if show.get('press_release')
       include press_release
 
-  - if (jsonLD)
+  if jsonLD
     include ../../../../desktop/components/main_layout/templates/json_ld

--- a/src/mobile/apps/show/templates/index.jade
+++ b/src/mobile/apps/show/templates/index.jade
@@ -38,3 +38,5 @@ block content
     if show.get('press_release')
       include press_release
 
+  - if (jsonLD)
+    include ../../../../desktop/components/main_layout/templates/json_ld

--- a/src/mobile/apps/show/test/helpers/view_helpers.test.coffee
+++ b/src/mobile/apps/show/test/helpers/view_helpers.test.coffee
@@ -1,0 +1,37 @@
+sinon = require 'sinon'
+Show = require '../../../../models/show'
+{ fabricate } = require 'antigravity'
+ViewHelper = require '../../helpers/view_helpers.coffee'
+
+describe 'toJSONLD', ->
+  context 'when show has location', ->
+    it 'creates jsonLD metedata', ->
+      show = new Show fabricate 'show'
+      jsonLD = ViewHelper.toJSONLD(show)
+      jsonLD.should.eql({
+        '@context': 'http://schema.org',
+        '@type': 'Event',
+        name: 'Inez & Vinoodh',
+        image: '/local/partner_show_images/51f6a51d275b24a787000c36/1/:version.jpg',
+        url: 'http://artsy.net/show/gagosian-gallery-inez-and-vinoodh1',
+        startDate: '2013-07-12T04:00:00.000Z',
+        endDate: '2013-08-23T04:00:00.000Z',
+        location: Object {
+          '@type': 'Place',
+          address: Object {
+            '@type': 'PostalAddress',
+            streetAddress: '529 W 20th St.2nd Floor',
+            addressLocality: 'New York',
+            addressRegion: 'NY',
+            postalCode: '10011'
+          }
+        }
+      })
+  context 'when show does not have location', ->
+    it 'set jsonLD to null', ->
+      show = new Show fabricate('show', location: null)
+      jsonLD = ViewHelper.toJSONLD(show)
+      (jsonLD == undefined).should.equal(true)
+      
+    
+

--- a/src/mobile/apps/show/test/helpers/view_helpers.test.coffee
+++ b/src/mobile/apps/show/test/helpers/view_helpers.test.coffee
@@ -5,29 +5,37 @@ ViewHelper = require '../../helpers/view_helpers.coffee'
 
 describe 'toJSONLD', ->
   context 'when show has location', ->
-    show = new Show fabricate 'show'
-    jsonLD = ViewHelper.toJSONLD(show)
+    beforeEach ->
+      show = new Show fabricate 'show'
+      @jsonLD = ViewHelper.toJSONLD(show)
+
     it 'jsonld has the show name', ->
-      jsonLD.name.should.containEql('Inez & Vinoodh')
+      @jsonLD.name.should.containEql('Inez & Vinoodh')
+
     it 'jsonld has the show url', ->
-      jsonLD.url.should.containEql('http://artsy.net/show/gagosian-gallery-inez-and-vinoo')
+      @jsonLD.url.should.containEql('http://artsy.net/show/gagosian-gallery-inez-and-vinoo')
+
     it 'jsonld has the image', ->
-      jsonLD.image.should.containEql('/local/partner_show_images/51f6a51d275b24a787000c36/1/:version.jpg')
+      @jsonLD.image.should.containEql('/local/partner_show_images/51f6a51d275b24a787000c36/1/:version.jpg')
+
     it 'jsonld has the show dates', ->
-      jsonLD.startDate.should.containEql('2013-07-12')
-      jsonLD.endDate.should.containEql('2013-08-23')
+      @jsonLD.startDate.should.containEql('2013-07-12')
+      @jsonLD.endDate.should.containEql('2013-08-23')
+
     it 'jsonld has the address', ->
-      jsonLD.location['@type'].should.eql('Place')
-      jsonLD.location.address['@type'].should.eql('PostalAddress')
-      jsonLD.location.address.streetAddress.should.eql('529 W 20th St.2nd Floor')
-      jsonLD.location.address.addressLocality.should.eql('New York')
-      jsonLD.location.address.addressRegion.should.eql('NY')
-      jsonLD.location.address.postalCode.should.eql('10011')
+      @jsonLD.location['@type'].should.eql('Place')
+      @jsonLD.location.address['@type'].should.eql('PostalAddress')
+      @jsonLD.location.address.streetAddress.should.eql('529 W 20th St.2nd Floor')
+      @jsonLD.location.address.addressLocality.should.eql('New York')
+      @jsonLD.location.address.addressRegion.should.eql('NY')
+      @jsonLD.location.address.postalCode.should.eql('10011')
+
   context 'when show does not have location', ->
-    it 'set jsonLD to null', ->
+    beforeEach ->
       show = new Show fabricate('show', location: null)
-      jsonLD = ViewHelper.toJSONLD(show)
-      (jsonLD == undefined).should.equal(true)
+      @jsonLD = ViewHelper.toJSONLD(show)
+    it 'set jsonLD to null', ->
+      (@jsonLD == undefined).should.equal(true)
       
     
 

--- a/src/mobile/apps/show/test/helpers/view_helpers.test.coffee
+++ b/src/mobile/apps/show/test/helpers/view_helpers.test.coffee
@@ -5,28 +5,24 @@ ViewHelper = require '../../helpers/view_helpers.coffee'
 
 describe 'toJSONLD', ->
   context 'when show has location', ->
-    it 'creates jsonLD metedata', ->
-      show = new Show fabricate 'show'
-      jsonLD = ViewHelper.toJSONLD(show)
-      jsonLD.should.eql({
-        '@context': 'http://schema.org',
-        '@type': 'Event',
-        name: 'Inez & Vinoodh',
-        image: '/local/partner_show_images/51f6a51d275b24a787000c36/1/:version.jpg',
-        url: 'http://artsy.net/show/gagosian-gallery-inez-and-vinoodh1',
-        startDate: '2013-07-12T04:00:00.000Z',
-        endDate: '2013-08-23T04:00:00.000Z',
-        location: Object {
-          '@type': 'Place',
-          address: Object {
-            '@type': 'PostalAddress',
-            streetAddress: '529 W 20th St.2nd Floor',
-            addressLocality: 'New York',
-            addressRegion: 'NY',
-            postalCode: '10011'
-          }
-        }
-      })
+    show = new Show fabricate 'show'
+    jsonLD = ViewHelper.toJSONLD(show)
+    it 'jsonld has the show name', ->
+      jsonLD.name.should.containEql('Inez & Vinoodh')
+    it 'jsonld has the show url', ->
+      jsonLD.url.should.containEql('http://artsy.net/show/gagosian-gallery-inez-and-vinoo')
+    it 'jsonld has the image', ->
+      jsonLD.image.should.containEql('/local/partner_show_images/51f6a51d275b24a787000c36/1/:version.jpg')
+    it 'jsonld has the show dates', ->
+      jsonLD.startDate.should.containEql('2013-07-12')
+      jsonLD.endDate.should.containEql('2013-08-23')
+    it 'jsonld has the address', ->
+      jsonLD.location['@type'].should.eql('Place')
+      jsonLD.location.address['@type'].should.eql('PostalAddress')
+      jsonLD.location.address.streetAddress.should.eql('529 W 20th St.2nd Floor')
+      jsonLD.location.address.addressLocality.should.eql('New York')
+      jsonLD.location.address.addressRegion.should.eql('NY')
+      jsonLD.location.address.postalCode.should.eql('10011')
   context 'when show does not have location', ->
     it 'set jsonLD to null', ->
       show = new Show fabricate('show', location: null)


### PR DESCRIPTION
Fixes [PURCHASE-1647](https://artsyproduct.atlassian.net/browse/PURCHASE-1647)

The new `view_helpers.coffee` contains needed functions from the ['Desktop' app](https://github.com/artsy/force/blob/920160b8c156bae897ba0259e8cd0e25c0067f75/src/desktop/apps/show/helpers/view_helpers.coffee#L171-L211) modified to use the `show` model object instead of MP returned object (`show.location` -> `show.location()` and `location.city` -> `location.get('city')` etc.).