### PR TITLE
[Clientside Routing] Fix legacy buyers premium modal css

### DIFF
--- a/src/desktop/assets/main_layout.styl
+++ b/src/desktop/assets/main_layout.styl
@@ -8,3 +8,14 @@
 @require '../components/clock'
 @require '../components/recently_viewed_artworks'
 @require '../components/inquiry_questionnaire/stylesheets'
+
+// TODO: Remove once Buyers Premium modal has been rebuilt in Reaction
+.artwork-auction-buyers-premium-modal
+  .modalize-body
+    padding 40px
+
+    h2
+      sans('l-headline')
+      margin-bottom: 10px;
+    p
+      margin-bottom: 20px


### PR DESCRIPTION
Realized Artwork page buyers premium modal is also old backbone-esque code. 

That brings the number of different modals on Artwork page to 4 😄 

<img width="762" alt="Screen Shot 2020-02-16 at 12 04 37 AM" src="https://user-images.githubusercontent.com/236943/74601189-3d0ba300-5050-11ea-93ce-ed503db4cbc3.png">
