### PR TITLE
Adds missing fields to fair info page

### DIFF
--- a/src/v2/Apps/Fair/Components/FairHeader.tsx
+++ b/src/v2/Apps/Fair/Components/FairHeader.tsx
@@ -26,7 +26,17 @@ const ResponsiveImage = styled(ResponsiveBox)<ResponsiveBoxProps>`
 
 const FairHeader: React.FC<FairHeaderProps> = ({ fair }) => {
   const img = fair?.image?.cropped
-  const { about, tagline, location, ticketsLink, hours, links } = fair
+  const {
+    about,
+    tagline,
+    location,
+    ticketsLink,
+    hours,
+    links,
+    contact,
+    summary,
+    tickets,
+  } = fair
 
   const canShowMoreInfoLink =
     !!about ||
@@ -34,7 +44,12 @@ const FairHeader: React.FC<FairHeaderProps> = ({ fair }) => {
     !!location?.summary ||
     !!ticketsLink ||
     !!hours ||
-    !!links
+    !!links ||
+    !!contact ||
+    !!summary ||
+    !!tickets
+
+  const previewText = summary || about
 
   return (
     <>
@@ -60,7 +75,7 @@ const FairHeader: React.FC<FairHeaderProps> = ({ fair }) => {
           <Text variant="caption">{fair.formattedOpeningHours}</Text>
         </Col>
         <Col sm="6" mt={[3, 0]}>
-          <Text variant="text">{about}</Text>
+          <Text variant="text">{previewText}</Text>
           {canShowMoreInfoLink && (
             <ForwardLink
               linkText="More info"
@@ -77,6 +92,7 @@ export const FairHeaderFragmentContainer = createFragmentContainer(FairHeader, {
   fair: graphql`
     fragment FairHeader_fair on Fair {
       about
+      summary
       formattedOpeningHours
       name
       slug
@@ -94,8 +110,10 @@ export const FairHeaderFragmentContainer = createFragmentContainer(FairHeader, {
         summary
       }
       ticketsLink
-      hours
-      links
+      hours(format: HTML)
+      links(format: HTML)
+      tickets(format: HTML)
+      contact(format: HTML)
     }
   `,
 })

--- a/src/v2/Apps/Fair/Components/__tests__/FairHeader.jest.tsx
+++ b/src/v2/Apps/Fair/Components/__tests__/FairHeader.jest.tsx
@@ -38,6 +38,17 @@ describe("FairHeader", () => {
   it("displays basic information about the fair", async () => {
     const wrapper = await getWrapper()
     expect(wrapper.text()).toContain("Miart 2020")
+    expect(wrapper.text()).toContain("This is the summary.")
+  })
+
+  it("displays the about content if there is no summary", async () => {
+    const noSummaryFair: FairHeader_QueryRawResponse = {
+      fair: {
+        ...FairHeaderFixture.fair,
+        summary: "",
+      },
+    }
+    const wrapper = await getWrapper("lg", noSummaryFair)
     expect(wrapper.text()).toContain("This is the about.")
   })
 
@@ -60,6 +71,9 @@ describe("FairHeader", () => {
         ticketsLink: "",
         hours: "",
         links: "",
+        tickets: "",
+        contact: "",
+        summary: "",
       },
     }
 
@@ -80,6 +94,9 @@ describe("FairHeader", () => {
         ticketsLink: "",
         hours: "",
         links: "",
+        tickets: "",
+        contact: "",
+        summary: "",
       },
     }
 
@@ -110,5 +127,8 @@ const FairHeaderFixture: FairHeader_QueryRawResponse = {
     ticketsLink: "",
     hours: "",
     links: "",
+    tickets: "<b>Tickets available today</b>",
+    contact: "<b>Contact us</b>",
+    summary: "This is the summary.",
   },
 }

--- a/src/v2/Apps/Fair/Routes/FairInfo.tsx
+++ b/src/v2/Apps/Fair/Routes/FairInfo.tsx
@@ -29,7 +29,12 @@ const FairInfo: React.FC<FairInfoProps> = ({ fair }) => {
 
       <Row>
         <Col sm="9" pr={2}>
-          {/** TODO: Add summary here when it exists **/}
+          {fair.summary && (
+            <>
+              <TextWithNewlines variant="text">{fair.summary}</TextWithNewlines>
+              <Spacer my={3} />
+            </>
+          )}
           {fair.about && (
             <>
               <TextWithNewlines variant="text">{fair.about}</TextWithNewlines>
@@ -50,11 +55,11 @@ const FairInfo: React.FC<FairInfoProps> = ({ fair }) => {
               <TextWithNewlines variant="text">
                 {fair.location?.summary}
               </TextWithNewlines>
+              <Spacer my={3} />
             </>
           )}
         </Col>
         <Col sm="3">
-          {/** TODO: Hours should be able to be formatted into HTML **/}
           {fair.hours && (
             <>
               <Text variant="mediumText">Hours</Text>
@@ -62,7 +67,13 @@ const FairInfo: React.FC<FairInfoProps> = ({ fair }) => {
               <Spacer my={3} />
             </>
           )}
-          {/** TODO: Add tickets here when it exists **/}
+          {fair.tickets && (
+            <>
+              <Text variant="mediumText">Tickets</Text>
+              <HTML variant="text" html={fair.tickets} />
+              <Spacer my={3} />
+            </>
+          )}
           {fair.ticketsLink && (
             <>
               <a href={fair.ticketsLink}>
@@ -71,11 +82,17 @@ const FairInfo: React.FC<FairInfoProps> = ({ fair }) => {
               <Spacer my={3} />
             </>
           )}
-          {/** TODO: Links should be able to be formatted into HTML **/}
           {fair.links && (
             <>
               <Text variant="mediumText">Links</Text>
               <HTML variant="text" html={fair.links} />
+              <Spacer my={3} />
+            </>
+          )}
+          {fair.contact && (
+            <>
+              <Text variant="mediumText">Contact</Text>
+              <HTML variant="text" html={fair.contact} />
               <Spacer my={3} />
             </>
           )}
@@ -96,8 +113,11 @@ export const FairInfoFragmentContainer = createFragmentContainer(FairInfo, {
         summary
       }
       ticketsLink
-      hours
-      links
+      hours(format: HTML)
+      links(format: HTML)
+      tickets(format: HTML)
+      summary
+      contact(format: HTML)
     }
   `,
 })

--- a/src/v2/Apps/Fair/Routes/__tests__/FairInfo.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairInfo.jest.tsx
@@ -63,6 +63,9 @@ describe("FairInfo", () => {
         ticketsLink: "",
         hours: "",
         links: "",
+        tickets: "",
+        contact: "",
+        summary: "",
       },
     }
     const wrapper = await getWrapper("lg", missingInfo)
@@ -70,6 +73,8 @@ describe("FairInfo", () => {
     expect(wrapper.text()).not.toContain("Hours")
     expect(wrapper.text()).not.toContain("Buy Tickets")
     expect(wrapper.text()).not.toContain("Links")
+    expect(wrapper.text()).not.toContain("Tickets")
+    expect(wrapper.text()).not.toContain("Contact")
   })
 })
 
@@ -87,5 +92,8 @@ const FairInfoFixture: FairInfo_QueryRawResponse = {
     ticketsLink: "https://eventbrite.com/cool-event",
     hours: "Open every day at 5am",
     links: "<a href='google.com'>Google it</a>",
+    tickets: "<b>Tickets available today</b>",
+    contact: "<b>Contact us</b>",
+    summary: "This is the summary.",
   },
 }

--- a/src/v2/Apps/Fair/Routes/__tests__/FairOverview.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairOverview.jest.tsx
@@ -59,5 +59,8 @@ const FairOverviewFixture: FairOverview_QueryRawResponse = {
     ticketsLink: "",
     hours: "",
     links: "",
+    tickets: "<b>Tickets available today</b>",
+    contact: "<b>Contact us</b>",
+    summary: "This is the summary.",
   },
 }

--- a/src/v2/__generated__/FairHeader_Query.graphql.ts
+++ b/src/v2/__generated__/FairHeader_Query.graphql.ts
@@ -14,6 +14,7 @@ export type FairHeader_QueryResponse = {
 export type FairHeader_QueryRawResponse = {
     readonly fair: ({
         readonly about: string | null;
+        readonly summary: string | null;
         readonly formattedOpeningHours: string | null;
         readonly name: string | null;
         readonly slug: string;
@@ -32,6 +33,8 @@ export type FairHeader_QueryRawResponse = {
         readonly ticketsLink: string | null;
         readonly hours: string | null;
         readonly links: string | null;
+        readonly tickets: string | null;
+        readonly contact: string | null;
         readonly id: string | null;
     }) | null;
 };
@@ -55,6 +58,7 @@ query FairHeader_Query(
 
 fragment FairHeader_fair on Fair {
   about
+  summary
   formattedOpeningHours
   name
   slug
@@ -71,8 +75,10 @@ fragment FairHeader_fair on Fair {
     id
   }
   ticketsLink
-  hours
-  links
+  hours(format: HTML)
+  links(format: HTML)
+  tickets(format: HTML)
+  contact(format: HTML)
 }
 */
 
@@ -96,9 +102,23 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "summary",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-};
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+];
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -146,6 +166,7 @@ return {
             "name": "about",
             "storageKey": null
           },
+          (v2/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -241,14 +262,8 @@ return {
             "name": "location",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "summary",
-                "storageKey": null
-              },
-              (v2/*: any*/)
+              (v2/*: any*/),
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
@@ -261,19 +276,33 @@ return {
           },
           {
             "alias": null,
-            "args": null,
+            "args": (v4/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
-            "storageKey": null
+            "storageKey": "hours(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": null,
+            "args": (v4/*: any*/),
             "kind": "ScalarField",
             "name": "links",
-            "storageKey": null
+            "storageKey": "links(format:\"HTML\")"
           },
-          (v2/*: any*/)
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
+            "kind": "ScalarField",
+            "name": "tickets",
+            "storageKey": "tickets(format:\"HTML\")"
+          },
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
+            "kind": "ScalarField",
+            "name": "contact",
+            "storageKey": "contact(format:\"HTML\")"
+          },
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
@@ -284,7 +313,7 @@ return {
     "metadata": {},
     "name": "FairHeader_Query",
     "operationKind": "query",
-    "text": "query FairHeader_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairHeader_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  formattedOpeningHours\n  name\n  slug\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours\n  links\n}\n"
+    "text": "query FairHeader_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairHeader_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  formattedOpeningHours\n  name\n  slug\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairHeader_fair.graphql.ts
+++ b/src/v2/__generated__/FairHeader_fair.graphql.ts
@@ -5,6 +5,7 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type FairHeader_fair = {
     readonly about: string | null;
+    readonly summary: string | null;
     readonly formattedOpeningHours: string | null;
     readonly name: string | null;
     readonly slug: string;
@@ -22,6 +23,8 @@ export type FairHeader_fair = {
     readonly ticketsLink: string | null;
     readonly hours: string | null;
     readonly links: string | null;
+    readonly tickets: string | null;
+    readonly contact: string | null;
     readonly " $refType": "FairHeader_fair";
 };
 export type FairHeader_fair$data = FairHeader_fair;
@@ -32,7 +35,22 @@ export type FairHeader_fair$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "summary",
+  "storageKey": null
+},
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+];
+return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
@@ -45,6 +63,7 @@ const node: ReaderFragment = {
       "name": "about",
       "storageKey": null
     },
+    (v0/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -140,13 +159,7 @@ const node: ReaderFragment = {
       "name": "location",
       "plural": false,
       "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "summary",
-          "storageKey": null
-        }
+        (v0/*: any*/)
       ],
       "storageKey": null
     },
@@ -159,20 +172,35 @@ const node: ReaderFragment = {
     },
     {
       "alias": null,
-      "args": null,
+      "args": (v1/*: any*/),
       "kind": "ScalarField",
       "name": "hours",
-      "storageKey": null
+      "storageKey": "hours(format:\"HTML\")"
     },
     {
       "alias": null,
-      "args": null,
+      "args": (v1/*: any*/),
       "kind": "ScalarField",
       "name": "links",
-      "storageKey": null
+      "storageKey": "links(format:\"HTML\")"
+    },
+    {
+      "alias": null,
+      "args": (v1/*: any*/),
+      "kind": "ScalarField",
+      "name": "tickets",
+      "storageKey": "tickets(format:\"HTML\")"
+    },
+    {
+      "alias": null,
+      "args": (v1/*: any*/),
+      "kind": "ScalarField",
+      "name": "contact",
+      "storageKey": "contact(format:\"HTML\")"
     }
   ],
   "type": "Fair"
 };
-(node as any).hash = '554a68c5a66a979acf68678d51941642';
+})();
+(node as any).hash = '748b0ed3393806f687251805ea7401f0';
 export default node;

--- a/src/v2/__generated__/FairInfo_Query.graphql.ts
+++ b/src/v2/__generated__/FairInfo_Query.graphql.ts
@@ -24,6 +24,9 @@ export type FairInfo_QueryRawResponse = {
         readonly ticketsLink: string | null;
         readonly hours: string | null;
         readonly links: string | null;
+        readonly tickets: string | null;
+        readonly summary: string | null;
+        readonly contact: string | null;
         readonly id: string | null;
     }) | null;
 };
@@ -55,8 +58,11 @@ fragment FairInfo_fair on Fair {
     id
   }
   ticketsLink
-  hours
-  links
+  hours(format: HTML)
+  links(format: HTML)
+  tickets(format: HTML)
+  summary
+  contact(format: HTML)
 }
 */
 
@@ -80,9 +86,23 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "summary",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-};
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+];
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -159,14 +179,8 @@ return {
             "name": "location",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "summary",
-                "storageKey": null
-              },
-              (v2/*: any*/)
+              (v2/*: any*/),
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
@@ -179,19 +193,34 @@ return {
           },
           {
             "alias": null,
-            "args": null,
+            "args": (v4/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
-            "storageKey": null
+            "storageKey": "hours(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": null,
+            "args": (v4/*: any*/),
             "kind": "ScalarField",
             "name": "links",
-            "storageKey": null
+            "storageKey": "links(format:\"HTML\")"
           },
-          (v2/*: any*/)
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
+            "kind": "ScalarField",
+            "name": "tickets",
+            "storageKey": "tickets(format:\"HTML\")"
+          },
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
+            "kind": "ScalarField",
+            "name": "contact",
+            "storageKey": "contact(format:\"HTML\")"
+          },
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
@@ -202,7 +231,7 @@ return {
     "metadata": {},
     "name": "FairInfo_Query",
     "operationKind": "query",
-    "text": "query FairInfo_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairInfo_fair\n    id\n  }\n}\n\nfragment FairInfo_fair on Fair {\n  about\n  name\n  slug\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours\n  links\n}\n"
+    "text": "query FairInfo_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairInfo_fair\n    id\n  }\n}\n\nfragment FairInfo_fair on Fair {\n  about\n  name\n  slug\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  summary\n  contact(format: HTML)\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairInfo_fair.graphql.ts
+++ b/src/v2/__generated__/FairInfo_fair.graphql.ts
@@ -14,6 +14,9 @@ export type FairInfo_fair = {
     readonly ticketsLink: string | null;
     readonly hours: string | null;
     readonly links: string | null;
+    readonly tickets: string | null;
+    readonly summary: string | null;
+    readonly contact: string | null;
     readonly " $refType": "FairInfo_fair";
 };
 export type FairInfo_fair$data = FairInfo_fair;
@@ -24,7 +27,22 @@ export type FairInfo_fair$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "summary",
+  "storageKey": null
+},
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+];
+return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
@@ -66,13 +84,7 @@ const node: ReaderFragment = {
       "name": "location",
       "plural": false,
       "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "summary",
-          "storageKey": null
-        }
+        (v0/*: any*/)
       ],
       "storageKey": null
     },
@@ -85,20 +97,36 @@ const node: ReaderFragment = {
     },
     {
       "alias": null,
-      "args": null,
+      "args": (v1/*: any*/),
       "kind": "ScalarField",
       "name": "hours",
-      "storageKey": null
+      "storageKey": "hours(format:\"HTML\")"
     },
     {
       "alias": null,
-      "args": null,
+      "args": (v1/*: any*/),
       "kind": "ScalarField",
       "name": "links",
-      "storageKey": null
+      "storageKey": "links(format:\"HTML\")"
+    },
+    {
+      "alias": null,
+      "args": (v1/*: any*/),
+      "kind": "ScalarField",
+      "name": "tickets",
+      "storageKey": "tickets(format:\"HTML\")"
+    },
+    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": (v1/*: any*/),
+      "kind": "ScalarField",
+      "name": "contact",
+      "storageKey": "contact(format:\"HTML\")"
     }
   ],
   "type": "Fair"
 };
-(node as any).hash = 'a5f4b009cac6a9ca25166951f14f82f1';
+})();
+(node as any).hash = 'ea4f45ae63264ece824c15f339698eee';
 export default node;

--- a/src/v2/__generated__/FairOverview_Query.graphql.ts
+++ b/src/v2/__generated__/FairOverview_Query.graphql.ts
@@ -14,6 +14,7 @@ export type FairOverview_QueryResponse = {
 export type FairOverview_QueryRawResponse = {
     readonly fair: ({
         readonly about: string | null;
+        readonly summary: string | null;
         readonly formattedOpeningHours: string | null;
         readonly name: string | null;
         readonly slug: string;
@@ -32,6 +33,8 @@ export type FairOverview_QueryRawResponse = {
         readonly ticketsLink: string | null;
         readonly hours: string | null;
         readonly links: string | null;
+        readonly tickets: string | null;
+        readonly contact: string | null;
         readonly id: string | null;
     }) | null;
 };
@@ -55,6 +58,7 @@ query FairOverview_Query(
 
 fragment FairHeader_fair on Fair {
   about
+  summary
   formattedOpeningHours
   name
   slug
@@ -71,8 +75,10 @@ fragment FairHeader_fair on Fair {
     id
   }
   ticketsLink
-  hours
-  links
+  hours(format: HTML)
+  links(format: HTML)
+  tickets(format: HTML)
+  contact(format: HTML)
 }
 
 fragment FairOverview_fair on Fair {
@@ -100,9 +106,23 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "summary",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-};
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+];
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -150,6 +170,7 @@ return {
             "name": "about",
             "storageKey": null
           },
+          (v2/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -245,14 +266,8 @@ return {
             "name": "location",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "summary",
-                "storageKey": null
-              },
-              (v2/*: any*/)
+              (v2/*: any*/),
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
@@ -265,19 +280,33 @@ return {
           },
           {
             "alias": null,
-            "args": null,
+            "args": (v4/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
-            "storageKey": null
+            "storageKey": "hours(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": null,
+            "args": (v4/*: any*/),
             "kind": "ScalarField",
             "name": "links",
-            "storageKey": null
+            "storageKey": "links(format:\"HTML\")"
           },
-          (v2/*: any*/)
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
+            "kind": "ScalarField",
+            "name": "tickets",
+            "storageKey": "tickets(format:\"HTML\")"
+          },
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
+            "kind": "ScalarField",
+            "name": "contact",
+            "storageKey": "contact(format:\"HTML\")"
+          },
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
@@ -288,7 +317,7 @@ return {
     "metadata": {},
     "name": "FairOverview_Query",
     "operationKind": "query",
-    "text": "query FairOverview_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  formattedOpeningHours\n  name\n  slug\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours\n  links\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairHeader_fair\n}\n"
+    "text": "query FairOverview_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  formattedOpeningHours\n  name\n  slug\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairHeader_fair\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/routes_FairInfoQuery.graphql.ts
+++ b/src/v2/__generated__/routes_FairInfoQuery.graphql.ts
@@ -38,8 +38,11 @@ fragment FairInfo_fair on Fair {
     id
   }
   ticketsLink
-  hours
-  links
+  hours(format: HTML)
+  links(format: HTML)
+  tickets(format: HTML)
+  summary
+  contact(format: HTML)
 }
 */
 
@@ -63,9 +66,23 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "summary",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-};
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+];
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -142,14 +159,8 @@ return {
             "name": "location",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "summary",
-                "storageKey": null
-              },
-              (v2/*: any*/)
+              (v2/*: any*/),
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
@@ -162,19 +173,34 @@ return {
           },
           {
             "alias": null,
-            "args": null,
+            "args": (v4/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
-            "storageKey": null
+            "storageKey": "hours(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": null,
+            "args": (v4/*: any*/),
             "kind": "ScalarField",
             "name": "links",
-            "storageKey": null
+            "storageKey": "links(format:\"HTML\")"
           },
-          (v2/*: any*/)
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
+            "kind": "ScalarField",
+            "name": "tickets",
+            "storageKey": "tickets(format:\"HTML\")"
+          },
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
+            "kind": "ScalarField",
+            "name": "contact",
+            "storageKey": "contact(format:\"HTML\")"
+          },
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
@@ -185,7 +211,7 @@ return {
     "metadata": {},
     "name": "routes_FairInfoQuery",
     "operationKind": "query",
-    "text": "query routes_FairInfoQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairInfo_fair\n    id\n  }\n}\n\nfragment FairInfo_fair on Fair {\n  about\n  name\n  slug\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours\n  links\n}\n"
+    "text": "query routes_FairInfoQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairInfo_fair\n    id\n  }\n}\n\nfragment FairInfo_fair on Fair {\n  about\n  name\n  slug\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  summary\n  contact(format: HTML)\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/routes_FairOverviewQuery.graphql.ts
+++ b/src/v2/__generated__/routes_FairOverviewQuery.graphql.ts
@@ -30,6 +30,7 @@ query routes_FairOverviewQuery(
 
 fragment FairHeader_fair on Fair {
   about
+  summary
   formattedOpeningHours
   name
   slug
@@ -46,8 +47,10 @@ fragment FairHeader_fair on Fair {
     id
   }
   ticketsLink
-  hours
-  links
+  hours(format: HTML)
+  links(format: HTML)
+  tickets(format: HTML)
+  contact(format: HTML)
 }
 
 fragment FairOverview_fair on Fair {
@@ -75,9 +78,23 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "summary",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-};
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+];
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -125,6 +142,7 @@ return {
             "name": "about",
             "storageKey": null
           },
+          (v2/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -220,14 +238,8 @@ return {
             "name": "location",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "summary",
-                "storageKey": null
-              },
-              (v2/*: any*/)
+              (v2/*: any*/),
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
@@ -240,19 +252,33 @@ return {
           },
           {
             "alias": null,
-            "args": null,
+            "args": (v4/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
-            "storageKey": null
+            "storageKey": "hours(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": null,
+            "args": (v4/*: any*/),
             "kind": "ScalarField",
             "name": "links",
-            "storageKey": null
+            "storageKey": "links(format:\"HTML\")"
           },
-          (v2/*: any*/)
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
+            "kind": "ScalarField",
+            "name": "tickets",
+            "storageKey": "tickets(format:\"HTML\")"
+          },
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
+            "kind": "ScalarField",
+            "name": "contact",
+            "storageKey": "contact(format:\"HTML\")"
+          },
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
@@ -263,7 +289,7 @@ return {
     "metadata": {},
     "name": "routes_FairOverviewQuery",
     "operationKind": "query",
-    "text": "query routes_FairOverviewQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  formattedOpeningHours\n  name\n  slug\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours\n  links\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairHeader_fair\n}\n"
+    "text": "query routes_FairOverviewQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  formattedOpeningHours\n  name\n  slug\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairHeader_fair\n}\n"
   }
 };
 })();


### PR DESCRIPTION
A follow-up to https://github.com/artsy/force/pull/6119 now that the necessary metaphysics changes are merged + deployed.

This addresses:
- Makes markdown-able fields render as proper HTML
- Shows the `summary` in the header and falls back to the `about` text.

![image](https://user-images.githubusercontent.com/2081340/90521035-0cf4a800-e138-11ea-82f2-c1370b2fd954.png)

