### PR TITLE
Updated artist header test with different dash mark

### DIFF
--- a/cypress/integration/artist.spec.js
+++ b/cypress/integration/artist.spec.js
@@ -18,6 +18,6 @@ describe("/artist/:id", () => {
 
   it("renders page content", () => {
     cy.get("h1").should("contain", "Pablo Picasso")
-    cy.get("h2").should("contain", "Spanish, 1881-1973")
+    cy.get("h2").should("contain", "Spanish, 1881–1973")
   })
 })


### PR DESCRIPTION
I updated reaction to use `formattedNationalityAndBirthday` in the artist header instead of using `nationality` and `years` and conjoining them with a comma. This caused this test to fail because the dash mark in `years` was different than the one in `formattedNationalityAndBirthday`. I have updated the test with the string from `formattedNationalityAndBirthday` 