### PR TITLE
[PURCHASE-2004] Adjust breakpoints for tablet experience

### DIFF
--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -219,7 +219,7 @@ const Conversation: React.FC<ConversationProps> = props => {
     <NoScrollFlex flexDirection="column" width="100%">
       <MessageContainer>
         <Box>
-          <Spacer mt={["75px", 2]} />
+          <Spacer mt={["75px", "75px", 2]} />
           <Flex flexDirection="column" width="100%" px={1}>
             {inquiryItemBox}
             {messageGroups}

--- a/src/v2/Apps/Conversation/Components/Conversations.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversations.tsx
@@ -32,7 +32,7 @@ const Conversations: React.FC<ConversationsProps> = props => {
     .indexOf(selectedConversationID)
 
   return (
-    <Container width={["100%", "375px"]}>
+    <Container width={["100%", "100%", "375px"]}>
       <Box>
         {conversations.map(edge => (
           <ConversationSnippet

--- a/src/v2/Apps/Conversation/Components/InboxHeaders.tsx
+++ b/src/v2/Apps/Conversation/Components/InboxHeaders.tsx
@@ -59,10 +59,10 @@ export const ConversationHeader: FC<ConversationHeaderProps> = ({
       <RouterLink to={`/user/conversations`}>
         <ArrowLeftIcon />
       </RouterLink>
-      <Sans size="3t" weight="medium" display={["none", "auto"]}>
+      <Sans size="3t" weight="medium" display={["none", "none", "auto"]}>
         Conversation with {partnerName}
       </Sans>
-      <Sans size="3t" weight="medium" display={["auto", "none"]}>
+      <Sans size="3t" weight="medium" display={["auto", "auto", "none"]}>
         Inquiry with {partnerName}
       </Sans>
       <DetailIcon showDetails={showDetails} setShowDetails={setShowDetails} />

--- a/src/v2/Apps/Conversation/ConversationApp.tsx
+++ b/src/v2/Apps/Conversation/ConversationApp.tsx
@@ -36,15 +36,15 @@ const getViewWidth = () => {
 const Inbox: React.FC<InboxProps> = ({ selectedConversation, me }) => {
   return (
     <>
-      <Media at="xs">
+      <Media lessThan="md">
         <MobileInboxHeader />
       </Media>
-      <Media greaterThan="xs">
+      <Media greaterThanOrEqual="md">
         <FullHeader partnerName={selectedConversation?.to?.name} />
       </Media>
       <Conversations me={me} />
       <Flex
-        display={["none", "flex"]}
+        display={["none", "none", "flex"]}
         height="100%"
         width="100%"
         justifyContent="center"
@@ -78,7 +78,7 @@ export const ConversationApp: React.FC<ConversationAppProps> = props => {
   useEffect(() => {
     if (
       isEnabled &&
-      width > parseInt(breakpoints.xs, 10) &&
+      width > parseInt(breakpoints.md, 10) &&
       firstConversation &&
       router
     ) {

--- a/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
@@ -26,14 +26,14 @@ interface ConversationRouteProps {
 
 const ConstrainedHeightFlex = styled(Flex)`
   height: calc(100vh - 145px);
-  ${media.xs`
+  ${media.sm`
     height: calc(100vh - 55px);
   `}
   & > * {
     overflow-y: scroll;
     overflow-x: hidden;
   }
-  & > .fresnel-greaterThan-xs {
+  & > .fresnel-greaterThan-sm {
     flex-shrink: 0;
   }
 `
@@ -54,15 +54,14 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
     return (
       <AppContainer maxWidth={maxWidth}>
         <Title>Inbox | Artsy</Title>
-
-        <Media lessThan="sm">
+        <Media between={["xs", "md"]}>
           <ConversationHeader
             showDetails={showDetails}
             setShowDetails={setShowDetails}
             partnerName={me.conversation.to.name}
           />
         </Media>
-        <Media greaterThan="xs">
+        <Media greaterThan="sm">
           <FullHeader
             showDetails={showDetails}
             setShowDetails={setShowDetails}
@@ -70,7 +69,7 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
           />
         </Media>
         <ConstrainedHeightFlex>
-          <Media greaterThan="xs">
+          <Media greaterThan="sm">
             <Conversations
               me={me as any}
               selectedConversationID={me.conversation.internalID}

--- a/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
@@ -26,8 +26,8 @@ interface ConversationRouteProps {
 
 const ConstrainedHeightFlex = styled(Flex)`
   height: calc(100vh - 145px);
-  ${media.sm`
-    height: calc(100vh - 55px);
+  ${media.md`
+    height: calc(100vh - 60px);
   `}
   & > * {
     overflow-y: scroll;


### PR DESCRIPTION
Adjust break points for tablet experience

We want tablet to display the same experience as mobile:
<img width="1337" alt="Screen Shot 2020-07-21 at 12 49 29 PM" src="https://user-images.githubusercontent.com/12748344/88084202-0b908980-cb52-11ea-808b-def6f8d80611.png">
