### PR TITLE
Use setImmediate to avoid race condition

### DIFF
--- a/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
+++ b/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
@@ -29,14 +29,14 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
     if (!user || !user.id) {
       // openAuthModal will fire off "open:auth" event before ModalContainer
       // is mounted, use setImmediate to fire after next tick
-      setImmediate(() => {
+      setTimeout(() => {
         openAuthModal(mediator, {
           mode: ModalType.signup,
           redirectTo: window.location.href,
           contextModule: ContextModule.viewingRoom,
           intent: Intent.viewViewingRoom,
         })
-      })
+      }, 0)
     }
   }, [user, mediator])
 

--- a/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
+++ b/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
@@ -26,18 +26,19 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
 }) => {
   const { mediator, user } = useContext(SystemContext)
   useEffect(() => {
-    if (!user || !user.id) {
-      // openAuthModal will fire off "open:auth" event before ModalContainer
-      // is mounted, use setImmediate to fire after next tick
-      setTimeout(() => {
-        openAuthModal(mediator, {
-          mode: ModalType.signup,
-          redirectTo: window.location.href,
-          contextModule: ContextModule.viewingRoom,
-          intent: Intent.viewViewingRoom,
-        })
-      }, 0)
-    }
+    if (user && user.id) return
+    // openAuthModal will fire off "open:auth" event before ModalContainer
+    // is mounted, use setImmediate to fire after next tick
+    const timeoutID = setTimeout(() => {
+      openAuthModal(mediator, {
+        mode: ModalType.signup,
+        redirectTo: window.location.href,
+        contextModule: ContextModule.viewingRoom,
+        intent: Intent.viewViewingRoom,
+      })
+    }, 0)
+
+    return () => clearTimeout(timeoutID)
   }, [user, mediator])
 
   if (!viewingRoom) {

--- a/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
+++ b/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
@@ -27,11 +27,15 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
   const { mediator, user } = useContext(SystemContext)
   useEffect(() => {
     if (!user || !user.id) {
-      openAuthModal(mediator, {
-        mode: ModalType.signup,
-        redirectTo: window.location.href,
-        contextModule: ContextModule.viewingRoom,
-        intent: Intent.viewViewingRoom,
+      // openAuthModal will fire off "open:auth" event before ModalContainer
+      // is mounted, use setImmediate to fire after next tick
+      setImmediate(() => {
+        openAuthModal(mediator, {
+          mode: ModalType.signup,
+          redirectTo: window.location.href,
+          contextModule: ContextModule.viewingRoom,
+          intent: Intent.viewViewingRoom,
+        })
       })
     }
   }, [user, mediator])

--- a/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
@@ -8,7 +8,6 @@ import { ViewingRoomApp_ClosedTest_QueryRawResponse } from "v2/__generated__/Vie
 import { ViewingRoomApp_UnfoundTest_QueryRawResponse } from "v2/__generated__/ViewingRoomApp_UnfoundTest_Query.graphql"
 import { ViewingRoomApp_LoggedOutTest_QueryRawResponse } from "v2/__generated__/ViewingRoomApp_LoggedOutTest_Query.graphql.ts"
 import { Breakpoint } from "@artsy/palette"
-import { act } from "react-dom/test-utils"
 
 jest.unmock("react-relay")
 jest.mock("v2/Artsy/Router/useRouter", () => ({
@@ -248,15 +247,13 @@ describe("ViewingRoomApp", () => {
     }
     it("shows sign up modal", async () => {
       const wrapper = await getWrapper()
-      act(() => {
-        const html = wrapper.html()
-        console.log(html)
-        expect(mediator.trigger).toBeCalledWith("open:auth", {
-          mode: "signup",
-          redirectTo: "http://localhost/" + slug,
-          contextModule: "viewingRoom",
-          intent: "viewViewingRoom",
-        })
+      const html = wrapper.html()
+      console.log(html)
+      expect(mediator.trigger).toBeCalledWith("open:auth", {
+        mode: "signup",
+        redirectTo: "http://localhost/" + slug,
+        contextModule: "viewingRoom",
+        intent: "viewViewingRoom",
       })
     })
   })


### PR DESCRIPTION
Paired with @dzucconi on this, going to merge straight away to get see if we can squeeze it out ahead of tomorrow. Basically the call to `openAuthModal` uses the mediator to fire off an event called "open:auth". In order for the sign up modal to appear, a corresponding `ModalContainer` needs to be mounted in order to ingest the "open:auth" event. So there was a race condition between the event being fired and the `ModalContainer` being mounted. Here, we hack around it by using `setImmediate` to wait for the next tick and call `openAuthModal` then.