### PR TITLE
[P-2446] Update recently_viewed_artworks to use Metaphysics v2

### DIFF
--- a/src/desktop/components/recently_viewed_artworks/index.coffee
+++ b/src/desktop/components/recently_viewed_artworks/index.coffee
@@ -1,5 +1,5 @@
 Cookies = require '../cookies/index.coffee'
-metaphysics = require '../../../lib/metaphysics.coffee'
+metaphysics = require '../../../lib/metaphysics2.coffee'
 { artworks, me } = require './queries.coffee'
 _ = require 'underscore'
 CurrentUser = require '../../models/current_user.coffee'


### PR DESCRIPTION
## Description

Change `recently_viewed_artworks` to use Metaphysics v2

**Ticket/Issue Link:** https://artsyproduct.atlassian.net/browse/PLATFORM-2446