### PR TITLE
Expose stitch context to user settings template client-side

### DIFF
--- a/src/desktop/apps/user/pages/settings/index.coffee
+++ b/src/desktop/apps/user/pages/settings/index.coffee
@@ -5,6 +5,7 @@ InformationView = require '../../components/information/view.coffee'
 LinkedAccountsView = require '../../components/linked_accounts/view.coffee'
 EmailPreferencesView = require '../../components/email_preferences/view.coffee'
 template = -> require('./index.jade') arguments...
+sd = require('sharify').data
 
 module.exports = class SettingsView extends Backbone.View
   subViews: []
@@ -38,6 +39,7 @@ module.exports = class SettingsView extends Backbone.View
   render: ->
     @$el.html template
       user: @user
+      stitch: sd.stitch
     @postRender()
     this
 


### PR DESCRIPTION
Stitch is available during server-side renders but when switching between settings tabs in a browser which triggers a client-side render of the same template, any stitch components fail to render due to the missing stitch context.

I took a look at the client-side setup for the payments tab which also uses a stitched component from artsy/reaction and found what was missing. Pass in stitch explicitly to the template during the client-side template render.

h/t to @eessex for catching this!