### PR TITLE
fix: profile views layout improvements on mobile

### DIFF
--- a/src/desktop/apps/user/components/tabs/index.styl
+++ b/src/desktop/apps/user/components/tabs/index.styl
@@ -22,3 +22,8 @@
   .settings-tabs
     overflow-x scroll
     position relative
+    margin-right: -40px
+    &::after
+      content: ''
+      display: block
+      min-width: 40px

--- a/src/desktop/apps/user/stylesheets/index.styl
+++ b/src/desktop/apps/user/stylesheets/index.styl
@@ -33,6 +33,10 @@
     &__main
       width 75%
 
+      @media screen and (max-width: 550px)
+        width 100%
+
+
 .settings-subnav
   //
 


### PR DESCRIPTION
Fixes FX-2079

- expand the horizontally scrollable nav bar to the right edge as an affordance
- expand the Collector Profile content to 100% width in mobile