### PR TITLE
Log identify calls

### DIFF
--- a/src/desktop/assets/analytics.ts
+++ b/src/desktop/assets/analytics.ts
@@ -22,9 +22,13 @@ if (sd.SHOW_ANALYTICS_CALLS) {
   analytics.on("page", function () {
     console.info("ANALYTICS PAGEVIEW: ", arguments[2], arguments[3])
   })
-  // Log all analytics calls
+  // Log all track calls
   analytics.on("track", (actionName: string, data?: any) => {
     console.info("ANALYTICS TRACK:", actionName, data)
+  })
+  // Log all identify calls
+  analytics.on("identify", (userId: string, data: object, context: any) => {
+    console.info("ANALYTICS IDENTIFY:", userId, data, context)
   })
 }
 
@@ -82,7 +86,7 @@ $(() =>
       const traits = extend(pick(sd.CURRENT_USER, allowedlist), {
         session_id: sd.SESSION_ID,
       })
-      analytics.identify(sd.CURRENT_USER.id, traits, {
+      window.analytics.identify(sd.CURRENT_USER.id, traits, {
         integrations: { Marketo: false },
       })
       // clear analytics cache when user logs out

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -1,8 +1,11 @@
 interface Window {
   analytics?: {
     identify: (userId: string, traits: object, object) => void
-    on: (action: string, cb: (nameOrData: any, data?: any) => void) => void
-    page: (object, object) => void
+    on: (
+      action: string,
+      cb: (nameOrData: any, data?: object, context?: object) => void
+    ) => void
+    page: (data: object, context: object) => void
     ready: (cb: () => void) => void
     reset: () => void
     track: (


### PR DESCRIPTION
Follow up to https://github.com/artsy/force/pull/6006, uses `window.analytics` over `analytics` for `identify` events, and adds identify to new logging. 

Related to https://artsyproduct.atlassian.net/browse/PLATFORM-2282