### PR TITLE
fix: make /user nav mobile friendly

### DIFF
--- a/src/desktop/apps/user/components/tabs/index.styl
+++ b/src/desktop/apps/user/components/tabs/index.styl
@@ -1,7 +1,7 @@
 .settings-tabs
   clearfix()
+  display flex
   margin gutter 0 0 0
-  border-bottom 2px solid gray-lighter-color
   &__tab
     display block
     float left
@@ -9,7 +9,6 @@
     padding (gutter / 2)
     color gray-darker-color
     border-bottom 2px solid gray-lighter-color
-    margin-bottom -2px
     transition color 0.25s, border-color 0.25s
     text-decoration none
     &:hover
@@ -18,3 +17,19 @@
       border-bottom-color gray-darker-color
     &:first-child
       padding-left 0
+  
+@media screen and (max-width 768px)
+  .settings-tabs
+    overflow-x scroll
+    position relative
+
+  .settings-page__header
+    display relative
+    &::after
+      background linear-gradient(to right, rgba(255,255,255,0), rgba(255, 255,255,1))
+      content ""
+      height 100%
+      position absolute
+      right 0
+      top 0
+      width 20px

--- a/src/desktop/apps/user/components/tabs/index.styl
+++ b/src/desktop/apps/user/components/tabs/index.styl
@@ -22,14 +22,3 @@
   .settings-tabs
     overflow-x scroll
     position relative
-
-  .settings-page__header
-    display relative
-    &::after
-      background linear-gradient(to right, rgba(255,255,255,0), rgba(255, 255,255,1))
-      content ""
-      height 100%
-      position absolute
-      right 0
-      top 0
-      width 20px


### PR DESCRIPTION
Fixes FX-2055

- made the nav bar scroll horizontally at < 768px
- added a gradient block as an affordance to make it clear that it's scrollable

![image](https://user-images.githubusercontent.com/1815204/86025095-1b72ed00-ba2e-11ea-9268-a5e4e56f42dd.png)

Questions:
- do I have to use magic number media queries like this in the stylus files, or is there a nicer way to do it?
- I made `.settings-tabs` use flexbox on all sizes - is this safe? if not, I could maybe move it into the media query?