### PR TITLE
Guard against potential race condition in consignments location search

### DIFF
--- a/src/desktop/apps/consign/client/actions.js
+++ b/src/desktop/apps/consign/client/actions.js
@@ -298,7 +298,7 @@ export function fetchLocationSuggestions(value) {
       if (status !== window.google.maps.places.PlacesServiceStatus.OK) {
         console.error("Unable to reach maps API", status)
       } else {
-        dispatch(updateLocationSuggestions(predictions))
+        dispatch(updateLocationSuggestions(value, predictions))
       }
     }
 
@@ -667,10 +667,11 @@ export function updateLocationFromSubmissionAndFreeze(city, state, country) {
   }
 }
 
-export function updateLocationSuggestions(suggestions) {
+export function updateLocationSuggestions(searchText, suggestions) {
   return {
     type: UPDATE_LOCATION_SUGGESTIONS,
     payload: {
+      searchText,
       suggestions,
     },
   }

--- a/src/desktop/apps/consign/client/reducers.js
+++ b/src/desktop/apps/consign/client/reducers.js
@@ -360,6 +360,9 @@ function submissionFlow(state = initialState, action) {
       )
     }
     case actions.UPDATE_LOCATION_SUGGESTIONS: {
+      if (action.payload.searchText !== state.locationAutocompleteValue) {
+        return state
+      }
       return u(
         {
           locationAutocompleteSuggestions: action.payload.suggestions,


### PR DESCRIPTION
We have a flappy integrity test against the consignment submission flow, where it occasionally fails because the suggested locations look like they're stale. Example [from this failed test run](https://app.circleci.com/pipelines/github/artsy/integrity/2287/workflows/97e7930e-2a2c-4d09-8c0d-fb8a0f275b84/jobs/10183): 

![image](https://user-images.githubusercontent.com/1627089/87064081-d93b6f80-c1d4-11ea-9d82-dc8095a126ee.png)

I've typed "Wauwatosa" into the box and would expect to see results that match that pretty well, but instead it looks like I'm seeing results for "W". 

My thought is: we are updating the suggestions with the last response. If they come back out of order, the last response does not correspond to the current search text.

So this PR includes the search text in the action, so that the reducer can verify that it is the "most recent" search response before updating the store.

There is a chance this test failure is not due to this anticipated race condition, and is instead because we're waiting for the google places resource to _appear_ in the browser performance log, but not waiting for it to _complete_. This race condition seems as likely as that though, and this was easier to address, and if it ends up not being the fix I'll look at the resource loading issue next.