### PR TITLE
Expose 2FA enrollment UI to all users

### DIFF
--- a/src/desktop/apps/user/pages/settings/index.jade
+++ b/src/desktop/apps/user/pages/settings/index.jade
@@ -6,10 +6,9 @@ include ../../templates/mixins
 +settings-section('password', 'Password')
   include ../../components/password/index
 
-if user.get('roles').includes('team') || user.get('lab_features').includes('2FA')
-  +settings-section('two-factor-authentication', '')
-    #stitch-two-factor-authentication
-      != stitch.components.TwoFactorAuthentication({ mountId: 'stitch-two-factor-authentication' })
++settings-section('two-factor-authentication', '')
+  #stitch-two-factor-authentication
+    != stitch.components.TwoFactorAuthentication({ mountId: 'stitch-two-factor-authentication' })
 
 +settings-section('linked-accounts', 'Linked Accounts')
   include ../../components/linked_accounts/index


### PR DESCRIPTION
Remove conditional for revealing 2FA enrollment UI, soft-launching 2FA for all users.

_Opening this to prepare for the 2FA soft launch_