### PR TITLE
refactor(type): Share palette helpers across desktop and mobile

### DIFF
--- a/src/desktop/apps/home/stylesheets/featured_items.styl
+++ b/src/desktop/apps/home/stylesheets/featured_items.styl
@@ -1,4 +1,4 @@
-@import '../../../lib/palette'
+@import '../../../../lib/palette'
 
 column-gap = 30px
 

--- a/src/lib/palette.styl
+++ b/src/lib/palette.styl
@@ -1,4 +1,4 @@
-THEME = json('../../../node_modules/@artsy/palette/dist/tokens.json', { hash: true })
+THEME = json('../../node_modules/@artsy/palette/dist/tokens.json', { hash: true })
 
 // Access themed values
 


### PR DESCRIPTION
In our mob session to kick of the Web Type Cleanup project we noted that these new helpers should move up a level since they will be shared across desktop and mobile sub-apps.

cc @pepopowitz @zephraph @sweir27 @dzucconi 