### PR TITLE
Revert heading of collect page for SEO juiciness

### DIFF
--- a/cypress/integration/collect.spec.js
+++ b/cypress/integration/collect.spec.js
@@ -16,7 +16,7 @@ describe("/collect", () => {
   })
 
   it("renders page content", () => {
-    cy.get("h1").should("contain", "Browse artworks")
+    cy.get("h1").should("contain", "Collect art and design online")
     artworkGridRenders()
   })
 })

--- a/src/test/acceptance/collect.js
+++ b/src/test/acceptance/collect.js
@@ -23,7 +23,7 @@ xdescribe("Collect page", () => {
 
   it("renders a title and header info", async () => {
     const $ = await browser.page("/collect")
-    $.html().should.containEql("Browse artworks")
+    $.html().should.containEql("Collect art and design online")
   })
 
   it("renders artwork grid", async () => {

--- a/src/v2/Apps/Collect/Routes/Collect/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collect/index.tsx
@@ -82,7 +82,7 @@ export const CollectApp: React.FC<CollectAppProps> = ({
 
               <Box mt={3}>
                 <Text variant="largeTitle">
-                  <h1>Browse artworks</h1>
+                  <h1>Collect art and design online</h1>
                 </Text>
                 <Separator mt={2} mb={[2, 2, 2, 4]} />
 


### PR DESCRIPTION
As pointed out by @joeyAghion, the heading on the collect page likely lost some SEO strength when I updated it in #6287. This reverts the heading to what it was.