### PR TITLE
Adds getSpace helper

### DIFF
--- a/src/lib/palette.styl
+++ b/src/lib/palette.styl
@@ -32,6 +32,15 @@ getColor(name)
     error('cannot find: ' + name)
   value
 
+getSpace(indices...)
+  values = ()
+  for i in indices
+    value = THEME.space[i]
+    if value == null
+      error('cannot find: ' + i)
+    push(values, value)
+  values
+
 // Access text treatments
 
 TEXT = THEME.textVariants


### PR DESCRIPTION
Adds `getSpace`

It accepts any number of args so you can give it a single key:

```styl
margin-top getSpace(1) // margin-top: 10px;
```

or multiple

```styl
margin getSpace(1, 2) // margin: 10px 20px;
```