### PR TITLE
GALL-3205--Clicking "View More" Bug Fix

### DIFF
--- a/src/v2/Apps/ViewingRoom/Components/ViewingRoomsLatestGrid.tsx
+++ b/src/v2/Apps/ViewingRoom/Components/ViewingRoomsLatestGrid.tsx
@@ -14,7 +14,7 @@ import {
   createPaginationContainer,
   graphql,
 } from "react-relay"
-
+import { scrollIntoView } from "v2/Utils/scrollHelpers"
 import { ViewingRoomsLatestGrid_viewingRooms } from "v2/__generated__/ViewingRoomsLatestGrid_viewingRooms.graphql"
 import { crop } from "v2/Utils/resizer"
 
@@ -62,7 +62,7 @@ export const PAGE_SIZE = 12
 export const ViewingRoomsLatestGrid: React.FC<ViewingRoomsLatestGridProps> = props => {
   const viewingRooms = props.viewingRooms?.viewingRoomsConnection
   const [isLoading, setIsLoading] = useState(false)
-  const hasMoreItems = props.relay.hasMore()
+  const hasMoreItems = props.relay.hasMore() as boolean
 
   const loadMore = () => {
     if (hasMoreItems) {
@@ -73,6 +73,11 @@ export const ViewingRoomsLatestGrid: React.FC<ViewingRoomsLatestGridProps> = pro
           console.error(error)
         }
         setIsLoading(false)
+
+        setTimeout(
+          () => scrollIntoView({ offset: 60, selector: "#jump--viewingRoom" }),
+          100
+        )
       })
     }
   }
@@ -113,7 +118,7 @@ export const ViewingRoomsLatestGrid: React.FC<ViewingRoomsLatestGridProps> = pro
           gridColumnGap={2}
           gridRowGap={6}
         >
-          {viewingRoomsForLatestGrid.map(vr => {
+          {viewingRoomsForLatestGrid.map((vr, index) => {
             const {
               slug,
               title,
@@ -135,7 +140,18 @@ export const ViewingRoomsLatestGrid: React.FC<ViewingRoomsLatestGridProps> = pro
             const tag = getTagProps(status, distanceToOpen, distanceToClose)
 
             return (
-              <Link href={`/viewing-room/${slug}`} key={slug} noUnderline>
+              <Link
+                href={`/viewing-room/${slug}`}
+                key={slug}
+                noUnderline
+                id={
+                  // Calling loadMore loads 12 VRs at a time. We want to add a css id selector to the last VR in the list (list length - 12)
+                  // before loadMore was called and scroll to that element when the Show More button is pressed.
+                  viewingRoomsForLatestGrid.length - 12 === index
+                    ? "jump--viewingRoom"
+                    : ""
+                }
+              >
                 <SmallCard
                   title={title}
                   subtitle={partner.name}

--- a/src/v2/Apps/ViewingRoom/Components/ViewingRoomsLatestGrid.tsx
+++ b/src/v2/Apps/ViewingRoom/Components/ViewingRoomsLatestGrid.tsx
@@ -5,7 +5,6 @@ import {
   CSSGrid,
   CardTagProps,
   Flex,
-  Link,
   Sans,
   SmallCard,
 } from "@artsy/palette"
@@ -17,6 +16,7 @@ import {
 import { scrollIntoView } from "v2/Utils/scrollHelpers"
 import { ViewingRoomsLatestGrid_viewingRooms } from "v2/__generated__/ViewingRoomsLatestGrid_viewingRooms.graphql"
 import { crop } from "v2/Utils/resizer"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
 
 export interface ViewingRoomsLatestGridProps {
   relay: RelayPaginationProp
@@ -140,25 +140,20 @@ export const ViewingRoomsLatestGrid: React.FC<ViewingRoomsLatestGridProps> = pro
             const tag = getTagProps(status, distanceToOpen, distanceToClose)
 
             return (
-              <Link
-                href={`/viewing-room/${slug}`}
-                key={slug}
-                noUnderline
-                id={
-                  // Calling loadMore loads 12 VRs at a time. We want to add a css id selector to the last VR in the list (list length - 12)
-                  // before loadMore was called and scroll to that element when the Show More button is pressed.
-                  viewingRoomsForLatestGrid.length - 12 === index
-                    ? "jump--viewingRoom"
-                    : ""
+              <RouterLink to={`/viewing-room/${slug}`} key={slug} noUnderline>
+                {
+                  // Add a css id selector to an empty div above the last list item and scroll to that div when the Show More button is pressed.
+                  viewingRoomsForLatestGrid.length - PAGE_SIZE === index && (
+                    <div id="jump--viewingRoom" />
+                  )
                 }
-              >
                 <SmallCard
                   title={title}
                   subtitle={partner.name}
                   images={[heroImageURL].concat(artworkImages)}
                   tag={tag}
                 />
-              </Link>
+              </RouterLink>
             )
           })}
         </CSSGrid>

--- a/src/v2/Artsy/Router/RouterLink.tsx
+++ b/src/v2/Artsy/Router/RouterLink.tsx
@@ -14,7 +14,12 @@ import { get } from "v2/Utils/get"
  * `
  */
 
-export type RouterLinkProps = LinkProps &
+interface StyleProps {
+  noUnderline?: boolean
+}
+
+export type RouterLinkProps = StyleProps &
+  LinkProps &
   React.HTMLAttributes<HTMLAnchorElement>
 
 export const RouterLink: React.FC<RouterLinkProps> = ({
@@ -22,6 +27,7 @@ export const RouterLink: React.FC<RouterLinkProps> = ({
   children,
   ...props
 }) => {
+  const styleProps = props.noUnderline ? { textDecoration: "none" } : {}
   const context = useContext(RouterContext)
   const routes = get(context, c => c?.router?.matcher?.routeConfig, [])
   const isSupportedInRouter = !!get(context, c =>
@@ -53,7 +59,7 @@ export const RouterLink: React.FC<RouterLinkProps> = ({
     ])
 
     return (
-      <Link to={to} {...allowedProps}>
+      <Link to={to} {...allowedProps} style={styleProps}>
         {children}
       </Link>
     )
@@ -62,7 +68,7 @@ export const RouterLink: React.FC<RouterLinkProps> = ({
       <a
         href={to as string}
         className={(props as LinkPropsSimple).className}
-        style={(props as LinkPropsSimple).style}
+        style={Object.assign(styleProps, (props as LinkPropsSimple).style)}
         {...omit(props, ["activeClassName", "hasLighterTextColor"])}
       >
         {children}


### PR DESCRIPTION
Addresses [GALL-3205 Landing page: Clicking "View More" loads more rooms above the button](https://artsyproduct.atlassian.net/browse/GALL-3205)

When a user clicks View More to load the next set of viewing rooms, the top of the newly loaded list of VRs should be in view so they needn't scroll up after. 

![Kapture 2020-08-13 at 18 26 54](https://user-images.githubusercontent.com/10385964/90193554-35288380-dd93-11ea-9560-c69b713556b9.gif)
