### PR TITLE
[Hotfix] Lazyload bottom carousel rails 

### DIFF
--- a/src/v2/Apps/ArtistSeries/ArtistSeriesApp.tsx
+++ b/src/v2/Apps/ArtistSeries/ArtistSeriesApp.tsx
@@ -12,6 +12,7 @@ import { userHasLabFeature } from "v2/Utils/user"
 import { ErrorPage } from "v2/Components/ErrorPage"
 import { ArtistSeriesRailFragmentContainer as OtherArtistSeriesRail } from "v2/Components/ArtistSeriesRail/ArtistSeriesRail"
 import { ArtistSeriesMetaFragmentContainer as ArtistSeriesMeta } from "./Components/ArtistSeriesMeta"
+import { LazyLoadComponent } from "react-lazy-load-image-component"
 
 interface ArtistSeriesAppProps {
   artistSeries: ArtistSeriesApp_artistSeries
@@ -31,11 +32,19 @@ const ArtistSeriesApp: React.FC<ArtistSeriesAppProps> = ({ artistSeries }) => {
         <Box m={3}>
           <ArtistSeriesArtworksFilter artistSeries={artistSeries} />
           <Separator mt={6} mb={3} />
-          {railArtist.length && (
-            <OtherArtistSeriesRail
-              artist={railArtist[0]}
-              title="More series by this artist"
-            />
+
+          {/* HOTFIX FIXME: This rail was causing an error if included in SSR render
+              pass and so it was deferred to the client.
+
+              See: https://github.com/artsy/force/pull/6137
+           */}
+          {railArtist.length && typeof window !== "undefined" && (
+            <LazyLoadComponent threshold={1000}>
+              <OtherArtistSeriesRail
+                artist={railArtist[0]}
+                title="More series by this artist"
+              />
+            </LazyLoadComponent>
           )}
           <Separator mt={6} mb={3} />
           <Footer />

--- a/src/v2/Apps/Collect/Routes/Collection/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/index.tsx
@@ -19,6 +19,7 @@ import { data as sd } from "sharify"
 import truncate from "trunc-html"
 import { CollectionAppQuery } from "./CollectionAppQuery"
 import { CollectionsHubRailsContainer as CollectionsHubRails } from "./Components/CollectionsHubRails"
+import { LazyLoadComponent } from "react-lazy-load-image-component"
 
 import { BaseArtworkFilter } from "v2/Components/v2/ArtworkFilter"
 import {
@@ -164,18 +165,24 @@ export class CollectionApp extends Component<CollectionAppProps> {
                 </ArtworkFilterContextProvider>
               </Box>
 
-              {collection.linkedCollections.length === 0 && (
-                <>
-                  <Separator mt={6} mb={3} />
-                  <Box mt="3">
-                    <RelatedCollectionsRail
-                      collections={collection.relatedCollections}
-                      title={collection.title}
-                      lazyLoadImages
-                    />
-                  </Box>
-                </>
-              )}
+              {/* HOTFIX FIXME: This rail was causing an error if included in SSR render
+                  pass and so it was deferred to the client.
+
+                  See: https://github.com/artsy/force/pull/6137
+              */}
+              {collection.linkedCollections.length === 0 &&
+                typeof window !== "undefined" && (
+                  <LazyLoadComponent threshold={1000}>
+                    <Separator mt={6} mb={3} />
+                    <Box mt="3">
+                      <RelatedCollectionsRail
+                        collections={collection.relatedCollections}
+                        title={collection.title}
+                        lazyLoadImages
+                      />
+                    </Box>
+                  </LazyLoadComponent>
+                )}
             </FrameWithRecentlyViewed>
           </Box>
         </AppContainer>


### PR DESCRIPTION
This is a hotfix for an issue that was identified here: https://artsy.slack.com/archives/CP9P4KR35/p1597859227496900

If a user searches for a collection or series, clicks it, and then searches or clicks another series or collection we encounter a race condition inside of our flickity carousel at the bottom of the page. 

I've seen this error in the past, and it manifests in somewhat unexpected ways, and is related to a race condition where the dom nodes managed by flickity -- which is a jquery library -- make a change to the DOM outside of the react lifecycle leadin to this error. It tends to happen on route transition, but i've seen it happen in other contexts as well (such as within tab components). 

```
reaction | Error: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```

Which points in the stack at our carousel:
```
in Box (created by BaseCarousel)
    in div (created by Context.Consumer)
    in StyledComponent (created by Carousel__FlickityCarousel)
    in Carousel__FlickityCarousel (created by BaseCarousel)
    in div (created by Context.Consumer)
    in StyledComponent (created by Carousel__CarouselContainer)
    in Carousel__CarouselContainer (created by BaseCarousel)
    in div (created by Context.Consumer)
    in StyledComponent (created by Flex)
    in Flex (created by BaseCarousel)
    in BaseCarousel (created by LargeCarousel)
    in LargeCarousel (created by Carousel)
    in div (created by Context.Consumer)
    in Media (created by Carousel)
    in div (created by Context.Consumer)
    in StyledComponent (created by Box)
    in Box (created by Carousel)
    in Carousel (created by ArtistSeriesRail)
```

This is merely a hotfix as I don't have a better solution ATM. The solution is taking the carousel out of the SSR cycle and only rendering on the client. Since these carousels are "below the fold" it might be less important, but there might be SEO implications. 



See this [video cap](https://artsy.slack.com/archives/CP9P4KR35/p1597859771001600?thread_ts=1597859227.496900&cid=CP9P4KR35)