### PR TITLE
Add ingress and update review app steps to work with Ingress.

### DIFF
--- a/docs/creating_review_app.md
+++ b/docs/creating_review_app.md
@@ -47,13 +47,13 @@ To access the review app, you must create a DNS name for it. A name ending in `a
 
 ### Updating the review app
 
-If you want to push subsequent changes to the review app you can push a new build to the same tag with the `--overwrite` flag:
+If you want to push subsequent changes to the review app, push a new build to the same tag with the `--overwrite` flag:
 
 ```sh
 hokusai registry push --overwrite --skip-latest --force --tag awesome-feature
 ```
 
-and you need to redeploy your app:
+and redeploy the app:
 
 ```sh
 hokusai review_app deploy awesome-feature awesome-feature
@@ -61,15 +61,18 @@ hokusai review_app deploy awesome-feature awesome-feature
 
 ### Deleting a Review App
 
-When you are done using the review app, please delete it and its DNS entry.
-
-Run:
+When you are done using the review app, please delete it by:
 
 ```sh
 yarn delete-review-app awesome-feature
 ```
 
-And please delete the DNS entry as mentioned above.
+And please delete its DNS entry by:
+
+1. [Login to Cloudflare](https://dash.cloudflare.com/), and navigate to **artsy.net** > **DNS**
+1. In the search box, type `awesome-feature`
+1. Locate the correct record in search results, hit `Edit` at end of line
+1. Hit the `Delete` button on lower left
 
 ### Conclusion
 

--- a/docs/creating_review_app.md
+++ b/docs/creating_review_app.md
@@ -35,7 +35,7 @@ The script will save a K8s spec in `hokusai/awesome-feature.yml`
 
 ### Accessing the review app.
 
-To access the review app, you must create a DNS name for it. A name ending in `artsy.net` is required for full OAuth flows (for, say, login redirects between Gravity and Force for Auction registration). On Cloudflare, please do:
+To access the review app, you must create a DNS name for it. The name must match the name of the review app, and it must end in `artsy.net`. So it must be `awesome-feature.artsy.net`. This is required for full OAuth flow to complete. On Cloudflare, please do:
 
 1. [Login to Cloudflare](https://dash.cloudflare.com/), and navigate to **artsy.net** > **DNS**
 1. Click `+ Add Record`

--- a/docs/creating_review_app.md
+++ b/docs/creating_review_app.md
@@ -1,6 +1,6 @@
 ## Creating a Force Review App
 
-If you want to create a deploy for a WIP feature or for QA, [Hokusai](), supports [Review Apps](https://github.com/artsy/hokusai/blob/master/docs/Review_Apps.md).
+If you want to create a deploy for a WIP feature or for QA, Hokusai supports [Review Apps](https://github.com/artsy/hokusai/blob/master/docs/Review_Apps.md).
 
 You can create a review app via CircleCI which runs the [`build_review_app.sh`](https://github.com/artsy/force/blob/master/scripts/build_review_app.sh) script. Or, you can run that script locally, which will be slower because it involves building the docker image locally and pushing it up to AWS ECR.
 

--- a/docs/creating_review_app.md
+++ b/docs/creating_review_app.md
@@ -80,28 +80,20 @@ and you need to redeploy your app:
 hokusai review_app deploy <name> <name>
 ```
 
-😇 After your review app is no longer needed please remember to clean up any CNAMEs you've created, and to de-provision the review app itself with `hokusai review_app delete <review-app-name>`
+😇 After your review app is no longer needed please remember to clean up any CNAMEs you've created, and to de-provision the review app itself with `hokusai review_app delete <review-app-name>` if there's a hokusai/<review-app-name>.yml, otherwise, please use the yarn command mentioned above.
 
 For more info on Review App maintenence, [see Hokusai docs](https://github.com/artsy/hokusai/blob/master/docs/Review_Apps.md).
 
 #### DNS Setup
 
-Regardless of how you created a review app (CircleCI or manually), `build_review_app.sh` will output a hostname like the following:
-
-```sh
-a99199101d01011e9aff2127c3b176f7-1359163722.us-east-1.elb.amazonaws.com
-```
-
-This is your Review App url, which should support all of the basic features inside of Force.
-
-If you'd like a pretty URL subdomain or need to test full OAuth flows (for, say, login redirects between Gravity and Force for Auction registration) then an additional non-automated step is required via Cloudflare:
+To access the review app, you must create a DNS name for it. A name ending in `artsy.net` is required for full OAuth flows (for, say, login redirects between Gravity and Force for Auction registration). On Cloudflare, please do:
 
 1. [Login to Cloudflare](https://dash.cloudflare.com/), and navigate to **artsy.net** > **DNS**
 1. Click `+ Add Record`
 1. Change `Type` dropdown to `CNAME`
-1. Under `Name` enter a new subdomain
-1. Under `Target` paste in URL output by `build_review_app.sh` script
+1. Under `Name` enter a new subdomain. This must be review-app-name, the same name that build_review_app.sh was called with.
+1. Under `Target` say `nginx-staging.artsy.net`
 1. Hit `Save`
-1. DNS will propagate and after a few minutes the review app will be available via `<your-subdomain>.artsy.net`
+1. DNS will propagate and after a few minutes the review app will be available via `<review-app-name>.artsy.net`
 
 Read over the [`build_review_app.sh`](https://github.com/artsy/force/blob/master/scripts/build_review_app.sh) script for more info on how this is all done.

--- a/docs/creating_review_app.md
+++ b/docs/creating_review_app.md
@@ -1,14 +1,14 @@
-## Creating a Review App
+## Creating a Force Review App
 
 If you want to create a deploy for a WIP feature or for QA, [Hokusai](), supports [Review Apps](https://github.com/artsy/hokusai/blob/master/docs/Review_Apps.md).
 
-You can create a Force review app via CircleCI which runs the [build_review_app.sh`](https://github.com/artsy/force/blob/master/scripts/build_review_app.sh) script. Or, you can run that script locally, which will be slower because it involves building the docker image locally and pushing it up to AWS ECR.
+You can create a review app via CircleCI which runs the [`build_review_app.sh`](https://github.com/artsy/force/blob/master/scripts/build_review_app.sh) script. Or, you can run that script locally, which will be slower because it involves building the docker image locally and pushing it up to AWS ECR.
 
 The rest of the doc assumes you are working with a review app called `awesome-feature`.
 
 ### Building on Circle
 
-This is the easiest and fastest way. Push a branch named `review-app-awesome-feature`
+This is the easiest and fastest way. Push up a branch named `review-app-awesome-feature`
 
 CircleCI will match the `review-app-` prefix and either:
 
@@ -28,10 +28,10 @@ brew install jq
 Then launch the script with:
 
 ```sh
-./scripts/build_review_app.sh awesome-app
+./scripts/build_review_app.sh awesome-feature
 ```
 
-The script will save a K8s spec in `hokusai/awesome-app.yml`.
+The script will save a K8s spec in `hokusai/awesome-feature.yml`
 
 ### Accessing the review app.
 

--- a/docs/creating_review_app.md
+++ b/docs/creating_review_app.md
@@ -47,7 +47,9 @@ To access the review app, you must create a DNS name for it. The name must match
 
 ### Updating the review app
 
-If you want to push subsequent changes to the review app, push a new build to the same tag with the `--overwrite` flag:
+If the review app was created via Circle as mentioned above, simply push up your changes on the `review-app-awesome-feature` branch.
+
+If the app was built locally, do:
 
 ```sh
 hokusai registry push --overwrite --skip-latest --force --tag awesome-feature

--- a/docs/creating_review_app.md
+++ b/docs/creating_review_app.md
@@ -61,13 +61,15 @@ hokusai review_app deploy awesome-feature awesome-feature
 
 ### Deleting a Review App
 
-When you are done using the review app, please delete it by:
+You should delete review apps as soon as QA is complete.
+
+Delete the app by:
 
 ```sh
 yarn delete-review-app awesome-feature
 ```
 
-And please delete its DNS entry by:
+Delete its DNS entry by:
 
 1. [Login to Cloudflare](https://dash.cloudflare.com/), and navigate to **artsy.net** > **DNS**
 1. In the search box, type `awesome-feature`

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -159,3 +159,40 @@ spec:
     - 104.16.0.0/12
     - 172.64.0.0/13
     - 131.0.72.0/22
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: force
+    component: web
+    layer: application
+  name: force-web-internal
+  namespace: default
+spec:
+  ports:
+    - port: 5000
+      protocol: TCP
+      name: force-http
+      targetPort: force-http
+  selector:
+    app: force
+    layer: application
+    component: web
+  type: ClusterIP
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: force
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
+spec:
+  rules:
+    - host: www.artsy.net
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: force-web-internal
+              servicePort: force-http

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -162,3 +162,41 @@ spec:
     - 104.16.0.0/12
     - 172.64.0.0/13
     - 131.0.72.0/22
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: force
+    component: web
+    layer: application
+  name: force-web-internal
+  namespace: default
+spec:
+  ports:
+    - port: 5000
+      protocol: TCP
+      name: force-http
+      targetPort: force-http
+  selector:
+    app: force
+    layer: application
+    component: web
+  type: ClusterIP
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: force
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
+spec:
+  rules:
+    - host: staging.artsy.net
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: force-web-internal
+              servicePort: force-http

--- a/scripts/build_review_app.sh
+++ b/scripts/build_review_app.sh
@@ -49,9 +49,6 @@ hokusai review_app create "$NAME" --verbose
 # Copy Force staging's ConfigMap to your review app
 hokusai review_app env copy "$NAME" --verbose
 
-# Copy the staging-shared nginx config to your review app
-hokusai review_app env copy "$NAME" --configmap nginx-config --verbose
-
 # To enable authentication via Force's server, we need to allow XHR requests
 # from Force's client to server. As such, Force's server needs to have the
 # proper name of the domain that the requests are coming from. Otherwise,
@@ -82,11 +79,9 @@ hokusai review_app refresh "$NAME"
 # ...
 # ...
 # yeah, I'm talking to you
-# you need to configure a CNAME record so that $NAME.artsy.net resolves to" \
-# the service's external IP:
+# you need to configure a CNAME record so that $NAME.artsy.net points to nginx-staging.artsy.net
 #
-echo $(kubectl get service force-web --namespace $NAME --context staging -o json \
-  | jq .status.loadBalancer.ingress[].hostname)
+echo "Create a CNAME record of $NAME.artsy.net pointing to nginx-staging.artsy.net"
 #
 # you may do this in the Cloudflare interface. Credentials are in 1pass.
 #

--- a/scripts/build_review_app.sh
+++ b/scripts/build_review_app.sh
@@ -40,6 +40,9 @@ hokusai registry push --force --skip-latest --overwrite --verbose --tag "$NAME"
 # Edit the K8S YAML to reference the proper Docker image
 sed -i.bak "s/:staging/:$NAME/g" "$review_app_file_path" && rm "$review_app_file_path.bak"
 
+# Edit the K8S YAML Ingress resource to use the Review App's name as the host.
+sed -i.bak "s/host: staging.artsy.net/host: $NAME.artsy.net/g" "$review_app_file_path" && rm "$review_app_file_path.bak"
+
 # Provision the review app
 hokusai review_app create "$NAME" --verbose
 

--- a/scripts/build_review_app.sh
+++ b/scripts/build_review_app.sh
@@ -40,20 +40,6 @@ hokusai registry push --force --skip-latest --overwrite --verbose --tag "$NAME"
 # Edit the K8S YAML to reference the proper Docker image
 sed -i.bak "s/:staging/:$NAME/g" "$review_app_file_path" && rm "$review_app_file_path.bak"
 
-# Edit the K8S YAML to remove the instructions that enforce that the service
-# can only be accessible via Cloudflare
-#
-# First, remove the `loadBalancerSourceRanges:` line
-sed -i.bak '/loadBalancer/d' "$review_app_file_path" && rm "$review_app_file_path.bak"
-
-# Then, delete all the IP address lines.
-#
-# WARNING: This is a bit sketchy as this will
-# delete any line of the form "- [number][number][number].". This is my best
-# approx for an regex for an IP address, and I'm sure that there are better
-# ones.
-sed -i.bak "/- [[:digit:]][[:digit:]][[:digit:]]./d" "$review_app_file_path" && rm "$review_app_file_path.bak"
-
 # Provision the review app
 hokusai review_app create "$NAME" --verbose
 


### PR DESCRIPTION
Addresses:

https://artsyproduct.atlassian.net/browse/PLATFORM-2595
https://artsyproduct.atlassian.net/browse/PLATFORM-2753

- Add ingress and clusterIP resources to k8s specs.
- Update `build_review_app.sh` to work with ingress.
- Major update to review app doc.

In regards to ingress migration, please see https://www.notion.so/artsy/Nginx-Ingress-Controllers-4b5d937f0acd480f938c34ef1509d3c4 and the section `Migrating an application from an external LoadBalancer-fronted service to an Ingress-fronted service`.

DNS will be migrated under this PR: https://github.com/artsy/infrastructure/pull/245
After DNS migration, another PR will be opened to clean up sidecar nginx and loadbalancer service.