### PR TITLE
Skip pointless flashbanner query if the user is present

### DIFF
--- a/src/v2/Components/FlashBanner/__tests__/FlashBanner.jest.tsx
+++ b/src/v2/Components/FlashBanner/__tests__/FlashBanner.jest.tsx
@@ -322,8 +322,9 @@ describe("Email Confirmation CTA", () => {
           <FlashBannerQueryRenderer />
         </SystemContextProvider>
       )
-      expect(wrapper.find(SystemQueryRenderer).prop("query")).toBeNull()
+      expect(wrapper.find(SystemQueryRenderer).exists()).toBeFalsy()
     })
+
     it("does requests user-specific data from metaphysics if there is a user", () => {
       const wrapper = mount(
         <SystemContextProvider user={{ id: "someonespecial" }}>

--- a/src/v2/Components/FlashBanner/__tests__/FlashBanner.jest.tsx
+++ b/src/v2/Components/FlashBanner/__tests__/FlashBanner.jest.tsx
@@ -1,11 +1,16 @@
 import "jest-styled-components"
 import React from "react"
-import { FlashBanner } from "v2/Components/FlashBanner"
+import {
+  FlashBanner,
+  FlashBannerQueryRenderer,
+} from "v2/Components/FlashBanner"
 import { graphql } from "react-relay"
 import { Banner } from "@artsy/palette"
 import { flushPromiseQueue, renderRelayTree } from "v2/DevTools"
 import { mount } from "enzyme"
 import { useTracking } from "v2/Artsy/Analytics/useTracking"
+import { SystemContextProvider } from "v2/Artsy/SystemContext"
+import { SystemQueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
 
 jest.mock("v2/Artsy/Analytics/useTracking")
 jest.unmock("react-relay")
@@ -309,6 +314,23 @@ describe("Email Confirmation CTA", () => {
       })
 
       expect(wrapper.text()).toContain("An error has occurred.")
+    })
+
+    it("does not request user-specific data from metaphysics if there is no user", () => {
+      const wrapper = mount(
+        <SystemContextProvider user={null}>
+          <FlashBannerQueryRenderer />
+        </SystemContextProvider>
+      )
+      expect(wrapper.find(SystemQueryRenderer).prop("query")).toBeNull()
+    })
+    it("does requests user-specific data from metaphysics if there is a user", () => {
+      const wrapper = mount(
+        <SystemContextProvider user={{ id: "someonespecial" }}>
+          <FlashBannerQueryRenderer />
+        </SystemContextProvider>
+      )
+      expect(wrapper.find(SystemQueryRenderer).prop("query")).not.toBeNull()
     })
   })
 })

--- a/src/v2/Components/FlashBanner/index.tsx
+++ b/src/v2/Components/FlashBanner/index.tsx
@@ -20,7 +20,6 @@ interface FlashBannerProps {
  *
  */
 export const FlashBanner: React.FC<FlashBannerProps> = props => {
-  if (typeof window === "undefined") return null
   /**
    * Choose which flash message should be shown in the banner, if any
    */

--- a/src/v2/Components/FlashBanner/index.tsx
+++ b/src/v2/Components/FlashBanner/index.tsx
@@ -20,6 +20,7 @@ interface FlashBannerProps {
  *
  */
 export const FlashBanner: React.FC<FlashBannerProps> = props => {
+  if (typeof window === "undefined") return null
   /**
    * Choose which flash message should be shown in the banner, if any
    */
@@ -82,18 +83,21 @@ const TrackedFlashBanner = track({
 })(FlashBanner)
 
 export const FlashBannerQueryRenderer: React.FC = () => {
-  const { relayEnvironment } = useSystemContext()
+  const { relayEnvironment, user } = useSystemContext()
 
   return (
     <SystemQueryRenderer
       environment={relayEnvironment}
-      query={graphql`
-        query FlashBannerQuery {
-          me {
-            canRequestEmailConfirmation
+      query={
+        user &&
+        graphql`
+          query FlashBannerQuery {
+            me {
+              canRequestEmailConfirmation
+            }
           }
-        }
-      `}
+        `
+      }
       render={({ props, error }) => {
         if (error) console.error(error)
         return <TrackedFlashBanner {...props} />

--- a/src/v2/Components/FlashBanner/index.tsx
+++ b/src/v2/Components/FlashBanner/index.tsx
@@ -20,7 +20,6 @@ interface FlashBannerProps {
  * The component responsible for selecting a determining and displaying a flash message
  */
 export const FlashBanner: React.FC<FlashBannerProps> = props => {
-  if (isServer) return null
   /**
    * Choose which flash message should be shown in the banner, if any
    */
@@ -84,6 +83,7 @@ const TrackedFlashBanner = track({
 
 export const FlashBannerQueryRenderer: React.FC = () => {
   const { relayEnvironment, user } = useSystemContext()
+  if (isServer) return null
 
   return user ? (
     <SystemQueryRenderer

--- a/src/v2/Components/FlashBanner/index.tsx
+++ b/src/v2/Components/FlashBanner/index.tsx
@@ -6,6 +6,7 @@ import { useSystemContext } from "v2/Artsy"
 import { EmailConfirmationCTA } from "v2/Components/FlashBanner/EmailConfirmationCTA"
 import { AnalyticsSchema as Schema, track } from "v2/Artsy/Analytics"
 import { SystemQueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
+import { isServer } from "lib/environment"
 import { EmailConfirmationLinkExpired } from "./EmailConfirmationLinkExpired"
 
 interface FlashBannerProps {
@@ -17,9 +18,9 @@ interface FlashBannerProps {
 
 /**
  * The component responsible for selecting a determining and displaying a flash message
- *
  */
 export const FlashBanner: React.FC<FlashBannerProps> = props => {
+  if (isServer) return null
   /**
    * Choose which flash message should be shown in the banner, if any
    */
@@ -84,23 +85,22 @@ const TrackedFlashBanner = track({
 export const FlashBannerQueryRenderer: React.FC = () => {
   const { relayEnvironment, user } = useSystemContext()
 
-  return (
+  return user ? (
     <SystemQueryRenderer
       environment={relayEnvironment}
-      query={
-        user &&
-        graphql`
-          query FlashBannerQuery {
-            me {
-              canRequestEmailConfirmation
-            }
+      query={graphql`
+        query FlashBannerQuery {
+          me {
+            canRequestEmailConfirmation
           }
-        `
-      }
+        }
+      `}
       render={({ props, error }) => {
         if (error) console.error(error)
         return <TrackedFlashBanner {...props} />
       }}
     />
+  ) : (
+    <TrackedFlashBanner />
   )
 }


### PR DESCRIPTION
[Jira ticket 🔒 ](https://artsyproduct.atlassian.net/browse/AUCT-1089)
I'll merge with @damassi's + one more approving review.

This PR updates the Flash Banner's `SystemQueryRenderer` `query` prop to be null, causing the underlying relay queryrenderer to [skip querying](https://relay.dev/docs/en/query-renderer.html#props) if there is no user to query for.

As an alternative approach I spent a little while trying to make `sd.CURRENT_USER` fully replace `me` ([diff here](https://gist.github.com/erikdstock/b49cbb9349a1f2623d701fb4fc132320)), basically by adding `can_request_email_confirmation` to the allow list for current_user's properties. Unfortunately I realized this user object does not pick up changes immediately, causing the 'request email confirmation' banner to continue appearing until I logged out and back in.