### PR TITLE
Put back inquiry styles

### DIFF
--- a/src/desktop/assets/artwork.styl
+++ b/src/desktop/assets/artwork.styl
@@ -1,5 +1,6 @@
 @require '../components/buyers_premium'
 @require '../components/view_in_room'
+@require '../components/inquiry_questionnaire/stylesheets'
 
 .modalize-body
   padding 30px


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/PURCHASE-1674

Require the inquiry styles on artwork page, which fixes mysterious "send anyways?" prompt and adds proper styling to forms. 

<img width="527" alt="Screen Shot 2020-01-15 at 1 32 06 PM" src="https://user-images.githubusercontent.com/1497424/72461255-986e1b00-379c-11ea-85aa-81e7a6954fe0.png">
<img width="486" alt="Screen Shot 2020-01-15 at 1 31 56 PM" src="https://user-images.githubusercontent.com/1497424/72461262-9c9a3880-379c-11ea-9f11-a75be9ac1460.png">
