### PR TITLE
Fixes an issue where spinner does not show up on registration and bid+register forms

### DIFF
--- a/src/v2/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/v2/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -183,6 +183,10 @@ export const ConfirmBidRoute: React.FC<ConfirmBidProps> = props => {
     values: FormValuesForBidding,
     actions: BidFormActions
   ) {
+    // FIXME: workaround for Formik calling `setSubmitting(false)` when the
+    //  `onSubmit` function does not block.
+    setTimeout(() => actions.setSubmitting(true), 0)
+
     const selectedBid = Number(values.selectedBid)
 
     if (requiresPaymentInformation) {

--- a/src/v2/Apps/Auction/Routes/Register/index.tsx
+++ b/src/v2/Apps/Auction/Routes/Register/index.tsx
@@ -109,6 +109,10 @@ export const RegisterRoute: React.FC<RegisterProps> = props => {
   }
 
   const createTokenAndSubmit: OnSubmitType = async (values, helpers) => {
+    // FIXME: workaround for Formik calling `setSubmitting(false)` when the
+    //  `onSubmit` function does not block.
+    setTimeout(() => helpers.setSubmitting(true), 0)
+
     const address = toStripeAddress(values.address)
     const { phoneNumber } = values.address
     const { setFieldError, setSubmitting } = helpers


### PR DESCRIPTION
Apparently the loading state is broken due to a non-blocking call passed in to `Formik`.

`Formik` internally calls `setSubmitting(true)` before execution and `setSubmitting(false)` once the entire work is done, which is supposed to be helpful. However, for some reason it assumes that the `onSubmit` call is a blocking call (which in most cases is not), and does not wait until the entire async task is done, resulting in just calling `setSubmitting(false)` right after calling `setSubmitting(true)`. This is also hard to test since we mock out async GraphQL calls with a blocking mock function in test.

For now I just added a workaround with a `setTimeout`, which is obviously a smell (and doesn't necessarily solves the problem due to a possible race condition), but it's better than nothing for now...

## Screenshots

### Registration

![spinner](https://user-images.githubusercontent.com/386234/85051744-e5985380-b165-11ea-820f-e018b757da67.gif)

### Bid+Register

![spinner-2](https://user-images.githubusercontent.com/386234/85051737-e29d6300-b165-11ea-85bb-8eca2f5cc958.gif)