### PR TITLE
Group images in VR featured carousel to fit 50% of viewport

### DIFF
--- a/src/v2/Apps/ViewingRoom/Components/ViewingRoomCarousel.tsx
+++ b/src/v2/Apps/ViewingRoom/Components/ViewingRoomCarousel.tsx
@@ -46,7 +46,7 @@ export const ViewingRoomCarousel: React.FC<ViewingRoomCarouselProps> = ({
             cellAlign: "center",
             draggable: showProgressBar,
             freeScroll: true,
-            groupCells: 1,
+            groupCells: "50%",
             pageDots: false,
           }}
           data={data}


### PR DESCRIPTION
This is a fix to the bug reported in [GALL-3046](https://artsyproduct.atlassian.net/browse/GALL-3046) where the carousel's arrow containing div obfuscated the selected VR card and required 2 clicks to begin bringing images into the center of the carousel.

![Kapture 2020-08-20 at 16 51 59](https://user-images.githubusercontent.com/10385964/90824596-a4f3bc80-e305-11ea-8144-6fd59d32d3f9.gif)
