### PR TITLE
Test 3: Set CDN public path in webpack config

### DIFF
--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -1,18 +1,3 @@
-/**
- * Set webpack public-path asset lookup to CDN in production
- */
-if (process.env.NODE_ENV === "production") {
-  __webpack_public_path__ = "https://d1rmpw1xlv9rxa.cloudfront.net/assets/"
-}
-
-// @ts-ignore
-window._setPublicPath = path => {
-  __webpack_public_path__ = path + "/assets/"
-}
-
-// @ts-ignore
-window._getPublicPath = () => __webpack_public_path__
-
 import $ from "jquery"
 import Backbone from "backbone"
 import _ from "underscore"

--- a/src/lib/environment.js
+++ b/src/lib/environment.js
@@ -3,7 +3,6 @@
 const { CI, NODE_ENV } = process.env
 const ANALYZE_BUNDLE = process.env.ANALYZE_BUNDLE === "true"
 const BUILD_SERVER = process.env.BUILD_SERVER === "true"
-const CDN_URL = process.env.CDN_URL
 const DEBUG = process.env.DEBUG !== undefined
 const isDevelopment = NODE_ENV === "development"
 const isStaging = NODE_ENV === "staging"
@@ -15,7 +14,6 @@ const basePath = process.cwd()
 module.exports = {
   ANALYZE_BUNDLE,
   BUILD_SERVER,
-  CDN_URL,
   DEBUG,
   NODE_ENV,
   isDevelopment,

--- a/webpack/envs/baseConfig.js
+++ b/webpack/envs/baseConfig.js
@@ -6,7 +6,6 @@ const LoadablePlugin = require("@loadable/webpack-plugin")
 const { getEntrypoints } = require("../utils/getEntrypoints")
 const {
   BUILD_SERVER,
-  CDN_URL,
   NODE_ENV,
   basePath,
   isCI,
@@ -66,7 +65,6 @@ exports.baseConfig = {
     new webpack.DefinePlugin({
       "process.env": {
         NODE_ENV: JSON.stringify(NODE_ENV),
-        CDN_URL: JSON.stringify(CDN_URL),
       },
     }),
     // Remove moment.js localization files

--- a/webpack/envs/productionConfig.js
+++ b/webpack/envs/productionConfig.js
@@ -21,6 +21,7 @@ exports.productionConfig = {
   devtool: "source-map",
   output: {
     filename: "[name].[contenthash].js",
+    publicPath: process.env.CDN_URL + "/assets/",
   },
   plugins: [
     new HashedModuleIdsPlugin(),


### PR DESCRIPTION
Simplify -- pass CDN directly into publicPath config since `__webpack_public_path__` is equal. 