### PR TITLE
[Consignments] Only query for target_supply artists

### DIFF
--- a/src/desktop/apps/consign/client/actions.js
+++ b/src/desktop/apps/consign/client/actions.js
@@ -284,7 +284,11 @@ export function fetchArtistSuggestions(value) {
       } = getState()
       const res = await request
         .get(`${sd.API_URL}/api/v1/match/artists`)
-        .query({ visible_to_public: "true", term: value })
+        .query({
+          target_supply: true,
+          term: value,
+          visible_to_public: true,
+        })
         .set("X-XAPP-TOKEN", sd.ARTSY_XAPP_TOKEN)
       dispatch(updateArtistSuggestions(res.body))
       dispatch(hideNotConsigningMessage())


### PR DESCRIPTION
Depends on https://github.com/artsy/gravity/pull/13258

Completes https://artsyproduct.atlassian.net/browse/CSGN-213

Updates consignment flow to only return artists where `target_supply=true`. 

Once this is merged will then un-`x` integrity specs. 