### PR TITLE
@damassi => [Assets] Skip profile check for erroneous asset route

### DIFF
--- a/src/desktop/apps/profile/routes.coffee
+++ b/src/desktop/apps/profile/routes.coffee
@@ -9,6 +9,7 @@ Following = require '../../components/follow_button/collection.coffee'
     success: -> res.redirect "/#{req.params.id}"
 
 @setProfile = (req, res, next) ->
+  return next() if req.params.id is 'assets'
   data = {}
   data.access_token = req.user.get('accessToken') if req.user
   return next() if res.locals.profile

--- a/src/desktop/apps/profile/test/routes.test.coffee
+++ b/src/desktop/apps/profile/test/routes.test.coffee
@@ -51,3 +51,8 @@ describe 'Profile routes', ->
       @res.locals.profile = new Profile fabricate 'profile'
       routes.setProfile @req, @res, next = sinon.stub()
       next.called.should.be.ok()
+
+    it 'nexts for a request for an `asset` profile', ->
+      @req.params.id = 'assets'
+      routes.setProfile @req, @res, next = sinon.stub()
+      next.called.should.be.ok()


### PR DESCRIPTION
With the route order updates, we no longer get the profile requests for 'artist', 'collection', etc.

However, we still get them for the erroneous '/assets/...' ones. This just skips that check for the 'assets' profile (🙈 )