### PR TITLE
[Typography] Update Auctions desktop landing page

### DIFF
--- a/src/desktop/apps/auctions/stylesheets/index.styl
+++ b/src/desktop/apps/auctions/stylesheets/index.styl
@@ -1,10 +1,8 @@
 @require '../../../components/stylus_lib'
+@require '../../../../lib/palette'
 
 .af-hero-image
   width 100%
-.af-name
-  margin 20px 0
-  garamond-size('headline')
 .af-metadata
   margin 20px 0
   display flex
@@ -62,7 +60,7 @@
 .auctions-list
   block-margins(30px)
   .leader-dots-list-item
-    garamond-size('l-body')
+    text('subtitle')
     &:after
       font-size 12px
       line-height 2.2
@@ -107,8 +105,6 @@
     display table-cell
     vertical-align middle
     padding 20px 0
-  h3
-    font-style italic
 
 .auction-cta-group .auction-cta-group__left
   width 20%
@@ -121,9 +117,9 @@
   padding-left 10px
 
 .auctions-header, .auctions-my-active-bids h3
-  garamond-size('headline')
+  text('largeTitle')
+  padding-bottom getSpace(2)
   border-bottom 1px solid gray-lighter-color
-  padding-bottom 17px
 
 .auctions-my-active-bids h3
   margin-bottom 30px
@@ -154,12 +150,14 @@
   flex-grow 1
 
 .af-name
-  garamond-size('s-headline')
-  margin 0
+  text('subtitle')
+
+.af-sale-time
+  text('caption')
 
 .af-live-header
-  avant-garde-size('body')
-  letter-spacing 3px
+  text('caption')
+  color getColor('black60')
 
 .af-go-button
   width 200px

--- a/src/desktop/apps/auctions/stylesheets/index.styl
+++ b/src/desktop/apps/auctions/stylesheets/index.styl
@@ -4,14 +4,14 @@
 .af-hero-image
   width 100%
 .af-metadata
-  margin 20px 0
+  margin getSpace(2, 0)
   display flex
   align-items flex-start
 .af-thumbnail
   display inline-block
 
 .ap-featured-item--small
-  margin-bottom 30px
+  margin-bottom getSpace(3)
   display table
   width 100%
 
@@ -32,10 +32,10 @@
   line-height 0
 
 .ap-featured-item__logo
-  margin-bottom 20px
+  margin-bottom getSpace(2)
 
 .ap-featured-item__title
-  padding 0 30px
+  padding getSpace(0, 3)
   max-width 300px
 
   h3
@@ -52,7 +52,7 @@
     text-align right
 
 #auctions-page > .aggregate-page-items
-  margin-bottom 30px
+  margin-bottom getSpace(3)
 
 .aggregate-page-items-featured-set
   margin 0
@@ -79,15 +79,15 @@
 
 .auctions-placeholder-metadata
   width 33.33%
-  padding 0 50px 0 20px
+  padding getSpace(0, 5, 0, 2)
   > h2
     text('largeTitle')
     // Visually center. Due to line-height and hard-edged bottom button
     margin -((@font-size * (@line-height - 1)) * 2) auto 10px
   > p
     text('subtitle')
-    margin 20px 0
-    padding 0 20px
+    margin getSpace(2, 0)
+    padding getSpace(0, 2)
   > a
     white-space nowrap
 .auctions-placeholder-hero
@@ -96,7 +96,7 @@
     width 100%
 
 .apu-clock
-  margin 20px 0 30px
+  margin getSpace(2, 0, 3)
   .clock-header
     display none
 
@@ -106,7 +106,7 @@
   > div
     display table-cell
     vertical-align middle
-    padding 20px 0
+    padding getSpace(2, 0)
 
 .auction-cta-group .auction-cta-group__left
   width 20%
@@ -116,15 +116,15 @@
     margin 0 auto
 
 .auction-cta-group .auction-cta-group__right
-  padding-left 10px
+  padding-left getSpace(1)
 
 .auctions-header, .auctions-my-active-bids h3
   text('largeTitle')
   padding-bottom getSpace(2)
-  border-bottom 1px solid gray-lighter-color
+  border-bottom 1px solid getColor('black10')
 
 .auctions-my-active-bids h3
-  margin-bottom 30px
+  margin-bottom getSpace(3)
   min-width 260px
 
 .my-active-bids-item-details
@@ -134,7 +134,7 @@
   margin-bottom -17px
 
 .af-hero-image
-  background center center gray-lightest-color
+  background center center getColor('black5')
   height 300px
   background-size cover
   position relative

--- a/src/desktop/apps/auctions/stylesheets/index.styl
+++ b/src/desktop/apps/auctions/stylesheets/index.styl
@@ -69,23 +69,25 @@
 .auctions-placeholder
   display table
   width 100%
+
 .auctions-placeholder-metadata
 .auctions-placeholder-hero
   display table-cell
   height 100%
   vertical-align middle
   text-align center
+
 .auctions-placeholder-metadata
   width 33.33%
   padding 0 50px 0 20px
   > h2
-    garamond-size('l-headline')
+    text('largeTitle')
     // Visually center. Due to line-height and hard-edged bottom button
     margin -((@font-size * (@line-height - 1)) * 2) auto 10px
   > p
+    text('subtitle')
     margin 20px 0
     padding 0 20px
-    garamond-size('l-body')
   > a
     white-space nowrap
 .auctions-placeholder-hero

--- a/src/desktop/apps/auctions/templates/index.jade
+++ b/src/desktop/apps/auctions/templates/index.jade
@@ -65,8 +65,8 @@ block body
           for auction in upcomingAuctions
             .ap-upcoming-item
               if auction.id == 'input-output'
-                a.fine-faux-underline.au-name( href= auction.href() ) Sotheby's Input/Output
+                a.au-name( href= auction.href() ) Sotheby's Input/Output
               else
-                a.fine-faux-underline.au-name( href= auction.href() )= auction.get('name')
+                a.au-name( href= auction.href() )= auction.get('name')
               .au-date Opens #{auction.overviewStartDate()}
 

--- a/src/desktop/apps/auctions/templates/placeholder.jade
+++ b/src/desktop/apps/auctions/templates/placeholder.jade
@@ -9,7 +9,7 @@
       p
         | Next Upcoming Auction:
         br
-        a.fine-faux-underline( href= nextAuction.href() )
+        a( href= nextAuction.href() )
           = nextAuction.get('name')
       .apu-clock.js-apu-clock( data-id= nextAuction.id )
         include ../../../components/clock/template

--- a/src/desktop/components/aggregate_page/index.styl
+++ b/src/desktop/components/aggregate_page/index.styl
@@ -1,4 +1,6 @@
 @require '../components/stylus_lib'
+@require '../components/stylus_lib'
+@require '../../../lib/palette'
 
 .aggregate-page
   padding 40px 0
@@ -8,8 +10,8 @@
   garamond-size('l-headline')
 
 .aggregate-page-subheader
-  margin 30px 0
-  avant-garde-size('m-headline', true)
+  text('mediumText')
+  margin getSpace(3, 0, 2, 0)
 
 .aggregate-page-items
   clearfix()
@@ -24,9 +26,10 @@
     border-bottom 1px solid gray-lighter-color
 
 .aggregate-page-items-upcoming
+  text('text')
+  padding-left getSpace(3)
   float left
   width 25%
-  padding-left 30px
 
 .aggregate-page-items-featured-set
   block-margins(120px)


### PR DESCRIPTION
Addresses: https://www.notion.so/artsy/Web-Type-Clean-up-94cae3cc227243e2a44128b315e65046?p=a78db6c1d4e24a59b78a52b2c9f5a65a

Signed off by @deliciousnachos ✅ 

- Updates page title, auction list items, sidebar
- Updates a zero state that wasn't in the comp — see below
- Does _not_ update countdown clocks, per discussion this morning
- Converts colors and spaces to Palette helpers

## Full page screenshot

See the first auction in the list for an example of the "live auction" label

<img width="100" src="https://user-images.githubusercontent.com/140521/93491860-2d9b5380-f8d8-11ea-8d4c-e16d380290b9.png" />

## Zero state before and after

When there are no current auctions, this header is displayed:

### Before

<img width="400" src="https://user-images.githubusercontent.com/140521/93491994-528fc680-f8d8-11ea-9c27-7679454af3a4.png" />

### After

<img width="400" src="https://user-images.githubusercontent.com/140521/93492010-57547a80-f8d8-11ea-8ff4-1a758954debc.png" />
