### PR TITLE
[Webpack] Move public path settings into own module

### DIFF
--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -1,33 +1,4 @@
-/**
- * Set webpack public-path asset lookup to CDN in production, but only on
- * the client, as we use the assetMiddleware helper to map URLs on the server.
- * @see https://github.com/artsy/force/blob/master/src/lib/middleware/assetMiddleware.ts
- *
- * FIXME: Move this into Circle config and or Docker
- */
-if (process.env.NODE_ENV === "production") {
-  const { hostname } = window.location
-  let cdnUrl
-
-  // Production
-  if (hostname === "artsy.net" || hostname === "www.artsy.net") {
-    cdnUrl = "https://d1s2w0upia4e9w.cloudfront.net"
-
-    // Localhost
-  } else if (hostname === "localhost" || hostname === "local.artsy.net") {
-    cdnUrl = ""
-
-    // Everything else, including staging and review apps
-  } else {
-    cdnUrl = "https://d1rmpw1xlv9rxa.cloudfront.net"
-  }
-
-  __webpack_public_path__ = cdnUrl + "/assets/"
-
-  // @ts-ignore
-  window.__getPublicPath = () => __webpack_public_path__
-}
-
+import "./webpackPublicPath"
 import $ from "jquery"
 import Backbone from "backbone"
 import _ from "underscore"

--- a/src/desktop/lib/webpackPublicPath.ts
+++ b/src/desktop/lib/webpackPublicPath.ts
@@ -1,0 +1,29 @@
+/**
+ * Set webpack public-path asset lookup to CDN in production, but only on
+ * the client, as we use the assetMiddleware helper to map URLs on the server.
+ * @see https://github.com/artsy/force/blob/master/src/lib/middleware/assetMiddleware.ts
+ *
+ * FIXME: Move this into Circle config and or Docker
+ */
+if (process.env.NODE_ENV === "production") {
+  const { hostname } = window.location
+  let cdnUrl
+
+  // Production
+  if (hostname === "artsy.net" || hostname === "www.artsy.net") {
+    cdnUrl = "https://d1s2w0upia4e9w.cloudfront.net"
+
+    // Localhost
+  } else if (hostname === "localhost" || hostname === "local.artsy.net") {
+    cdnUrl = ""
+
+    // Everything else, including staging and review apps
+  } else {
+    cdnUrl = "https://d1rmpw1xlv9rxa.cloudfront.net"
+  }
+
+  __webpack_public_path__ = cdnUrl + "/assets/"
+
+  // @ts-ignore
+  window.__getPublicPath = () => __webpack_public_path__
+}


### PR DESCRIPTION
Noticed this issue when reading the docs: https://webpack.js.org/guides/public-path/#on-the-fly