### PR TITLE
Make nav bar on mobile web for "force-only" pages sticky

### DIFF
--- a/src/mobile/components/layout/bootstrap.coffee
+++ b/src/mobile/components/layout/bootstrap.coffee
@@ -48,6 +48,8 @@ module.exports = ->
   if sd.stitch?.renderQueue?
     mountStitch()
 
+  handleNavBarScroll()
+
 mountStitch = ->
   hydrateStitch({
     sharifyData: sd
@@ -90,3 +92,18 @@ checkForAfterSignUpAction = ->
     ops and ops(@currentUser, objectId, kind)
 
     Cookies.expire 'afterSignUpAction'
+
+handleNavBarScroll = ->
+  # We only need this special case when the user sees the "login/signup"
+  # banner on mobile web.
+  if !CurrentUser.orNull()
+    $mainNav = $("#header-content #main-layout-header")
+    $loginSignupBanner = $('#header-content .login-signup')
+
+    window.addEventListener "scroll", () ->
+      if $(window).scrollTop() > $loginSignupBanner.outerHeight()
+        $loginSignupBanner.css('display', 'none')
+        $mainNav.css('position', 'fixed')
+      else
+        $loginSignupBanner.css('display', 'block')
+        $mainNav.css('position', 'relative')

--- a/src/mobile/components/layout/stylesheets/index.styl
+++ b/src/mobile/components/layout/stylesheets/index.styl
@@ -91,10 +91,24 @@ main
 .is-scrolling-disabled
   overflow-y hidden
 
+// Hide second header, used for pushing layout down the appropriate amount
+main
+  .login-signup, #main-layout-header
+    visibility hidden
+
+#header-content
+  position absolute
+  z-index 1001
+  width 100%
+
 // Logged in layout
 html.layout-logged-in
   .login-signup
     display none
+
+  // Fix the entire header for logged-in user
+  #header-content #main-layout-header
+    position fixed
 
 // Hide the header and footer if the Artsy Mobile app is looking at the page
 html.layout-artsy-mobile-app

--- a/src/mobile/components/layout/templates/main.jade
+++ b/src/mobile/components/layout/templates/main.jade
@@ -3,13 +3,15 @@ include ./login-signup
 
 block body
   #content
-    block banner
-      mixin login-signup("Header")
-
-    header
-      != stitch && stitch.components.NavBar({ user: sd.CURRENT_USER, notificationCount: sd.NOTIFICATION_COUNT })
+    #header-content
+      block banner
+        mixin login-signup("Header")
+      header
+        != stitch && stitch.components.NavBar({ user: sd.CURRENT_USER, notificationCount: sd.NOTIFICATION_COUNT })
 
     main
+      mixin login-signup("Header")
+      != stitch && stitch.components.NavBar({ user: sd.CURRENT_USER, notificationCount: sd.NOTIFICATION_COUNT })
       block content
 
     include footer


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/FX-1818 (for the second time 😄)

The requirements are:
- When logged in on mobile web, don't show the login/signup banner and fix the general nav bar.
- When logged out on mobile web, show the login/signup banner and _only after scrolling to it_, fix the general nav bar.

I took a couple of approaches to achieve this:
- For the logged in case, it's easy-- we can just push the content down (I achieved this in a non-JS way by replicating the header element with `visibility: hidden` per guidance I found on stack overflow) and fix the header.
- For the logged out case, we do that ☝️ , and add a little JS to achieve the conditional fixed effect.