### PR TITLE
[MX-292] - Don't show email validation error for 3rd party auth

### DIFF
--- a/src/v2/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/v2/Components/Authentication/Desktop/LoginForm.tsx
@@ -57,16 +57,25 @@ const ConditionalOtpInput: React.FC<ConditionalOtpInputProps> = props => {
 
 export interface LoginFormState {
   error: string
+  isSocialSignUp: boolean
 }
 
 export class LoginForm extends Component<FormProps, LoginFormState> {
   state = {
     error: this.props.error,
+    isSocialSignUp: false,
   }
 
   onSubmit = (values: InputValues, formikBag: FormikProps<InputValues>) => {
     recaptcha("login_submit")
-    this.props.handleSubmit(values, formikBag)
+    this.setState(
+      {
+        isSocialSignUp: false,
+      },
+      () => {
+        this.props.handleSubmit(values, formikBag)
+      }
+    )
   }
 
   render() {
@@ -100,7 +109,9 @@ export class LoginForm extends Component<FormProps, LoginFormState> {
             <Form onSubmit={handleSubmit} data-test="LoginForm">
               <QuickInput
                 block
-                error={touched.email && errors.email}
+                error={
+                  !this.state.isSocialSignUp && touched.email && errors.email
+                }
                 placeholder="Enter your email address"
                 name="email"
                 label="Email"
@@ -136,8 +147,26 @@ export class LoginForm extends Component<FormProps, LoginFormState> {
                   this.props.handleTypeChange(ModalType.signup)
                 }
                 mode={"login" as ModalType}
-                onAppleLogin={this.props.onAppleLogin}
-                onFacebookLogin={this.props.onFacebookLogin}
+                onAppleLogin={e => {
+                  this.setState(
+                    {
+                      isSocialSignUp: true,
+                    },
+                    () => {
+                      this.props.onAppleLogin(e)
+                    }
+                  )
+                }}
+                onFacebookLogin={e => {
+                  this.setState(
+                    {
+                      isSocialSignUp: true,
+                    },
+                    () => {
+                      this.props.onFacebookLogin(e)
+                    }
+                  )
+                }}
                 inline
               />
             </Form>

--- a/src/v2/Components/Authentication/Mobile/LoginForm.tsx
+++ b/src/v2/Components/Authentication/Mobile/LoginForm.tsx
@@ -81,6 +81,7 @@ const OtpInputTrigger: React.FC<OtpInputTriggerProps> = props => {
 interface LoginFormState {
   error: string
   showOtp: boolean
+  isSocialSignUp: boolean
 }
 
 class MobileLoginFormWithSystemContext extends Component<
@@ -91,6 +92,7 @@ class MobileLoginFormWithSystemContext extends Component<
     super(props)
 
     this.state = {
+      isSocialSignUp: false,
       error: props.error,
       showOtp: props.error === "missing two-factor authentication code",
     }
@@ -130,7 +132,7 @@ class MobileLoginFormWithSystemContext extends Component<
       {({ form: { errors, values, handleChange, handleBlur, setTouched } }) => (
         <QuickInput
           block
-          error={errors.email}
+          error={!this.state.isSocialSignUp && errors.email}
           placeholder="Enter your email address"
           name="email"
           label="Email"
@@ -226,7 +228,16 @@ class MobileLoginFormWithSystemContext extends Component<
                   setShowOtp={this.setShowOtp}
                 />
                 <SubmitButton
-                  onClick={handleSubmit}
+                  onClick={e => {
+                    this.setState(
+                      {
+                        isSocialSignUp: false,
+                      },
+                      () => {
+                        handleSubmit(e)
+                      }
+                    )
+                  }}
                   loading={isLastStep && isSubmitting}
                 >
                   {isLastStep ? "Log in" : "Next"}
@@ -234,8 +245,26 @@ class MobileLoginFormWithSystemContext extends Component<
                 <Footer
                   mode={"login" as ModalType}
                   handleTypeChange={this.props.handleTypeChange}
-                  onAppleLogin={this.props.onAppleLogin}
-                  onFacebookLogin={this.props.onFacebookLogin}
+                  onAppleLogin={e => {
+                    this.setState(
+                      {
+                        isSocialSignUp: true,
+                      },
+                      () => {
+                        this.props.onAppleLogin(e)
+                      }
+                    )
+                  }}
+                  onFacebookLogin={e => {
+                    this.setState(
+                      {
+                        isSocialSignUp: true,
+                      },
+                      () => {
+                        this.props.onFacebookLogin(e)
+                      }
+                    )
+                  }}
                 />
               </MobileInnerWrapper>
             </MobileContainer>

--- a/src/v2/Components/Authentication/__tests__/Desktop/LoginForm.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/Desktop/LoginForm.jest.tsx
@@ -14,6 +14,8 @@ describe("LoginForm", () => {
   beforeEach(() => {
     props = {
       handleSubmit: jest.fn(),
+      onFacebookLogin: jest.fn(),
+      onAppleLogin: jest.fn(),
     }
     window.grecaptcha.execute.mockClear()
   })
@@ -139,6 +141,18 @@ describe("LoginForm", () => {
       expect(props.handleSubmit.mock.calls[0][0]).toEqual({
         email: "email@email.com",
         password: "password",
+      })
+    })
+
+    it("does not render email errors for social sign ups", done => {
+      const wrapper = getWrapper()
+      const socialLink = wrapper.find("Link").at(1)
+      socialLink.simulate("click")
+      wrapper.update()
+
+      setTimeout(() => {
+        expect(wrapper.html()).not.toMatch("Please enter a valid email.")
+        done()
       })
     })
 

--- a/src/v2/Components/Authentication/__tests__/Desktop/SignUpForm.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/Desktop/SignUpForm.jest.tsx
@@ -23,6 +23,8 @@ describe("SignUpForm", () => {
   beforeEach(() => {
     props = {
       handleSubmit: jest.fn(),
+      onFacebookLogin: jest.fn(),
+      onAppleLogin: jest.fn(),
     }
     window.grecaptcha.execute.mockClear()
   })
@@ -119,7 +121,6 @@ describe("SignUpForm", () => {
 
   it("calls apple callback on tapping link", done => {
     mockEnableRequestSignInWithApple.mockReturnValue(true)
-    props.onAppleLogin = jest.fn()
     props.values = SignupValues
     const wrapper = getWrapper()
 
@@ -167,6 +168,18 @@ describe("SignUpForm", () => {
 
     setTimeout(() => {
       expect(props.onAppleLogin).not.toBeCalled()
+      done()
+    })
+  })
+
+  it("does not render email errors for social sign ups", done => {
+    const wrapper = getWrapper()
+    const socialLink = wrapper.find("Link").at(1)
+    socialLink.simulate("click")
+    wrapper.update()
+
+    setTimeout(() => {
+      expect(wrapper.html()).not.toMatch("Please enter a valid email.")
       done()
     })
   })

--- a/src/v2/Components/Authentication/__tests__/Mobile/LoginForm.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/Mobile/LoginForm.jest.tsx
@@ -28,6 +28,8 @@ describe("MobileLoginForm", () => {
       values: {},
       handleSubmit: jest.fn(),
       handleTypeChange: jest.fn(),
+      onFacebookLogin: jest.fn(),
+      onAppleLogin: jest.fn(),
     }
     window.grecaptcha.execute.mockClear()
     location.assign = jest.fn()
@@ -52,6 +54,18 @@ describe("MobileLoginForm", () => {
 
     setTimeout(() => {
       expect(wrapper.html()).toMatch("Please enter a valid email.")
+      done()
+    })
+  })
+
+  it("does not render email errors for social sign ups", done => {
+    const wrapper = getWrapper()
+    const socialLink = wrapper.find("Link").at(0)
+    socialLink.simulate("click")
+    wrapper.update()
+
+    setTimeout(() => {
+      expect(wrapper.html()).not.toMatch("Please enter a valid email.")
       done()
     })
   })

--- a/src/v2/Components/Authentication/__tests__/Mobile/SignUpForm.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/Mobile/SignUpForm.jest.tsx
@@ -205,6 +205,18 @@ describe("MobileSignUpForm", () => {
     expect(wrapper.html()).toMatch("some password error")
   })
 
+  it("does not render email errors for social sign ups", done => {
+    const wrapper = getWrapper()
+    const socialLink = wrapper.find("Link").at(0)
+    socialLink.simulate("click")
+    wrapper.update()
+
+    setTimeout(() => {
+      expect(wrapper.html()).not.toMatch("Please enter a valid email.")
+      done()
+    })
+  })
+
   it("renders the default title", () => {
     const wrapper = getWrapper()
     expect(wrapper.text()).toContain("Sign up for Artsy")


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/MX-292

- Don't show email error on social in mobile login
- Don't show email error on social in desktop login
- Add test for email validation errors

**Co-authored with @ds300**

Adds a check that was already present for some login dialogs to prevent showing email validation errors when signing in with a 3rd party. 

**Before**

![before-remove-email-error](https://user-images.githubusercontent.com/49686530/83418907-4dbf0980-a3f2-11ea-93ba-f3ac8573d939.gif)


**After**

![after-remove-email-error](https://user-images.githubusercontent.com/49686530/83418918-50216380-a3f2-11ea-90d4-f9f7fc508199.gif)




Related to this pull request, these dialogs seem to show errors pretty aggressively (onBlur events) so was wondering if it would be better to only show errors on tapping 'Login' 'Sign Up' etc. As it stands you get a validation error when clicking anywhere on screen, including for example the button to close the dialog.