### PR TITLE
Type conversion: /collect page and all artwork filters

### DIFF
--- a/cypress/integration/collect.spec.js
+++ b/cypress/integration/collect.spec.js
@@ -16,7 +16,7 @@ describe("/collect", () => {
   })
 
   it("renders page content", () => {
-    cy.get("h1").should("contain", "Collect art and design online")
+    cy.get("h1").should("contain", "Browse artworks")
     artworkGridRenders()
   })
 })

--- a/src/test/acceptance/collect.js
+++ b/src/test/acceptance/collect.js
@@ -23,7 +23,7 @@ xdescribe("Collect page", () => {
 
   it("renders a title and header info", async () => {
     const $ = await browser.page("/collect")
-    $.html().should.containEql("Collect art and design online")
+    $.html().should.containEql("Browse artworks")
   })
 
   it("renders artwork grid", async () => {

--- a/src/v2/Apps/Collect/Routes/Collect/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collect/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Separator, Serif, Spacer } from "@artsy/palette"
+import { Box, Separator, Spacer, Text } from "@artsy/palette"
 import { OwnerType, clickedMainArtworkGrid } from "@artsy/cohesion"
 import { Match, Router } from "found"
 import React from "react"
@@ -81,9 +81,9 @@ export const CollectApp: React.FC<CollectAppProps> = ({
               )}
 
               <Box mt={3}>
-                <Serif size="8">
-                  <h1>Collect art and design online</h1>
-                </Serif>
+                <Text variant="largeTitle">
+                  <h1>Browse artworks</h1>
+                </Text>
                 <Separator mt={2} mb={[2, 2, 2, 4]} />
 
                 <CollectionsHubsNav

--- a/src/v2/Components/CollectionsHubsNav.tsx
+++ b/src/v2/Components/CollectionsHubsNav.tsx
@@ -1,4 +1,4 @@
-import { CSSGrid, Serif } from "@artsy/palette"
+import { CSSGrid, Text } from "@artsy/palette"
 import { CollectionsHubsNav_marketingHubCollections } from "v2/__generated__/CollectionsHubsNav_marketingHubCollections.graphql"
 import { useTracking } from "v2/Artsy/Analytics"
 import * as Schema from "v2/Artsy/Analytics/Schema"
@@ -29,7 +29,11 @@ export const CollectionsHubsNav: FC<CollectionsHubsNavProps> = props => {
           to={`/collection/${hub.slug}`}
           src={resize(hub.thumbnail, { width: 357, height: 175 })}
           ratio={[0.49]}
-          title={<Serif size="4t">{hub.title}</Serif>}
+          title={
+            <Text variant="text" px={1}>
+              {hub.title}
+            </Text>
+          }
           key={hub.slug}
           onClick={() => {
             trackEvent({

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/FollowedArtistsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/FollowedArtistsFilter.tsx
@@ -2,6 +2,7 @@ import { Checkbox, Flex, Toggle } from "@artsy/palette"
 import React, { FC } from "react"
 
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
+import { OptionText } from "./OptionText"
 
 export const FollowedArtistsFilter: FC = () => {
   const filterContext = useArtworkFilterContext()
@@ -20,7 +21,9 @@ export const FollowedArtistsFilter: FC = () => {
     <Toggle label="Artists" expanded>
       <Flex flexDirection="column">
         <Checkbox {...props}>
-          Artists I Follow ({filterContext.counts.followedArtists})
+          <OptionText>
+            Artists I Follow ({filterContext.counts.followedArtists})
+          </OptionText>
         </Checkbox>
       </Flex>
     </Toggle>

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/GalleryFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/GalleryFilter.tsx
@@ -2,6 +2,7 @@ import { Flex, Radio, RadioGroup, Toggle } from "@artsy/palette"
 import { sortBy } from "lodash"
 import React, { FC } from "react"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
+import { OptionText } from "./OptionText"
 
 export const GalleryFilter: FC = () => {
   const { aggregations, ...filterContext } = useArtworkFilterContext()
@@ -29,7 +30,7 @@ export const GalleryFilter: FC = () => {
                 key={index}
                 my={0.3}
                 value={item.value.toLocaleLowerCase()}
-                label={item.name}
+                label={<OptionText>{item.name}</OptionText>}
               />
             )
           })}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/InstitutionFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/InstitutionFilter.tsx
@@ -2,6 +2,7 @@ import { Flex, Radio, RadioGroup, Toggle } from "@artsy/palette"
 import { sortBy } from "lodash"
 import React, { FC } from "react"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
+import { OptionText } from "./OptionText"
 
 export const InstitutionFilter: FC = () => {
   const { aggregations, ...filterContext } = useArtworkFilterContext()
@@ -29,7 +30,7 @@ export const InstitutionFilter: FC = () => {
                 key={index}
                 my={0.3}
                 value={item.value.toLocaleLowerCase()}
-                label={item.name}
+                label={<OptionText>{item.name}</OptionText>}
               />
             )
           })}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
@@ -1,6 +1,7 @@
 import { Flex, Radio, RadioGroup, Toggle } from "@artsy/palette"
 import React, { FC } from "react"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
+import { OptionText } from "./OptionText"
 
 export const MediumFilter: FC = () => {
   const { aggregations, counts, ...filterContext } = useArtworkFilterContext()
@@ -30,7 +31,7 @@ export const MediumFilter: FC = () => {
                 key={index}
                 my={0.3}
                 value={medium.value.toLocaleLowerCase()}
-                label={medium.name}
+                label={<OptionText>{medium.name}</OptionText>}
               />
             )
           })}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/OptionText.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/OptionText.tsx
@@ -1,0 +1,10 @@
+import { Text } from "@artsy/palette"
+import React, { FC } from "react"
+
+export const OptionText: FC = ({ children }) => {
+  return (
+    <Text variant="text" pt="3px">
+      {children}
+    </Text>
+  )
+}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Flex, Radio, RadioGroup, Toggle } from "@artsy/palette"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
+import { OptionText } from "./OptionText"
 
 export const PriceRangeFilter: React.FC = () => {
   const filterContext = useArtworkFilterContext()
@@ -22,7 +23,7 @@ export const PriceRangeFilter: React.FC = () => {
             <Radio
               key={`${index}`}
               my={0.3}
-              label={range.name}
+              label={<OptionText>{range.name}</OptionText>}
               value={range.value}
             />
           ))}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Box, Checkbox, Flex, Sans, Toggle } from "@artsy/palette"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
+import { OptionText } from "./OptionText"
 
 const sizeMap = [
   { displayName: "Small (under 40cm)", name: "SMALL" },
@@ -44,7 +45,11 @@ export const SizeFilter: React.FC = () => {
                 .currentlySelectedFilters()
                 .sizes.includes(name),
             }
-            return <Checkbox {...props}>{displayName}</Checkbox>
+            return (
+              <Checkbox {...props}>
+                <OptionText>{displayName}</OptionText>
+              </Checkbox>
+            )
           })}
         </Box>
       </Flex>

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
@@ -2,6 +2,7 @@ import { Flex, Radio, RadioGroup, Toggle } from "@artsy/palette"
 import React, { FC } from "react"
 import { get } from "v2/Utils/get"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
+import { OptionText } from "./OptionText"
 
 interface TimePeriodFilterProps {
   expanded?: boolean
@@ -43,7 +44,7 @@ export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({
                 my={0.3}
                 value={timePeriod.name}
                 key={index}
-                label={timePeriod.name}
+                label={<OptionText>{timePeriod.name}</OptionText>}
               />
             )
           })}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/WaysToBuyFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/WaysToBuyFilter.tsx
@@ -6,6 +6,7 @@ import {
   ArtworkFilters,
   useArtworkFilterContext,
 } from "../ArtworkFilterContext"
+import { OptionText } from "./OptionText"
 
 interface WayToBuy {
   disabled: any
@@ -65,7 +66,11 @@ export const WaysToBuyFilter: FC = () => {
               filterContext.currentlySelectedFilters()[checkbox.state]
             ),
           }
-          return <Checkbox {...props}>{checkbox.name}</Checkbox>
+          return (
+            <Checkbox {...props}>
+              <OptionText>{checkbox.name}</OptionText>
+            </Checkbox>
+          )
         })}
       </Flex>
     </Toggle>


### PR DESCRIPTION
This started as a type conversion for the /collect page, and ballooned into several other pages. As I started converting artwork filter components, I decided I should do **all** of them instead of leaving half sans, half serif.

As a result, several pages were all affected by these changes.

## Collect page

All type on this page should now be using new variants. 

![local artsy net_5000_collect](https://user-images.githubusercontent.com/1627089/93382874-67ad1c80-f828-11ea-9afe-82dc18db2242.jpg)

## Artist artwork page
![local artsy net_5000_artist_pablo-picasso_works-for-sale](https://user-images.githubusercontent.com/1627089/93383923-f53d3c00-f829-11ea-9b6b-78eff8f73191.jpg)


## Fairs2 artwork page

cc @mzikherman (because it looks like you've worked on this page pretty recently)

![image](https://user-images.githubusercontent.com/1627089/93382131-4bf54680-f827-11ea-8aff-de24e523235d.png)

## Others?

There are probably other places we have artwork filters, but all filters are accounted for in these three pages. 

## Radio button/checkbox alignment

If I'd only converted the type in radio buttons and checkboxes without making additional padding changes, text was pretty misaligned from the associated control. I added a smidge of top padding to each option to better center the option. I didn't notice until now that by doing so, I also added more space between the options. Take a look and let me know which you'd prefer: 

### 1. without any padding

![image](https://user-images.githubusercontent.com/1627089/93384937-15b9c600-f82b-11ea-9ae2-8497e2587e84.png)

### 2. with padding, but extra space

![image](https://user-images.githubusercontent.com/1627089/93384101-359cba00-f82a-11ea-88eb-4d21c59ac75b.png)

### 3. put some more effort into it Steve, and get it center-aligned without adding space between options (not shown)