### PR TITLE
[BundleSplitting] Fix issue where CDN_URL isnt respected

### DIFF
--- a/src/v2/Artsy/Router/buildServerApp.tsx
+++ b/src/v2/Artsy/Router/buildServerApp.tsx
@@ -139,9 +139,11 @@ export function buildServerApp(
           )
         }
 
+        const assetPublicPath = (getENV("CDN_URL") || "") + "/assets"
         const extractor = new ChunkExtractor({
           statsFile,
           entrypoints: [],
+          publicPath: assetPublicPath,
         })
 
         // Wrap component tree in library contexts to extract usage
@@ -169,7 +171,7 @@ export function buildServerApp(
               if (getENV("CDN_URL")) {
                 const scriptTagWithCDN = script.replace(
                   /src="\/assets/g,
-                  `src="${getENV("CDN_URL")}/assets`
+                  `src="${assetPublicPath}`
                 )
                 return scriptTagWithCDN
               } else {


### PR DESCRIPTION
Via https://github.com/gregberge/loadable-components/issues/269

Noticed that _some, not all_ of our assets will still being requested from artsy.net domain, vs CDN. This should fix that.

Ignore the red: what is most important is that each url is consistent and `initiator` comes from the same place: 

<img width="524" alt="Screen Shot 2020-06-05 at 2 57 52 PM" src="https://user-images.githubusercontent.com/236943/83925899-2c855280-a73d-11ea-8fdd-15a6c004db8e.png">
