### PR TITLE
Tweak CPU request to match recent usage

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -46,7 +46,7 @@ spec:
             timeoutSeconds: 10
           resources:
             requests:
-              cpu: 900m
+              cpu: 1000m
               memory: 1536Mi
             limits:
               memory: 3.5Gi


### PR DESCRIPTION
Memory usage is always around 1.6GB per pod so the current value seems acceptable.

Very small tweak to CPU request to reflect that usage tends to average between 0.6 and 0.8 depending on the week.

https://artsyproduct.atlassian.net/browse/PLATFORM-2644