### PR TITLE
Fix list spacing in markdown pages

### DIFF
--- a/src/desktop/apps/page/index.styl
+++ b/src/desktop/apps/page/index.styl
@@ -32,12 +32,18 @@
     line-height 1.5em
   ul
     list-style disc
+    margin-left 1em
     li
       margin-bottom 1em
+      margin-left 1em
+      line-height 1.5em
   ol
     list-style decimal
+    margin-left 1em
     li
       margin-bottom 1em
+      margin-left 1em
+      line-height 1.5em
 
 @media (max-width: 600px)
   #page-markdown-content


### PR DESCRIPTION
Re: https://artsy.slack.com/archives/C9XJKPY9W/p1578064164017200

CCPA + Hackathon + typographical OCD = this PR

We have some Markdown-powered pages on the website that are administered in old admin (e.g. https://admin.artsy.net/page/privacy) 

These are rendered by the `page` sub app within Force, where a few corrections to some `ul` and `ol` styles were in order. Thanks to @jeffreytr for reviewing.

<img width="1438" alt="list" src="https://user-images.githubusercontent.com/140521/72175009-08e5f800-33a9-11ea-9fe9-51fe14251310.png">
