### PR TITLE
@dleve123 => [Sale Page] Dont overfetch aggregations when paginating

### DIFF
--- a/src/desktop/apps/auction/reducers/__tests__/artworkBrowser.test.js
+++ b/src/desktop/apps/auction/reducers/__tests__/artworkBrowser.test.js
@@ -273,6 +273,21 @@ describe("auction/actions/artworkBrowser.test.js", () => {
           false
         )
       })
+
+      it("includes the full list of aggregations", () => {
+        initialResponse.artworkBrowser.filterParams.artist_ids.should.eql([])
+        const oneArtist = auctions(
+          initialResponse,
+          actions.updateArtistId("artist1")
+        )
+        oneArtist.artworkBrowser.filterParams.artist_ids.should.eql(["artist1"])
+        oneArtist.artworkBrowser.filterParams.aggregations.should.eql([
+          "ARTIST",
+          "FOLLOWED_ARTISTS",
+          "MEDIUM",
+          "TOTAL",
+        ])
+      })
     })
 
     describe("#updateArtworks", () => {
@@ -371,6 +386,22 @@ describe("auction/actions/artworkBrowser.test.js", () => {
           "40000-2000000"
         )
       })
+
+      it("includes the full list of aggregations", () => {
+        initialResponse.artworkBrowser.filterParams.estimate_range.should.eql(
+          ""
+        )
+        const updatedEstimateRange = auctions(
+          initialResponse,
+          actions.updateEstimateRangeParams(100, 20000)
+        )
+        updatedEstimateRange.artworkBrowser.filterParams.estimate_range.should.eql(
+          "10000-2000000"
+        )
+        updatedEstimateRange.artworkBrowser.filterParams.aggregations.should.eql(
+          ["ARTIST", "FOLLOWED_ARTISTS", "MEDIUM", "TOTAL"]
+        )
+      })
     })
 
     describe("#updateInitialMediumMap", () => {
@@ -441,26 +472,60 @@ describe("auction/actions/artworkBrowser.test.js", () => {
         )
         allMediums.artworkBrowser.filterParams.gene_ids.should.eql([])
       })
+
+      it("includes the full list of aggregations", () => {
+        initialResponse.artworkBrowser.filterParams.gene_ids.should.eql([])
+        const oneMedium = auctions(
+          initialResponse,
+          actions.updateMediumId("gene-1")
+        )
+        oneMedium.artworkBrowser.filterParams.gene_ids.should.eql(["gene-1"])
+        oneMedium.artworkBrowser.filterParams.aggregations.should.eql([
+          "ARTIST",
+          "FOLLOWED_ARTISTS",
+          "MEDIUM",
+          "TOTAL",
+        ])
+      })
     })
 
     describe("#updatePage", () => {
-      it("updates the page param", () => {
+      it("updates the page param, and doesn't over-fetch aggregations", () => {
         initialResponse.artworkBrowser.filterParams.page.should.eql(1)
+        initialResponse.artworkBrowser.filterParams.aggregations.should.eql([
+          "ARTIST",
+          "FOLLOWED_ARTISTS",
+          "MEDIUM",
+          "TOTAL",
+        ])
         const incrementedPage = auctions(
           initialResponse,
           actions.updatePage(false)
         )
         incrementedPage.artworkBrowser.filterParams.page.should.eql(2)
+        incrementedPage.artworkBrowser.filterParams.aggregations.should.eql([
+          "TOTAL",
+          "FOLLOWED_ARTISTS",
+        ])
         const furtherIncrementedPage = auctions(
           incrementedPage,
           actions.updatePage(false)
         )
         furtherIncrementedPage.artworkBrowser.filterParams.page.should.eql(3)
+        furtherIncrementedPage.artworkBrowser.filterParams.aggregations.should.eql(
+          ["TOTAL", "FOLLOWED_ARTISTS"]
+        )
         const resetPage = auctions(
           furtherIncrementedPage,
           actions.updatePage(true)
         )
         resetPage.artworkBrowser.filterParams.page.should.eql(1)
+        resetPage.artworkBrowser.filterParams.aggregations.should.eql([
+          "ARTIST",
+          "FOLLOWED_ARTISTS",
+          "MEDIUM",
+          "TOTAL",
+        ])
       })
     })
 

--- a/src/desktop/apps/auction/reducers/artworkBrowser.js
+++ b/src/desktop/apps/auction/reducers/artworkBrowser.js
@@ -254,11 +254,15 @@ export default function auctionArtworkFilter(state = initialState, action) {
     }
     case actions.UPDATE_PAGE: {
       const reset = action.payload.reset
+      const {
+        filterParams: { aggregations },
+      } = initialState
       if (reset === true) {
         return u(
           {
             filterParams: {
               page: 1,
+              aggregations,
             },
           },
           state
@@ -269,6 +273,7 @@ export default function auctionArtworkFilter(state = initialState, action) {
           {
             filterParams: {
               page: currentPage + 1,
+              aggregations: ["TOTAL", "FOLLOWED_ARTISTS"],
             },
           },
           state


### PR DESCRIPTION
As discussed in https://github.com/artsy/gravity/pull/13055#discussion_r423977138 , this removes aggregations (which are expensive, and don't change), during pagination.

When you 'reset' back to page 1 (clicking a filter, etc.) , we set the aggregations back to their defaults.

Jira: https://artsyproduct.atlassian.net/browse/AUCT-1015

Review app: https://sale-browser-optimization.artsy.net/