### PR TITLE
Require user for collector inbox (PURCHASE-1914)

### DIFF
--- a/src/desktop/apps/artsy-v2/middleware/userRequiredMiddleware.tsx
+++ b/src/desktop/apps/artsy-v2/middleware/userRequiredMiddleware.tsx
@@ -1,11 +1,19 @@
-import { getPageType } from "../utils/getPageType"
+import { match } from "path-to-regexp"
 
-const USER_REQUIRED_PAGES = ["identity-verification", "orders", "user"]
+const USER_REQUIRED_ROUTES = [
+  "/identity-verification(.*)",
+  "/orders(.*)",
+  "/user/conversations(.*)",
+]
+
+const isRequestRequiringUser = req => {
+  return USER_REQUIRED_ROUTES.map(route => match(route)).some(matcher =>
+    matcher(req)
+  )
+}
 
 export const userRequiredMiddleware = (req, res, next) => {
-  const { pageType } = getPageType(req)
-
-  if (USER_REQUIRED_PAGES.includes(pageType)) {
+  if (isRequestRequiringUser(req.path)) {
     if (!res.locals.sd.CURRENT_USER) {
       return res.redirect(
         `/login?redirectTo=${encodeURIComponent(req.originalUrl)}`

--- a/src/desktop/apps/artsy-v2/middleware/userRequiredMiddleware.tsx
+++ b/src/desktop/apps/artsy-v2/middleware/userRequiredMiddleware.tsx
@@ -1,6 +1,6 @@
 import { getPageType } from "../utils/getPageType"
 
-const USER_REQUIRED_PAGES = ["identity-verification", "orders"]
+const USER_REQUIRED_PAGES = ["identity-verification", "orders", "user"]
 
 export const userRequiredMiddleware = (req, res, next) => {
   const { pageType } = getPageType(req)

--- a/src/desktop/apps/artsy-v2/utils/getPageType.ts
+++ b/src/desktop/apps/artsy-v2/utils/getPageType.ts
@@ -9,6 +9,7 @@ type PageTypes =
   | "orders"
   | "search"
   | "identity-verification"
+  | "user"
 
 export function getPageType(
   req: Request

--- a/src/desktop/apps/artsy-v2/utils/getPageType.ts
+++ b/src/desktop/apps/artsy-v2/utils/getPageType.ts
@@ -9,7 +9,6 @@ type PageTypes =
   | "orders"
   | "search"
   | "identity-verification"
-  | "user"
 
 export function getPageType(
   req: Request


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-1914

Depending on https://github.com/artsy/force/pull/5780.

The current conversations app does not require a logged-in user, and that causes:

- visiting /user/conversations would 500
- visiting /user/conversations/:id would 404
- logging out from conversations page would visit the same route, so 500 or 404 similarly

This PR requires a user for the conversations app, and follows the existing behavior for logging out from other pages: rendering the login page with proper redirect param (to take user back to the original page after logging in).

## Before

![conversations-not-requiring-user](https://user-images.githubusercontent.com/796573/84506882-fc363a80-ac8d-11ea-9fb9-f95ce4934fbc.gif)


## After

![conversations-requiring-user](https://user-images.githubusercontent.com/796573/84506889-ff312b00-ac8d-11ea-901e-a18af973932e.gif)
