### PR TITLE
[typography] Desktop homepage conversion

### DIFF
--- a/src/desktop/apps/home/components/artists_to_follow/stylesheets/index.styl
+++ b/src/desktop/apps/home/components/artists_to_follow/stylesheets/index.styl
@@ -1,35 +1,43 @@
 @require '../../../../../components/artist_cell'
+@require '../../../../lib/palette'
 
 .artists-to-follow
   height 450px
-  background-color gray-lightest-color
-  margin-bottom 60px
+  background-color getColor('black5')
+  margin-bottom getSpace(6)
+
   &__inner
-    padding 30px 0 50px
+    padding getSpace(3, 0, 5)
+
     &__header
       h1
-        garamond-size('headline')
+        text('title')
         display inline-block
+
       &__tabs
         display inline-block
+
         &__tab
+          text('subtitle')
           cursor pointer
-          margin 0 15px
+          margin getSpace(0, 1.5)
           display inline-block
-          avant-garde-size('body')
-          color gray-darker-color
+
           &:first-child
-            margin-left 25px
+            margin-left getSpace(3)
+
           &.is-active
-            color black
-            border-bottom 2px solid black
+            color getColor('black100')
+            text-decoration underline
+
     &__results
-      padding-top 22px
+      padding-top getSpace(2)
+
       .artist-rail-cell
         padding 0
-        margin-right 30px
+        margin-right getSpace(3)
         width calc(25% \- 22.5px)
-        background-color white
-        // transition opacity, 800ms, ease
+        background-color getColor('white100')
+
       .hoverable-image-link
         width 100%

--- a/src/desktop/apps/home/components/followed_artists/index.styl
+++ b/src/desktop/apps/home/components/followed_artists/index.styl
@@ -1,4 +1,5 @@
 @require '../../../../components/typeahead/index'
+@require '../../../../../lib/palette'
 
 .abrv-context__content--followed-artists
   &__more-artists
@@ -9,7 +10,7 @@
   float left
   .tt-suggestion
     padding 0
-    border-bottom 1px solid gray-lighter-color
+    border-bottom 1px solid getColor('black10')
     position relative
     height 63px
     &:last-child
@@ -20,20 +21,20 @@
     align-items center
     flex 1
     &__selected
-      color white
-      background-color purple-color !important
+      color getColor('white100')
+      background-color getColor('purple100') !important
   .tt-dropdown-menu
-    border 1px solid gray-lighter-color
+    border 1px solid getColor('black10')
   .tt-cursor
   .tt-suggestion:hover
-      background-color gray-lightest-color
-      color black
+      background-color getColor('black5')
+      color getColor('black100')
   .typeahead-suggestion-follow
     margin-right 10px
     &[data-state="follow"] .avant-garde-button-underlined:before
       content 'Follow'
     &[data-state="following"] .avant-garde-button-underlined
-      border-bottom-color white
+      border-bottom-color getColor('white100')
       &:before
         content 'Following'
-        color white
+        color getColor('white100')

--- a/src/desktop/apps/home/components/followed_artists/templates/context.jade
+++ b/src/desktop/apps/home/components/followed_artists/templates/context.jade
@@ -8,5 +8,5 @@
   else
     p Follow artists for better recommendations and to receive alerts when new works are available
     P
-      span.avant-garde-body Or&nbsp;
+      span Or&nbsp;
       a(href="/artists") Browse all artists

--- a/src/desktop/apps/home/components/related_artists_context/annotation.jade
+++ b/src/desktop/apps/home/components/related_artists_context/annotation.jade
@@ -1,1 +1,1 @@
-.abrv-follow-annotation.avant-garde-s-headline Based on #[a(href=based_on.href) #{based_on.name}]
+.abrv-follow-annotation Based on #[a(href=based_on.href) #{based_on.name}]

--- a/src/desktop/apps/home/stylesheets/featured_items.styl
+++ b/src/desktop/apps/home/stylesheets/featured_items.styl
@@ -7,7 +7,7 @@ column-gap = 30px
 
 .home-featured-header
   margin (column-gap - 10px) 0 column-gap 0
-  garamond-size('headline')
+  text('title')
 
 .home-featured-list
   position relative
@@ -25,8 +25,9 @@ column-gap = 30px
 .home-browse-all-right
   float right
   a
-    fine-faux-underline()
-    font-size 17px
+    text('text')
+    color getColor('black60')
+    text-decoration none
 
 .home-featured-cover-img
   overflow hidden
@@ -86,17 +87,17 @@ li.grid-item .artwork-item-contact-seller
 .htfl-details
   padding (column-gap / 2)
   > h3
-  > h4
     text('small')
-  > h3
     color getColor('black60')
+  > h4
+    text('subtitle')
 
 // Featured articles
 // --------------
 
 #home-featured-articles-section
   .home-featured-header
-    garamond-size('headline')
+    text('title')
 
 .home-featured-article-link
   display inline-block
@@ -111,8 +112,7 @@ li.grid-item .artwork-item-contact-seller
     padding-right column-gap
     height auto
     h4
-      font-size 24px
-      line-height 1.2em
+      text('subtitle')
     .home-featured-cover-img
       padding-bottom 410px
   &:nth-child(2), &:nth-child(5)
@@ -128,12 +128,11 @@ li.grid-item .artwork-item-contact-seller
     padding-bottom 140px
     width 100%
   h4
-    margin-top 10px
+    text('mediumText')
+    margin-top getSpace(1)
   h5
-    avant-garde()
-    font-size 11px
-    padding-top 3px
-    color gray-darker-color
+    text('text')
+    color getColor('black60')
   a
     text-decoration none
 

--- a/src/desktop/apps/home/stylesheets/hero_units.styl
+++ b/src/desktop/apps/home/stylesheets/hero_units.styl
@@ -1,3 +1,5 @@
+@require '../../../../lib/palette'
+
 fade-duration = 0.2s
 hhu-credit-height = 30px
 
@@ -22,13 +24,13 @@ hhu-credit-height = 30px
     transition opacity fade-duration ease-in fade-duration
   .avant-garde-button
     padding 10px 20px
-    border 3px solid black
+    border 3px solid getColor('black100')
     background transparent
     &:hover
     &:focus
     &:active
-      color white
-      background black
+      color getColor('white100')
+      background getColor('black100')
 
 .hhu-frame
   display block
@@ -45,22 +47,18 @@ hhu-credit-height = 30px
 .hhu-inner
   margin-top -(hhu-credit-height)
 .hhu-header
-  font-size 21px
-  line-height 1
+  text('text')
 .hhu-title
   display inline-block
-  margin 25px 0 0 0
+  margin-top getSpace(2)
 .hhu-subheading
-  margin 30px 0
-  font-size 27px
-  line-height 1.3
+  text('subtitle')
+  margin getSpace(2, 0, 3, 0)
 .hhu-credit
+  text('small')
   position absolute
   left 0
-  bottom 0
-  line-height hhu-credit-height
-  font-style italic
-  font-size 11px
+  bottom getSpace(1)
   opacity 0.65
 
 .home-hero-unit-left-light
@@ -69,15 +67,15 @@ hhu-credit-height = 30px
   .hhu-subheading
   .hhu-header
   .hhu-credit
-    color white
+    color getColor('white100')
   .avant-garde-button
-    border-color white
-    color white
+    border-color getColor('white100')
+    color getColor('white100')
     &:hover
     &:focus
     &:active
-      background white
-      color black
+      background getColor('white100')
+      color getColor('black100')
 
 #home-hero-units-controls
   width 100%
@@ -101,7 +99,7 @@ hhu-credit-height = 30px
     height @width
     border-radius @width
     margin-right 10px
-    background gray-color
+    background getColor('black30')
     display inline-block
     cursor pointer
     transition background-color 0.3s
@@ -109,13 +107,12 @@ hhu-credit-height = 30px
     &:hover
     &:focus
     &:active
-      background black
+      background getColor('black100')
     &:last-child
       margin-right 0
 
-welcome-background-color = #dedede
 .home-hero-unit-welcome
-  background-color welcome-background-color
+  background-color getColor('black5')
   .hhu-inner
     width 40%
     margin 0
@@ -125,13 +122,7 @@ welcome-background-color = #dedede
     font-size 45px
     line-height @font-size
   .hhu-header
-    font-size 40px
-    text-transform none
-    letter-spacing 0
-    line-height 1.25
-  .hhu-subheading
-    margin 20px 0 30px 0
-    font-size 18px
+    text('largeTitle')
   .avant-garde-button
-    background-color black
-    color white
+    background-color getColor('black100')
+    color getColor('white100')

--- a/src/desktop/apps/home/stylesheets/modules.styl
+++ b/src/desktop/apps/home/stylesheets/modules.styl
@@ -1,3 +1,5 @@
+@require '../../lib/palette'
+
 .abrv-context--float
   float left
   position relative
@@ -10,13 +12,13 @@
     border-bottom none
     padding-right 15px
     margin-right 15px
-    border-right 1px solid gray-lighter-color
+    border-right 1px solid getColor('black10')
     display inline-block
     width calc(25% \- 15px)
     min-width value
     .my-active-bids-item-details
       padding-top 8px
-      garamond-size('l-caption', true)
+      text('text')
     .my-active-bids-warning, .my-active-bids-bid-button
       right 15px
     .bid-status
@@ -28,6 +30,8 @@
   z-index 100
   overflow ellipsis
   height 100%
+  text('text')
+
   &--fair
     img
       width 75px
@@ -42,7 +46,7 @@
   &--iconic-artists, &--followed-artists
     &__artist, &__more-artists
       display block
-      avant-garde-size('body', true)
+      text('mediumText')
       text-decoration none
       margin 10px 0
       width 100%
@@ -50,7 +54,7 @@
       overflow hidden
       text-overflow ellipsis
       &:hover
-        color purple-color
+        color getColor('purple100')
       &:first-child
         margin-top 0
 

--- a/src/desktop/apps/home/templates/hero_unit.jade
+++ b/src/desktop/apps/home/templates/hero_unit.jade
@@ -11,7 +11,7 @@
       if heroUnit.mode === 'WELCOME'
         i.icon-logotype
 
-      .hhu-header.small-caps
+      .hhu-header
         = heroUnit.heading
       if heroUnit.title_image_url
         img.hhu-title(

--- a/src/desktop/components/artist_cell/index.styl
+++ b/src/desktop/components/artist_cell/index.styl
@@ -1,32 +1,39 @@
+@require '../../lib/palette'
+
 .artist-cell-item
-  border 1px solid gray-lighter-color
-  padding 10px
+  padding getSpace(1)
+  border 1px solid getColor('black10')
+  background-color getColor('white100')
 
   &__link
     display block
     text-decoration none
+
+    .hoverable-image-link
+      display block
+
     &:hover
     &.is-hover
-      .hoverable-image-link:after, .hoverable-image-link:after
+      .hoverable-image-link:after
         opacity 0.5
+
   &__artist-information
-    margin-bottom 3px
-  &__artist-name
-    avant-garde-size('body')
-  &__artist-information
-    min-height 63px
-  &__followers
-    color gray-darker-color
+    margin getSpace(1, 0)
+
   &__follow-button
     width 100%
 
-  &__bio
-  &__followers
-    garamond-size(s-body)
-    line-height 1.2
   &__artist-name
   &__bio
   &__followers
+    text('text')
     overflow hidden
     text-overflow ellipsis
     white-space nowrap
+
+  &__artist-name
+    text('mediumText')
+
+  &__bio
+  &__followers
+    color getColor('black60')

--- a/src/desktop/components/artwork_brick_rail/index.styl
+++ b/src/desktop/components/artwork_brick_rail/index.styl
@@ -1,5 +1,6 @@
 @require '../components/merry_go_round'
 @require '../components/artwork_brick/'
+@require '../../lib/palette'
 
 image-height = 180px
 header-height = 40px
@@ -8,7 +9,7 @@ header-margin = 30px
 .abrv-container
   margin-top 20px
   padding-top 20px
-  border-top 1px solid gray-lighter-color
+  border-top 1px solid getColor('black10')
   position relative
   &:first-child
     border-top none
@@ -17,13 +18,15 @@ header-margin = 30px
     opacity 1 !important
 
 .abrv-header
-  margin-bottom header-margin
   position relative
+  display flex
+  align-items flex-end
   width 100%
+  margin-bottom getSpace(2)
   height header-height
 
   h1
-    garamond-size('headline', true)
+    text('title')
     margin-right 10px
     display inline-block
 
@@ -31,24 +34,26 @@ header-margin = 30px
     display inline-block
     vertical-align text-bottom
 
-  .abrv-follow-annotation, .abrv-category-annotation
-    color gray-darker-color
+  .abrv-follow-annotation,
+  .abrv-category-annotation
+    text('text')
     a
-      color gray-darker-color
       text-decoration none
-      
+
   .abrv-view-all
-    faux-underline(black)
-    position absolute !important
+    text('text')
+    color getColor('black60')
+    text-decoration none
+    position absolute
     right 0
-    top 10px
+    bottom 0
 
 .abrv-content
   clearfix()
 
 .abrv-context.abrv-fillwidth-row
   width 200px
-  border-right 1px solid gray-lighter-color
+  border-right 1px solid getColor('black10')
   margin 0 30px 20px 0
   padding-right 30px
   height 270px
@@ -61,16 +66,17 @@ header-margin = 30px
     width 180px
     height 180px
     position relative
-    border 2px solid gray-lighter-color
+    border 2px solid getColor('black10')
     &__link
+      text('mediumText')
       position absolute
       top 0
-      left 0px
+      left 0
       width 100%
       height 100%
-      sans('body')
-      line-height 180px
-      text-align center
+      display flex
+      align-items center
+      justify-content center
       text-decoration none
 
 .abrv-carousel

--- a/src/desktop/components/artwork_brick_rail/templates/index.jade
+++ b/src/desktop/components/artwork_brick_rail/templates/index.jade
@@ -1,14 +1,16 @@
 .abrv-inner( data-rail= railId )
   .abrv-header
-    if annotation
-      != annotation
-    if category
-      .abrv-category-annotation.avant-garde-s-headline Category
-    if viewAllUrl
-      a( href= viewAllUrl )
+    div
+      if annotation
+        != annotation
+      if category
+        .abrv-category-annotation Category
+      if viewAllUrl
+        a( href= viewAllUrl )
+          h1= title
+      else
         h1= title
-    else
-      h1= title
+
     .abrv-follow-button
       //- rendered on the client
 

--- a/src/desktop/components/artwork_metadata_stub/index.styl
+++ b/src/desktop/components/artwork_metadata_stub/index.styl
@@ -1,10 +1,13 @@
 @require '../stylus_lib'
+@require '../../lib/palette'
+
+LINE_HEIGHT = 21px
 
 .artwork-metadata-stub
-  serif('l-caption')
-  margin distance(gutter / 2) 0 distance(gutter) 0
+  text('text')
+  margin getSpace(1) 0 distance(gutter) 0
   lines = 5
-  height (line-height-in-px('garamond-l-caption') * lines)
+  height (LINE_HEIGHT * lines)
   overflow hidden
 
   &__sale-artwork__estimate
@@ -16,7 +19,7 @@
 
     &
     & > a
-      color gray-darker-color
+      color getColor('black60')
       text-decoration none
 
   &__bid-now:before
@@ -30,11 +33,14 @@
 
   &__artists
     font-weight bold
+    &
+    & > a
+      color getColor('black100')
 
   &__placeholder-line
     offset = 3px
-    height (line-height-in-px('garamond-l-caption') - (offset * 2))
-    background-color gray-lightest-color
+    height (LINE_HEIGHT - (offset * 2))
+    background-color getColor('black5')
     margin offset 0
 
     &:nth-child(2)

--- a/src/desktop/components/featured_shows/index.styl
+++ b/src/desktop/components/featured_shows/index.styl
@@ -1,32 +1,29 @@
 @require '../../components/stylus_lib'
+@require '../../../lib/palette'
 
 .fsfs-metadata
+  text('text')
   display block
-  margin 10px 0 20px 0
-  padding-right 20px
+  margin getSpace(1, 0, 2, 0)
+  padding-right getSpace(2)
   text-decoration none
-  line-height 1.4
 
 .fsfs-contextual-label
-  margin-top 20px
-  avant-garde()
-  font-size 10px
-  line-height 2
+  margin-top getSpace(2)
 
 .fsfs-partner-name
-  avant-garde()
-  font-size default-avant-garde-font-size
-  line-height 1.75
+  font-weight bold
 
 .fsfs-partner-name
 .fsfs-show-name
 .fsfs-running-dates
   overflow ellipsis
 
+.fsfs-show-name
 .fsfs-closing-date
 .fsfs-street-address
 .fsfs-running-dates
-  color gray-darker-color
+  color getColor('black60')
 
 .fsfs-warning
-  color red-color
+  color getColor('red100')

--- a/src/desktop/components/follow_button/artist_suggestions.jade
+++ b/src/desktop/components/follow_button/artist_suggestions.jade
@@ -1,5 +1,5 @@
 .popover-header
-  span.avant-garde-s-headline.popover-left-side You might also like
+  span.popover-left-side You might also like
   span.popover-close ×
 .popover-artists
   ul

--- a/src/desktop/components/follow_button/index.styl
+++ b/src/desktop/components/follow_button/index.styl
@@ -1,4 +1,5 @@
 @require './popover'
+@require '../../lib/palette'
 
 .follow-button
   &:before
@@ -10,18 +11,19 @@
   &.no-touch[data-state='following'],
   &.no-touch.is-following
     &:hover
-      color purple-color
+      color getColor('purple100')
       &:before
         content 'Unfollow'
       &.is-clicked:before
         content 'Following'
 
 .plus-follow-button
+  text('text')
   cursor pointer
   display inline-block
   min-width 86px
   &.is-following, &:hover, &[data-state='following']
-    color purple-color
+    color getColor('purple100')
   .icon-follow-circle, .follow-button-text
     display inline
   .icon-follow-circle

--- a/src/desktop/components/main_layout/footer/index.styl
+++ b/src/desktop/components/main_layout/footer/index.styl
@@ -1,21 +1,22 @@
 @require '../../../components/stylus_lib'
+@require '../../../../lib/palette'
 
 mlf-upper-column-aside-width = 28%
 mlf-upper-column-width = ((100% - mlf-upper-column-aside-width) / 4)
 
 #main-layout-footer
-  padding 20px 0
-  background-color white
+  padding getSpace(2, 0)
+  background-color getColor('white100')
   clearfix()
 .mlf
   .mlf-upper
-    margin-bottom 10px
+    margin-bottom getSpace(1)
 
   .mlf-upper
   .mlf-lower
     clearfix()
-    padding 20px 0
-    border-top 1px solid gray-lighter-color
+    padding getSpace(2, 0)
+    border-top 1px solid getColor('black10')
 
   .mlf-lower
     position relative
@@ -26,27 +27,23 @@ mlf-upper-column-width = ((100% - mlf-upper-column-aside-width) / 4)
   .mlf-upper-column
   .mlf-upper-column-aside
     float left
-    line-height 1.7
-    padding-right 20px
+    padding-right getSpace(2)
+    h4
+      text('mediumText')
+      margin-bottom getSpace(1)
     a
+      text('text')
+      padding getSpace(1, 0)
       display block
       overflow ellipsis
+      text-decoration none
   .mlf-upper-column-aside
     width mlf-upper-column-aside-width
     display flex
     justify-content flex-end
-    padding-right 10px
-    h4
-      font-weight bold
-      block-margins(5px)
+    padding-right getSpace(1)
   .mlf-upper-column
     width mlf-upper-column-width
-    h4
-      avant-garde()
-      font-size 13px
-      margin-bottom 5px
-    a
-      text-decoration none
 
   @media screen and (max-width: 1024px)
     mlf-upper-column-aside-width = 25%
@@ -57,40 +54,48 @@ mlf-upper-column-width = ((100% - mlf-upper-column-aside-width) / 4)
 
   // Lower
   #main-layout-footer-internal
-    span#ccpa-request
+    text('small')
+    display flex
+    justify-content center
+
+    &
+    & a
+      color getColor('black60')
       text-decoration none
-      display inline-block
-      vertical-align middle
-      a
-        margin 0
-        text-decoration underline
-        vertical-align unset
 
     a
-    span:not(.ccpa-request)
-      display inline-block
+    span
+      display inline-flex
+      align-items center
       text-decoration none
-      vertical-align middle
-      margin 0 7px
-      &:first-child
-        margin-left 0
+      margin-right getSpace(1)
+
       &:last-child
         margin-right 0
 
   #main-layout-footer-logo
     display inline-block
     font-size 30px
-    margin-right 20px
+    margin-right getSpace(2)
 
   #main-layout-footer-external
     display flex
     position relative
     margin-left auto
 
-  .mlf-social
-    display inline-block
+  .mlf-links
+    display flex
+    justify-content center
 
-  .mlf-icon-instagram, .mlf-icon-wechat
+    > *
+      &:first-child
+        margin-left getSpace(1)
+
+  .mlf-social
+    display block
+
+  .mlf-icon-instagram
+  .mlf-icon-wechat
     width 20px
     margin 7px 5px 0 5px
     height 20px
@@ -100,8 +105,8 @@ mlf-upper-column-width = ((100% - mlf-upper-column-aside-width) / 4)
   .mlf-icon-wechat:hover
     .mlf-wechat-qr-code-container
       display flex
-      background-color white
-      border 1px solid gray-lighter-color
+      background-color getColor('white100')
+      border 1px solid getColor('black10')
       box-shadow 0px 10px 20px gray-color
       width 150px
       height 150px
@@ -120,7 +125,7 @@ mlf-upper-column-width = ((100% - mlf-upper-column-aside-width) / 4)
         height 0
         border-left 8px solid transparent
         border-right 8px solid transparent
-        border-top 10px solid white
+        border-top 10px solid getColor('white100')
         position absolute
         right 65px
         bottom -9px
@@ -128,26 +133,26 @@ mlf-upper-column-width = ((100% - mlf-upper-column-aside-width) / 4)
 .mlf__mobile
   background-color black
   width 100vw
-  color white
+  color getColor('white100')
   display none
   a
-    color white
+    color getColor('white100')
     text-decoration none
   h4
-    avant-garde-size('m-headline')
-    margin-bottom 10px
+    text('mediumText')
+    margin-bottom getSpace(1)
   .mlf-upper-column, .mlf-user-column
-    padding 20px
+    text('text')
+    padding getSpace(2)
     width 100vw
-    garamond-size('l-body')
     float none
     a
       width 50%
       display inline-block
   .mlf-upper-column a:nth-child(even),
   .mlf-user-column a:nth-child(odd)
-      margin-left 15px
-      width calc(50% \- 15px)
+      margin-left getSpace(1.5)
+      width calc(50% \- getSpace(1.5))
   .mlf-user-column
     border-top 1px solid gray-darkest-color
   .mlf-login-signup
@@ -156,15 +161,15 @@ mlf-upper-column-width = ((100% - mlf-upper-column-aside-width) / 4)
     justify-content space-between
     a
       text-align center
-      width calc(50% \- 15px)
+      width calc(50% \- getSpace(1.5))
       &:first-child
-        margin-left 10px
+        margin-left getSpace(1)
       &:last-child
-        margin-right 10px
+        margin-right getSpace(1)
   .mlf-lower
-     border none
-     padding 30px 20px
-     garamond-size('l-caption')
+    text('small')
+    border none
+    padding getSpace(3, 2)
 
 @media (max-width: 600px)
   #main-layout-footer

--- a/src/desktop/components/main_layout/stylesheets/buttons.styl
+++ b/src/desktop/components/main_layout/stylesheets/buttons.styl
@@ -10,11 +10,11 @@
   margin 0 10px
   height @width
   cursor pointer
-  color black
+  color getColor('black100')
   background-color transparent
   text-align center
   vertical-align middle
-  border 2px solid gray-lighter-color
+  border 2px solid getColor('black10')
   border-radius (@width / 2)
   opacity 1
   user-select none
@@ -22,12 +22,12 @@
   line-height @height !important
   transition all 0.125s
   &:hover
-    background-color gray-darker-color
+    background-color getColor('black60')
     border-color @background-color
     color white
   &.is-active
   &[data-state='active']
-    background-color purple-color
+    background-color getColor('purple100')
     border-color @background-color
     color white
 
@@ -36,21 +36,20 @@
   text-align center
 
 .circle-button-label
-  avant-garde()
-  font-size 11px
-  color black
-  margin-top 5px
+  text('small')
+  color getColor('black100')
+  margin-top getSpace(0.5)
 
 .highlight-link
   line-height 1.1
   text-decoration none
   transition color 0.25s
   &:hover
-    color purple-color
+    color getColor('purple100')
 
 .play-button
   position absolute
-  background-color black
+  background-color getColor('black100')
   cursor pointer
   height 55px
   width 75px
@@ -61,7 +60,7 @@
   padding 25px
   transition background-color 0.25s
   &:hover
-    background-color purple-color
+    background-color getColor('purple100')
   &:after
     display block
     position absolute
@@ -82,36 +81,35 @@
   margin 0 5px
 
 .avant-garde-button
+  text('mediumText')
   display inline-block
   position relative
-  padding 15px 30px
-  font-size 13px
-  line-height 1
+  padding getSpace(1.5, 3)
+  line-height 1 !important
   cursor pointer
   border none
-  background-color gray-lightest-color
-  text('mediumText')
+  background-color getColor('black5')
   transition background-color 0.25s, color 0.25s
   border 1px solid transparent
   text-decoration none
   &:focus, &:hover
     outline none
-    background-color gray-lighter-color
+    background-color getColor('black10')
   // States
   &[data-state='success'], &.is-success
-    background-color green-color
-    color #fff
+    background-color getColor('green100')
+    color getColor('white100')
     &:hover
-      background-color darken(green-color, 25%)
+      background-color darken(getColor('green100'), 25%)
   &[data-state='error'], &.is-error
     &, &:focus
-      background-color red-color
-      color #fff
+      background-color getColor('red100')
+      color getColor('white100')
       &:hover
-        background-color darken(red-color, 25%)
+        background-color darken(getColor('red100'), 25%)
   &[data-state='loading'], &.is-loading
     &, &[disabled], &[disabled]:hover
-      background-color purple-color
+      background-color getColor('purple100')
       color transparent !important
       // Note:
       // Giving the loading state to input[type='submit']
@@ -120,7 +118,7 @@
       &::before
         display block
         content ''
-        spinner(25px, 6px, #fff)
+        spinner(25px, 6px, getColor('white100'))
   // Handle icons
   > i
     line-height 0
@@ -131,42 +129,41 @@
     &, &:hover
       background-color gray-lightest-color
       cursor default
-      color rgba(black, 0.5)
+      color rgba(getColor('black100'), 0.5)
       &[data-state='success'], &.is-success
-        background-color green-color
+        background-color getColor('green100')
       &[data-state='error'], &.is-error
-        background-color red-color
+        background-color getColor('red100')
 
   // Structural variants
   &.is-block
     width 100%
     text-align center
   &.is-small
-    font-size 11px
-    padding 10px 20px
+    padding getSpace(1, 2)
     &[data-state='loading'], &.is-loading
       &::before
-        spinner(16px, 4px, #fff)
+        spinner(16px, 4px, getColor('white100'))
   &.is-tiny
     font-size 11px
     padding 6px 12px 5px
     &[data-state='loading'], &.is-loading
       &::before
-        spinner(12px, 3px, #fff)
+        spinner(12px, 3px, getColor('white100'))
 
 // Stylistic variants
 .avant-garde-button-black
   @extends .avant-garde-button
   text-align center
-  background-color black
-  color #fff
+  background-color getColor('black100')
+  color getColor('white100')
   border 1px solid transparent
   &:focus, &:hover
-    background-color purple-color
+    background-color getColor('purple100')
   &[disabled], &.is-disabled
     &, &:hover
-      background-color gray-darker-color
-      color rgba(white, 0.75)
+      background-color getColor('black60')
+      color rgba(getColor('white100'), 0.75)
 
 .avant-garde-follow-button-black
   @extends .avant-garde-button
@@ -174,55 +171,55 @@
   &, &:hover, &:focus
     user-select none
     text-align center
-    color white
+    color getColor('white100')
   &, &:focus
     background-color black
   &:hover
-    background-color purple-color
+    background-color getColor('purple100')
   &[data-state='following'], &.is-following
-    background-color white
+    background-color getColor('white100')
     color gray-color
-    border 1px solid gray-lighter-color
+    border 1px solid getColor('black10')
   &.no-touch[data-state='following'],
   &.no-touch.is-following
     &:hover
-      color purple-color
+      color getColor('purple100')
 
 .avant-garde-button-dark
   @extends .avant-garde-button
-  color white
-  background-color gray-darkest-color
+  color getColor('white100')
+  background-color getColor('black60')
   &:focus, &:hover
-    background-color purple-color
+    background-color getColor('purple100')
   &[disabled], &.is-disabled
     &, &:hover
-      background-color gray-darkest-color
-      color rgba(white, 0.25)
+      background-color getColor('black60')
+      color rgba(getColor('white100'), 0.25)
 
 .avant-garde-button-white
   @extends .avant-garde-button
   background-color transparent
-  border 1px solid gray-lighter-color
+  border 1px solid getColor('black10')
   &:focus, &:hover, &:active
-    color purple-color
+    color getColor('purple100')
     background-color transparent
   &[data-state='success'], &.is-success
     background-color transparent
-    color green-color
+    color getColor('green100')
     &:hover
       background-color transparent
-      color purple-color
+      color getColor('purple100')
   &[data-state='error'], &.is-error
     &, &:focus
       background-color transparent
-      color red-color
+      color getColor('red100')
       &:hover
         background-color transparent
-        color purple-color
+        color getColor('purple100')
   &[data-state='loading'], &.is-loading
     background-color white
     &::before
-      background-color purple-color
+      background-color getColor('purple100')
   &[disabled], &.is-disabled
     &, &:hover
       background-color transparent
@@ -266,14 +263,12 @@
     vertical-align middle
 
 .garamond-button-text
+  text('text')
   display inline-block
   position relative
-  garamond()
-  text-transform uppercase
-  letter-spacing 1px
-  color black
+  color getColor('black100')
   text-decoration none
-  line-height 1
+  line-height 1 !important
   cursor pointer
   border none
   &[data-state='loading'], &.is-loading
@@ -286,4 +281,4 @@
       &::before
         display block
         content ''
-        spinner(25px, 6px, black)
+        spinner(25px, 6px, getColor('black100'))

--- a/src/desktop/components/merry_go_round/index.styl
+++ b/src/desktop/components/merry_go_round/index.styl
@@ -1,4 +1,5 @@
 @require '../stylus_lib'
+@require '../../lib/palette'
 
 mgr-n-up(n, gutter, imageRatio, alignArrows = false)
   n-up(n, gutter, imageRatio)
@@ -160,4 +161,4 @@ mgr-n-up(n, gutter, imageRatio, alignArrows = false)
     top 0
     bottom 0
   &__text
-    avant-garde-size('body')
+    text('text')

--- a/src/desktop/components/recently_viewed_artworks/index.jade
+++ b/src/desktop/components/recently_viewed_artworks/index.jade
@@ -1,6 +1,6 @@
 .responsive-layout-container
   .rva-container.main-layout-container
-    .rva-header.avant-garde-s-headline
+    .rva-header
       | Recently Viewed
 
     .rva-content

--- a/src/desktop/components/slider/index.jade
+++ b/src/desktop/components/slider/index.jade
@@ -1,7 +1,7 @@
 .slider
   .slider__top
-    .slider__top__name.avant-garde-s-headline #{name}
-    .slider__top__label.garamond-l-caption
+    .slider__top__name #{name}
+    .slider__top__label
       //- rendered on the client
   .slider__slider
     //- rendered on the client

--- a/src/lib/palette.styl
+++ b/src/lib/palette.styl
@@ -32,13 +32,16 @@ getColor(name)
     error('cannot find: ' + name)
   value
 
-getSpace(indices...)
+getSpace(keys...)
   values = ()
-  for i in indices
-    value = THEME.space[i]
-    if value == null
-      error('cannot find: ' + i)
-    push(values, value)
+  for key in keys
+    if key == 0 || key == 'auto'
+      push(values, key)
+    else
+      value = THEME.space[key]
+      if value == null
+        error('cannot find: ' + key)
+      push(values, value)
   values
 
 // Access text treatments

--- a/src/v2/Components/CollectionsHubsHomepageNav.tsx
+++ b/src/v2/Components/CollectionsHubsHomepageNav.tsx
@@ -1,5 +1,4 @@
-import { CSSGrid } from "@artsy/palette"
-import { Serif } from "@artsy/palette"
+import { CSSGrid, Text } from "@artsy/palette"
 import { CollectionsHubsHomepageNav_marketingHubCollections } from "v2/__generated__/CollectionsHubsHomepageNav_marketingHubCollections.graphql"
 import { AnalyticsSchema } from "v2/Artsy/Analytics"
 import React from "react"
@@ -37,8 +36,8 @@ export const CollectionsHubsHomepageNav = track(
           to={`/collection/${hub.slug}`}
           src={resize(hub.thumbnail, { width: 357, height: 175 })}
           ratio={[0.49]}
-          title={<Serif size={["3", "4"]}>{hub.title}</Serif>}
-          subtitle={<Serif size="2">{subtitleFor(hub.title)}</Serif>}
+          title={<Text variant="text">{hub.title}</Text>}
+          subtitle={<Text variant="caption">{subtitleFor(hub.title)}</Text>}
           key={hub.slug}
           onClick={() => {
             trackEvent({


### PR DESCRIPTION
@deliciousnachos reviewed these screenshots ✅ 

![](http://static.damonzucconi.com/_capture/W7g3FueuQ1AM.png)

[Click here for a giant scroll of <del>rails</del> shelves](https://static.damonzucconi.com/_capture/PSvjfwYkNSa5.png)

Logged out the only addition is this component:

![](http://static.damonzucconi.com/_capture/FbTg6We0gSU6.png)

----

I'm trying to replace tokens like `gray-lighter-color` and spacing with the equivalents as I come across them. They are close but slightly different. Not hugely important but it makes me *feel better*.
