### PR TITLE
Close expanded text input on message send

### DIFF
--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -65,6 +65,7 @@ export const Reply: React.FC<ReplyProps> = props => {
         _response => {
           // @ts-ignore
           textArea.current.value = ""
+          // @ts-ignore
           textArea.current.style.height = "inherit"
           setLoading(false)
           setButtonDisabled(true)

--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -65,6 +65,7 @@ export const Reply: React.FC<ReplyProps> = props => {
         _response => {
           // @ts-ignore
           textArea.current.value = ""
+          textArea.current.style.height = "inherit"
           setLoading(false)
           setButtonDisabled(true)
         },


### PR DESCRIPTION
[PURCHASE-1984]

Text input stays in the expanded state after replying long messages and covers the last message

https://www.notion.so/artsy/Text-box-gets-stuck-open-when-long-messages-are-written-3895fcb1ae74412f9875e5adad24a66e

[PURCHASE-1984]: https://artsyproduct.atlassian.net/browse/PURCHASE-1984