### PR TITLE
Only call Sailthru.init if it is a function

### DIFF
--- a/src/desktop/components/main_layout/templates/scripts.jade
+++ b/src/desktop/components/main_layout/templates/scripts.jade
@@ -159,7 +159,7 @@ if options.sailthru && sd.SAILTHRU_CUSTOMER_ID
       }
       loadHorizon();
       function loadSailthru() {
-        if(typeof Sailthru !== "undefined"){
+        if(typeof Sailthru !== "undefined" && typeof Sailthru.init === "function"){
           Sailthru.init({ customerId: sd.SAILTHRU_CUSTOMER_ID });
         }
         else{

--- a/src/mobile/components/layout/templates/scaffold.jade
+++ b/src/mobile/components/layout/templates/scaffold.jade
@@ -53,7 +53,7 @@ html( class=htmlClass )
             }
             loadHorizon();
             function loadSailthru() {
-              if(typeof Sailthru !== "undefined"){
+              if(typeof Sailthru !== "undefined" && typeof Sailthru.init === "function"){
                 Sailthru.init({ customerId: sd.SAILTHRU_CUSTOMER_ID });
               }
               else{


### PR DESCRIPTION
Hopefully fixes [this sentry error](https://sentry.io/organizations/artsynet/issues/1579904158/events/83eaedcd9d814bcea66b3daeadffdf33/?project=28316&query=is%3Aunresolved) that popped up after we updated our Sailthru lib.