### PR TITLE
Ensure dynamic chunks get cdn url prefix

### DIFF
--- a/src/lib/middleware/assetMiddleware.ts
+++ b/src/lib/middleware/assetMiddleware.ts
@@ -19,7 +19,7 @@ export const assetMiddleware = () => {
     return (_req, res, next) => {
       res.locals.asset = filename => {
         let manifestFile = manifest[filename] || filename
-        if (CDN_URL) {
+        if (CDN_URL && !manifestFile.includes(CDN_URL)) {
           manifestFile = CDN_URL + manifestFile
         }
         return manifestFile

--- a/webpack/envs/productionConfig.js
+++ b/webpack/envs/productionConfig.js
@@ -21,6 +21,9 @@ exports.productionConfig = {
   devtool: "source-map",
   output: {
     filename: "[name].[contenthash].js",
+    publicPath: process.env.CDN_URL
+      ? `${process.env.CDN_URL}/assets/`
+      : undefined,
   },
   plugins: [
     new HashedModuleIdsPlugin(),


### PR DESCRIPTION
Fixes an issue we saw on production where dynamic chunks were getting pulled from force instead of from the CDN. 