### PR TITLE
Close mobile menu

### DIFF
--- a/src/v2/Components/NavBar/Menus/MobileNavMenu/LoggedInLinks.tsx
+++ b/src/v2/Components/NavBar/Menus/MobileNavMenu/LoggedInLinks.tsx
@@ -63,14 +63,16 @@ export const LoggedInLinks: React.FC<
     <Box>
       <Separator my={1} color={color("black10")} />
       {conversationsEnabled && (
-        <Flex justifyContent="space-between">
-          <MobileLink href="/user/conversations">Inbox</MobileLink>
-          {conversationCount > 0 && (
-            <Sans size="5t" color={color("purple100")} py="4px">
-              {`${conversationCount} new`}
-            </Sans>
-          )}
-        </Flex>
+        <MobileLink href="/user/conversations">
+          <Flex justifyContent="space-between">
+            Inbox
+            {conversationCount > 0 && (
+              <Sans size="5t" color={color("purple100")}>
+                {`${conversationCount} new`}
+              </Sans>
+            )}
+          </Flex>
+        </MobileLink>
       )}
       <MobileLink href="/works-for-you">Works for you</MobileLink>
       <MobileSubmenuLink menu={menu}>{menu.title}</MobileSubmenuLink>

--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -96,10 +96,8 @@ export const NavBar: React.FC = track(
    *
    * TODO: Find a less naive way to check if route is in appshell
    */
-  const handleMobileNavClick = event => {
-    if (event.target?.parentNode?.href?.includes("/collect")) {
-      toggleMobileNav(false)
-    }
+  const handleMobileNavClick = () => {
+    toggleMobileNav(false)
   }
 
   return (

--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -90,12 +90,6 @@ export const NavBar: React.FC = track(
     }
   }, [isMobile])
 
-  /**
-   * Check to see if we're clicking a link that lives within the new app shell
-   * and close the navbar.
-   *
-   * TODO: Find a less naive way to check if route is in appshell
-   */
   const handleMobileNavClick = () => {
     toggleMobileNav(false)
   }


### PR DESCRIPTION
__Issue:__
If on the Inbox page already, tapping on "Inbox" in the menu doesn't close the menu (other links do).

__Fix:__
Previously we were checking to see if we're clicking a link that lives within the new app shell and firing toggleMobileNav(false) to close the navbar. Since the check didn't include the inbox URL we weren't closing it. This PR removes that check and fires it at all times.


![mobile navigation menu](https://user-images.githubusercontent.com/5201004/87332667-ea082000-c509-11ea-945f-d10a1c3c90c5.gif)
