### PR TITLE
[GALL-2732] - removing references to Fair on Fair pages

### DIFF
--- a/src/desktop/apps/fair/templates/footer.jade
+++ b/src/desktop/apps/fair/templates/footer.jade
@@ -1,6 +1,6 @@
 .fair-page-footer
   .fair-footer-left
-    .footer-section-heading Explore the Fair
+    .footer-section-heading Explore the Event
     .footer-square-sections
       a.footer-square-section( href=profile.href() + "/browse" )
         img(src=fair.imageUrl('large_rectangle') )
@@ -19,7 +19,7 @@
 
   .fair-footer-right
     if editorialItems
-      .footer-section-heading Read Highlights from the Fair
+      .footer-section-heading Read Highlights from the Event
       .fair-footer-posts-container
         for item in editorialItems.slice(0, 2)
           a.small-post( href=item.get('href') )

--- a/src/desktop/apps/fair/templates/for_you.jade
+++ b/src/desktop/apps/fair/templates/for_you.jade
@@ -1,9 +1,9 @@
 .main-layout-container
   if sd.CURRENT_USER
-    .foryou-section.blank-state Follow exhibitors and artists at the fair to personalize your “For You” section. We’ll let you know when new works and shows are added.
+    .foryou-section.blank-state Follow exhibitors and artists at the event to personalize your “For You” section. We’ll let you know when new works and shows are added.
     include ./for_you_logged_in
   else
-    .foryou-section.blank-state.blank-state-visible Follow exhibitors and artists at the fair to personalize your “For You” section. We’ll let you know when new works and shows are added.
+    .foryou-section.blank-state.blank-state-visible Follow exhibitors and artists at the event to personalize your “For You” section. We’ll let you know when new works and shows are added.
   .foryou-section.booths
-    .avant-garde-header-center Exhibitors at the fair to follow
+    .avant-garde-header-center Exhibitors to follow
     .exhibitors-column-container

--- a/src/desktop/apps/fair/templates/overview.jade
+++ b/src/desktop/apps/fair/templates/overview.jade
@@ -13,6 +13,6 @@ block body
   if primarySets
     include ./overview_bottom
   .for-you-container
-  h2.overview-section-heading Browse the fair
+  .overview-section-heading
   .fair-page-content.main-layout-container
     include ../components/browse/template

--- a/src/desktop/apps/fair/templates/overview_top.jade
+++ b/src/desktop/apps/fair/templates/overview_top.jade
@@ -19,7 +19,7 @@
   .fair-overview-below-top
     .container-left
       .fair-follow
-        p Follow the fair for updates and personalized recommendations.
+        p Follow for updates and personalized recommendations.
         button.avant-garde-follow-button-black.follow-button.no-touch( id='fair-follow-button', data-id= fair.get('default_profile_id') )
       if primarySets.where({ key: 'explore' })
         for set in primarySets.where({ key: 'explore' })

--- a/src/desktop/apps/fair/templates/sections.jade
+++ b/src/desktop/apps/fair/templates/sections.jade
@@ -1,7 +1,7 @@
 .fair-sections-container
   .sections-left
     .section-left-info-nav
-      h2 Fair Information
+      h2 Information
       .fair-nav-info-menu.chevron-nav-list
         a(href="/#{profile.id}/info/visitors") visitors
         if infoMenu.programming
@@ -9,12 +9,10 @@
         if infoMenu.events
           a(href="/#{profile.id}/info/events") events
         if infoMenu.artsyAtTheFair
-          a(href="/#{profile.id}/info/artsy-at-the-fair") artsy at the fair
-        a(href="/#{profile.id}/info/about-the-fair") about the fair
+          a(href="/#{profile.id}/info/artsy-at-the-fair") artsy at the event
+        a(href="/#{profile.id}/info/about-the-fair") about
   a.sections-right( href="https://apps.apple.com/us/app/artsy-buy-sell-original-art/id703796080", target="_blank" )
     .mobile-section-heading
-      | Going to the fair?
-      br
       i Download Artsy for iPhone
       br
       | — Your personal guide to

--- a/src/desktop/apps/fair_info/templates/nav.jade
+++ b/src/desktop/apps/fair_info/templates/nav.jade
@@ -5,7 +5,7 @@ aside.fair-info2-nav
   if infoMenu.events
     a(href="/#{profile.id}/info/events" class=sd.CURRENT_PATH.includes('events') ? 'is-active' : '') events
   if infoMenu.artsyAtTheFair
-    a(href="/#{profile.id}/info/artsy-at-the-fair" class=sd.CURRENT_PATH.includes('artsy-at-the-fair') ? 'is-active' : '') artsy at the fair
-  a(href="/#{profile.id}/info/about-the-fair" class=sd.CURRENT_PATH.includes('about-the-fair') ? 'is-active' : '') about the fair
+    a(href="/#{profile.id}/info/artsy-at-the-fair" class=sd.CURRENT_PATH.includes('artsy-at-the-fair') ? 'is-active' : '') artsy at the event
+  a(href="/#{profile.id}/info/about-the-fair" class=sd.CURRENT_PATH.includes('about-the-fair') ? 'is-active' : '') about
   if profile.id == 'the-armory-show-2016'
     a(href="/#{profile.id}/info/armory-arts-week" class=sd.CURRENT_PATH.includes('armory-arts-week') ? 'is-active' : '') armory arts week

--- a/src/desktop/apps/fair_info/templates/visitors.jade
+++ b/src/desktop/apps/fair_info/templates/visitors.jade
@@ -62,8 +62,6 @@ block body
 
           .fair-info2-mobile-section
             .fair-info2-iphone-heading-section
-              | Going to the fair?
-              br
               i Download Artsy for iPhone
               | — Your personal
               br

--- a/src/desktop/apps/fair_organizer/templates/overview.jade
+++ b/src/desktop/apps/fair_organizer/templates/overview.jade
@@ -18,10 +18,10 @@ block body
           img.large-profile-image( alt=fairOrg.get('name'), title=fairOrg.get('name'), src=profile.icon().imageUrl('square') )
         .fair-organizer-top__header
           h1 Explore #{fairOrg.get('name')} on Artsy
-        .fair-organizer-top__sub-header Discover the fair and stay connected with the latest news
+        .fair-organizer-top__sub-header Discover and stay connected with the latest news
         a#fair-organizer-follow.fair-organizer-top__notify.avant-garde-follow-button-black.follow-button(data-id="#{profile.id}")
         .fair-organizer-top__countdown
-          .fair-organizer-top__countdown__headline Fair opens in:
+          .fair-organizer-top__countdown__headline Opens in:
           .fair-organizer-top__countdown__clock
             .clock
               ul.clock-value
@@ -40,7 +40,7 @@ block body
 
       .fair-organizer-content__right
         if pastFairs.length
-          .fair-organizer-content__header Revisit Previous Fairs
+          .fair-organizer-content__header Past Events
           .fair-organizer-content__section.fair-organizer-content__section--past-fairs
             for fair in pastFairs
               include fair
@@ -56,8 +56,6 @@ block body
           .mobile-section-iphone &nbsp;
           a(href="https://iphone.artsy.net/")
             .fair-organizer-content__section--app__copy
-              | Going to the fair?
-              br
               i Download Artsy for iPhone
               br
               //- | — Your personal guide to #{fairOrg.get('name'}

--- a/src/desktop/apps/fairs/templates/current_fairs.jade
+++ b/src/desktop/apps/fairs/templates/current_fairs.jade
@@ -3,7 +3,7 @@ mixin current-fair-figure(fair)
     .fairs__current-fair__image
       a.hoverable-image-link( href= fair.href )
         .hoverable-image( style="background-image: url(#{fair.image.url});" )
-        .fairs__current-fair__image__overlay Explore the fair
+        .fairs__current-fair__image__overlay Explore the event
     .fairs-fair__meta
       a( href= fair.href )
         .fairs-fair__meta__profile

--- a/src/desktop/apps/fairs/templates/index.jade
+++ b/src/desktop/apps/fairs/templates/index.jade
@@ -10,17 +10,17 @@ block body
   #fairs-page.main-layout-container
     if currentFairRows.length
       .fairs__current-fairs
-        h1.fair-header Current Fairs
+        h1.fair-header Current Events
         include current_fairs
     else
       include promo
     .fairs__past-fairs
-      h1.fair-header.fair-header--underlined Past Fairs
+      h1.fair-header.fair-header--underlined Past Events
       .fairs__past-fairs-list
         include past_fairs
       button#fairs-see-more.avant-garde-button-white.is-block
         | View More
     .fairs__upcoming-fairs
-      h1.fair-header.fair-header--underlined Upcoming Fairs
+      h1.fair-header.fair-header--underlined Upcoming Events
       for fair in upcomingFairs
         include fair_upcoming

--- a/src/desktop/apps/fairs/test/template.test.coffee
+++ b/src/desktop/apps/fairs/test/template.test.coffee
@@ -39,7 +39,7 @@ describe 'Fairs template', ->
     # TODO: Intermittent failure, we should probably refactor this suite to use
     # cheerio and jade.render to avoid DOM finickyness
     xit 'renders correctly', ->
-      $('.fairs__current-fairs h1.fair-header').text().should.equal 'Current Fairs'
+      $('.fairs__current-fairs h1.fair-header').text().should.equal 'Current Events'
       $('.fairs__current-fair').length.should.equal 2
 
     xit 'groups the splits the current fairs into one row', ->
@@ -66,5 +66,5 @@ describe 'Fairs template', ->
 
     xit 'renders correctly, with a fair promo', ->
       $('.fairs__promo').length.should.equal 1
-      $('.fairs__past-fairs h1.fair-header').text().should.equal 'Past Fairs'
+      $('.fairs__past-fairs h1.fair-header').text().should.equal 'Past Events'
       $('.fairs__past-fair').length.should.equal 4

--- a/src/desktop/components/clock/view.coffee
+++ b/src/desktop/components/clock/view.coffee
@@ -39,10 +39,10 @@ module.exports = class ClockView extends Backbone.View
         @$el.html "<div class='clock-header clock-closed'>Live Bidding Now Open</div>"
         return
       when 'preview'
-        @$('.clock-header').html "Opening in"
+        @$('.clock-header').html "Opening in:"
         @toDate = @model.get 'offsetStartAtMoment'
       when 'open'
-        @$('.clock-header').html "#{@modelName} closes in:"
+        @$('.clock-header').html "Closes in:"
         @toDate = @model.get 'offsetEndAtMoment'
       when 'closed'
         mediator.trigger 'clock:is-over'

--- a/src/mobile/apps/art_fairs/routes.coffee
+++ b/src/mobile/apps/art_fairs/routes.coffee
@@ -25,7 +25,7 @@ module.exports.index = (req, res, next) ->
         { name: 'Upcoming', hasItems: upcomingFairs.length },
         { name: 'Past', hasItems: pastFairs.length }
       ]
-      emptyMessage: "Past Fairs"
+      emptyMessage: "Past Events"
       extraClasses: "art-fairs-tabs"
       currentFairs: currentFairs
       upcomingFairs: upcomingFairs

--- a/src/mobile/apps/art_fairs/test/template.test.coffee
+++ b/src/mobile/apps/art_fairs/test/template.test.coffee
@@ -37,7 +37,7 @@ describe 'Art fairs template', ->
             { name: 'Upcoming', hasItems: @upcomingFairs.length },
             { name: 'Past', hasItems: @pastFairs.length }
           ]
-          emptyMessage: "Past Fairs"
+          emptyMessage: "Past Events"
           extraClasses: "art-fairs-tabs"
           featuredFairs: @currentFairs
           currentFairs: @currentFairs
@@ -68,7 +68,7 @@ describe 'Art fairs template', ->
             { name: 'Upcoming', hasItems: @upcomingFairs.length },
             { name: 'Past', hasItems: @pastFairs.length }
           ]
-          emptyMessage: "Past Fairs"
+          emptyMessage: "Past Events"
           extraClasses: "art-fairs-tabs"
           asset: (->)
           currentFairs: []

--- a/src/mobile/apps/fair_info/templates/article.jade
+++ b/src/mobile/apps/fair_info/templates/article.jade
@@ -20,5 +20,5 @@ block content
                   for id in section.ids
                     li( data-id=id )
   else
-    h1.fair-info2-page-header About The Fair
+    h1.fair-info2-page-header About
     include ./about_fair.jade

--- a/src/mobile/apps/fair_info/templates/index.jade
+++ b/src/mobile/apps/fair_info/templates/index.jade
@@ -14,8 +14,8 @@ block content
         if infoMenu.programming
           a(href="/#{sd.PROFILE.id}/info/programming") programming
         if infoMenu.artsyAtTheFair
-          a(href="/#{sd.PROFILE.id}/info/artsy-at-the-fair") artsy at the fair
-        a(href="/#{sd.PROFILE.id}/info/about-the-fair") about the fair
+          a(href="/#{sd.PROFILE.id}/info/artsy-at-the-fair") artsy at the event
+        a(href="/#{sd.PROFILE.id}/info/about-the-fair") about
 
         if sd.PROFILE.id == 'the-armory-show-2016'
           a(href="/#{sd.PROFILE.id}/info/armory-arts-week") armory arts week

--- a/src/mobile/apps/fair_info/test/templates/article.test.coffee
+++ b/src/mobile/apps/fair_info/test/templates/article.test.coffee
@@ -61,6 +61,6 @@ describe 'Article template', ->
         sd: { FAIR: @fair }
       }
     it 'renders fallback correctly', ->
-      @page.should.containEql 'About The Fair'
+      @page.should.containEql 'About'
       @page.should.containEql 'fair-info2-content'
       @page.should.not.containEql 'On The Heels of A Stellar Year in the West'

--- a/src/mobile/apps/fair_info/test/templates/index.test.coffee
+++ b/src/mobile/apps/fair_info/test/templates/index.test.coffee
@@ -38,7 +38,7 @@ describe 'Fair Information ', ->
 
     it 'renders fair information correctly', ->
       @page.should.containEql 'visitors'
-      @page.should.containEql 'about the fair'
+      @page.should.containEql 'about'
       @page.should.containEql 'events'
 
   describe 'Fair with articles ', ->
@@ -66,7 +66,7 @@ describe 'Fair Information ', ->
 
     it 'renders fair information correctly', ->
       @page.should.containEql 'visitors'
-      @page.should.containEql 'about the fair'
+      @page.should.containEql 'about'
       @page.should.containEql 'events'
-      @page.should.containEql 'artsy at the fair'
+      @page.should.containEql 'artsy at the event'
       @page.should.containEql 'programming'

--- a/src/mobile/components/avant_garde_tabs/README.md
+++ b/src/mobile/components/avant_garde_tabs/README.md
@@ -3,9 +3,10 @@
 ===
 
 This component is a work-in-progress (like all of us). It:
- - 1. provides event handling for tab navigation
- - 2. animates a cursor to the active tab
- - 3. provides a template to include to construct the nav bar
+
+- 1.  provides event handling for tab navigation
+- 2.  animates a cursor to the active tab
+- 3.  provides a template to include to construct the nav bar
 
 ## Avant Garde Tab Nav
 
@@ -18,11 +19,11 @@ res.render 'index',
       { name: 'Upcoming', hasItems: upcomingFairs.length },
       { name: 'Past', hasItems: pastFairs.length }
     ]
-    emptyMessage: "Past Fairs"
+    emptyMessage: "Past Events"
     extraClasses: "art-fairs-tabs"
 ```
 
-The part(s) we are concerned with here are `navItems`, `emptyMessage`, and `extraClasses`.  `navItems` should be an array of objects, each with a name and `hasItems` (which should be either a boolean or length of a collection).
+The part(s) we are concerned with here are `navItems`, `emptyMessage`, and `extraClasses`. `navItems` should be an array of objects, each with a name and `hasItems` (which should be either a boolean or length of a collection).
 
 Once these variables are passed to the template, you can simply include the nav:
 


### PR DESCRIPTION
I ended up updating couple of more places where fair is used than what the card asked. But those places seem to follow the same pattern of changes that are requested in the issue.


What is strange to me is that the main menu still says `Fairs` but we try not to reference `Fair` anywhere on the page. But 🤷 