### PR TITLE
Stop modal when user are using back button from Artist to Artwork To Artist again

### DIFF
--- a/src/desktop/apps/artist/components/__tests__/cta.jest.ts
+++ b/src/desktop/apps/artist/components/__tests__/cta.jest.ts
@@ -112,7 +112,7 @@ describe("CTA", () => {
   it("#setCookie sets a cookie", () => {
     setCookie()
     expect(CookiesSetMock).toBeCalledWith("artist-page-signup-dismissed", 1, {
-      expires: 3600000,
+      expires: 3600,
     })
   })
   it("calls set cookie on modal close", async () => {

--- a/src/desktop/apps/artist/components/cta.ts
+++ b/src/desktop/apps/artist/components/cta.ts
@@ -29,7 +29,7 @@ const send = {
   variables: { artistID: sd.ARTIST_PAGE_CTA_ARTIST_ID },
 }
 export const setCookie = () => {
-  Cookies.set("artist-page-signup-dismissed", 1, { expires: 3600000 })
+  Cookies.set("artist-page-signup-dismissed", 1, { expires: 3600 })
 }
 export const setupArtistSignUpModal = () => {
   const artistPageAuthDismissedCookie = Cookies.get(

--- a/src/desktop/apps/artist/components/cta.ts
+++ b/src/desktop/apps/artist/components/cta.ts
@@ -1,6 +1,8 @@
 import { get } from "lodash"
 import { data as sd } from "sharify"
 import { handleScrollingAuthModal } from "desktop/lib/openAuthModal"
+const Cookies = require("desktop/components/cookies/index.coffee")
+const mediator = require("desktop/lib/mediator.coffee")
 const metaphysics = require("lib/metaphysics.coffee")
 
 export const query = `
@@ -22,12 +24,22 @@ const send = {
   query,
   variables: { artistID: sd.ARTIST_PAGE_CTA_ARTIST_ID },
 }
-
+export const setCookie = () => {
+  Cookies.set("artist-page-signup-dismissed", 1, { expires: 3600000 })
+}
 export const setupArtistSignUpModal = () => {
-  if (sd.ARTIST_PAGE_CTA_ENABLED && sd.ARTIST_PAGE_CTA_ARTIST_ID) {
+  const artistPageAuthDismissedCookie = Cookies.get(
+    "artist-page-signup-dismissed"
+  )
+
+  if (
+    sd.ARTIST_PAGE_CTA_ENABLED &&
+    sd.ARTIST_PAGE_CTA_ARTIST_ID &&
+    !artistPageAuthDismissedCookie
+  ) {
     return metaphysics(send).then(({ artist: artistData }) => {
       const image = get(artistData, "artworks[0].image.cropped.url")
-
+      mediator.on("modal:closed", setCookie)
       handleScrollingAuthModal({
         copy: `Join Artsy to discover new works by ${artistData.name} and more artists you love`,
         intent: "signup",


### PR DESCRIPTION
[PURCHASE-1792]

Remember user preferences when using back button
For more examples, please check: https://share.getcloudapp.com/04uKGnAL

In order to accomplish this I set a cookie when the user closes the modal, and check for that cookie when opening the modal, and don't show the modal if the cookie is present. The cookie expires after 1 hour as Guillaume suggested.

[PURCHASE-1792]: https://artsyproduct.atlassian.net/browse/PURCHASE-1792