### PR TITLE
Test 4: Only set webpack CDN public path on client

### DIFF
--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -1,3 +1,15 @@
+/**
+ * Set webpack public-path asset lookup to CDN in production, but only on
+ * the client, as we use the assetMiddleware helper to map URLs on the server.
+ * @see https://github.com/damassi/force/blob/master/src/lib/middleware/assetMiddleware.ts
+ */
+if (process.env.NODE_ENV === "production") {
+  __webpack_public_path__ = "https://d1rmpw1xlv9rxa.cloudfront.net/assets/"
+
+  // @ts-ignore
+  window._logAssetPath = () => process.env.CDN_URL + "/assets/"
+}
+
 import $ from "jquery"
 import Backbone from "backbone"
 import _ from "underscore"

--- a/webpack/envs/baseConfig.js
+++ b/webpack/envs/baseConfig.js
@@ -65,6 +65,7 @@ exports.baseConfig = {
     new webpack.DefinePlugin({
       "process.env": {
         NODE_ENV: JSON.stringify(NODE_ENV),
+        CDN_URL: JSON.stringify(process.env.CDN_URL),
       },
     }),
     // Remove moment.js localization files
@@ -73,16 +74,16 @@ exports.baseConfig = {
     ...(BUILD_SERVER
       ? []
       : [
-          // Remove server side of relay network layer.
-          new webpack.IgnorePlugin(
-            /^react-relay-network-modern-ssr\/node8\/server/
-          ),
-          // No matter what, we don't want the graphql-js package in client
-          // bundles. This /may/ lead to a broken build when e.g. a reaction
-          // module that's used on the client side imports something from
-          // graphql-js, but that's better than silently including this.
-          new webpack.IgnorePlugin(/^graphql(\/.*)?$/),
-        ]),
+        // Remove server side of relay network layer.
+        new webpack.IgnorePlugin(
+          /^react-relay-network-modern-ssr\/node8\/server/
+        ),
+        // No matter what, we don't want the graphql-js package in client
+        // bundles. This /may/ lead to a broken build when e.g. a reaction
+        // module that's used on the client side imports something from
+        // graphql-js, but that's better than silently including this.
+        new webpack.IgnorePlugin(/^graphql(\/.*)?$/),
+      ]),
     new webpack.NamedModulesPlugin(),
     new webpack.ProvidePlugin({
       $: "jquery",


### PR DESCRIPTION
Turns out https://github.com/artsy/force/pull/5102 will prefix server-side aspects as well, going back to https://github.com/artsy/force/pull/5101