### PR TITLE
[Refactor] Move v2/Components > /Components & Collect2 > Collect

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@artsy/gemup": "0.0.3",
     "@artsy/palette": "7.3.0",
     "@artsy/passport": "1.1.11",
-    "@artsy/reaction": "25.34.6",
+    "@artsy/reaction": "25.34.7",
     "@artsy/stitch": "6.1.6",
     "@babel/core": "7.6.0",
     "@babel/node": "7.6.1",

--- a/src/desktop/apps/collect/client.js
+++ b/src/desktop/apps/collect/client.js
@@ -1,6 +1,6 @@
 import { buildClientApp } from "reaction/Artsy/Router/buildClientApp"
 import { data as sd } from "sharify"
-import { collectRoutes } from "reaction/Apps/Collect2/collectRoutes"
+import { collectRoutes } from "reaction/Apps/Collect/collectRoutes"
 import mediator from "desktop/lib/mediator.coffee"
 import React from "react"
 import ReactDOM from "react-dom"

--- a/src/desktop/apps/collect/server.tsx
+++ b/src/desktop/apps/collect/server.tsx
@@ -1,6 +1,6 @@
 import { buildServerApp } from "reaction/Artsy/Router/buildServerApp"
 import { stitch } from "@artsy/stitch"
-import { collectRoutes } from "reaction/Apps/Collect2/collectRoutes"
+import { collectRoutes } from "reaction/Apps/Collect/collectRoutes"
 import express from "express"
 import React from "react"
 import { Meta } from "./meta"

--- a/src/desktop/components/react/stitch_components/CCPARequest.tsx
+++ b/src/desktop/components/react/stitch_components/CCPARequest.tsx
@@ -1,4 +1,4 @@
 import React from "react"
-import { CCPARequest } from "reaction/Components/v2/CCPARequest"
+import { CCPARequest } from "reaction/Components/CCPARequest"
 
 export const ReactionCCPARequest = props => <CCPARequest {...props} />

--- a/src/desktop/components/react/stitch_components/CollectionsHubsHomepageNav.tsx
+++ b/src/desktop/components/react/stitch_components/CollectionsHubsHomepageNav.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { CollectionsHubsHomepageNav as ReactionHubsNav } from "reaction/Components/v2/CollectionsHubsHomepageNav"
+import { CollectionsHubsHomepageNav as ReactionHubsNav } from "reaction/Components/CollectionsHubsHomepageNav"
 
 export const CollectionsHubsHomepageNav = ({ collectionsHubs }) => {
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,10 +76,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/react-html-parser/-/react-html-parser-3.0.2.tgz#6213d662441acf0bd8c9ee953aa77ac8d9cf1cdd"
   integrity sha512-FXiRSqfSvwpz/QgwaqFvjJsbDmo9qMGpvUp/0p1V6muaJbGnfxkTSxAYWmYlFst6bmjhVxCYKxvgQhEVE03Wfg==
 
-"@artsy/reaction@25.34.6":
-  version "25.34.6"
-  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-25.34.6.tgz#3776841667c4a1de6130ea34be3d9393d3d80edb"
-  integrity sha512-S/AYLHcwBBk4lEKcSAAqaVO9uQHVj/GZzeQIXQXGMyAY1h3u2Mgag84UWP3KNG24qdnsNv7udDI7p8BSW+et2g==
+"@artsy/reaction@25.34.7":
+  version "25.34.7"
+  resolved "https://registry.yarnpkg.com/@artsy/reaction/-/reaction-25.34.7.tgz#d3f9d5baac720dfef5a2864f8207bfc0e7fafbda"
+  integrity sha512-rAVnDto/OeclcMAWMo2B3XP0drvkV+vtvIv1ZEgEv92tsqosHZ6MErOScinr0zUFjK+nvPjPsVztAmpstiFKmQ==
   dependencies:
     "@artsy/detect-responsive-traits" "^0.0.5"
     "@artsy/fresnel" "^1.0.13"


### PR DESCRIPTION
Blocker: https://github.com/artsy/reaction/pull/3296

Been meaning to flatten the v2 folder for a while and rename Collect2 to Collect.