### PR TITLE
Typography cleanup: Search results page

### DIFF
--- a/src/v2/Apps/Search/Components/SendFeedback.tsx
+++ b/src/v2/Apps/Search/Components/SendFeedback.tsx
@@ -4,7 +4,7 @@ import {
   CheckCircleIcon,
   Flex,
   Input,
-  Serif,
+  Text,
   TextArea,
   color,
 } from "@artsy/palette"
@@ -176,10 +176,10 @@ class SendFeedbackForm extends React.Component<SystemContextProps, State> {
       <>
         <CheckCircleIcon />
         <Box mt={1} textAlign="center">
-          <Serif size="4">Your message has been sent!</Serif>
+          <Text variant="text">Your message has been sent!</Text>
         </Box>
         <Box>
-          <Serif size="2">Thank you for helping to improve Artsy.</Serif>
+          <Text variant="caption">Thank you for helping to improve Artsy.</Text>
         </Box>
       </>
     )
@@ -190,13 +190,13 @@ class SendFeedbackForm extends React.Component<SystemContextProps, State> {
     return (
       <>
         <Box textAlign="center">
-          <Serif size="5">Your feedback is important to us.</Serif>
-        </Box>
-        <Box>
-          <Serif size="3">
+          <Text variant="subtitle" mb={1}>
+            Your feedback is important to us.
+          </Text>
+          <Text variant="text">
             Tell us how we can improve and help you find what you are looking
             for.
-          </Serif>
+          </Text>
         </Box>
         {!user ? this.renderPersonalInfoInputs() : null}
         {this.renderFeedbackTextArea()}

--- a/src/v2/Apps/Search/Components/ZeroState.tsx
+++ b/src/v2/Apps/Search/Components/ZeroState.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Serif } from "@artsy/palette"
+import { Box, Flex, Text } from "@artsy/palette"
 import { SendFeedback } from "v2/Apps/Search/Components/SendFeedback"
 import { useArtworkFilterContext } from "v2/Components/v2/ArtworkFilter/ArtworkFilterContext"
 import React, { FC } from "react"
@@ -21,14 +21,14 @@ export const ZeroState: FC<ZeroStateProps> = props => {
       justifyContent="center"
     >
       <Box m={3} textAlign="center">
-        <Serif size="6">
+        <Text variant="subtitle" mb={1}>
           {hasFilters ? "No results found." : `No results found for "${term}".`}
-        </Serif>
-        <Serif size="3">
+        </Text>
+        <Text variant="text">
           {hasFilters
             ? "Try removing some filters or try another search term."
             : "Try checking for spelling errors or try another search term."}
-        </Serif>
+        </Text>
       </Box>
       <Box width="100%">
         <SendFeedback />

--- a/src/v2/Apps/Search/SearchApp.tsx
+++ b/src/v2/Apps/Search/SearchApp.tsx
@@ -1,4 +1,4 @@
-import { Box, Col, Row, Separator, Serif, Spacer } from "@artsy/palette"
+import { Box, Col, Row, Separator, Spacer, Text } from "@artsy/palette"
 import { SearchApp_viewer } from "v2/__generated__/SearchApp_viewer.graphql"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
@@ -39,7 +39,7 @@ const TotalResults: React.SFC<{ count: number; term: string }> = ({
     setResults(formatResults())
   }, [count, formatResults])
 
-  return <Serif size="5">{results}</Serif>
+  return <Text variant="subtitle">{results}</Text>
 }
 
 @track({


### PR DESCRIPTION
Most of the type on this page was cleaned up by #6287. Included here are updates to the page heading and the "no search results" view.


## Desktop

### With results
![image](https://user-images.githubusercontent.com/1627089/93630889-5b53cb80-f9b0-11ea-819f-3677c5a0d867.png)

### Without results

![image](https://user-images.githubusercontent.com/1627089/93637086-9e1aa100-f9ba-11ea-834b-f4d9d3bcb591.png)

## Mobile

## With results

![image](https://user-images.githubusercontent.com/1627089/93631004-850cf280-f9b0-11ea-871e-8655b41a7b82.png)

### Without results

![image](https://user-images.githubusercontent.com/1627089/93637212-d15d3000-f9ba-11ea-9b6c-ea9ff1bd27b0.png)

