### PR TITLE
No tests on staging or release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,11 +120,13 @@ workflows:
 
       # Pre-staging
       - yarn/jest:
+          <<: *not_staging_or_release
           args: --runInBand
           requires:
             - yarn/workflow-queue
 
       - yarn/run:
+          <<: *not_staging_or_release
           name: test:mocha
           script: "test:mocha"
           requires:


### PR DESCRIPTION
Adds back `<<: *not_staging_or_release` to test steps 

This matches how it was previously: https://github.com/artsy/force/pull/5636/files#diff-1d37e48f9ceff6d8030570cd36286a61L123

