### PR TITLE
HOLD => [Clientside Nav] Bump A/B test to v5

### DIFF
--- a/hokusai/experimental-app-shell.yml
+++ b/hokusai/experimental-app-shell.yml
@@ -12,8 +12,7 @@ metadata:
 spec:
   strategy:
     rollingUpdate:
-      maxSurge: 2
-      maxUnavailable: 0
+      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:
@@ -37,12 +36,14 @@ spec:
       - env:
         - name: PORT
           value: '5000'
-        - name: EXPERIMENTAL_APP_SHELL
-          value: 'true'
         - name: DD_TRACE_AGENT_HOSTNAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KEEPALIVE_TIMEOUT_SECONDS
+          value: '95'
+        - name: HEADERS_TIMEOUT_SECONDS
+          value: '105'
         envFrom:
         - configMapRef:
             name: force-environment
@@ -123,7 +124,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: staging-force
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: 'true'
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '300'
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '90'
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:iam::585031190124:server-certificate/2018-01-17_artsy-net-wildcard
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: '443'

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@artsy/gemup": "0.0.3",
     "@artsy/palette": "7.8.0",
     "@artsy/passport": "1.1.11",
-    "@artsy/reaction": "26.0.3",
+    "@artsy/reaction": "26.1.0",
     "@artsy/stitch": "6.1.6",
     "@babel/core": "7.6.0",
     "@babel/node": "7.6.1",

--- a/src/desktop/analytics/inquiry_questionnaire.js
+++ b/src/desktop/analytics/inquiry_questionnaire.js
@@ -24,7 +24,7 @@
     // inquiries would then not get tracked as there's no "hard jumps"
     // between pages. See: https://github.com/artsy/force/pull/5232
     // FIXME: Remove once A/B test completes
-    if (window.sd.CLIENT_NAVIGATION_V4 === "experiment") {
+    if (window.sd.CLIENT_NAVIGATION_V5 === "experiment") {
       analyticsHooks.on(namespace(name), handler)
     } else {
       analyticsHooks.once(namespace(name), handler)

--- a/src/desktop/apps/experimental-app-shell/server.tsx
+++ b/src/desktop/apps/experimental-app-shell/server.tsx
@@ -23,7 +23,7 @@ app.get("/artwork/:artworkID/download/:filename", handleArtworkImageDownload)
 app.get(
   "/*",
   (_req, res, next) => {
-    const isExperiment = res.locals.sd.CLIENT_NAVIGATION_V4 === "experiment"
+    const isExperiment = res.locals.sd.CLIENT_NAVIGATION_V5 === "experiment"
 
     if (!isExperiment) {
       return next("route")

--- a/src/desktop/components/inquiry_questionnaire/index.coffee
+++ b/src/desktop/components/inquiry_questionnaire/index.coffee
@@ -8,6 +8,7 @@ Trail = require './trail.coffee'
 analytics = require './analytics.coffee'
 openErrorFlash = require './error.coffee'
 sd = require('sharify').data
+mediator = require('../../lib/mediator.coffee')
 { steps, decisions, views } = require './map.coffee'
 
 module.exports = ({ user, artwork, inquiry, bypass, state_attrs, ask_specialist }) ->
@@ -53,6 +54,10 @@ module.exports = ({ user, artwork, inquiry, bypass, state_attrs, ask_specialist 
   analytics.attach state.context
   modal.view.on 'closed', ->
     analytics.teardown state.context
+
+    # Dispatch a reload event to the new reaction app shell. If user has created
+    # account or logged in, page will reload to sync logged in state.
+    mediator.trigger('auth:login:inquiry_form:maybeReloadOnModalClose')
 
   # Log to both the `Logger` and the `Trail`
   log = (step) ->

--- a/src/desktop/components/inquiry_questionnaire/views/account.coffee
+++ b/src/desktop/components/inquiry_questionnaire/views/account.coffee
@@ -11,6 +11,8 @@ templates =
   forgot: -> require('../templates/account/forgot.jade') arguments...
 { recaptcha } = require "@artsy/reaction/dist/Utils/recaptcha"
 
+mediator = require('../../../lib/mediator.coffee')
+
 module.exports = class Account extends StepView
   _.extend @prototype, FormMixin
   _.extend @prototype, FormErrorHelpers
@@ -67,6 +69,7 @@ module.exports = class Account extends StepView
         @user.repossess user.id,
           error: form.error.bind form
           success: =>
+            mediator.trigger('auth:login:inquiry_form', @user.toJSON())
             if sd.COMMERCIAL?.enableNewInquiryFlow
               @next()
             else

--- a/src/desktop/components/split_test/middleware.coffee
+++ b/src/desktop/components/split_test/middleware.coffee
@@ -15,8 +15,4 @@ module.exports = (req, res, next) ->
       test.set v
       res.locals.sd[k.toUpperCase()] = v
 
-  # FIXME: Remove when new A/B test launches
-  if runningTests['client_navigation_v4']
-    res.locals.sd['CLIENT_NAVIGATION_V4'] = 'control'
-
   next()

--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -27,8 +27,8 @@
 # module.exports = {}
 
 module.exports = {
-  client_navigation_v4:
-    key: "client_navigation_v4"
+  client_navigation_v5:
+    key: "client_navigation_v5"
     outcomes:
       control: 50
       experiment: 50

--- a/src/desktop/components/split_test/skipIfClientSideRoutingEnabled.ts
+++ b/src/desktop/components/split_test/skipIfClientSideRoutingEnabled.ts
@@ -1,6 +1,6 @@
 export const skipIfClientSideRoutingEnabled = (_req, res, next) => {
   // Remove once A/B test completes
-  if (res.locals.sd.CLIENT_NAVIGATION_V4 === "experiment") {
+  if (res.locals.sd.CLIENT_NAVIGATION_V5 === "experiment") {
     return next("route")
   }
   return next()

--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -83,20 +83,18 @@ export function syncAuth() {
 }
 
 function logoutEventHandler() {
-  if (sd.CURRENT_USER) {
-    $.ajax({
-      url: "/users/sign_out",
-      type: "DELETE",
-      success() {
-        analyticsHooks.trigger("auth:logged-out")
-        location.reload()
-      },
-      error(_xhr, _status, errorMessage) {
-        // tslint:disable-next-line:no-unused-expression
-        new FlashMessage({ message: errorMessage })
-      },
-    })
-  }
+  $.ajax({
+    url: "/users/sign_out",
+    type: "DELETE",
+    success() {
+      analyticsHooks.trigger("auth:logged-out")
+      location.reload()
+    },
+    error(_xhr, _status, errorMessage) {
+      // tslint:disable-next-line:no-unused-expression
+      new FlashMessage({ message: errorMessage })
+    },
+  })
 }
 
 function setupReferrerTracking() {

--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -149,7 +149,7 @@ function setupErrorReporting() {
     // FIXME: Remove once A/B test ends
     Sentry.addBreadcrumb({
       category: "experimental-app-shell-ab-test",
-      message: `A/B test group: ${sd.CLIENT_NAVIGATION_V4}`,
+      message: `A/B v5 test group: ${sd.CLIENT_NAVIGATION_V5}`,
       level: Sentry.Severity.Info,
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,6 +78,7 @@
 
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 "@artsy/reaction@26.0.3":
   version "26.0.3"
   resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-26.0.3.tgz#ad0ab80d6ae9bd60f8677dbd535275cd7bd9421e"
@@ -94,6 +95,12 @@
   resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-25.36.1-canary.4-3285.tgz#fa4638ceb2bb7d0101c5542ed162123d8ca486c0"
   integrity sha512-Nq3cASXjxAssDTSA9RoMSZJJ7Gbzo5m0CYUUPF0PD6jqHCSMOOaKPIXvYTmo9PecC8f9u/p+ABpc0jtZwp9pGg==
 >>>>>>> Similfy inquiry reload
+=======
+"@artsy/reaction@^26.0.1-canary.0-3285":
+  version "26.0.1-canary.0-3285"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-26.0.1-canary.0-3285.tgz#906c6f486b119a8dcbc95694e3692ae2b4fc926e"
+  integrity sha512-jMJ92wTZWTU+nBNopKThZ3+pV9oXdFsJj7u5WaYIEIC7klIYWKzHlqVMeqHWSWXAZocNYVm81F67em0/yGwCvw==
+>>>>>>> Bump canary
   dependencies:
     "@artsy/detect-responsive-traits" "^0.0.5"
     "@artsy/fresnel" "^1.0.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,6 +77,7 @@
   integrity sha512-FXiRSqfSvwpz/QgwaqFvjJsbDmo9qMGpvUp/0p1V6muaJbGnfxkTSxAYWmYlFst6bmjhVxCYKxvgQhEVE03Wfg==
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 "@artsy/reaction@26.0.3":
   version "26.0.3"
   resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-26.0.3.tgz#ad0ab80d6ae9bd60f8677dbd535275cd7bd9421e"
@@ -87,6 +88,12 @@
   resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-25.36.1-canary.3-3285.tgz#0f6e7c2ce41c62b625b5d7782611e7c7f259d276"
   integrity sha512-f36sNj9jZuDB4mTtpysdSJ6u5FSEI5RhPP+XOSZUAoJlDLYGlIssMYejFUecjXtA7ZKQshbj7iE+N6jZXZqfVg==
 >>>>>>> Bump canary
+=======
+"@artsy/reaction@^25.36.1-canary.4-3285":
+  version "25.36.1-canary.4-3285"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-25.36.1-canary.4-3285.tgz#fa4638ceb2bb7d0101c5542ed162123d8ca486c0"
+  integrity sha512-Nq3cASXjxAssDTSA9RoMSZJJ7Gbzo5m0CYUUPF0PD6jqHCSMOOaKPIXvYTmo9PecC8f9u/p+ABpc0jtZwp9pGg==
+>>>>>>> Similfy inquiry reload
   dependencies:
     "@artsy/detect-responsive-traits" "^0.0.5"
     "@artsy/fresnel" "^1.0.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,10 +76,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/react-html-parser/-/react-html-parser-3.0.2.tgz#6213d662441acf0bd8c9ee953aa77ac8d9cf1cdd"
   integrity sha512-FXiRSqfSvwpz/QgwaqFvjJsbDmo9qMGpvUp/0p1V6muaJbGnfxkTSxAYWmYlFst6bmjhVxCYKxvgQhEVE03Wfg==
 
-"@artsy/reaction@26.0.3":
-  version "26.0.3"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-26.0.3.tgz#ad0ab80d6ae9bd60f8677dbd535275cd7bd9421e"
-  integrity sha512-576m2K9KZotxKVItD0aFQ5h3U25MUdVpTGAHpCqExzEoUPg/Y47izIYtzAfDdLFC9oWJqHJQ56ZIyWCyZ4s10g==
+"@artsy/reaction@26.1.0":
+  version "26.1.0"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-26.1.0.tgz#f00f8a6f1736b9a4b6bf562015e004d8a4aca746"
+  integrity sha512-s/I73ZKJp5YgU1G7QxM8f/wNoFMc+RRUvkXu11+jy0QuZzZQNJ/myKnLj2cMKQsqLViC15hTtI7UJ8s+HuKa7Q==
   dependencies:
     "@artsy/detect-responsive-traits" "^0.0.5"
     "@artsy/fresnel" "^1.0.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,10 +76,17 @@
   resolved "https://registry.yarnpkg.com/@artsy/react-html-parser/-/react-html-parser-3.0.2.tgz#6213d662441acf0bd8c9ee953aa77ac8d9cf1cdd"
   integrity sha512-FXiRSqfSvwpz/QgwaqFvjJsbDmo9qMGpvUp/0p1V6muaJbGnfxkTSxAYWmYlFst6bmjhVxCYKxvgQhEVE03Wfg==
 
+<<<<<<< HEAD
 "@artsy/reaction@26.0.3":
   version "26.0.3"
   resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-26.0.3.tgz#ad0ab80d6ae9bd60f8677dbd535275cd7bd9421e"
   integrity sha512-576m2K9KZotxKVItD0aFQ5h3U25MUdVpTGAHpCqExzEoUPg/Y47izIYtzAfDdLFC9oWJqHJQ56ZIyWCyZ4s10g==
+=======
+"@artsy/reaction@^25.36.1-canary.3-3285":
+  version "25.36.1-canary.3-3285"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-25.36.1-canary.3-3285.tgz#0f6e7c2ce41c62b625b5d7782611e7c7f259d276"
+  integrity sha512-f36sNj9jZuDB4mTtpysdSJ6u5FSEI5RhPP+XOSZUAoJlDLYGlIssMYejFUecjXtA7ZKQshbj7iE+N6jZXZqfVg==
+>>>>>>> Bump canary
   dependencies:
     "@artsy/detect-responsive-traits" "^0.0.5"
     "@artsy/fresnel" "^1.0.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,31 +76,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/react-html-parser/-/react-html-parser-3.0.2.tgz#6213d662441acf0bd8c9ee953aa77ac8d9cf1cdd"
   integrity sha512-FXiRSqfSvwpz/QgwaqFvjJsbDmo9qMGpvUp/0p1V6muaJbGnfxkTSxAYWmYlFst6bmjhVxCYKxvgQhEVE03Wfg==
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 "@artsy/reaction@26.0.3":
   version "26.0.3"
   resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-26.0.3.tgz#ad0ab80d6ae9bd60f8677dbd535275cd7bd9421e"
   integrity sha512-576m2K9KZotxKVItD0aFQ5h3U25MUdVpTGAHpCqExzEoUPg/Y47izIYtzAfDdLFC9oWJqHJQ56ZIyWCyZ4s10g==
-=======
-"@artsy/reaction@^25.36.1-canary.3-3285":
-  version "25.36.1-canary.3-3285"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-25.36.1-canary.3-3285.tgz#0f6e7c2ce41c62b625b5d7782611e7c7f259d276"
-  integrity sha512-f36sNj9jZuDB4mTtpysdSJ6u5FSEI5RhPP+XOSZUAoJlDLYGlIssMYejFUecjXtA7ZKQshbj7iE+N6jZXZqfVg==
->>>>>>> Bump canary
-=======
-"@artsy/reaction@^25.36.1-canary.4-3285":
-  version "25.36.1-canary.4-3285"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-25.36.1-canary.4-3285.tgz#fa4638ceb2bb7d0101c5542ed162123d8ca486c0"
-  integrity sha512-Nq3cASXjxAssDTSA9RoMSZJJ7Gbzo5m0CYUUPF0PD6jqHCSMOOaKPIXvYTmo9PecC8f9u/p+ABpc0jtZwp9pGg==
->>>>>>> Similfy inquiry reload
-=======
-"@artsy/reaction@^26.0.1-canary.0-3285":
-  version "26.0.1-canary.0-3285"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-26.0.1-canary.0-3285.tgz#906c6f486b119a8dcbc95694e3692ae2b4fc926e"
-  integrity sha512-jMJ92wTZWTU+nBNopKThZ3+pV9oXdFsJj7u5WaYIEIC7klIYWKzHlqVMeqHWSWXAZocNYVm81F67em0/yGwCvw==
->>>>>>> Bump canary
   dependencies:
     "@artsy/detect-responsive-traits" "^0.0.5"
     "@artsy/fresnel" "^1.0.13"


### PR DESCRIPTION
Corresponding Reaction PR: https://github.com/artsy/reaction/pull/3285

1) Bumps A/B test var to `CLIENT_NAVIGATION_V5` 
2) Fixes issue where inquiry form doesn't reload after a user logins / registers
3) Fixes issue around tracking across consecutive artwork page views 

- [x] QA'd by wider team: http://experimental-app-shell.artsy.net/. See [QA script](https://www.notion.so/artsy/2020-03-18-Artsy-net-New-App-Shell-QA-4909d96ae0984060a454dccb5e90a2f5).