### PR TITLE
[2FA] Handle OTP during inquiry auth flow

### DIFF
--- a/src/desktop/components/inquiry_questionnaire/stylesheets/desktop.styl
+++ b/src/desktop/components/inquiry_questionnaire/stylesheets/desktop.styl
@@ -141,6 +141,10 @@
 .iq-sticky-spacer
   height 150px
 
+.iq-otp-field
+  &.is-hidden
+    display none
+
 .gdpr-signup .tos-error
   color red-color
   text-align left

--- a/src/desktop/components/inquiry_questionnaire/templates/account/login.jade
+++ b/src/desktop/components/inquiry_questionnaire/templates/account/login.jade
@@ -16,6 +16,11 @@ form.stacked-form
     | Enter your password
   include password
 
+  .iq-otp-field.is-hidden
+    label.avant-garde-form-label( for='otp_attempt' )
+      | Enter an authentication code
+    include otp_attempt
+
   button.avant-garde-button-black.js-form-submit.js-login-email( type='submit' )
     | Log in
 

--- a/src/desktop/components/inquiry_questionnaire/templates/account/otp_attempt.jade
+++ b/src/desktop/components/inquiry_questionnaire/templates/account/otp_attempt.jade
@@ -1,0 +1,6 @@
+input.bordered-input(
+  id='otp_attempt'
+  name='otp_attempt'
+  type='text'
+  placeholder='Authentication code'
+)


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/TRUST-220

This makes the inquiry flow login modal compatible with 2FA enforcement by intercepting the usual error handling and providing some specialized behavior if Gravity returns the `missing two-factor authentication code` or `invalid two-factor authentication code` error messages.

As noted below, this increases the number of places where we test against these specific strings, so if we do change that strategy we should add this to the list of places we'd need to change.

![otpfinal](https://user-images.githubusercontent.com/140521/81743829-4f8b5200-9470-11ea-9333-3102ea8d0762.gif)
