### PR TITLE
Center Align Viewing Room Title Text

### DIFF
--- a/src/v2/Apps/ViewingRoom/Components/ViewingRoomHeader.tsx
+++ b/src/v2/Apps/ViewingRoom/Components/ViewingRoomHeader.tsx
@@ -85,7 +85,7 @@ const ViewingRoomHeaderLarge: React.FC<ViewingRoomHeaderProps> = props => {
         width="50%"
         style={{ position: "relative" }}
       >
-        <Sans size="10" element="h1" p={2} unstable_trackIn>
+        <Sans textAlign="center" size="10" element="h1" p={2} unstable_trackIn>
           {title}
         </Sans>
 
@@ -145,7 +145,7 @@ const ViewingRoomHeaderSmall: React.FC<ViewingRoomHeaderProps> = props => {
       />
 
       <Box position="absolute" bottom="20%">
-        <Sans size="8" element="h1" color="white100" p={2}>
+        <Sans textAlign="center" size="8" element="h1" color="white100" p={2}>
           {title}
         </Sans>
       </Box>


### PR DESCRIPTION
Small text alignment fix on VR titles reported in [GALL-3204](https://artsyproduct.atlassian.net/browse/GALL-3204):

**After:**
<img width="1302" alt="Screen Shot 2020-08-12 at 4 15 27 PM" src="https://user-images.githubusercontent.com/10385964/90063745-d4784880-dcb7-11ea-949a-6d6f1dc04085.png">
<img width="1294" alt="Screen Shot 2020-08-12 at 4 17 22 PM" src="https://user-images.githubusercontent.com/10385964/90063754-da6e2980-dcb7-11ea-859b-f7e5438aa160.png">


**Before:**
<img width="765" alt="Screen Shot 2020-08-12 at 4 22 16 PM" src="https://user-images.githubusercontent.com/10385964/90063894-038eba00-dcb8-11ea-9256-19ceed402152.png">

