### PR TITLE
Fix artist.css 404 and inquire form css

### DIFF
--- a/src/desktop/assets/artist.styl
+++ b/src/desktop/assets/artist.styl
@@ -1,0 +1,2 @@
+.artist__foo
+  width: 100%

--- a/src/desktop/assets/main_layout.styl
+++ b/src/desktop/assets/main_layout.styl
@@ -7,3 +7,4 @@
 @require '../components/publish_modal'
 @require '../components/clock'
 @require '../components/recently_viewed_artworks'
+@require '../components/inquiry_questionnaire/stylesheets'


### PR DESCRIPTION
Fixes longstanding 404 issue around `artist.css`. File didn't exist in `assets` since we build our css in a new way now in reaction via styled-components; however, our legacy pages expect an asset that matches the js file. This is no longer an issue in the new client-side-routing scheme of things.

Also, fixes the unstyled inquire form on artist page in client-side routing context by importing legacy inquire form css (built with backbone) into the main layout css file. 

This is the only old .js I believe we're using in our new pages, but for reference I moved the file reference from [here](https://github.com/artsy/force/blob/master/src/desktop/assets/artwork.styl#L3) to [here](https://github.com/artsy/force/blob/master/src/desktop/assets/main_layout.styl). If we ever encounter the need to access old js in new pages and that js has an associated stylesheet we'll need to do something similar. 