### PR TITLE
[Analytics] Fix double firing

### DIFF
--- a/src/desktop/assets/analytics.coffee
+++ b/src/desktop/assets/analytics.coffee
@@ -4,13 +4,13 @@ setupSplitTests = require '../components/split_test/setup.coffee'
 window._ = require 'underscore'
 window.Cookies = require 'cookies-js'
 
-PublishingEvents = require('@artsy/reaction/dist/Utils/Events.js').default
-ReactionEvents = require('../../v2/Utils/Events').default
+# This event bus also connects to reaction's publishing event emitter because
+# both piggyback on `window`. See Utils/Events for more info.
+Events = require('../../v2/Utils/Events').default
 
 # All Force mediator events can be hooked into for tracking purposes
 mediator.on 'all', (name, data) ->
   analyticsHooks.trigger "mediator:#{name}", data
-
 
 trackEvent = (data) ->
   # TODO: This is old schema
@@ -63,8 +63,7 @@ trackEvent = (data) ->
     console.error("Unknown analytics schema being used: #{JSON.stringify(data)}")
 
 # All Reaction events are sent directly to Segment
-PublishingEvents.onEvent trackEvent
-ReactionEvents.onEvent trackEvent
+Events.onEvent trackEvent
 
 require '../analytics/main_layout.js'
 

--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -126,7 +126,7 @@ function setupJquery() {
   // once you click it. For these cases do `$el.click -> $(@).hidehover()` and
   // the menu will hide and then remove the `display` property so the default
   // CSS will kick in again.
-  $.fn.hidehover = function() {
+  $.fn.hidehover = function () {
     const $el = $(this)
     $el.css({ display: "none" })
     return setTimeout(() => $el.css({ display: "" }), 200)
@@ -156,7 +156,7 @@ function setupErrorReporting() {
     const user = sd && sd.CURRENT_USER
 
     if (sd.CURRENT_USER) {
-      Sentry.configureScope(scope => {
+      Sentry.configureScope((scope) => {
         scope.setUser(_.pick(user, "id", "email"))
       })
     }
@@ -182,7 +182,7 @@ export function trackAuthenticationEvents() {
   const modes = ["login", "signup"]
   const user = sd && sd.CURRENT_USER
 
-  modes.forEach(mode => {
+  modes.forEach((mode) => {
     if (Cookies.get(`analytics-${mode}`)) {
       const data = JSON.parse(Cookies.get(`analytics-${mode}`))
       Cookies.expire(`analytics-${mode}`)


### PR DESCRIPTION
Noticed that things were double firing because we had two instances of the same event bus (reaction + publishing event emitter) being attached to the same event handler. 

Since in the end our events all attach to [`window.__reactionEvents`](https://github.com/artsy/force/blob/4dcece28d24bdc92c664d5d79db99f337ab6524b/src/v2/Utils/Events.ts#L9-L13) only need one declaration. (Need to clean up naming once things settle.)