### PR TITLE
Prevents collection rail from overflowing

### DIFF
--- a/src/v2/Apps/Collect/Routes/Collection/Components/Header/DefaultHeader.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/Header/DefaultHeader.tsx
@@ -11,6 +11,7 @@ import { DefaultHeaderArtworkFragmentContainer as DefaultHeaderArtwork } from ".
 const Rail = styled(Box)`
   display: flex;
   flex-direction: row;
+  overflow: hidden;
 `
 
 export const fitHeaderArtworks = (


### PR DESCRIPTION
Minor bug stemming from https://github.com/artsy/palette/pull/716

Previously the entire layout at large had an `overflow: hidden` set on it by default. Here we just set it on the relevant component.