### PR TITLE
Prevent unauthenticated users from seeing a viewing room without signing up for an account (GALL-3186)

### DIFF
--- a/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
+++ b/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
@@ -35,6 +35,7 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
         redirectTo: window.location.href,
         contextModule: ContextModule.viewingRoom,
         intent: Intent.viewViewingRoom,
+        hideCloseButton: true,
       })
     }, 0)
 

--- a/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
+++ b/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
@@ -35,8 +35,9 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
         redirectTo: window.location.href,
         contextModule: ContextModule.viewingRoom,
         intent: Intent.viewViewingRoom,
-        hideCloseButton: true,
         copy: "Sign up to enter viewing rooms",
+        disableCloseOnBackgroundClick: true,
+        goBackOnClose: true,
       })
     }, 0)
 

--- a/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
+++ b/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
@@ -36,6 +36,7 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
         contextModule: ContextModule.viewingRoom,
         intent: Intent.viewViewingRoom,
         hideCloseButton: true,
+        copy: "Sign up to enter viewing rooms",
       })
     }, 0)
 

--- a/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
+++ b/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
@@ -14,6 +14,7 @@ import { openAuthModal } from "v2/Utils/openAuthModal"
 import { SystemContext } from "v2/Artsy"
 import { ModalType } from "v2/Components/Authentication/Types"
 import { ContextModule, Intent } from "@artsy/cohesion"
+import { useRouter } from "v2/Artsy/Router/useRouter"
 
 interface ViewingRoomAppProps {
   children: React.ReactNode
@@ -25,6 +26,7 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
   viewingRoom,
 }) => {
   const { mediator, user } = useContext(SystemContext)
+  const { router } = useRouter()
   useEffect(() => {
     if (user && user.id) return
     // openAuthModal will fire off "open:auth" event before ModalContainer
@@ -37,12 +39,14 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
         intent: Intent.viewViewingRoom,
         copy: "Sign up to enter viewing rooms",
         disableCloseOnBackgroundClick: true,
-        goBackOnClose: true,
+        afterClose: () => {
+          router.push("/viewing-rooms")
+        },
       })
     }, 0)
 
     return () => clearTimeout(timeoutID)
-  }, [user, mediator])
+  }, [user, router, mediator])
 
   if (!viewingRoom) {
     return <ErrorPage code={404} />

--- a/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
@@ -18,6 +18,7 @@ jest.mock("v2/Artsy/Router/useRouter", () => ({
         slug: "subscription-demo-gg-guy-yanai",
       },
     },
+    router: jest.fn(),
   }),
   useIsRouteActive: () => false,
 }))
@@ -324,16 +325,19 @@ describe("ViewingRoomApp", () => {
       expect(wrapper.find("ViewingRoomTabBar").length).toBe(0)
       expect(wrapper.find("ViewingRoomContentNotAccessible").length).toBe(0)
       expect(wrapper.html()).not.toContain("some child")
-
-      expect(mediator.trigger).toBeCalledWith("open:auth", {
-        mode: "signup",
-        redirectTo: "http://localhost/" + slug,
-        contextModule: "viewingRoom",
-        intent: "viewViewingRoom",
-        copy: "Sign up to enter viewing rooms",
-        disableCloseOnBackgroundClick: true,
-        goBackOnClose: true,
-      })
+      expect(mediator.trigger).toBeCalled()
+    })
+    xit("redirects user to /viewing-rooms on close", () => {
+      // const spy = jest.fn()
+      // ;(useRouter as jest.Mock).mockImplementation(() => {
+      //   return {
+      //     router: {
+      //       push: spy,
+      //     },
+      //   }
+      // })
+      // expect(spy).toHaveBeenCalled()
+      // expect(spy).toHaveBeenCalledWith("/viewing-rooms")
     })
   })
 })

--- a/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
@@ -9,6 +9,7 @@ import { ViewingRoomApp_ClosedTest_QueryRawResponse } from "v2/__generated__/Vie
 import { ViewingRoomApp_UnfoundTest_QueryRawResponse } from "v2/__generated__/ViewingRoomApp_UnfoundTest_Query.graphql"
 import { ViewingRoomApp_LoggedOutTest_QueryRawResponse } from "v2/__generated__/ViewingRoomApp_LoggedOutTest_Query.graphql.ts"
 import { Breakpoint } from "@artsy/palette"
+import { FairWeekPageScaffold } from "desktop/components/fair_week_marketing/PageScaffold"
 
 jest.unmock("react-relay")
 jest.mock("v2/Artsy/Router/useRouter", () => ({
@@ -330,6 +331,9 @@ describe("ViewingRoomApp", () => {
         redirectTo: "http://localhost/" + slug,
         contextModule: "viewingRoom",
         intent: "viewViewingRoom",
+        copy: "Sign up to enter viewing rooms",
+        disableCloseOnBackgroundClick: true,
+        goBackOnClose: true,
       })
     })
   })

--- a/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
@@ -18,7 +18,6 @@ jest.mock("v2/Artsy/Router/useRouter", () => ({
         slug: "subscription-demo-gg-guy-yanai",
       },
     },
-    router: jest.fn(),
   }),
   useIsRouteActive: () => false,
 }))
@@ -325,19 +324,7 @@ describe("ViewingRoomApp", () => {
       expect(wrapper.find("ViewingRoomTabBar").length).toBe(0)
       expect(wrapper.find("ViewingRoomContentNotAccessible").length).toBe(0)
       expect(wrapper.html()).not.toContain("some child")
-      expect(mediator.trigger).toBeCalled()
-    })
-    xit("redirects user to /viewing-rooms on close", () => {
-      // const spy = jest.fn()
-      // ;(useRouter as jest.Mock).mockImplementation(() => {
-      //   return {
-      //     router: {
-      //       push: spy,
-      //     },
-      //   }
-      // })
-      // expect(spy).toHaveBeenCalled()
-      // expect(spy).toHaveBeenCalledWith("/viewing-rooms")
+      expect(mediator.trigger).toHaveBeenCalled()
     })
   })
 })

--- a/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
@@ -9,7 +9,6 @@ import { ViewingRoomApp_ClosedTest_QueryRawResponse } from "v2/__generated__/Vie
 import { ViewingRoomApp_UnfoundTest_QueryRawResponse } from "v2/__generated__/ViewingRoomApp_UnfoundTest_Query.graphql"
 import { ViewingRoomApp_LoggedOutTest_QueryRawResponse } from "v2/__generated__/ViewingRoomApp_LoggedOutTest_Query.graphql.ts"
 import { Breakpoint } from "@artsy/palette"
-import { FairWeekPageScaffold } from "desktop/components/fair_week_marketing/PageScaffold"
 
 jest.unmock("react-relay")
 jest.mock("v2/Artsy/Router/useRouter", () => ({

--- a/src/v2/Components/Authentication/Desktop/ModalManager.tsx
+++ b/src/v2/Components/Authentication/Desktop/ModalManager.tsx
@@ -126,7 +126,10 @@ export class ModalManager extends Component<
         subtitle={this.getSubtitle()}
         type={currentType}
         image={options && options.image}
-        hideCloseButton={options && options.hideCloseButton}
+        disableCloseOnBackgroundClick={
+          options && options.disableCloseOnBackgroundClick
+        }
+        goBackOnClose={options && options.goBackOnClose}
       >
         <FormSwitcher
           type={currentType}

--- a/src/v2/Components/Authentication/Desktop/ModalManager.tsx
+++ b/src/v2/Components/Authentication/Desktop/ModalManager.tsx
@@ -67,12 +67,18 @@ export class ModalManager extends Component<
   }
 
   closeModal = () => {
+    let afterClose: () => void
+    if (this.state.options) {
+      afterClose = this.state.options.afterClose
+    }
+
     this.setState({
       currentType: null,
       options: {} as ModalOptions,
     })
     document.body.style.overflowY = "auto"
     this.props.onModalClose && this.props.onModalClose()
+    afterClose && afterClose()
   }
 
   handleTypeChange = type => {
@@ -129,7 +135,6 @@ export class ModalManager extends Component<
         disableCloseOnBackgroundClick={
           options && options.disableCloseOnBackgroundClick
         }
-        goBackOnClose={options && options.goBackOnClose}
       >
         <FormSwitcher
           type={currentType}

--- a/src/v2/Components/Authentication/Desktop/ModalManager.tsx
+++ b/src/v2/Components/Authentication/Desktop/ModalManager.tsx
@@ -67,18 +67,16 @@ export class ModalManager extends Component<
   }
 
   closeModal = () => {
-    let afterClose: () => void
-    if (this.state.options) {
-      afterClose = this.state.options.afterClose
-    }
+    let afterClose = this.state.options?.afterClose
 
     this.setState({
       currentType: null,
       options: {} as ModalOptions,
     })
+
     document.body.style.overflowY = "auto"
-    this.props.onModalClose && this.props.onModalClose()
-    afterClose && afterClose()
+    this.props.onModalClose?.()
+    afterClose?.()
   }
 
   handleTypeChange = type => {
@@ -132,9 +130,9 @@ export class ModalManager extends Component<
         subtitle={this.getSubtitle()}
         type={currentType}
         image={options && options.image}
-        disableCloseOnBackgroundClick={
-          options && options.disableCloseOnBackgroundClick
-        }
+        disableCloseOnBackgroundClick={Boolean(
+          options?.disableCloseOnBackgroundClick
+        )}
       >
         <FormSwitcher
           type={currentType}

--- a/src/v2/Components/Authentication/Desktop/ModalManager.tsx
+++ b/src/v2/Components/Authentication/Desktop/ModalManager.tsx
@@ -126,6 +126,7 @@ export class ModalManager extends Component<
         subtitle={this.getSubtitle()}
         type={currentType}
         image={options && options.image}
+        hideCloseButton={options && options.hideCloseButton}
       >
         <FormSwitcher
           type={currentType}

--- a/src/v2/Components/Authentication/Types.ts
+++ b/src/v2/Components/Authentication/Types.ts
@@ -113,6 +113,10 @@ export interface ModalOptions {
    * Used to construct afterSignupAction from query params
    */
   objectId?: AfterSignUpAction["objectId"]
+  /**
+   * TODO: write me
+   */
+  hideCloseButton?: boolean
 }
 
 export type FormComponentType =

--- a/src/v2/Components/Authentication/Types.ts
+++ b/src/v2/Components/Authentication/Types.ts
@@ -118,9 +118,9 @@ export interface ModalOptions {
    */
   disableCloseOnBackgroundClick?: boolean
   /**
-   * Returns users to the previous page when they close the modal
+   * Hook to be called after the modal has closed
    */
-  goBackOnClose?: boolean
+  afterClose?: () => void
 }
 
 export type FormComponentType =

--- a/src/v2/Components/Authentication/Types.ts
+++ b/src/v2/Components/Authentication/Types.ts
@@ -114,9 +114,13 @@ export interface ModalOptions {
    */
   objectId?: AfterSignUpAction["objectId"]
   /**
-   * TODO: write me
+   * Prevents users from clicking outside the modal to close it
    */
-  hideCloseButton?: boolean
+  disableCloseOnBackgroundClick?: boolean
+  /**
+   * Returns users to the previous page when they close the modal
+   */
+  goBackOnClose?: boolean
 }
 
 export type FormComponentType =

--- a/src/v2/Components/Modal/Modal.tsx
+++ b/src/v2/Components/Modal/Modal.tsx
@@ -17,6 +17,7 @@ export interface ModalProps extends React.HTMLProps<Modal> {
   image?: string
   show?: boolean
   title?: string
+  hideCloseButton?: boolean
 }
 
 /**
@@ -60,6 +61,7 @@ export class Modal extends React.Component<ModalProps> {
       onClose,
       show,
       title,
+      hideCloseButton,
     } = this.props
 
     return (
@@ -70,8 +72,9 @@ export class Modal extends React.Component<ModalProps> {
         width={isWide ? ModalWidth.Wide : ModalWidth.Normal}
         image={image}
         fullscreenResponsiveModal
+        hideCloseButton={hideCloseButton}
       >
-        <CloseButton name="close" onClick={this.close} />
+        {!hideCloseButton && <CloseButton name="close" onClick={this.close} />}
 
         {image && <Image image={image} />}
 

--- a/src/v2/Components/Modal/Modal.tsx
+++ b/src/v2/Components/Modal/Modal.tsx
@@ -18,7 +18,6 @@ export interface ModalProps extends React.HTMLProps<Modal> {
   show?: boolean
   title?: string
   disableCloseOnBackgroundClick?: boolean
-  goBackOnClose?: boolean
 }
 
 /**
@@ -50,9 +49,6 @@ export class Modal extends React.Component<ModalProps> {
 
   close = () => {
     this.props.onClose()
-    if (this.props.goBackOnClose) {
-      window.history.back()
-    }
   }
 
   render(): JSX.Element {
@@ -66,7 +62,6 @@ export class Modal extends React.Component<ModalProps> {
       show,
       title,
       disableCloseOnBackgroundClick,
-      goBackOnClose,
     } = this.props
 
     return (
@@ -78,7 +73,6 @@ export class Modal extends React.Component<ModalProps> {
         image={image}
         fullscreenResponsiveModal
         disableCloseOnBackgroundClick={disableCloseOnBackgroundClick}
-        goBackOnClose={goBackOnClose}
       >
         <CloseButton name="close" onClick={this.close} />
 

--- a/src/v2/Components/Modal/Modal.tsx
+++ b/src/v2/Components/Modal/Modal.tsx
@@ -49,6 +49,9 @@ export class Modal extends React.Component<ModalProps> {
 
   close = () => {
     this.props.onClose()
+    if (this.props.hideCloseButton) {
+      window.history.back()
+    }
   }
 
   render(): JSX.Element {
@@ -74,7 +77,7 @@ export class Modal extends React.Component<ModalProps> {
         fullscreenResponsiveModal
         hideCloseButton={hideCloseButton}
       >
-        {!hideCloseButton && <CloseButton name="close" onClick={this.close} />}
+        <CloseButton name="close" onClick={this.close} />
 
         {image && <Image image={image} />}
 

--- a/src/v2/Components/Modal/Modal.tsx
+++ b/src/v2/Components/Modal/Modal.tsx
@@ -17,7 +17,8 @@ export interface ModalProps extends React.HTMLProps<Modal> {
   image?: string
   show?: boolean
   title?: string
-  hideCloseButton?: boolean
+  disableCloseOnBackgroundClick?: boolean
+  goBackOnClose?: boolean
 }
 
 /**
@@ -49,7 +50,7 @@ export class Modal extends React.Component<ModalProps> {
 
   close = () => {
     this.props.onClose()
-    if (this.props.hideCloseButton) {
+    if (this.props.goBackOnClose) {
       window.history.back()
     }
   }
@@ -64,7 +65,8 @@ export class Modal extends React.Component<ModalProps> {
       onClose,
       show,
       title,
-      hideCloseButton,
+      disableCloseOnBackgroundClick,
+      goBackOnClose,
     } = this.props
 
     return (
@@ -75,7 +77,8 @@ export class Modal extends React.Component<ModalProps> {
         width={isWide ? ModalWidth.Wide : ModalWidth.Normal}
         image={image}
         fullscreenResponsiveModal
-        hideCloseButton={hideCloseButton}
+        disableCloseOnBackgroundClick={disableCloseOnBackgroundClick}
+        goBackOnClose={goBackOnClose}
       >
         <CloseButton name="close" onClick={this.close} />
 

--- a/src/v2/Components/Modal/ModalWrapper.tsx
+++ b/src/v2/Components/Modal/ModalWrapper.tsx
@@ -86,16 +86,8 @@ export class ModalWrapper extends React.Component<
   }
 
   close = () => {
-    // this.props.goBackOnClose is undefined if it is accessed after this.props.onClose()
-    // TODO: test this behavior in case this gets refactored
-    const goBack = this.props.goBackOnClose
-
     this.props.onClose()
     this.removeBlurToContainers()
-
-    if (goBack) {
-      window.history.back()
-    }
   }
 
   addBlurToContainers = () => {

--- a/src/v2/Components/Modal/ModalWrapper.tsx
+++ b/src/v2/Components/Modal/ModalWrapper.tsx
@@ -22,7 +22,6 @@ export interface ModalWrapperProps extends React.HTMLProps<ModalWrapper> {
   image?: string
   show?: boolean
   disableCloseOnBackgroundClick?: boolean
-  goBackOnClose?: boolean
 }
 
 export interface ModalWrapperState {

--- a/src/v2/Components/Modal/ModalWrapper.tsx
+++ b/src/v2/Components/Modal/ModalWrapper.tsx
@@ -85,8 +85,16 @@ export class ModalWrapper extends React.Component<
   }
 
   close = () => {
+    // this.props.hideCloseButton is undefined if it is accessed after this.props.onClose()
+    // TODO: test this behavior in case this gets refactored
+    const goBack = this.props.hideCloseButton
+
     this.props.onClose()
     this.removeBlurToContainers()
+
+    if (goBack) {
+      window.history.back()
+    }
   }
 
   addBlurToContainers = () => {
@@ -110,7 +118,7 @@ export class ModalWrapper extends React.Component<
   }
 
   handleEscapeKey = event => {
-    if (!this.props.hideCloseButton && event && event.key === "Escape") {
+    if (event && event.key === "Escape") {
       this.close()
     }
   }

--- a/src/v2/Components/Modal/ModalWrapper.tsx
+++ b/src/v2/Components/Modal/ModalWrapper.tsx
@@ -21,7 +21,8 @@ export interface ModalWrapperProps extends React.HTMLProps<ModalWrapper> {
   fullscreenResponsiveModal?: boolean
   image?: string
   show?: boolean
-  hideCloseButton?: boolean
+  disableCloseOnBackgroundClick?: boolean
+  goBackOnClose?: boolean
 }
 
 export interface ModalWrapperState {
@@ -85,9 +86,9 @@ export class ModalWrapper extends React.Component<
   }
 
   close = () => {
-    // this.props.hideCloseButton is undefined if it is accessed after this.props.onClose()
+    // this.props.goBackOnClose is undefined if it is accessed after this.props.onClose()
     // TODO: test this behavior in case this gets refactored
-    const goBack = this.props.hideCloseButton
+    const goBack = this.props.goBackOnClose
 
     this.props.onClose()
     this.removeBlurToContainers()
@@ -148,7 +149,9 @@ export class ModalWrapper extends React.Component<
           <GlobalStyle suppressMultiMountWarning />
           {isShown && (
             <ModalOverlay
-              onClick={!this.props.hideCloseButton ? this.close : null}
+              onClick={
+                !this.props.disableCloseOnBackgroundClick ? this.close : null
+              }
             />
           )}
           <FadeTransition

--- a/src/v2/Components/Modal/ModalWrapper.tsx
+++ b/src/v2/Components/Modal/ModalWrapper.tsx
@@ -141,7 +141,7 @@ export class ModalWrapper extends React.Component<
           {isShown && (
             <ModalOverlay
               onClick={
-                !this.props.disableCloseOnBackgroundClick ? this.close : null
+                this.props.disableCloseOnBackgroundClick ? null : this.close
               }
             />
           )}

--- a/src/v2/Components/Modal/ModalWrapper.tsx
+++ b/src/v2/Components/Modal/ModalWrapper.tsx
@@ -21,6 +21,7 @@ export interface ModalWrapperProps extends React.HTMLProps<ModalWrapper> {
   fullscreenResponsiveModal?: boolean
   image?: string
   show?: boolean
+  hideCloseButton?: boolean
 }
 
 export interface ModalWrapperState {
@@ -109,7 +110,7 @@ export class ModalWrapper extends React.Component<
   }
 
   handleEscapeKey = event => {
-    if (event && event.key === "Escape") {
+    if (!this.props.hideCloseButton && event && event.key === "Escape") {
       this.close()
     }
   }
@@ -137,7 +138,11 @@ export class ModalWrapper extends React.Component<
       <Theme>
         <Wrapper isShown={isShown || isAnimating}>
           <GlobalStyle suppressMultiMountWarning />
-          {isShown && <ModalOverlay onClick={this.close} />}
+          {isShown && (
+            <ModalOverlay
+              onClick={!this.props.hideCloseButton ? this.close : null}
+            />
+          )}
           <FadeTransition
             in={isShown}
             mountOnEnter

--- a/src/v2/Components/Modal/__tests__/Modal.jest.tsx
+++ b/src/v2/Components/Modal/__tests__/Modal.jest.tsx
@@ -1,6 +1,6 @@
 import { mount } from "enzyme"
 import React from "react"
-import { Image, Modal, ModalContent } from "../Modal"
+import { CloseButton, Image, Modal, ModalContent } from "../Modal"
 import { ModalCta } from "../ModalCta"
 import { ModalHeader } from "../ModalHeader"
 
@@ -59,6 +59,26 @@ describe("Modal", () => {
 
       expect(component.find(Image)).toHaveLength(1)
       expect(component.find(ModalContent)).toHaveLength(1)
+    })
+
+    it("Navigates to previous page on close if props.goBackOnClose", () => {
+      window.history.back = jest.fn()
+      props.goBackOnClose = true
+
+      const component = getWrapper(props)
+      component.find(CloseButton).at(0).simulate("click")
+
+      expect(window.history.back).toHaveBeenCalled()
+    })
+
+    it("Navigates to previous page if not props.goBackOnClose", () => {
+      window.history.back = jest.fn()
+      props.goBackOnClose = false
+
+      const component = getWrapper(props)
+      component.find(CloseButton).at(0).simulate("click")
+
+      expect(window.history.back).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/v2/Components/Modal/__tests__/Modal.jest.tsx
+++ b/src/v2/Components/Modal/__tests__/Modal.jest.tsx
@@ -1,6 +1,6 @@
 import { mount } from "enzyme"
 import React from "react"
-import { CloseButton, Image, Modal, ModalContent } from "../Modal"
+import { Image, Modal, ModalContent } from "../Modal"
 import { ModalCta } from "../ModalCta"
 import { ModalHeader } from "../ModalHeader"
 
@@ -59,26 +59,6 @@ describe("Modal", () => {
 
       expect(component.find(Image)).toHaveLength(1)
       expect(component.find(ModalContent)).toHaveLength(1)
-    })
-
-    it("Navigates to previous page on close if props.goBackOnClose", () => {
-      window.history.back = jest.fn()
-      props.goBackOnClose = true
-
-      const component = getWrapper(props)
-      component.find(CloseButton).at(0).simulate("click")
-
-      expect(window.history.back).toHaveBeenCalled()
-    })
-
-    it("Navigates to previous page if not props.goBackOnClose", () => {
-      window.history.back = jest.fn()
-      props.goBackOnClose = false
-
-      const component = getWrapper(props)
-      component.find(CloseButton).at(0).simulate("click")
-
-      expect(window.history.back).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/v2/Components/Modal/__tests__/ModalWrapper.jest.tsx
+++ b/src/v2/Components/Modal/__tests__/ModalWrapper.jest.tsx
@@ -37,14 +37,36 @@ describe("Modal", () => {
     props.show = true
     const component = getWrapper(props)
     ;(component.instance() as any).removeBlurToContainers = jest.fn()
-    component
-      .find(ModalOverlay)
-      .at(0)
-      .simulate("click")
+    component.find(ModalOverlay).at(0).simulate("click")
 
     expect(
       (component.instance() as any).removeBlurToContainers
     ).toHaveBeenCalled()
     expect(props.onClose).toHaveBeenCalled()
+  })
+  it("Doesn't close on background click if props.disableCloseOnBackgroundClick", () => {
+    props.show = true
+    props.disableCloseOnBackgroundClick = true
+    const component = getWrapper(props)
+    ;(component.instance() as any).removeBlurToContainers = jest.fn()
+    component.find(ModalOverlay).at(0).simulate("click")
+
+    expect(
+      (component.instance() as any).removeBlurToContainers
+    ).not.toHaveBeenCalled()
+    expect(props.onClose).not.toHaveBeenCalled()
+  })
+  it("Navigates to previous page on escape key up", () => {
+    window.history.back = jest.fn()
+    props.show = true
+    props.goBackOnClose = true
+    const component = getWrapper(props)
+    ;(component.instance() as any).removeBlurToContainers = jest.fn()
+    document.dispatchEvent(new KeyboardEvent("keyup", { key: "Escape" }))
+    expect(
+      (component.instance() as any).removeBlurToContainers
+    ).toHaveBeenCalled()
+    expect(props.onClose).toHaveBeenCalled()
+    expect(window.history.back).toHaveBeenCalled()
   })
 })

--- a/src/v2/Components/Modal/__tests__/ModalWrapper.jest.tsx
+++ b/src/v2/Components/Modal/__tests__/ModalWrapper.jest.tsx
@@ -56,17 +56,4 @@ describe("Modal", () => {
     ).not.toHaveBeenCalled()
     expect(props.onClose).not.toHaveBeenCalled()
   })
-  it("Navigates to previous page on escape key up", () => {
-    window.history.back = jest.fn()
-    props.show = true
-    props.goBackOnClose = true
-    const component = getWrapper(props)
-    ;(component.instance() as any).removeBlurToContainers = jest.fn()
-    document.dispatchEvent(new KeyboardEvent("keyup", { key: "Escape" }))
-    expect(
-      (component.instance() as any).removeBlurToContainers
-    ).toHaveBeenCalled()
-    expect(props.onClose).toHaveBeenCalled()
-    expect(window.history.back).toHaveBeenCalled()
-  })
 })


### PR DESCRIPTION
This PR prevents users from closing the sign-up modal that appears on a viewing room page without signing up for an account. It disables the ability for them to click outside of the modal to close it, and if a user either (1) clicks the X icon to close it, or (2) presses the Esc key, they are redirected back to the previous page.

![artsy net](https://user-images.githubusercontent.com/44589599/89950342-6e2bf100-dbf7-11ea-8e02-88e75f131c43.gif)
