### PR TITLE
Preload Most Used Fonts

### DIFF
--- a/src/desktop/apps/artists/test/template.test.js
+++ b/src/desktop/apps/artists/test/template.test.js
@@ -81,6 +81,7 @@ describe("Artists", function () {
         sd: _.extend(sd, {
           APP_URL: "http://localhost:5000",
           CURRENT_PATH: "/artists-starting-with-a",
+          WEBFONT_URL: "http://webfonts.artsy.net/",
         }),
         letter: "A",
         letterRange: ["a", "b", "c"],

--- a/src/desktop/apps/fair_organizer/test/template.test.js
+++ b/src/desktop/apps/fair_organizer/test/template.test.js
@@ -42,6 +42,7 @@ describe("Fair Organizer", () =>
         CURRENT_PATH: "/cool-fair",
         PROFILE: fabricate("fair_organizer_profile"),
         FAIR_ORGANIZER: fabricate("fair_organizer"),
+        WEBFONT_URL: "http://webfonts.artsy.net/",
       })
       const fairOrg = new FairOrganizer(sd.FAIR_ORGANIZER)
       const profile = new Profile(sd.PROFILE)

--- a/src/desktop/components/main_layout/templates/head.jade
+++ b/src/desktop/components/main_layout/templates/head.jade
@@ -28,9 +28,15 @@ meta( property="fb:pages" content="342443413406")
 script( type="text/javascript" )
   include ../../../../../node_modules/scroll-frame/scroll-frame-head.js
 
+link( rel="preload" href="#{sd.WEBFONT_URL}/artsy-icons.woff2" as="font" type="font/woff2" crossorigin )
+link( rel="preload" href="#{sd.WEBFONT_URL}/ll-unica77_regular.woff2" as="font" type="font/woff2" crossorigin )
+link( rel="preload" href="#{sd.WEBFONT_URL}/ll-unica77_medium.woff2" as="font" type="font/woff2" crossorigin )
+link( rel="preload" href="#{sd.WEBFONT_URL}/adobe-garamond-pro_regular.woff2" as="font" type="font/woff2" crossorigin )
+link( rel="preload" href="#{sd.WEBFONT_URL}/adobe-garamond-pro_bold.woff2" as="font" type="font/woff2" crossorigin )
+
 //- Don't include fonts if Reflection is requesting it
 if sd.BROWSER && sd.BROWSER.family != 'Other'
-  link( type='text/css', rel='stylesheet', href='#{sd.WEBFONT_URL}/all-webfonts.css')
+  link( type='text/css', rel='stylesheet', href='#{sd.WEBFONT_URL}/all-webfonts.css' )
 
 //- TTI measurement
 script( type="text/javascript" )


### PR DESCRIPTION
Description

Add preload tags to download the most used fonts sooner. This approach
provides better rendering performance when used in combination with the
@font-face tags already in place.

A slightly more complex approach that I would like to trial in the future is [Critical Font with Preload](https://www.zachleat.com/web/comprehensive-webfonts/#critical-foft-with-preload)