### PR TITLE
Updates Eigen deeplink config

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "analytics-node": "2.4.1",
     "annyang": "mzikherman/annyang",
     "artsy-backbone-mixins": "artsy/artsy-backbone-mixins",
-    "artsy-eigen-web-association": "artsy/artsy-eigen-web-association",
+    "artsy-eigen-web-association": "git://github.com/artsy/artsy-eigen-web-association.git",
     "artsy-ezel-components": "artsy/artsy-ezel-components",
     "artsy-morgan": "artsy/artsy-morgan",
     "artsy-xapp": "artsy/artsy-xapp",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2329,9 +2329,9 @@ artsy-backbone-mixins@artsy/artsy-backbone-mixins:
     qs "5.2.0"
     underscore "*"
 
-artsy-eigen-web-association@artsy/artsy-eigen-web-association:
+"artsy-eigen-web-association@git://github.com/artsy/artsy-eigen-web-association.git":
   version "1.0.7"
-  resolved "https://codeload.github.com/artsy/artsy-eigen-web-association/tar.gz/0d28dc247b6a1366fabe0b95f365a61b95261c1e"
+  resolved "git://github.com/artsy/artsy-eigen-web-association.git#faf724b5486912cc3da3876b881d1bda12f187f6"
   dependencies:
     express "*"
 


### PR DESCRIPTION
The resolved field here changed based on updated instructions (using `yarn add` instead of `yarn upgrade): https://github.com/artsy/artsy-eigen-web-association/pull/35 This makes the resolution consistent with `artsy-wwwify` (https://github.com/artsy/artsy-wwwify/pull/31) but if there's any reason to be concerned, let me know