### PR TITLE
Fix hosthame in bundle lookup

### DIFF
--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -10,7 +10,7 @@ if (process.env.NODE_ENV === "production") {
   let cdnUrl
 
   // Production
-  if (hostname === "www.artsy.net") {
+  if (hostname === "artsy.net" || hostname === "www.artsy.net") {
     cdnUrl = "https://d1s2w0upia4e9w.cloudfront.net"
 
     // Localhost


### PR DESCRIPTION
Looking at DD stats: https://app.datadoghq.com/apm/resource/force/express.request/10c6b04c37bfce28?end=1591295052881&env=production&event=AQAAAXKAc2KIz_Fj6gAAAABBWEtBYzJpODVTSWtsUGtCNEN0ag&index=apm-search&paused=false&spanID=7154884793715102852&start=1591291452881&traceID=7154884793715102852

It seems like somehow folks are able to access artsy via `artsy.net`, without the www, even though we have https://github.com/artsy/artsy-wwwify. 

This makes things a bit safer by checking for a bare hostname. 