### PR TITLE
Tweak staging rollout strategy to avoid downtime

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -5,7 +5,8 @@ metadata:
 spec:
   strategy:
     rollingUpdate:
-      maxUnavailable: 1
+      maxSurge: 2
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:
@@ -52,6 +53,10 @@ spec:
               memory: 1Gi
             limits:
               memory: 1.5Gi
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
         - name: force-nginx
           image: artsy/docker-nginx:latest
           ports:
@@ -68,7 +73,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/usr/sbin/nginx", "-s", "quit"]
+                command: ["sh", "-c", "sleep 5 && /usr/sbin/nginx -s quit"]
           env:
             - name: "NGINX_DEFAULT_CONF"
               valueFrom:


### PR DESCRIPTION
Updates staging rollout strategy to match what we recently implemented in Exchange. 

I suspect that downtime during staging deploys is a source of flake and spurious 500s in our in our Integrity tests:
<img width="493" alt="Screen Shot 2020-03-24 at 6 36 39 PM" src="https://user-images.githubusercontent.com/1497424/77483490-9fe61c00-6dfe-11ea-91b5-10433084bac8.png">
