### PR TITLE
@anandaroop => [Search] Use toString on search term, to avoid GraphQL type crash on term

### DIFF
--- a/src/v2/Apps/Search/routes.tsx
+++ b/src/v2/Apps/Search/routes.tsx
@@ -14,7 +14,7 @@ import SearchApp from "./SearchApp"
 const prepareVariables = (_params, { location }) => {
   return {
     ...paramsToCamelCase(location.query),
-    keyword: location.query.term,
+    keyword: location.query.term.toString(),
   }
 }
 
@@ -52,13 +52,13 @@ const entityTabs = Object.entries(tabsToEntitiesMap).map(([key, entities]) => {
     },
     query: graphql`
       query routes_SearchResultsEntityQuery(
-        $term: String!
+        $keyword: String!
         $entities: [SearchEntity]
         $page: Int
       ) {
         viewer {
           ...SearchResultsEntity_viewer
-            @arguments(term: $term, entities: $entities, page: $page)
+            @arguments(term: $keyword, entities: $entities, page: $page)
         }
       }
     `,
@@ -70,9 +70,9 @@ export const routes: RouteConfig[] = [
     path: "/search",
     Component: SearchApp,
     query: graphql`
-      query routes_SearchResultsTopLevelQuery($term: String!) {
+      query routes_SearchResultsTopLevelQuery($keyword: String!) {
         viewer {
-          ...SearchApp_viewer @arguments(term: $term)
+          ...SearchApp_viewer @arguments(term: $keyword)
         }
       }
     `,
@@ -89,10 +89,13 @@ export const routes: RouteConfig[] = [
         Component: ArtistsRoute,
         prepareVariables,
         query: graphql`
-          query routes_SearchResultsArtistsQuery($term: String!, $page: Int) {
+          query routes_SearchResultsArtistsQuery(
+            $keyword: String!
+            $page: Int
+          ) {
             viewer {
               ...SearchResultsArtists_viewer
-                @arguments(term: $term, page: $page)
+                @arguments(term: $keyword, page: $page)
             }
           }
         `,

--- a/src/v2/__generated__/routes_SearchResultsArtistsQuery.graphql.ts
+++ b/src/v2/__generated__/routes_SearchResultsArtistsQuery.graphql.ts
@@ -4,7 +4,7 @@
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type routes_SearchResultsArtistsQueryVariables = {
-    term: string;
+    keyword: string;
     page?: number | null;
 };
 export type routes_SearchResultsArtistsQueryResponse = {
@@ -21,11 +21,11 @@ export type routes_SearchResultsArtistsQuery = {
 
 /*
 query routes_SearchResultsArtistsQuery(
-  $term: String!
+  $keyword: String!
   $page: Int
 ) {
   viewer {
-    ...SearchResultsArtists_viewer_2iLyA0
+    ...SearchResultsArtists_viewer_2zsz5P
   }
 }
 
@@ -51,8 +51,8 @@ fragment Pagination_pageCursors on PageCursors {
   }
 }
 
-fragment SearchResultsArtists_viewer_2iLyA0 on Viewer {
-  searchConnection(query: $term, first: 10, page: $page, entities: [ARTIST]) @principalField {
+fragment SearchResultsArtists_viewer_2zsz5P on Viewer {
+  searchConnection(query: $keyword, first: 10, page: $page, entities: [ARTIST]) @principalField {
     pageInfo {
       hasNextPage
       endCursor
@@ -84,7 +84,7 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "term",
+    "name": "keyword",
     "type": "String!"
   },
   {
@@ -145,7 +145,7 @@ return {
               {
                 "kind": "Variable",
                 "name": "term",
-                "variableName": "term"
+                "variableName": "keyword"
               }
             ],
             "kind": "FragmentSpread",
@@ -190,7 +190,7 @@ return {
               {
                 "kind": "Variable",
                 "name": "query",
-                "variableName": "term"
+                "variableName": "keyword"
               }
             ],
             "concreteType": "SearchableConnection",
@@ -367,9 +367,9 @@ return {
     "metadata": {},
     "name": "routes_SearchResultsArtistsQuery",
     "operationKind": "query",
-    "text": "query routes_SearchResultsArtistsQuery(\n  $term: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_2iLyA0\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SearchResultsArtists_viewer_2iLyA0 on Viewer {\n  searchConnection(query: $term, first: 10, page: $page, entities: [ARTIST]) @principalField {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query routes_SearchResultsArtistsQuery(\n  $keyword: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_2zsz5P\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SearchResultsArtists_viewer_2zsz5P on Viewer {\n  searchConnection(query: $keyword, first: 10, page: $page, entities: [ARTIST]) @principalField {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '1a3f143f1f7e1089dea56bcc73c2b49b';
+(node as any).hash = 'd135fb999c7eb00f8159031a543916e3';
 export default node;

--- a/src/v2/__generated__/routes_SearchResultsEntityQuery.graphql.ts
+++ b/src/v2/__generated__/routes_SearchResultsEntityQuery.graphql.ts
@@ -5,7 +5,7 @@ import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type SearchEntity = "ARTICLE" | "ARTIST" | "ARTIST_SERIES" | "ARTWORK" | "CITY" | "COLLECTION" | "FAIR" | "FEATURE" | "GALLERY" | "GENE" | "INSTITUTION" | "PAGE" | "PROFILE" | "SALE" | "SHOW" | "TAG" | "%future added value";
 export type routes_SearchResultsEntityQueryVariables = {
-    term: string;
+    keyword: string;
     entities?: Array<SearchEntity | null> | null;
     page?: number | null;
 };
@@ -23,12 +23,12 @@ export type routes_SearchResultsEntityQuery = {
 
 /*
 query routes_SearchResultsEntityQuery(
-  $term: String!
+  $keyword: String!
   $entities: [SearchEntity]
   $page: Int
 ) {
   viewer {
-    ...SearchResultsEntity_viewer_1qCJIT
+    ...SearchResultsEntity_viewer_gkVBu
   }
 }
 
@@ -54,8 +54,8 @@ fragment Pagination_pageCursors on PageCursors {
   }
 }
 
-fragment SearchResultsEntity_viewer_1qCJIT on Viewer {
-  searchConnection(query: $term, first: 10, page: $page, entities: $entities) @principalField {
+fragment SearchResultsEntity_viewer_gkVBu on Viewer {
+  searchConnection(query: $keyword, first: 10, page: $page, entities: $entities) @principalField {
     pageInfo {
       hasNextPage
       endCursor
@@ -88,7 +88,7 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "term",
+    "name": "keyword",
     "type": "String!"
   },
   {
@@ -161,7 +161,7 @@ return {
               {
                 "kind": "Variable",
                 "name": "term",
-                "variableName": "term"
+                "variableName": "keyword"
               }
             ],
             "kind": "FragmentSpread",
@@ -200,7 +200,7 @@ return {
               {
                 "kind": "Variable",
                 "name": "query",
-                "variableName": "term"
+                "variableName": "keyword"
               }
             ],
             "concreteType": "SearchableConnection",
@@ -384,9 +384,9 @@ return {
     "metadata": {},
     "name": "routes_SearchResultsEntityQuery",
     "operationKind": "query",
-    "text": "query routes_SearchResultsEntityQuery(\n  $term: String!\n  $entities: [SearchEntity]\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsEntity_viewer_1qCJIT\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SearchResultsEntity_viewer_1qCJIT on Viewer {\n  searchConnection(query: $term, first: 10, page: $page, entities: $entities) @principalField {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          internalID\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query routes_SearchResultsEntityQuery(\n  $keyword: String!\n  $entities: [SearchEntity]\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsEntity_viewer_gkVBu\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SearchResultsEntity_viewer_gkVBu on Viewer {\n  searchConnection(query: $keyword, first: 10, page: $page, entities: $entities) @principalField {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          description\n          displayLabel\n          href\n          internalID\n          imageUrl\n          displayType\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = 'fe6c5e86fda971399b1d8f8dc6edb0df';
+(node as any).hash = '7f840e4f16ba4fd4df026f3a972cf6c5';
 export default node;

--- a/src/v2/__generated__/routes_SearchResultsTopLevelQuery.graphql.ts
+++ b/src/v2/__generated__/routes_SearchResultsTopLevelQuery.graphql.ts
@@ -4,7 +4,7 @@
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type routes_SearchResultsTopLevelQueryVariables = {
-    term: string;
+    keyword: string;
 };
 export type routes_SearchResultsTopLevelQueryResponse = {
     readonly viewer: {
@@ -20,10 +20,10 @@ export type routes_SearchResultsTopLevelQuery = {
 
 /*
 query routes_SearchResultsTopLevelQuery(
-  $term: String!
+  $keyword: String!
 ) {
   viewer {
-    ...SearchApp_viewer_4hh6ED
+    ...SearchApp_viewer_2hPz0N
   }
 }
 
@@ -37,8 +37,8 @@ fragment NavigationTabs_searchableConnection on SearchableConnection {
   }
 }
 
-fragment SearchApp_viewer_4hh6ED on Viewer {
-  searchConnection(query: $term, first: 1, aggregations: [TYPE]) {
+fragment SearchApp_viewer_2hPz0N on Viewer {
+  searchConnection(query: $keyword, first: 1, aggregations: [TYPE]) {
     aggregations {
       slice
       counts {
@@ -61,7 +61,7 @@ fragment SearchApp_viewer_4hh6ED on Viewer {
       }
     }
   }
-  artworksConnection(keyword: $term, size: 0, aggregations: [TOTAL]) {
+  artworksConnection(keyword: $keyword, size: 0, aggregations: [TOTAL]) {
     counts {
       total
     }
@@ -75,7 +75,7 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "term",
+    "name": "keyword",
     "type": "String!"
   }
 ],
@@ -106,7 +106,7 @@ return {
               {
                 "kind": "Variable",
                 "name": "term",
-                "variableName": "term"
+                "variableName": "keyword"
               }
             ],
             "kind": "FragmentSpread",
@@ -150,7 +150,7 @@ return {
               {
                 "kind": "Variable",
                 "name": "query",
-                "variableName": "term"
+                "variableName": "keyword"
               }
             ],
             "concreteType": "SearchableConnection",
@@ -274,7 +274,7 @@ return {
               {
                 "kind": "Variable",
                 "name": "keyword",
-                "variableName": "term"
+                "variableName": "keyword"
               },
               {
                 "kind": "Literal",
@@ -319,9 +319,9 @@ return {
     "metadata": {},
     "name": "routes_SearchResultsTopLevelQuery",
     "operationKind": "query",
-    "text": "query routes_SearchResultsTopLevelQuery(\n  $term: String!\n) {\n  viewer {\n    ...SearchApp_viewer_4hh6ED\n  }\n}\n\nfragment NavigationTabs_searchableConnection on SearchableConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n    }\n  }\n}\n\nfragment SearchApp_viewer_4hh6ED on Viewer {\n  searchConnection(query: $term, first: 1, aggregations: [TYPE]) {\n    aggregations {\n      slice\n      counts {\n        count\n        name\n      }\n    }\n    ...NavigationTabs_searchableConnection\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          slug\n          displayLabel\n          displayType\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n  artworksConnection(keyword: $term, size: 0, aggregations: [TOTAL]) {\n    counts {\n      total\n    }\n    id\n  }\n}\n"
+    "text": "query routes_SearchResultsTopLevelQuery(\n  $keyword: String!\n) {\n  viewer {\n    ...SearchApp_viewer_2hPz0N\n  }\n}\n\nfragment NavigationTabs_searchableConnection on SearchableConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n    }\n  }\n}\n\nfragment SearchApp_viewer_2hPz0N on Viewer {\n  searchConnection(query: $keyword, first: 1, aggregations: [TYPE]) {\n    aggregations {\n      slice\n      counts {\n        count\n        name\n      }\n    }\n    ...NavigationTabs_searchableConnection\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          slug\n          displayLabel\n          displayType\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n  artworksConnection(keyword: $keyword, size: 0, aggregations: [TOTAL]) {\n    counts {\n      total\n    }\n    id\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '6f3892041bb97db5f3ad7fb947d804bc';
+(node as any).hash = 'a66426847932472697ce0fda4cae92f7';
 export default node;


### PR DESCRIPTION
Kind of a weird one! Adds a `toString` onto the `keyword` and switches the queries to use it (over `term`, which is just included from the query params).