### PR TITLE
Attach details panel and reply on mobile

### DIFF
--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -48,6 +48,7 @@ const DetailsContainer = styled(Flex)<{ opacity?: 0 | 1; transform?: string }>`
     transform: none;
     opacity: ${({ opacity }: { opacity?: 0 | 1 }) => opacity};
     top: 114px;
+    position: fixed;
     ${zIndex}
   `}
 `

--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -121,7 +121,14 @@ export const Reply: React.FC<ReplyProps> = props => {
           text: "Discard message",
         }}
       />
-      <StyledFlex p={1} right={[0, null]} zIndex={[null, 2]}>
+      <StyledFlex
+        p={1}
+        right={[0, null]}
+        zIndex={[null, 2]}
+        position={["fixed", "static"]}
+        bottom={0}
+        left={0}
+      >
         <FullWidthFlex width="100%">
           <StyledTextArea
             onInput={event => {
@@ -147,7 +154,7 @@ export const Reply: React.FC<ReplyProps> = props => {
             ref={textArea}
           />
         </FullWidthFlex>
-        <Flex alignItems="flex-end">
+        <Flex alignItems="flex-end" height="100%">
           <Button
             ml={1}
             disabled={buttonDisabled}


### PR DESCRIPTION
This fixes three issues:

1. The submit button was floating outside the input (putting a height on the reply component fixed that)
2. Moved the details panel to be fixed on xs to avoid weird scrolling issues on iOS
3. Changed the reply comonent to be fixed on iOS to avoid more scrolling issues. 