### PR TITLE
Remove appShell related code that was causing 404 on staging and prod

### DIFF
--- a/src/desktop/apps/purchases/server.tsx
+++ b/src/desktop/apps/purchases/server.tsx
@@ -4,13 +4,11 @@ import { routes } from "reaction/Apps/Purchase/routes"
 import React from "react"
 import { buildServerAppContext } from "desktop/lib/buildServerAppContext"
 import express, { Request, Response, NextFunction } from "express"
-import { skipIfClientSideRoutingEnabled } from "desktop/components/split_test/skipIfClientSideRoutingEnabled"
 
 export const app = express()
 
 app.get(
   "/user/purchases",
-  skipIfClientSideRoutingEnabled,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const context = buildServerAppContext(req, res, {})


### PR DESCRIPTION
# Problem
We are getting 404 for newly added `user/purchases` on staging and production.

# Solution
Remove `skipIfClientSideRoutingEnabled` which would work for apps in our app shell which this purchase app is not one of those :)

https://artsy.slack.com/archives/C9YNS4X32/p1580827434305600

