### PR TITLE
chore(type): Update mobile fairs landing page typography

### DIFF
--- a/src/mobile/apps/art_fairs/index.styl
+++ b/src/mobile/apps/art_fairs/index.styl
@@ -1,21 +1,23 @@
 @import '../../components/stylus_lib'
 @import '../../components/avant_garde_tabs/index'
+@require '../../../lib/palette'
 
 #art-fairs-page
   min-height 600px
 
-  .art-fairs-header--background-image.garamond-header
+  .art-fairs-header
+    h1
+      text('largeTitle')
+      text-align center
+      padding-top getSpace(3)
+      padding-bottom getSpace(1)
+
+  .art-fairs-header--background-image
     background-size cover
     background-position center
     height 200px
     color white
     margin-bottom 30px
-
-    h1
-      font-size 30px
-      position relative
-      top 50%
-      transform translateY(-50%)
 
   .art-fairs-content--sign-up-container
     padding-bottom 30px
@@ -26,7 +28,7 @@
       margin-top 20px
 
     .art-fairs-content--sign-up-container__label
-      serif()
+      text('text')
       font-size 18px
 
   #art-fairs-content
@@ -69,11 +71,10 @@
     height 50px
 
   .fair-details h5.fair-name
-    avant-garde-size('s-headline', true)
-    margin-bottom 4px
+    text('text')
 
   .fair-details p.fair-content
-    garamond-size('l-caption')
+    text('text')
 
   .fair-content__location
     max-width 90%

--- a/src/mobile/apps/art_fairs/templates/index.jade
+++ b/src/mobile/apps/art_fairs/templates/index.jade
@@ -5,13 +5,11 @@ block head
 
 block content
   #art-fairs-page
-    header.art-fairs-header.garamond-header(
+    header.art-fairs-header(
       style= !currentFairs.length ? "background-image: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url('/images/fairs-header-img.jpg')" : ""
       class= !currentFairs.length ? "art-fairs-header--background-image" : ""
     )
-      h1 Collect from leading
-        br
-        | art fairs on Artsy
+      h1 Fairs
 
     #art-fairs-content.main-side-margin
 

--- a/src/mobile/apps/art_fairs/test/template.test.js
+++ b/src/mobile/apps/art_fairs/test/template.test.js
@@ -98,8 +98,8 @@ describe("Art fairs template", function () {
     after(() => benv.teardown())
 
     // this test always fails ci
-    return xit("renders header with current fairs active", function () {
-      $(".art-fairs-header").html().should.containEql("Collect from leading")
+    return it("renders header with current fairs active", function () {
+      $(".art-fairs-header").html().should.containEql("Fairs")
       return $(".art-fairs-tab[data-tab=current]").hasClass(
         "art-fairs-tab--active"
       )
@@ -135,7 +135,7 @@ describe("Art fairs template", function () {
     after(() => benv.teardown())
 
     return it("renders header with upcoming fairs active", function () {
-      $(".art-fairs-header").html().should.containEql("Collect from leading")
+      $(".art-fairs-header").html().should.containEql("Fairs")
       $(".art-fairs-header").hasClass("art-fairs-header--background-image")
       return $(".art-fairs-tab[data-tab=upcoming]").hasClass(
         "art-fairs-tab--active"

--- a/src/mobile/components/layout/stylesheets/buttons.styl
+++ b/src/mobile/components/layout/stylesheets/buttons.styl
@@ -2,6 +2,7 @@
 // Button styles used project-wide
 //
 @import '../../stylus_lib'
+@require '../../../../lib/palette'
 
 .circle-border-icon-button
   display inline-block
@@ -112,8 +113,7 @@ a.nav-image-item
 
 // Avant Garde rectangular buttons
 .avant-garde-box-button
-  avant-garde()
-  font-size avant-garde-font-size
+  text('mediumText')
   padding 12px
   border 1px solid light-gray-border-color
   background transparent


### PR DESCRIPTION
Addresses: https://www.notion.so/artsy/Web-Type-Clean-up-94cae3cc227243e2a44128b315e65046?p=e07c745e0e7a453dad853dd540e1efdc

- Updates the typography on the **fairs landing page** on **mobile**
- Also makes a [global change](https://artsy.slack.com/archives/C9XJKPY9W/p1600274937047200) to Avant Garde button/tab styles

<img width="500" src="https://user-images.githubusercontent.com/140521/93380414-3256fd80-f82d-11ea-9d95-f4b51b221287.png" />

