### PR TITLE
use state field for determining if VR is open/closed

### DIFF
--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
     "eslint-config-prettier": "6.11.0",
     "eslint-plugin-graphql": "3.1.1",
     "eslint-plugin-react": "7.19.0",
-    "eslint-plugin-react-hooks": "3.0.0",
+    "eslint-plugin-react-hooks": "^4.0.4",
     "fork-ts-checker-notifier-webpack-plugin": "0.4.0",
     "fork-ts-checker-webpack-plugin": "0.4.10",
     "friendly-errors-webpack-plugin": "1.6.1",

--- a/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
+++ b/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
@@ -28,7 +28,7 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
       <AppContainer maxWidth="100%">
         <ViewingRoomHeader viewingRoom={viewingRoom} />
 
-        {viewingRoom.formattedEndAt === "Closed" ? (
+        {viewingRoom.status === "closed" ? (
           <ViewingRoomClosed viewingRoom={viewingRoom} />
         ) : (
           <>
@@ -53,7 +53,7 @@ export default createFragmentContainer(ViewingRoomApp, {
       ...ViewingRoomMeta_viewingRoom
       ...ViewingRoomHeader_viewingRoom
       ...ViewingRoomClosed_viewingRoom
-      formattedEndAt
+      status
     }
   `,
 })

--- a/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
@@ -171,6 +171,7 @@ const OpenViewingRoomAppFixture: ViewingRoomApp_OpenTest_QueryRawResponse = {
       href: "/partner-demo-gg",
     },
     formattedEndAt: "Closes in about 1 month",
+    status: "live",
   },
 }
 
@@ -185,5 +186,6 @@ const ClosedViewingRoomAppFixture: ViewingRoomApp_ClosedTest_QueryRawResponse = 
       href: "/partner-demo-gg",
     },
     formattedEndAt: "Closed",
+    status: "closed",
   },
 }

--- a/src/v2/__generated__/ViewingRoomApp_ClosedTest_Query.graphql.ts
+++ b/src/v2/__generated__/ViewingRoomApp_ClosedTest_Query.graphql.ts
@@ -20,6 +20,7 @@ export type ViewingRoomApp_ClosedTest_QueryRawResponse = {
             readonly href: string | null;
         }) | null;
         readonly formattedEndAt: string | null;
+        readonly status: string;
     }) | null;
 };
 export type ViewingRoomApp_ClosedTest_Query = {
@@ -43,7 +44,7 @@ fragment ViewingRoomApp_viewingRoom on ViewingRoom {
   ...ViewingRoomMeta_viewingRoom
   ...ViewingRoomHeader_viewingRoom
   ...ViewingRoomClosed_viewingRoom
-  formattedEndAt
+  status
 }
 
 fragment ViewingRoomClosed_viewingRoom on ViewingRoom {
@@ -177,6 +178,13 @@ return {
             "name": "formattedEndAt",
             "args": null,
             "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "status",
+            "args": null,
+            "storageKey": null
           }
         ]
       }
@@ -186,7 +194,7 @@ return {
     "operationKind": "query",
     "name": "ViewingRoomApp_ClosedTest_Query",
     "id": null,
-    "text": "query ViewingRoomApp_ClosedTest_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomClosed_viewingRoom\n  formattedEndAt\n}\n\nfragment ViewingRoomClosed_viewingRoom on ViewingRoom {\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  heroImageURL\n  title\n  partner {\n    name\n    id\n  }\n  formattedEndAt\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n}\n",
+    "text": "query ViewingRoomApp_ClosedTest_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomClosed_viewingRoom\n  status\n}\n\nfragment ViewingRoomClosed_viewingRoom on ViewingRoom {\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  heroImageURL\n  title\n  partner {\n    name\n    id\n  }\n  formattedEndAt\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n}\n",
     "metadata": {}
   }
 };

--- a/src/v2/__generated__/ViewingRoomApp_OpenTest_Query.graphql.ts
+++ b/src/v2/__generated__/ViewingRoomApp_OpenTest_Query.graphql.ts
@@ -20,6 +20,7 @@ export type ViewingRoomApp_OpenTest_QueryRawResponse = {
             readonly href: string | null;
         }) | null;
         readonly formattedEndAt: string | null;
+        readonly status: string;
     }) | null;
 };
 export type ViewingRoomApp_OpenTest_Query = {
@@ -43,7 +44,7 @@ fragment ViewingRoomApp_viewingRoom on ViewingRoom {
   ...ViewingRoomMeta_viewingRoom
   ...ViewingRoomHeader_viewingRoom
   ...ViewingRoomClosed_viewingRoom
-  formattedEndAt
+  status
 }
 
 fragment ViewingRoomClosed_viewingRoom on ViewingRoom {
@@ -177,6 +178,13 @@ return {
             "name": "formattedEndAt",
             "args": null,
             "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "status",
+            "args": null,
+            "storageKey": null
           }
         ]
       }
@@ -186,7 +194,7 @@ return {
     "operationKind": "query",
     "name": "ViewingRoomApp_OpenTest_Query",
     "id": null,
-    "text": "query ViewingRoomApp_OpenTest_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomClosed_viewingRoom\n  formattedEndAt\n}\n\nfragment ViewingRoomClosed_viewingRoom on ViewingRoom {\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  heroImageURL\n  title\n  partner {\n    name\n    id\n  }\n  formattedEndAt\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n}\n",
+    "text": "query ViewingRoomApp_OpenTest_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomClosed_viewingRoom\n  status\n}\n\nfragment ViewingRoomClosed_viewingRoom on ViewingRoom {\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  heroImageURL\n  title\n  partner {\n    name\n    id\n  }\n  formattedEndAt\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n}\n",
     "metadata": {}
   }
 };

--- a/src/v2/__generated__/ViewingRoomApp_viewingRoom.graphql.ts
+++ b/src/v2/__generated__/ViewingRoomApp_viewingRoom.graphql.ts
@@ -3,7 +3,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ViewingRoomApp_viewingRoom = {
-    readonly formattedEndAt: string | null;
+    readonly status: string;
     readonly " $fragmentRefs": FragmentRefs<"ViewingRoomMeta_viewingRoom" | "ViewingRoomHeader_viewingRoom" | "ViewingRoomClosed_viewingRoom">;
     readonly " $refType": "ViewingRoomApp_viewingRoom";
 };
@@ -25,7 +25,7 @@ const node: ReaderFragment = {
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "formattedEndAt",
+      "name": "status",
       "args": null,
       "storageKey": null
     },
@@ -46,5 +46,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = 'c3b6c8102fe6a5d190c45fbaadf14faa';
+(node as any).hash = '6881a238219da84b5907fbe6560578c2';
 export default node;

--- a/src/v2/__generated__/routes_ViewingRoomQuery.graphql.ts
+++ b/src/v2/__generated__/routes_ViewingRoomQuery.graphql.ts
@@ -30,7 +30,7 @@ fragment ViewingRoomApp_viewingRoom on ViewingRoom {
   ...ViewingRoomMeta_viewingRoom
   ...ViewingRoomHeader_viewingRoom
   ...ViewingRoomClosed_viewingRoom
-  formattedEndAt
+  status
 }
 
 fragment ViewingRoomClosed_viewingRoom on ViewingRoom {
@@ -164,6 +164,13 @@ return {
             "name": "formattedEndAt",
             "args": null,
             "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "status",
+            "args": null,
+            "storageKey": null
           }
         ]
       }
@@ -173,7 +180,7 @@ return {
     "operationKind": "query",
     "name": "routes_ViewingRoomQuery",
     "id": null,
-    "text": "query routes_ViewingRoomQuery(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomClosed_viewingRoom\n  formattedEndAt\n}\n\nfragment ViewingRoomClosed_viewingRoom on ViewingRoom {\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  heroImageURL\n  title\n  partner {\n    name\n    id\n  }\n  formattedEndAt\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n}\n",
+    "text": "query routes_ViewingRoomQuery(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomClosed_viewingRoom\n  status\n}\n\nfragment ViewingRoomClosed_viewingRoom on ViewingRoom {\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  heroImageURL\n  title\n  partner {\n    name\n    id\n  }\n  formattedEndAt\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n}\n",
     "metadata": {}
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9371,10 +9371,10 @@ eslint-plugin-promise@~3.4.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.4.2.tgz#1be2793eafe2d18b5b123b8136c269f804fe7122"
   integrity sha1-G+J5Pq/i0YtbEjuBNsJp+AT+cSI=
 
-eslint-plugin-react-hooks@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-3.0.0.tgz#9e80c71846eb68dd29c3b21d832728aa66e5bd35"
-  integrity sha512-EjxTHxjLKIBWFgDJdhKKzLh5q+vjTFrqNZX36uIxWS4OfyXe5DawqPj3U5qeJ1ngLwatjzQnmR0Lz0J0YH3kxw==
+eslint-plugin-react-hooks@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.4.tgz#aed33b4254a41b045818cacb047b81e6df27fa58"
+  integrity sha512-equAdEIsUETLFNCmmCkiCGq6rkSK5MoJhXFPFYeUebcjKgBmWWcgVOqZyQC8Bv1BwVCnTq9tBxgJFgAJTWoJtA==
 
 eslint-plugin-react@7.19.0:
   version "7.19.0"


### PR DESCRIPTION
This surfaced the fact that we really need to limit access to `Unpublished` VRs. Now all the drafts are visible and we do not have a separate state for either fraft/scheduled. But I think this is still a proper way to go about Closed ones.