### PR TITLE
[PURCHASE-1923] Conversation mutation error handling

### DIFF
--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, FlexProps, color, media } from "@artsy/palette"
+import { Button, Dialog, Flex, FlexProps, color, media } from "@artsy/palette"
 import { Conversation_conversation } from "v2/__generated__/Conversation_conversation.graphql"
 import React, { useRef, useState } from "react"
 import { Environment } from "react-relay"
@@ -50,51 +50,81 @@ interface ReplyProps {
 export const Reply: React.FC<ReplyProps> = props => {
   const { environment, conversation } = props
   const [buttonDisabled, setButtonDisabled] = useState(true)
+  const [loading, setLoading] = useState(false)
+  const [showModal, setShowModal] = useState(false)
   const textArea = useRef()
 
+  const setupAndSendMessage = () => {
+    {
+      setLoading(true)
+      return SendConversationMessage(
+        environment,
+        conversation,
+        // @ts-ignore
+        textArea?.current?.value,
+        _response => {
+          // @ts-ignore
+          textArea.current.value = ""
+          setLoading(false)
+          setButtonDisabled(true)
+        },
+        _error => {
+          setLoading(false)
+          setShowModal(true)
+        }
+      )
+    }
+  }
+
   return (
-    <StyledFlex p={1} right={[0, null]} zIndex={2}>
-      <FullWidthFlex width="100%">
-        <StyledTextArea
-          onInput={event => {
-            const field = event.target as HTMLTextAreaElement
-            field.style.height = "inherit"
-            if (buttonDisabled && field.value.length > 2) {
-              setButtonDisabled(false)
-            }
-            if (!buttonDisabled && field.value.length <= 2) {
-              setButtonDisabled(true)
-            }
-            const height = field.scrollHeight
-            field.style.height = height + "px"
-          }}
-          placeholder="Type your message"
-          ref={textArea}
-        />
-      </FullWidthFlex>
-      <Flex alignItems="flex-end">
-        <StyledButton
-          disabled={buttonDisabled}
-          onClick={_event => {
-            return SendConversationMessage(
-              environment,
-              conversation,
-              // @ts-ignore
-              textArea?.current?.value,
-              _response => {
-                // @ts-ignore
-                textArea.current.value = ""
-                setButtonDisabled(true)
-              },
-              _error => {
-                // TBD
+    <>
+      <Dialog
+        show={showModal}
+        title="We coudln’t deliver your message."
+        detail="Sorry, something went wrong while sending your message. Try and resend the message or discard it."
+        primaryCta={{
+          action: () => {
+            setShowModal(false)
+            setupAndSendMessage()
+          },
+          text: "Retry",
+        }}
+        secondaryCta={{
+          action: () => setShowModal(false),
+          text: "Discard message",
+        }}
+      />
+      <StyledFlex p={1} right={[0, null]} zIndex={2}>
+        <FullWidthFlex width="100%">
+          <StyledTextArea
+            onInput={event => {
+              const field = event.target as HTMLTextAreaElement
+              field.style.height = "inherit"
+              if (buttonDisabled && field.value.length > 2) {
+                setButtonDisabled(false)
               }
-            )
-          }}
-        >
-          Send
-        </StyledButton>
-      </Flex>
-    </StyledFlex>
+              if (!buttonDisabled && field.value.length <= 2) {
+                setButtonDisabled(true)
+              }
+              const height = field.scrollHeight
+              field.style.height = height + "px"
+            }}
+            placeholder="Type your message"
+            ref={textArea}
+          />
+        </FullWidthFlex>
+        <Flex alignItems="flex-end">
+          <StyledButton
+            disabled={buttonDisabled}
+            loading={loading}
+            onClick={_event => {
+              setupAndSendMessage()
+            }}
+          >
+            Send
+          </StyledButton>
+        </Flex>
+      </StyledFlex>
+    </>
   )
 }

--- a/src/v2/Apps/Conversation/Mutation/SendConversationMessage.ts
+++ b/src/v2/Apps/Conversation/Mutation/SendConversationMessage.ts
@@ -29,7 +29,6 @@ export const SendConversationMessage = (
   return commitMutation<SendConversationMessageMutation>(environment, {
     onError,
     onCompleted,
-    optimisticUpdater: storeUpdater,
     updater: storeUpdater,
     variables: {
       input: {
@@ -76,25 +75,5 @@ export const SendConversationMessage = (
         ],
       },
     ],
-
-    optimisticResponse: {
-      sendConversationMessage: {
-        messageEdge: {
-          node: {
-            id: null,
-            internalID: null,
-            impulseID: null,
-            body: text,
-            from: {
-              email: conversation.from.email,
-              name: null,
-            },
-            isFromUser: true,
-            createdAt: null, // Intentionally left blank so Message can recognize this as an optimistic response.
-            attachments: [],
-          } as any,
-        },
-      },
-    },
   })
 }


### PR DESCRIPTION
Fixes [PURCHASE-1923](https://artsyproduct.atlassian.net/browse/PURCHASE-1923)

Add SendConversationMessage mutation error handling modal

Also (temporarily) removes the `uptimisticUpdater` because relay doesn't roll it back when error?!

[Double checked](https://artsy.slack.com/archives/C9YNS4X32/p1592503222359800) with Will on design changes.

![mutfailsmall](https://user-images.githubusercontent.com/687513/85076237-bc8bb900-b18d-11ea-8844-0b4fb32d57dd.gif)