### PR TITLE
[FX-2088, FX-2089, FX-2090] NavBar a11y updates

### DIFF
--- a/src/v2/Apps/Feature/Components/FeatureHeader.tsx
+++ b/src/v2/Apps/Feature/Components/FeatureHeader.tsx
@@ -11,7 +11,7 @@ import {
 } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FeatureHeader_feature } from "v2/__generated__/FeatureHeader_feature.graphql"
-import { NavBarHeight } from "v2/Components/NavBar"
+import { NAV_BAR_HEIGHT } from "v2/Components/NavBar"
 
 const Container = styled(Flex)`
   width: 100%;
@@ -46,7 +46,7 @@ export const FeatureHeader: React.FC<FeatureHeaderProps> = ({
   return (
     <Container
       display={["block", "flex"]}
-      height={["auto", !!image ? `calc(95vh - ${NavBarHeight}px)` : "50vh"]}
+      height={["auto", !!image ? `calc(95vh - ${NAV_BAR_HEIGHT}px)` : "50vh"]}
       {...rest}
     >
       {image && (

--- a/src/v2/Apps/ViewingRoom/Components/ViewingRoomHeader.tsx
+++ b/src/v2/Apps/ViewingRoom/Components/ViewingRoomHeader.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Box, Flex, ResponsiveImage, Sans, color } from "@artsy/palette"
-import { NavBarHeight } from "v2/Components/NavBar"
+import { NAV_BAR_HEIGHT } from "v2/Components/NavBar"
 import { Media } from "v2/Utils/Responsive"
 import { createFragmentContainer, graphql } from "react-relay"
 
@@ -58,7 +58,7 @@ const ViewingRoomHeaderLarge: React.FC<ViewingRoomHeaderProps> = props => {
   return (
     <Flex
       style={{
-        height: `calc(90vh - ${NavBarHeight}px)`,
+        height: `calc(90vh - ${NAV_BAR_HEIGHT}px)`,
         borderBottom: `1px solid ${color("black10")}`,
       }}
     >
@@ -99,7 +99,7 @@ const ViewingRoomHeaderSmall: React.FC<ViewingRoomHeaderProps> = props => {
     viewingRoom: { heroImageURL, title },
   } = props
 
-  const HeaderHeight = `calc(100vh - ${NavBarHeight * 2.8}px)`
+  const HeaderHeight = `calc(100vh - ${NAV_BAR_HEIGHT * 2.8}px)`
 
   return (
     <Flex

--- a/src/v2/Artsy/Router/RouterLink.tsx
+++ b/src/v2/Artsy/Router/RouterLink.tsx
@@ -14,7 +14,14 @@ import { get } from "v2/Utils/get"
  * `
  */
 
-export const RouterLink: React.FC<LinkProps> = ({ to, children, ...props }) => {
+export type RouterLinkProps = LinkProps &
+  React.HTMLAttributes<HTMLAnchorElement>
+
+export const RouterLink: React.FC<RouterLinkProps> = ({
+  to,
+  children,
+  ...props
+}) => {
   const context = useContext(RouterContext)
   const routes = get(context, c => c.router.matcher.routeConfig, [])
   const isSupportedInRouter = !!get(context, c =>

--- a/src/v2/Components/Menu.tsx
+++ b/src/v2/Components/Menu.tsx
@@ -28,14 +28,13 @@ interface MenuProps {
 /** Menu */
 export const Menu: React.FC<MenuProps> = ({
   children,
-  m = "2px",
   py = 1,
   title,
   width = 230,
   ...props
 }) => {
   return (
-    <MenuContainer width={width} m={m} {...props}>
+    <MenuContainer width={width} {...props}>
       <BorderBox p={0} py={py} background="white">
         <Flex flexDirection="column" width="100%">
           {title && (
@@ -61,7 +60,9 @@ const MenuContainer = styled(Box)`
 
 // Menu Item
 
-interface MenuItemProps extends BoxProps {
+interface MenuItemProps
+  extends BoxProps,
+    React.HTMLAttributes<HTMLAnchorElement> {
   children: React.ReactNode
   fontSize?: SansSize
   href?: string
@@ -107,9 +108,11 @@ const MenuLink = styled(RouterLink)<{ hasLighterTextColor: boolean }>`
 
   ${display};
 
-  &:hover {
-    background-color: ${p =>
-      p.hasLighterTextColor ? color("black10") : color("black5")};
+  &:hover,
+  &:focus {
+    outline: none;
+    background-color: ${({ hasLighterTextColor }) =>
+      hasLighterTextColor ? color("black10") : color("black5")};
   }
 
   ${Sans} {

--- a/src/v2/Components/NavBar/LoggedInActions.tsx
+++ b/src/v2/Components/NavBar/LoggedInActions.tsx
@@ -47,6 +47,7 @@ export const LoggedInActions: React.FC<
       <NavItem
         href="/works-for-you"
         Menu={NotificationsMenu}
+        menuAnchor="right"
         Overlay={() => (
           <NotificationOverlay showOverlay={hasUnreadNotifications} />
         )}
@@ -60,7 +61,12 @@ export const LoggedInActions: React.FC<
         }}
       >
         {({ hover }) => {
-          return <BellIcon fill={hover ? "purple100" : "black80"} />
+          return (
+            <BellIcon
+              fill={hover ? "purple100" : "black80"}
+              title="Notifications"
+            />
+          )
         }}
       </NavItem>
       {conversationsEnabled && (
@@ -80,9 +86,14 @@ export const LoggedInActions: React.FC<
           }}
         </NavItem>
       )}
-      <NavItem Menu={UserMenu}>
+      <NavItem Menu={UserMenu} menuAnchor="right">
         {({ hover }) => {
-          return <SoloIcon fill={hover ? "purple100" : "black80"} />
+          return (
+            <SoloIcon
+              fill={hover ? "purple100" : "black80"}
+              title="Your account"
+            />
+          )
         }}
       </NavItem>
     </>

--- a/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownMenu.tsx
@@ -43,10 +43,9 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
   }
 
   return (
-    <Menu onClick={handleClick} width={width} m={0} py={0}>
+    <Menu onClick={handleClick} width={width} py={0}>
       <Flex justifyContent="center">
         <SimpleLinksContainer
-          mt={0.5}
           py={3}
           mr={[3, 3, 3, "50px"]}
           viewAllTopMargin={viewAllTopMargin[contextModule]}

--- a/src/v2/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
@@ -25,6 +25,7 @@ import {
   NavigatorContextProvider,
   useNavigation,
 } from "./NavigatorContextProvider"
+import { NAV_BAR_BORDER_OFFSET, NAV_BAR_HEIGHT } from "v2/Components/NavBar"
 
 const Close = styled(Clickable)`
   position: absolute;
@@ -34,9 +35,8 @@ const Close = styled(Clickable)`
   display: flex;
   align-items: center;
   justify-content: center;
-  /* Position menu toggle *just so* because the values in the actual navbar are hardcoded */
-  width: ${space(6) + 2}px;
-  height: ${space(6) - 2}px;
+  width: ${space(6)}px;
+  height: ${NAV_BAR_HEIGHT - NAV_BAR_BORDER_OFFSET}px;
 `
 
 interface Props {

--- a/src/v2/Components/NavBar/Menus/MoreNavMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/MoreNavMenu.tsx
@@ -21,9 +21,7 @@ export const MoreNavMenu: React.FC<{ width?: number }> = ({ width = 160 }) => {
 
   return (
     <Menu onClick={trackClick} width={width}>
-      {/*
-        Hide nav items at md / lg as they appear in the top nav
-      */}
+      {/* Hide nav items at md / lg as they appear in the top nav */}
       <MenuItem href="/galleries">Galleries</MenuItem>
       <MenuItem href="/fairs">Fairs</MenuItem>
       <MenuItem href="/shows">Shows</MenuItem>

--- a/src/v2/Components/NavBar/Menus/UserMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/UserMenu.tsx
@@ -22,10 +22,13 @@ export const UserMenu: React.FC = () => {
   const { trackEvent } = useTracking()
   const { mediator, user } = useContext(SystemContext)
 
-  const trackClick = event => {
-    const link = event.target
+  const trackClick = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+    const link = event.currentTarget
+
+    if (!(link instanceof HTMLAnchorElement)) return
+
     const text = link.innerText
-    const href = link.parentNode.parentNode.getAttribute("href")
+    const href = link.getAttribute("href")
 
     trackEvent({
       action_type: AnalyticsSchema.ActionType.Click,
@@ -39,39 +42,59 @@ export const UserMenu: React.FC = () => {
   const hasPartnerAccess = Boolean(user.has_partner_access)
 
   return (
-    <Menu onClick={trackClick}>
-      {isAdmin && <MenuItem href={sd.ADMIN_URL}>Admin</MenuItem>}
-      {(isAdmin || hasPartnerAccess) && (
-        <MenuItem href={sd.CMS_URL}>CMS</MenuItem>
-      )}
-      {(isAdmin || hasPartnerAccess) && (
-        <Flex width="100%" justifyContent="center" my={1}>
-          <Box width="90%">
-            <Separator />
-          </Box>
-        </Flex>
-      )}
+    <Menu>
       {isAdmin && (
-        <MenuItem href="/user/purchases">
-          <TagIcon mr={1} /> Purchases
+        <MenuItem href={sd.ADMIN_URL} onClick={trackClick}>
+          Admin
         </MenuItem>
       )}
-      <MenuItem href="/user/saves">
-        <HeartIcon mr={1} /> Saves & Follows
+
+      {(isAdmin || hasPartnerAccess) && (
+        <>
+          <MenuItem href={sd.CMS_URL} onClick={trackClick}>
+            CMS
+          </MenuItem>
+
+          <Flex width="100%" justifyContent="center" my={1}>
+            <Box width="90%">
+              <Separator />
+            </Box>
+          </Flex>
+        </>
+      )}
+
+      {isAdmin && (
+        <MenuItem href="/user/purchases" onClick={trackClick}>
+          <TagIcon mr={1} title="View your purchases" /> Purchases
+        </MenuItem>
+      )}
+
+      <MenuItem href="/user/saves" onClick={trackClick}>
+        <HeartIcon mr={1} title="View your Saves &amp; Follows" /> Saves &amp;
+        Follows
       </MenuItem>
-      <MenuItem href="/profile/edit">
-        <SoloIcon mr={1} /> Collector Profile
+
+      <MenuItem href="/profile/edit" onClick={trackClick}>
+        <SoloIcon mr={1} title="View your Collector Profile" /> Collector
+        Profile
       </MenuItem>
-      <MenuItem href="/user/edit">
-        <SettingsIcon mr={1} /> Settings
+
+      <MenuItem href="/user/edit" onClick={trackClick}>
+        <SettingsIcon mr={1} title="Edit your settings" /> Settings
       </MenuItem>
+
       <MenuItem
-        onClick={event => {
-          event.preventDefault() // `href` is only for tracking purposes
+        tabIndex={0}
+        onKeyPress={event => {
+          if (event.key === "Enter" || event.key === " ") {
+            mediator.trigger("auth:logout")
+          }
+        }}
+        onClick={() => {
           mediator.trigger("auth:logout")
         }}
       >
-        <PowerIcon mr={1} /> Log out
+        <PowerIcon mr={1} title="Log out of your account" /> Log out
       </MenuItem>
     </Menu>
   )

--- a/src/v2/Components/NavBar/Menus/__tests__/UserMenu.jest.tsx
+++ b/src/v2/Components/NavBar/Menus/__tests__/UserMenu.jest.tsx
@@ -26,9 +26,9 @@ describe("UserMenu", () => {
 
   // Label also includes SVG image title
   const defaultLinks = [
-    ["/user/saves", "Save Saves & Follows"],
-    ["/profile/edit", "User Collector Profile"],
-    ["/user/edit", "Settings Settings"],
+    ["/user/saves", "View your Saves & Follows Saves & Follows"],
+    ["/profile/edit", "View your Collector Profile Collector Profile"],
+    ["/user/edit", "Edit your settings Settings"],
   ]
 
   it("renders correct menu items", () => {
@@ -41,20 +41,12 @@ describe("UserMenu", () => {
       expect(linkLabel).toEqual(navLink.text())
     })
 
-    expect(
-      wrapper
-        .find("MenuItem")
-        .last()
-        .text()
-    ).toContain("Log out")
+    expect(wrapper.find("MenuItem").last().text()).toContain("Log out")
   })
 
   it("calls logout auth action on logout menu click", () => {
     const wrapper = getWrapper()
-    wrapper
-      .find("MenuItem")
-      .last()
-      .simulate("click")
+    wrapper.find("MenuItem").last().simulate("click")
     expect(mediator.trigger).toBeCalledWith("auth:logout")
   })
 

--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -1,23 +1,16 @@
 import React, { useEffect, useState } from "react"
 import styled from "styled-components"
-
 import {
-  ArtsyMarkIcon,
   Box,
   Button,
   ChevronIcon,
   Flex,
-  Link,
-  Spacer,
-  Text,
+  FlexProps,
   color,
-  space,
   themeProps,
 } from "@artsy/palette"
-
 import { useSystemContext } from "v2/Artsy/SystemContext"
 import { SearchBarQueryRenderer as SearchBar } from "v2/Components/Search/SearchBar"
-
 import {
   DropDownNavMenu,
   MobileNavMenu,
@@ -25,35 +18,20 @@ import {
   MoreNavMenu,
 } from "./Menus"
 import { InboxNotificationCountQueryRenderer as InboxNotificationCount } from "./Menus/MobileNavMenu/InboxNotificationCount"
-
+import { userHasLabFeature } from "v2/Utils/user"
 import { ModalType } from "v2/Components/Authentication/Types"
 import { MenuLinkData, menuData } from "v2/Components/NavBar/menuData"
 import { openAuthModal } from "v2/Utils/openAuthModal"
-import { userHasLabFeature } from "v2/Utils/user"
-
 import { NavItem } from "./NavItem"
-
 import { ContextModule, Intent } from "@artsy/cohesion"
 import { AnalyticsSchema } from "v2/Artsy"
 import { track, useTracking } from "v2/Artsy/Analytics"
 import Events from "v2/Utils/Events"
 import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
+import { NavBarPrimaryLogo } from "./NavBarPrimaryLogo"
+import { NavBarSkipLink } from "./NavBarSkipLink"
 import { LoggedInActionsQueryRenderer as LoggedInActions } from "./LoggedInActions"
-
-const SkipLink = styled.a`
-  display: block;
-  position: absolute;
-  top: -100%;
-  left: 0;
-  color: ${color("black100")};
-  background-color: ${color("black10")};
-
-  &:focus {
-    position: relative;
-    top: 0;
-    padding: ${space(1)}px;
-  }
-`
+import { NAV_BAR_HEIGHT } from "./constants"
 
 export const NavBar: React.FC = track(
   {
@@ -104,19 +82,13 @@ export const NavBar: React.FC = track(
 
   return (
     <>
-      <SkipLink href="#main">
-        <Text variant="text">Skip to Main Content</Text>
-      </SkipLink>
+      <NavBarSkipLink />
 
       <header>
-        <NavBarContainer as="nav" px={1}>
-          <NavSection>
-            <Link href="/" style={{ display: "flex" }}>
-              <ArtsyMarkIcon height={40} width={40} />
-            </Link>
+        <NavBarContainer as="nav">
+          <NavSection mx={0.5}>
+            <NavBarPrimaryLogo />
           </NavSection>
-
-          <Spacer mr={1} />
 
           <NavSection width="100%">
             <Box width="100%">
@@ -124,30 +96,24 @@ export const NavBar: React.FC = track(
             </Box>
           </NavSection>
 
-          <Spacer mr={2} />
-
-          {/*
-            Desktop. Collapses into mobile at `sm` breakpoint.
-        */}
+          {/* Desktop. Collapses into mobile at `sm` breakpoint. */}
           <NavSection display={["none", "none", "flex"]}>
-            <NavSection>
+            <NavSection alignItems="center" ml={2}>
               <NavItem
                 label="Artworks"
-                isFullScreenDropDown
+                menuAnchor="full"
                 Menu={({ setIsVisible }) => {
                   return (
-                    <Box>
-                      <DropDownNavMenu
-                        width="100vw"
-                        menu={(artworks as MenuLinkData).menu}
-                        contextModule={
-                          AnalyticsSchema.ContextModule.HeaderArtworksDropdown
-                        }
-                        onClick={() => {
-                          setIsVisible(false)
-                        }}
-                      />
-                    </Box>
+                    <DropDownNavMenu
+                      width="100vw"
+                      menu={(artworks as MenuLinkData).menu}
+                      contextModule={
+                        AnalyticsSchema.ContextModule.HeaderArtworksDropdown
+                      }
+                      onClick={() => {
+                        setIsVisible(false)
+                      }}
+                    />
                   )
                 }}
               >
@@ -166,21 +132,19 @@ export const NavBar: React.FC = track(
 
               <NavItem
                 label="Artists"
-                isFullScreenDropDown
+                menuAnchor="full"
                 Menu={({ setIsVisible }) => {
                   return (
-                    <Box>
-                      <DropDownNavMenu
-                        width="100vw"
-                        menu={(artists as MenuLinkData).menu}
-                        contextModule={
-                          AnalyticsSchema.ContextModule.HeaderArtistsDropdown
-                        }
-                        onClick={() => {
-                          setIsVisible(false)
-                        }}
-                      />
-                    </Box>
+                    <DropDownNavMenu
+                      width="100vw"
+                      menu={(artists as MenuLinkData).menu}
+                      contextModule={
+                        AnalyticsSchema.ContextModule.HeaderArtistsDropdown
+                      }
+                      onClick={() => {
+                        setIsVisible(false)
+                      }}
+                    />
                   )
                 }}
               >
@@ -201,12 +165,9 @@ export const NavBar: React.FC = track(
               <NavItem href="/articles">Editorial</NavItem>
               <NavItem
                 label="More"
+                menuAnchor="center"
                 Menu={() => {
-                  return (
-                    <Box mr={-150}>
-                      <MoreNavMenu width={160} />
-                    </Box>
-                  )
+                  return <MoreNavMenu width={160} />
                 }}
               >
                 <Flex>
@@ -223,49 +184,49 @@ export const NavBar: React.FC = track(
               </NavItem>
             </NavSection>
 
-            {isLoggedIn && (
-              <NavSection>
+            <NavSection mr={1}>
+              {isLoggedIn ? (
                 <LoggedInActions />
-              </NavSection>
-            )}
-
-            {!isLoggedIn && (
-              <NavSection>
-                <Spacer mr={2} />
-                <Button
-                  variant="secondaryOutline"
-                  onClick={() => {
-                    openAuthModal(mediator, {
-                      mode: ModalType.login,
-                      intent: Intent.login,
-                      contextModule: ContextModule.header,
-                    })
-                  }}
-                >
-                  Log in
-                </Button>
-                <Spacer mr={1} />
-                <Button
-                  onClick={() => {
-                    openAuthModal(mediator, {
-                      mode: ModalType.signup,
-                      intent: Intent.signup,
-                      contextModule: ContextModule.header,
-                    })
-                  }}
-                >
-                  Sign up
-                </Button>
-              </NavSection>
-            )}
+              ) : (
+                <>
+                  <Button
+                    ml={2}
+                    mr={1}
+                    variant="secondaryOutline"
+                    onClick={() => {
+                      openAuthModal(mediator, {
+                        mode: ModalType.login,
+                        intent: Intent.login,
+                        contextModule: ContextModule.header,
+                      })
+                    }}
+                  >
+                    Log in
+                  </Button>
+                  <Button
+                    onClick={() => {
+                      openAuthModal(mediator, {
+                        mode: ModalType.signup,
+                        intent: Intent.signup,
+                        contextModule: ContextModule.header,
+                      })
+                    }}
+                  >
+                    Sign up
+                  </Button>
+                </>
+              )}
+            </NavSection>
           </NavSection>
 
-          {/*
-          Mobile. Triggers at the `sm` breakpoint.
-        */}
+          {/* Mobile. Triggers at the `sm` breakpoint. */}
           <NavSection display={["flex", "flex", "none"]}>
             <NavItem
               className="mobileHamburgerButton"
+              borderLeft="1px solid"
+              borderColor="black10"
+              px={1}
+              ml={1}
               onClick={() => {
                 const showMenu = !showMobileMenu
                 if (showMenu) {
@@ -279,16 +240,8 @@ export const NavBar: React.FC = track(
                 toggleMobileNav(showMenu)
               }}
             >
-              <Flex
-                alignItems="center"
-                justifyContent="center"
-                width={22}
-                height={22}
-              >
-                <MobileNavDivider />
-                <MobileToggleIcon open={showMobileMenu} />
-                {showNotificationCount && <InboxNotificationCount />}
-              </Flex>
+              <MobileToggleIcon open={showMobileMenu} />
+              {showNotificationCount && <InboxNotificationCount />}
             </NavItem>
           </NavSection>
         </NavBarContainer>
@@ -308,26 +261,20 @@ export const NavBar: React.FC = track(
   )
 })
 
-export const NavBarHeight = space(6) - 1 // border offset
-
-const NavSection = ({ children, ...props }) => (
-  <Flex alignItems="center" {...props}>
-    {children}
-  </Flex>
-)
+const NavSection: React.FC<FlexProps> = ({ children, ...rest }) => {
+  return (
+    <Flex alignItems="stretch" height="100%" bg={rest.bg} {...rest}>
+      <Flex width="100%" height="100%" alignItems="center">
+        {children}
+      </Flex>
+    </Flex>
+  )
+}
 
 const NavBarContainer = styled(Flex)`
   background-color: ${color("white100")};
   border-bottom: 1px solid ${color("black10")};
   position: relative;
   z-index: 3;
-  height: ${NavBarHeight}px;
-`
-
-// FIXME: This needs to be cleaned up once we get proper icons
-const MobileNavDivider = styled(Box)`
-  border-left: 1px solid ${color("black10")};
-  height: 63px;
-  position: absolute;
-  left: -12px;
+  height: ${NAV_BAR_HEIGHT}px;
 `

--- a/src/v2/Components/NavBar/NavBarPrimaryLogo.tsx
+++ b/src/v2/Components/NavBar/NavBarPrimaryLogo.tsx
@@ -1,0 +1,36 @@
+import React from "react"
+import { ArtsyMarkIcon, color, space } from "@artsy/palette"
+import styled from "styled-components"
+import { RouterLink, RouterLinkProps } from "v2/Artsy/Router/RouterLink"
+
+const HitArea = styled(RouterLink)`
+  display: flex;
+  align-items: center;
+
+  > svg {
+    box-sizing: content-box;
+    padding: ${space(0.3)}px;
+    border: 1px solid transparent;
+  }
+
+  &:focus {
+    outline: none;
+
+    > svg {
+      border-color: ${color("purple100")};
+    }
+  }
+`
+
+export const NavBarPrimaryLogo: React.FC<Omit<
+  Partial<RouterLinkProps>,
+  "children"
+>> = props => {
+  return (
+    <HitArea to="/" {...props}>
+      <ArtsyMarkIcon height={40} width={40} name="Artsy" />
+    </HitArea>
+  )
+}
+
+NavBarPrimaryLogo.displayName = "NavBarPrimaryLogo"

--- a/src/v2/Components/NavBar/NavBarSkipLink.tsx
+++ b/src/v2/Components/NavBar/NavBarSkipLink.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+import styled from "styled-components"
+import { Text, color, space } from "@artsy/palette"
+
+const Container = styled.a`
+  display: block;
+  position: absolute;
+  top: -100%;
+  left: 0;
+  padding: ${space(1)}px;
+  color: ${color("black100")};
+  background-color: ${color("black10")};
+
+  &:focus {
+    position: relative;
+    top: 0;
+  }
+`
+
+export const NavBarSkipLink: React.FC = () => {
+  return (
+    <Container href="#main">
+      <Text variant="text">Skip to Main Content</Text>
+    </Container>
+  )
+}
+
+NavBarSkipLink.displayName = "NavBarSkipLink"

--- a/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
@@ -37,6 +37,7 @@ describe("NavBar", () => {
   }
 
   beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {})
     ;(useTracking as jest.Mock).mockImplementation(() => {
       return {
         trackEvent,
@@ -65,8 +66,12 @@ describe("NavBar", () => {
     it("renders correct lg, xl nav items", () => {
       const wrapper = getWrapper()
 
-      // Logo
-      expect(wrapper.find("Link").first().prop("href")).toEqual("/")
+      // Should always be first
+      expect(wrapper.find("a").first().text()).toEqual("Skip to Main Content")
+
+      expect(wrapper.find("NavBarPrimaryLogo").find("a").prop("href")).toEqual(
+        "/"
+      )
 
       const links = wrapper.find("NavItem")
 
@@ -139,13 +144,14 @@ describe("NavBar", () => {
   describe("mobile", () => {
     it("toggles menu", () => {
       const wrapper = getWrapper()
+
       expect(wrapper.find("MobileToggleIcon").length).toEqual(1)
 
       const toggle = () =>
         wrapper
           .find("NavSection")
           .find("NavItem")
-          .find("Link")
+          .find("a")
           .last()
           .simulate("click")
 

--- a/src/v2/Components/NavBar/__tests__/NavBarTracking.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBarTracking.jest.tsx
@@ -30,6 +30,7 @@ describe("NavBarTracking", () => {
   }
 
   beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {})
     ;(useTracking as jest.Mock).mockImplementation(() => {
       return { trackEvent }
     })
@@ -46,8 +47,9 @@ describe("NavBarTracking", () => {
           <NavBar />
         </Wrapper>
       )
+
       wrapper
-        .find("Link")
+        .find("a")
         .find({ href: "/works-for-you" })
         .first()
         .simulate("click")
@@ -94,16 +96,11 @@ describe("NavBarTracking", () => {
           <UserMenu />
         </Wrapper>
       )
+
       const menuItems = wrapper.find("MenuItem")
-      menuItems.first().simulate("click", {
-        target: {
-          parentNode: {
-            parentNode: {
-              getAttribute: () => "/user/saves",
-            },
-          },
-        },
-      })
+
+      menuItems.first().simulate("click")
+
       expect(trackEvent).toBeCalledWith({
         action_type: AnalyticsSchema.ActionType.Click,
         context_module: AnalyticsSchema.ContextModule.HeaderUserDropdown,
@@ -120,7 +117,7 @@ describe("NavBarTracking", () => {
         </Wrapper>
       )
 
-      wrapper.find("Link").simulate("click")
+      wrapper.find("a").simulate("click")
 
       expect(trackEvent).toBeCalledWith({
         action_type: AnalyticsSchema.ActionType.Click,
@@ -137,11 +134,7 @@ describe("NavBarTracking", () => {
           <NavBar />
         </Wrapper>
       )
-      wrapper
-        .find(".mobileHamburgerButton")
-        .find("Link")
-        .first()
-        .simulate("click")
+      wrapper.find(".mobileHamburgerButton").find("a").first().simulate("click")
 
       expect(trackEvent).toBeCalledWith({
         action_type: AnalyticsSchema.ActionType.Click,

--- a/src/v2/Components/NavBar/__tests__/NavItem.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavItem.jest.tsx
@@ -12,13 +12,23 @@ jest.mock("v2/Artsy/Analytics/useTracking", () => {
 
 jest.mock("v2/Utils/Hooks/useMatchMedia")
 
+jest.useFakeTimers()
+
 describe("NavItem", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it("renders proper content", () => {
     const wrapper = mount(
       <NavItem href="/some-link">hello how are you</NavItem>
     )
     expect(wrapper.html()).toContain("hello how are you")
-    expect(wrapper.find("Link").prop("href")).toContain("/some-link")
+    expect(wrapper.find("a").prop("href")).toContain("/some-link")
   })
 
   it("renders a Menu", () => {
@@ -30,7 +40,7 @@ describe("NavItem", () => {
     expect(wrapper.html()).toContain("Menu Item")
   })
 
-  it("passes a setIsVisible toggle to Menu component", done => {
+  it("passes a setIsVisible toggle to Menu component", () => {
     let toggle
     const wrapper = mount(
       <NavItem
@@ -45,12 +55,8 @@ describe("NavItem", () => {
       </NavItem>
     )
     expect(wrapper.html()).toContain("Menu Item")
-    setTimeout(() => {
-      toggle()
-      wrapper.update()
-      expect(wrapper.html()).not.toContain("Menu Item")
-      done()
-    })
+    toggle()
+    expect(wrapper.html()).not.toContain("Menu Item")
   })
 
   it("shows / hides Menu on mouse interactions", () => {
@@ -61,8 +67,23 @@ describe("NavItem", () => {
     )
     expect(wrapper.html()).not.toContain("Menu Item")
     wrapper.simulate("mouseenter")
+    jest.runAllTimers()
     expect(wrapper.html()).toContain("Menu Item")
     wrapper.simulate("mouseleave")
+    jest.runAllTimers()
+    expect(wrapper.html()).not.toContain("Menu Item")
+  })
+
+  it("shows / hides Menu on button click", () => {
+    const wrapper = mount(
+      <NavItem href="/some-link" Menu={() => <div>Menu Item</div>}>
+        hello how are you
+      </NavItem>
+    )
+    expect(wrapper.html()).not.toContain("Menu Item")
+    wrapper.find("button").simulate("click")
+    expect(wrapper.html()).toContain("Menu Item")
+    wrapper.find("button").simulate("click")
     expect(wrapper.html()).not.toContain("Menu Item")
   })
 
@@ -82,7 +103,7 @@ describe("NavItem", () => {
         hello how are you
       </NavItem>
     )
-    wrapper.find("Link").simulate("click")
+    wrapper.find("a").simulate("click")
     expect(spy).toHaveBeenCalled()
   })
 

--- a/src/v2/Components/NavBar/constants.ts
+++ b/src/v2/Components/NavBar/constants.ts
@@ -1,0 +1,4 @@
+import { space } from "@artsy/palette"
+
+export const NAV_BAR_BORDER_OFFSET = 1
+export const NAV_BAR_HEIGHT = space(6) - NAV_BAR_BORDER_OFFSET

--- a/src/v2/Components/NavBar/index.tsx
+++ b/src/v2/Components/NavBar/index.tsx
@@ -1,1 +1,2 @@
+export * from "./constants"
 export * from "./NavBar"

--- a/src/v2/Components/Search/SearchInputContainer.tsx
+++ b/src/v2/Components/Search/SearchInputContainer.tsx
@@ -16,9 +16,10 @@ const SearchButton = styled.button`
   background: none;
   padding: 0;
 
-  :focus {
+  &:focus {
     background: ${color("purple100")};
     border-radius: 50%;
+    outline: none;
 
     svg > path {
       fill: ${color("white100")};


### PR DESCRIPTION
Re: [FX-2088](https://artsyproduct.atlassian.net/browse/FX-2088), [FX-2088](https://artsyproduct.atlassian.net/browse/FX-2089), [FX-2090](https://artsyproduct.atlassian.net/browse/FX-2090)

On desktop — navigating with `<tab>` & `<shift+tab>` + `<enter>` or `<spacebar>` to open subnavs

![](http://static.damonzucconi.com/_capture/bS0XTVbYbjGg.gif)

The subnav stays open so long as the subnav button or anything within the subnav retains focus, once those are blurred the subnav will close.

I also made a few updates to the styling so that we aren't relying on magic numbers throughout. Notably the API for anchoring the subnav was changed to be `left | right | center | full`. Realistically we should be using a [positioning engine](https://popper.js.org/) here to handle this stuff automatically, but I think this is an improvement for the time being and simplifies the props API a bit.

Will leave some more comments inline throughout the code explaining a few points.

On mobile; the only real changes were to fixing the overflowing button to ensure the borders line up correctly:

![](http://static.damonzucconi.com/_capture/NyAyxHdDV9wC.png)
