### PR TITLE
@eessex => [Article] Switch Force server-side to use MP V2

### DIFF
--- a/src/desktop/apps/article/__tests__/routes.jest.ts
+++ b/src/desktop/apps/article/__tests__/routes.jest.ts
@@ -10,7 +10,7 @@ jest.mock("desktop/lib/positronql", () => ({
   positronql: jest.fn(),
 }))
 
-jest.mock("lib/metaphysics.coffee", () => jest.fn())
+jest.mock("lib/metaphysics2.coffee", () => jest.fn())
 
 jest.mock("sharify", () => ({
   data: {
@@ -29,7 +29,7 @@ jest.mock("@artsy/stitch", () => ({
 
 const positronql = require("desktop/lib/positronql").positronql as jest.Mock
 const stitch = require("@artsy/stitch").stitch as jest.Mock
-const metaphysics = require("lib/metaphysics.coffee") as jest.Mock
+const metaphysics = require("lib/metaphysics2.coffee") as jest.Mock
 
 describe("Article Routes", () => {
   let req

--- a/src/desktop/apps/article/queries/promotedContent.js
+++ b/src/desktop/apps/article/queries/promotedContent.js
@@ -3,14 +3,14 @@ export const partnerQuery = id => {
     {
       partner(id: "${id}")
       {
-        default_profile_id
+        default_profile_id: defaultProfileID
         name
         type
         profile {
-          id
+          id: internalID
           href
           image {
-            cropped(width: 250 height: 165 version: "large_rectangle"){
+            cropped(width: 250, height: 165, version: "large_rectangle"){
               url
             }
           }
@@ -25,10 +25,10 @@ export const auctionQuery = id => {
     {
       sale(id: "${id}")
       {
-        id
+        id: internalID
         name
         href
-        cover_image {
+        cover_image: coverImage {
           cropped(width: 250 height: 165 version: "large_rectangle"){
             url
           }

--- a/src/desktop/apps/article/routes.tsx
+++ b/src/desktop/apps/article/routes.tsx
@@ -38,7 +38,7 @@ const markdown = require("desktop/components/util/markdown.coffee")
 const { crop, resize } = require("desktop/components/resizer/index.coffee")
 const Article = require("desktop/models/article.coffee")
 const { stringifyJSONForWeb } = require("desktop/components/util/json.coffee")
-const metaphysics = require("lib/metaphysics.coffee")
+const metaphysics = require("lib/metaphysics2.coffee")
 
 export const index = async (req, res, next) => {
   let articleId = req.params.slug
@@ -49,9 +49,9 @@ export const index = async (req, res, next) => {
 
     if (!req.path.includes(`/series/`)) {
       return res.redirect(
-        `/series/artsy-vanguard-2019${(req.params.slug &&
-          `/${req.params.slug}`) ||
-          ""}`
+        `/series/artsy-vanguard-2019${
+          (req.params.slug && `/${req.params.slug}`) || ""
+        }`
       )
     }
   }


### PR DESCRIPTION
Article page/setup as I understand it:
  - Article code generally hits PositronQL and is fetched from within Force. The React components still live in Reaction (not merged with Force).
  - Some editorial code in Reaction though does hit Metaphysics (tooltips), and that was updated to use V2 during the migration: https://github.com/artsy/reaction/pull/2982
  - There remains some minimal Metaphysics code for the article page in Force (which otherwise uses PositronQL), updated here.