### PR TITLE
Fixes issue where new feature page wouldn't show if you're part of the client nav experiment group

### DIFF
--- a/src/desktop/apps/feature-reaction/server.tsx
+++ b/src/desktop/apps/feature-reaction/server.tsx
@@ -4,14 +4,12 @@ import { routes as featureRoutes } from "reaction/Apps/Feature/routes"
 import React from "react"
 import { buildServerAppContext } from "desktop/lib/buildServerAppContext"
 import express, { Request, Response, NextFunction } from "express"
-import { skipIfClientSideRoutingEnabled } from "desktop/components/split_test/skipIfClientSideRoutingEnabled"
 import adminOnly from "desktop/lib/admin_only"
 
 export const app = express()
 
 app.get(
   "/feature*",
-  skipIfClientSideRoutingEnabled,
   adminOnly,
   async (req: Request, res: Response, next: NextFunction) => {
     try {


### PR DESCRIPTION
Since this page needs force logic to route properly, it's not yet fully part of our new app router.

Forgot this line was added! Noticed that if you're part of the experiment group, accessing this page throws a 404. This fixes it.