### PR TITLE
[FX-1840] Bulk replaces iphone.artsy.net and old itunes URLs

### DIFF
--- a/src/desktop/apps/fair_info/templates/visitors.jade
+++ b/src/desktop/apps/fair_info/templates/visitors.jade
@@ -67,7 +67,7 @@ block body
               br
               | guide to #{fair.get('name')}
 
-              a.avant-garde-button-white.block-link(href="https://iphone.artsy.net") Get The App
+              a.avant-garde-button-white.block-link(href="https://apps.apple.com/us/app/artsy-buy-sell-original-art/id703796080") Get The App
 
             .fair-info2-iphone-app-section
 

--- a/src/desktop/apps/fair_organizer/templates/overview.jade
+++ b/src/desktop/apps/fair_organizer/templates/overview.jade
@@ -54,7 +54,7 @@ block body
         .fair-organizer-content__header Get the App
         .fair-organizer-content__section.fair-organizer-content__section--app
           .mobile-section-iphone &nbsp;
-          a(href="https://iphone.artsy.net/")
+          a(href="https://apps.apple.com/us/app/artsy-buy-sell-original-art/id703796080")
             .fair-organizer-content__section--app__copy
               i Download Artsy for iPhone
               br

--- a/src/desktop/apps/fairs/templates/current_fairs.jade
+++ b/src/desktop/apps/fairs/templates/current_fairs.jade
@@ -21,7 +21,7 @@ each row in currentFairRows
       +current-fair-figure(fair)
     if row.type == 'two-third-promo' || row.type == 'half-promo'
       .fairs__current__promo
-        a(href="https://iphone.artsy.net/")
+        a(href="https://apps.apple.com/us/app/artsy-buy-sell-original-art/id703796080")
           .mobile-section-iphone-large &nbsp;
           .fairs__current__promo__copy
             | Download Artsy for iPhone for a

--- a/src/desktop/apps/how_auctions_work/test/fixture.json
+++ b/src/desktop/apps/how_auctions_work/test/fixture.json
@@ -2,7 +2,7 @@
     "description": "Browse lots from premier benefit auctions hosted on Artsy. Bidding online is simple with just a few easy steps.",
     "mobile_cta": {
         "button": {
-            "href": "https://itunes.apple.com/us/app/artsy-art-world-in-your-pocket/id703796080",
+            "href": "https://apps.apple.com/us/app/artsy-buy-sell-original-art/id703796080",
             "label": "Download"
         },
         "description": "Download Artsy for your iPhone or iPad and easily register, browse, and bid.",
@@ -29,7 +29,7 @@
             "title": "Register"
         },
         {
-            "description": "View lots online to learn about celebrated contemporary artists. See estimates, provenance, and connect with our Specialists.\n\n[Download Artsy for iPad or iPhone](https://itunes.apple.com/us/app/artsy-art-world-in-your-pocket/id703796080)",
+            "description": "View lots online to learn about celebrated contemporary artists. See estimates, provenance, and connect with our Specialists.\n\n[Download Artsy for iPad or iPhone](https://apps.apple.com/us/app/artsy-buy-sell-original-art/id703796080)",
             "id": "browse",
             "image": {
                 "alt": "Browse",

--- a/src/desktop/apps/press/test/fixtures/press_releases.json
+++ b/src/desktop/apps/press/test/fixtures/press_releases.json
@@ -123,7 +123,7 @@
         {
             "day": 0,
             "description": null,
-            "href": "https://itunes.apple.com/us/app/artsy-art-world-in-your-pocket/id703796080?mt=8",
+            "href": "https://apps.apple.com/us/app/artsy-buy-sell-original-art/id703796080?mt=8",
             "month": "June",
             "title": "Artsy is now on the iPad",
             "year": 2015

--- a/src/mobile/apps/how_auctions_work/fixtures/data.json
+++ b/src/mobile/apps/how_auctions_work/fixtures/data.json
@@ -2,7 +2,7 @@
   "description": "Browse lots from premier benefit auctions hosted on Artsy. Bidding online is simple with just a few easy steps.",
   "mobile_cta": {
     "button": {
-      "href": "https://itunes.apple.com/us/app/artsy-art-world-in-your-pocket/id703796080",
+      "href": "https://apps.apple.com/us/app/artsy-buy-sell-original-art/id703796080",
       "label": "Download"
     },
     "description": "Download Artsy for your iPhone or iPad and easily register, browse, and bid.",
@@ -29,7 +29,7 @@
       "title": "Register"
     },
     {
-      "description": "View lots online to learn about celebrated contemporary artists. See estimates, provenance, and connect with our Specialists.\n\n[Download Artsy for iPad or iPhone](https://itunes.apple.com/us/app/artsy-art-world-in-your-pocket/id703796080)",
+      "description": "View lots online to learn about celebrated contemporary artists. See estimates, provenance, and connect with our Specialists.\n\n[Download Artsy for iPad or iPhone](https://apps.apple.com/us/app/artsy-buy-sell-original-art/id703796080)",
       "id": "browse",
       "image": {
         "alt": "Browse",


### PR DESCRIPTION
Re: [FX-1840](https://artsyproduct.atlassian.net/browse/FX-1840)

Replaces the iphone.artsy.net URLs as well as some itunes URLs (which work fine, they just redirect, but why not).

For that iphone.artsy.net app: I think we should be able to use [Cloudflare page rules](https://support.cloudflare.com/hc/en-us/articles/200172286-Configuring-URL-forwarding-or-redirects-with-Cloudflare-Page-Rules) to just 301 the whole thing? It looks like it's an app on Heroku — but the nameservers that's resolving that subdomain aren't on Cloudflare for some reason.