### PR TITLE
Fix Circle CI config DANGER_GITHUB_API_TOKEN value

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - yarn/setup
       - run:
           name: Danger
-          command: DANGER_GITHUB_API_TOKEN="15e52de81a772b174cc5""e1813d0083564c69c325" yarn danger ci
+          command: DANGER_GITHUB_API_TOKEN="15e52de81a772b174cc5e1813d0083564c69c325" yarn danger ci
 
   create_or_update_review_app:
     executor: hokusai/deploy


### PR DESCRIPTION
We may have been executing unauthenticated GitHub API requests and hitting rate limits more often if this token was mangled.

cc/ @eessex @zephraph @damassi 