### PR TITLE
Fix scrolling to bottom on conversation page (PURCHASE-1916)

### DIFF
--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -121,11 +121,18 @@ export interface ConversationProps {
 const Conversation: React.FC<ConversationProps> = props => {
   const { conversation, relay } = props
 
-  const bottomOfPage = useRef()
+  const bottomOfPage = useRef(null)
+  const initialMount = useRef(true)
 
   const scrollToBottom = () => {
-    const bottomOfPageCurrent = bottomOfPage.current as any
-    bottomOfPageCurrent.scrollIntoView({ behavior: "smooth" })
+    if (bottomOfPage.current !== null) {
+      const scrollOptions = initialMount.current ? {} : { behavior: "smooth" }
+      bottomOfPage.current.scrollIntoView(scrollOptions)
+    }
+
+    if (initialMount.current) {
+      initialMount.current = false
+    }
   }
 
   useEffect(scrollToBottom, [conversation])

--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -128,10 +128,6 @@ const Conversation: React.FC<ConversationProps> = props => {
     bottomOfPageCurrent.scrollIntoView({ behavior: "smooth" })
   }
 
-  useEffect(() => {
-    scrollToBottom()
-  })
-
   useEffect(scrollToBottom, [conversation])
 
   useEffect(() => {

--- a/src/v2/Apps/Conversation/routes.tsx
+++ b/src/v2/Apps/Conversation/routes.tsx
@@ -42,5 +42,6 @@ export const conversationRoutes: RouteConfig[] = [
     cacheConfig: {
       force: true,
     },
+    ignoreScrollBehavior: true,
   },
 ]


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-1916

We implemented the scrolling to bottom behavior on the conversation page when

- the conversations page (`/user/conversations/:id`) first renders, and
- user replies and adds a new message to the view.

The scrolling on page render was broken (on Chrome, but Safari was fine), and it turns out to be [`<ScrollManager>`](https://github.com/artsy/force/blob/3994ddd12d85bf548256751d8da141ad59e06a5d/src/v2/Artsy/Router/buildClientApp.tsx#L91) interfering the scrolling behavior. I don't know exactly why but turning that off on conversation page fixes it.

#### UX Improvement
We are using `smooth` transition animation for both use cases. _I think_ it'd be nice when the page renders it starts from the bottom as soon as possible, so I change to only apply the transition when a new message is added to the view. Let me know how you think!

#### Alternatives to manual scrolling
A possibly better/CSS solution to start from bottom would be using `flex-direction: column-reverse`. However, [Firefox](https://caniuse.com/#search=flex-direction) currently has a [bug](https://bugzil.la/1042151) that doesn't support overflow when using `*-reverse`, so there would be no scrollbar. We currently have 3%-4% users on Firefox so let's stick with the JavaScript approach for now.


![conversations-scrolling](https://user-images.githubusercontent.com/796573/85204585-76486e00-b2e3-11ea-86b0-af86504c68ca.gif)
