### PR TITLE
Date of the last message not updated in conversation

### DIFF
--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -95,6 +95,7 @@ const groupMessages = (messages: Message[]): Message[][] => {
     const lastMessageCreatedAt = DateTime.fromISO(lastMessage.createdAt)
     const currentMessageCreatedAt = DateTime.fromISO(currentMessage.createdAt)
     const sameDay = lastMessageCreatedAt.hasSame(currentMessageCreatedAt, "day")
+
     const today = fromToday(currentMessageCreatedAt)
 
     if (sameDay && !today) {
@@ -102,6 +103,8 @@ const groupMessages = (messages: Message[]): Message[][] => {
     } else if (!today) {
       groups.push([currentMessage])
     } else if (lastMessage.isFromUser !== currentMessage.isFromUser) {
+      groups.push([currentMessage])
+    } else if (!sameDay && today) {
       groups.push([currentMessage])
     } else {
       lastGroup.push(currentMessage)
@@ -167,6 +170,7 @@ const Conversation: React.FC<ConversationProps> = props => {
                 />
                 {messageGroup.map((message, messageIndex) => {
                   const nextMessage = messageGroup[messageIndex + 1]
+
                   return (
                     <Message
                       message={message}


### PR DESCRIPTION
[PURCHASE-1918]

https://www.notion.so/artsy/Conversation-not-updated-correctly-when-new-messages-is-entered-by-collector-61d0224fe67e4d44bf8c13fe52565a4b

__Before:__
<img width="455" alt="Screen Shot 2020-06-08 at 1 42 17 PM" src="https://user-images.githubusercontent.com/5643895/84062801-ebd04800-a98d-11ea-8668-642322ea4ce2.png">

__After:__
<img width="634" alt="Screen Shot 2020-06-08 at 1 23 44 PM" src="https://user-images.githubusercontent.com/5643895/84062840-fdb1eb00-a98d-11ea-97d1-7b9176fa29b3.png">



[PURCHASE-1918]: https://artsyproduct.atlassian.net/browse/PURCHASE-1918