### PR TITLE
Conversation QA bug fixes

### DIFF
--- a/src/v2/Apps/Conversation/Components/InboxHeaders.tsx
+++ b/src/v2/Apps/Conversation/Components/InboxHeaders.tsx
@@ -33,6 +33,7 @@ const ConversationHeaderContainer = styled(Flex)`
   right: 0;
   border-bottom: 1px solid ${color("black10")};
   background: white;
+  z-index: 1;
 `
 
 interface DetailsProps {
@@ -126,6 +127,7 @@ export const DetailsHeader: FC<DetailsHeaderProps> = props => {
     <AnimatedFlex
       flexDirection="column"
       width={showDetails ? "375px" : "0"}
+      maxWidth={showDetails ? "auto" : "0"}
       {...props}
     >
       <Flex flexDirection="row" justifyContent="space-between">

--- a/src/v2/Apps/Conversation/Components/Message.tsx
+++ b/src/v2/Apps/Conversation/Components/Message.tsx
@@ -23,10 +23,10 @@ import {
 } from "styled-system"
 import Linkify from "react-linkify"
 
-const AttachmentLink = styled.a`
-  width: min-content;
+const AttachmentLink = styled.a<{ isImage: boolean }>`
   text-decoration: none;
   max-width: 66.67%;
+  width: ${({ isImage }) => (isImage ? "100%" : "min-content")};
 `
 
 const AttachmentContainer = styled(Flex)<
@@ -36,7 +36,6 @@ const AttachmentContainer = styled(Flex)<
   ${background};
   border-radius: 15px;
   white-space: no-wrap;
-  width: min-content;
   justify-content: space-between;
 `
 
@@ -59,17 +58,27 @@ interface AttachmentProps {
 
 export const Attachment: React.FC<AttachmentProps> = props => {
   const { attachment, alignSelf, bgColor, textColor } = props
+  const isImage = attachment.contentType.startsWith("image")
 
   return (
-    <AttachmentLink href={attachment.downloadURL} target="_blank">
+    <AttachmentLink
+      href={attachment.downloadURL}
+      target="_blank"
+      isImage={isImage}
+    >
       <AttachmentContainer
         p={1}
         mt={0.5}
         alignSelf={alignSelf}
         background={color(bgColor)}
+        width={isImage ? "100%" : "min-content"}
       >
-        {attachment.contentType.startsWith("image") ? (
-          <Image src={attachment.downloadURL} alt={attachment.fileName} />
+        {isImage ? (
+          <Image
+            src={attachment.downloadURL}
+            alt={attachment.fileName}
+            width="100%"
+          />
         ) : (
           <>
             <Sans color={textColor} weight="medium" size="4" mr={2}>

--- a/src/v2/Apps/Conversation/Components/Message.tsx
+++ b/src/v2/Apps/Conversation/Components/Message.tsx
@@ -75,7 +75,9 @@ export const Attachment: React.FC<AttachmentProps> = props => {
             <Sans color={textColor} weight="medium" size="4" mr={2}>
               {attachment.fileName}
             </Sans>
-            <DownloadIcon width="24px" height="24px" />
+            <Box flexShrink={0}>
+              <DownloadIcon width="24px" height="24px" viewBox="0 0 24 24" />
+            </Box>
           </>
         )}
       </AttachmentContainer>


### PR DESCRIPTION
Fixes some bugs reported [here](https://www.notion.so/artsy/2020-07-07-Collector-inbox-5212de7b7be0416caed0a6334ed05084)

First commit:
- Attachment icon becomes tiny when filename is long
  <details><summary>screenshot</summary>

  Before:
  
  ![Screen Shot 2020-07-10 at 3 19 57 PM](https://user-images.githubusercontent.com/687513/87190667-e03fac00-c2c0-11ea-9341-455ce7669819.png)

  </details>
- Attachment icon goes over header when scrolling [bug report](https://www.notion.so/artsy/2020-07-07-Collector-inbox-5212de7b7be0416caed0a6334ed05084?p=9bb8c0250c5f48279bc90bb86a11d418) 

- Fix conversation detail header XL for safari. [bug report](https://www.notion.so/artsy/2020-07-07-Collector-inbox-5212de7b7be0416caed0a6334ed05084?p=3ea791d00f5e4f66a9afd14007a8d9ea) Not perfect but good for [now](https://artsy.slack.com/archives/C9YNS4X32/p1594327219238700)



Second commit:
- Large image width
  <details><summary>screenshot</summary>
  After:
  ![image60](https://user-images.githubusercontent.com/687513/87190461-850db980-c2c0-11ea-8fab-82b463fe8673.gif)

  </details>
