### PR TITLE
fixed crash on CoversationApp on iniial load

### DIFF
--- a/src/v2/Apps/Conversation/ConversationApp.tsx
+++ b/src/v2/Apps/Conversation/ConversationApp.tsx
@@ -64,8 +64,7 @@ export const ConversationApp: React.FC<ConversationAppProps> = props => {
   const route = findCurrentRoute(props.match)
   let maxWidth
 
-  const isEmpty = me.conversationsConnection.edges.length === 0
-  const conversation = me.conversationsConnection.edges[0]?.node
+  const firstConversation = me?.conversationsConnection?.edges[0]?.node
 
   useEffect(() => {
     setWidth(getViewWidth())
@@ -80,12 +79,12 @@ export const ConversationApp: React.FC<ConversationAppProps> = props => {
     if (
       isEnabled &&
       width > parseInt(breakpoints.xs, 10) &&
-      conversation &&
+      firstConversation &&
       router
     ) {
-      router.replace(`/user/conversations/${conversation.internalID}`)
+      router.replace(`/user/conversations/${firstConversation.internalID}`)
     }
-  }, [isEnabled, router, conversation, width])
+  }, [isEnabled, router, firstConversation, width])
 
   if (!isEnabled) {
     return <ErrorPage code={404} />
@@ -98,10 +97,10 @@ export const ConversationApp: React.FC<ConversationAppProps> = props => {
   return (
     <AppContainer maxWidth={maxWidth}>
       <Title>Conversations | Artsy</Title>
-      {isEmpty ? (
+      {!firstConversation ? (
         <NoMessages />
       ) : (
-        <Inbox selectedConversation={conversation} me={me} />
+        <Inbox selectedConversation={firstConversation} me={me} />
       )}
     </AppContainer>
   )

--- a/src/v2/Apps/Conversation/__tests__/ConversationApp.jest.tsx
+++ b/src/v2/Apps/Conversation/__tests__/ConversationApp.jest.tsx
@@ -73,10 +73,31 @@ describe("Conversation app", () => {
       })
     })
     describe("without previous conversations", () => {
-      it("shows an empty state", async () => {
+      it("shows an empty state when loading the conversationsConnection", async () => {
         const mockMe = {
           id: "111",
           conversationsConnection: { edges: [], pageInfo },
+        }
+
+        const component = await render(mockMe, userType)
+        const text = component.text()
+        expect(text).toContain("You don't have any messages yet.")
+        expect(text).toContain(
+          "Contact galleries to purchase available work. You'll find your ongoing conversations here."
+        )
+
+        const button = component.find("Button")
+        expect(button.length).toBe(1)
+        expect(button.text()).toBe("Explore artworks")
+
+        const link = component.find("RouterLink")
+        expect(link.html()).toContain(`href="/collect"`)
+      })
+
+      it("shows an empty state on failure on loading the conversationsConnection", async () => {
+        const mockMe = {
+          id: "111",
+          conversationsConnection: null,
         }
 
         const component = await render(mockMe, userType)


### PR DESCRIPTION
The type of this PR is: **Bugfix**

### Description
The conversations app was failing at initial load because we still not getting the `conversationsConnection`.

Co-authored by: Sepand Ansari <sepans@sepans.com>