### PR TITLE
Fixes a bug where user sees error message telling them to accept conditions of sale after they've already checked the checkbox

### DIFF
--- a/src/v2/Apps/Auction/Components/BidForm.tsx
+++ b/src/v2/Apps/Auction/Components/BidForm.tsx
@@ -46,11 +46,9 @@ export interface FormValues {
   selectedBid: string
 }
 
-Yup.addMethod(Yup.string, "present", function(message) {
+Yup.addMethod(Yup.string, "present", function (message) {
   return this.test("test-present", message, value => {
-    return this.trim()
-      .required(message)
-      .isValid(value)
+    return this.trim().required(message).isValid(value)
   })
 })
 
@@ -252,35 +250,27 @@ export const BidForm: React.FC<Props> = ({
                   </Box>
                 )}
 
-                <Flex
-                  pb={3}
-                  flexDirection="column"
-                  justifyContent="center"
-                  width="100%"
-                >
+                <Flex mb={3} flexDirection="column" justifyContent="center">
                   {requiresCheckbox && (
                     <>
                       <Separator mb={3} />
 
-                      <Box mx="auto" mb={3}>
+                      <Box mx="auto">
                         <ConditionsOfSaleCheckbox
                           selected={values.agreeToTerms}
                           onSelect={value => {
-                            setFieldValue("agreeToTerms", value)
+                            // `setFieldTouched` needs to be called first otherwise it would cause race condition.
                             setFieldTouched("agreeToTerms")
+                            setFieldValue("agreeToTerms", value)
                           }}
                         />
-                        {touched.agreeToTerms && errors.agreeToTerms && (
-                          <Sans
-                            mt={1}
-                            color="red100"
-                            size="2"
-                            textAlign="center"
-                          >
-                            {errors.agreeToTerms}
-                          </Sans>
-                        )}
                       </Box>
+
+                      {touched.agreeToTerms && errors.agreeToTerms && (
+                        <Sans mt={1} color="red100" size="2" textAlign="center">
+                          {errors.agreeToTerms}
+                        </Sans>
+                      )}
                     </>
                   )}
 
@@ -289,16 +279,16 @@ export const BidForm: React.FC<Props> = ({
                       {status}.
                     </Sans>
                   )}
-
-                  <Button
-                    size="large"
-                    width="100%"
-                    loading={isSubmitting}
-                    {...({ type: "submit" } as any)}
-                  >
-                    Confirm bid
-                  </Button>
                 </Flex>
+
+                <Button
+                  size="large"
+                  width="100%"
+                  loading={isSubmitting}
+                  {...({ type: "submit" } as any)}
+                >
+                  Confirm bid
+                </Button>
               </Flex>
             </Form>
           )

--- a/src/v2/Apps/Auction/Components/RegistrationForm.tsx
+++ b/src/v2/Apps/Auction/Components/RegistrationForm.tsx
@@ -91,8 +91,9 @@ const InnerForm: React.FC<InnerFormProps> = props => {
           <ConditionsOfSaleCheckbox
             selected={values.agreeToTerms}
             onSelect={value => {
-              setFieldValue("agreeToTerms", value)
+              // `setFieldTouched` needs to be called first otherwise it would cause race condition.
               setFieldTouched("agreeToTerms")
+              setFieldValue("agreeToTerms", value)
             }}
           />
         </Box>
@@ -117,11 +118,9 @@ const InnerForm: React.FC<InnerFormProps> = props => {
   )
 }
 
-Yup.addMethod(Yup.string, "present", function(message) {
+Yup.addMethod(Yup.string, "present", function (message) {
   return this.test("test-present", message, value => {
-    return this.trim()
-      .required(message)
-      .isValid(value)
+    return this.trim().required(message).isValid(value)
   })
 })
 


### PR DESCRIPTION
addresses https://artsyproduct.atlassian.net/browse/AUCT-1018

This fixes a bug where user sees error message telling them to accept conditions of sale after they've already checked the checkbox. The root cause of this seems to be a racing condition in `setFieldTouched` and `setFieldValue`, and flipping the function order fixed the issue, but I don't have a definite answer as to why it fixed it or the previous order caused a bug. There might be more places that have a similar bug.

I tried to write a test for this but sadly it didn't fail in test, so just leaving it here as a reference:

```tsx
it("validates against an unchecked conditions of sale checkbox", async () => {
  const env = setupTestEnv()
  const page = await env.buildPage()

  setupCreateTokenMock()
  await page.submitForm()

  expect(page.text()).toMatch("You must agree to the Conditions of Sale")

  page.agreeToTermsInput.props().onSelect(true)
  await page.update()

  expect(page.text()).not.toMatch("You must agree to the Conditions of Sale")
})
```

## Screenshots

### Register

![AUCT-1018-2](https://user-images.githubusercontent.com/386234/83429054-78fd2500-a401-11ea-8df0-0d511451f29a.gif)

### Register and Bid

![AUCT-1018](https://user-images.githubusercontent.com/386234/83429038-74387100-a401-11ea-8f2d-b71946c948c2.gif)
