### PR TITLE
Log pageviews to console

### DIFF
--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -94,6 +94,15 @@ if (sd.SHOW_ANALYTICS_CALLS) {
   analytics.on("track", function() {
     console.info("TRACKED: ", arguments[0], JSON.stringify(arguments[1]))
   })
+  analytics.on("page", function() {
+    console.info(
+      "PAGEVIEW TRACKED: ",
+      arguments[2],
+      arguments[3],
+      JSON.stringify(arguments[2]),
+      JSON.stringify(arguments[3])
+    )
+  })
 }
 
 if (sd.SHOW_ANALYTICS_CALLS) {


### PR DESCRIPTION
We log tracking events, but not pageviews: 

<img width="600" alt="Screen Shot 2020-03-24 at 1 13 05 PM" src="https://user-images.githubusercontent.com/236943/77472511-44ea0000-6dd1-11ea-84f1-96916fcb05f3.png">
