### PR TITLE
Instrument Datadog Redis Tracing

### DIFF
--- a/src/lib/datadog.ts
+++ b/src/lib/datadog.ts
@@ -33,6 +33,9 @@ if (process.env.DD_APM_ENABLED) {
     },
   })
   ddTracer.use("http", {
-    service: `force.http-client`,
+    service: "force.http-client",
+  })
+  ddTracer.use("redis", {
+    service: "force.redis",
   })
 }


### PR DESCRIPTION
Enable tracing for redis now that we are caching data to it.