### PR TITLE
Fixes hidden images within CSS columns

### DIFF
--- a/src/v2/Components/Artwork/GridItem.tsx
+++ b/src/v2/Components/Artwork/GridItem.tsx
@@ -20,10 +20,10 @@ const Placeholder = styled.div`
   background-color: ${color("black10")};
   position: relative;
   width: 100%;
-  overflow: hidden;
 `
 
-const Image = styled(BaseImage)`
+const Link = styled(RouterLink)`
+  display: block;
   width: 100%;
   height: 100%;
   position: absolute;
@@ -31,15 +31,12 @@ const Image = styled(BaseImage)`
   right: 0;
   bottom: 0;
   left: 0;
+`
 
-  /**
-   * HACK: the border here is to hack around an issue where Chrome doesn't
-   * pick up the lazyLoad intersection observer unless there's a border around
-   * the element or some modification to the sub-tree occurs. 'box-sizing' is set
-   * to 'content-box' so the image appears to be the same dimensions.
-   */
-  border: 1px solid transparent;
-  box-sizing: content-box;
+const Image = styled(BaseImage)`
+  display: block;
+  width: 100%;
+  height: 100%;
 `
 
 interface Props extends React.HTMLProps<ArtworkGridItemContainer> {
@@ -125,7 +122,7 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
         style={style}
       >
         <Placeholder style={{ paddingBottom: artwork.image.placeholder }}>
-          <RouterLink
+          <Link
             to={artwork.href}
             onClick={() => {
               if (this.props.onClick) {
@@ -140,7 +137,7 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
               lazyLoad={IMAGE_LAZY_LOADING && lazyLoad}
               preventRightClick={!isAdmin}
             />
-          </RouterLink>
+          </Link>
 
           <Badge artwork={artwork} />
 


### PR DESCRIPTION
So this is an interesting one. I had been assuming this was something weird with the lazy loading implementation but it turns out this is due to an edge case in rendering CSS columns in WebKit — best I can tell — going to try to create a minimal replication and file a bug report.

The artwork grid items utilize aspect ratio boxes, which is a pretty common and well supported hack using a `0px` `height` and a `padding-bottom` to size the container to the correct dimensions while making it responsive in width. Which is fine, but apparently in WebKit's columns implementation, the first column treats the stacked absolute element correctly but then on subsequent columns is incorrectly respecting `overflow: hidden` + the `0px` `height` and not rendering the absolutely positioned element.

![](http://static.damonzucconi.com/_capture/Dr6DASF5UtxT.png)

So a quick fix here is to just remove `overflow: hidden;` — All the grids look correct in Chrome/Safar/FF with that change, and since the inner images just apply 100% x 100%, I don't anticipate any issues with anything actually overflowing. Definitely open to alternative suggestions though.