### PR TITLE
Check if sd.PROFILE exists to avoid undefined error

### DIFF
--- a/src/mobile/apps/partner_profile/client/articles.coffee
+++ b/src/mobile/apps/partner_profile/client/articles.coffee
@@ -1,11 +1,13 @@
+sd = require('sharify').data
 bootstrap = require '../../../components/layout/bootstrap.coffee'
 Articles = require '../../../collections/articles.coffee'
 articleFigureTemplate = -> require('../../../components/article_figure/template.jade') arguments...
 
 $ ->
   bootstrap()
+  owner = sd.PROFILE && sd.PROFILE.owner && sd.PROFILE.owner._id
   new Articles().fetch
-    data: partner_id: sd.PROFILE.owner._id, published: true
+    data: partner_id: owner, published: true
     success: (articles) ->
       $('#profile-page-articles').html articles.map((article) ->
         articleFigureTemplate article: article

--- a/src/mobile/apps/profile/client.coffee
+++ b/src/mobile/apps/profile/client.coffee
@@ -8,8 +8,9 @@ articleFigureTemplate = -> require('../../components/article_figure/template.jad
 $ ->
   bootstrap()
   profile = new Profile sd.PROFILE
+  owner = sd.PROFILE && sd.PROFILE.owner && sd.PROFILE.owner.id
   new Articles().fetch
-    data: all_by_author: sd.PROFILE.owner.id, published: true
+    data: all_by_author: owner, published: true
     success: (articles) ->
       $('#profile-page-articles').html articles.map((article) ->
         articleFigureTemplate article: article


### PR DESCRIPTION
The `src/mobile/assets/mobile_all.ts` includes a fuzzy match at the end loads up many partner client files: https://github.com/artsy/force/blob/master/src/mobile/assets/mobile_all.ts#L67. 

This match causes partner client files to be loaded in addition to expected assets on the `/art-fairs` page. However, the files were erroring because a `sharify` require was missing, and `sd.PROFILE` doesn't exist on non-profile pages. This caused the `art-fairs` client js not to execute. 

I haven't changed the matching because i'm not sure why it is there, but I've fixed the bugs so JS loads when the files are included on unrealted pages. 

<img width="514" alt="Screen Shot 2020-09-02 at 11 24 11 AM" src="https://user-images.githubusercontent.com/1497424/92004099-ce521680-ed0f-11ea-8ea6-238387cd79a1.png">

