### PR TITLE
Add eval as default devtool in webpack build

### DIFF
--- a/webpack/envs/developmentConfig.js
+++ b/webpack/envs/developmentConfig.js
@@ -25,7 +25,7 @@ if (!isCI && !fs.existsSync(cacheDirectory)) {
 
 exports.developmentConfig = {
   mode: NODE_ENV,
-  devtool: WEBPACK_DEVTOOL,
+  devtool: WEBPACK_DEVTOOL || "eval",
   stats: WEBPACK_STATS || "errors-only",
   module: {
     rules: [


### PR DESCRIPTION
I noticed that force builds were hanging for a bit locally and realized it was due to source map generation. Providing `eval` as a default makes it more snappy. 