### PR TITLE
Use typed helpers over mediator when opening auth modals

### DIFF
--- a/src/desktop/apps/article/components/InfiniteScrollArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollArticle.tsx
@@ -11,6 +11,7 @@ import {
 import { articlesQuery } from "desktop/apps/article/queries/articles"
 import { ArticleData } from "@artsy/reaction/dist/Components/Publishing/Typings"
 import { shouldAdRender } from "desktop/apps/article/helpers"
+import { handleOpenAuthModal } from "desktop/apps/authentication/helpers"
 
 const FETCH_TOP_OFFSET = 200
 
@@ -132,7 +133,6 @@ export class InfiniteScrollArticle extends React.Component<
       isMobile,
       showTooltips,
       showCollectionsRail,
-      onOpenAuthModal,
     } = this.props
     const { articles } = this.state
 
@@ -152,7 +152,7 @@ export class InfiniteScrollArticle extends React.Component<
               isMobile={isMobile}
               showTooltips={showTooltips}
               showCollectionsRail={showCollectionsRail}
-              onOpenAuthModal={onOpenAuthModal}
+              onOpenAuthModal={handleOpenAuthModal}
               infiniteScrollEntrySlug={slug}
               shouldAdRender={renderAd}
               articleSerial={i + 1}

--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -5,10 +5,7 @@ import React, { Component, Fragment } from "react"
 import { flatten, debounce, once } from "lodash"
 import Waypoint from "react-waypoint"
 import { positronql } from "desktop/lib/positronql"
-import {
-  ModalOptions,
-  ModalType,
-} from "@artsy/reaction/dist/Components/Authentication/Types"
+import { ModalType } from "@artsy/reaction/dist/Components/Authentication/Types"
 import { newsArticlesQuery } from "desktop/apps/article/queries/articles"
 import {
   ArticleData,
@@ -18,13 +15,9 @@ import { NewsNav } from "reaction/Components/Publishing/Nav/NewsNav"
 import { LoadingSpinner } from "./InfiniteScrollArticle"
 import { NewsArticle } from "./NewsArticle"
 import { NewsDateDivider } from "reaction/Components/Publishing/News/NewsDateDivider"
-import { shouldAdRender } from "desktop/apps/article/helpers"
 const Cookies = require("desktop/components/cookies/index.coffee")
-const mediator = require("desktop/lib/mediator.coffee")
-
-interface ArticleModalOptions extends ModalOptions {
-  signupIntent: string
-}
+import { shouldAdRender } from "desktop/apps/article/helpers"
+import { handleOpenAuthModal } from "desktop/apps/authentication/helpers"
 
 export interface Props {
   article?: ArticleData
@@ -235,10 +228,9 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
       "scroll",
       once(() => {
         setTimeout(() => {
-          this.handleOpenAuthModal("register", {
+          handleOpenAuthModal(ModalType.signup, {
             mode: ModalType.signup,
             intent: "Viewed editorial",
-            signupIntent: "signup",
             trigger: "timed",
             triggerSeconds: 2,
             copy: "Sign up for the Best Stories in Art and Visual Culture",
@@ -246,18 +238,11 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
             afterSignUpAction: {
               action: "editorialSignup",
             },
-          } as any)
+          })
         }, 2000)
       }),
       { once: true }
     )
-  }
-
-  handleOpenAuthModal = (mode, options: ArticleModalOptions) => {
-    mediator.trigger("open:auth", {
-      mode,
-      ...options,
-    })
   }
 
   render() {

--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -2,7 +2,7 @@ import { data as sd } from "sharify"
 import moment from "moment"
 import styled from "styled-components"
 import React, { Component, Fragment } from "react"
-import { flatten, debounce, once } from "lodash"
+import { flatten, debounce } from "lodash"
 import Waypoint from "react-waypoint"
 import { positronql } from "desktop/lib/positronql"
 import { ModalType } from "@artsy/reaction/dist/Components/Authentication/Types"
@@ -17,7 +17,7 @@ import { NewsArticle } from "./NewsArticle"
 import { NewsDateDivider } from "reaction/Components/Publishing/News/NewsDateDivider"
 const Cookies = require("desktop/components/cookies/index.coffee")
 import { shouldAdRender } from "desktop/apps/article/helpers"
-import { handleOpenAuthModal } from "desktop/apps/authentication/helpers"
+import { handleScrollingAuthModal } from "desktop/apps/authentication/helpers"
 
 export interface Props {
   article?: ArticleData
@@ -224,25 +224,15 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
   }
 
   showAuthModal() {
-    window.addEventListener(
-      "scroll",
-      once(() => {
-        setTimeout(() => {
-          handleOpenAuthModal(ModalType.signup, {
-            mode: ModalType.signup,
-            intent: "Viewed editorial",
-            trigger: "timed",
-            triggerSeconds: 2,
-            copy: "Sign up for the Best Stories in Art and Visual Culture",
-            destination: location.href,
-            afterSignUpAction: {
-              action: "editorialSignup",
-            },
-          })
-        }, 2000)
-      }),
-      { once: true }
-    )
+    handleScrollingAuthModal({
+      mode: ModalType.signup,
+      intent: "Viewed editorial",
+      copy: "Sign up for the Best Stories in Art and Visual Culture",
+      destination: location.href,
+      afterSignUpAction: {
+        action: "editorialSignup",
+      },
+    })
   }
 
   render() {

--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -5,7 +5,6 @@ import React, { Component, Fragment } from "react"
 import { flatten, debounce } from "lodash"
 import Waypoint from "react-waypoint"
 import { positronql } from "desktop/lib/positronql"
-import { ModalType } from "@artsy/reaction/dist/Components/Authentication/Types"
 import { newsArticlesQuery } from "desktop/apps/article/queries/articles"
 import {
   ArticleData,
@@ -225,7 +224,6 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
 
   showAuthModal() {
     handleScrollingAuthModal({
-      mode: ModalType.signup,
       intent: "Viewed editorial",
       copy: "Sign up for the Best Stories in Art and Visual Culture",
       destination: location.href,

--- a/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.jest.tsx
+++ b/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.jest.tsx
@@ -5,7 +5,6 @@ import { NewsArticle } from "@artsy/reaction/dist/Components/Publishing/Fixtures
 import { NewsLayout } from "@artsy/reaction/dist/Components/Publishing/Layouts/NewsLayout"
 import { NewsNav } from "reaction/Components/Publishing/Nav/NewsNav"
 import { extend, times } from "lodash"
-import { data as sd } from "sharify"
 import moment from "moment"
 import Waypoint from "react-waypoint"
 import { SystemContextProvider } from "@artsy/reaction/dist/Artsy"
@@ -35,6 +34,12 @@ const handleScrollingAuthModal = require("desktop/apps/authentication/helpers")
   .handleScrollingAuthModal as jest.Mock
 
 jest.useFakeTimers()
+jest.mock("sharify", () => {
+  return {
+    data: {},
+  }
+})
+const sd = require("sharify").data
 
 describe("InfiniteScrollNewsArticle", () => {
   let props
@@ -42,7 +47,7 @@ describe("InfiniteScrollNewsArticle", () => {
 
   const getWrapper = (passedProps = props) => {
     return mount(
-      <SystemContextProvider user={null}>
+      <SystemContextProvider user={null} relayEnvironment={{ environment: {} }}>
         <InfiniteScrollNewsArticle {...passedProps} />
       </SystemContextProvider>
     )

--- a/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.jest.tsx
+++ b/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.jest.tsx
@@ -196,7 +196,6 @@ describe("InfiniteScrollNewsArticle", () => {
       copy: "Sign up for the Best Stories in Art and Visual Culture",
       destination: "https://artsy.net/",
       intent: "Viewed editorial",
-      mode: "signup",
     })
   })
 

--- a/src/desktop/apps/article/components/layouts/Article.tsx
+++ b/src/desktop/apps/article/components/layouts/Article.tsx
@@ -1,11 +1,12 @@
 import React from "react"
-import { once } from "lodash"
 import { Article } from "@artsy/reaction/dist/Components/Publishing/Article"
-import { ModalType } from "@artsy/reaction/dist/Components/Authentication/Types"
 import { AppProps } from "../App"
 import { InfiniteScrollArticle } from "../InfiniteScrollArticle"
 import { shouldAdRender } from "desktop/apps/article/helpers"
-import { handleOpenAuthModal } from "desktop/apps/authentication/helpers"
+import {
+  handleOpenAuthModal,
+  handleScrollingAuthModal,
+} from "desktop/apps/authentication/helpers"
 const SuperArticleView = require("desktop/components/article/client/super_article.coffee")
 const ArticleModel = require("desktop/models/article.coffee")
 const Cookies = require("desktop/components/cookies/index.coffee")
@@ -39,27 +40,14 @@ export class ArticleLayout extends React.Component<AppProps> {
   }
 
   showAuthModal() {
-    if (!this.props.isLoggedIn && !this.props.isMobile) {
-      window.addEventListener(
-        "scroll",
-        once(() => {
-          setTimeout(() => {
-            handleOpenAuthModal(ModalType.signup, {
-              mode: ModalType.signup,
-              intent: "Viewed editorial",
-              trigger: "timed",
-              triggerSeconds: 2,
-              copy: "Sign up for the Best Stories in Art and Visual Culture",
-              destination: location.href,
-              afterSignUpAction: {
-                action: "editorialSignup",
-              },
-            })
-          }, 2000)
-        }),
-        { once: true }
-      )
-    }
+    handleScrollingAuthModal({
+      intent: "Viewed editorial",
+      copy: "Sign up for the Best Stories in Art and Visual Culture",
+      destination: location.href,
+      afterSignUpAction: {
+        action: "editorialSignup",
+      },
+    })
   }
 
   render() {
@@ -106,7 +94,6 @@ export class ArticleLayout extends React.Component<AppProps> {
           <InfiniteScrollArticle
             article={article}
             isMobile={isMobile}
-            onOpenAuthModal={handleOpenAuthModal}
             showTooltips={showTooltips}
             showCollectionsRail={showCollectionsRail}
             shouldAdRender={renderAd}

--- a/src/desktop/apps/article/components/layouts/Article.tsx
+++ b/src/desktop/apps/article/components/layouts/Article.tsx
@@ -4,11 +4,8 @@ import { Article } from "@artsy/reaction/dist/Components/Publishing/Article"
 import { ModalType } from "@artsy/reaction/dist/Components/Authentication/Types"
 import { AppProps } from "../App"
 import { InfiniteScrollArticle } from "../InfiniteScrollArticle"
-import {
-  shouldAdRender,
-  handleOpenAuthModal,
-} from "desktop/apps/article/helpers"
-
+import { shouldAdRender } from "desktop/apps/article/helpers"
+import { handleOpenAuthModal } from "desktop/apps/authentication/helpers"
 const SuperArticleView = require("desktop/components/article/client/super_article.coffee")
 const ArticleModel = require("desktop/models/article.coffee")
 const Cookies = require("desktop/components/cookies/index.coffee")
@@ -47,10 +44,9 @@ export class ArticleLayout extends React.Component<AppProps> {
         "scroll",
         once(() => {
           setTimeout(() => {
-            handleOpenAuthModal("register", {
+            handleOpenAuthModal(ModalType.signup, {
               mode: ModalType.signup,
               intent: "Viewed editorial",
-              signupIntent: "signup",
               trigger: "timed",
               triggerSeconds: 2,
               copy: "Sign up for the Best Stories in Art and Visual Culture",
@@ -58,7 +54,7 @@ export class ArticleLayout extends React.Component<AppProps> {
               afterSignUpAction: {
                 action: "editorialSignup",
               },
-            } as any)
+            })
           }, 2000)
         }),
         { once: true }

--- a/src/desktop/apps/article/components/layouts/Classic.tsx
+++ b/src/desktop/apps/article/components/layouts/Classic.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Article } from "@artsy/reaction/dist/Components/Publishing/Article"
 import { AppProps } from "../App"
-import { handleOpenAuthModal } from "desktop/apps/article/helpers"
+import { handleOpenAuthModal } from "desktop/apps/authentication/helpers"
 
 const ArticlesGridView = require("desktop/components/articles_grid/view.coffee")
 const Articles = require("desktop/collections/articles.coffee")

--- a/src/desktop/apps/article/helpers.tsx
+++ b/src/desktop/apps/article/helpers.tsx
@@ -1,8 +1,6 @@
 import { isCustomEditorial } from "./editorial_features"
-import { ModalOptions } from "@artsy/reaction/dist/Components/Authentication/Types"
 const { stringifyJSONForWeb } = require("desktop/components/util/json.coffee")
 const Article = require("desktop/models/article.coffee")
-const mediator = require("desktop/lib/mediator.coffee")
 
 // Helper method to determine how frequently ads should be rendered in Article components
 export const shouldAdRender = (
@@ -40,7 +38,8 @@ export const getLayoutTemplate = article => {
   const isFeatureInSeries =
     article.seriesArticle &&
     article.layout === "feature" &&
-    (article.hero_section && article.hero_section.type === "fullscreen")
+    article.hero_section &&
+    article.hero_section.type === "fullscreen"
 
   const hasSeriesNav =
     ["series", "video"].includes(article.layout) || isFeatureInSeries
@@ -71,15 +70,4 @@ export const getSuperArticleTemplates = article => {
 export const getJsonLd = article => {
   const articleModel = new Article(article)
   return stringifyJSONForWeb(articleModel.toJSONLD())
-}
-
-interface ArticleModalOptions extends ModalOptions {
-  signupIntent: string
-}
-
-export const handleOpenAuthModal = (mode, options: ArticleModalOptions) => {
-  mediator.trigger("open:auth", {
-    mode,
-    ...options,
-  })
 }

--- a/src/desktop/apps/articles/components/AuthWrapper.tsx
+++ b/src/desktop/apps/articles/components/AuthWrapper.tsx
@@ -3,6 +3,9 @@ import { data as sd } from "sharify"
 import qs from "querystring"
 import Waypoint from "react-waypoint"
 import { once } from "lodash"
+import { handleOpenAuthModal } from "desktop/apps/authentication/helpers"
+import { ModalType } from "@artsy/reaction/dist/Components/Authentication/Types"
+
 const Cookies = require("desktop/components/cookies/index.coffee")
 const mediator = require("desktop/lib/mediator.coffee")
 
@@ -37,10 +40,8 @@ export class AuthWrapper extends React.Component {
   }
 
   onOpenModal = () => {
-    mediator.trigger("open:auth", {
-      mode: "signup",
+    handleOpenAuthModal(ModalType.signup, {
       intent: "Viewed editorial",
-      signupIntent: "signup",
       trigger: "timed",
       triggerSeconds: 2,
       copy: "Sign up for the Best Stories in Art and Visual Culture",

--- a/src/desktop/apps/articles/components/__tests__/AuthWrapper.jest.tsx
+++ b/src/desktop/apps/articles/components/__tests__/AuthWrapper.jest.tsx
@@ -119,7 +119,6 @@ describe("AuthWrapper", () => {
     expect(mediatorTrigger).toBeCalledWith("open:auth", {
       mode: "signup",
       intent: "Viewed editorial",
-      signupIntent: "signup",
       trigger: "timed",
       triggerSeconds: 2,
       copy: "Sign up for the Best Stories in Art and Visual Culture",

--- a/src/desktop/apps/artist/components/__tests__/cta.jest.ts
+++ b/src/desktop/apps/artist/components/__tests__/cta.jest.ts
@@ -79,7 +79,7 @@ describe("CTA", () => {
       destination: "https://artsy.net/",
       image: "https://d32dm0rphc51dk.cloudfront.net/6q6LeyKvA_vpT5YzHRSNUA",
       intent: "signup",
-      trigger: "scroll",
+      trigger: "timed",
       triggerSeconds: 4,
     })
 

--- a/src/desktop/apps/artist/components/__tests__/cta.jest.ts
+++ b/src/desktop/apps/artist/components/__tests__/cta.jest.ts
@@ -1,9 +1,14 @@
 import { setupArtistSignUpModal, query } from "../cta"
+import * as helpers from "desktop/apps/authentication/helpers"
 
 jest.mock("lib/metaphysics.coffee", () =>
   jest.fn().mockReturnValue(Promise.resolve({}))
 )
 
+jest.spyOn(helpers, "handleScrollingAuthModal")
+
+const handleScrollingAuthModal = require("desktop/apps/authentication/helpers")
+  .handleScrollingAuthModal
 const mockMetaphysics = require("lib/metaphysics.coffee")
 
 jest.mock("sharify", () => ({
@@ -49,24 +54,37 @@ describe("CTA", () => {
     ],
   }
 
+  let addEventListener
+  beforeEach(() => {
+    addEventListener = jest.spyOn(window, "addEventListener")
+    mockMetaphysics.mockReturnValue(Promise.resolve({ artist }))
+  })
+
   it("should get artist data when artist cta is enabled and there is an artist id", async () => {
-    const options = {
+    await setupArtistSignUpModal()
+
+    expect(mockMetaphysics).toBeCalledWith({
       method: "post",
       query: query,
       variables: { artistID: artist.id },
-    }
-    await setupArtistSignUpModal()
-
-    expect(mockMetaphysics).toBeCalledWith(options)
+    })
   })
 
-  it("should set up a scroll event listener when in the experiment group", async () => {
-    const spy = jest.spyOn(window, "addEventListener")
-    mockMetaphysics.mockReturnValue(Promise.resolve({ artist }))
+  it("should set up a scroll event listener", async () => {
     await setupArtistSignUpModal()
 
-    expect(spy).toHaveBeenCalled()
-    expect(spy.mock.calls[0][0]).toBe("scroll")
-    expect(spy.mock.calls[0][2]).toEqual({ once: true })
+    expect(handleScrollingAuthModal).toBeCalledWith({
+      copy:
+        "Join Artsy to discover new works by Claes Oldenburg and more artists you love",
+      destination: "https://artsy.net/",
+      image: "https://d32dm0rphc51dk.cloudfront.net/6q6LeyKvA_vpT5YzHRSNUA",
+      intent: "signup",
+      trigger: "scroll",
+      triggerSeconds: 4,
+    })
+
+    expect(addEventListener).toHaveBeenCalled()
+    expect(addEventListener.mock.calls[0][0]).toBe("scroll")
+    expect(addEventListener.mock.calls[0][2]).toEqual({ once: true })
   })
 })

--- a/src/desktop/apps/artist/components/cta.ts
+++ b/src/desktop/apps/artist/components/cta.ts
@@ -31,7 +31,7 @@ export const setupArtistSignUpModal = () => {
       handleScrollingAuthModal({
         copy: `Join Artsy to discover new works by ${artistData.name} and more artists you love`,
         intent: "signup",
-        trigger: "scroll",
+        trigger: "timed",
         triggerSeconds: 4,
         destination: location.href,
         image,

--- a/src/desktop/apps/artist/components/cta.ts
+++ b/src/desktop/apps/artist/components/cta.ts
@@ -1,8 +1,7 @@
 import { get } from "lodash"
 import { data as sd } from "sharify"
-
+import { handleScrollingAuthModal } from "desktop/apps/authentication/helpers"
 const metaphysics = require("lib/metaphysics.coffee")
-const mediator = require("desktop/lib/mediator.coffee")
 
 export const query = `
 query ArtistCTAQuery($artistID: String!) {
@@ -29,28 +28,14 @@ export const setupArtistSignUpModal = () => {
     return metaphysics(send).then(({ artist: artistData }) => {
       const image = get(artistData, "artworks[0].image.cropped.url")
 
-      if (!sd.CURRENT_USER && !sd.IS_MOBILE) {
-        window.addEventListener(
-          "scroll",
-          () => {
-            setTimeout(() => {
-              mediator.trigger("open:auth", {
-                copy: `Join Artsy to discover new works by ${
-                  artistData.name
-                } and more artists you love`,
-                mode: "signup",
-                intent: "signup",
-                signupIntent: "signup",
-                trigger: "scroll",
-                triggerSeconds: 4,
-                destination: location.href,
-                image,
-              })
-            }, 4000)
-          },
-          { once: true }
-        )
-      }
+      handleScrollingAuthModal({
+        copy: `Join Artsy to discover new works by ${artistData.name} and more artists you love`,
+        intent: "signup",
+        trigger: "scroll",
+        triggerSeconds: 4,
+        destination: location.href,
+        image,
+      })
     })
   }
 }

--- a/src/desktop/apps/auction/components/DOM.js
+++ b/src/desktop/apps/auction/components/DOM.js
@@ -1,9 +1,11 @@
+// @ts-check
 import PropTypes from "prop-types"
-import mediator from "desktop/lib/mediator.coffee"
 import scrollToTop from "desktop/apps/auction/utils/scrollToTop"
 import { Component } from "react"
 import { connect } from "react-redux"
 import { showModal } from "../actions/app"
+import { handleOpenAuthModal } from "desktop/apps/authentication/helpers"
+import { ModalType } from "@artsy/reaction/dist/Components/Authentication/Types"
 
 class DOM extends Component {
   static propTypes = {
@@ -74,15 +76,13 @@ class DOM extends Component {
     }
   }
 
-  handleRegister = event => {
+  handleRegister = _event => {
     const { auction, me } = this.props
     // If there is no user, log in and redirect to this flow
     if (!me) {
-      mediator.trigger("open:auth", {
-        mode: "signup",
+      handleOpenAuthModal(ModalType.signup, {
         redirectTo: auction.registrationFlowUrl(),
         intent: "register to bid",
-        signupIntent: "register to bid",
         trigger: "click",
       })
 

--- a/src/desktop/apps/auction/components/__tests__/DOM.jest.js
+++ b/src/desktop/apps/auction/components/__tests__/DOM.jest.js
@@ -1,6 +1,5 @@
 import { test } from "../DOM"
 import mediator from "desktop/lib/mediator.coffee"
-import { AuctionRegistrationModal } from "reaction/Components/Auction/AuctionRegistrationModal"
 
 const { DOM } = test
 
@@ -102,7 +101,6 @@ describe("DOM Interactions", () => {
       expect(mediator.trigger).toHaveBeenCalledWith("open:auth", {
         mode: "signup",
         redirectTo: "/auction/auction-id/registration-flow",
-        signupIntent: "register to bid",
         intent: "register to bid",
         trigger: "click",
       })

--- a/src/desktop/apps/authentication/__tests__/routes.jest.ts
+++ b/src/desktop/apps/authentication/__tests__/routes.jest.ts
@@ -142,7 +142,7 @@ describe("Routes", () => {
           copy: "Sign up to follow David Zwirner",
           intent: "follow partner",
           mode: "signup",
-          trigger: "scroll",
+          trigger: "timed",
           "redirect-to": "/david-zwirner",
         }
 
@@ -164,7 +164,7 @@ describe("Routes", () => {
           expect(kind).toBe("profile")
           expect(objectId).toBe("david-zwirner")
           expect(redirectTo).toBe("/david-zwirner")
-          expect(trigger).toBe("scroll")
+          expect(trigger).toBe("timed")
           done()
         })
       })

--- a/src/desktop/apps/authentication/helpers.ts
+++ b/src/desktop/apps/authentication/helpers.ts
@@ -121,7 +121,7 @@ export const handleSubmit = (
 
       const result = await apiAuthWithRedirectUrl(res, afterAuthURL)
 
-      window.location.href = result.href
+      window.location.assign(result.href)
     },
     error: (_, res) => {
       const error = res.responseJSON
@@ -197,6 +197,7 @@ export async function apiAuthWithRedirectUrl(
 export function getRedirect(type): URL {
   const appBaseURL = new URL(sd.APP_URL)
   const { location } = window
+
   switch (type) {
     case "login":
     case "forgot":

--- a/src/desktop/apps/authentication/helpers.ts
+++ b/src/desktop/apps/authentication/helpers.ts
@@ -13,13 +13,38 @@ const mediator = require("../../lib/mediator.coffee")
 const LoggedOutUser = require("../../models/logged_out_user.coffee")
 
 /**
- * Helper to open authentication modals
+ * Open authentication modal via 'click' trigger
  */
 export const handleOpenAuthModal = (mode: ModalType, options: ModalOptions) => {
   mediator.trigger("open:auth", {
     mode,
     ...options,
   })
+}
+
+/**
+ * Set up scroll event to open authentication modal via 'timed' trigger
+ * Opens 2 seconds after first scroll by default
+ */
+export const handleScrollingAuthModal = (options: ModalOptions) => {
+  if (!sd.CURRENT_USER && !sd.IS_MOBILE) {
+    const modalOptions = Object.assign(
+      {
+        triggerSeconds: 2,
+        trigger: "timed",
+      },
+      options
+    )
+    window.addEventListener(
+      "scroll",
+      () => {
+        setTimeout(() => {
+          handleOpenAuthModal(ModalType.signup, modalOptions)
+        }, 2000)
+      },
+      { once: true }
+    )
+  }
 }
 
 export const handleSubmit = (

--- a/src/desktop/apps/authentication/helpers.ts
+++ b/src/desktop/apps/authentication/helpers.ts
@@ -12,6 +12,16 @@ import { captureException } from "@sentry/browser"
 const mediator = require("../../lib/mediator.coffee")
 const LoggedOutUser = require("../../models/logged_out_user.coffee")
 
+/**
+ * Helper to open authentication modals
+ */
+export const handleOpenAuthModal = (mode: ModalType, options: ModalOptions) => {
+  mediator.trigger("open:auth", {
+    mode,
+    ...options,
+  })
+}
+
 export const handleSubmit = (
   type: ModalType,
   modalOptions: ModalOptions,

--- a/src/desktop/apps/authentication/helpers.ts
+++ b/src/desktop/apps/authentication/helpers.ts
@@ -27,24 +27,25 @@ export const handleOpenAuthModal = (mode: ModalType, options: ModalOptions) => {
  * Opens 2 seconds after first scroll by default
  */
 export const handleScrollingAuthModal = (options: ModalOptions) => {
-  if (!sd.CURRENT_USER && !sd.IS_MOBILE) {
-    const modalOptions = Object.assign(
-      {
-        triggerSeconds: 2,
-        trigger: "timed",
-      },
-      options
-    )
-    window.addEventListener(
-      "scroll",
-      () => {
-        setTimeout(() => {
-          handleOpenAuthModal(ModalType.signup, modalOptions)
-        }, 2000)
-      },
-      { once: true }
-    )
+  if (sd.CURRENT_USER || sd.IS_MOBILE) {
+    return
   }
+  const modalOptions = Object.assign(
+    {
+      triggerSeconds: 2,
+      trigger: "timed",
+    },
+    options
+  )
+  window.addEventListener(
+    "scroll",
+    () => {
+      setTimeout(() => {
+        handleOpenAuthModal(ModalType.signup, modalOptions)
+      }, 2000)
+    },
+    { once: true }
+  )
 }
 
 export const handleSubmit = (

--- a/src/desktop/components/fair_week_marketing/__tests__/BannerPopUp.jest.tsx
+++ b/src/desktop/components/fair_week_marketing/__tests__/BannerPopUp.jest.tsx
@@ -45,7 +45,6 @@ describe("BannerPopUp", () => {
       image: "http://files.artsy.net/images/art-fair.jpg",
       intent: "signup",
       mode: "signup",
-      signupIntent: "signup",
     })
   })
 })

--- a/src/desktop/components/marketing_signup_modal/__test__/triggerMarketingModal.jest.ts
+++ b/src/desktop/components/marketing_signup_modal/__test__/triggerMarketingModal.jest.ts
@@ -1,8 +1,4 @@
-import {
-  scrollingMarketingModal,
-  staticMarketingModal,
-  triggerMarketingModal,
-} from "../triggerMarketingModal"
+import { triggerMarketingModal } from "../triggerMarketingModal"
 import { data as sd } from "sharify"
 
 jest.mock("desktop/lib/mediator.coffee", () => ({
@@ -66,7 +62,6 @@ describe("MarketingSignupModal", () => {
         image: "http://files.artsy.net/images/fair.jpg",
         intent: "signup",
         mode: "signup",
-        signupIntent: "signup",
       })
     })
 
@@ -82,7 +77,6 @@ describe("MarketingSignupModal", () => {
         image: "http://files.artsy.net/images/art.jpg",
         intent: "signup",
         mode: "signup",
-        signupIntent: "signup",
       })
     })
 
@@ -96,8 +90,7 @@ describe("MarketingSignupModal", () => {
         image: "http://files.artsy.net/images/fair.jpg",
         intent: "signup",
         mode: "signup",
-        signupIntent: "signup",
-        trigger: "scroll",
+        trigger: "timed",
         triggerSeconds: 2,
       })
     })
@@ -110,59 +103,6 @@ describe("MarketingSignupModal", () => {
         image: "http://files.artsy.net/images/fair.jpg",
         intent: "signup",
         mode: "signup",
-        signupIntent: "signup",
-      })
-    })
-  })
-
-  describe("#scrollingMarketingModal", () => {
-    it("calls the mediator with expected args", () => {
-      scrollingMarketingModal({
-        copy: "Discover Works from Art Fairs",
-        image: "http://files.artsy.net/images/art.jpg",
-      })
-      expect(window.addEventListener).toBeCalled()
-      jest.runAllTimers()
-
-      expect(mediator).toBeCalledWith("open:auth", {
-        copy: "Discover Works from Art Fairs",
-        destination: "https://artsy.net/",
-        image: "http://files.artsy.net/images/art.jpg",
-        intent: "signup",
-        mode: "signup",
-        signupIntent: "signup",
-        trigger: "scroll",
-        triggerSeconds: 2,
-      })
-    })
-
-    it("does nothing if sd.IS_MOBILE", () => {
-      sd.IS_MOBILE = true
-
-      expect(window.addEventListener).not.toBeCalled()
-      jest.runAllTimers()
-
-      scrollingMarketingModal({
-        copy: "Discover Works from Art Fairs",
-        image: "http://files.artsy.net/images/art.jpg",
-      })
-      expect(mediator).not.toBeCalled()
-    })
-  })
-
-  describe("#staticMarketingModal", () => {
-    it("calls the mediator with expected args", () => {
-      staticMarketingModal({
-        copy: "Discover Works from Art Fairs",
-        image: "http://files.artsy.net/images/art.jpg",
-      })
-      expect(mediator).toBeCalledWith("open:auth", {
-        copy: "Discover Works from Art Fairs",
-        destination: "https://artsy.net/",
-        image: "http://files.artsy.net/images/art.jpg",
-        intent: "signup",
-        mode: "signup",
-        signupIntent: "signup",
       })
     })
   })

--- a/src/desktop/components/marketing_signup_modal/triggerMarketingModal.ts
+++ b/src/desktop/components/marketing_signup_modal/triggerMarketingModal.ts
@@ -1,12 +1,11 @@
 import { data as sd } from "sharify"
 import qs from "querystring"
 import { findWhere } from "underscore"
-const mediator = require("desktop/lib/mediator.coffee")
-
-interface ModalData {
-  image: string
-  copy: string
-}
+import {
+  handleScrollingAuthModal,
+  handleOpenAuthModal,
+} from "desktop/apps/authentication/helpers"
+import { ModalType } from "@artsy/reaction/dist/Components/Authentication/Types"
 
 export const triggerMarketingModal = (isScrolling?: boolean) => {
   const query = qs.parse(location.search.replace(/^\?/, ""))
@@ -14,49 +13,19 @@ export const triggerMarketingModal = (isScrolling?: boolean) => {
   const slug = query["m-id"] || (isTargetCampaign && "ca3")
   const modalData = findWhere(sd.MARKETING_SIGNUP_MODALS, { slug: slug })
 
-  if (sd.MARKETING_SIGNUP_MODALS && modalData) {
-    if (!sd.CURRENT_USER) {
-      if (isScrolling) {
-        scrollingMarketingModal(modalData)
-      } else {
-        staticMarketingModal(modalData)
-      }
+  if (sd.MARKETING_SIGNUP_MODALS && modalData && !sd.CURRENT_USER) {
+    const { image, copy } = modalData
+    const options = {
+      copy,
+      intent: "signup",
+      destination: location.href,
+      image,
+    }
+
+    if (isScrolling) {
+      handleScrollingAuthModal(options)
+    } else {
+      handleOpenAuthModal(ModalType.signup, options)
     }
   }
-}
-
-export const scrollingMarketingModal = (modalData: ModalData) => {
-  if (!sd.IS_MOBILE) {
-    window.addEventListener(
-      "scroll",
-      () => {
-        setTimeout(() => {
-          const { image, copy } = modalData
-          mediator.trigger("open:auth", {
-            copy,
-            mode: "signup",
-            intent: "signup",
-            signupIntent: "signup",
-            trigger: "scroll",
-            triggerSeconds: 2,
-            destination: location.href,
-            image,
-          })
-        }, 2000)
-      },
-      { once: true }
-    )
-  }
-}
-
-export const staticMarketingModal = (modalData: ModalData) => {
-  const { image, copy } = modalData
-  mediator.trigger("open:auth", {
-    copy,
-    mode: "signup",
-    intent: "signup",
-    signupIntent: "signup",
-    destination: location.href,
-    image,
-  })
 }


### PR DESCRIPTION
To help us confirm that args are correct, this PR sets up/consolidates typed helpers `handleOpenAuthModal ` and `handleScrollingAuthModal` in the `authentication` app.

The idea is to use them when opening auth modals from Force, rather than the untyped `mediator` or implementing a one-off scroll triggers. 

The helpers are now in use for all `js`/`ts` files, coffee implementations are currently unchanged.
 