### PR TITLE
Possibly fix the loading issue on the auction registration form

### DIFF
--- a/src/desktop/apps/auction_reaction/client.tsx
+++ b/src/desktop/apps/auction_reaction/client.tsx
@@ -3,6 +3,7 @@ import { routes } from "v2/Apps/Auction/routes"
 import { data as sd } from "sharify"
 import React from "react"
 import ReactDOM from "react-dom"
+import { loadableReady } from "@loadable/component"
 
 buildClientApp({
   routes,
@@ -11,7 +12,9 @@ buildClientApp({
   },
 })
   .then(({ ClientApp }) => {
-    ReactDOM.hydrate(<ClientApp />, document.getElementById("react-root"))
+    loadableReady(() => {
+      ReactDOM.hydrate(<ClientApp />, document.getElementById("react-root"))
+    })
   })
   .catch(error => {
     console.error(error)


### PR DESCRIPTION
addresses https://artsyproduct.atlassian.net/browse/AUCT-1093

Chris and I paired and he found that the `loadableReady` call is missing in `src/desktop/apps/auction_reaction/client.tsx`. I tried to run the integrity test against the locally running instance 10 times and they all succeeded while 1 out of 10 times with the current master failed. The statistics may not be that accurate due to, well, I might have been just lucky when running the test, but I feel pretty good about it.

Once this is staging I'm also going to revert https://github.com/artsy/integrity/pull/143.