### PR TITLE
[Webpack] Make loading dynamic bundle split chunks safer

### DIFF
--- a/package.json
+++ b/package.json
@@ -335,6 +335,7 @@
     "webpack-manifest-plugin": "2.0.4",
     "webpack-merge": "4.2.1",
     "webpack-notifier": "1.7.0",
+    "webpack-retry-chunk-load-plugin": "^1.2.0",
     "yalc": "1.0.0-pre.34"
   },
   "license": "MIT",

--- a/webpack/envs/baseConfig.js
+++ b/webpack/envs/baseConfig.js
@@ -3,6 +3,7 @@
 const path = require("path")
 const webpack = require("webpack")
 const LoadablePlugin = require("@loadable/webpack-plugin")
+const { RetryChunkLoadPlugin } = require("webpack-retry-chunk-load-plugin")
 const { getEntrypoints } = require("../utils/getEntrypoints")
 const {
   BUILD_SERVER,
@@ -92,6 +93,9 @@ exports.baseConfig = {
       waypoints: "jquery-waypoints/waypoints.js",
     }),
     new LoadablePlugin(),
+    new RetryChunkLoadPlugin({
+      maxRetries: 5,
+    }),
   ],
   resolve: {
     alias: {

--- a/webpack/envs/baseConfig.js
+++ b/webpack/envs/baseConfig.js
@@ -95,6 +95,9 @@ exports.baseConfig = {
     new LoadablePlugin(),
     new RetryChunkLoadPlugin({
       maxRetries: 5,
+      cacheBust: `function() {
+        return "cache-bust=" + Date.now();
+      }`,
     }),
   ],
   resolve: {

--- a/webpack/envs/baseConfig.js
+++ b/webpack/envs/baseConfig.js
@@ -93,6 +93,14 @@ exports.baseConfig = {
       waypoints: "jquery-waypoints/waypoints.js",
     }),
     new LoadablePlugin(),
+
+    /**
+     * If something goes wrong while loading a dynmic split chunk (import())
+     * retry the fetch once per second up to `maxRetries`.
+     *
+     * NOTE: Since this plugin patches the native loading mechanism from webpack
+     * we (may) need to revist once we upgrade to Webpack 5.
+     */
     new RetryChunkLoadPlugin({
       maxRetries: 5,
       cacheBust: `function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12349,7 +12349,7 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@1.19.1:
+prettier@1.19.1, prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
@@ -16612,6 +16612,13 @@ webpack-notifier@1.7.0:
     node-notifier "^5.1.2"
     object-assign "^4.1.0"
     strip-ansi "^3.0.1"
+
+webpack-retry-chunk-load-plugin@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-retry-chunk-load-plugin/-/webpack-retry-chunk-load-plugin-1.2.0.tgz#bf818a6e9f07a79af141f159ff7c48735d24925d"
+  integrity sha512-NyE+7e4jzpF9YbDZEEmwpRw5krfiuSdFQvFfOGzLS9cIurTXFHfQMtFrqGHj53+CzQtrPbeAHC6VJGmuVLnkrQ==
+  dependencies:
+    prettier "^1.19.1"
 
 webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-sources@^1.4.3:
   version "1.4.3"


### PR DESCRIPTION
Related to other bulletproofing work around detecting [network timeouts and offline status](https://github.com/artsy/reaction/pull/3240), this adds a new [`webpack-retry-chunk-load-plugin`](https://github.com/mattlewis92/webpack-retry-chunk-load-plugin) that will check to see if there's been an error in making a fetch to a dynamic runtime split bundle and retry the request. This is particularly relevant on mobile where network connectivity can be an issue, or caching, where the bundle manifest has changed but the user is browsing a cached version of the html page. 

#### Hypothetical error flow including improvement:

1) User browsing on their phone to `/collect`
1) Network goes out just before they click an artwork
1) Request to dynamically load js related to artwork bundle fails and app hangs
1) Webpack plugin sees this failure, and retries request
1) Still offline
1) Retries every second, up to `maxRetries` in config
1) Network comes back online, bundle loads, and execution recovers

Note that a more resilient solution would be to use [webpack-offline plugin](https://github.com/NekR/offline-plugin) but there's a lot of delicate configuration complexity there that we'd have to closely look at. (For a later point in time.)