### PR TITLE
Removed events over 15 secs (PLATFORM-2414)

### DIFF
--- a/src/desktop/analytics/editorial_features.js
+++ b/src/desktop/analytics/editorial_features.js
@@ -1,12 +1,5 @@
 if (location.pathname.indexOf("/2016-year-in-art") > -1) {
-  setTimeout(function() {
-    analytics.track("time on page more than 30 seconds", {
-      category: "30 Seconds",
-      message: sd.CURRENT_PATH,
-    })
-  }, 30000)
-
-  analyticsHooks.on("scroll:sa-body", function() {
+  analyticsHooks.on("scroll:sa-body", function () {
     analytics.track("EOY2016 Scroll Into Body", {
       destination_path: null,
       impression_type: "scroll_body",
@@ -18,7 +11,7 @@ if (location.pathname.indexOf("/gender-equality") > -1) {
   $(document.body).on(
     "click",
     '.article__text-section a[href*="gucci"]',
-    function() {
+    function () {
       analytics.track("Click", {
         destination_path: $(this)[0].href.replace(/^.*\/\/[^\/]+/, ""),
         type: "external link",
@@ -31,57 +24,57 @@ if (location.pathname.indexOf("/venice-biennale") > -1) {
     .on(
       "click",
       ".venice-body__partner, .venice-nav__sticky-ubs-logo",
-      function() {
+      function () {
         analytics.track("Clicked partner logo", {
           destination_path: $(this)[0].href.replace(/^.*\/\/[^\/]+/, ""),
           context_type: "venice_biennale_2017",
         })
       }
     )
-    .on("click", ".venice-overlay__play", function() {
-      var label = location.pathname.split("venice-biennale/")[1]
+    .on("click", ".venice-overlay__play", function () {
+      let label = location.pathname.split("venice-biennale/")[1]
       analytics.track("Video play", {
         context_type: "venice_biennale_2017",
         context_label: label || "",
       })
     })
-    .on("click", ".share-to-twitter", function() {
+    .on("click", ".share-to-twitter", function () {
       analytics.track("Article share", {
         service: "twitter",
         context_type: "venice_biennale_2017",
       })
     })
-    .on("click", ".share-to-facebook", function() {
+    .on("click", ".share-to-facebook", function () {
       analytics.track("Article share", {
         service: "facebook",
         context_type: "venice_biennale_2017",
       })
     })
-    .on("click", ".share-by-email", function() {
+    .on("click", ".share-by-email", function () {
       analytics.track("Article share", {
         service: "email",
         context_type: "venice_biennale_2017",
       })
     })
-    .on("click", ".webvr-button", function() {
+    .on("click", ".webvr-button", function () {
       analytics.track("VR Mode", {
         context_type: "venice_biennale_2017",
       })
     })
-    .on("click", ".venice-carousel .mgr-arrow-left", function() {
+    .on("click", ".venice-carousel .mgr-arrow-left", function () {
       analytics.track("Carousel click", {
         context_type: "venice_biennale_2017",
         context_label: "previous_page_in_carousel",
       })
     })
-    .on("click", ".venice-carousel .mgr-arrow-right", function() {
+    .on("click", ".venice-carousel .mgr-arrow-right", function () {
       analytics.track("Carousel click", {
         context_type: "venice_biennale_2017",
         context_label: "next_page_in_carousel",
       })
     })
 
-  analyticsHooks.on("video:duration", function(options) {
+  analyticsHooks.on("video:duration", function (options) {
     analytics.track("Video duration", {
       percent_complete: options.duration,
       context_type: "venice_biennale_2017",
@@ -89,7 +82,7 @@ if (location.pathname.indexOf("/venice-biennale") > -1) {
     })
   })
 
-  analyticsHooks.on("video:seconds", function(options) {
+  analyticsHooks.on("video:seconds", function (options) {
     analytics.track("Video seconds", {
       seconds_complete: options.seconds,
       context_type: "venice_biennale_2017",
@@ -97,7 +90,7 @@ if (location.pathname.indexOf("/venice-biennale") > -1) {
     })
   })
 
-  analyticsHooks.on("email:signup", function(options) {
+  analyticsHooks.on("email:signup", function (options) {
     analytics.track("Sign up for editorial email", {
       user_email: options.user_email,
       context_type: "venice_biennale_2017",

--- a/src/desktop/analytics/main_layout.js
+++ b/src/desktop/analytics/main_layout.js
@@ -127,9 +127,6 @@ class PageTimeTracker {
 
 window.desktopPageTimeTrackers = [
   new PageTimeTracker(sd.CURRENT_PATH, 15000, "15 seconds"),
-  new PageTimeTracker(sd.CURRENT_PATH, 30000, "30 seconds"),
-  new PageTimeTracker(sd.CURRENT_PATH, 60000, "1 minute"),
-  new PageTimeTracker(sd.CURRENT_PATH, 180000, "3 minutes"),
 ]
 
 // debug tracking calls

--- a/src/mobile/analytics/global.js
+++ b/src/mobile/analytics/global.js
@@ -3,34 +3,26 @@
 // before you add to this file.
 //
 
-analyticsHooks.on("track", function(message, options) {
+analyticsHooks.on("track", function (message, options) {
   analytics.track(message, options)
 })
 
 // Track 15 second bounce rate
-setTimeout(function() {
+setTimeout(function () {
   analytics.track("time on page more than 15 seconds", {
     category: "15 Seconds",
     message: sd.CURRENT_PATH,
   })
 }, 15000)
 
-// Track 30 second bounce rate
-setTimeout(function() {
-  analytics.track("time on page more than 30 seconds", {
-    category: "30 Seconds",
-    message: sd.CURRENT_PATH,
-  })
-}, 180000)
-
 // Debug tracking calls
 if (sd.SHOW_ANALYTICS_CALLS) {
-  analytics.on("track", function() {
+  analytics.on("track", function () {
     console.debug("TRACKED: ", arguments[0], JSON.stringify(arguments[1]))
   })
 }
 if (sd.SHOW_ANALYTICS_CALLS) {
-  analyticsHooks.on("all", function(name, data) {
+  analyticsHooks.on("all", function (name, data) {
     console.info("ANALYTICS HOOK: ", name, data)
   })
 }


### PR DESCRIPTION
Removed additional, non 15 secs, events being fired. In progress: switching to use `timeOnPage`.