### PR TITLE
[Toolchain] Fix storybooks

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -154,7 +154,7 @@ module.exports = async ({ config, mode }) => {
     },
     {
       test: /\.tsx?$/,
-      include: [/src\/v2/],
+      include: [/src\/v2/, /src\/lib/],
       exclude: [/node_modules/],
       use: [
         {
@@ -178,6 +178,12 @@ module.exports = async ({ config, mode }) => {
       use: [],
     }
   )
+
+  config.externals = {
+    // Don't bundle modules and consider them external
+    redis: "redis",
+    request: "request",
+  }
 
   return config
 }


### PR DESCRIPTION
Storybooks started failing once we introduced a new code-path to the compile pipeline -- `src/lib` -- where previously we were only compiling `v2`. We also needed to exclude redis from webpack. 