### PR TITLE
Fix artwork referrer

### DIFF
--- a/src/desktop/analytics/inquiry_questionnaire.js
+++ b/src/desktop/analytics/inquiry_questionnaire.js
@@ -1,23 +1,23 @@
 import { data as sd } from "sharify"
 import {
-  createdAccount,
-  successfullyLoggedIn,
   ContextModule,
   Intent,
+  createdAccount,
+  successfullyLoggedIn,
 } from "@artsy/cohesion"
 import $ from "jquery"
 import { omit } from "lodash"
 const analyticsHooks = require("desktop/lib/analytics_hooks.coffee")
 const analytics = window.analytics
-;(function() {
+;(function () {
   "use strict"
 
-  var namespace, track, trackWithoutNamespace, bind, bindOnce
+  let namespace, track, trackWithoutNamespace, bind, bindOnce
 
   function getTrackingOptions() {
-    var trackingOptions = {}
+    let trackingOptions = {}
 
-    const referrer = window.analytics.__artsyReferrer
+    const referrer = window.analytics.__artsyClientSideRoutingReferrer
     // Grab referrer from our trackingMiddleware in Reaction, since we're in a
     // single-page-app context and the value will need to be refreshed on route
     // change. See: https://github.com/artsy/reaction/blob/master/src/Artsy/Analytics/trackingMiddleware.ts
@@ -32,24 +32,24 @@ const analytics = window.analytics
     return trackingOptions
   }
 
-  namespace = function(name) {
+  namespace = function (name) {
     return "inquiry_questionnaire:" + name
   }
 
-  track = function(event, props = {}) {
+  track = function (event, props = {}) {
     event = namespace(" " + event)
     analytics.track(event, props, getTrackingOptions())
   }
 
-  trackWithoutNamespace = function(event, props = {}) {
+  trackWithoutNamespace = function (event, props = {}) {
     analytics.track(event, props, getTrackingOptions())
   }
 
-  bind = function(name, handler) {
+  bind = function (name, handler) {
     analyticsHooks.on(namespace(name), handler)
   }
 
-  bindOnce = function(name, handler) {
+  bindOnce = function (name, handler) {
     // In the experimental page shell, we might have multiple inquiries
     // _per session_, and therefore can't rely on `once`, as subsequent
     // inquiries would then not get tracked as there's no "hard jumps"
@@ -58,123 +58,123 @@ const analytics = window.analytics
   }
 
   // DOM events
-  var $document = $(document)
+  let $document = $(document)
 
-  $document.on("click", ".js-choice", function() {
-    var choice = $(this).data("value")
+  $document.on("click", ".js-choice", function () {
+    let choice = $(this).data("value")
     track("Clicked on how_can_we_help option", {
       choice: choice,
     })
   })
 
-  $document.on("click", ".js-iq-collector-level", function(e) {
+  $document.on("click", ".js-iq-collector-level", function (e) {
     track('Clicked "Yes" or "No" button on commercial_interest', {
       collector_level: e.currentTarget.value,
     })
   })
 
-  $document.on("click", ".js-login-email", function() {
+  $document.on("click", ".js-login-email", function () {
     track('Clicked "Log in"')
   })
 
-  $document.on("click", ".js-forgot-password", function() {
+  $document.on("click", ".js-forgot-password", function () {
     track('Clicked "Forgot Password?"')
   })
 
-  $document.on("click", ".js-send-inquiry", function() {
+  $document.on("click", ".js-send-inquiry", function () {
     track('Clicked "Send" on inquiry form')
   })
 
-  $document.one("input", ".js-inquiry-message", function(e) {
+  $document.one("input", ".js-inquiry-message", function (e) {
     track("User changed inquiry message from default")
   })
 
-  $document.on("alert", ".js-inquiry-message", function(e) {
+  $document.on("alert", ".js-inquiry-message", function (e) {
     track("User nudged to change inquiry message from default")
   })
 
-  $document.on("click", ".js-iq-save-skip", function() {
+  $document.on("click", ".js-iq-save-skip", function () {
     track('Clicked on "No thanks don’t save my information"')
   })
 
   // Proxied events
-  bind("modal:opened", function(context) {
+  bind("modal:opened", function (context) {
     track("Opened inquiry flow")
   })
 
-  bind("modal:closed", function(context) {
+  bind("modal:closed", function (context) {
     track("Closed inquiry flow")
   })
 
-  bind("state:completed", function(context) {
+  bind("state:completed", function (context) {
     track("Completed inquiry flow")
   })
 
-  bind("state:aborted", function(context) {
+  bind("state:aborted", function (context) {
     track("Aborted inquiry flow", {
       current: context.state.current(),
     })
   })
 
-  bind("state:next", function(context) {
+  bind("state:next", function (context) {
     track("State changed to " + context.state.current())
     track("State change", {
       current: context.state.current(),
     })
   })
 
-  bind("user:change:profession", function(context) {
+  bind("user:change:profession", function (context) {
     track("User set profession", {
       profession: context.user.get("profession"),
     })
   })
 
-  bind("user:change:location", function(context) {
+  bind("user:change:location", function (context) {
     track("User set location", {
       location: context.user.get("location"),
     })
   })
 
-  bind("user:change:phone", function(context) {
+  bind("user:change:phone", function (context) {
     track("User set phone", {
       phone: context.user.get("phone"),
     })
   })
 
-  bind("user:sync", function(context) {
+  bind("user:sync", function (context) {
     track("User data saved")
   })
 
-  bind("collector_profile:sync", function(context) {
+  bind("collector_profile:sync", function (context) {
     track("CollectorProfile data saved")
   })
 
-  bind("user_interests:add", function(context) {
-    var userInterest = context.userInterests.last()
+  bind("user_interests:add", function (context) {
+    let userInterest = context.userInterests.last()
     track("User added an interest in artist", {
       artist_id: userInterest.related().interest.id,
     })
   })
 
-  bind("user_interests:remove", function(context) {
+  bind("user_interests:remove", function (context) {
     track("User removed an interest in artist")
   })
 
-  bindOnce("inquiry:sync", function(context) {
+  bindOnce("inquiry:sync", function (context) {
     track("Inquiry successfully sent")
   })
 
-  bind("inquiry:error", function(context) {
+  bind("inquiry:error", function (context) {
     track("Problem sending inquiry", context.inquiry.attributes)
   })
 
-  bind("collector_profile:change:affiliated_gallery_ids", function(context) {
+  bind("collector_profile:change:affiliated_gallery_ids", function (context) {
     track("Changed collector_profile:affiliated_gallery_ids", {
       ids: context.collectorProfile.get("affiliated_gallery_ids"),
     })
   })
 
-  bind("collector_profile:change:affiliated_auction_house_ids", function(
+  bind("collector_profile:change:affiliated_auction_house_ids", function (
     context
   ) {
     track("Changed collector_profile:affiliated_auction_house_ids", {
@@ -182,13 +182,13 @@ const analytics = window.analytics
     })
   })
 
-  bind("collector_profile:change:affiliated_fair_ids", function(context) {
+  bind("collector_profile:change:affiliated_fair_ids", function (context) {
     track("Changed collector_profile:affiliated_fair_ids", {
       ids: context.collectorProfile.get("affiliated_fair_ids"),
     })
   })
 
-  bind("collector_profile:change:institutional_affiliations", function(
+  bind("collector_profile:change:institutional_affiliations", function (
     context
   ) {
     track("Changed collector_profile:institutional_affiliations", {
@@ -197,7 +197,7 @@ const analytics = window.analytics
   })
 
   // Non-namespaced events
-  bind("user:login", function(context) {
+  bind("user:login", function (context) {
     const userId = context.user.get("id")
     const analyticsOptions = successfullyLoggedIn({
       authRedirect: location.href,
@@ -212,7 +212,7 @@ const analytics = window.analytics
     )
   })
 
-  bind("user:signup", function(context) {
+  bind("user:signup", function (context) {
     const userId = context.user.get("id")
     const analyticsOptions = createdAccount({
       authRedirect: location.href,
@@ -227,7 +227,7 @@ const analytics = window.analytics
     )
   })
 
-  bindOnce("inquiry:sync", function(context) {
+  bindOnce("inquiry:sync", function (context) {
     trackWithoutNamespace("Sent artwork inquiry", {
       artwork_id: context.artwork.get("_id"),
       products: [
@@ -242,31 +242,31 @@ const analytics = window.analytics
     })
   })
 
-  bindOnce("inquiry:show", function(context) {
+  bindOnce("inquiry:show", function (context) {
     trackWithoutNamespace("Sent show inquiry", {
       label: context.label,
     })
   })
 
-  bindOnce("contact:hover", function(context) {
+  bindOnce("contact:hover", function (context) {
     trackWithoutNamespace("Hovered over contact form 'Send' button")
   })
 
-  bindOnce("contact:close-x", function(context) {
+  bindOnce("contact:close-x", function (context) {
     trackWithoutNamespace("Closed the inquiry form via the '×' button")
   })
 
-  bindOnce("contact:close-back", function(context) {
+  bindOnce("contact:close-back", function (context) {
     trackWithoutNamespace(
       "Closed the inquiry form by clicking the modal window backdrop"
     )
   })
 
-  bindOnce("contact:submitted", function(context) {
+  bindOnce("contact:submitted", function (context) {
     trackWithoutNamespace("Contact form submitted", context.attributes)
   })
 
-  bind("inquiry:sent", function(context) {
+  bind("inquiry:sent", function (context) {
     track("Sent artwork inquiry", { label: context.label })
     track("Submit confirm inquiry modal", context.attributes)
     track(context.changed + " default message")

--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -9,7 +9,7 @@ import { match } from "path-to-regexp"
 
 // Track pageview
 const pageType = window.sd.PAGE_TYPE || window.location.pathname.split("/")[1]
-var properties = { path: location.pathname }
+let properties = { path: location.pathname }
 
 // We exclude these routes from analytics.page calls because they're already
 // taken care of in Reaction.
@@ -49,7 +49,7 @@ if (pageType === "auction") {
   })
   const matchedBidRoute = matcher(window.location.pathname)
   if (!matchedBidRoute) {
-    window.addEventListener("load", function() {
+    window.addEventListener("load", function () {
       // distinct event required for marketing integrations (Criteo)
       const saleSlug = window.location.pathname.split("/")[2]
       window.analytics.track("Auction Pageview", { auction_slug: saleSlug })
@@ -63,10 +63,10 @@ if (
   window.performance.timing &&
   sd.TRACK_PAGELOAD_PATHS
 ) {
-  window.addEventListener("load", function() {
+  window.addEventListener("load", function () {
     if (sd.TRACK_PAGELOAD_PATHS.split("|").includes(pageType)) {
-      window.setTimeout(function() {
-        var deviceType = sd.IS_MOBILE ? "mobile" : "desktop"
+      window.setTimeout(function () {
+        let deviceType = sd.IS_MOBILE ? "mobile" : "desktop"
         reportLoadTimeToVolley(pageType, deviceType)
       }, 0)
     }
@@ -91,7 +91,7 @@ class PageTimeTracker {
     this.timer = setTimeout(() => {
       let trackingOptions = {}
 
-      const referrer = window.analytics.__artsyReferrer
+      const referrer = window.analytics.__artsyClientSideRoutingReferrer
       // Grab referrer from our trackingMiddleware in Reaction, since we're in a
       // single-page-app context and the value will need to be refreshed on route
       // change. See: https://github.com/artsy/reaction/blob/master/src/Artsy/Analytics/trackingMiddleware.ts
@@ -134,10 +134,10 @@ window.desktopPageTimeTrackers = [
 
 // debug tracking calls
 if (sd.SHOW_ANALYTICS_CALLS) {
-  analytics.on("track", function() {
+  analytics.on("track", function () {
     console.info("TRACKED: ", arguments[0], JSON.stringify(arguments[1]))
   })
-  analytics.on("page", function() {
+  analytics.on("page", function () {
     console.info(
       "PAGEVIEW TRACKED: ",
       arguments[2],
@@ -149,7 +149,7 @@ if (sd.SHOW_ANALYTICS_CALLS) {
 }
 
 if (sd.SHOW_ANALYTICS_CALLS) {
-  analyticsHooks.on("all", function(name, data) {
+  analyticsHooks.on("all", function (name, data) {
     console.info("ANALYTICS HOOK: ", name, data)
   })
 }

--- a/src/desktop/assets/analytics.coffee
+++ b/src/desktop/assets/analytics.coffee
@@ -45,7 +45,7 @@ trackEvent = (data) ->
     trackingData = _.omit data, 'action_type'
     trackingOptions = {}
 
-    referrer = analytics.__artsyReferrer
+    referrer = analytics.__artsyClientSideRoutingReferrer
     # Grab referrer from our trackingMiddleware in Reaction, since we're in a
     # single-page-app context and the value will need to be refreshed on route
     # change. See: https://github.com/artsy/reaction/blob/master/src/Artsy/Analytics/trackingMiddleware.ts

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -7,7 +7,7 @@ interface Window {
       properties: object,
       getTrackingOptions?: object
     ) => void
-    __artsyReferrer?: string
+    __artsyClientSideRoutingReferrer?: string
   }
   __BOOTSTRAP__?: any
 }

--- a/src/v2/Artsy/Analytics/__tests__/trackingMiddleware.jest.ts
+++ b/src/v2/Artsy/Analytics/__tests__/trackingMiddleware.jest.ts
@@ -138,7 +138,7 @@ describe("trackingMiddleware", () => {
           { integrations: { Marketo: false } }
         )
 
-        expect(window.analytics.__artsyReferrer).toEqual(
+        expect(window.analytics.__artsyClientSideRoutingReferrer).toEqual(
           "http://testing.com/referrer?with=queryparams"
         )
       })


### PR DESCRIPTION
This fixes an issue that came up from cleanup work in https://github.com/artsy/force/pull/5679

In short, we now use our `RouterLink` component more widely for routing between pages, and rely less on link interception as described in #5679. This caused things to break because we would previously
- intercept a link click to, say, `/artwork/andy-warhol` 
- store a ref to the current url as the referrer 
- _push_ the intercepted link onto the stack
- then when performing the tracking on the artist page, use the stored referrer.

See https://github.com/artsy/force/blob/master/src/v2/Artsy/Router/interceptLinks.ts#L21-L28

However, now that we use the `<Link>` component we no longer need to intercept and can simplify our referrer tracking pipeline, and consolidate everything inside of our pageview tracking middleware. So this simplifies things a bit. 

Also cleaned up some naming for clarity. 

Will add comments inline in the PR. 

![referrer](https://user-images.githubusercontent.com/236943/84075636-5632b980-a989-11ea-934f-71d51caac003.gif)


