### PR TITLE
Update datadog path output

### DIFF
--- a/src/lib/datadog.ts
+++ b/src/lib/datadog.ts
@@ -13,16 +13,21 @@ if (process.env.DD_APM_ENABLED) {
     // We want the root spans of MP to be labelled as just `service`
     service: "force",
     headers: ["User-Agent"],
-    // See: https://github.com/DataDog/dd-trace-js/issues/477#issuecomment-470299277
     // @ts-ignore
     hooks: {
+      /**
+       * Because of our wildcard routes in `apps/artsy-v2` we need to
+       * dynamically construct the path for for a given request.
+       * @see https://github.com/DataDog/dd-trace-js/issues/477#issuecomment-470299277
+       *
+       * TODO: Update this logic by parsing our routes via `path-to-regex`.
+       */
       request: (span: Span, req: Request) => {
         if (req.route.path.includes("*")) {
-          span.setTag(
-            "http.route",
-            // Remove query string, fragment and trailing slash
-            url.parse(req.originalUrl).pathname.replace(/\/$/, "")
-          )
+          const pathname = url.parse(req.originalUrl).pathname
+          const pathWithoutParams = pathname?.replace(/\/$/, "") // Remove query string, fragment and trailing slash
+          const rootPath = pathWithoutParams?.split("/")?.[1] ?? "" // eg, /artist
+          span.setTag("http.route", `/${rootPath}`)
         }
       },
     },


### PR DESCRIPTION
This updates our data-dog traces to scope only to the root path segment, like `/artist`. 