### PR TITLE
Add error logging for Metaphysics v2 requests

### DIFF
--- a/src/lib/metaphysics2.coffee
+++ b/src/lib/metaphysics2.coffee
@@ -4,6 +4,7 @@ request = require 'superagent'
 { extend, some } = require 'underscore'
 { METAPHYSICS_ENDPOINT, API_REQUEST_TIMEOUT, REQUEST_ID } = require('sharify').data
 ip = require 'ip'
+chalk = require 'chalk'
 
 resolveIPv4 = (ipAddress) ->
   if ip.isV6Format(ipAddress)? and ipAddress.indexOf('::ffff') >= 0
@@ -39,7 +40,11 @@ metaphysics2 = ({ query, variables, req } = {}) ->
         variables: variables
 
       .end (err, response) ->
-        return reject err if err?
+        if err?
+          errorObject = JSON.parse(err?.response?.text)
+          formattedError = JSON.stringify(errorObject, null, 2)
+          console.error chalk.red(formattedError)
+          return reject err
 
         if response.body.errors?
           error = new Error JSON.stringify response.body.errors

--- a/src/test/lib/metaphysics2.test.coffee
+++ b/src/test/lib/metaphysics2.test.coffee
@@ -61,8 +61,20 @@ describe 'metaphysics2', ->
         data.should.eql artist: id: 'foo-bar'
 
   describe 'error', ->
+    beforeEach ->
+      sinon.stub(console, "error")
+
+    afterEach ->
+      console.error.restore()
+
     it 'rejects with the error', ->
-      @request.end.yields new Error 'some error'
+      serverError = {
+        status: 400,
+        response: {
+          text: '"some error"'
+        }
+      }
+      @request.end.yields serverError
 
       metaphysics2
         variables: id: 'foo-bar'
@@ -74,7 +86,8 @@ describe 'metaphysics2', ->
           }
         '
       .catch (err) ->
-        err.message.should.equal 'some error'
+        console.error.firstCall.args[0].should.containEql 'some error'
+        err.should.equal serverError
 
     it 'includes the data', ->
       @request.end.yields null,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2042

Just a lil DX improvement here as we undertake the Metaphysics v1 → v2 migration.
 
Since step 1 in many cases will be to just switch from Force's MP v1 client to the MP v2 client in order to see what breaks, it would be nice to have immediately useful feedback in local Force's server console output.

### Before

<img width="1854" alt="before" src="https://user-images.githubusercontent.com/140521/84537734-551dc700-acbe-11ea-82b2-ba52be71d82f.png">

### After

<img width="1898" alt="after" src="https://user-images.githubusercontent.com/140521/84537741-5818b780-acbe-11ea-838c-22f6e474cd5a.png">
