### PR TITLE
Add a section to docs on authenticating locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,32 @@ environment variable to disable webpack optimizations.
 env DEBUG=true yarn start:prod
 ```
 
+## Authentication in your local Force app
+
+Authentication in Force is handled through OAuth, with [Gravity](https://github.com/artsy/gravity) authenticating the user and redirecting back to Force. For security reasons, the `localhost` origin [is forbidden as a redirect URL by Gravity in the staging environment](https://github.com/artsy/gravity/blob/543373d7d4413f5c8b1c8f84f73b2a592c00cba2/app/models/util/url_validation.rb#L23). This means that when running Force locally at `http://localhost:5000`, you won't be able to sign up or log in.
+
+### Browse locally while logged in
+
+If you need to run Force locally while logged in but don't need authentication to run locally, you can log into `http://staging.artsy.net`. The user information will propagate to your local browsing session.
+
+### Run authentication logic locally
+
+If you need to run authentication logic locally, you can configure Force to run at an `*.artsy.net` subdomain. Gravity's staging environment considers `*.artsy.net` subdomains to be valid redirect URLs, and authentication actions will succeed.
+
+1. Add the following entry to your local hosts file (`/etc/hosts`):
+
+```
+127.0.0.1 local.artsy.net
+```
+
+2. Update your `.env` file with the following setting:
+
+```
+APP_URL=http://local.artsy.net:5000
+```
+
+3. Visit [`http://local.artsy.net:5000`](http://local.artsy.net:5000).
+
 ## Creating a Review App
 
 See [the docs](docs/creating_review_app.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,15 +76,11 @@ env DEBUG=true yarn start:prod
 
 ## Authentication in your local Force app
 
-Authentication in Force is handled through OAuth, with [Gravity](https://github.com/artsy/gravity) authenticating the user and redirecting back to Force. For security reasons, the `localhost` origin [is forbidden as a redirect URL by Gravity in the staging environment](https://github.com/artsy/gravity/blob/543373d7d4413f5c8b1c8f84f73b2a592c00cba2/app/models/util/url_validation.rb#L23). This means that when running Force locally at `http://localhost:5000`, you won't be able to sign up or log in.
+Authentication in Force is handled by a modified OAuth flow, with [Gravity](https://github.com/artsy/gravity) authenticating the user and redirecting back to Force. For security reasons, the `localhost` origin [is forbidden as a redirect URL by Gravity in the staging environment](https://github.com/artsy/gravity/blob/543373d7d4413f5c8b1c8f84f73b2a592c00cba2/app/models/util/url_validation.rb#L23). This means that when running Force locally at `http://localhost:5000`, the staging Gravity environment won't redirect back to your locally running app to complete the flow.
 
-### Browse locally while logged in
+For most local development in Force, this shouldn't be a problem. The login will still take effect and you can manually visit the desired local URL after logging in.
 
-If you need to run Force locally while logged in but don't need authentication to run locally, you can log into `http://staging.artsy.net`. The user information will propagate to your local browsing session.
-
-### Run authentication logic locally
-
-If you need to run authentication logic locally, you can configure Force to run at an `*.artsy.net` subdomain. Gravity's staging environment considers `*.artsy.net` subdomains to be valid redirect URLs, and authentication actions will succeed.
+If you require the authentication flow to redirect back to your local version, you can configure Force to run locally at an `*.artsy.net` subdomain. Gravity's staging environment considers all `*.artsy.net` subdomains to be valid redirect URLs.
 
 1. Add the following entry to your local hosts file (`/etc/hosts`):
 


### PR DESCRIPTION
While investigating https://artsyproduct.atlassian.net/browse/INTGRTY-3, I learned that running Force under a `local.artsy.net` subdomain instead of `localhost` enabled authentication to function locally. This PR adds docs on how to configure Force in this way.

My long-term intention is to point the [Integrity](https://github.com/artsy/integrity) docs at this bit to inform devs how to run the Integrity test suite against a local instance of Force.