### PR TITLE
@sweir27 => [ArtistSeries] Add other series rail to page

### DIFF
--- a/src/v2/Apps/ArtistSeries/ArtistSeriesApp.tsx
+++ b/src/v2/Apps/ArtistSeries/ArtistSeriesApp.tsx
@@ -10,6 +10,7 @@ import { ArtistSeriesHeaderFragmentContainer as ArtistSeriesHeader } from "./Com
 import { ArtistSeriesArtworksFilterRefetchContainer as ArtistSeriesArtworksFilter } from "./Components/ArtistSeriesArtworksFilter"
 import { userHasLabFeature } from "v2/Utils/user"
 import { ErrorPage } from "v2/Components/ErrorPage"
+import { ArtistSeriesRailFragmentContainer as OtherArtistSeriesRail } from "./Components/OtherArtistSeries/ArtistSeriesRail"
 
 interface ArtistSeriesAppProps {
   artistSeries: ArtistSeriesApp_artistSeries
@@ -19,12 +20,15 @@ const ArtistSeriesApp: React.FC<ArtistSeriesAppProps> = ({ artistSeries }) => {
   const { user } = React.useContext(SystemContext)
   const isEnabled = userHasLabFeature(user, "Artist Series")
 
-  if (isEnabled) {
+  if (isEnabled && artistSeries) {
+    const { railArtist } = artistSeries
     return (
       <AppContainer maxWidth="100%">
         <ArtistSeriesHeader artistSeries={artistSeries} />
         <Box m={3}>
           <ArtistSeriesArtworksFilter artistSeries={artistSeries} />
+          <Separator mt={6} mb={3} />
+          <OtherArtistSeriesRail artist={railArtist} />
           <Separator mt={6} mb={3} />
           <Footer />
         </Box>
@@ -59,6 +63,9 @@ export default createFragmentContainer(ArtistSeriesApp, {
         width: { type: "String" }
       ) {
       ...ArtistSeriesHeader_artistSeries
+      railArtist: artists(size: 1) {
+        ...ArtistSeriesRail_artist
+      }
       ...ArtistSeriesArtworksFilter_artistSeries
         @arguments(
           acquireable: $acquireable

--- a/src/v2/Apps/ArtistSeries/Components/OtherArtistSeries/ArtistSeriesItem.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/OtherArtistSeries/ArtistSeriesItem.tsx
@@ -1,0 +1,77 @@
+import { Box, Image, Sans, Spacer, color } from "@artsy/palette"
+import { ArtistSeriesItem_artistSeries } from "v2/__generated__/ArtistSeriesItem_artistSeries.graphql"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import styled from "styled-components"
+
+interface Props {
+  artistSeries: ArtistSeriesItem_artistSeries
+  lazyLoad: boolean
+}
+
+export const ArtistSeriesItem: React.SFC<Props> = props => {
+  const {
+    artistSeries: { slug, title, image, forSaleArtworksCount },
+    lazyLoad,
+  } = props
+
+  return (
+    <Box pr={2}>
+      <StyledLink to={`/artist-series/${slug}`}>
+        <SeriesImage
+          src={image.cropped.url}
+          alt={title}
+          lazyLoad={lazyLoad}
+          width={160}
+          style={{ objectFit: "cover", objectPosition: "center" }}
+        />
+        <Box mt={1} ml={1}>
+          <SeriesTitle size={"3"}>{title}</SeriesTitle>
+          <Spacer />
+          <Sans size={"3"} color={"black30"}>
+            {forSaleArtworksCount} available
+          </Sans>
+        </Box>
+      </StyledLink>
+    </Box>
+  )
+}
+
+const SeriesTitle = styled(Sans)`
+  width: max-content;
+`
+
+const StyledLink = styled(RouterLink)`
+  text-decoration: none;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+
+  &:hover {
+    text-decoration: none;
+  }
+`
+
+export const SeriesImage = styled(Image)<{ width: number }>`
+  width: ${({ width }) => width}px;
+  height: 160px;
+  background-color: ${color("black10")};
+  opacity: 0.9;
+`
+
+export const ArtistSeriesItemFragmentContainer = createFragmentContainer(
+  ArtistSeriesItem,
+  {
+    artistSeries: graphql`
+      fragment ArtistSeriesItem_artistSeries on ArtistSeries {
+        title
+        slug
+        forSaleArtworksCount
+        image {
+          cropped(width: 160, height: 160) {
+            url
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/ArtistSeries/Components/OtherArtistSeries/ArtistSeriesRail.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/OtherArtistSeries/ArtistSeriesRail.tsx
@@ -1,0 +1,90 @@
+import { Box, Sans } from "@artsy/palette"
+import { ArrowButton, Carousel } from "v2/Components/Carousel"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import styled from "styled-components"
+import { getENV } from "v2/Utils/getENV"
+import { ArtistSeriesRail_artist } from "v2/__generated__/ArtistSeriesRail_artist.graphql"
+import { ArtistSeriesItemFragmentContainer as ArtistSeriesItem } from "./ArtistSeriesItem"
+
+interface Props {
+  artist: ArtistSeriesRail_artist
+}
+
+const ArtistSeriesRail: React.SFC<Props> = props => {
+  const isMobile = getENV("IS_MOBILE") === true
+  const { artist } = props
+
+  if (!artist.length) return null
+
+  const edges =
+    artist[0].artistSeriesConnection && artist[0].artistSeriesConnection.edges
+
+  if (edges.length) {
+    return (
+      <Box my={3}>
+        <Sans size="4" color="black100" my={1}>
+          More series by this artist
+        </Sans>
+
+        <Box mx={[-20, 0]}>
+          <Carousel
+            height={200}
+            options={{
+              pageDots: false,
+            }}
+            data={edges}
+            render={(slide, index: number) => {
+              const { node } = slide
+              return (
+                <Box ml={isMobile && index === 0 ? 2 : 0}>
+                  <ArtistSeriesItem lazyLoad={index > 5} artistSeries={node} />
+                </Box>
+              )
+            }}
+            renderLeftArrow={({ Arrow }) => {
+              return (
+                <ArrowContainer>
+                  <Arrow />
+                </ArrowContainer>
+              )
+            }}
+            renderRightArrow={({ Arrow }) => {
+              return (
+                <ArrowContainer>{edges.length > 4 && <Arrow />}</ArrowContainer>
+              )
+            }}
+          />
+        </Box>
+      </Box>
+    )
+  } else {
+    return null
+  }
+}
+
+const ArrowContainer = styled(Box)`
+  align-self: flex-start;
+
+  ${ArrowButton} {
+    height: 80%;
+  }
+`
+
+export const ArtistSeriesRailFragmentContainer = createFragmentContainer(
+  ArtistSeriesRail,
+  {
+    artist: graphql`
+      fragment ArtistSeriesRail_artist on Artist @relay(plural: true) {
+        artistSeriesConnection {
+          edges {
+            node {
+              internalID
+              ...ArtistSeriesItem_artistSeries
+            }
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/ArtistSeries/Components/OtherArtistSeries/index.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/OtherArtistSeries/index.tsx
@@ -1,0 +1,36 @@
+import { Box } from "@artsy/palette"
+import { useSystemContext } from "v2/Artsy"
+import { renderWithLoadProgress } from "v2/Artsy/Relay/renderWithLoadProgress"
+import { SystemQueryRenderer as QueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
+import React from "react"
+import { graphql } from "react-relay"
+import { ArtistSeriesRailFragmentContainer as ArtistSeriesRail } from "./ArtistSeriesRail"
+import { OtherArtistSeriesQuery } from "v2/__generated__/OtherArtistSeriesQuery.graphql"
+
+interface Props {
+  artistID: string
+}
+
+export const ArtistSeriesQueryRenderer: React.SFC<Props> = props => {
+  const { relayEnvironment } = useSystemContext()
+  const { artistID } = props
+
+  return (
+    <Box>
+      <QueryRenderer<OtherArtistSeriesQuery>
+        environment={relayEnvironment}
+        variables={{
+          artistID,
+        }}
+        query={graphql`
+          query OtherArtistSeriesQuery($artistID: String!) {
+            artist(id: $artistID) {
+              ...ArtistSeriesRail_artist
+            }
+          }
+        `}
+        render={renderWithLoadProgress(ArtistSeriesRail)}
+      />
+    </Box>
+  )
+}

--- a/src/v2/Apps/ArtistSeries/__tests__/ArtistSeriesApp.jest.tsx
+++ b/src/v2/Apps/ArtistSeries/__tests__/ArtistSeriesApp.jest.tsx
@@ -57,6 +57,7 @@ describe("ArtistSeriesApp", () => {
         expect(wrapper.find("AppContainer").length).toBe(1)
         expect(wrapper.find("ArtistSeriesHeader").length).toBe(1)
         expect(wrapper.find("ArtistSeriesArtworksFilter").length).toBe(1)
+        expect(wrapper.find("ArtistSeriesRail").length).toBe(1)
       })
 
       describe("ArtistSeriesArtworksFilter", () => {
@@ -128,6 +129,22 @@ describe("ArtistSeriesApp", () => {
           })
         })
       })
+
+      describe("ArtistSeriesRail", () => {
+        describe("with an artist", () => {
+          it("renders correctly", async () => {
+            const wrapper = await getWrapper()
+            expect(wrapper.find("ArtistSeriesRail").length).toBe(1)
+            expect(wrapper.find("ArtistSeriesItem").length).toBe(1)
+            expect(wrapper.find("ArtistSeriesItem").text()).toContain(
+              "Aardvark Series"
+            )
+            expect(wrapper.find("ArtistSeriesItem").text()).toContain(
+              "20 available"
+            )
+          })
+        })
+      })
     })
   })
 
@@ -171,6 +188,28 @@ describe("ArtistSeriesApp", () => {
 
 const ArtistSeriesAppFixture: ArtistSeriesApp_QueryRawResponse = {
   artistSeries: {
+    railArtist: [
+      {
+        id: "yayoi-kusama",
+        artistSeriesConnection: {
+          edges: [
+            {
+              node: {
+                internalID: "id",
+                slug: "aardvark",
+                forSaleArtworksCount: 20,
+                image: {
+                  cropped: {
+                    url: "/path/to/aardvarks.jpg",
+                  },
+                },
+                title: "Aardvark Series",
+              },
+            },
+          ],
+        },
+      },
+    ],
     title: "Pumpkins",
     description: "All of the pumpkins",
     image: {
@@ -356,6 +395,7 @@ const ArtistSeriesWithoutArtistAppFixture: ArtistSeriesApp_QueryRawResponse = {
   artistSeries: {
     ...ArtistSeriesAppFixture.artistSeries,
     artists: [],
+    railArtist: [],
   },
 }
 

--- a/src/v2/__generated__/ArtistSeriesApp_Query.graphql.ts
+++ b/src/v2/__generated__/ArtistSeriesApp_Query.graphql.ts
@@ -32,6 +32,24 @@ export type ArtistSeriesApp_QueryRawResponse = {
                 readonly follows: number | null;
             }) | null;
         }) | null> | null;
+        readonly railArtist: ReadonlyArray<({
+            readonly artistSeriesConnection: ({
+                readonly edges: ReadonlyArray<({
+                    readonly node: ({
+                        readonly internalID: string;
+                        readonly title: string;
+                        readonly slug: string;
+                        readonly forSaleArtworksCount: number;
+                        readonly image: ({
+                            readonly cropped: ({
+                                readonly url: string | null;
+                            }) | null;
+                        }) | null;
+                    }) | null;
+                }) | null> | null;
+            }) | null;
+            readonly id: string | null;
+        }) | null> | null;
         readonly filtered_artworks: ({
             readonly id: string;
             readonly aggregations: ReadonlyArray<({
@@ -144,6 +162,10 @@ query ArtistSeriesApp_Query(
 
 fragment ArtistSeriesApp_artistSeries on ArtistSeries {
   ...ArtistSeriesHeader_artistSeries
+  railArtist: artists(size: 1) {
+    ...ArtistSeriesRail_artist
+    id
+  }
   ...ArtistSeriesArtworksFilter_artistSeries_1QCCZM
 }
 
@@ -169,6 +191,28 @@ fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
     slug
     ...FollowArtistButton_artist
     id
+  }
+}
+
+fragment ArtistSeriesItem_artistSeries on ArtistSeries {
+  title
+  slug
+  forSaleArtworksCount
+  image {
+    cropped(width: 160, height: 160) {
+      url
+    }
+  }
+}
+
+fragment ArtistSeriesRail_artist on Artist {
+  artistSeriesConnection {
+    edges {
+      node {
+        internalID
+        ...ArtistSeriesItem_artistSeries
+      }
+    }
   }
 }
 
@@ -375,7 +419,16 @@ v2 = {
   "args": null,
   "storageKey": null
 },
-v3 = {
+v3 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "url",
+    "args": null,
+    "storageKey": null
+  }
+],
+v4 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "image",
@@ -383,68 +436,67 @@ v3 = {
   "args": null,
   "concreteType": "Image",
   "plural": false,
-  "selections": [
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "url",
-      "args": null,
-      "storageKey": null
-    }
-  ]
+  "selections": (v3/*: any*/)
 },
-v4 = {
+v5 = [
+  {
+    "kind": "Literal",
+    "name": "size",
+    "value": 1
+  }
+],
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v5 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "slug",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "internalID",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v11 = [
-  (v9/*: any*/),
-  (v10/*: any*/),
+v13 = [
+  (v11/*: any*/),
+  (v12/*: any*/),
   {
     "kind": "ScalarField",
     "alias": null,
@@ -453,14 +505,14 @@ v11 = [
     "storageKey": null
   }
 ],
-v12 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v13 = [
+v15 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -518,28 +570,22 @@ return {
             "args": null,
             "storageKey": null
           },
-          (v3/*: any*/),
+          (v4/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
             "name": "artists",
             "storageKey": "artists(size:1)",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "size",
-                "value": 1
-              }
-            ],
+            "args": (v5/*: any*/),
             "concreteType": "Artist",
             "plural": true,
             "selections": [
-              (v4/*: any*/),
-              (v3/*: any*/),
-              (v5/*: any*/),
               (v6/*: any*/),
+              (v4/*: any*/),
               (v7/*: any*/),
               (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": "is_followed",
@@ -565,6 +611,93 @@ return {
                   }
                 ]
               }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": "railArtist",
+            "name": "artists",
+            "storageKey": "artists(size:1)",
+            "args": (v5/*: any*/),
+            "concreteType": "Artist",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "artistSeriesConnection",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtistSeriesConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistSeriesEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ArtistSeries",
+                        "plural": false,
+                        "selections": [
+                          (v10/*: any*/),
+                          (v2/*: any*/),
+                          (v8/*: any*/),
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "forSaleArtworksCount",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "cropped",
+                                "storageKey": "cropped(height:160,width:160)",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "height",
+                                    "value": 160
+                                  },
+                                  {
+                                    "kind": "Literal",
+                                    "name": "width",
+                                    "value": 160
+                                  }
+                                ],
+                                "concreteType": "CroppedImageUrl",
+                                "plural": false,
+                                "selections": (v3/*: any*/)
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              (v9/*: any*/)
             ]
           },
           {
@@ -597,7 +730,7 @@ return {
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
+              (v9/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -630,7 +763,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v4/*: any*/),
+                      (v6/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -684,7 +817,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": true,
-                    "selections": (v11/*: any*/)
+                    "selections": (v13/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -694,7 +827,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v11/*: any*/)
+                    "selections": (v13/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -704,7 +837,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v11/*: any*/)
+                    "selections": (v13/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -715,8 +848,8 @@ return {
                     "concreteType": "PageCursor",
                     "plural": false,
                     "selections": [
-                      (v9/*: any*/),
-                      (v10/*: any*/)
+                      (v11/*: any*/),
+                      (v12/*: any*/)
                     ]
                   }
                 ]
@@ -739,10 +872,10 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v7/*: any*/),
-                      (v6/*: any*/),
-                      (v5/*: any*/),
+                      (v9/*: any*/),
                       (v8/*: any*/),
+                      (v7/*: any*/),
+                      (v10/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -815,13 +948,13 @@ return {
                         "alias": null,
                         "name": "artists",
                         "storageKey": "artists(shallow:true)",
-                        "args": (v12/*: any*/),
+                        "args": (v14/*: any*/),
                         "concreteType": "Artist",
                         "plural": true,
                         "selections": [
+                          (v9/*: any*/),
                           (v7/*: any*/),
-                          (v5/*: any*/),
-                          (v4/*: any*/)
+                          (v6/*: any*/)
                         ]
                       },
                       {
@@ -836,13 +969,13 @@ return {
                         "alias": null,
                         "name": "partner",
                         "storageKey": "partner(shallow:true)",
-                        "args": (v12/*: any*/),
+                        "args": (v14/*: any*/),
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v5/*: any*/),
+                          (v6/*: any*/),
                           (v7/*: any*/),
+                          (v9/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -875,7 +1008,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v7/*: any*/),
+                          (v9/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": "is_live_open",
@@ -941,7 +1074,7 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkHighestBid",
                             "plural": false,
-                            "selections": (v13/*: any*/)
+                            "selections": (v15/*: any*/)
                           },
                           {
                             "kind": "LinkedField",
@@ -951,9 +1084,9 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkOpeningBid",
                             "plural": false,
-                            "selections": (v13/*: any*/)
+                            "selections": (v15/*: any*/)
                           },
-                          (v7/*: any*/)
+                          (v9/*: any*/)
                         ]
                       },
                       {
@@ -979,7 +1112,7 @@ return {
                       }
                     ]
                   },
-                  (v7/*: any*/)
+                  (v9/*: any*/)
                 ]
               }
             ]
@@ -992,7 +1125,7 @@ return {
     "operationKind": "query",
     "name": "ArtistSeriesApp_Query",
     "id": null,
-    "text": "query ArtistSeriesApp_Query(\n  $slug: ID!\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesApp_artistSeries\n  }\n}\n\nfragment ArtistSeriesApp_artistSeries on ArtistSeries {\n  ...ArtistSeriesHeader_artistSeries\n  ...ArtistSeriesArtworksFilter_artistSeries_1QCCZM\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries_1QCCZM on ArtistSeries {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-partner_updated_at\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtistSeriesHeader_artistSeries on ArtistSeries {\n  title\n  description\n  image {\n    url\n  }\n  artists(size: 1) {\n    name\n    image {\n      url\n    }\n    href\n    slug\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query ArtistSeriesApp_Query(\n  $slug: ID!\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesApp_artistSeries\n  }\n}\n\nfragment ArtistSeriesApp_artistSeries on ArtistSeries {\n  ...ArtistSeriesHeader_artistSeries\n  railArtist: artists(size: 1) {\n    ...ArtistSeriesRail_artist\n    id\n  }\n  ...ArtistSeriesArtworksFilter_artistSeries_1QCCZM\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries_1QCCZM on ArtistSeries {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-partner_updated_at\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtistSeriesHeader_artistSeries on ArtistSeries {\n  title\n  description\n  image {\n    url\n  }\n  artists(size: 1) {\n    name\n    image {\n      url\n    }\n    href\n    slug\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment ArtistSeriesItem_artistSeries on ArtistSeries {\n  title\n  slug\n  forSaleArtworksCount\n  image {\n    cropped(width: 160, height: 160) {\n      url\n    }\n  }\n}\n\nfragment ArtistSeriesRail_artist on Artist {\n  artistSeriesConnection {\n    edges {\n      node {\n        internalID\n        ...ArtistSeriesItem_artistSeries\n      }\n    }\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
     "metadata": {}
   }
 };

--- a/src/v2/__generated__/ArtistSeriesApp_UnfoundTest_Query.graphql.ts
+++ b/src/v2/__generated__/ArtistSeriesApp_UnfoundTest_Query.graphql.ts
@@ -32,6 +32,24 @@ export type ArtistSeriesApp_UnfoundTest_QueryRawResponse = {
                 readonly follows: number | null;
             }) | null;
         }) | null> | null;
+        readonly railArtist: ReadonlyArray<({
+            readonly artistSeriesConnection: ({
+                readonly edges: ReadonlyArray<({
+                    readonly node: ({
+                        readonly internalID: string;
+                        readonly title: string;
+                        readonly slug: string;
+                        readonly forSaleArtworksCount: number;
+                        readonly image: ({
+                            readonly cropped: ({
+                                readonly url: string | null;
+                            }) | null;
+                        }) | null;
+                    }) | null;
+                }) | null> | null;
+            }) | null;
+            readonly id: string | null;
+        }) | null> | null;
         readonly filtered_artworks: ({
             readonly id: string;
             readonly aggregations: ReadonlyArray<({
@@ -144,6 +162,10 @@ query ArtistSeriesApp_UnfoundTest_Query(
 
 fragment ArtistSeriesApp_artistSeries on ArtistSeries {
   ...ArtistSeriesHeader_artistSeries
+  railArtist: artists(size: 1) {
+    ...ArtistSeriesRail_artist
+    id
+  }
   ...ArtistSeriesArtworksFilter_artistSeries_1QCCZM
 }
 
@@ -169,6 +191,28 @@ fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
     slug
     ...FollowArtistButton_artist
     id
+  }
+}
+
+fragment ArtistSeriesItem_artistSeries on ArtistSeries {
+  title
+  slug
+  forSaleArtworksCount
+  image {
+    cropped(width: 160, height: 160) {
+      url
+    }
+  }
+}
+
+fragment ArtistSeriesRail_artist on Artist {
+  artistSeriesConnection {
+    edges {
+      node {
+        internalID
+        ...ArtistSeriesItem_artistSeries
+      }
+    }
   }
 }
 
@@ -375,7 +419,16 @@ v2 = {
   "args": null,
   "storageKey": null
 },
-v3 = {
+v3 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "url",
+    "args": null,
+    "storageKey": null
+  }
+],
+v4 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "image",
@@ -383,68 +436,67 @@ v3 = {
   "args": null,
   "concreteType": "Image",
   "plural": false,
-  "selections": [
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "url",
-      "args": null,
-      "storageKey": null
-    }
-  ]
+  "selections": (v3/*: any*/)
 },
-v4 = {
+v5 = [
+  {
+    "kind": "Literal",
+    "name": "size",
+    "value": 1
+  }
+],
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v5 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "slug",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "internalID",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v11 = [
-  (v9/*: any*/),
-  (v10/*: any*/),
+v13 = [
+  (v11/*: any*/),
+  (v12/*: any*/),
   {
     "kind": "ScalarField",
     "alias": null,
@@ -453,14 +505,14 @@ v11 = [
     "storageKey": null
   }
 ],
-v12 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v13 = [
+v15 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -518,28 +570,22 @@ return {
             "args": null,
             "storageKey": null
           },
-          (v3/*: any*/),
+          (v4/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
             "name": "artists",
             "storageKey": "artists(size:1)",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "size",
-                "value": 1
-              }
-            ],
+            "args": (v5/*: any*/),
             "concreteType": "Artist",
             "plural": true,
             "selections": [
-              (v4/*: any*/),
-              (v3/*: any*/),
-              (v5/*: any*/),
               (v6/*: any*/),
+              (v4/*: any*/),
               (v7/*: any*/),
               (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": "is_followed",
@@ -565,6 +611,93 @@ return {
                   }
                 ]
               }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": "railArtist",
+            "name": "artists",
+            "storageKey": "artists(size:1)",
+            "args": (v5/*: any*/),
+            "concreteType": "Artist",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "artistSeriesConnection",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtistSeriesConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistSeriesEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ArtistSeries",
+                        "plural": false,
+                        "selections": [
+                          (v10/*: any*/),
+                          (v2/*: any*/),
+                          (v8/*: any*/),
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "forSaleArtworksCount",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "cropped",
+                                "storageKey": "cropped(height:160,width:160)",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "height",
+                                    "value": 160
+                                  },
+                                  {
+                                    "kind": "Literal",
+                                    "name": "width",
+                                    "value": 160
+                                  }
+                                ],
+                                "concreteType": "CroppedImageUrl",
+                                "plural": false,
+                                "selections": (v3/*: any*/)
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              (v9/*: any*/)
             ]
           },
           {
@@ -597,7 +730,7 @@ return {
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
+              (v9/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -630,7 +763,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v4/*: any*/),
+                      (v6/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -684,7 +817,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": true,
-                    "selections": (v11/*: any*/)
+                    "selections": (v13/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -694,7 +827,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v11/*: any*/)
+                    "selections": (v13/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -704,7 +837,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v11/*: any*/)
+                    "selections": (v13/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -715,8 +848,8 @@ return {
                     "concreteType": "PageCursor",
                     "plural": false,
                     "selections": [
-                      (v9/*: any*/),
-                      (v10/*: any*/)
+                      (v11/*: any*/),
+                      (v12/*: any*/)
                     ]
                   }
                 ]
@@ -739,10 +872,10 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v7/*: any*/),
-                      (v6/*: any*/),
-                      (v5/*: any*/),
+                      (v9/*: any*/),
                       (v8/*: any*/),
+                      (v7/*: any*/),
+                      (v10/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -815,13 +948,13 @@ return {
                         "alias": null,
                         "name": "artists",
                         "storageKey": "artists(shallow:true)",
-                        "args": (v12/*: any*/),
+                        "args": (v14/*: any*/),
                         "concreteType": "Artist",
                         "plural": true,
                         "selections": [
+                          (v9/*: any*/),
                           (v7/*: any*/),
-                          (v5/*: any*/),
-                          (v4/*: any*/)
+                          (v6/*: any*/)
                         ]
                       },
                       {
@@ -836,13 +969,13 @@ return {
                         "alias": null,
                         "name": "partner",
                         "storageKey": "partner(shallow:true)",
-                        "args": (v12/*: any*/),
+                        "args": (v14/*: any*/),
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v5/*: any*/),
+                          (v6/*: any*/),
                           (v7/*: any*/),
+                          (v9/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -875,7 +1008,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v7/*: any*/),
+                          (v9/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": "is_live_open",
@@ -941,7 +1074,7 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkHighestBid",
                             "plural": false,
-                            "selections": (v13/*: any*/)
+                            "selections": (v15/*: any*/)
                           },
                           {
                             "kind": "LinkedField",
@@ -951,9 +1084,9 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkOpeningBid",
                             "plural": false,
-                            "selections": (v13/*: any*/)
+                            "selections": (v15/*: any*/)
                           },
-                          (v7/*: any*/)
+                          (v9/*: any*/)
                         ]
                       },
                       {
@@ -979,7 +1112,7 @@ return {
                       }
                     ]
                   },
-                  (v7/*: any*/)
+                  (v9/*: any*/)
                 ]
               }
             ]
@@ -992,7 +1125,7 @@ return {
     "operationKind": "query",
     "name": "ArtistSeriesApp_UnfoundTest_Query",
     "id": null,
-    "text": "query ArtistSeriesApp_UnfoundTest_Query(\n  $slug: ID!\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesApp_artistSeries\n  }\n}\n\nfragment ArtistSeriesApp_artistSeries on ArtistSeries {\n  ...ArtistSeriesHeader_artistSeries\n  ...ArtistSeriesArtworksFilter_artistSeries_1QCCZM\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries_1QCCZM on ArtistSeries {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-partner_updated_at\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtistSeriesHeader_artistSeries on ArtistSeries {\n  title\n  description\n  image {\n    url\n  }\n  artists(size: 1) {\n    name\n    image {\n      url\n    }\n    href\n    slug\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query ArtistSeriesApp_UnfoundTest_Query(\n  $slug: ID!\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesApp_artistSeries\n  }\n}\n\nfragment ArtistSeriesApp_artistSeries on ArtistSeries {\n  ...ArtistSeriesHeader_artistSeries\n  railArtist: artists(size: 1) {\n    ...ArtistSeriesRail_artist\n    id\n  }\n  ...ArtistSeriesArtworksFilter_artistSeries_1QCCZM\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries_1QCCZM on ArtistSeries {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-partner_updated_at\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtistSeriesHeader_artistSeries on ArtistSeries {\n  title\n  description\n  image {\n    url\n  }\n  artists(size: 1) {\n    name\n    image {\n      url\n    }\n    href\n    slug\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment ArtistSeriesItem_artistSeries on ArtistSeries {\n  title\n  slug\n  forSaleArtworksCount\n  image {\n    cropped(width: 160, height: 160) {\n      url\n    }\n  }\n}\n\nfragment ArtistSeriesRail_artist on Artist {\n  artistSeriesConnection {\n    edges {\n      node {\n        internalID\n        ...ArtistSeriesItem_artistSeries\n      }\n    }\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
     "metadata": {}
   }
 };

--- a/src/v2/__generated__/ArtistSeriesApp_artistSeries.graphql.ts
+++ b/src/v2/__generated__/ArtistSeriesApp_artistSeries.graphql.ts
@@ -3,6 +3,9 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistSeriesApp_artistSeries = {
+    readonly railArtist: ReadonlyArray<{
+        readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesRail_artist">;
+    } | null> | null;
     readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesHeader_artistSeries" | "ArtistSeriesArtworksFilter_artistSeries">;
     readonly " $refType": "ArtistSeriesApp_artistSeries";
 };
@@ -131,6 +134,28 @@ const node: ReaderFragment = {
   ],
   "selections": [
     {
+      "kind": "LinkedField",
+      "alias": "railArtist",
+      "name": "artists",
+      "storageKey": "artists(size:1)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "size",
+          "value": 1
+        }
+      ],
+      "concreteType": "Artist",
+      "plural": true,
+      "selections": [
+        {
+          "kind": "FragmentSpread",
+          "name": "ArtistSeriesRail_artist",
+          "args": null
+        }
+      ]
+    },
+    {
       "kind": "FragmentSpread",
       "name": "ArtistSeriesHeader_artistSeries",
       "args": null
@@ -233,5 +258,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '0bd3e085761715c13ee2392434b6e676';
+(node as any).hash = '54f2094f5c9c3096ee854fe89b4b35f2';
 export default node;

--- a/src/v2/__generated__/ArtistSeriesItem_artistSeries.graphql.ts
+++ b/src/v2/__generated__/ArtistSeriesItem_artistSeries.graphql.ts
@@ -1,0 +1,95 @@
+/* tslint:disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistSeriesItem_artistSeries = {
+    readonly title: string;
+    readonly slug: string;
+    readonly forSaleArtworksCount: number;
+    readonly image: {
+        readonly cropped: {
+            readonly url: string | null;
+        } | null;
+    } | null;
+    readonly " $refType": "ArtistSeriesItem_artistSeries";
+};
+export type ArtistSeriesItem_artistSeries$data = ArtistSeriesItem_artistSeries;
+export type ArtistSeriesItem_artistSeries$key = {
+    readonly " $data"?: ArtistSeriesItem_artistSeries$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesItem_artistSeries">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "ArtistSeriesItem_artistSeries",
+  "type": "ArtistSeries",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "title",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "slug",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "forSaleArtworksCount",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "image",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Image",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "cropped",
+          "storageKey": "cropped(height:160,width:160)",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 160
+            },
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 160
+            }
+          ],
+          "concreteType": "CroppedImageUrl",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "url",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = '7819304847a520aab927606e86cac175';
+export default node;

--- a/src/v2/__generated__/ArtistSeriesRail_artist.graphql.ts
+++ b/src/v2/__generated__/ArtistSeriesRail_artist.graphql.ts
@@ -1,0 +1,81 @@
+/* tslint:disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistSeriesRail_artist = ReadonlyArray<{
+    readonly artistSeriesConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string;
+                readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesItem_artistSeries">;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "ArtistSeriesRail_artist";
+}>;
+export type ArtistSeriesRail_artist$data = ArtistSeriesRail_artist;
+export type ArtistSeriesRail_artist$key = ReadonlyArray<{
+    readonly " $data"?: ArtistSeriesRail_artist$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesRail_artist">;
+}>;
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "ArtistSeriesRail_artist",
+  "type": "Artist",
+  "metadata": {
+    "plural": true
+  },
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "artistSeriesConnection",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "ArtistSeriesConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ArtistSeriesEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "ArtistSeries",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "internalID",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "FragmentSpread",
+                  "name": "ArtistSeriesItem_artistSeries",
+                  "args": null
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = '441dcf9c58d322b2b531faf79eb5bdb8';
+export default node;

--- a/src/v2/__generated__/OtherArtistSeriesQuery.graphql.ts
+++ b/src/v2/__generated__/OtherArtistSeriesQuery.graphql.ts
@@ -1,0 +1,232 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type OtherArtistSeriesQueryVariables = {
+    artistID: string;
+};
+export type OtherArtistSeriesQueryResponse = {
+    readonly artist: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesRail_artist">;
+    } | null;
+};
+export type OtherArtistSeriesQuery = {
+    readonly response: OtherArtistSeriesQueryResponse;
+    readonly variables: OtherArtistSeriesQueryVariables;
+};
+
+
+
+/*
+query OtherArtistSeriesQuery(
+  $artistID: String!
+) {
+  artist(id: $artistID) {
+    ...ArtistSeriesRail_artist
+    id
+  }
+}
+
+fragment ArtistSeriesItem_artistSeries on ArtistSeries {
+  title
+  slug
+  forSaleArtworksCount
+  image {
+    cropped(width: 160, height: 160) {
+      url
+    }
+  }
+}
+
+fragment ArtistSeriesRail_artist on Artist {
+  artistSeriesConnection {
+    edges {
+      node {
+        internalID
+        ...ArtistSeriesItem_artistSeries
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "artistID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artistID"
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "OtherArtistSeriesQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ArtistSeriesRail_artist",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "OtherArtistSeriesQuery",
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artist",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artistSeriesConnection",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "ArtistSeriesConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtistSeriesEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistSeries",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "internalID",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "title",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "slug",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "forSaleArtworksCount",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "cropped",
+                            "storageKey": "cropped(height:160,width:160)",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 160
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 160
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "OtherArtistSeriesQuery",
+    "id": null,
+    "text": "query OtherArtistSeriesQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistSeriesRail_artist\n    id\n  }\n}\n\nfragment ArtistSeriesItem_artistSeries on ArtistSeries {\n  title\n  slug\n  forSaleArtworksCount\n  image {\n    cropped(width: 160, height: 160) {\n      url\n    }\n  }\n}\n\nfragment ArtistSeriesRail_artist on Artist {\n  artistSeriesConnection {\n    edges {\n      node {\n        internalID\n        ...ArtistSeriesItem_artistSeries\n      }\n    }\n  }\n}\n",
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = 'd38677c2c96dd1e176db92437cc0743b';
+export default node;

--- a/src/v2/__generated__/routes_ArtistSeriesQuery.graphql.ts
+++ b/src/v2/__generated__/routes_ArtistSeriesQuery.graphql.ts
@@ -66,6 +66,10 @@ query routes_ArtistSeriesQuery(
 
 fragment ArtistSeriesApp_artistSeries_1DvBHA on ArtistSeries {
   ...ArtistSeriesHeader_artistSeries
+  railArtist: artists(size: 1) {
+    ...ArtistSeriesRail_artist
+    id
+  }
   ...ArtistSeriesArtworksFilter_artistSeries_1DvBHA
 }
 
@@ -91,6 +95,28 @@ fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
     slug
     ...FollowArtistButton_artist
     id
+  }
+}
+
+fragment ArtistSeriesItem_artistSeries on ArtistSeries {
+  title
+  slug
+  forSaleArtworksCount
+  image {
+    cropped(width: 160, height: 160) {
+      url
+    }
+  }
+}
+
+fragment ArtistSeriesRail_artist on Artist {
+  artistSeriesConnection {
+    edges {
+      node {
+        internalID
+        ...ArtistSeriesItem_artistSeries
+      }
+    }
   }
 }
 
@@ -501,7 +527,16 @@ v20 = {
   "args": null,
   "storageKey": null
 },
-v21 = {
+v21 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "url",
+    "args": null,
+    "storageKey": null
+  }
+],
+v22 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "image",
@@ -509,68 +544,67 @@ v21 = {
   "args": null,
   "concreteType": "Image",
   "plural": false,
-  "selections": [
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "url",
-      "args": null,
-      "storageKey": null
-    }
-  ]
+  "selections": (v21/*: any*/)
 },
-v22 = {
+v23 = [
+  {
+    "kind": "Literal",
+    "name": "size",
+    "value": 1
+  }
+],
+v24 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v23 = {
+v25 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v24 = {
+v26 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "slug",
   "args": null,
   "storageKey": null
 },
-v25 = {
+v27 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v26 = {
+v28 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "internalID",
   "args": null,
   "storageKey": null
 },
-v27 = {
+v29 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v28 = {
+v30 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v29 = [
-  (v27/*: any*/),
-  (v28/*: any*/),
+v31 = [
+  (v29/*: any*/),
+  (v30/*: any*/),
   {
     "kind": "ScalarField",
     "alias": null,
@@ -579,14 +613,14 @@ v29 = [
     "storageKey": null
   }
 ],
-v30 = [
+v32 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v31 = [
+v33 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -663,28 +697,22 @@ return {
             "args": null,
             "storageKey": null
           },
-          (v21/*: any*/),
+          (v22/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
             "name": "artists",
             "storageKey": "artists(size:1)",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "size",
-                "value": 1
-              }
-            ],
+            "args": (v23/*: any*/),
             "concreteType": "Artist",
             "plural": true,
             "selections": [
-              (v22/*: any*/),
-              (v21/*: any*/),
-              (v23/*: any*/),
               (v24/*: any*/),
+              (v22/*: any*/),
               (v25/*: any*/),
               (v26/*: any*/),
+              (v27/*: any*/),
+              (v28/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": "is_followed",
@@ -710,6 +738,93 @@ return {
                   }
                 ]
               }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": "railArtist",
+            "name": "artists",
+            "storageKey": "artists(size:1)",
+            "args": (v23/*: any*/),
+            "concreteType": "Artist",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "artistSeriesConnection",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtistSeriesConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistSeriesEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ArtistSeries",
+                        "plural": false,
+                        "selections": [
+                          (v28/*: any*/),
+                          (v20/*: any*/),
+                          (v26/*: any*/),
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "forSaleArtworksCount",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "cropped",
+                                "storageKey": "cropped(height:160,width:160)",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "height",
+                                    "value": 160
+                                  },
+                                  {
+                                    "kind": "Literal",
+                                    "name": "width",
+                                    "value": 160
+                                  }
+                                ],
+                                "concreteType": "CroppedImageUrl",
+                                "plural": false,
+                                "selections": (v21/*: any*/)
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              (v27/*: any*/)
             ]
           },
           {
@@ -750,7 +865,7 @@ return {
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
-              (v25/*: any*/),
+              (v27/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -783,7 +898,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v22/*: any*/),
+                      (v24/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -837,7 +952,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": true,
-                    "selections": (v29/*: any*/)
+                    "selections": (v31/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -847,7 +962,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v29/*: any*/)
+                    "selections": (v31/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -857,7 +972,7 @@ return {
                     "args": null,
                     "concreteType": "PageCursor",
                     "plural": false,
-                    "selections": (v29/*: any*/)
+                    "selections": (v31/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -868,8 +983,8 @@ return {
                     "concreteType": "PageCursor",
                     "plural": false,
                     "selections": [
-                      (v27/*: any*/),
-                      (v28/*: any*/)
+                      (v29/*: any*/),
+                      (v30/*: any*/)
                     ]
                   }
                 ]
@@ -892,10 +1007,10 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v25/*: any*/),
-                      (v24/*: any*/),
-                      (v23/*: any*/),
+                      (v27/*: any*/),
                       (v26/*: any*/),
+                      (v25/*: any*/),
+                      (v28/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -968,13 +1083,13 @@ return {
                         "alias": null,
                         "name": "artists",
                         "storageKey": "artists(shallow:true)",
-                        "args": (v30/*: any*/),
+                        "args": (v32/*: any*/),
                         "concreteType": "Artist",
                         "plural": true,
                         "selections": [
+                          (v27/*: any*/),
                           (v25/*: any*/),
-                          (v23/*: any*/),
-                          (v22/*: any*/)
+                          (v24/*: any*/)
                         ]
                       },
                       {
@@ -989,13 +1104,13 @@ return {
                         "alias": null,
                         "name": "partner",
                         "storageKey": "partner(shallow:true)",
-                        "args": (v30/*: any*/),
+                        "args": (v32/*: any*/),
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v22/*: any*/),
-                          (v23/*: any*/),
+                          (v24/*: any*/),
                           (v25/*: any*/),
+                          (v27/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1028,7 +1143,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v25/*: any*/),
+                          (v27/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": "is_live_open",
@@ -1094,7 +1209,7 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkHighestBid",
                             "plural": false,
-                            "selections": (v31/*: any*/)
+                            "selections": (v33/*: any*/)
                           },
                           {
                             "kind": "LinkedField",
@@ -1104,9 +1219,9 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkOpeningBid",
                             "plural": false,
-                            "selections": (v31/*: any*/)
+                            "selections": (v33/*: any*/)
                           },
-                          (v25/*: any*/)
+                          (v27/*: any*/)
                         ]
                       },
                       {
@@ -1132,7 +1247,7 @@ return {
                       }
                     ]
                   },
-                  (v25/*: any*/)
+                  (v27/*: any*/)
                 ]
               }
             ]
@@ -1145,7 +1260,7 @@ return {
     "operationKind": "query",
     "name": "routes_ArtistSeriesQuery",
     "id": null,
-    "text": "query routes_ArtistSeriesQuery(\n  $slug: ID!\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD]\n  $atAuction: Boolean\n  $attributionClass: [String]\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $keyword: String\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sizes: [ArtworkSizes]\n  $sort: String\n  $width: String\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesApp_artistSeries_1DvBHA\n  }\n}\n\nfragment ArtistSeriesApp_artistSeries_1DvBHA on ArtistSeries {\n  ...ArtistSeriesHeader_artistSeries\n  ...ArtistSeriesArtworksFilter_artistSeries_1DvBHA\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries_1DvBHA on ArtistSeries {\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: \"\", sort: $sort, width: $width) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtistSeriesHeader_artistSeries on ArtistSeries {\n  title\n  description\n  image {\n    url\n  }\n  artists(size: 1) {\n    name\n    image {\n      url\n    }\n    href\n    slug\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
+    "text": "query routes_ArtistSeriesQuery(\n  $slug: ID!\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MEDIUM, TOTAL, GALLERY, INSTITUTION, MAJOR_PERIOD]\n  $atAuction: Boolean\n  $attributionClass: [String]\n  $color: String\n  $forSale: Boolean\n  $height: String\n  $inquireableOnly: Boolean\n  $keyword: String\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sizes: [ArtworkSizes]\n  $sort: String\n  $width: String\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesApp_artistSeries_1DvBHA\n  }\n}\n\nfragment ArtistSeriesApp_artistSeries_1DvBHA on ArtistSeries {\n  ...ArtistSeriesHeader_artistSeries\n  railArtist: artists(size: 1) {\n    ...ArtistSeriesRail_artist\n    id\n  }\n  ...ArtistSeriesArtworksFilter_artistSeries_1DvBHA\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries_1DvBHA on ArtistSeries {\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, attributionClass: $attributionClass, color: $color, forSale: $forSale, height: $height, inquireableOnly: $inquireableOnly, keyword: $keyword, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: \"\", sort: $sort, width: $width) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ArtistSeriesHeader_artistSeries on ArtistSeries {\n  title\n  description\n  image {\n    url\n  }\n  artists(size: 1) {\n    name\n    image {\n      url\n    }\n    href\n    slug\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment ArtistSeriesItem_artistSeries on ArtistSeries {\n  title\n  slug\n  forSaleArtworksCount\n  image {\n    cropped(width: 160, height: 160) {\n      url\n    }\n  }\n}\n\nfragment ArtistSeriesRail_artist on Artist {\n  artistSeriesConnection {\n    edges {\n      node {\n        internalID\n        ...ArtistSeriesItem_artistSeries\n      }\n    }\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
Looks like:

![search](https://user-images.githubusercontent.com/1457859/88428521-0b4af500-cdc3-11ea-9a3e-acf7522ea8d7.gif)

![search](https://user-images.githubusercontent.com/1457859/88428565-20c01f00-cdc3-11ea-90f4-a6f66e4839c9.gif)


Relatively straightforward. I added the usual fragment container, but also included a query renderer (in case we wanted to skip SSR). For the collections on the artist page, we already intentionally defer those client-side (expensive ES-backed queries).

However, for this rail, even on the artist page, we probably don't need that, but left the renderer in just in case.