### PR TITLE
Add test hook to know if app requires rehydration

### DIFF
--- a/src/desktop/components/main_layout/templates/blank.jade
+++ b/src/desktop/components/main_layout/templates/blank.jade
@@ -1,4 +1,5 @@
 block locals
+  - attributes = {}
   - bodyClass = helpers ? helpers.buildBodyClass(sd) : ''
   - defaultOptions = {modal: true, flash: true, stripev3: false, sailthru: true, marketo: true, quantcast: false}
 - options = options ? Object.assign({}, defaultOptions, options) : defaultOptions
@@ -14,7 +15,7 @@ html( data-useragent= userAgent lang="en")
     if assetPackage
       link( type='text/css', rel='stylesheet', href= asset('/assets/#{assetPackage}.css') )
 
-  body( class= bodyClass )
+  body( class= bodyClass )&attributes(attributes)
     if options.modal
       include ../../modal/template
 

--- a/src/desktop/components/main_layout/templates/experimental_app_shell.jade
+++ b/src/desktop/components/main_layout/templates/experimental_app_shell.jade
@@ -3,6 +3,7 @@ extends blank
 append locals
   - assetPackage = locals.assetPackage || ''
   - bodyClass = bodyClass + ' ' + (locals.bodyClass || '')
+  - attributes = { 'data-test': "SSRApp" }
 
 block head
   != head

--- a/src/desktop/components/main_layout/templates/experimental_app_shell.jade
+++ b/src/desktop/components/main_layout/templates/experimental_app_shell.jade
@@ -3,7 +3,7 @@ extends blank
 append locals
   - assetPackage = locals.assetPackage || ''
   - bodyClass = bodyClass + ' ' + (locals.bodyClass || '')
-  - attributes = { 'data-test': "SSRApp" }
+  - attributes = { 'data-test-ssr-app': true }
 
 block head
   != head

--- a/src/desktop/components/main_layout/templates/minimal_header.jade
+++ b/src/desktop/components/main_layout/templates/minimal_header.jade
@@ -1,5 +1,6 @@
 //- Override any locals with `append locals`
 block locals
+  - attributes = {}
   - bodyClass = helpers ? helpers.buildBodyClass(sd, 'body-header-fixed minimal-header') : ''
   - defaultOptions = {modal: true, flash: true, stripev3: false, sailthru: true, marketo: true, quantcast: false}
 - options = options ? Object.assign({}, defaultOptions, options) : defaultOptions
@@ -13,7 +14,7 @@ html( data-useragent= userAgent lang="en")
     if assetPackage
       link( type='text/css', rel='stylesheet', href=asset('/assets/#{assetPackage}.css') )
 
-  body( class=bodyClass )
+  body( class=bodyClass )&attributes(attributes)
     -if (!hideHeaderOnEigen)
       include ../header/templates/minimal_header
     include ../../modal/template

--- a/src/desktop/components/main_layout/templates/react_minimal_header.jade
+++ b/src/desktop/components/main_layout/templates/react_minimal_header.jade
@@ -1,6 +1,7 @@
 extends minimal_header
 
 append locals
+  - attributes = { "data-test-ssr-app": true }
   - assetPackage = locals.assetPackage || ''
   - bodyClass = bodyClass + ' ' + (locals.bodyClass || '')
 

--- a/src/desktop/components/main_layout/templates/react_redesign.jade
+++ b/src/desktop/components/main_layout/templates/react_redesign.jade
@@ -3,7 +3,7 @@ extends redesign
 append locals
   - assetPackage = locals.assetPackage || ''
   - bodyClass = bodyClass + ' ' + (locals.bodyClass || '')
-  - attributes = { 'data-test': "SSRApp" }
+  - attributes = { 'data-test-ssr-app': true }
 
 block head
   != head

--- a/src/desktop/components/main_layout/templates/react_redesign.jade
+++ b/src/desktop/components/main_layout/templates/react_redesign.jade
@@ -3,6 +3,7 @@ extends redesign
 append locals
   - assetPackage = locals.assetPackage || ''
   - bodyClass = bodyClass + ' ' + (locals.bodyClass || '')
+  - attributes = { 'data-test': "SSRApp" }
 
 block head
   != head

--- a/src/desktop/components/main_layout/templates/redesign.jade
+++ b/src/desktop/components/main_layout/templates/redesign.jade
@@ -3,6 +3,7 @@ block locals
   - bodyClass = helpers ? helpers.buildBodyClass(sd, 'body-header-fixed') : '';
   - defaultOptions = {modal: true, flash: true, stripev3: false, sailthru: true, marketo: true, quantcast: false}
   - options = options ? Object.assign({}, defaultOptions, options) : defaultOptions
+  - attributes = {}
 
 doctype html
 html(
@@ -21,7 +22,7 @@ html(
       if assetPackage
         link( type='text/css', rel='stylesheet', href=asset('/assets/#{assetPackage}.css') )
 
-  body( class=bodyClass )
+  body( class=bodyClass )&attributes(attributes)
     //- Global component mixins
     include ../../modal/template
     include ../../flash/template


### PR DESCRIPTION
cc @eessex 

Many of the flaky test failures we've been seen in integrity can be correlated with race conditions related to rehydration. An element that we're searching for may be on the page, but it may not yet be ready to be clicked. We've already added some mechanisms for waiting for an app to rehydrate. 

The biggest missing piece is knowing _if_ we should wait for an app to rehydrate. That's where this PR comes in. 

I've added the `data-test-ssr-app` to the server rendered attributes of any app that uses reaction templates. That means on server render, this attribute will be available on the body of the app and be an effective mechanism for integrity to know if it should try to wait. 

With this, we can add more hooks into global actions (like logging in) to _automatically_ wait if it's necessary. 