### PR TITLE
[Typography] Update responsive collection and collections landing pages

### DIFF
--- a/src/v2/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Sans, Serif, color } from "@artsy/palette"
+import { Box, Flex, Text, color } from "@artsy/palette"
 import { ArtistSeriesEntity_member } from "v2/__generated__/ArtistSeriesEntity_member.graphql"
 import { useTracking } from "v2/Artsy/Analytics/useTracking"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
@@ -81,19 +81,17 @@ export const ArtistSeriesEntity: React.FC<ArtistSeriesEntityProps> = ({
               })
             : headerImage && <ArtworkImage src={headerImage} width={221} />}
         </ImgWrapper>
-        {
-          <CollectionTitle pt={1} pb={0.5} size="3">
-            <Truncator maxLineCount={1}>{title}</Truncator>
-          </CollectionTitle>
-        }
+        <Text variant="text" pt={2}>
+          <Truncator maxLineCount={1}>{title}</Truncator>
+        </Text>
         {price_guidance && (
-          <Sans size="2" color="black60" pb={1}>
+          <Text variant="small" color="black60" pb={1}>
             From $
             {currency(price_guidance, {
               separator: ",",
               precision: 0,
             }).format()}
-          </Sans>
+          </Text>
         )}
       </StyledLink>
     </Container>
@@ -136,10 +134,6 @@ const SingleImgContainer = styled(Box)`
   &:last-child {
     margin-right: 0;
   }
-`
-
-const CollectionTitle = styled(Serif)`
-  width: 100%;
 `
 
 export const ImgWrapper = styled(Flex)`

--- a/src/v2/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Serif, color } from "@artsy/palette"
+import { Box, Text, color } from "@artsy/palette"
 import { ArtistSeriesRail_collectionGroup } from "v2/__generated__/ArtistSeriesRail_collectionGroup.graphql"
 import { Carousel } from "v2/Components/Carousel"
 import React from "react"
@@ -14,9 +14,9 @@ export const ArtistSeriesRail: React.FC<ArtistSeriesRailProps> = ({
 }) => {
   return (
     <Content mt={2} py={3}>
-      <Serif size="5" mb={1}>
+      <Text variant="subtitle" pb={2}>
         {name}
-      </Serif>
+      </Text>
 
       <Carousel>
         {members.map((slide, slideIndex) => {

--- a/src/v2/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index.tsx
@@ -1,12 +1,4 @@
-import {
-  Box,
-  Flex,
-  ResponsiveImage,
-  Sans,
-  Serif,
-  Spacer,
-  color,
-} from "@artsy/palette"
+import { Box, Flex, ResponsiveImage, Spacer, Text, color } from "@artsy/palette"
 import { FeaturedCollectionsRails_collectionGroup } from "v2/__generated__/FeaturedCollectionsRails_collectionGroup.graphql"
 import { useTracking } from "v2/Artsy/Analytics/useTracking"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
@@ -30,9 +22,9 @@ export const FeaturedCollectionsRails: React.FC<Props> = ({
 }) => {
   return (
     <FeaturedCollectionsContainer>
-      <Serif size="5" mt={3} mb={1}>
+      <Text variant="subtitle" pt={3} pb={2}>
         {name}
-      </Serif>
+      </Text>
 
       <Carousel>
         {members.map((slide, slideIndex) => {
@@ -95,9 +87,7 @@ export const FeaturedCollectionEntity: React.FC<FeaturedCollectionEntityProps> =
           return (
             <>
               {`... `}
-              <ReadMoreLink size="2" weight="medium" display="inline">
-                Read more
-              </ReadMoreLink>
+              <ReadMoreLink display="inline">Read more</ReadMoreLink>
             </>
           )
         }}
@@ -124,16 +114,21 @@ export const FeaturedCollectionEntity: React.FC<FeaturedCollectionEntityProps> =
             })}
           />
         </Flex>
-        <Serif size="4" mt={1} maxWidth={["246px", "100%"]}>
+        <Text variant="subtitle" mt={1} maxWidth={["246px", "100%"]}>
           <Truncator maxLineCount={1}>{title}</Truncator>
-        </Serif>
+        </Text>
         {price_guidance && (
-          <Sans size="2" color="black60">{`From $${formattedPrice}`}</Sans>
+          <Text variant="small" color="black60">
+            {`From $${formattedPrice}`}
+          </Text>
         )}
-        <ExtendedSerif size="3" mt={1}>
-          <Media lessThan="md">{getTruncatedDescription(4)}</Media>
-          <Media greaterThan="sm">{getTruncatedDescription(3)}</Media>
-        </ExtendedSerif>
+        {/* TODO: fix this truncation/overflow issue properly, rather than this overflow:hidden Box */}
+        <Box style={{ overflow: "hidden" }}>
+          <ExtendedText mt={1}>
+            <Media lessThan="md">{getTruncatedDescription(4)}</Media>
+            <Media greaterThan="sm">{getTruncatedDescription(3)}</Media>
+          </ExtendedText>
+        </Box>
       </StyledLink>
     </Container>
   )
@@ -173,7 +168,7 @@ const FeaturedCollectionsContainer = styled(Box)`
   border-top: 1px solid ${color("black10")};
 `
 
-const ExtendedSerif = styled(Serif)`
+const ExtendedText = styled(Text)`
   div span {
     span p {
       display: inline;
@@ -197,6 +192,6 @@ export const StyledLink = styled(RouterLink)`
   }
 `
 
-const ReadMoreLink = styled(Sans)`
+const ReadMoreLink = styled(Text).attrs({ variant: "mediumText" })`
   text-decoration: underline;
 `

--- a/src/v2/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, ResponsiveImage, Serif, color } from "@artsy/palette"
+import { Box, Flex, ResponsiveImage, Text, color } from "@artsy/palette"
 import { OtherCollectionEntity_member } from "v2/__generated__/OtherCollectionEntity_member.graphql"
 import { useTracking } from "v2/Artsy/Analytics/useTracking"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
@@ -54,7 +54,7 @@ export const OtherCollectionEntity: React.FC<CollectionProps> = ({
           </ImageContainer>
         )}
         <Box>
-          <TitleContainer size="3" px={2}>
+          <TitleContainer variant="text" px={2}>
             {title}
           </TitleContainer>
         </Box>
@@ -100,7 +100,7 @@ export const ThumbnailImage = styled(ResponsiveImage)`
   border-radius: 2px 1px 1px 2px;
 `
 
-const TitleContainer = styled(Serif)`
+const TitleContainer = styled(Text)`
   width: max-content;
   white-space: nowrap;
 `

--- a/src/v2/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Serif, color } from "@artsy/palette"
+import { Box, Text, color } from "@artsy/palette"
 import { OtherCollectionsRail_collectionGroup } from "v2/__generated__/OtherCollectionsRail_collectionGroup.graphql"
 import { Carousel } from "v2/Components/Carousel"
 import React from "react"
@@ -14,9 +14,9 @@ export const OtherCollectionsRail: React.FC<OtherCollectionsRailProps> = ({
 }) => {
   return (
     <Container mb={4}>
-      <Serif size="5" mt={3} mb={2}>
+      <Text variant="subtitle" pt={3} pb={2}>
         {name}
-      </Serif>
+      </Text>
 
       <Carousel>
         {members.map((slide, index) => {

--- a/src/v2/Apps/Collect/Routes/Collection/Components/Header/FeaturedArtists.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/Header/FeaturedArtists.tsx
@@ -1,4 +1,4 @@
-import { Box, Breakpoint, EntityHeader, Flex, Sans } from "@artsy/palette"
+import { Box, Breakpoint, EntityHeader, Flex, Text } from "@artsy/palette"
 import React, { useState } from "react"
 import styled from "styled-components"
 
@@ -18,9 +18,7 @@ export const FeaturedArtists: React.FC<FeaturedArtistsProps> = props => {
 
   return (
     <Box pb={1}>
-      <Sans size="2" weight="medium" pb={15}>
-        {headlineLabel}
-      </Sans>
+      <Text pb={15}>{headlineLabel}</Text>
       <Flex flexWrap="wrap">
         {showAll || featuredArtists.length <= artistCount ? (
           featuredArtists
@@ -49,7 +47,7 @@ export const FeaturedArtists: React.FC<FeaturedArtistsProps> = props => {
   )
 }
 
-const ViewMore = styled(Sans)`
+const ViewMore = styled(Text)`
   div {
     div {
       text-decoration: underline;

--- a/src/v2/Apps/Collect/Routes/Collection/Components/Header/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/Header/index.tsx
@@ -1,17 +1,6 @@
 import { ContextModule, Intent } from "@artsy/cohesion"
-import { EntityHeader, ReadMore, breakpoints } from "@artsy/palette"
-import {
-  Box,
-  Col,
-  Flex,
-  Grid,
-  Row,
-  Sans,
-  Serif,
-  Spacer,
-  color,
-  media,
-} from "@artsy/palette"
+import { EntityHeader, ReadMore, Text, breakpoints } from "@artsy/palette"
+import { Box, Col, Flex, Grid, Row, Spacer, color, media } from "@artsy/palette"
 import { Header_artworks } from "v2/__generated__/Header_artworks.graphql"
 import { Header_collection } from "v2/__generated__/Header_collection.graphql"
 import { CollectionDefaultHeaderFragmentContainer as CollectionDefaultHeader } from "v2/Apps/Collect/Routes/Collection/Components/Header/DefaultHeader"
@@ -103,9 +92,8 @@ export const featuredArtistsEntityCollection: (
               onOpenAuthModal={() => handleOpenAuth(mediator, artist)}
               render={({ is_followed }) => {
                 return (
-                  <Sans
-                    size="2"
-                    weight="medium"
+                  <Text
+                    variant="caption"
                     color="black"
                     data-test="followArtistButton"
                     style={{
@@ -114,7 +102,7 @@ export const featuredArtistsEntityCollection: (
                     }}
                   >
                     {is_followed ? "Following" : "Follow"}
-                  </Sans>
+                  </Text>
                 )
               }}
             />
@@ -221,23 +209,23 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                 >
                   <HorizontalPadding>
                     <MetaContainer my={2}>
-                      <BreadcrumbContainer size={["2", "3"]} mt={[2, 0]}>
+                      <BreadcrumbContainer mt={[2, 0]}>
                         <Link to="/collect">All works</Link> /{" "}
                         <Link to={categoryTarget}>{collection.category}</Link>
                       </BreadcrumbContainer>
 
                       <Spacer mt={1} />
 
-                      <Serif size={["6", "10"]} element="h1">
+                      <Text variant="largeTitle" as="h1">
                         {collection.title}
-                      </Serif>
+                      </Text>
                     </MetaContainer>
 
                     <Grid>
                       <Row>
                         <Col sm="12" md="8">
                           <Flex>
-                            <ExtendedSerif size="3">
+                            <ExtendedText size="3">
                               {smallerScreen ? (
                                 <ReadMore
                                   maxChars={chars}
@@ -247,7 +235,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                                 htmlUnsafeDescription
                               )}
                               {collection.description && <Spacer mt={2} />}
-                            </ExtendedSerif>
+                            </ExtendedText>
                           </Flex>
                         </Col>
 
@@ -312,7 +300,7 @@ const MetaContainer = styled(Box)`
   z-index: 1;
 `
 
-const BreadcrumbContainer = styled(Sans)`
+const BreadcrumbContainer = styled(Text)`
   a {
     text-decoration: none;
   }
@@ -330,7 +318,7 @@ const ImageCaption = styled(Box)`
   text-shadow: 0 0 15px rgba(0, 0, 0, 0.25);
 `
 
-const ExtendedSerif = styled(Serif)`
+const ExtendedText = styled(Text)`
   div span {
     span p {
       display: inline;

--- a/src/v2/Apps/Collect/Routes/Collections/Components/CollectionsGrid.tsx
+++ b/src/v2/Apps/Collect/Routes/Collections/Components/CollectionsGrid.tsx
@@ -7,9 +7,9 @@ import {
   Box,
   EntityHeader,
   Flex,
-  Sans,
   Separator,
   Spacer,
+  Text,
 } from "@artsy/palette"
 import { Router } from "found"
 
@@ -35,9 +35,9 @@ export class CollectionsGrid extends Component<CollectionsGridProps> {
     return (
       <Box pb={80}>
         <CollectionsGridAnchor id={name && slugify(name)} />
-        <Sans size="3" weight="medium" pb={15}>
+        <Text variant="mediumText" pb={15}>
           {name}
-        </Sans>
+        </Text>
 
         <Flex flexWrap="wrap" justifyContent="space-between">
           {[...collections] // needs to create a new array since the sort function modifies the array.
@@ -66,7 +66,7 @@ export class CollectionsGrid extends Component<CollectionsGridProps> {
                     href={`/collection/${collection.slug}`}
                     imageUrl={imageUrl || undefined}
                     name={collection.title}
-                    onClick={(event) => {
+                    onClick={event => {
                       event.preventDefault()
                       router.push(`/collection/${collection.slug}`)
                     }}

--- a/src/v2/Apps/Collect/Routes/Collections/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collections/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Sans, Serif } from "@artsy/palette"
+import { Box, Button, Flex, Text } from "@artsy/palette"
 import { Collections_marketingCategories } from "v2/__generated__/Collections_marketingCategories.graphql"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { withSystemContext } from "v2/Artsy"
@@ -47,14 +47,14 @@ export class CollectionsApp extends Component<CollectionsAppProps> {
               justifyContent="space-between"
               alignItems="flex-end"
             >
-              <Serif size="8">
-                <h1>Collections</h1>
-              </Serif>
+              <Text variant="largeTitle" as="h1">
+                Collections
+              </Text>
 
               <Box pb={0.3}>
-                <Sans size="3" weight="medium">
+                <Text variant="mediumText">
                   <Link to="/collect">View works</Link>
-                </Sans>
+                </Text>
               </Box>
             </Flex>
             {marketingCategories &&


### PR DESCRIPTION
Addresses: 
https://www.notion.so/artsy/Web-Type-Clean-up-94cae3cc227243e2a44128b315e65046?p=7739bd240e9f467ba4a6055ed5584245

- Collection page (desktop and mobile)
  - Title
  - Featured artist subheading
  - Hub rails titles & cards
- Collections landing page (not really for humans, but still...)
  - Title
  - Section subheadings

## Collection (desktop)

<img width="200" src="https://user-images.githubusercontent.com/140521/93816776-facdc400-fc25-11ea-90ce-2d71316b7e50.png" />

## Collection (mobile)

<img width="200" src="https://user-images.githubusercontent.com/140521/93816774-fa352d80-fc25-11ea-8edf-1ca32523a370.png" />


## Collections landing

<img width="400" src="https://user-images.githubusercontent.com/140521/93816773-fa352d80-fc25-11ea-87c7-b43c6ebddacf.png" />
