### PR TITLE
Update production keepalive/header timeouts to avoid hung connections to ELB

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -26,6 +26,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: KEEPALIVE_TIMEOUT_SECONDS
+              value: "95"
+            - name: HEADERS_TIMEOUT_SECONDS
+              value: "105"
           envFrom:
             - configMapRef:
                 name: force-environment
@@ -123,7 +127,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: "60"
     service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: "artsy-elb-logs"
     service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: "production-force"
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "90"
 spec:
   ports:
     - port: 80


### PR DESCRIPTION
This is related to https://github.com/nodejs/node/issues/27363

Background:

Somewhere after Node 10.13 a security fix for the slow mo attack was added to node. This caused us to see an elevated rate of 502s due to some timeout connections between the node processes and the ELB. (I won't pretend to understand all the specifics). @mzikherman updated node for force and added the these settings for staging in https://github.com/artsy/force/pull/5022, but that we never updated production... which seems important? 

I'm also going through this song and dance for metaphysics via https://github.com/artsy/metaphysics/pull/2358