### PR TITLE
Adjusts FairHeader hero image

### DIFF
--- a/src/v2/Apps/Fair/Components/FairHeader.tsx
+++ b/src/v2/Apps/Fair/Components/FairHeader.tsx
@@ -5,31 +5,43 @@ import {
   Col,
   Flex,
   Grid,
-  ResponsiveBox,
-  ResponsiveBoxProps,
+  Image,
   Row,
   Spacer,
   Text,
+  space,
 } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairHeader_fair } from "v2/__generated__/FairHeader_fair.graphql"
-import styled from "styled-components"
 import { ForwardLink } from "v2/Components/Links/ForwardLink"
+import styled from "styled-components"
 
 interface FairHeaderProps extends BoxProps {
   fair: FairHeader_fair
 }
 
-const ResponsiveImage = styled(ResponsiveBox)<ResponsiveBoxProps>`
-  img {
-    width: 100%;
-    height: 100%;
+const MediumHero = styled(Image).attrs({ lazyLoad: true })`
+  display: none;
+  @media (min-height: 1000px) {
+    display: block;
+  }
+`
+
+const SmallHero = styled(Image).attrs({ lazyLoad: true })`
+  display: none;
+  @media (max-height: 1000px) {
+    display: block;
   }
 `
 
 const FairHeader: React.FC<FairHeaderProps> = ({ fair, ...rest }) => {
-  const img = fair?.image?.cropped
-  const profileIcon = fair?.profile?.icon?.cropped
+  const image = {
+    small: fair?.smallHero,
+    medium: fair?.mediumHero,
+  }
+
+  const icon = fair.profile?.icon
+
   const {
     about,
     tagline,
@@ -57,32 +69,52 @@ const FairHeader: React.FC<FairHeaderProps> = ({ fair, ...rest }) => {
 
   return (
     <Box {...rest}>
-      {img && (
-        <Flex
-          alignItems="center"
-          justifyContent="center"
-          style={{ position: "relative" }}
-        >
-          <ResponsiveImage
-            aspectWidth={img.width}
-            aspectHeight={img.height}
-            maxWidth={375}
-            bg="black10"
+      {image && (
+        <Flex position="relative" alignItems="center" justifyContent="center">
+          <Box
+            display="inline-block"
+            position="relative"
+            mx="auto"
+            height="100%"
           >
-            <img src={img.src} alt={fair.name} />
-            {profileIcon && (
+            <MediumHero
+              alt={fair.name}
+              src={image.medium._1x.src}
+              srcSet={`${image.medium._1x.src} 1x, ${image.medium._2x.src} 2x`}
+              width={image.medium._1x.width}
+              height={image.medium._1x.height}
+            />
+
+            <SmallHero
+              alt={fair.name}
+              src={image.small._1x.src}
+              srcSet={`${image.small._1x.src} 1x, ${image.small._2x.src} 2x`}
+              width={image.small._1x.width}
+              height={image.small._1x.height}
+            />
+
+            {icon && (
               <Box
                 bg="white100"
                 width={80}
-                px={1}
+                height={60}
                 position="absolute"
                 bottom={0}
-                left="1rem"
+                left={space(2)}
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
               >
-                <img src={profileIcon.src} />
+                <img
+                  src={icon._1x.src}
+                  srcSet={`${icon._1x.src} 1x, ${icon._2x.src} 2x`}
+                  alt={`Logo of ${fair.name}`}
+                  width={40}
+                  height={40}
+                />
               </Box>
             )}
-          </ResponsiveImage>
+          </Box>
         </Flex>
       )}
 
@@ -127,18 +159,32 @@ export const FairHeaderFragmentContainer = createFragmentContainer(FairHeader, {
       slug
       profile {
         icon {
-          # Always 60px wide * 2 for retina
-          cropped(width: 120, height: 120, version: "square140") {
+          _1x: cropped(width: 40, height: 40, version: "square140") {
+            src: url
+          }
+          _2x: cropped(width: 80, height: 80, version: "square140") {
             src: url
           }
         }
       }
-      image {
-        # 3:4 - 375×500 native max dimensions * 2 for retina
-        cropped(width: 750, height: 1000, version: "wide") {
+      smallHero: image {
+        _1x: cropped(width: 375, height: 500, version: "wide") {
           src: url
           width
           height
+        }
+        _2x: cropped(width: 750, height: 1000, version: "wide") {
+          src: url
+        }
+      }
+      mediumHero: image {
+        _1x: cropped(width: 600, height: 800, version: "wide") {
+          src: url
+          width
+          height
+        }
+        _2x: cropped(width: 1200, height: 1600, version: "wide") {
+          src: url
         }
       }
       # Used to figure out if we should render the More info link

--- a/src/v2/Apps/Fair/Components/__tests__/FairHeader.jest.tsx
+++ b/src/v2/Apps/Fair/Components/__tests__/FairHeader.jest.tsx
@@ -115,11 +115,24 @@ const FairHeaderFixture: FairHeader_QueryRawResponse = {
     name: "Miart 2020",
     formattedOpeningHours: "Closes in 12 days",
     slug: "miart-2020",
-    image: {
-      cropped: {
+    smallHero: {
+      _1x: {
         src: "https://cloudfront.com/square.jpg",
-        width: 100,
+        width: 300,
         height: 400,
+      },
+      _2x: {
+        src: "https://cloudfront.com/square.jpg",
+      },
+    },
+    mediumHero: {
+      _1x: {
+        src: "https://cloudfront.com/square.jpg",
+        width: 600,
+        height: 800,
+      },
+      _2x: {
+        src: "https://cloudfront.com/square.jpg",
       },
     },
     tagline: "",
@@ -133,7 +146,10 @@ const FairHeaderFixture: FairHeader_QueryRawResponse = {
     profile: {
       id: "profile",
       icon: {
-        cropped: {
+        _1x: {
+          src: "/path/to/cats.jpg",
+        },
+        _2x: {
           src: "/path/to/cats.jpg",
         },
       },

--- a/src/v2/Apps/Fair/__tests__/FairApp.jest.tsx
+++ b/src/v2/Apps/Fair/__tests__/FairApp.jest.tsx
@@ -14,11 +14,24 @@ const FAIR_APP_FIXTURE: FairApp_QueryRawResponse = {
     name: "Miart 2020",
     formattedOpeningHours: "Closes in 12 days",
     slug: "miart-2020",
-    image: {
-      cropped: {
+    smallHero: {
+      _1x: {
         src: "https://cloudfront.com/square.jpg",
-        width: 100,
+        width: 300,
         height: 400,
+      },
+      _2x: {
+        src: "https://cloudfront.com/square.jpg",
+      },
+    },
+    mediumHero: {
+      _1x: {
+        src: "https://cloudfront.com/square.jpg",
+        width: 600,
+        height: 800,
+      },
+      _2x: {
+        src: "https://cloudfront.com/square.jpg",
       },
     },
     tagline: "",
@@ -35,7 +48,10 @@ const FAIR_APP_FIXTURE: FairApp_QueryRawResponse = {
     profile: {
       id: "profile",
       icon: {
-        cropped: {
+        _1x: {
+          src: "/path/to/cats.jpg",
+        },
+        _2x: {
           src: "/path/to/cats.jpg",
         },
       },

--- a/src/v2/__generated__/FairApp_Query.graphql.ts
+++ b/src/v2/__generated__/FairApp_Query.graphql.ts
@@ -24,17 +24,33 @@ export type FairApp_QueryRawResponse = {
         readonly formattedOpeningHours: string | null;
         readonly profile: ({
             readonly icon: ({
-                readonly cropped: ({
+                readonly _1x: ({
+                    readonly src: string | null;
+                }) | null;
+                readonly _2x: ({
                     readonly src: string | null;
                 }) | null;
             }) | null;
             readonly id: string | null;
         }) | null;
-        readonly image: ({
-            readonly cropped: ({
+        readonly smallHero: ({
+            readonly _1x: ({
                 readonly src: string | null;
                 readonly width: number | null;
                 readonly height: number | null;
+            }) | null;
+            readonly _2x: ({
+                readonly src: string | null;
+            }) | null;
+        }) | null;
+        readonly mediumHero: ({
+            readonly _1x: ({
+                readonly src: string | null;
+                readonly width: number | null;
+                readonly height: number | null;
+            }) | null;
+            readonly _2x: ({
+                readonly src: string | null;
             }) | null;
         }) | null;
         readonly tagline: string | null;
@@ -143,17 +159,33 @@ fragment FairHeader_fair on Fair {
   slug
   profile {
     icon {
-      cropped(width: 120, height: 120, version: "square140") {
+      _1x: cropped(width: 40, height: 40, version: "square140") {
+        src: url
+      }
+      _2x: cropped(width: 80, height: 80, version: "square140") {
         src: url
       }
     }
     id
   }
-  image {
-    cropped(width: 750, height: 1000, version: "wide") {
+  smallHero: image {
+    _1x: cropped(width: 375, height: 500, version: "wide") {
       src: url
       width
       height
+    }
+    _2x: cropped(width: 750, height: 1000, version: "wide") {
+      src: url
+    }
+  }
+  mediumHero: image {
+    _1x: cropped(width: 600, height: 800, version: "wide") {
+      src: url
+      width
+      height
+    }
+    _2x: cropped(width: 1200, height: 1600, version: "wide") {
+      src: url
     }
   }
   tagline
@@ -202,44 +234,67 @@ v2 = {
   "storageKey": null
 },
 v3 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "square140"
+},
+v4 = {
   "alias": "src",
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v4 = {
+v5 = [
+  (v4/*: any*/)
+],
+v6 = {
+  "kind": "Literal",
+  "name": "height",
+  "value": 80
+},
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = {
+v8 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "wide"
+},
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "width",
   "storageKey": null
 },
-v6 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v7 = [
+v11 = [
+  (v4/*: any*/),
+  (v9/*: any*/),
+  (v10/*: any*/)
+],
+v12 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "HTML"
   }
 ],
-v8 = [
-  (v5/*: any*/),
-  (v6/*: any*/),
-  (v3/*: any*/)
+v13 = [
+  (v9/*: any*/),
+  (v10/*: any*/),
+  (v4/*: any*/)
 ];
 return {
   "fragment": {
@@ -358,42 +413,54 @@ return {
                 "plural": false,
                 "selections": [
                   {
-                    "alias": null,
+                    "alias": "_1x",
                     "args": [
                       {
                         "kind": "Literal",
                         "name": "height",
-                        "value": 120
+                        "value": 40
                       },
-                      {
-                        "kind": "Literal",
-                        "name": "version",
-                        "value": "square140"
-                      },
+                      (v3/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
-                        "value": 120
+                        "value": 40
                       }
                     ],
                     "concreteType": "CroppedImageUrl",
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": [
-                      (v3/*: any*/)
+                    "selections": (v5/*: any*/),
+                    "storageKey": "cropped(height:40,version:\"square140\",width:40)"
+                  },
+                  {
+                    "alias": "_2x",
+                    "args": [
+                      (v6/*: any*/),
+                      (v3/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 80
+                      }
                     ],
-                    "storageKey": "cropped(height:120,version:\"square140\",width:120)"
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v5/*: any*/),
+                    "storageKey": "cropped(height:80,version:\"square140\",width:80)"
                   }
                 ],
                 "storageKey": null
               },
-              (v4/*: any*/)
+              (v7/*: any*/)
             ],
             "storageKey": null
           },
           {
-            "alias": null,
+            "alias": "smallHero",
             "args": null,
             "concreteType": "Image",
             "kind": "LinkedField",
@@ -401,18 +468,36 @@ return {
             "plural": false,
             "selections": [
               {
-                "alias": null,
+                "alias": "_1x",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 500
+                  },
+                  (v8/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 375
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": (v11/*: any*/),
+                "storageKey": "cropped(height:500,version:\"wide\",width:375)"
+              },
+              {
+                "alias": "_2x",
                 "args": [
                   {
                     "kind": "Literal",
                     "name": "height",
                     "value": 1000
                   },
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "wide"
-                  },
+                  (v8/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "width",
@@ -423,12 +508,63 @@ return {
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": [
-                  (v3/*: any*/),
-                  (v5/*: any*/),
-                  (v6/*: any*/)
-                ],
+                "selections": (v5/*: any*/),
                 "storageKey": "cropped(height:1000,version:\"wide\",width:750)"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": "mediumHero",
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": "_1x",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 800
+                  },
+                  (v8/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 600
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": (v11/*: any*/),
+                "storageKey": "cropped(height:800,version:\"wide\",width:600)"
+              },
+              {
+                "alias": "_2x",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 1600
+                  },
+                  (v8/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 1200
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": (v5/*: any*/),
+                "storageKey": "cropped(height:1600,version:\"wide\",width:1200)"
               }
             ],
             "storageKey": null
@@ -449,7 +585,7 @@ return {
             "plural": false,
             "selections": [
               (v2/*: any*/),
-              (v4/*: any*/)
+              (v7/*: any*/)
             ],
             "storageKey": null
           },
@@ -462,28 +598,28 @@ return {
           },
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v12/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
             "storageKey": "hours(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v12/*: any*/),
             "kind": "ScalarField",
             "name": "links",
             "storageKey": "links(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v12/*: any*/),
             "kind": "ScalarField",
             "name": "tickets",
             "storageKey": "tickets(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v12/*: any*/),
             "kind": "ScalarField",
             "name": "contact",
             "storageKey": "contact(format:\"HTML\")"
@@ -523,7 +659,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
+                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -569,11 +705,7 @@ return {
                           {
                             "alias": "_1x",
                             "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "height",
-                                "value": 80
-                              },
+                              (v6/*: any*/),
                               {
                                 "kind": "Literal",
                                 "name": "width",
@@ -584,7 +716,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v13/*: any*/),
                             "storageKey": "cropped(height:80,width:140)"
                           },
                           {
@@ -605,7 +737,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v13/*: any*/),
                             "storageKey": "cropped(height:160,width:280)"
                           }
                         ],
@@ -627,7 +759,7 @@ return {
             ],
             "storageKey": "articlesConnection(first:5,sort:\"PUBLISHED_AT_DESC\")"
           },
-          (v4/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
@@ -638,7 +770,7 @@ return {
     "metadata": {},
     "name": "FairApp_Query",
     "operationKind": "query",
-    "text": "query FairApp_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairEditorial_fair\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  title\n  href\n  publishedAt(format: \"MMM Do, YY\")\n  thumbnailTitle\n  thumbnailImage {\n    _1x: cropped(width: 140, height: 80) {\n      width\n      height\n      src: url\n    }\n    _2x: cropped(width: 280, height: 160) {\n      width\n      height\n      src: url\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  formattedOpeningHours\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n"
+    "text": "query FairApp_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairEditorial_fair\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  title\n  href\n  publishedAt(format: \"MMM Do, YY\")\n  thumbnailTitle\n  thumbnailImage {\n    _1x: cropped(width: 140, height: 80) {\n      width\n      height\n      src: url\n    }\n    _2x: cropped(width: 280, height: 160) {\n      width\n      height\n      src: url\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  formattedOpeningHours\n  name\n  slug\n  profile {\n    icon {\n      _1x: cropped(width: 40, height: 40, version: \"square140\") {\n        src: url\n      }\n      _2x: cropped(width: 80, height: 80, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  smallHero: image {\n    _1x: cropped(width: 375, height: 500, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n    _2x: cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n    }\n  }\n  mediumHero: image {\n    _1x: cropped(width: 600, height: 800, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n    _2x: cropped(width: 1200, height: 1600, version: \"wide\") {\n      src: url\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairHeader_Query.graphql.ts
+++ b/src/v2/__generated__/FairHeader_Query.graphql.ts
@@ -20,17 +20,33 @@ export type FairHeader_QueryRawResponse = {
         readonly slug: string;
         readonly profile: ({
             readonly icon: ({
-                readonly cropped: ({
+                readonly _1x: ({
+                    readonly src: string | null;
+                }) | null;
+                readonly _2x: ({
                     readonly src: string | null;
                 }) | null;
             }) | null;
             readonly id: string | null;
         }) | null;
-        readonly image: ({
-            readonly cropped: ({
+        readonly smallHero: ({
+            readonly _1x: ({
                 readonly src: string | null;
                 readonly width: number | null;
                 readonly height: number | null;
+            }) | null;
+            readonly _2x: ({
+                readonly src: string | null;
+            }) | null;
+        }) | null;
+        readonly mediumHero: ({
+            readonly _1x: ({
+                readonly src: string | null;
+                readonly width: number | null;
+                readonly height: number | null;
+            }) | null;
+            readonly _2x: ({
+                readonly src: string | null;
             }) | null;
         }) | null;
         readonly tagline: string | null;
@@ -72,17 +88,33 @@ fragment FairHeader_fair on Fair {
   slug
   profile {
     icon {
-      cropped(width: 120, height: 120, version: "square140") {
+      _1x: cropped(width: 40, height: 40, version: "square140") {
+        src: url
+      }
+      _2x: cropped(width: 80, height: 80, version: "square140") {
         src: url
       }
     }
     id
   }
-  image {
-    cropped(width: 750, height: 1000, version: "wide") {
+  smallHero: image {
+    _1x: cropped(width: 375, height: 500, version: "wide") {
       src: url
       width
       height
+    }
+    _2x: cropped(width: 750, height: 1000, version: "wide") {
+      src: url
+    }
+  }
+  mediumHero: image {
+    _1x: cropped(width: 600, height: 800, version: "wide") {
+      src: url
+      width
+      height
+    }
+    _2x: cropped(width: 1200, height: 1600, version: "wide") {
+      src: url
     }
   }
   tagline
@@ -122,20 +154,50 @@ v2 = {
   "storageKey": null
 },
 v3 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "square140"
+},
+v4 = {
   "alias": "src",
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v4 = {
+v5 = [
+  (v4/*: any*/)
+],
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = [
+v7 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "wide"
+},
+v8 = [
+  (v4/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "width",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "height",
+    "storageKey": null
+  }
+],
+v9 = [
   {
     "kind": "Literal",
     "name": "format",
@@ -228,42 +290,58 @@ return {
                 "plural": false,
                 "selections": [
                   {
-                    "alias": null,
+                    "alias": "_1x",
                     "args": [
                       {
                         "kind": "Literal",
                         "name": "height",
-                        "value": 120
+                        "value": 40
                       },
-                      {
-                        "kind": "Literal",
-                        "name": "version",
-                        "value": "square140"
-                      },
+                      (v3/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
-                        "value": 120
+                        "value": 40
                       }
                     ],
                     "concreteType": "CroppedImageUrl",
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": [
-                      (v3/*: any*/)
+                    "selections": (v5/*: any*/),
+                    "storageKey": "cropped(height:40,version:\"square140\",width:40)"
+                  },
+                  {
+                    "alias": "_2x",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 80
+                      },
+                      (v3/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 80
+                      }
                     ],
-                    "storageKey": "cropped(height:120,version:\"square140\",width:120)"
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v5/*: any*/),
+                    "storageKey": "cropped(height:80,version:\"square140\",width:80)"
                   }
                 ],
                 "storageKey": null
               },
-              (v4/*: any*/)
+              (v6/*: any*/)
             ],
             "storageKey": null
           },
           {
-            "alias": null,
+            "alias": "smallHero",
             "args": null,
             "concreteType": "Image",
             "kind": "LinkedField",
@@ -271,18 +349,36 @@ return {
             "plural": false,
             "selections": [
               {
-                "alias": null,
+                "alias": "_1x",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 500
+                  },
+                  (v7/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 375
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": (v8/*: any*/),
+                "storageKey": "cropped(height:500,version:\"wide\",width:375)"
+              },
+              {
+                "alias": "_2x",
                 "args": [
                   {
                     "kind": "Literal",
                     "name": "height",
                     "value": 1000
                   },
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "wide"
-                  },
+                  (v7/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "width",
@@ -293,24 +389,63 @@ return {
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": [
-                  (v3/*: any*/),
+                "selections": (v5/*: any*/),
+                "storageKey": "cropped(height:1000,version:\"wide\",width:750)"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": "mediumHero",
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": "_1x",
+                "args": [
                   {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "width",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
+                    "kind": "Literal",
                     "name": "height",
-                    "storageKey": null
+                    "value": 800
+                  },
+                  (v7/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 600
                   }
                 ],
-                "storageKey": "cropped(height:1000,version:\"wide\",width:750)"
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": (v8/*: any*/),
+                "storageKey": "cropped(height:800,version:\"wide\",width:600)"
+              },
+              {
+                "alias": "_2x",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 1600
+                  },
+                  (v7/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 1200
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": (v5/*: any*/),
+                "storageKey": "cropped(height:1600,version:\"wide\",width:1200)"
               }
             ],
             "storageKey": null
@@ -331,7 +466,7 @@ return {
             "plural": false,
             "selections": [
               (v2/*: any*/),
-              (v4/*: any*/)
+              (v6/*: any*/)
             ],
             "storageKey": null
           },
@@ -344,33 +479,33 @@ return {
           },
           {
             "alias": null,
-            "args": (v5/*: any*/),
+            "args": (v9/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
             "storageKey": "hours(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v5/*: any*/),
+            "args": (v9/*: any*/),
             "kind": "ScalarField",
             "name": "links",
             "storageKey": "links(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v5/*: any*/),
+            "args": (v9/*: any*/),
             "kind": "ScalarField",
             "name": "tickets",
             "storageKey": "tickets(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v5/*: any*/),
+            "args": (v9/*: any*/),
             "kind": "ScalarField",
             "name": "contact",
             "storageKey": "contact(format:\"HTML\")"
           },
-          (v4/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
@@ -381,7 +516,7 @@ return {
     "metadata": {},
     "name": "FairHeader_Query",
     "operationKind": "query",
-    "text": "query FairHeader_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairHeader_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  formattedOpeningHours\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n"
+    "text": "query FairHeader_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairHeader_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  formattedOpeningHours\n  name\n  slug\n  profile {\n    icon {\n      _1x: cropped(width: 40, height: 40, version: \"square140\") {\n        src: url\n      }\n      _2x: cropped(width: 80, height: 80, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  smallHero: image {\n    _1x: cropped(width: 375, height: 500, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n    _2x: cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n    }\n  }\n  mediumHero: image {\n    _1x: cropped(width: 600, height: 800, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n    _2x: cropped(width: 1200, height: 1600, version: \"wide\") {\n      src: url\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairHeader_fair.graphql.ts
+++ b/src/v2/__generated__/FairHeader_fair.graphql.ts
@@ -11,16 +11,32 @@ export type FairHeader_fair = {
     readonly slug: string;
     readonly profile: {
         readonly icon: {
-            readonly cropped: {
+            readonly _1x: {
+                readonly src: string | null;
+            } | null;
+            readonly _2x: {
                 readonly src: string | null;
             } | null;
         } | null;
     } | null;
-    readonly image: {
-        readonly cropped: {
+    readonly smallHero: {
+        readonly _1x: {
             readonly src: string | null;
             readonly width: number | null;
             readonly height: number | null;
+        } | null;
+        readonly _2x: {
+            readonly src: string | null;
+        } | null;
+    } | null;
+    readonly mediumHero: {
+        readonly _1x: {
+            readonly src: string | null;
+            readonly width: number | null;
+            readonly height: number | null;
+        } | null;
+        readonly _2x: {
+            readonly src: string | null;
         } | null;
     } | null;
     readonly tagline: string | null;
@@ -51,13 +67,43 @@ var v0 = {
   "storageKey": null
 },
 v1 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "square140"
+},
+v2 = {
   "alias": "src",
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v2 = [
+v3 = [
+  (v2/*: any*/)
+],
+v4 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "wide"
+},
+v5 = [
+  (v2/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "width",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "height",
+    "storageKey": null
+  }
+],
+v6 = [
   {
     "kind": "Literal",
     "name": "format",
@@ -116,32 +162,48 @@ return {
           "plural": false,
           "selections": [
             {
-              "alias": null,
+              "alias": "_1x",
               "args": [
                 {
                   "kind": "Literal",
                   "name": "height",
-                  "value": 120
+                  "value": 40
                 },
-                {
-                  "kind": "Literal",
-                  "name": "version",
-                  "value": "square140"
-                },
+                (v1/*: any*/),
                 {
                   "kind": "Literal",
                   "name": "width",
-                  "value": 120
+                  "value": 40
                 }
               ],
               "concreteType": "CroppedImageUrl",
               "kind": "LinkedField",
               "name": "cropped",
               "plural": false,
-              "selections": [
-                (v1/*: any*/)
+              "selections": (v3/*: any*/),
+              "storageKey": "cropped(height:40,version:\"square140\",width:40)"
+            },
+            {
+              "alias": "_2x",
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "height",
+                  "value": 80
+                },
+                (v1/*: any*/),
+                {
+                  "kind": "Literal",
+                  "name": "width",
+                  "value": 80
+                }
               ],
-              "storageKey": "cropped(height:120,version:\"square140\",width:120)"
+              "concreteType": "CroppedImageUrl",
+              "kind": "LinkedField",
+              "name": "cropped",
+              "plural": false,
+              "selections": (v3/*: any*/),
+              "storageKey": "cropped(height:80,version:\"square140\",width:80)"
             }
           ],
           "storageKey": null
@@ -150,7 +212,7 @@ return {
       "storageKey": null
     },
     {
-      "alias": null,
+      "alias": "smallHero",
       "args": null,
       "concreteType": "Image",
       "kind": "LinkedField",
@@ -158,18 +220,36 @@ return {
       "plural": false,
       "selections": [
         {
-          "alias": null,
+          "alias": "_1x",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 500
+            },
+            (v4/*: any*/),
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 375
+            }
+          ],
+          "concreteType": "CroppedImageUrl",
+          "kind": "LinkedField",
+          "name": "cropped",
+          "plural": false,
+          "selections": (v5/*: any*/),
+          "storageKey": "cropped(height:500,version:\"wide\",width:375)"
+        },
+        {
+          "alias": "_2x",
           "args": [
             {
               "kind": "Literal",
               "name": "height",
               "value": 1000
             },
-            {
-              "kind": "Literal",
-              "name": "version",
-              "value": "wide"
-            },
+            (v4/*: any*/),
             {
               "kind": "Literal",
               "name": "width",
@@ -180,24 +260,63 @@ return {
           "kind": "LinkedField",
           "name": "cropped",
           "plural": false,
-          "selections": [
-            (v1/*: any*/),
+          "selections": (v3/*: any*/),
+          "storageKey": "cropped(height:1000,version:\"wide\",width:750)"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": "mediumHero",
+      "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "image",
+      "plural": false,
+      "selections": [
+        {
+          "alias": "_1x",
+          "args": [
             {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "width",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
+              "kind": "Literal",
               "name": "height",
-              "storageKey": null
+              "value": 800
+            },
+            (v4/*: any*/),
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 600
             }
           ],
-          "storageKey": "cropped(height:1000,version:\"wide\",width:750)"
+          "concreteType": "CroppedImageUrl",
+          "kind": "LinkedField",
+          "name": "cropped",
+          "plural": false,
+          "selections": (v5/*: any*/),
+          "storageKey": "cropped(height:800,version:\"wide\",width:600)"
+        },
+        {
+          "alias": "_2x",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 1600
+            },
+            (v4/*: any*/),
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 1200
+            }
+          ],
+          "concreteType": "CroppedImageUrl",
+          "kind": "LinkedField",
+          "name": "cropped",
+          "plural": false,
+          "selections": (v3/*: any*/),
+          "storageKey": "cropped(height:1600,version:\"wide\",width:1200)"
         }
       ],
       "storageKey": null
@@ -230,28 +349,28 @@ return {
     },
     {
       "alias": null,
-      "args": (v2/*: any*/),
+      "args": (v6/*: any*/),
       "kind": "ScalarField",
       "name": "hours",
       "storageKey": "hours(format:\"HTML\")"
     },
     {
       "alias": null,
-      "args": (v2/*: any*/),
+      "args": (v6/*: any*/),
       "kind": "ScalarField",
       "name": "links",
       "storageKey": "links(format:\"HTML\")"
     },
     {
       "alias": null,
-      "args": (v2/*: any*/),
+      "args": (v6/*: any*/),
       "kind": "ScalarField",
       "name": "tickets",
       "storageKey": "tickets(format:\"HTML\")"
     },
     {
       "alias": null,
-      "args": (v2/*: any*/),
+      "args": (v6/*: any*/),
       "kind": "ScalarField",
       "name": "contact",
       "storageKey": "contact(format:\"HTML\")"
@@ -260,5 +379,5 @@ return {
   "type": "Fair"
 };
 })();
-(node as any).hash = '602875de975ebad7d480faa41e409f8f';
+(node as any).hash = '6d4fbd90e31c7389bf7f2ea3cacb86dd';
 export default node;

--- a/src/v2/__generated__/routes_FairQuery.graphql.ts
+++ b/src/v2/__generated__/routes_FairQuery.graphql.ts
@@ -79,17 +79,33 @@ fragment FairHeader_fair on Fair {
   slug
   profile {
     icon {
-      cropped(width: 120, height: 120, version: "square140") {
+      _1x: cropped(width: 40, height: 40, version: "square140") {
+        src: url
+      }
+      _2x: cropped(width: 80, height: 80, version: "square140") {
         src: url
       }
     }
     id
   }
-  image {
-    cropped(width: 750, height: 1000, version: "wide") {
+  smallHero: image {
+    _1x: cropped(width: 375, height: 500, version: "wide") {
       src: url
       width
       height
+    }
+    _2x: cropped(width: 750, height: 1000, version: "wide") {
+      src: url
+    }
+  }
+  mediumHero: image {
+    _1x: cropped(width: 600, height: 800, version: "wide") {
+      src: url
+      width
+      height
+    }
+    _2x: cropped(width: 1200, height: 1600, version: "wide") {
+      src: url
     }
   }
   tagline
@@ -138,44 +154,67 @@ v2 = {
   "storageKey": null
 },
 v3 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "square140"
+},
+v4 = {
   "alias": "src",
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v4 = {
+v5 = [
+  (v4/*: any*/)
+],
+v6 = {
+  "kind": "Literal",
+  "name": "height",
+  "value": 80
+},
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = {
+v8 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "wide"
+},
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "width",
   "storageKey": null
 },
-v6 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v7 = [
+v11 = [
+  (v4/*: any*/),
+  (v9/*: any*/),
+  (v10/*: any*/)
+],
+v12 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "HTML"
   }
 ],
-v8 = [
-  (v5/*: any*/),
-  (v6/*: any*/),
-  (v3/*: any*/)
+v13 = [
+  (v9/*: any*/),
+  (v10/*: any*/),
+  (v4/*: any*/)
 ];
 return {
   "fragment": {
@@ -294,42 +333,54 @@ return {
                 "plural": false,
                 "selections": [
                   {
-                    "alias": null,
+                    "alias": "_1x",
                     "args": [
                       {
                         "kind": "Literal",
                         "name": "height",
-                        "value": 120
+                        "value": 40
                       },
-                      {
-                        "kind": "Literal",
-                        "name": "version",
-                        "value": "square140"
-                      },
+                      (v3/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
-                        "value": 120
+                        "value": 40
                       }
                     ],
                     "concreteType": "CroppedImageUrl",
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": [
-                      (v3/*: any*/)
+                    "selections": (v5/*: any*/),
+                    "storageKey": "cropped(height:40,version:\"square140\",width:40)"
+                  },
+                  {
+                    "alias": "_2x",
+                    "args": [
+                      (v6/*: any*/),
+                      (v3/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 80
+                      }
                     ],
-                    "storageKey": "cropped(height:120,version:\"square140\",width:120)"
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v5/*: any*/),
+                    "storageKey": "cropped(height:80,version:\"square140\",width:80)"
                   }
                 ],
                 "storageKey": null
               },
-              (v4/*: any*/)
+              (v7/*: any*/)
             ],
             "storageKey": null
           },
           {
-            "alias": null,
+            "alias": "smallHero",
             "args": null,
             "concreteType": "Image",
             "kind": "LinkedField",
@@ -337,18 +388,36 @@ return {
             "plural": false,
             "selections": [
               {
-                "alias": null,
+                "alias": "_1x",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 500
+                  },
+                  (v8/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 375
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": (v11/*: any*/),
+                "storageKey": "cropped(height:500,version:\"wide\",width:375)"
+              },
+              {
+                "alias": "_2x",
                 "args": [
                   {
                     "kind": "Literal",
                     "name": "height",
                     "value": 1000
                   },
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "wide"
-                  },
+                  (v8/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "width",
@@ -359,12 +428,63 @@ return {
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": [
-                  (v3/*: any*/),
-                  (v5/*: any*/),
-                  (v6/*: any*/)
-                ],
+                "selections": (v5/*: any*/),
                 "storageKey": "cropped(height:1000,version:\"wide\",width:750)"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": "mediumHero",
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": "_1x",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 800
+                  },
+                  (v8/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 600
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": (v11/*: any*/),
+                "storageKey": "cropped(height:800,version:\"wide\",width:600)"
+              },
+              {
+                "alias": "_2x",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 1600
+                  },
+                  (v8/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 1200
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": (v5/*: any*/),
+                "storageKey": "cropped(height:1600,version:\"wide\",width:1200)"
               }
             ],
             "storageKey": null
@@ -385,7 +505,7 @@ return {
             "plural": false,
             "selections": [
               (v2/*: any*/),
-              (v4/*: any*/)
+              (v7/*: any*/)
             ],
             "storageKey": null
           },
@@ -398,28 +518,28 @@ return {
           },
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v12/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
             "storageKey": "hours(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v12/*: any*/),
             "kind": "ScalarField",
             "name": "links",
             "storageKey": "links(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v12/*: any*/),
             "kind": "ScalarField",
             "name": "tickets",
             "storageKey": "tickets(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v12/*: any*/),
             "kind": "ScalarField",
             "name": "contact",
             "storageKey": "contact(format:\"HTML\")"
@@ -459,7 +579,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
+                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -505,11 +625,7 @@ return {
                           {
                             "alias": "_1x",
                             "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "height",
-                                "value": 80
-                              },
+                              (v6/*: any*/),
                               {
                                 "kind": "Literal",
                                 "name": "width",
@@ -520,7 +636,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v13/*: any*/),
                             "storageKey": "cropped(height:80,width:140)"
                           },
                           {
@@ -541,7 +657,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v13/*: any*/),
                             "storageKey": "cropped(height:160,width:280)"
                           }
                         ],
@@ -563,7 +679,7 @@ return {
             ],
             "storageKey": "articlesConnection(first:5,sort:\"PUBLISHED_AT_DESC\")"
           },
-          (v4/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
@@ -574,7 +690,7 @@ return {
     "metadata": {},
     "name": "routes_FairQuery",
     "operationKind": "query",
-    "text": "query routes_FairQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairEditorial_fair\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  title\n  href\n  publishedAt(format: \"MMM Do, YY\")\n  thumbnailTitle\n  thumbnailImage {\n    _1x: cropped(width: 140, height: 80) {\n      width\n      height\n      src: url\n    }\n    _2x: cropped(width: 280, height: 160) {\n      width\n      height\n      src: url\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  formattedOpeningHours\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n"
+    "text": "query routes_FairQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairEditorial_fair\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  title\n  href\n  publishedAt(format: \"MMM Do, YY\")\n  thumbnailTitle\n  thumbnailImage {\n    _1x: cropped(width: 140, height: 80) {\n      width\n      height\n      src: url\n    }\n    _2x: cropped(width: 280, height: 160) {\n      width\n      height\n      src: url\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  formattedOpeningHours\n  name\n  slug\n  profile {\n    icon {\n      _1x: cropped(width: 40, height: 40, version: \"square140\") {\n        src: url\n      }\n      _2x: cropped(width: 80, height: 80, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  smallHero: image {\n    _1x: cropped(width: 375, height: 500, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n    _2x: cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n    }\n  }\n  mediumHero: image {\n    _1x: cropped(width: 600, height: 800, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n    _2x: cropped(width: 1200, height: 1600, version: \"wide\") {\n      src: url\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
So looking at [the Figma spec](https://www.figma.com/file/I5sz0m16SiW7F3tsSoLRxK/Fair-Page?node-id=0%3A1) I noticed:

![](http://static.damonzucconi.com/_capture/yZZm26ghR3ri.png)

There's a few issues with this. It *seems* like in theory it's possible to create a responsive aspect ratio box that respects fluid heights, but it's based around using viewport units as a font size or something. I think it's worth looking into but after pondering that for a bit, I was also thinking about how we could just use the `picture` tag to do some art direction here based on `min-height` media queries.

There's a problem with *that* too, which is that you can't swap out the fixed dimensions of the image. For instance my thinking was given `(min-height: 1000px)` swap into the image that's `800px @ 1x` as well as swap out the height.

My next thought was using responsive values to change the height, but again, those are based on widths.

So here's the compromise: Include two image tags with actual media queries for show/hiding. Then `lazyLoad` them so that you don't double stuff the loading (`display: none` images are still loaded).

[And so as you can see in this screen recording...](http://static.damonzucconi.com/_capture/8x8OT9QS4j1M.gif) it works.

------

Another way to achieve this would be to simply use a background image and size it to contain/center. Which, I'd definitely consider if we didn't have to have the logo overlaid on top of this. But that relatively positioned logo prevents that from being a viable option as well.

------

I would like to investigate [a responsive height aspect ratio box](https://www.thetopsites.net/article/52593940.shtml), however. I think the artwork page is also a place where this would be useful currently.