### PR TITLE
Fix infinite scrolling on mobile partner profile works/shop tab (GALL-2867)

### DIFF
--- a/src/mobile/apps/partner_profile/client/artworks.coffee
+++ b/src/mobile/apps/partner_profile/client/artworks.coffee
@@ -27,7 +27,9 @@ module.exports.PartnerArtworksView = class PartnerArtworksView extends Backbone.
           @$('#partner-artworks-spinner').hide()
 
   render: =>
-    @$('#partner-artworks-list ul').append $(artworkColumnsTemplate(artworkColumns: @collection.groupByColumnsInOrder())).html()
+    $columns = $(artworkColumnsTemplate(artworkColumns: @collection.groupByColumnsInOrder()))
+    @$('#partner-artworks-list .artwork-columns-column').each (i, column) =>
+      $(column).append $columns.find('.artwork-columns-column').eq(i).html()
     @$('#partner-artworks-spinner').hide()
 
 module.exports.init = ->

--- a/src/mobile/apps/partner_profile/test/client/artworks.test.coffee
+++ b/src/mobile/apps/partner_profile/test/client/artworks.test.coffee
@@ -1,0 +1,48 @@
+benv = require 'benv'
+Backbone = require 'backbone'
+sinon = require 'sinon'
+path = require 'path'
+Artworks = require '../../../../collections/artworks.coffee'
+Artwork = require '../../../../models/artwork.coffee'
+Profile = require '../../../../models/profile'
+{ fabricate } = require '@artsy/antigravity'
+
+describe 'PartnerArtworksView', ->
+  beforeEach (done) ->
+    benv.setup =>
+      benv.expose { $: benv.require 'jquery' }
+      $.onInfiniteScroll = sinon.stub()
+      Backbone.$ = $
+      sinon.stub Backbone, 'sync'
+
+      artworkColumns = [[new Artwork(fabricate('artwork'))], [new Artwork(fabricate('artwork'))]]
+      benv.render path.resolve(__dirname, '../../templates/artworks.jade'),
+        sd: {}
+        profile: new Profile(fabricate('profile'))
+        artworkColumns: artworkColumns
+      , =>
+        { PartnerArtworksView } = benv.requireWithJadeify path.resolve(__dirname, '../../client/artworks.coffee'), ['artworkColumnsTemplate']
+        @view = new PartnerArtworksView(
+          collection: new Artworks([]),
+          el: $ 'body'
+          params: {}
+        )
+        done()
+
+  afterEach ->
+    benv.teardown()
+    Backbone.sync.restore()
+
+  describe '#render', ->
+    it 'appends artworks in collection to columns', ->
+      $('.artwork-columns-column').length.should.equal 2
+      $('.artwork-columns-column').eq(0).find('.artwork-columns-artwork').length.should.equal 1
+      $('.artwork-columns-column').eq(1).find('.artwork-columns-artwork').length.should.equal 1
+
+      artworks = new Artworks([fabricate('artwork'), fabricate('artwork'), fabricate('artwork')])
+      @view.collection = artworks
+      @view.render()
+
+      $('.artwork-columns-column').length.should.equal 2
+      $('.artwork-columns-column').eq(0).find('.artwork-columns-artwork').length.should.equal 3
+      $('.artwork-columns-column').eq(1).find('.artwork-columns-artwork').length.should.equal 2


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GALL-2867

See the screencast below for the issue and local result from the fix.

The issue was we tried to append fetched artworks to a non-existing element when scrolling. This quickly fixes it by appending to individual column.

![mobile-ppp-artworks](https://user-images.githubusercontent.com/796573/82968302-002e4100-9f9b-11ea-8528-949323144c42.gif)
