### PR TITLE
Remove failing slack alerts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ orbs:
   hokusai: artsy/hokusai@0.7.3
   horizon: artsy/release@0.0.1
   node: artsy/node@1.0.0
-  slack: circleci/slack@3.4.2
   yarn: artsy/yarn@5.1.3
 
 jobs:
@@ -184,9 +183,6 @@ workflows:
           project-name: force
           requires:
             - push-staging-image
-          post-steps:
-            - slack/status:
-                success_message: Force staging has been deployed!
 
       # Release
       - validate_production_schema:


### PR DESCRIPTION
It was noted that slack alerts for staging are no longer needed to the integrity channel. Given that this is currently causing force master to be red (but not necessarily blocking deploys) it'd be good to go ahead and remove this. 