### PR TITLE
Fix conversation M screen scroll

### DIFF
--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -56,7 +56,13 @@ export const Details: FC<DetailsProps> = ({ conversation, ...props }) => {
     <DetailsContainer
       flexDirection="column"
       justifyContent="flex-start"
-      height="100%"
+      height={[
+        "calc(100% - 115px)",
+        "calc(100% - 145px)",
+        "calc(100% - 145px)",
+        "calc(100% - 145px)",
+        "100%",
+      ]}
       flexShrink={0}
       position={["absolute", "absolute", "absolute", "absolute", "static"]}
       right={[0, 0, 0, 0, "auto"]}

--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -53,7 +53,7 @@ export const Reply: React.FC<ReplyProps> = props => {
   const textArea = useRef()
 
   return (
-    <StyledFlex p={1} right={[0, null]}>
+    <StyledFlex p={1} right={[0, null]} zIndex={2}>
       <FullWidthFlex width="100%">
         <StyledTextArea
           onInput={event => {


### PR DESCRIPTION
In [the previous PR](https://github.com/artsy/force/pull/5735), changed the `<Detail />` position to `absolute` for S/M/L screens so now the height must exclude header(s)

Also changed the reply box `z-index` to make it show up over the detail box.

I was interested to get rid of those `px` sizes as much as possible but seems it needs major restructuring of the page 😬 

Before (gap on the bottom of the page after scrolling all the way to the bottom)

<img width="1181" alt="Screen Shot 2020-06-08 at 9 21 50 AM" src="https://user-images.githubusercontent.com/687513/84192723-07a41e80-aa60-11ea-8269-99dfde3d7c1b.png">

After:

<img width="1005" alt="Screen Shot 2020-06-09 at 1 48 04 PM" src="https://user-images.githubusercontent.com/687513/84192922-4e921400-aa60-11ea-9d23-915ef8fc4da1.png">
