### PR TITLE
Fix cohesion TS errors in tracking Notable Works rail content

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "superagent": "3.8.3"
   },
   "dependencies": {
-    "@artsy/cohesion": "1.10.0",
+    "@artsy/cohesion": "1.12.0",
     "@artsy/express-reloadable": "1.4.8",
     "@artsy/gemup": "0.0.3",
     "@artsy/palette": "10.1.0",

--- a/src/v2/Apps/Artist/Components/ArtistTopWorksRail/ArtistTopWorksRail.tsx
+++ b/src/v2/Apps/Artist/Components/ArtistTopWorksRail/ArtistTopWorksRail.tsx
@@ -36,7 +36,7 @@ export const ArtistTopWorksRail: React.FC<ArtistTopWorksRailProps> = ({
         type: "viewAll",
         contextPageOwnerSlug: artist.slug,
         contextPageOwnerId: artist.id,
-      }) as any
+      })
     )
 
     return setTimeout(
@@ -108,7 +108,7 @@ export const ArtistTopWorksRail: React.FC<ArtistTopWorksRailProps> = ({
                       type: "thumbnail",
                       contextPageOwnerSlug: artist.slug,
                       contextPageOwnerId: artist.id,
-                    }) as any
+                    })
                   )
                 }}
               />

--- a/src/v2/Artsy/Analytics/Schema/index.ts
+++ b/src/v2/Artsy/Analytics/Schema/index.ts
@@ -18,6 +18,8 @@ import { AuthenticationInteraction, Interaction } from "./Interaction"
 import { Label } from "./Label"
 import { Failure, Success } from "./Result"
 import { Type } from "./Type"
+import { Event } from "@artsy/cohesion"
+import { ActionType } from "v2/Artsy/Analytics/Schema/Values"
 
 interface Uncategorized {
   changed: any
@@ -31,6 +33,7 @@ interface Uncategorized {
   variation_id: string
   variation_name: string
   nonInteraction: number
+  action_type: ActionType | string
 }
 
 export type Trackables =
@@ -46,6 +49,7 @@ export type Trackables =
   | Uncategorized
   | AuctionInfo
   | CriteoInfo
+  | Event
 
 /**
  * A sentinel type used to signal that anything goes in order to be able to

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,10 +11,10 @@
     lodash "4.17.15"
     prettier "1.19.1"
 
-"@artsy/cohesion@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-1.10.0.tgz#3c9eef07235b9950adc95a797645b4e0464b3cba"
-  integrity sha512-jaSRodbJD7NRJoj9JMOE5T8CbWotmjpvBF9y0jgdDzy87TZocyFYSRSvVB9kddC8UzWcYXk801QO5BYRNQLKBg==
+"@artsy/cohesion@1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-1.12.0.tgz#4ee91c83f53c9f59d18765ded3defc69ef47778f"
+  integrity sha512-TSU90e5j8mjK90mUkMZsXXt/qo9PtmPym6/CmzPf9gIKMTNS9wZbi6OD+Kb1li0C8S2ZIxWdKfc5pgfqxz4gfQ==
 
 "@artsy/detect-responsive-traits@^0.0.5":
   version "0.0.5"


### PR DESCRIPTION
- Also bumps up cohesion version to 1.12.0