### PR TITLE
Display error messages from Stripe as a credit card field error

### DIFF
--- a/src/v2/Apps/Auction/Components/Form/__tests__/helpers.jest.tsx
+++ b/src/v2/Apps/Auction/Components/Form/__tests__/helpers.jest.tsx
@@ -1,0 +1,39 @@
+import { errorMessageForCard } from "v2/Apps/Auction/Components/Form"
+
+describe("helpers", () => {
+  describe("#errorMessageForCard", () => {
+    it("appends a message for a declined card", () => {
+      expect(errorMessageForCard("Your card was declined.")).toEqual(
+        "Your card was declined. Please contact your bank or use a different card."
+      )
+    })
+
+    it("appends a message for a card with insufficient funds", () => {
+      expect(errorMessageForCard("Your card has insufficient funds.")).toEqual(
+        "Your card has insufficient funds. Please contact your bank or use a different card."
+      )
+    })
+
+    it("appends a message for an expired card", () => {
+      expect(errorMessageForCard("Your card has expired.")).toEqual(
+        "Your card has expired. Please contact your bank or use a different card."
+      )
+    })
+
+    it("appends a message for a submission with an invalid security code", () => {
+      expect(
+        errorMessageForCard("Your card's security code is incorrect.")
+      ).toEqual("Your card's security code is incorrect. Please try again.")
+    })
+
+    it("does not modify the message for any other types of error", () => {
+      expect(
+        errorMessageForCard(
+          "An error occurred while processing your card. Try again in a little bit."
+        )
+      ).toEqual(
+        "An error occurred while processing your card. Try again in a little bit. "
+      )
+    })
+  })
+})

--- a/src/v2/Apps/Auction/Components/Form/helpers.tsx
+++ b/src/v2/Apps/Auction/Components/Form/helpers.tsx
@@ -15,7 +15,7 @@ const ERROR_SUFFIX = {
 }
 
 export const errorMessageForCard = (errorMessage: string) => {
-  return `${errorMessage} ${ERROR_PREFIX[errorMessage] || ""}`
+  return `${errorMessage} ${ERROR_SUFFIX[errorMessage] || ""}`
 }
 
 export const toStripeAddress = (address: Address): stripe.TokenOptions => {

--- a/src/v2/Apps/Auction/Components/Form/helpers.tsx
+++ b/src/v2/Apps/Auction/Components/Form/helpers.tsx
@@ -5,7 +5,7 @@ import { data as sd } from "sharify"
 
 import { Address } from "v2/Components/AddressForm"
 
-const ERROR_PREFIX = {
+const ERROR_SUFFIX = {
   "Your card was declined.":
     "Please contact your bank or use a different card.",
   "Your card has insufficient funds.":

--- a/src/v2/Apps/Auction/Components/Form/helpers.tsx
+++ b/src/v2/Apps/Auction/Components/Form/helpers.tsx
@@ -5,6 +5,19 @@ import { data as sd } from "sharify"
 
 import { Address } from "v2/Components/AddressForm"
 
+const ERROR_PREFIX = {
+  "Your card was declined.":
+    "Please contact your bank or use a different card.",
+  "Your card has insufficient funds.":
+    "Please contact your bank or use a different card.",
+  "Your card has expired.": "Please contact your bank or use a different card.",
+  "Your card's security code is incorrect.": "Please try again.",
+}
+
+export const errorMessageForCard = (errorMessage: string) => {
+  return `${errorMessage} ${ERROR_PREFIX[errorMessage] || ""}`
+}
+
 export const toStripeAddress = (address: Address): stripe.TokenOptions => {
   return {
     name: address.name,

--- a/src/v2/Apps/Auction/Components/RegistrationForm.tsx
+++ b/src/v2/Apps/Auction/Components/RegistrationForm.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Flex, Sans, Serif, Spacer } from "@artsy/palette"
-import { Form, Formik, FormikHelpers as FormikActions } from "formik"
+import { Form, Formik, FormikConfig } from "formik"
 import React from "react"
 
 import { CreditCardInstructions } from "v2/Apps/Auction/Components/CreditCardInstructions"
@@ -17,11 +17,8 @@ import {
   TrackErrors,
 } from "v2/Apps/Auction/Components/OnSubmitValidationError"
 
-export interface RegistrationFormProps {
-  onSubmit: (
-    values: FormValuesForRegistration,
-    actions: FormikActions<FormValuesForRegistration>
-  ) => void
+interface RegistrationFormProps {
+  onSubmit: FormikConfig<FormValuesForRegistration>["onSubmit"]
   trackSubmissionErrors: TrackErrors
   needsIdentityVerification: boolean
 }

--- a/src/v2/Apps/Auction/Operations/CreateCreditCardAndUpdatePhone.ts
+++ b/src/v2/Apps/Auction/Operations/CreateCreditCardAndUpdatePhone.ts
@@ -1,60 +1,52 @@
 import { commitMutation, graphql } from "react-relay"
-import { CreateCreditCardAndUpdatePhoneMutation } from "v2/__generated__/CreateCreditCardAndUpdatePhoneMutation.graphql"
+import {
+  CreateCreditCardAndUpdatePhoneMutation,
+  CreateCreditCardAndUpdatePhoneMutationResponse,
+} from "v2/__generated__/CreateCreditCardAndUpdatePhoneMutation.graphql"
 
 export function createCreditCardAndUpdatePhone(relayEnvironment, phone, token) {
-  return new Promise(async (resolve, reject) => {
-    commitMutation<CreateCreditCardAndUpdatePhoneMutation>(relayEnvironment, {
-      onCompleted: (data, errors) => {
-        const {
-          createCreditCard: { creditCardOrError },
-        } = data
-
-        if (creditCardOrError.creditCardEdge) {
-          resolve()
-        } else {
-          if (errors) {
-            reject(errors)
-          } else {
-            reject(creditCardOrError.mutationError)
-          }
-        }
-      },
-      onError: reject,
-      mutation: graphql`
-        mutation CreateCreditCardAndUpdatePhoneMutation(
-          $creditCardInput: CreditCardInput!
-          $profileInput: UpdateMyProfileInput!
-        ) {
-          updateMyUserProfile(input: $profileInput) {
-            user {
-              internalID
+  return new Promise<CreateCreditCardAndUpdatePhoneMutationResponse>(
+    (resolve, reject) => {
+      commitMutation<CreateCreditCardAndUpdatePhoneMutation>(relayEnvironment, {
+        onCompleted: (data, errors) =>
+          errors ? reject(errors) : resolve(data),
+        onError: reject,
+        mutation: graphql`
+          mutation CreateCreditCardAndUpdatePhoneMutation(
+            $creditCardInput: CreditCardInput!
+            $profileInput: UpdateMyProfileInput!
+          ) {
+            updateMyUserProfile(input: $profileInput) {
+              user {
+                internalID
+              }
             }
-          }
 
-          createCreditCard(input: $creditCardInput) {
-            creditCardOrError {
-              ... on CreditCardMutationSuccess {
-                creditCardEdge {
-                  node {
-                    lastDigits
+            createCreditCard(input: $creditCardInput) {
+              creditCardOrError {
+                ... on CreditCardMutationSuccess {
+                  creditCardEdge {
+                    node {
+                      lastDigits
+                    }
+                  }
+                }
+                ... on CreditCardMutationFailure {
+                  mutationError {
+                    type
+                    message
+                    detail
                   }
                 }
               }
-              ... on CreditCardMutationFailure {
-                mutationError {
-                  type
-                  message
-                  detail
-                }
-              }
             }
           }
-        }
-      `,
-      variables: {
-        creditCardInput: { token },
-        profileInput: { phone },
-      },
-    })
-  })
+        `,
+        variables: {
+          creditCardInput: { token },
+          profileInput: { phone },
+        },
+      })
+    }
+  )
 }

--- a/src/v2/Apps/Auction/Routes/__fixtures__/MutationResults/createCreditCardAndUpdatePhone.ts
+++ b/src/v2/Apps/Auction/Routes/__fixtures__/MutationResults/createCreditCardAndUpdatePhone.ts
@@ -26,9 +26,9 @@ export const createCreditCardAndUpdatePhoneFailed: CreateCreditCardAndUpdatePhon
   createCreditCard: {
     creditCardOrError: {
       mutationError: {
-        message: "The `createCreditCard` mutation failed.",
-        type: "",
-        detail: "",
+        message: "Payment information could not be processed.",
+        type: "payment_error",
+        detail: "Your card was declined.",
       },
     },
   },

--- a/src/v2/Apps/Auction/Routes/__tests__/ConfirmBid.jest.tsx
+++ b/src/v2/Apps/Auction/Routes/__tests__/ConfirmBid.jest.tsx
@@ -876,7 +876,7 @@ describe("Routes/ConfirmBid", () => {
 
       expect(window.location.assign).not.toHaveBeenCalled()
       expect(page.text()).toContain(
-        "Please make sure your internet connection is active and try again"
+        "Your card was declined. Please contact your bank or use a different card."
       )
 
       expect(mockPostEvent).toHaveBeenCalledTimes(1)
@@ -884,7 +884,7 @@ describe("Routes/ConfirmBid", () => {
         action_type: AnalyticsSchema.ActionType.ConfirmBidFailed,
         context_page: AnalyticsSchema.PageName.AuctionConfirmBidPage,
         error_messages: [
-          "JavaScript error: The `createCreditCard` mutation failed.",
+          "Your card was declined. Please contact your bank or use a different card.",
         ],
         auction_slug: "saleslug",
         artwork_slug: "artworkslug",


### PR DESCRIPTION
addresses: https://artsyproduct.atlassian.net/browse/AUCT-1087
~~blocked by: https://github.com/artsy/force/pull/5770~~ unblocked

This PR extracts a more detailed error message from the GraphQL response (which originally comes from Stripe) and show it to the user. See screenshot for what it looks like.

## Todo

 * [x] Rebase against master once https://github.com/artsy/force/pull/5770 is merged

## Screenshot

![card-error](https://user-images.githubusercontent.com/386234/84434366-e37e4400-abfd-11ea-92b8-bd4742848cd0.gif)
