### PR TITLE
[MX-464] Hide manage cards on Eigen

### DIFF
--- a/src/typings/sharify.d.ts
+++ b/src/typings/sharify.d.ts
@@ -24,6 +24,7 @@ declare module "sharify" {
       readonly CDN_URL: string
       CURRENT_PATH: string
       CURRENT_USER: User
+      readonly EIGEN: boolean
       readonly ENABLE_SERVER_SIDE_CACHE: string
       readonly ENABLE_SIGN_IN_WITH_APPLE: string // TODO: Remove once sign in with apple is rolled out.
       readonly FACEBOOK_APP_NAMESPACE: string

--- a/src/v2/Apps/Order/Components/__tests__/PaymentPicker.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/PaymentPicker.jest.tsx
@@ -166,7 +166,7 @@ describe("PaymentPickerFragmentContainer", () => {
       ...creatingCreditCardSuccess,
     },
     query: graphql`
-      query PaymentPickerTestQuery @raw_response_type {
+      query PaymentPickerEigenTestQuery @raw_response_type {
         me {
           ...PaymentPicker_me
         }

--- a/src/v2/Apps/Order/Components/__tests__/PaymentPicker.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/PaymentPicker.jest.tsx
@@ -26,6 +26,7 @@ jest.unmock("react-tracking")
 jest.mock("v2/Utils/Events", () => ({
   postEvent: jest.fn(),
 }))
+
 const mockPostEvent = require("v2/Utils/Events").postEvent as jest.Mock
 
 jest.mock("react-stripe-elements", () => {
@@ -93,15 +94,11 @@ class PaymentPickerTestPage extends RootTestPage {
   }
 
   get addressFormIsVisible() {
-    return this.find(Collapse)
-      .at(1)
-      .props().open
+    return this.find(Collapse).at(1).props().open
   }
 
   get useNewCardSectionIsVisible() {
-    return this.find(Collapse)
-      .at(0)
-      .props().open
+    return this.find(Collapse).at(0).props().open
   }
 
   async toggleSameAddressCheckbox() {
@@ -158,6 +155,27 @@ describe("PaymentPickerFragmentContainer", () => {
         }
       }
     `,
+    systemContextProps: { isEigen: false },
+  })
+
+  const eigenEnv = createTestEnv({
+    Component: injectCommitMutation(PaymentPickerFragmentContainer as any),
+    TestPage: PaymentPickerTestPage,
+    defaultData,
+    defaultMutationResults: {
+      ...creatingCreditCardSuccess,
+    },
+    query: graphql`
+      query PaymentPickerTestQuery @raw_response_type {
+        me {
+          ...PaymentPicker_me
+        }
+        order: commerceOrder(id: "unused") {
+          ...PaymentPicker_order
+        }
+      }
+    `,
+    systemContextProps: { isEigen: true },
   })
 
   beforeEach(() => {
@@ -170,8 +188,10 @@ describe("PaymentPickerFragmentContainer", () => {
 
   describe("with no existing cards", () => {
     let page: PaymentPickerTestPage
+    let eigenPage: PaymentPickerTestPage
     beforeAll(async () => {
       page = await env.buildPage()
+      eigenPage = await eigenEnv.buildPage()
     })
     it("always shows the 'use new card' section", () => {
       expect(page.useNewCardSectionIsVisible).toBeTruthy()
@@ -179,8 +199,11 @@ describe("PaymentPickerFragmentContainer", () => {
     it("does not show any radio buttons", () => {
       expect(page.radios).toHaveLength(0)
     })
-    it("does not show the 'manage cards' link", () => {
+    it("does not show the 'manage cards' link if not eigen", () => {
       expect(page.find(Link)).toHaveLength(0)
+    })
+    it("does not show the 'manage cards' link if eigen", () => {
+      expect(eigenPage.find(Link)).toHaveLength(0)
     })
   })
 
@@ -442,19 +465,37 @@ describe("PaymentPickerFragmentContainer", () => {
       })
     }
 
+    function getEigenPage(_cards: typeof cards, _order) {
+      return eigenEnv.buildPage({
+        mockData: {
+          me: {
+            creditCards: {
+              edges: _cards.map(node => ({ node })),
+            },
+          },
+          order: _order,
+        },
+      })
+    }
+
     describe("with one card", () => {
       let page: PaymentPickerTestPage
+      let eigenPage: PaymentPickerTestPage
       beforeAll(async () => {
         page = await getPage(cards.slice(0, 1), orderWithoutCard)
+        eigenPage = await getEigenPage(cards.slice(0, 1), orderWithoutCard)
       })
       it("has two radio buttons", async () => {
         expect(page.radios).toHaveLength(2)
       })
-      it("shows the 'manage cards' link", () => {
+      it("shows the 'manage cards' link if not eigen", () => {
         expect(page.find(Link)).toHaveLength(1)
         expect(page.find(Link).props().href).toMatchInlineSnapshot(
           `"/user/payments"`
         )
+      })
+      it("has no 'manage cards' link if eigen", () => {
+        expect(eigenPage.find(Link)).toHaveLength(0)
       })
       it("has the credit card option at the top", async () => {
         expect(page.radios.at(0).text()).toMatchInlineSnapshot(
@@ -492,17 +533,22 @@ describe("PaymentPickerFragmentContainer", () => {
 
     describe("with two cards", () => {
       let page: PaymentPickerTestPage
+      let eigenPage: PaymentPickerTestPage
       beforeAll(async () => {
         page = await getPage(cards, orderWithoutCard)
+        eigenPage = await getEigenPage(cards, orderWithoutCard)
       })
       it("has three radio buttons", async () => {
         expect(page.radios).toHaveLength(3)
       })
-      it("shows the 'manage cards' link", () => {
+      it("shows the 'manage cards' link if not eigen", () => {
         expect(page.find(Link)).toHaveLength(1)
         expect(page.find(Link).props().href).toMatchInlineSnapshot(
           `"/user/payments"`
         )
+      })
+      it("shows the 'manage cards' link if eigen", () => {
+        expect(eigenPage.find(Link)).toHaveLength(0)
       })
       it("has the credit card options at the top", async () => {
         expect(page.radios.at(0).text()).toMatchInlineSnapshot(

--- a/src/v2/Artsy/Router/__tests__/buildClientApp.jest.tsx
+++ b/src/v2/Artsy/Router/__tests__/buildClientApp.jest.tsx
@@ -99,6 +99,7 @@ describe("buildClientApp", () => {
         <SystemContextConsumer>
           {context => {
             expect(Object.keys(context).sort()).toEqual([
+              "isEigen",
               "isFetching",
               "mediator",
               "relayEnvironment",

--- a/src/v2/Artsy/Router/__tests__/buildServerApp.jest.tsx
+++ b/src/v2/Artsy/Router/__tests__/buildServerApp.jest.tsx
@@ -129,6 +129,7 @@ describe("buildServerApp", () => {
         <SystemContextConsumer>
           {context => {
             expect(Object.keys(context).sort()).toEqual([
+              "isEigen",
               "isFetching",
               "mediator",
               "relayEnvironment",

--- a/src/v2/Artsy/SystemContext.tsx
+++ b/src/v2/Artsy/SystemContext.tsx
@@ -1,5 +1,6 @@
 import { Router } from "found"
 import React, { SFC, useContext, useState } from "react"
+import { data as sd } from "sharify"
 import { Environment } from "relay-runtime"
 
 import { createRelaySSREnvironment } from "v2/Artsy/Relay/createRelaySSREnvironment"
@@ -103,6 +104,7 @@ export const SystemContextProvider: SFC<SystemContextProps> = ({
     relayEnvironment,
     user,
     setUser,
+    isEigen: sd.EIGEN,
   }
 
   return (

--- a/src/v2/Artsy/__tests__/SystemContext.jest.tsx
+++ b/src/v2/Artsy/__tests__/SystemContext.jest.tsx
@@ -11,9 +11,11 @@ jest.mock("v2/Artsy/Relay/createRelaySSREnvironment", () => ({
   }),
 }))
 
-const ShowCurrentUser: React.SFC<SystemContextProps & {
-  additionalProp?: string
-}> = props => {
+const ShowCurrentUser: React.SFC<
+  SystemContextProps & {
+    additionalProp?: string
+  }
+> = props => {
   let text = props.user ? props.user.id : "no-current-user"
   if (props.additionalProp) {
     text = `${text} & ${props.additionalProp}`
@@ -41,6 +43,7 @@ describe("Artsy context", () => {
         <Artsy.SystemContextConsumer>
           {props => {
             expect(Object.keys(props).sort()).toEqual([
+              "isEigen",
               "isFetching",
               "relayEnvironment",
               "router",

--- a/src/v2/__generated__/PaymentPickerEigenTestQuery.graphql.ts
+++ b/src/v2/__generated__/PaymentPickerEigenTestQuery.graphql.ts
@@ -1,0 +1,541 @@
+/* tslint:disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
+export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "PENDING" | "REFUNDED" | "SUBMITTED" | "%future added value";
+export type PaymentPickerEigenTestQueryVariables = {};
+export type PaymentPickerEigenTestQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"PaymentPicker_me">;
+    } | null;
+    readonly order: {
+        readonly " $fragmentRefs": FragmentRefs<"PaymentPicker_order">;
+    } | null;
+};
+export type PaymentPickerEigenTestQueryRawResponse = {
+    readonly me: ({
+        readonly creditCards: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly internalID: string;
+                    readonly brand: string;
+                    readonly lastDigits: string;
+                    readonly expirationMonth: number;
+                    readonly expirationYear: number;
+                    readonly id: string | null;
+                }) | null;
+            }) | null> | null;
+        }) | null;
+        readonly id: string | null;
+    }) | null;
+    readonly order: ({
+        readonly __typename: string | null;
+        readonly internalID: string;
+        readonly mode: CommerceOrderModeEnum | null;
+        readonly state: CommerceOrderStateEnum;
+        readonly creditCard: ({
+            readonly internalID: string;
+            readonly name: string | null;
+            readonly street1: string | null;
+            readonly street2: string | null;
+            readonly city: string | null;
+            readonly state: string | null;
+            readonly country: string | null;
+            readonly postalCode: string | null;
+            readonly expirationMonth: number;
+            readonly expirationYear: number;
+            readonly lastDigits: string;
+            readonly brand: string;
+            readonly id: string | null;
+        }) | null;
+        readonly requestedFulfillment: ({
+            readonly __typename: "CommerceShip";
+            readonly name: string | null;
+            readonly addressLine1: string | null;
+            readonly addressLine2: string | null;
+            readonly city: string | null;
+            readonly region: string | null;
+            readonly country: string | null;
+            readonly postalCode: string | null;
+        } | {
+            readonly __typename: "CommercePickup";
+            readonly fulfillmentType: string;
+        } | {
+            readonly __typename: string;
+        }) | null;
+        readonly lineItems: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly artwork: ({
+                        readonly slug: string;
+                        readonly id: string | null;
+                    }) | null;
+                    readonly id: string | null;
+                }) | null;
+            }) | null> | null;
+        }) | null;
+        readonly id: string | null;
+    }) | null;
+};
+export type PaymentPickerEigenTestQuery = {
+    readonly response: PaymentPickerEigenTestQueryResponse;
+    readonly variables: PaymentPickerEigenTestQueryVariables;
+    readonly rawResponse: PaymentPickerEigenTestQueryRawResponse;
+};
+
+
+
+/*
+query PaymentPickerEigenTestQuery {
+  me {
+    ...PaymentPicker_me
+    id
+  }
+  order: commerceOrder(id: "unused") {
+    __typename
+    ...PaymentPicker_order
+    id
+  }
+}
+
+fragment PaymentPicker_me on Me {
+  creditCards(first: 100) {
+    edges {
+      node {
+        internalID
+        brand
+        lastDigits
+        expirationMonth
+        expirationYear
+        id
+      }
+    }
+  }
+}
+
+fragment PaymentPicker_order on CommerceOrder {
+  internalID
+  mode
+  state
+  creditCard {
+    internalID
+    name
+    street1
+    street2
+    city
+    state
+    country
+    postalCode
+    expirationMonth
+    expirationYear
+    lastDigits
+    brand
+    id
+  }
+  requestedFulfillment {
+    __typename
+    ... on CommerceShip {
+      name
+      addressLine1
+      addressLine2
+      city
+      region
+      country
+      postalCode
+    }
+    ... on CommercePickup {
+      fulfillmentType
+    }
+  }
+  lineItems {
+    edges {
+      node {
+        artwork {
+          slug
+          id
+        }
+        id
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "unused"
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "brand",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "lastDigits",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "expirationMonth",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "expirationYear",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "state",
+  "args": null,
+  "storageKey": null
+},
+v9 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "city",
+  "args": null,
+  "storageKey": null
+},
+v11 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "country",
+  "args": null,
+  "storageKey": null
+},
+v12 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "postalCode",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "PaymentPickerEigenTestQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "me",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Me",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "PaymentPicker_me",
+            "args": null
+          }
+        ]
+      },
+      {
+        "kind": "LinkedField",
+        "alias": "order",
+        "name": "commerceOrder",
+        "storageKey": "commerceOrder(id:\"unused\")",
+        "args": (v0/*: any*/),
+        "concreteType": null,
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "PaymentPicker_order",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "PaymentPickerEigenTestQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "me",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Me",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "creditCards",
+            "storageKey": "creditCards(first:100)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 100
+              }
+            ],
+            "concreteType": "CreditCardConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "CreditCardEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "CreditCard",
+                    "plural": false,
+                    "selections": [
+                      (v1/*: any*/),
+                      (v2/*: any*/),
+                      (v3/*: any*/),
+                      (v4/*: any*/),
+                      (v5/*: any*/),
+                      (v6/*: any*/)
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          (v6/*: any*/)
+        ]
+      },
+      {
+        "kind": "LinkedField",
+        "alias": "order",
+        "name": "commerceOrder",
+        "storageKey": "commerceOrder(id:\"unused\")",
+        "args": (v0/*: any*/),
+        "concreteType": null,
+        "plural": false,
+        "selections": [
+          (v7/*: any*/),
+          (v1/*: any*/),
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "mode",
+            "args": null,
+            "storageKey": null
+          },
+          (v8/*: any*/),
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "creditCard",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "CreditCard",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              (v9/*: any*/),
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "street1",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "street2",
+                "args": null,
+                "storageKey": null
+              },
+              (v10/*: any*/),
+              (v8/*: any*/),
+              (v11/*: any*/),
+              (v12/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v3/*: any*/),
+              (v2/*: any*/),
+              (v6/*: any*/)
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "requestedFulfillment",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              (v7/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "type": "CommerceShip",
+                "selections": [
+                  (v9/*: any*/),
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "addressLine1",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "addressLine2",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  (v10/*: any*/),
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "region",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  (v11/*: any*/),
+                  (v12/*: any*/)
+                ]
+              },
+              {
+                "kind": "InlineFragment",
+                "type": "CommercePickup",
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "fulfillmentType",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "lineItems",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "CommerceLineItemConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "CommerceLineItemEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "CommerceLineItem",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "artwork",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "slug",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v6/*: any*/)
+                        ]
+                      },
+                      (v6/*: any*/)
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          (v6/*: any*/)
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "PaymentPickerEigenTestQuery",
+    "id": null,
+    "text": "query PaymentPickerEigenTestQuery {\n  me {\n    ...PaymentPicker_me\n    id\n  }\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...PaymentPicker_order\n    id\n  }\n}\n\nfragment PaymentPicker_me on Me {\n  creditCards(first: 100) {\n    edges {\n      node {\n        internalID\n        brand\n        lastDigits\n        expirationMonth\n        expirationYear\n        id\n      }\n    }\n  }\n}\n\nfragment PaymentPicker_order on CommerceOrder {\n  internalID\n  mode\n  state\n  creditCard {\n    internalID\n    name\n    street1\n    street2\n    city\n    state\n    country\n    postalCode\n    expirationMonth\n    expirationYear\n    lastDigits\n    brand\n    id\n  }\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n    }\n    ... on CommercePickup {\n      fulfillmentType\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        id\n      }\n    }\n  }\n}\n",
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = 'cdcd8cd56b0daaf8481d3935644e58a2';
+export default node;


### PR DESCRIPTION
This PR resolves **[[MX-464](https://artsyproduct.atlassian.net/browse/MX-427)]**

### Description

For the BNMO flows on iOS, the Manage cards link should be hidden when rendered within the Eigen modal.

### Screenshots
![hide_eigen](https://user-images.githubusercontent.com/11945712/89794355-3a819600-db27-11ea-8576-82d130876c53.gif)
