### PR TITLE
No crawl login

### DIFF
--- a/src/desktop/apps/authentication/components/meta.tsx
+++ b/src/desktop/apps/authentication/components/meta.tsx
@@ -19,6 +19,8 @@ export const AuthenticationMeta: React.SFC<MetaProps> = props => {
       <meta property="description" content={description} />
       <meta property="og:description" content={description} />
       <meta property="twitter:description" content={description} />
+      {/* Don't index or follow links on this page */}
+      <meta name="robots" content="none" />
     </>
   )
 }

--- a/src/desktop/apps/fairs/templates/promo.jade
+++ b/src/desktop/apps/fairs/templates/promo.jade
@@ -5,7 +5,7 @@
         h1 Preview and collect from the world's leading art fairs
       else
         h1 Sign up to follow fairs and be the first to preview them on Artsy
-        a.fairs__promo__sign-up.avant-garde-button-white(href="/sign_up") Sign Up
+        a.fairs__promo__sign-up.avant-garde-button-white(href="/sign_up", rel="nofollow") Sign Up
       - length = featuredFairs.length
       include ../../../components/merry_go_round/templates/bottom_navigation
   section.fairs__promo__slideshow

--- a/src/desktop/components/auction_lots/templates/_detail.jade
+++ b/src/desktop/components/auction_lots/templates/_detail.jade
@@ -35,7 +35,7 @@ if lot.hasImage('thumbnail')
       if (user)
         = lot.get('price_realized_text') || '–'
       else
-        a.auction-lot-sale-signup( href='/sign_up' )
+        a.auction-lot-sale-signup( href='/sign_up', rel='nofollow' )
           | Sign up to see sale price
 
   if lot.get('description')

--- a/src/desktop/components/auction_lots/templates/auction_lots_table.jade
+++ b/src/desktop/components/auction_lots/templates/auction_lots_table.jade
@@ -48,5 +48,5 @@ tbody
         if (user)
           = lot.get('price_realized_text')
         else
-          a.auction-lot-sale-signup( href='/sign_up' )
+          a.auction-lot-sale-signup( href='/sign_up', rel='nofollow' )
             | Sign up to see sale price

--- a/src/desktop/components/fair_layout/templates/user.jade
+++ b/src/desktop/components/fair_layout/templates/user.jade
@@ -23,5 +23,5 @@
           | Log out
 
   else
-    a.avant-garde-button-white.mlh-login( href='/log_in' ) Log in
-    a.avant-garde-button-black.mlh-signup( href='/sign_up' ) Sign up
+    a.avant-garde-button-white.mlh-login( href='/log_in', rel='nofollow' ) Log in
+    a.avant-garde-button-black.mlh-signup( href='/sign_up', rel='nofollow' ) Sign up

--- a/src/desktop/components/inquiry_questionnaire/templates/account/login.jade
+++ b/src/desktop/components/inquiry_questionnaire/templates/account/login.jade
@@ -33,12 +33,12 @@ form.stacked-form
         | Remember me
 
     span
-      a.fine-faux-underline.js-mode.js-forgot-password( data-mode='forgot' )
+      a.fine-faux-underline.js-mode.js-forgot-password( data-mode='forgot', rel='nofollow' )
         | Forgot Password?
 
       unless user.isWithAccount()
         span.garamond-tab-separator.is-vertical
-        a.fine-faux-underline.js-mode( data-mode='signup' )
+        a.fine-faux-underline.js-mode( data-mode='signup', rel='nofollow' )
           | Sign up
 
   .iq-account-sub

--- a/src/desktop/components/main_layout/footer/mobile_footer_menu.jade
+++ b/src/desktop/components/main_layout/footer/mobile_footer_menu.jade
@@ -15,8 +15,8 @@
       a( href='/user/edit' ) Account
   else
     .mlf-login-signup
-      a.mlf-signup.avant-garde-button-dark( href='/sign_up' ) Sign up
-      a.mlf-login.avant-garde-button-dark( href='/log_in' ) Log in
+      a.mlf-signup.avant-garde-button-dark( href='/sign_up', rel='nofollow' ) Sign up
+      a.mlf-login.avant-garde-button-dark( href='/log_in', rel='nofollow') Log in
   .mlf-lower
       nav#main-layout-footer-internal
         span.mlf-links

--- a/src/mobile/apps/art_fairs/templates/index.jade
+++ b/src/mobile/apps/art_fairs/templates/index.jade
@@ -18,7 +18,7 @@ block content
       if !user
         .art-fairs-content--sign-up-container
           .art-fairs-content--sign-up-container__label Get notified when fair previews open
-          a.avant-garde-box-button.avant-garde-box-button-gray( href="/sign_up?intent=signup&contextModule=fairsHeader" ) Sign up
+          a.avant-garde-box-button.avant-garde-box-button-gray( href="/sign_up?intent=signup&contextModule=fairsHeader", rel='nofollow' ) Sign up
 
       include ../../../components/avant_garde_tabs/nav
 

--- a/src/mobile/apps/auctions/templates/index.jade
+++ b/src/mobile/apps/auctions/templates/index.jade
@@ -19,7 +19,7 @@ block content
       if !user
         .auction-page-content--sign-up-container
           .auction-page-content--sign-up-container__label Get notified when auctions open
-          a.avant-garde-box-button.avant-garde-box-button-gray( href="/sign_up?redirect-to=/auctions&intent=signup&contextModule=auctionsHeader" ) Sign up
+          a.avant-garde-box-button.avant-garde-box-button-gray( href="/sign_up?redirect-to=/auctions&intent=signup&contextModule=auctionsHeader", rel='nofollow' ) Sign up
 
       include ../../../components/avant_garde_tabs/nav
 

--- a/src/mobile/apps/how_auctions_work/templates/learn_more.jade
+++ b/src/mobile/apps/how_auctions_work/templates/learn_more.jade
@@ -4,7 +4,7 @@
 
     if section.id === 'register'
       unless user
-        a.avant-garde-box-button.avant-garde-box-button-black( href='/sign_up' ) Register
+        a.avant-garde-box-button.avant-garde-box-button-black( href='/sign_up', rel='nofollow' ) Register
 
     if section.id === 'watch'
       .haw-bid-increments

--- a/src/mobile/components/layout/templates/login-signup.jade
+++ b/src/mobile/components/layout/templates/login-signup.jade
@@ -1,6 +1,6 @@
 mixin login-signup(template)
   .login-signup
     .login-signup-button-container
-      a.avant-garde-box-button.avant-garde-box-button-gray( href="/sign_up?intent=signup&contextModule=#{template}&destination=#{sd.CURRENT_PATH}", data-test="mobileSignUpCTA" ) Sign up
+      a.avant-garde-box-button.avant-garde-box-button-gray( href="/sign_up?intent=signup&contextModule=#{template}&destination=#{sd.CURRENT_PATH}", data-test="mobileSignUpCTA", rel="nofollow" ) Sign up
     .login-signup-button-container
-      a.avant-garde-box-button.avant-garde-box-button-gray( href="/log_in?intent=login&contextModule=#{template}&destination=#{sd.CURRENT_PATH}", data-test="mobileLogInCTA" ) Log in
+      a.avant-garde-box-button.avant-garde-box-button-gray( href="/log_in?intent=login&contextModule=#{template}&destination=#{sd.CURRENT_PATH}", data-test="mobileLogInCTA", rel="nofollow" ) Log in

--- a/src/v2/Components/Authentication/commonElements.tsx
+++ b/src/v2/Components/Authentication/commonElements.tsx
@@ -81,7 +81,7 @@ export const FooterText = (props: { children: any; mt?: number }) => (
 
 export const ForgotPassword = (props: { onClick: () => void }) => (
   <Sans size="2">
-    <Link color="black60" {...props} data-test="forgot">
+    <Link color="black60" {...props} data-test="forgot" rel="nofollow">
       Forgot Password?
     </Link>
   </Sans>


### PR DESCRIPTION
Fixes [PURCHASE-2080](https://artsyproduct.atlassian.net/browse/PURCHASE-2080).

There are ultimately two parts to the above ticket that we really want to accomplish:

1. Avoid indexing `/sign_up` & `/log_in` pages, including query parameterized variations of the page
2. Reduce our crawl budget burn by ensure the pages aren't followed to by the crawler

The first one was easiest to fix codewise, but it took me a while to figure out the right thing to do. I implemented a robots meta tag with content `none`. This means that crawlers shouldn't index the page _nor_ should it try to follow any of the URLs on the page. Straight forward enough. There was a recommendation to add a self referring canonical to avoid the query parameterization indexes of the page, but given that the robots meta tag is _always_ present on those pages, it shouldn't really matter. I actually found advice online that recommended against using both signals (the meta tag and self canonicals) because one is telling google not to index while the other is telling it _to_ index (if it's the root canonical). So yeah, there's that part. 

The second is pretty tricky and the updates I made really aren't exhaustive. Essentially we want to tell the crawler to ignore links that lead to `/sign_up`, `/log_in`, or `/forgot`. If it never tries to go to those, they don't use crawl budget. The `rel='nofollow'` part achieves that. 