### PR TITLE
Automate review app building via CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           name: Danger
           command: DANGER_GITHUB_API_TOKEN="15e52de81a772b174cc5""e1813d0083564c69c325" yarn danger ci
 
-  build_review_app:
+  update_review_app:
     executor: hokusai/deploy
     steps:
       - hokusai/setup-docker
@@ -69,8 +69,19 @@ jobs:
           name: Make jq executable
           command: chmod u+x /usr/local/bin/jq
       - run:
-          name: "Create review app"
-          command: ./scripts/build_review_app.sh $(echo $CIRCLE_BRANCH | sed 's/review-app-//')
+          name: "Create or update review app"
+          command: |
+            review_app_name=$(echo $CIRCLE_BRANCH | sed 's/review-app-//')
+
+            kubectl config use-context staging
+
+            if $(kubectl get namespace | grep -qi $review_app_name); then
+              hokusai registry push --force --skip-latest --overwrite --verbose --tag $review_app_name
+              hokusai review_app setup $review_app_name
+              hokusai review_app deploy $review_app_name $review_app_name
+            else
+              ./scripts/build_review_app.sh $review_app_name
+            fi
 
 not_master_or_staging_or_release: &not_master_or_staging_or_release
   filters:
@@ -171,7 +182,7 @@ workflows:
             - horizon/block
             - validate_production_schema
 
-      - build_review_app:
+      - update_review_app:
           context: hokusai
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           name: Danger
           command: DANGER_GITHUB_API_TOKEN="15e52de81a772b174cc5""e1813d0083564c69c325" yarn danger ci
 
-  update_review_app:
+  create_or_update_review_app:
     executor: hokusai/deploy
     steps:
       - hokusai/setup-docker
@@ -180,7 +180,7 @@ workflows:
             - horizon/block
             - validate_production_schema
 
-      - update_review_app:
+      - create_or_update_review_app:
           context: hokusai
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,22 @@ jobs:
           name: Danger
           command: DANGER_GITHUB_API_TOKEN="15e52de81a772b174cc5""e1813d0083564c69c325" yarn danger ci
 
+  build_review_app:
+    executor: hokusai/deploy
+    steps:
+      - hokusai/setup-docker
+      - hokusai/install-aws-iam-authenticator
+      - hokusai/configure-hokusai
+      - run:
+          name: Install jq
+          command: curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 > /usr/local/bin/jq
+      - run:
+          name: Make jq executable
+          command: chmod u+x /usr/local/bin/jq
+      - run:
+          name: "Create review app"
+          command: ./scripts/build_review_app.sh $(echo $CIRCLE_BRANCH | sed 's/review-app-//')
+
 not_master_or_staging_or_release: &not_master_or_staging_or_release
   filters:
     branches:
@@ -154,3 +170,9 @@ workflows:
           requires:
             - horizon/block
             - validate_production_schema
+
+      - build_review_app:
+          context: hokusai
+          filters:
+            branches:
+              only: /^review-app-.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,7 @@ jobs:
             kubectl config use-context staging
 
             if $(kubectl get namespace | grep -qi $review_app_name); then
-              hokusai registry push --force --skip-latest --overwrite --verbose --tag $review_app_name
-              hokusai review_app setup $review_app_name
-              hokusai review_app deploy $review_app_name $review_app_name
+              ./scripts/update_review_app.sh $review_app_name
             else
               ./scripts/build_review_app.sh $review_app_name
             fi

--- a/.circleci/deploy_event.sh
+++ b/.circleci/deploy_event.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-echo "_e{18,18}:Force was deployed|force was deployed|#service:force" > /dev/udp/datadog/8125

--- a/docs/creating_review_app.md
+++ b/docs/creating_review_app.md
@@ -4,7 +4,7 @@ If wanting to create a deploy for a WIP feature or for QA, [Hokusai](), supports
 
 The process for launching the review app differs somewhat depending on whether your unmerged changes are in Reaction or in Force.
 
-### If your unmerged changes are in Reaction
+### Pre-building steps for Reaction diff
 
 You will first cut a release of Reaction and publish it as a "canary" version to the NPM registry. You will then install this canary release into your copy of Force and launch _that_ as review app.
 
@@ -22,9 +22,24 @@ You will first cut a release of Reaction and publish it as a "canary" version to
 
 From here on out follow the steps in the next section for launching a Force review app. When you are done with the review process revert your change in step 2 above so that Reaction will resume normal versioning.
 
-### If your unmerged changes are in Force
+### Building Review Apps
 
 Launching a Force review app can be automated via the [`build_review_app.sh`](https://github.com/artsy/force/blob/master/scripts/build_review_app.sh) script.
+
+#### Building on Circle
+
+The easiest and fastest way to spin up a review app is to push your work to
+a branch starting with `review-app`. For example, `review-app-new-form`.
+
+CircleCI will match the `review-app` prefix and either:
+
+1. Create a review app using `build_review_app.sh` if the review app doesn't
+   exist yet (i.e. first successful push of the branch), or
+2. Update an existing review app using `update_review_app.sh`
+
+#### Manual Steps
+
+##### Manual Build
 
 First, make sure `jq` is installed:
 
@@ -38,7 +53,28 @@ Then launch the script:
 ./scripts/build_review_app.sh review-app-name
 ```
 
-When this process is done (and it will take a while) it should output a url similar to
+
+##### Manual Update
+
+If you want to push subsequent changes to the review app you can push a new build to the same tag with the `--overwrite` flag:
+
+```sh
+hokusai registry push --overwrite --skip-latest --force --tag <name>
+```
+
+and you need to redeploy your app:
+
+```sh
+hokusai review_app deploy <name> <name>
+```
+
+😇 After your review app is no longer needed please remember to clean up any CNAMEs you've created, and to de-provision the review app itself with `hokusai review_app delete <review-app-name>`
+
+For more info on Review App maintenence, [see Hokusai docs](https://github.com/artsy/hokusai/blob/master/docs/Review_Apps.md).
+
+#### DNS Setup
+
+Regardless of how you created a review app (CircleCI or manually), `build_review_app.sh` will output a hostname like the following:
 
 ```sh
 a99199101d01011e9aff2127c3b176f7-1359163722.us-east-1.elb.amazonaws.com
@@ -57,21 +93,3 @@ If you'd like a pretty URL subdomain or need to test full OAuth flows (for, say,
 1. DNS will propagate and after a few minutes the review app will be available via `<your-subdomain>.artsy.net`
 
 Read over the [`build_review_app.sh`](https://github.com/artsy/force/blob/master/scripts/build_review_app.sh) script for more info on how this is all done.
-
-## Updating a Review App 
-
-If you want to push subsequent changes to the review app you can push a new build to the same tag with the `--overwrite` flag:
-
-```sh
-hokusai registry push --overwrite --skip-latest --force --tag <name>
-```
-
-and you need to redeploy your app:
-
-```sh
-hokusai review_app deploy <name> <name>
-```
-
-😇 After your review app is no longer needed please remember to clean up any CNAMEs you've created, and to de-provision the review app itself with `hokusai review_app delete <review-app-name>`
-
-For more info on Review App maintenence, [see Hokusai docs](https://github.com/artsy/hokusai/blob/master/docs/Review_Apps.md).

--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -1,6 +1,5 @@
 project-name: force
 pre-deploy: yarn publish-assets
-post-deploy: .circleci/deploy_event.sh
 hokusai-required-version: ">=0.5.8"
 template-config-files:
   - s3://artsy-citadel/k8s/hokusai-vars.yml

--- a/scripts/build_review_app.sh
+++ b/scripts/build_review_app.sh
@@ -99,7 +99,10 @@ hokusai review_app refresh "$NAME"
 echo $(kubectl get service force-web --namespace $NAME --context staging -o json \
   | jq .status.loadBalancer.ingress[].hostname)
 #
-# you may do this in the Cloudflare interface. Credentials are in 1pass
+# you may do this in the Cloudflare interface. Credentials are in 1pass.
+#
+# Step-by-step instructions:
+# https://github.com/artsy/force/blob/master/docs/creating_review_app.md#dns-setup
 echo "[build_review_app.sh] SUCCESS"
 
 exit 0

--- a/scripts/build_review_app.sh
+++ b/scripts/build_review_app.sh
@@ -10,7 +10,7 @@
 
 echo "[build_review_app.sh] START"
 
-# Bail out of script on first expression failure and sprint the commands as
+# Bail out of script on first expression failure and echo the commands as
 # they are being run.
 set -ev
 

--- a/scripts/build_review_app.sh
+++ b/scripts/build_review_app.sh
@@ -16,13 +16,13 @@ set -ev
 
 NAME="$1"
 
-if test -z $NAME; then
+if test -z "$NAME"; then
   echo "You didn't provide a shell argument, so NAME isn't meaningful, exiting."
   exit 1
 fi
 
 # Generate the Kubernetes YAML needed to provision the application.
-hokusai review_app setup $NAME
+hokusai review_app setup "$NAME"
 review_app_file_path="hokusai/$NAME.yml"
 
 # Create the Docker image of your current working direct of Force, and push
@@ -35,16 +35,16 @@ review_app_file_path="hokusai/$NAME.yml"
 # --tag to name the image.
 # WARNING: This is likely going to take ~10 mins on your MBP.
 # Be patient and grab some baby carrots.
-hokusai registry push --force --skip-latest --overwrite --verbose --tag $NAME
+hokusai registry push --force --skip-latest --overwrite --verbose --tag "$NAME"
 
 # Edit the K8S YAML to reference the proper Docker image
-sed -i.bak "s/:staging/:$NAME/g" $review_app_file_path && rm $review_app_file_path.bak
+sed -i.bak "s/:staging/:$NAME/g" "$review_app_file_path" && rm "$review_app_file_path.bak"
 
 # Edit the K8S YAML to remove the instructions that enforce that the service
 # can only be accessible via Cloudflare
 #
 # First, remove the `loadBalancerSourceRanges:` line
-sed -i.bak '/loadBalancer/d' $review_app_file_path && rm $review_app_file_path.bak
+sed -i.bak '/loadBalancer/d' "$review_app_file_path" && rm "$review_app_file_path.bak"
 
 # Then, delete all the IP address lines.
 #
@@ -52,32 +52,32 @@ sed -i.bak '/loadBalancer/d' $review_app_file_path && rm $review_app_file_path.b
 # delete any line of the form "- [number][number][number].". This is my best
 # approx for an regex for an IP address, and I'm sure that there are better
 # ones.
-sed -i.bak "/- [[:digit:]][[:digit:]][[:digit:]]./d" $review_app_file_path && rm $review_app_file_path.bak
+sed -i.bak "/- [[:digit:]][[:digit:]][[:digit:]]./d" "$review_app_file_path" && rm "$review_app_file_path.bak"
 
 # Provision the review app
-hokusai review_app create $NAME --verbose
+hokusai review_app create "$NAME" --verbose
 
 # Copy Force staging's ConfigMap to your review app
-hokusai review_app env copy $NAME --verbose
+hokusai review_app env copy "$NAME" --verbose
 
 # Copy the staging-shared nginx config to your review app
-hokusai review_app env copy $NAME --configmap nginx-config --verbose
+hokusai review_app env copy "$NAME" --configmap nginx-config --verbose
 
 # To enable authentication via Force's server, we need to allow XHR requests
 # from Force's client to server. As such, Force's server needs to have the
 # proper name of the domain that the requests are coming from. Otherwise,
 # authentication requests won't work!
-hokusai review_app env set $NAME \
+hokusai review_app env set "$NAME" \
   APP_URL="https://$NAME.artsy.net" \
   APPLICATION_NAME="$NAME" \
   COOKIE_DOMAIN="$NAME.artsy.net" \
   FORCE_URL="https://$NAME.artsy.net"
 
 # Publish Force assets to S3
-hokusai review_app run $NAME 'yarn publish-assets'
+hokusai review_app run "$NAME" 'yarn publish-assets'
 
 # Refresh ENV
-hokusai review_app refresh $NAME
+hokusai review_app refresh "$NAME"
 
 # Now you need to create a CNAME for your review app and wait. This is required
 # as Gravity only allows authentication requests from requests of originating

--- a/scripts/update_review_app.sh
+++ b/scripts/update_review_app.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -ev
-
 # Bail out of script on first expression failure and echo the commands as
 # they are being run.
 set -ev

--- a/scripts/update_review_app.sh
+++ b/scripts/update_review_app.sh
@@ -6,11 +6,11 @@ set -ev
 
 NAME="$1"
 
-if test -z $NAME; then
+if test -z "$NAME"; then
   echo "You didn't provide a shell argument, so NAME isn't meaningful, exiting."
   exit 1
 fi
 
-hokusai registry push --force --skip-latest --overwrite --verbose --tag $NAME
-hokusai review_app setup $NAME
-hokusai review_app deploy $NAME $NAME
+hokusai registry push --force --skip-latest --overwrite --verbose --tag "$NAME"
+hokusai review_app setup "$NAME"
+hokusai review_app deploy "$NAME" "$NAME"

--- a/scripts/update_review_app.sh
+++ b/scripts/update_review_app.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -ev
+
+# Bail out of script on first expression failure and echo the commands as
+# they are being run.
+set -ev
+
+NAME="$1"
+
+if test -z $NAME; then
+  echo "You didn't provide a shell argument, so NAME isn't meaningful, exiting."
+  exit 1
+fi
+
+hokusai registry push --force --skip-latest --overwrite --verbose --tag $NAME
+hokusai review_app setup $NAME
+hokusai review_app deploy $NAME $NAME


### PR DESCRIPTION
Problem

Review apps are great, particularly for long-running work like redesigns, major refactors and anything else that might risk causing regressions (blocking our deploy pipeline), but need further testing in a live environment.

During a platform practice meeting, it was surfaced that:

1. It's a bit too hard to create/update a review app, even with build_review_app.sh
2. It can be **super slow** to build and push a Docker image of Force (~2 GB) depending on the conditions of the developer host running build_review_app.sh and the network.

Solution

* Create a review app when pushing to a branch matching review-app-*: d0d7edf82b83230ab741296a1404f1f104d98090
* Update a review app if it already exists upon subsequent commits: 6cb75b7aeb35cf74e963337e4396ef17391c6cdc
* Remove data dog deploy instrumentation after a Hokusai deploy: bdc804f380b8d9afb785c09c9deaf6973d2be314

Impact

It now takes ~15 minutes, consistently to create/update a Force review app, similar to the time takes to deploy `master` to `staging`

TODO

- [x] Remove commented out build steps / rebase away 82f1373
- [x] Detect existence of existing review app and update it instead of creating