### PR TITLE
[FX-2148] Adjusts title typography and spacing

### DIFF
--- a/src/v2/Apps/Feature/Components/FeatureSet/FeatureSetMeta.tsx
+++ b/src/v2/Apps/Feature/Components/FeatureSet/FeatureSetMeta.tsx
@@ -14,13 +14,13 @@ export const FeatureSetMeta: React.FC<FeatureSetMetaProps> = ({
   return (
     <Box {...rest}>
       {set.name && (
-        <Text variant="title" color="black100">
+        <Text variant="largeTitle" color="black100" mb={1}>
           {set.name}
         </Text>
       )}
 
       {set.description && (
-        <HTML variant="text" color="black60" html={set.description} />
+        <HTML variant="text" color="black60" html={set.description} mt={1} />
       )}
     </Box>
   )


### PR DESCRIPTION
Re: [FX-2148](https://artsyproduct.atlassian.net/browse/FX-2148)

Quick/easy one, adjustments to the set titles to line up with the [Figma spec](https://www.figma.com/file/3VpNrlYhYXuSvI2xzqfVZT/Campaign_Feature-Page?node-id=947%3A2353)

![](http://static.damonzucconi.com/_capture/8INteJUCQGXa.png)