### PR TITLE
Add artist series header image

### DIFF
--- a/src/v2/Apps/ArtistSeries/Components/ArtistSeriesHeader.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/ArtistSeriesHeader.tsx
@@ -5,6 +5,7 @@ import {
   EntityHeader,
   Flex,
   Grid,
+  Image,
   Row,
   Sans,
   Separator,
@@ -16,6 +17,9 @@ import { openAuthToFollowSave } from "v2/Utils/openAuthModal"
 import { ArtistSeriesHeader_artistSeries } from "v2/__generated__/ArtistSeriesHeader_artistSeries.graphql"
 import { useSystemContext } from "v2/Artsy"
 import { Intent } from "@artsy/cohesion"
+import { resize } from "v2/Utils/resizer"
+import styled from "styled-components"
+import theme from "../../../Assets/Theme"
 
 interface ArtistSeriesHeaderProps {
   artistSeries: ArtistSeriesHeader_artistSeries
@@ -84,7 +88,7 @@ const ArtistSeriesHeader: React.FC<ArtistSeriesHeaderProps> = props => {
 
 const ArtistSeriesHeaderLarge: React.FC<ArtistSeriesHeaderProps> = props => {
   const {
-    artistSeries: { title, description, artists },
+    artistSeries: { title, description, artists, image },
   } = props
   return (
     <>
@@ -101,7 +105,7 @@ const ArtistSeriesHeaderLarge: React.FC<ArtistSeriesHeaderProps> = props => {
       </Flex>
       <Separator />
       <Box m={3}>
-        <Grid>
+        <StyledGrid>
           <Row>
             <Col sm={6}>
               <Flex
@@ -117,16 +121,11 @@ const ArtistSeriesHeaderLarge: React.FC<ArtistSeriesHeaderProps> = props => {
                 </Sans>
               </Flex>
             </Col>
-            <Col sm={6}>
-              <Box
-                // FIXME: Use Image
-                bg="black10"
-                width={1}
-                height={400}
-              ></Box>
-            </Col>
+            <CenteredCol sm={6}>
+              <HeaderImage src={resize(image.url, { height: 400 })} />
+            </CenteredCol>
           </Row>
-        </Grid>
+        </StyledGrid>
       </Box>
     </>
   )
@@ -134,7 +133,7 @@ const ArtistSeriesHeaderLarge: React.FC<ArtistSeriesHeaderProps> = props => {
 
 const ArtistSeriesHeaderSmall: React.FC<ArtistSeriesHeaderProps> = props => {
   const {
-    artistSeries: { title, description, artists },
+    artistSeries: { title, description, artists, image },
   } = props
   return (
     <>
@@ -143,13 +142,10 @@ const ArtistSeriesHeaderSmall: React.FC<ArtistSeriesHeaderProps> = props => {
       </Box>
       <Separator />
       <Box m={3}>
-        <Box
-          // FIXME: Use Image
-          mx="auto"
-          bg="black10"
-          width={180}
-          height={180}
-        ></Box>
+        <HeaderImage
+          src={resize(image.url, { height: 180, width: 180 })}
+          pb={1}
+        />
         <Sans size="8" element="h1" my={1} unstable_trackIn>
           {title}
         </Sans>
@@ -164,6 +160,33 @@ const ArtistSeriesHeaderSmall: React.FC<ArtistSeriesHeaderProps> = props => {
   )
 }
 
+const StyledGrid = styled(Grid)`
+  @media (max-width: ${theme.flexboxgrid.breakpoints.lg - 1}px) {
+    max-width: 100%;
+  }
+`
+
+const HeaderImage = styled(Image)`
+  border-radius: 2px;
+
+  @media (max-width: ${theme.flexboxgrid.breakpoints.sm - 1}px) {
+    max-width: 180px;
+    max-height: 180px;
+    margin: auto;
+  }
+
+  @media (min-width: ${theme.flexboxgrid.breakpoints.sm}px) {
+    max-height: 400px;
+    max-width: 100%;
+  }
+`
+
+const CenteredCol = styled(Col)`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+`
+
 export const ArtistSeriesHeaderFragmentContainer = createFragmentContainer(
   ArtistSeriesHeader,
   {
@@ -171,6 +194,9 @@ export const ArtistSeriesHeaderFragmentContainer = createFragmentContainer(
       fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
         title
         description
+        image {
+          url
+        }
         artists(size: 1) {
           name
           image {

--- a/src/v2/Apps/ArtistSeries/Components/ArtistSeriesHeader.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/ArtistSeriesHeader.tsx
@@ -121,9 +121,9 @@ const ArtistSeriesHeaderLarge: React.FC<ArtistSeriesHeaderProps> = props => {
                 </Sans>
               </Flex>
             </Col>
-            <CenteredCol sm={6}>
+            <AlignedCol sm={6}>
               <HeaderImage src={resize(image.url, { height: 400 })} />
-            </CenteredCol>
+            </AlignedCol>
           </Row>
         </StyledGrid>
       </Box>
@@ -166,7 +166,7 @@ const StyledGrid = styled(Grid)`
   }
 `
 
-const HeaderImage = styled(Image)`
+export const HeaderImage = styled(Image)`
   border-radius: 2px;
 
   @media (max-width: ${theme.flexboxgrid.breakpoints.sm - 1}px) {
@@ -181,7 +181,7 @@ const HeaderImage = styled(Image)`
   }
 `
 
-const CenteredCol = styled(Col)`
+const AlignedCol = styled(Col)`
   display: flex;
   justify-content: flex-end;
   align-items: center;

--- a/src/v2/Apps/ArtistSeries/Components/ArtistSeriesHeader.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/ArtistSeriesHeader.tsx
@@ -19,7 +19,7 @@ import { useSystemContext } from "v2/Artsy"
 import { Intent } from "@artsy/cohesion"
 import { resize } from "v2/Utils/resizer"
 import styled from "styled-components"
-import theme from "../../../Assets/Theme"
+import theme from "v2/Assets/Theme"
 
 interface ArtistSeriesHeaderProps {
   artistSeries: ArtistSeriesHeader_artistSeries

--- a/src/v2/Apps/ArtistSeries/__tests__/ArtistSeriesApp.jest.tsx
+++ b/src/v2/Apps/ArtistSeries/__tests__/ArtistSeriesApp.jest.tsx
@@ -6,7 +6,6 @@ import { ArtistSeriesApp_QueryRawResponse } from "v2/__generated__/ArtistSeriesA
 import { ArtistSeriesApp_UnfoundTest_QueryRawResponse } from "v2/__generated__/ArtistSeriesApp_UnfoundTest_Query.graphql"
 import { Breakpoint } from "@artsy/palette"
 import { HeaderImage } from "../Components/ArtistSeriesHeader"
-import { resize } from "v2/Utils/resizer"
 
 jest.unmock("react-relay")
 jest.mock("v2/Artsy/Router/useRouter", () => ({
@@ -63,7 +62,8 @@ describe("ArtistSeriesApp", () => {
       describe("ArtistSeriesArtworksFilter", () => {
         it("renders correctly", async () => {
           const wrapper = await getWrapper()
-          expect(wrapper.find("ArtworkGrid").length).toBe(2)
+          expect(wrapper.find("ArtworkFilterArtworkGrid").length).toBe(1)
+          expect(wrapper.find("GridItem__ArtworkGridItem").length).toBe(2)
         })
       })
 
@@ -80,10 +80,8 @@ describe("ArtistSeriesApp", () => {
 
             it("has a correctly sized header image", async () => {
               const wrapper = await getWrapper()
-              const expectedUrl = resize(
-                ArtistSeriesAppFixture.artistSeries.image.url,
-                { height: 400 }
-              )
+              const expectedUrl =
+                "https://d7hftxdivxxvm.cloudfront.net?resize_to=height&src=https%3A%2F%2Ftest.artsy.net%2Fpumpkins-header-image.jpg&height=400&quality=80"
               expect(wrapper.find(HeaderImage).props().src).toBe(expectedUrl)
             })
           })
@@ -112,10 +110,8 @@ describe("ArtistSeriesApp", () => {
 
             it("has a correctly sized header image", async () => {
               const wrapper = await getWrapper("xs")
-              const expectedUrl = resize(
-                ArtistSeriesAppFixture.artistSeries.image.url,
-                { height: 180, width: 180 }
-              )
+              const expectedUrl =
+                "https://d7hftxdivxxvm.cloudfront.net?resize_to=fit&src=https%3A%2F%2Ftest.artsy.net%2Fpumpkins-header-image.jpg&width=180&height=180&quality=80"
               expect(wrapper.find(HeaderImage).props().src).toBe(expectedUrl)
             })
           })

--- a/src/v2/Apps/ArtistSeries/__tests__/ArtistSeriesApp.jest.tsx
+++ b/src/v2/Apps/ArtistSeries/__tests__/ArtistSeriesApp.jest.tsx
@@ -5,6 +5,8 @@ import { graphql } from "react-relay"
 import { ArtistSeriesApp_QueryRawResponse } from "v2/__generated__/ArtistSeriesApp_Query.graphql"
 import { ArtistSeriesApp_UnfoundTest_QueryRawResponse } from "v2/__generated__/ArtistSeriesApp_UnfoundTest_Query.graphql"
 import { Breakpoint } from "@artsy/palette"
+import { HeaderImage } from "../Components/ArtistSeriesHeader"
+import { resize } from "v2/Utils/resizer"
 
 jest.unmock("react-relay")
 jest.mock("v2/Artsy/Router/useRouter", () => ({
@@ -55,6 +57,14 @@ describe("ArtistSeriesApp", () => {
         const wrapper = await getWrapper()
         expect(wrapper.find("AppContainer").length).toBe(1)
         expect(wrapper.find("ArtistSeriesHeader").length).toBe(1)
+        expect(wrapper.find("ArtistSeriesArtworksFilter").length).toBe(1)
+      })
+
+      describe("ArtistSeriesArtworksFilter", () => {
+        it("renders correctly", async () => {
+          const wrapper = await getWrapper()
+          expect(wrapper.find("ArtworkGrid").length).toBe(2)
+        })
       })
 
       describe("ArtistSeriesHeader", () => {
@@ -62,24 +72,19 @@ describe("ArtistSeriesApp", () => {
           describe("with an artist", () => {
             it("renders correctly", async () => {
               const wrapper = await getWrapper()
-              // TODO: expect(wrapper.find("ResponsiveImage").length).toBe(1)
               expect(wrapper.find("ArtistSeriesHeaderLarge").length).toBe(1)
               expect(wrapper.find("ArtistSeriesHeaderSmall").length).toBe(0)
               expect(wrapper.find("ArtistInfo").length).toBe(1)
-              expect(wrapper.find("FollowArtistButton").length).toBe(1)
-              expect(wrapper.find("ArtistSeriesArtworksFilter").length).toBe(1)
-              const html = wrapper.html()
-              expect(html).toContain("Pumpkins")
-              expect(html).toContain("All of the pumpkins")
-              expect(html).toContain("Yayoi Kusama")
-              expect(html).toContain("https://test.artsy.net/yayoi-kusama.jpg")
-              expect(html).toContain("/artist/yayoi-kusama")
-              expect(html).toContain(
-                "/artwork/yayoi-kusama-pumpkin-2222222222222222"
+              expect(wrapper.find(HeaderImage).length).toBe(1)
+            })
+
+            it("has a correctly sized header image", async () => {
+              const wrapper = await getWrapper()
+              const expectedUrl = resize(
+                ArtistSeriesAppFixture.artistSeries.image.url,
+                { height: 400 }
               )
-              expect(html).toContain(
-                "/artwork/yayoi-kusama-pumpkin-33333333333333333"
-              )
+              expect(wrapper.find(HeaderImage).props().src).toBe(expectedUrl)
             })
           })
 
@@ -99,24 +104,19 @@ describe("ArtistSeriesApp", () => {
           describe("with an artist", () => {
             it("renders correctly", async () => {
               const wrapper = await getWrapper("xs")
-              // TODO: expect(wrapper.find("ResponsiveImage").length).toBe(1)
               expect(wrapper.find("ArtistSeriesHeaderLarge").length).toBe(0)
               expect(wrapper.find("ArtistSeriesHeaderSmall").length).toBe(1)
               expect(wrapper.find("ArtistInfo").length).toBe(1)
-              expect(wrapper.find("FollowArtistButton").length).toBe(1)
-              expect(wrapper.find("ArtistSeriesArtworksFilter").length).toBe(1)
-              const html = wrapper.html()
-              expect(html).toContain("Pumpkins")
-              expect(html).toContain("All of the pumpkins")
-              expect(html).toContain("Yayoi Kusama")
-              expect(html).toContain("https://test.artsy.net/yayoi-kusama.jpg")
-              expect(html).toContain("/artist/yayoi-kusama")
-              expect(html).toContain(
-                "/artwork/yayoi-kusama-pumpkin-2222222222222222"
+              expect(wrapper.find(HeaderImage).length).toBe(1)
+            })
+
+            it("has a correctly sized header image", async () => {
+              const wrapper = await getWrapper("xs")
+              const expectedUrl = resize(
+                ArtistSeriesAppFixture.artistSeries.image.url,
+                { height: 180, width: 180 }
               )
-              expect(html).toContain(
-                "/artwork/yayoi-kusama-pumpkin-33333333333333333"
-              )
+              expect(wrapper.find(HeaderImage).props().src).toBe(expectedUrl)
             })
           })
 
@@ -177,6 +177,9 @@ const ArtistSeriesAppFixture: ArtistSeriesApp_QueryRawResponse = {
   artistSeries: {
     title: "Pumpkins",
     description: "All of the pumpkins",
+    image: {
+      url: "https://test.artsy.net/pumpkins-header-image.jpg",
+    },
     artists: [
       {
         name: "Yayoi Kusama",

--- a/src/v2/__generated__/ArtistSeriesApp_Query.graphql.ts
+++ b/src/v2/__generated__/ArtistSeriesApp_Query.graphql.ts
@@ -15,6 +15,9 @@ export type ArtistSeriesApp_QueryRawResponse = {
     readonly artistSeries: ({
         readonly title: string;
         readonly description: string | null;
+        readonly image: ({
+            readonly url: string | null;
+        }) | null;
         readonly artists: ReadonlyArray<({
             readonly name: string | null;
             readonly image: ({
@@ -154,6 +157,9 @@ fragment ArtistSeriesArtworksFilter_artistSeries_1QCCZM on ArtistSeries {
 fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
   title
   description
+  image {
+    url
+  }
   artists(size: 1) {
     name
     image {
@@ -370,57 +376,75 @@ v2 = {
   "storageKey": null
 },
 v3 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "image",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Image",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "url",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v4 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v5 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "slug",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "internalID",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v10 = [
-  (v8/*: any*/),
+v11 = [
   (v9/*: any*/),
+  (v10/*: any*/),
   {
     "kind": "ScalarField",
     "alias": null,
@@ -429,14 +453,14 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = [
+v12 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v12 = [
+v13 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -494,6 +518,7 @@ return {
             "args": null,
             "storageKey": null
           },
+          (v3/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
@@ -509,29 +534,12 @@ return {
             "concreteType": "Artist",
             "plural": true,
             "selections": [
-              (v3/*: any*/),
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "image",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "Image",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "url",
-                    "args": null,
-                    "storageKey": null
-                  }
-                ]
-              },
               (v4/*: any*/),
+              (v3/*: any*/),
               (v5/*: any*/),
               (v6/*: any*/),
               (v7/*: any*/),
+              (v8/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": "is_followed",
@@ -589,7 +597,7 @@ return {
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
-              (v6/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -622,7 +630,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v4/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -676,7 +684,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": true,
-                    "selections": (v10/*: any*/)
+                    "selections": (v11/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -686,7 +694,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v10/*: any*/)
+                    "selections": (v11/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -696,7 +704,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v10/*: any*/)
+                    "selections": (v11/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -707,8 +715,8 @@ return {
                     "concreteType": "PageCursor",
                     "plural": false,
                     "selections": [
-                      (v8/*: any*/),
-                      (v9/*: any*/)
+                      (v9/*: any*/),
+                      (v10/*: any*/)
                     ]
                   }
                 ]
@@ -731,10 +739,10 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
+                      (v7/*: any*/),
                       (v6/*: any*/),
                       (v5/*: any*/),
-                      (v4/*: any*/),
-                      (v7/*: any*/),
+                      (v8/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -807,13 +815,13 @@ return {
                         "alias": null,
                         "name": "artists",
                         "storageKey": "artists(shallow:true)",
-                        "args": (v11/*: any*/),
+                        "args": (v12/*: any*/),
                         "concreteType": "Artist",
                         "plural": true,
                         "selections": [
-                          (v6/*: any*/),
-                          (v4/*: any*/),
-                          (v3/*: any*/)
+                          (v7/*: any*/),
+                          (v5/*: any*/),
+                          (v4/*: any*/)
                         ]
                       },
                       {
@@ -828,13 +836,13 @@ return {
                         "alias": null,
                         "name": "partner",
                         "storageKey": "partner(shallow:true)",
-                        "args": (v11/*: any*/),
+                        "args": (v12/*: any*/),
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/),
                           (v4/*: any*/),
-                          (v6/*: any*/),
+                          (v5/*: any*/),
+                          (v7/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -867,7 +875,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v6/*: any*/),
+                          (v7/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": "is_live_open",
@@ -933,7 +941,7 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkHighestBid",
                             "plural": false,
-                            "selections": (v12/*: any*/)
+                            "selections": (v13/*: any*/)
                           },
                           {
                             "kind": "LinkedField",
@@ -943,9 +951,9 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkOpeningBid",
                             "plural": false,
-                            "selections": (v12/*: any*/)
+                            "selections": (v13/*: any*/)
                           },
-                          (v6/*: any*/)
+                          (v7/*: any*/)
                         ]
                       },
                       {
@@ -971,7 +979,7 @@ return {
                       }
                     ]
                   },
-                  (v6/*: any*/)
+                  (v7/*: any*/)
                 ]
               }
             ]
@@ -984,7 +992,7 @@ return {
     "operationKind": "query",
     "name": "ArtistSeriesApp_Query",
     "id": null,
-    "text": "query ArtistSeriesApp_Query(\n  $slug: ID!\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesApp_artistSeries\n  }\n}\n\nfragment ArtistSeriesApp_artistSeries on ArtistSeries {\n  ...ArtistSeriesHeader_artistSeries\n  ...ArtistSeriesArtworksFilter_artistSeries_1QCCZM\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries_1QCCZM on ArtistSeries {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-partner_updated_at\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtistSeriesHeader_artistSeries on ArtistSeries {\n  title\n  description\n  artists(size: 1) {\n    name\n    image {\n      url\n    }\n    href\n    slug\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query ArtistSeriesApp_Query(\n  $slug: ID!\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesApp_artistSeries\n  }\n}\n\nfragment ArtistSeriesApp_artistSeries on ArtistSeries {\n  ...ArtistSeriesHeader_artistSeries\n  ...ArtistSeriesArtworksFilter_artistSeries_1QCCZM\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries_1QCCZM on ArtistSeries {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-partner_updated_at\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtistSeriesHeader_artistSeries on ArtistSeries {\n  title\n  description\n  image {\n    url\n  }\n  artists(size: 1) {\n    name\n    image {\n      url\n    }\n    href\n    slug\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
     "metadata": {}
   }
 };

--- a/src/v2/__generated__/ArtistSeriesApp_UnfoundTest_Query.graphql.ts
+++ b/src/v2/__generated__/ArtistSeriesApp_UnfoundTest_Query.graphql.ts
@@ -15,6 +15,9 @@ export type ArtistSeriesApp_UnfoundTest_QueryRawResponse = {
     readonly artistSeries: ({
         readonly title: string;
         readonly description: string | null;
+        readonly image: ({
+            readonly url: string | null;
+        }) | null;
         readonly artists: ReadonlyArray<({
             readonly name: string | null;
             readonly image: ({
@@ -154,6 +157,9 @@ fragment ArtistSeriesArtworksFilter_artistSeries_1QCCZM on ArtistSeries {
 fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
   title
   description
+  image {
+    url
+  }
   artists(size: 1) {
     name
     image {
@@ -370,57 +376,75 @@ v2 = {
   "storageKey": null
 },
 v3 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "image",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Image",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "url",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v4 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v5 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "slug",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "internalID",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v10 = [
-  (v8/*: any*/),
+v11 = [
   (v9/*: any*/),
+  (v10/*: any*/),
   {
     "kind": "ScalarField",
     "alias": null,
@@ -429,14 +453,14 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = [
+v12 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v12 = [
+v13 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -494,6 +518,7 @@ return {
             "args": null,
             "storageKey": null
           },
+          (v3/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
@@ -509,29 +534,12 @@ return {
             "concreteType": "Artist",
             "plural": true,
             "selections": [
-              (v3/*: any*/),
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "image",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "Image",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "url",
-                    "args": null,
-                    "storageKey": null
-                  }
-                ]
-              },
               (v4/*: any*/),
+              (v3/*: any*/),
               (v5/*: any*/),
               (v6/*: any*/),
               (v7/*: any*/),
+              (v8/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": "is_followed",
@@ -589,7 +597,7 @@ return {
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
-              (v6/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -622,7 +630,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v4/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -676,7 +684,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": true,
-                    "selections": (v10/*: any*/)
+                    "selections": (v11/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -686,7 +694,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v10/*: any*/)
+                    "selections": (v11/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -696,7 +704,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v10/*: any*/)
+                    "selections": (v11/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -707,8 +715,8 @@ return {
                     "concreteType": "PageCursor",
                     "plural": false,
                     "selections": [
-                      (v8/*: any*/),
-                      (v9/*: any*/)
+                      (v9/*: any*/),
+                      (v10/*: any*/)
                     ]
                   }
                 ]
@@ -731,10 +739,10 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
+                      (v7/*: any*/),
                       (v6/*: any*/),
                       (v5/*: any*/),
-                      (v4/*: any*/),
-                      (v7/*: any*/),
+                      (v8/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -807,13 +815,13 @@ return {
                         "alias": null,
                         "name": "artists",
                         "storageKey": "artists(shallow:true)",
-                        "args": (v11/*: any*/),
+                        "args": (v12/*: any*/),
                         "concreteType": "Artist",
                         "plural": true,
                         "selections": [
-                          (v6/*: any*/),
-                          (v4/*: any*/),
-                          (v3/*: any*/)
+                          (v7/*: any*/),
+                          (v5/*: any*/),
+                          (v4/*: any*/)
                         ]
                       },
                       {
@@ -828,13 +836,13 @@ return {
                         "alias": null,
                         "name": "partner",
                         "storageKey": "partner(shallow:true)",
-                        "args": (v11/*: any*/),
+                        "args": (v12/*: any*/),
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/),
                           (v4/*: any*/),
-                          (v6/*: any*/),
+                          (v5/*: any*/),
+                          (v7/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -867,7 +875,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v6/*: any*/),
+                          (v7/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": "is_live_open",
@@ -933,7 +941,7 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkHighestBid",
                             "plural": false,
-                            "selections": (v12/*: any*/)
+                            "selections": (v13/*: any*/)
                           },
                           {
                             "kind": "LinkedField",
@@ -943,9 +951,9 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkOpeningBid",
                             "plural": false,
-                            "selections": (v12/*: any*/)
+                            "selections": (v13/*: any*/)
                           },
-                          (v6/*: any*/)
+                          (v7/*: any*/)
                         ]
                       },
                       {
@@ -971,7 +979,7 @@ return {
                       }
                     ]
                   },
-                  (v6/*: any*/)
+                  (v7/*: any*/)
                 ]
               }
             ]
@@ -984,7 +992,7 @@ return {
     "operationKind": "query",
     "name": "ArtistSeriesApp_UnfoundTest_Query",
     "id": null,
-    "text": "query ArtistSeriesApp_UnfoundTest_Query(\n  $slug: ID!\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesApp_artistSeries\n  }\n}\n\nfragment ArtistSeriesApp_artistSeries on ArtistSeries {\n  ...ArtistSeriesHeader_artistSeries\n  ...ArtistSeriesArtworksFilter_artistSeries_1QCCZM\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries_1QCCZM on ArtistSeries {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-partner_updated_at\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtistSeriesHeader_artistSeries on ArtistSeries {\n  title\n  description\n  artists(size: 1) {\n    name\n    image {\n      url\n    }\n    href\n    slug\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query ArtistSeriesApp_UnfoundTest_Query(\n  $slug: ID!\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesApp_artistSeries\n  }\n}\n\nfragment ArtistSeriesApp_artistSeries on ArtistSeries {\n  ...ArtistSeriesHeader_artistSeries\n  ...ArtistSeriesArtworksFilter_artistSeries_1QCCZM\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries_1QCCZM on ArtistSeries {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-partner_updated_at\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtistSeriesHeader_artistSeries on ArtistSeries {\n  title\n  description\n  image {\n    url\n  }\n  artists(size: 1) {\n    name\n    image {\n      url\n    }\n    href\n    slug\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
     "metadata": {}
   }
 };

--- a/src/v2/__generated__/ArtistSeriesHeader_artistSeries.graphql.ts
+++ b/src/v2/__generated__/ArtistSeriesHeader_artistSeries.graphql.ts
@@ -5,6 +5,9 @@ import { FragmentRefs } from "relay-runtime";
 export type ArtistSeriesHeader_artistSeries = {
     readonly title: string;
     readonly description: string | null;
+    readonly image: {
+        readonly url: string | null;
+    } | null;
     readonly artists: ReadonlyArray<{
         readonly name: string | null;
         readonly image: {
@@ -24,7 +27,26 @@ export type ArtistSeriesHeader_artistSeries$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "image",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Image",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "url",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+return {
   "kind": "Fragment",
   "name": "ArtistSeriesHeader_artistSeries",
   "type": "ArtistSeries",
@@ -45,6 +67,7 @@ const node: ReaderFragment = {
       "args": null,
       "storageKey": null
     },
+    (v0/*: any*/),
     {
       "kind": "LinkedField",
       "alias": null,
@@ -67,24 +90,7 @@ const node: ReaderFragment = {
           "args": null,
           "storageKey": null
         },
-        {
-          "kind": "LinkedField",
-          "alias": null,
-          "name": "image",
-          "storageKey": null,
-          "args": null,
-          "concreteType": "Image",
-          "plural": false,
-          "selections": [
-            {
-              "kind": "ScalarField",
-              "alias": null,
-              "name": "url",
-              "args": null,
-              "storageKey": null
-            }
-          ]
-        },
+        (v0/*: any*/),
         {
           "kind": "ScalarField",
           "alias": null,
@@ -108,5 +114,6 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = 'b7f8ca35258c57e6400d162d1413cc34';
+})();
+(node as any).hash = 'f31639df0433b44fb4f5aa094edf9b17';
 export default node;

--- a/src/v2/__generated__/routes_ArtistSeriesQuery.graphql.ts
+++ b/src/v2/__generated__/routes_ArtistSeriesQuery.graphql.ts
@@ -79,6 +79,9 @@ fragment ArtistSeriesArtworksFilter_artistSeries_1DvBHA on ArtistSeries {
 fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
   title
   description
+  image {
+    url
+  }
   artists(size: 1) {
     name
     image {
@@ -499,57 +502,75 @@ v20 = {
   "storageKey": null
 },
 v21 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "image",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Image",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "url",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
+v22 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v22 = {
+v23 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v23 = {
+v24 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "slug",
   "args": null,
   "storageKey": null
 },
-v24 = {
+v25 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v25 = {
+v26 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "internalID",
   "args": null,
   "storageKey": null
 },
-v26 = {
+v27 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v27 = {
+v28 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v28 = [
-  (v26/*: any*/),
+v29 = [
   (v27/*: any*/),
+  (v28/*: any*/),
   {
     "kind": "ScalarField",
     "alias": null,
@@ -558,14 +579,14 @@ v28 = [
     "storageKey": null
   }
 ],
-v29 = [
+v30 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v30 = [
+v31 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -642,6 +663,7 @@ return {
             "args": null,
             "storageKey": null
           },
+          (v21/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
@@ -657,29 +679,12 @@ return {
             "concreteType": "Artist",
             "plural": true,
             "selections": [
-              (v21/*: any*/),
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "image",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "Image",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "url",
-                    "args": null,
-                    "storageKey": null
-                  }
-                ]
-              },
               (v22/*: any*/),
+              (v21/*: any*/),
               (v23/*: any*/),
               (v24/*: any*/),
               (v25/*: any*/),
+              (v26/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": "is_followed",
@@ -745,7 +750,7 @@ return {
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
-              (v24/*: any*/),
+              (v25/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -778,7 +783,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v21/*: any*/),
+                      (v22/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -832,7 +837,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": true,
-                    "selections": (v28/*: any*/)
+                    "selections": (v29/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -842,7 +847,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v28/*: any*/)
+                    "selections": (v29/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -852,7 +857,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v28/*: any*/)
+                    "selections": (v29/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -863,8 +868,8 @@ return {
                     "concreteType": "PageCursor",
                     "plural": false,
                     "selections": [
-                      (v26/*: any*/),
-                      (v27/*: any*/)
+                      (v27/*: any*/),
+                      (v28/*: any*/)
                     ]
                   }
                 ]
@@ -887,10 +892,10 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
+                      (v25/*: any*/),
                       (v24/*: any*/),
                       (v23/*: any*/),
-                      (v22/*: any*/),
-                      (v25/*: any*/),
+                      (v26/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -963,13 +968,13 @@ return {
                         "alias": null,
                         "name": "artists",
                         "storageKey": "artists(shallow:true)",
-                        "args": (v29/*: any*/),
+                        "args": (v30/*: any*/),
                         "concreteType": "Artist",
                         "plural": true,
                         "selections": [
-                          (v24/*: any*/),
-                          (v22/*: any*/),
-                          (v21/*: any*/)
+                          (v25/*: any*/),
+                          (v23/*: any*/),
+                          (v22/*: any*/)
                         ]
                       },
                       {
@@ -984,13 +989,13 @@ return {
                         "alias": null,
                         "name": "partner",
                         "storageKey": "partner(shallow:true)",
-                        "args": (v29/*: any*/),
+                        "args": (v30/*: any*/),
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v21/*: any*/),
                           (v22/*: any*/),
-                          (v24/*: any*/),
+                          (v23/*: any*/),
+                          (v25/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1023,7 +1028,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v24/*: any*/),
+                          (v25/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": "is_live_open",
@@ -1089,7 +1094,7 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkHighestBid",
                             "plural": false,
-                            "selections": (v30/*: any*/)
+                            "selections": (v31/*: any*/)
                           },
                           {
                             "kind": "LinkedField",
@@ -1099,9 +1104,9 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkOpeningBid",
                             "plural": false,
-                            "selections": (v30/*: any*/)
+                            "selections": (v31/*: any*/)
                           },
-                          (v24/*: any*/)
+                          (v25/*: any*/)
                         ]
                       },
                       {
@@ -1127,7 +1132,7 @@ return {
                       }
                     ]
                   },
-                  (v24/*: any*/)
+                  (v25/*: any*/)
                 ]
               }
             ]
@@ -1140,7 +1145,7 @@ return {
     "operationKind": "query",
     "name": "routes_ArtistSeriesQuery",
     "id": null,
-    "text": "query routes_ArtistSeriesQuery(\n  $slug: ID!\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD]\n  $atAuction: Boolean\n  $attributionClass: [String]\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $keyword: String\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sizes: [ArtworkSizes]\n  $sort: String\n  $width: String\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesApp_artistSeries_1DvBHA\n  }\n}\n\nfragment ArtistSeriesApp_artistSeries_1DvBHA on ArtistSeries {\n  ...ArtistSeriesHeader_artistSeries\n  ...ArtistSeriesArtworksFilter_artistSeries_1DvBHA\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries_1DvBHA on ArtistSeries {\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: \"\", sort: $sort, width: $width) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtistSeriesHeader_artistSeries on ArtistSeries {\n  title\n  description\n  artists(size: 1) {\n    name\n    image {\n      url\n    }\n    href\n    slug\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query routes_ArtistSeriesQuery(\n  $slug: ID!\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD]\n  $atAuction: Boolean\n  $attributionClass: [String]\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $keyword: String\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sizes: [ArtworkSizes]\n  $sort: String\n  $width: String\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesApp_artistSeries_1DvBHA\n  }\n}\n\nfragment ArtistSeriesApp_artistSeries_1DvBHA on ArtistSeries {\n  ...ArtistSeriesHeader_artistSeries\n  ...ArtistSeriesArtworksFilter_artistSeries_1DvBHA\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries_1DvBHA on ArtistSeries {\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: \"\", sort: $sort, width: $width) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtistSeriesHeader_artistSeries on ArtistSeries {\n  title\n  description\n  image {\n    url\n  }\n  artists(size: 1) {\n    name\n    image {\n      url\n    }\n    href\n    slug\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2071
---
# Problem

Users should see a representative image on an artist series to ground the artist series in a work and contextualize the page.

# Solution

Add header image to artist series page.

This PR also does a light refactoring of our artist series test suite to (1) break up some overly long tests into smaller, more targeted tests and (2) to test the components we've created and not the underlying implementation.

### Screenshots

<details>
<summary>L/XL</summary>

![Screen Shot 2020-07-20 at 5 58 52 PM](https://user-images.githubusercontent.com/4432348/88191635-a7c99780-cc09-11ea-8624-67c35872e136.png)

</details>

<details>
<summary>S/MD</summary>

![Screen Shot 2020-07-22 at 10 53 26 AM](https://user-images.githubusercontent.com/4432348/88191684-b31cc300-cc09-11ea-8391-912242181eea.png)


</details>

<details>
<summary>XS (mobile)</summary>

![Screen Shot 2020-07-22 at 10 53 46 AM](https://user-images.githubusercontent.com/4432348/88191702-b748e080-cc09-11ea-9fa2-432a1771c454.png)


</details>