### PR TITLE
@damassi => [Mount] Change mount order, and dont use wildcard for V2 apps

### DIFF
--- a/src/desktop/index.ts
+++ b/src/desktop/index.ts
@@ -91,13 +91,8 @@ app.use(require("./apps/articles").app)
 app.use(require("./apps/page"))
 app.use(require("./apps/shortcuts"))
 
-// Apps that need to fetch a profile
-app.use(require("./apps/profile"))
-app.use(require("./apps/partner2"))
-app.use(require("./apps/partner"))
-app.use(require("./apps/fair"))
-app.use(require("./apps/fair_info"))
-app.use(require("./apps/fair_organizer"))
+// Mount all `v2/Apps`.
+app.use(require("./apps/artsy-v2/server").app)
 
 // User profiles
 app.use(require("./apps/user"))
@@ -105,6 +100,13 @@ app.use(require("./apps/user"))
 // Used to test various SSR configurations
 app.use(require("./apps/ssr-experiments/server").app)
 
-// Mount all `v2/Apps`. This ~must~ come last as it mounts our v2 apps in a
-// wild-card fashion.
-app.use(require("./apps/artsy-v2/server").app)
+// Apps that need to fetch a profile.
+// Because profile routes are usually top-level and use wild-card matchers in their routers,
+// it's best to keep them last. Otherwise it's easy for these to unexpectedly
+// catch conventional app routes.
+app.use(require("./apps/profile"))
+app.use(require("./apps/partner2"))
+app.use(require("./apps/partner"))
+app.use(require("./apps/fair"))
+app.use(require("./apps/fair_info"))
+app.use(require("./apps/fair_organizer"))

--- a/src/v2/Apps/Artwork/routes.tsx
+++ b/src/v2/Apps/Artwork/routes.tsx
@@ -5,7 +5,7 @@ const ArtworkApp = loadable(() => import("./ArtworkApp"))
 
 export const routes = [
   {
-    path: "/artwork/:artworkID/(confirm-bid)?",
+    path: "/artwork/:artworkID/:optional?", // There's a `confirm-bid` nested route.
     getComponent: () => ArtworkApp,
     prepare: () => {
       ArtworkApp.preload()

--- a/src/v2/Apps/ViewingRoom/routes.tsx
+++ b/src/v2/Apps/ViewingRoom/routes.tsx
@@ -35,7 +35,7 @@ export const routes: RouteConfig[] = [
         `,
       },
       {
-        path: "/works",
+        path: "works",
         Component: WorksRoute,
         ignoreScrollBehavior: true,
         query: graphql`


### PR DESCRIPTION
Wondering what you think of this approach? It should stop the flood of `/profile/artist` requests (something that currently happens when someone hits an artist page, due to being matched in https://github.com/artsy/force/blob/add867633daab1cb648b6eec5432bcf6158620c1/src/desktop/apps/profile/index.coffee#L14)