### PR TITLE
[Refactor] Use RouterLink where we can

### DIFF
--- a/package.json
+++ b/package.json
@@ -400,6 +400,7 @@
     "lines": 0
   },
   "prettier": {
+    "arrowParens": "avoid",
     "bracketSpacing": true,
     "printWidth": 80,
     "semi": false,

--- a/src/v2/Apps/Artist/ArtistApp.tsx
+++ b/src/v2/Apps/Artist/ArtistApp.tsx
@@ -70,39 +70,39 @@ export const ArtistApp: React.FC<ArtistAppProps> = props => {
                 <Spacer mb={2} />
               </>
             ) : (
-                /**
-                 * If full page, then we take over the entire area; if not, then
-                 * display the "Back to Artist link"
-                 */
-                !route.displayFullPage && (
-                  <>
-                    <Flex flexDirection="row" alignItems="center" my={3}>
-                      <ChevronIcon
-                        direction="left"
-                        color="black"
-                        height="18px"
-                        width="14px"
-                        top="-1px"
-                      />
-                      <Sans size="3" weight="medium" color="black100" ml="3px">
-                        <StyledLink
-                          to={`/artist/${artist.slug}`}
-                          onClick={() =>
-                            trackEvent({
-                              action_type: Schema.ActionType.Click,
-                              subject: "Back to artist link",
-                              destination_path: `/artist/${artist.slug}`,
-                            })
-                          }
-                        >
-                          {`Back to ${artist.name}`}
-                        </StyledLink>
-                      </Sans>
-                    </Flex>
-                    <Spacer mb={2} />
-                  </>
-                )
-              )}
+              /**
+               * If full page, then we take over the entire area; if not, then
+               * display the "Back to Artist link"
+               */
+              !route.displayFullPage && (
+                <>
+                  <Flex flexDirection="row" alignItems="center" my={3}>
+                    <ChevronIcon
+                      direction="left"
+                      color="black"
+                      height="18px"
+                      width="14px"
+                      top="-1px"
+                    />
+                    <Sans size="3" weight="medium" color="black100" ml="3px">
+                      <StyledLink
+                        to={`/artist/${artist.slug}`}
+                        onClick={() =>
+                          trackEvent({
+                            action_type: Schema.ActionType.Click,
+                            subject: "Back to artist link",
+                            destination_path: `/artist/${artist.slug}`,
+                          })
+                        }
+                      >
+                        {`Back to ${artist.name}`}
+                      </StyledLink>
+                    </Sans>
+                  </Flex>
+                  <Spacer mb={2} />
+                </>
+              )
+            )}
 
             <Box minHeight="30vh">{children}</Box>
           </Col>
@@ -124,8 +124,8 @@ export const ArtistApp: React.FC<ArtistAppProps> = props => {
         {route.displayFullPage ? (
           <Spacer mb={3} />
         ) : (
-            <Separator mt={6} mb={3} />
-          )}
+          <Separator mt={6} mb={3} />
+        )}
 
         <Row>
           <Col>

--- a/src/v2/Apps/Artist/Components/ArtistHeader.tsx
+++ b/src/v2/Apps/Artist/Components/ArtistHeader.tsx
@@ -151,11 +151,8 @@ export class LargeArtistHeader extends Component<Props> {
                 data={carousel.images as object[]}
                 render={(slide: Image, slideIndex: number) => {
                   return (
-                    // FIXME: Update this type to appropriately accept children
-                    // @ts-ignore
                     <RouterLink
-                      // FIXME: this `as never` should go away
-                      href={slide.href as never}
+                      to={slide.href}
                       onClick={() => this.onClickSlide(slide)}
                     >
                       <Image
@@ -287,7 +284,10 @@ export class SmallArtistHeader extends Component<Props> {
               options={{ pageDots: false }}
               render={slide => {
                 return (
-                  <a href={slide.href} onClick={() => this.onClickSlide(slide)}>
+                  <RouterLink
+                    to={slide.href}
+                    onClick={() => this.onClickSlide(slide)}
+                  >
                     <Image
                       src={slide.resized.url}
                       px={0.3}
@@ -295,7 +295,7 @@ export class SmallArtistHeader extends Component<Props> {
                       height={slide.resized.height}
                       preventRightClick={!isAdmin}
                     />
-                  </a>
+                  </RouterLink>
                 )
               }}
             />

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtists.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtists.tsx
@@ -10,6 +10,7 @@ import { ContextModule, Intent } from "@artsy/cohesion"
 import { ArtworkSidebarArtists_artwork } from "v2/__generated__/ArtworkSidebarArtists_artwork.graphql"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "v2/Components/FollowButton/FollowArtistButton"
 import { openAuthToFollowSave } from "v2/Utils/openAuthModal"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
 
 export interface ArtistsProps {
   artwork: ArtworkSidebarArtists_artwork
@@ -21,7 +22,7 @@ export class ArtworkSidebarArtists extends React.Component<ArtistsProps> {
   private renderArtistName(artist: Artist) {
     return artist.href ? (
       <Serif size="5t" display="inline" weight="semibold" element="h1">
-        <a href={artist.href}>{artist.name}</a>
+        <RouterLink to={artist.href}>{artist.name}</RouterLink>
       </Serif>
     ) : (
       <Serif size="5t" display="inline" weight="semibold" element="h1">

--- a/src/v2/Artsy/Router/RouterLink.tsx
+++ b/src/v2/Artsy/Router/RouterLink.tsx
@@ -55,7 +55,7 @@ export const RouterLink: React.FC<LinkProps> = ({ to, children, ...props }) => {
         href={to as string}
         className={(props as LinkPropsSimple).className}
         style={(props as LinkPropsSimple).style}
-        {...omit(props, ["activeClassName"])}
+        {...omit(props, ["activeClassName", "hasLighterTextColor"])}
       >
         {children}
       </a>

--- a/src/v2/Components/ArtistCard.tsx
+++ b/src/v2/Components/ArtistCard.tsx
@@ -15,13 +15,13 @@ import {
   Box,
   Button,
   Flex,
-  Link,
   Sans,
   Serif,
   Spacer,
   space,
 } from "@artsy/palette"
 import styled from "styled-components"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
 
 export interface ArtistCardProps {
   artist: ArtistCard_artist
@@ -40,10 +40,10 @@ export class ArtistCard extends React.Component<ArtistCardProps> {
 
   render() {
     return (
-      <Link
+      <RouterLink
         onClick={this.props.onClick}
-        href={this.props.artist.href}
-        noUnderline
+        to={this.props.artist.href}
+        style={{ textDecoration: "none" }}
       >
         <Media at="xs">
           <SmallArtistCard {...this.props} />
@@ -51,7 +51,7 @@ export class ArtistCard extends React.Component<ArtistCardProps> {
         <Media greaterThan="xs">
           <LargeArtistCard {...this.props} />
         </Media>
-      </Link>
+      </RouterLink>
     )
   }
 }

--- a/src/v2/Components/Artwork/FillwidthItem.tsx
+++ b/src/v2/Components/Artwork/FillwidthItem.tsx
@@ -13,17 +13,11 @@ import { userIsAdmin } from "v2/Utils/user"
 import Badge from "./Badge"
 import Metadata from "./Metadata"
 import SaveButton from "./Save"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
 
 const logger = createLogger("FillwidthItem.tsx")
 
 const IMAGE_QUALITY = 80
-
-const ImageLink = styled.a`
-  width: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-`
 
 const Placeholder = styled.div`
   position: relative;
@@ -32,7 +26,7 @@ const Placeholder = styled.div`
 
 export interface FillwidthItemContainerProps
   extends SystemContextProps,
-  React.HTMLProps<FillwidthItemContainer> {
+    React.HTMLProps<FillwidthItemContainer> {
   artwork: FillwidthItem_artwork
   contextModule: AuthContextModule
   imageHeight?: number
@@ -48,7 +42,7 @@ export interface FillwidthItemContainerProps
 
 export class FillwidthItemContainer extends React.Component<
   FillwidthItemContainerProps
-  > {
+> {
   static defaultProps = {
     showMetadata: true,
   }
@@ -92,9 +86,9 @@ export class FillwidthItemContainer extends React.Component<
     // tslint:disable-next-line:max-line-length
     return `${getENV("GEMINI_CLOUDFRONT_URL")}/?resize_to=${type}&width=${
       this.imageWidth
-      }&height=${
+    }&height=${
       this.imageHeight
-      }&quality=${IMAGE_QUALITY}&src=${encodeURIComponent(imageURL)}`
+    }&quality=${IMAGE_QUALITY}&src=${encodeURIComponent(imageURL)}`
   }
 
   render() {
@@ -127,8 +121,8 @@ export class FillwidthItemContainer extends React.Component<
     return (
       <div className={className}>
         <Placeholder style={{ height: targetHeight }}>
-          <ImageLink
-            href={artwork.href}
+          <RouterLink
+            to={artwork.href}
             onClick={() => {
               if (this.props.onClick) {
                 this.props.onClick()
@@ -142,7 +136,7 @@ export class FillwidthItemContainer extends React.Component<
               lazyLoad={lazyLoad}
               preventRightClick={!isAdmin}
             />
-          </ImageLink>
+          </RouterLink>
 
           {showExtended && <Badge artwork={artwork} width={this.imageWidth} />}
 

--- a/src/v2/Components/Artwork/GridItem.tsx
+++ b/src/v2/Components/Artwork/GridItem.tsx
@@ -12,6 +12,7 @@ import { userIsAdmin } from "v2/Utils/user"
 import Badge from "./Badge"
 import Metadata from "./Metadata"
 import SaveButton from "./Save"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
 
 let IMAGE_LAZY_LOADING = true
 
@@ -113,8 +114,8 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
         style={style}
       >
         <Placeholder style={{ paddingBottom: artwork.image.placeholder }}>
-          <a
-            href={artwork.href}
+          <RouterLink
+            to={artwork.href}
             onClick={() => {
               if (this.props.onClick) {
                 this.props.onClick()
@@ -128,7 +129,7 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
               lazyLoad={IMAGE_LAZY_LOADING && lazyLoad}
               preventRightClick={!isAdmin}
             />
-          </a>
+          </RouterLink>
 
           <Badge artwork={artwork} />
 

--- a/src/v2/Components/Menu.tsx
+++ b/src/v2/Components/Menu.tsx
@@ -1,0 +1,122 @@
+import React from "react"
+import styled from "styled-components"
+
+import { SpaceProps, display } from "styled-system"
+
+import {
+  BorderBox,
+  Box,
+  BoxProps,
+  Flex,
+  Sans,
+  SansSize,
+  Separator,
+  Spacer,
+  color,
+} from "@artsy/palette"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
+
+interface MenuProps {
+  children?: React.ReactNode
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void
+  m?: SpaceProps["m"]
+  py?: SpaceProps["p"]
+  title?: string
+  width?: number | string
+}
+
+/** Menu */
+export const Menu: React.FC<MenuProps> = ({
+  children,
+  m = "2px",
+  py = 1,
+  title,
+  width = 230,
+  ...props
+}) => {
+  return (
+    <MenuContainer width={width} m={m} {...props}>
+      <BorderBox p={0} py={py} background="white">
+        <Flex flexDirection="column" width="100%">
+          {title && (
+            <Box px={2} pt={1} pb={1}>
+              <Sans size="3" weight="medium">
+                {title}
+              </Sans>
+              <Spacer py={0.5} />
+              <Separator />
+            </Box>
+          )}
+
+          <Flex flexDirection="column">{children}</Flex>
+        </Flex>
+      </BorderBox>
+    </MenuContainer>
+  )
+}
+
+const MenuContainer = styled(Box)`
+  box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.05);
+`
+
+// Menu Item
+
+interface MenuItemProps extends BoxProps {
+  children: React.ReactNode
+  fontSize?: SansSize
+  href?: string
+  color?: string // TODO:  Look into type conflict with styled-system
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void
+  px?: SpaceProps["px"]
+  py?: SpaceProps["py"]
+  textColor?: string
+  textWeight?: "medium" | "regular"
+  hasLighterTextColor?: boolean
+}
+
+/** MenuItem */
+export const MenuItem: React.FC<MenuItemProps> = ({
+  children,
+  fontSize = "2",
+  href,
+  px = 2,
+  py = 1,
+  textWeight = "medium",
+  textColor,
+  hasLighterTextColor,
+  ...props
+}) => {
+  return (
+    <MenuLink to={href} {...props} hasLighterTextColor={hasLighterTextColor}>
+      <Box px={px} py={py}>
+        <MenuLinkText size={fontSize} weight={textWeight} color={textColor}>
+          {children}
+        </MenuLinkText>
+      </Box>
+    </MenuLink>
+  )
+}
+
+const MenuLink = styled(RouterLink)<{ hasLighterTextColor: boolean }>`
+  cursor: pointer;
+  display: flex;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+
+  ${display};
+
+  &:hover {
+    background-color: ${p =>
+      p.hasLighterTextColor ? color("black10") : color("black5")};
+  }
+
+  ${Sans} {
+    display: flex;
+    align-items: center;
+  }
+`
+const MenuLinkText = styled(Sans)<{ color: string }>`
+  color: ${p => p.color || color("black100")};
+`

--- a/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownMenu.tsx
@@ -1,9 +1,10 @@
-import { Box, Flex, Menu, MenuItem, color } from "@artsy/palette"
+import { Box, Flex, color } from "@artsy/palette"
 import { AnalyticsSchema, ContextModule } from "v2/Artsy"
 import { useTracking } from "v2/Artsy/Analytics/useTracking"
 import React from "react"
 import styled from "styled-components"
 import { DropDownSection } from "./DropDownSection"
+import { Menu, MenuItem } from "v2/Components/Menu"
 
 interface DropDownNavMenuProps {
   width?: string

--- a/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownSection.tsx
+++ b/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownSection.tsx
@@ -1,7 +1,8 @@
-import { Box, MenuItem, Sans, color } from "@artsy/palette"
+import { Box, Sans, color } from "@artsy/palette"
 import { MenuLinkData, SimpleLinkData } from "v2/Components/NavBar/menuData"
 import React from "react"
 import { TwoColumnDropDownSection } from "./TwoColumnDropDownSection"
+import { MenuItem } from "v2/Components/Menu"
 
 interface DropDownSectionProps {
   section: MenuLinkData

--- a/src/v2/Components/NavBar/Menus/DropDownMenu/TwoColumnDropDownSection.tsx
+++ b/src/v2/Components/NavBar/Menus/DropDownMenu/TwoColumnDropDownSection.tsx
@@ -1,6 +1,8 @@
-import { Box, Flex, MenuItem, Sans, color } from "@artsy/palette"
+import { Box, Flex, Sans, color } from "@artsy/palette"
 import { MenuLinkData, SimpleLinkData } from "v2/Components/NavBar/menuData"
 import React from "react"
+
+import { MenuItem } from "v2/Components/Menu"
 
 interface TwoColumnDropDownSectionProps {
   section: MenuLinkData

--- a/src/v2/Components/NavBar/Menus/DropDownMenu/__tests__/DropDownMenu.jest.tsx
+++ b/src/v2/Components/NavBar/Menus/DropDownMenu/__tests__/DropDownMenu.jest.tsx
@@ -1,4 +1,4 @@
-import { MenuItem } from "@artsy/palette"
+import { MenuItem } from "v2/Components/Menu"
 import { ContextModule } from "v2/Artsy"
 import { useTracking } from "v2/Artsy/Analytics/useTracking"
 import { MenuLinkData, menuData } from "v2/Components/NavBar/menuData"

--- a/src/v2/Components/NavBar/Menus/DropDownMenu/__tests__/DropDownSection.jest.tsx
+++ b/src/v2/Components/NavBar/Menus/DropDownMenu/__tests__/DropDownSection.jest.tsx
@@ -1,9 +1,9 @@
-import { MenuItem } from "@artsy/palette"
-import { useTracking } from "v2/Artsy/Analytics/useTracking"
-import { MenuLinkData, menuData } from "v2/Components/NavBar/menuData"
-import { mount } from "enzyme"
 import React from "react"
 import { DropDownSection } from "../DropDownSection"
+import { MenuItem } from "v2/Components/Menu"
+import { MenuLinkData, menuData } from "v2/Components/NavBar/menuData"
+import { mount } from "enzyme"
+import { useTracking } from "v2/Artsy/Analytics/useTracking"
 
 jest.mock("v2/Artsy/Analytics/useTracking")
 

--- a/src/v2/Components/NavBar/Menus/MoreNavMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/MoreNavMenu.tsx
@@ -1,4 +1,4 @@
-import { Menu, MenuItem } from "@artsy/palette"
+import { Menu, MenuItem } from "v2/Components/Menu"
 import { AnalyticsSchema } from "v2/Artsy"
 import { useTracking } from "v2/Artsy/Analytics/useTracking"
 import React from "react"

--- a/src/v2/Components/NavBar/Menus/NotificationsMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/NotificationsMenu.tsx
@@ -16,17 +16,8 @@ import {
   NotificationsMenuQueryResponse,
 } from "v2/__generated__/NotificationsMenuQuery.graphql"
 
-import {
-  Box,
-  Flex,
-  Image,
-  Link,
-  Menu,
-  MenuItem,
-  Sans,
-  Separator,
-  Serif,
-} from "@artsy/palette"
+import { Box, Flex, Image, Link, Sans, Separator, Serif } from "@artsy/palette"
+import { Menu, MenuItem } from "v2/Components/Menu"
 import { SystemQueryRenderer as QueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
 
 export const NotificationMenuItems: React.FC<NotificationsMenuQueryResponse> = props => {

--- a/src/v2/Components/NavBar/Menus/UserMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/UserMenu.tsx
@@ -4,14 +4,14 @@ import {
   Box,
   Flex,
   HeartIcon,
-  Menu,
-  MenuItem,
   PowerIcon,
   Separator,
   SettingsIcon,
   SoloIcon,
   TagIcon,
 } from "@artsy/palette"
+
+import { Menu, MenuItem } from "v2/Components/Menu"
 
 import { AnalyticsSchema, SystemContext } from "v2/Artsy"
 import { useTracking } from "v2/Artsy/Analytics/useTracking"


### PR DESCRIPTION
Now that the new appshell is in we should use `<RouterLink>` where we can for links and a tags. 

While this isn't strictly necessary thanks to our [interceptLinks](https://github.com/artsy/force/blob/master/src/v2/Artsy/Router/interceptLinks.ts) and [catchLinks](https://github.com/artsy/force/blob/master/src/v2/Artsy/Router/Utils/catchLinks.tsx) helpers which will detect `<a>` tag clicks and see if the route exists in the global router, i _did_ notice that in development, after a save / hot reload, catchLinks will no longer transition on route change which is real confusing for dev team. Couldn't figure out why, but found that if we use `RouterLink` (which is more correct anyways) it fixes the problem. 

The areas I fixed aren't exhaustive but are the most common / reused spots. 

I also moved the `<Menu>` component over from palette as its more appropriate in force (not reused anywhere), and needed direct access to its internals to swap in RouterLink. 