### PR TITLE
Excludes /campaign route from pageviews

### DIFF
--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -20,6 +20,7 @@ const excludedRoutes = [
   "collection",
   "collect",
   "collections",
+  "campaign",
 ]
 if (!excludedRoutes.includes(pageType)) {
   analytics.page(properties, { integrations: { Marketo: false } })


### PR DESCRIPTION
We already track pageviews for this route in reaction. Needed to add to this list so we don't double-fire.