### PR TITLE
[PURCHASE-2001] Fix inbox nav

### DIFF
--- a/src/v2/Components/NavBar/Menus/MobileNavMenu/InboxNotificationCount.tsx
+++ b/src/v2/Components/NavBar/Menus/MobileNavMenu/InboxNotificationCount.tsx
@@ -21,8 +21,8 @@ const FloatingDot = styled(Flex)`
   align-items: center;
   justify-content: center;
   position: absolute;
-  top: 16px;
-  left: 19px;
+  top: 11px;
+  left: 25px;
 `
 
 export const InboxNotificationCount: React.FC<

--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -71,11 +71,17 @@ export const NavBar: React.FC = track(
   const handleMobileNavClick = (
     event: React.MouseEvent<HTMLElement, MouseEvent>
   ) => {
-    const target = event.target as HTMLElement
+    let target = event.target as HTMLElement
 
-    // Only close MobileNav if the underlying tapped element is a link
-    if (target.parentNode instanceof HTMLAnchorElement) {
-      toggleMobileNav(false)
+    // Only close MobileNav if the underlying tapped element is a link.
+    // Because event.target is the most nested element in the tree we lookup to
+    // see if it's wrapped in a link.
+    while (target !== event.currentTarget) {
+      if (target instanceof HTMLAnchorElement) {
+        toggleMobileNav(false)
+        return
+      }
+      target = target.parentElement
     }
   }
 


### PR DESCRIPTION
Addresses: [PURCHASE-2001](https://artsyproduct.atlassian.net/browse/PURCHASE-2001)

Paired with @lilyfromseattle & @zephraph 

__Context:__
When a user clicks the inbox link within the mobile nav menu, the mobile nav drop down doesn't get closed. We attempted to fix this in https://github.com/artsy/force/pull/5925 but that introduced other issues (erroneous taps closed MobileNav unintentionally). The broken inbox link was re-introduced in the fix to address the erroneous taps bug https://github.com/artsy/force/pull/5947.

__Issue:__
The current implementation doesn't account for nested elements as children in `MobileLink`. In the case of nested element passed to `MobileLink` the `parentNode` isn't an anchor element and is a flexbox div instead. As a result `toggleMobileNav(false)` doesn't get fired.

__Fix:__
This PR iterates on @dzucconi fix by using a while loop to climb up the tree from the most nested element until we reach the anchor element then execute `toggleMobileNav(false)`
