### PR TITLE
Layout breaks on tablet devices

### DIFF
--- a/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
@@ -54,14 +54,14 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
       <AppContainer maxWidth={maxWidth}>
         <Title>Inbox | Artsy</Title>
 
-        <Media at="xs">
+        <Media at="sm">
           <ConversationHeader
             showDetails={showDetails}
             setShowDetails={setShowDetails}
             partnerName={me.conversation.to.name}
           />
         </Media>
-        <Media greaterThan="xs">
+        <Media greaterThan="sm">
           <FullHeader
             showDetails={showDetails}
             setShowDetails={setShowDetails}
@@ -69,7 +69,7 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
           />
         </Media>
         <ConstrainedHeightFlex>
-          <Media greaterThan="xs">
+          <Media greaterThan="sm">
             <Conversations
               me={me as any}
               selectedConversationID={me.conversation.internalID}


### PR DESCRIPTION
[PURCHASE-2004]

https://www.notion.so/artsy/Layout-breaks-on-tablet-devices-18b6a33b91a3422d9a1efe80a6e52a97

__Before:__
<img width="781" alt="Screen Shot 2020-07-13 at 3 34 04 PM" src="https://user-images.githubusercontent.com/5643895/87346192-47f33280-c51f-11ea-976a-b355cae41f08.png">


__After:__
<img width="776" alt="Screen Shot 2020-07-13 at 3 35 54 PM" src="https://user-images.githubusercontent.com/5643895/87346173-4164bb00-c51f-11ea-9903-837d6377386d.png">


[PURCHASE-2004]: https://artsyproduct.atlassian.net/browse/PURCHASE-2004