### PR TITLE
Remove trailing ? from article redirect slug

### DIFF
--- a/src/desktop/apps/article/gallery_insights_redirects.ts
+++ b/src/desktop/apps/article/gallery_insights_redirects.ts
@@ -18,7 +18,7 @@ export const GalleryInsightsRedirects = {
   "gallery-insights-3-misconceptions-about-professional-art-buyers":
     "resource/professional-art-buyers",
 
-  "gallery-insights-vr-galleries-04-04-17?": "resource/vr-for-galleries",
+  "gallery-insights-vr-galleries-04-04-17": "resource/vr-for-galleries",
 
   "gallery-insights-focus-in-on-better-gallery-photography":
     "resource/focus-in-on-better-gallery-photography",


### PR DESCRIPTION
Missed this extra character in https://github.com/artsy/force/pull/5082.

The redirect doesn't fire because the slug doesn't exactly match up with this character present.

One character change FTW :muscle: 