### PR TITLE
Remove outdated buying links from footer

### DIFF
--- a/src/desktop/components/main_layout/footer/upper.jade
+++ b/src/desktop/components/main_layout/footer/upper.jade
@@ -1,8 +1,6 @@
 .mlf-upper: .main-layout-container
   .mlf-upper-column
     h4 Collecting
-    a.mlf-collector-faq( href='/#' ) Buying from Galleries FAQ
-    a.mlf-auction-faq( href='/#' ) Buying from Auctions FAQ
     a( href='https://support.artsy.net/hc/en-us/categories/360003689513-Buy' ) Buying on Artsy
     a( href='/consign' ) Consign with Artsy
   .mlf-upper-column

--- a/src/desktop/components/main_layout/footer/view.coffee
+++ b/src/desktop/components/main_layout/footer/view.coffee
@@ -1,7 +1,6 @@
 _ = require 'underscore'
 Backbone = require 'backbone'
 mediator = require '../../../lib/mediator.coffee'
-openMultiPageModal = require '../../multi_page_modal/index.coffee'
 { openAuthModal } = require '../../../lib/openAuthModal'
 { ModalType } = require "../../../../v2/Components/Authentication/Types"
 { setupRail, shouldShowRVARail, reInitRVARail } = require '../../recently_viewed_artworks/index.coffee'
@@ -10,16 +9,12 @@ openMultiPageModal = require '../../multi_page_modal/index.coffee'
 module.exports = class FooterView extends Backbone.View
   events:
     'click .mlf-specialist': 'openSpecialist'
-    'click .mlf-collector-faq': 'openCollectorModal'
-    'click .mlf-auction-faq': 'openAuctionModal'
     'click .mlf-login': 'login'
     'click .mlf-signup': 'signup'
 
   initialize: ->
     @listenTo mediator, 'infinite:scroll:start', @hide
     @listenTo mediator, 'infinite:scroll:end', @show
-    @listenTo mediator, 'openCollectorFAQModal', @openCollectorModal
-    @listenTo mediator, 'openAuctionFAQModal', @openAuctionModal
     @$recentlyViewedArtworks = $('#recently-viewed-artworks')
     if shouldShowRVARail() && @$recentlyViewedArtworks.length > 0
       setupRail @$recentlyViewedArtworks
@@ -31,14 +26,6 @@ module.exports = class FooterView extends Backbone.View
   show: ->
     @$el.show()
     reInitRVARail(@$recentlyViewedArtworks) if shouldShowRVARail() && @$recentlyViewedArtworks.length > 0
-
-  openCollectorModal: (e) ->
-    e?.preventDefault()
-    openMultiPageModal 'collector-faqs'
-
-  openAuctionModal: (e) ->
-    e?.preventDefault()
-    openMultiPageModal 'auction-faqs'
 
   signup: (e) ->
     e.preventDefault()

--- a/src/v2/Components/Footer.tsx
+++ b/src/v2/Components/Footer.tsx
@@ -60,14 +60,6 @@ const FooterContainer: React.SFC<FlexDirectionProps & Props> = props => {
             Buy
           </Sans>
           <Serif size="2">
-            <Link
-              onClick={() => props.mediator.trigger("openCollectorFAQModal")}
-            >
-              Buying from Galleries FAQ
-            </Link>
-            <Link onClick={() => props.mediator.trigger("openAuctionFAQModal")}>
-              Buying from Auctions FAQ
-            </Link>
             <Link href="https://support.artsy.net/hc/en-us/categories/360003689513-Buy">
               Buying on Artsy
             </Link>


### PR DESCRIPTION
Ooops-- missed this from the ticket!

Removes the outdated `Buying from Galleries FAQ` and `Buying from Auctions FAQ` links from the footer.

Old:
![image](https://user-images.githubusercontent.com/2081340/83791982-75b7a280-a668-11ea-84eb-8ce728708a4e.png)
![image](https://user-images.githubusercontent.com/2081340/83792016-80723780-a668-11ea-9d8a-a5ca44d086ce.png)

New:
![image](https://user-images.githubusercontent.com/2081340/83792035-8536eb80-a668-11ea-8b23-f29b1e16a061.png)
![image](https://user-images.githubusercontent.com/2081340/83792042-8831dc00-a668-11ea-841d-c92beab498b0.png)
