### PR TITLE
[A/B] Temporarily force into control

### DIFF
--- a/src/desktop/components/split_test/middleware.coffee
+++ b/src/desktop/components/split_test/middleware.coffee
@@ -15,4 +15,8 @@ module.exports = (req, res, next) ->
       test.set v
       res.locals.sd[k.toUpperCase()] = v
 
+  # FIXME: Remove when new A/B test launches
+  if runningTests['client_navigation_v4']
+    res.locals.sd['CLIENT_NAVIGATION_V4'] = 'control'
+
   next()


### PR DESCRIPTION
This temporarily forces app into `control` state before we launch new test with inquiry analytics fix.