### PR TITLE
Text Not Guaranteed to be JSON

### DIFF
--- a/src/lib/metaphysics2.coffee
+++ b/src/lib/metaphysics2.coffee
@@ -43,7 +43,11 @@ metaphysics2 = ({ query, variables, req } = {}) ->
         if err?
           errorObject = err
           if err?.response?.text?
-            errorObject = JSON.parse(err?.response?.text)
+            try
+              errorObject = JSON.parse(err?.response?.text)
+            catch
+              console.error chalk.red('Failed to JSON.parse `err.response.text`')
+
           formattedError = JSON.stringify(errorObject, null, 2)
           console.error chalk.red(formattedError)
           return reject err


### PR DESCRIPTION
Description

When testing in development the `err.response.text` was not always valid 
JSON. e.g. It could also be an HTML 404 or 500 page. 

Solution

Add an additional safety check to handle any cases where the error was 
not JSON but instead was HTML