### PR TITLE
 Conversation not updated correctly when new messages is entered by collector

### DIFF
--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -49,7 +49,6 @@ interface ReplyProps {
 
 export const Reply: React.FC<ReplyProps> = props => {
   const { environment, conversation } = props
-  const [bodyText, setBodyText] = useState("")
   const [buttonDisabled, setButtonDisabled] = useState(true)
   const textArea = useRef()
 
@@ -71,27 +70,27 @@ export const Reply: React.FC<ReplyProps> = props => {
           }}
           placeholder="Type your message"
           ref={textArea}
-          onChange={event => {
-            setBodyText(event.target.value)
-          }}
         />
       </FullWidthFlex>
       <Flex alignItems="flex-end">
         <StyledButton
           disabled={buttonDisabled}
-          onClick={_event =>
-            SendConversationMessage(
+          onClick={_event => {
+            return SendConversationMessage(
               environment,
               conversation,
-              bodyText,
+              // @ts-ignore
+              textArea?.current?.value,
               _response => {
-                setBodyText(null)
+                // @ts-ignore
+                textArea.current.value = ""
+                setButtonDisabled(true)
               },
               _error => {
-                setBodyText(null)
+                // TBD
               }
             )
-          }
+          }}
         >
           Send
         </StyledButton>

--- a/src/v2/Apps/Conversation/Mutation/SendConversationMessage.ts
+++ b/src/v2/Apps/Conversation/Mutation/SendConversationMessage.ts
@@ -24,7 +24,7 @@ export const SendConversationMessage = (
       conversationStore,
       "Messages_messages"
     )
-    ConnectionHandler.insertEdgeAfter(connection, newMessageEdge)
+    ConnectionHandler.insertEdgeBefore(connection, newMessageEdge)
   }
   return commitMutation<SendConversationMessageMutation>(environment, {
     onError,


### PR DESCRIPTION
[PURCHASE-1904]

https://www.notion.so/artsy/Conversation-not-updated-correctly-when-new-messages-is-entered-by-collector-61d0224fe67e4d44bf8c13fe52565a4b

This PR is the result of our mob pairing session. In addition to the message order bug, we fixed an issue where the text area input wasn't clearing properly.

The changes did not make it into force master so this is a new PR to address this

[PURCHASE-1904]: https://artsyproduct.atlassian.net/browse/PURCHASE-1904