### PR TITLE
@joeyAghion => [Performance] Cache unauthenticated pages, configurable via ENV

### DIFF
--- a/src/desktop/apps/artist/server.tsx
+++ b/src/desktop/apps/artist/server.tsx
@@ -58,6 +58,8 @@ app.get(
         },
       })
 
+      res.locals.PAGE_CACHE = { status, key: req.url, html: layout }
+
       res.status(status).send(layout)
     } catch (error) {
       next(error)

--- a/src/desktop/apps/collect/server.tsx
+++ b/src/desktop/apps/collect/server.tsx
@@ -19,6 +19,7 @@ const index = async (req, res, next) => {
       redirect,
       scripts,
       styleTags,
+      status,
     } = await buildServerApp({
       routes: collectRoutes,
       url: req.url,
@@ -48,6 +49,7 @@ const index = async (req, res, next) => {
       },
     })
 
+    res.locals.PAGE_CACHE = { status, key: req.url, html: layout }
     res.send(layout)
   } catch (error) {
     console.log(error)

--- a/src/desktop/apps/experimental-app-shell/server.tsx
+++ b/src/desktop/apps/experimental-app-shell/server.tsx
@@ -82,6 +82,7 @@ app.get(
         },
       })
 
+      res.locals.PAGE_CACHE = { status, key: req.url, html: layout }
       res.status(status).send(layout)
     } catch (error) {
       console.log(error)

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -24,11 +24,4 @@
 # this should export empty Object
 # module.exports = {}
 
-module.exports = {
-  client_navigation_v2:
-    key: "client_navigation_v2"
-    outcomes:
-      control: 50
-      experiment: 50
-    edge: "experiment"
-}
+module.exports = {}

--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -85,6 +85,12 @@ module.exports =
   MOBILE_MEDIA_QUERY: "only screen and (max-width: 640px)"
   NODE_ENV: 'development'
   OPENREDIS_URL: null
+  PAGE_CACHE_ENABLED: false
+  PAGE_CACHE_TYPES: 'artist'
+  PAGE_CACHE_NAMESPACE: 'page-cache'
+  PAGE_CACHE_VERSION: '1'
+  PAGE_CACHE_EXPIRY_SECONDS: 600
+  PAGE_CACHE_RETRIEVAL_TIMEOUT_MS: 400
   PARSELY_KEY: 'artsy.net'
   EDITORIAL_PATHS: '^\/article|^\/2016-year-in-art|^\/venice-biennale|^\/gender-equality|^\/series|^\/video|^\/news'
   PARSELY_SECRET: null

--- a/src/lib/middleware/pageCacheMiddleware.ts
+++ b/src/lib/middleware/pageCacheMiddleware.ts
@@ -1,0 +1,113 @@
+import {
+  // @ts-ignore
+  PAGE_CACHE_ENABLED,
+  // @ts-ignore
+  PAGE_CACHE_TYPES,
+  // @ts-ignore
+  PAGE_CACHE_NAMESPACE,
+  // @ts-ignore
+  PAGE_CACHE_VERSION,
+  // @ts-ignore
+  PAGE_CACHE_EXPIRY_SECONDS,
+  // @ts-ignore
+  PAGE_CACHE_RETRIEVAL_TIMEOUT_MS,
+} from "../../config"
+import { Request, Response, NextFunction } from "express"
+const cache = require("lib/cache.coffee")
+const runningTests = Object.keys(
+  require("desktop/components/split_test/running_tests.coffee")
+).sort()
+const cacheablePageTypes: string[] = PAGE_CACHE_TYPES.split("|")
+
+// Middleware will `next` and do nothing if any of the following is true:
+//
+// * page cache feature is disabled.
+// * a user is signed in.
+// * this isnt a supported cacheable path (there is an allow-list set in ENV).
+// * the page content is uncached.
+// * the cache errors.
+export const pageCacheMiddleware = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  if (!PAGE_CACHE_ENABLED) return next()
+
+  // Returns true if the page type corresponding to `url` is configured cacheable.
+  const isCacheablePageType = (url: string) => {
+    const pathWithQueryParams = url.split("/")[1]
+    const pageType = pathWithQueryParams.split("?")[0]
+
+    return cacheablePageTypes.includes(pageType)
+  }
+  if (!isCacheablePageType(req.url)) return next()
+
+  // @ts-ignore
+  const hasUser = !!req.user
+  if (hasUser) return next()
+
+  // Generate cache key that includes all currently running AB tests and outcomes.
+  const runningTestsCacheKey = runningTests
+    .map(test => {
+      const outcome = res.locals.sd[test.toUpperCase()]
+      return `${test}:${outcome}`
+    })
+    .join("|")
+
+  // `key` should be a full URL w/ query params, and not a path.
+  // This is to separate URL's like `/collect` and `/collect?acquireable=true`.
+  const cacheKey = (key: string) => {
+    return [PAGE_CACHE_NAMESPACE, runningTestsCacheKey, PAGE_CACHE_VERSION, key]
+      .filter(Boolean)
+      .join("|")
+  }
+
+  // `key` is the full URL.
+  const cacheHtmlForPage = ({ status, key, html }) => {
+    if (status !== 200) return
+
+    cache.set(cacheKey(key), html, PAGE_CACHE_EXPIRY_SECONDS)
+  }
+
+  const cacheKeyForRequest = cacheKey(req.url)
+
+  // Register callback to write rendered page data to cache.
+  res.once("finish", () => {
+    if (res.locals.PAGE_CACHE) {
+      console.log(`[Page Cache]: Writing ${cacheKeyForRequest} to cache`)
+      cacheHtmlForPage(res.locals.PAGE_CACHE)
+    }
+  })
+
+  try {
+    await new Promise((resolve, reject) => {
+      // Cache timeout handler, will reject if hit.
+      let timeoutId: NodeJS.Timer | null = setTimeout(() => {
+        timeoutId = null
+        const error = new Error(
+          `Timeout of ${PAGE_CACHE_RETRIEVAL_TIMEOUT_MS}ms, skipping...`
+        )
+        reject(error)
+      }, PAGE_CACHE_RETRIEVAL_TIMEOUT_MS)
+
+      const handleCacheGet = (_err, html) => {
+        if (!timeoutId) return // Already timed out.
+
+        clearTimeout(timeoutId)
+
+        if (html) {
+          console.log(`[Page Cache]: Reading ${cacheKeyForRequest} from cache`)
+          return res.send(html)
+        }
+
+        resolve()
+      }
+
+      cache.get(cacheKey(req.url), handleCacheGet)
+    })
+  } catch (e) {
+    console.log(`[Page Cache Middleware]: ${e.message}`)
+  } finally {
+    next()
+  }
+}

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -45,6 +45,7 @@ import compression from "compression"
 import { assetMiddleware } from "./middleware/assetMiddleware"
 import { isDevelopment, isProduction } from "lib/environment"
 import { unsupportedBrowserCheck } from "lib/middleware/unsupportedBrowser"
+import { pageCacheMiddleware } from "lib/middleware/pageCacheMiddleware"
 
 // FIXME: When deploying new Sentry SDK to prod we quickly start to see errors
 // like "`CURRENT_USER` is undefined". We need more investigation because this
@@ -218,6 +219,7 @@ export default function(app) {
   app.use(unsupportedBrowserCheck)
   if (NODE_ENV !== "test") app.use(splitTestMiddleware)
   app.use(addIntercomUserHash)
+  app.use(pageCacheMiddleware)
 
   // Routes for pinging system time and up
   app.get("/system/time", (req, res) =>


### PR DESCRIPTION
cc @damassi @zephraph 

This implements a [relatively] simple mechanism for caching the full HTML of pages.

Which 'types' of pages to cache (artist, artwork, collection, etc.), and how long to cache are all configurable via ENV (as-is this entire feature, which can be enabled with a feature flag).

Additionally, there are some cache namespace and version ENV vars which can be used to effectively bust the cache anytime (for instance, after a deploy where a change is desired to be visible right away).

It's pretty simple, and locally seems to work great. Here are some local (not particularly realistic) benchmarks:

Without cache:

```
Document Path:          /artist/andy-warhol
Document Length:        274180 bytes

Concurrency Level:      1
Time taken for tests:   4.894 seconds
Complete requests:      5
Failed requests:        4
   (Connect: 0, Receive: 0, Length: 4, Exceptions: 0)
Total transferred:      1389383 bytes
HTML transferred:       1385812 bytes
Requests per second:    1.02 [#/sec] (mean)
Time per request:       978.766 [ms] (mean)
Time per request:       978.766 [ms] (mean, across all concurrent requests)
Transfer rate:          277.25 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:   781  979 190.5   1048    1223
Waiting:      781  978 190.4   1048    1223
Total:        781  979 190.5   1048    1224

Percentage of the requests served within a certain time (ms)
  50%   1020
  66%   1077
  75%   1077
  80%   1224
  90%   1224
  95%   1224
  98%   1224
  99%   1224
 100%   1224 (longest request)
```

With cache:

```
Document Path:          /artist/andy-warhol
Document Length:        279504 bytes

Concurrency Level:      1
Time taken for tests:   0.752 seconds
Complete requests:      5
Failed requests:        0
Total transferred:      1401091 bytes
HTML transferred:       1397520 bytes
Requests per second:    6.65 [#/sec] (mean)
Time per request:       150.388 [ms] (mean)
Time per request:       150.388 [ms] (mean, across all concurrent requests)
Transfer rate:          1819.63 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:   110  150  27.0    156     184
Waiting:      109  149  25.6    156     179
Total:        110  150  27.0    156     184

Percentage of the requests served within a certain time (ms)
  50%    152
  66%    160
  75%    160
  80%    184
  90%    184
  95%    184
  98%    184
  99%    184
 100%    184 (longest request)
```

It can be safely merged (since it's opt-in and fully disabled by default), and we can experiment on staging (and prod?!).

I'm curious to hear other's thoughts. It's not as 'complete' a solution as true edge caching with a CDN, but there are a host of hurdles to overcome for that, whereas this winds up being easier to understand and immediately implement, and possibly gives us a lot of benefit.