### PR TITLE
[PURCHASE-1977] Conversation visual fixes - part II

### DIFF
--- a/src/v2/Apps/Conversation/Components/Conversations.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversations.tsx
@@ -6,10 +6,13 @@ import { ConversationSnippetFragmentContainer as ConversationSnippet } from "./C
 import styled from "styled-components"
 
 const Container = styled(Box)`
-  min-height: 100vh;
+  height: 100%;
+  overflow-y: scroll;
+  border-bottom: 30px solid ${color("white100")};
   border-right: 1px solid ${color("black10")};
   ${media.xs`
     border-right: none;
+    border-bottom: none;
   `};
 `
 
@@ -28,25 +31,23 @@ const Conversations: React.FC<ConversationsProps> = props => {
     .indexOf(selectedConversationID)
 
   return (
-    <>
-      <Container width={["100%", "375px"]}>
-        <Box>
-          {conversations.map(edge => (
-            <ConversationSnippet
-              selectedConversationID={selectedConversationID}
-              isSelected={edge.node.internalID === selectedConversationID}
-              conversation={edge.node}
-              key={edge.cursor}
-              hasDivider={
-                conversations.indexOf(edge) !== selectedConversationIndex &&
-                conversations.indexOf(edge) !== selectedConversationIndex - 1 &&
-                conversations.indexOf(edge) !== conversations.length - 1
-              }
-            />
-          ))}
-        </Box>
-      </Container>
-    </>
+    <Container width={["100%", "375px"]}>
+      <Box>
+        {conversations.map(edge => (
+          <ConversationSnippet
+            selectedConversationID={selectedConversationID}
+            isSelected={edge.node.internalID === selectedConversationID}
+            conversation={edge.node}
+            key={edge.cursor}
+            hasDivider={
+              conversations.indexOf(edge) !== selectedConversationIndex &&
+              conversations.indexOf(edge) !== selectedConversationIndex - 1 &&
+              conversations.indexOf(edge) !== conversations.length - 1
+            }
+          />
+        ))}
+      </Box>
+    </Container>
   )
 }
 

--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -4,12 +4,13 @@ import {
   EntityHeader,
   Flex,
   FlexProps,
+  Join,
   Link,
-  MessageIcon,
   QuestionCircleIcon,
   ResponsiveImage,
   Sans,
   Separator,
+  Spacer,
   color,
   media,
 } from "@artsy/palette"
@@ -61,6 +62,22 @@ export const Details: FC<DetailsProps> = ({ conversation, ...props }) => {
     .filter(attachments => attachments.length > 0)
     .reduce((previous, current) => previous.concat(current), [])
     .filter(attachment => !attachment.contentType.includes("image"))
+
+  const attachmentItems = attachments?.map(attachment => {
+    return (
+      <Link
+        key={attachment.id}
+        href={attachment.downloadURL}
+        target="_blank"
+        noUnderline
+      >
+        <Flex alignItems="center">
+          <DocumentIcon mr={0.5} />
+          <Sans size="3">{attachment.fileName}</Sans>
+        </Flex>
+      </Link>
+    )
+  })
 
   return (
     <DetailsContainer
@@ -119,21 +136,7 @@ export const Details: FC<DetailsProps> = ({ conversation, ...props }) => {
             <Sans size="3" weight="medium" mb={2}>
               Attachments
             </Sans>
-            {attachments.map(attachment => {
-              return (
-                <Link
-                  key={attachment.id}
-                  href={attachment.downloadURL}
-                  target="_blank"
-                  noUnderline
-                >
-                  <Flex alignItems="center">
-                    <DocumentIcon mr={0.5} />
-                    <Sans size="3">{attachment.fileName}</Sans>
-                  </Flex>
-                </Link>
-              )
-            })}
+            <Join separator={<Spacer mb={1} />}>{attachmentItems}</Join>
           </Box>
         </>
       )}
@@ -145,10 +148,6 @@ export const Details: FC<DetailsProps> = ({ conversation, ...props }) => {
         <Flex alignItems="center" mb={1}>
           <QuestionCircleIcon mr={1} />
           <Sans size="3">Inquiries FAQ</Sans>
-        </Flex>
-        <Flex alignItems="center" mb={1}>
-          <MessageIcon mr={1} />
-          <Sans size="3">Contact an Artsy Specialist</Sans>
         </Flex>
       </Flex>
     </DetailsContainer>

--- a/src/v2/Apps/Conversation/Components/InboxHeaders.tsx
+++ b/src/v2/Apps/Conversation/Components/InboxHeaders.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components"
 import {
   ArrowLeftIcon,
   Box,
+  CloseIcon,
   Flex,
   FlexProps,
   Icon,
@@ -49,7 +50,7 @@ export const ConversationHeader: FC<ConversationHeaderProps> = ({
   return (
     <ConversationHeaderContainer
       height="55px"
-      px={2}
+      px={[1, 2]}
       alignItems="center"
       justifyContent="space-between"
       width="100%"
@@ -57,8 +58,11 @@ export const ConversationHeader: FC<ConversationHeaderProps> = ({
       <RouterLink to={`/user/conversations`}>
         <ArrowLeftIcon />
       </RouterLink>
-      <Sans size="3t" weight="medium">
+      <Sans size="3t" weight="medium" display={["none", "auto"]}>
         Conversation with {partnerName}
+      </Sans>
+      <Sans size="3t" weight="medium" display={["auto", "none"]}>
+        Inquiry with {partnerName}
       </Sans>
       <DetailIcon showDetails={showDetails} setShowDetails={setShowDetails} />
     </ConversationHeaderContainer>
@@ -110,25 +114,31 @@ export const InboxHeader: FC<BorderedFlexProps> = props => {
   )
 }
 
-interface DetailsHeaderProps extends BorderedFlexProps {
-  showDetails: boolean
-}
+interface DetailsHeaderProps extends BorderedFlexProps, DetailsProps {}
 
 const AnimatedFlex = styled(Flex)`
   ${DETAIL_BOX_ANIMATION}
 `
 
 export const DetailsHeader: FC<DetailsHeaderProps> = props => {
-  const { showDetails } = props
+  const { showDetails, setShowDetails } = props
   return (
     <AnimatedFlex
       flexDirection="column"
       width={showDetails ? "375px" : "0"}
       {...props}
     >
-      <Sans size="4" ml={2}>
-        Details
-      </Sans>
+      <Flex flexDirection="row" justifyContent="space-between">
+        <Sans size="4" ml={2}>
+          Details
+        </Sans>
+        <CloseIcon
+          mr={1}
+          mt={0.5}
+          cursor="pointer"
+          onClick={() => setShowDetails(false)}
+        />
+      </Flex>
       <Separator mt={1} />
     </AnimatedFlex>
   )
@@ -168,7 +178,10 @@ export const FullHeader: FC<Partial<ConversationHeaderProps>> = props => {
       </BorderedFlex>
       <Flex flexShrink={0} height="100%" alignItems="flex-end">
         <Media greaterThan="lg">
-          <DetailsHeader showDetails={props.showDetails} />
+          <DetailsHeader
+            showDetails={props.showDetails}
+            setShowDetails={props.setShowDetails}
+          />
         </Media>
       </Flex>
     </Flex>
@@ -179,8 +192,10 @@ const DetailIcon: React.FC<DetailsProps> = props => {
   const { showDetails, setShowDetails } = props
   return (
     <StatefulIcon
+      width="28"
+      height="28"
       viewBox="0 0 28 28"
-      mr={1}
+      mr={[0, 1]}
       onClick={() => {
         setShowDetails(!showDetails)
       }}

--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -94,7 +94,7 @@ export const Reply: React.FC<ReplyProps> = props => {
           text: "Discard message",
         }}
       />
-      <StyledFlex p={1} right={[0, null]} zIndex={2}>
+      <StyledFlex p={1} right={[0, null]} zIndex={[null, 2]}>
         <FullWidthFlex width="100%">
           <StyledTextArea
             onInput={event => {


### PR DESCRIPTION
Fixes remaining from [PURCHASE-1977](https://artsyproduct.atlassian.net/browse/PURCHASE-1977) reported [here](https://www.figma.com/file/vtXzdPefblvRiAapA79fTh/Conversations-Inbox?node-id=1449%3A28359)

(first commit)
- Attachment list margins
- Remove `contact artsy ...`
- Close button for L detail screens
- Detail box icon size
- Mobile header tweaks
- Reply box should be below detail box on mobile

(2nd commit)
- Add margin bottom to conversations left panel 
