### PR TITLE
Make path lookup safer

### DIFF
--- a/src/lib/datadog.ts
+++ b/src/lib/datadog.ts
@@ -23,7 +23,7 @@ if (process.env.DD_APM_ENABLED) {
        * TODO: Update this logic by parsing our routes via `path-to-regex`.
        */
       request: (span: Span, req: Request) => {
-        if (req.route.path.includes("*")) {
+        if (req?.route?.path?.includes("*")) {
           const pathname = url.parse(req.originalUrl).pathname
           const pathWithoutParams = pathname?.replace(/\/$/, "") // Remove query string, fragment and trailing slash
           const rootPath = pathWithoutParams?.split("/")?.[1] ?? "" // eg, /artist


### PR DESCRIPTION
There was a strange failure on deploy, so this makes path lookup a bit safer. 

See convo here: https://artsy.slack.com/archives/C02BC3HEJ/p1591231783023200?thread_ts=1591197201.008300&cid=C02BC3HEJ

