### PR TITLE
Fixes an issue where not selecting country on registration form leads to silent error when trying to register and bid

### DIFF
--- a/src/v2/Apps/Auction/Components/BidForm.tsx
+++ b/src/v2/Apps/Auction/Components/BidForm.tsx
@@ -151,7 +151,7 @@ export const BidForm: React.FC<Props> = ({
           agreeToTerms: false,
           address: {
             name: "",
-            country: "",
+            country: "US",
             postalCode: "",
             addressLine1: "",
             addressLine2: "",

--- a/src/v2/Apps/Auction/Routes/__tests__/ConfirmBid.jest.tsx
+++ b/src/v2/Apps/Auction/Routes/__tests__/ConfirmBid.jest.tsx
@@ -709,6 +709,15 @@ describe("Routes/ConfirmBid", () => {
       }
     )
 
+    it("renders a form with a pre-selected country", async () => {
+      const env = setupTestEnv()
+      const page = await env.buildPage({
+        mockData: FixtureForUnregisteredUserWithoutCreditCard,
+      })
+
+      expect(page.find("select").at(1).props().value).toMatch("US")
+    })
+
     it("allows the user to place a bid after agreeing to terms", async () => {
       const env = setupTestEnv()
       const page = await env.buildPage({


### PR DESCRIPTION
addresses https://artsyproduct.atlassian.net/browse/AUCT-1024

This PR updates the bid and register form to have the country field pre-selected with United States.

## Screenshot

![AUCT-1024](https://user-images.githubusercontent.com/386234/83675762-8d7b2200-a5a7-11ea-925e-06436ce30f0b.gif)
