### PR TITLE
[PURCHASE-2083] Adjust canonical url for gallery pages to point to root gallery slug

### DIFF
--- a/src/desktop/apps/partner2/templates/meta.jade
+++ b/src/desktop/apps/partner2/templates/meta.jade
@@ -15,7 +15,7 @@ if profile.iconImageUrl()
 if params.artistId
   link( rel="canonical", href=("#{sd.APP_URL}/artist/#{params.artistId}") )
 else
-  link( rel="canonical", href=(sd.APP_URL + sd.CURRENT_PATH) )
+  link( rel="canonical", href=("#{sd.APP_URL}/#{profile.get('id')}") )
 if sd.INCLUDE_ESCAPED_FRAGMENT
   unless tab
     meta( name="fragment", content="!" )

--- a/src/desktop/apps/partner2/test/templates.test.js
+++ b/src/desktop/apps/partner2/test/templates.test.js
@@ -18,15 +18,24 @@ const render = function (templateName) {
 describe("Partner header", () =>
   describe("canonical links", function () {
     beforeEach(function () {
-      return (this.profile = new Profile(fabricate("profile")))
+      return (this.profile = new Profile(
+        fabricate("profile", {
+          id: "pace-gallery",
+        })
+      ))
     })
 
     it("has a canonical link to the full artist page on partner artist pages", function () {
       this.template = render("index")({
         profile: this.profile,
-        sd: { APP_URL: "http://localhost:3004", CURRENT_PATH: "/pace-gallery" },
+        sd: {
+          APP_URL: "http://localhost:3004",
+        },
         asset() {},
-        params: { id: "pace-gallery", artistId: "yoshitomo-nara" },
+        params: {
+          id: "pace-gallery",
+          artistId: "yoshitomo-nara",
+        },
       })
       return this.template.should.containEql(
         '<link rel="canonical" href="http://localhost:3004/artist/yoshitomo-nara">'
@@ -36,9 +45,13 @@ describe("Partner header", () =>
     it("has a canonical link to current url on other pages", function () {
       this.template = render("index")({
         profile: this.profile,
-        sd: { APP_URL: "http://localhost:3004", CURRENT_PATH: "/pace-gallery" },
+        sd: {
+          APP_URL: "http://localhost:3004",
+        },
         asset() {},
-        params: { id: "pace-gallery" },
+        params: {
+          id: "pace-gallery",
+        },
       })
       return this.template.should.containEql(
         '<link rel="canonical" href="http://localhost:3004/pace-gallery">'
@@ -50,11 +63,12 @@ describe("Partner header", () =>
         profile: this.profile,
         sd: {
           APP_URL: "http://localhost:3004",
-          CURRENT_PATH: "/pace-gallery",
           INCLUDE_ESCAPED_FRAGMENT: true,
         },
         asset() {},
-        params: { id: "pace-gallery" },
+        params: {
+          id: "pace-gallery",
+        },
       })
       return this.template.should.containEql(
         '<meta name="fragment" content="!">'
@@ -67,11 +81,12 @@ describe("Partner header", () =>
         tab: "overview",
         sd: {
           APP_URL: "http://localhost:3004",
-          CURRENT_PATH: "/pace-gallery",
           INCLUDE_ESCAPED_FRAGMENT: true,
         },
         asset() {},
-        params: { id: "pace-gallery" },
+        params: {
+          id: "pace-gallery",
+        },
       })
       return this.template.should.not.containEql(
         '<meta name="fragment" content="!">'


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/PURCHASE-2083
This change will also adjust the canonical url for Partner Institutions as well
Eg
The collection tab for Partner Institution Madison Sq Park
https://staging.artsy.net/madisonsquarepark/collection
would have the canonical to the root slug of
https://staging.artsy.net/madisonsquarepark/


We are grabbing it from the Profile instance we have access too [here](https://github.com/artsy/force/blob/master/src/desktop/models/profile.coffee#L49)

Eg:
```
Profile {
  cid: 'c92',
  attributes: {
    id: 'galerie-mirchandani-plus-steinruecke',
// more fields
  
```

Up next: edit the sitemap itself