### PR TITLE
GALL-3237 Fix VR featured rail progress bar

### DIFF
--- a/src/v2/Apps/ViewingRoom/Components/ViewingRoomCarousel.tsx
+++ b/src/v2/Apps/ViewingRoom/Components/ViewingRoomCarousel.tsx
@@ -16,6 +16,7 @@ interface ViewingRoomCarouselProps {
   height: number[] | number
   maxWidth?: string | number
   justifyContent?: string
+  scrollPercentByCustomCount?: number
 }
 
 export const ViewingRoomCarousel: React.FC<ViewingRoomCarouselProps> = ({
@@ -24,9 +25,11 @@ export const ViewingRoomCarousel: React.FC<ViewingRoomCarouselProps> = ({
   height,
   maxWidth = breakpoints.lg,
   justifyContent = "center",
+  scrollPercentByCustomCount,
 }) => {
-  const computeScrollPercent = selectedIndex =>
-    ((selectedIndex + 1) / data.length) * 100
+  const scrollLength = scrollPercentByCustomCount || data.length
+  const computeScrollPercent = selectedIndex => ((selectedIndex + 1) / scrollLength) * 100
+
   const [scrollPercent, setScrollPercent] = useState(computeScrollPercent(0))
   const update = flowRight(setScrollPercent, computeScrollPercent)
   const showProgressBar = data.length > 1
@@ -66,8 +69,11 @@ export const ViewingRoomCarousel: React.FC<ViewingRoomCarouselProps> = ({
               />
             )
           }}
-          renderRightArrow={({ currentSlideIndex, flickity }) => {
-            const opacity = currentSlideIndex === data.length - 1 ? 0 : 1
+          renderRightArrow={({ flickity }) => {
+            const opacity =
+              flickity && computeScrollPercent(flickity.selectedIndex) === 100
+                ? 0
+                : 1
             return (
               <Arrow
                 direction="right"

--- a/src/v2/Apps/ViewingRoom/Components/ViewingRoomsFeaturedRail.tsx
+++ b/src/v2/Apps/ViewingRoom/Components/ViewingRoomsFeaturedRail.tsx
@@ -19,7 +19,9 @@ export const ViewingRoomsFeaturedRail: React.FC<ViewingRoomsFeaturedRailProps> =
     })
     .filter(Boolean)
 
-  if (featuredViewingRoomsForRail.length === 0) {
+  const numFeaturedViewingRooms = featuredViewingRoomsForRail.length
+
+  if (numFeaturedViewingRooms === 0) {
     return null
   }
 
@@ -57,6 +59,7 @@ export const ViewingRoomsFeaturedRail: React.FC<ViewingRoomsFeaturedRailProps> =
         render={carouselItemRender}
         maxWidth="100%"
         justifyContent="left"
+        scrollPercentByCustomCount={numFeaturedViewingRooms - 2}
       />
     </Box>
   )


### PR DESCRIPTION
Introduce a new way of progressing the progress bar. Since the Featured Viewing Room rail has narrower cards, the way of incrementing the progress bar by flickity element doesn't work as well.

Do a bit of magic number math for the number of steps to progress, but it works. 🤷 


![Kapture 2020-09-16 at 12 35 58](https://user-images.githubusercontent.com/1389948/93366473-3416c600-f819-11ea-842d-53964d263b42.gif)

Also works with fewer Viewing Rooms in the Featured rail:

![Kapture 2020-09-16 at 12 20 44](https://user-images.githubusercontent.com/1389948/93366345-0467be00-f819-11ea-81ec-4f5b372fa6ab.gif)
