### PR TITLE
Auth forgot titles/query params

### DIFF
--- a/src/desktop/apps/authentication/__tests__/routes.jest.ts
+++ b/src/desktop/apps/authentication/__tests__/routes.jest.ts
@@ -131,6 +131,83 @@ describe("Routes", () => {
             done()
           })
         })
+
+        it("returns the correct title for forgot", done => {
+          req.path = "/forgot"
+          index(req, res, next).then(() => {
+            expect(stitch.mock.calls[0][0].data.meta.title).toBe(
+              "Reset your password"
+            )
+            done()
+          })
+        })
+      })
+
+      describe("intent", () => {
+        it("returns correct title for save artwork intent", done => {
+          req.path = "/signup"
+          req.query = {
+            intent: "save artwork",
+          }
+          index(req, res, next).then(() => {
+            expect(stitch.mock.calls[0][0].data.options.title).toBe(
+              "Sign up to save artworks"
+            )
+            done()
+          })
+        })
+
+        it("returns correct title for follow partner intent", done => {
+          req.path = "/signup"
+          req.query = {
+            intent: "follow partner",
+          }
+          index(req, res, next).then(() => {
+            expect(stitch.mock.calls[0][0].data.options.title).toBe(
+              "Sign up to follow partners"
+            )
+            done()
+          })
+        })
+
+        it("returns correct title for follow artist intent", done => {
+          req.path = "/signup"
+          req.query = {
+            intent: "follow artist",
+          }
+          index(req, res, next).then(() => {
+            expect(stitch.mock.calls[0][0].data.options.title).toBe(
+              "Sign up to follow artists"
+            )
+            done()
+          })
+        })
+
+        it("returns correct title when other intent provided", done => {
+          req.path = "/signup"
+          req.query = {
+            intent: "viewedEditorial",
+          }
+          index(req, res, next).then(() => {
+            expect(stitch.mock.calls[0][0].data.options.title).toBe(
+              "Signup for Artsy"
+            )
+            done()
+          })
+        })
+
+        it("returns correct title when other intent provided", done => {
+          req.path = "/forgot"
+          req.query = {
+            set_password: "reset",
+          }
+          index(req, res, next).then(() => {
+            expect(stitch.mock.calls[0][0].data.options.title).toBe(
+              "Set your password"
+            )
+            done()
+          })
+        })
       })
 
       it("Options returns all expected fields from query", done => {

--- a/src/desktop/apps/authentication/helpers.ts
+++ b/src/desktop/apps/authentication/helpers.ts
@@ -93,7 +93,7 @@ export const handleSubmit = (
           action = "Created account"
           break
         case ModalType.forgot:
-          action = "Forgot Password"
+          action = "Reset your password"
           break
       }
 

--- a/src/desktop/apps/authentication/routes.ts
+++ b/src/desktop/apps/authentication/routes.ts
@@ -33,7 +33,7 @@ export const index = async (req, res, next) => {
       pageTitle = "Signup for Artsy"
       break
     case ModalType.forgot:
-      pageTitle = "Forgot Password"
+      pageTitle = "Reset your password"
       break
   }
   const meta = {
@@ -66,7 +66,7 @@ export const index = async (req, res, next) => {
       title = copy || "Sign up to follow artists"
       break
     default:
-      title = `Sign up for Artsy`
+      title = pageTitle || `Sign up for Artsy`
       break
   }
 
@@ -74,6 +74,9 @@ export const index = async (req, res, next) => {
     res.locals.sd.RESET_PASSWORD_REDIRECT_TO =
       req.query.reset_password_redirect_to
     res.locals.sd.SET_PASSWORD = req.query.set_password
+    if (req.query.set_password) {
+      title = "Set your password"
+    }
   }
 
   const redirectTo = getRedirectTo(req)

--- a/src/desktop/apps/authentication/routes.ts
+++ b/src/desktop/apps/authentication/routes.ts
@@ -73,6 +73,8 @@ export const index = async (req, res, next) => {
   if (type === ModalType.forgot) {
     res.locals.sd.RESET_PASSWORD_REDIRECT_TO =
       req.query.reset_password_redirect_to
+
+    // Used to customize reset copy/emails for partners etc
     res.locals.sd.SET_PASSWORD = req.query.set_password
     if (req.query.set_password) {
       title = "Set your password"

--- a/src/desktop/models/logged_out_user.coffee
+++ b/src/desktop/models/logged_out_user.coffee
@@ -92,12 +92,12 @@ module.exports = class LoggedOutUser extends User
   forgot: (options = {}) ->
     attrs = @pick('email')
     attrs.reset_password_redirect_to = sd.RESET_PASSWORD_REDIRECT_TO || null
-    attrs.mode = if sd.SET_PASSWORD is 'true' then 'fair_set_password' else null
+    attrs.mode = if sd.SET_PASSWORD == 'true' then 'fair_set_password' else sd.SET_PASSWORD || null
 
     new Backbone.Model()
       .save attrs, _.extend {}, options,
         url: "#{API_URL}/api/v1/users/send_reset_password_instructions"
-        success: _.wrap options.success, (success, args...) =>
+        success: _.wrap options.success, (success, args...) ->
           success? args...
 
   repossess: (subsequent_user_id, options = {}) ->

--- a/src/desktop/test/models/logged_out_user.test.coffee
+++ b/src/desktop/test/models/logged_out_user.test.coffee
@@ -110,19 +110,19 @@ describe 'LoggedOutUser', ->
         attributes = Backbone.sync.args[0][1].attributes
         attributes.should.containEql reset_password_redirect_to: 'https://cms.artsy.net'
 
-      it 'sends the mode when set password is true', ->
+      it 'sets the mode to fair_set_password when set password is true', ->
         LoggedOutUser.__set__ 'sd', SET_PASSWORD: 'true'
         user = new LoggedOutUser email: 'foo@bar.com'
         user.forgot()
         attributes = Backbone.sync.args[0][1].attributes
         attributes.should.containEql mode: 'fair_set_password'
 
-      it 'ignores other values of SET_PASSWORD', ->
-        LoggedOutUser.__set__ 'sd', SET_PASSWORD: 'invalid'
+      it 'passes value of SET_PASSWORD when present and not "true"', ->
+        LoggedOutUser.__set__ 'sd', SET_PASSWORD: 'reset'
         user = new LoggedOutUser email: 'foo@bar.com'
         user.forgot()
         attributes = Backbone.sync.args[0][1].attributes
-        attributes.should.containEql mode: null
+        attributes.should.containEql mode: 'reset'
 
       it 'accepts options and overwrites the default success', (done) ->
         user = new LoggedOutUser email: 'foo@bar.com'


### PR DESCRIPTION
- Updates `forgot` form text to read `Reset your password` instead of `Forgot Password`
- Overwrites `forgot` title to `Set your password` when `set_password` param provided
- Updates logic for `sd.SET_PASSWORD` to pass  all values to Gravity