### PR TITLE
Updates Footer typography

### DIFF
--- a/src/v2/Components/Footer.tsx
+++ b/src/v2/Components/Footer.tsx
@@ -3,33 +3,44 @@ import React from "react"
 import styled from "styled-components"
 import { FlexDirectionProps } from "styled-system"
 import { Media } from "v2/Utils/Responsive"
-
 import {
   ArtsyMarkIcon,
   FacebookIcon,
   Flex,
   InstagramIcon,
-  Sans,
   Separator,
-  Serif,
   Spacer,
+  Text,
   TwitterIcon,
   WeChatIcon,
   breakpoints,
   space,
 } from "@artsy/palette"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
+
+const Column = styled(Flex).attrs({
+  flex: 1,
+  flexDirection: "column",
+  mr: 2,
+  mb: 3,
+})`
+  a {
+    padding: ${space(1)}px 0;
+  }
+`
 
 interface Props {
   mediator?: Mediator
 }
 
-export const Footer: React.SFC<Props> = props => {
+export const Footer: React.FC<Props> = props => {
   const { mediator } = useSystemContext()
   return (
     <>
       <Media at="xs">
         <SmallFooter mediator={mediator} />
       </Media>
+
       <Media greaterThan="xs">
         <LargeFooter mediator={mediator} />
       </Media>
@@ -45,9 +56,9 @@ export const SmallFooter = (props: Props) => (
   <FooterContainer mediator={props.mediator} flexDirection="column" />
 )
 
-const FooterContainer: React.SFC<FlexDirectionProps & Props> = props => {
+const FooterContainer: React.FC<FlexDirectionProps & Props> = props => {
   return (
-    <React.Fragment>
+    <footer>
       <Flex
         flexDirection={props.flexDirection}
         justifyContent="space-between"
@@ -55,56 +66,58 @@ const FooterContainer: React.SFC<FlexDirectionProps & Props> = props => {
         maxWidth={breakpoints.xl}
         m="auto"
       >
-        <Flex flexDirection="column" mb={1}>
-          <Sans size="2" weight="medium">
+        <Column>
+          <Text variant="mediumText" mb={1}>
             Buy
-          </Sans>
-          <Serif size="2">
-            <Link href="https://support.artsy.net/hc/en-us/categories/360003689513-Buy">
+          </Text>
+          <Text variant="text">
+            <Link to="https://support.artsy.net/hc/en-us/categories/360003689513-Buy">
               Buying on Artsy
             </Link>
-            <Link href="https://www.artsy.net/consign">Consign with Artsy</Link>
-          </Serif>
-        </Flex>
-        <Flex flexDirection="column" mb={1}>
-          <Sans size="2" weight="medium">
+            <Link to="/consign">Consign with Artsy</Link>
+          </Text>
+        </Column>
+
+        <Column>
+          <Text variant="mediumText" mb={1}>
             Learn
-          </Sans>
-          <Serif size="2">
-            <Link href="https://www.artsy.net/artsy-education">Education</Link>
-            <Link href="https://www.artsy.net/categories">
-              The Art Genome Project
-            </Link>
-          </Serif>
-        </Flex>
-        <Flex flexDirection="column" mb={1}>
-          <Sans size="2" weight="medium">
+          </Text>
+
+          <Text variant="text">
+            <Link to="/artsy-education">Education</Link>
+            <Link to="/categories">The Art Genome Project</Link>
+          </Text>
+        </Column>
+
+        <Column>
+          <Text variant="mediumText" mb={1}>
             About us
-          </Sans>
-          <Serif size="2">
-            <Link href="https://www.artsy.net/about">About</Link>
-            <Link href="https://medium.com/artsy-blog">Blog</Link>
-            <Link href="https://www.artsy.net/about/jobs">Jobs</Link>
-            <Link href="https://artsy.github.com/open-source">Open Source</Link>
-            <Link href="https://www.artsy.net/about/press">Press</Link>
-            <Link href="https://www.artsy.net/contact">Contact</Link>
-            <Link href="https://support.artsy.net">Visit our Help Center</Link>
-          </Serif>
-        </Flex>
-        <Flex flexDirection="column" mb={1}>
-          <Sans size="2" weight="medium">
+          </Text>
+
+          <Text variant="text">
+            <Link to="/about">About</Link>
+            <Link to="https://medium.com/artsy-blog">Blog</Link>
+            <Link to="/about/jobs">Jobs</Link>
+            <Link to="https://artsy.github.com/open-source">Open Source</Link>
+            <Link to="/about/press">Press</Link>
+            <Link to="/contact">Contact</Link>
+            <Link to="https://support.artsy.net">Visit our Help Center</Link>
+          </Text>
+        </Column>
+
+        <Column>
+          <Text variant="mediumText" mb={1}>
             Partners
-          </Sans>
-          <Serif size="2">
-            <Link href="https://partners.artsy.net">Artsy for Galleries</Link>
-            <Link href="https://www.artsy.net/institution-partnerships">
-              Artsy for Museums
-            </Link>
-            <Link href="https://www.artsy.net/auction-partnerships">
-              Artsy for Auctions
-            </Link>
-          </Serif>
-        </Flex>
+          </Text>
+
+          <Text variant="text">
+            <Link to="https://partners.artsy.net">Artsy for Galleries</Link>
+
+            <Link to="/institution-partnerships">Artsy for Museums</Link>
+
+            <Link to="/auction-partnerships">Artsy for Auctions</Link>
+          </Text>
+        </Column>
 
         <Media at="xs">
           <Flex mb={1} flexWrap="wrap">
@@ -113,72 +126,102 @@ const FooterContainer: React.SFC<FlexDirectionProps & Props> = props => {
         </Media>
       </Flex>
 
-      <Separator mt={1} mb={2} />
+      <Separator />
 
-      <Flex justifyContent="space-between" width="100%">
-        <Flex mb={4}>
+      <Flex
+        justifyContent="space-between"
+        alignItems="center"
+        width="100%"
+        py={2}
+      >
+        <Flex>
           <Media at="xs">
-            <ArtsyMarkIcon width="20px" height="20px" mr={2} />
+            <Flex>
+              <ArtsyMarkIcon width="20px" height="20px" mr={2} />
+            </Flex>
           </Media>
 
           <Media greaterThan="xs">
             <Flex flexDirection="row">
               <ArtsyMarkIcon width="30px" height="30px" mr={2} />
+
               <Spacer mr={1} />
-              <Flex pt={"6px"} flexDirection="row">
+
+              <Flex flexDirection="row">
                 <PolicyLinks />
               </Flex>
             </Flex>
           </Media>
         </Flex>
-        <Flex>
-          <WeChatIcon width={space(2)} height={space(2)} mr={1} />
-          <a href="https://twitter.com/artsy">
+
+        <Flex alignItems="center">
+          <WeChat>
+            <WeChatIcon width={space(2)} height={space(2)} mr={1} />
+          </WeChat>
+
+          <Link to="https://twitter.com/artsy">
             <TwitterIcon width={space(2)} height={space(2)} mr={1} />
-          </a>
-          <a href="https://www.facebook.com/artsy">
+          </Link>
+
+          <Link to="https://www.facebook.com/artsy">
             <FacebookIcon width={space(2)} height={space(2)} mr={1} />
-          </a>
-          <a href="https://www.instagram.com/artsy/">
-            <InstagramIcon width={space(2)} height={space(2)} mr={1} />
-          </a>
+          </Link>
+
+          <Link to="https://www.instagram.com/artsy/">
+            <InstagramIcon width={space(2)} height={space(2)} />
+          </Link>
         </Flex>
       </Flex>
-    </React.Fragment>
+    </footer>
   )
 }
 
-const Link = styled.a`
-  display: block;
-  margin-top: ${space(1)}px;
-  margin-bottom: ${space(1)}px;
-  text-decoration: none;
+const WeChat = styled(Flex)`
+  > a {
+    display: flex;
+  }
 `
 
-const UnstyledLink = styled.a`
+const Link = styled(RouterLink)`
+  display: flex;
   text-decoration: none;
-  white-space: nowrap;
+  align-items: center;
 `
 
 const PolicyLinks = () => (
   <>
-    <Serif size="2">© {new Date().getFullYear()} Artsy</Serif>
-    <Spacer mr={1} />
-    <UnstyledLink href="https://www.artsy.net/terms">
-      <Serif size="2">Terms of Use</Serif>
-    </UnstyledLink>
-    <Spacer mr={1} />
-    <UnstyledLink href="https://www.artsy.net/privacy">
-      <Serif size="2">Privacy Policy</Serif>
-    </UnstyledLink>
-    <Spacer mr={1} />
-    <UnstyledLink href="https://www.artsy.net/security">
-      <Serif size="2">Security</Serif>
-    </UnstyledLink>
-    <Spacer mr={1} />
-    <UnstyledLink href="https://www.artsy.net/conditions-of-sale">
-      <Serif size="2">Conditions of Sale</Serif>
-    </UnstyledLink>
-    <Spacer mr={1} />
+    <Text
+      display="flex"
+      alignItems="center"
+      variant="caption"
+      color="black60"
+      mr={1}
+    >
+      © {new Date().getFullYear()} Artsy
+    </Text>
+
+    <Link to="/terms">
+      <Text variant="caption" color="black60" mr={1}>
+        Terms of Use
+      </Text>
+    </Link>
+
+    <Link to="/privacy">
+      <Text variant="caption" color="black60" mr={1}>
+        Privacy Policy
+      </Text>
+    </Link>
+
+    <Link to="/security">
+      <Text variant="caption" color="black60" mr={1}>
+        Security
+      </Text>
+    </Link>
+
+    <Link to="/conditions-of-sale">
+      <Text variant="caption" color="black60">
+        Conditions of Sale
+      </Text>
+    </Link>
   </>
 )


### PR DESCRIPTION
Quick little thing — updates footer to utilize new typography & serif => sans.

Just bring it inline with [this figma spec](https://www.figma.com/file/LKKhtse11fjmdFI6AaVqGM/Palette-%5BWIP%5D?node-id=1590%3A2142). The contact forms on the right-hand side aren't in this footer so I just left them out — the intent here was just to give the type a facelift. @nicoleyeo gives the 👍 

![localhost_5000_feature_alserkal-art-week (1)](https://user-images.githubusercontent.com/112297/90174481-0f3fb680-dd74-11ea-8589-56e74dc634b8.png)
