### PR TITLE
Update Sailthru's JS to latest version and include it on all pages

### DIFF
--- a/src/desktop/components/main_layout/templates/scripts.jade
+++ b/src/desktop/components/main_layout/templates/scripts.jade
@@ -146,38 +146,34 @@ if options.quantcast
     img( src="//pixel.quantserve.com/pixel/p-cMwS3F29bthyC.gif?labels=_fp.event.Default" style="display: none;" border="0" height="1" width="1" alt="Quantcast" )
 
 //- Sailthru Horizon JS - user interest data, personalization
-if options.sailthru
-  if sd.INCLUDE_SAILTHRU
-    script( type="text/javascript" ).
-      (function() {
-        function loadHorizon() {
-          var s = document.createElement('script');
-          s.type = 'text/javascript';
-          s.async = true;
-          s.src = location.protocol + '//ak.sail-horizon.com/horizon/v1.js';
-          var x = document.getElementsByTagName('script')[0];
-          x.parentNode.insertBefore(s, x);
+if options.sailthru && sd.SAILTHRU_CUSTOMER_ID
+  script( type="text/javascript" ).
+    (function() {
+      function loadHorizon() {
+        var s = document.createElement('script');
+        s.type = 'text/javascript';
+        s.async = true;
+        s.src = location.protocol + '//ak.sail-horizon.com/spm/spm.v1.min.js';
+        var x = document.getElementsByTagName('script')[0];
+        x.parentNode.insertBefore(s, x);
+      }
+      loadHorizon();
+      function loadSailthru() {
+        if(typeof Sailthru !== "undefined"){
+          Sailthru.init({ customerId: sd.SAILTHRU_CUSTOMER_ID });
         }
-        loadHorizon();
-        function loadSailthru() {
-          if(typeof Sailthru !== "undefined"){
-            Sailthru.setup({
-              domain: 'horizon.artsy.net',
-              useStoredTags: false
-            });
-          }
-          else{
-              setTimeout(loadSailthru, 250);
-          }
+        else{
+          setTimeout(loadSailthru, 250);
         }
-        var oldOnLoad = window.onload;
-        window.onload = function() {
-          if (typeof oldOnLoad === 'function') {
-            oldOnLoad();
-          }
-          loadSailthru();
-        };
-      })();
+      }
+      var oldOnLoad = window.onload;
+      window.onload = function() {
+        if (typeof oldOnLoad === 'function') {
+          oldOnLoad();
+        }
+        loadSailthru();
+      };
+    })();
 
 //- Prefetch links on hover. See: https://instant.page/
 if sd.ENABLE_INSTANT_PAGE

--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -114,6 +114,7 @@ module.exports =
   S3_SECRET: null
   S3_BUCKET: null
   SAILTHRU_AUCTION_NOTIFICATION_LIST: 'Auction Notifications'
+  SAILTHRU_CUSTOMER_ID: null
   SAILTHRU_KEY: null
   SAILTHRU_MASTER_LIST: 'Master List'
   SAILTHRU_SECRET: null

--- a/src/lib/setup_sharify.js
+++ b/src/lib/setup_sharify.js
@@ -89,6 +89,7 @@ sharify.data = _.extend(
     "PREDICTION_URL",
     "RECAPTCHA_KEY",
     "S3_BUCKET",
+    "SAILTHRU_CUSTOMER_ID",
     "SAILTHRU_MASTER_LIST",
     "SECURE_IMAGES_URL",
     "SEGMENT_AMP_WRITE_KEY",

--- a/src/mobile/components/layout/templates/scaffold.jade
+++ b/src/mobile/components/layout/templates/scaffold.jade
@@ -39,5 +39,35 @@ html( class=htmlClass )
       //- Stripe
       script( type="text/javascript", src="https://js.stripe.com/v3/" )
 
+      //- Sailthru Horizon JS - user interest data, personalization
+      if sd.SAILTHRU_CUSTOMER_ID
+        script( type="text/javascript" ).
+          (function() {
+            function loadHorizon() {
+              var s = document.createElement('script');
+              s.type = 'text/javascript';
+              s.async = true;
+              s.src = location.protocol + '//ak.sail-horizon.com/spm/spm.v1.min.js';
+              var x = document.getElementsByTagName('script')[0];
+              x.parentNode.insertBefore(s, x);
+            }
+            loadHorizon();
+            function loadSailthru() {
+              if(typeof Sailthru !== "undefined"){
+                Sailthru.init({ customerId: sd.SAILTHRU_CUSTOMER_ID });
+              }
+              else{
+                setTimeout(loadSailthru, 250);
+              }
+            }
+            var oldOnLoad = window.onload;
+            window.onload = function() {
+              if (typeof oldOnLoad === 'function') {
+                oldOnLoad();
+              }
+              loadSailthru();
+            };
+          })();
+
       //- Include any scripts into the scripts block
       block scripts

--- a/src/mobile/config.coffee
+++ b/src/mobile/config.coffee
@@ -43,6 +43,7 @@ module.exports =
   S3_BUCKET: null
   S3_KEY: null
   S3_SECRET: null
+  SAILTHRU_CUSTOMER_ID: null
   SAILTHRU_KEY: ''
   SAILTHRU_MASTER_LIST: 'Master List'
   SAILTHRU_SECRET: ''


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/FX-1812

TL;RD: In order to leverage more features in Sailthru (browse abandon, abandoned cart emails, etc.), we need to update the JS snippet that we're pulling in on our pages.

In addition... these features aren't useful unless we actually include it on all of our pages.

This PR:
- Updates desktop and mobile web to include the Sailthru JS snippet on all pages.
- Includes config options for the `SAILTHRU_CUSTOMER_ID`. Will need to add this to staging and production for the events to actually fire.

There are a couple of places where we're using this JS to explicitly `track` something, and many places where we include specific sailthru `meta` tags. It doesn't look like the API for any of this has changed in the new version, but I'll monitor.

I verified that we're successfully authenticating using a correct customer ID, but won't be able to verify pageviews/etc. until we specify allowed domains in Sailthru's UI.

Some notes:
- This script is loaded `async` to hopefully minimize any perf impact (but it's something we need to be aware of).
- We don't intend to use this script/Sailthru's functionality to explicitly send `track` calls, as we use Segment for that. However, whatever default tracking Sailthru includes in this script should be enough to allow our marketing team to have greater freedom when constructing their campaigns.

Follow ups:
- Remove places where we explicitly `INCLUDE_SAILTHRU` in force's code, and potentially remove the custom tracking calls that we have (in case they can be replaced by the defaults).