### PR TITLE
[Typography] Converts auction pages (above the fold)

### DIFF
--- a/src/desktop/apps/auction/components/artwork_rail/ArtworkRail.styl
+++ b/src/desktop/apps/auction/components/artwork_rail/ArtworkRail.styl
@@ -1,11 +1,13 @@
+@require '../../../../lib/palette'
+
 .auction-ArtworkRail
   user-select none
 
   &__title
-    font-size 30px
-    padding-top 30px
-    margin-top 30px
-    border-top 1px solid gray-lighter-color
+    text('title')
+    padding-top getSpace(3)
+    margin-top getSpace(3)
+    border-top 1px solid getColor('black10')
 
   &__content
     display flex
@@ -15,8 +17,9 @@
     &:hover svg
       visibility visible
 
-  &__page-left, &__page-right
-    width 50px
+  &__page-left
+  &__page-right
+    width getSpace(5)
     height 300px
     display flex
     align-items center
@@ -36,7 +39,7 @@
   &__artwork
     float left
     width 25%
-    padding 15px
+    padding getSpace(1.5)
     a
       text-decoration none
 
@@ -44,4 +47,4 @@
     pointer-events none
 
     svg
-      fill gray-lighter-color
+      fill getColor('black10')

--- a/src/desktop/apps/auction/components/layout/Banner.styl
+++ b/src/desktop/apps/auction/components/layout/Banner.styl
@@ -1,3 +1,5 @@
+@require '../../../../lib/palette'
+
 height-desktop = 240px
 height-mobile = 150px
 
@@ -5,14 +7,14 @@ height-mobile = 150px
   height height-desktop
   position relative
   overflow hidden
-  background-color gray-lighter-color
+  background-color getColor('black100')
 
   +respond-desktop()
-    margin-bottom 40px
+    margin-bottom getSpace(4)
 
   +respond-mobile()
     height height-mobile
-    margin-bottom 21px
+    margin-bottom getSpace(2)
 
   &__background-image
     background-size cover
@@ -32,7 +34,7 @@ height-mobile = 150px
       background-blend-mode none
 
   &_isLiveOpen
-    color white
+    color getColor('white100')
     text-align center
     height 600px
 
@@ -40,23 +42,22 @@ height-mobile = 150px
       height 200px
 
     h1
-      garamond-size('headline')
+      text('largeTitle')
+      margin-bottom getSpace(2)
 
       +respond-mobile()
-        garamond-size('s-headline')
+        margin-bottom getSpace(1)
 
     .avant-garde-button-white
-      background-color white
+      background-color getColor('white100')
       width 400px
-      margin-top 20px
-      padding 17px 0
+      padding getSpace(1.5)
       border 0
-      avant-garde-size('l-headline')
+      border-radius getSpace(0.3)
 
       +respond-mobile()
-        padding 10px
+        padding getSpace(1)
         width 90%
-        avant-garde-size('s-headline')
 
   &__live-details
     z-index 2
@@ -67,12 +68,8 @@ height-mobile = 150px
     transform translate(-50%, -50%)
 
   &__closed
-    avant-garde-size('xl-headline')
-
-    +respond-mobile()
-      avant-garde-size('l-headline')
-
-    color white
+    text('largeTitle')
+    color getColor('white100')
     z-index 2
     position absolute
     display flex

--- a/src/desktop/apps/auction/components/layout/active_bids/ActiveBidItem.styl
+++ b/src/desktop/apps/auction/components/layout/active_bids/ActiveBidItem.styl
@@ -1,10 +1,11 @@
 @require '../../../components/stylus_lib'
+@require '../../../../lib/palette'
 
 .auction-ActiveBidItem
   display flex
-  justify-content flext-start
+  justify-content flex-start
   align-items center
-  margin-bottom: 10px
+  margin-bottom getSpace(1)
 
   &__artwork-container
     text-align center
@@ -36,23 +37,21 @@
         overflow: auto
 
     h3
-      garamond-size('l-caption')
-      font-weight 600
+      text('text')
 
   +respond-mobile()
     .bid-status
-      padding-bottom 2px
       position relative
 
   &__title
-    garamond-size('l-caption')
+    text('text')
 
   &__lot-number
-    avant-garde-size('s-headline')
+    text('text')
 
-  &__current-bid, &__bids-num
-    garamond-size('l-caption')
-    font-style normal
+  &__current-bid
+  &__bids-num
+    text('text')
 
     +respond-mobile()
       display none
@@ -65,21 +64,19 @@
 
   &__current-and-bids
     +respond-mobile()
-      garamond-size('l-caption')
-      font-style normal
+      text('text')
       width 100%
 
       &::before
         display inline-block
         background-image url(/images/paddle.png)
         background-repeat no-repeat
-        background-position 2px 6px
-        -webkit-background-size 63%
-        -moz-background-size 63%
+        background-position center left
         background-size 63%
         padding-right 15px
         height 18px
         content ''
+        vertical-align middle
 
   &__img
     display inline-block
@@ -95,4 +92,4 @@
     .bid-status
       position relative
       p
-        avant-garde-size('s-headline')
+        text('text')

--- a/src/desktop/apps/auction/components/layout/active_bids/MyActiveBids.styl
+++ b/src/desktop/apps/auction/components/layout/active_bids/MyActiveBids.styl
@@ -1,26 +1,12 @@
 @require '../../../components/stylus_lib'
+@require '../../../../lib/palette'
 
 .auction-MyActiveBids
-  &__active-bid
-    display flex
-    justify-content space-between
-    height 130px
-    align-items center
-    border-bottom 1px solid gray-lighter-color
-
-    +respond-mobile()
-      justify-content flex-start
-
-    &:last-child
-      border-bottom none
-      margin-bottom 40px
   h2
-    garamond-size('headline')
-    padding 20px 0px
-    border-top 1px solid gray-lighter-color
+    text('title')
+    padding getSpace(2, 0)
+    border-top 1px solid getColor('black10')
 
     +respond-mobile()
-      font-weight 600
-      garamond-size('s-body')
-      padding-bottom 20px
-      margin-top: 20px
+      border-top 0
+      padding-top 0

--- a/src/desktop/apps/auction/components/layout/auction_info/AuctionInfo.styl
+++ b/src/desktop/apps/auction/components/layout/auction_info/AuctionInfo.styl
@@ -1,3 +1,5 @@
+@require '../../../../lib/palette'
+
 .auction-AuctionInfo
   clearfix()
 
@@ -41,6 +43,7 @@
       width 100%
 
     &__info-window-title
+      text('subtitle')
 
     &__info-window-close-button
       cursor pointer
@@ -90,7 +93,7 @@
       font-size size
       width size
       height size
-      border 2px solid gray-lighter-color
+      border 2px solid getColor('black10')
       display block
       padding-left 14px
       padding-top 2px
@@ -99,95 +102,71 @@
   // Main Content
 
   &__sub-header
-    avant-garde-size('body', true)
+    text('text')
 
   &__title
-    garamond-size('l-headline')
-    padding-right 30px
-
-    +respond-mobile()
-      garamond-size('l-body')
+    text('largeTitle')
+    padding-right getSpace(3)
 
   &__description
-    garamond-size('l-body')
-    margin 30px 0
+    text('text')
+    margin getSpace(2, 0)
     > p
-      block-margins(15px)
+      block-margins(getSpace(1.5))
     a
-      fine-faux-underline()
+      text-decoration underline
 
     +respond-mobile()
-      garamond-size('s-body')
-      margin 10px 0 20px 0
+      margin getSpace(1, 0, 2, 0)
 
   &__date-time
+    text('text')
+
     +respond-mobile()
-      margin-bottom 25px
+      text('small')
+      margin-bottom getSpace(2)
 
   &__register-button
-    margin-bottom 30px
-
-  &__metadata-cell
-    margin-bottom 20px
-
-    > h3
-      margin 0.5em 0
-      avant-garde-size('body', true)
-
-  &__metadata-cell-contents
-    > p
-      block-margins(10px)
+    margin-bottom getSpace(3)
 
   &__callout
-    border-bottom 1px solid gray-lighter-color
-    border-top 1px solid gray-lighter-color
-    garamond-size('l-body')
-    margin 20px 0
-    position relative
+    display flex
+    justify-content space-between
+    border-bottom 1px solid getColor('black10')
+    border-top 1px solid getColor('black10')
+    margin getSpace(2, 0)
 
     +respond-desktop()
-      padding 10px 0 12px 0
+      text('subtitle')
+      padding getSpace(1, 0)
 
     +respond-mobile()
+      text('caption')
       border-bottom 0
       border-top 0
-      garamond-size('s-body')
-      margin 0
+      margin getSpace(1, 0, 0, 0)
       padding 0
 
-  &__callout-live-label
-    position absolute
-    right 0
-    top 10px
-
-    +respond-mobile()
-      avant-garde-size('s-headline')
-      position relative
-      top -5px
-
   &__live-label
-    avant-garde-size('body')
-    letter-spacing 3px
+    text('subtitle')
 
     +respond-mobile()
-      avant-garde-size('s-headline')
-
+      text('small')
 
   &__live-tooltip
-    garamond-size('s-body')
     margin-left 10px
     margin-left 14px
     top -3px
 
     &:hover::before
-      background gray-darker-color
+      background getColor('black60')
       border 0
-      color white
+      color getColor('white100')
 
     &::before
       background transparent
-      border 1px solid gray-lighter-color
-      color black
+      border 1px solid getColor('black10')
+      color getColor('black100')
       width 20px
       height @width
       line-height @width - 1px

--- a/src/desktop/apps/auction/components/layout/auction_info/Registration.styl
+++ b/src/desktop/apps/auction/components/layout/auction_info/Registration.styl
@@ -1,66 +1,66 @@
+@require '../../../../lib/palette'
+
 .auction-Registration
+  text('text')
+
   +respond-mobile()
-    padding-bottom 20px
+    padding-bottom getSpace(2)
 
     &:after
       content ''
-      border-bottom 1px solid #e5e5e5
+      border-bottom 1px solid getColor('black10')
       width 120%
       right 0
       position absolute
-      padding-top 20px
+      padding-top getSpace(2)
 
   &__wrapper
-    border 1px solid gray-lighter-color
-    padding 20px 20px 10px
+    border 1px solid getColor('black10')
+    padding getSpace(2, 2, 1)
 
     +respond-desktop()
-      margin-bottom 20px
+      margin-bottom getSpace(2)
 
     +respond-mobile()
       border none
-      margin-top 16px
+      margin-top getSpace(1.5)
       padding 0
 
 
   &__small
-    color gray-dark-color
-    padding-top 20px
+    color getColor('black60')
+    padding-top getSpace(2)
     text-align center
 
     +respond-mobile()
-      padding-top 15px
+      padding-top getSpace(1.5)
 
     &_warning
-      color #f0cc49
+      color getColor('yellow100')
 
   &__preview
     p
-      garamond-size('l-body')
-      margin-bottom 15px
+      margin-bottom getSpace(1.5)
     .bordered-input
-      margin-bottom 15px
+      margin-bottom getSpace(1.5)
 
   &__approved
-    color new-green-color
-    garamond-size('l-body')
+    color getColor('green100')
 
     +respond-desktop()
-      margin-bottom 20px
-      padding-left 20px
+      margin-bottom getSpace(2)
+      padding-left getSpace(2)
 
     +respond-mobile()
-      garamond-size('s-body')
-      margin-top 15px
+      margin-top getSpace(1)
       padding-left 0
 
       .icon-check
         display none
 
     .icon-check
-      color new-green-color
+      color getColor('green100')
       width 23px
-      //
       border 2px solid
       border-color @color
       border-radius @width
@@ -73,17 +73,17 @@
 
   &__how-to-bid
     display block
-    margin 0 0 20px 0
+    margin getSpace(0, 0, 2, 0)
     text-decoration none
 
     img
       display inline-block
       height 40px
-      margin-right 15px
+      margin-right getSpace(1.5)
       vertical-align middle
 
   &__wrapper + &__how-to-bid
-    margin-top 30px
+    margin-top getSpace(3)
 
   &__how-to-bid, &__question
-    margin-left 20px
+    margin-left getSpace(2)

--- a/src/desktop/apps/auctions/stylesheets/index.styl
+++ b/src/desktop/apps/auctions/stylesheets/index.styl
@@ -118,12 +118,15 @@
 .auction-cta-group .auction-cta-group__right
   padding-left getSpace(1)
 
-.auctions-header, .auctions-my-active-bids h3
+.auctions-header
   text('largeTitle')
+
+.auctions-header, .auctions-my-active-bids h3
   padding-bottom getSpace(2)
   border-bottom 1px solid getColor('black10')
 
 .auctions-my-active-bids h3
+  text('title')
   margin-bottom getSpace(3)
   min-width 260px
 

--- a/src/desktop/apps/fair/stylesheets/overview.styl
+++ b/src/desktop/apps/fair/stylesheets/overview.styl
@@ -1,4 +1,5 @@
 @require '../../../components/stylus_lib'
+@require '../../../../lib/palette'
 
 browse-container-width = 663px
 browse-container-height = 442px
@@ -364,12 +365,15 @@ html[data-useragent*="Firefox"]
   margin-top: 25px
 
 .clock
-  margin-top 15px
-  text-align: left
-  .clock-header
-    text-transform: none
-    font-size: 17px
-    margin-bottom: 5px
+  .clock-value
+    align-items flex-start
+
+    small
+      text('small')
+
+  .clock-separator
+    padding-right getSpace(1)
+
   .clock-closed
     display none
 

--- a/src/desktop/apps/fair_organizer/stylesheets/index.styl
+++ b/src/desktop/apps/fair_organizer/stylesheets/index.styl
@@ -184,10 +184,9 @@ browse-container-height = 442px
 .fair-organizer-top__countdown__clock .clock-header
   border 0
   padding 0
-  margin 20px 0
+  margin 20px 0 0 0
   text-align left
 
 .fair-organizer-top__countdown__clock .clock
   width 190px
-  margin-top 10px
   white-space nowrap

--- a/src/desktop/components/add_to_calendar/index.coffee
+++ b/src/desktop/components/add_to_calendar/index.coffee
@@ -1,14 +1,12 @@
 Backbone = require 'backbone'
 
 module.exports = class AddToCalendar extends Backbone.View
-
   events:
     'mouseover .add-to-calendar-event-item-date__add-to-calender': 'showCalenderOptions'
     'mouseleave .add-to-calendar__wrapper': 'hideCalenderOptions'
 
   showCalenderOptions: (e) ->
     e.preventDefault()
-    @$el.find('.add-to-calendar__wrapper').css({height: '205px'})
     $(e.currentTarget).next().show()
 
   hideCalenderOptions: (e) ->

--- a/src/desktop/components/add_to_calendar/index.styl
+++ b/src/desktop/components/add_to_calendar/index.styl
@@ -1,43 +1,45 @@
+@require '../../lib/palette'
+
 .add-to-calendar
   position relative
   display inline-block
 
-  &__wrapper
-    position absolute
-    width 150px
-    top -18px
-
 .add-to-calendar-event-item-date
   &__add-to-calender
-    color gray-dark-color
-    font-size 17px
+    text('text')
+    color getColor('black60')
     text-decoration none
 
 .add-to-calendar-event-calendar-wrapper
   display none
-  margin-top 10px
   position absolute
   z-index 100
+  top 100%
+  left 50%
+  transform translateX(-50%)
+
   .add-to-calendar-event-arrow-up
+    position relative
     width 0
     height 0
     border-left 8px solid transparent
     border-right 8px solid transparent
-    border-bottom 8px solid black
-    margin-left 70px
+    border-bottom 8px solid getColor('black100')
+    left 50%
+    transform translateX(-50%)
+
   .add-to-calendar-event-calendar-container
-    width 150px
-    height 160px
-    background-color #000
-    padding-top 15px
+    text('text')
+    min-width 150px
+    background-color getColor('black100')
+    padding getSpace(1, 0)
+
     a
       width 100%
       display block
-      color white
-      garamond()
+      color getColor('white100')
       text-decoration none
-      font-size 17px
-      padding 0 20px
-      line-height 2
-    a:hover
-      background-color gray-darkest-color
+      padding getSpace(0.5, 2)
+
+      &:hover
+        background-color getColor('black60')

--- a/src/desktop/components/bid_status/index.styl
+++ b/src/desktop/components/bid_status/index.styl
@@ -1,25 +1,34 @@
+@require '../../../lib/palette'
+
 .bid-status
   p
-    color new-red-color
-    avant-garde()
-    avant-garde-size('m-headline')
+    text('small')
+    color getColor('red100')
+
   &__is-winning p
-    color new-green-color
+    color getColor('green100')
+
   &__is-winning-reserve-not-met p
-    color new-yellow-color
+    color getColor('yellow100')
+
   &__is-losing p
-    color new-red-color
+    color getColor('red100')
+
   &__increase-bid
     color gray-dark-color
     display none
-  &__arrow-up, &__arrow-down
+
+  &__arrow-up
+  &__arrow-down
     position relative
     fill currentColor
     padding-left 3px
     svg
       margin-left 4px
       height .8em
+
   &__arrow-up svg
     transform rotate(180deg)
+
   &__arrow-down svg
     transform rotate(0deg)

--- a/src/desktop/components/chevron_list/index.styl
+++ b/src/desktop/components/chevron_list/index.styl
@@ -1,6 +1,7 @@
 @require '../../components/stylus_lib'
+@require '../../../lib/palette'
 
-overlapping-border(border-color = gray-lighter-color)
+overlapping-border(border-color = getColor('black10'))
   border-top 1px solid border-color
   border-bottom @border-top
   margin-top -1px
@@ -12,7 +13,7 @@ chevron()
   &::after
     iconfont-styling()
     content '\e607'
-    color gray-color
+    color getColor('black30')
     vertical-align middle
     position absolute
     top 50%
@@ -33,16 +34,17 @@ chevron-item()
 .small-chevron-list a
   chevron-item()
   overlapping-border()
-  padding 15px 5px
+  padding getSpace(1.5, 0.5)
 
 // Nav
 .chevron-nav-list a
+  text('text')
   chevron-item()
   overlapping-border()
-  avant-garde-size('m-headline', true)
-  padding 14px 0
+  padding getSpace(1.5, 0)
+
   &.is-active
-    color purple-color
+    color getColor('purple100')
 
 // Large
 .large-chevron-list a
@@ -54,6 +56,6 @@ chevron-item()
     font-size 40px
     right 10px
   &:hover
-    background-color gray-lightest-color
+    background-color getColor('black5')
     border-color @background-color
     z-index 1

--- a/src/desktop/components/clock/index.styl
+++ b/src/desktop/components/clock/index.styl
@@ -1,65 +1,36 @@
 @require '../stylus_lib'
-
-header-font-size = garamond-s-body-font-size
-value-font-size = avant-garde-l-headline-font-size
-small-font-size = 9px
-closed-font-size = avant-garde-body-font-size
-closed-border-size = 2px
-clock-height = (header-font-size + (value-font-size * 2) + small-font-size)
-closed-padding = (((clock-height - closed-font-size) - (closed-border-size * 2)) / 2)
+@require '../../lib/palette'
 
 .clock
   display inline-block
-  height clock-height
   text-align left
 
-  +respond-mobile()
-    height 50px
-
 .clock-header
-  font-size header-font-size
-  line-height 1
-
-  +respond-mobile()
-    font-size 8px
+  text('mediumText')
 
 .clock-value
-  avant-garde()
-  prevent-content-shift()
+  text('mediumText')
+  display flex
+  align-items center
   list-style none
-  font-size value-font-size
-  line-height 2
+  text-transform capitalize
+
   li
     display inline-block
     vertical-align top
-    inline-block-margins(3px)
-
-    +respond-mobile()
-      margin -7px -3px
 
     small
+      text('mediumText')
       display block
-      color transparify(gray-dark-color, black)
-      font-size small-font-size
-      line-height 1
+      color transparify(getColor('black60'), getColor('black100'))
 
 .clock-closed
+  text('subtitle')
   position relative
-  padding closed-padding 0
-  avant-garde()
-  font-size closed-font-size
-  line-height 1
-  border-top 2px solid black
-  border-bottom @border-top
   text-align center
-  // Often overwritten unintentionally
-  text-transform uppercase !important
-
-  +respond-mobile()
-    avant-garde-size('l-headline')
 
 .white-overlay-clock
-  color white
+  color getColor('white100')
   left 50%
   top 50%
   display inline-block
@@ -68,34 +39,25 @@ closed-padding = (((clock-height - closed-font-size) - (closed-border-size * 2))
   z-index 1
 
   .clock-header.clock-closed
-    avant-garde-size('xl-headline')
-    color white
+    text('subtitle')
+    color color('white100')
     border 0
-    letter-spacing 2px
-
-    +respond-mobile()
-      avant-garde-size('l-headline')
 
   .clock
     text-align center
 
   .clock-header
-    margin-bottom 5px
-    avant-garde-size('s-headline')
+    margin-bottom getSpace(0.5)
 
-    +respond-mobile()
-      font-size 8px
-      margin-bottom 2px
+  .clock-months
+  .clock-days
+  .clock-hours
+  .clock-minutes
+  .clock-seconds
+    text('subtitle')
+    margin getSpace(0, 1)
 
-  .clock-months, .clock-days, .clock-hours, .clock-minutes, .clock-seconds
-    avant-garde-size('l-headline')
-    margin 0 12px
     small
-      avant-garde-size('s-headline')
-      color white
-      margin-top 5px
-
-      +respond-mobile()
-        font-size 8px
-        margin-top 2px
-        margin-bottom 2px
+      text('mediumText')
+      color getColor('white100')
+      margin-top getSpace(0.5)

--- a/src/desktop/components/clock/view.coffee
+++ b/src/desktop/components/clock/view.coffee
@@ -67,7 +67,7 @@ module.exports = class ClockView extends Backbone.View
             <small>#{label}</small>
           </li>
         """
-    )).join '<li>:</li>'
+    )).join '<li class="clock-separator">:</li>'
 
     # emit event every render when timer is almost over
     if @toDate?.diff(moment(), 'seconds') < @almostOver

--- a/src/desktop/components/my_active_bids/index.styl
+++ b/src/desktop/components/my_active_bids/index.styl
@@ -1,11 +1,14 @@
 @require '../stylus_lib'
 @require '../bid_status'
+@require '../../lib/palette'
 
 item-margin-bottom = 16px
 
-.my-active-bids-bid-button, .my-active-bids-bid-live-button, .my-active-bids-warning, .my-active-bids-item h4
-  avant-garde()
-  font-size 10px
+.my-active-bids-bid-button
+.my-active-bids-bid-live-button
+.my-active-bids-warning
+.my-active-bids-item h4
+  text('small')
 
 .my-active-bids-item
   position relative
@@ -13,16 +16,16 @@ item-margin-bottom = 16px
   min-width 260px
   margin-bottom item-margin-bottom
   padding-bottom item-margin-bottom
-  border-bottom 1px solid gray-lighter-color
+  border-bottom 1px solid getColor('black10')
   &:last-child
     border-bottom 0
   &.my-active-bids-winning
     .my-active-bids-bid-button
       background transparent
-      color black
-      border-color gray-lighter-color
+      color getColor('black100')
+      border-color getColor('black10')
       &:hover
-        color purple-color
+        color getColor('purple100')
   img
     margin-right 12px
     width 60px
@@ -45,8 +48,6 @@ item-margin-bottom = 16px
   position absolute
   top 0
   right 0
-  p
-    font-size 10px
 
 .my-active-bids-bid-button
   small-avant-garde()


### PR DESCRIPTION
So this is primarily dealing with the desktop/mobile above the fold auction pages, but there's some bleed into a few global things.

* The add to calendar component, which was only also used on the fair events page — tested there and looks good.
* The clock component — this one I'm not 100% on all the actual active call sites. It appears that there's a different clock that's used, for instance, on artwork pages. If someone can point out other places the CoffeeScript version lives, I'd like to double check them.
* Active bids, which is used in the auctions index and shows up in settings, in addition to the actual auction pages

----

![](http://static.damonzucconi.com/_capture/W7nNKGcTH6Tk.png)

![](http://static.damonzucconi.com/_capture/WKU3fKcdfnpj.png)

![](http://static.damonzucconi.com/_capture/tyP7yoP7My3I.png)

----

![](http://static.damonzucconi.com/_capture/POhw8XWCWDTZ.png)

![](http://static.damonzucconi.com/_capture/d5SuE3qKHXg3.png)

![](http://static.damonzucconi.com/_capture/e3xDeEYHVlkG.png)

![](http://static.damonzucconi.com/_capture/uKsLO1Bvnrya.png)

----

![](http://static.damonzucconi.com/_capture/VcaaqSBpkmyy.png)

----

![](http://static.damonzucconi.com/_capture/zMWgT70HAJdD.png)

----

![](http://static.damonzucconi.com/_capture/fgeq1UTabIsX.png)