### PR TITLE
User should see an error message in the error modal on the bid+register form

### DIFF
--- a/src/v2/Apps/Auction/Components/AuctionErrorModal.tsx
+++ b/src/v2/Apps/Auction/Components/AuctionErrorModal.tsx
@@ -1,0 +1,39 @@
+import React, { ComponentProps } from "react"
+
+import { ErrorModal } from "v2/Components/Modal/ErrorModal"
+import {
+  BiddingStatus,
+  errorMessageForBidding,
+} from "v2/Apps/Auction/Components/Form"
+
+const HEADER_TEXT_MAPPING = {
+  SALE_CLOSED: "Sale Closed",
+  LIVE_BIDDING_STARTED: "Live Auction in Progress",
+
+  // In case of bidder not qualified, the user would be redirected back to the
+  // sale top page (same behaviour as registration form) and we do not have to
+  // display error messages on the form.
+  BIDDER_NOT_QUALIFIED: null,
+  ERROR: null,
+
+  // When the bid is low, the error message is inlined so the error modal does
+  // not have to host it here.
+  OUTBID: null,
+  RESERVE_NOT_MET: null,
+}
+
+interface AuctionErrorModalProps extends ComponentProps<typeof ErrorModal> {
+  status: BiddingStatus
+}
+
+export const AuctionErrorModal = (props: AuctionErrorModalProps) => {
+  const { status, ...remainderProps } = props
+
+  return (
+    <ErrorModal
+      headerText={HEADER_TEXT_MAPPING[status]}
+      detailText={errorMessageForBidding(status)}
+      {...remainderProps}
+    />
+  )
+}

--- a/src/v2/Apps/Auction/Components/BidForm.tsx
+++ b/src/v2/Apps/Auction/Components/BidForm.tsx
@@ -36,6 +36,7 @@ import {
   getSelectedBid,
   initialValuesForBidding,
 } from "v2/Apps/Auction/Components/Form"
+import { AuctionErrorModal } from "v2/Apps/Auction/Components/AuctionErrorModal"
 
 const {
   validationSchemaForRegisteredUsers,
@@ -95,6 +96,7 @@ export const BidForm: React.FC<Props> = ({
         setFieldError,
         setFieldValue,
         setFieldTouched,
+        setStatus,
         setSubmitting,
         status,
         submitCount,
@@ -123,13 +125,8 @@ export const BidForm: React.FC<Props> = ({
               setFieldTouched("selectedBid")
             }}
             options={displayIncrements}
+            error={touched.selectedBid && errors.selectedBid}
           />
-
-          {touched.selectedBid && errors.selectedBid && (
-            <Sans mt={1} color="red100" size="2">
-              {errors.selectedBid}
-            </Sans>
-          )}
 
           <PricingTransparency
             relayEnvironment={relay.environment}
@@ -169,36 +166,28 @@ export const BidForm: React.FC<Props> = ({
             </>
           )}
 
-          <Flex mb={3} flexDirection="column" justifyContent="center">
-            {requiresCheckbox && (
-              <>
-                <Separator mb={3} />
+          <Spacer mt={3} />
 
-                <Box mx="auto">
-                  <ConditionsOfSaleCheckbox
-                    selected={values.agreeToTerms}
-                    onSelect={value => {
-                      // `setFieldTouched` needs to be called first otherwise it would cause race condition.
-                      setFieldTouched("agreeToTerms")
-                      setFieldValue("agreeToTerms", value)
-                    }}
-                  />
-                </Box>
+          {requiresCheckbox && (
+            <Flex mb={3} flexDirection="column" justifyContent="center">
+              <Box mx="auto">
+                <ConditionsOfSaleCheckbox
+                  selected={values.agreeToTerms}
+                  onSelect={value => {
+                    // `setFieldTouched` needs to be called first otherwise it would cause race condition.
+                    setFieldTouched("agreeToTerms")
+                    setFieldValue("agreeToTerms", value)
+                  }}
+                />
+              </Box>
 
-                {touched.agreeToTerms && errors.agreeToTerms && (
-                  <Sans mt={1} color="red100" size="2" textAlign="center">
-                    {errors.agreeToTerms}
-                  </Sans>
-                )}
-              </>
-            )}
-
-            {status && (
-              <Sans textAlign="center" size="3" color="red100" mb={2}>
-                {status}.
-              </Sans>
-            )}
-          </Flex>
+              {touched.agreeToTerms && errors.agreeToTerms && (
+                <Sans mt={1} color="red100" size="2" textAlign="center">
+                  {errors.agreeToTerms}
+                </Sans>
+              )}
+            </Flex>
+          )}
 
           <Button
             size="large"
@@ -208,6 +197,12 @@ export const BidForm: React.FC<Props> = ({
           >
             Confirm bid
           </Button>
+
+          <AuctionErrorModal
+            show={!!status}
+            onClose={() => setStatus(null)}
+            status={status}
+          />
         </Form>
       )}
     </Formik>

--- a/src/v2/Apps/Auction/Components/Form/helpers.tsx
+++ b/src/v2/Apps/Auction/Components/Form/helpers.tsx
@@ -5,7 +5,22 @@ import { data as sd } from "sharify"
 
 import { Address } from "v2/Components/AddressForm"
 
-const ERROR_SUFFIX = {
+// TODO: Duplicate of `confirmRegistrationPath` in `src/v2/Apps/Auction/getRedirect.ts`
+export const saleConfirmRegistrationPath = (saleSlug: string) => {
+  return `/auction/${saleSlug}/confirm-registration`
+}
+
+// From https://github.com/artsy/metaphysics/blob/d6257e33/src/schema/v2/me/bidder_position_messages.ts#L3-L10
+export type BiddingStatus =
+  | "BIDDER_NOT_QUALIFIED"
+  | "ERROR"
+  | "LIVE_BIDDING_STARTED"
+  | "OUTBID"
+  | "RESERVE_NOT_MET"
+  | "SALE_CLOSED"
+  | string
+
+const CARD_ERROR_MAPPING = {
   "Your card was declined.":
     "Please contact your bank or use a different card.",
   "Your card has insufficient funds.":
@@ -14,8 +29,25 @@ const ERROR_SUFFIX = {
   "Your card's security code is incorrect.": "Please try again.",
 }
 
-export const errorMessageForCard = (errorMessage: string) => {
-  return `${errorMessage} ${ERROR_SUFFIX[errorMessage] || ""}`
+const BIDDING_STATE_TO_MESSAGE_MAPPING = {
+  // In case of bidder not qualified, the user would be redirected back to the
+  // sale top page (same behaviour as registration form) and we do not have to
+  // display error messages on the form.
+  BIDDER_NOT_QUALIFIED: null,
+  ERROR: null,
+
+  LIVE_BIDDING_STARTED: "Continue to the live sale to place your bid.",
+  OUTBID: "Your bid wasn't high enough. Please select a higher bid.",
+  RESERVE_NOT_MET: "Your bid wasn't high enough. Please select a higher bid.",
+  SALE_CLOSED: "This sale had been closed. Please browse other open sales.",
+}
+
+export const errorMessageForCard = (errorMessage: BiddingStatus) => {
+  return `${errorMessage} ${CARD_ERROR_MAPPING[errorMessage] || ""}`
+}
+
+export const errorMessageForBidding = (errorMessage: BiddingStatus) => {
+  return BIDDING_STATE_TO_MESSAGE_MAPPING[errorMessage]
 }
 
 export const toStripeAddress = (address: Address): stripe.TokenOptions => {

--- a/src/v2/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/v2/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -32,13 +32,20 @@ import {
   FormValuesForBidding,
   createStripeWrapper,
   determineDisplayRequirements,
+  errorMessageForBidding,
   errorMessageForCard,
+  saleConfirmRegistrationPath,
   toStripeAddress,
 } from "v2/Apps/Auction/Components/Form"
 
 const logger = createLogger("Apps/Auction/Routes/ConfirmBid")
 
 type BidFormActions = FormikActions<FormValuesForBidding>
+// TODO: Replace with a GraphQL type
+interface BidderPosition {
+  status: string
+  messageHeader: string
+}
 
 interface ConfirmBidProps extends ReactStripeElements.InjectedStripeProps {
   artwork: routes_ConfirmBidQueryResponse["artwork"]
@@ -110,9 +117,30 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
     logger.error(error)
     trackConfirmBidFailed([`JavaScript error: ${error.message}`])
     actions.setSubmitting(false)
-    actions.setStatus(
-      "Something went wrong while processing your bid. Please make sure your internet connection is active and try again"
-    )
+    actions.setStatus("ERROR")
+  }
+
+  function handleMutationError(
+    helpers: BidFormActions,
+    bidderPosition: BidderPosition
+  ) {
+    const { status, messageHeader } = bidderPosition
+
+    trackConfirmBidFailed([messageHeader])
+
+    if (status === "OUTBID" || status === "RESERVE_NOT_MET") {
+      helpers.setFieldError("selectedBid", errorMessageForBidding(status))
+      helpers.setSubmitting(false)
+    } else if (
+      status === "BIDDER_NOT_QUALIFIED" ||
+      (status === "ERROR" && messageHeader === "Bid not placed")
+    ) {
+      // The found router does not seem to work with a non-found route.
+      window.location.assign(saleConfirmRegistrationPath(sale.slug))
+    } else {
+      helpers.setStatus(status)
+      helpers.setSubmitting(false)
+    }
   }
 
   function trackConfirmBidFailed(errors: string[]) {
@@ -206,7 +234,7 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
     selectedBid: number
   }) {
     const { result } = data.createBidderPosition
-    const { position, messageHeader } = result
+    const { position } = result
 
     if (!bidderId && !registrationTracked) {
       const newBidderId =
@@ -229,9 +257,7 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
         .then(res => checkBidderPosition({ actions, data: res, selectedBid }))
         .catch(error => onJsError(actions, error))
     } else {
-      actions.setStatus(messageHeader)
-      actions.setSubmitting(false)
-      trackConfirmBidFailed([messageHeader])
+      handleMutationError(actions, result)
     }
   }
 
@@ -245,7 +271,7 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
     selectedBid: number
   }) {
     const { bidderPosition } = data.me
-    const { status, position, messageHeader } = bidderPosition
+    const { status, position } = bidderPosition
 
     if (status === "PENDING" && pollCount < MAX_POLL_ATTEMPTS) {
       // initiating new request here (vs setInterval) to make sure we wait for
@@ -265,12 +291,9 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
       pollCount += 1
     } else if (status === "WINNING") {
       trackConfirmBidSuccess(position.internalID, selectedBid)
-      const href = `/artwork/${artwork.slug}`
-      window.location.assign(href)
+      window.location.assign(`/artwork/${artwork.slug}`)
     } else {
-      actions.setStatus(messageHeader)
-      actions.setSubmitting(false)
-      trackConfirmBidFailed([messageHeader])
+      handleMutationError(actions, bidderPosition)
     }
   }
 

--- a/src/v2/Apps/Auction/Routes/Register/index.tsx
+++ b/src/v2/Apps/Auction/Routes/Register/index.tsx
@@ -19,12 +19,12 @@ import {
   graphql,
 } from "react-relay"
 import { TrackingProp } from "react-tracking"
-import { data as sd } from "sharify"
 import { bidderNeedsIdentityVerification } from "v2/Utils/identityVerificationRequirements"
 import createLogger from "v2/Utils/logger"
 import {
   createStripeWrapper,
   errorMessageForCard,
+  saleConfirmRegistrationPath,
   toStripeAddress,
 } from "v2/Apps/Auction/Components/Form"
 import { ReactStripeElements } from "react-stripe-elements"
@@ -53,11 +53,6 @@ function createBidder(relayEnvironment: RelayProp.environment, saleID: string) {
       })
     }
   )
-}
-
-// TODO: Move it to helpers?
-const saleConfirmRegistrationPath = (saleSlug: string) => {
-  return `${sd.APP_URL}/auction/${saleSlug}/confirm-registration`
 }
 
 type OnSubmitType = ComponentProps<typeof RegistrationForm>["onSubmit"]

--- a/src/v2/Apps/Auction/Routes/__fixtures__/MutationResults/createBidderPosition.ts
+++ b/src/v2/Apps/Auction/Routes/__fixtures__/MutationResults/createBidderPosition.ts
@@ -45,8 +45,38 @@ export const createBidderPositionFailed: ConfirmBidCreateBidderPositionMutationR
   createBidderPosition: {
     result: {
       position: null,
-      status: "FAILED",
-      messageHeader: "Sale Closed to Bids",
+      status: "SALE_CLOSED",
+      messageHeader: "Lot closed",
+    },
+  },
+}
+
+export const createBidderPositionWithLiveBiddingStarted: ConfirmBidCreateBidderPositionMutationResponse = {
+  createBidderPosition: {
+    result: {
+      position: null,
+      status: "LIVE_BIDDING_STARTED",
+      messageHeader: "Live bidding has started",
+    },
+  },
+}
+
+export const createBidderPositionWithErrorBidNotPlaced: ConfirmBidCreateBidderPositionMutationResponse = {
+  createBidderPosition: {
+    result: {
+      position: null,
+      status: "ERROR",
+      messageHeader: "Bid not placed",
+    },
+  },
+}
+
+export const createBidderPositionWithBidderNotQualified: ConfirmBidCreateBidderPositionMutationResponse = {
+  createBidderPosition: {
+    result: {
+      position: null,
+      status: "BIDDER_NOT_QUALIFIED",
+      messageHeader: "Bid not placed",
     },
   },
 }

--- a/src/v2/Apps/Auction/Routes/__tests__/Register.jest.tsx
+++ b/src/v2/Apps/Auction/Routes/__tests__/Register.jest.tsx
@@ -177,7 +177,7 @@ describe("Routes/Register ", () => {
     expect(mockPostEvent).toHaveBeenCalledTimes(1)
 
     expect(window.location.assign).toHaveBeenCalledWith(
-      `https://example.com/auction/${RegisterQueryResponseFixture.sale.slug}/confirm-registration`
+      `/auction/${RegisterQueryResponseFixture.sale.slug}/confirm-registration`
     )
   })
 

--- a/src/v2/Apps/Auction/getRedirect.ts
+++ b/src/v2/Apps/Auction/getRedirect.ts
@@ -76,8 +76,11 @@ export function confirmBidRedirect(
 const auctionPath = (sale: { slug: string }): string => `/auction/${sale.slug}`
 const registrationFlowPath = (sale: { slug: string }): string =>
   auctionPath(sale) + "/registration-flow"
+
+// TODO: Duplicate of `saleConfirmRegistrationPath` in `src/v2/Apps/Auction/Components/Form/helpers.tsx`
 const confirmRegistrationPath = (sale: { slug: string }): string =>
   auctionPath(sale) + "/confirm-registration"
+
 const artworkPath = (
   sale: { slug: string },
   artwork: { slug: string }


### PR DESCRIPTION
addresses https://artsyproduct.atlassian.net/browse/AUCT-1090

This PR replaces the general `status` message with an appropriate UI. There is another doc that hosts a list of error cases on the registration and bid+register forms and I'm going to update this PR once we are all on the same page.

## Todos

 * [x] Add a new test for bidder not qualified for bidding.
 * [x] Add a new test to cover a case where the sale is already closed.
 * [x] Add a new test to cover a case where the live sale has already started.

## Screenshots

<!--
### Before

<img width="659" alt="Screen Shot 2020-06-02 at 3 08 12 PM" src="https://user-images.githubusercontent.com/386234/84703467-46394d80-af26-11ea-8203-d458cb44033f.png">

### After
-->

### Outbid or reserve not met

<img width="1072" alt="Screen Shot 2020-06-15 at 2 27 40 PM" src="https://user-images.githubusercontent.com/386234/84702856-484edc80-af25-11ea-9632-692171d7abb1.png">

### Bidder not qualified

![AUCT-1090](https://user-images.githubusercontent.com/386234/84810072-d0da8500-afd8-11ea-808d-e539693148d3.gif)

### Sale closed

<img width="1072" alt="Screen Shot 2020-06-15 at 2 51 59 PM" src="https://user-images.githubusercontent.com/386234/84702795-33724900-af25-11ea-8776-528e872e0c93.png">

