### PR TITLE
Fix nav bar on mobile

### DIFF
--- a/src/mobile/components/layout/stylesheets/main_header.styl
+++ b/src/mobile/components/layout/stylesheets/main_header.styl
@@ -95,3 +95,6 @@ header-height = 54px
 
 #main-header-search-button
   display none
+
+#main-layout-header
+  position fixed


### PR DESCRIPTION
This feels... too easy, so let me know if I'm missing something.

For non-reaction pages (i.e. the home page), the nav bar on mobile web isn't fixed to the top of the screen. That makes general browsing different than the other pages, but also creates a weird experience when you open the nav menu:
![mobilenav-old](https://user-images.githubusercontent.com/2081340/75553961-6db3eb00-5a07-11ea-84ac-71e026a732cf.gif)

This fixes both of those issues, but like I said let me know what I'm missing!