### PR TITLE
[Consignments] Only track when subject and contextPath

### DIFF
--- a/src/desktop/apps/consign/__tests__/routes.jest.ts
+++ b/src/desktop/apps/consign/__tests__/routes.jest.ts
@@ -108,6 +108,17 @@ describe("#submissionFlowWithFetch", () => {
       expect(spy).not.toHaveBeenCalled()
     })
 
+    it("does not track if no subject and contextPath", async () => {
+      req.user = { id: "some-userid" }
+      req.query = {}
+      const spy = jest.fn()
+      Analytics.mockImplementation(() => ({
+        track: spy,
+      }))
+      await routes.submissionFlow(req, res, next)
+      expect(spy).not.toHaveBeenCalled()
+    })
+
     it("sends tracking event", async () => {
       req.user = { id: "some-userid" }
       req.query = {

--- a/src/desktop/apps/consign/routes.ts
+++ b/src/desktop/apps/consign/routes.ts
@@ -93,6 +93,10 @@ function sendTrackingEvent(req, res) {
   }
 
   const { contextPath, subject } = req.query || {}
+  if (!(contextPath && subject)) {
+    return
+  }
+
   const analytics = new Analytics(res.locals.sd.SEGMENT_WRITE_KEY)
   const event = {
     event: AnalyticsSchema.ActionType.ClickedConsign,


### PR DESCRIPTION
Don't send server-side tracking event if we're lacking subject and contextPath

From @louislecluse via [slack](https://artsy.slack.com/archives/CS3H1K4BD/p1588103533233200?thread_ts=1587566765.121000&cid=CS3H1K4BD)

```
We know whenever the user enters the submission flow (and successfully goes through it) since we have the submission record

Since our objective is to assign each submission to its origin page, we only need to know when it comes from a page. If we can’t find a page then it means the user went directly to the submission flow.
clicked consign is very easy to understand and clearly suggests click intent. A more elaborate event such as entered submission flow would be much harder to describe and grasp for other engineers/analyts I think.

In conclusion we shouldn’t fire an event if there is no path or subject
```