### PR TITLE
[Clieintside Nav] Remove Auction routes from shell 

### DIFF
--- a/src/desktop/apps/auction_reaction/server.tsx
+++ b/src/desktop/apps/auction_reaction/server.tsx
@@ -1,22 +1,9 @@
 import express from "express"
-import { skipIfClientSideRoutingEnabled } from "desktop/components/split_test/skipIfClientSideRoutingEnabled"
 import { bidderRegistration, auctionFAQRoute, confirmBidRoute } from "./routes"
 
 export const app = express()
 
-app.get("/auction-faq", skipIfClientSideRoutingEnabled, auctionFAQRoute)
-app.get(
-  "/auction-registration/:auctionID",
-  skipIfClientSideRoutingEnabled,
-  bidderRegistration
-)
-app.get(
-  "/auction-registration2/:auctionID*",
-  skipIfClientSideRoutingEnabled,
-  bidderRegistration
-)
-app.get(
-  "/auction/:auctionID/bid/:artworkID",
-  skipIfClientSideRoutingEnabled,
-  confirmBidRoute
-)
+app.get("/auction-faq", auctionFAQRoute)
+app.get("/auction-registration/:auctionID", bidderRegistration)
+app.get("/auction-registration2/:auctionID*", bidderRegistration)
+app.get("/auction/:auctionID/bid/:artworkID", confirmBidRoute)

--- a/src/desktop/apps/auction_support/index.coffee
+++ b/src/desktop/apps/auction_support/index.coffee
@@ -6,9 +6,5 @@ app = module.exports = express()
 app.set 'views', __dirname + '/templates'
 app.set 'view engine', 'jade'
 
-# Used in EXPERIMENTAL_APP_SHELL A/B test
-# FIXME: Remove once A/B test completes
-app.get '/auction-registration-modal/:id', routes.modalAuctionRegistration
-
 app.get '/auction-registration/:id', routes.modalAuctionRegistration
 app.get '/auction/:id/buyers-premium', routes.buyersPremium


### PR DESCRIPTION
We found a case where users in the experimental app shell `experiment` group who _didn't_ have a credit card on file were erroneously being redirected to Auction page when trying to register for a sale and not the reaction app.

Corresponding Reaction PR: https://github.com/artsy/reaction/pull/3255 

Here's the PR when the PR was introduced: https://github.com/artsy/force/pull/5064

And there was some follow-up QA from Auctions team around the time that this was released here:  https://artsy.slack.com/archives/CA3D02SDN/p1582232761065900

Somehow this slipped through the cracks. 