### PR TITLE
Removes separator between top works and collection rail on artist page

### DIFF
--- a/src/v2/Apps/Artist/Components/ArtistCollectionsRail/ArtistCollectionsRail.tsx
+++ b/src/v2/Apps/Artist/Components/ArtistCollectionsRail/ArtistCollectionsRail.tsx
@@ -1,4 +1,4 @@
-import { Box, Sans, Separator } from "@artsy/palette"
+import { Box, Sans } from "@artsy/palette"
 import { ArtistCollectionsRail_collections } from "v2/__generated__/ArtistCollectionsRail_collections.graphql"
 import { track } from "v2/Artsy/Analytics"
 import * as Schema from "v2/Artsy/Analytics/Schema"
@@ -48,10 +48,9 @@ export class ArtistCollectionsRail extends React.Component<
 
     if (collections.length > 3) {
       return (
-        <Box>
+        <Box my={3}>
           <Waypoint onEnter={once(this.trackImpression.bind(this))} />
 
-          <Separator my={3} />
           {/**
            * The H2 tag was added for SEO purposes
            * TODO: Remove when palette provides the ability to override typography element


### PR DESCRIPTION
#minor QA followup to the Artist rails work in #5817 

Before:
<img width="1133" alt="Screen Shot 2020-06-24 at 2 00 20 PM" src="https://user-images.githubusercontent.com/10385964/85608468-16bfca80-b623-11ea-8d1e-02cff3358387.png">
<img width="367" alt="Screen Shot 2020-06-24 at 1 59 27 PM" src="https://user-images.githubusercontent.com/10385964/85608487-1c1d1500-b623-11ea-969e-90f028c47777.png">



After:
<img width="1073" alt="Screen Shot 2020-06-24 at 1 50 59 PM" src="https://user-images.githubusercontent.com/10385964/85608251-e37d3b80-b622-11ea-8a35-48e025a79021.png">
<img width="368" alt="Screen Shot 2020-06-24 at 1 56 26 PM" src="https://user-images.githubusercontent.com/10385964/85608255-e415d200-b622-11ea-9160-62fdf2f1feae.png">
