### PR TITLE
Use the error modal to display any error message on the registration form

### DIFF
--- a/src/v2/Apps/Auction/Components/__stories__/RegistrationForm.story.tsx
+++ b/src/v2/Apps/Auction/Components/__stories__/RegistrationForm.story.tsx
@@ -1,21 +1,15 @@
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
 import { Section } from "v2/Utils/Section"
-import { StripeWrappedRegistrationForm } from "../RegistrationForm"
+import { RegistrationForm } from "../RegistrationForm"
 
 storiesOf("Apps/Auction/Components", module)
   .add("RegistrationForm w/o ID verification", () => {
     return (
       <Section>
-        <StripeWrappedRegistrationForm
-          onSubmit={(actions, result) => {
-            window.alert(
-              JSON.stringify(
-                { telephone: result.phoneNumber, token: result.token.id },
-                null,
-                2
-              )
-            )
+        <RegistrationForm
+          onSubmit={(values, actions) => {
+            window.alert(JSON.stringify(values, null, 2))
             actions.setSubmitting(false)
           }}
           trackSubmissionErrors={errors =>
@@ -29,15 +23,9 @@ storiesOf("Apps/Auction/Components", module)
   .add("RegistrationForm with ID verification", () => {
     return (
       <Section>
-        <StripeWrappedRegistrationForm
-          onSubmit={(actions, result) => {
-            window.alert(
-              JSON.stringify(
-                { telephone: result.phoneNumber, token: result.token.id },
-                null,
-                2
-              )
-            )
+        <RegistrationForm
+          onSubmit={(values, actions) => {
+            window.alert(window.alert(JSON.stringify(values, null, 2)))
             actions.setSubmitting(false)
           }}
           trackSubmissionErrors={errors =>

--- a/src/v2/Apps/Auction/Routes/__tests__/Register.jest.tsx
+++ b/src/v2/Apps/Auction/Routes/__tests__/Register.jest.tsx
@@ -270,7 +270,7 @@ describe("Routes/Register ", () => {
     await page.submitForm()
 
     expect(page.text()).toContain(
-      "Please make sure your internet connection is active and try again"
+      "Something went wrong. Please try again or contact support@artsy.net."
     )
   })
 })


### PR DESCRIPTION
This pull request replaces the `status` message added in [the previous PR](https://github.com/artsy/force/pull/5699/files#diff-11bf8a936a98ab5a5856792a42114073R116-R120) with the error modal that was already in place.

## Screenshot

![error-modal](https://user-images.githubusercontent.com/386234/84405089-b0c05580-abd5-11ea-99eb-14f488d6304f.gif)
