### PR TITLE
Move CSRF_TOKEN to Cookie to Allow for Page Caching

### DIFF
--- a/src/desktop/apps/authentication/components/ModalContainer.tsx
+++ b/src/desktop/apps/authentication/components/ModalContainer.tsx
@@ -97,7 +97,7 @@ export class ModalContainer extends React.Component<any> {
           facebook: sd.AP.facebookPath,
           twitter: sd.AP.twitterPath,
         }}
-        csrf={sd.CSRF_TOKEN}
+        csrf={Cookies && Cookies.get && Cookies.get("CSRF_TOKEN")}
         handleSubmit={handleSubmit}
         onSocialAuthEvent={this.onSocialAuthEvent}
         onModalClose={() => {

--- a/src/desktop/apps/authentication/components/__tests__/ModalContainer.jest.tsx
+++ b/src/desktop/apps/authentication/components/__tests__/ModalContainer.jest.tsx
@@ -23,7 +23,6 @@ describe("ModalContainer", () => {
       loginPagePath: "/login",
       signupPagePath: "/signup",
     }
-    sd.CSRF_TOKEN = "sample-token"
   })
 
   it("Mediator can open a login modal", () => {

--- a/src/desktop/apps/authentication/helpers.ts
+++ b/src/desktop/apps/authentication/helpers.ts
@@ -40,7 +40,7 @@ export const handleSubmit = (
    * towards using `intent` on analytics, but Gravity expects `signupIntent`
    */
   const userAttributes = Object.assign({}, values, {
-    _csrf: sd.CSRF_TOKEN,
+    _csrf: Cookies && Cookies.get && Cookies.get("CSRF_TOKEN"),
     signupIntent: intent,
     signupReferer,
     agreed_to_receive_emails: values.accepted_terms_of_service,

--- a/src/desktop/models/logged_out_user.coffee
+++ b/src/desktop/models/logged_out_user.coffee
@@ -1,7 +1,8 @@
 Q = require 'bluebird-q'
 _ = require 'underscore'
+Cookies = require 'cookies-js'
 Backbone = require 'backbone'
-{ API_URL, CSRF_TOKEN, APP_URL, SESSION_ID } = require('sharify').data
+{ API_URL, APP_URL, SESSION_ID } = require('sharify').data
 User = require './user.coffee'
 sd = require('sharify').data
 IS_TEST_ENV = require('sharify').data.NODE_ENV not in ['production', 'staging', 'development']
@@ -29,7 +30,7 @@ module.exports = class LoggedOutUser extends User
   __isRecentlyRegistered__: false
 
   defaults:
-    _csrf: CSRF_TOKEN
+    _csrf: Cookies && Cookies.get && Cookies.get 'CSRF_TOKEN' || undefined
 
   initialize: ->
     syncWithSessionId()

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -173,6 +173,17 @@ export default function(app) {
     )
   )
 
+  // Add CSRF to the cookie and remove it from the page. This will allows the
+  // caching on the html.
+  app.use((req, res, next) => {
+    const csrf = res.locals.sd.CSRF_TOKEN
+    res.cookie("CSRF_TOKEN", res.locals.sd.CSRF_TOKEN)
+    // Clear the embedded CSRF_TOKEN, an alternative method would be to update
+    // @artsy/passport to make the CSRF_TOKEN optional.
+    res.locals.sd.CSRF_TOKEN = ""
+    next()
+  })
+
   // Development servers
   if (isDevelopment) {
     app.use(require("./webpack-dev-server").app)

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -176,11 +176,10 @@ export default function(app) {
   // Add CSRF to the cookie and remove it from the page. This will allows the
   // caching on the html.
   app.use((req, res, next) => {
-    const csrf = res.locals.sd.CSRF_TOKEN
     res.cookie("CSRF_TOKEN", res.locals.sd.CSRF_TOKEN)
     // Clear the embedded CSRF_TOKEN, an alternative method would be to update
     // @artsy/passport to make the CSRF_TOKEN optional.
-    res.locals.sd.CSRF_TOKEN = ""
+    delete res.locals.sd.CSRF_TOKEN
     next()
   })
 


### PR DESCRIPTION
Problem

Storing the CSRF_TOKEN in the page causes issues when doing full html
caching because many users will see the same token and that token will
only be valid for a single users session.

Solution

Move the delivery of the CSRF_TOKEN from sharify to the cookie. This
allows the page to be cached while using dynamic tokens.