### PR TITLE
Alert #integrity when force is deployed to staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,12 @@
 version: 2.1
 
 orbs:
-  yarn: artsy/yarn@dev:cfbc411ee961792773c79ebfa9806c7d
-  hokusai: artsy/hokusai@0.7.2
-  node: artsy/node@dev:dc523d4428b2260798906013dc4d8221
-  horizon: artsy/release@0.0.1
   codecov: codecov/codecov@1.0.5
+  hokusai: artsy/hokusai@0.7.2
+  horizon: artsy/release@0.0.1
+  node: artsy/node@dev:dc523d4428b2260798906013dc4d8221
+  slack: circleci/slack@3.4.2
+  yarn: artsy/yarn@dev:cfbc411ee961792773c79ebfa9806c7d
 
 jobs:
   acceptance:
@@ -139,6 +140,9 @@ workflows:
           project-name: force
           requires:
             - push-staging-image
+          post-steps:
+            - slack/status:
+                success_message: Force staging has been deployed!
 
       # Release
       - validate_production_schema:


### PR DESCRIPTION
Follow up from Platform Practice meeting.

In order to create a better timeline between integrity going from green to red, alert in the #integrity channel when Force is deployed to staging.
