### PR TITLE
Update redirects and links for Gallery Insights content

### DIFF
--- a/src/desktop/apps/article/__tests__/routes.jest.ts
+++ b/src/desktop/apps/article/__tests__/routes.jest.ts
@@ -3,6 +3,7 @@ import { getCurrentUnixTimestamp } from "@artsy/reaction/dist/Components/Publish
 import * as fixtures from "@artsy/reaction/dist/Components/Publishing/Fixtures/Articles"
 import * as routes from "../routes"
 import { extend } from "lodash"
+import { GalleryInsightsRedirects } from "../gallery_insights_redirects"
 const Article = require("desktop/models/article.coffee")
 const Channel = require("desktop/models/channel.coffee")
 
@@ -169,6 +170,22 @@ describe("Article Routes", () => {
 
       routes.index(req, res, next).then(() => {
         expect(res.redirect).toBeCalledWith("https://partners.artsy.net")
+        done()
+      })
+    })
+
+    it("redirects to specific partners.artsy.net content if slug exists in redirect mapping", done => {
+      const slug = Object.keys(GalleryInsightsRedirects)[0]
+      const redirectSlug = GalleryInsightsRedirects[slug]
+
+      article.channel_id = "987"
+      article.slug = slug
+      positronql.mockReturnValue(Promise.resolve({ article }))
+
+      routes.index(req, res, next).then(() => {
+        expect(res.redirect).toBeCalledWith(
+          `https://partners.artsy.net/${redirectSlug}`
+        )
         done()
       })
     })

--- a/src/desktop/apps/article/gallery_insights_redirects.ts
+++ b/src/desktop/apps/article/gallery_insights_redirects.ts
@@ -1,0 +1,30 @@
+export const GalleryInsightsRedirects = {
+  "elena-soboleva-what-we-learned-from-writing-7-000-artist-bios":
+    "resource/what-we-learned-from-writing-artist-bios",
+
+  "gallery-insights-practical-digital-security-for-your-gallery":
+    "resource/digital-security-for-your-gallery",
+
+  "gallery-insights-brett-gorvy-new-storefont":
+    "resource/brett-gorvy-online-storefront",
+
+  "gallery-insights-the-pop-up-gallery-checklist?": "resource/pop-up-galleries",
+
+  "gallery-insights-artful-pitch": "resource/press-for-your-gallery",
+
+  "elena-soboleva-how-to-write-an-effective-press-release":
+    "resource/write-an-effective-press-release-for-your-gallery",
+
+  "gallery-insights-3-misconceptions-about-professional-art-buyers":
+    "resource/professional-art-buyers",
+
+  "gallery-insights-vr-galleries-04-04-17?": "resource/vr-for-galleries",
+
+  "gallery-insights-focus-in-on-better-gallery-photography":
+    "resource/focus-in-on-better-gallery-photography",
+
+  "elena-soboleva-sale-scam-verifying-online-inquiries":
+    "resource/verify-online-inquiries",
+
+  "gallery-insights-collectors-engaged": "resource/keep-collectors-engaged",
+}

--- a/src/desktop/apps/article/routes.tsx
+++ b/src/desktop/apps/article/routes.tsx
@@ -1,6 +1,6 @@
 import * as _ from "underscore"
 import embed from "particle"
-import { URL } from "url"
+import { URL, resolve } from "url"
 import { App } from "desktop/apps/article/components/App"
 import ArticleQuery from "desktop/apps/article/queries/article"
 import {
@@ -28,6 +28,7 @@ import {
 import cheerio from "cheerio"
 import React from "react"
 import { ArticleMeta } from "@artsy/reaction/dist/Components/Publishing/ArticleMeta"
+import { GalleryInsightsRedirects } from "./gallery_insights_redirects"
 const Articles = require("desktop/collections/articles.coffee")
 const markdown = require("desktop/components/util/markdown.coffee")
 const { crop, resize } = require("desktop/components/resizer/index.coffee")
@@ -61,7 +62,15 @@ export const index = async (req, res, next) => {
     if (article.channel_id !== sd.ARTSY_EDITORIAL_CHANNEL) {
       // Redirect deprecated Gallery Insights articles
       if (article.channel_id === sd.GALLERY_INSIGHTS_CHANNEL) {
-        return res.redirect("https://partners.artsy.net")
+        const resourceSlug = GalleryInsightsRedirects[article.slug]
+
+        if (resourceSlug) {
+          return res.redirect(
+            resolve("https://partners.artsy.net", resourceSlug)
+          )
+        } else {
+          return res.redirect("https://partners.artsy.net")
+        }
       }
       return classic(req, res, next)
     }

--- a/src/desktop/apps/galleries_institutions/templates/main.jade
+++ b/src/desktop/apps/galleries_institutions/templates/main.jade
@@ -24,7 +24,7 @@ block body
         a.gallery-partnership-link.fine-faux-underline( data-context='galleries header' href='/#{type}-partnerships' )
           | Partner with Artsy
         if type === 'gallery'
-          a.fine-faux-underline( href='https://partners.artsy.net' )
+          a.fine-faux-underline( href='https://partners.artsy.net/gallery-resources' )
             | Gallery Insights
 
     block content


### PR DESCRIPTION
- Add specific redirects for Gallery Insights articles

    Instead of redirecting all articles in the Gallery Insights channel to the partners.artsy.net homepage, if a redirect mapping exists, redirect to specific content.

- Redirect Gallery Insights link to /gallery-resources page

    Instead of linking Gallery Insights on the /galleries page to the partners.artsy.net home page, link to the /gallery-resources page directly.

jira: https://artsyproduct.atlassian.net/browse/GALL-1560