### PR TITLE
Conversations small bug fixes

### DIFF
--- a/src/v2/Apps/Conversation/Components/ConversationSnippet.tsx
+++ b/src/v2/Apps/Conversation/Components/ConversationSnippet.tsx
@@ -36,12 +36,15 @@ const TimeSinceFlex = styled(Flex)`
 const StyledSans = styled(Sans)`
   word-break: break-word;
 `
+const TextContainer = styled(Box)`
+  overflow: hidden;
+`
 
 const TruncatedTitle = styled(Sans)`
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  max-width: 140px;
+  max-width: 130px;
 
   @media (max-width: 570px) {
     max-width: 270px;
@@ -122,7 +125,7 @@ const ConversationSnippet: React.FC<ConversationSnippetProps> = props => {
             )}
           </StyledFlex>
           <Flex pt={2} pl={1} width="100%" height="100%">
-            <Box width="100%">
+            <TextContainer width="100%">
               <Row mb="2px">
                 <Flex width="100%" justifyContent="space-between">
                   <Flex>
@@ -156,7 +159,7 @@ const ConversationSnippet: React.FC<ConversationSnippetProps> = props => {
                   <Truncator maxLineCount={3}>{conversationText}</Truncator>
                 </StyledSans>
               </Row>
-            </Box>
+            </TextContainer>
           </Flex>
         </Flex>
       </Link>

--- a/src/v2/Apps/Conversation/Components/Message.tsx
+++ b/src/v2/Apps/Conversation/Components/Message.tsx
@@ -41,6 +41,7 @@ const AttachmentContainer = styled(Flex)<
 `
 
 const MessageText = styled(Sans)`
+  word-break: break-word;
   white-space: pre-line;
   && {
     a:hover {

--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -37,7 +37,6 @@ const StyledTextArea = styled.textarea<{ height?: string }>`
     max-height: calc(60vh - 115px);
   `};
 `
-const StyledButton = styled(Button)``
 
 interface ReplyProps {
   conversation: Conversation_conversation
@@ -132,7 +131,8 @@ export const Reply: React.FC<ReplyProps> = props => {
           />
         </FullWidthFlex>
         <Flex alignItems="flex-end">
-          <StyledButton
+          <Button
+            ml={1}
             disabled={buttonDisabled}
             loading={loading}
             onClick={_event => {
@@ -140,7 +140,7 @@ export const Reply: React.FC<ReplyProps> = props => {
             }}
           >
             Send
-          </StyledButton>
+          </Button>
         </Flex>
       </StyledFlex>
     </>


### PR DESCRIPTION
Paired with @xtina-starr 

# adjusted gallery name truncation 
<img width="390" alt="Screen Shot 2020-07-09 at 4 50 12 PM" src="https://user-images.githubusercontent.com/5643895/87089925-26373a00-c205-11ea-8e3e-38d6f4124a07.png">

# fixed message word break
__Before:__
<img width="610" alt="Screen Shot 2020-07-09 at 4 51 23 PM" src="https://user-images.githubusercontent.com/5643895/87089675-c6d92a00-c204-11ea-80e0-8e6dbf2e1394.png">

__After:__
<img width="775" alt="Screen Shot 2020-07-09 at 4 50 07 PM" src="https://user-images.githubusercontent.com/5643895/87090084-67c7e500-c205-11ea-87a7-10bdc09d7633.png">

# hid overflow in message snippet
__Before:__
<img width="375" alt="Screen Shot 2020-07-09 at 4 51 33 PM" src="https://user-images.githubusercontent.com/5643895/87089719-dd7f8100-c204-11ea-8414-e35448660959.png">

__After:__
<img width="385" alt="Screen Shot 2020-07-09 at 4 50 31 PM" src="https://user-images.githubusercontent.com/5643895/87090016-48c95300-c205-11ea-995c-77f5beb59ec8.png">

# added margin to send button
__Before:__
<img width="230" alt="Screen Shot 2020-07-09 at 4 51 28 PM" src="https://user-images.githubusercontent.com/5643895/87089813-fdaf4000-c204-11ea-8cbd-6eed4a2c8c23.png">

__After:__
<img width="200" alt="Screen Shot 2020-07-09 at 4 50 01 PM" src="https://user-images.githubusercontent.com/5643895/87089832-06077b00-c205-11ea-9e2c-b856c9ebf5f7.png">

