### PR TITLE
[CI] Add type-check job to circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,8 @@ workflows:
                 path: ./reports
       - yarn/update-cache:
           <<: *not_staging_or_release
+      - yarn/type-check:
+          <<: *not_staging_or_release
       - acceptance:
           <<: *not_staging_or_release
       - acceptance_cypress:


### PR DESCRIPTION
Noticed that there was some confusion today around type-checking and yarn linking and looking closer noticed that we're not type-checking our PRs in CI. This adds that job to our flow. 