### PR TITLE
[PURCHASE-1990] Reply box should not extent when detail box is open

### DIFF
--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -158,64 +158,64 @@ const Conversation: React.FC<ConversationProps> = props => {
     UpdateConversation(relay.environment, conversation)
   }, [conversation, relay.environment, conversation.lastMessageID])
 
+  const inquiryItemBox = conversation.items.map((i, idx) => (
+    <Item
+      item={i.item}
+      key={
+        i.item.__typename === "Artwork" || i.item.__typename === "Show"
+          ? i.item.id
+          : idx
+      }
+    />
+  ))
+
+  const messageGroups = groupMessages(
+    conversation.messagesConnection.edges.map(edge => edge.node)
+  ).map((messageGroup, groupIndex) => {
+    const today = fromToday(messageGroup[0].createdAt)
+    return (
+      <React.Fragment key={`group-${groupIndex}-${messageGroup[0].internalID}`}>
+        <TimeSince
+          style={{ alignSelf: "center" }}
+          time={messageGroup[0].createdAt}
+          exact
+          mb={1}
+        />
+        {messageGroup.map((message, messageIndex) => {
+          const nextMessage = messageGroup[messageIndex + 1]
+          const senderChanges =
+            nextMessage && nextMessage.isFromUser !== message.isFromUser
+          const lastMessageInGroup = messageIndex === messageGroup.length - 1
+          const spaceAfter = senderChanges || lastMessageInGroup ? 2 : 0.5
+
+          return (
+            <>
+              <Message
+                message={message}
+                initialMessage={conversation.initialMessage}
+                key={message.internalID}
+                isFirst={groupIndex + messageIndex === 0}
+                showTimeSince={
+                  message.createdAt &&
+                  today &&
+                  messageGroup.length - 1 === messageIndex
+                }
+              />
+              <Spacer mb={spaceAfter} />
+            </>
+          )
+        })}
+      </React.Fragment>
+    )
+  })
+
   return (
     <Flex flexDirection="column" width="100%">
       <Box>
         <Spacer mt={["75px", 2]} />
         <Flex flexDirection="column" width="100%" px={1}>
-          {conversation.items.map((i, idx) => (
-            <Item
-              item={i.item}
-              key={
-                i.item.__typename === "Artwork" || i.item.__typename === "Show"
-                  ? i.item.id
-                  : idx
-              }
-            />
-          ))}
-          {groupMessages(
-            conversation.messagesConnection.edges.map(edge => edge.node)
-          ).map((messageGroup, groupIndex) => {
-            const today = fromToday(messageGroup[0].createdAt)
-            return (
-              <React.Fragment
-                key={`group-${groupIndex}-${messageGroup[0].internalID}`}
-              >
-                <TimeSince
-                  style={{ alignSelf: "center" }}
-                  time={messageGroup[0].createdAt}
-                  exact
-                  mb={1}
-                />
-                {messageGroup.map((message, messageIndex) => {
-                  const nextMessage = messageGroup[messageIndex + 1]
-                  const senderChanges =
-                    nextMessage && nextMessage.isFromUser !== message.isFromUser
-                  const lastMessageInGroup =
-                    messageIndex === messageGroup.length - 1
-                  const spaceAfter =
-                    senderChanges || lastMessageInGroup ? 2 : 0.5
-
-                  return (
-                    <>
-                      <Message
-                        message={message}
-                        initialMessage={conversation.initialMessage}
-                        key={message.internalID}
-                        isFirst={groupIndex + messageIndex === 0}
-                        showTimeSince={
-                          message.createdAt &&
-                          today &&
-                          messageGroup.length - 1 === messageIndex
-                        }
-                      />
-                      <Spacer mb={spaceAfter} />
-                    </>
-                  )
-                })}
-              </React.Fragment>
-            )
-          })}
+          {inquiryItemBox}
+          {messageGroups}
           <Spacer mb={[undefined, 6]} />
           <Box ref={bottomOfPage}></Box>
         </Flex>

--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -8,6 +8,7 @@ import { MessageFragmentContainer as Message } from "./Message"
 import { Reply } from "./Reply"
 import { TimeSince, fromToday } from "./TimeSince"
 import { UpdateConversation } from "../Mutation/UpdateConversationMutation"
+import styled from "styled-components"
 
 interface ItemProps {
   item: Conversation_conversation["items"][0]["item"]
@@ -210,20 +211,32 @@ const Conversation: React.FC<ConversationProps> = props => {
   })
 
   return (
-    <Flex flexDirection="column" width="100%">
-      <Box>
-        <Spacer mt={["75px", 2]} />
-        <Flex flexDirection="column" width="100%" px={1}>
-          {inquiryItemBox}
-          {messageGroups}
-          <Spacer mb={[undefined, 6]} />
-          <Box ref={bottomOfPage}></Box>
-        </Flex>
-      </Box>
+    <NoScrollFlex flexDirection="column" width="100%">
+      <MessageContainer>
+        <Box>
+          <Spacer mt={["75px", 2]} />
+          <Flex flexDirection="column" width="100%" px={1}>
+            {inquiryItemBox}
+            {messageGroups}
+            <Box ref={bottomOfPage}></Box>
+          </Flex>
+        </Box>
+      </MessageContainer>
       <Reply conversation={conversation} environment={relay.environment} />
-    </Flex>
+    </NoScrollFlex>
   )
 }
+
+const MessageContainer = styled(Box)`
+  height: calc(100% - 300px);
+  flex-grow: 1;
+  overflow-y: scroll;
+  overflow-x: hidden;
+`
+
+const NoScrollFlex = styled(Flex)`
+  overflow: hidden;
+`
 
 export const ConversationFragmentContainer = createFragmentContainer(
   Conversation,

--- a/src/v2/Apps/Conversation/Components/Message.tsx
+++ b/src/v2/Apps/Conversation/Components/Message.tsx
@@ -95,6 +95,7 @@ const Message: React.FC<MessageProps> = props => {
           alignSelf,
         }}
         maxWidth="66.67%"
+        width="fit-content"
       >
         <Sans size="4" color={textColor}>
           {text}

--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -4,19 +4,11 @@ import React, { useRef, useState } from "react"
 import { Environment } from "react-relay"
 import styled from "styled-components"
 import { SendConversationMessage } from "../Mutation/SendConversationMessage"
-import { RightProps, right } from "styled-system"
+import { RightProps } from "styled-system"
 
 const StyledFlex = styled(Flex)<FlexProps & RightProps>`
-  ${right};
   border-top: 1px solid ${color("black10")};
-  position: fixed;
   background: white;
-  bottom: 0;
-  left: 375px;
-  ${media.xs`
-    width: 100%;
-    left: 0;
-  `}
 `
 
 const FullWidthFlex = styled(Flex)<{ height?: string }>`

--- a/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
@@ -1,4 +1,4 @@
-import { Flex, Title } from "@artsy/palette"
+import { Flex, Title, media } from "@artsy/palette"
 import { Conversation_me } from "v2/__generated__/Conversation_me.graphql"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { ConversationFragmentContainer as Conversation } from "v2/Apps/Conversation/Components/Conversation"
@@ -25,6 +25,9 @@ interface ConversationRouteProps {
 
 const ConstrainedHeightFlex = styled(Flex)`
   height: calc(100vh - 145px);
+  ${media.xs`
+    height: calc(100vh - 55px);
+  `}
   & > * {
     overflow-y: scroll;
     overflow-x: hidden;


### PR DESCRIPTION
Fixes [PURCHASE-1990](https://artsyproduct.atlassian.net/browse/PURCHASE-1990)


<details><summary>screenshots:</summary>
<p>

Note the. `send` button in the bottom of the page

### Before:
<img src="https://user-images.githubusercontent.com/687513/86604598-93cc3780-bf73-11ea-8614-c42225ab58a8.gif " data-canonical-src="https://user-images.githubusercontent.com/687513/86604598-93cc3780-bf73-11ea-8614-c42225ab58a8.gif " width="600" />

### After:
<img src="https://user-images.githubusercontent.com/687513/86604618-9c247280-bf73-11ea-987e-d939391f20e0.gif" data-canonical-src="https://user-images.githubusercontent.com/687513/86604618-9c247280-bf73-11ea-987e-d939391f20e0.gif " width="600" />


</details>

**Tip:** In the first commit, I just rearranged the elements a bit so you can just check out the second commit.

In order to fix this, I had to change the `position: fixed` style to flex box. The idea is that instead of sticking the box to the bottom with `position: fixed; bottom: 0;` put the messages and reply box in a flexbox and set the height of messages box to take the entire section. Then move the scrolling to a container inside the 'messages' box.

