### PR TITLE
@joeyAghion => [CCPA] Add CCPA trigger to mobile

### DIFF
--- a/src/mobile/components/layout/stylesheets/footer.styl
+++ b/src/mobile/components/layout/stylesheets/footer.styl
@@ -9,6 +9,9 @@ footer
 .footer__bottom-nav
   padding 30px 12px
 
+#ccpa-request > div > div:first-child
+  color white
+
 .footer__bottom-nav__link
   serif()
   display inline-block

--- a/src/mobile/components/layout/templates/footer.jade
+++ b/src/mobile/components/layout/templates/footer.jade
@@ -6,4 +6,7 @@ footer
     a.footer__bottom-nav__link(href="/about") About Artsy
     a.footer__bottom-nav__link(href="/terms") Terms of Use
     a.footer__bottom-nav__link(href="/privacy") Privacy Policy
+    if sd.PAGE_TYPE === 'home'
+      span#ccpa-request
+        != stitch && stitch.components.CCPARequest({ user: sd.CURRENT_USER })
     a.footer__bottom-nav__link(href='/conditions-of-sale') Conditions of Sale


### PR DESCRIPTION
Whoops! Since the mobile homepage is a different app and layout, it needs it's own modification to accommodate a stitched-in CCPA modal component. Luckily our modal already goes full-screen on smaller layouts, so doesn't need any further modifications.

However, the CTA text winds up spilling over:

<img width="464" alt="Screen Shot 2019-12-31 at 3 56 02 PM" src="https://user-images.githubusercontent.com/1457859/71634029-62e70080-2be6-11ea-975e-eeec93131904.png">
