### PR TITLE
[FX-2080] Utilizes ModalBase to break out of weird homepage stacking context

### DIFF
--- a/src/v2/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
@@ -6,12 +6,12 @@ import {
   CloseIcon,
   Flex,
   MenuIcon,
+  ModalBase,
   Sans,
   Separator,
   color,
   space,
 } from "@artsy/palette"
-import { RemoveScroll } from "react-remove-scroll"
 import { AnalyticsSchema, useSystemContext } from "v2/Artsy"
 import { useTracking } from "v2/Artsy/Analytics"
 import { ModalType } from "v2/Components/Authentication/Types"
@@ -58,7 +58,13 @@ export const MobileNavMenu: React.FC<Props> = ({
 
   return (
     <NavigatorContextProvider>
-      <RemoveScroll>
+      <ModalBase
+        dialogProps={{
+          width: "100%",
+          height: "100%",
+          background: color("white100"),
+        }}
+      >
         <MenuViewport onClick={onNavButtonClick}>
           <Close onClick={onClose}>
             <MobileToggleIcon open />
@@ -87,7 +93,7 @@ export const MobileNavMenu: React.FC<Props> = ({
             </ul>
           </AnimatingMenuWrapper>
         </MenuViewport>
-      </RemoveScroll>
+      </ModalBase>
     </NavigatorContextProvider>
   )
 }


### PR DESCRIPTION
Re: https://artsy.slack.com/archives/C04KVDZU6/p1593699708206700

There's a lot that's weird about this 😅 

You'll notice in the video in that Slack thread that it's a touch device (iPad) but if you actually try to debug this in Chrome and hit the site with touch enabled you get the Microgravity homepage view, which has a stacking context for the nav in which this isn't an issue.

So how touch is detected and routed — there's almost certainly a bug there...

The desktop/non-touch homepage also renders the nav in a different container than the rest of the site which is why it's behind everything on that view. You won't see this unless you disable touch in the responsive view. (Side note: the stack on the homepage is deeply weird — which I think stems from the way that sticky hero is hacked in there with a `position: fixed` and `z-index: -1`.)

Anyway; the `ModalBase` component portals out to the bottom of the document — which is how any kind of modal should work — so as to exit any immediate stacking context.