### PR TITLE
Reduce force-web staging k8s cpu request.

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -49,7 +49,7 @@ spec:
             periodSeconds: 5
           resources:
             requests:
-              cpu: 700m
+              cpu: 50m
               memory: 1Gi
             limits:
               memory: 1.5Gi


### PR DESCRIPTION
We are having a problem where staging Kubernetes not able to schedule new force-web pods. Staging deployments have been failing.

https://artsy.slack.com/archives/CA8SANW3W/p1593104547350200

Reducing force-web CPU request to make it more schedulable.