### PR TITLE
Hacks around race condition in setup for "super_article"

### DIFF
--- a/src/desktop/components/article/client/super_article.coffee
+++ b/src/desktop/components/article/client/super_article.coffee
@@ -63,6 +63,10 @@ module.exports = class SuperArticleView extends Backbone.View
   setWaypoints: ->
     return unless @$stickyHeader.length
 
+    # HACK: `globalClientSetup` which requires this library is somehow being
+    # called *after* this view method, causing this to error.
+    require("jquery-waypoints/waypoints.js")
+
     @$(".article-content").waypoint (direction) =>
       if direction == 'down'
         @$stickyHeader.addClass 'visible'


### PR DESCRIPTION
`this.$(...).waypoint is not a function` on "super articles" which require the use of the jQuery Waypoints plugin.

This fixes the immediate problem but, for whatever reason, the `globalClientSetup` (which requires all the jQuery plugins) is happening after these articles get initialized. Which *is* worrying — any ideas @damassi or @zephraph or @eessex?