### PR TITLE
Clear Yarn Cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ COPY package.json yarn.lock ./
 COPY patches ./patches
 
 # Install application dependencies
-RUN yarn install --frozen-lockfile --quiet
+RUN yarn install --frozen-lockfile --quiet && \
+  yarn cache clean --force
 
 # Copy application code
 COPY . ./


### PR DESCRIPTION
Problen

The yarn cache is being not being cleaned during the build causing the
docker image to be larger than needed.

Solution

Clean the yarn cache after install node modules.