### PR TITLE
[PURCHASE-2121] Point canonical to Gallery root url for mobile partner pages

### DIFF
--- a/src/mobile/components/layout/templates/head.jade
+++ b/src/mobile/components/layout/templates/head.jade
@@ -13,7 +13,12 @@ link( rel='apple-touch-icon', sizes='76x76', href=asset('/images/icon-76.png') )
 link( rel='apple-touch-icon', sizes='120x120', href=asset('/images/icon-120.png') )
 link( rel='apple-touch-icon', sizes='152x152', href=asset('/images/icon-152.png') )
 link( rel='apple-touch-icon', href=asset('/images/icon-152.png') )
-link( href="#{sd.APP_URL}#{sd.CURRENT_PATH}", rel="canonical" )
+
+if sd.PAGE_TYPE == "partner" && sd.PROFILE.id
+ link( href="#{sd.APP_URL}/#{sd.PROFILE.id}", rel="canonical" )
+else 
+  link( href="#{sd.APP_URL}#{sd.CURRENT_PATH}", rel="canonical" )
+
 //- Include asset package's CSS
 link( type='text/css', rel='stylesheet', href=('//fast.fonts.net/cssapi/f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.css') )
 link( type='text/css', rel='stylesheet', href=asset('/assets/' + assetPackage + '.css') )


### PR DESCRIPTION
Mirrors the new behavior we just implemented for [Gallery pages on desktop](https://github.com/artsy/force/pull/6260/files). 


We want the same behavior applied on mobile screens.

<img width="1900" alt="Screen Shot 2020-09-21 at 1 05 59 PM" src="https://user-images.githubusercontent.com/12748344/93801747-758be480-fc10-11ea-893a-28ef67a94602.png">







Addresses https://artsyproduct.atlassian.net/browse/PURCHASE-2121

