### PR TITLE
[Clientside Routing] Ensure search loads main bundle when loading /search from SSR context

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@artsy/gemup": "0.0.3",
     "@artsy/palette": "5.1.16",
     "@artsy/passport": "1.1.11",
-    "@artsy/reaction": "25.9.2",
+    "@artsy/reaction": "25.9.3",
     "@artsy/stitch": "6.1.6",
     "@babel/core": "7.6.0",
     "@babel/node": "7.6.1",

--- a/src/desktop/apps/experimental-app-shell/client.tsx
+++ b/src/desktop/apps/experimental-app-shell/client.tsx
@@ -5,6 +5,7 @@ import { getAppRoutes } from "reaction/Apps/getAppRoutes"
 import { data as sd } from "sharify"
 import { client as artworkClient } from "./artwork/client"
 import { client as artistClient } from "./artist/client"
+import { loadableReady } from "@loadable/component"
 
 /**
  * FIXME: Do we actually need this to rehydrate split bundles? Noticing that
@@ -12,7 +13,6 @@ import { client as artistClient } from "./artist/client"
  * needed, or we're doing something incorrect when emitting split bundled scripts
  * from `Reaction/Router/buildServerApp`.
  */
-// import { loadableReady } from "@loadable/component"
 
 const mediator = require("desktop/lib/mediator.coffee")
 
@@ -24,18 +24,20 @@ buildClientApp({
   } as any,
 })
   .then(({ ClientApp }) => {
-    ReactDOM.hydrate(
-      <ClientApp />,
-      document.getElementById("react-root"),
-      () => {
-        const pageType = window.location.pathname.split("/")[1]
+    loadableReady(() => {
+      ReactDOM.hydrate(
+        <ClientApp />,
+        document.getElementById("react-root"),
+        () => {
+          const pageType = window.location.pathname.split("/")[1]
 
-        if (pageType === "search") {
-          document.getElementById("loading-container").remove()
-          document.getElementById("search-page-header").remove()
+          if (pageType === "search") {
+            document.getElementById("loading-container").remove()
+            document.getElementById("search-page-header").remove()
+          }
         }
-      }
-    )
+      )
+    })
   })
   .catch(error => {
     console.error(error)

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,10 +84,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/react-html-parser/-/react-html-parser-3.0.2.tgz#6213d662441acf0bd8c9ee953aa77ac8d9cf1cdd"
   integrity sha512-FXiRSqfSvwpz/QgwaqFvjJsbDmo9qMGpvUp/0p1V6muaJbGnfxkTSxAYWmYlFst6bmjhVxCYKxvgQhEVE03Wfg==
 
-"@artsy/reaction@25.9.2":
-  version "25.9.2"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-25.9.2.tgz#6a6886665e953e504ab4e4c9371d79f020ed97bb"
-  integrity sha512-C8stal66fhMsmcEHqjCf+tL0x7yV8iJxs9BF4yKkp4a+zE/Wfjb9G7a0x6ZeCzdjsW0KObKzvoiWSEmTkVC2vw==
+"@artsy/reaction@25.9.3":
+  version "25.9.3"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-25.9.3.tgz#53976033311eac2706f17017348230c40637b4eb"
+  integrity sha512-U9DnrfxkbOEW/akydQdSK4jkUrNhEFoVMOfnd0+vPneaSe/iM4znRZ6LTqn5XwC3wZDVup+WHx3V0ZWRC+rB5g==
   dependencies:
     "@artsy/detect-responsive-traits" "^0.0.5"
     "@artsy/fresnel" "^1.0.13"


### PR DESCRIPTION
Noticed that search works great when already in the client-side routing context, but when going directly to `/search` after a hard jump the page never loads. This is a bit of fallout from bundle splitting in that we now dynamically inject all relevant scripts into the shell during SSR render, from reaction's [buildServerApp](https://github.com/artsy/reaction/blob/master/src/Artsy/Router/buildServerApp.tsx#L172-L173).  

Since we don't _fully_ render the search app on the server (we only render the flashing loading component -- and therefore don't use `buildServerApp`), we still need to inject in the new app shell JS script tag in so that the client has something to attach to once it mounts. 