### PR TITLE
[Experiment] Update path

### DIFF
--- a/src/desktop/apps/experimental-app-shell/server.tsx
+++ b/src/desktop/apps/experimental-app-shell/server.tsx
@@ -24,8 +24,14 @@ app.get("/artwork/:artworkID/download/:filename", handleArtworkImageDownload)
  * Mount routes that will connect to global SSR router
  */
 app.get(
-  "/*",
+  "*",
   (_req, _res, next) => {
+    console.log(
+      `[force] EXPERIMENTAL_APP_SHELL A/B test: getSplitTest: ${getSplitTest(
+        "EXPERIMENTAL_APP_SHELL"
+      )} | env var: ${process.env.EXPERIMENTAL_APP_SHELL}`
+    )
+
     if (
       !getSplitTest("EXPERIMENTAL_APP_SHELL") &&
       !process.env.EXPERIMENTAL_APP_SHELL


### PR DESCRIPTION
Still seeing a small locally-unreproducible edge-case that occurs when ENV var unset, but only at top-level routes (e.g., `/collect`; nested routes are fine -- `/collect/painting`). With env set everything is all good and deployable, but this is still kinda weird. Following a hunch here, and adding a console log to get a bit more info. 