### PR TITLE
Pass tracking subprops over in props key

### DIFF
--- a/src/desktop/apps/consign/__tests__/routes.jest.ts
+++ b/src/desktop/apps/consign/__tests__/routes.jest.ts
@@ -120,11 +120,13 @@ describe("#submissionFlowWithFetch", () => {
       }))
       await routes.submissionFlow(req, res, next)
       expect(spy).toHaveBeenCalledWith({
-        context_page_path: "foo",
         event: "Clicked consign",
-        flow: "Consignments",
-        subject: "bar",
         userId: "some-userid",
+        properties: {
+          context_page_path: "foo",
+          flow: "Consignments",
+          subject: "bar",
+        },
       })
     })
   })

--- a/src/desktop/apps/consign/routes.ts
+++ b/src/desktop/apps/consign/routes.ts
@@ -96,10 +96,12 @@ function sendTrackingEvent(req, res) {
   const analytics = new Analytics(res.locals.sd.SEGMENT_WRITE_KEY)
   const event = {
     event: AnalyticsSchema.ActionType.ClickedConsign,
-    context_page_path: contextPath,
-    flow: AnalyticsSchema.Flow.Consignments,
-    subject,
     userId: req.user.id,
+    properties: {
+      context_page_path: contextPath,
+      flow: AnalyticsSchema.Flow.Consignments,
+      subject,
+    },
   }
   analytics.track(event)
 }


### PR DESCRIPTION
When looking at server-side [tracking results](https://numeracy.co/artsy/3laHqA5zSel#query) we noticed that some props weren't being passed over. This fixes the invocation by passing server-side props across via the `properties` key. 