### PR TITLE
(fix) Cache Clear Method

### DIFF
--- a/src/lib/__tests__/cache.jest.ts
+++ b/src/lib/__tests__/cache.jest.ts
@@ -1,0 +1,63 @@
+jest.mock("redis", () => ({
+  createClient: () => {
+    const localCache = new Map()
+    return {
+      set: (key, val) => {
+        localCache.set(key, val)
+      },
+      get: (key, cb) => {
+        const val = localCache.get(key)
+        cb(val)
+      },
+      expire: () => {
+        return null
+      },
+      flushall: cb => {
+        localCache.clear()
+        cb()
+      },
+      on: () => {},
+    }
+  },
+}))
+
+let cache
+describe("#cache", () => {
+  const OLD_ENV = process.env
+  beforeAll(async () => {
+    process.env = {
+      ...OLD_ENV,
+      OPENREDIS_URL: "test",
+      NODE_ENV: "production",
+    }
+    cache = await import("../cache")
+    cache.setup(() => {})
+  })
+
+  afterAll(() => {
+    process.env = OLD_ENV
+  })
+
+  it("should find cached values", done => {
+    const key = "TEST_KEY"
+    cache.set(key, "test", null)
+    cache.get(key, val => {
+      expect(val).toBe("test")
+      done()
+    })
+  })
+
+  it("should clear the cache", done => {
+    const key = "TEST_KEY"
+    cache.set(key, "test", null)
+    cache.get(key, val => {
+      expect(val).toBe("test")
+      cache.flushall(() => {
+        cache.get(key, val => {
+          expect(val).toBeUndefined()
+          done()
+        })
+      })
+    })
+  })
+})

--- a/src/lib/cache.js
+++ b/src/lib/cache.js
@@ -124,7 +124,7 @@ class Cache {
     if (this.client == null) {
       return callback()
     }
-    return client.flushall(callback)
+    return this.client.flushall(callback)
   }
 }
 


### PR DESCRIPTION
Description

The cache clear method currently fails due to an improperly scoped
variable reference. This corrects that mistake.