### PR TITLE
Fix conversation layout when thread is short

### DIFF
--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -87,7 +87,7 @@ const Conversation: React.FC<ConversationProps> = props => {
   }
 
   return (
-    <Flex flexDirection="column">
+    <Flex flexDirection="column" flexGrow={1}>
       <ConversationHeader
         partnerName={conversation.to.name}
         showDetails={showDetails}
@@ -130,6 +130,7 @@ const MessageContainer = styled(Box)`
 
 const NoScrollFlex = styled(Flex)`
   overflow: hidden;
+  flex-grow: 1;
 `
 
 const SpinnerContainer = styled.div`


### PR DESCRIPTION
Quick follow-up for https://github.com/artsy/force/pull/6135

I mostly did QA on long conversations so missed this bug.

without `flex-grow` the conversation box doesn't fill the width/height

Before:

<img width="1046" alt="Screen Shot 2020-08-24 at 12 45 06 PM" src="https://user-images.githubusercontent.com/687513/91073524-2fd7fe00-e609-11ea-986f-30474d843481.png">

After:

<img width="1047" alt="Screen Shot 2020-08-24 at 12 45 57 PM" src="https://user-images.githubusercontent.com/687513/91073538-35cddf00-e609-11ea-8368-dfe5e7bb7f61.png">
