### PR TITLE
Remove trailing ? from article redirect slug

### DIFF
--- a/src/desktop/apps/article/gallery_insights_redirects.ts
+++ b/src/desktop/apps/article/gallery_insights_redirects.ts
@@ -8,7 +8,7 @@ export const GalleryInsightsRedirects = {
   "gallery-insights-brett-gorvy-new-storefont":
     "resource/brett-gorvy-online-storefront",
 
-  "gallery-insights-the-pop-up-gallery-checklist?": "resource/pop-up-galleries",
+  "gallery-insights-the-pop-up-gallery-checklist": "resource/pop-up-galleries",
 
   "gallery-insights-artful-pitch": "resource/press-for-your-gallery",
 


### PR DESCRIPTION
Missed this extra character in https://github.com/artsy/force/pull/5082. The redirect doesn't fire because the slug doesn't exactly match up with this character present.