### PR TITLE
Stylus palette helpers to aid in typographic clean up

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@artsy/cohesion": "1.35.0",
     "@artsy/express-reloadable": "1.4.8",
     "@artsy/gemup": "0.1.0",
-    "@artsy/palette": "13.3.0",
+    "@artsy/palette": "13.4.0",
     "@artsy/passport": "1.3.2",
     "@artsy/reaction": "28.5.0",
     "@artsy/stitch": "6.1.6",

--- a/src/desktop/apps/home/stylesheets/featured_items.styl
+++ b/src/desktop/apps/home/stylesheets/featured_items.styl
@@ -1,3 +1,5 @@
+@import '../../../lib/palette'
+
 column-gap = 30px
 
 // Generic elements
@@ -83,12 +85,11 @@ li.grid-item .artwork-item-contact-seller
   max-height @max-width
 .htfl-details
   padding (column-gap / 2)
-  avant-garde()
   > h3
-    avant-garde-size('s-headline')
-    color gray-darker-color
   > h4
-    avant-garde-size('body')
+    text('small')
+  > h3
+    color getColor('black60')
 
 // Featured articles
 // --------------

--- a/src/desktop/lib/palette.styl
+++ b/src/desktop/lib/palette.styl
@@ -1,0 +1,69 @@
+THEME = json('../../../node_modules/@artsy/palette/dist/tokens.json', { hash: true })
+
+// Access themed values
+
+getFontFamily(name)
+  value = THEME.fonts[name]
+  if value == null
+    error('cannot find: ' + name)
+  value
+
+getFontSize(name)
+  value = THEME.fontSizes[name]
+  if value == null
+    error('cannot find: ' + name)
+  value
+
+getLineHeight(name)
+  value = THEME.lineHeights[name]
+  if value == null
+    error('cannot find: ' + name)
+  value
+
+getLetterSpacing(name)
+  value = THEME.letterSpacings[name]
+  if value == null
+    error('cannot find: ' + name)
+  value
+
+getColor(name)
+  value = THEME.colors[name]
+  if value == null
+    error('cannot find: ' + name)
+  value
+
+// Access text treatments
+
+TEXT = THEME.textVariants
+
+PROPERTIES = {
+  fontSize: {
+    name: 'font-size',
+    theme: 'fontSizes'
+  },
+  lineHeight: {
+    name: 'line-height',
+    theme: 'lineHeights'
+  },
+  letterSpacing: {
+    name: 'letter-spacing',
+    theme: 'letterSpacings'
+  },
+  fontWeight: {
+    name: 'font-weight',
+    theme: 'fontWeights'
+  }
+}
+
+treatment(variant, size)
+  treatment = TEXT[size][variant]
+  if treatment == null
+    error('cannot find variant: ' + variant)
+  for attr, value in treatment
+    {PROPERTIES[attr][name]}: THEME[PROPERTIES[attr][theme]][value] || value
+
+text(variant, font = 'sans')
+  font-family: getFontFamily(font)
+  treatment(variant, small)
+  @media (min-width: THEME[breakpoints]['0'])
+    treatment(variant, large)

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,10 +53,10 @@
   dependencies:
     uuid "^8.3.0"
 
-"@artsy/palette@13.3.0":
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-13.3.0.tgz#ae11866633c8b9d666bc63cb912680b73fba0115"
-  integrity sha512-J8Lylao8XdMblrX46BUJ191KksZx7B96D1OeJl9PmoimndsvgISRxgLHfKJ/vevVTMFsKuXmVHZjbWvSHZBnRw==
+"@artsy/palette@13.4.0":
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-13.4.0.tgz#732ef0782fc76dacde9550628790e9def7ad1f32"
+  integrity sha512-J72qusWYO6h07jhkxQIhDCH06LT0q12i28dYNtQMhS0FFgc6TPojZaCFq83a6n9B/kczvzmZ0HYWU16kfsXAbQ==
   dependencies:
     "@styled-system/theme-get" "^5.1.2"
     babel-plugin-styled-components "^1.10.0"


### PR DESCRIPTION
To support the [[Web] Type Clean-up](https://www.notion.so/artsy/Web-Type-Clean-up-94cae3cc227243e2a44128b315e65046) — I wanted to get this in before we started so we can hit the ground running on the legacy routes.

By importing the lib/palette.styl file you gain access to some mixins and functions.

`getFontFamily`, `getFontSize`, `getLineHeight`, `getLetterSpacing`, `getColor` all accept the token names and return back themed values. So:

```styl
color: getColor('black60') // => #666
background-color: getColor('purple100') // => #6e1eff
// etc...
``` 

The `text` mixin accepts [a variant name](https://palette.artsy.net/tokens/typography/) and mixes in the styles that comprise the treatment:

```styl
.Example
  text('small')
```

Will yield:

```css
.Example {
  font-family: "ll-unica77", "Helvetica Neue", Helvetica, Arial, sans-serif;
  font-size: 13px;
  line-height: 1.5;
  font-weight: normal;
}
@media (min-width: 768px) {
  .Example {
    font-size: 12px;
    line-height: 1.5;
    font-weight: normal;
  }
}
```