### PR TITLE
Render attachments in conversation threads and details

### DIFF
--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -1,8 +1,10 @@
 import {
   Box,
+  DocumentIcon,
   EntityHeader,
   Flex,
   FlexProps,
+  Link,
   MessageIcon,
   QuestionCircleIcon,
   ResponsiveImage,
@@ -52,6 +54,13 @@ export const Details: FC<DetailsProps> = ({ conversation, ...props }) => {
   const item =
     conversation.items?.[0]?.item?.__typename !== "%other" &&
     conversation.items?.[0]?.item
+
+  const attachments = conversation.messagesConnection.edges
+    .map(({ node }) => node.attachments)
+    .filter(attachments => attachments.length > 0)
+    .reduce((previous, current) => previous.concat(current), [])
+    .filter(attachment => !attachment.contentType.includes("image"))
+
   return (
     <DetailsContainer
       flexDirection="column"
@@ -96,6 +105,26 @@ export const Details: FC<DetailsProps> = ({ conversation, ...props }) => {
           </Flex>
         </>
       )}
+      {attachments?.length > 0 && (
+        <>
+          <Separator my={2} />
+          <Box px={2}>
+            <Sans size="3" weight="medium" mb={2}>
+              Attachments
+            </Sans>
+            {attachments.map(attachment => {
+              return (
+                <Link href={attachment.downloadURL} target="_blank" noUnderline>
+                  <Flex alignItems="center">
+                    <DocumentIcon mr={0.5} />
+                    <Sans size="3">{attachment.fileName}</Sans>
+                  </Flex>
+                </Link>
+              )
+            })}
+          </Box>
+        </>
+      )}
       <Separator my={2} />
       <Flex flexDirection="column" px={2}>
         <Sans size="3" weight="medium" mb={2}>
@@ -124,6 +153,19 @@ export const DetailsFragmentContainer = createFragmentContainer(Details, {
       to {
         name
         initials
+      }
+      messagesConnection(first: $count, after: $after, sort: DESC)
+        @connection(key: "Messages_messagesConnection", filters: []) {
+        edges {
+          node {
+            attachments {
+              id
+              contentType
+              fileName
+              downloadURL
+            }
+          }
+        }
       }
       items {
         item {

--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -114,7 +114,12 @@ export const Details: FC<DetailsProps> = ({ conversation, ...props }) => {
             </Sans>
             {attachments.map(attachment => {
               return (
-                <Link href={attachment.downloadURL} target="_blank" noUnderline>
+                <Link
+                  key={attachment.id}
+                  href={attachment.downloadURL}
+                  target="_blank"
+                  noUnderline
+                >
                   <Flex alignItems="center">
                     <DocumentIcon mr={0.5} />
                     <Sans size="3">{attachment.fileName}</Sans>

--- a/src/v2/Apps/Conversation/Components/Message.tsx
+++ b/src/v2/Apps/Conversation/Components/Message.tsx
@@ -49,36 +49,28 @@ interface AttachmentProps {
 
 export const Attachment: React.FC<AttachmentProps> = props => {
   const { attachment, alignSelf, bgColor, textColor } = props
-  if (attachment.contentType.startsWith("image")) {
-    return (
-      <AttachmentLink href={attachment.downloadURL} target="_blank">
-        <AttachmentContainer
-          p={1}
-          mt={0.5}
-          alignSelf={alignSelf}
-          background={color(bgColor)}
-        >
+
+  return (
+    <AttachmentLink href={attachment.downloadURL} target="_blank">
+      <AttachmentContainer
+        p={1}
+        mt={0.5}
+        alignSelf={alignSelf}
+        background={color(bgColor)}
+      >
+        {attachment.contentType.startsWith("image") ? (
           <Image src={attachment.downloadURL} />
-        </AttachmentContainer>
-      </AttachmentLink>
-    )
-  } else {
-    return (
-      <AttachmentLink href={attachment.downloadURL} target="_blank">
-        <AttachmentContainer
-          alignSelf={alignSelf}
-          background={color(bgColor)}
-          p={1}
-          mt={0.5}
-        >
-          <Sans color={textColor} weight="medium" size="4" mr={2}>
-            {attachment.fileName}
-          </Sans>
-          <DownloadIcon width="24px" height="24px" />
-        </AttachmentContainer>
-      </AttachmentLink>
-    )
-  }
+        ) : (
+          <>
+            <Sans color={textColor} weight="medium" size="4" mr={2}>
+              {attachment.fileName}
+            </Sans>
+            <DownloadIcon width="24px" height="24px" />
+          </>
+        )}
+      </AttachmentContainer>
+    </AttachmentLink>
+  )
 }
 interface MessageProps extends Omit<BoxProps, "color"> {
   message: Message_message

--- a/src/v2/__generated__/Details_conversation.graphql.ts
+++ b/src/v2/__generated__/Details_conversation.graphql.ts
@@ -7,6 +7,18 @@ export type Details_conversation = {
         readonly name: string;
         readonly initials: string | null;
     };
+    readonly messagesConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly attachments: ReadonlyArray<{
+                    readonly id: string;
+                    readonly contentType: string;
+                    readonly fileName: string;
+                    readonly downloadURL: string;
+                } | null> | null;
+            } | null;
+        } | null> | null;
+    } | null;
     readonly items: ReadonlyArray<{
         readonly item: ({
             readonly __typename: "Artwork";
@@ -41,11 +53,18 @@ const node: ReaderFragment = (function(){
 var v0 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v1 = [
+v2 = [
   {
     "kind": "ScalarField",
     "alias": "thumbnailUrl",
@@ -64,7 +83,18 @@ return {
   "kind": "Fragment",
   "name": "Details_conversation",
   "type": "Conversation",
-  "metadata": null,
+  "metadata": {
+    "connection": [
+      {
+        "count": "count",
+        "cursor": "after",
+        "direction": "forward",
+        "path": [
+          "messagesConnection"
+        ]
+      }
+    ]
+  },
   "argumentDefinitions": [
     {
       "kind": "LocalArgument",
@@ -107,6 +137,111 @@ return {
     },
     {
       "kind": "LinkedField",
+      "alias": "messagesConnection",
+      "name": "__Messages_messagesConnection_connection",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "MessageConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "MessageEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Message",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "attachments",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "Attachment",
+                  "plural": true,
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "id",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "contentType",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "fileName",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "downloadURL",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
+                },
+                (v0/*: any*/)
+              ]
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "cursor",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "pageInfo",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "endCursor",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "hasNextPage",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "LinkedField",
       "alias": null,
       "name": "items",
       "storageKey": null,
@@ -123,18 +258,12 @@ return {
           "concreteType": null,
           "plural": false,
           "selections": [
-            {
-              "kind": "ScalarField",
-              "alias": null,
-              "name": "__typename",
-              "args": null,
-              "storageKey": null
-            },
+            (v0/*: any*/),
             {
               "kind": "InlineFragment",
               "type": "Artwork",
               "selections": [
-                (v0/*: any*/),
+                (v1/*: any*/),
                 {
                   "kind": "LinkedField",
                   "alias": null,
@@ -143,7 +272,7 @@ return {
                   "args": null,
                   "concreteType": "Image",
                   "plural": false,
-                  "selections": (v1/*: any*/)
+                  "selections": (v2/*: any*/)
                 },
                 {
                   "kind": "FragmentSpread",
@@ -156,7 +285,7 @@ return {
               "kind": "InlineFragment",
               "type": "Show",
               "selections": [
-                (v0/*: any*/),
+                (v1/*: any*/),
                 {
                   "kind": "LinkedField",
                   "alias": "image",
@@ -165,7 +294,7 @@ return {
                   "args": null,
                   "concreteType": "Image",
                   "plural": false,
-                  "selections": (v1/*: any*/)
+                  "selections": (v2/*: any*/)
                 }
               ]
             }
@@ -176,5 +305,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '2dd761847f272aa82aa89742fb2aac0d';
+(node as any).hash = 'adf50c39a69901a855db9dd38c7176d4';
 export default node;

--- a/src/v2/__generated__/Message_message.graphql.ts
+++ b/src/v2/__generated__/Message_message.graphql.ts
@@ -13,7 +13,6 @@ export type Message_message = {
     } | null;
     readonly attachments: ReadonlyArray<{
         readonly id: string;
-        readonly internalID: string;
         readonly contentType: string;
         readonly fileName: string;
         readonly downloadURL: string;
@@ -28,22 +27,20 @@ export type Message_message$key = {
 
 
 
-const node: ReaderFragment = (function(){
-var v0 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "internalID",
-  "args": null,
-  "storageKey": null
-};
-return {
+const node: ReaderFragment = {
   "kind": "Fragment",
   "name": "Message_message",
   "type": "Message",
   "metadata": null,
   "argumentDefinitions": [],
   "selections": [
-    (v0/*: any*/),
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "internalID",
+      "args": null,
+      "storageKey": null
+    },
     {
       "kind": "ScalarField",
       "alias": null,
@@ -106,7 +103,6 @@ return {
           "args": null,
           "storageKey": null
         },
-        (v0/*: any*/),
         {
           "kind": "ScalarField",
           "alias": null,
@@ -132,6 +128,5 @@ return {
     }
   ]
 };
-})();
-(node as any).hash = 'a0bb840faf9e20e16a5b20a7e14582aa';
+(node as any).hash = 'ca8c0d1402d6fa269ac0c6573884d489';
 export default node;

--- a/src/v2/__generated__/SendConversationMessageMutation.graphql.ts
+++ b/src/v2/__generated__/SendConversationMessageMutation.graphql.ts
@@ -62,7 +62,6 @@ fragment Message_message on Message {
   }
   attachments {
     id
-    internalID
     contentType
     fileName
     downloadURL
@@ -254,7 +253,6 @@ return {
                     "plural": true,
                     "selections": [
                       (v5/*: any*/),
-                      (v6/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -290,7 +288,7 @@ return {
     "operationKind": "mutation",
     "name": "SendConversationMessageMutation",
     "id": null,
-    "text": "mutation SendConversationMessageMutation(\n  $input: SendConversationMessageMutationInput!\n) {\n  sendConversationMessage(input: $input) {\n    messageEdge {\n      node {\n        impulseID\n        isFromUser\n        body\n        id\n        internalID\n        ...Message_message\n      }\n    }\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    internalID\n    contentType\n    fileName\n    downloadURL\n  }\n}\n",
+    "text": "mutation SendConversationMessageMutation(\n  $input: SendConversationMessageMutationInput!\n) {\n  sendConversationMessage(input: $input) {\n    messageEdge {\n      node {\n        impulseID\n        isFromUser\n        body\n        id\n        internalID\n        ...Message_message\n      }\n    }\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    contentType\n    fileName\n    downloadURL\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/v2/__generated__/routes_DetailQuery.graphql.ts
+++ b/src/v2/__generated__/routes_DetailQuery.graphql.ts
@@ -237,6 +237,25 @@ fragment Details_conversation on Conversation {
     initials
     id
   }
+  messagesConnection(first: 30, sort: DESC) {
+    edges {
+      node {
+        attachments {
+          id
+          contentType
+          fileName
+          downloadURL
+        }
+        id
+        __typename
+      }
+      cursor
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+  }
   items {
     item {
       __typename
@@ -271,7 +290,6 @@ fragment Message_message on Message {
   }
   attachments {
     id
-    internalID
     contentType
     fileName
     downloadURL
@@ -826,7 +844,6 @@ return {
                             "plural": true,
                             "selections": [
                               (v2/*: any*/),
-                              (v3/*: any*/),
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -1114,7 +1131,7 @@ return {
     "operationKind": "query",
     "name": "routes_DetailQuery",
     "id": null,
-    "text": "query routes_DetailQuery(\n  $conversationID: String!\n) {\n  me {\n    ...Conversation_me_3oGfhn\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  messagesConnection {\n    totalCount\n  }\n}\n\nfragment Conversation_conversation on Conversation {\n  id\n  internalID\n  from {\n    name\n    email\n    id\n  }\n  to {\n    name\n    initials\n    id\n  }\n  initialMessage\n  lastMessageID\n  unread\n  messagesConnection(first: 30, sort: DESC) {\n    pageInfo {\n      startCursor\n      endCursor\n      hasPreviousPage\n      hasNextPage\n    }\n    edges {\n      node {\n        id\n        internalID\n        createdAt\n        isFromUser\n        ...Message_message\n        __typename\n      }\n      cursor\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        id\n        date\n        title\n        artistNames\n        href\n        image {\n          url(version: [\"large\"])\n        }\n      }\n      ... on Show {\n        id\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversation_me_3oGfhn on Me {\n  ...Conversations_me\n  conversation(id: $conversationID) {\n    internalID\n    to {\n      name\n      id\n    }\n    ...Conversation_conversation\n    ...Details_conversation\n    id\n  }\n}\n\nfragment Conversations_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      cursor\n      node {\n        id\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Details_conversation on Conversation {\n  to {\n    name\n    initials\n    id\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        href\n        ...Metadata_artwork\n        image {\n          thumbnailUrl: url(version: \"small\")\n        }\n      }\n      ... on Show {\n        href\n        image: coverImage {\n          thumbnailUrl: url(version: \"small\")\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    internalID\n    contentType\n    fileName\n    downloadURL\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n",
+    "text": "query routes_DetailQuery(\n  $conversationID: String!\n) {\n  me {\n    ...Conversation_me_3oGfhn\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  messagesConnection {\n    totalCount\n  }\n}\n\nfragment Conversation_conversation on Conversation {\n  id\n  internalID\n  from {\n    name\n    email\n    id\n  }\n  to {\n    name\n    initials\n    id\n  }\n  initialMessage\n  lastMessageID\n  unread\n  messagesConnection(first: 30, sort: DESC) {\n    pageInfo {\n      startCursor\n      endCursor\n      hasPreviousPage\n      hasNextPage\n    }\n    edges {\n      node {\n        id\n        internalID\n        createdAt\n        isFromUser\n        ...Message_message\n        __typename\n      }\n      cursor\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        id\n        date\n        title\n        artistNames\n        href\n        image {\n          url(version: [\"large\"])\n        }\n      }\n      ... on Show {\n        id\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversation_me_3oGfhn on Me {\n  ...Conversations_me\n  conversation(id: $conversationID) {\n    internalID\n    to {\n      name\n      id\n    }\n    ...Conversation_conversation\n    ...Details_conversation\n    id\n  }\n}\n\nfragment Conversations_me on Me {\n  conversationsConnection(first: 10) {\n    edges {\n      cursor\n      node {\n        id\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Details_conversation on Conversation {\n  to {\n    name\n    initials\n    id\n  }\n  messagesConnection(first: 30, sort: DESC) {\n    edges {\n      node {\n        attachments {\n          id\n          contentType\n          fileName\n          downloadURL\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        href\n        ...Metadata_artwork\n        image {\n          thumbnailUrl: url(version: \"small\")\n        }\n      }\n      ... on Show {\n        href\n        image: coverImage {\n          thumbnailUrl: url(version: \"small\")\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    contentType\n    fileName\n    downloadURL\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
In the conversation thread:
<img width="653" alt="image" src="https://user-images.githubusercontent.com/3087225/84936399-292c8800-b0a8-11ea-9649-c4c7b3263f6b.png">

In the details panel:
<img width="361" alt="image" src="https://user-images.githubusercontent.com/3087225/84936436-38133a80-b0a8-11ea-8e50-4a4bc3049e86.png">

Note that image attachments don't show up in the attachments details view (by design)