### PR TITLE
[INTGRTY-38] Add hooks for consign submission form integration tests

### DIFF
--- a/src/desktop/apps/consign/components/choose_artist/index.js
+++ b/src/desktop/apps/consign/components/choose_artist/index.js
@@ -50,6 +50,7 @@ function ChooseArtist(props) {
     autoFocus: true,
     value: artistAutocompleteValue,
     onChange: updateArtistAutocompleteValueAction,
+    "data-test": "chooseArtist",
   }
 
   const renderInputComponent = inputProps => (

--- a/src/desktop/apps/consign/components/choose_artist/index.js
+++ b/src/desktop/apps/consign/components/choose_artist/index.js
@@ -84,7 +84,7 @@ function ChooseArtist(props) {
             inputProps={inputProps}
           />
         </div>
-        <div
+        <button
           className={b
             .builder()("next-button")
             .mix("avant-garde-button-black")()}
@@ -96,7 +96,7 @@ function ChooseArtist(props) {
           disabled={!nextEnabled}
         >
           Next
-        </div>
+        </button>
         {notConsigningArtist && (
           <div className={b("not-consigning")}>
             Unfortunately we are not accepting consignments for works by{" "}

--- a/src/desktop/apps/consign/components/location_autocomplete/index.js
+++ b/src/desktop/apps/consign/components/location_autocomplete/index.js
@@ -32,6 +32,7 @@ function LocationAutocomplete(props) {
     disabled: locationAutocompleteFrozen,
     onChange: updateLocationAutocompleteAction,
     value: locationAutocompleteValue,
+    "data-test": "location",
   }
 
   const renderInputComponent = inputProps => (

--- a/src/desktop/apps/consign/components/upload_photo/index.js
+++ b/src/desktop/apps/consign/components/upload_photo/index.js
@@ -63,7 +63,7 @@ function UploadPhoto(props) {
         {uploadedImages.map((file, index) => (
           <UploadedImage file={file} key={`${file.fileName}-${index}`} />
         ))}
-        <div
+        <button
           className={b
             .builder()("submit-button")
             .mix("avant-garde-button-black")()}
@@ -71,7 +71,7 @@ function UploadPhoto(props) {
           disabled={!nextEnabled}
         >
           {isLoading ? <div className="loading-spinner-white" /> : "Submit"}
-        </div>
+        </button>
         {error && <div className={b("error")}>{error}</div>}
       </div>
     </div>


### PR DESCRIPTION
Partially addresses https://artsyproduct.atlassian.net/browse/INTGRTY-38

* Adds a couple `data-test` attributes to hook into elements in integration tests
* Converts a couple "clickable div's" to buttons. (This change is not _required_ to write the integration tests, but I noticed them and if they're meant to be clicked, they should be buttons.)

No noticeable changes to the user.