### PR TITLE
[PURCHASE-1905] Conversation detail animation

### DIFF
--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -5,13 +5,14 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { Details_conversation } from "v2/__generated__/Details_conversation.graphql"
 import { Media } from "v2/Utils/Responsive"
 
-export const DETAIL_BOX_ANIMATION = `transition: width 0.2s ease-in-out;`
-const DETAIL_BOX_XS_ANIMATION = `transition: opacity 0.3s ease-in-out;`
+export const DETAIL_BOX_ANIMATION = `transition: width 0.3s ;`
+const DETAIL_BOX_XS_ANIMATION = `transition: opacity 0.3s;`
 
 const DetailsContainer = styled(Flex)<{ opacity?: 0 | 1 }>`
   border-left: 1px solid ${color("black10")};
   flex-shrink: 0;
   ${DETAIL_BOX_ANIMATION}
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   background-color: ${color("white100")};
 `
 // XS screen has opacity animation instead of width

--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -1,33 +1,64 @@
-import { EntityHeader, Flex, FlexProps, Separator, color } from "@artsy/palette"
+import {
+  EntityHeader,
+  Flex,
+  FlexProps,
+  Separator,
+  color,
+  media,
+} from "@artsy/palette"
 import React, { FC } from "react"
 import styled from "styled-components"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Details_conversation } from "v2/__generated__/Details_conversation.graphql"
-import { Media } from "v2/Utils/Responsive"
 
-export const DETAIL_BOX_ANIMATION = `transition: width 0.3s ;`
-const DETAIL_BOX_XS_ANIMATION = `transition: opacity 0.3s;`
+export const DETAIL_BOX_ANIMATION = `transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1);`
+const DETAIL_BOX_XS_ANIMATION = `transition: opacity 0.3s, z-index 0.3s;`
+const DETAIL_BOX_MD_ANIMATION = `transition: transform 0.3s;`
 
-const DetailsContainer = styled(Flex)<{ opacity?: 0 | 1 }>`
+// in XS screens transition is animated with `opacity`. z-index: -1 is also needed when showDetail is false
+// in XL screen it is animated with `width` because animation needs to push the mid column content
+// in S/M/L screens it is animated with `translate` for better performance (than `width`)
+const DetailsContainer = styled(Flex)<{ opacity?: 0 | 1; transform?: string }>`
   border-left: 1px solid ${color("black10")};
-  flex-shrink: 0;
-  ${DETAIL_BOX_ANIMATION}
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   background-color: ${color("white100")};
+  transform: none;
+  ${DETAIL_BOX_ANIMATION}
+  ${media.xl`
+    transform: ${({ transform }) => transform};
+    ${DETAIL_BOX_MD_ANIMATION}
+    z-index: 0;
+  `}
+  ${media.xs`
+    ${DETAIL_BOX_XS_ANIMATION}
+    transform: none;
+    opacity: ${({ opacity }) => opacity};
+    top: 114px;
+  `}
 `
-// XS screen has opacity animation instead of width
-const XSDetailsContainer = styled(DetailsContainer)`
-  ${DETAIL_BOX_XS_ANIMATION}
-  opacity: ${({ opacity }) => opacity};
-`
+
 interface DetailsProps extends FlexProps {
   conversation: Details_conversation
   showDetails: boolean
 }
 
 export const Details: FC<DetailsProps> = ({ conversation, ...props }) => {
-  const content = (
-    <>
+  return (
+    <DetailsContainer
+      flexDirection="column"
+      justifyContent="flex-start"
+      height="100%"
+      flexShrink={0}
+      position={["absolute", "absolute", "absolute", "absolute", "static"]}
+      right={[0, 0, 0, 0, "auto"]}
+      width={
+        props.showDetails ? "376px" : ["376px", "376px", "376px", "376px", "0"]
+      }
+      opacity={props.showDetails ? 1 : 0}
+      transform={props.showDetails ? "translateX(0)" : "translateX(376px)"}
+      zIndex={props.showDetails ? 1 : -1}
+      {...props}
+    >
       <EntityHeader
         px={2}
         py={1}
@@ -35,43 +66,7 @@ export const Details: FC<DetailsProps> = ({ conversation, ...props }) => {
         initials={conversation.to.initials}
       />
       <Separator />
-    </>
-  )
-
-  return (
-    <>
-      <Media greaterThan="xs">
-        <DetailsContainer
-          flexDirection="column"
-          justifyContent="flex-start"
-          flexShrink={0}
-          height="100%"
-          position={["absolute", "absolute", "absolute", "absolute", "static"]}
-          right={[0, 0, 0, 0, "auto"]}
-          width={props.showDetails ? "376px" : "0"}
-          {...props}
-        >
-          {content}
-        </DetailsContainer>
-      </Media>
-      <Media at="xs">
-        <XSDetailsContainer
-          flexDirection="column"
-          justifyContent="flex-start"
-          flexShrink={0}
-          height="100%"
-          position="absolute"
-          right={0}
-          top="114px" /* FIXME: why this is needed? */
-          width="376px"
-          opacity={props.showDetails ? 1 : 0}
-          zIndex={props.showDetails ? 1 : -1}
-          {...props}
-        >
-          {content}
-        </XSDetailsContainer>
-      </Media>
-    </>
+    </DetailsContainer>
   )
 }
 

--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -4,10 +4,15 @@ import styled from "styled-components"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Details_conversation } from "v2/__generated__/Details_conversation.graphql"
 
+export const DETAIL_BOX_ANIMATION = `transition: width 0.2s ease-in-out;`
+
 const BorderedFlex = styled(Flex)`
   border-left: 1px solid ${color("black10")};
   flex-shrink: 0;
   margin-left: -1px;
+  ${DETAIL_BOX_ANIMATION}
+  height: 100%;
+  background-color: ${color("white100")};
 `
 
 interface DetailsProps extends FlexProps {
@@ -20,6 +25,8 @@ export const Details: FC<DetailsProps> = ({ conversation, ...props }) => {
       flexDirection="column"
       justifyContent="flex-start"
       flexShrink={0}
+      position={["absolute", "absolute", "absolute", "absolute", "static"]}
+      right={[0, 0, 0, 0, "auto"]}
       {...props}
     >
       <EntityHeader

--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -3,32 +3,30 @@ import React, { FC } from "react"
 import styled from "styled-components"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Details_conversation } from "v2/__generated__/Details_conversation.graphql"
+import { Media } from "v2/Utils/Responsive"
 
 export const DETAIL_BOX_ANIMATION = `transition: width 0.2s ease-in-out;`
+const DETAIL_BOX_XS_ANIMATION = `transition: opacity 0.3s ease-in-out;`
 
-const BorderedFlex = styled(Flex)`
+const DetailsContainer = styled(Flex)<{ opacity?: 0 | 1 }>`
   border-left: 1px solid ${color("black10")};
   flex-shrink: 0;
-  margin-left: -1px;
   ${DETAIL_BOX_ANIMATION}
-  height: 100%;
   background-color: ${color("white100")};
 `
-
+// XS screen has opacity animation instead of width
+const XSDetailsContainer = styled(DetailsContainer)`
+  ${DETAIL_BOX_XS_ANIMATION}
+  opacity: ${({ opacity }) => opacity};
+`
 interface DetailsProps extends FlexProps {
   conversation: Details_conversation
+  showDetails: boolean
 }
 
 export const Details: FC<DetailsProps> = ({ conversation, ...props }) => {
-  return (
-    <BorderedFlex
-      flexDirection="column"
-      justifyContent="flex-start"
-      flexShrink={0}
-      position={["absolute", "absolute", "absolute", "absolute", "static"]}
-      right={[0, 0, 0, 0, "auto"]}
-      {...props}
-    >
+  const content = (
+    <>
       <EntityHeader
         px={2}
         py={1}
@@ -36,7 +34,42 @@ export const Details: FC<DetailsProps> = ({ conversation, ...props }) => {
         initials={conversation.to.initials}
       />
       <Separator />
-    </BorderedFlex>
+    </>
+  )
+
+  return (
+    <>
+      <Media greaterThan="xs">
+        <DetailsContainer
+          flexDirection="column"
+          justifyContent="flex-start"
+          flexShrink={0}
+          height="100%"
+          position={["absolute", "absolute", "absolute", "absolute", "static"]}
+          right={[0, 0, 0, 0, "auto"]}
+          width={props.showDetails ? "376px" : "0"}
+          {...props}
+        >
+          {content}
+        </DetailsContainer>
+      </Media>
+      <Media at="xs">
+        <XSDetailsContainer
+          flexDirection="column"
+          justifyContent="flex-start"
+          flexShrink={0}
+          height="100%"
+          position="absolute"
+          right={0}
+          top="114px" /* FIXME: why this is needed? */
+          width="376px"
+          opacity={props.showDetails ? 1 : 0}
+          {...props}
+        >
+          {content}
+        </XSDetailsContainer>
+      </Media>
+    </>
   )
 }
 

--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -65,6 +65,7 @@ export const Details: FC<DetailsProps> = ({ conversation, ...props }) => {
           top="114px" /* FIXME: why this is needed? */
           width="376px"
           opacity={props.showDetails ? 1 : 0}
+          zIndex={props.showDetails ? 1 : -1}
           {...props}
         >
           {content}

--- a/src/v2/Apps/Conversation/Components/InboxHeaders.tsx
+++ b/src/v2/Apps/Conversation/Components/InboxHeaders.tsx
@@ -6,7 +6,6 @@ import {
   Flex,
   FlexProps,
   Icon,
-  InfoCircleIcon,
   Path,
   Sans,
   Separator,
@@ -44,6 +43,8 @@ interface ConversationHeaderProps extends DetailsProps {
 }
 export const ConversationHeader: FC<ConversationHeaderProps> = ({
   partnerName,
+  showDetails,
+  setShowDetails,
 }) => {
   return (
     <ConversationHeaderContainer
@@ -59,7 +60,7 @@ export const ConversationHeader: FC<ConversationHeaderProps> = ({
       <Sans size="3t" weight="medium">
         Conversation with {partnerName}
       </Sans>
-      <InfoCircleIcon />
+      <DetailIcon showDetails={showDetails} setShowDetails={setShowDetails} />
     </ConversationHeaderContainer>
   )
 }
@@ -181,4 +182,5 @@ const DetailIcon: React.FC<DetailsProps> = props => {
 
 const StatefulIcon = styled(Icon)<{ active?: boolean }>`
   background-color: ${({ active }) => (active ? color("black30") : "")};
+  cursor: pointer;
 `

--- a/src/v2/Apps/Conversation/Components/InboxHeaders.tsx
+++ b/src/v2/Apps/Conversation/Components/InboxHeaders.tsx
@@ -2,15 +2,20 @@ import React, { FC } from "react"
 import styled from "styled-components"
 import {
   ArrowLeftIcon,
+  Box,
   Flex,
   FlexProps,
+  Icon,
   InfoCircleIcon,
+  Path,
   Sans,
   Separator,
+  Title,
   color,
 } from "@artsy/palette"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import { Media } from "v2/Utils/Responsive"
+import { DETAIL_BOX_ANIMATION } from "./Details"
 
 interface BorderedFlexProps extends FlexProps {
   bordered?: boolean
@@ -30,7 +35,11 @@ const ConversationHeaderContainer = styled(Flex)`
   background: white;
 `
 
-interface ConversationHeaderProps {
+interface DetailsProps {
+  showDetails: boolean
+  setShowDetails: (boolean) => void
+}
+interface ConversationHeaderProps extends DetailsProps {
   partnerName: string
 }
 export const ConversationHeader: FC<ConversationHeaderProps> = ({
@@ -55,7 +64,9 @@ export const ConversationHeader: FC<ConversationHeaderProps> = ({
   )
 }
 
-export const MobileInboxHeader: FC<FlexProps> = props => {
+interface MobileInboxHeaderProps extends FlexProps, DetailsProps {}
+
+export const MobileInboxHeader: FC<Partial<MobileInboxHeaderProps>> = props => {
   return (
     <Flex
       justifyContent="flex-end"
@@ -82,14 +93,27 @@ export const InboxHeader: FC<BorderedFlexProps> = props => {
   )
 }
 
-export const DetailsHeader: FC<BorderedFlexProps> = props => {
+interface DetailsHeaderProps extends BorderedFlexProps {
+  showDetails: boolean
+}
+
+const AnimatedFlex = styled(Flex)`
+  ${DETAIL_BOX_ANIMATION}
+`
+
+export const DetailsHeader: FC<DetailsHeaderProps> = props => {
+  const { showDetails } = props
   return (
-    <Flex flexDirection="column" {...props}>
+    <AnimatedFlex
+      flexDirection="column"
+      width={showDetails ? "375px" : "0"}
+      {...props}
+    >
       <Sans size="4" ml={2}>
         Details
       </Sans>
       <Separator mt={1} />
-    </Flex>
+    </AnimatedFlex>
   )
 }
 
@@ -108,20 +132,53 @@ export const FullHeader: FC<Partial<ConversationHeaderProps>> = props => {
         width="100%"
         justifyContent="flex-end"
       >
-        {props.partnerName ? (
-          <Sans size="4" ml={2}>
-            Conversation with {props.partnerName}
-          </Sans>
-        ) : (
-          <>{props.children}</>
-        )}
+        <Flex justifyContent="space-between">
+          <Box>
+            {props.partnerName ? (
+              <Sans size="4" ml={2}>
+                Conversation with {props.partnerName}
+              </Sans>
+            ) : (
+              <>{props.children}</>
+            )}
+          </Box>
+          <DetailIcon
+            showDetails={props.showDetails}
+            setShowDetails={props.setShowDetails}
+          />
+        </Flex>
         <Separator mt={1} />
       </BorderedFlex>
       <Flex flexShrink={0} height="100%" alignItems="flex-end">
         <Media greaterThan="lg">
-          <DetailsHeader width="375px" />
+          <DetailsHeader showDetails={props.showDetails} />
         </Media>
       </Flex>
     </Flex>
   )
 }
+
+const DetailIcon: React.FC<DetailsProps> = props => {
+  const { showDetails, setShowDetails } = props
+  return (
+    <StatefulIcon
+      viewBox="0 0 28 28"
+      mr={1}
+      onClick={() => {
+        setShowDetails(!showDetails)
+      }}
+      active={showDetails}
+    >
+      <Title>Show details</Title>
+      <Path
+        d="M6.5 21.5V6.5H16L16 21.5H6.5ZM17.5 21.5H21.5V6.5H17.5L17.5 21.5ZM5 5.5C5 5.22386 5.22386 5 5.5 5H22.5C22.7761 5 23 5.22386 23 5.5V22.5C23 22.7761 22.7761 23 22.5 23H5.5C5.22386 23 5 22.7761 5 22.5V5.5Z"
+        fill={color("black100")}
+        fillRule="evenodd"
+      />
+    </StatefulIcon>
+  )
+}
+
+const StatefulIcon = styled(Icon)<{ active?: boolean }>`
+  background-color: ${({ active }) => (active ? color("black30") : "")};
+`

--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -53,7 +53,7 @@ export const Reply: React.FC<ReplyProps> = props => {
   const textArea = useRef()
 
   return (
-    <StyledFlex p={1} right={[0, null, null, null, null]}>
+    <StyledFlex p={1} right={[0, null]}>
       <FullWidthFlex width="100%">
         <StyledTextArea
           onInput={event => {

--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -53,7 +53,7 @@ export const Reply: React.FC<ReplyProps> = props => {
   const textArea = useRef()
 
   return (
-    <StyledFlex p={1} right={[0, null, null, null, "376px"]}>
+    <StyledFlex p={1} right={[0, null, null, null, null]}>
       <FullWidthFlex width="100%">
         <StyledTextArea
           onInput={event => {

--- a/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
@@ -7,7 +7,7 @@ import { SystemContext } from "v2/Artsy"
 import { findCurrentRoute } from "v2/Artsy/Router/Utils/findCurrentRoute"
 import { ErrorPage } from "v2/Components/ErrorPage"
 import { Match } from "found"
-import React, { useContext } from "react"
+import React, { useContext, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { userHasLabFeature } from "v2/Utils/user"
 import { Media } from "v2/Utils/Responsive"
@@ -42,6 +42,7 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
   const { me } = props
   const { user } = useContext(SystemContext)
   const isEnabled = userHasLabFeature(user, "User Conversations View")
+  const [showDetails, setShowDetails] = useState(false) // TODO based on screen size
 
   if (isEnabled) {
     const route = findCurrentRoute(props.match)
@@ -56,11 +57,19 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
 
         <Media at="xs">
           {/* @ts-ignore */}
-          <ConversationHeader partnerName={me.conversation.to.name} />
+          <ConversationHeader
+            showDetails={showDetails}
+            setShowDetails={setShowDetails}
+            partnerName={me.conversation.to.name}
+          />
         </Media>
         <Media greaterThan="xs">
           {/* @ts-ignore */}
-          <FullHeader partnerName={me.conversation.to.name} />
+          <FullHeader
+            showDetails={showDetails}
+            setShowDetails={setShowDetails}
+            partnerName={me.conversation.to.name}
+          />
         </Media>
         <ConstrainedHeightFlex>
           <Media greaterThan="xs">
@@ -74,8 +83,8 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
           <Details
             // @ts-ignore
             conversation={me.conversation as any /** FIXME: Correct type */}
-            display={["none", null, null, null, "flex"]}
-            width={["100%", "376px"]}
+            display="flex"
+            width={showDetails ? "376px" : "0"}
           />
         </ConstrainedHeightFlex>
       </AppContainer>

--- a/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
@@ -73,11 +73,7 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
             />
           </Media>
           <Conversation conversation={me.conversation} />
-          <Details
-            conversation={me.conversation}
-            display="flex"
-            showDetails={showDetails}
-          />
+          <Details conversation={me.conversation} showDetails={showDetails} />
         </ConstrainedHeightFlex>
       </AppContainer>
     )

--- a/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
@@ -34,10 +34,6 @@ const ConstrainedHeightFlex = styled(Flex)`
   }
 `
 
-/**
- * FIXME: Added some @ts-ignores to get TypeScript 3.9 updated
- */
-
 export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
   const { me } = props
   const { user } = useContext(SystemContext)
@@ -56,7 +52,6 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
         <Title>Inbox | Artsy</Title>
 
         <Media at="xs">
-          {/* @ts-ignore */}
           <ConversationHeader
             showDetails={showDetails}
             setShowDetails={setShowDetails}
@@ -64,7 +59,6 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
           />
         </Media>
         <Media greaterThan="xs">
-          {/* @ts-ignore */}
           <FullHeader
             showDetails={showDetails}
             setShowDetails={setShowDetails}
@@ -78,13 +72,11 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
               selectedConversationID={me.conversation.internalID}
             />
           </Media>
-          {/* @ts-ignore */}
           <Conversation conversation={me.conversation} />
           <Details
-            // @ts-ignore
-            conversation={me.conversation as any /** FIXME: Correct type */}
+            conversation={me.conversation}
             display="flex"
-            width={showDetails ? "376px" : "0"}
+            showDetails={showDetails}
           />
         </ConstrainedHeightFlex>
       </AppContainer>


### PR DESCRIPTION
Fixes [PURCHASE-1905](https://artsyproduct.atlassian.net/browse/PURCHASE-1905)

[A mini tour of the PR](https://github.com/artsy/force/pull/5735/files#r436007460)

There are 3 types of animation:
* **xs:** detail box fades in
* **xl:** detail box slides in while pushing the middle box content left
* **s/m/l:** detail box slides over middle box
 
[Designs](https://www.figma.com/proto/vtXzdPefblvRiAapA79fTh/Conversations-Inbox?node-id=1189%3A27405&viewport=1502%2C507%2C0.3293892741203308&scaling=scale-down)

**xs**

![xs-conv-detail](https://user-images.githubusercontent.com/687513/83817022-5aa95a80-a689-11ea-8208-695733f155b6.gif)

**md**

![md-conv-detail](https://user-images.githubusercontent.com/687513/83817030-5f6e0e80-a689-11ea-8d9b-3abbb3ab67ec.gif)

**lg**

![xl-conv-detail-2](https://user-images.githubusercontent.com/687513/83817694-099a6600-a68b-11ea-9836-71e437fd38f8.gif)
