### PR TITLE
Fix undefined track function in mocha tests

### DIFF
--- a/src/desktop/components/jump/test/view.test.js
+++ b/src/desktop/components/jump/test/view.test.js
@@ -12,7 +12,11 @@ const { resolve } = require("path")
 describe("JumpView", function () {
   beforeEach(function (done) {
     return benv.setup(() => {
-      benv.expose({ $: benv.require("jquery"), jQuery: benv.require("jquery") })
+      benv.expose({
+        $: benv.require("jquery"),
+        jQuery: benv.require("jquery"),
+        analytics: { track: sinon.stub() },
+      })
       Backbone.$ = $
       this.view = new JumpView()
       return done()

--- a/src/desktop/components/jump/view.coffee
+++ b/src/desktop/components/jump/view.coffee
@@ -1,7 +1,6 @@
 _ = require 'underscore'
 Backbone = require 'backbone'
 mediator = require '../../lib/mediator.coffee'
-analyticsHooks = require '../../lib/analytics_hooks.coffee'
 
 module.exports = class JumpView extends Backbone.View
   className: 'jump-to-top icon-chevron-up'

--- a/src/desktop/components/user_interests/test/view.test.js
+++ b/src/desktop/components/user_interests/test/view.test.js
@@ -13,7 +13,11 @@ let UserInterestsView = null
 describe("UserInterestsView", function () {
   before(done =>
     benv.setup(function () {
-      benv.expose({ $: benv.require("jquery"), jQuery: benv.require("jquery") })
+      benv.expose({
+        $: benv.require("jquery"),
+        jQuery: benv.require("jquery"),
+        analytics: { track: sinon.stub() },
+      })
       UserInterestsView = rewire("../view")
       UserInterestsView.__set__("CURRENT_USER", "existy")
       UserInterestsView.__set__("ResultsListView", Backbone.View)

--- a/src/desktop/components/user_interests/view.coffee
+++ b/src/desktop/components/user_interests/view.coffee
@@ -1,7 +1,6 @@
 _ = require 'underscore'
 { CURRENT_USER } = require('sharify').data
 Backbone = require 'backbone'
-analyticsHooks = require '../../lib/analytics_hooks.coffee'
 Following = require '../follow_button/collection.coffee'
 UserInterests = require '../../collections/user_interests.coffee'
 TypeaheadView = require '../typeahead/view.coffee'


### PR DESCRIPTION
The master builds have been [failing](https://app.circleci.com/pipelines/github/artsy/force/9045/workflows/0328659a-13d2-421b-8d8f-766d053344a9/jobs/62393) with a few errors:
```
TypeError: Cannot read property 'track' of undefined
```
It's likely due to the change in https://github.com/artsy/force/pull/6227 (https://github.com/artsy/force/pull/6249/commits/cafff1a63b61bafddf649380234ad004716f535b). This fixes it by mocking it in tests.

![Screen Shot 2020-09-14 at 10 04 29 AM](https://user-images.githubusercontent.com/796573/93095902-b5cbef80-f671-11ea-8d36-a18f1814f8e5.png)
