### PR TITLE
Make reaction app exclude tracking more robust

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,6 +189,7 @@
     "nyc": "13.3.0",
     "openseadragon": "2.4.0",
     "particle": "artsy/particle",
+    "path-to-regexp": "^6.1.0",
     "places": "artsy/places",
     "popover": "2.4.1",
     "prop-types": "15.7.2",

--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -124,7 +124,7 @@ function setupJquery() {
   // once you click it. For these cases do `$el.click -> $(@).hidehover()` and
   // the menu will hide and then remove the `display` property so the default
   // CSS will kick in again.
-  $.fn.hidehover = function() {
+  $.fn.hidehover = function () {
     const $el = $(this)
     $el.css({ display: "none" })
     return setTimeout(() => $el.css({ display: "" }), 200)
@@ -154,7 +154,7 @@ function setupErrorReporting() {
     const user = sd && sd.CURRENT_USER
 
     if (sd.CURRENT_USER) {
-      Sentry.configureScope(scope => {
+      Sentry.configureScope((scope) => {
         scope.setUser(_.pick(user, "id", "email"))
       })
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12144,6 +12144,11 @@ path-to-regexp@^2.2.1:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
   integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
 
+path-to-regexp@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.1.0.tgz#0b18f88b7a0ce0bfae6a25990c909ab86f512427"
+  integrity sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"


### PR DESCRIPTION
This makes our reaction app pageview tracking exclusion more robust, allowing us to match dynamic path names / copy paste reaction routes directly into the exclude list. Uses [path-to-regex](https://github.com/pillarjs/path-to-regexp) under the hood.

See this slack convo: https://artsy.slack.com/archives/C02BC3HEJ/p1589488137239700
And this JIRA ticket: https://artsyproduct.atlassian.net/browse/PLATFORM-2362
for more context.

See [Reaction PR](https://github.com/artsy/reaction/pull/3543) for some tests. 

Before / After: 

![before](https://user-images.githubusercontent.com/236943/81997382-682c7100-9604-11ea-829b-ec49d6d3e412.gif)
