### PR TITLE
[PURCHASE-2016] Ensure Conversations list is the correct width for all screen sizes

### DIFF
--- a/src/v2/Apps/Conversation/Components/Conversations.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversations.tsx
@@ -8,6 +8,7 @@ import styled from "styled-components"
 const Container = styled(Box)`
   height: 100%;
   overflow-y: scroll;
+  overflow-x: hidden;
   border-bottom: 30px solid ${color("white100")};
   border-right: 1px solid ${color("black10")};
   ${media.xs`

--- a/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
@@ -54,14 +54,14 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
       <AppContainer maxWidth={maxWidth}>
         <Title>Inbox | Artsy</Title>
 
-        <Media at="sm">
+        <Media lessThan="sm">
           <ConversationHeader
             showDetails={showDetails}
             setShowDetails={setShowDetails}
             partnerName={me.conversation.to.name}
           />
         </Media>
-        <Media greaterThan="sm">
+        <Media greaterThan="xs">
           <FullHeader
             showDetails={showDetails}
             setShowDetails={setShowDetails}
@@ -69,7 +69,7 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
           />
         </Media>
         <ConstrainedHeightFlex>
-          <Media greaterThan="sm">
+          <Media greaterThan="xs">
             <Conversations
               me={me as any}
               selectedConversationID={me.conversation.internalID}


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-2016


Adjusts some breakpoints to make sure conversations list is displayed with the correct width
Hides overflow-x scroll on conversations list
Thanks Christina for the pair sesh!!

---

### Before
Inbox header and conversations list are not aligned, message view is over expanded

<img width="1108" alt="Screen Shot 2020-07-15 at 4 28 14 PM" src="https://user-images.githubusercontent.com/12748344/87593171-08f8e480-c6b9-11ea-8926-9f8abfc7cc27.png">


<br>
<br>

---



### With adjustments

**Large screens**
1. Ensure width of conversations list aligns with header width

<img width="1069" alt="Screen Shot 2020-07-15 at 4 25 10 PM" src="https://user-images.githubusercontent.com/12748344/87593208-17470080-c6b9-11ea-9590-60acdcc1ba87.png">
<br>
<br>

**Small/tablet screens**
1. Ensure width of conversations list equals width of message view
2. Ensure correct header component is displayed

<img width="573" alt="Screen Shot 2020-07-15 at 4 24 52 PM" src="https://user-images.githubusercontent.com/12748344/87593238-25951c80-c6b9-11ea-9d59-8149c519fa4e.png">
<br>
<br>

**x-small screens**
1. Ensure width of conversations list equals 100% of screen
2. Ensure correct header component is displayed
<img width="361" alt="Screen Shot 2020-07-15 at 4 24 33 PM" src="https://user-images.githubusercontent.com/12748344/87593270-32197500-c6b9-11ea-8903-c0495aef61e3.png">
<br>
<br>