### PR TITLE
[Clientside Routing] Wire in Auctions app 

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@artsy/gemup": "0.0.3",
     "@artsy/palette": "5.1.16",
     "@artsy/passport": "1.1.11",
-    "@artsy/reaction": "25.10.0",
+    "@artsy/reaction": "25.11.0",
     "@artsy/stitch": "6.1.6",
     "@babel/core": "7.6.0",
     "@babel/node": "7.6.1",

--- a/src/desktop/apps/auction_reaction/server.tsx
+++ b/src/desktop/apps/auction_reaction/server.tsx
@@ -1,9 +1,22 @@
 import express from "express"
+import { skipIfClientSideRoutingEnabled } from "desktop/components/split_test/skipIfClientSideRoutingEnabled"
 import { bidderRegistration, auctionFAQRoute, confirmBidRoute } from "./routes"
 
 export const app = express()
 
-app.get("/auction-faq", auctionFAQRoute)
-app.get("/auction-registration/:auctionID", bidderRegistration)
-app.get("/auction-registration2/:auctionID*", bidderRegistration)
-app.get("/auction/:auctionID/bid/:artworkID", confirmBidRoute)
+app.get("/auction-faq", skipIfClientSideRoutingEnabled, auctionFAQRoute)
+app.get(
+  "/auction-registration/:auctionID",
+  skipIfClientSideRoutingEnabled,
+  bidderRegistration
+)
+app.get(
+  "/auction-registration2/:auctionID*",
+  skipIfClientSideRoutingEnabled,
+  bidderRegistration
+)
+app.get(
+  "/auction/:auctionID/bid/:artworkID",
+  skipIfClientSideRoutingEnabled,
+  confirmBidRoute
+)

--- a/src/desktop/apps/auction_support/index.coffee
+++ b/src/desktop/apps/auction_support/index.coffee
@@ -1,9 +1,15 @@
 express = require 'express'
 routes = require './routes'
+{ skipIfClientSideRoutingEnabled } = require("../../components/split_test/skipIfClientSideRoutingEnabled")
 
 app = module.exports = express()
 app.set 'views', __dirname + '/templates'
 app.set 'view engine', 'jade'
 
-app.get '/auction-registration/:id', routes.modalAuctionRegistration
+# FIXME: Remove once A/B test completes
+if process.env.EXPERIMENTAL_APP_SHELL
+  app.get '/auction-registration-modal/:id', routes.modalAuctionRegistration
+else
+  app.get '/auction-registration/:id', routes.modalAuctionRegistration
+
 app.get '/auction/:id/buyers-premium', routes.buyersPremium

--- a/src/desktop/apps/auction_support/routes.coffee
+++ b/src/desktop/apps/auction_support/routes.coffee
@@ -7,6 +7,8 @@ registerAndRedirect = (sale, req, res, next) ->
   req.user.fetchCreditCards
     error: res.backboneError
     success: (creditCards) ->
+
+      # FIXME: What happens when creditCards.length === 0? Noticing that the app hangs
       if (creditCards.length > 0)
         # If the user did not accept conditions explicitly
         # (through the AcceptConditionsOfSaleModal) redirect to the auction flow
@@ -29,12 +31,16 @@ registerAndRedirect = (sale, req, res, next) ->
                 }
               )
               res.redirect sale.registrationSuccessUrl()
+      else
+        # FIXME: Not sure how to handle this case
+        console.log('Error: No credit card...')
+        res.redirect sale.redirectUrl(sale.get('href'))
 
 
 @modalAuctionRegistration = (req, res, next) ->
   unless req.user
     return res.redirect "/log_in?redirect_uri=/auction-registration/#{req.params.id}"
-    
+
   new Sale(id: req.params.id).fetch
     error: res.backboneError
     success: (sale) ->

--- a/src/desktop/apps/experimental-app-shell/auction/bidderRegistrationMiddleware.ts
+++ b/src/desktop/apps/experimental-app-shell/auction/bidderRegistrationMiddleware.ts
@@ -1,0 +1,30 @@
+export const bidderRegistrationMiddleware = (req, res, next) => {
+  const pageParts = req.path.split("/")
+  const pageType = pageParts[1]
+  console.log(req.params)
+
+  if (
+    pageType === "auction-registration" ||
+    pageType === "auction-registration2"
+  ) {
+    /**
+     * If this request is from a registration modal (trying to create a bidder),
+     * defer to the auction_support app router.
+     *
+     * @see Force: src/desktop/apps/auction_support/index.coffee
+     */
+    if (req.query["accepted-conditions"] === "true") {
+      const newUrl = req.url.replace(
+        "/auction-registration/",
+        "/auction-registration-modal/"
+      )
+      return res.redirect(newUrl)
+    } else if (!res.locals.sd.CURRENT_USER) {
+      return res.redirect(
+        `/login?redirectTo=${encodeURIComponent(req.originalUrl)}`
+      )
+    }
+  }
+
+  next()
+}

--- a/src/desktop/apps/experimental-app-shell/auction/confirmBidMiddleware.ts
+++ b/src/desktop/apps/experimental-app-shell/auction/confirmBidMiddleware.ts
@@ -1,0 +1,14 @@
+export const confirmBidMiddleware = (req, res, next) => {
+  const pageParts = req.path.split("/")
+  const pageType = pageParts[1]
+
+  if (pageType === "auction") {
+    if (!res.locals.sd.CURRENT_USER) {
+      return res.redirect(
+        `/login?redirectTo=${encodeURIComponent(req.originalUrl)}`
+      )
+    }
+  }
+
+  next()
+}

--- a/src/desktop/apps/experimental-app-shell/server.tsx
+++ b/src/desktop/apps/experimental-app-shell/server.tsx
@@ -12,19 +12,35 @@ import { StitchWrapper } from "desktop/components/react/stitch_components/Stitch
 
 import { handleArtworkImageDownload } from "./artwork/artworkMiddleware"
 import { artistMiddleware } from "./artist/artistMiddleware"
-import { searchMiddleware } from "./search/middleware"
+import { bidderRegistrationMiddleware } from "./auction/bidderRegistrationMiddleware"
+import { confirmBidMiddleware } from "./auction/confirmBidMiddleware"
 import { orderMiddleware } from "./order/orderMiddleware"
+import { searchMiddleware } from "./search/middleware"
 
 export const app = express()
 
 // Non-Reaction routes
 app.get("/artwork/:artworkID/download/:filename", handleArtworkImageDownload)
 
+/**
+ * Mount routes that will connect to global SSR router
+ */
 app.get(
   "/*",
-  searchMiddleware,
+
+  /**
+   * Mount middleware for handling server-side portions of apps mounted into
+   * global router.
+   */
   artistMiddleware,
+  bidderRegistrationMiddleware,
+  confirmBidMiddleware,
   orderMiddleware,
+  searchMiddleware,
+
+  /**
+   * Route handler
+   */
   async (req: Request, res, next) => {
     try {
       const pageParts = req.path.split("/")

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,10 +84,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/react-html-parser/-/react-html-parser-3.0.2.tgz#6213d662441acf0bd8c9ee953aa77ac8d9cf1cdd"
   integrity sha512-FXiRSqfSvwpz/QgwaqFvjJsbDmo9qMGpvUp/0p1V6muaJbGnfxkTSxAYWmYlFst6bmjhVxCYKxvgQhEVE03Wfg==
 
-"@artsy/reaction@25.10.0":
-  version "25.10.0"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-25.10.0.tgz#f514fd201dc7c45885919f6b3403c686de043b52"
-  integrity sha512-0QEC1FNW7j2DZ+IPwT9VaI3etaMQ8Hd+JRpciWv6m0DHtVzA++Rp0g8TI310GUAx1PMYB4LT9R3CTSEn5mbWaw==
+"@artsy/reaction@25.11.0":
+  version "25.11.0"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-25.11.0.tgz#6e3c94808e9532e9add4c4259b5cd3241e90230b"
+  integrity sha512-eFaEj9muxEVx8r9Sdflji8oRYbt06YRA8+dvmguxpTQAPB3aXnrpP7sBFwmLHuo2FFdK+qi+XeQ+kUdf6cfZMg==
   dependencies:
     "@artsy/detect-responsive-traits" "^0.0.5"
     "@artsy/fresnel" "^1.0.13"


### PR DESCRIPTION
Reaction PR: https://github.com/artsy/reaction/pull/3163

Moves the auctions app into the main app shell and moves server-side redirect code into middleware that's mounted in global app shell.  No real behavior changes, but did notice two things:

1) Discovered a bug where during registration if a user doesn't have a card on file the express app hangs. Will note it inline
2) Renamed the legacy `auction-registration` route in `bid_support` to `auction-registration-modal` to a) more accurately describe what's happening; and b) to remove a conflict between the new global router and express having multiple `auction-registration` routes defined. 

#### Todo:
- [x] QA with person on Auctions team (with @erikdstock) 

#### To test:
- `yarn link` with reaction PR above
- Add `EXPERIMENTAL_APP_SHELL=true` to env file. If this is missing or set to false everything behaves as it did before. 

![bid](https://user-images.githubusercontent.com/236943/74612549-251d3900-50bb-11ea-8fec-2eeda2584f2a.gif)

