### PR TITLE
GALL-2880 Signup for viewing rooms

### DIFF
--- a/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
@@ -6,6 +6,7 @@ import { graphql } from "react-relay"
 import { ViewingRoomApp_OpenTest_QueryRawResponse } from "v2/__generated__/ViewingRoomApp_OpenTest_Query.graphql"
 import { ViewingRoomApp_ClosedTest_QueryRawResponse } from "v2/__generated__/ViewingRoomApp_ClosedTest_Query.graphql"
 import { ViewingRoomApp_UnfoundTest_QueryRawResponse } from "v2/__generated__/ViewingRoomApp_UnfoundTest_Query.graphql"
+import { ViewingRoomApp_LoggedOutTest_QueryRawResponse } from "v2/__generated__/ViewingRoomApp_LoggedOutTest_Query.graphql.ts"
 import { Breakpoint } from "@artsy/palette"
 import { act } from "react-dom/test-utils"
 
@@ -217,7 +218,7 @@ describe("ViewingRoomApp", () => {
   describe("with logged out user", () => {
     const getWrapper = async (
       breakpoint: Breakpoint = "lg",
-      response: ViewingRoomApp_OpenTest_QueryRawResponse = OpenViewingRoomAppFixture
+      response: ViewingRoomApp_LoggedOutTest_QueryRawResponse = LoggedOutViewingRoomAppFixture
     ) => {
       return renderRelayTree({
         Component: ({ viewingRoom }) => {
@@ -232,7 +233,8 @@ describe("ViewingRoomApp", () => {
           )
         },
         query: graphql`
-          query ViewingRoomApp_OpenTest_Query($slug: ID!) @raw_response_type {
+          query ViewingRoomApp_LoggedOutTest_Query($slug: ID!)
+            @raw_response_type {
             viewingRoom(id: $slug) {
               ...ViewingRoomApp_viewingRoom
             }
@@ -294,4 +296,20 @@ const ClosedViewingRoomAppFixture: ViewingRoomApp_ClosedTest_QueryRawResponse = 
 
 const UnfoundViewingRoomAppFixture: ViewingRoomApp_UnfoundTest_QueryRawResponse = {
   viewingRoom: null,
+}
+
+const LoggedOutViewingRoomAppFixture: ViewingRoomApp_LoggedOutTest_QueryRawResponse = {
+  viewingRoom: {
+    title: "Guy Yanai",
+    heroImageURL:
+      "https://d7hftxdivxxvm.cloudfront.net/?resize_to=width&src=https%3A%2F%2Fartsy-media-uploads.s3.amazonaws.com%2F0RnxWDsVmKuALfpmd75YyA%2FCTPHSEPT19_018_JO_Guy_Yanai_TLV_031_20190913.jpg&width=1200&quality=80",
+    partner: {
+      name: "Subscription Demo GG",
+      id: "UGFydG5lcjo1NTQxMjM3MzcyNjE2OTJiMTk4YzAzMDA=",
+      href: "/partner-demo-gg",
+    },
+    distanceToOpen: null,
+    distanceToClose: "Closes in 1 month",
+    status: "live",
+  },
 }

--- a/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { MockBoot, renderRelayTree } from "v2/DevTools"
+import { SystemContextProvider } from "v2/Artsy"
 import ViewingRoomApp from "../ViewingRoomApp"
 import { graphql } from "react-relay"
 import { ViewingRoomApp_OpenTest_QueryRawResponse } from "v2/__generated__/ViewingRoomApp_OpenTest_Query.graphql"
@@ -20,7 +21,14 @@ jest.mock("v2/Artsy/Router/useRouter", () => ({
 }))
 
 describe("ViewingRoomApp", () => {
+  let user
+  const mediator = { trigger: jest.fn() }
   const slug = "subscription-demo-gg-guy-yanai"
+
+  beforeEach(() => {
+    user = { id: "blah" }
+    window.history.pushState({}, "Viewing Room Title", slug)
+  })
 
   describe("with open viewing room", () => {
     const getWrapper = async (
@@ -31,9 +39,11 @@ describe("ViewingRoomApp", () => {
         Component: ({ viewingRoom }) => {
           return (
             <MockBoot breakpoint={breakpoint}>
-              <ViewingRoomApp viewingRoom={viewingRoom}>
-                some child
-              </ViewingRoomApp>
+              <SystemContextProvider mediator={mediator} user={user}>
+                <ViewingRoomApp viewingRoom={viewingRoom}>
+                  some child
+                </ViewingRoomApp>
+              </SystemContextProvider>
             </MockBoot>
           )
         },
@@ -105,9 +115,11 @@ describe("ViewingRoomApp", () => {
         Component: ({ viewingRoom }) => {
           return (
             <MockBoot breakpoint={breakpoint}>
-              <ViewingRoomApp viewingRoom={viewingRoom}>
-                some child
-              </ViewingRoomApp>
+              <SystemContextProvider mediator={mediator} user={user}>
+                <ViewingRoomApp viewingRoom={viewingRoom}>
+                  some child
+                </ViewingRoomApp>
+              </SystemContextProvider>
             </MockBoot>
           )
         },
@@ -169,9 +181,11 @@ describe("ViewingRoomApp", () => {
         Component: ({ viewingRoom }) => {
           return (
             <MockBoot breakpoint={breakpoint}>
-              <ViewingRoomApp viewingRoom={viewingRoom}>
-                some child
-              </ViewingRoomApp>
+              <SystemContextProvider mediator={mediator} user={user}>
+                <ViewingRoomApp viewingRoom={viewingRoom}>
+                  some child
+                </ViewingRoomApp>
+              </SystemContextProvider>
             </MockBoot>
           )
         },

--- a/src/v2/__generated__/ViewingRoomApp_LoggedOutTest_Query.graphql.ts
+++ b/src/v2/__generated__/ViewingRoomApp_LoggedOutTest_Query.graphql.ts
@@ -1,0 +1,213 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ViewingRoomApp_LoggedOutTest_QueryVariables = {
+    slug: string;
+};
+export type ViewingRoomApp_LoggedOutTest_QueryResponse = {
+    readonly viewingRoom: {
+        readonly " $fragmentRefs": FragmentRefs<"ViewingRoomApp_viewingRoom">;
+    } | null;
+};
+export type ViewingRoomApp_LoggedOutTest_QueryRawResponse = {
+    readonly viewingRoom: ({
+        readonly title: string;
+        readonly heroImageURL: string | null;
+        readonly partner: ({
+            readonly name: string | null;
+            readonly id: string | null;
+            readonly href: string | null;
+        }) | null;
+        readonly distanceToOpen: string | null;
+        readonly distanceToClose: string | null;
+        readonly status: string;
+    }) | null;
+};
+export type ViewingRoomApp_LoggedOutTest_Query = {
+    readonly response: ViewingRoomApp_LoggedOutTest_QueryResponse;
+    readonly variables: ViewingRoomApp_LoggedOutTest_QueryVariables;
+    readonly rawResponse: ViewingRoomApp_LoggedOutTest_QueryRawResponse;
+};
+
+
+
+/*
+query ViewingRoomApp_LoggedOutTest_Query(
+  $slug: ID!
+) {
+  viewingRoom(id: $slug) {
+    ...ViewingRoomApp_viewingRoom
+  }
+}
+
+fragment ViewingRoomApp_viewingRoom on ViewingRoom {
+  ...ViewingRoomMeta_viewingRoom
+  ...ViewingRoomHeader_viewingRoom
+  ...ViewingRoomClosed_viewingRoom
+  status
+}
+
+fragment ViewingRoomClosed_viewingRoom on ViewingRoom {
+  partner {
+    href
+    id
+  }
+}
+
+fragment ViewingRoomHeader_viewingRoom on ViewingRoom {
+  heroImageURL
+  title
+  partner {
+    name
+    id
+  }
+  distanceToOpen
+  distanceToClose
+  status
+}
+
+fragment ViewingRoomMeta_viewingRoom on ViewingRoom {
+  title
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "slug",
+    "type": "ID!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "slug"
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ViewingRoomApp_LoggedOutTest_Query",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRoom",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ViewingRoom",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ViewingRoomApp_viewingRoom",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ViewingRoomApp_LoggedOutTest_Query",
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRoom",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ViewingRoom",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "heroImageURL",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "partner",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Partner",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "name",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "id",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "href",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "distanceToOpen",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "distanceToClose",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "status",
+            "args": null,
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ViewingRoomApp_LoggedOutTest_Query",
+    "id": null,
+    "text": "query ViewingRoomApp_LoggedOutTest_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomClosed_viewingRoom\n  status\n}\n\nfragment ViewingRoomClosed_viewingRoom on ViewingRoom {\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  heroImageURL\n  title\n  partner {\n    name\n    id\n  }\n  distanceToOpen\n  distanceToClose\n  status\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n}\n",
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = 'a776017f1a7e8b9dba99b5335a74d057';
+export default node;


### PR DESCRIPTION
- This checks the context for a user log-in status and does the following if the user is logged out: 
  - Opens sign up modal
  - Removes viewing room content or any messages related to viewing room status if user if logged out.
- Adds the `<SystemContextProvider>` in jest tests for the needed `SystemContext`. 
- Use `useEffect` to render modal in client side context since we need access to `location.href` to redirect to after sign-up/log-in.