### PR TITLE
[AppShell] Add `debug-routes` app for baseline tests

### DIFF
--- a/src/v2/Apps/Debug/debugRoutes.tsx
+++ b/src/v2/Apps/Debug/debugRoutes.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+
+/**
+ * This route is just for testing baseline page shell stuff -- Lighthouse,
+ * Calibre, assets loaded on page, and other debugging things that might
+ * impact global performance.
+ */
+export const debugRoutes = [
+  {
+    path: "/debug",
+    Component: ({ children }) => children,
+    children: [
+      {
+        path: "baseline",
+        Component: () => <div>Baseline</div>,
+      },
+    ],
+  },
+]

--- a/src/v2/Apps/getAppRoutes.tsx
+++ b/src/v2/Apps/getAppRoutes.tsx
@@ -10,6 +10,7 @@ import { routes as orderRoutes } from "v2/Apps/Order/routes"
 import { routes as purchasesRoutes } from "v2/Apps/Purchase/routes"
 import { routes as searchRoutes } from "v2/Apps/Search/routes"
 import { routes as viewingRoomRoutes } from "./ViewingRoom/routes"
+import { debugRoutes } from "./Debug/debugRoutes"
 
 export function getAppRoutes(): RouteConfig[] {
   return buildAppRoutes([
@@ -42,6 +43,11 @@ export function getAppRoutes(): RouteConfig[] {
     },
     {
       routes: viewingRoomRoutes,
+    },
+
+    // For debugging baseline app shell stuff
+    {
+      routes: debugRoutes,
     },
   ])
 }


### PR DESCRIPTION
Adds a baseline app shell app that we can use for testing, lighthouse, Calibre, etc. 

Thanks for the suggestion @dzucconi 👍 