### PR TITLE
[FX-2103] Supports permanent redirects for artist page

### DIFF
--- a/src/desktop/apps/artsy-v2/server.tsx
+++ b/src/desktop/apps/artsy-v2/server.tsx
@@ -74,7 +74,7 @@ app.get(
       })
 
       if (redirect) {
-        res.redirect(302, redirect.url)
+        res.redirect(status ?? 302, redirect.url)
         return
       }
 

--- a/src/v2/Apps/Artist/__tests__/routes.jest.tsx
+++ b/src/v2/Apps/Artist/__tests__/routes.jest.tsx
@@ -6,6 +6,7 @@ import { FarceRedirectResult } from "found/lib/server"
 import getFarceResult from "found/lib/server/getFarceResult"
 import React from "react"
 import { Environment, RecordSource, Store } from "relay-runtime"
+import { PermanentRedirectException } from "v2/Artsy/Router/PermanentRedirectException"
 
 describe("Artist/routes", () => {
   async function render(url, mockData: routes_ArtistTopLevelQueryRawResponse) {
@@ -42,12 +43,15 @@ describe("Artist/routes", () => {
   })
 
   it("redirects trailing a trailing slash on the artist page back to the root", async () => {
-    const { redirect } = await render(
-      "/artist/juan-gris/",
-      mockResolver(overviewArtist)
-    )
+    await expect(
+      render("/artist/juan-gris/", mockResolver(overviewArtist))
+    ).rejects.toThrow(PermanentRedirectException)
 
-    expect(redirect.url).toBe("/artist/juan-gris")
+    try {
+      await render("/artist/juan-gris/", mockResolver(overviewArtist))
+    } catch (err) {
+      expect(err.pathname).toEqual("/artist/juan-gris")
+    }
   })
 
   it("doesn't redirect from /auction-results to /works-for-sale if auction-results", async () => {
@@ -103,30 +107,37 @@ describe("Artist/routes", () => {
   })
 
   it("redirects from / to the /works-for-sale page if there is no data", async () => {
-    const { redirect } = await render(
-      "/artist/juan-gris",
-      mockResolver({
-        ...overviewArtist,
-        highlights: {
-          partnersConnection: null,
-        },
-        statuses: {
-          shows: false,
-          articles: false,
-          cv: false,
-          auctionLots: false,
-          artworks: false,
-        },
-        biographyBlurb: {
-          text: null,
-        },
-        related: {
-          genes: null,
-        },
-      })
-    )
+    const exec = async () =>
+      await render(
+        "/artist/juan-gris",
+        mockResolver({
+          ...overviewArtist,
+          highlights: {
+            partnersConnection: null,
+          },
+          statuses: {
+            shows: false,
+            articles: false,
+            cv: false,
+            auctionLots: false,
+            artworks: false,
+          },
+          biographyBlurb: {
+            text: null,
+          },
+          related: {
+            genes: null,
+          },
+        })
+      )
 
-    expect(redirect.url).toBe("/artist/juan-gris/works-for-sale")
+    await expect(exec()).rejects.toThrow(PermanentRedirectException)
+
+    try {
+      await exec()
+    } catch (err) {
+      expect(err.pathname).toEqual("/artist/juan-gris/works-for-sale")
+    }
   })
 
   it("does not redirect from /cv", async () => {
@@ -157,27 +168,34 @@ describe("Artist/routes", () => {
   })
 
   it("redirects from /cv to the /works-for-sale page if there is no data", async () => {
-    const { redirect } = await render(
-      "/artist/juan-gris/cv",
-      mockResolver({
-        ...overviewArtist,
-        statuses: {
-          shows: false,
-          articles: false,
-          cv: false,
-          auctionLots: false,
-          artworks: false,
-        },
-        biographyBlurb: {
-          text: null,
-        },
-        related: {
-          genes: null,
-        },
-      })
-    )
+    const exec = async () =>
+      await render(
+        "/artist/juan-gris/cv",
+        mockResolver({
+          ...overviewArtist,
+          statuses: {
+            shows: false,
+            articles: false,
+            cv: false,
+            auctionLots: false,
+            artworks: false,
+          },
+          biographyBlurb: {
+            text: null,
+          },
+          related: {
+            genes: null,
+          },
+        })
+      )
 
-    expect(redirect.url).toBe("/artist/juan-gris/works-for-sale")
+    await expect(exec()).rejects.toThrow(PermanentRedirectException)
+
+    try {
+      await exec()
+    } catch (err) {
+      expect(err.pathname).toEqual("/artist/juan-gris/works-for-sale")
+    }
   })
 })
 

--- a/src/v2/Apps/Artist/routes.tsx
+++ b/src/v2/Apps/Artist/routes.tsx
@@ -15,6 +15,7 @@ import {
   initialArtworkFilterState,
 } from "v2/Components/v2/ArtworkFilter/ArtworkFilterContext"
 import { userHasLabFeature } from "v2/Utils/user"
+import { PermanentRedirectException } from "v2/Artsy/Router/PermanentRedirectException"
 
 graphql`
   fragment routes_Artist on Artist {
@@ -118,11 +119,13 @@ export const routes: RouteConfig[] = [
       const canShowOverview = showArtistInsights || hasArtistContent
 
       if (pathname === `/artist/${artist.slug}/`) {
-        throw new RedirectException(`/artist/${artist.slug}`)
+        throw new PermanentRedirectException(`/artist/${artist.slug}`)
       }
 
       if (!canShowOverview && !alreadyAtWorksForSalePath) {
-        throw new RedirectException(`/artist/${artist.slug}/works-for-sale`)
+        throw new PermanentRedirectException(
+          `/artist/${artist.slug}/works-for-sale`
+        )
       }
 
       return <Component {...props} />

--- a/src/v2/Artsy/Router/PermanentRedirectException.tsx
+++ b/src/v2/Artsy/Router/PermanentRedirectException.tsx
@@ -1,0 +1,8 @@
+export class PermanentRedirectException extends Error {
+  pathname: string
+
+  constructor(pathname: string) {
+    super()
+    this.pathname = pathname
+  }
+}


### PR DESCRIPTION
[Re: FX-2103](https://artsyproduct.atlassian.net/browse/FX-2103)

![](http://static.damonzucconi.com/_capture/sBwLsmOpA25j.png)

So interestingly, while you can [tack a status code on to your error in found](https://github.com/4Catalyzer/found/blob/42b4944216654b0cad231caccd16f715dca987a6/src/server.js#L87), if that error is a redirect, [it ignores the status.](https://github.com/4Catalyzer/found/blob/42b4944216654b0cad231caccd16f715dca987a6/src/server.js#L69-L77)

I'm not familiar (at all) with found, but this seems like something worth PRing?

In any event, here we create a new exception specifically for permanent redirects and then handle it with the appropriate status code.