### PR TITLE
[CI] Fixes failing specs by tearing down stubs/benv

### DIFF
--- a/src/mobile/components/layout/test/layout.test.coffee
+++ b/src/mobile/components/layout/test/layout.test.coffee
@@ -155,7 +155,7 @@ xdescribe 'afterSignUpAction', ->
     }
     @bootstrap()
     @Cookies.expire.callCount.should.equal 0
-  
+
   it 'saves an artwork', ->
     @getCookie.returns(
       JSON.stringify({
@@ -204,7 +204,13 @@ describe 'logoutEventHandler', ->
       @bootstrap.__set__('FlashMessage', @FlashMessage)
       @logoutEventHandler = @bootstrap.__get__('logoutEventHandler')
       done()
-  
+
+  after ->
+    window.location.reload.restore()
+    $.ajax.restore()
+    benv.teardown()
+
+
   it 'logs out the user and tracks the logout event', ->
     @logoutEventHandler()
     $.ajax.args[0][0].url.should.be.eql '/users/sign_out'


### PR DESCRIPTION
Re: https://artsy.slack.com/archives/CP9P4KR35/p1593543490366500

I had assumed this was something to do with the timers since it was failing in the `ClockView` spec, which is difficult to track down but had I just read the error message:

```
TypeError: Attempted to wrap reload which is already wrapped
```

There was only one other place where `reload` was being stubbed — so this was easier to track down.