### PR TITLE
[Webpack] Quiet the output a bit

### DIFF
--- a/src/desktop/apps/artsy-v2/client.tsx
+++ b/src/desktop/apps/artsy-v2/client.tsx
@@ -45,10 +45,12 @@ buildClientApp({
       )
     })
   })
-  .catch(error => {
+  .catch((error) => {
     console.error(error)
   })
 
 if (module.hot) {
   module.hot.accept()
 }
+
+//

--- a/src/lib/webpack-dev-server.js
+++ b/src/lib/webpack-dev-server.js
@@ -14,6 +14,7 @@ app.use(
 app.use(
   require("webpack-dev-middleware")(compiler, {
     quiet: true,
+    stats: webpackConfig.stats,
     publicPath: webpackConfig.output.publicPath,
     serverSideRender: true,
     writeToDisk(filePath) {

--- a/webpack/envs/developmentConfig.js
+++ b/webpack/envs/developmentConfig.js
@@ -10,7 +10,7 @@ const FriendlyErrorsWebpackPlugin = require("friendly-errors-webpack-plugin")
 const WebpackNotifierPlugin = require("webpack-notifier")
 const SimpleProgressWebpackPlugin = require("simple-progress-webpack-plugin")
 const { NODE_ENV, basePath, isCI } = require("../../src/lib/environment")
-const { PORT, WEBPACK_DEVTOOL } = process.env
+const { PORT, WEBPACK_DEVTOOL, WEBPACK_STATS } = process.env
 
 const cacheDirectory = path.resolve(basePath, ".cache")
 
@@ -26,6 +26,7 @@ if (!isCI && !fs.existsSync(cacheDirectory)) {
 exports.developmentConfig = {
   mode: NODE_ENV,
   devtool: WEBPACK_DEVTOOL,
+  stats: WEBPACK_STATS || "errors-only",
   module: {
     rules: [
       {


### PR DESCRIPTION
Most devs aren't concerned with the full chunk output. However, if wanting to view, can use an env var:

```
WEBPACK_STATS="normal"
```