### PR TITLE
Set staging web container cpu request to 100m.

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -49,7 +49,7 @@ spec:
             periodSeconds: 5
           resources:
             requests:
-              cpu: 50m
+              cpu: 100m
               memory: 1Gi
             limits:
               memory: 1.5Gi


### PR DESCRIPTION
Staging web container CPU request was originally at 700m. Last week when deployments were failing due to CPU, I drastically reduced the spec to 50m, to ensure deployments would go through. I have just now gone through every Force review app and reduced its spec to 100m. We have more CPU head room now. So I would like to raise staging spec to 100m which is probably sufficient.