### PR TITLE
Update homepage meta description

### DIFF
--- a/src/desktop/apps/home/templates/meta.jade
+++ b/src/desktop/apps/home/templates/meta.jade
@@ -1,5 +1,5 @@
 - title= "Artsy - Discover & Buy Art"
-- description= "Artsy is the world’s largest online art marketplace. Browse over 1 million artworks by iconic and emerging artists, presented by 4000+ galleries and top auction houses in over 100 countries."
+- description= "Artsy is the world’s largest online art marketplace. Browse over 1 million artworks by iconic and emerging artists from 4000+ galleries and top auction houses."
 title= title
 meta( property="og:title", content=title )
 meta( name="description", content=description )

--- a/src/desktop/apps/page/meta/default.jade
+++ b/src/desktop/apps/page/meta/default.jade
@@ -1,5 +1,5 @@
 - title= "Artsy - Discover & Buy Art"
-- description= "Artsy is the world’s largest online art marketplace. Browse over 1 million artworks by iconic and emerging artists, presented by 4000+ galleries and top auction houses in over 100 countries."
+- description= "Artsy is the world’s largest online art marketplace. Browse over 1 million artworks by iconic and emerging artists from 4000+ galleries and top auction houses."
 title= title
 meta( property="og:title", content=title )
 meta( name="description", content=description )


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2236

## Problem

Our current meta description on the homepage is too long and Google's crawlers do not read it, leading to bad SEO.

## Solution

Shorten the meta description for our homepage.

![Screen Shot 2020-09-14 at 12 42 46 PM](https://user-images.githubusercontent.com/4432348/93113881-d30bb880-f687-11ea-9d98-cb604e62a6bc.png)
