### PR TITLE
Removes last couple of instances of lab feature

### DIFF
--- a/src/desktop/apps/artsy-v2/apps/collection/__tests__/collectionMiddleware.jest.ts
+++ b/src/desktop/apps/artsy-v2/apps/collection/__tests__/collectionMiddleware.jest.ts
@@ -19,29 +19,7 @@ describe("handleCollectionToArtistSeriesRedirect", () => {
     expect(next).toHaveBeenCalled()
   })
 
-  it("does not redirect for a migrated artist series without the lab feature enabled", () => {
-    const req = {
-      params: {
-        collectionSlug: "kaws-four-foot-companion",
-      },
-    }
-    const res = {
-      redirect: jest.fn(),
-      locals: {
-        sd: {
-          CURRENT_USER: { id: "id" },
-        },
-      },
-    }
-    const next = jest.fn()
-
-    handleCollectionToArtistSeriesRedirect(req, res, next)
-
-    expect(res.redirect).not.toHaveBeenCalled()
-    expect(next).toHaveBeenCalled()
-  })
-
-  it("redirects for a migrated series with the lab feature enabled", () => {
+  it("redirects for a migrated series", () => {
     const spy = jest.fn()
     const req = {
       params: {
@@ -51,9 +29,7 @@ describe("handleCollectionToArtistSeriesRedirect", () => {
     const res = {
       redirect: spy,
       locals: {
-        sd: {
-          CURRENT_USER: { lab_features: ["Artist Series"] },
-        },
+        sd: {},
       },
     }
 

--- a/src/desktop/apps/artsy-v2/apps/collection/collectionMiddleware.ts
+++ b/src/desktop/apps/artsy-v2/apps/collection/collectionMiddleware.ts
@@ -1,5 +1,4 @@
 import { NextFunction } from "express"
-import { userHasLabFeature } from "v2/Utils/user"
 import { collectionToArtistSeriesSlugMap } from "v2/Apps/Collect/Utils/collectionToArtistSeriesSlugMap"
 
 export const handleCollectionToArtistSeriesRedirect = async (
@@ -7,16 +6,13 @@ export const handleCollectionToArtistSeriesRedirect = async (
   res,
   next: NextFunction
 ) => {
-  const user = res.locals.sd.CURRENT_USER
   const collectionSlug: string = req.params.collectionSlug
 
-  if (userHasLabFeature(user, "Artist Series")) {
-    const seriesSlug: string = collectionToArtistSeriesSlugMap[collectionSlug]
-    if (seriesSlug) {
-      const artistSeriesPath = `/artist-series/${seriesSlug}`
-      res.redirect(301, artistSeriesPath)
-      return
-    }
+  const seriesSlug: string = collectionToArtistSeriesSlugMap[collectionSlug]
+  if (seriesSlug) {
+    const artistSeriesPath = `/artist-series/${seriesSlug}`
+    res.redirect(301, artistSeriesPath)
+    return
   }
 
   next()

--- a/src/v2/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/v2/Apps/Search/Components/NavigationTabs.tsx
@@ -7,7 +7,6 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "v2/Utils/get"
 import { SystemContextProps, withSystemContext } from "v2/Artsy"
-import { userHasLabFeature } from "v2/Utils/user"
 
 export interface Props extends SystemContextProps {
   searchableConnection: NavigationTabs_searchableConnection
@@ -56,12 +55,8 @@ export class NavigationTabs extends React.Component<Props> {
       count?: number
     } = {}
   ) => {
-    const { user } = this.props
-    const artistSeriesIsEnabled = userHasLabFeature(user, "Artist Series")
     const { exact, count } = options
     const tabName = text.replace(/[0-9]/g, "").trim()
-
-    if (tabName === "Artist Series" && !artistSeriesIsEnabled) return null
 
     return (
       <RouteTab


### PR DESCRIPTION
Not sure how I missed these!

In any case, this removes the lab feature check from the router (so that we'll correctly route from the soon-to-be-deprecated collections) _and_ from the search results page.

<img width="846" alt="image" src="https://user-images.githubusercontent.com/2081340/92020293-e92f8580-ed25-11ea-83c6-b2e7e0d0fa69.png">
