### PR TITLE
[Experiment 2] Move express context middleware down

### DIFF
--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -209,18 +209,6 @@ export default function(app) {
   )
   app.use("/(.well-known/)?apple-app-site-association", siteAssociation)
 
-  /**
-   * Add support for request-scoped contexts; meaning, a variable set in the
-   * scope of a request can be accessed outside of the express chain. Think,
-   * A/B tests.
-   *
-   * NOTE: some popular middlewares (such as body-parser, express-jwt) may cause
-   * context to get lost. To workaround such issues, you are advised to use any
-   * third party middleware that does NOT need the context BEFORE you use this
-   * middleware.
-   */
-  app.use(httpContext.middleware)
-
   // Redirect requests before they even have to deal with Force routing
   app.use(downcase)
   app.use(hardcodedRedirects)
@@ -230,8 +218,6 @@ export default function(app) {
   app.use(escapedFragmentMiddleware)
   app.use(logger)
   app.use(unsupportedBrowserCheck)
-
-  if (NODE_ENV !== "test") app.use(splitTestMiddleware)
   app.use(addIntercomUserHash)
   app.use(pageCacheMiddleware)
 
@@ -245,6 +231,22 @@ export default function(app) {
 
   // Sets up mobile marketing signup modal
   app.use(marketingModals)
+
+  /**
+   * Add support for request-scoped contexts; meaning, a variable set in the
+   * scope of a request can be accessed outside of the express chain. Think,
+   * A/B tests.
+   *
+   * NOTE: some popular middlewares (such as body-parser, express-jwt) may cause
+   * context to get lost. To workaround such issues, you are advised to use any
+   * third party middleware that does NOT need the context BEFORE you use this
+   * middleware.
+   */
+  app.use(httpContext.middleware)
+
+  if (NODE_ENV !== "test") {
+    app.use(splitTestMiddleware)
+  }
 
   // Setup hot-swap loader. See https://github.com/artsy/express-reloadable
   if (isDevelopment) {


### PR DESCRIPTION
So the log in https://github.com/artsy/force/pull/5121 revealed something interesting on the top-level routes that 404: 

```
[force] EXPERIMENTAL_APP_SHELL A/B test: getSplitTest: undefined | env var: undefined
```

A/B test is undefined, leading me to think that there might be a prod-only middleware setting (relevant only to real arty.net prod environment) that causes us to lose the request context during the first past. Moving middleware down to the lowest possible point to see if there's any impact. 