### PR TITLE
Jest Force Garbage Collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "cypress:run": "./node_modules/.bin/cypress run",
     "cypress": "./node_modules/.bin/cypress open",
     "integrate": "./scripts/quicklink-to-project.sh",
-    "jest": "JEST_JUNIT_OUTPUT=reports/junit/js-test-results.xml node --max_old_space_size=4096 ./node_modules/.bin/jest --no-cache --runInBand --logHeapUsage",
+    "jest": "JEST_JUNIT_OUTPUT=reports/junit/js-test-results.xml node --expose-gc --max_old_space_size=4096 ./node_modules/.bin/jest --no-cache --runInBand --logHeapUsage",
     "lint": "eslint --cache --cache-location '.cache/eslint/' --ext ts,tsx --ignore-pattern 'src/v2/__generated__'",
     "mocha": "scripts/mocha.sh",
     "prepare": "patch-package",

--- a/src/v2/jest.envSetup.ts
+++ b/src/v2/jest.envSetup.ts
@@ -25,7 +25,22 @@ jest.mock("v2/Utils/logger")
 import "v2/DevTools/renderUntil"
 Enzyme.configure({ adapter: new Adapter() })
 
-import "jsdom"
+// Manually run the garbage collector after 30 seconds. Only works if the
+// --expose-gc flag is used.
+let time = Date.now()
+afterEach(() => {
+  if (global.gc && Math.floor((Date.now() - time) / 1000) > 30) {
+    global.gc()
+    time = Date.now()
+  }
+})
+
+afterAll(() => {
+  if (global.gc && Math.floor((Date.now() - time) / 1000) > 30) {
+    global.gc()
+    time = Date.now()
+  }
+})
 
 if (typeof window !== "undefined") {
   window.open = jest.fn()


### PR DESCRIPTION
Force garbage collection every ~30 seconds or so. This increases the 
runtime of the tests slightly, however, keeps the memory usage well below
the limit at which the process is OOM killed.

This is a better band-aid until we can identify the memory leak. With this change
the heap after finishing all the tests is ~1450 MB.