### PR TITLE
Search results typography followup: minor changes

### DIFF
--- a/src/v2/Apps/Search/Components/ZeroState.tsx
+++ b/src/v2/Apps/Search/Components/ZeroState.tsx
@@ -22,7 +22,9 @@ export const ZeroState: FC<ZeroStateProps> = props => {
     >
       <Box m={3} textAlign="center">
         <Text variant="subtitle" mb={1}>
-          {hasFilters ? "No results found." : `No results found for "${term}".`}
+          {hasFilters
+            ? "No results found."
+            : `No results found for \u201C${term}\u201D.`}
         </Text>
         <Text variant="text">
           {hasFilters

--- a/src/v2/Apps/Search/SearchApp.tsx
+++ b/src/v2/Apps/Search/SearchApp.tsx
@@ -29,7 +29,9 @@ const TotalResults: React.SFC<{ count: number; term: string }> = ({
 }) => {
   const formatResults = useCallback(
     () =>
-      `${count.toLocaleString()} Result${count > 1 ? "s" : ""} for "${term}"`,
+      `${count.toLocaleString()} result${
+        count > 1 ? "s" : ""
+      } for \u201C${term}\u201D`,
     [count, term]
   )
 

--- a/src/v2/Apps/Search/__tests__/SearchApp.jest.tsx
+++ b/src/v2/Apps/Search/__tests__/SearchApp.jest.tsx
@@ -52,7 +52,7 @@ describe("SearchApp", () => {
   it("includes the total count", () => {
     const wrapper = getWrapper(props).find("TotalResults")
     const html = wrapper.text()
-    expect(html).toContain('520 Results for "andy"')
+    expect(html).toContain("520 results for \u201Candy\u201D")
   })
 
   it("includes tabs w/ counts", () => {


### PR DESCRIPTION
Based on feedback from @nicoleyeo, this PR makes a couple small changes to the search results page.

1. Change from title case to sentence case for results headline ("1001 Results" -> "1001 results")
2. Use left/right quotation marks instead of neutral ones.

## When there are results:
![image](https://user-images.githubusercontent.com/1627089/93646151-45073900-f9cb-11ea-9f37-1af95876c533.png)

## When there are no results:
![image](https://user-images.githubusercontent.com/1627089/93646275-8566b700-f9cb-11ea-8e5c-3e724afe13d8.png)

## Followup

This work will break integrity tests. [Here's a followup PR to fix them once this is merged](https://github.com/artsy/integrity/pull/186).
