### PR TITLE
Guard new 2FA component behind team role (vs admin)

### DIFF
--- a/src/desktop/apps/user/pages/settings/index.jade
+++ b/src/desktop/apps/user/pages/settings/index.jade
@@ -6,7 +6,7 @@ include ../../templates/mixins
 +settings-section('password', 'Password')
   include ../../components/password/index
 
-if user.get('type') === 'Admin'
+if user.get('roles').includes('team')
   +settings-section('two-factor-authentication', '')
     #stitch-two-factor-authentication
       != stitch.components.UserSettingsTwoFactorAuthentication({ mountId: 'stitch-two-factor-authentication' })


### PR DESCRIPTION
The team role should be present for any Artsy employee so this should sufficient as we iterate on this UI.