### PR TITLE
Staging clean up after ingress migration.

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -57,29 +57,6 @@ spec:
             preStop:
               exec:
                 command: ["sh", "-c", "sleep 35"]
-        - name: force-nginx
-          image: artsy/docker-nginx:latest
-          ports:
-            - name: nginx-http
-              containerPort: 8080
-            - name: nginx-https
-              containerPort: 443
-          readinessProbe:
-            tcpSocket:
-              port: nginx-http
-            initialDelaySeconds: 5
-            periodSeconds: 15
-            timeoutSeconds: 10
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sh", "-c", "sleep 30 && /usr/sbin/nginx -s quit"]
-          env:
-            - name: "NGINX_DEFAULT_CONF"
-              valueFrom:
-                configMapKeyRef:
-                  name: nginx-config
-                  key: force
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:
@@ -94,7 +71,6 @@ spec:
                     operator: In
                     values:
                       - foreground
-
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -109,59 +85,6 @@ spec:
   minReplicas: 2
   maxReplicas: 3
   targetCPUUtilizationPercentage: 70
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: force
-    layer: application
-    component: web
-  name: force-web
-  namespace: default
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ artsyNetWildcardSSLCert }}
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-access-log-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: "60"
-    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: "artsy-elb-logs"
-    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: "staging-force"
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "90"
-spec:
-  ports:
-    - port: 80
-      protocol: TCP
-      name: http
-      targetPort: nginx-http
-    - port: 443
-      protocol: TCP
-      name: https
-      targetPort: nginx-http
-  selector:
-    app: force
-    layer: application
-    component: web
-  sessionAffinity: None
-  type: LoadBalancer
-  loadBalancerSourceRanges:
-    - 173.245.48.0/20
-    - 103.21.244.0/22
-    - 103.22.200.0/22
-    - 103.31.4.0/22
-    - 141.101.64.0/18
-    - 108.162.192.0/18
-    - 190.93.240.0/20
-    - 188.114.96.0/20
-    - 197.234.240.0/22
-    - 198.41.128.0/17
-    - 162.158.0.0/15
-    - 104.16.0.0/12
-    - 172.64.0.0/13
-    - 131.0.72.0/22
 ---
 apiVersion: v1
 kind: Service
@@ -183,7 +106,6 @@ spec:
     layer: application
     component: web
   type: ClusterIP
-
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/PLATFORM-2595
Follow up to: https://github.com/artsy/force/pull/6234

Staging was migrated to ingress. This PR cleans up staging.

Normally, we submit one clean-up PR for both prod and staging. In this case, prod has yet to be migrated to ingress, and I would like to clean up staging right away, because the presence of sidecar nginx prevents review app pods from launching, and that is b/c in the previous PR, I removed nginx steps in review app build script (in anticipation of moving to ingress).
