### PR TITLE
Fix /categories navigation

### DIFF
--- a/src/desktop/apps/categories/components/FeaturedGenes.js
+++ b/src/desktop/apps/categories/components/FeaturedGenes.js
@@ -26,7 +26,7 @@ const FeaturedGenes = ({ featuredGeneLinks }) => {
         featuredGeneLinks.length > 0 &&
         featuredGeneLinks
           .map(featuredGene => (
-            <FeaturedGene key={featuredGene.id} {...featuredGene} />
+            <FeaturedGene key={featuredGene.href} {...featuredGene} />
           ))
           .slice(0, 3)}
     </Layout>

--- a/src/desktop/apps/categories/components/GeneFamily.js
+++ b/src/desktop/apps/categories/components/GeneFamily.js
@@ -29,11 +29,11 @@ const GeneList = styled.ul`
   }
 `
 
-const GeneFamily = ({ id, name, genes, featuredGeneLinks }) => {
+const GeneFamily = ({ slug, name, genes, featuredGeneLinks }) => {
   const publishedGenes = genes.filter(g => g.is_published)
   const sortedGenes = alphabetizeGenes(publishedGenes)
   return (
-    <div id={id}>
+    <div id={slug}>
       <GeneFamilyName>{name}</GeneFamilyName>
       <FeaturedGenes featuredGeneLinks={featuredGeneLinks} />
       <GeneList>

--- a/src/desktop/apps/categories/components/GeneFamilyNav.js
+++ b/src/desktop/apps/categories/components/GeneFamilyNav.js
@@ -81,9 +81,9 @@ class GeneFamilyNav extends React.Component {
           offset={-1 * TOP_BUFFER}
         >
           {geneFamilies.map(geneFamily => (
-            <GeneFamilyItem key={geneFamily.id}>
+            <GeneFamilyItem key={geneFamily.slug}>
               <GeneFamilyLink
-                href={`#${geneFamily.id}`}
+                href={`#${geneFamily.slug}`}
                 onClick={this.handleClick}
               >
                 {geneFamily.name}

--- a/src/desktop/apps/categories/queries/geneFamilies.js
+++ b/src/desktop/apps/categories/queries/geneFamilies.js
@@ -5,6 +5,7 @@ export default function GeneFamiliesQuery() {
       edges {
         node {
           id
+          slug
           name
           genes {
             id


### PR DESCRIPTION
Small follow-up to the MP v2 migration in #5881 

Some of the changes to the  ID related fields in MP v2 caused a regression in the scrolly nav. This should fix that!

This interaction is not covered by tests, so this squeaked through to staging 😅 

<img height="400" src="https://user-images.githubusercontent.com/140521/86848431-fd376d80-c07b-11ea-9f58-7182d9f67983.gif" />