### PR TITLE
[Webpack] Bust asset fingerprinting cache

### DIFF
--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -23,6 +23,9 @@ if (process.env.NODE_ENV === "production") {
   }
 
   __webpack_public_path__ = cdnUrl + "/assets/"
+
+  // @ts-ignore
+  window.__getPublicPath = () => __webpack_public_path__
 }
 
 import $ from "jquery"

--- a/webpack/envs/productionConfig.js
+++ b/webpack/envs/productionConfig.js
@@ -20,7 +20,7 @@ exports.productionConfig = {
   mode: DEBUG ? "development" : NODE_ENV,
   devtool: "source-map",
   output: {
-    filename: "[name].[contenthash].js",
+    filename: "[name].22820.[contenthash].js",
     // NOTE: On the client, we're setting `publicPath` during runtime in order to
     // ensure that dynamically loaded split chunks are being pulled from CDN.
     // @see: https://github.com/artsy/force/blob/master/src/desktop/lib/global_client_setup.tsx#L7


### PR DESCRIPTION
Yesterday we updated webpack to 4.8, which is a minor version update from 4.3. When deploying today, noticed that we were getting random errors regarding certain split chunks not loading. My working theory, which I have not been able to produce locally, is that due to consistent hash's across builds we were loading some assets from webpack 4.3 and other older assets from 4.8. 