### PR TITLE
Removes extra white space below header

### DIFF
--- a/src/desktop/assets/art_keeps_going.styl
+++ b/src/desktop/assets/art_keeps_going.styl
@@ -1,0 +1,2 @@
+#main-layout-container
+  margin-top 59px !important


### PR DESCRIPTION
This is #minor but there's an extra 10-or-so pixels below the header for react layouts which use the `#main-layout-container`.

It made the big video header look suboptimal, so I'm explicitly removing it. 😬

![image](https://user-images.githubusercontent.com/2081340/78624280-41d22380-7857-11ea-9155-f8ce2dde237b.png)

(I noticed this is not an issue with apps that use the `experimental_app_shell` layout 😄!)