### PR TITLE
[2FA] Pass through OTP in login request to Gravity

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@artsy/express-reloadable": "1.4.8",
     "@artsy/gemup": "0.0.3",
     "@artsy/palette": "8.2.1",
-    "@artsy/passport": "1.1.13",
+    "@artsy/passport": "1.2.0",
     "@artsy/reaction": "26.34.0",
     "@artsy/stitch": "6.1.6",
     "@babel/core": "7.6.0",

--- a/src/desktop/models/logged_out_user.coffee
+++ b/src/desktop/models/logged_out_user.coffee
@@ -58,7 +58,7 @@ module.exports = class LoggedOutUser extends User
 
   login: (options = {}) ->
     new Backbone.Model()
-      .save @pick('email', 'password', '_csrf'), _.extend {}, options,
+      .save @pick('email', 'password', 'otp_attempt', '_csrf'), _.extend {}, options,
         url: "#{APP_URL}#{sd.AP.loginPagePath}"
         success: _.wrap options.success, (success, model, response, options) =>
           @__isLoggedIn__ = true

--- a/src/desktop/test/models/logged_out_user.test.coffee
+++ b/src/desktop/test/models/logged_out_user.test.coffee
@@ -48,6 +48,11 @@ describe 'LoggedOutUser', ->
         user.login()
         $.ajaxSettings.headers['X-ACCESS-TOKEN'].should.equal 'secrets'
 
+      it 'passes through the supplied OTP attempt', ->
+        user = new LoggedOutUser email: 'foo@bar.com', password: 'foobar', otp_attempt: '123456'
+        user.login()
+        Backbone.sync.args[0][1].attributes.should.containEql otp_attempt: '123456'
+
     describe '#signup', ->
       it 'registers the user model', ->
         LoggedOutUser.__set__ 'sd', AP: signupPagePath: '/users/sign_in'

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,11 +58,19 @@
     styled-system "^3.1.11"
     trunc-html "^1.1.2"
 
-"@artsy/passport@1.1.13":
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@artsy/passport/-/passport-1.1.13.tgz#320afafedf904eec94921a6c805a8ae0c7f43a44"
-  integrity sha512-Q1nfPknUrNgYvEszfjIMvigGoSFTHXWOxw5kfn9zzOPBN/+KaRPjE2T0J4GDgs0ytgTBmiw5ODbveDOWeTDH4A==
+"@artsy/passport-local-with-otp@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@artsy/passport-local-with-otp/-/passport-local-with-otp-0.3.0.tgz#c27bf342ad0cff13378ace9caae7395bec3c46fd"
+  integrity sha512-gzN4InPgDdtNLxmziTk9ZmrMAf41zCGxG0CP8Fm5Q5RxWZxBJt6FkCqfQeBhpihU2L74lvseDxi5LYI8mkdOdQ==
   dependencies:
+    passport-strategy "1.x.x"
+
+"@artsy/passport@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@artsy/passport/-/passport-1.2.0.tgz#1f405254b61f3cffacdc5def5d220c960b701787"
+  integrity sha512-3jRlEfMkisREQyETd0ls24Tz2SIvcMiQpNZ885tab6oRcUomfbPjOkWFp/ojqWYjaXxen72t83tAoih/tleIpQ==
+  dependencies:
+    "@artsy/passport-local-with-otp" "^0.3.0"
     "@nicokaiser/passport-apple" "^0.2.1"
     analytics-node "^2.1.0"
     async "^1.5.0"
@@ -73,7 +81,6 @@
     mailcheck "^1.1.1"
     passport "^0.3.0"
     passport-facebook "^2.0.0"
-    passport-local "^1.0.0"
     superagent "^1.2.0"
     underscore.string "^3.2.2"
 
@@ -12019,13 +12026,6 @@ passport-facebook@^2.0.0:
   integrity sha1-w50LUq5NWRYyRaTiGnubYyEwMxE=
   dependencies:
     passport-oauth2 "1.x.x"
-
-passport-local@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/passport-local/-/passport-local-1.0.0.tgz#1fe63268c92e75606626437e3b906662c15ba6ee"
-  integrity sha1-H+YyaMkudWBmJkN+O5BmYsFbpu4=
-  dependencies:
-    passport-strategy "1.x.x"
 
 passport-oauth2@1.x.x:
   version "1.4.0"


### PR DESCRIPTION
~_#dontmerge because merging this as of now would break the desktop login form, until support for OTPs in that form lands_~ This is good to go after https://github.com/artsy/reaction/pull/3496

https://artsyproduct.atlassian.net/browse/TRUST-213

This closes the loop on the work to get Force's Passport stack supporting one-time password (OTP) fields and passing them through to Gravity when required, namely when:

- the Force ClientApplication has `enforces_otp: true` (not true in production yet, but soon)
- the user has a second factor enabled

This builds on:

- https://github.com/artsy/passport-local-with-otp/pull/1
- https://github.com/artsy/artsy-passport/pull/143

### Desktop 

![werking](https://user-images.githubusercontent.com/140521/81346426-4113f380-9088-11ea-8ade-57d324b18fdd.gif)
### Mobile 

![otp](https://user-images.githubusercontent.com/140521/81252875-1a58ad00-8ff5-11ea-8643-438cbaf67af0.gif)
