### PR TITLE
[GALL-3017] - view Works on Statement page should include works count

### DIFF
--- a/src/v2/Apps/ViewingRoom/Routes/Statement/Components/ViewWorksButton.tsx
+++ b/src/v2/Apps/ViewingRoom/Routes/Statement/Components/ViewWorksButton.tsx
@@ -5,7 +5,13 @@ import { AnalyticsSchema, useTracking } from "v2/Artsy"
 import { Button } from "@artsy/palette"
 import { useRouter } from "v2/Artsy/Router/useRouter"
 
-export const ViewWorksButton: React.FC = () => {
+interface ViewWorksButtonProps {
+  artworksCount: number
+}
+
+export const ViewWorksButton: React.FC<ViewWorksButtonProps> = ({
+  artworksCount,
+}) => {
   const tracking = useTracking()
 
   const {
@@ -15,6 +21,10 @@ export const ViewWorksButton: React.FC = () => {
   } = useRouter()
 
   const navigateTo = `/viewing-room/${slug}/works`
+
+  if (artworksCount === 0) {
+    return null
+  }
 
   return (
     <RouterLink
@@ -31,7 +41,7 @@ export const ViewWorksButton: React.FC = () => {
       }}
     >
       <Button size="large" width="100%">
-        View works
+        View works ({artworksCount})
       </Button>
     </RouterLink>
   )

--- a/src/v2/Apps/ViewingRoom/Routes/Statement/Components/ViewingRoomWorks.tsx
+++ b/src/v2/Apps/ViewingRoom/Routes/Statement/Components/ViewingRoomWorks.tsx
@@ -15,6 +15,7 @@ interface ViewingRoomWorksProps {
 
 const ViewingRoomWorks: React.FC<ViewingRoomWorksProps> = ({
   viewingRoom: {
+    artworkIDs,
     artworksConnection: { edges },
   },
 }) => {
@@ -29,7 +30,7 @@ const ViewingRoomWorks: React.FC<ViewingRoomWorksProps> = ({
   return (
     <>
       <Flex>
-        {edges.slice(0, 2).map(({ node: artwork }, index) => {
+        {edges.map(({ node: artwork }, index) => {
           return (
             <ArtworkItem
               key={artwork.internalID}
@@ -40,7 +41,7 @@ const ViewingRoomWorks: React.FC<ViewingRoomWorksProps> = ({
         })}
       </Flex>
       <Spacer my={4} />
-      <ViewWorksButton />
+      <ViewWorksButton artworksCount={artworkIDs.length} />
     </>
   )
 }
@@ -50,7 +51,8 @@ export const ViewingRoomWorksFragmentContainer = createFragmentContainer(
   {
     viewingRoom: graphql`
       fragment ViewingRoomWorks_viewingRoom on ViewingRoom {
-        artworksConnection {
+        artworkIDs
+        artworksConnection(first: 2) {
           edges {
             node {
               internalID

--- a/src/v2/Apps/ViewingRoom/Routes/Statement/Components/ViewingRoomWorks.tsx
+++ b/src/v2/Apps/ViewingRoom/Routes/Statement/Components/ViewingRoomWorks.tsx
@@ -15,8 +15,7 @@ interface ViewingRoomWorksProps {
 
 const ViewingRoomWorks: React.FC<ViewingRoomWorksProps> = ({
   viewingRoom: {
-    artworkIDs,
-    artworksConnection: { edges },
+    artworksConnection: { totalCount, edges },
   },
 }) => {
   const {
@@ -41,7 +40,7 @@ const ViewingRoomWorks: React.FC<ViewingRoomWorksProps> = ({
         })}
       </Flex>
       <Spacer my={4} />
-      <ViewWorksButton artworksCount={artworkIDs.length} />
+      <ViewWorksButton artworksCount={totalCount} />
     </>
   )
 }
@@ -51,8 +50,8 @@ export const ViewingRoomWorksFragmentContainer = createFragmentContainer(
   {
     viewingRoom: graphql`
       fragment ViewingRoomWorks_viewingRoom on ViewingRoom {
-        artworkIDs
         artworksConnection(first: 2) {
+          totalCount
           edges {
             node {
               internalID

--- a/src/v2/Apps/ViewingRoom/Routes/Statement/ViewingRoomStatementRoute.tsx
+++ b/src/v2/Apps/ViewingRoom/Routes/Statement/ViewingRoomStatementRoute.tsx
@@ -25,7 +25,7 @@ const StatementRoute: React.FC<ViewingRoomStatementRouteProps> = ({
           <ViewingRoomPullQuote viewingRoom={viewingRoom} />
           <ViewingRoomBody viewingRoom={viewingRoom} />
           <ViewingRoomSubsections viewingRoom={viewingRoom} />
-          <ViewWorksButton />
+          <ViewWorksButton artworksCount={viewingRoom.artworkIDs.length} />
         </Join>
       </Box>
       <Spacer mt={4} mb={[4, 9]} />
@@ -38,6 +38,7 @@ export const ViewingRoomStatementRouteFragmentContainer = createFragmentContaine
   {
     viewingRoom: graphql`
       fragment ViewingRoomStatementRoute_viewingRoom on ViewingRoom {
+        artworkIDs
         ...ViewingRoomIntro_viewingRoom
         ...ViewingRoomWorks_viewingRoom
         ...ViewingRoomPullQuote_viewingRoom

--- a/src/v2/Apps/ViewingRoom/Routes/Statement/ViewingRoomStatementRoute.tsx
+++ b/src/v2/Apps/ViewingRoom/Routes/Statement/ViewingRoomStatementRoute.tsx
@@ -25,7 +25,9 @@ const StatementRoute: React.FC<ViewingRoomStatementRouteProps> = ({
           <ViewingRoomPullQuote viewingRoom={viewingRoom} />
           <ViewingRoomBody viewingRoom={viewingRoom} />
           <ViewingRoomSubsections viewingRoom={viewingRoom} />
-          <ViewWorksButton artworksCount={viewingRoom.artworkIDs.length} />
+          <ViewWorksButton
+            artworksCount={viewingRoom.artworksConnection.totalCount}
+          />
         </Join>
       </Box>
       <Spacer mt={4} mb={[4, 9]} />
@@ -38,12 +40,14 @@ export const ViewingRoomStatementRouteFragmentContainer = createFragmentContaine
   {
     viewingRoom: graphql`
       fragment ViewingRoomStatementRoute_viewingRoom on ViewingRoom {
-        artworkIDs
         ...ViewingRoomIntro_viewingRoom
         ...ViewingRoomWorks_viewingRoom
         ...ViewingRoomPullQuote_viewingRoom
         ...ViewingRoomBody_viewingRoom
         ...ViewingRoomSubsections_viewingRoom
+        artworksConnection(first: 2) {
+          totalCount
+        }
       }
     `,
   }

--- a/src/v2/Apps/ViewingRoom/Routes/Statement/__tests__/ViewingRoomStatementRoute.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/Routes/Statement/__tests__/ViewingRoomStatementRoute.jest.tsx
@@ -57,7 +57,16 @@ describe("ViewingRoomStatementRoute", () => {
     expect(wrapper.find("ViewingRoomPullQuote").length).toBe(1)
     expect(wrapper.find("ViewingRoomBody").length).toBe(1)
     expect(wrapper.find("ViewingRoomSubsections").length).toBe(1)
-    expect(wrapper.find("ViewWorksButton").length).toBe(2)
+  })
+
+  it("renders view works", async () => {
+    const wrapper = await getWrapper()
+    const buttons = wrapper.find("ViewWorksButton")
+    expect(buttons.length).toBe(2)
+    const a = buttons.at(0).html()
+    expect(a).toContain("View works (5)")
+    const b = buttons.at(0).html()
+    expect(b).toContain("View works (5)")
   })
 
   describe("ViewingRoomIntro", () => {

--- a/src/v2/Apps/ViewingRoom/Routes/Statement/__tests__/ViewingRoomStatementRoute.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/Routes/Statement/__tests__/ViewingRoomStatementRoute.jest.tsx
@@ -177,10 +177,10 @@ describe("ViewingRoomStatementRoute", () => {
 
 const ViewingRoomStatmentRouteFixture: ViewingRoomStatementRoute_Test_QueryRawResponse = {
   viewingRoom: {
-    artworkIDs: ["5de6b49aa665fc000db78197", "5de6b3a46882b7000eee31f8"],
     introStatement:
       "Checked into a Club Med in the French Alps, and quickly discovered it was not what he expected. The hotel was an outdated ski lodge without any snow. “It was this horrible vacation,” the fortysomething artist said of his family trip there, a few years back. Still, he wanted to paint the drab resort—maybe so he could get a do-over of his vacation, this time in colorful and glorious surroundings.",
     artworksConnection: {
+      totalCount: 5,
       edges: [
         {
           node: {

--- a/src/v2/Apps/ViewingRoom/Routes/Statement/__tests__/ViewingRoomStatementRoute.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/Routes/Statement/__tests__/ViewingRoomStatementRoute.jest.tsx
@@ -57,6 +57,7 @@ describe("ViewingRoomStatementRoute", () => {
     expect(wrapper.find("ViewingRoomPullQuote").length).toBe(1)
     expect(wrapper.find("ViewingRoomBody").length).toBe(1)
     expect(wrapper.find("ViewingRoomSubsections").length).toBe(1)
+    expect(wrapper.find("ViewWorksButton").length).toBe(2)
   })
 
   describe("ViewingRoomIntro", () => {
@@ -176,6 +177,7 @@ describe("ViewingRoomStatementRoute", () => {
 
 const ViewingRoomStatmentRouteFixture: ViewingRoomStatementRoute_Test_QueryRawResponse = {
   viewingRoom: {
+    artworkIDs: ["5de6b49aa665fc000db78197", "5de6b3a46882b7000eee31f8"],
     introStatement:
       "Checked into a Club Med in the French Alps, and quickly discovered it was not what he expected. The hotel was an outdated ski lodge without any snow. “It was this horrible vacation,” the fortysomething artist said of his family trip there, a few years back. Still, he wanted to paint the drab resort—maybe so he could get a do-over of his vacation, this time in colorful and glorious surroundings.",
     artworksConnection: {

--- a/src/v2/__generated__/ViewingRoomStatementRoute_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ViewingRoomStatementRoute_Test_Query.graphql.ts
@@ -12,9 +12,9 @@ export type ViewingRoomStatementRoute_Test_QueryResponse = {
 };
 export type ViewingRoomStatementRoute_Test_QueryRawResponse = {
     readonly viewingRoom: ({
-        readonly artworkIDs: ReadonlyArray<string>;
         readonly introStatement: string | null;
         readonly artworksConnection: ({
+            readonly totalCount: number | null;
             readonly edges: ReadonlyArray<({
                 readonly node: ({
                     readonly internalID: string;
@@ -68,12 +68,14 @@ fragment ViewingRoomPullQuote_viewingRoom on ViewingRoom {
 }
 
 fragment ViewingRoomStatementRoute_viewingRoom on ViewingRoom {
-  artworkIDs
   ...ViewingRoomIntro_viewingRoom
   ...ViewingRoomWorks_viewingRoom
   ...ViewingRoomPullQuote_viewingRoom
   ...ViewingRoomBody_viewingRoom
   ...ViewingRoomSubsections_viewingRoom
+  artworksConnection(first: 2) {
+    totalCount
+  }
 }
 
 fragment ViewingRoomSubsections_viewingRoom on ViewingRoom {
@@ -87,8 +89,8 @@ fragment ViewingRoomSubsections_viewingRoom on ViewingRoom {
 }
 
 fragment ViewingRoomWorks_viewingRoom on ViewingRoom {
-  artworkIDs
   artworksConnection(first: 2) {
+    totalCount
     edges {
       node {
         internalID
@@ -185,13 +187,6 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "artworkIDs",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
             "name": "introStatement",
             "args": null,
             "storageKey": null
@@ -211,6 +206,13 @@ return {
             "concreteType": "ArtworkConnection",
             "plural": false,
             "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "totalCount",
+                "args": null,
+                "storageKey": null
+              },
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -316,7 +318,7 @@ return {
     "operationKind": "query",
     "name": "ViewingRoomStatementRoute_Test_Query",
     "id": null,
-    "text": "query ViewingRoomStatementRoute_Test_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomStatementRoute_viewingRoom\n  }\n}\n\nfragment ViewingRoomBody_viewingRoom on ViewingRoom {\n  body\n}\n\nfragment ViewingRoomIntro_viewingRoom on ViewingRoom {\n  introStatement\n}\n\nfragment ViewingRoomPullQuote_viewingRoom on ViewingRoom {\n  pullQuote\n}\n\nfragment ViewingRoomStatementRoute_viewingRoom on ViewingRoom {\n  artworkIDs\n  ...ViewingRoomIntro_viewingRoom\n  ...ViewingRoomWorks_viewingRoom\n  ...ViewingRoomPullQuote_viewingRoom\n  ...ViewingRoomBody_viewingRoom\n  ...ViewingRoomSubsections_viewingRoom\n}\n\nfragment ViewingRoomSubsections_viewingRoom on ViewingRoom {\n  subsections {\n    internalID\n    title\n    body\n    imageURL\n    caption\n  }\n}\n\nfragment ViewingRoomWorks_viewingRoom on ViewingRoom {\n  artworkIDs\n  artworksConnection(first: 2) {\n    edges {\n      node {\n        internalID\n        imageUrl\n        artistNames\n        title\n        date\n        saleMessage\n        id\n      }\n    }\n  }\n}\n",
+    "text": "query ViewingRoomStatementRoute_Test_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomStatementRoute_viewingRoom\n  }\n}\n\nfragment ViewingRoomBody_viewingRoom on ViewingRoom {\n  body\n}\n\nfragment ViewingRoomIntro_viewingRoom on ViewingRoom {\n  introStatement\n}\n\nfragment ViewingRoomPullQuote_viewingRoom on ViewingRoom {\n  pullQuote\n}\n\nfragment ViewingRoomStatementRoute_viewingRoom on ViewingRoom {\n  ...ViewingRoomIntro_viewingRoom\n  ...ViewingRoomWorks_viewingRoom\n  ...ViewingRoomPullQuote_viewingRoom\n  ...ViewingRoomBody_viewingRoom\n  ...ViewingRoomSubsections_viewingRoom\n  artworksConnection(first: 2) {\n    totalCount\n  }\n}\n\nfragment ViewingRoomSubsections_viewingRoom on ViewingRoom {\n  subsections {\n    internalID\n    title\n    body\n    imageURL\n    caption\n  }\n}\n\nfragment ViewingRoomWorks_viewingRoom on ViewingRoom {\n  artworksConnection(first: 2) {\n    totalCount\n    edges {\n      node {\n        internalID\n        imageUrl\n        artistNames\n        title\n        date\n        saleMessage\n        id\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/v2/__generated__/ViewingRoomStatementRoute_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ViewingRoomStatementRoute_Test_Query.graphql.ts
@@ -12,6 +12,7 @@ export type ViewingRoomStatementRoute_Test_QueryResponse = {
 };
 export type ViewingRoomStatementRoute_Test_QueryRawResponse = {
     readonly viewingRoom: ({
+        readonly artworkIDs: ReadonlyArray<string>;
         readonly introStatement: string | null;
         readonly artworksConnection: ({
             readonly edges: ReadonlyArray<({
@@ -67,6 +68,7 @@ fragment ViewingRoomPullQuote_viewingRoom on ViewingRoom {
 }
 
 fragment ViewingRoomStatementRoute_viewingRoom on ViewingRoom {
+  artworkIDs
   ...ViewingRoomIntro_viewingRoom
   ...ViewingRoomWorks_viewingRoom
   ...ViewingRoomPullQuote_viewingRoom
@@ -85,7 +87,8 @@ fragment ViewingRoomSubsections_viewingRoom on ViewingRoom {
 }
 
 fragment ViewingRoomWorks_viewingRoom on ViewingRoom {
-  artworksConnection {
+  artworkIDs
+  artworksConnection(first: 2) {
     edges {
       node {
         internalID
@@ -182,6 +185,13 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "artworkIDs",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "introStatement",
             "args": null,
             "storageKey": null
@@ -190,8 +200,14 @@ return {
             "kind": "LinkedField",
             "alias": null,
             "name": "artworksConnection",
-            "storageKey": null,
-            "args": null,
+            "storageKey": "artworksConnection(first:2)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 2
+              }
+            ],
             "concreteType": "ArtworkConnection",
             "plural": false,
             "selections": [
@@ -300,7 +316,7 @@ return {
     "operationKind": "query",
     "name": "ViewingRoomStatementRoute_Test_Query",
     "id": null,
-    "text": "query ViewingRoomStatementRoute_Test_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomStatementRoute_viewingRoom\n  }\n}\n\nfragment ViewingRoomBody_viewingRoom on ViewingRoom {\n  body\n}\n\nfragment ViewingRoomIntro_viewingRoom on ViewingRoom {\n  introStatement\n}\n\nfragment ViewingRoomPullQuote_viewingRoom on ViewingRoom {\n  pullQuote\n}\n\nfragment ViewingRoomStatementRoute_viewingRoom on ViewingRoom {\n  ...ViewingRoomIntro_viewingRoom\n  ...ViewingRoomWorks_viewingRoom\n  ...ViewingRoomPullQuote_viewingRoom\n  ...ViewingRoomBody_viewingRoom\n  ...ViewingRoomSubsections_viewingRoom\n}\n\nfragment ViewingRoomSubsections_viewingRoom on ViewingRoom {\n  subsections {\n    internalID\n    title\n    body\n    imageURL\n    caption\n  }\n}\n\nfragment ViewingRoomWorks_viewingRoom on ViewingRoom {\n  artworksConnection {\n    edges {\n      node {\n        internalID\n        imageUrl\n        artistNames\n        title\n        date\n        saleMessage\n        id\n      }\n    }\n  }\n}\n",
+    "text": "query ViewingRoomStatementRoute_Test_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomStatementRoute_viewingRoom\n  }\n}\n\nfragment ViewingRoomBody_viewingRoom on ViewingRoom {\n  body\n}\n\nfragment ViewingRoomIntro_viewingRoom on ViewingRoom {\n  introStatement\n}\n\nfragment ViewingRoomPullQuote_viewingRoom on ViewingRoom {\n  pullQuote\n}\n\nfragment ViewingRoomStatementRoute_viewingRoom on ViewingRoom {\n  artworkIDs\n  ...ViewingRoomIntro_viewingRoom\n  ...ViewingRoomWorks_viewingRoom\n  ...ViewingRoomPullQuote_viewingRoom\n  ...ViewingRoomBody_viewingRoom\n  ...ViewingRoomSubsections_viewingRoom\n}\n\nfragment ViewingRoomSubsections_viewingRoom on ViewingRoom {\n  subsections {\n    internalID\n    title\n    body\n    imageURL\n    caption\n  }\n}\n\nfragment ViewingRoomWorks_viewingRoom on ViewingRoom {\n  artworkIDs\n  artworksConnection(first: 2) {\n    edges {\n      node {\n        internalID\n        imageUrl\n        artistNames\n        title\n        date\n        saleMessage\n        id\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/v2/__generated__/ViewingRoomStatementRoute_viewingRoom.graphql.ts
+++ b/src/v2/__generated__/ViewingRoomStatementRoute_viewingRoom.graphql.ts
@@ -3,6 +3,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ViewingRoomStatementRoute_viewingRoom = {
+    readonly artworkIDs: ReadonlyArray<string>;
     readonly " $fragmentRefs": FragmentRefs<"ViewingRoomIntro_viewingRoom" | "ViewingRoomWorks_viewingRoom" | "ViewingRoomPullQuote_viewingRoom" | "ViewingRoomBody_viewingRoom" | "ViewingRoomSubsections_viewingRoom">;
     readonly " $refType": "ViewingRoomStatementRoute_viewingRoom";
 };
@@ -21,6 +22,13 @@ const node: ReaderFragment = {
   "metadata": null,
   "argumentDefinitions": [],
   "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "artworkIDs",
+      "args": null,
+      "storageKey": null
+    },
     {
       "kind": "FragmentSpread",
       "name": "ViewingRoomIntro_viewingRoom",
@@ -48,5 +56,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = 'f407bc7c23d72df0e083441cdbd5bece';
+(node as any).hash = '8f189f22d2939cfece7cf0e73ccd3f35';
 export default node;

--- a/src/v2/__generated__/ViewingRoomStatementRoute_viewingRoom.graphql.ts
+++ b/src/v2/__generated__/ViewingRoomStatementRoute_viewingRoom.graphql.ts
@@ -3,7 +3,9 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ViewingRoomStatementRoute_viewingRoom = {
-    readonly artworkIDs: ReadonlyArray<string>;
+    readonly artworksConnection: {
+        readonly totalCount: number | null;
+    } | null;
     readonly " $fragmentRefs": FragmentRefs<"ViewingRoomIntro_viewingRoom" | "ViewingRoomWorks_viewingRoom" | "ViewingRoomPullQuote_viewingRoom" | "ViewingRoomBody_viewingRoom" | "ViewingRoomSubsections_viewingRoom">;
     readonly " $refType": "ViewingRoomStatementRoute_viewingRoom";
 };
@@ -23,11 +25,28 @@ const node: ReaderFragment = {
   "argumentDefinitions": [],
   "selections": [
     {
-      "kind": "ScalarField",
+      "kind": "LinkedField",
       "alias": null,
-      "name": "artworkIDs",
-      "args": null,
-      "storageKey": null
+      "name": "artworksConnection",
+      "storageKey": "artworksConnection(first:2)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 2
+        }
+      ],
+      "concreteType": "ArtworkConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "totalCount",
+          "args": null,
+          "storageKey": null
+        }
+      ]
     },
     {
       "kind": "FragmentSpread",
@@ -56,5 +75,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '8f189f22d2939cfece7cf0e73ccd3f35';
+(node as any).hash = 'eb89dc547a16f9d2e7413352b51ab944';
 export default node;

--- a/src/v2/__generated__/ViewingRoomWorks_viewingRoom.graphql.ts
+++ b/src/v2/__generated__/ViewingRoomWorks_viewingRoom.graphql.ts
@@ -3,8 +3,8 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ViewingRoomWorks_viewingRoom = {
-    readonly artworkIDs: ReadonlyArray<string>;
     readonly artworksConnection: {
+        readonly totalCount: number | null;
         readonly edges: ReadonlyArray<{
             readonly node: {
                 readonly internalID: string;
@@ -34,13 +34,6 @@ const node: ReaderFragment = {
   "argumentDefinitions": [],
   "selections": [
     {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "artworkIDs",
-      "args": null,
-      "storageKey": null
-    },
-    {
       "kind": "LinkedField",
       "alias": null,
       "name": "artworksConnection",
@@ -55,6 +48,13 @@ const node: ReaderFragment = {
       "concreteType": "ArtworkConnection",
       "plural": false,
       "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "totalCount",
+          "args": null,
+          "storageKey": null
+        },
         {
           "kind": "LinkedField",
           "alias": null,
@@ -123,5 +123,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '966149e90d3526761ae079aa41581a7b';
+(node as any).hash = 'bb3cd65dc62fcfd09d126365aecc9e51';
 export default node;

--- a/src/v2/__generated__/ViewingRoomWorks_viewingRoom.graphql.ts
+++ b/src/v2/__generated__/ViewingRoomWorks_viewingRoom.graphql.ts
@@ -3,6 +3,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ViewingRoomWorks_viewingRoom = {
+    readonly artworkIDs: ReadonlyArray<string>;
     readonly artworksConnection: {
         readonly edges: ReadonlyArray<{
             readonly node: {
@@ -33,11 +34,24 @@ const node: ReaderFragment = {
   "argumentDefinitions": [],
   "selections": [
     {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "artworkIDs",
+      "args": null,
+      "storageKey": null
+    },
+    {
       "kind": "LinkedField",
       "alias": null,
       "name": "artworksConnection",
-      "storageKey": null,
-      "args": null,
+      "storageKey": "artworksConnection(first:2)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 2
+        }
+      ],
       "concreteType": "ArtworkConnection",
       "plural": false,
       "selections": [
@@ -109,5 +123,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = 'fffb4a8df458a9188446bfe3cc917ed1';
+(node as any).hash = '966149e90d3526761ae079aa41581a7b';
 export default node;

--- a/src/v2/__generated__/routes_ViewingRoomStatementRouteQuery.graphql.ts
+++ b/src/v2/__generated__/routes_ViewingRoomStatementRouteQuery.graphql.ts
@@ -39,6 +39,7 @@ fragment ViewingRoomPullQuote_viewingRoom on ViewingRoom {
 }
 
 fragment ViewingRoomStatementRoute_viewingRoom on ViewingRoom {
+  artworkIDs
   ...ViewingRoomIntro_viewingRoom
   ...ViewingRoomWorks_viewingRoom
   ...ViewingRoomPullQuote_viewingRoom
@@ -57,7 +58,8 @@ fragment ViewingRoomSubsections_viewingRoom on ViewingRoom {
 }
 
 fragment ViewingRoomWorks_viewingRoom on ViewingRoom {
-  artworksConnection {
+  artworkIDs
+  artworksConnection(first: 2) {
     edges {
       node {
         internalID
@@ -154,6 +156,13 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "artworkIDs",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "introStatement",
             "args": null,
             "storageKey": null
@@ -162,8 +171,14 @@ return {
             "kind": "LinkedField",
             "alias": null,
             "name": "artworksConnection",
-            "storageKey": null,
-            "args": null,
+            "storageKey": "artworksConnection(first:2)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 2
+              }
+            ],
             "concreteType": "ArtworkConnection",
             "plural": false,
             "selections": [
@@ -272,7 +287,7 @@ return {
     "operationKind": "query",
     "name": "routes_ViewingRoomStatementRouteQuery",
     "id": null,
-    "text": "query routes_ViewingRoomStatementRouteQuery(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomStatementRoute_viewingRoom\n  }\n}\n\nfragment ViewingRoomBody_viewingRoom on ViewingRoom {\n  body\n}\n\nfragment ViewingRoomIntro_viewingRoom on ViewingRoom {\n  introStatement\n}\n\nfragment ViewingRoomPullQuote_viewingRoom on ViewingRoom {\n  pullQuote\n}\n\nfragment ViewingRoomStatementRoute_viewingRoom on ViewingRoom {\n  ...ViewingRoomIntro_viewingRoom\n  ...ViewingRoomWorks_viewingRoom\n  ...ViewingRoomPullQuote_viewingRoom\n  ...ViewingRoomBody_viewingRoom\n  ...ViewingRoomSubsections_viewingRoom\n}\n\nfragment ViewingRoomSubsections_viewingRoom on ViewingRoom {\n  subsections {\n    internalID\n    title\n    body\n    imageURL\n    caption\n  }\n}\n\nfragment ViewingRoomWorks_viewingRoom on ViewingRoom {\n  artworksConnection {\n    edges {\n      node {\n        internalID\n        imageUrl\n        artistNames\n        title\n        date\n        saleMessage\n        id\n      }\n    }\n  }\n}\n",
+    "text": "query routes_ViewingRoomStatementRouteQuery(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomStatementRoute_viewingRoom\n  }\n}\n\nfragment ViewingRoomBody_viewingRoom on ViewingRoom {\n  body\n}\n\nfragment ViewingRoomIntro_viewingRoom on ViewingRoom {\n  introStatement\n}\n\nfragment ViewingRoomPullQuote_viewingRoom on ViewingRoom {\n  pullQuote\n}\n\nfragment ViewingRoomStatementRoute_viewingRoom on ViewingRoom {\n  artworkIDs\n  ...ViewingRoomIntro_viewingRoom\n  ...ViewingRoomWorks_viewingRoom\n  ...ViewingRoomPullQuote_viewingRoom\n  ...ViewingRoomBody_viewingRoom\n  ...ViewingRoomSubsections_viewingRoom\n}\n\nfragment ViewingRoomSubsections_viewingRoom on ViewingRoom {\n  subsections {\n    internalID\n    title\n    body\n    imageURL\n    caption\n  }\n}\n\nfragment ViewingRoomWorks_viewingRoom on ViewingRoom {\n  artworkIDs\n  artworksConnection(first: 2) {\n    edges {\n      node {\n        internalID\n        imageUrl\n        artistNames\n        title\n        date\n        saleMessage\n        id\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/v2/__generated__/routes_ViewingRoomStatementRouteQuery.graphql.ts
+++ b/src/v2/__generated__/routes_ViewingRoomStatementRouteQuery.graphql.ts
@@ -39,12 +39,14 @@ fragment ViewingRoomPullQuote_viewingRoom on ViewingRoom {
 }
 
 fragment ViewingRoomStatementRoute_viewingRoom on ViewingRoom {
-  artworkIDs
   ...ViewingRoomIntro_viewingRoom
   ...ViewingRoomWorks_viewingRoom
   ...ViewingRoomPullQuote_viewingRoom
   ...ViewingRoomBody_viewingRoom
   ...ViewingRoomSubsections_viewingRoom
+  artworksConnection(first: 2) {
+    totalCount
+  }
 }
 
 fragment ViewingRoomSubsections_viewingRoom on ViewingRoom {
@@ -58,8 +60,8 @@ fragment ViewingRoomSubsections_viewingRoom on ViewingRoom {
 }
 
 fragment ViewingRoomWorks_viewingRoom on ViewingRoom {
-  artworkIDs
   artworksConnection(first: 2) {
+    totalCount
     edges {
       node {
         internalID
@@ -156,13 +158,6 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "artworkIDs",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "ScalarField",
-            "alias": null,
             "name": "introStatement",
             "args": null,
             "storageKey": null
@@ -182,6 +177,13 @@ return {
             "concreteType": "ArtworkConnection",
             "plural": false,
             "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "totalCount",
+                "args": null,
+                "storageKey": null
+              },
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -287,7 +289,7 @@ return {
     "operationKind": "query",
     "name": "routes_ViewingRoomStatementRouteQuery",
     "id": null,
-    "text": "query routes_ViewingRoomStatementRouteQuery(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomStatementRoute_viewingRoom\n  }\n}\n\nfragment ViewingRoomBody_viewingRoom on ViewingRoom {\n  body\n}\n\nfragment ViewingRoomIntro_viewingRoom on ViewingRoom {\n  introStatement\n}\n\nfragment ViewingRoomPullQuote_viewingRoom on ViewingRoom {\n  pullQuote\n}\n\nfragment ViewingRoomStatementRoute_viewingRoom on ViewingRoom {\n  artworkIDs\n  ...ViewingRoomIntro_viewingRoom\n  ...ViewingRoomWorks_viewingRoom\n  ...ViewingRoomPullQuote_viewingRoom\n  ...ViewingRoomBody_viewingRoom\n  ...ViewingRoomSubsections_viewingRoom\n}\n\nfragment ViewingRoomSubsections_viewingRoom on ViewingRoom {\n  subsections {\n    internalID\n    title\n    body\n    imageURL\n    caption\n  }\n}\n\nfragment ViewingRoomWorks_viewingRoom on ViewingRoom {\n  artworkIDs\n  artworksConnection(first: 2) {\n    edges {\n      node {\n        internalID\n        imageUrl\n        artistNames\n        title\n        date\n        saleMessage\n        id\n      }\n    }\n  }\n}\n",
+    "text": "query routes_ViewingRoomStatementRouteQuery(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomStatementRoute_viewingRoom\n  }\n}\n\nfragment ViewingRoomBody_viewingRoom on ViewingRoom {\n  body\n}\n\nfragment ViewingRoomIntro_viewingRoom on ViewingRoom {\n  introStatement\n}\n\nfragment ViewingRoomPullQuote_viewingRoom on ViewingRoom {\n  pullQuote\n}\n\nfragment ViewingRoomStatementRoute_viewingRoom on ViewingRoom {\n  ...ViewingRoomIntro_viewingRoom\n  ...ViewingRoomWorks_viewingRoom\n  ...ViewingRoomPullQuote_viewingRoom\n  ...ViewingRoomBody_viewingRoom\n  ...ViewingRoomSubsections_viewingRoom\n  artworksConnection(first: 2) {\n    totalCount\n  }\n}\n\nfragment ViewingRoomSubsections_viewingRoom on ViewingRoom {\n  subsections {\n    internalID\n    title\n    body\n    imageURL\n    caption\n  }\n}\n\nfragment ViewingRoomWorks_viewingRoom on ViewingRoom {\n  artworksConnection(first: 2) {\n    totalCount\n    edges {\n      node {\n        internalID\n        imageUrl\n        artistNames\n        title\n        date\n        saleMessage\n        id\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
This is the counter part of the ticket. We still need to refactor to use the first 4 artworks and put them into greed.

But the counter was listed as higher priority for tomorrow's Community pages.

Generates this button:
<img width="669" alt="Screen Shot 2020-07-01 at 12 26 37 AM" src="https://user-images.githubusercontent.com/437156/86203280-9d4c3e80-bb32-11ea-8e0b-3b510a1c8763.png">
