### PR TITLE
@anandaroop => [Filter] Expose 18th Century & Earlier period filter

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
@@ -70,4 +70,5 @@ const allowedPeriods = [
   "Late 19th Century",
   "Mid 19th Century",
   "Early 19th Century",
+  "18th Century & Earlier",
 ]

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/TimePeriodFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/TimePeriodFilter.jest.tsx
@@ -32,23 +32,23 @@ describe("TimePeriodFilter", () => {
               name: "Late 19th Century",
               value: "foo-period",
             },
+            {
+              name: "18th Century & Earlier",
+              value: "bar-period",
+            },
           ],
         },
       ],
     })
 
     expect(wrapper.html()).toContain("Late 19th Century")
+    expect(wrapper.html()).toContain("18th Century &amp; Earlier")
     expect(wrapper.html()).not.toContain("2010")
   })
 
   it("updates context on filter change", done => {
     const wrapper = getWrapper()
-    wrapper
-      .find("Radio")
-      .first()
-      .find("Flex")
-      .first()
-      .simulate("click")
+    wrapper.find("Radio").first().find("Flex").first().simulate("click")
 
     setTimeout(() => {
       expect(context.filters.majorPeriods).toEqual(["2010"])


### PR DESCRIPTION
Now that artworks are re-indexed, we can expose this filter! The results are still messy, lots of free form text entry, etc.

But, maybe its fine? At the very least it's easy enough to hide, and it might serve to stimulate discussion around...possibly cleaning up or structuring the date fields and Volt inputs?