### PR TITLE
prevent nude from showing in artist signup modal 

### DIFF
--- a/src/desktop/apps/artist/components/__tests__/cta.jest.ts
+++ b/src/desktop/apps/artist/components/__tests__/cta.jest.ts
@@ -18,7 +18,7 @@ const CookiesGetMock = require("desktop/components/cookies/index.coffee")
 
 const mediatorOn = require("desktop/lib/mediator.coffee").on as jest.Mock
 
-jest.mock("lib/metaphysics.coffee", () =>
+jest.mock("lib/metaphysics2.coffee", () =>
   jest.fn().mockReturnValue(Promise.resolve({}))
 )
 
@@ -26,7 +26,7 @@ jest.spyOn(helpers, "handleScrollingAuthModal")
 
 const handleScrollingAuthModal = require("desktop/lib/openAuthModal")
   .handleScrollingAuthModal
-const mockMetaphysics = require("lib/metaphysics.coffee")
+const mockMetaphysics = require("lib/metaphysics2.coffee")
 
 jest.mock("sharify", () => ({
   data: {
@@ -60,15 +60,20 @@ describe("CTA", () => {
         },
       },
     ],
-    artworks: [
-      {
-        image: {
-          cropped: {
-            url: "https://d32dm0rphc51dk.cloudfront.net/6q6LeyKvA_vpT5YzHRSNUA",
+    filterArtworksConnection: {
+      edges: [
+        {
+          node: {
+            image: {
+              cropped: {
+                url:
+                  "https://d32dm0rphc51dk.cloudfront.net/6q6LeyKvA_vpT5YzHRSNUA",
+              },
+            },
           },
         },
-      },
-    ],
+      ],
+    },
   }
 
   let addEventListener

--- a/src/desktop/apps/artist/components/cta.ts
+++ b/src/desktop/apps/artist/components/cta.ts
@@ -4,22 +4,27 @@ import { handleScrollingAuthModal } from "desktop/lib/openAuthModal"
 import { Intent, ContextModule } from "@artsy/cohesion"
 const Cookies = require("desktop/components/cookies/index.coffee")
 const mediator = require("desktop/lib/mediator.coffee")
-const metaphysics = require("lib/metaphysics.coffee")
+const metaphysics2 = require("lib/metaphysics2.coffee")
 
 export const query = `
 query ArtistCTAQuery($artistID: String!) {
   artist(id: $artistID) {
     name
-    artworks(size: 1) {
-      image {
-        cropped(width: 390, height: 644) {
-          url
+    filterArtworksConnection(first: 1, marketable: true) {
+      edges {
+        node {
+          image {
+            cropped(width: 390, height: 644) {
+              url
+            }
+          }
         }
       }
     }
   }
 }
 `
+
 const send = {
   method: "post",
   query,
@@ -38,8 +43,11 @@ export const setupArtistSignUpModal = () => {
     sd.ARTIST_PAGE_CTA_ARTIST_ID &&
     !artistPageAuthDismissedCookie
   ) {
-    return metaphysics(send).then(({ artist: artistData }) => {
-      const image = get(artistData, "artworks[0].image.cropped.url")
+    return metaphysics2(send).then(({ artist: artistData }) => {
+      const image = get(
+        artistData,
+        "filterArtworksConnection.edges[0].node.image.cropped.url"
+      )
       mediator.on("modal:closed", setCookie)
       handleScrollingAuthModal({
         copy: `Join Artsy to discover new works by ${artistData.name} and more artists you love`,

--- a/src/desktop/apps/artist/components/cta.ts
+++ b/src/desktop/apps/artist/components/cta.ts
@@ -10,7 +10,7 @@ export const query = `
 query ArtistCTAQuery($artistID: String!) {
   artist(id: $artistID) {
     name
-    filterArtworksConnection(first: 1, marketable: true) {
+    filterArtworksConnection(first: 1, marketable: true, sort: "-decayed_merch") {
       edges {
         node {
           image {


### PR DESCRIPTION
Addresses: [FX-1892](https://artsyproduct.atlassian.net/browse/FX-1892)

Currently nudes sometimes display in the David Hockney artist signup modal and get blocked by ads. This PR uses the `marketable: true` argument to prevent nudes from displaying in the modal.

<img width="1674" alt="Screen Shot 2020-05-05 at 12 44 00 PM" src="https://user-images.githubusercontent.com/5201004/81092368-7d9bef80-8ece-11ea-8bb3-1b950bfd0e30.png">
