### PR TITLE
[MWeb] Remove the explicit for_sale filter on mweb artworks grid

### DIFF
--- a/src/mobile/components/filter2/index.coffee
+++ b/src/mobile/components/filter2/index.coffee
@@ -18,7 +18,6 @@ module.exports =
       page: 1
       size: 10
       aggregations: aggregations
-      sort: '-decayed_merch'
 
     if stuckParam
       params.set stuckParam, stuckFacet.id

--- a/src/mobile/components/filter2/index.coffee
+++ b/src/mobile/components/filter2/index.coffee
@@ -18,7 +18,7 @@ module.exports =
       page: 1
       size: 10
       aggregations: aggregations
-      for_sale: true
+      sort: '-decayed_merch'
 
     if stuckParam
       params.set stuckParam, stuckFacet.id


### PR DESCRIPTION
As reported [on slack](https://artsy.slack.com/archives/C9ZJYFDNF/p1592312653447800), we noticed that institutional works were not showing up in a fair's `/browse/artworks` section on mobile web.

Digging into the code, I found that we are (by default) filtering by `for_sale` true in our `filter2` component on mobile web (which is also used by the gene page and a deprecated browse page).

We also don't give users the ability to add/remove a "For sale" filter on any of these views, so users are never able to see not-for-sale works.

Note that this change means that we are now displaying not-for-sale works on gene pages, but given the explanation above I think that's probably okay.

(Gene page) Before:
<img width="352" alt="Screen Shot 2020-06-16 at 12 34 51 PM" src="https://user-images.githubusercontent.com/2081340/84804377-ae446e00-afd0-11ea-8bb5-38d25127fe00.png">

(Gene page) After:
<img width="403" alt="Screen Shot 2020-06-16 at 12 35 11 PM" src="https://user-images.githubusercontent.com/2081340/84804390-b1d7f500-afd0-11ea-80d1-8fadd08a7f4d.png">

(Fair page) Before-- the specific bug:
![image](https://user-images.githubusercontent.com/2081340/84804437-c74d1f00-afd0-11ea-99fa-df557cd92051.png)

(Fair page) After-- the specific bug:
![image](https://user-images.githubusercontent.com/2081340/84804476-d46a0e00-afd0-11ea-801a-a0bea15824b4.png)
