### PR TITLE
update preStop sleep hooks to 30s for Nginx and 35s for force in staging

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -56,7 +56,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["sh", "-c", "sleep 10"]
+                command: ["sh", "-c", "sleep 35"]
         - name: force-nginx
           image: artsy/docker-nginx:latest
           ports:
@@ -73,7 +73,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["sh", "-c", "sleep 5 && /usr/sbin/nginx -s quit"]
+                command: ["sh", "-c", "sleep 30 && /usr/sbin/nginx -s quit"]
           env:
             - name: "NGINX_DEFAULT_CONF"
               valueFrom:


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/PLATFORM-1996

The 504s on pod termination are reported by other users in this thread https://github.com/kubernetes/kubernetes/issues/88236 and the Kubernetes authors' response is 

> Once the pod is deleted, the "upstream" load-balancers need to actually remove it from their backend sets. This is async and can take time, during which you will continue to receive requests. This is "normal". I expect that somewhere between 2 and 30 seconds later those new requests will cease.
If this is a real problem for the app, you can add a preStop lifecycle hook that exec's sleep 60 or something similar. That will be triggered BEFORE you get SIGTERM, but LBs will be able to observe the deletionTimestamp.
Since this is not a "bug", I am going to close it. This is (unfortunately) a pretty common misunderstanding, but fixing it is a fairly deep change to pod lifecycle.

Try a 30s delay in staging to see how well it mitigates 504s on app shutdown.  We can bump this higher if we still see problems.
