### PR TITLE
[Artwork] Show other works from the series, if lab feature is present

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -998,6 +998,7 @@ type ArtistSeries {
   artistIDs: [String!]!
   artists(page: Int, size: Int): [Artist]
   artworkIDs: [ID!]!
+  artworksConnection(after: String, first: Int): ArtworkConnection
   description: String
   featured: Boolean!
   filterArtworksConnection(

--- a/src/v2/Apps/Artwork/ArtworkApp.tsx
+++ b/src/v2/Apps/Artwork/ArtworkApp.tsx
@@ -221,7 +221,7 @@ export class ArtworkApp extends React.Component<Props> {
 
           <Row>
             <Col>
-              <Box mt={6}>
+              <Box mt={3}>
                 <OtherWorks artwork={artwork} />
               </Box>
             </Col>
@@ -293,7 +293,10 @@ export const ArtworkAppFragmentContainer = createFragmentContainer(
   },
   {
     artwork: graphql`
-      fragment ArtworkApp_artwork on Artwork {
+      fragment ArtworkApp_artwork on Artwork
+        @argumentDefinitions(
+          shouldFetchArtistSeriesData: { type: "Boolean!" }
+        ) {
         slug
         internalID
         is_acquireable: isAcquireable
@@ -329,6 +332,7 @@ export const ArtworkAppFragmentContainer = createFragmentContainer(
         ...ArtworkDetails_artwork
         ...ArtworkImageBrowser_artwork
         ...OtherWorks_artwork
+          @arguments(shouldFetchArtistSeriesData: $shouldFetchArtistSeriesData)
         ...PricingContext_artwork
       }
     `,

--- a/src/v2/Apps/Artwork/Components/OtherWorks/ArtistSeriesArtworkRail.tsx
+++ b/src/v2/Apps/Artwork/Components/OtherWorks/ArtistSeriesArtworkRail.tsx
@@ -1,0 +1,99 @@
+import { Box, Flex, Sans, Separator } from "@artsy/palette"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { ArtistSeriesArtworkRail_artwork } from "v2/__generated__/ArtistSeriesArtworkRail_artwork.graphql"
+import { Carousel } from "v2/Components/Carousel"
+import FillwidthItem from "v2/Components/Artwork/FillwidthItem"
+import { StyledLink } from "v2/Apps/Artist/Components/StyledLink"
+import { getENV } from "v2/Utils/getENV"
+
+interface Props {
+  artwork: ArtistSeriesArtworkRail_artwork
+}
+
+export const ArtistSeriesArtworkRail: React.FC<Props> = ({
+  artwork: { artistSeriesConnection },
+}) => {
+  if (!artistSeriesConnection.edges.length) {
+    return null
+  }
+
+  const artistSeries = artistSeriesConnection.edges[0].node
+  const { artworksConnection, slug } = artistSeries
+
+  const artworks = artworksConnection.edges.map(({ node }) => node)
+
+  const isMobile = getENV("IS_MOBILE") === true
+
+  return artworks.length > 0 ? (
+    <>
+      <Separator my={3} />
+      <Flex mb={1} justifyContent="space-between">
+        <Sans size="4" color="black100">
+          More from this series
+        </Sans>
+
+        <StyledLink to={`/artist-series/${slug}`}>
+          <Sans size="4" color="black60">
+            View all works
+          </Sans>
+        </StyledLink>
+      </Flex>
+      <Box mx={[-20, 0]}>
+        <Carousel
+          data={artworks}
+          options={{
+            pageDots: false,
+          }}
+          render={(artwork, index) => {
+            const { image } = artwork
+            return (
+              <Box mb={3} width="auto">
+                <FillwidthItem
+                  artwork={artwork}
+                  useLighterFont
+                  targetHeight={200}
+                  imageHeight={image?.resized.height}
+                  width={image?.resized.width}
+                  marginRight={5}
+                  marginLeft={isMobile && index === 0 ? 20 : 0}
+                />
+              </Box>
+            )
+          }}
+        />
+      </Box>
+      <Separator my={3} />
+    </>
+  ) : null
+}
+
+export const ArtistSeriesArtworkRailFragmentContainer = createFragmentContainer(
+  ArtistSeriesArtworkRail,
+  {
+    artwork: graphql`
+      fragment ArtistSeriesArtworkRail_artwork on Artwork {
+        artistSeriesConnection(first: 1) {
+          edges {
+            node {
+              slug
+              artworksConnection(first: 20) {
+                edges {
+                  node {
+                    image {
+                      resized(height: 200) {
+                        height
+                        width
+                      }
+                    }
+                    ...FillwidthItem_artwork
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Artwork/Components/OtherWorks/index.tsx
+++ b/src/v2/Apps/Artwork/Components/OtherWorks/index.tsx
@@ -4,13 +4,20 @@ import { OtherWorks_artwork } from "v2/__generated__/OtherWorks_artwork.graphql"
 import { OtherAuctionsQueryRenderer as OtherAuctions } from "v2/Apps/Artwork/Components/OtherAuctions"
 import { Header } from "v2/Apps/Artwork/Components/OtherWorks/Header"
 import { RelatedWorksArtworkGridRefetchContainer as RelatedWorksArtworkGrid } from "v2/Apps/Artwork/Components/OtherWorks/RelatedWorksArtworkGrid"
-import { Mediator, SystemContextProps, withSystemContext } from "v2/Artsy"
+import {
+  Mediator,
+  SystemContext,
+  SystemContextProps,
+  withSystemContext,
+} from "v2/Artsy"
 import { track, useTracking } from "v2/Artsy/Analytics"
 import * as Schema from "v2/Artsy/Analytics/Schema"
 import ArtworkGrid from "v2/Components/ArtworkGrid"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "v2/Utils/get"
+import { ArtistSeriesArtworkRailFragmentContainer as ArtistSeriesArtworkRail } from "./ArtistSeriesArtworkRail"
+import { userHasLabFeature } from "v2/Utils/user"
 
 export interface OtherWorksContextProps {
   artwork: OtherWorks_artwork
@@ -76,6 +83,9 @@ export const OtherWorks = track()(
     const { context, contextGrids, sale } = props.artwork
     const gridsToShow = populatedGrids(contextGrids)
     const tracking = useTracking()
+    const { user } = React.useContext(SystemContext)
+    const artistSeriesIsEnabled = userHasLabFeature(user, "Artist Series")
+
     return (
       <>
         {gridsToShow && gridsToShow.length > 0 && (
@@ -86,6 +96,13 @@ export const OtherWorks = track()(
               )
               return (
                 <Box key={`Grid-${index}`} data-test={contextModule}>
+                  {artistSeriesIsEnabled &&
+                    grid.__typename === "ArtistArtworkGrid" && (
+                      <>
+                        <ArtistSeriesArtworkRail artwork={props.artwork} />
+                      </>
+                    )}
+
                   <Header title={grid.title} buttonHref={grid.ctaHref} />
                   <ArtworkGrid
                     artworks={grid.artworksConnection}
@@ -113,10 +130,10 @@ export const OtherWorks = track()(
           context.__typename === "ArtworkContextAuction" &&
           !(sale && sale.is_closed)
         ) && (
-            <Box mt={3}>
-              <RelatedWorksArtworkGrid artwork={props.artwork} />
-            </Box>
-          )}
+          <Box mt={3}>
+            <RelatedWorksArtworkGrid artwork={props.artwork} />
+          </Box>
+        )}
         {context && context.__typename === "ArtworkContextAuction" && (
           <OtherAuctions />
         )}
@@ -129,7 +146,10 @@ export const OtherWorksFragmentContainer = createFragmentContainer<{
   artwork: OtherWorks_artwork
 }>(withSystemContext(OtherWorks), {
   artwork: graphql`
-    fragment OtherWorks_artwork on Artwork {
+    fragment OtherWorks_artwork on Artwork
+      @argumentDefinitions(
+        shouldFetchArtistSeriesData: { type: "Boolean!", defaultValue: false }
+      ) {
       contextGrids {
         __typename
         title
@@ -145,6 +165,8 @@ export const OtherWorksFragmentContainer = createFragmentContainer<{
         }
       }
       ...RelatedWorksArtworkGrid_artwork
+      ...ArtistSeriesArtworkRail_artwork
+        @include(if: $shouldFetchArtistSeriesData)
       slug
       internalID
       sale {

--- a/src/v2/Apps/Artwork/Components/__tests__/OtherWorks.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/__tests__/OtherWorks.jest.tsx
@@ -3,6 +3,8 @@ import { mount, shallow } from "enzyme"
 import React from "react"
 import { Header } from "../OtherWorks/Header"
 import { OtherWorksFragmentContainer as OtherWorks } from "../OtherWorks/index"
+import { SystemContextProvider } from "v2/Artsy"
+import { ArtistSeriesArtworkRail } from "../OtherWorks/ArtistSeriesArtworkRail"
 
 describe("OtherWorks", () => {
   let genericOtherWorksData
@@ -58,6 +60,62 @@ describe("OtherWorks", () => {
     expect(component.find(Serif).text()).toEqual("Other works by Andy Warhol")
   })
 
+  describe("artist series", () => {
+    beforeEach(() => {
+      genericOtherWorksData.contextGrids = [
+        {
+          __typename: "ArtistArtworkGrid",
+          title: "Other works by Andy Warhol",
+          ctaTitle: "View all works by Andy Warhol",
+          ctaHref: "/artist/andy-warhol",
+          artworksConnection: {
+            edges: [
+              {
+                node: {
+                  internalID: "artwork1",
+                },
+              },
+            ],
+          },
+        },
+      ]
+
+      genericOtherWorksData.artistSeriesConnection = {
+        edges: [
+          {
+            node: {
+              slug: "artist-series",
+              artworksConnection: {
+                edges: [
+                  {
+                    node: {
+                      internalID: "artwork",
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      }
+    })
+
+    it("renders the other works from the artist series when the lab feature is enabled", () => {
+      const user = { lab_features: ["Artist Series"] }
+      const component = mount(
+        <SystemContextProvider user={user}>
+          <OtherWorks artwork={genericOtherWorksData} />
+        </SystemContextProvider>
+      )
+      expect(component.find(ArtistSeriesArtworkRail).length).toEqual(1)
+    })
+
+    it("doesnt render the other works from the artist series without the lab feature", () => {
+      const component = mount(<OtherWorks artwork={genericOtherWorksData} />)
+      expect(component.find(ArtistSeriesArtworkRail).length).toEqual(0)
+    })
+  })
+
   it("renders the grids if multiple are provided", () => {
     genericOtherWorksData.contextGrids = [
       {
@@ -77,18 +135,12 @@ describe("OtherWorks", () => {
     ]
     const component = mount(<OtherWorks artwork={genericOtherWorksData} />)
     expect(component.find(Header).length).toEqual(2)
-    expect(
-      component
-        .find(Serif)
-        .first()
-        .text()
-    ).toEqual("Other works by Andy Warhol")
-    expect(
-      component
-        .find(Serif)
-        .last()
-        .text()
-    ).toEqual("Other works from Gagosian Gallery")
+    expect(component.find(Serif).first().text()).toEqual(
+      "Other works by Andy Warhol"
+    )
+    expect(component.find(Serif).last().text()).toEqual(
+      "Other works from Gagosian Gallery"
+    )
   })
 
   it("excludes the related artwork grid", () => {

--- a/src/v2/Apps/Artwork/routes.tsx
+++ b/src/v2/Apps/Artwork/routes.tsx
@@ -1,5 +1,6 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
+import { userHasLabFeature } from "v2/Utils/user"
 
 const ArtworkApp = loadable(() => import("./ArtworkApp"))
 
@@ -10,10 +11,28 @@ export const routes = [
     prepare: () => {
       ArtworkApp.preload()
     },
+    prepareVariables: ({ artworkID }, props) => {
+      const user = props.context.user
+
+      const shouldFetchArtistSeriesData = userHasLabFeature(
+        user,
+        "Artist Series"
+      )
+      return {
+        artworkID,
+        shouldFetchArtistSeriesData,
+      }
+    },
     query: graphql`
-      query routes_ArtworkQuery($artworkID: String!) {
+      query routes_ArtworkQuery(
+        $artworkID: String!
+        $shouldFetchArtistSeriesData: Boolean!
+      ) {
         artwork(id: $artworkID) @principalField {
           ...ArtworkApp_artwork
+            @arguments(
+              shouldFetchArtistSeriesData: $shouldFetchArtistSeriesData
+            )
         }
         me {
           ...ArtworkApp_me

--- a/src/v2/__generated__/ArtistSeriesArtworkRail_artwork.graphql.ts
+++ b/src/v2/__generated__/ArtistSeriesArtworkRail_artwork.graphql.ts
@@ -1,0 +1,178 @@
+/* tslint:disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistSeriesArtworkRail_artwork = {
+    readonly artistSeriesConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly slug: string;
+                readonly artworksConnection: {
+                    readonly edges: ReadonlyArray<{
+                        readonly node: {
+                            readonly image: {
+                                readonly resized: {
+                                    readonly height: number | null;
+                                    readonly width: number | null;
+                                } | null;
+                            } | null;
+                            readonly " $fragmentRefs": FragmentRefs<"FillwidthItem_artwork">;
+                        } | null;
+                    } | null> | null;
+                } | null;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "ArtistSeriesArtworkRail_artwork";
+};
+export type ArtistSeriesArtworkRail_artwork$data = ArtistSeriesArtworkRail_artwork;
+export type ArtistSeriesArtworkRail_artwork$key = {
+    readonly " $data"?: ArtistSeriesArtworkRail_artwork$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesArtworkRail_artwork">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "ArtistSeriesArtworkRail_artwork",
+  "type": "Artwork",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "artistSeriesConnection",
+      "storageKey": "artistSeriesConnection(first:1)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 1
+        }
+      ],
+      "concreteType": "ArtistSeriesConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ArtistSeriesEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "ArtistSeries",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "slug",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "artworksConnection",
+                  "storageKey": "artworksConnection(first:20)",
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "first",
+                      "value": 20
+                    }
+                  ],
+                  "concreteType": "ArtworkConnection",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "edges",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "ArtworkEdge",
+                      "plural": true,
+                      "selections": [
+                        {
+                          "kind": "LinkedField",
+                          "alias": null,
+                          "name": "node",
+                          "storageKey": null,
+                          "args": null,
+                          "concreteType": "Artwork",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "kind": "LinkedField",
+                              "alias": null,
+                              "name": "image",
+                              "storageKey": null,
+                              "args": null,
+                              "concreteType": "Image",
+                              "plural": false,
+                              "selections": [
+                                {
+                                  "kind": "LinkedField",
+                                  "alias": null,
+                                  "name": "resized",
+                                  "storageKey": "resized(height:200)",
+                                  "args": [
+                                    {
+                                      "kind": "Literal",
+                                      "name": "height",
+                                      "value": 200
+                                    }
+                                  ],
+                                  "concreteType": "ResizedImageUrl",
+                                  "plural": false,
+                                  "selections": [
+                                    {
+                                      "kind": "ScalarField",
+                                      "alias": null,
+                                      "name": "height",
+                                      "args": null,
+                                      "storageKey": null
+                                    },
+                                    {
+                                      "kind": "ScalarField",
+                                      "alias": null,
+                                      "name": "width",
+                                      "args": null,
+                                      "storageKey": null
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "FragmentSpread",
+                              "name": "FillwidthItem_artwork",
+                              "args": null
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = 'a51597e3761d7cabb5642743fda2eb0e';
+export default node;

--- a/src/v2/__generated__/ArtworkApp_artwork.graphql.ts
+++ b/src/v2/__generated__/ArtworkApp_artwork.graphql.ts
@@ -69,7 +69,14 @@ return {
   "name": "ArtworkApp_artwork",
   "type": "Artwork",
   "metadata": null,
-  "argumentDefinitions": [],
+  "argumentDefinitions": [
+    {
+      "kind": "LocalArgument",
+      "name": "shouldFetchArtistSeriesData",
+      "type": "Boolean!",
+      "defaultValue": null
+    }
+  ],
   "selections": [
     (v0/*: any*/),
     (v1/*: any*/),
@@ -200,7 +207,13 @@ return {
     {
       "kind": "FragmentSpread",
       "name": "OtherWorks_artwork",
-      "args": null
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "shouldFetchArtistSeriesData",
+          "variableName": "shouldFetchArtistSeriesData"
+        }
+      ]
     },
     {
       "kind": "FragmentSpread",
@@ -210,5 +223,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'b5ee0e1dcc98c7bdd728725f012674a8';
+(node as any).hash = '164faee917283ce6cb127d9a3ee0ca1d';
 export default node;

--- a/src/v2/__generated__/OtherWorks_artwork.graphql.ts
+++ b/src/v2/__generated__/OtherWorks_artwork.graphql.ts
@@ -25,7 +25,7 @@ export type OtherWorks_artwork = {
     readonly context: {
         readonly __typename: string;
     } | null;
-    readonly " $fragmentRefs": FragmentRefs<"RelatedWorksArtworkGrid_artwork">;
+    readonly " $fragmentRefs": FragmentRefs<"RelatedWorksArtworkGrid_artwork" | "ArtistSeriesArtworkRail_artwork">;
     readonly " $refType": "OtherWorks_artwork";
 };
 export type OtherWorks_artwork$data = OtherWorks_artwork;
@@ -56,7 +56,14 @@ return {
   "name": "OtherWorks_artwork",
   "type": "Artwork",
   "metadata": null,
-  "argumentDefinitions": [],
+  "argumentDefinitions": [
+    {
+      "kind": "LocalArgument",
+      "name": "shouldFetchArtistSeriesData",
+      "type": "Boolean!",
+      "defaultValue": false
+    }
+  ],
   "selections": [
     {
       "kind": "LinkedField",
@@ -178,9 +185,21 @@ return {
       "kind": "FragmentSpread",
       "name": "RelatedWorksArtworkGrid_artwork",
       "args": null
+    },
+    {
+      "kind": "Condition",
+      "passingValue": true,
+      "condition": "shouldFetchArtistSeriesData",
+      "selections": [
+        {
+          "kind": "FragmentSpread",
+          "name": "ArtistSeriesArtworkRail_artwork",
+          "args": null
+        }
+      ]
     }
   ]
 };
 })();
-(node as any).hash = '001b89e8373c47657f58f46c8886d829';
+(node as any).hash = '9f92c6f7ef8640d934350a89ba7ec1c7';
 export default node;

--- a/src/v2/__generated__/routes_ArtworkQuery.graphql.ts
+++ b/src/v2/__generated__/routes_ArtworkQuery.graphql.ts
@@ -4,6 +4,7 @@ import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type routes_ArtworkQueryVariables = {
     artworkID: string;
+    shouldFetchArtistSeriesData: boolean;
 };
 export type routes_ArtworkQueryResponse = {
     readonly artwork: {
@@ -23,9 +24,10 @@ export type routes_ArtworkQuery = {
 /*
 query routes_ArtworkQuery(
   $artworkID: String!
+  $shouldFetchArtistSeriesData: Boolean!
 ) {
   artwork(id: $artworkID) @principalField {
-    ...ArtworkApp_artwork
+    ...ArtworkApp_artwork_2juLqN
     id
   }
   me {
@@ -129,6 +131,30 @@ fragment ArtistMarketInsights_artist on Artist {
   }
 }
 
+fragment ArtistSeriesArtworkRail_artwork on Artwork {
+  artistSeriesConnection(first: 1) {
+    edges {
+      node {
+        slug
+        artworksConnection(first: 20) {
+          edges {
+            node {
+              image {
+                resized(height: 200) {
+                  height
+                  width
+                }
+              }
+              ...FillwidthItem_artwork
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 fragment ArtworkActions_artwork on Artwork {
   ...Save_artwork
   ...ArtworkSharePanel_artwork
@@ -162,7 +188,7 @@ fragment ArtworkActions_artwork on Artwork {
   }
 }
 
-fragment ArtworkApp_artwork on Artwork {
+fragment ArtworkApp_artwork_2juLqN on Artwork {
   slug
   internalID
   is_acquireable: isAcquireable
@@ -198,7 +224,7 @@ fragment ArtworkApp_artwork on Artwork {
   ...ArtworkSidebar_artwork
   ...ArtworkDetails_artwork
   ...ArtworkImageBrowser_artwork
-  ...OtherWorks_artwork
+  ...OtherWorks_artwork_2juLqN
   ...PricingContext_artwork
 }
 
@@ -784,6 +810,19 @@ fragment Details_artwork on Artwork {
   }
 }
 
+fragment FillwidthItem_artwork on Artwork {
+  image {
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  imageTitle
+  title
+  href
+  ...Metadata_artwork
+  ...Save_artwork
+  ...Badge_artwork
+}
+
 fragment FollowArtistButton_artist on Artist {
   id
   internalID
@@ -856,7 +895,7 @@ fragment Metadata_artwork on Artwork {
   href
 }
 
-fragment OtherWorks_artwork on Artwork {
+fragment OtherWorks_artwork_2juLqN on Artwork {
   contextGrids {
     __typename
     title
@@ -873,6 +912,7 @@ fragment OtherWorks_artwork on Artwork {
     }
   }
   ...RelatedWorksArtworkGrid_artwork
+  ...ArtistSeriesArtworkRail_artwork @include(if: $shouldFetchArtistSeriesData)
   slug
   internalID
   sale {
@@ -1051,6 +1091,12 @@ var v0 = [
     "kind": "LocalArgument",
     "name": "artworkID",
     "type": "String!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "shouldFetchArtistSeriesData",
+    "type": "Boolean!",
     "defaultValue": null
   }
 ],
@@ -1456,16 +1502,17 @@ v32 = {
   ]
 },
 v33 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 1
+},
+v34 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "auctionResultsConnection",
   "storageKey": "auctionResultsConnection(first:1,recordsTrusted:true,sort:\"PRICE_AND_DATE_DESC\")",
   "args": [
-    {
-      "kind": "Literal",
-      "name": "first",
-      "value": 1
-    },
+    (v33/*: any*/),
     {
       "kind": "Literal",
       "name": "recordsTrusted",
@@ -1544,18 +1591,18 @@ v33 = {
     }
   ]
 },
-v34 = {
+v35 = {
   "kind": "Literal",
   "name": "format",
   "value": "HTML"
 },
-v35 = {
+v36 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "biographyBlurb",
   "storageKey": "biographyBlurb(format:\"HTML\",partnerBio:true)",
   "args": [
-    (v34/*: any*/),
+    (v35/*: any*/),
     {
       "kind": "Literal",
       "name": "partnerBio",
@@ -1574,14 +1621,14 @@ v35 = {
     }
   ]
 },
-v36 = {
+v37 = {
   "kind": "ScalarField",
   "alias": "is_followed",
   "name": "isFollowed",
   "args": null,
   "storageKey": null
 },
-v37 = [
+v38 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -1598,56 +1645,56 @@ v37 = [
     "value": "MAIN"
   }
 ],
-v38 = {
+v39 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "date",
   "args": null,
   "storageKey": null
 },
-v39 = {
+v40 = {
   "kind": "ScalarField",
   "alias": "sale_message",
   "name": "saleMessage",
   "args": null,
   "storageKey": null
 },
-v40 = {
+v41 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "type",
   "args": null,
   "storageKey": null
 },
-v41 = {
+v42 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "initials",
   "args": null,
   "storageKey": null
 },
-v42 = {
+v43 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "width",
   "args": null,
   "storageKey": null
 },
-v43 = {
+v44 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "height",
   "args": null,
   "storageKey": null
 },
-v44 = {
+v45 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "title",
   "args": null,
   "storageKey": null
 },
-v45 = [
+v46 = [
   {
     "kind": "LinkedField",
     "alias": "img",
@@ -1671,14 +1718,14 @@ v45 = [
     "selections": (v22/*: any*/)
   }
 ],
-v46 = {
+v47 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "category",
   "args": null,
   "storageKey": null
 },
-v47 = {
+v48 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "dimensions",
@@ -1703,31 +1750,31 @@ v47 = {
     }
   ]
 },
-v48 = {
+v49 = {
   "kind": "ScalarField",
   "alias": "cultural_maker",
   "name": "culturalMaker",
   "args": null,
   "storageKey": null
 },
-v49 = {
+v50 = {
   "kind": "ScalarField",
   "alias": "is_biddable",
   "name": "isBiddable",
   "args": null,
   "storageKey": null
 },
-v50 = {
+v51 = {
   "kind": "ScalarField",
   "alias": "edition_of",
   "name": "editionOf",
   "args": null,
   "storageKey": null
 },
-v51 = [
+v52 = [
   (v7/*: any*/)
 ],
-v52 = {
+v53 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "counts",
@@ -1745,24 +1792,24 @@ v52 = {
     }
   ]
 },
-v53 = {
+v54 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cents",
   "args": null,
   "storageKey": null
 },
-v54 = {
+v55 = {
   "kind": "ScalarField",
   "alias": "is_inquireable",
   "name": "isInquireable",
   "args": null,
   "storageKey": null
 },
-v55 = [
-  (v34/*: any*/)
-],
 v56 = [
+  (v35/*: any*/)
+],
+v57 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -1778,21 +1825,134 @@ v56 = [
     "storageKey": null
   }
 ],
-v57 = {
+v58 = {
   "kind": "ScalarField",
   "alias": "is_saved",
   "name": "isSaved",
   "args": null,
   "storageKey": null
 },
-v58 = [
+v59 = {
+  "kind": "ScalarField",
+  "alias": "aspect_ratio",
+  "name": "aspectRatio",
+  "args": null,
+  "storageKey": null
+},
+v60 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "url",
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "version",
+      "value": "large"
+    }
+  ],
+  "storageKey": "url(version:\"large\")"
+},
+v61 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v59 = {
+v62 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "artists",
+  "storageKey": "artists(shallow:true)",
+  "args": (v61/*: any*/),
+  "concreteType": "Artist",
+  "plural": true,
+  "selections": [
+    (v11/*: any*/),
+    (v19/*: any*/),
+    (v18/*: any*/)
+  ]
+},
+v63 = {
+  "kind": "ScalarField",
+  "alias": "collecting_institution",
+  "name": "collectingInstitution",
+  "args": null,
+  "storageKey": null
+},
+v64 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "partner",
+  "storageKey": "partner(shallow:true)",
+  "args": (v61/*: any*/),
+  "concreteType": "Partner",
+  "plural": false,
+  "selections": [
+    (v18/*: any*/),
+    (v19/*: any*/),
+    (v11/*: any*/),
+    (v41/*: any*/)
+  ]
+},
+v65 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "sale",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Sale",
+  "plural": false,
+  "selections": [
+    (v12/*: any*/),
+    (v14/*: any*/),
+    (v11/*: any*/),
+    (v15/*: any*/),
+    (v17/*: any*/),
+    (v16/*: any*/),
+    {
+      "kind": "ScalarField",
+      "alias": "display_timely_at",
+      "name": "displayTimelyAt",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
+v66 = {
+  "kind": "LinkedField",
+  "alias": "sale_artwork",
+  "name": "saleArtwork",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "SaleArtwork",
+  "plural": false,
+  "selections": [
+    (v53/*: any*/),
+    {
+      "kind": "LinkedField",
+      "alias": "highest_bid",
+      "name": "highestBid",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "SaleArtworkHighestBid",
+      "plural": false,
+      "selections": (v52/*: any*/)
+    },
+    {
+      "kind": "LinkedField",
+      "alias": "opening_bid",
+      "name": "openingBid",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "SaleArtworkOpeningBid",
+      "plural": false,
+      "selections": (v52/*: any*/)
+    },
+    (v11/*: any*/)
+  ]
+},
+v67 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "artworksConnection",
@@ -1839,13 +1999,7 @@ v59 = {
               "concreteType": "Image",
               "plural": false,
               "selections": [
-                {
-                  "kind": "ScalarField",
-                  "alias": "aspect_ratio",
-                  "name": "aspectRatio",
-                  "args": null,
-                  "storageKey": null
-                },
+                (v59/*: any*/),
                 {
                   "kind": "ScalarField",
                   "alias": null,
@@ -1853,22 +2007,10 @@ v59 = {
                   "args": null,
                   "storageKey": null
                 },
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "url",
-                  "args": [
-                    {
-                      "kind": "Literal",
-                      "name": "version",
-                      "value": "large"
-                    }
-                  ],
-                  "storageKey": "url(version:\"large\")"
-                }
+                (v60/*: any*/)
               ]
             },
-            (v44/*: any*/),
+            (v45/*: any*/),
             {
               "kind": "ScalarField",
               "alias": "image_title",
@@ -1876,105 +2018,17 @@ v59 = {
               "args": null,
               "storageKey": null
             },
-            (v38/*: any*/),
             (v39/*: any*/),
-            (v48/*: any*/),
-            {
-              "kind": "LinkedField",
-              "alias": null,
-              "name": "artists",
-              "storageKey": "artists(shallow:true)",
-              "args": (v58/*: any*/),
-              "concreteType": "Artist",
-              "plural": true,
-              "selections": [
-                (v11/*: any*/),
-                (v19/*: any*/),
-                (v18/*: any*/)
-              ]
-            },
-            {
-              "kind": "ScalarField",
-              "alias": "collecting_institution",
-              "name": "collectingInstitution",
-              "args": null,
-              "storageKey": null
-            },
-            {
-              "kind": "LinkedField",
-              "alias": null,
-              "name": "partner",
-              "storageKey": "partner(shallow:true)",
-              "args": (v58/*: any*/),
-              "concreteType": "Partner",
-              "plural": false,
-              "selections": [
-                (v18/*: any*/),
-                (v19/*: any*/),
-                (v11/*: any*/),
-                (v40/*: any*/)
-              ]
-            },
-            {
-              "kind": "LinkedField",
-              "alias": null,
-              "name": "sale",
-              "storageKey": null,
-              "args": null,
-              "concreteType": "Sale",
-              "plural": false,
-              "selections": [
-                (v12/*: any*/),
-                (v14/*: any*/),
-                (v11/*: any*/),
-                (v15/*: any*/),
-                (v17/*: any*/),
-                (v16/*: any*/),
-                {
-                  "kind": "ScalarField",
-                  "alias": "display_timely_at",
-                  "name": "displayTimelyAt",
-                  "args": null,
-                  "storageKey": null
-                }
-              ]
-            },
-            {
-              "kind": "LinkedField",
-              "alias": "sale_artwork",
-              "name": "saleArtwork",
-              "storageKey": null,
-              "args": null,
-              "concreteType": "SaleArtwork",
-              "plural": false,
-              "selections": [
-                (v52/*: any*/),
-                {
-                  "kind": "LinkedField",
-                  "alias": "highest_bid",
-                  "name": "highestBid",
-                  "storageKey": null,
-                  "args": null,
-                  "concreteType": "SaleArtworkHighestBid",
-                  "plural": false,
-                  "selections": (v51/*: any*/)
-                },
-                {
-                  "kind": "LinkedField",
-                  "alias": "opening_bid",
-                  "name": "openingBid",
-                  "storageKey": null,
-                  "args": null,
-                  "concreteType": "SaleArtworkOpeningBid",
-                  "plural": false,
-                  "selections": (v51/*: any*/)
-                },
-                (v11/*: any*/)
-              ]
-            },
-            (v54/*: any*/),
-            (v57/*: any*/),
-            (v49/*: any*/)
+            (v40/*: any*/),
+            (v49/*: any*/),
+            (v62/*: any*/),
+            (v63/*: any*/),
+            (v64/*: any*/),
+            (v65/*: any*/),
+            (v66/*: any*/),
+            (v55/*: any*/),
+            (v58/*: any*/),
+            (v50/*: any*/)
           ]
         },
         (v11/*: any*/)
@@ -2003,7 +2057,13 @@ return {
           {
             "kind": "FragmentSpread",
             "name": "ArtworkApp_artwork",
-            "args": null
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "shouldFetchArtistSeriesData",
+                "variableName": "shouldFetchArtistSeriesData"
+              }
+            ]
           }
         ]
       },
@@ -2252,9 +2312,9 @@ return {
               (v30/*: any*/),
               (v31/*: any*/),
               (v32/*: any*/),
-              (v33/*: any*/),
-              (v35/*: any*/),
+              (v34/*: any*/),
               (v36/*: any*/),
+              (v37/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -2373,10 +2433,10 @@ return {
               (v30/*: any*/),
               (v31/*: any*/),
               (v32/*: any*/),
-              (v33/*: any*/),
-              (v35/*: any*/),
-              (v11/*: any*/),
+              (v34/*: any*/),
               (v36/*: any*/),
+              (v11/*: any*/),
+              (v37/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -2391,7 +2451,7 @@ return {
                     "alias": null,
                     "name": "artistsConnection",
                     "storageKey": "artistsConnection(after:\"\",first:4,kind:\"MAIN\")",
-                    "args": (v37/*: any*/),
+                    "args": (v38/*: any*/),
                     "concreteType": "ArtistConnection",
                     "plural": false,
                     "selections": [
@@ -2476,7 +2536,7 @@ return {
                               (v24/*: any*/),
                               (v11/*: any*/),
                               (v3/*: any*/),
-                              (v36/*: any*/),
+                              (v37/*: any*/),
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -2507,7 +2567,7 @@ return {
                     "kind": "LinkedHandle",
                     "alias": null,
                     "name": "artistsConnection",
-                    "args": (v37/*: any*/),
+                    "args": (v38/*: any*/),
                     "handle": "connection",
                     "key": "ArtworkRelatedArtists_artistsConnection",
                     "filters": [
@@ -2519,7 +2579,7 @@ return {
             ]
           },
           (v19/*: any*/),
-          (v38/*: any*/),
+          (v39/*: any*/),
           {
             "kind": "ScalarField",
             "alias": "artist_names",
@@ -2527,7 +2587,7 @@ return {
             "args": null,
             "storageKey": null
           },
-          (v39/*: any*/),
+          (v40/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
@@ -2539,7 +2599,7 @@ return {
             "selections": [
               (v18/*: any*/),
               (v11/*: any*/),
-              (v40/*: any*/),
+              (v41/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -2590,7 +2650,7 @@ return {
                   },
                   (v11/*: any*/),
                   (v3/*: any*/),
-                  (v36/*: any*/),
+                  (v37/*: any*/),
                   (v2/*: any*/),
                   {
                     "kind": "LinkedField",
@@ -2618,7 +2678,7 @@ return {
                   }
                 ]
               },
-              (v41/*: any*/),
+              (v42/*: any*/),
               (v19/*: any*/),
               {
                 "kind": "LinkedField",
@@ -2703,8 +2763,8 @@ return {
                 "concreteType": "ResizedImageUrl",
                 "plural": false,
                 "selections": [
-                  (v42/*: any*/),
                   (v43/*: any*/),
+                  (v44/*: any*/),
                   (v21/*: any*/)
                 ]
               }
@@ -2719,7 +2779,7 @@ return {
             "concreteType": "ArtworkMeta",
             "plural": false,
             "selections": [
-              (v44/*: any*/),
+              (v45/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -2775,7 +2835,7 @@ return {
                     "concreteType": "Profile",
                     "plural": false,
                     "selections": [
-                      (v41/*: any*/),
+                      (v42/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -2784,7 +2844,7 @@ return {
                         "args": null,
                         "concreteType": "Image",
                         "plural": false,
-                        "selections": (v45/*: any*/)
+                        "selections": (v46/*: any*/)
                       },
                       (v11/*: any*/)
                     ]
@@ -2820,7 +2880,7 @@ return {
                     "args": null,
                     "concreteType": "Image",
                     "plural": false,
-                    "selections": (v45/*: any*/)
+                    "selections": (v46/*: any*/)
                   }
                 ]
               }
@@ -2840,10 +2900,10 @@ return {
             "args": null,
             "storageKey": null
           },
-          (v46/*: any*/),
           (v47/*: any*/),
           (v48/*: any*/),
           (v49/*: any*/),
+          (v50/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "edition_sets",
@@ -2858,9 +2918,9 @@ return {
               (v3/*: any*/),
               (v4/*: any*/),
               (v5/*: any*/),
-              (v39/*: any*/),
-              (v47/*: any*/),
-              (v50/*: any*/)
+              (v40/*: any*/),
+              (v48/*: any*/),
+              (v51/*: any*/)
             ]
           },
           {
@@ -2916,9 +2976,9 @@ return {
                 "args": null,
                 "concreteType": "SaleArtworkCurrentBid",
                 "plural": false,
-                "selections": (v51/*: any*/)
+                "selections": (v52/*: any*/)
               },
-              (v52/*: any*/),
+              (v53/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -2928,13 +2988,13 @@ return {
                 "concreteType": "BidIncrementsFormatted",
                 "plural": true,
                 "selections": [
-                  (v53/*: any*/),
+                  (v54/*: any*/),
                   (v7/*: any*/)
                 ]
               }
             ]
           },
-          (v44/*: any*/),
+          (v45/*: any*/),
           {
             "kind": "ScalarField",
             "alias": null,
@@ -2942,7 +3002,7 @@ return {
             "args": null,
             "storageKey": null
           },
-          (v50/*: any*/),
+          (v51/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "attribution_class",
@@ -3015,7 +3075,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v7/*: any*/),
-                      (v53/*: any*/)
+                      (v54/*: any*/)
                     ]
                   },
                   (v11/*: any*/)
@@ -3030,7 +3090,7 @@ return {
             "args": null,
             "storageKey": null
           },
-          (v54/*: any*/),
+          (v55/*: any*/),
           {
             "kind": "ScalarField",
             "alias": null,
@@ -3063,14 +3123,14 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "description",
-            "args": (v55/*: any*/),
+            "args": (v56/*: any*/),
             "storageKey": "description(format:\"HTML\")"
           },
           {
             "kind": "ScalarField",
             "alias": "additional_information",
             "name": "additionalInformation",
-            "args": (v55/*: any*/),
+            "args": (v56/*: any*/),
             "storageKey": "additionalInformation(format:\"HTML\")"
           },
           {
@@ -3109,7 +3169,7 @@ return {
             "args": null,
             "concreteType": "ArtworkInfoRow",
             "plural": false,
-            "selections": (v56/*: any*/)
+            "selections": (v57/*: any*/)
           },
           {
             "kind": "LinkedField",
@@ -3119,7 +3179,7 @@ return {
             "args": null,
             "concreteType": "ArtworkInfoRow",
             "plural": false,
-            "selections": (v56/*: any*/)
+            "selections": (v57/*: any*/)
           },
           {
             "kind": "LinkedField",
@@ -3129,7 +3189,7 @@ return {
             "args": null,
             "concreteType": "ArtworkInfoRow",
             "plural": false,
-            "selections": (v56/*: any*/)
+            "selections": (v57/*: any*/)
           },
           {
             "kind": "LinkedField",
@@ -3139,7 +3199,7 @@ return {
             "args": null,
             "concreteType": "ArtworkInfoRow",
             "plural": false,
-            "selections": (v56/*: any*/)
+            "selections": (v57/*: any*/)
           },
           {
             "kind": "LinkedField",
@@ -3222,21 +3282,21 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "literature",
-            "args": (v55/*: any*/),
+            "args": (v56/*: any*/),
             "storageKey": "literature(format:\"HTML\")"
           },
           {
             "kind": "ScalarField",
             "alias": "exhibition_history",
             "name": "exhibitionHistory",
-            "args": (v55/*: any*/),
+            "args": (v56/*: any*/),
             "storageKey": "exhibitionHistory(format:\"HTML\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "provenance",
-            "args": (v55/*: any*/),
+            "args": (v56/*: any*/),
             "storageKey": "provenance(format:\"HTML\")"
           },
           {
@@ -3247,7 +3307,7 @@ return {
             "storageKey": null
           },
           (v11/*: any*/),
-          (v57/*: any*/),
+          (v58/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
@@ -3446,8 +3506,8 @@ return {
                 ],
                 "storageKey": "url(version:\"larger\")"
               },
-              (v43/*: any*/),
-              (v42/*: any*/)
+              (v44/*: any*/),
+              (v43/*: any*/)
             ]
           },
           {
@@ -3474,7 +3534,7 @@ return {
             "plural": true,
             "selections": [
               (v6/*: any*/),
-              (v44/*: any*/),
+              (v45/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -3489,7 +3549,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              (v59/*: any*/)
+              (v67/*: any*/)
             ]
           },
           {
@@ -3516,7 +3576,7 @@ return {
             "plural": false,
             "selections": [
               (v18/*: any*/),
-              (v59/*: any*/),
+              (v67/*: any*/),
               (v11/*: any*/)
             ]
           },
@@ -3552,7 +3612,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v46/*: any*/)
+                  (v47/*: any*/)
                 ]
               },
               {
@@ -3602,6 +3662,143 @@ return {
                 ]
               }
             ]
+          },
+          {
+            "kind": "Condition",
+            "passingValue": true,
+            "condition": "shouldFetchArtistSeriesData",
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "artistSeriesConnection",
+                "storageKey": "artistSeriesConnection(first:1)",
+                "args": [
+                  (v33/*: any*/)
+                ],
+                "concreteType": "ArtistSeriesConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistSeriesEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ArtistSeries",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "artworksConnection",
+                            "storageKey": "artworksConnection(first:20)",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "first",
+                                "value": 20
+                              }
+                            ],
+                            "concreteType": "ArtworkConnection",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "edges",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "ArtworkEdge",
+                                "plural": true,
+                                "selections": [
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "node",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Artwork",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "image",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "Image",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "kind": "LinkedField",
+                                            "alias": null,
+                                            "name": "resized",
+                                            "storageKey": "resized(height:200)",
+                                            "args": [
+                                              {
+                                                "kind": "Literal",
+                                                "name": "height",
+                                                "value": 200
+                                              }
+                                            ],
+                                            "concreteType": "ResizedImageUrl",
+                                            "plural": false,
+                                            "selections": [
+                                              (v44/*: any*/),
+                                              (v43/*: any*/)
+                                            ]
+                                          },
+                                          (v60/*: any*/),
+                                          (v59/*: any*/)
+                                        ]
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "imageTitle",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      (v45/*: any*/),
+                                      (v19/*: any*/),
+                                      (v39/*: any*/),
+                                      (v40/*: any*/),
+                                      (v49/*: any*/),
+                                      (v62/*: any*/),
+                                      (v63/*: any*/),
+                                      (v64/*: any*/),
+                                      (v65/*: any*/),
+                                      (v66/*: any*/),
+                                      (v55/*: any*/),
+                                      (v11/*: any*/),
+                                      (v3/*: any*/),
+                                      (v2/*: any*/),
+                                      (v58/*: any*/),
+                                      (v50/*: any*/)
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -3630,10 +3827,10 @@ return {
     "operationKind": "query",
     "name": "routes_ArtworkQuery",
     "id": null,
-    "text": "query routes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...ArtworkApp_artwork\n    id\n  }\n  me {\n    ...ArtworkApp_me\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment ArtistCard_artist on Artist {\n  name\n  slug\n  href\n  image {\n    cropped(width: 400, height: 300) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  ...FollowArtistButton_artist\n}\n\nfragment ArtistInfo_artist on Artist {\n  internalID\n  slug\n  name\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  counts {\n    partner_shows: partnerShows\n  }\n  exhibition_highlights: exhibitionHighlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    id\n  }\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        __typename\n        id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  ...FollowArtistButton_artist\n  biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n}\n\nfragment ArtworkApp_artwork on Artwork {\n  slug\n  internalID\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  availability\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  is_in_auction: isInAuction\n  sale {\n    internalID\n    slug\n    id\n  }\n  artists {\n    id\n    slug\n    ...ArtistInfo_artist\n  }\n  artist {\n    ...ArtistInfo_artist\n    id\n  }\n  ...ArtworkRelatedArtists_artwork\n  ...ArtworkMeta_artwork\n  ...ArtworkBanner_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkDetails_artwork\n  ...ArtworkImageBrowser_artwork\n  ...OtherWorks_artwork\n  ...PricingContext_artwork\n}\n\nfragment ArtworkApp_me on Me {\n  ...ArtworkSidebar_me\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    name\n    initials\n    id\n  }\n  sale {\n    is_auction: isAuction\n    isBenefit\n    isGalleryAuction\n    cover_image: coverImage {\n      url(version: \"square\")\n    }\n    id\n  }\n  context {\n    __typename\n    ... on Sale {\n      name\n      href\n    }\n    ... on Fair {\n      name\n      href\n      profile {\n        initials\n        icon {\n          img: resized(width: 70, height: 70, version: \"square\") {\n            url\n          }\n        }\n        id\n      }\n    }\n    ... on Show {\n      name\n      href\n      status\n      thumbnail: coverImage {\n        img: resized(width: 70, height: 70, version: \"square\") {\n          url\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information: additionalInformation(format: HTML)\n  sale {\n    isBenefit\n    isGalleryAuction\n    id\n  }\n  partner {\n    internalID\n    slug\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      id\n    }\n    is_default_profile_public: isDefaultProfilePublic\n    profile {\n      ...FollowProfileButton_profile\n      slug\n      icon {\n        url(version: \"square140\")\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  category\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  canRequestLotConditionsReport\n  internalID\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      id\n    }\n    href\n    published_at: publishedAt(format: \"MMM Do, YYYY\")\n    thumbnail_image: thumbnailImage {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title: thumbnailTitle\n    id\n  }\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    slug\n    id\n  }\n  literature(format: HTML)\n  exhibition_history: exhibitionHistory(format: HTML)\n  provenance(format: HTML)\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  image_alt: formattedMetadata\n  ...ArtworkActions_artwork\n  image {\n    internalID\n  }\n  images {\n    internalID\n    uri: url(version: [\"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio\n    is_zoomable: isZoomable\n    is_default: isDefault\n    deepZoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  href\n  internalID\n  date\n  artist_names: artistNames\n  sale_message: saleMessage\n  partner {\n    name\n    id\n  }\n  image_rights: imageRights\n  is_in_auction: isInAuction\n  is_acquireable: isAcquireable\n  is_shareable: isShareable\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    long_description: description(limit: 200)\n  }\n  context {\n    __typename\n    ... on Fair {\n      slug\n      name\n    }\n    ... on Node {\n      id\n    }\n  }\n  ...SeoDataForArtwork_artwork\n}\n\nfragment ArtworkRelatedArtists_artwork on Artwork {\n  slug\n  artist {\n    href\n    related {\n      artistsConnection(kind: MAIN, first: 4, after: \"\") {\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        edges {\n          node {\n            ...ArtistCard_artist\n            id\n            __typename\n          }\n          cursor\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    id\n    internalID\n    slug\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale_artwork: saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    internalID\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    requireIdentityVerification\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarBidAction_me on Me {\n  identityVerified\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class: attributionClass {\n    short_description: shortDescription\n    id\n  }\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  slug\n  internalID\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  is_offerable: isOfferable\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  priceIncludesTaxDisplay\n  sale_message: saleMessage\n  shippingInfo\n  shippingOrigin\n  edition_sets: editionSets {\n    internalID\n    id\n    is_acquireable: isAcquireable\n    is_offerable: isOfferable\n    sale_message: saleMessage\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  internalID\n  is_in_auction: isInAuction\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  artists {\n    is_consignable: isConsignable\n    id\n  }\n  sale {\n    is_closed: isClosed\n    isBenefit\n    partner {\n      name\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    href\n    locations {\n      city\n      id\n    }\n    id\n  }\n  sale {\n    name\n    href\n    id\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction: isInAuction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  ...SecurePayment_artwork\n  ...VerifiedSeller_artwork\n  ...AuthenticityCertificate_artwork\n  sale {\n    is_closed: isClosed\n    ...AuctionTimer_sale\n    id\n  }\n}\n\nfragment ArtworkSidebar_me on Me {\n  ...ArtworkSidebarBidAction_me\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at: liveStartAt\n  end_at: endAt\n}\n\nfragment AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  is_biddable: isBiddable\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_artist\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment OtherWorks_artwork on Artwork {\n  contextGrids {\n    __typename\n    title\n    ctaTitle\n    ctaHref\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n  }\n  ...RelatedWorksArtworkGrid_artwork\n  slug\n  internalID\n  sale {\n    is_closed: isClosed\n    id\n  }\n  context {\n    __typename\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment PricingContext_artwork on Artwork {\n  listPrice {\n    __typename\n    ... on PriceRange {\n      maxPrice {\n        minor\n      }\n      minPrice {\n        minor\n      }\n    }\n    ... on Money {\n      minor\n    }\n  }\n  artists {\n    slug\n    id\n  }\n  category\n  pricingContext {\n    appliedFiltersDisplay\n    appliedFilters {\n      dimension\n      category\n    }\n    bins {\n      maxPrice\n      maxPriceCents\n      minPrice\n      minPriceCents\n      numArtworks\n    }\n  }\n}\n\nfragment RelatedWorksArtworkGrid_artwork on Artwork {\n  layers {\n    name\n    internalID\n    id\n  }\n  slug\n  layer {\n    name\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SecurePayment_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n  }\n  name\n  start_at: startAt(format: \"YYYY\")\n  cover_image: coverImage {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n}\n\nfragment SeoDataForArtwork_artwork on Artwork {\n  href\n  date\n  is_price_hidden: isPriceHidden\n  is_price_range: isPriceRange\n  listPrice {\n    __typename\n    ... on PriceRange {\n      minPrice {\n        major\n        currencyCode\n      }\n      maxPrice {\n        major\n      }\n    }\n    ... on Money {\n      major\n      currencyCode\n    }\n  }\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n  }\n  partner {\n    name\n    type\n    profile {\n      image {\n        resized(width: 320, height: 320, version: [\"medium\"]) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n  artist_names: artistNames\n  availability\n  category\n  dimensions {\n    in\n  }\n}\n\nfragment VerifiedSeller_artwork on Artwork {\n  is_biddable: isBiddable\n  partner {\n    isVerifiedSeller\n    name\n    id\n  }\n}\n",
+    "text": "query routes_ArtworkQuery(\n  $artworkID: String!\n  $shouldFetchArtistSeriesData: Boolean!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...ArtworkApp_artwork_2juLqN\n    id\n  }\n  me {\n    ...ArtworkApp_me\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment ArtistCard_artist on Artist {\n  name\n  slug\n  href\n  image {\n    cropped(width: 400, height: 300) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  ...FollowArtistButton_artist\n}\n\nfragment ArtistInfo_artist on Artist {\n  internalID\n  slug\n  name\n  href\n  image {\n    cropped(width: 100, height: 100) {\n      url\n    }\n  }\n  formatted_nationality_and_birthday: formattedNationalityAndBirthday\n  counts {\n    partner_shows: partnerShows\n  }\n  exhibition_highlights: exhibitionHighlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    id\n  }\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        __typename\n        id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  ...FollowArtistButton_artist\n  biographyBlurb(format: HTML, partnerBio: true) {\n    text\n  }\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistSeriesArtworkRail_artwork on Artwork {\n  artistSeriesConnection(first: 1) {\n    edges {\n      node {\n        slug\n        artworksConnection(first: 20) {\n          edges {\n            node {\n              image {\n                resized(height: 200) {\n                  height\n                  width\n                }\n              }\n              ...FillwidthItem_artwork\n              id\n            }\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtworkActions_artwork on Artwork {\n  ...Save_artwork\n  ...ArtworkSharePanel_artwork\n  artists {\n    name\n    id\n  }\n  date\n  dimensions {\n    cm\n  }\n  href\n  slug\n  image {\n    internalID\n    url(version: \"larger\")\n    height\n    width\n  }\n  is_downloadable: isDownloadable\n  is_hangable: isHangable\n  partner {\n    slug\n    id\n  }\n  title\n  sale {\n    is_closed: isClosed\n    is_auction: isAuction\n    id\n  }\n}\n\nfragment ArtworkApp_artwork_2juLqN on Artwork {\n  slug\n  internalID\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n  availability\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  is_in_auction: isInAuction\n  sale {\n    internalID\n    slug\n    id\n  }\n  artists {\n    id\n    slug\n    ...ArtistInfo_artist\n  }\n  artist {\n    ...ArtistInfo_artist\n    id\n  }\n  ...ArtworkRelatedArtists_artwork\n  ...ArtworkMeta_artwork\n  ...ArtworkBanner_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkDetails_artwork\n  ...ArtworkImageBrowser_artwork\n  ...OtherWorks_artwork_2juLqN\n  ...PricingContext_artwork\n}\n\nfragment ArtworkApp_me on Me {\n  ...ArtworkSidebar_me\n}\n\nfragment ArtworkBanner_artwork on Artwork {\n  partner {\n    name\n    initials\n    id\n  }\n  sale {\n    is_auction: isAuction\n    isBenefit\n    isGalleryAuction\n    cover_image: coverImage {\n      url(version: \"square\")\n    }\n    id\n  }\n  context {\n    __typename\n    ... on Sale {\n      name\n      href\n    }\n    ... on Fair {\n      name\n      href\n      profile {\n        initials\n        icon {\n          img: resized(width: 70, height: 70, version: \"square\") {\n            url\n          }\n        }\n        id\n      }\n    }\n    ... on Show {\n      name\n      href\n      status\n      thumbnail: coverImage {\n        img: resized(width: 70, height: 70, version: \"square\") {\n          url\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ArtworkDetailsAboutTheWorkFromArtsy_artwork on Artwork {\n  description(format: HTML)\n}\n\nfragment ArtworkDetailsAboutTheWorkFromPartner_artwork on Artwork {\n  additional_information: additionalInformation(format: HTML)\n  sale {\n    isBenefit\n    isGalleryAuction\n    id\n  }\n  partner {\n    internalID\n    slug\n    type\n    href\n    name\n    initials\n    locations {\n      city\n      id\n    }\n    is_default_profile_public: isDefaultProfilePublic\n    profile {\n      ...FollowProfileButton_profile\n      slug\n      icon {\n        url(version: \"square140\")\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  category\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  canRequestLotConditionsReport\n  internalID\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n}\n\nfragment ArtworkDetailsArticles_artwork on Artwork {\n  articles(size: 10) {\n    author {\n      name\n      id\n    }\n    href\n    published_at: publishedAt(format: \"MMM Do, YYYY\")\n    thumbnail_image: thumbnailImage {\n      resized(width: 300) {\n        url\n      }\n    }\n    thumbnail_title: thumbnailTitle\n    id\n  }\n}\n\nfragment ArtworkDetails_artwork on Artwork {\n  ...ArtworkDetailsAboutTheWorkFromArtsy_artwork\n  ...ArtworkDetailsAboutTheWorkFromPartner_artwork\n  ...ArtworkDetailsAdditionalInfo_artwork\n  ...ArtworkDetailsArticles_artwork\n  articles(size: 10) {\n    slug\n    id\n  }\n  literature(format: HTML)\n  exhibition_history: exhibitionHistory(format: HTML)\n  provenance(format: HTML)\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  image_alt: formattedMetadata\n  ...ArtworkActions_artwork\n  image {\n    internalID\n  }\n  images {\n    internalID\n    uri: url(version: [\"large\"])\n    placeholder: resized(width: 30, height: 30, version: \"small\") {\n      url\n    }\n    aspectRatio\n    is_zoomable: isZoomable\n    is_default: isDefault\n    deepZoom {\n      Image {\n        xmlns\n        Url\n        Format\n        TileSize\n        Overlap\n        Size {\n          Width\n          Height\n        }\n      }\n    }\n  }\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  href\n  internalID\n  date\n  artist_names: artistNames\n  sale_message: saleMessage\n  partner {\n    name\n    id\n  }\n  image_rights: imageRights\n  is_in_auction: isInAuction\n  is_acquireable: isAcquireable\n  is_shareable: isShareable\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    long_description: description(limit: 200)\n  }\n  context {\n    __typename\n    ... on Fair {\n      slug\n      name\n    }\n    ... on Node {\n      id\n    }\n  }\n  ...SeoDataForArtwork_artwork\n}\n\nfragment ArtworkRelatedArtists_artwork on Artwork {\n  slug\n  artist {\n    href\n    related {\n      artistsConnection(kind: MAIN, first: 4, after: \"\") {\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        edges {\n          node {\n            ...ArtistCard_artist\n            id\n            __typename\n          }\n          cursor\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ArtworkSharePanel_artwork on Artwork {\n  href\n  images {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  cultural_maker: culturalMaker\n  artists {\n    id\n    internalID\n    slug\n    name\n    href\n    ...FollowArtistButton_artist_2eN9lh\n  }\n}\n\nfragment ArtworkSidebarAuctionPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    id\n  }\n  sale_artwork: saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    internalID\n    is_closed: isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    requireIdentityVerification\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarBidAction_me on Me {\n  identityVerified\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attribution_class: attributionClass {\n    short_description: shortDescription\n    id\n  }\n}\n\nfragment ArtworkSidebarCommercial_artwork on Artwork {\n  slug\n  internalID\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  is_offerable: isOfferable\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  priceIncludesTaxDisplay\n  sale_message: saleMessage\n  shippingInfo\n  shippingOrigin\n  edition_sets: editionSets {\n    internalID\n    id\n    is_acquireable: isAcquireable\n    is_offerable: isOfferable\n    sale_message: saleMessage\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarExtraLinks_artwork on Artwork {\n  internalID\n  is_in_auction: isInAuction\n  is_for_sale: isForSale\n  is_acquireable: isAcquireable\n  is_inquireable: isInquireable\n  artists {\n    is_consignable: isConsignable\n    id\n  }\n  sale {\n    is_closed: isClosed\n    isBenefit\n    partner {\n      name\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkSidebarMetadata_artwork on Artwork {\n  is_biddable: isBiddable\n  edition_sets: editionSets {\n    __typename\n    id\n  }\n  sale_artwork: saleArtwork {\n    lot_label: lotLabel\n    id\n  }\n  ...ArtworkSidebarTitleInfo_artwork\n  ...ArtworkSidebarSizeInfo_piece\n  ...ArtworkSidebarClassification_artwork\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  partner {\n    name\n    href\n    locations {\n      city\n      id\n    }\n    id\n  }\n  sale {\n    name\n    href\n    id\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  dimensions {\n    in\n    cm\n  }\n  edition_of: editionOf\n}\n\nfragment ArtworkSidebarTitleInfo_artwork on Artwork {\n  title\n  date\n  medium\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  is_in_auction: isInAuction\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarMetadata_artwork\n  ...ArtworkSidebarAuctionPartnerInfo_artwork\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n  ...ArtworkSidebarCommercial_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarExtraLinks_artwork\n  ...SecurePayment_artwork\n  ...VerifiedSeller_artwork\n  ...AuthenticityCertificate_artwork\n  sale {\n    is_closed: isClosed\n    ...AuctionTimer_sale\n    id\n  }\n}\n\nfragment ArtworkSidebar_me on Me {\n  ...ArtworkSidebarBidAction_me\n}\n\nfragment AuctionTimer_sale on Sale {\n  live_start_at: liveStartAt\n  end_at: endAt\n}\n\nfragment AuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  is_biddable: isBiddable\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment FollowArtistButton_artist_2eN9lh on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n  ...FollowArtistPopover_artist\n}\n\nfragment FollowArtistPopoverRow_artist on Artist {\n  internalID\n  name\n  image {\n    cropped(width: 45, height: 45) {\n      url\n    }\n  }\n}\n\nfragment FollowArtistPopover_artist on Artist {\n  related {\n    suggestedConnection(first: 3, excludeFollowedArtists: true) {\n      edges {\n        node {\n          id\n          internalID\n          ...FollowArtistPopoverRow_artist\n        }\n      }\n    }\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  internalID\n  is_followed: isFollowed\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment OtherWorks_artwork_2juLqN on Artwork {\n  contextGrids {\n    __typename\n    title\n    ctaTitle\n    ctaHref\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n  }\n  ...RelatedWorksArtworkGrid_artwork\n  ...ArtistSeriesArtworkRail_artwork @include(if: $shouldFetchArtistSeriesData)\n  slug\n  internalID\n  sale {\n    is_closed: isClosed\n    id\n  }\n  context {\n    __typename\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment PricingContext_artwork on Artwork {\n  listPrice {\n    __typename\n    ... on PriceRange {\n      maxPrice {\n        minor\n      }\n      minPrice {\n        minor\n      }\n    }\n    ... on Money {\n      minor\n    }\n  }\n  artists {\n    slug\n    id\n  }\n  category\n  pricingContext {\n    appliedFiltersDisplay\n    appliedFilters {\n      dimension\n      category\n    }\n    bins {\n      maxPrice\n      maxPriceCents\n      minPrice\n      minPriceCents\n      numArtworks\n    }\n  }\n}\n\nfragment RelatedWorksArtworkGrid_artwork on Artwork {\n  layers {\n    name\n    internalID\n    id\n  }\n  slug\n  layer {\n    name\n    artworksConnection(first: 8) {\n      ...ArtworkGrid_artworks\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SecurePayment_artwork on Artwork {\n  is_acquireable: isAcquireable\n  is_offerable: isOfferable\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      id\n    }\n  }\n  name\n  start_at: startAt(format: \"YYYY\")\n  cover_image: coverImage {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n}\n\nfragment SeoDataForArtwork_artwork on Artwork {\n  href\n  date\n  is_price_hidden: isPriceHidden\n  is_price_range: isPriceRange\n  listPrice {\n    __typename\n    ... on PriceRange {\n      minPrice {\n        major\n        currencyCode\n      }\n      maxPrice {\n        major\n      }\n    }\n    ... on Money {\n      major\n      currencyCode\n    }\n  }\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n  }\n  partner {\n    name\n    type\n    profile {\n      image {\n        resized(width: 320, height: 320, version: [\"medium\"]) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n  artist_names: artistNames\n  availability\n  category\n  dimensions {\n    in\n  }\n}\n\nfragment VerifiedSeller_artwork on Artwork {\n  is_biddable: isBiddable\n  partner {\n    isVerifiedSeller\n    name\n    id\n  }\n}\n",
     "metadata": {}
   }
 };
 })();
-(node as any).hash = 'bce2f54d6aeb6737f3ec7ce0d7e03888';
+(node as any).hash = '4b4b8f1ec43eaec252b5257a59ac78b9';
 export default node;


### PR DESCRIPTION
Looks like:

![search](https://user-images.githubusercontent.com/1457859/88211152-4a424480-cc23-11ea-88d3-01685d695cb3.gif)


If the lab feature is enabled, the data is fetched and an artwork carousel is rendered above the artwork grid, in the 'Other works by this artist' section. 

Depends on https://github.com/artsy/metaphysics/pull/2551
