### PR TITLE
[GALL-2979] - Starting a placeholder for ViewingRoomsApp and route

### DIFF
--- a/src/v2/Apps/ViewingRoom/ViewingRoomsApp.tsx
+++ b/src/v2/Apps/ViewingRoom/ViewingRoomsApp.tsx
@@ -1,0 +1,75 @@
+import React from "react"
+import { AppContainer } from "v2/Apps/Components/AppContainer"
+import { Box, Sans, breakpoints } from "@artsy/palette"
+import { ViewingRoomsApp_viewingRooms } from "v2/__generated__/ViewingRoomsApp_viewingRooms.graphql"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface ViewingRoomsAppProps {
+  viewingRooms: ViewingRoomsApp_viewingRooms
+}
+
+const ViewingRoomsApp: React.FC<ViewingRoomsAppProps> = props => {
+  const viewingRooms = props.viewingRooms
+
+  if (!viewingRooms?.edges?.length) {
+    return null
+  }
+
+  const viewingRoomsForLatestGrid = viewingRooms.edges
+    .map(vr => {
+      if (!vr.node) {
+        return null
+      }
+
+      if (vr.node.status != "scheduled" && vr.node.status != "live") {
+        return null
+      }
+
+      return {
+        ...vr.node,
+      }
+    })
+    .filter(vr => vr)
+
+  return (
+    <AppContainer maxWidth="100%">
+      <Box maxWidth={breakpoints.xl} mx="auto" width="100%">
+        <Sans size="10" my={3}>
+          Viewing Rooms
+        </Sans>
+        <Box>
+          <Sans size="5">Latest</Sans>
+          <Box>
+            {viewingRoomsForLatestGrid.map(vr => {
+              return (
+                <Sans size="3t" key={vr.slug}>
+                  {vr.title}
+                </Sans>
+              )
+            })}
+          </Box>
+        </Box>
+      </Box>
+    </AppContainer>
+  )
+}
+
+export const ViewingRoomsAppFragmentContainer = createFragmentContainer(
+  ViewingRoomsApp,
+  {
+    viewingRooms: graphql`
+      fragment ViewingRoomsApp_viewingRooms on ViewingRoomConnection {
+        edges {
+          node {
+            slug
+            status
+            title
+          }
+        }
+      }
+    `,
+  }
+)
+
+// Top-level route needs to be exported for bundle splitting in the router
+export default ViewingRoomsAppFragmentContainer

--- a/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomsApp.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomsApp.jest.tsx
@@ -1,0 +1,96 @@
+import React from "react"
+import { MockBoot, renderRelayTree } from "v2/DevTools"
+import ViewingRoomsApp from "../ViewingRoomsApp"
+import { graphql } from "react-relay"
+import { ViewingRoomsApp_Test_QueryRawResponse } from "v2/__generated__/ViewingRoomsApp_Test_Query.graphql"
+import { Breakpoint } from "@artsy/palette"
+
+jest.unmock("react-relay")
+jest.mock("v2/Artsy/Router/useRouter", () => ({
+  useRouter: () => ({
+    match: {
+      params: {
+        slug: "subscription-demo-gg-guy-yanai",
+      },
+    },
+  }),
+  useIsRouteActive: () => false,
+}))
+
+describe("ViewingRoomsApp", () => {
+  describe("with viewing rooms", () => {
+    const getWrapper = async (
+      breakpoint: Breakpoint = "lg",
+      response: ViewingRoomsApp_Test_QueryRawResponse = ViewingRoomsAppFixture
+    ) => {
+      return renderRelayTree({
+        Component: ({ viewingRooms }) => {
+          return (
+            <MockBoot breakpoint={breakpoint}>
+              <ViewingRoomsApp viewingRooms={viewingRooms} />
+            </MockBoot>
+          )
+        },
+        query: graphql`
+          query ViewingRoomsApp_Test_Query @raw_response_type {
+            viewingRooms {
+              ...ViewingRoomsApp_viewingRooms
+            }
+          }
+        `,
+        mockData: response,
+      })
+    }
+
+    it("renders the correct components", async () => {
+      const wrapper = await getWrapper()
+      expect(wrapper.html()).toContain("Viewing Rooms")
+    })
+
+    describe("Viewing rooms grid", () => {
+      it("renders correct viewing rooms", async () => {
+        const wrapper = await getWrapper()
+        const html = wrapper.html()
+        expect(html).not.toContain("Draft VR")
+        expect(html).toContain("Scheduled VR")
+        expect(html).toContain("Live VR")
+        expect(html).not.toContain("Closed VR")
+      })
+    })
+  })
+})
+
+const ViewingRoomsAppFixture: ViewingRoomsApp_Test_QueryRawResponse = {
+  viewingRooms: {
+    edges: [
+      {
+        node: {
+          status: "draft",
+          slug: "test-draft",
+          title: "Draft VR",
+        },
+      },
+      {
+        node: {
+          status: "scheduled",
+          slug: "test-scheduled",
+          title: "Scheduled VR",
+        },
+      },
+      {
+        node: {
+          status: "live",
+          slug: "test-live",
+          title: "Live VR",
+        },
+      },
+      {
+        node: {
+          status: "closed",
+          slug: "test-closed",
+          title: "Closed VR",
+        },
+      },
+    ],
+  },
+}

--- a/src/v2/Apps/ViewingRoom/routes.tsx
+++ b/src/v2/Apps/ViewingRoom/routes.tsx
@@ -6,8 +6,26 @@ import { ViewingRoomStatementRouteFragmentContainer as StatementRoute } from "./
 import { ViewingRoomWorksRouteFragmentContainer as WorksRoute } from "./Routes/Works/ViewingRoomWorksRoute"
 
 const ViewingRoomApp = loadable(() => import("./ViewingRoomApp"))
+const ViewingRoomsApp = loadable(() => import("./ViewingRoomsApp"))
 
 export const routes: RouteConfig[] = [
+  {
+    path: "/viewing-rooms",
+    getComponent: () => ViewingRoomsApp,
+    prepare: () => {
+      ViewingRoomsApp.preload()
+    },
+    query: graphql`
+      query routes_ViewingRoomsAppQuery {
+        viewingRooms {
+          ...ViewingRoomsApp_viewingRooms
+        }
+      }
+    `,
+    cacheConfig: {
+      force: true,
+    },
+  },
   {
     path: "/viewing-room/:slug",
     getComponent: () => ViewingRoomApp,

--- a/src/v2/__generated__/ViewingRoomsApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ViewingRoomsApp_Test_Query.graphql.ts
@@ -1,0 +1,145 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ViewingRoomsApp_Test_QueryVariables = {};
+export type ViewingRoomsApp_Test_QueryResponse = {
+    readonly viewingRooms: {
+        readonly " $fragmentRefs": FragmentRefs<"ViewingRoomsApp_viewingRooms">;
+    } | null;
+};
+export type ViewingRoomsApp_Test_QueryRawResponse = {
+    readonly viewingRooms: ({
+        readonly edges: ReadonlyArray<({
+            readonly node: ({
+                readonly slug: string;
+                readonly status: string;
+                readonly title: string;
+            }) | null;
+        }) | null> | null;
+    }) | null;
+};
+export type ViewingRoomsApp_Test_Query = {
+    readonly response: ViewingRoomsApp_Test_QueryResponse;
+    readonly variables: ViewingRoomsApp_Test_QueryVariables;
+    readonly rawResponse: ViewingRoomsApp_Test_QueryRawResponse;
+};
+
+
+
+/*
+query ViewingRoomsApp_Test_Query {
+  viewingRooms {
+    ...ViewingRoomsApp_viewingRooms
+  }
+}
+
+fragment ViewingRoomsApp_viewingRooms on ViewingRoomConnection {
+  edges {
+    node {
+      slug
+      status
+      title
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ViewingRoomsApp_Test_Query",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRooms",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "ViewingRoomConnection",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ViewingRoomsApp_viewingRooms",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ViewingRoomsApp_Test_Query",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRooms",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "ViewingRoomConnection",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "edges",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "ViewingRoomEdge",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "node",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ViewingRoom",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "slug",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "status",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "title",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ViewingRoomsApp_Test_Query",
+    "id": null,
+    "text": "query ViewingRoomsApp_Test_Query {\n  viewingRooms {\n    ...ViewingRoomsApp_viewingRooms\n  }\n}\n\nfragment ViewingRoomsApp_viewingRooms on ViewingRoomConnection {\n  edges {\n    node {\n      slug\n      status\n      title\n    }\n  }\n}\n",
+    "metadata": {}
+  }
+};
+(node as any).hash = '9c5560fcd60d7ed4ebfab6f143bccfb7';
+export default node;

--- a/src/v2/__generated__/ViewingRoomsApp_viewingRooms.graphql.ts
+++ b/src/v2/__generated__/ViewingRoomsApp_viewingRooms.graphql.ts
@@ -1,0 +1,76 @@
+/* tslint:disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ViewingRoomsApp_viewingRooms = {
+    readonly edges: ReadonlyArray<{
+        readonly node: {
+            readonly slug: string;
+            readonly status: string;
+            readonly title: string;
+        } | null;
+    } | null> | null;
+    readonly " $refType": "ViewingRoomsApp_viewingRooms";
+};
+export type ViewingRoomsApp_viewingRooms$data = ViewingRoomsApp_viewingRooms;
+export type ViewingRoomsApp_viewingRooms$key = {
+    readonly " $data"?: ViewingRoomsApp_viewingRooms$data;
+    readonly " $fragmentRefs": FragmentRefs<"ViewingRoomsApp_viewingRooms">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "ViewingRoomsApp_viewingRooms",
+  "type": "ViewingRoomConnection",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "edges",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "ViewingRoomEdge",
+      "plural": true,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "node",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ViewingRoom",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "slug",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "status",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "title",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = '2b68ac862b09713726f8f1bb9c442c1f';
+export default node;

--- a/src/v2/__generated__/routes_ViewingRoomsAppQuery.graphql.ts
+++ b/src/v2/__generated__/routes_ViewingRoomsAppQuery.graphql.ts
@@ -1,0 +1,133 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type routes_ViewingRoomsAppQueryVariables = {};
+export type routes_ViewingRoomsAppQueryResponse = {
+    readonly viewingRooms: {
+        readonly " $fragmentRefs": FragmentRefs<"ViewingRoomsApp_viewingRooms">;
+    } | null;
+};
+export type routes_ViewingRoomsAppQuery = {
+    readonly response: routes_ViewingRoomsAppQueryResponse;
+    readonly variables: routes_ViewingRoomsAppQueryVariables;
+};
+
+
+
+/*
+query routes_ViewingRoomsAppQuery {
+  viewingRooms {
+    ...ViewingRoomsApp_viewingRooms
+  }
+}
+
+fragment ViewingRoomsApp_viewingRooms on ViewingRoomConnection {
+  edges {
+    node {
+      slug
+      status
+      title
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "routes_ViewingRoomsAppQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRooms",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "ViewingRoomConnection",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ViewingRoomsApp_viewingRooms",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "routes_ViewingRoomsAppQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRooms",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "ViewingRoomConnection",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "edges",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "ViewingRoomEdge",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "node",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ViewingRoom",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "slug",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "status",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "title",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "routes_ViewingRoomsAppQuery",
+    "id": null,
+    "text": "query routes_ViewingRoomsAppQuery {\n  viewingRooms {\n    ...ViewingRoomsApp_viewingRooms\n  }\n}\n\nfragment ViewingRoomsApp_viewingRooms on ViewingRoomConnection {\n  edges {\n    node {\n      slug\n      status\n      title\n    }\n  }\n}\n",
+    "metadata": {}
+  }
+};
+(node as any).hash = 'd455fbea22d4042ba5fb4bd5e0564f5b';
+export default node;


### PR DESCRIPTION
Thanks @damassi and @ansor4 for bearing with me here.

This is by no means a finished page but a beginning of `/viewing-rooms` page here.

@pvinis - I'm hoping in the next step here we can see how to create the VRs Grid reusing some of those cards I believe you've created for iOs view. Maybe we can pair on that at some point?