### PR TITLE
Fix mobile web logout bug

### DIFF
--- a/src/mobile/components/layout/bootstrap.coffee
+++ b/src/mobile/components/layout/bootstrap.coffee
@@ -23,6 +23,7 @@ globalReactModules = require('../../../desktop/lib/global_react_modules.tsx')
 hydrateStitch = require('@artsy/stitch/dist/internal/hydrate').hydrate
 analyticsHooks = require('../../lib/analytics_hooks.coffee')
 mediator = require('../../../desktop/lib/mediator.coffee')
+FlashMessage = require('../../../desktop/components/flash/index.coffee')
 
 module.exports = ->
   # Add the Gravity XAPP or access token to all ajax requests
@@ -48,6 +49,7 @@ module.exports = ->
 
   # Setup jQuery plugins
   require 'jquery-on-infinite-scroll'
+  require 'jquery.transition'
   if sd.stitch?.renderQueue?
     mountStitch()
 
@@ -119,4 +121,4 @@ logoutEventHandler = ->
       analyticsHooks.trigger 'auth:logged-out'
       window.location.reload()
     error: (xhr, status, errorMessage) ->
-      # TODO: Error message handling
+      new FlashMessage message: errorMessage

--- a/src/mobile/components/layout/bootstrap.coffee
+++ b/src/mobile/components/layout/bootstrap.coffee
@@ -49,7 +49,7 @@ module.exports = ->
 
   # Setup jQuery plugins
   require 'jquery-on-infinite-scroll'
-  require 'jquery.transition'
+  require 'jquery.transition' # This is required for FlashMessage
   if sd.stitch?.renderQueue?
     mountStitch()
 

--- a/src/mobile/components/layout/stylesheets/index.styl
+++ b/src/mobile/components/layout/stylesheets/index.styl
@@ -26,6 +26,7 @@
 @import './utilities'
 @import './navigation'
 @import '../../app_banner'
+@import '../../../../desktop/components/main_layout/stylesheets/alerts'
 
 global-reset()
 

--- a/src/mobile/components/layout/templates/main.jade
+++ b/src/mobile/components/layout/templates/main.jade
@@ -2,6 +2,8 @@ extends ./scaffold
 include ./login-signup
 
 block body
+  include ../../../../desktop/components/modal/template
+  include ../../../../desktop/components/flash/template
   #content
     #header-content
       block banner


### PR DESCRIPTION
## Problem

https://artsyproduct.atlassian.net/browse/FX-1927

#### User-facing issue
Clicking "Logout" from the navbar on old mobile web views (i.e. not Reaction) produces no result and the user is not able to log out. Users can still logout on desktop and mobile web views using Reaction.


#### Issue root
The handler for the `auth:logout` event lives in `global_client_setup.tsx` and is set up by invoking `globalClientSetup`. Desktop views and Reaction views both use this client setup but old mobile web views do not. When the user attempts to logout, the mediator triggers the `auth:logout` event but the corresponding listener doesn't exist. The result is that the user cannot logout.

## Solution

- Add new `logoutEventHandler` method  that listens for the `auth:logout` event to common mobile layout code for old mobile web routes.
- Add desktop `FlashMessage` component to common old mobile web layout. This error handling UI is currently used on Reaction pages on mobile web.

`FlashMessage` UI on mobile web:

![Screen Shot 2020-06-12 at 3 02 43 PM](https://user-images.githubusercontent.com/4432348/84537469-cdd05380-acbd-11ea-8fda-31580614003c.png)
