### PR TITLE
[CSGN-107] Specify callback URL for consign sign-up auth flow

### DIFF
--- a/src/desktop/apps/consign/components/create_account/__test__/index.jest.tsx
+++ b/src/desktop/apps/consign/components/create_account/__test__/index.jest.tsx
@@ -100,8 +100,15 @@ describe("React components", () => {
     )
     expect(handleSubmitMock).toBeCalledWith(
       "login",
-      { copy: "Log In", contextModule: "consignments" },
-      { email: "user@email.com", password: "mypassword" },
+      {
+        copy: "Log In",
+        contextModule: "consignments",
+        redirectTo: "/consign/submission",
+      },
+      {
+        email: "user@email.com",
+        password: "mypassword",
+      },
       {}
     )
   })

--- a/src/desktop/apps/consign/components/create_account/index.tsx
+++ b/src/desktop/apps/consign/components/create_account/index.tsx
@@ -20,6 +20,7 @@ export class CreateAccount extends React.Component<CreateAccountProps> {
       {
         copy: this.props.title,
         contextModule: "consignments",
+        redirectTo: "/consign/submission",
       },
       values,
       formikBag
@@ -38,6 +39,7 @@ export class CreateAccount extends React.Component<CreateAccountProps> {
         <FormSwitcher
           options={{
             title: this.props.title,
+            redirectTo: "/consign/submission",
           }}
           type={this.props.type}
           handleSubmit={this.handleSubmit}


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/CSGN-107

Setting the `redirectTo` property redirects the user back into the consignment flow after they've signed up, rather than the homepage/onboarding.

![consign-auth-flow](https://user-images.githubusercontent.com/1627089/78177848-6330ab00-7424-11ea-819b-d92472e10a37.gif)
