### PR TITLE
Fix malformed drop down links and redirect them to correct one (for SEO)

### DIFF
--- a/src/desktop/apps/fair/index.coffee
+++ b/src/desktop/apps/fair/index.coffee
@@ -29,6 +29,7 @@ app.get '/:id/articles', getFairData, routes.fairArticles
 app.get '/:id/for-you', getFairData, routes.forYou
 app.get '/:id/search', getFairData, routes.search
 app.get '/:id/browse/show/:partner_id', getFairData, routes.showRedirect
+app.get '/:id/browse/artworks/artworks', routes.malformedFilterRedirect
 app.get '/:id/browse', getFairData, routes.browse
 app.get '/:id/browse/*', getFairData, routes.browse
 app.get '/:id/sign_up', getFairData, routes.overview

--- a/src/desktop/apps/fair/routes.coffee
+++ b/src/desktop/apps/fair/routes.coffee
@@ -113,6 +113,9 @@ DEFAULT_CACHE_TIME = 60
     error: res.backboneError
     success: (show) -> res.redirect "/show/#{show.id}"
 
+@malformedFilterRedirect = (req, res, next) ->
+  res.redirect 301, "/#{req.params.id}/browse/artworks"
+
 # Captures fair-specific sign-up.
 # Adds a user fair action to the users collector profile and follows the fair profile.
 # If the user is an attendee, redirect to fair page with flash message (found in ./components/capture_signup)

--- a/src/desktop/apps/fair/test/routes.test.coffee
+++ b/src/desktop/apps/fair/test/routes.test.coffee
@@ -171,6 +171,18 @@ describe 'Fair routes', ->
       ]
       @res.redirect.args[0][0].should.containEql '/show/gagosian-gallery-inez-and-vinood'
 
+  describe 'malformed /artworks/artworks urls', ->
+    beforeEach ->
+      sinon.stub Backbone, 'sync'
+
+    afterEach ->
+      Backbone.sync.restore()
+
+    it 'redirects to /:id/browse/artworks', ->
+      routes.malformedFilterRedirect @req, @res
+      @res.redirect.args[0][0].should.eql 301
+      @res.redirect.args[0][1].should.containEql '/some-fair/browse/artworks'
+
 describe '#fetchFairData', ->
 
   beforeEach ->

--- a/src/desktop/components/filter2/dropdown/template.jade
+++ b/src/desktop/components/filter2/dropdown/template.jade
@@ -26,7 +26,7 @@ unless name == 'total' || name == 'for_sale'
             href=(
               filterRoot && filterRoot.match('booths') ?
               "#{filterRoot}/#{attr}/#{val}" :
-              "#{filterRoot ? filterRoot : sd.CURRENT_PATH + '/artworks'}?#{name}=#{val}"
+              "#{filterRoot ? filterRoot : sd.CURRENT_PATH}?#{name}=#{val}"
             )
             class=extraClasses.join(' ')
           )


### PR DESCRIPTION
Fixes [PURCHASE-2019](https://artsyproduct.atlassian.net/browse/PURCHASE-2019)

Deepcrawl noticed we have incorrect URLs in the fair page affecting our SEO.
Looking at the [code](https://github.com/artsy/force/blob/85f4d423a6f966b6edd82335891b0662220559ab/src/desktop/components/filter2/dropdown/view.coffee#L35) those URLs are not being used for navigation but there is a backbone `onSelect` event that updates the filters so that URL was wrong since it was added 5 years ago.

I looked to see if there are any other usages of that filter and didn't find any to make sure this change doesn't create new malformed URLs.

Also added a redirect for `artworks/artworks` links as per Jira ticket to properly redirect search engine cached URLs

The redirect spec doesn't check the pattern matching but that's the way it is set up and I don't think it is worth spending more time figuring out an end to end test in backbone.

Before:

<img width="1245" alt="Screen Shot 2020-07-30 at 10 48 35 AM" src="https://user-images.githubusercontent.com/687513/88939492-92c9b580-d254-11ea-9721-afefbc838c2a.png">

After:

<img width="1185" alt="Screen Shot 2020-07-30 at 10 50 13 AM" src="https://user-images.githubusercontent.com/687513/88939467-8c3b3e00-d254-11ea-9a08-a8cb2b0b04a1.png">


