### PR TITLE
staging doesn't need to create 2 pods before destroying the old ones

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -5,8 +5,7 @@ metadata:
 spec:
   strategy:
     rollingUpdate:
-      maxSurge: 2
-      maxUnavailable: 0
+      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:


### PR DESCRIPTION
We can stand to go down to 1 pod on staging during rollouts

cc @eessex @mzikherman 