### PR TITLE
Fix Auction and Collector FAQ mediator hooks

### DIFF
--- a/src/desktop/apps/artsy-v2/apps/artwork/artworkClient.tsx
+++ b/src/desktop/apps/artsy-v2/apps/artwork/artworkClient.tsx
@@ -9,6 +9,8 @@ export const artworkClient = () => {
   const openInquiryQuestionnaireFor = require("desktop/components/inquiry_questionnaire/index.coffee")
   const openAuctionBuyerPremium = require("desktop/components/artworkBuyersPremium/index.coffee")
   const ViewInRoomView = require("desktop/components/view_in_room/view.coffee")
+  const openMultiPageModal = require("desktop/components/multi_page_modal/index.coffee")
+
   const $ = require("jquery")
   const mediator = require("desktop/lib/mediator.coffee")
   const pageType = window.location.pathname.split("/")[1]
@@ -59,6 +61,14 @@ export const artworkClient = () => {
       { ask_specialist: true },
       { is_in_auction: true }
     )
+  })
+
+  mediator.on("openCollectorFAQModal", () => {
+    openMultiPageModal("collector-faqs")
+  })
+
+  mediator.on("openAuctionFAQModal", () => {
+    openMultiPageModal("auction-faqs")
   })
 
   mediator.on("openViewInRoom", options => {

--- a/src/desktop/assets/main_layout.styl
+++ b/src/desktop/assets/main_layout.styl
@@ -8,6 +8,8 @@
 @require '../components/recently_viewed_artworks'
 @require '../components/inquiry_questionnaire/stylesheets'
 @require '../components/view_in_room'
+@require '../components/multi_page_modal'
+@require '../components/chevron_list'
 
 // TODO: Remove once Buyers Premium modal has been rebuilt in Reaction
 .artwork-auction-buyers-premium-modal


### PR DESCRIPTION
With https://github.com/artsy/force/pull/5724 I accidentally broke the Auctions + Collector FAQ hooks on the artwork page.

For context, since I'd removed those FAQs from the footer, I thought it was safe to remove the mediator hooks _within_ the footer component. But turns out that was also being used to hook into the artwork page!

Since I believe the only usage of these FAQs is on the artwork page now, I stuck the hooks there for clarity.

![auction-faq](https://user-images.githubusercontent.com/2081340/83912405-d368ef00-a73b-11ea-91ca-91018c28a64a.gif)

![collector-faq](https://user-images.githubusercontent.com/2081340/83912412-d5cb4900-a73b-11ea-81db-41f1b159dc30.gif)
