### PR TITLE
[Clientside Nav] Fix path to orders

### DIFF
--- a/src/desktop/apps/experimental-app-shell/order/orderMiddleware.tsx
+++ b/src/desktop/apps/experimental-app-shell/order/orderMiddleware.tsx
@@ -2,7 +2,7 @@ export const orderMiddleware = (req, res, next) => {
   const pageParts = req.path.split("/")
   const pageType = pageParts[1]
 
-  if (pageType === "order") {
+  if (pageType === "orders") {
     if (!res.locals.sd.CURRENT_USER) {
       return res.redirect(
         `/login?redirectTo=${encodeURIComponent(req.originalUrl)}`


### PR DESCRIPTION
The pathname for orders app is `orders` not `order`. Integrity caught this issue.