### PR TITLE
Use gene slug instead of id in /categories app

### DIFF
--- a/src/desktop/apps/categories/components/Gene.js
+++ b/src/desktop/apps/categories/components/Gene.js
@@ -22,10 +22,10 @@ const GeneLink = styled.a`
     color: ${colors.purpleRegular};
   }
 `
-const Gene = ({ id, name, display_name }) => {
+const Gene = ({ slug, name, display_name }) => {
   return (
     <GeneItem>
-      <GeneLink href={`/gene/${id}`}>{display_name || name}</GeneLink>
+      <GeneLink href={`/gene/${slug}`}>{display_name || name}</GeneLink>
     </GeneItem>
   )
 }

--- a/src/desktop/apps/categories/components/__tests__/Gene.test.js
+++ b/src/desktop/apps/categories/components/__tests__/Gene.test.js
@@ -8,20 +8,15 @@ describe("Gene", () => {
 
   beforeEach(() => {
     gene = {
-      id: "gold",
+      id: "42",
+      slug: "gold",
       name: "Gold",
     }
     rendered = render(<Gene {...gene} />)
   })
 
   it("renders a link to the gene", () => {
-    rendered
-      .find("a")
-      .text()
-      .should.equal("Gold")
-    rendered
-      .find("a")
-      .attr("href")
-      .should.equal("/gene/gold")
+    rendered.find("a").text().should.equal("Gold")
+    rendered.find("a").attr("href").should.equal("/gene/gold")
   })
 })

--- a/src/desktop/apps/categories/queries/geneFamilies.js
+++ b/src/desktop/apps/categories/queries/geneFamilies.js
@@ -9,6 +9,7 @@ export default function GeneFamiliesQuery() {
           name
           genes {
             id
+            slug
             name
             display_name: displayName
             is_published: isPublished


### PR DESCRIPTION
This corrects one more instance of id/slug confusion in the /categories app MP v2 migration.

Fixes [malformed URLs](https://artsy.slack.com/archives/C9SATFLUU/p1594657044011800) in the links to gene pages.