### PR TITLE
[FX-1861] Prevents mobile nav from scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
     "react-relay": "7.1.0",
     "react-relay-network-modern": "2.5.1",
     "react-relay-network-modern-ssr": "1.2.2",
+    "react-remove-scroll": "^2.3.0",
     "react-router": "4.2.0",
     "react-router-redux": "4.0.8",
     "react-scrollspy": "3.3.3",

--- a/src/v2/Components/NavBar/Menus/MobileNavMenu/__tests__/MobileNavMenu.jest.tsx
+++ b/src/v2/Components/NavBar/Menus/MobileNavMenu/__tests__/MobileNavMenu.jest.tsx
@@ -18,10 +18,11 @@ describe("MobileNavMenu", () => {
     trigger: jest.fn(),
   }
   const trackEvent = jest.fn()
+  const noop = () => {}
   const getWrapper = props => {
     return mount(
       <SystemContextProvider mediator={mediator} user={props.user}>
-        <MobileNavMenu isOpen menuData={menuData} />
+        <MobileNavMenu isOpen menuData={menuData} onClose={noop} />
       </SystemContextProvider>
     )
   }
@@ -38,10 +39,7 @@ describe("MobileNavMenu", () => {
 
   it("calls logout auth action on logout menu click", () => {
     const wrapper = getWrapper({ user: { type: "NotAdmin" } })
-    wrapper
-      .find("MobileLink")
-      .last()
-      .simulate("click")
+    wrapper.find("MobileLink").last().simulate("click")
     expect(mediator.trigger).toBeCalledWith("auth:logout")
   })
 
@@ -103,7 +101,7 @@ describe("MobileNavMenu", () => {
     it("tracks back button click", () => {
       const wrapper = mount(
         <SystemContextProvider user={null}>
-          <MobileNavMenu isOpen menuData={menuData} />
+          <MobileNavMenu isOpen menuData={menuData} onClose={noop} />
         </SystemContextProvider>
       )
 
@@ -120,7 +118,7 @@ describe("MobileNavMenu", () => {
     it("tracks MobileSubmenuLink click", () => {
       const wrapper = mount(
         <SystemContextProvider user={null}>
-          <MobileNavMenu isOpen menuData={menuData} />
+          <MobileNavMenu isOpen menuData={menuData} onClose={noop} />
         </SystemContextProvider>
       )
 

--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -320,8 +320,8 @@ export const NavBar: React.FC = track(
 
       {showMobileMenu && (
         <>
-          <MobileNavCover onClick={() => toggleMobileNav(false)} />
           <MobileNavMenu
+            onClose={() => toggleMobileNav(false)}
             isOpen={showMobileMenu}
             menuData={menuData}
             onNavButtonClick={handleMobileNavClick}
@@ -354,14 +354,4 @@ const MobileNavDivider = styled(Box)`
   height: 63px;
   position: absolute;
   left: -12px;
-`
-
-const MobileNavCover = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100vh;
-  background: rgba(194, 194, 194, 0.3);
-  z-index: 0;
 `

--- a/src/v2/Components/__stories__/NavBar.story.tsx
+++ b/src/v2/Components/__stories__/NavBar.story.tsx
@@ -81,7 +81,7 @@ storiesOf("Components/NavBar/Menus", module)
     return <Menus.UserMenu />
   })
   .add("MobileNavMenu", () => {
-    return <Menus.MobileNavMenu isOpen menuData={menuData} />
+    return <Menus.MobileNavMenu isOpen menuData={menuData} onClose={() => {}} />
   })
 
 const Container = ({ children }) => {


### PR DESCRIPTION
Re: [FX-1861](https://artsyproduct.atlassian.net/browse/FX-1861)

![](http://static.damonzucconi.com/_capture/c6t7un2VxdsN.gif)

This utilizes the same dependency we're using in palette for removing scroll. In addition the design changes a bit to just fully overlay content.

I'm not exactly happy with this because:

* Extra divs and a separate position fixed stacking context are required because the animated panes relies on moving z-indexes. (This is the reason we can't just use `ModalBase`)
* There's still the whole issue of scrolling panes WITHIN the menu, which is less annoying but still annoying (due to the same issue of moving around z-indexes in pre-rendered panes)
* The close button requires hardcoded values because the underlying mobile nav also requires hardcoded values

-----
A related bug due to all the hardcoded values we've got some weird positioning overflow happening, but that's apparently been a bug. I just can't unsee it:

![](http://static.damonzucconi.com/_capture/uCaVuqbBEbln.png)