### PR TITLE
Add Identity Verification FAQ page

### DIFF
--- a/src/desktop/apps/page/index.coffee
+++ b/src/desktop/apps/page/index.coffee
@@ -25,6 +25,7 @@ app.get '/rrf-emerging-curator-competition-official-rules', routes.vanityUrl('rr
 app.get '/past-privacy-8-5-13', routes.vanityUrl('past-privacy-8-5-13')
 app.get '/past-terms-9-26-13', routes.vanityUrl('past-terms-9-26-13')
 app.get '/buy-now-feature-faq', routes.vanityUrl('buy-now-feature-faq')
+app.get '/identity-verification-faq', routes.vanityUrl('identity-verification-faq')
 
 app.get '/page/:id', routes.index
 app.get '/job/:id', routes.index

--- a/src/desktop/models/page.coffee
+++ b/src/desktop/models/page.coffee
@@ -11,5 +11,13 @@ module.exports = class Page extends Backbone.Model
   urlRoot: "#{sd.API_URL}/api/v1/page"
 
   sanitizedHtml: (attr) ->
-    clean = insane(@get(attr))
+    clean = insane(@get(attr), {
+      allowedAttributes: {
+        a: ["href", "name", "target"],
+        img: ["src"],
+        h1: ['style'],
+        h2: ['style'],
+        div: ['style']
+      }
+    })
     Markdown.mdToHtml.apply { get: -> clean }, [null, sanitize: false]


### PR DESCRIPTION
It seems like the pattern here is to create a new page in admin.artsy.net and add a new route to Force.

 * The new identity verification FAQ page could be found here (and also editable): https://admin.artsy.net/page/identity-verification-faq
 * The page will be on e.g. https://staging.artsy.net/identity-verification-faq

IMO the page looks a bit too different visually, and these pages need a bit upgrades in general. But let's check in with @deliciousnachos.

## Todos

 * [x] Check in with @deliciousnachos to make sure the visual design quality meets our (and users') expectation
 * [x] Time-box ~2 hours to see if there's any easy way to tweak visual style


## Screenshot

![screencapture-localhost-5000-identity-verification-faq-2020-03-18-15_50_27](https://user-images.githubusercontent.com/386234/77001413-4a0e0180-6930-11ea-86bf-0c541df2238f.png)
