### PR TITLE
Test 5: Ensure were not setting public path globally

### DIFF
--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -1,7 +1,7 @@
 /**
  * Set webpack public-path asset lookup to CDN in production, but only on
  * the client, as we use the assetMiddleware helper to map URLs on the server.
- * @see https://github.com/damassi/force/blob/master/src/lib/middleware/assetMiddleware.ts
+ * @see https://github.com/artsy/force/blob/master/src/lib/middleware/assetMiddleware.ts
  */
 if (process.env.NODE_ENV === "production") {
   __webpack_public_path__ = "https://d1rmpw1xlv9rxa.cloudfront.net/assets/"

--- a/webpack/envs/productionConfig.js
+++ b/webpack/envs/productionConfig.js
@@ -21,7 +21,9 @@ exports.productionConfig = {
   devtool: "source-map",
   output: {
     filename: "[name].[contenthash].js",
-    publicPath: process.env.CDN_URL + "/assets/",
+    // NOTE: On the client, we're setting `publicPath` during runtime in order to
+    // ensure that dynamically loaded split chunks are being pulled from CDN.
+    // @see: https://github.com/artsy/force/blob/master/src/desktop/lib/global_client_setup.tsx#L7
   },
   plugins: [
     new HashedModuleIdsPlugin(),


### PR DESCRIPTION
Make sure we're not injecting `publicPath` globally in webpack config, instead only setting it at runtime on the client. 