### PR TITLE
Fixes pixel to spacing scale value conversion

### DIFF
--- a/src/v2/Apps/Artist/Components/ArtistHeader.tsx
+++ b/src/v2/Apps/Artist/Components/ArtistHeader.tsx
@@ -136,7 +136,7 @@ export class LargeArtistHeader extends Component<Props> {
         <Flex flexDirection="row">
           {renderRepresentationStatus(props.artist)}
           {renderAuctionHighlight(props.artist) &&
-            renderRepresentationStatus(props.artist) && <Spacer mr={5} />}
+            renderRepresentationStatus(props.artist) && <Spacer mr={0.5} />}
           {renderAuctionHighlight(props.artist)}
         </Flex>
       </HorizontalPadding>
@@ -214,7 +214,7 @@ export class SmallArtistHeader extends Component<Props> {
         <Flex flexDirection="row" justifyContent="center">
           {renderRepresentationStatus(props.artist)}
           {renderAuctionHighlight(props.artist) &&
-            renderRepresentationStatus(props.artist) && <Spacer mr={5} />}
+            renderRepresentationStatus(props.artist) && <Spacer mr={0.5} />}
           {renderAuctionHighlight(props.artist)}
         </Flex>
       </Flex>

--- a/src/v2/Apps/Artist/Components/ArtistIndicator.tsx
+++ b/src/v2/Apps/Artist/Components/ArtistIndicator.tsx
@@ -31,7 +31,7 @@ export class ArtistIndicator extends React.Component<ArtistIndicatorProps> {
   renderIcon(insightType) {
     const Component = ICON_MAPPING[insightType]
 
-    return <Component size="20px" pr={5} />
+    return <Component size="20px" pr={0.5} />
   }
 
   render() {
@@ -42,8 +42,8 @@ export class ArtistIndicator extends React.Component<ArtistIndicatorProps> {
         <RoundedFlex
           background={color("black5")}
           width="auto"
-          py={5}
-          px={10}
+          py={0.5}
+          px={1}
           mt={1}
         >
           {this.renderIcon(type)}


### PR DESCRIPTION
Fixes:
![](http://static.damonzucconi.com/_capture/i2VlJXRgAlp7.png)

I tried project searching around for some variations on this and I think this might be the only example. It might be worth looking around staging a bit though.

-----
I very much believe we should introduce aliases for the spacing scale keys that are string based: `"1x"`, `"2x"`, etc, which would be much less confusing to work with.