### PR TITLE
Untie client-side-routing from A/B test

### DIFF
--- a/src/desktop/components/split_test/skipIfClientSideRoutingEnabled.ts
+++ b/src/desktop/components/split_test/skipIfClientSideRoutingEnabled.ts
@@ -1,7 +1,7 @@
-export const skipIfClientSideRoutingEnabled = (_req, res, next) => {
+export const skipIfClientSideRoutingEnabled = (_req, _res, next) => {
   if (
-    process.env.EXPERIMENTAL_APP_SHELL &&
-    res.locals.sd.CLIENT_NAVIGATION_V2 === "experiment"
+    process.env.EXPERIMENTAL_APP_SHELL
+    // && res.locals.sd.CLIENT_NAVIGATION_V2 === "experiment"
   ) {
     return next("route")
   } else {

--- a/src/lib/webpack-dev-server.js
+++ b/src/lib/webpack-dev-server.js
@@ -23,7 +23,7 @@ app.use(
        *
        * @see https://github.com/artsy/reaction/blob/master/src/Artsy/Router/buildServerApp.tsx
        */
-      return /loadable-stats/.test(filePath)
+      return /loadable-stats/.test(filePath) || /manifest/.test(filePath)
     },
   })
 )


### PR DESCRIPTION
This allows us to test client-side nav on staging without the need to be within an A/B test context. 