### PR TITLE
[PURCHASE-2031] Fix Safari/Firefox reply box cutoff issue

### DIFF
--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -128,6 +128,7 @@ export const Reply: React.FC<ReplyProps> = props => {
         position={["fixed", "fixed", "fixed", "static"]}
         bottom={0}
         left={0}
+        flexShrink={0}
       >
         <FullWidthFlex width="100%">
           <StyledTextArea


### PR DESCRIPTION
Fixes [PURCHASE-2031](https://artsyproduct.atlassian.net/browse/PURCHASE-2031)

For some reason, the `div`s enclosing `textArea`  (green and red borders in the screenshot) were not expanding with text area (blue border). Adding `flex-shrink: 0` magically fixed that.

Before:

<img width="1043" alt="Screen Shot 2020-08-27 at 3 53 20 PM" src="https://user-images.githubusercontent.com/687513/91491568-4046dd80-e882-11ea-9ee5-36fe57c5e2a5.png">

After:

<img width="1043" alt="Screen Shot 2020-08-27 at 3 53 35 PM" src="https://user-images.githubusercontent.com/687513/91491608-4d63cc80-e882-11ea-90dc-a1d58f2c9934.png">
