### PR TITLE
Handle Superagent Errors

### DIFF
--- a/src/lib/metaphysics2.coffee
+++ b/src/lib/metaphysics2.coffee
@@ -41,7 +41,9 @@ metaphysics2 = ({ query, variables, req } = {}) ->
 
       .end (err, response) ->
         if err?
-          errorObject = JSON.parse(err?.response?.text)
+          errorObject = err
+          if err?.response?.text?
+            errorObject = JSON.parse(err?.response?.text)
           formattedError = JSON.stringify(errorObject, null, 2)
           console.error chalk.red(formattedError)
           return reject err


### PR DESCRIPTION
Description

Is certain circumstances such as timeouts `superagent` will throw an
exception that does not contain a `response` or `text`. In these cases
`force` will crash when it attempts to `JSON.stingify` a null value.

Solution

Verify that there is a 'response' and a 'text' field before parsing them.