### PR TITLE
CSGN-15: Directly query shared data for mobile check

### DIFF
--- a/src/desktop/apps/consign/components/describe_work_container/index.js
+++ b/src/desktop/apps/consign/components/describe_work_container/index.js
@@ -5,9 +5,11 @@ import { formattedLocation } from "../../helpers"
 import { makeDescribeWorkDesktop } from "../describe_work_desktop"
 import { makeDescribeWorkMobile } from "../describe_work_mobile"
 import { isEmpty, pick } from "underscore"
+import { data as sd } from "sharify"
 
 function DescribeWorkContainer(props) {
-  const { isMobile, phone, submission } = props
+  const isMobile = sd.IS_MOBILE
+  const { phone, submission } = props
   const location = formattedLocation(
     submission.location_city,
     submission.location_state,


### PR DESCRIPTION
What was happening was that we were never setting the mobile flag correctly, just hard-coding it to false in an initial state. So my solution here is to directly query the shared data for this check down in the container that decided whether to render the desktop or mobile version of the form.

It's possible that we have other places where this flag is not being set correctly and so a better solution would be to update that flag in the state, but I can't quite figure out where/how to do that. In my testing locally with this change, the bug is fixed so I think it's worth shipping this but open to ideas!