### PR TITLE
Fix conversation scroll bug

### DIFF
--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -42,6 +42,7 @@ const DetailsContainer = styled(Flex)<{ opacity?: 0 | 1; transform?: string }>`
     transform: none;
     opacity: ${({ opacity }) => opacity};
     top: 114px;
+    z-index: ${({ zIndex }) => zIndex};
   `}
 `
 


### PR DESCRIPTION
The invisible detail box (with `opacity: 0`) was above the conversation box and blocking the events to get to the below level and breaking the scroll. I had a `z-index: -1` there but it was overridden by the large screen media query so I had to add it again to `xs` media query.

Before:

![Screen Shot 2020-06-23 at 3 13 34 PM](https://user-images.githubusercontent.com/687513/85454467-f92f2a00-b56a-11ea-9724-806364ec7e8a.png)

After:

![Screen Shot 2020-06-23 at 3 14 36 PM](https://user-images.githubusercontent.com/687513/85454506-00563800-b56b-11ea-89c3-1e364357f52c.png)
