### PR TITLE
Initial artist series page

### DIFF
--- a/src/v2/Apps/ArtistSeries/ArtistSeriesApp.tsx
+++ b/src/v2/Apps/ArtistSeries/ArtistSeriesApp.tsx
@@ -2,27 +2,37 @@ import React from "react"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { Box, Separator } from "@artsy/palette"
 
+import { SystemContext } from "v2/Artsy"
 import { Footer } from "v2/Components/Footer"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtistSeriesApp_artistSeries } from "v2/__generated__/ArtistSeriesApp_artistSeries.graphql"
 import { ArtistSeriesHeaderFragmentContainer as ArtistSeriesHeader } from "./Components/ArtistSeriesHeader"
+import { userHasLabFeature } from "v2/Utils/user"
+import { ErrorPage } from "v2/Components/ErrorPage"
 
 interface ArtistSeriesAppProps {
   artistSeries: ArtistSeriesApp_artistSeries
 }
 
 const ArtistSeriesApp: React.FC<ArtistSeriesAppProps> = ({ artistSeries }) => {
-  return (
-    <>
-      <AppContainer maxWidth="100%">
-        <Box m={4}>
-          <ArtistSeriesHeader artistSeries={artistSeries} />
-          <Separator mt={6} mb={3} />
-          <Footer />
-        </Box>
-      </AppContainer>
-    </>
-  )
+  const { user } = React.useContext(SystemContext)
+  const isEnabled = userHasLabFeature(user, "Artist Series")
+
+  if (isEnabled) {
+    return (
+      <>
+        <AppContainer maxWidth="100%">
+          <Box m={4}>
+            <ArtistSeriesHeader artistSeries={artistSeries} />
+            <Separator mt={6} mb={3} />
+            <Footer />
+          </Box>
+        </AppContainer>
+      </>
+    )
+  } else {
+    return <ErrorPage code={404} />
+  }
 }
 
 export default createFragmentContainer(ArtistSeriesApp, {

--- a/src/v2/Apps/ArtistSeries/ArtistSeriesApp.tsx
+++ b/src/v2/Apps/ArtistSeries/ArtistSeriesApp.tsx
@@ -20,15 +20,13 @@ const ArtistSeriesApp: React.FC<ArtistSeriesAppProps> = ({ artistSeries }) => {
 
   if (isEnabled) {
     return (
-      <>
-        <AppContainer maxWidth="100%">
-          <Box m={4}>
-            <ArtistSeriesHeader artistSeries={artistSeries} />
-            <Separator mt={6} mb={3} />
-            <Footer />
-          </Box>
-        </AppContainer>
-      </>
+      <AppContainer maxWidth="100%">
+        <Box m={3}>
+          <ArtistSeriesHeader artistSeries={artistSeries} />
+          <Separator mt={6} mb={3} />
+          <Footer />
+        </Box>
+      </AppContainer>
     )
   } else {
     return <ErrorPage code={404} />

--- a/src/v2/Apps/ArtistSeries/ArtistSeriesApp.tsx
+++ b/src/v2/Apps/ArtistSeries/ArtistSeriesApp.tsx
@@ -1,0 +1,34 @@
+import React from "react"
+import { AppContainer } from "v2/Apps/Components/AppContainer"
+import { Box, Separator } from "@artsy/palette"
+
+import { Footer } from "v2/Components/Footer"
+import { createFragmentContainer, graphql } from "react-relay"
+import { ArtistSeriesApp_artistSeries } from "v2/__generated__/ArtistSeriesApp_artistSeries.graphql"
+import { ArtistSeriesHeaderFragmentContainer as ArtistSeriesHeader } from "./Components/ArtistSeriesHeader"
+
+interface ArtistSeriesAppProps {
+  artistSeries: ArtistSeriesApp_artistSeries
+}
+
+const ArtistSeriesApp: React.FC<ArtistSeriesAppProps> = ({ artistSeries }) => {
+  return (
+    <>
+      <AppContainer maxWidth="100%">
+        <Box m={4}>
+          <ArtistSeriesHeader artistSeries={artistSeries} />
+          <Separator mt={6} mb={3} />
+          <Footer />
+        </Box>
+      </AppContainer>
+    </>
+  )
+}
+
+export default createFragmentContainer(ArtistSeriesApp, {
+  artistSeries: graphql`
+    fragment ArtistSeriesApp_artistSeries on ArtistSeries {
+      ...ArtistSeriesHeader_artistSeries
+    }
+  `,
+})

--- a/src/v2/Apps/ArtistSeries/Components/ArtistSeriesHeader.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/ArtistSeriesHeader.tsx
@@ -39,7 +39,9 @@ const ArtistSeriesHeaderLarge: React.FC<ArtistSeriesHeaderProps> = props => {
               <Sans size="8" element="h1" unstable_trackIn>
                 {title}
               </Sans>
-              <Sans size="3t">{description}</Sans>
+              <Sans lineHeight={1.5} size="3t">
+                {description}
+              </Sans>
             </Flex>
           </Col>
           <Col sm={6}>
@@ -72,7 +74,9 @@ const ArtistSeriesHeaderSmall: React.FC<ArtistSeriesHeaderProps> = props => {
       <Sans size="8" element="h1" my={1} unstable_trackIn>
         {title}
       </Sans>
-      <Sans size="3t">{description}</Sans>
+      <Sans lineHeight={1.5} size="3t">
+        {description}
+      </Sans>
     </>
   )
 }

--- a/src/v2/Apps/ArtistSeries/Components/ArtistSeriesHeader.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/ArtistSeriesHeader.tsx
@@ -39,7 +39,7 @@ const ArtistSeriesHeaderLarge: React.FC<ArtistSeriesHeaderProps> = props => {
               <Sans size="8" element="h1" unstable_trackIn>
                 {title}
               </Sans>
-              <Sans lineHeight={1.5} size="3t">
+              <Sans lineHeight={1.5} size="3t" pr={1}>
                 {description}
               </Sans>
             </Flex>

--- a/src/v2/Apps/ArtistSeries/Components/ArtistSeriesHeader.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/ArtistSeriesHeader.tsx
@@ -1,0 +1,59 @@
+import React from "react"
+import { Box, Col, Flex, Grid, Row, Sans } from "@artsy/palette"
+import { Media } from "v2/Utils/Responsive"
+import { createFragmentContainer, graphql } from "react-relay"
+
+import { ArtistSeriesHeader_artistSeries } from "v2/__generated__/ArtistSeriesHeader_artistSeries.graphql"
+
+interface ArtistSeriesHeaderProps {
+  artistSeries: ArtistSeriesHeader_artistSeries
+}
+
+const ArtistSeriesHeader: React.FC<ArtistSeriesHeaderProps> = props => {
+  return (
+    <>
+      <Media greaterThanOrEqual="sm">
+        <ArtistSeriesHeaderLarge {...props} />
+      </Media>
+    </>
+  )
+}
+
+const ArtistSeriesHeaderLarge: React.FC<ArtistSeriesHeaderProps> = props => {
+  const {
+    artistSeries: { title, description },
+  } = props
+  return (
+    <Box>
+      <Grid>
+        <Row>
+          <Col sm={6}>
+            <Flex
+              height="100%"
+              flexDirection="column"
+              justifyContent="space-between"
+            >
+              <Sans size="8">{title}</Sans>
+              <Sans size="3t">{description}</Sans>
+            </Flex>
+          </Col>
+          <Col sm={6}>
+            <Box bg="black10" width={1} height={400}></Box>
+          </Col>
+        </Row>
+      </Grid>
+    </Box>
+  )
+}
+
+export const ArtistSeriesHeaderFragmentContainer = createFragmentContainer(
+  ArtistSeriesHeader,
+  {
+    artistSeries: graphql`
+      fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
+        title
+        description
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/ArtistSeries/Components/ArtistSeriesHeader.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/ArtistSeriesHeader.tsx
@@ -15,6 +15,9 @@ const ArtistSeriesHeader: React.FC<ArtistSeriesHeaderProps> = props => {
       <Media greaterThanOrEqual="sm">
         <ArtistSeriesHeaderLarge {...props} />
       </Media>
+      <Media lessThan="sm">
+        <ArtistSeriesHeaderSmall {...props} />
+      </Media>
     </>
   )
 }
@@ -33,16 +36,44 @@ const ArtistSeriesHeaderLarge: React.FC<ArtistSeriesHeaderProps> = props => {
               flexDirection="column"
               justifyContent="space-between"
             >
-              <Sans size="8">{title}</Sans>
+              <Sans size="8" element="h1" unstable_trackIn>
+                {title}
+              </Sans>
               <Sans size="3t">{description}</Sans>
             </Flex>
           </Col>
           <Col sm={6}>
-            <Box bg="black10" width={1} height={400}></Box>
+            <Box
+              // FIXME: Use Image
+              bg="black10"
+              width={1}
+              height={400}
+            ></Box>
           </Col>
         </Row>
       </Grid>
     </Box>
+  )
+}
+
+const ArtistSeriesHeaderSmall: React.FC<ArtistSeriesHeaderProps> = props => {
+  const {
+    artistSeries: { title, description },
+  } = props
+  return (
+    <>
+      <Box
+        // FIXME: Use Image
+        mx="auto"
+        bg="black10"
+        width={180}
+        height={180}
+      ></Box>
+      <Sans size="8" element="h1" my={1} unstable_trackIn>
+        {title}
+      </Sans>
+      <Sans size="3t">{description}</Sans>
+    </>
   )
 }
 

--- a/src/v2/Apps/ArtistSeries/__tests__/ArtistSeriesApp.jest.tsx
+++ b/src/v2/Apps/ArtistSeries/__tests__/ArtistSeriesApp.jest.tsx
@@ -1,0 +1,135 @@
+import React from "react"
+import { MockBoot, renderRelayTree } from "v2/DevTools"
+import ArtistSeriesApp from "../ArtistSeriesApp"
+import { graphql } from "react-relay"
+import { ArtistSeriesApp_QueryRawResponse } from "v2/__generated__/ArtistSeriesApp_Query.graphql"
+import { ArtistSeriesApp_UnfoundTest_QueryRawResponse } from "v2/__generated__/ArtistSeriesApp_UnfoundTest_Query.graphql"
+import { Breakpoint } from "@artsy/palette"
+
+jest.unmock("react-relay")
+jest.mock("v2/Artsy/Router/useRouter", () => ({
+  useRouter: () => ({
+    match: {
+      params: {
+        slug: "pumpkins",
+      },
+    },
+  }),
+  useIsRouteActive: () => false,
+}))
+
+describe("ArtistSeriesApp", () => {
+  let slug = "pumpkins"
+
+  describe("with a user who has the Artist Series lab feature", () => {
+    let user = { lab_features: ["Artist Series"] }
+
+    describe("with a published artist series", () => {
+      const getWrapper = async (
+        breakpoint: Breakpoint = "lg",
+        response: ArtistSeriesApp_QueryRawResponse = ArtistSeriesAppFixture
+      ) => {
+        return renderRelayTree({
+          Component: ({ artistSeries }) => {
+            return (
+              <MockBoot breakpoint={breakpoint} user={user}>
+                <ArtistSeriesApp artistSeries={artistSeries} />
+              </MockBoot>
+            )
+          },
+          query: graphql`
+            query ArtistSeriesApp_Query($slug: ID!) @raw_response_type {
+              artistSeries(id: $slug) {
+                ...ArtistSeriesApp_artistSeries
+              }
+            }
+          `,
+          variables: {
+            slug,
+          },
+          mockData: response,
+        })
+      }
+
+      it("renders the correct components", async () => {
+        const wrapper = await getWrapper()
+        expect(wrapper.find("AppContainer").length).toBe(1)
+        expect(wrapper.find("ArtistSeriesHeader").length).toBe(1)
+      })
+
+      describe("ArtistSeriesHeader", () => {
+        describe("desktop", () => {
+          it("renders correctly", async () => {
+            const wrapper = await getWrapper()
+            // TODO: expect(wrapper.find("ResponsiveImage").length).toBe(1)
+            expect(wrapper.find("ArtistSeriesHeaderLarge").length).toBe(1)
+            expect(wrapper.find("ArtistSeriesHeaderSmall").length).toBe(0)
+            const html = wrapper.html()
+            expect(html).toContain("Pumpkins")
+            expect(html).toContain("All of the pumpkins")
+          })
+        })
+
+        describe("mobile", () => {
+          it("renders correctly", async () => {
+            const wrapper = await getWrapper("xs")
+            // TODO: expect(wrapper.find("ResponsiveImage").length).toBe(1)
+            expect(wrapper.find("ArtistSeriesHeaderLarge").length).toBe(0)
+            expect(wrapper.find("ArtistSeriesHeaderSmall").length).toBe(1)
+            const html = wrapper.html()
+            expect(html).toContain("Pumpkins")
+            expect(html).toContain("All of the pumpkins")
+          })
+        })
+      })
+    })
+  })
+
+  describe("with an unpublished or unfound artist series", () => {
+    const getWrapper = async (
+      breakpoint: Breakpoint = "lg",
+      response: ArtistSeriesApp_UnfoundTest_QueryRawResponse = UnfoundArtistSeriesAppFixture
+    ) => {
+      return renderRelayTree({
+        Component: ({ artistSeries }) => {
+          return (
+            <MockBoot breakpoint={breakpoint}>
+              <ArtistSeriesApp artistSeries={artistSeries} />
+            </MockBoot>
+          )
+        },
+        query: graphql`
+          query ArtistSeriesApp_UnfoundTest_Query($slug: ID!)
+            @raw_response_type {
+            artistSeries(id: $slug) {
+              ...ArtistSeriesApp_artistSeries
+            }
+          }
+        `,
+        variables: {
+          slug: "nonexistent slug",
+        },
+        mockData: response,
+      })
+    }
+
+    it("returns 404 page", async () => {
+      const wrapper = await getWrapper()
+      const html = wrapper.html()
+      expect(html).toContain(
+        "Sorry, the page you were looking for doesn’t exist at this URL."
+      )
+    })
+  })
+})
+
+const ArtistSeriesAppFixture: ArtistSeriesApp_QueryRawResponse = {
+  artistSeries: {
+    title: "Pumpkins",
+    description: "All of the pumpkins",
+  },
+}
+
+const UnfoundArtistSeriesAppFixture: ArtistSeriesApp_UnfoundTest_QueryRawResponse = {
+  artistSeries: null,
+}

--- a/src/v2/Apps/ArtistSeries/routes.tsx
+++ b/src/v2/Apps/ArtistSeries/routes.tsx
@@ -1,0 +1,25 @@
+import loadable from "@loadable/component"
+import { graphql } from "react-relay"
+import { RouteConfig } from "found"
+// import React from "react"
+
+const ArtistSeriesApp = loadable(() => import("./ArtistSeriesApp"))
+
+// const ArtistSeriesApp = props => <h1>{props.artistSeries.internalID}</h1>
+
+export const routes: RouteConfig[] = [
+  {
+    path: "/artist-series/:slug",
+    getComponent: () => ArtistSeriesApp,
+    prepare: () => {
+      ArtistSeriesApp.preload()
+    },
+    query: graphql`
+      query routes_ArtistSeriesQuery($slug: ID!) {
+        artistSeries(id: $slug) {
+          ...ArtistSeriesApp_artistSeries
+        }
+      }
+    `,
+  },
+]

--- a/src/v2/Apps/ArtistSeries/routes.tsx
+++ b/src/v2/Apps/ArtistSeries/routes.tsx
@@ -1,11 +1,8 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { RouteConfig } from "found"
-// import React from "react"
 
 const ArtistSeriesApp = loadable(() => import("./ArtistSeriesApp"))
-
-// const ArtistSeriesApp = props => <h1>{props.artistSeries.internalID}</h1>
 
 export const routes: RouteConfig[] = [
   {

--- a/src/v2/Apps/getAppRoutes.tsx
+++ b/src/v2/Apps/getAppRoutes.tsx
@@ -1,6 +1,7 @@
 import { buildAppRoutes } from "v2/Artsy/Router/buildAppRoutes"
 import { RouteConfig } from "found"
 import { routes as artistRoutes } from "v2/Apps/Artist/routes"
+import { routes as artistSeriesRoutes } from "./ArtistSeries/routes"
 import { routes as artworkRoutes } from "v2/Apps/Artwork/routes"
 import { collectRoutes } from "v2/Apps/Collect/collectRoutes"
 import { conversationRoutes } from "v2/Apps/Conversation/routes"
@@ -16,6 +17,9 @@ export function getAppRoutes(): RouteConfig[] {
   return buildAppRoutes([
     {
       routes: artistRoutes,
+    },
+    {
+      routes: artistSeriesRoutes,
     },
     {
       routes: artworkRoutes,

--- a/src/v2/__generated__/ArtistSeriesApp_Query.graphql.ts
+++ b/src/v2/__generated__/ArtistSeriesApp_Query.graphql.ts
@@ -1,0 +1,131 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistSeriesApp_QueryVariables = {
+    slug: string;
+};
+export type ArtistSeriesApp_QueryResponse = {
+    readonly artistSeries: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesApp_artistSeries">;
+    } | null;
+};
+export type ArtistSeriesApp_QueryRawResponse = {
+    readonly artistSeries: ({
+        readonly title: string;
+        readonly description: string | null;
+    }) | null;
+};
+export type ArtistSeriesApp_Query = {
+    readonly response: ArtistSeriesApp_QueryResponse;
+    readonly variables: ArtistSeriesApp_QueryVariables;
+    readonly rawResponse: ArtistSeriesApp_QueryRawResponse;
+};
+
+
+
+/*
+query ArtistSeriesApp_Query(
+  $slug: ID!
+) {
+  artistSeries(id: $slug) {
+    ...ArtistSeriesApp_artistSeries
+  }
+}
+
+fragment ArtistSeriesApp_artistSeries on ArtistSeries {
+  ...ArtistSeriesHeader_artistSeries
+}
+
+fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
+  title
+  description
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "slug",
+    "type": "ID!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "slug"
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ArtistSeriesApp_Query",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artistSeries",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ArtistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ArtistSeriesApp_artistSeries",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ArtistSeriesApp_Query",
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artistSeries",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ArtistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "description",
+            "args": null,
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ArtistSeriesApp_Query",
+    "id": null,
+    "text": "query ArtistSeriesApp_Query(\n  $slug: ID!\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesApp_artistSeries\n  }\n}\n\nfragment ArtistSeriesApp_artistSeries on ArtistSeries {\n  ...ArtistSeriesHeader_artistSeries\n}\n\nfragment ArtistSeriesHeader_artistSeries on ArtistSeries {\n  title\n  description\n}\n",
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = '9a9d2cb498871e69d436c9b96069c897';
+export default node;

--- a/src/v2/__generated__/ArtistSeriesApp_UnfoundTest_Query.graphql.ts
+++ b/src/v2/__generated__/ArtistSeriesApp_UnfoundTest_Query.graphql.ts
@@ -1,0 +1,131 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistSeriesApp_UnfoundTest_QueryVariables = {
+    slug: string;
+};
+export type ArtistSeriesApp_UnfoundTest_QueryResponse = {
+    readonly artistSeries: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesApp_artistSeries">;
+    } | null;
+};
+export type ArtistSeriesApp_UnfoundTest_QueryRawResponse = {
+    readonly artistSeries: ({
+        readonly title: string;
+        readonly description: string | null;
+    }) | null;
+};
+export type ArtistSeriesApp_UnfoundTest_Query = {
+    readonly response: ArtistSeriesApp_UnfoundTest_QueryResponse;
+    readonly variables: ArtistSeriesApp_UnfoundTest_QueryVariables;
+    readonly rawResponse: ArtistSeriesApp_UnfoundTest_QueryRawResponse;
+};
+
+
+
+/*
+query ArtistSeriesApp_UnfoundTest_Query(
+  $slug: ID!
+) {
+  artistSeries(id: $slug) {
+    ...ArtistSeriesApp_artistSeries
+  }
+}
+
+fragment ArtistSeriesApp_artistSeries on ArtistSeries {
+  ...ArtistSeriesHeader_artistSeries
+}
+
+fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
+  title
+  description
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "slug",
+    "type": "ID!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "slug"
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ArtistSeriesApp_UnfoundTest_Query",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artistSeries",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ArtistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ArtistSeriesApp_artistSeries",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ArtistSeriesApp_UnfoundTest_Query",
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artistSeries",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ArtistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "description",
+            "args": null,
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ArtistSeriesApp_UnfoundTest_Query",
+    "id": null,
+    "text": "query ArtistSeriesApp_UnfoundTest_Query(\n  $slug: ID!\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesApp_artistSeries\n  }\n}\n\nfragment ArtistSeriesApp_artistSeries on ArtistSeries {\n  ...ArtistSeriesHeader_artistSeries\n}\n\nfragment ArtistSeriesHeader_artistSeries on ArtistSeries {\n  title\n  description\n}\n",
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = 'f6f14e625bd96fdfefd5d230b5070c95';
+export default node;

--- a/src/v2/__generated__/ArtistSeriesApp_artistSeries.graphql.ts
+++ b/src/v2/__generated__/ArtistSeriesApp_artistSeries.graphql.ts
@@ -1,0 +1,32 @@
+/* tslint:disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistSeriesApp_artistSeries = {
+    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesHeader_artistSeries">;
+    readonly " $refType": "ArtistSeriesApp_artistSeries";
+};
+export type ArtistSeriesApp_artistSeries$data = ArtistSeriesApp_artistSeries;
+export type ArtistSeriesApp_artistSeries$key = {
+    readonly " $data"?: ArtistSeriesApp_artistSeries$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesApp_artistSeries">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "ArtistSeriesApp_artistSeries",
+  "type": "ArtistSeries",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "FragmentSpread",
+      "name": "ArtistSeriesHeader_artistSeries",
+      "args": null
+    }
+  ]
+};
+(node as any).hash = '39dba1f661fe054a7acf8582256c4f96';
+export default node;

--- a/src/v2/__generated__/ArtistSeriesHeader_artistSeries.graphql.ts
+++ b/src/v2/__generated__/ArtistSeriesHeader_artistSeries.graphql.ts
@@ -1,0 +1,42 @@
+/* tslint:disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistSeriesHeader_artistSeries = {
+    readonly title: string;
+    readonly description: string | null;
+    readonly " $refType": "ArtistSeriesHeader_artistSeries";
+};
+export type ArtistSeriesHeader_artistSeries$data = ArtistSeriesHeader_artistSeries;
+export type ArtistSeriesHeader_artistSeries$key = {
+    readonly " $data"?: ArtistSeriesHeader_artistSeries$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesHeader_artistSeries">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "ArtistSeriesHeader_artistSeries",
+  "type": "ArtistSeries",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "title",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "description",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = '56ec2250328a1b89ce4ce14781aa6e51';
+export default node;

--- a/src/v2/__generated__/routes_ArtistSeriesQuery.graphql.ts
+++ b/src/v2/__generated__/routes_ArtistSeriesQuery.graphql.ts
@@ -1,0 +1,124 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type routes_ArtistSeriesQueryVariables = {
+    slug: string;
+};
+export type routes_ArtistSeriesQueryResponse = {
+    readonly artistSeries: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesApp_artistSeries">;
+    } | null;
+};
+export type routes_ArtistSeriesQuery = {
+    readonly response: routes_ArtistSeriesQueryResponse;
+    readonly variables: routes_ArtistSeriesQueryVariables;
+};
+
+
+
+/*
+query routes_ArtistSeriesQuery(
+  $slug: ID!
+) {
+  artistSeries(id: $slug) {
+    ...ArtistSeriesApp_artistSeries
+  }
+}
+
+fragment ArtistSeriesApp_artistSeries on ArtistSeries {
+  ...ArtistSeriesHeader_artistSeries
+}
+
+fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
+  title
+  description
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "slug",
+    "type": "ID!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "slug"
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "routes_ArtistSeriesQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artistSeries",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ArtistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ArtistSeriesApp_artistSeries",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "routes_ArtistSeriesQuery",
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artistSeries",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ArtistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "description",
+            "args": null,
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "routes_ArtistSeriesQuery",
+    "id": null,
+    "text": "query routes_ArtistSeriesQuery(\n  $slug: ID!\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesApp_artistSeries\n  }\n}\n\nfragment ArtistSeriesApp_artistSeries on ArtistSeries {\n  ...ArtistSeriesHeader_artistSeries\n}\n\nfragment ArtistSeriesHeader_artistSeries on ArtistSeries {\n  title\n  description\n}\n",
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = '3e46b82bc00c38774bff9d41bbbe1c2c';
+export default node;


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2007

---

**Goal**: Set up basic structure of the artist series page and display minimal artist series metadata on desktop and mobile web.

- Creates a basic artist series page for desktop and mobile web with a minimal header showing the title and description of an artist series.
  - URL structure is `/artist-series/$slug`
  - It does not show a header image for the artist series, which will come as a follow up. We currently have a gray box as a stand-in for the image.
  - It also does not implement "Read more" functionality for the description.
- The page is only accessible to users who have the lab feature turned on -- otherwise, navigation to an artist series page results in a 404.

Collab: @anandaroop @ashleyjelks @mzikherman 

---

### Desktop
#### Comp
![Screen Shot 2020-06-26 at 5 39 40 PM](https://user-images.githubusercontent.com/4432348/85903324-0a2ea400-b7d4-11ea-8f84-9cc0f242a435.png)


#### This PR
![Screen Shot 2020-06-26 at 5 39 00 PM](https://user-images.githubusercontent.com/4432348/85903290-f84d0100-b7d3-11ea-9aa3-c51b49611d3f.png)


### Mobile web
#### Comp
![Screen Shot 2020-06-26 at 5 32 16 PM](https://user-images.githubusercontent.com/4432348/85902867-02223480-b7d3-11ea-9fbc-8d884abf0e34.png)


#### This PR
![Screen Shot 2020-06-26 at 5 41 02 PM](https://user-images.githubusercontent.com/4432348/85903404-406c2380-b7d4-11ea-92c4-a272eb6ac2ee.png)

