### PR TITLE
Throw less Exceptions in the Router

### DIFF
--- a/src/v2/Artsy/Router/RouterLink.tsx
+++ b/src/v2/Artsy/Router/RouterLink.tsx
@@ -23,9 +23,9 @@ export const RouterLink: React.FC<RouterLinkProps> = ({
   ...props
 }) => {
   const context = useContext(RouterContext)
-  const routes = get(context, c => c.router.matcher.routeConfig, [])
+  const routes = get(context, c => c?.router?.matcher?.routeConfig, [])
   const isSupportedInRouter = !!get(context, c =>
-    c.router.matcher.matchRoutes(routes, to)
+    c?.router?.matcher?.matchRoutes(routes, to)
   )
 
   /**

--- a/src/v2/Utils/get.ts
+++ b/src/v2/Utils/get.ts
@@ -17,10 +17,9 @@ export function get<O, T>(
     if (result) {
       return result
     } else {
-      throw new Error()
+      return valueIfFailOrUndefined
     }
-    return
-  } catch (error) {
+  } catch {
     return valueIfFailOrUndefined
   }
 }


### PR DESCRIPTION
**Description**

Throwing an exception is a really expensive operation as it must walk
the call stack to generate a stack trace. This should be done with care
and only when necessary.

This minor tweak increases performance slightly by only throwing when
necessary and updating the route link matching to handle nulls instead
of relying on throwing an exception to default.

The percentages in this case are a bit misleading due to the idle time 
during the testing. The main take away is that `RouteLink.tsx` is no longer
utilizing a significant amount of time.

![previous](https://user-images.githubusercontent.com/403814/89549889-ebf69380-d7d6-11ea-9308-75badfb88690.png)

![after](https://user-images.githubusercontent.com/403814/89552412-185fdf00-d7da-11ea-99b5-ce4547171633.png)

