### PR TITLE
Move cdn envs to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM node:12.14-alpine
 
 WORKDIR /app
 
+ENV CDN_PRODUCTION_URL=https://d1s2w0upia4e9w.cloudfront.net CDN_STAGING_URL=https://d1rmpw1xlv9rxa.cloudfront.net
+
 # Install system dependencies
 # Add deploy user
 RUN apk --no-cache --quiet add \

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -8,6 +8,4 @@ services:
     environment:
       - CI=true
       - CIRCLE_NODE_INDEX
-      - CDN_PRODUCTION_URL
-      - CDN_STAGING_URL
     env_file: ../.env.test


### PR DESCRIPTION
So #5105 failed because the envs weren't available at build time like I expected they would be. I've moved them directly to the dockerfile because I'm _mostly_ sure that'll make them available...

cc @eessex or @izakp  If there's a better way to do this we should probably follow up w/ a cleanup