### PR TITLE
Webpack Analyzer Defaults

### DIFF
--- a/webpack/plugins/bundleAnalyzer.js
+++ b/webpack/plugins/bundleAnalyzer.js
@@ -15,6 +15,11 @@ export function bundleAnalyzer(config) {
     optimization: {
       concatenateModules: false,
     },
-    plugins: [new BundleAnalyzerPlugin()],
+    plugins: [
+      new BundleAnalyzerPlugin({
+        analyzerMode: "static",
+        defaultSizes: "gzip",
+      }),
+    ],
   })
 }


### PR DESCRIPTION
Description

Changes the default settings for `webpack-bundle-analyzer` to display
the gzipped size and render a static page instead of running a
web server. The main reason for disabling the web server is that it makes 
it difficult to compare multiple branches because of port conflicts.