### PR TITLE
Redirect to artist/works-for-sale instead of artist/works

### DIFF
--- a/src/desktop/apps/notifications/routes.coffee
+++ b/src/desktop/apps/notifications/routes.coffee
@@ -13,7 +13,7 @@ qs = require 'qs'
     return res.redirect("/log_in?redirect_uri=#{req.url}") unless artist_id and from_email
     params = _.extend sort: '-published_at', _.pick req.query, 'utm_content', 'utm_medium', 'utm_source', 'utm_campaign'
     queryString = qs.stringify params
-    return res.redirect("/artist/#{artist_id}/works?#{queryString}")
+    return res.redirect("/artist/#{artist_id}/works-for-sale?#{queryString}")
 
   Q.allSettled([
     req.user.followingArtists()

--- a/src/desktop/apps/notifications/test/routes.test.coffee
+++ b/src/desktop/apps/notifications/test/routes.test.coffee
@@ -29,7 +29,7 @@ describe 'Notification Routing', ->
     it 'redirects to artist works page without a user, when linked to from email', ->
       @req = { url: '/works-for-you', query: { artist_id: 'percy-the-cat', from_email: true } }
       routes.worksForYou @req, @res
-      @res.redirect.args[0][0].should.equal '/artist/percy-the-cat/works?sort=-published_at'
+      @res.redirect.args[0][0].should.equal '/artist/percy-the-cat/works-for-sale?sort=-published_at'
 
     it 'redirects to login without a user, when not linked to from email', ->
       @req = { url: '/works-for-you', query: { artist_id: 'percy-the-cat' } }


### PR DESCRIPTION
When linking to `artsy.net/works-for-you?artist_id=josef-albers&from_email=true`, if the user is logged out, they should be taken to the Works tab for the artist in question.

Some time in the past we changed `[artist]/works` to `[artist]/works-for-sale` and missed this redirect. This PR fixes the issue, so that logged out users clicking a link like the above will be properly taken to the `Works for sale` tab of the artist page.

Full [Slack discussion](https://artsy.slack.com/archives/C04KVDZU6/p1594307247216400) of the issue