### PR TITLE
Ensure messages have space under input, fix input on ipad

### DIFF
--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -218,7 +218,7 @@ const Conversation: React.FC<ConversationProps> = props => {
   return (
     <NoScrollFlex flexDirection="column" width="100%">
       <MessageContainer>
-        <Box>
+        <Box pb={[6, 6, 6, 0]}>
           <Spacer mt={["75px", "75px", 2]} />
           <Flex flexDirection="column" width="100%" px={1}>
             {inquiryItemBox}

--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -125,7 +125,7 @@ export const Reply: React.FC<ReplyProps> = props => {
         p={1}
         right={[0, null]}
         zIndex={[null, 2]}
-        position={["fixed", "static"]}
+        position={["fixed", "fixed", "fixed", "static"]}
         bottom={0}
         left={0}
       >


### PR DESCRIPTION
Okay, last few issues. 

Fixes:
<details>
<summary>Input overlapping last message on mobile</summary>

![image](https://user-images.githubusercontent.com/3087225/88416575-70e0b680-cdae-11ea-88d5-ab1d85197599.png)

</details>
-  Input incorrectly positioned on ipad