### PR TITLE
[FX-2072] Skip link, landmarks

### DIFF
--- a/src/desktop/apps/unsupported_browser/template.jade
+++ b/src/desktop/apps/unsupported_browser/template.jade
@@ -1,28 +1,29 @@
 doctype html
 html
   head
-    link( type='text/css', rel='stylesheet', href=asset('/assets/main_layout.css') )
-    link( type='text/css', rel='stylesheet', href=asset('/assets/unsupported_browser.css') )
+    link( type='text/css' rel='stylesheet', href=asset('/assets/main_layout.css') )
+    link( type='text/css' rel='stylesheet', href=asset('/assets/unsupported_browser.css') )
   body.body-header-fixed.minimal-header
-    #main-layout-container
-      #unsupported-browser.main-layout-container
-        img.unsupported-browser-artsy-logo( src="images/full_logo.png" )
-        .unsupported-browser-message
-          p #{sd.BROWSER.family} #{sd.BROWSER.major} is not supported.
-          p Please update your browser.
-        .unsupported-browser-recommendations
-          a.unsupported-browser-update-first.avant-garde-button-black.settings-submit( href="https://www.google.com/intl/en/chrome/browser/" )
-            | Chrome
-          a.avant-garde-button-black.settings-submit( href="http://www.apple.com/safari" )
-            | Safari
-          a.unsupported-browser-update-first.avant-garde-button-black.settings-submit( href="https://www.mozilla.org/en-US/firefox/new/?utm_source=artsy-net&utm_medium=referral")
-            | FireFox
-          a.avant-garde-button-black.settings-submit( href="https://www.microsoft.com/en-us/windows/microsoft-edge" )
-            | Microsoft Edge
+    main#main
+      #main-layout-container
+        #unsupported-browser.main-layout-container
+          img.unsupported-browser-artsy-logo( src="images/full_logo.png" )
+          .unsupported-browser-message
+            p #{sd.BROWSER.family} #{sd.BROWSER.major} is not supported.
+            p Please update your browser.
+          .unsupported-browser-recommendations
+            a.unsupported-browser-update-first.avant-garde-button-black.settings-submit( href="https://www.google.com/intl/en/chrome/browser/" )
+              | Chrome
+            a.avant-garde-button-black.settings-submit( href="http://www.apple.com/safari" )
+              | Safari
+            a.unsupported-browser-update-first.avant-garde-button-black.settings-submit( href="https://www.mozilla.org/en-US/firefox/new/?utm_source=artsy-net&utm_medium=referral")
+              | FireFox
+            a.avant-garde-button-black.settings-submit( href="https://www.microsoft.com/en-us/windows/microsoft-edge" )
+              | Microsoft Edge
 
-        br
-        br
+          br
+          br
 
-        form.unsupported-browser-continue( action='', method='post' )
-          input( type="hidden", name="redirect-to", value=sd.UNSUPPORTED_BROWSER_REDIRECT || '/' )
-          button.avant-garde-button-black.unsupported-browser-submit.is-block Continue with #{sd.BROWSER.family} #{sd.BROWSER.major}
+          form.unsupported-browser-continue( action='' method='post' )
+            input( type="hidden" name="redirect-to", value=sd.UNSUPPORTED_BROWSER_REDIRECT || '/' )
+            button.avant-garde-button-black.unsupported-browser-submit.is-block Continue with #{sd.BROWSER.family} #{sd.BROWSER.major}

--- a/src/desktop/components/error_handler/index.jade
+++ b/src/desktop/components/error_handler/index.jade
@@ -15,31 +15,32 @@ block body
       a.error-handler-logo( href='/' )
         include ../main_layout/public/icons/logo.svg
     - }
-    #main-layout-container.responsive-layout-container.error-handler-layout
-      .error-handler-container( data-code=code )
-        h1.error-handler-headline
-          if code === 404
-            | Sorry, the page you were looking for doesn’t exist at this URL.
-          else
-            | Internal Error
+    main#main
+      #main-layout-container.responsive-layout-container.error-handler-layout
+        .error-handler-container( data-code=code )
+          h1.error-handler-headline
+            if code === 404
+              | Sorry, the page you were looking for doesn’t exist at this URL.
+            else
+              | Internal Error
 
-        .error-handler-inner
-          if code !== 404
-            if message
-              pre.error-handler-trace
-                | Error Message: #{message}
-            if detail
-              pre.error-handler-trace
-                = detail
-          p
-            | Please contact
-            = ' '
-            a.fine-faux-underline( href='mailto:support@artsy.net' )
-              | support@artsy.net
-            = ' '
-            | with any questions.
+          .error-handler-inner
+            if code !== 404
+              if message
+                pre.error-handler-trace
+                  | Error Message: #{message}
+              if detail
+                pre.error-handler-trace
+                  = detail
+            p
+              | Please contact
+              = ' '
+              a.fine-faux-underline( href='mailto:support@artsy.net' )
+                | support@artsy.net
+              = ' '
+              | with any questions.
 
-        .error-handler-return: a( href='/' )
-          | Go to Artsy homepage
+          .error-handler-return: a( href='/' )
+            | Go to Artsy homepage
 
   include ../main_layout/footer/template

--- a/src/desktop/components/main_layout/templates/index.jade
+++ b/src/desktop/components/main_layout/templates/index.jade
@@ -15,11 +15,11 @@ html(
     include head
     block head
 
-    link( type='text/css', rel='stylesheet', href=asset('/assets/main_layout.css') )
+    link( type='text/css' rel='stylesheet', href=asset('/assets/main_layout.css') )
 
     unless styledComponents
       if assetPackage
-        link( type='text/css', rel='stylesheet', href=asset('/assets/#{assetPackage}.css') )
+        link( type='text/css' rel='stylesheet', href=asset('/assets/#{assetPackage}.css') )
 
   body( class=bodyClass )
     //- Global component mixins
@@ -29,8 +29,9 @@ html(
     //- Header, body block, footer
     include ../header/templates/index
 
-    #main-layout-container.responsive-layout-container(role='main')
-      block body
+    main#main
+      #main-layout-container.responsive-layout-container
+        block body
 
     #scroll-frame-spinner: .loading-spinner
     include ../footer/template

--- a/src/desktop/components/main_layout/templates/minimal_header.jade
+++ b/src/desktop/components/main_layout/templates/minimal_header.jade
@@ -10,9 +10,9 @@ html( data-useragent= userAgent lang="en")
   head
     include head
     block head
-    link( type='text/css', rel='stylesheet', href=asset('/assets/main_layout.css') )
+    link( type='text/css' rel='stylesheet', href=asset('/assets/main_layout.css') )
     if assetPackage
-      link( type='text/css', rel='stylesheet', href=asset('/assets/#{assetPackage}.css') )
+      link( type='text/css' rel='stylesheet', href=asset('/assets/#{assetPackage}.css') )
 
   body( class=bodyClass )&attributes(attributes)
     -if (!hideHeaderOnEigen)
@@ -20,8 +20,9 @@ html( data-useragent= userAgent lang="en")
     include ../../modal/template
     include ../../flash/template
 
-    #main-layout-container
-      block body
+    main#main
+      #main-layout-container
+        block body
 
     #scripts
       //- Don't replace this block, rather prepend or append!

--- a/src/desktop/components/main_layout/templates/redesign.jade
+++ b/src/desktop/components/main_layout/templates/redesign.jade
@@ -16,11 +16,11 @@ html(
     include head
     block head
 
-    link( type='text/css', rel='stylesheet', href=asset('/assets/main_layout.css') )
+    link( type='text/css' rel='stylesheet', href=asset('/assets/main_layout.css') )
 
     if !styledComponents
       if assetPackage
-        link( type='text/css', rel='stylesheet', href=asset('/assets/#{assetPackage}.css') )
+        link( type='text/css' rel='stylesheet', href=asset('/assets/#{assetPackage}.css') )
 
   body( class=bodyClass )&attributes(attributes)
     //- Global component mixins
@@ -30,8 +30,9 @@ html(
     //- Header, body block, footer
     include ../header/templates/index
 
-    #main-layout-container
-      block body
+    main#main
+      #main-layout-container
+        block body
 
     #scroll-frame-spinner: .loading-spinner
 

--- a/src/v2/Apps/Components/AppShell.tsx
+++ b/src/v2/Apps/Components/AppShell.tsx
@@ -54,8 +54,8 @@ export const AppShell: React.FC<AppShellProps> = props => {
         </Box>
       </Box>
 
-      <Box>
-        <Box>{children}</Box>
+      <Box as="main" id="main">
+        {children}
       </Box>
 
       <NetworkOfflineMonitor />

--- a/src/v2/Apps/Debug/debugRoutes.tsx
+++ b/src/v2/Apps/Debug/debugRoutes.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { Title } from "react-head"
 
 /**
  * This route is just for testing baseline page shell stuff -- Lighthouse,
@@ -12,7 +13,12 @@ export const debugRoutes = [
     children: [
       {
         path: "baseline",
-        Component: () => <div>Baseline</div>,
+        Component: () => (
+          <>
+            <Title>Baseline</Title>
+            <div>Baseline</div>
+          </>
+        ),
       },
     ],
   },

--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -13,6 +13,7 @@ import {
   Link,
   SoloIcon,
   Spacer,
+  Text,
   color,
   space,
   themeProps,
@@ -43,6 +44,19 @@ import { track, useTracking } from "v2/Artsy/Analytics"
 import Events from "v2/Utils/Events"
 import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 import { userHasLabFeature } from "v2/Utils/user"
+
+const SkipLink = styled.a`
+  position: absolute;
+  top: -100%;
+  left: 0;
+  color: ${color("black100")};
+  background-color: ${color("white100")};
+  z-index: 9999;
+
+  &:focus {
+    top: 0;
+  }
+`
 
 export const NavBar: React.FC = track(
   {
@@ -90,245 +104,254 @@ export const NavBar: React.FC = track(
   }
 
   return (
-    <header>
-      <NavBarContainer px={1}>
-        <NavSection>
-          <Link href="/" style={{ display: "flex" }}>
-            <ArtsyMarkIcon height={40} width={40} />
-          </Link>
-        </NavSection>
+    <>
+      <SkipLink href="#main">
+        <Text variant="text">Skip to content</Text>
+      </SkipLink>
 
-        <Spacer mr={1} />
-
-        <NavSection width="100%">
-          <Box width="100%">
-            <SearchBar />
-          </Box>
-        </NavSection>
-
-        <Spacer mr={2} />
-
-        {/*
-          Desktop. Collapses into mobile at `sm` breakpoint.
-        */}
-        <NavSection display={["none", "none", "flex"]}>
+      <header>
+        <NavBarContainer as="nav" px={1}>
           <NavSection>
-            <NavItem
-              label="Artworks"
-              isFullScreenDropDown
-              Menu={({ setIsVisible }) => {
-                return (
-                  <Box>
-                    <DropDownNavMenu
-                      width="100vw"
-                      menu={(artworks as MenuLinkData).menu}
-                      contextModule={
-                        AnalyticsSchema.ContextModule.HeaderArtworksDropdown
-                      }
-                      onClick={() => {
-                        setIsVisible(false)
-                      }}
-                    />
-                  </Box>
-                )
-              }}
-            >
-              <Flex>
-                Artworks
-                <ChevronIcon
-                  direction="down"
-                  color={color("black100")}
-                  height="15px"
-                  width="15px"
-                  top="5px"
-                  left="4px"
-                />
-              </Flex>
-            </NavItem>
-
-            <NavItem
-              label="Artists"
-              isFullScreenDropDown
-              Menu={({ setIsVisible }) => {
-                return (
-                  <Box>
-                    <DropDownNavMenu
-                      width="100vw"
-                      menu={(artists as MenuLinkData).menu}
-                      contextModule={
-                        AnalyticsSchema.ContextModule.HeaderArtistsDropdown
-                      }
-                      onClick={() => {
-                        setIsVisible(false)
-                      }}
-                    />
-                  </Box>
-                )
-              }}
-            >
-              <Flex>
-                Artists
-                <ChevronIcon
-                  direction="down"
-                  color={color("black100")}
-                  height="15px"
-                  width="15px"
-                  top="5px"
-                  left="4px"
-                />
-              </Flex>
-            </NavItem>
-
-            <NavItem href="/auctions">Auctions</NavItem>
-            <NavItem href="/articles">Editorial</NavItem>
-            <NavItem
-              label="More"
-              Menu={() => {
-                return (
-                  <Box mr={-150}>
-                    <MoreNavMenu width={160} />
-                  </Box>
-                )
-              }}
-            >
-              <Flex>
-                More
-                <ChevronIcon
-                  direction="down"
-                  color={color("black100")}
-                  height="15px"
-                  width="15px"
-                  top="5px"
-                  left="4px"
-                />
-              </Flex>
-            </NavItem>
+            <Link href="/" style={{ display: "flex" }}>
+              <ArtsyMarkIcon height={40} width={40} />
+            </Link>
           </NavSection>
 
-          <NavSection>
-            {isLoggedIn && (
-              <>
-                <NavItem
-                  href="/works-for-you"
-                  Menu={NotificationsMenu}
-                  Overlay={NotificationsBadge}
+          <Spacer mr={1} />
+
+          <NavSection width="100%">
+            <Box width="100%">
+              <SearchBar />
+            </Box>
+          </NavSection>
+
+          <Spacer mr={2} />
+
+          {/*
+          Desktop. Collapses into mobile at `sm` breakpoint.
+        */}
+          <NavSection display={["none", "none", "flex"]}>
+            <NavSection>
+              <NavItem
+                label="Artworks"
+                isFullScreenDropDown
+                Menu={({ setIsVisible }) => {
+                  return (
+                    <Box>
+                      <DropDownNavMenu
+                        width="100vw"
+                        menu={(artworks as MenuLinkData).menu}
+                        contextModule={
+                          AnalyticsSchema.ContextModule.HeaderArtworksDropdown
+                        }
+                        onClick={() => {
+                          setIsVisible(false)
+                        }}
+                      />
+                    </Box>
+                  )
+                }}
+              >
+                <Flex>
+                  Artworks
+                  <ChevronIcon
+                    direction="down"
+                    color={color("black100")}
+                    height="15px"
+                    width="15px"
+                    top="5px"
+                    left="4px"
+                  />
+                </Flex>
+              </NavItem>
+
+              <NavItem
+                label="Artists"
+                isFullScreenDropDown
+                Menu={({ setIsVisible }) => {
+                  return (
+                    <Box>
+                      <DropDownNavMenu
+                        width="100vw"
+                        menu={(artists as MenuLinkData).menu}
+                        contextModule={
+                          AnalyticsSchema.ContextModule.HeaderArtistsDropdown
+                        }
+                        onClick={() => {
+                          setIsVisible(false)
+                        }}
+                      />
+                    </Box>
+                  )
+                }}
+              >
+                <Flex>
+                  Artists
+                  <ChevronIcon
+                    direction="down"
+                    color={color("black100")}
+                    height="15px"
+                    width="15px"
+                    top="5px"
+                    left="4px"
+                  />
+                </Flex>
+              </NavItem>
+
+              <NavItem href="/auctions">Auctions</NavItem>
+              <NavItem href="/articles">Editorial</NavItem>
+              <NavItem
+                label="More"
+                Menu={() => {
+                  return (
+                    <Box mr={-150}>
+                      <MoreNavMenu width={160} />
+                    </Box>
+                  )
+                }}
+              >
+                <Flex>
+                  More
+                  <ChevronIcon
+                    direction="down"
+                    color={color("black100")}
+                    height="15px"
+                    width="15px"
+                    top="5px"
+                    left="4px"
+                  />
+                </Flex>
+              </NavItem>
+            </NavSection>
+
+            <NavSection>
+              {isLoggedIn && (
+                <>
+                  <NavItem
+                    href="/works-for-you"
+                    Menu={NotificationsMenu}
+                    Overlay={NotificationsBadge}
+                    onClick={() => {
+                      trackEvent({
+                        action_type: AnalyticsSchema.ActionType.Click,
+                        subject: AnalyticsSchema.Subject.NotificationBell,
+                        new_notification_count: getNotificationCount(),
+                        destination_path: "/works-for-you",
+                      })
+                    }}
+                  >
+                    {({ hover }) => {
+                      if (hover) {
+                        trackEvent({
+                          action_type: AnalyticsSchema.ActionType.Hover,
+                          subject: AnalyticsSchema.Subject.NotificationBell,
+                          new_notification_count: getNotificationCount(),
+                        })
+                      }
+                      return <BellIcon fill={hover ? "purple100" : "black80"} />
+                    }}
+                  </NavItem>
+                  {conversationsEnabled && (
+                    <NavItem href="/user/conversations">
+                      {({ hover }) => {
+                        return (
+                          <EnvelopeIcon
+                            fill={hover ? "purple100" : "black80"}
+                          />
+                        )
+                      }}
+                    </NavItem>
+                  )}
+                  <NavItem Menu={UserMenu}>
+                    {({ hover }) => {
+                      if (hover) {
+                        trackEvent({
+                          action_type: AnalyticsSchema.ActionType.Hover,
+                          subject: "User",
+                        })
+                      }
+                      return <SoloIcon fill={hover ? "purple100" : "black80"} />
+                    }}
+                  </NavItem>
+                </>
+              )}
+            </NavSection>
+
+            {!isLoggedIn && (
+              <NavSection>
+                <Spacer mr={2} />
+                <Button
+                  variant="secondaryOutline"
                   onClick={() => {
-                    trackEvent({
-                      action_type: AnalyticsSchema.ActionType.Click,
-                      subject: AnalyticsSchema.Subject.NotificationBell,
-                      new_notification_count: getNotificationCount(),
-                      destination_path: "/works-for-you",
+                    openAuthModal(mediator, {
+                      mode: ModalType.login,
+                      intent: Intent.login,
+                      contextModule: ContextModule.header,
                     })
                   }}
                 >
-                  {({ hover }) => {
-                    if (hover) {
-                      trackEvent({
-                        action_type: AnalyticsSchema.ActionType.Hover,
-                        subject: AnalyticsSchema.Subject.NotificationBell,
-                        new_notification_count: getNotificationCount(),
-                      })
-                    }
-                    return <BellIcon fill={hover ? "purple100" : "black80"} />
+                  Log in
+                </Button>
+                <Spacer mr={1} />
+                <Button
+                  onClick={() => {
+                    openAuthModal(mediator, {
+                      mode: ModalType.signup,
+                      intent: Intent.signup,
+                      contextModule: ContextModule.header,
+                    })
                   }}
-                </NavItem>
-                {conversationsEnabled && (
-                  <NavItem href="/user/conversations">
-                    {({ hover }) => {
-                      return (
-                        <EnvelopeIcon fill={hover ? "purple100" : "black80"} />
-                      )
-                    }}
-                  </NavItem>
-                )}
-                <NavItem Menu={UserMenu}>
-                  {({ hover }) => {
-                    if (hover) {
-                      trackEvent({
-                        action_type: AnalyticsSchema.ActionType.Hover,
-                        subject: "User",
-                      })
-                    }
-                    return <SoloIcon fill={hover ? "purple100" : "black80"} />
-                  }}
-                </NavItem>
-              </>
+                >
+                  Sign up
+                </Button>
+              </NavSection>
             )}
           </NavSection>
 
-          {!isLoggedIn && (
-            <NavSection>
-              <Spacer mr={2} />
-              <Button
-                variant="secondaryOutline"
-                onClick={() => {
-                  openAuthModal(mediator, {
-                    mode: ModalType.login,
-                    intent: Intent.login,
-                    contextModule: ContextModule.header,
-                  })
-                }}
-              >
-                Log in
-              </Button>
-              <Spacer mr={1} />
-              <Button
-                onClick={() => {
-                  openAuthModal(mediator, {
-                    mode: ModalType.signup,
-                    intent: Intent.signup,
-                    contextModule: ContextModule.header,
-                  })
-                }}
-              >
-                Sign up
-              </Button>
-            </NavSection>
-          )}
-        </NavSection>
-
-        {/*
+          {/*
           Mobile. Triggers at the `sm` breakpoint.
         */}
-        <NavSection display={["flex", "flex", "none"]}>
-          <NavItem
-            className="mobileHamburgerButton"
-            onClick={() => {
-              const showMenu = !showMobileMenu
-              if (showMenu) {
-                trackEvent({
-                  action_type: AnalyticsSchema.ActionType.Click,
-                  subject: AnalyticsSchema.Subject.SmallScreenMenuSandwichIcon,
-                })
-              }
+          <NavSection display={["flex", "flex", "none"]}>
+            <NavItem
+              className="mobileHamburgerButton"
+              onClick={() => {
+                const showMenu = !showMobileMenu
+                if (showMenu) {
+                  trackEvent({
+                    action_type: AnalyticsSchema.ActionType.Click,
+                    subject:
+                      AnalyticsSchema.Subject.SmallScreenMenuSandwichIcon,
+                  })
+                }
 
-              toggleMobileNav(showMenu)
-            }}
-          >
-            <Flex
-              alignItems="center"
-              justifyContent="center"
-              width={22}
-              height={22}
+                toggleMobileNav(showMenu)
+              }}
             >
-              <MobileNavDivider />
-              <MobileToggleIcon open={showMobileMenu} />
-            </Flex>
-          </NavItem>
-        </NavSection>
-      </NavBarContainer>
+              <Flex
+                alignItems="center"
+                justifyContent="center"
+                width={22}
+                height={22}
+              >
+                <MobileNavDivider />
+                <MobileToggleIcon open={showMobileMenu} />
+              </Flex>
+            </NavItem>
+          </NavSection>
+        </NavBarContainer>
 
-      {showMobileMenu && (
-        <>
-          <MobileNavMenu
-            onClose={() => toggleMobileNav(false)}
-            isOpen={showMobileMenu}
-            menuData={menuData}
-            onNavButtonClick={handleMobileNavClick}
-          />
-        </>
-      )}
-    </header>
+        {showMobileMenu && (
+          <>
+            <MobileNavMenu
+              onClose={() => toggleMobileNav(false)}
+              isOpen={showMobileMenu}
+              menuData={menuData}
+              onNavButtonClick={handleMobileNavClick}
+            />
+          </>
+        )}
+      </header>
+    </>
   )
 })
 


### PR DESCRIPTION
Here's what the normal tab order looks like (I added the purple outlines just so you can see what's happening, those aren't there (yet)).

![](http://static.damonzucconi.com/_capture/oTLGn0hvDz21.gif)

Here's what the tab order looks like if you choose to engage the skip to content link

![](http://static.damonzucconi.com/_capture/6HVWYKeFDQoO.gif)

This doesn't explicitly help on it's own because *so much* of our UI is completely invisible to keyboards — that's a separate issue that still needs a ticket. But this is one of the easier things in the Lighthouse audit to knock down.