### PR TITLE
chore(type): Update desktop fairs landing page typography

### DIFF
--- a/src/desktop/apps/fairs/stylesheets/index.styl
+++ b/src/desktop/apps/fairs/stylesheets/index.styl
@@ -1,15 +1,17 @@
 @require '../../../components/stylus_lib'
 @require '../../../components/chevron_list'
+@require '../../../../lib/palette'
 
 #fairs-page
   clearfix()
   margin-bottom 20%
 
 #fairs-page .entity-follow
+  text('text')
   margin-left -8px
 
 h1.fair-header
-  garamond-size('headline')
+  text('largeTitle')
   padding-bottom 10px
   margin-top 30px
 
@@ -55,11 +57,11 @@ h1.fair-header
   display table-cell
 
 .fairs-fair__name
-  avant-garde-size('body')
+  text('text')
   display inline
 
 .fairs-fair__info
-  garamond-size('s-body')
+  text('text')
 
 .fairs__promo
   width 100%
@@ -137,7 +139,7 @@ h1.fair-header
     margin 0 auto
 
 .fairs__current__promo__copy
-  garamond-size('headline')
+  text('text')
   font-size 25px
 
 .fairs-fair__follow

--- a/src/desktop/apps/fairs/templates/index.jade
+++ b/src/desktop/apps/fairs/templates/index.jade
@@ -19,7 +19,7 @@ block body
       .fairs__past-fairs-list(data-test="pastFairs")
         include past_fairs
       button#fairs-see-more.avant-garde-button-white.is-block
-        | View More
+        | View more
     .fairs__upcoming-fairs
       h1.fair-header.fair-header--underlined Upcoming Events
       for fair in upcomingFairs

--- a/src/desktop/components/main_layout/stylesheets/buttons.styl
+++ b/src/desktop/components/main_layout/stylesheets/buttons.styl
@@ -1,6 +1,7 @@
 @require '../../stylus_lib'
 @require '../../../../../node_modules/artsy-ezel-components/spinners'
 @require '../../follow_button'
+@require '../../../../lib/palette'
 
 .circle-button
   display inline-block
@@ -89,7 +90,7 @@
   cursor pointer
   border none
   background-color gray-lightest-color
-  avant-garde()
+  text('mediumText')
   transition background-color 0.25s, color 0.25s
   border 1px solid transparent
   text-decoration none


### PR DESCRIPTION
Addresses: https://www.notion.so/artsy/Web-Type-Clean-up-94cae3cc227243e2a44128b315e65046?p=eca675d56e3c43a3ae3c2d63b9417802

This updates the typography on the **fairs landing page** on **desktop**.

<img src="https://user-images.githubusercontent.com/140521/93390647-05f6ad80-f83c-11ea-90bf-a3f7caeb9994.png" width="500" />
