### PR TITLE
Fix whitespace on artwork filters

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
@@ -24,7 +24,7 @@ export const ColorFilter: FC<ColorFilterProps> = ({ expanded = false }) => {
   }
   return (
     <Toggle label="Color" expanded={expanded}>
-      <Flex flexDirection="column" alignItems="center" my={1}>
+      <Flex flexDirection="column" alignItems="center">
         <>
           <svg
             version="1.1"

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/GalleryFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/GalleryFilter.tsx
@@ -15,7 +15,7 @@ export const GalleryFilter: FC = () => {
 
   return (
     <Toggle label="Gallery">
-      <Flex flexDirection="column" alignItems="left" my={1}>
+      <Flex flexDirection="column" alignItems="left">
         <RadioGroup
           deselectable
           defaultValue={selectedGallery}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/InstitutionFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/InstitutionFilter.tsx
@@ -15,7 +15,7 @@ export const InstitutionFilter: FC = () => {
 
   return (
     <Toggle label="Institution">
-      <Flex flexDirection="column" alignItems="left" my={1}>
+      <Flex flexDirection="column" alignItems="left">
         <RadioGroup
           deselectable
           defaultValue={selectedItem}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
@@ -16,7 +16,7 @@ export const MediumFilter: FC = () => {
 
   return (
     <Toggle label="Medium" expanded={isExpanded}>
-      <Flex flexDirection="column" alignItems="left" mb={1}>
+      <Flex flexDirection="column" alignItems="left">
         <RadioGroup
           deselectable
           defaultValue={selectedMedium}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
@@ -8,7 +8,7 @@ export const PriceRangeFilter: React.FC = () => {
 
   return (
     <Toggle label="Price" expanded>
-      <Flex flexDirection="column" alignItems="left" my={1}>
+      <Flex flexDirection="column" alignItems="left">
         <RadioGroup
           deselectable
           defaultValue={initialRange}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
@@ -29,7 +29,7 @@ export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({
 
   return (
     <Toggle label="Time period" expanded={expanded}>
-      <Flex flexDirection="column" my={1}>
+      <Flex flexDirection="column">
         <RadioGroup
           deselectable
           defaultValue={selectedPeriod}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/WaysToBuyFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/WaysToBuyFilter.tsx
@@ -54,7 +54,7 @@ export const WaysToBuyFilter: FC = () => {
 
   return (
     <Toggle label="Ways to buy" expanded>
-      <Flex flexDirection="column" my={1}>
+      <Flex flexDirection="column">
         {checkboxes.map((checkbox, index) => {
           const props = {
             disabled: checkbox.disabled,


### PR DESCRIPTION
Related Palette PR: https://github.com/artsy/palette/pull/712

## Problem

White spacing on artwork filters is too large (https://artsyproduct.atlassian.net/browse/FX-1993).

#### Current behavior

![current](https://user-images.githubusercontent.com/4432348/84932645-99380f80-b0a2-11ea-99a4-e902d12c6864.png)

#### Intended design

![intended_design](https://user-images.githubusercontent.com/4432348/84932675-a654fe80-b0a2-11ea-85e8-951e3f830f39.png)

## Solution

In addition to https://github.com/artsy/palette/pull/712 which removes the top margin in Palette's `Toggle` component, we need to remove the additional top/bottom margins on the top level child component to `Toggle`. This impacts the `ArtworkFilters` on both desktop and mobile web and keeps the whitespacing consistent.

![Screen Shot 2020-06-17 at 10 31 01 AM](https://user-images.githubusercontent.com/4432348/84932845-e61be600-b0a2-11ea-8e14-8b0f32a65f83.png)

![Screen Shot 2020-06-17 at 10 48 43 AM](https://user-images.githubusercontent.com/4432348/84932892-f7fd8900-b0a2-11ea-83cd-787f2a4900e9.png)