### PR TITLE
Hard-code CDN for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM node:12.14-alpine
 
 WORKDIR /app
 
-ENV CDN_PRODUCTION_URL=https://d1s2w0upia4e9w.cloudfront.net CDN_STAGING_URL=https://d1rmpw1xlv9rxa.cloudfront.net
-
 # Install system dependencies
 # Add deploy user
 RUN apk --no-cache --quiet add \

--- a/src/desktop/apps/experimental-app-shell/apps/search/searchMiddleware.tsx
+++ b/src/desktop/apps/experimental-app-shell/apps/search/searchMiddleware.tsx
@@ -66,6 +66,7 @@ export const searchMiddleware = async (req, res, next) => {
         html: layout,
       }
       res.status(status).send(layout)
+      return
     } catch (error) {
       console.log(error)
       next(error)

--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -2,12 +2,27 @@
  * Set webpack public-path asset lookup to CDN in production, but only on
  * the client, as we use the assetMiddleware helper to map URLs on the server.
  * @see https://github.com/artsy/force/blob/master/src/lib/middleware/assetMiddleware.ts
+ *
+ * FIXME: Move this into Circle config and or Docker
  */
 if (process.env.NODE_ENV === "production") {
-  __webpack_public_path__ =
-    (window.location.hostname === "www.artsy.net"
-      ? process.env.CDN_PRODUCTION_URL
-      : process.env.CDN_STAGING_URL) + "/assets/"
+  const { hostname } = window.location
+  let cdnUrl
+
+  // Production
+  if (hostname === "www.artsy.net") {
+    cdnUrl = "https://d1s2w0upia4e9w.cloudfront.net"
+
+    // Localhost
+  } else if (hostname === "localhost") {
+    cdnUrl = ""
+
+    // Everything else
+  } else {
+    cdnUrl = "https://d1rmpw1xlv9rxa.cloudfront.net"
+  }
+
+  __webpack_public_path__ = cdnUrl + "/assets/"
 }
 
 import $ from "jquery"

--- a/webpack/envs/baseConfig.js
+++ b/webpack/envs/baseConfig.js
@@ -65,8 +65,6 @@ exports.baseConfig = {
     new webpack.DefinePlugin({
       "process.env": {
         NODE_ENV: JSON.stringify(NODE_ENV),
-        CND_PRODUCTION_URL: JSON.stringify(process.env.CND_PRODUCTION_URL),
-        CDN_STAGING_URL: JSON.stringify(process.env.CDN_STAGING_URL),
       },
     }),
     // Remove moment.js localization files


### PR DESCRIPTION
Noticed an `undefined` path in the search asset when deploying to prod earlier which has been observed in the past when `CDN_URL` was not found. We're still not 100% sure about the best way to encode `CDN_URL` so going to stick with hard-coding for right now. 

This has been tested locally with `EXPERIMENTAL_APP_SHELL=true` and also removed with these commands:  
- `yarn start` 
- `yarn start:prod`

See [slack convo from #dev](https://artsy.slack.com/archives/C02BC3HEJ/p1582558932007100?thread_ts=1582557643.007000&cid=C02BC3HEJ) where initial issue was reported. 

![image](https://user-images.githubusercontent.com/236943/75177393-e99df280-56ea-11ea-867a-242950163228.png)

(Note the `undefined` in the asset path) 
