### PR TITLE
Adds role="presentation" to unfocusable anchors

### DIFF
--- a/src/v2/Artsy/Router/RouterLink.tsx
+++ b/src/v2/Artsy/Router/RouterLink.tsx
@@ -54,7 +54,9 @@ export const RouterLink: React.FC<RouterLinkProps> = ({
       "data-test",
       "exact",
       "replace",
+      "role",
       "style",
+      "tabIndex",
       ...handlers,
     ])
 

--- a/src/v2/Components/NavBar/NavItem.tsx
+++ b/src/v2/Components/NavBar/NavItem.tsx
@@ -41,7 +41,10 @@ const HitArea = styled(Link)`
   }
 `
 
-const UnfocusableAnchor = styled(RouterLink).attrs({ tabIndex: -1 })`
+const UnfocusableAnchor = styled(RouterLink).attrs({
+  tabIndex: -1,
+  role: "presentation",
+})`
   display: block;
   position: absolute;
   top: 0;


### PR DESCRIPTION
Minor: was trying out [this extension from Microsoft](https://accessibilityinsights.io/docs/en/web/overview) (recommended!) and it caught this: we're laying an unfocusable anchor tag over the dropdown items so that we can have the keypress handler open the submenu and any mouse click go to the href — since if you're using a pointing device, the submenu will open on hover.

Adding `role="presentation"` overwrites the semantics of the given element and ensures it's ignored (it wasn't focusable anyway so I don't believe this was an actual issue but dotting the i here).