### PR TITLE
[PURCHASE-1992] Add logic for customizing message sent timestamps

### DIFF
--- a/src/v2/Apps/Conversation/Components/TimeSince.tsx
+++ b/src/v2/Apps/Conversation/Components/TimeSince.tsx
@@ -35,9 +35,38 @@ const exactDate = (time: string) => {
   }
 }
 
+const minutesSinceDate = (time: string | DateTime): number => {
+  if (!time) {
+    return null
+  }
+  const date = typeof time === "string" ? DateTime.fromISO(time) : time
+  return Math.floor(Math.abs(date.diffNow("minutes").toObject().minutes))
+}
+
 const relativeDate = (time: string) => {
   if (!time) return null
-  return DateTime.fromISO(time).toRelative()
+  const date = DateTime.fromISO(time)
+  const minutesSince = minutesSinceDate(date)
+
+  if (minutesSince <= 1) {
+    return "Just now"
+  } else if (minutesSince <= 300) {
+    return date.toRelative()
+  } else if (minutesSince <= 1440) {
+    return date.toFormat("t")
+  } else if (minutesSince <= 10080) {
+    return date.toRelative()
+  } else if (minutesSince <= 40320) {
+    const numberOfWeeksAgo = Math.floor(Math.abs(minutesSince / 10080))
+    const formattedDate =
+      numberOfWeeksAgo == 1
+        ? `${numberOfWeeksAgo} week ago`
+        : `${numberOfWeeksAgo} weeks ago`
+
+    return formattedDate
+  } else {
+    return date.toFormat("D")
+  }
 }
 
 interface TimeSinceProps extends Omit<BoxProps, "color"> {

--- a/src/v2/Apps/Conversation/Components/TimeSince.tsx
+++ b/src/v2/Apps/Conversation/Components/TimeSince.tsx
@@ -40,10 +40,10 @@ const minutesSinceDate = (time: string | DateTime): number => {
     return null
   }
   const date = typeof time === "string" ? DateTime.fromISO(time) : time
-  return Math.floor(Math.abs(date.diffNow("minutes").toObject().minutes))
+  return Math.floor(Math.abs(date.diffNow("minutes").minutes))
 }
 
-const relativeDate = (time: string) => {
+export const relativeDate = (time: string) => {
   if (!time) return null
   const date = DateTime.fromISO(time)
   const minutesSince = minutesSinceDate(date)

--- a/src/v2/Apps/Conversation/Components/__tests__/TimeSince.jest.tsx
+++ b/src/v2/Apps/Conversation/Components/__tests__/TimeSince.jest.tsx
@@ -1,0 +1,51 @@
+import { relativeDate } from "../TimeSince"
+
+describe("relativeDate", () => {
+  beforeEach(() => {
+    const dateSpy = jest.spyOn(Date, "now")
+    dateSpy.mockReturnValue(1594072253087)
+    // EPOCH value for Mon Jul 06 2020 17:50:53 GMT-0400 (Eastern Daylight Time)
+  })
+
+  describe("when given time occured 30 seconds ago", () => {
+    it("returns the correct string", () => {
+      expect(relativeDate("2020-07-06T21:50:40.756Z")).toBe("Just now")
+    })
+  })
+
+  describe("when given time occured 30 minutes ago", () => {
+    it("returns the correct string", () => {
+      expect(relativeDate("2020-07-06T21:20:40.756Z")).toBe("30 minutes ago")
+    })
+  })
+
+  describe("when given time occured 1 hour ago", () => {
+    it("returns the correct string", () => {
+      expect(relativeDate("2020-07-06T20:50:40.756Z")).toBe("1 hour ago")
+    })
+  })
+
+  describe("when given time occured 48 hours ago", () => {
+    it("returns the correct string", () => {
+      expect(relativeDate("2020-07-04T21:50:40.756Z")).toBe("2 days ago")
+    })
+  })
+
+  describe("when given time occured 1 week ago", () => {
+    it("returns the correct string", () => {
+      expect(relativeDate("2020-06-28T21:50:40.756Z")).toBe("1 week ago")
+    })
+  })
+
+  describe("when given time occured 2 weeks ago", () => {
+    it("returns the correct string", () => {
+      expect(relativeDate("2020-06-22T21:50:40.756Z")).toBe("2 weeks ago")
+    })
+  })
+
+  describe("when given time occured 2 months ago", () => {
+    it("returns the correct string", () => {
+      expect(relativeDate("2020-05-06T21:50:40.756Z")).toBe("5/6/2020")
+    })
+  })
+})


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-1992

Did a lot of manual testing by changing the machine time on my computer locally


Ex of changes:

If last message sent less than 1 minute ago:
Timestamp reads `Just now`
<img width="951" alt="Screen Shot 2020-07-06 at 10 28 12 AM" src="https://user-images.githubusercontent.com/12748344/86626939-75773380-bf95-11ea-97f7-b87f2f5f54f6.png">

If last message sent less than 5 hours ago:
Timestamp reads `X hours ago`
<img width="1461" alt="Screen Shot 2020-07-06 at 6 34 40 PM" src="https://user-images.githubusercontent.com/12748344/86627290-0ea64a00-bf96-11ea-920d-c34d119b49d7.png">


If last message sent less than 24 hours ago:
Timestamp reads `1:00PM` format
<img width="1443" alt="Screen Shot 2020-07-07 at 6 35 00 AM" src="https://user-images.githubusercontent.com/12748344/86627323-2087ed00-bf96-11ea-9729-347396ac14e2.png">

If last message sent less than a week ago:
Timestamp reads `X days ago` format
<img width="1460" alt="Screen Shot 2020-07-09 at 6 35 21 AM" src="https://user-images.githubusercontent.com/12748344/86627368-34335380-bf96-11ea-801c-d610e9ba6d27.png">

If last message sent less than a month ago:
Timestamp reads `1 week/X weeks ago` format
<img width="951" alt="Screen Shot 2020-07-06 at 10 28 12 AM" src="https://user-images.githubusercontent.com/12748344/86627446-5927c680-bf96-11ea-93f6-f55f3fb17e07.png">

If last message sent greater than a month ago:
Timestamp reads `MM/DD/YYYY` format
<img width="946" alt="Screen Shot 2020-07-06 at 10 16 56 AM" src="https://user-images.githubusercontent.com/12748344/86627499-7066b400-bf96-11ea-9cbd-6294b87a9dda.png">

