### PR TITLE
@sweir27 => [Search] Show artist series in search

### DIFF
--- a/src/v2/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/v2/Apps/Search/Components/NavigationTabs.tsx
@@ -18,6 +18,7 @@ const MORE_TABS = ["tag", "city", "feature", "page"]
 const TAB_NAME_MAP = {
   artist: "Artists",
   marketing_collection: "Collections",
+  artist_series: "Artist Series",
   PartnerGallery: "Galleries",
   partner_show: "Shows",
   fair: "Fairs",
@@ -57,7 +58,7 @@ export class NavigationTabs extends React.Component<Props> {
     const tabName = text.replace(/[0-9]/g, "").trim()
     return (
       <RouteTab
-        to={to}
+        to={to.replace(/\s/g, "_")}
         exact={exact}
         onClick={() => {
           this.trackClick(tabName, to)
@@ -160,6 +161,7 @@ export interface TabCounts {
   Categories?: number
   Articles?: number
   Auctions?: number
+  "Artist Series"?: number
 }
 
 export const tabCountMap: (props: Props) => TabCounts = props => {

--- a/src/v2/Apps/Search/routes.tsx
+++ b/src/v2/Apps/Search/routes.tsx
@@ -19,6 +19,7 @@ const prepareVariables = (_params, { location }) => {
 }
 
 const tabsToEntitiesMap = {
+  artist_series: ["ARTIST_SERIES"],
   collections: ["COLLECTION"],
   shows: ["SHOW"],
   fairs: ["FAIR"],


### PR DESCRIPTION
If the artist series data is included in search results (which is determined wholly by the gravity feature flag), then it will correctly render:

![search](https://user-images.githubusercontent.com/1457859/89208524-8ada8000-d58a-11ea-87e0-9e6240ba6d0d.gif)

(The description, and proper image fallback should also appear shortly once gravity is deployed and artist series re-indexed).