### PR TITLE
Fixes erroneous tap to close on MobileNav

### DIFF
--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -68,8 +68,15 @@ export const NavBar: React.FC = track(
     }
   }, [isMobile])
 
-  const handleMobileNavClick = () => {
-    toggleMobileNav(false)
+  const handleMobileNavClick = (
+    event: React.MouseEvent<HTMLElement, MouseEvent>
+  ) => {
+    const target = event.target as HTMLElement
+
+    // Only close MobileNav if the underlying tapped element is a link
+    if (target.parentNode instanceof HTMLAnchorElement) {
+      toggleMobileNav(false)
+    }
   }
 
   return (


### PR DESCRIPTION
This just fixes a simple bug I noticed that prevented one from navigating the mobile subnavs. Just wanted to quickly cherry-pick this fix off my working branch.