### PR TITLE
[PURCHASE-2005] Fix issue with details panel

### DIFF
--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -82,7 +82,7 @@ export const Details: FC<DetailsProps> = ({
     window.addEventListener("resize", listenForResize)
     return () => window.removeEventListener("resize", listenForResize)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setShowDetails, showDetails])
+  }, [showDetails])
 
   const item =
     conversation.items?.[0]?.item?.__typename !== "%other" &&

--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -11,15 +11,19 @@ import {
   Sans,
   Separator,
   Spacer,
+  breakpoints,
   color,
   media,
 } from "@artsy/palette"
-import React, { FC } from "react"
+import React, { FC, useEffect } from "react"
 import styled from "styled-components"
 import { createFragmentContainer, graphql } from "react-relay"
+import { useWindowSize } from "v2/Utils/Hooks/useWindowSize"
 import { Details_conversation } from "v2/__generated__/Details_conversation.graphql"
 import ArtworkDetails from "v2/Components/Artwork/Metadata"
 import { zIndex } from "styled-system"
+import { debounce } from "lodash"
+import { getViewportDimensions } from "v2/Utils/viewport"
 
 export const DETAIL_BOX_ANIMATION = `transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1);`
 const DETAIL_BOX_XS_ANIMATION = `transition: opacity 0.3s, z-index 0.3s;`
@@ -51,9 +55,35 @@ const DetailsContainer = styled(Flex)<{ opacity?: 0 | 1; transform?: string }>`
 interface DetailsProps extends FlexProps {
   conversation: Details_conversation
   showDetails: boolean
+  setShowDetails: (showDetails: boolean) => void
 }
 
-export const Details: FC<DetailsProps> = ({ conversation, ...props }) => {
+export const Details: FC<DetailsProps> = ({
+  conversation,
+  setShowDetails,
+  showDetails,
+  ...props
+}) => {
+  const { width } = useWindowSize()
+
+  useEffect(() => {
+    const initialWidth = width
+    const listenForResize = debounce(() => {
+      const screenWidth = getViewportDimensions().width
+      // Check if the screen width got smaller while the details panel was open
+      if (
+        screenWidth <= parseInt(breakpoints.xs, 10) &&
+        initialWidth > parseInt(breakpoints.xs, 10) &&
+        showDetails
+      ) {
+        setShowDetails(false)
+      }
+    })
+    window.addEventListener("resize", listenForResize)
+    return () => window.removeEventListener("resize", listenForResize)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setShowDetails, showDetails])
+
   const item =
     conversation.items?.[0]?.item?.__typename !== "%other" &&
     conversation.items?.[0]?.item
@@ -80,6 +110,19 @@ export const Details: FC<DetailsProps> = ({ conversation, ...props }) => {
     )
   })
 
+  const getDetailsContainerWidth = () => {
+    // For big screens
+    if (width > parseInt(breakpoints.xs, 10)) {
+      if (showDetails) {
+        return "376px"
+      }
+      return ["376px", "376px", "376px", "376px", "0"]
+    }
+
+    // For small screens
+    return "100%"
+  }
+
   return (
     <DetailsContainer
       flexDirection="column"
@@ -94,12 +137,10 @@ export const Details: FC<DetailsProps> = ({ conversation, ...props }) => {
       flexShrink={0}
       position={["absolute", "absolute", "absolute", "absolute", "static"]}
       right={[0, 0, 0, 0, "auto"]}
-      width={
-        props.showDetails ? "376px" : ["376px", "376px", "376px", "376px", "0"]
-      }
-      opacity={props.showDetails ? 1 : (0 as any)}
-      transform={props.showDetails ? "translateX(0)" : "translateX(376px)"}
-      zIndex={props.showDetails ? 1 : -1}
+      width={getDetailsContainerWidth()}
+      opacity={showDetails ? 1 : (0 as any)}
+      transform={showDetails ? "translateX(0)" : "translateX(376px)"}
+      zIndex={showDetails ? 1 : -1}
       {...props}
     >
       <EntityHeader

--- a/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
@@ -29,7 +29,6 @@ const ConstrainedHeightFlex = styled(Flex)`
     height: calc(100vh - 55px);
   `}
   & > * {
-    overflow-y: scroll;
     overflow-x: hidden;
   }
   & > .fresnel-greaterThan-xs {
@@ -75,8 +74,14 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
               selectedConversationID={me.conversation.internalID}
             />
           </Media>
+
           <Conversation conversation={me.conversation} />
-          <Details conversation={me.conversation} showDetails={showDetails} />
+
+          <Details
+            conversation={me.conversation}
+            showDetails={showDetails}
+            setShowDetails={setShowDetails}
+          />
         </ConstrainedHeightFlex>
       </AppContainer>
     )

--- a/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
@@ -31,6 +31,7 @@ const ConstrainedHeightFlex = styled(Flex)`
   `}
   & > * {
     overflow-x: hidden;
+    overflow-y: scroll;
   }
   & > .fresnel-greaterThan-xs {
     flex-shrink: 0;

--- a/src/v2/Apps/Conversation/routes.tsx
+++ b/src/v2/Apps/Conversation/routes.tsx
@@ -26,7 +26,7 @@ export const conversationRoutes: RouteConfig[] = [
   {
     path: "/user/conversations/:conversationID",
     displayFullPage: true,
-    getComponent: () => loadable(() => import("./Routes/Conversation")),
+    Component: loadable(() => import("./Routes/Conversation")),
     prepareVariables: (params, _props) => {
       return {
         conversationID: params.conversationID,


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves: **[[PURCHASE-2005](https://artsyproduct.atlassian.net/browse/PURCHASE-2005)]**

### Description

- Details panel should remain open when switching between conversations
- Hide Details panel on user screen resize for small screens

### Screenshots

![ezgif-2-78f6fac974e6](https://user-images.githubusercontent.com/11945712/87945981-c1e86600-caa1-11ea-9e34-bdaecce10744.gif)


