### PR TITLE
Revert hotfix; Add back dynamic news header

### DIFF
--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -2,7 +2,7 @@ import { data as sd } from "sharify"
 import moment from "moment"
 import styled from "styled-components"
 import React, { Component, Fragment } from "react"
-import { flatten, debounce } from "lodash"
+import { flatten, throttle } from "lodash"
 import Waypoint from "react-waypoint"
 import { positronql } from "desktop/lib/positronql"
 import { newsArticlesQuery } from "desktop/apps/article/queries/articles"
@@ -40,7 +40,7 @@ interface State {
 }
 
 export class InfiniteScrollNewsArticle extends Component<Props, State> {
-  private debouncedDateChange
+  private throttledDateChange
   constructor(props) {
     super(props)
 
@@ -49,7 +49,7 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
     const omit = props.article ? props.article.id : null
     const offset = props.article ? 0 : 6
 
-    this.debouncedDateChange = debounce(this.onDateChange, 200)
+    this.throttledDateChange = throttle(this.onDateChange, 50)
 
     this.state = {
       activeArticle: "",
@@ -152,7 +152,7 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
       // and the top date is updated, it leads to a reset of the current scroll
       // position, preventing the user from scrolling down the page.
       // FIXME: Reenable once newsfeed scrolling bug tracked down.
-      // this.setState({ date })
+      this.setState({ date })
     }
   }
 
@@ -211,7 +211,7 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
               isMobile={isMobile || false}
               article={article}
               isTruncated={isTruncated}
-              onDateChange={this.debouncedDateChange}
+              onDateChange={this.throttledDateChange}
               nextArticle={articles[i + 1] as any}
               onActiveArticleChange={id => this.onActiveArticleChange(id)}
               isActive={activeArticle === article.id}

--- a/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.jest.tsx
+++ b/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.jest.tsx
@@ -267,7 +267,7 @@ describe("InfiniteScrollNewsArticle", () => {
   })
 
   // FIXME: Reenable once scrolling date issue is resolved
-  xdescribe("#onDateChange", () => {
+  describe("#onDateChange", () => {
     it("it sets date if it has a new one", () => {
       const component = getWrapper()
       const instance = component


### PR DESCRIPTION
Reverts: https://github.com/artsy/force/pull/5322/files and fixes the bug.

Depends on: https://github.com/artsy/reaction/pull/3413

![newsbug](https://user-images.githubusercontent.com/2081340/79509266-27dbd200-8009-11ea-9c9f-8661eba06ed0.gif)


We call `onDateChange`, which sets the state of the header with the new date, whenever a component enters/leaves the viewport or is appended to the bottom of the list. While playing around, I noticed that we were calling this method in bursts and it seemed to non-deterministically be called with out-of-order dates.

I'm not _exactly_ sure what the underlying cause was, but when pairing with @eessex we decided to try using `throttle` instead of `debounce`, and it appeared to make the problem go away. Conceptually, `throttle` makes more sense here anyways as we need to handle a consistent scroll behavior (vs. an event that's very bursty).


