### PR TITLE
Skip cypress tests on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,12 @@ jobs:
       - run:
           name: Acceptance Tests
           command: yarn acceptance src/test/acceptance/*.js
+
+  acceptance_cypress:
+    docker:
+      - image: circleci/node:10-stretch-browsers
+    steps:
+      - yarn/setup
       - run:
           name: Cypress Tests
           command: yarn test:smoke
@@ -48,6 +54,14 @@ jobs:
       - run:
           name: Danger
           command: DANGER_GITHUB_API_TOKEN="15e52de81a772b174cc5""e1813d0083564c69c325" yarn danger ci
+
+not_master_or_staging_or_release: &not_master_or_staging_or_release
+  filters:
+    branches:
+      ignore:
+        - master
+        - staging
+        - release
 
 not_staging_or_release: &not_staging_or_release
   filters:
@@ -104,6 +118,8 @@ workflows:
           <<: *not_staging_or_release
       - acceptance:
           <<: *not_staging_or_release
+      - acceptance_cypress:
+          <<: *not_master_or_staging_or_release
       - build:
           <<: *not_staging_or_release
       - danger:


### PR DESCRIPTION
Skip cypress test suite on master builds while we work on its stability.