### PR TITLE
Fix double footer on about page

### DIFF
--- a/src/desktop/apps/about/stylesheets/index.styl
+++ b/src/desktop/apps/about/stylesheets/index.styl
@@ -130,6 +130,9 @@ header-margin = 180px
 .about-footer
   position relative
 
+  #main-layout-footer
+    overflow hidden
+
 @require './nav'
 @require './hero_unit'
 @require './the_art_world_online'


### PR DESCRIPTION
Fixes: https://artsyproduct.atlassian.net/browse/FX-1841

The /about page takes up the full height of the browser, so we actually include an additional footer (because the main one is covered up!). But it appears to be peeking through. This fixes that.

<img width="1436" alt="Screen Shot 2020-05-19 at 6 21 06 PM" src="https://user-images.githubusercontent.com/2081340/82384573-26356d80-99fe-11ea-914f-7ee026b0e179.png">
