### PR TITLE
Adds routing for new feature page

### DIFF
--- a/src/desktop/apps/feature-reaction/client.tsx
+++ b/src/desktop/apps/feature-reaction/client.tsx
@@ -1,0 +1,28 @@
+import { buildClientApp } from "reaction/Artsy/Router/client"
+import { data as sd } from "sharify"
+import { routes as featureRoutes } from "reaction/Apps/Feature/routes"
+import React from "react"
+import ReactDOM from "react-dom"
+import { loadableReady } from "@loadable/component"
+
+const mediator = require("desktop/lib/mediator.coffee")
+
+buildClientApp({
+  routes: featureRoutes,
+  context: {
+    user: sd.CURRENT_USER,
+    mediator,
+  } as any,
+})
+  .then(({ ClientApp }) => {
+    loadableReady(() => {
+      ReactDOM.hydrate(<ClientApp />, document.getElementById("react-root"))
+    })
+  })
+  .catch(error => {
+    console.error(error)
+  })
+
+if (module.hot) {
+  module.hot.accept()
+}

--- a/src/desktop/apps/feature-reaction/client.tsx
+++ b/src/desktop/apps/feature-reaction/client.tsx
@@ -12,7 +12,7 @@ buildClientApp({
   context: {
     user: sd.CURRENT_USER,
     mediator,
-  } as any,
+  },
 })
   .then(({ ClientApp }) => {
     loadableReady(() => {

--- a/src/desktop/apps/feature-reaction/server.tsx
+++ b/src/desktop/apps/feature-reaction/server.tsx
@@ -44,7 +44,7 @@ app.get(
         },
         locals: {
           ...res.locals,
-          assetPackage: "feature_reaction",
+          assetPackage: "feature-reaction",
           scripts,
           styleTags,
         },

--- a/src/desktop/apps/feature-reaction/server.tsx
+++ b/src/desktop/apps/feature-reaction/server.tsx
@@ -1,0 +1,58 @@
+import { buildServerApp } from "reaction/Artsy/Router/server"
+import { stitch } from "@artsy/stitch"
+import { routes as featureRoutes } from "reaction/Apps/Feature/routes"
+import React from "react"
+import { buildServerAppContext } from "desktop/lib/buildServerAppContext"
+import express, { Request, Response, NextFunction } from "express"
+import { skipIfClientSideRoutingEnabled } from "desktop/components/split_test/skipIfClientSideRoutingEnabled"
+import adminOnly from "desktop/lib/admin_only"
+
+export const app = express()
+
+app.get(
+  "/feature*",
+  skipIfClientSideRoutingEnabled,
+  adminOnly,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const {
+        bodyHTML,
+        redirect,
+        status,
+        headTags,
+        styleTags,
+        scripts,
+      } = await buildServerApp({
+        context: buildServerAppContext(req, res),
+        routes: featureRoutes,
+        url: req.url,
+        userAgent: req.header("User-Agent"),
+      })
+
+      if (redirect) {
+        res.redirect(302, redirect.url)
+        return
+      }
+
+      // Render layout
+      const layout = await stitch({
+        basePath: __dirname,
+        layout: "../../components/main_layout/templates/react_redesign.jade",
+        blocks: {
+          head: () => <React.Fragment>{headTags}</React.Fragment>,
+          body: bodyHTML,
+        },
+        locals: {
+          ...res.locals,
+          assetPackage: "feature_reaction",
+          scripts,
+          styleTags,
+        },
+      })
+
+      res.status(status).send(layout)
+    } catch (error) {
+      next(error)
+    }
+  }
+)

--- a/src/desktop/apps/feature/routes.coffee
+++ b/src/desktop/apps/feature/routes.coffee
@@ -1,14 +1,16 @@
 Feature = require '../../models/feature.coffee'
 
-@index = (req, res) ->
+@index = (req, res, next) ->
   new Feature(id: req.params.id).fetch
     error: res.backboneError
     success: (feature) ->
-      res.locals.sd.FEATURE = feature
-      res.locals.sd.TAB = req.params.tab
-      res.render 'templates/index',
-        feature: feature
+      if req.params.id == "alserkal-art-week"
+        next()
+      else
+        res.locals.sd.FEATURE = feature
+        res.locals.sd.TAB = req.params.tab
+        res.render 'templates/index',
+          feature: feature
 
 @redirectCityGuide = (req, res) ->
   res.redirect 301, 'https://iphone.artsy.net'
-  

--- a/src/desktop/apps/feature/routes.coffee
+++ b/src/desktop/apps/feature/routes.coffee
@@ -4,7 +4,7 @@ Feature = require '../../models/feature.coffee'
   new Feature(id: req.params.id).fetch
     error: res.backboneError
     success: (feature) ->
-      if feature.get('version') && feature.get('version') > 1
+      if feature.has('version') && feature.get('version') > 1
         next()
       else
         res.locals.sd.FEATURE = feature

--- a/src/desktop/apps/feature/routes.coffee
+++ b/src/desktop/apps/feature/routes.coffee
@@ -4,7 +4,7 @@ Feature = require '../../models/feature.coffee'
   new Feature(id: req.params.id).fetch
     error: res.backboneError
     success: (feature) ->
-      if req.params.id == "alserkal-art-week"
+      if feature.get('version') && feature.get('version') > 1
         next()
       else
         res.locals.sd.FEATURE = feature

--- a/src/desktop/apps/feature/test/routes.test.coffee
+++ b/src/desktop/apps/feature/test/routes.test.coffee
@@ -15,15 +15,21 @@ describe '#index', ->
       locals:
         sd:
           API_URL: 'http://localhost:5000'
+    @next = sinon.stub()
 
   afterEach ->
     Backbone.sync.restore()
 
   it 'renders the feature page', ->
-    routes.index @req, @res
+    routes.index @req, @res, @next
     Backbone.sync.args[0][2].success fabricate 'feature', name: 'Awesome Feature'
     @res.render.args[0][0].should.equal 'templates/index'
     @res.render.args[0][1].feature.get('name').should.equal 'Awesome Feature'
+
+  it 'passes through the route if the version is too high', ->
+    routes.index @req, @res, @next
+    Backbone.sync.args[0][2].success fabricate 'feature', name: 'Awesome Feature', version: 2
+    @next.calledOnce.should.be.ok()
 
 describe '#redirectCityGuide', ->
 

--- a/src/desktop/apps/viewing-room/client.tsx
+++ b/src/desktop/apps/viewing-room/client.tsx
@@ -12,7 +12,7 @@ buildClientApp({
   context: {
     user: sd.CURRENT_USER,
     mediator,
-  } as any,
+  },
 })
   .then(({ ClientApp }) => {
     loadableReady(() => {

--- a/src/desktop/assets/feature-reaction.tsx
+++ b/src/desktop/assets/feature-reaction.tsx
@@ -1,0 +1,1 @@
+import "desktop/apps/feature-reaction/client"

--- a/src/desktop/index.js
+++ b/src/desktop/index.js
@@ -92,6 +92,9 @@ app.use(require("./apps/fair_info"))
 app.use(require("./apps/fair_organizer"))
 app.use(require("./apps/feature"))
 
+// Must appear _after_ /feature so that we properly pass through in only some cases
+app.use(require("./apps/feature-reaction/server").app)
+
 // User profiles
 app.use(require("./apps/user"))
 


### PR DESCRIPTION
Making this a Draft until the gravity work is in and we can check for that field.

This PR:
- Adds basic route handling for a new `Feature` App in reaction (called `feature-reaction` here). I also don't love the `feature-reaction` naming... could call it `feature-version-2`?
- Demonstrates how we can short-circuit the existing feature page routing. It's not _ideal_ as it means we're making an extra request. We could try to be fancy and pass some data around but doesn't seem worth it.