### PR TITLE
Use image instead of hero_image_url for ViewingRoomsApp

### DIFF
--- a/src/v2/Apps/ViewingRoom/Components/ViewingRoomsFeaturedRail.tsx
+++ b/src/v2/Apps/ViewingRoom/Components/ViewingRoomsFeaturedRail.tsx
@@ -4,6 +4,7 @@ import { ViewingRoomsFeaturedRail_featuredViewingRooms } from "v2/__generated__/
 import { createFragmentContainer, graphql } from "react-relay"
 import { ViewingRoomCarousel } from "./ViewingRoomCarousel"
 import { getTagProps } from "../Components/ViewingRoomsLatestGrid"
+import { crop } from "v2/Utils/resizer"
 
 interface ViewingRoomsFeaturedRailProps {
   featuredViewingRooms: ViewingRoomsFeaturedRail_featuredViewingRooms
@@ -23,18 +24,15 @@ export const ViewingRoomsFeaturedRail: React.FC<ViewingRoomsFeaturedRailProps> =
   }
 
   const carouselItemRender = (
-    {
-      heroImageURL,
-      slug,
-      title,
-      partner,
-      status,
-      distanceToOpen,
-      distanceToClose,
-    },
+    { image, slug, title, partner, status, distanceToOpen, distanceToClose },
     slideIndex: number
   ): React.ReactElement => {
     const tag = getTagProps(status, distanceToOpen, distanceToClose)
+    const heroImageURL = crop(image?.imageURLs?.normalized, {
+      height: 740,
+      width: 560,
+    })
+
     return (
       <Flex flexDirection="row">
         {slideIndex !== 0 && <Spacer ml="15px" />}
@@ -73,7 +71,11 @@ export const ViewingRoomsFeaturedRailFragmentContainer = createFragmentContainer
             status
             slug
             title
-            heroImageURL
+            image {
+              imageURLs {
+                normalized
+              }
+            }
             distanceToOpen(short: true)
             distanceToClose(short: true)
             partner {

--- a/src/v2/Apps/ViewingRoom/Components/ViewingRoomsLatestGrid.tsx
+++ b/src/v2/Apps/ViewingRoom/Components/ViewingRoomsLatestGrid.tsx
@@ -16,6 +16,7 @@ import {
 } from "react-relay"
 
 import { ViewingRoomsLatestGrid_viewingRooms } from "v2/__generated__/ViewingRoomsLatestGrid_viewingRooms.graphql"
+import { crop } from "v2/Utils/resizer"
 
 export interface ViewingRoomsLatestGridProps {
   relay: RelayPaginationProp
@@ -117,12 +118,16 @@ export const ViewingRoomsLatestGrid: React.FC<ViewingRoomsLatestGridProps> = pro
               slug,
               title,
               status,
-              heroImageURL,
+              image,
               partner,
               distanceToOpen,
               distanceToClose,
               artworksConnection,
             } = vr
+            const heroImageURL = crop(image?.imageURLs?.normalized, {
+              height: 800,
+              width: 800,
+            })
             const artworksCount = artworksConnection.totalCount
             const artworkImages = artworksConnection.edges.map(({ node }) =>
               artworksCount < 2 ? node.image.regular : node.image.square
@@ -174,9 +179,11 @@ export const ViewingRoomsLatestGridFragmentContainer = createPaginationContainer
               slug
               status
               title
-              # TODO: Need to either figure out how to get dimensions here
-              # or request a square vervion
-              heroImageURL
+              image {
+                imageURLs {
+                  normalized
+                }
+              }
               distanceToOpen(short: true)
               distanceToClose(short: true)
               partner {

--- a/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomsApp.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomsApp.jest.tsx
@@ -119,7 +119,11 @@ const ViewingRoomsAppFixture: ViewingRoomsApp_Test_QueryRawResponse = {
             status: "draft",
             slug: "test-draft",
             title: "Draft VR",
-            heroImageURL: "https://www.example.com/rikki.jpg",
+            image: {
+              imageURLs: {
+                normalized: "https://www.example.com/rikki.jpg",
+              },
+            },
             distanceToClose: null,
             distanceToOpen: null,
             partner: {
@@ -139,7 +143,11 @@ const ViewingRoomsAppFixture: ViewingRoomsApp_Test_QueryRawResponse = {
             status: "scheduled",
             slug: "test-scheduled",
             title: "Scheduled VR",
-            heroImageURL: "https://www.example.com/tikki.jpg",
+            image: {
+              imageURLs: {
+                normalized: "https://www.example.com/tikki.jpg",
+              },
+            },
             distanceToOpen: "soon",
             distanceToClose: null,
             partner: {
@@ -169,7 +177,11 @@ const ViewingRoomsAppFixture: ViewingRoomsApp_Test_QueryRawResponse = {
             status: "live",
             slug: "test-live",
             title: "Live VR",
-            heroImageURL: "https://www.example.com/tavi.jpg",
+            image: {
+              imageURLs: {
+                normalized: "https://www.example.com/tavi.jpg",
+              },
+            },
             distanceToOpen: null,
             distanceToClose: "3 days",
             partner: {
@@ -208,7 +220,11 @@ const ViewingRoomsAppFixture: ViewingRoomsApp_Test_QueryRawResponse = {
             status: "closed",
             slug: "test-closed",
             title: "Closed VR",
-            heroImageURL: "https://www.example.com/nag.jpg",
+            image: {
+              imageURLs: {
+                normalized: "https://www.example.com/nag.jpg",
+              },
+            },
             distanceToOpen: null,
             distanceToClose: null,
             partner: {
@@ -255,7 +271,11 @@ const ViewingRoomsAppFixture: ViewingRoomsApp_Test_QueryRawResponse = {
           status: "live",
           slug: "test-featured-live",
           title: "Featured Live VR",
-          heroImageURL: "https://www.example.com/featured-live.jpg",
+          image: {
+            imageURLs: {
+              normalized: "https://www.example.com/featured-live.jpg",
+            },
+          },
           distanceToOpen: null,
           distanceToClose: "4 days",
           partner: {

--- a/src/v2/__generated__/ViewingRoomsApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ViewingRoomsApp_Test_Query.graphql.ts
@@ -19,7 +19,11 @@ export type ViewingRoomsApp_Test_QueryRawResponse = {
                     readonly slug: string;
                     readonly status: string;
                     readonly title: string;
-                    readonly heroImageURL: string | null;
+                    readonly image: ({
+                        readonly imageURLs: ({
+                            readonly normalized: string | null;
+                        }) | null;
+                    }) | null;
                     readonly distanceToOpen: string | null;
                     readonly distanceToClose: string | null;
                     readonly partner: ({
@@ -54,7 +58,11 @@ export type ViewingRoomsApp_Test_QueryRawResponse = {
                 readonly status: string;
                 readonly slug: string;
                 readonly title: string;
-                readonly heroImageURL: string | null;
+                readonly image: ({
+                    readonly imageURLs: ({
+                        readonly normalized: string | null;
+                    }) | null;
+                }) | null;
                 readonly distanceToOpen: string | null;
                 readonly distanceToClose: string | null;
                 readonly partner: ({
@@ -97,7 +105,11 @@ fragment ViewingRoomsFeaturedRail_featuredViewingRooms on ViewingRoomConnection 
       status
       slug
       title
-      heroImageURL
+      image {
+        imageURLs {
+          normalized
+        }
+      }
       distanceToOpen(short: true)
       distanceToClose(short: true)
       partner {
@@ -115,7 +127,11 @@ fragment ViewingRoomsLatestGrid_viewingRooms_9Znkm on Viewer {
         slug
         status
         title
-        heroImageURL
+        image {
+          imageURLs {
+            normalized
+          }
+        }
         distanceToOpen(short: true)
         distanceToClose(short: true)
         partner {
@@ -176,11 +192,33 @@ v3 = {
   "storageKey": null
 },
 v4 = {
-  "kind": "ScalarField",
+  "kind": "LinkedField",
   "alias": null,
-  "name": "heroImageURL",
+  "name": "image",
+  "storageKey": null,
   "args": null,
-  "storageKey": null
+  "concreteType": "ARImage",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "imageURLs",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "ImageURLs",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "normalized",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
 },
 v5 = [
   {
@@ -506,7 +544,7 @@ return {
     "operationKind": "query",
     "name": "ViewingRoomsApp_Test_Query",
     "id": null,
-    "text": "query ViewingRoomsApp_Test_Query {\n  allViewingRooms: viewer {\n    ...ViewingRoomsApp_allViewingRooms\n  }\n  featuredViewingRooms: viewingRooms(featured: true) {\n    ...ViewingRoomsApp_featuredViewingRooms\n  }\n}\n\nfragment ViewingRoomsApp_allViewingRooms on Viewer {\n  ...ViewingRoomsLatestGrid_viewingRooms_9Znkm\n}\n\nfragment ViewingRoomsApp_featuredViewingRooms on ViewingRoomConnection {\n  ...ViewingRoomsFeaturedRail_featuredViewingRooms\n}\n\nfragment ViewingRoomsFeaturedRail_featuredViewingRooms on ViewingRoomConnection {\n  edges {\n    node {\n      status\n      slug\n      title\n      heroImageURL\n      distanceToOpen(short: true)\n      distanceToClose(short: true)\n      partner {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment ViewingRoomsLatestGrid_viewingRooms_9Znkm on Viewer {\n  viewingRoomsConnection {\n    edges {\n      node {\n        slug\n        status\n        title\n        heroImageURL\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        partner {\n          name\n          id\n        }\n        artworksConnection(first: 2) {\n          totalCount\n          edges {\n            node {\n              image {\n                square: url(version: \"square\")\n                regular: url(version: \"large\")\n              }\n              id\n            }\n          }\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n",
+    "text": "query ViewingRoomsApp_Test_Query {\n  allViewingRooms: viewer {\n    ...ViewingRoomsApp_allViewingRooms\n  }\n  featuredViewingRooms: viewingRooms(featured: true) {\n    ...ViewingRoomsApp_featuredViewingRooms\n  }\n}\n\nfragment ViewingRoomsApp_allViewingRooms on Viewer {\n  ...ViewingRoomsLatestGrid_viewingRooms_9Znkm\n}\n\nfragment ViewingRoomsApp_featuredViewingRooms on ViewingRoomConnection {\n  ...ViewingRoomsFeaturedRail_featuredViewingRooms\n}\n\nfragment ViewingRoomsFeaturedRail_featuredViewingRooms on ViewingRoomConnection {\n  edges {\n    node {\n      status\n      slug\n      title\n      image {\n        imageURLs {\n          normalized\n        }\n      }\n      distanceToOpen(short: true)\n      distanceToClose(short: true)\n      partner {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment ViewingRoomsLatestGrid_viewingRooms_9Znkm on Viewer {\n  viewingRoomsConnection {\n    edges {\n      node {\n        slug\n        status\n        title\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        partner {\n          name\n          id\n        }\n        artworksConnection(first: 2) {\n          totalCount\n          edges {\n            node {\n              image {\n                square: url(version: \"square\")\n                regular: url(version: \"large\")\n              }\n              id\n            }\n          }\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/v2/__generated__/ViewingRoomsFeaturedRail_featuredViewingRooms.graphql.ts
+++ b/src/v2/__generated__/ViewingRoomsFeaturedRail_featuredViewingRooms.graphql.ts
@@ -8,7 +8,11 @@ export type ViewingRoomsFeaturedRail_featuredViewingRooms = {
             readonly status: string;
             readonly slug: string;
             readonly title: string;
-            readonly heroImageURL: string | null;
+            readonly image: {
+                readonly imageURLs: {
+                    readonly normalized: string | null;
+                } | null;
+            } | null;
             readonly distanceToOpen: string | null;
             readonly distanceToClose: string | null;
             readonly partner: {
@@ -81,11 +85,33 @@ return {
               "storageKey": null
             },
             {
-              "kind": "ScalarField",
+              "kind": "LinkedField",
               "alias": null,
-              "name": "heroImageURL",
+              "name": "image",
+              "storageKey": null,
               "args": null,
-              "storageKey": null
+              "concreteType": "ARImage",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "imageURLs",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "ImageURLs",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "normalized",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
+                }
+              ]
             },
             {
               "kind": "ScalarField",
@@ -126,5 +152,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'b0db84fe428ac769d4f470ef6e09732f';
+(node as any).hash = '9dd834600e28760b97b9b24b16f60122';
 export default node;

--- a/src/v2/__generated__/ViewingRoomsLatestGrid_ViewingRoomsAppQuery.graphql.ts
+++ b/src/v2/__generated__/ViewingRoomsLatestGrid_ViewingRoomsAppQuery.graphql.ts
@@ -39,7 +39,11 @@ fragment ViewingRoomsLatestGrid_viewingRooms_2QE1um on Viewer {
         slug
         status
         title
-        heroImageURL
+        image {
+          imageURLs {
+            normalized
+          }
+        }
         distanceToOpen(short: true)
         distanceToClose(short: true)
         partner {
@@ -209,11 +213,33 @@ return {
                         "storageKey": null
                       },
                       {
-                        "kind": "ScalarField",
+                        "kind": "LinkedField",
                         "alias": null,
-                        "name": "heroImageURL",
+                        "name": "image",
+                        "storageKey": null,
                         "args": null,
-                        "storageKey": null
+                        "concreteType": "ARImage",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "imageURLs",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "ImageURLs",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "normalized",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
                         "kind": "ScalarField",
@@ -394,7 +420,7 @@ return {
     "operationKind": "query",
     "name": "ViewingRoomsLatestGrid_ViewingRoomsAppQuery",
     "id": null,
-    "text": "query ViewingRoomsLatestGrid_ViewingRoomsAppQuery(\n  $count: Int!\n  $after: String\n) {\n  allViewingRooms: viewer {\n    ...ViewingRoomsApp_allViewingRooms_2QE1um\n  }\n}\n\nfragment ViewingRoomsApp_allViewingRooms_2QE1um on Viewer {\n  ...ViewingRoomsLatestGrid_viewingRooms_2QE1um\n}\n\nfragment ViewingRoomsLatestGrid_viewingRooms_2QE1um on Viewer {\n  viewingRoomsConnection(first: $count, after: $after) {\n    edges {\n      node {\n        slug\n        status\n        title\n        heroImageURL\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        partner {\n          name\n          id\n        }\n        artworksConnection(first: 2) {\n          totalCount\n          edges {\n            node {\n              image {\n                square: url(version: \"square\")\n                regular: url(version: \"large\")\n              }\n              id\n            }\n          }\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n",
+    "text": "query ViewingRoomsLatestGrid_ViewingRoomsAppQuery(\n  $count: Int!\n  $after: String\n) {\n  allViewingRooms: viewer {\n    ...ViewingRoomsApp_allViewingRooms_2QE1um\n  }\n}\n\nfragment ViewingRoomsApp_allViewingRooms_2QE1um on Viewer {\n  ...ViewingRoomsLatestGrid_viewingRooms_2QE1um\n}\n\nfragment ViewingRoomsLatestGrid_viewingRooms_2QE1um on Viewer {\n  viewingRoomsConnection(first: $count, after: $after) {\n    edges {\n      node {\n        slug\n        status\n        title\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        partner {\n          name\n          id\n        }\n        artworksConnection(first: 2) {\n          totalCount\n          edges {\n            node {\n              image {\n                square: url(version: \"square\")\n                regular: url(version: \"large\")\n              }\n              id\n            }\n          }\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/src/v2/__generated__/ViewingRoomsLatestGrid_viewingRooms.graphql.ts
+++ b/src/v2/__generated__/ViewingRoomsLatestGrid_viewingRooms.graphql.ts
@@ -9,7 +9,11 @@ export type ViewingRoomsLatestGrid_viewingRooms = {
                 readonly slug: string;
                 readonly status: string;
                 readonly title: string;
-                readonly heroImageURL: string | null;
+                readonly image: {
+                    readonly imageURLs: {
+                        readonly normalized: string | null;
+                    } | null;
+                } | null;
                 readonly distanceToOpen: string | null;
                 readonly distanceToClose: string | null;
                 readonly partner: {
@@ -127,11 +131,33 @@ return {
                   "storageKey": null
                 },
                 {
-                  "kind": "ScalarField",
+                  "kind": "LinkedField",
                   "alias": null,
-                  "name": "heroImageURL",
+                  "name": "image",
+                  "storageKey": null,
                   "args": null,
-                  "storageKey": null
+                  "concreteType": "ARImage",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "imageURLs",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "ImageURLs",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "normalized",
+                          "args": null,
+                          "storageKey": null
+                        }
+                      ]
+                    }
+                  ]
                 },
                 {
                   "kind": "ScalarField",
@@ -296,5 +322,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '2f56f2a39d4bba121a522191698787ba';
+(node as any).hash = 'b6896b93750dae0588d5bf553f583f93';
 export default node;

--- a/src/v2/__generated__/routes_ViewingRoomsAppQuery.graphql.ts
+++ b/src/v2/__generated__/routes_ViewingRoomsAppQuery.graphql.ts
@@ -48,7 +48,11 @@ fragment ViewingRoomsFeaturedRail_featuredViewingRooms on ViewingRoomConnection 
       status
       slug
       title
-      heroImageURL
+      image {
+        imageURLs {
+          normalized
+        }
+      }
       distanceToOpen(short: true)
       distanceToClose(short: true)
       partner {
@@ -66,7 +70,11 @@ fragment ViewingRoomsLatestGrid_viewingRooms_2QE1um on Viewer {
         slug
         status
         title
-        heroImageURL
+        image {
+          imageURLs {
+            normalized
+          }
+        }
         distanceToOpen(short: true)
         distanceToClose(short: true)
         partner {
@@ -154,11 +162,33 @@ v6 = {
   "storageKey": null
 },
 v7 = {
-  "kind": "ScalarField",
+  "kind": "LinkedField",
   "alias": null,
-  "name": "heroImageURL",
+  "name": "image",
+  "storageKey": null,
   "args": null,
-  "storageKey": null
+  "concreteType": "ARImage",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "imageURLs",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "ImageURLs",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "normalized",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    }
+  ]
 },
 v8 = [
   {
@@ -491,7 +521,7 @@ return {
     "operationKind": "query",
     "name": "routes_ViewingRoomsAppQuery",
     "id": null,
-    "text": "query routes_ViewingRoomsAppQuery(\n  $count: Int!\n  $after: String\n) {\n  allViewingRooms: viewer {\n    ...ViewingRoomsApp_allViewingRooms_2QE1um\n  }\n  featuredViewingRooms: viewingRooms(featured: true) {\n    ...ViewingRoomsApp_featuredViewingRooms\n  }\n}\n\nfragment ViewingRoomsApp_allViewingRooms_2QE1um on Viewer {\n  ...ViewingRoomsLatestGrid_viewingRooms_2QE1um\n}\n\nfragment ViewingRoomsApp_featuredViewingRooms on ViewingRoomConnection {\n  ...ViewingRoomsFeaturedRail_featuredViewingRooms\n}\n\nfragment ViewingRoomsFeaturedRail_featuredViewingRooms on ViewingRoomConnection {\n  edges {\n    node {\n      status\n      slug\n      title\n      heroImageURL\n      distanceToOpen(short: true)\n      distanceToClose(short: true)\n      partner {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment ViewingRoomsLatestGrid_viewingRooms_2QE1um on Viewer {\n  viewingRoomsConnection(first: $count, after: $after) {\n    edges {\n      node {\n        slug\n        status\n        title\n        heroImageURL\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        partner {\n          name\n          id\n        }\n        artworksConnection(first: 2) {\n          totalCount\n          edges {\n            node {\n              image {\n                square: url(version: \"square\")\n                regular: url(version: \"large\")\n              }\n              id\n            }\n          }\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n",
+    "text": "query routes_ViewingRoomsAppQuery(\n  $count: Int!\n  $after: String\n) {\n  allViewingRooms: viewer {\n    ...ViewingRoomsApp_allViewingRooms_2QE1um\n  }\n  featuredViewingRooms: viewingRooms(featured: true) {\n    ...ViewingRoomsApp_featuredViewingRooms\n  }\n}\n\nfragment ViewingRoomsApp_allViewingRooms_2QE1um on Viewer {\n  ...ViewingRoomsLatestGrid_viewingRooms_2QE1um\n}\n\nfragment ViewingRoomsApp_featuredViewingRooms on ViewingRoomConnection {\n  ...ViewingRoomsFeaturedRail_featuredViewingRooms\n}\n\nfragment ViewingRoomsFeaturedRail_featuredViewingRooms on ViewingRoomConnection {\n  edges {\n    node {\n      status\n      slug\n      title\n      image {\n        imageURLs {\n          normalized\n        }\n      }\n      distanceToOpen(short: true)\n      distanceToClose(short: true)\n      partner {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment ViewingRoomsLatestGrid_viewingRooms_2QE1um on Viewer {\n  viewingRoomsConnection(first: $count, after: $after) {\n    edges {\n      node {\n        slug\n        status\n        title\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        partner {\n          name\n          id\n        }\n        artworksConnection(first: 2) {\n          totalCount\n          edges {\n            node {\n              image {\n                square: url(version: \"square\")\n                regular: url(version: \"large\")\n              }\n              id\n            }\n          }\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n",
     "metadata": {}
   }
 };


### PR DESCRIPTION
I think this address the usage in `/viewing-rooms`. Still need to do the same for `viewing-room/id` but I'll do it in a separate PR. Want to verify this is working as expected first.

Thanks @dblandin, @mdole for all the work that went into making this possible.

jira: https://artsyproduct.atlassian.net/browse/GALL-3113