### PR TITLE
Revert mobile fairs heading for SEO

### DIFF
--- a/src/mobile/apps/art_fairs/templates/index.jade
+++ b/src/mobile/apps/art_fairs/templates/index.jade
@@ -9,7 +9,9 @@ block content
       style= !currentFairs.length ? "background-image: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url('/images/fairs-header-img.jpg')" : ""
       class= !currentFairs.length ? "art-fairs-header--background-image" : ""
     )
-      h1 Fairs
+      h1 Collect from leading
+        br
+        | art fairs on Artsy
 
     #art-fairs-content.main-side-margin
 

--- a/src/mobile/apps/art_fairs/test/template.test.js
+++ b/src/mobile/apps/art_fairs/test/template.test.js
@@ -99,7 +99,7 @@ describe("Art fairs template", function () {
 
     // this test always fails ci
     return it("renders header with current fairs active", function () {
-      $(".art-fairs-header").html().should.containEql("Fairs")
+      $(".art-fairs-header").html().should.containEql("Collect from leading")
       return $(".art-fairs-tab[data-tab=current]").hasClass(
         "art-fairs-tab--active"
       )
@@ -135,7 +135,7 @@ describe("Art fairs template", function () {
     after(() => benv.teardown())
 
     return it("renders header with upcoming fairs active", function () {
-      $(".art-fairs-header").html().should.containEql("Fairs")
+      $(".art-fairs-header").html().should.containEql("Collect from leading")
       $(".art-fairs-header").hasClass("art-fairs-header--background-image")
       return $(".art-fairs-tab[data-tab=upcoming]").hasClass(
         "art-fairs-tab--active"


### PR DESCRIPTION
https://github.com/artsy/force/pull/6283 included a copy change to the H1 on the mobile fairs landing page. It was changed to just "Fairs". 

This PR reverts to:

![Screen Shot 2020-09-17 at 5 56 01 PM](https://user-images.githubusercontent.com/140521/93532589-55f27480-f90f-11ea-9a3b-dd9372904798.png)
