### PR TITLE
Consolidate CLIENT_ID/SECRET and ARTSY_ID/SECRET #migration

### DIFF
--- a/.env.oss
+++ b/.env.oss
@@ -1,5 +1,5 @@
 # OSS version of the .env file
-# Note: The ARTSY_ID & ARTSY_SECRET are known keys for Artsy OSS
+# Note: The CLIENT_ID & CLIENT_SECRET are known keys for Artsy OSS
 # projects, and are not a problem. OSS people: Please don't abuse the keys,
 # as then we'll have to change it, making it harder for others to learn from.
 # As such, these keys do not come under the Artsy security bounty either.
@@ -12,8 +12,6 @@ API_URL=https://stagingapi.artsy.net
 APP_TIMEOUT=29s
 APP_URL=http://localhost:5000
 APPLICATION_NAME=
-ARTSY_ID=e750db60ac506978fc70
-ARTSY_SECRET=3a33d2085cbd1176153f99781bbce7c6
 CLIENT_ID=e750db60ac506978fc70
 CLIENT_SECRET=3a33d2085cbd1176153f99781bbce7c6
 COOKIE_DOMAIN=

--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -15,8 +15,6 @@ module.exports =
   APP_URL: 'http://localhost:3004'
   ARTIST_COLLECTIONS_RAIL_IDS: null
   ARTSY_EDITORIAL_CHANNEL: '5759e3efb5989e6f98f77993'
-  ARTSY_ID: null
-  ARTSY_SECRET: null
   BIDDER_INFO_COPY_P1: 'Please enter your credit card information below. The name on your Artsy account must match the name on the card, and a valid credit card is required in order to bid.'
   BIDDER_INFO_COPY_P2: 'Registration is free. Artsy will never charge this card without your permission, and you are not required to use this card to pay if you win.'
   CDN_URL: 'https://d1s2w0upia4e9w.cloudfront.net'

--- a/src/lib/__tests__/setup.jest.js
+++ b/src/lib/__tests__/setup.jest.js
@@ -1,0 +1,33 @@
+// Requiring all desktop apps takes a long time, probably due to transpilation.
+// Since we are not interested in testing them, let's mock it.
+// https://github.com/artsy/force/blob/b607b3b2bd9459981203c879ae3b3a3b04e9e587/src/lib/setup.js#L284
+jest.mock("../../desktop", () => {
+  return jest.fn()
+})
+
+const express = require("express")
+const artsyPassport = require("@artsy/passport")
+
+describe("setup", () => {
+  describe("artsyPassport", () => {
+    const originalEnv = process.env
+
+    afterEach(() => {
+      process.env = originalEnv
+    })
+
+    it("sets ARTSY_ID/ARTSY_SECRET with CLIENT_ID/CLIENT_SECRET from env vars", () => {
+      process.env = Object.assign({}, originalEnv, {
+        CLIENT_ID: "client-id-123",
+        CLIENT_SECRET: "client-secret-123",
+      })
+
+      const app = express()
+      const setup = require("../setup").default
+      setup(app)
+
+      expect(artsyPassport.options.ARTSY_ID).toEqual("client-id-123")
+      expect(artsyPassport.options.ARTSY_SECRET).toEqual("client-secret-123")
+    })
+  })
+})

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -58,6 +58,8 @@ const {
   API_REQUEST_TIMEOUT,
   API_URL,
   APP_TIMEOUT,
+  CLIENT_ID,
+  CLIENT_SECRET,
   COOKIE_DOMAIN,
   DEFAULT_CACHE_TIME,
   IP_DENYLIST,
@@ -155,6 +157,8 @@ export default function (app) {
       _.extend({}, config, {
         CurrentUser: CurrentUser,
         ARTSY_URL: API_URL,
+        ARTSY_ID: CLIENT_ID,
+        ARTSY_SECRET: CLIENT_SECRET,
         SEGMENT_WRITE_KEY: SEGMENT_WRITE_KEY_SERVER,
         userKeys: [
           "collector_level",


### PR DESCRIPTION
https://artsy.slack.com/archives/CP9P4KR35/p1591794809087900

artsy-xapp and artsy-passport both respect implicit `ARTSY_ID/SECRET` from environment variables and support explicit configuration. However, Force currently maintains 2 sets of environment variables (with the same values):

- `CLIENT_ID/SECRET` for [explicitly configuring](https://github.com/artsy/force/blob/5ecb9acc1777e4a077565946783077299cacd931/src/index.js#L124) artsy-xapp, and
- `ARTSY_ID/SECRET` for [implicitly configuring](https://github.com/artsy/force/blob/b607b3b2bd9459981203c879ae3b3a3b04e9e587/src/lib/setup.js#L154-L172) artsy-passport.

This consolidates them and only uses `CLIENT_ID/SECRET` to explicitly configure both dependencies. We can then clean up the `ARTSY_ID/SECRET` from the environment variables.

I choose `CLIENT_ID/SECRET` because that's more consistent with other apps, but happy to change if people prefer `ARTSY_ID/SECRET` or something else.

## Migration
- [ ] After deploying to staging, `hokusai staging env unset ARTSY_ID ARTSY_SECRET`
- [ ] After deploying to production, `hokusai production env unset ARTSY_ID ARTSY_SECRET`