### PR TITLE
Remove clickthrough from welcome hero unit, add test attrs

### DIFF
--- a/src/desktop/apps/home/templates/hero_unit.jade
+++ b/src/desktop/apps/home/templates/hero_unit.jade
@@ -4,6 +4,7 @@
   class= 'home-hero-unit' + _s.dasherize(_s.humanize(heroUnit.mode)) + (i == 0 ? ' home-hero-unit-active' : '')
   style="background-image: url('#{backgroundImageUrl}')"
   data-mode=heroUnit.mode
+  data-test=heroUnit.mode
 )
   a.hhu-frame( class='js-homepage-hero-unit', href=heroUnit.href ): .responsive-layout-container: .main-layout-container
     .vam-outer: .vam-inner: .hhu-inner

--- a/src/desktop/apps/home/templates/hero_units.jade
+++ b/src/desktop/apps/home/templates/hero_units.jade
@@ -1,3 +1,3 @@
-#home-hero-units
+#home-hero-units( data-test="mainCarousel")
   for heroUnit, i in heroUnits
     include ./hero_unit

--- a/src/desktop/apps/home/welcome.coffee
+++ b/src/desktop/apps/home/welcome.coffee
@@ -2,7 +2,6 @@ module.exports =
   mode: 'WELCOME'
   subtitle: 'Sign up to get updates on your favorite artists'
   heading: 'Learn about and collect art from leading galleries, fairs, and museums'
-  href: '/sign_up?redirect-to=/personalize'
   link_text: 'Sign Up'
   background_image_url: '/images/welcome-hero.jpg'
   credit_line: '© 2020 Calder Foundation, New York / Artists Rights Society (ARS), New York.'


### PR DESCRIPTION
Minor QA fix as follow up to Auth changes in Reaction v26.0:
- Homepage hero unit does not click through to signup (this link overwrites args passed to the modal)
- add test attrs for integrity