### PR TITLE
[PURCHASE-1953] style show inquiry item and refactor Item component

### DIFF
--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -1,13 +1,4 @@
-import {
-  Box,
-  Flex,
-  Image,
-  Link,
-  Sans,
-  Serif,
-  Spacer,
-  color,
-} from "@artsy/palette"
+import { Box, Flex, Image, Link, Sans, Spacer, color } from "@artsy/palette"
 import { Conversation_conversation } from "v2/__generated__/Conversation_conversation.graphql"
 import { DateTime } from "luxon"
 import React, { useEffect, useRef } from "react"
@@ -24,7 +15,42 @@ interface ItemProps {
 
 const Item: React.FC<ItemProps> = props => {
   const { item } = props
-  if (item.__typename === "Artwork") {
+  const itemType = item.__typename
+
+  const getImage = item => {
+    if (itemType === "Artwork") {
+      return item.image?.url
+    } else if (itemType === "Show") {
+      return item.coverImage?.url
+    } else {
+      return null
+    }
+  }
+
+  const itemDetails = item => {
+    if (item.__typename === "Artwork") {
+      return [
+        <Sans size="4" weight="medium" color="white100">
+          {item.artistNames}
+        </Sans>,
+        <Sans size="2" color="white100">
+          {item.title} / {item.date}
+        </Sans>,
+      ]
+    } else if (item.__typename === "Show") {
+      const itemLocation = item.fair?.location?.city
+      return [
+        <Sans size="4" weight="medium" color="white100">
+          {item.fair.name}
+        </Sans>,
+        <Sans size="2" color="white100">
+          {itemLocation && `${itemLocation}, `} {item?.fair?.exhibitionPeriod}
+        </Sans>,
+      ]
+    }
+  }
+
+  if (itemType === "Artwork" || itemType === "Show") {
     return (
       <Link
         href={item.href}
@@ -34,7 +60,7 @@ const Item: React.FC<ItemProps> = props => {
       >
         <Flex flexDirection="column">
           <Image
-            src={item.image.url}
+            src={getImage(item)}
             width="350px"
             borderRadius="15px 15px 0 0"
           />
@@ -45,29 +71,10 @@ const Item: React.FC<ItemProps> = props => {
             background={color("black100")}
             borderRadius="0 0 15px 15px"
           >
-            <Sans size="4" weight="medium" color="white100">
-              {item.artistNames}
-            </Sans>
-            <Sans size="2" color="white100">
-              {item.title} / {item.date}
-            </Sans>
+            {itemDetails(item)}
           </Flex>
         </Flex>
       </Link>
-    )
-  } else if (item.__typename === "Show") {
-    // it's a partnerShow
-    return (
-      <Flex width="350px">
-        <Flex height="auto" alignItems="center" mr={2}>
-          <Image src={item.coverImage.url} width="55px" />
-        </Flex>
-        <Flex flexDirection="column" justifyContent="center">
-          <Serif size="2" weight="semibold">
-            {item.fair.name}
-          </Serif>
-        </Flex>
-      </Flex>
     )
   } else {
     return null
@@ -263,7 +270,12 @@ export const ConversationFragmentContainer = createFragmentContainer(
               id
               fair {
                 name
+                exhibitionPeriod
+                location {
+                  city
+                }
               }
+              href
               name
               coverImage {
                 url

--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -13,9 +13,12 @@ interface ItemProps {
   item: Conversation_conversation["items"][0]["item"]
 }
 
+type ItemType = "Artwork" | "Show"
+
 const Item: React.FC<ItemProps> = props => {
   const { item } = props
-  const itemType = item.__typename
+  if (item.__typename === "%other") return null
+  const itemType = item.__typename as ItemType
 
   const getImage = item => {
     if (itemType === "Artwork") {

--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -13,9 +13,9 @@ interface ItemProps {
   item: Conversation_conversation["items"][0]["item"]
 }
 
-type ItemType = "Artwork" | "Show"
+export type ItemType = "Artwork" | "Show"
 
-const Item: React.FC<ItemProps> = props => {
+export const Item: React.FC<ItemProps> = props => {
   const { item } = props
   if (item.__typename === "%other") return null
   const itemType = item.__typename as ItemType
@@ -33,21 +33,22 @@ const Item: React.FC<ItemProps> = props => {
   const itemDetails = item => {
     if (item.__typename === "Artwork") {
       return [
-        <Sans size="4" weight="medium" color="white100">
+        <Sans key={1} size="4" weight="medium" color="white100">
           {item.artistNames}
         </Sans>,
-        <Sans size="2" color="white100">
+        <Sans key={2} size="2" color="white100">
           {item.title} / {item.date}
         </Sans>,
       ]
     } else if (item.__typename === "Show") {
       const itemLocation = item.fair?.location?.city
       return [
-        <Sans size="4" weight="medium" color="white100">
+        <Sans key={1} size="4" weight="medium" color="white100">
           {item.fair.name}
         </Sans>,
-        <Sans size="2" color="white100">
-          {itemLocation && `${itemLocation}, `} {item?.fair?.exhibitionPeriod}
+        <Sans key={2} size="2" color="white100">
+          {itemLocation && `${itemLocation}, `}
+          {item?.fair?.exhibitionPeriod}
         </Sans>,
       ]
     }

--- a/src/v2/Apps/Conversation/Components/__tests__/Conversation.jest.tsx
+++ b/src/v2/Apps/Conversation/Components/__tests__/Conversation.jest.tsx
@@ -1,0 +1,80 @@
+import { mount } from "enzyme"
+import React from "react"
+import { Item } from "../Conversation"
+import { Conversation_conversation } from "v2/__generated__/Conversation_conversation.graphql"
+
+describe("Conversation", () => {
+  describe("Item", () => {
+    describe("when inquiry item is an artwork", () => {
+      const artworkItemProps: Conversation_conversation["items"][0]["item"] = {
+        __typename: "Artwork",
+        id: "12345",
+        date: "June 22, 2020",
+        title: "Untitled",
+        artistNames: "Banksy",
+        href: "site.com/banksy",
+        image: {
+          url: "image.com/banksy-image",
+        },
+      }
+
+      it("renders the artwork item", () => {
+        const wrapper = mount(<Item item={artworkItemProps} />)
+        const imageSrc = wrapper.find("Image").first().prop("src")
+        const linkHref = wrapper.find("Link").first().prop("href")
+        const name = wrapper.find("Sans").first()
+        const title = wrapper.find("Sans").last()
+
+        expect(imageSrc).toBe("image.com/banksy-image")
+        expect(linkHref).toBe("site.com/banksy")
+        expect(name.text()).toContain("Banksy")
+        expect(title.text()).toContain("Untitled / June 22, 2020")
+      })
+    })
+
+    describe("when inquiry item is a show", () => {
+      const showItemProps: Conversation_conversation["items"][0]["item"] = {
+        __typename: "Show",
+        id: "12345",
+        fair: {
+          name: "Art Fair 2020",
+          exhibitionPeriod: "June 25 - June 28",
+          location: {
+            city: "New York",
+          },
+        },
+        href: "site.com/art-fair-2020",
+        name: "Art Fair 2020",
+        coverImage: {
+          url: "image.com/fair-image",
+        },
+      }
+
+      it("renders the show item", () => {
+        const wrapper = mount(<Item item={showItemProps} />)
+        const imageSrc = wrapper.find("Image").first().prop("src")
+        const linkHref = wrapper.find("Link").first().prop("href")
+        const name = wrapper.find("Sans").first()
+        const locationAndDate = wrapper.find("Sans").last()
+
+        expect(imageSrc).toBe("image.com/fair-image")
+        expect(linkHref).toBe("site.com/art-fair-2020")
+        expect(name.text()).toContain("Art Fair 2020")
+        expect(locationAndDate.text()).toContain("New York, June 25 - June 28")
+      })
+    })
+  })
+
+  describe("when inquiry item is %other", () => {
+    const otherItemProps: Conversation_conversation["items"][0]["item"] = {
+      __typename: "%other",
+    }
+
+    it("renders the show item", () => {
+      const wrapper = mount(<Item item={otherItemProps} />)
+
+      expect(wrapper.find("Link")).toHaveLength(0)
+      expect(wrapper.children()).toHaveLength(0)
+    })
+  })
+})

--- a/src/v2/__generated__/Conversation_conversation.graphql.ts
+++ b/src/v2/__generated__/Conversation_conversation.graphql.ts
@@ -49,7 +49,12 @@ export type Conversation_conversation = {
             readonly id: string;
             readonly fair: {
                 readonly name: string | null;
+                readonly exhibitionPeriod: string | null;
+                readonly location: {
+                    readonly city: string | null;
+                } | null;
             } | null;
+            readonly href: string | null;
             readonly name: string | null;
             readonly coverImage: {
                 readonly url: string | null;
@@ -96,6 +101,13 @@ v3 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
   "args": null,
   "storageKey": null
 };
@@ -337,13 +349,7 @@ return {
                   "args": null,
                   "storageKey": null
                 },
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "href",
-                  "args": null,
-                  "storageKey": null
-                },
+                (v4/*: any*/),
                 {
                   "kind": "LinkedField",
                   "alias": null,
@@ -386,9 +392,35 @@ return {
                   "concreteType": "Fair",
                   "plural": false,
                   "selections": [
-                    (v2/*: any*/)
+                    (v2/*: any*/),
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "exhibitionPeriod",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "location",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "Location",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "city",
+                          "args": null,
+                          "storageKey": null
+                        }
+                      ]
+                    }
                   ]
                 },
+                (v4/*: any*/),
                 (v2/*: any*/),
                 {
                   "kind": "LinkedField",
@@ -417,5 +449,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '2b55ef84e7aa4bfd35bc7585eabc3c11';
+(node as any).hash = 'c7eb6ad394197b3f381a612ca7bbcb12';
 export default node;

--- a/src/v2/__generated__/routes_DetailQuery.graphql.ts
+++ b/src/v2/__generated__/routes_DetailQuery.graphql.ts
@@ -147,8 +147,14 @@ fragment Conversation_conversation on Conversation {
         id
         fair {
           name
+          exhibitionPeriod
+          location {
+            city
+            id
+          }
           id
         }
+        href
         name
         coverImage {
           url
@@ -391,16 +397,6 @@ v11 = [
 v12 = {
   "kind": "LinkedField",
   "alias": null,
-  "name": "fair",
-  "storageKey": null,
-  "args": null,
-  "concreteType": "Fair",
-  "plural": false,
-  "selections": (v5/*: any*/)
-},
-v13 = {
-  "kind": "LinkedField",
-  "alias": null,
   "name": "coverImage",
   "storageKey": null,
   "args": null,
@@ -408,42 +404,42 @@ v13 = {
   "plural": false,
   "selections": (v11/*: any*/)
 },
-v14 = {
+v13 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "endCursor",
   "args": null,
   "storageKey": null
 },
-v15 = {
+v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "hasNextPage",
   "args": null,
   "storageKey": null
 },
-v16 = {
+v15 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "hasPreviousPage",
   "args": null,
   "storageKey": null
 },
-v17 = {
+v16 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "startCursor",
   "args": null,
   "storageKey": null
 },
-v18 = {
+v17 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "email",
   "args": null,
   "storageKey": null
 },
-v19 = [
+v18 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -455,14 +451,14 @@ v19 = [
     "value": "DESC"
   }
 ],
-v20 = {
+v19 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v21 = {
+v20 = {
   "kind": "ScalarField",
   "alias": "thumbnailUrl",
   "name": "url",
@@ -475,14 +471,14 @@ v21 = {
   ],
   "storageKey": "url(version:\"small\")"
 },
-v22 = [
+v21 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v23 = [
+v22 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -642,9 +638,18 @@ return {
                                 "kind": "InlineFragment",
                                 "type": "Show",
                                 "selections": [
-                                  (v12/*: any*/),
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "fair",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Fair",
+                                    "plural": false,
+                                    "selections": (v5/*: any*/)
+                                  },
                                   (v4/*: any*/),
-                                  (v13/*: any*/)
+                                  (v12/*: any*/)
                                 ]
                               }
                             ]
@@ -682,10 +687,10 @@ return {
                 "concreteType": "PageInfo",
                 "plural": false,
                 "selections": [
+                  (v13/*: any*/),
                   (v14/*: any*/),
                   (v15/*: any*/),
-                  (v16/*: any*/),
-                  (v17/*: any*/)
+                  (v16/*: any*/)
                 ]
               }
             ]
@@ -737,7 +742,7 @@ return {
                 "plural": false,
                 "selections": [
                   (v4/*: any*/),
-                  (v18/*: any*/),
+                  (v17/*: any*/),
                   (v2/*: any*/)
                 ]
               },
@@ -761,7 +766,7 @@ return {
                 "alias": null,
                 "name": "messagesConnection",
                 "storageKey": "messagesConnection(first:30,sort:\"DESC\")",
-                "args": (v19/*: any*/),
+                "args": (v18/*: any*/),
                 "concreteType": "MessageConnection",
                 "plural": false,
                 "selections": [
@@ -774,10 +779,10 @@ return {
                     "concreteType": "PageInfo",
                     "plural": false,
                     "selections": [
-                      (v17/*: any*/),
-                      (v14/*: any*/),
                       (v16/*: any*/),
-                      (v15/*: any*/)
+                      (v13/*: any*/),
+                      (v15/*: any*/),
+                      (v14/*: any*/)
                     ]
                   },
                   {
@@ -831,7 +836,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v4/*: any*/),
-                              (v18/*: any*/)
+                              (v17/*: any*/)
                             ]
                           },
                           {
@@ -879,7 +884,7 @@ return {
                 "kind": "LinkedHandle",
                 "alias": null,
                 "name": "messagesConnection",
-                "args": (v19/*: any*/),
+                "args": (v18/*: any*/),
                 "handle": "connection",
                 "key": "Messages_messagesConnection",
                 "filters": []
@@ -911,7 +916,7 @@ return {
                           (v8/*: any*/),
                           (v9/*: any*/),
                           (v10/*: any*/),
-                          (v20/*: any*/),
+                          (v19/*: any*/),
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -936,7 +941,7 @@ return {
                                 ],
                                 "storageKey": "url(version:[\"large\"])"
                               },
-                              (v21/*: any*/)
+                              (v20/*: any*/)
                             ]
                           },
                           {
@@ -958,12 +963,12 @@ return {
                             "alias": null,
                             "name": "artists",
                             "storageKey": "artists(shallow:true)",
-                            "args": (v22/*: any*/),
+                            "args": (v21/*: any*/),
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
                               (v2/*: any*/),
-                              (v20/*: any*/),
+                              (v19/*: any*/),
                               (v4/*: any*/)
                             ]
                           },
@@ -979,12 +984,12 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": (v22/*: any*/),
+                            "args": (v21/*: any*/),
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
                               (v4/*: any*/),
-                              (v20/*: any*/),
+                              (v19/*: any*/),
                               (v2/*: any*/),
                               {
                                 "kind": "ScalarField",
@@ -1070,7 +1075,7 @@ return {
                                 "args": null,
                                 "concreteType": "SaleArtworkHighestBid",
                                 "plural": false,
-                                "selections": (v23/*: any*/)
+                                "selections": (v22/*: any*/)
                               },
                               {
                                 "kind": "LinkedField",
@@ -1080,7 +1085,7 @@ return {
                                 "args": null,
                                 "concreteType": "SaleArtworkOpeningBid",
                                 "plural": false,
-                                "selections": (v23/*: any*/)
+                                "selections": (v22/*: any*/)
                               },
                               (v2/*: any*/)
                             ]
@@ -1098,10 +1103,48 @@ return {
                         "kind": "InlineFragment",
                         "type": "Show",
                         "selections": [
-                          (v12/*: any*/),
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "fair",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Fair",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "exhibitionPeriod",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "location",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "Location",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "city",
+                                    "args": null,
+                                    "storageKey": null
+                                  },
+                                  (v2/*: any*/)
+                                ]
+                              },
+                              (v2/*: any*/)
+                            ]
+                          },
+                          (v19/*: any*/),
                           (v4/*: any*/),
-                          (v13/*: any*/),
-                          (v20/*: any*/),
+                          (v12/*: any*/),
                           {
                             "kind": "LinkedField",
                             "alias": "image",
@@ -1111,7 +1154,7 @@ return {
                             "concreteType": "Image",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/)
+                              (v20/*: any*/)
                             ]
                           }
                         ]
@@ -1131,7 +1174,7 @@ return {
     "operationKind": "query",
     "name": "routes_DetailQuery",
     "id": null,
-    "text": "query routes_DetailQuery(\n  $conversationID: String!\n) {\n  me {\n    ...Conversation_me_3oGfhn\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  messagesConnection {\n    totalCount\n  }\n}\n\nfragment Conversation_conversation on Conversation {\n  id\n  internalID\n  from {\n    name\n    email\n    id\n  }\n  to {\n    name\n    initials\n    id\n  }\n  initialMessage\n  lastMessageID\n  unread\n  messagesConnection(first: 30, sort: DESC) {\n    pageInfo {\n      startCursor\n      endCursor\n      hasPreviousPage\n      hasNextPage\n    }\n    edges {\n      node {\n        id\n        internalID\n        createdAt\n        isFromUser\n        ...Message_message\n        __typename\n      }\n      cursor\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        id\n        date\n        title\n        artistNames\n        href\n        image {\n          url(version: [\"large\"])\n        }\n      }\n      ... on Show {\n        id\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversation_me_3oGfhn on Me {\n  ...Conversations_me\n  conversation(id: $conversationID) {\n    internalID\n    to {\n      name\n      id\n    }\n    ...Conversation_conversation\n    ...Details_conversation\n    id\n  }\n}\n\nfragment Conversations_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      cursor\n      node {\n        id\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Details_conversation on Conversation {\n  to {\n    name\n    initials\n    id\n  }\n  messagesConnection(first: 30, sort: DESC) {\n    edges {\n      node {\n        attachments {\n          id\n          contentType\n          fileName\n          downloadURL\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        href\n        ...Metadata_artwork\n        image {\n          thumbnailUrl: url(version: \"small\")\n        }\n      }\n      ... on Show {\n        href\n        image: coverImage {\n          thumbnailUrl: url(version: \"small\")\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    contentType\n    fileName\n    downloadURL\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n",
+    "text": "query routes_DetailQuery(\n  $conversationID: String!\n) {\n  me {\n    ...Conversation_me_3oGfhn\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  messagesConnection {\n    totalCount\n  }\n}\n\nfragment Conversation_conversation on Conversation {\n  id\n  internalID\n  from {\n    name\n    email\n    id\n  }\n  to {\n    name\n    initials\n    id\n  }\n  initialMessage\n  lastMessageID\n  unread\n  messagesConnection(first: 30, sort: DESC) {\n    pageInfo {\n      startCursor\n      endCursor\n      hasPreviousPage\n      hasNextPage\n    }\n    edges {\n      node {\n        id\n        internalID\n        createdAt\n        isFromUser\n        ...Message_message\n        __typename\n      }\n      cursor\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        id\n        date\n        title\n        artistNames\n        href\n        image {\n          url(version: [\"large\"])\n        }\n      }\n      ... on Show {\n        id\n        fair {\n          name\n          exhibitionPeriod\n          location {\n            city\n            id\n          }\n          id\n        }\n        href\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversation_me_3oGfhn on Me {\n  ...Conversations_me\n  conversation(id: $conversationID) {\n    internalID\n    to {\n      name\n      id\n    }\n    ...Conversation_conversation\n    ...Details_conversation\n    id\n  }\n}\n\nfragment Conversations_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      cursor\n      node {\n        id\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Details_conversation on Conversation {\n  to {\n    name\n    initials\n    id\n  }\n  messagesConnection(first: 30, sort: DESC) {\n    edges {\n      node {\n        attachments {\n          id\n          contentType\n          fileName\n          downloadURL\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        href\n        ...Metadata_artwork\n        image {\n          thumbnailUrl: url(version: \"small\")\n        }\n      }\n      ... on Show {\n        href\n        image: coverImage {\n          thumbnailUrl: url(version: \"small\")\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    contentType\n    fileName\n    downloadURL\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
Addresses: [PURCHASE-1953](https://artsyproduct.atlassian.net/browse/PURCHASE-1953)

This styles the show inquiry item. I labelled this as WIP because I'm refactoring the `Item` component a bit and wanted to get some eyes and feedback on it.

**Artwork Item:**
<img width="374" alt="Screen Shot 2020-06-12 at 3 51 43 PM" src="https://user-images.githubusercontent.com/5201004/84541098-ac269a80-acc4-11ea-9957-780fc12ea469.png">

**Show Inquiry:**
<img width="382" alt="Screen Shot 2020-06-12 at 3 51 30 PM" src="https://user-images.githubusercontent.com/5201004/84541118-b9438980-acc4-11ea-8f31-0b25e60888db.png">


[PURCHASE-1953]: https://artsyproduct.atlassian.net/browse/PURCHASE-1953