### PR TITLE
[SEO] Use h1 for viewing rooms page title

### DIFF
--- a/src/v2/Apps/ViewingRoom/ViewingRoomsApp.tsx
+++ b/src/v2/Apps/ViewingRoom/ViewingRoomsApp.tsx
@@ -23,7 +23,7 @@ const ViewingRoomsApp: React.FC<ViewingRoomsAppProps> = props => {
       <AppContainer maxWidth="100%">
         <Box maxWidth={breakpoints.xl} mx="auto" width="100%">
           <Box mx={2}>
-            <Sans size="10" my={3}>
+            <Sans size="10" my={3} element="h1">
               Viewing Rooms
             </Sans>
             <ViewingRoomsFeaturedRail


### PR DESCRIPTION
Companion PR to https://github.com/artsy/integrity/pull/176/files#diff-32758bee56d9b6d4947129eacef004bdR6, adds `h1` element for page title on `/viewing-rooms`