### PR TITLE
[FX-2127] Make the display title of ArtistSeriesRail configurable

### DIFF
--- a/src/v2/Apps/ArtistSeries/ArtistSeriesApp.tsx
+++ b/src/v2/Apps/ArtistSeries/ArtistSeriesApp.tsx
@@ -29,7 +29,10 @@ const ArtistSeriesApp: React.FC<ArtistSeriesAppProps> = ({ artistSeries }) => {
           <ArtistSeriesArtworksFilter artistSeries={artistSeries} />
           <Separator mt={6} mb={3} />
           {railArtist.length && (
-            <OtherArtistSeriesRail artist={railArtist[0]} />
+            <OtherArtistSeriesRail
+              artist={railArtist[0]}
+              title="More series by this artist"
+            />
           )}
           <Separator mt={6} mb={3} />
           <Footer />

--- a/src/v2/Apps/Artwork/Components/OtherWorks/index.tsx
+++ b/src/v2/Apps/Artwork/Components/OtherWorks/index.tsx
@@ -101,7 +101,10 @@ export const OtherWorks = track()(
                     grid.__typename === "ArtistArtworkGrid" && (
                       <>
                         <ArtistSeriesArtworkRail artwork={props.artwork} />
-                        <ArtistSeriesRail artist={seriesArtist} />
+                        <ArtistSeriesRail
+                          artist={seriesArtist}
+                          title="More series by this artist"
+                        />
                       </>
                     )}
 

--- a/src/v2/Components/ArtistSeriesRail/ArtistSeriesRail.tsx
+++ b/src/v2/Components/ArtistSeriesRail/ArtistSeriesRail.tsx
@@ -9,6 +9,7 @@ import { ArtistSeriesItemFragmentContainer as ArtistSeriesItem } from "./ArtistS
 
 interface Props {
   artist: ArtistSeriesRail_artist
+  title?: string
 }
 
 const ArtistSeriesRail: React.SFC<Props> = props => {
@@ -17,6 +18,8 @@ const ArtistSeriesRail: React.SFC<Props> = props => {
 
   if (!artist) return null
 
+  const displayTitle = props.title ?? "Artist Series"
+
   const { artistSeriesConnection } = artist
   const edges = artistSeriesConnection && artistSeriesConnection.edges
 
@@ -24,7 +27,7 @@ const ArtistSeriesRail: React.SFC<Props> = props => {
     return (
       <Box my={3}>
         <Sans size="4" color="black100" my={1}>
-          More series by this artist
+          {displayTitle}
         </Sans>
 
         <Box mx={[-20, 0]}>


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2127

### Problem

The `ArtistSeriesRail` — which shows artist series associated with a given artist — currently always shows a title of "More series by this artist". But we want to be able to choose a different display title depending on the context.

### Solution

- Make the display title configurable with an optional `title` prop
- Fall back to a reasonable default if `title` is not supplied. 

It seemed natural to me for the vanilla phrase "Artist Series" (spec'd in this ticket) to be the default title, and for other instances to supply a more specific title depending on the use case, so that's how this PR looks.

### Before

![before](https://user-images.githubusercontent.com/140521/89687454-4292c900-d8ce-11ea-8a4b-097284c5c0c8.png)

---

### After

![afterr](https://user-images.githubusercontent.com/140521/89687501-5a6a4d00-d8ce-11ea-8271-50619485ca6e.png)

---

<details>
  <summary>
    <b>Other usages</b>
  </summary>

**On the Artist Series page, retains the old title:**

![series](https://user-images.githubusercontent.com/140521/89687968-2cd1d380-d8cf-11ea-9a36-3dd3be0d81a1.png)

**On the Artwork page, retains the old title:**

![artwork](https://user-images.githubusercontent.com/140521/89687975-2fccc400-d8cf-11ea-88db-a457920f3ff4.png)
</details>

