### PR TITLE
@damassi => [App Shell] Move guard into middleware, and always mount

### DIFF
--- a/src/desktop/apps/experimental-app-shell/server.tsx
+++ b/src/desktop/apps/experimental-app-shell/server.tsx
@@ -11,6 +11,7 @@ import { bidderRegistrationMiddleware } from "./apps/auction/bidderRegistrationM
 import { confirmBidMiddleware } from "./apps/auction/confirmBidMiddleware"
 import { orderMiddleware } from "./apps/order/orderMiddleware"
 import { searchMiddleware } from "./apps/search/searchMiddleware"
+import { getSplitTest } from "desktop/components/split_test/splitTestContext"
 
 export const app = express()
 
@@ -24,7 +25,15 @@ app.get("/artwork/:artworkID/download/:filename", handleArtworkImageDownload)
  */
 app.get(
   "/*",
-
+  (_req, _res, next) => {
+    if (
+      !getSplitTest("EXPERIMENTAL_APP_SHELL") &&
+      !process.env.EXPERIMENTAL_APP_SHELL
+    ) {
+      return next("route")
+    }
+    return next()
+  },
   /**
    * Mount middleware for handling server-side portions of apps mounted into
    * global router.

--- a/src/desktop/components/split_test/skipIfClientSideRoutingEnabled.ts
+++ b/src/desktop/components/split_test/skipIfClientSideRoutingEnabled.ts
@@ -6,7 +6,6 @@ export const skipIfClientSideRoutingEnabled = (_req, _res, next) => {
     process.env.EXPERIMENTAL_APP_SHELL
   ) {
     return next("route")
-  } else {
-    return next()
   }
+  return next()
 }

--- a/src/desktop/index.js
+++ b/src/desktop/index.js
@@ -95,9 +95,4 @@ app.use(require("./apps/user"))
 // Used to test various SSR configurations
 app.use(require("./apps/ssr-experiments/server").app)
 
-if (
-  getSplitTest("EXPERIMENTAL_APP_SHELL") ||
-  process.env.EXPERIMENTAL_APP_SHELL
-) {
-  app.use(require("./apps/experimental-app-shell/server").app)
-}
+app.use(require("./apps/experimental-app-shell/server").app)


### PR DESCRIPTION
## The Story

We saw unfortunate results earlier when deploying the AB test. The experiment group seemed to 404, when the `EXPERIMENTAL_APP_SHELL` flag was not present. It was present on staging (from work _prior_ to the AB test launch), but was not present on production.

Locally, this wasn't really repro'able, which was...surprising(?) (although nothing surprises me anymore). I tested it locally, with the flag not being set, and things were...fine!

However, with `yarn start:prod`, this was fully repro'able locally. Looking at the code with fresh eyes, the reason becomes clear.

When the flag is not set, individual apps have request middleware which can skip them for the experiment group (and falls through to the app shell). However, the app shell isn't even mounted without that flag being set (and `express-reloadable` sort of 'masks' this by reloading in a way that _does_ mount the app).

When the flag is set, individual apps already correctly respond, or are skipped. So the app shell is always mounted, but only reached by the experimental group. And all is well.

## The Solution

The main fix was moving a guard into a proper request middleware, mirroring the behavior (inversely), of all the individual apps. When in the control group, the individual apps will correctly respond (and it's fine for the app shell to be mounted). When in the experiment group, the individual apps will correctly skip, and the app shell will respond. The presence of a feature flag is immaterial during the life of the AB test, but once the AB test is removed, behavior goes back to being gated behind a flag.