### PR TITLE
Fix a bug where user gets unhelpful error message when encountering Stripe error on bid+register form

### DIFF
--- a/src/v2/Apps/Auction/Components/BidForm.tsx
+++ b/src/v2/Apps/Auction/Components/BidForm.tsx
@@ -169,6 +169,7 @@ export const BidForm: React.FC<Props> = ({
           errors,
           isSubmitting,
           isValid,
+          setFieldError,
           setFieldValue,
           setFieldTouched,
           setSubmitting,
@@ -235,6 +236,9 @@ export const BidForm: React.FC<Props> = ({
 
                     <CreditCardInput
                       error={{ message: errors.creditCard } as stripe.Error}
+                      onChange={({ error }) =>
+                        setFieldError("creditCard", error?.message)
+                      }
                     />
 
                     <Box mt={2}>

--- a/src/v2/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/v2/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -160,16 +160,6 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
     })
   }
 
-  const createTokenFromAddress = async (address: stripe.TokenOptions) => {
-    const { error, token } = await stripe.createToken(address)
-
-    if (error) {
-      throw new Error(`Stripe error: ${error.message || error.decline_code}`)
-    } else {
-      return token
-    }
-  }
-
   async function handleSubmit(values: FormValues, actions: BidFormActions) {
     const selectedBid = Number(values.selectedBid)
 
@@ -186,7 +176,14 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
           address_zip: address.postalCode,
         }
 
-        const token = await createTokenFromAddress(stripeAddress)
+        const { error, token } = await stripe.createToken(stripeAddress)
+
+        if (error) {
+          actions.setFieldError("creditCard", error.message)
+          actions.setSubmitting(false)
+          return
+        }
+
         await createCreditCardAndUpdatePhone(
           environment,
           address.phoneNumber,

--- a/src/v2/Apps/Auction/Routes/__tests__/ConfirmBid.jest.tsx
+++ b/src/v2/Apps/Auction/Routes/__tests__/ConfirmBid.jest.tsx
@@ -48,6 +48,7 @@ import { stripeTokenResponse } from "../__fixtures__/Stripe"
 import { ConfirmBidRouteFragmentContainer } from "../ConfirmBid"
 import { ConfirmBidTestPage } from "./Utils/ConfirmBidTestPage"
 import { ValidFormValues } from "./Utils/RegisterTestPage"
+import { CreditCardInput } from "v2/Apps/Order/Components/CreditCardInput"
 
 jest.unmock("react-relay")
 jest.unmock("react-tracking")
@@ -795,13 +796,57 @@ describe("Routes/ConfirmBid", () => {
       expect(window.location.assign).not.toHaveBeenCalled()
     })
 
-    it("displays an error when Stripe returns an error", async () => {
+    it("displays an error as the user types invalid input", async () => {
       const env = setupTestEnv()
       const page = await env.buildPage({
         mockData: FixtureForUnregisteredUserWithoutCreditCard,
       })
 
-      createTokenMock.mockResolvedValue({ error: { message: "Card inlivad" } })
+      page
+        .find(CreditCardInput)
+        .props()
+        .onChange({ error: { message: "Your card number is invalid." } } as any)
+
+      expect(page.text()).toContain("Your card number is invalid.")
+    })
+
+    it("displays an error when the input in the credit card field is invalid", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage({
+        mockData: FixtureForUnregisteredUserWithoutCreditCard,
+      })
+
+      createTokenMock.mockResolvedValue({
+        error: { message: "Your card number is incomplete." },
+      })
+
+      await page.fillFormWithValidValues()
+      await page.agreeToTerms()
+      await page.submitForm()
+
+      expect(window.location.assign).not.toHaveBeenCalled()
+      expect(page.text()).toContain("Your card number is incomplete.")
+
+      expect(mockPostEvent).toHaveBeenCalledTimes(1)
+      expect(mockPostEvent).toBeCalledWith({
+        action_type: AnalyticsSchema.ActionType.ConfirmBidFailed,
+        context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
+        error_messages: ["Your card number is incomplete."],
+        auction_slug: "saleslug",
+        artwork_slug: "artworkslug",
+        bidder_id: null,
+        sale_id: "saleid",
+        user_id: "my-user-id",
+      })
+    })
+
+    it("displays an error when Stripe Element throws an error", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage({
+        mockData: FixtureForUnregisteredUserWithoutCreditCard,
+      })
+
+      createTokenMock.mockRejectedValue(new TypeError("Network request failed"))
 
       await page.fillFormWithValidValues()
       await page.agreeToTerms()
@@ -816,7 +861,7 @@ describe("Routes/ConfirmBid", () => {
       expect(mockPostEvent).toBeCalledWith({
         action_type: AnalyticsSchema.ActionType.ConfirmBidFailed,
         context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
-        error_messages: ["JavaScript error: Stripe error: Card inlivad"],
+        error_messages: ["JavaScript error: Network request failed"],
         auction_slug: "saleslug",
         artwork_slug: "artworkslug",
         bidder_id: null,


### PR DESCRIPTION
addresses https://artsyproduct.atlassian.net/browse/AUCT-857

 1. The `onChange` event was not captured so the display-error-as-you-type feature wasn't working (or was it actually implemented in the first place?)
 2. Client-side stripe validation errors were [converted to Javascript errors](https://github.com/artsy/force/pull/5699/files#diff-202e308e153e715988a1f211d68143beL167) and they weren't displayed to the user properly
 3. On the registration form we weren't handling Javascript errors (e.g. network error)

All of these cases are now covered both in the registration and bid+register forms.

## Screenshot

### Stripe validations

![AUCT-857](https://user-images.githubusercontent.com/386234/83653738-27cc6d00-a58a-11ea-96bd-5bfbbfe195a8.gif)

### General error handling for the registration form

<img width="659" alt="Screen Shot 2020-06-02 at 3 08 12 PM" src="https://user-images.githubusercontent.com/386234/83654928-c4dbd580-a58b-11ea-8065-b965341bbe64.png">
