### PR TITLE
[PURCHASE-2014] add height value for Image component

### DIFF
--- a/src/v2/Apps/Conversation/Components/Message.tsx
+++ b/src/v2/Apps/Conversation/Components/Message.tsx
@@ -78,6 +78,7 @@ export const Attachment: React.FC<AttachmentProps> = props => {
             src={attachment.downloadURL}
             alt={attachment.fileName}
             width="100%"
+            height="100%"
           />
         ) : (
           <>


### PR DESCRIPTION
Addresses: [PURCHASE-2014](https://artsyproduct.atlassian.net/browse/PURCHASE-2014)

This PR addresses the issue of distorted images when multiple image attachments are sent. I initially pursued a [fix](https://github.com/artsy/force/compare/attachment-image-width?expand=1) where we fetched the image width as it was loading, but after doing a little more digging I noticed that really all we needed was to include the height as a prop to the `<Image>` component.

__Before:__
![image attachment](https://user-images.githubusercontent.com/5201004/87822409-69199300-c83f-11ea-89ff-0d32707ec5eb.gif)

__After:__
![image attachment fix](https://user-images.githubusercontent.com/5201004/87822434-759deb80-c83f-11ea-93e1-9b73199e9756.gif)
