### PR TITLE
fix: Correct a faulty href in submenu data

### DIFF
--- a/src/v2/Components/NavBar/menuData.ts
+++ b/src/v2/Components/NavBar/menuData.ts
@@ -34,7 +34,7 @@ export const ARTISTS_SUBMENU_DATA: MenuLinkData = {
       },
       {
         text: "Black Figurative Painters on the Rise",
-        href: "/collection/the-rise-of-craft",
+        href: "/collection/black-figurative-painters",
       },
       {
         text: "Modern & Contemporary Masters",


### PR DESCRIPTION
Quick small fix for a faulty submenu href:

### Before

![Screen Shot 2020-09-18 at 5 37 27 PM](https://user-images.githubusercontent.com/140521/93772847-53349f80-fbed-11ea-81d8-05322fa16b8f.png)

### After

![Screen Shot 2020-09-21 at 9 30 12 AM](https://user-images.githubusercontent.com/140521/93772849-53cd3600-fbed-11ea-81f7-8293fc82510b.png)
