### PR TITLE
Removes hover tracking on nav bar + fixes double /about footer

### DIFF
--- a/src/desktop/apps/about/stylesheets/index.styl
+++ b/src/desktop/apps/about/stylesheets/index.styl
@@ -131,7 +131,7 @@ header-margin = 180px
   position relative
 
   #main-layout-footer
-    overflow hidden
+    display none
 
 @require './nav'
 @require './hero_unit'

--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -241,13 +241,6 @@ export const NavBar: React.FC = track(
                     }}
                   >
                     {({ hover }) => {
-                      if (hover) {
-                        trackEvent({
-                          action_type: AnalyticsSchema.ActionType.Hover,
-                          subject: AnalyticsSchema.Subject.NotificationBell,
-                          new_notification_count: getNotificationCount(),
-                        })
-                      }
                       return <BellIcon fill={hover ? "purple100" : "black80"} />
                     }}
                   </NavItem>
@@ -264,12 +257,6 @@ export const NavBar: React.FC = track(
                   )}
                   <NavItem Menu={UserMenu}>
                     {({ hover }) => {
-                      if (hover) {
-                        trackEvent({
-                          action_type: AnalyticsSchema.ActionType.Hover,
-                          subject: "User",
-                        })
-                      }
                       return <SoloIcon fill={hover ? "purple100" : "black80"} />
                     }}
                   </NavItem>

--- a/src/v2/Components/NavBar/NavItem.tsx
+++ b/src/v2/Components/NavBar/NavItem.tsx
@@ -2,7 +2,7 @@ import { Box, BoxProps, Link, Sans, space } from "@artsy/palette"
 import { AnalyticsSchema } from "v2/Artsy"
 import { useTracking } from "v2/Artsy/Analytics/useTracking"
 import { isFunction, isString } from "lodash"
-import React, { useCallback, useEffect, useState } from "react"
+import React, { useState } from "react"
 import { animated, config, useSpring } from "react-spring"
 import styled from "styled-components"
 
@@ -68,20 +68,6 @@ export const NavItem: React.FC<NavItemProps> = ({
       })
     }
   }
-
-  const trackHover = useCallback(() => {
-    if (isString(navItemLabel) || label)
-      trackEvent({
-        action_type: AnalyticsSchema.ActionType.Hover,
-        subject: label || navItemLabel.toString(),
-      })
-  }, [label, navItemLabel, trackEvent])
-
-  useEffect(() => {
-    if (hover) {
-      trackHover()
-    }
-  }, [hover, trackHover])
 
   return (
     <Box

--- a/src/v2/Components/NavBar/__tests__/NavBarTracking.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBarTracking.jest.tsx
@@ -124,33 +124,6 @@ describe("NavBarTracking", () => {
         destination_path: "/art-fairs",
       })
     })
-
-    it("tracks navItem on hover", () => {
-      mount(
-        <Wrapper>
-          <NavItem href="/art-fairs" active>
-            {({ hover }) => {
-              if (hover) {
-                trackEvent({
-                  action_type: AnalyticsSchema.ActionType.Hover,
-                  subject: AnalyticsSchema.Subject.NotificationBell,
-                  destination_path: "/works-for-you",
-                  new_notification_count: 0,
-                })
-              }
-              return <div>hi</div>
-            }}
-          </NavItem>
-        </Wrapper>
-      )
-
-      expect(trackEvent).toBeCalledWith({
-        action_type: AnalyticsSchema.ActionType.Hover,
-        subject: AnalyticsSchema.Subject.NotificationBell,
-        destination_path: "/works-for-you",
-        new_notification_count: 0,
-      })
-    })
   })
 
   describe("Mobile", () => {


### PR DESCRIPTION
I swear I fixed the double /about footer back in [this PR](https://github.com/artsy/force/pull/5604), but I would not be surprised if some other change to the global footer/general styling caused this to come back 😅. 

![image](https://user-images.githubusercontent.com/2081340/86623997-925d3800-bf90-11ea-93fb-0d95baa153bd.png)

This also addresses https://artsyproduct.atlassian.net/browse/FX-2055 . We want to remove hover tracking on the NavBar because the events are currently eating away at our Segment quota (and we don't actually use the events for anything).