### PR TITLE
Limit the width of gallery names to not overflow conversation snippets

### DIFF
--- a/src/v2/Apps/Conversation/Components/ConversationSnippet.tsx
+++ b/src/v2/Apps/Conversation/Components/ConversationSnippet.tsx
@@ -32,7 +32,7 @@ const TruncatedTitle = styled(Sans)`
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  max-width: 350px;
+  max-width: 140px;
 
   @media (max-width: 570px) {
     max-width: 270px;


### PR DESCRIPTION
Truncates the title after 140px

After:
<img width="362" alt="image" src="https://user-images.githubusercontent.com/3087225/84412021-9f2e7c00-abdc-11ea-927a-364898da2cd4.png">


Before:

<img width="388" alt="image" src="https://user-images.githubusercontent.com/3087225/84411955-87ef8e80-abdc-11ea-9689-3811aa95c18b.png">


