### PR TITLE
Adds fair header and more info page

### DIFF
--- a/src/v2/Apps/Fair/Components/FairHeader.tsx
+++ b/src/v2/Apps/Fair/Components/FairHeader.tsx
@@ -1,14 +1,41 @@
 import React from "react"
-import { Placeholder } from "v2/Utils"
-import { Col, Flex, Row, Spacer, Text } from "@artsy/palette"
+import {
+  Col,
+  Flex,
+  ResponsiveBox,
+  ResponsiveBoxProps,
+  Row,
+  Spacer,
+  Text,
+} from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairHeader_fair } from "v2/__generated__/FairHeader_fair.graphql"
+import styled from "styled-components"
+import { ForwardLink } from "v2/Components/Links/ForwardLink"
 
 interface FairHeaderProps {
   fair: FairHeader_fair
 }
 
+const ResponsiveImage = styled(ResponsiveBox)<ResponsiveBoxProps>`
+  img {
+    width: 100%;
+    height: 100%;
+  }
+`
+
 const FairHeader: React.FC<FairHeaderProps> = ({ fair }) => {
+  const img = fair?.image?.cropped
+  const { about, tagline, location, ticketsLink, hours, links } = fair
+
+  const canShowMoreInfoLink =
+    !!about ||
+    !!tagline ||
+    !!location?.summary ||
+    !!ticketsLink ||
+    !!hours ||
+    !!links
+
   return (
     <>
       <Spacer mb="2" />
@@ -17,7 +44,14 @@ const FairHeader: React.FC<FairHeaderProps> = ({ fair }) => {
         justifyContent="center"
         style={{ position: "relative" }}
       >
-        <Placeholder height="500px" width="375px" name="header image" />
+        <ResponsiveImage
+          aspectWidth={img.width}
+          aspectHeight={img.height}
+          maxWidth={375}
+          bg="black10"
+        >
+          <img src={img.src} alt={fair.name} />
+        </ResponsiveImage>
       </Flex>
       <Spacer mb="2" />
       <Row>
@@ -26,7 +60,13 @@ const FairHeader: React.FC<FairHeaderProps> = ({ fair }) => {
           <Text variant="caption">{fair.formattedOpeningHours}</Text>
         </Col>
         <Col sm="6" mt={[3, 0]}>
-          <Text variant="text">{fair.about}</Text>
+          <Text variant="text">{about}</Text>
+          {canShowMoreInfoLink && (
+            <ForwardLink
+              linkText="More info"
+              path={`/fair2/${fair.slug}/info`}
+            />
+          )}
         </Col>
       </Row>
     </>
@@ -39,6 +79,23 @@ export const FairHeaderFragmentContainer = createFragmentContainer(FairHeader, {
       about
       formattedOpeningHours
       name
+      slug
+      image {
+        # 3:4 - 375×500 native max dimensions * 2 for retina
+        cropped(width: 750, height: 1000, version: "wide") {
+          src: url
+          width
+          height
+        }
+      }
+      # Used to figure out if we should render the More info link
+      tagline
+      location {
+        summary
+      }
+      ticketsLink
+      hours
+      links
     }
   `,
 })

--- a/src/v2/Apps/Fair/Components/__tests__/FairHeader.jest.tsx
+++ b/src/v2/Apps/Fair/Components/__tests__/FairHeader.jest.tsx
@@ -1,0 +1,114 @@
+import { Breakpoint } from "@artsy/palette"
+import { MockBoot, renderRelayTree } from "v2/DevTools"
+import React from "react"
+import { FairHeaderFragmentContainer } from "../FairHeader"
+import { graphql } from "react-relay"
+import { FairHeader_QueryRawResponse } from "v2/__generated__/FairHeader_Query.graphql"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
+
+jest.unmock("react-relay")
+
+describe("FairHeader", () => {
+  const getWrapper = async (
+    breakpoint: Breakpoint = "lg",
+    response: FairHeader_QueryRawResponse = FairHeaderFixture
+  ) => {
+    return renderRelayTree({
+      Component: ({ fair }) => {
+        return (
+          <MockBoot breakpoint={breakpoint}>
+            <FairHeaderFragmentContainer fair={fair} />
+          </MockBoot>
+        )
+      },
+      query: graphql`
+        query FairHeader_Query($slug: String!) @raw_response_type {
+          fair(id: $slug) {
+            ...FairHeader_fair
+          }
+        }
+      `,
+      variables: {
+        slug: "miart-2020",
+      },
+      mockData: response,
+    })
+  }
+
+  it("displays basic information about the fair", async () => {
+    const wrapper = await getWrapper()
+    expect(wrapper.text()).toContain("Miart 2020")
+    expect(wrapper.text()).toContain("This is the about.")
+  })
+
+  it("displays a link to see more info about the fair", async () => {
+    const wrapper = await getWrapper()
+    const MoreInfoButton = wrapper
+      .find(RouterLink)
+      .filterWhere(t => t.text() === "More info")
+    expect(MoreInfoButton.length).toEqual(1)
+    expect(MoreInfoButton.first().prop("to")).toEqual("/fair2/miart-2020/info")
+  })
+
+  it("doesn't display the More info link if there is no info", async () => {
+    const missingInfoFair: FairHeader_QueryRawResponse = {
+      fair: {
+        ...FairHeaderFixture.fair,
+        about: "",
+        tagline: "",
+        location: null,
+        ticketsLink: "",
+        hours: "",
+        links: "",
+      },
+    }
+
+    const wrapper = await getWrapper("lg", missingInfoFair)
+    const MoreInfoButton = wrapper
+      .find(RouterLink)
+      .filterWhere(t => t.text() === "More info")
+    expect(MoreInfoButton.length).toEqual(0)
+  })
+
+  it("displays the More info link as long as there is some information", async () => {
+    const missingInfoFair: FairHeader_QueryRawResponse = {
+      fair: {
+        ...FairHeaderFixture.fair,
+        about: "",
+        tagline: "I have a tagline",
+        location: null,
+        ticketsLink: "",
+        hours: "",
+        links: "",
+      },
+    }
+
+    const wrapper = await getWrapper("lg", missingInfoFair)
+    const MoreInfoButton = wrapper
+      .find(RouterLink)
+      .filterWhere(t => t.text() === "More info")
+    expect(MoreInfoButton.length).toEqual(1)
+  })
+})
+
+const FairHeaderFixture: FairHeader_QueryRawResponse = {
+  fair: {
+    id: "fair12345",
+    about: "This is the about.",
+    name: "Miart 2020",
+    formattedOpeningHours: "Closes in 12 days",
+    slug: "miart-2020",
+    image: {
+      cropped: {
+        src: "https://cloudfront.com/square.jpg",
+        width: 100,
+        height: 400,
+      },
+    },
+    tagline: "",
+    location: null,
+    ticketsLink: "",
+    hours: "",
+    links: "",
+  },
+}

--- a/src/v2/Apps/Fair/FairApp.tsx
+++ b/src/v2/Apps/Fair/FairApp.tsx
@@ -2,27 +2,24 @@ import React from "react"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairApp_fair } from "v2/__generated__/FairApp_fair.graphql"
-import { Separator } from "@artsy/palette"
+import { Box, Separator } from "@artsy/palette"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
 import { Footer } from "v2/Components/Footer"
-import { FairHeaderFragmentContainer } from "./Components/FairHeader"
 import { ErrorPage } from "v2/Components/ErrorPage"
 
 interface FairAppProps {
   fair: FairApp_fair
 }
 
-const FairApp: React.FC<FairAppProps> = ({ fair }) => {
+const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
   if (!fair) return <ErrorPage code={404} />
 
   return (
     <>
       <AppContainer>
         <HorizontalPadding>
-          <FairHeaderFragmentContainer fair={fair} />
-
+          <Box minHeight="30vh">{children}</Box>
           <Separator my={3} />
-
           <Footer />
         </HorizontalPadding>
       </AppContainer>
@@ -34,7 +31,7 @@ const FairApp: React.FC<FairAppProps> = ({ fair }) => {
 export default createFragmentContainer(FairApp, {
   fair: graphql`
     fragment FairApp_fair on Fair {
-      ...FairHeader_fair
+      id
     }
   `,
 })

--- a/src/v2/Apps/Fair/Routes/FairInfo.tsx
+++ b/src/v2/Apps/Fair/Routes/FairInfo.tsx
@@ -1,0 +1,106 @@
+import React from "react"
+import { Col, HTML, Row, Spacer, Text } from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { FairInfo_fair } from "v2/__generated__/FairInfo_fair.graphql"
+import { BackLink } from "v2/Components/Links/BackLink"
+import styled from "styled-components"
+
+interface FairInfoProps {
+  fair: FairInfo_fair
+}
+
+const TextWithNewlines = styled(Text)`
+  white-space: pre-wrap;
+`
+
+const FairInfo: React.FC<FairInfoProps> = ({ fair }) => {
+  return (
+    <>
+      <BackLink
+        linkText={`Back to ${fair.name}`}
+        path={`/fair2/${fair.slug}`}
+      />
+
+      <Spacer my={3} />
+
+      <Text variant="largeTitle">About</Text>
+
+      <Spacer my={1} />
+
+      <Row>
+        <Col sm="9" pr={2}>
+          {/** TODO: Add summary here when it exists **/}
+          {fair.about && (
+            <>
+              <TextWithNewlines variant="text">{fair.about}</TextWithNewlines>
+              <Spacer my={3} />
+            </>
+          )}
+
+          {fair.tagline && (
+            <>
+              <TextWithNewlines variant="text">{fair.tagline}</TextWithNewlines>
+              <Spacer my={3} />
+            </>
+          )}
+
+          {fair.location?.summary && (
+            <>
+              <Text variant="mediumText">Location</Text>
+              <TextWithNewlines variant="text">
+                {fair.location?.summary}
+              </TextWithNewlines>
+            </>
+          )}
+        </Col>
+        <Col sm="3">
+          {/** TODO: Hours should be able to be formatted into HTML **/}
+          {fair.hours && (
+            <>
+              <Text variant="mediumText">Hours</Text>
+              <HTML variant="text" html={fair.hours} />
+              <Spacer my={3} />
+            </>
+          )}
+          {/** TODO: Add tickets here when it exists **/}
+          {fair.ticketsLink && (
+            <>
+              <a href={fair.ticketsLink}>
+                <Text variant="text">Buy Tickets</Text>
+              </a>
+              <Spacer my={3} />
+            </>
+          )}
+          {/** TODO: Links should be able to be formatted into HTML **/}
+          {fair.links && (
+            <>
+              <Text variant="mediumText">Links</Text>
+              <HTML variant="text" html={fair.links} />
+              <Spacer my={3} />
+            </>
+          )}
+        </Col>
+      </Row>
+    </>
+  )
+}
+
+export const FairInfoFragmentContainer = createFragmentContainer(FairInfo, {
+  fair: graphql`
+    fragment FairInfo_fair on Fair {
+      about
+      name
+      slug
+      tagline
+      location {
+        summary
+      }
+      ticketsLink
+      hours
+      links
+    }
+  `,
+})
+
+// Top-level route needs to be exported for bundle splitting in the router
+export default FairInfoFragmentContainer

--- a/src/v2/Apps/Fair/Routes/FairOverview.tsx
+++ b/src/v2/Apps/Fair/Routes/FairOverview.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { FairOverview_fair } from "v2/__generated__/FairOverview_fair.graphql"
+import { FairHeaderFragmentContainer } from "../Components/FairHeader"
+
+interface FairOverviewProps {
+  fair: FairOverview_fair
+}
+
+const FairOverview: React.FC<FairOverviewProps> = ({ fair }) => {
+  return (
+    <>
+      <FairHeaderFragmentContainer fair={fair} />
+    </>
+  )
+}
+
+export const FairOverviewFragmentContainer = createFragmentContainer(
+  FairOverview,
+  {
+    fair: graphql`
+      fragment FairOverview_fair on Fair {
+        ...FairHeader_fair
+      }
+    `,
+  }
+)
+
+// Top-level route needs to be exported for bundle splitting in the router
+export default FairOverviewFragmentContainer

--- a/src/v2/Apps/Fair/Routes/__tests__/FairInfo.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairInfo.jest.tsx
@@ -1,0 +1,91 @@
+import { Breakpoint } from "@artsy/palette"
+import { MockBoot, renderRelayTree } from "v2/DevTools"
+import React from "react"
+import { FairInfoFragmentContainer } from "../FairInfo"
+import { graphql } from "react-relay"
+import { FairInfo_QueryRawResponse } from "v2/__generated__/FairInfo_Query.graphql"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
+
+jest.unmock("react-relay")
+
+describe("FairInfo", () => {
+  const getWrapper = async (
+    breakpoint: Breakpoint = "lg",
+    response: FairInfo_QueryRawResponse = FairInfoFixture
+  ) => {
+    return renderRelayTree({
+      Component: ({ fair }) => {
+        return (
+          <MockBoot breakpoint={breakpoint}>
+            <FairInfoFragmentContainer fair={fair} />
+          </MockBoot>
+        )
+      },
+      query: graphql`
+        query FairInfo_Query($slug: String!) @raw_response_type {
+          fair(id: $slug) {
+            ...FairInfo_fair
+          }
+        }
+      `,
+      variables: {
+        slug: "miart-2020",
+      },
+      mockData: response,
+    })
+  }
+
+  it("displays more information about the fair", async () => {
+    const wrapper = await getWrapper()
+    expect(wrapper.text()).toContain("This is the about.")
+    expect(wrapper.text()).toContain("LocationJavitz Center")
+    expect(wrapper.text()).toContain("HoursOpen every day at 5am")
+    expect(wrapper.text()).toContain("Buy Tickets")
+    expect(wrapper.text()).toContain("LinksGoogle it")
+  })
+
+  it("displays a link to get back to the fair", async () => {
+    const wrapper = await getWrapper()
+    const BackButton = wrapper
+      .find(RouterLink)
+      .filterWhere(t => t.text() === "Back to Miart 2020")
+    expect(BackButton.length).toEqual(1)
+    expect(BackButton.first().prop("to")).toEqual("/fair2/miart-2020")
+  })
+
+  it("handles missing information", async () => {
+    const missingInfo = {
+      fair: {
+        ...FairInfoFixture.fair,
+        about: "",
+        tagline: "",
+        location: null,
+        ticketsLink: "",
+        hours: "",
+        links: "",
+      },
+    }
+    const wrapper = await getWrapper("lg", missingInfo)
+    expect(wrapper.text()).not.toContain("Location")
+    expect(wrapper.text()).not.toContain("Hours")
+    expect(wrapper.text()).not.toContain("Buy Tickets")
+    expect(wrapper.text()).not.toContain("Links")
+  })
+})
+
+const FairInfoFixture: FairInfo_QueryRawResponse = {
+  fair: {
+    id: "fair12345",
+    about: "This is the about.",
+    name: "Miart 2020",
+    slug: "miart-2020",
+    tagline: "The tagline.",
+    location: {
+      id: "location124",
+      summary: "Javitz Center",
+    },
+    ticketsLink: "https://eventbrite.com/cool-event",
+    hours: "Open every day at 5am",
+    links: "<a href='google.com'>Google it</a>",
+  },
+}

--- a/src/v2/Apps/Fair/Routes/__tests__/FairOverview.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairOverview.jest.tsx
@@ -1,0 +1,63 @@
+import { Breakpoint } from "@artsy/palette"
+import { MockBoot, renderRelayTree } from "v2/DevTools"
+import React from "react"
+import FairOverview from "../FairOverview"
+import { graphql } from "react-relay"
+import { FairOverview_QueryRawResponse } from "v2/__generated__/FairOverview_Query.graphql"
+
+jest.unmock("react-relay")
+
+describe("FairOverview", () => {
+  const getWrapper = async (
+    breakpoint: Breakpoint = "lg",
+    response: FairOverview_QueryRawResponse = FairOverviewFixture
+  ) => {
+    return renderRelayTree({
+      Component: ({ fair }) => {
+        return (
+          <MockBoot breakpoint={breakpoint}>
+            <FairOverview fair={fair} />
+          </MockBoot>
+        )
+      },
+      query: graphql`
+        query FairOverview_Query($slug: String!) @raw_response_type {
+          fair(id: $slug) {
+            ...FairOverview_fair
+          }
+        }
+      `,
+      variables: {
+        slug: "miart-2020",
+      },
+      mockData: response,
+    })
+  }
+
+  it("displays basic information about the fair", async () => {
+    const wrapper = await getWrapper()
+    expect(wrapper.find("FairHeader").length).toBe(1)
+  })
+})
+
+const FairOverviewFixture: FairOverview_QueryRawResponse = {
+  fair: {
+    id: "fair12345",
+    about: "Lorem ipsum",
+    name: "Miart 2020",
+    formattedOpeningHours: "Closes in 12 days",
+    slug: "miart-2020",
+    image: {
+      cropped: {
+        src: "https://cloudfront.com/square.jpg",
+        width: 100,
+        height: 400,
+      },
+    },
+    tagline: "",
+    location: null,
+    ticketsLink: "",
+    hours: "",
+    links: "",
+  },
+}

--- a/src/v2/Apps/Fair/__tests__/FairApp.jest.tsx
+++ b/src/v2/Apps/Fair/__tests__/FairApp.jest.tsx
@@ -37,16 +37,11 @@ describe("FairApp", () => {
   it("displays basic information about the fair", async () => {
     const wrapper = await getWrapper()
     expect(wrapper.find("AppContainer").length).toBe(1)
-    expect(wrapper.find("FairHeader").length).toBe(1)
-    expect(wrapper.text()).toContain("Miart 2020")
   })
 })
 
 const FairAppFixture: FairApp_QueryRawResponse = {
   fair: {
     id: "fair12345",
-    about: "Lorem ipsum",
-    name: "Miart 2020",
-    formattedOpeningHours: "Closes in 12 days",
   },
 }

--- a/src/v2/Apps/Fair/routes.tsx
+++ b/src/v2/Apps/Fair/routes.tsx
@@ -3,6 +3,8 @@ import { graphql } from "react-relay"
 import { RouteConfig } from "found"
 
 const FairApp = loadable(() => import("./FairApp"))
+const FairOverviewRoute = loadable(() => import("./Routes/FairOverview"))
+const FairInfoRoute = loadable(() => import("./Routes/FairInfo"))
 
 export const routes: RouteConfig[] = [
   {
@@ -18,5 +20,35 @@ export const routes: RouteConfig[] = [
         }
       }
     `,
+    children: [
+      {
+        path: "/",
+        getComponent: () => FairOverviewRoute,
+        prepare: () => {
+          FairOverviewRoute.preload()
+        },
+        query: graphql`
+          query routes_FairOverviewQuery($slug: String!) {
+            fair(id: $slug) {
+              ...FairOverview_fair
+            }
+          }
+        `,
+      },
+      {
+        path: "info",
+        getComponent: () => FairInfoRoute,
+        prepare: () => {
+          FairInfoRoute.preload()
+        },
+        query: graphql`
+          query routes_FairInfoQuery($slug: String!) {
+            fair(id: $slug) {
+              ...FairInfo_fair
+            }
+          }
+        `,
+      },
+    ],
   },
 ]

--- a/src/v2/Components/Links/BackLink.tsx
+++ b/src/v2/Components/Links/BackLink.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { ChevronIcon, Flex, Text } from "@artsy/palette"
+import { StyledLink } from "./StyledLink"
+
+interface BackLinkProps {
+  linkText: string
+  path: string
+}
+
+export const BackLink: React.FC<BackLinkProps> = ({ linkText, path }) => {
+  return (
+    <>
+      <Flex flexDirection="row" alignItems="center" my={3}>
+        <ChevronIcon
+          direction="left"
+          color="black"
+          height="18px"
+          width="14px"
+          top="-2px"
+        />
+        <Text variant="mediumText" ml="8px">
+          <StyledLink to={path}>{linkText}</StyledLink>
+        </Text>
+      </Flex>
+    </>
+  )
+}

--- a/src/v2/Components/Links/ForwardLink.tsx
+++ b/src/v2/Components/Links/ForwardLink.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import { ChevronIcon, Flex, Text } from "@artsy/palette"
+import { StyledLink } from "./StyledLink"
+
+interface ForwardLinkProps {
+  linkText: string
+  path: string
+}
+
+export const ForwardLink: React.FC<ForwardLinkProps> = ({ linkText, path }) => {
+  return (
+    <Flex flexDirection="row" alignItems="center" mt={1}>
+      <Text variant="mediumText" mr="3px">
+        <StyledLink to={path}>{linkText}</StyledLink>
+      </Text>
+      <ChevronIcon
+        direction="right"
+        color="black"
+        height="18px"
+        width="14px"
+        top="-1px"
+      />
+    </Flex>
+  )
+}

--- a/src/v2/Components/Links/StyledLink.tsx
+++ b/src/v2/Components/Links/StyledLink.tsx
@@ -1,0 +1,13 @@
+import styled from "styled-components"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
+import { color } from "@artsy/palette"
+
+export const StyledLink = styled(RouterLink)`
+  text-decoration: none;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+
+  &:hover {
+    text-decoration: none;
+    color: ${color("black60")};
+  }
+`

--- a/src/v2/__generated__/FairApp_Query.graphql.ts
+++ b/src/v2/__generated__/FairApp_Query.graphql.ts
@@ -13,10 +13,7 @@ export type FairApp_QueryResponse = {
 };
 export type FairApp_QueryRawResponse = {
     readonly fair: ({
-        readonly about: string | null;
-        readonly formattedOpeningHours: string | null;
-        readonly name: string | null;
-        readonly id: string | null;
+        readonly id: string;
     }) | null;
 };
 export type FairApp_Query = {
@@ -38,13 +35,7 @@ query FairApp_Query(
 }
 
 fragment FairApp_fair on Fair {
-  ...FairHeader_fair
-}
-
-fragment FairHeader_fair on Fair {
-  about
-  formattedOpeningHours
-  name
+  id
 }
 */
 
@@ -108,27 +99,6 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "about",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "formattedOpeningHours",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "name",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
             "name": "id",
             "storageKey": null
           }
@@ -142,7 +112,7 @@ return {
     "metadata": {},
     "name": "FairApp_Query",
     "operationKind": "query",
-    "text": "query FairApp_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  ...FairHeader_fair\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  formattedOpeningHours\n  name\n}\n"
+    "text": "query FairApp_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  id\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairApp_fair.graphql.ts
+++ b/src/v2/__generated__/FairApp_fair.graphql.ts
@@ -4,7 +4,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type FairApp_fair = {
-    readonly " $fragmentRefs": FragmentRefs<"FairHeader_fair">;
+    readonly id: string;
     readonly " $refType": "FairApp_fair";
 };
 export type FairApp_fair$data = FairApp_fair;
@@ -22,12 +22,14 @@ const node: ReaderFragment = {
   "name": "FairApp_fair",
   "selections": [
     {
+      "alias": null,
       "args": null,
-      "kind": "FragmentSpread",
-      "name": "FairHeader_fair"
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
     }
   ],
   "type": "Fair"
 };
-(node as any).hash = '64cfd90722039e0fdaea83516c278516';
+(node as any).hash = 'dc1cbeebc696f6fe973e718928a3a8c6';
 export default node;

--- a/src/v2/__generated__/FairHeader_Query.graphql.ts
+++ b/src/v2/__generated__/FairHeader_Query.graphql.ts
@@ -1,0 +1,292 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type FairHeader_QueryVariables = {
+    slug: string;
+};
+export type FairHeader_QueryResponse = {
+    readonly fair: {
+        readonly " $fragmentRefs": FragmentRefs<"FairHeader_fair">;
+    } | null;
+};
+export type FairHeader_QueryRawResponse = {
+    readonly fair: ({
+        readonly about: string | null;
+        readonly formattedOpeningHours: string | null;
+        readonly name: string | null;
+        readonly slug: string;
+        readonly image: ({
+            readonly cropped: ({
+                readonly src: string | null;
+                readonly width: number | null;
+                readonly height: number | null;
+            }) | null;
+        }) | null;
+        readonly tagline: string | null;
+        readonly location: ({
+            readonly summary: string | null;
+            readonly id: string | null;
+        }) | null;
+        readonly ticketsLink: string | null;
+        readonly hours: string | null;
+        readonly links: string | null;
+        readonly id: string | null;
+    }) | null;
+};
+export type FairHeader_Query = {
+    readonly response: FairHeader_QueryResponse;
+    readonly variables: FairHeader_QueryVariables;
+    readonly rawResponse: FairHeader_QueryRawResponse;
+};
+
+
+
+/*
+query FairHeader_Query(
+  $slug: String!
+) {
+  fair(id: $slug) {
+    ...FairHeader_fair
+    id
+  }
+}
+
+fragment FairHeader_fair on Fair {
+  about
+  formattedOpeningHours
+  name
+  slug
+  image {
+    cropped(width: 750, height: 1000, version: "wide") {
+      src: url
+      width
+      height
+    }
+  }
+  tagline
+  location {
+    summary
+    id
+  }
+  ticketsLink
+  hours
+  links
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "slug",
+    "type": "String!"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "slug"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "FairHeader_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "FairHeader_fair"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "FairHeader_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "about",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "formattedOpeningHours",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 1000
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "wide"
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 750
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": "src",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "url",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "width",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "height",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "cropped(height:1000,version:\"wide\",width:750)"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "tagline",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Location",
+            "kind": "LinkedField",
+            "name": "location",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "summary",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "ticketsLink",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "hours",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "links",
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "FairHeader_Query",
+    "operationKind": "query",
+    "text": "query FairHeader_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairHeader_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  formattedOpeningHours\n  name\n  slug\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours\n  links\n}\n"
+  }
+};
+})();
+(node as any).hash = 'af5c0d423dbab8c7879f98b99dd99ebd';
+export default node;

--- a/src/v2/__generated__/FairHeader_fair.graphql.ts
+++ b/src/v2/__generated__/FairHeader_fair.graphql.ts
@@ -7,6 +7,21 @@ export type FairHeader_fair = {
     readonly about: string | null;
     readonly formattedOpeningHours: string | null;
     readonly name: string | null;
+    readonly slug: string;
+    readonly image: {
+        readonly cropped: {
+            readonly src: string | null;
+            readonly width: number | null;
+            readonly height: number | null;
+        } | null;
+    } | null;
+    readonly tagline: string | null;
+    readonly location: {
+        readonly summary: string | null;
+    } | null;
+    readonly ticketsLink: string | null;
+    readonly hours: string | null;
+    readonly links: string | null;
     readonly " $refType": "FairHeader_fair";
 };
 export type FairHeader_fair$data = FairHeader_fair;
@@ -43,9 +58,121 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "name",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "image",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 1000
+            },
+            {
+              "kind": "Literal",
+              "name": "version",
+              "value": "wide"
+            },
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 750
+            }
+          ],
+          "concreteType": "CroppedImageUrl",
+          "kind": "LinkedField",
+          "name": "cropped",
+          "plural": false,
+          "selections": [
+            {
+              "alias": "src",
+              "args": null,
+              "kind": "ScalarField",
+              "name": "url",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "width",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "height",
+              "storageKey": null
+            }
+          ],
+          "storageKey": "cropped(height:1000,version:\"wide\",width:750)"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "tagline",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Location",
+      "kind": "LinkedField",
+      "name": "location",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "summary",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "ticketsLink",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hours",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "links",
+      "storageKey": null
     }
   ],
   "type": "Fair"
 };
-(node as any).hash = 'b658b473bd0796f5ab79de97e7277319';
+(node as any).hash = '554a68c5a66a979acf68678d51941642';
 export default node;

--- a/src/v2/__generated__/FairInfo_Query.graphql.ts
+++ b/src/v2/__generated__/FairInfo_Query.graphql.ts
@@ -1,0 +1,210 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type FairInfo_QueryVariables = {
+    slug: string;
+};
+export type FairInfo_QueryResponse = {
+    readonly fair: {
+        readonly " $fragmentRefs": FragmentRefs<"FairInfo_fair">;
+    } | null;
+};
+export type FairInfo_QueryRawResponse = {
+    readonly fair: ({
+        readonly about: string | null;
+        readonly name: string | null;
+        readonly slug: string;
+        readonly tagline: string | null;
+        readonly location: ({
+            readonly summary: string | null;
+            readonly id: string | null;
+        }) | null;
+        readonly ticketsLink: string | null;
+        readonly hours: string | null;
+        readonly links: string | null;
+        readonly id: string | null;
+    }) | null;
+};
+export type FairInfo_Query = {
+    readonly response: FairInfo_QueryResponse;
+    readonly variables: FairInfo_QueryVariables;
+    readonly rawResponse: FairInfo_QueryRawResponse;
+};
+
+
+
+/*
+query FairInfo_Query(
+  $slug: String!
+) {
+  fair(id: $slug) {
+    ...FairInfo_fair
+    id
+  }
+}
+
+fragment FairInfo_fair on Fair {
+  about
+  name
+  slug
+  tagline
+  location {
+    summary
+    id
+  }
+  ticketsLink
+  hours
+  links
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "slug",
+    "type": "String!"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "slug"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "FairInfo_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "FairInfo_fair"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "FairInfo_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "about",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "tagline",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Location",
+            "kind": "LinkedField",
+            "name": "location",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "summary",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "ticketsLink",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "hours",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "links",
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "FairInfo_Query",
+    "operationKind": "query",
+    "text": "query FairInfo_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairInfo_fair\n    id\n  }\n}\n\nfragment FairInfo_fair on Fair {\n  about\n  name\n  slug\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours\n  links\n}\n"
+  }
+};
+})();
+(node as any).hash = 'eb54ecc0bc4103280559443acbcf0ae1';
+export default node;

--- a/src/v2/__generated__/FairInfo_fair.graphql.ts
+++ b/src/v2/__generated__/FairInfo_fair.graphql.ts
@@ -1,0 +1,104 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type FairInfo_fair = {
+    readonly about: string | null;
+    readonly name: string | null;
+    readonly slug: string;
+    readonly tagline: string | null;
+    readonly location: {
+        readonly summary: string | null;
+    } | null;
+    readonly ticketsLink: string | null;
+    readonly hours: string | null;
+    readonly links: string | null;
+    readonly " $refType": "FairInfo_fair";
+};
+export type FairInfo_fair$data = FairInfo_fair;
+export type FairInfo_fair$key = {
+    readonly " $data"?: FairInfo_fair$data;
+    readonly " $fragmentRefs": FragmentRefs<"FairInfo_fair">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "FairInfo_fair",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "about",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "tagline",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Location",
+      "kind": "LinkedField",
+      "name": "location",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "summary",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "ticketsLink",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hours",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "links",
+      "storageKey": null
+    }
+  ],
+  "type": "Fair"
+};
+(node as any).hash = 'a5f4b009cac6a9ca25166951f14f82f1';
+export default node;

--- a/src/v2/__generated__/FairOverview_Query.graphql.ts
+++ b/src/v2/__generated__/FairOverview_Query.graphql.ts
@@ -1,0 +1,296 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type FairOverview_QueryVariables = {
+    slug: string;
+};
+export type FairOverview_QueryResponse = {
+    readonly fair: {
+        readonly " $fragmentRefs": FragmentRefs<"FairOverview_fair">;
+    } | null;
+};
+export type FairOverview_QueryRawResponse = {
+    readonly fair: ({
+        readonly about: string | null;
+        readonly formattedOpeningHours: string | null;
+        readonly name: string | null;
+        readonly slug: string;
+        readonly image: ({
+            readonly cropped: ({
+                readonly src: string | null;
+                readonly width: number | null;
+                readonly height: number | null;
+            }) | null;
+        }) | null;
+        readonly tagline: string | null;
+        readonly location: ({
+            readonly summary: string | null;
+            readonly id: string | null;
+        }) | null;
+        readonly ticketsLink: string | null;
+        readonly hours: string | null;
+        readonly links: string | null;
+        readonly id: string | null;
+    }) | null;
+};
+export type FairOverview_Query = {
+    readonly response: FairOverview_QueryResponse;
+    readonly variables: FairOverview_QueryVariables;
+    readonly rawResponse: FairOverview_QueryRawResponse;
+};
+
+
+
+/*
+query FairOverview_Query(
+  $slug: String!
+) {
+  fair(id: $slug) {
+    ...FairOverview_fair
+    id
+  }
+}
+
+fragment FairHeader_fair on Fair {
+  about
+  formattedOpeningHours
+  name
+  slug
+  image {
+    cropped(width: 750, height: 1000, version: "wide") {
+      src: url
+      width
+      height
+    }
+  }
+  tagline
+  location {
+    summary
+    id
+  }
+  ticketsLink
+  hours
+  links
+}
+
+fragment FairOverview_fair on Fair {
+  ...FairHeader_fair
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "slug",
+    "type": "String!"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "slug"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "FairOverview_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "FairOverview_fair"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "FairOverview_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "about",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "formattedOpeningHours",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 1000
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "wide"
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 750
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": "src",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "url",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "width",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "height",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "cropped(height:1000,version:\"wide\",width:750)"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "tagline",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Location",
+            "kind": "LinkedField",
+            "name": "location",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "summary",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "ticketsLink",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "hours",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "links",
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "FairOverview_Query",
+    "operationKind": "query",
+    "text": "query FairOverview_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  formattedOpeningHours\n  name\n  slug\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours\n  links\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairHeader_fair\n}\n"
+  }
+};
+})();
+(node as any).hash = 'd8bf959461da7aaede757e2d228d5547';
+export default node;

--- a/src/v2/__generated__/FairOverview_fair.graphql.ts
+++ b/src/v2/__generated__/FairOverview_fair.graphql.ts
@@ -1,0 +1,33 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type FairOverview_fair = {
+    readonly " $fragmentRefs": FragmentRefs<"FairHeader_fair">;
+    readonly " $refType": "FairOverview_fair";
+};
+export type FairOverview_fair$data = FairOverview_fair;
+export type FairOverview_fair$key = {
+    readonly " $data"?: FairOverview_fair$data;
+    readonly " $fragmentRefs": FragmentRefs<"FairOverview_fair">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "FairOverview_fair",
+  "selections": [
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "FairHeader_fair"
+    }
+  ],
+  "type": "Fair"
+};
+(node as any).hash = 'ce592077153e19952b2a3763bc853eea';
+export default node;

--- a/src/v2/__generated__/routes_FairInfoQuery.graphql.ts
+++ b/src/v2/__generated__/routes_FairInfoQuery.graphql.ts
@@ -1,0 +1,193 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type routes_FairInfoQueryVariables = {
+    slug: string;
+};
+export type routes_FairInfoQueryResponse = {
+    readonly fair: {
+        readonly " $fragmentRefs": FragmentRefs<"FairInfo_fair">;
+    } | null;
+};
+export type routes_FairInfoQuery = {
+    readonly response: routes_FairInfoQueryResponse;
+    readonly variables: routes_FairInfoQueryVariables;
+};
+
+
+
+/*
+query routes_FairInfoQuery(
+  $slug: String!
+) {
+  fair(id: $slug) {
+    ...FairInfo_fair
+    id
+  }
+}
+
+fragment FairInfo_fair on Fair {
+  about
+  name
+  slug
+  tagline
+  location {
+    summary
+    id
+  }
+  ticketsLink
+  hours
+  links
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "slug",
+    "type": "String!"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "slug"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "routes_FairInfoQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "FairInfo_fair"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "routes_FairInfoQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "about",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "tagline",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Location",
+            "kind": "LinkedField",
+            "name": "location",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "summary",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "ticketsLink",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "hours",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "links",
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "routes_FairInfoQuery",
+    "operationKind": "query",
+    "text": "query routes_FairInfoQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairInfo_fair\n    id\n  }\n}\n\nfragment FairInfo_fair on Fair {\n  about\n  name\n  slug\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours\n  links\n}\n"
+  }
+};
+})();
+(node as any).hash = 'd0fdf69923e4836dc6a43fcce92b1319';
+export default node;

--- a/src/v2/__generated__/routes_FairOverviewQuery.graphql.ts
+++ b/src/v2/__generated__/routes_FairOverviewQuery.graphql.ts
@@ -1,0 +1,271 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type routes_FairOverviewQueryVariables = {
+    slug: string;
+};
+export type routes_FairOverviewQueryResponse = {
+    readonly fair: {
+        readonly " $fragmentRefs": FragmentRefs<"FairOverview_fair">;
+    } | null;
+};
+export type routes_FairOverviewQuery = {
+    readonly response: routes_FairOverviewQueryResponse;
+    readonly variables: routes_FairOverviewQueryVariables;
+};
+
+
+
+/*
+query routes_FairOverviewQuery(
+  $slug: String!
+) {
+  fair(id: $slug) {
+    ...FairOverview_fair
+    id
+  }
+}
+
+fragment FairHeader_fair on Fair {
+  about
+  formattedOpeningHours
+  name
+  slug
+  image {
+    cropped(width: 750, height: 1000, version: "wide") {
+      src: url
+      width
+      height
+    }
+  }
+  tagline
+  location {
+    summary
+    id
+  }
+  ticketsLink
+  hours
+  links
+}
+
+fragment FairOverview_fair on Fair {
+  ...FairHeader_fair
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "slug",
+    "type": "String!"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "slug"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "routes_FairOverviewQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "FairOverview_fair"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "routes_FairOverviewQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "about",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "formattedOpeningHours",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 1000
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "wide"
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 750
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": "src",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "url",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "width",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "height",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "cropped(height:1000,version:\"wide\",width:750)"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "tagline",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Location",
+            "kind": "LinkedField",
+            "name": "location",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "summary",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "ticketsLink",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "hours",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "links",
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "routes_FairOverviewQuery",
+    "operationKind": "query",
+    "text": "query routes_FairOverviewQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  formattedOpeningHours\n  name\n  slug\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours\n  links\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairHeader_fair\n}\n"
+  }
+};
+})();
+(node as any).hash = '2abb38d1d6ad0321872674c1b458e13e';
+export default node;

--- a/src/v2/__generated__/routes_FairQuery.graphql.ts
+++ b/src/v2/__generated__/routes_FairQuery.graphql.ts
@@ -29,13 +29,7 @@ query routes_FairQuery(
 }
 
 fragment FairApp_fair on Fair {
-  ...FairHeader_fair
-}
-
-fragment FairHeader_fair on Fair {
-  about
-  formattedOpeningHours
-  name
+  id
 }
 */
 
@@ -99,27 +93,6 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "about",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "formattedOpeningHours",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "name",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
             "name": "id",
             "storageKey": null
           }
@@ -133,7 +106,7 @@ return {
     "metadata": {},
     "name": "routes_FairQuery",
     "operationKind": "query",
-    "text": "query routes_FairQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  ...FairHeader_fair\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  formattedOpeningHours\n  name\n}\n"
+    "text": "query routes_FairQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  id\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/FX-2168 and https://artsyproduct.atlassian.net/browse/FX-2170

This PR adds:
- A more filled-out `FairHeader` with the correct image.
- A "More info" link and corresponding page.
- Explicitly adds a `FairOverview` route in anticipation of needing a `FairArtworks` route in the future.

![image](https://user-images.githubusercontent.com/2081340/90448963-6adfac00-e0b4-11ea-9060-631fc04b602c.png)
![image](https://user-images.githubusercontent.com/2081340/90448974-6fa46000-e0b4-11ea-9059-4c0fc3a61768.png)


## Follow-ups
- A metaphysics PR to add `summary`, `tickets`, and `contact` to `FairType` and allow `hours` and `links` to be formatted into HTML.
- A force PR to address ☝️ .