### PR TITLE
Fix jest test path for artsy-v2 app

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
      */
     {
       ...sharedConfig,
+      displayName: "v1",
       testPathIgnorePatterns: ["<rootDir>/src/v2"],
       testRegex: ".*\\.jest\\.(ts|tsx|js|jsx)$",
       setupFiles: ["<rootDir>/test.config.js"],
@@ -28,6 +29,7 @@ module.exports = {
     // Config for src/v2 (former Reaction code)
     {
       ...sharedConfig,
+      displayName: "v2",
       testMatch: ["**/src/v2/**/*.jest.(ts|tsx)"],
       moduleDirectories: ["node_modules", "<rootDir>/src/v2"],
       setupFilesAfterEnv: ["<rootDir>/src/v2/jest.envSetup.ts"],

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,7 +19,7 @@ module.exports = {
      */
     {
       ...sharedConfig,
-      modulePathIgnorePatterns: ["v2"],
+      testPathIgnorePatterns: ["<rootDir>/src/v2"],
       testRegex: ".*\\.jest\\.(ts|tsx|js|jsx)$",
       setupFiles: ["<rootDir>/test.config.js"],
       roots: ["<rootDir>/src"],


### PR DESCRIPTION
While working on https://github.com/artsy/force/pull/5779, I noticed my tests are not picked up by `jest`. Looking a little deeper, it seems the `artsy-v2` app was ignored because of current jest config.

### Before

Total of 277 test suites

<img width="1440" alt="Screen Shot 2020-06-12 at 12 20 50 AM" src="https://user-images.githubusercontent.com/796573/84464585-ed766600-ac42-11ea-8ca8-2817b16c023e.png">

### After

Total of 282 test suites

<img width="1440" alt="Screen Shot 2020-06-12 at 12 20 21 AM" src="https://user-images.githubusercontent.com/796573/84464602-fbc48200-ac42-11ea-87ce-3653261c8b09.png">
