### PR TITLE
add sale slug to Auction Pageview tracking event

### DIFF
--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -20,7 +20,8 @@ if (!excludedRoutes.includes(pageType)) {
 if (pageType == "auction") {
   window.addEventListener("load", function() {
     // distinct event required for marketing integrations (Criteo)
-    window.analytics.track("Auction Pageview")
+    const saleSlug = window.location.pathname.split("/")[2]
+    window.analytics.track("Auction Pageview", { auction_slug: saleSlug })
   })
 }
 


### PR DESCRIPTION
Adds an `auction_slug` property to our `Auction Pageview` tracking event at the request of marketing. This is needed for lifecycle email marketing via Sailthru... pageviews can act as triggers for marketing emails under certain conditions.