### PR TITLE
Make start_at on auctions overview page use New York time

### DIFF
--- a/src/desktop/apps/auctions/templates/index.jade
+++ b/src/desktop/apps/auctions/templates/index.jade
@@ -68,5 +68,5 @@ block body
                 a.fine-faux-underline.au-name( href= auction.href() ) Sotheby's Input/Output
               else
                 a.fine-faux-underline.au-name( href= auction.href() )= auction.get('name')
-              .au-date Opens #{auction.date('start_at').format('MMMM Do')}
+              .au-date Opens #{auction.overviewStartDate()}
 

--- a/src/desktop/models/sale.coffee
+++ b/src/desktop/models/sale.coffee
@@ -179,6 +179,9 @@ module.exports = class Sale extends Backbone.Model
     _.extend event, CalendarUrls({ title: 'name' })
     event
 
+  overviewStartDate: ->
+    moment(@get('start_at')).tz('America/New_York').format('MMMM Do')
+
   upcomingLabel: ->
     timeFormat = 'MMM D h:mm A z'
     label = if @isClosed()


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/AUCT-1124

slack thread https://artsyproduct.atlassian.net/browse/AUCT-1124

We will eventually show times in the time zone of the auction. This is a quick fix to make the pages consistent.