### PR TITLE
Articles feed is browsable without JavaScript

### DIFF
--- a/src/desktop/apps/articles/queries/editorial_articles.coffee
+++ b/src/desktop/apps/articles/queries/editorial_articles.coffee
@@ -1,7 +1,7 @@
-module.exports =
+module.exports = (limit = 50, offset = 0) ->
   """
   query EditorialArticlesQuery {
-    articles(published: true, limit: 50, sort: "-published_at", featured: true ) {
+    articles(published: true, limit: #{limit}, sort: "-published_at", featured: true, offset: #{offset}) {
       slug
       thumbnail_title
       thumbnail_image

--- a/src/desktop/apps/articles/routes.ts
+++ b/src/desktop/apps/articles/routes.ts
@@ -22,8 +22,8 @@ let stitch = _stitch
 
 export const articles = (req, res, next) => {
   const limit = 50
-  const page = parseInt(req.query.page, 10) || 1
-  const offset = page * limit - limit
+  const page = Math.max(parseInt(req.query.page, 10) || 1, 1)
+  const offset = limit * (page - 1)
   const query = { query: magazineQuery(limit, offset) }
   return positronql(query)
     .then(async result => {

--- a/src/desktop/apps/articles/routes.ts
+++ b/src/desktop/apps/articles/routes.ts
@@ -20,8 +20,10 @@ let positronql = _positronql
 let topParselyArticles = _topParselyArticles
 let stitch = _stitch
 
-export const articles = (_req, res, next) => {
-  const query = { query: magazineQuery }
+export const articles = (req, res, next) => {
+  const limit = 50
+  const offset = (parseInt(req.query.page, 10) || 1) * limit - limit
+  const query = { query: magazineQuery(limit, offset) }
   return positronql(query)
     .then(async result => {
       const articles = new Articles(result.articles)

--- a/src/desktop/apps/articles/routes.ts
+++ b/src/desktop/apps/articles/routes.ts
@@ -22,12 +22,14 @@ let stitch = _stitch
 
 export const articles = (req, res, next) => {
   const limit = 50
-  const offset = (parseInt(req.query.page, 10) || 1) * limit - limit
+  const page = parseInt(req.query.page, 10) || 1
+  const offset = page * limit - limit
   const query = { query: magazineQuery(limit, offset) }
   return positronql(query)
     .then(async result => {
       const articles = new Articles(result.articles)
       res.locals.sd.ARTICLES = articles.toJSON()
+      res.locals.sd.PAGE = page
 
       // Fetch News Panel Articles
       positronql({ query: newsPanelQuery() }).then(result => {
@@ -38,6 +40,7 @@ export const articles = (req, res, next) => {
           articles: articles,
           crop,
           newsArticles,
+          page,
         })
       })
     })

--- a/src/desktop/components/articles_feed/templates/button.jade
+++ b/src/desktop/components/articles_feed/templates/button.jade
@@ -1,5 +1,5 @@
 if articles.length && !(articles.length >= articles.count)
-  button.avant-garde-button-white.is-block.js-load-more-articles
+  a.avant-garde-button-white.is-block.js-load-more-articles(href="?page=#{page + 1}")
     | More Articles
     = ' '
     if articles.count

--- a/src/desktop/components/articles_feed/test/view.test.js
+++ b/src/desktop/components/articles_feed/test/view.test.js
@@ -86,7 +86,10 @@ describe("ArticlesFeedView", function () {
       })
 
       return it("renders the button", function () {
-        return this.view.$("button").text().should.equal("More Articles (8)")
+        return this.view
+          .$("a.js-load-more-articles")
+          .text()
+          .should.equal("More Articles (8)")
       })
     })
   })

--- a/src/desktop/components/articles_feed/view.coffee
+++ b/src/desktop/components/articles_feed/view.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore'
 Backbone = require 'backbone'
+sd = require('sharify').data
 ArticleView = require './article.coffee'
 template = -> require('./templates/index.jade') arguments...
 button = -> require('./templates/button.jade') arguments...
@@ -15,11 +16,12 @@ module.exports = class ArticlesFeedView extends Backbone.View
 
   initialize: ({ @fetchWith } = {}) ->
     @renderOuter = _.once =>
-      @$el.html template(articles: @collection)
+      @$el.html template(articles: @collection, page: sd.PAGE)
 
     @listenTo @collection, 'sync', @render
 
   more: (e) ->
+    e.preventDefault()
     return if @collection.length >= @collection.count
 
     @$('.js-load-more-articles').attr 'data-state', 'loading'
@@ -31,7 +33,7 @@ module.exports = class ArticlesFeedView extends Backbone.View
 
   renderButton: =>
     (@$more ?= @$('.js-articles-feed-more'))
-      .html button(articles: @collection)
+      .html button(articles: @collection, page: sd.PAGE)
 
   renderArticle: (article, options = {}) =>
     article.set rendered: true


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2235

## Problem

Search engine crawlers may have difficulty browsing through the articles feed on `/articles` since fetching more articles requires JavaScript.

## Solution

Modify the "More Articles" button to link directly to the next page of article results when JavaScript is disabled.