### PR TITLE
Update artwork typography

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtistInfo.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtistInfo.tsx
@@ -2,9 +2,9 @@ import {
   Button,
   EntityHeader,
   Flex,
-  Sans,
   Spacer,
   StackableBorderBox,
+  Text,
 } from "@artsy/palette"
 import { ArtistInfo_artist } from "v2/__generated__/ArtistInfo_artist.graphql"
 import { ArtistInfoQuery } from "v2/__generated__/ArtistInfoQuery.graphql"
@@ -137,9 +137,8 @@ export class ArtistInfo extends Component<ArtistInfoProps, ArtistInfoState> {
                     }
                     render={({ is_followed }) => {
                       return (
-                        <Sans
-                          size="2"
-                          weight="medium"
+                        <Text
+                          variant="caption"
                           color="black"
                           data-test="followButton"
                           style={{
@@ -148,7 +147,7 @@ export class ArtistInfo extends Component<ArtistInfoProps, ArtistInfoState> {
                           }}
                         >
                           {is_followed ? "Following" : "Follow"}
-                        </Sans>
+                        </Text>
                       )
                     }}
                   />

--- a/src/v2/Apps/Artwork/Components/ArtworkArtistSeries/ArtistSeriesArtworkRail.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkArtistSeries/ArtistSeriesArtworkRail.tsx
@@ -1,4 +1,4 @@
-import { Flex, Sans } from "@artsy/palette"
+import { Flex, Text } from "@artsy/palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtistSeriesArtworkRail_artwork } from "v2/__generated__/ArtistSeriesArtworkRail_artwork.graphql"
@@ -70,17 +70,17 @@ export const ArtistSeriesArtworkRail: React.FC<Props> = ({ artwork }) => {
   return artworks.length > 0 ? (
     <>
       <Flex mb={1} justifyContent="space-between">
-        <Sans size="4" color="black100">
+        <Text variant="subtitle" color="black100">
           More from this series
-        </Sans>
+        </Text>
 
         <StyledLink
           to={`/artist-series/${slug}`}
           onClick={() => trackViewSeriesClick()}
         >
-          <Sans size="4" color="black60">
+          <Text variant="text" color="black60">
             View series
-          </Sans>
+          </Text>
         </StyledLink>
       </Flex>
       <Carousel>

--- a/src/v2/Apps/Artwork/Components/ArtworkBanner/Banner.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkBanner/Banner.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Flex, Link, Sans, Serif } from "@artsy/palette"
+import { Avatar, Flex, Link, Text } from "@artsy/palette"
 import { Truncator } from "v2/Components/Truncator"
 import React from "react"
 import styled from "styled-components"
@@ -52,13 +52,11 @@ export const LargeBanner = props => (
   <Flex flexDirection="row" mt={2}>
     <Avatar size="sm" src={props.imageUrl} initials={props.initials} />
     <Flex flexDirection="column" justifyContent="center" ml={2}>
-      <Sans weight="medium" size="2">
-        {props.meta}
-      </Sans>
-      <Serif size="4t">{props.name}</Serif>
-      <Serif size="4t" color="black60">
+      <Text variant="mediumText">{props.meta}</Text>
+      <Text variant="text">{props.name}</Text>
+      <Text variant="caption" color="black60">
         {props.subHeadline}
-      </Serif>
+      </Text>
     </Flex>
   </Flex>
 )
@@ -66,15 +64,15 @@ export const LargeBanner = props => (
 export const SmallBanner = props => (
   <Flex flexDirection="row" width="100%" justifyContent="space-between" mt={2}>
     <Flex flexDirection="column" justifyContent="center" mr={2}>
-      <Sans weight="medium" size="2">
+      <Text variant="mediumText">
         <Truncator maxLineCount={1}>{props.meta}</Truncator>
-      </Sans>
-      <Serif size="4t">
+      </Text>
+      <Text variant="text">
         <Truncator maxLineCount={1}>{props.name}</Truncator>
-      </Serif>
-      <Serif size="4t" color="black60">
+      </Text>
+      <Text variant="caption" color="black60">
         <Truncator maxLineCount={1}>{props.subHeadline}</Truncator>
-      </Serif>
+      </Text>
     </Flex>
     <Avatar size="sm" src={props.imageUrl} initials={props.initials} />
   </Flex>

--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromArtsy.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromArtsy.tsx
@@ -1,4 +1,4 @@
-import { Box, ReadMore, Serif } from "@artsy/palette"
+import { Box, ReadMore, Text } from "@artsy/palette"
 import React, { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Media } from "v2/Utils/Responsive"
@@ -21,7 +21,7 @@ export interface ArtworkDetailsAboutTheWorkFromArtsyProps {
   context_module: Schema.ContextModule.AboutTheWork,
 })
 export class ArtworkDetailsAboutTheWorkFromArtsy extends Component<
-ArtworkDetailsAboutTheWorkFromArtsyProps
+  ArtworkDetailsAboutTheWorkFromArtsyProps
 > {
   @track({
     action_type: Schema.ActionType.Click,
@@ -53,10 +53,10 @@ ArtworkDetailsAboutTheWorkFromArtsyProps
     }
     return (
       <Box pb={2}>
-        <Serif size="3">
+        <Text variant="text">
           <Media at="xs">{this.renderReadMore("xs")}</Media>
           <Media greaterThan="xs">{this.renderReadMore()}</Media>
-        </Serif>
+        </Text>
       </Box>
     )
   }

--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
@@ -20,10 +20,9 @@ import {
   Box,
   EntityHeader,
   ReadMore,
-  Sans,
-  Serif,
   Spacer,
   StackableBorderBox,
+  Text,
 } from "@artsy/palette"
 import { FollowProfileButton_profile } from "v2/__generated__/FollowProfileButton_profile.graphql"
 import { openAuthToFollowSave } from "v2/Utils/openAuthModal"
@@ -128,9 +127,8 @@ export class ArtworkDetailsAboutTheWorkFromPartner extends React.Component<
                         render={(profile: FollowProfileButton_profile) => {
                           const is_followed = profile.is_followed || false
                           return (
-                            <Sans
-                              size="2"
-                              weight="medium"
+                            <Text
+                              variant="caption"
                               color="black"
                               data-test="followButton"
                               style={{
@@ -139,7 +137,7 @@ export class ArtworkDetailsAboutTheWorkFromPartner extends React.Component<
                               }}
                             >
                               {is_followed ? "Following" : "Follow"}
-                            </Sans>
+                            </Text>
                           )
                         }}
                       >
@@ -151,10 +149,10 @@ export class ArtworkDetailsAboutTheWorkFromPartner extends React.Component<
                 {additional_information && (
                   <React.Fragment>
                     <Spacer mb={1} />
-                    <Serif size="3">
+                    <Text variant="text">
                       <Media at="xs">{this.renderReadMore("xs")}</Media>
                       <Media greaterThan="xs">{this.renderReadMore()}</Media>
-                    </Serif>
+                    </Text>
                   </React.Fragment>
                 )}
               </Box>

--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAdditionalInfo.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAdditionalInfo.tsx
@@ -3,8 +3,8 @@ import {
   Grid,
   ReadMore,
   Row,
-  Sans,
   StackableBorderBox,
+  Text,
 } from "@artsy/palette"
 import { ArtworkDetailsAdditionalInfo_artwork } from "v2/__generated__/ArtworkDetailsAdditionalInfo_artwork.graphql"
 import React from "react"
@@ -18,7 +18,7 @@ export interface ArtworkDetailsAdditionalInfoProps {
 
 export class ArtworkDetailsAdditionalInfo extends React.Component<
   ArtworkDetailsAdditionalInfoProps
-  > {
+> {
   render() {
     const {
       category,
@@ -44,8 +44,8 @@ export class ArtworkDetailsAdditionalInfo extends React.Component<
         value: canRequestLotConditionsReport ? (
           <RequestConditionReportQueryRenderer artworkID={internalID} />
         ) : (
-            conditionDescription && conditionDescription.details
-          ),
+          conditionDescription && conditionDescription.details
+        ),
       },
 
       {
@@ -83,18 +83,18 @@ export class ArtworkDetailsAdditionalInfo extends React.Component<
               pb={index === displayItems.length - 1 ? 0 : 1}
             >
               <Col xs={12} sm={6} md={6} lg={3}>
-                <Sans size="2" weight="medium" pr={2}>
+                <Text variant="mediumText" pr={2}>
                   {title}
-                </Sans>
+                </Text>
               </Col>
               <Col xs={12} sm={6} md={6} lg={9}>
-                <Sans size="2" weight="regular" color="black60">
+                <Text variant="text" color="black60">
                   {React.isValidElement(value) ? (
                     value
                   ) : (
-                      <ReadMore maxChars={140} content={value} />
-                    )}
-                </Sans>
+                    <ReadMore maxChars={140} content={value} />
+                  )}
+                </Text>
               </Col>
             </Row>
           ))}

--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/RequestConditionReport.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/RequestConditionReport.tsx
@@ -1,13 +1,4 @@
-import {
-  Button,
-  Col,
-  Link,
-  Modal,
-  Row,
-  Sans,
-  Serif,
-  Spinner,
-} from "@artsy/palette"
+import { Button, Col, Link, Modal, Row, Spinner, Text } from "@artsy/palette"
 import React, { useState } from "react"
 import { commitMutation, createFragmentContainer, graphql } from "react-relay"
 
@@ -138,9 +129,9 @@ export const RequestConditionReport: React.FC<RequestConditionReportProps> = pro
       >
         Log in
       </Button>
-      <Sans display="inline" ml={1} size="2">
+      <Text variant="caption" display="inline" ml={1}>
         to request
-      </Sans>
+      </Text>
     </>
   )
 
@@ -163,15 +154,15 @@ export const RequestConditionReport: React.FC<RequestConditionReportProps> = pro
       }}
       show={showRequestedModal}
     >
-      <Serif mt={1} color="black100" textAlign="center" size="4">
+      <Text variant="text" mt={1} color="black100" textAlign="center">
         We have received your request. The condition report will be sent to{" "}
         {me && me.email}.
-      </Serif>
+      </Text>
 
-      <Serif mt={2} textAlign="center" color="black100" size="4">
+      <Text variant="text" mt={2} textAlign="center" color="black100">
         For questions, contact{" "}
         <Link href="mailto:specialist@artsy.net">specialist@artsy.net</Link>.
-      </Serif>
+      </Text>
 
       <Button block mt={4} onClick={() => setShowRequestedModal(false)}>
         OK

--- a/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
@@ -27,9 +27,9 @@ import {
   Link,
   MoreIcon,
   OpenEyeIcon,
-  Sans,
   ShareIcon,
   Spacer,
+  Text,
   color,
 } from "@artsy/palette"
 import { userIsAdmin } from "v2/Utils/user"
@@ -385,18 +385,18 @@ export class UtilButton extends React.Component<
           <UtilButtonLink className="noUnderline" href={href} target="_blank">
             <ActionIcon {...props} fill={"black100"} />
             {label && (
-              <Sans size="2" pl={0.5} pt="1px">
+              <Text variant="caption" pl={0.5} pt="1px">
                 {label}
-              </Sans>
+              </Text>
             )}
           </UtilButtonLink>
         ) : (
           <>
             <ActionIcon {...props} fill={fill} />
             {label && (
-              <Sans size="2" pl={0.5} pt="1px">
+              <Text variant="caption" pl={0.5} pt="1px">
                 {label}
-              </Sans>
+              </Text>
             )}
           </>
         )}

--- a/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkPopoutPanel.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkPopoutPanel.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Sans, color, space } from "@artsy/palette"
+import { Box, Flex, Text, color, space } from "@artsy/palette"
 import Icon from "v2/Components/Icon"
 import React from "react"
 import styled from "styled-components"
@@ -19,9 +19,9 @@ export class ArtworkPopoutPanel extends React.Component<
         </Box>
         <Flex flexDirection="column" p={2}>
           <Flex flexDirection="row" mb={2}>
-            <Sans size="3" weight="medium" color="black100">
+            <Text variant="mediumText" color="black100">
               {this.props.title}
-            </Sans>
+            </Text>
           </Flex>
           {this.props.children}
         </Flex>

--- a/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkSharePanel.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkSharePanel.tsx
@@ -1,4 +1,4 @@
-import { Flex, Sans, Separator, color, media } from "@artsy/palette"
+import { Flex, Separator, Text, color, media } from "@artsy/palette"
 import { ArtworkSharePanel_artwork } from "v2/__generated__/ArtworkSharePanel_artwork.graphql"
 import Icon from "v2/Components/Icon"
 import React from "react"
@@ -87,7 +87,7 @@ export class ArtworkSharePanel extends React.Component<
 
   renderShareButton({ service, label, message, url }) {
     return (
-      <Flex
+      <ShareButtonContainer
         flexDirection="row"
         flexBasis="50%"
         mt={2}
@@ -97,10 +97,10 @@ export class ArtworkSharePanel extends React.Component<
         })}
       >
         <Icon name={service} color="black" />
-        <Sans size="3" color="black60">
-          <a>{label}</a>
-        </Sans>
-      </Flex>
+        <Text variant="text" color="black60">
+          {label}
+        </Text>
+      </ShareButtonContainer>
     )
   }
 
@@ -119,7 +119,7 @@ export class ArtworkSharePanel extends React.Component<
     return (
       <ArtworkPopoutPanel title="Share" onClose={this.props.onClose}>
         <Flex flexDirection="row" mb={1}>
-          <SansGrow size={["3", "2"]} color="black60" mr={4}>
+          <SansGrow variant="text" color="black60" mr={4}>
             <URLInput
               type="text"
               readOnly
@@ -128,9 +128,11 @@ export class ArtworkSharePanel extends React.Component<
               onClick={this.handleCopy}
             />
           </SansGrow>
-          <Sans size={["3", "2"]} weight="medium" color="black60">
+          <Text variant="mediumText" color="black60">
+            {/* FIXME Remove lint ignore */}
+            {/* eslint-disable-next-line  */}
             <a onClick={this.handleCopy}>{this.state.copyLabelText}</a>
-          </Sans>
+          </Text>
         </Flex>
         <Separator />
         <Flex flexDirection="row" flexWrap="wrap">
@@ -153,13 +155,13 @@ export class ArtworkSharePanel extends React.Component<
             */}
           <Flex flexDirection="row" flexBasis="50%" mt={2}>
             <Icon name="mail" color="black" />
-            <Sans size="3" color="black60">
+            <Text variant="text" color="black60">
               <UnstyledLink
                 href={`mailto:?subject=${share}&body=${share} on Artsy: ${url}`}
               >
                 Mail
               </UnstyledLink>
-            </Sans>
+            </Text>
           </Flex>
 
           {this.renderShareButton({
@@ -197,7 +199,11 @@ export const ArtworkSharePanelFragmentContainer = createFragmentContainer(
   }
 )
 
-const SansGrow = styled(Sans)`
+const ShareButtonContainer = styled(Flex)`
+  cursor: pointer;
+`
+
+const SansGrow = styled(Text)`
   display: flex;
   flex-grow: 1;
 `

--- a/src/v2/Apps/Artwork/Components/ArtworkRelatedArtists.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkRelatedArtists.tsx
@@ -1,5 +1,5 @@
 import { ContextModule } from "@artsy/cohesion"
-import { Box, Button, Flex, Serif } from "@artsy/palette"
+import { Box, Button, Flex, Text } from "@artsy/palette"
 import { ArtworkRelatedArtists_artwork } from "v2/__generated__/ArtworkRelatedArtists_artwork.graphql"
 import { hideGrid } from "v2/Apps/Artwork/Components/OtherWorks"
 import { useSystemContext } from "v2/Artsy"
@@ -53,9 +53,9 @@ export const ArtworkRelatedArtists: React.FC<ArtworkRelatedArtistsProps> = track
     return (
       <Box mt={6} data-test={ContextModule.relatedArtistsRail}>
         <Flex flexDirection="column" alignItems="center">
-          <Serif size={["5t", "8"]} color="black100" mb={2} textAlign="center">
+          <Text variant="title" color="black100" mb={2} textAlign="center">
             Related artists
-          </Serif>
+          </Text>
         </Flex>
         <Flex flexWrap="wrap" mr={-2} width="100%">
           {artist.related.artistsConnection.edges.map(({ node }, index) => {

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtists.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtists.tsx
@@ -1,4 +1,4 @@
-import { Box, Serif } from "@artsy/palette"
+import { Box, Text } from "@artsy/palette"
 import { SystemContextConsumer } from "v2/Artsy"
 import * as Schema from "v2/Artsy/Analytics/Schema"
 
@@ -19,15 +19,15 @@ export interface ArtistsProps {
 type Artist = ArtworkSidebarArtists_artwork["artists"][0]
 
 export class ArtworkSidebarArtists extends React.Component<ArtistsProps> {
-  private renderArtistName(artist: Artist) {
+  private renderArtistName(artist: Artist, multiple = false) {
     return artist.href ? (
-      <Serif size="5t" display="inline" weight="semibold" element="h1">
+      <Text variant="subtitle" as={multiple ? "span" : "h1"}>
         <RouterLink to={artist.href}>{artist.name}</RouterLink>
-      </Serif>
+      </Text>
     ) : (
-      <Serif size="5t" display="inline" weight="semibold" element="h1">
+      <Text variant="subtitle" as={multiple ? "span" : "h1"}>
         {artist.name}
-      </Serif>
+      </Text>
     )
   }
 
@@ -42,7 +42,7 @@ export class ArtworkSidebarArtists extends React.Component<ArtistsProps> {
   private renderSingleArtist = (artist: Artist, user, mediator) => {
     return (
       <React.Fragment>
-        <Box>{this.renderArtistName(artist)}</Box>
+        {this.renderArtistName(artist)}
         <FollowArtistButton
           artist={artist}
           user={user}
@@ -69,21 +69,25 @@ export class ArtworkSidebarArtists extends React.Component<ArtistsProps> {
     const {
       artwork: { artists },
     } = this.props
-    return artists.map((artist, index) => {
-      return (
-        <React.Fragment key={artist.id}>
-          {this.renderArtistName(artist)}
-          {index !== artists.length - 1 && ", "}
-        </React.Fragment>
-      )
-    })
+    return (
+      <Box as="h1">
+        {artists.map((artist, index) => {
+          return (
+            <React.Fragment key={artist.id}>
+              {this.renderArtistName(artist, true)}
+              {index !== artists.length - 1 && ", "}
+            </React.Fragment>
+          )
+        })}
+      </Box>
+    )
   }
 
   renderCulturalMaker(cultural_maker: string) {
     return (
-      <Serif size="5t" display="inline-block" weight="semibold">
+      <Text variant="subtitle" display="inline-block" as="h1">
         {cultural_maker}
-      </Serif>
+      </Text>
     )
   }
   render() {

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtists.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtists.tsx
@@ -21,11 +21,11 @@ type Artist = ArtworkSidebarArtists_artwork["artists"][0]
 export class ArtworkSidebarArtists extends React.Component<ArtistsProps> {
   private renderArtistName(artist: Artist, multiple = false) {
     return artist.href ? (
-      <Text variant="subtitle" as={multiple ? "span" : "h1"}>
+      <Text variant="title" as={multiple ? "span" : "h1"}>
         <RouterLink to={artist.href}>{artist.name}</RouterLink>
       </Text>
     ) : (
-      <Text variant="subtitle" as={multiple ? "span" : "h1"}>
+      <Text variant="title" as={multiple ? "span" : "h1"}>
         {artist.name}
       </Text>
     )

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarAuctionPartnerInfo.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarAuctionPartnerInfo.tsx
@@ -1,4 +1,4 @@
-import { Box, Serif } from "@artsy/palette"
+import { Box, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import React from "react"
 
@@ -10,7 +10,7 @@ export interface ArtworkSidebarAuctionPartnerInfoProps {
 
 export class ArtworkSidebarAuctionPartnerInfo extends React.Component<
   ArtworkSidebarAuctionPartnerInfoProps
-  > {
+> {
   render() {
     const { partner, sale_artwork, sale } = this.props.artwork
     if (sale.is_closed) {
@@ -19,14 +19,14 @@ export class ArtworkSidebarAuctionPartnerInfo extends React.Component<
     return (
       <Box pb={3}>
         {partner && (
-          <Serif size="2" weight="semibold" color="black100">
+          <Text variant="caption" color="black100">
             {partner.name}
-          </Serif>
+          </Text>
         )}
         {sale_artwork && sale_artwork.estimate && (
-          <Serif size="2" color="black60">
+          <Text variant="caption" color="black60">
             Estimated value: {sale_artwork.estimate}
-          </Serif>
+          </Text>
         )}
       </Box>
     )

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarBidAction.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarBidAction.tsx
@@ -5,10 +5,9 @@ import {
   HelpIcon,
   LargeSelect,
   Link,
-  Sans,
   Separator,
-  Serif,
   Spacer,
+  Text,
   Tooltip,
 } from "@artsy/palette"
 import React from "react"
@@ -42,17 +41,17 @@ const RegisterToBidButton: React.FC<{ onClick: () => void }> = ({
 
 const IdentityVerificationDisclaimer: React.FC = () => {
   return (
-    <Sans mt="1" size="3" color="black60" pb={1} textAlign="center">
+    <Text mt="1" variant="text" color="black60" pb={1} textAlign="center">
       Identity verification required to bid.{" "}
       <Link href="/identity-verification-faq">FAQ</Link>
-    </Sans>
+    </Text>
   )
 }
 
 @track()
 export class ArtworkSidebarBidAction extends React.Component<
-ArtworkSidebarBidActionProps,
-ArtworkSidebarBidActionState
+  ArtworkSidebarBidActionProps,
+  ArtworkSidebarBidActionState
 > {
   state: ArtworkSidebarBidActionState = {
     selectedMaxBidCents: null,
@@ -172,9 +171,9 @@ ArtworkSidebarBidActionState
       if (notApprovedBidderBeforeRegistrationClosed) {
         return (
           <Box>
-            <Sans size="2" color="black60" pb={1} textAlign="center">
+            <Text variant="caption" color="black60" pb={1} textAlign="center">
               Registration closed
-            </Sans>
+            </Text>
             <Button
               width="100%"
               size="large"
@@ -246,9 +245,9 @@ ArtworkSidebarBidActionState
           <Box>
             <Separator mb={2} />
             <Flex width="100%" flexDirection="row">
-              <Serif size="3t" color="black100" mr={1}>
+              <Text variant="text" color="black100" mr={1}>
                 Place max bid
-              </Serif>
+              </Text>
               <Tooltip content="Set the maximum amount you would like Artsy to bid up to on your behalf">
                 <HelpIcon />
               </Tooltip>

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarClassification.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarClassification.tsx
@@ -1,4 +1,4 @@
-import { Box, Sans, Serif, Spacer } from "@artsy/palette"
+import { Box, Spacer, Text } from "@artsy/palette"
 import Modal from "v2/Components/Modal/Modal"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -18,8 +18,8 @@ interface State {
 
 @track()
 export class ArtworkSidebarClassification extends React.Component<
-ArtworkSidebarClassificationProps,
-State
+  ArtworkSidebarClassificationProps,
+  State
 > {
   state = {
     isModalOpen: false,
@@ -56,12 +56,12 @@ State
         </Modal>
         <Box color="black60" textAlign="left">
           <Spacer mt={2} />
-          <Serif size="2">
+          <Text variant="caption">
             <ClassificationLink onClick={this.openModal.bind(this)}>
               {artwork.attribution_class.short_description}
             </ClassificationLink>
             .
-          </Serif>
+          </Text>
         </Box>
       </ClassificationContainer>
     )
@@ -141,20 +141,18 @@ const ClassificationDetails = () => {
         {classificationOptions.map(option => {
           return (
             <React.Fragment key={option.name}>
-              <Serif size="3" weight="semibold">
-                {option.name}
-              </Serif>
-              <Serif size="3" mb={2}>
+              <Text variant="mediumText">{option.name}</Text>
+              <Text variant="text" mb={2}>
                 {option.long_description}
-              </Serif>
+              </Text>
             </React.Fragment>
           )
         })}
       </Box>
-      <Sans size="2" color="black60" mb={3}>
+      <Text variant="caption" color="black60" mb={3}>
         Our partners are responsible for providing accurate classification
         information for all works.
-      </Sans>
+      </Text>
     </>
   )
 }

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -6,10 +6,9 @@ import {
   FlexProps,
   Radio,
   RadioGroup,
-  Sans,
   Separator,
-  Serif,
   Spacer,
+  Text,
 } from "@artsy/palette"
 import { ArtworkSidebarCommercial_artwork } from "v2/__generated__/ArtworkSidebarCommercial_artwork.graphql"
 import { ArtworkSidebarCommercialOfferOrderMutation } from "v2/__generated__/ArtworkSidebarCommercialOfferOrderMutation.graphql"
@@ -82,9 +81,9 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
 
   renderSaleMessage(saleMessage: string) {
     return (
-      <Serif size="5t" weight="semibold" data-test="SaleMessage">
+      <Text variant="subtitle" data-test="SaleMessage">
         {saleMessage}
-      </Serif>
+      </Text>
     )
   }
 
@@ -95,9 +94,9 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
     const editionFragment = (
       <>
         <SizeInfo piece={editionSet} />
-        <Serif ml="auto" size="2" data-test="SaleMessage">
+        <Text ml="auto" variant="caption" data-test="SaleMessage">
           {editionSet.sale_message}
-        </Serif>
+        </Text>
       </>
     )
     if (includeSelectOption) {
@@ -379,19 +378,19 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
         {artworkEcommerceAvailable &&
           (artwork.shippingOrigin || artwork.shippingInfo) && <Spacer mt={1} />}
         {artworkEcommerceAvailable && artwork.shippingOrigin && (
-          <Sans size="2" color="black60">
+          <Text variant="caption" color="black60">
             Ships from {artwork.shippingOrigin}
-          </Sans>
+          </Text>
         )}
         {artworkEcommerceAvailable && artwork.shippingInfo && (
-          <Sans size="2" color="black60">
+          <Text variant="caption" color="black60">
             {artwork.shippingInfo}
-          </Sans>
+          </Text>
         )}
         {artworkEcommerceAvailable && artwork.priceIncludesTaxDisplay && (
-          <Sans size="2" color="black60">
+          <Text variant="caption" color="black60">
             {artwork.priceIncludesTaxDisplay}
-          </Sans>
+          </Text>
         )}
 
         {artwork.is_inquireable ||

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCurrentBidInfo.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCurrentBidInfo.tsx
@@ -10,10 +10,9 @@ import {
   Box,
   Flex,
   LosingBidIcon,
-  Sans,
   Separator,
-  Serif,
   Spacer,
+  Text,
   WinningBidIcon,
 } from "@artsy/palette"
 
@@ -23,7 +22,7 @@ export interface ArtworkSidebarCurrentBidInfoProps {
 
 @track()
 export class ArtworkSidebarCurrentBidInfo extends React.Component<
-ArtworkSidebarCurrentBidInfoProps
+  ArtworkSidebarCurrentBidInfoProps
 > {
   @track(() => {
     return {
@@ -52,9 +51,9 @@ ArtworkSidebarCurrentBidInfoProps
       return (
         <Box>
           <Separator mb={3} />
-          <Serif size="5t" weight="semibold" color="black100">
+          <Text variant="subtitle" color="black100">
             Bidding closed
-          </Serif>
+          </Text>
           <Spacer mb={3} />
         </Box>
       )
@@ -67,8 +66,8 @@ ArtworkSidebarCurrentBidInfoProps
     const bidsPresent = bidsCount > 0
     const bidColor =
       artwork.sale_artwork.is_with_reserve &&
-        bidsPresent &&
-        artwork.sale_artwork.reserve_status === "reserve_not_met"
+      bidsPresent &&
+      artwork.sale_artwork.reserve_status === "reserve_not_met"
         ? "red100"
         : "black60"
 
@@ -105,9 +104,9 @@ ArtworkSidebarCurrentBidInfoProps
               flexDirection="row"
               justifyContent="space-between"
             >
-              <Serif size="5t" weight="semibold" pr={1}>
+              <Text variant="subtitle" pr={1}>
                 {bidsPresent ? "Current bid" : "Starting bid"}
-              </Serif>
+              </Text>
               <Flex
                 flexDirection="row"
                 justifyContent="right"
@@ -118,13 +117,13 @@ ArtworkSidebarCurrentBidInfoProps
                     {myBidWinning ? (
                       <WinningBidIcon fill="green100" />
                     ) : (
-                        <LosingBidIcon fill="red100" />
-                      )}
+                      <LosingBidIcon fill="red100" />
+                    )}
                   </Box>
                 )}
-                <Serif size="5t" weight="semibold" pl={0.5}>
+                <Text variant="subtitle" pl={0.5}>
                   {artwork.sale_artwork.current_bid.display}
-                </Serif>
+                </Text>
               </Flex>
             </Flex>
             <Flex
@@ -132,25 +131,26 @@ ArtworkSidebarCurrentBidInfoProps
               flexDirection="row"
               justifyContent="space-between"
             >
-              <Sans size="2" color={bidColor} pr={1}>
+              <Text variant="caption" color={bidColor} pr={1}>
                 {bidText}
-              </Sans>
+              </Text>
               {myMaxBid && (
-                <Sans size="2" color="black60" pl={1}>
+                <Text variant="caption" color="black60" pl={1}>
                   Your max: {myMaxBid}
-                </Sans>
+                </Text>
               )}
             </Flex>
             {artwork.sale && artwork.sale.is_with_buyers_premium && (
-              <Serif size="2" color="black60">
+              <Text variant="caption" color="black60">
                 <br />
-                This auction has a{" "}
+                This auction has a {/* FIXME: Remove this lint ignore */}
+                {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                 <Link onClick={() => this.handleClickBuyerPremium(mediator)}>
                   buyer's premium
                 </Link>
                 .<br />
                 Shipping, taxes, and additional fees may apply.
-              </Serif>
+              </Text>
             )}
             <Spacer mb={3} />
           </Box>

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarExtraLinks.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarExtraLinks.tsx
@@ -1,4 +1,6 @@
-import { Box, Link, Sans, Separator, Spacer } from "@artsy/palette"
+// FIXME -- Remove this lint disable
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import { Box, Link, Separator, Spacer, Text } from "@artsy/palette"
 import { Mediator, SystemContext } from "v2/Artsy"
 import { track } from "v2/Artsy/Analytics"
 import * as Schema from "v2/Artsy/Analytics/Schema"
@@ -18,9 +20,9 @@ export interface ArtworkSidebarExtraLinksContainerProps
 }
 
 const Container = ({ children }) => (
-  <Sans size="2" color="black60">
+  <Text variant="caption" color="black60">
     {children}
-  </Sans>
+  </Text>
 )
 
 @track({

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarMetadata.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarMetadata.tsx
@@ -1,4 +1,4 @@
-import { Box, Serif } from "@artsy/palette"
+import { Box, Text } from "@artsy/palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { get } from "v2/Utils/get"
@@ -14,7 +14,7 @@ export interface ArtworkSidebarMetadataProps {
 
 export class ArtworkSidebarMetadata extends React.Component<
   ArtworkSidebarMetadataProps
-  > {
+> {
   render() {
     const { artwork } = this.props
     const lotLabel = get(
@@ -24,9 +24,9 @@ export class ArtworkSidebarMetadata extends React.Component<
     return (
       <Box>
         {lotLabel && (
-          <Serif size="2" weight="semibold" color="black100">
+          <Text variant="mediumText" color="black100">
             Lot {lotLabel}
-          </Serif>
+          </Text>
         )}
         <TitleInfo artwork={artwork} />
         {artwork.edition_sets.length < 2 && <SizeInfo piece={artwork} />}

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarPartnerInfo.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarPartnerInfo.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, LocationIcon, Serif, Spacer } from "@artsy/palette"
+import { Box, Flex, LocationIcon, Spacer, Text } from "@artsy/palette"
 import { filterLocations } from "v2/Apps/Artwork/Utils/filterLocations"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -11,14 +11,14 @@ export interface ArtworkSidebarPartnerInfoProps {
 
 export class ArtworkSidebarPartnerInfo extends React.Component<
   ArtworkSidebarPartnerInfoProps
-  > {
+> {
   renderPartnerName() {
     const sale = this.props.artwork.sale
     if (sale) {
       return (
-        <Serif size="5t" display="inline-block" weight="semibold">
+        <Text variant="subtitle" display="inline-block">
           <a href={sale.href}>{sale.name}</a>
-        </Serif>
+        </Text>
       )
     }
 
@@ -28,20 +28,26 @@ export class ArtworkSidebarPartnerInfo extends React.Component<
     }
 
     return partner.href ? (
-      <Serif size="5t" display="inline-block" weight="semibold">
+      <Text variant="subtitle" display="inline-block">
         <a href={partner.href}>{partner.name}</a>
-      </Serif>
+      </Text>
     ) : (
-        <Serif size="5t" display="inline-block" weight="semibold">
-          {partner.name}
-        </Serif>
-      )
+      <Text variant="subtitle" display="inline-block">
+        {partner.name}
+      </Text>
+    )
   }
   renderLocations(locationNames) {
     return (
-      <Serif size="2" display="inline-block" pl={1} pt={0.3}>
+      <Text
+        variant="caption"
+        color="black60"
+        display="inline-block"
+        pl={1}
+        pt={0.3}
+      >
         {locationNames.join(", ")}
-      </Serif>
+      </Text>
     )
   }
 
@@ -59,8 +65,8 @@ export class ArtworkSidebarPartnerInfo extends React.Component<
         {this.renderPartnerName()}
         {locationNames && locationNames.length > 0 && (
           <Box>
-            <Flex width="100%" pt={1}>
-              <Flex flexDirection="column">
+            <Flex width="100%">
+              <Flex flexDirection="column" pt={0.3}>
                 <LocationIcon />
               </Flex>
               <Flex flexDirection="column">

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarSizeInfo.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarSizeInfo.tsx
@@ -1,4 +1,4 @@
-import { Box, Serif } from "@artsy/palette"
+import { Box, Text } from "@artsy/palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
@@ -10,7 +10,7 @@ export interface ArtworkSidebarSizeInfoProps {
 
 export class ArtworkSidebarSizeInfo extends React.Component<
   ArtworkSidebarSizeInfoProps
-  > {
+> {
   render() {
     const {
       piece: { dimensions, edition_of },
@@ -23,9 +23,9 @@ export class ArtworkSidebarSizeInfo extends React.Component<
     }
     return (
       <Box color="black60">
-        {dimensions.in && <Serif size="2">{dimensions.in}</Serif>}
-        {dimensions.cm && <Serif size="2">{dimensions.cm}</Serif>}
-        {edition_of && <Serif size="2">{edition_of}</Serif>}
+        {dimensions.in && <Text variant="caption">{dimensions.in}</Text>}
+        {dimensions.cm && <Text variant="caption">{dimensions.cm}</Text>}
+        {edition_of && <Text variant="caption">{edition_of}</Text>}
       </Box>
     )
   }

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarTitleInfo.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarTitleInfo.tsx
@@ -1,4 +1,4 @@
-import { Box, Serif } from "@artsy/palette"
+import { Box, Text } from "@artsy/palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
@@ -10,18 +10,18 @@ export interface ArtworkSidebarTitleInfoProps {
 
 export class ArtworkSidebarTitleInfo extends React.Component<
   ArtworkSidebarTitleInfoProps
-  > {
+> {
   render() {
     const { artwork } = this.props
     return (
       <Box color="black60">
-        <Serif size="2" element="h2">
+        <Text variant="caption" as="h2">
           <i>{artwork.title}</i>
           {artwork.date &&
             artwork.date.replace(/\s+/g, "").length > 0 &&
             ", " + artwork.date}
-        </Serif>
-        {artwork.medium && <Serif size="2">{artwork.medium}</Serif>}
+        </Text>
+        {artwork.medium && <Text variant="caption">{artwork.medium}</Text>}
       </Box>
     )
   }

--- a/src/v2/Apps/Artwork/Components/OtherWorks/Header.tsx
+++ b/src/v2/Apps/Artwork/Components/OtherWorks/Header.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Serif } from "@artsy/palette"
+import { Button, Flex, Text } from "@artsy/palette"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import React from "react"
 
@@ -13,9 +13,9 @@ export const Header: React.SFC<HeaderProps> = props => {
 
   return (
     <Flex flexDirection="column" alignItems="center">
-      <Serif size={["5t", "8"]} color="black100" mb={2} textAlign="center">
+      <Text variant="title" color="black100" mb={2} textAlign="center">
         {title}
-      </Serif>
+      </Text>
       {buttonHref && (
         <RouterLink to={buttonHref}>
           <Button variant="secondaryOutline" mb={3}>

--- a/src/v2/Apps/Artwork/Components/PricingContext.tsx
+++ b/src/v2/Apps/Artwork/Components/PricingContext.tsx
@@ -4,8 +4,8 @@ import {
   BorderBox,
   Flex,
   Link,
-  Sans,
   Spacer,
+  Text,
 } from "@artsy/palette"
 import { PricingContext_artwork } from "v2/__generated__/PricingContext_artwork.graphql"
 import { track } from "v2/Artsy/Analytics"
@@ -97,11 +97,13 @@ export class PricingContext extends React.Component<PricingContextProps> {
       <BorderBox mb={2} flexDirection="column">
         <Waypoint onEnter={once(this.trackImpression.bind(this))} />
         <Flex>
-          <Sans size="2" weight="medium">
+          <Text variant="caption">
             {artwork.pricingContext.appliedFiltersDisplay}
-          </Sans>
+          </Text>
           <PricingContextModal />
         </Flex>
+        {/* FIXME: Remove this lint ignore */}
+        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
         <Link
           onClick={this.collectPageLinkClick.bind(this, {
             dimension: artwork.pricingContext.appliedFilters.dimension,
@@ -110,7 +112,7 @@ export class PricingContext extends React.Component<PricingContextProps> {
           })}
           color="black60"
         >
-          <Sans size="2">Browse works in this category</Sans>
+          <Text variant="caption">Browse works in this category</Text>
         </Link>
         <Spacer mb={[2, 3]} />
         <BarChart

--- a/src/v2/Apps/Artwork/Components/PricingContextModal.tsx
+++ b/src/v2/Apps/Artwork/Components/PricingContextModal.tsx
@@ -4,8 +4,8 @@ import {
   Link,
   Modal,
   QuestionCircleIcon,
-  Serif,
   Spacer,
+  Text,
   Tooltip,
 } from "@artsy/palette"
 import { track } from "v2/Artsy/Analytics"
@@ -59,19 +59,19 @@ export class PricingContextModal extends React.Component<State> {
           }
         >
           <Spacer mt={2} />
-          <Serif size="3" color="black80">
+          <Text variant="text" color="black80">
             This feature aims to provide insight into the range of prices for an
             artist's works and allow buyers to discover other available works by
             the artist at different price points.
-          </Serif>
+          </Text>
           <Spacer mt={2} />
-          <Serif size="3" color="black80">
+          <Text variant="text" color="black80">
             The graph displays current and past list prices for works that are
             similar in size and category to the work you're viewing. The prices
             included in the graph are only from galleries and dealers on Artsy.
-          </Serif>
+          </Text>
           <Spacer mt={2} />
-          <Serif size="3" color="black80">
+          <Text variant="text" color="black80">
             Artwork prices are affected by{" "}
             <Link
               href={sd.APP_URL + "/article/artsy-editorial-artworks-prices"}
@@ -84,7 +84,7 @@ export class PricingContextModal extends React.Component<State> {
             to provide pricing guidance for the artwork being viewed. If you
             have feedback or questions{" "}
             <Link href="mailto:support@artsy.net">let us know</Link>.
-          </Serif>
+          </Text>
           <Spacer mt={2} />
         </Modal>
         <Tooltip width={73} size="sm" content="Learn more">

--- a/src/v2/Apps/Artwork/Components/TrustSignals/AuthenticityCertificate.tsx
+++ b/src/v2/Apps/Artwork/Components/TrustSignals/AuthenticityCertificate.tsx
@@ -1,4 +1,4 @@
-import { CertificateIcon, Flex, Modal, Serif } from "@artsy/palette"
+import { CertificateIcon, Flex, Modal, Text } from "@artsy/palette"
 import { AuthenticityCertificate_artwork } from "v2/__generated__/AuthenticityCertificate_artwork.graphql"
 import React, { useState } from "react"
 import { createFragmentContainer } from "react-relay"
@@ -42,19 +42,19 @@ export const AuthenticityCertificate: React.FC<AuthenticityCertificateProps> = (
           title="Certificate of Authenticity"
         >
           <Flex flexGrow={1} flexDirection="column">
-            <Serif size="3t" pb={2}>
+            <Text variant="text" pb={2}>
               A certificate of authenticity (COA) is a signed document from an
               authoritative source that verifies the artwork’s authenticity.
               While many COAs are signed by the artist, others will be signed by
               the representing gallery or the printmaker who collaborated with
               the artist on the work. For secondary market works, authorized
               estates or foundations are often the issuing party.
-            </Serif>
-            <Serif size="3t" pb={2}>
+            </Text>
+            <Text variant="text" pb={2}>
               COAs typically include the name of the artist, the details (title,
               date, medium, dimensions) of the work in question, and whenever
               possible an image of the work.
-            </Serif>
+            </Text>
           </Flex>
         </Modal>
       </>

--- a/src/v2/Apps/Artwork/Components/TrustSignals/TrustSignal.tsx
+++ b/src/v2/Apps/Artwork/Components/TrustSignals/TrustSignal.tsx
@@ -1,4 +1,4 @@
-import { Flex, FlexProps, Link, Sans } from "@artsy/palette"
+import { Flex, FlexProps, Link, Text } from "@artsy/palette"
 import React, { FC } from "react"
 
 export interface TrustSignalProps extends Omit<FlexProps, "flexDirection"> {
@@ -19,14 +19,16 @@ export const TrustSignal: FC<TrustSignalProps> = ({
     <Flex {...other}>
       {Icon}
       <Flex flexDirection="column" ml={1}>
+        {/* FIXME: Remove this lint ignore */}
+        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
         <Link onClick={onClick}>
-          <Sans size="2" weight="medium" color="black100">
+          <Text variant="caption" color="black100">
             {label}
-          </Sans>
+          </Text>
         </Link>
-        <Sans size="2" color="black60">
+        <Text variant="caption" color="black60">
           {description}
-        </Sans>
+        </Text>
       </Flex>
     </Flex>
   )

--- a/src/v2/Apps/Artwork/Components/__tests__/OtherWorks.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/__tests__/OtherWorks.jest.tsx
@@ -1,4 +1,4 @@
-import { Serif } from "@artsy/palette"
+import { Text } from "@artsy/palette"
 import { mount, shallow } from "enzyme"
 import React from "react"
 import { Header } from "../OtherWorks/Header"
@@ -68,7 +68,7 @@ describe("OtherWorks", () => {
     ]
     const component = mount(<OtherWorks artwork={genericOtherWorksData} />)
     expect(component.find(Header).length).toEqual(1)
-    expect(component.find(Serif).text()).toEqual("Other works by Andy Warhol")
+    expect(component.find(Text).text()).toEqual("Other works by Andy Warhol")
   })
 
   it("renders the grids if multiple are provided", () => {
@@ -90,10 +90,10 @@ describe("OtherWorks", () => {
     ]
     const component = mount(<OtherWorks artwork={genericOtherWorksData} />)
     expect(component.find(Header).length).toEqual(2)
-    expect(component.find(Serif).first().text()).toEqual(
+    expect(component.find(Text).first().text()).toEqual(
       "Other works by Andy Warhol"
     )
-    expect(component.find(Serif).last().text()).toEqual(
+    expect(component.find(Text).last().text()).toEqual(
       "Other works from Gagosian Gallery"
     )
   })
@@ -115,7 +115,7 @@ describe("OtherWorks", () => {
     ]
     const component = mount(<OtherWorks artwork={genericOtherWorksData} />)
     expect(component.find(Header).length).toEqual(1)
-    expect(component.find(Serif).text()).toEqual("Other works by Andy Warhol")
+    expect(component.find(Text).text()).toEqual("Other works by Andy Warhol")
   })
 
   it("renders only grids with artworks", () => {
@@ -144,7 +144,7 @@ describe("OtherWorks", () => {
     ]
     const component = mount(<OtherWorks artwork={genericOtherWorksData} />)
     expect(component.find(Header).length).toEqual(1)
-    expect(component.find(Serif).text()).toEqual("Other works by Andy Warhol")
+    expect(component.find(Text).text()).toEqual("Other works by Andy Warhol")
   })
 
   describe("Context-specific behavior", () => {


### PR DESCRIPTION
This is _quite_ a significant change. Lots of text updates and lots of places that could possibly go wrong.

Most of this was straight conversion. I _did_ alter how h1's are rendered from the artist's name. Previously we had it where if there were multiple artists then there would be multiple h1's which is invalid from an SEO perspective.

There are also some accessibility lint rules that were failing around links that don't have hrefs but simply act as buttons. I disabled them for now, but I'd be open to fixing in this PR or a follow up. @dzucconi your thoughts would be welcome here.

Before:

<img width="1186" alt="image" src="https://user-images.githubusercontent.com/3087225/93822284-fefddf80-fc2d-11ea-96c5-846fbce40bbd.png">

After:

<img width="1197" alt="image" src="https://user-images.githubusercontent.com/3087225/93822229-e8578880-fc2d-11ea-9236-731716e5257e.png">

Before:

<img width="378" alt="image" src="https://user-images.githubusercontent.com/3087225/93822551-63b93a00-fc2e-11ea-96bd-c610e0b4c893.png">

After:

<img width="378" alt="image" src="https://user-images.githubusercontent.com/3087225/93822505-51d79700-fc2e-11ea-8cbb-0a0cbb067c1c.png">

Before:

<img width="720" alt="image" src="https://user-images.githubusercontent.com/3087225/93822726-a549e500-fc2e-11ea-834a-9792bb3c9be8.png">

After:

<img width="726" alt="image" src="https://user-images.githubusercontent.com/3087225/93822766-b2ff6a80-fc2e-11ea-9364-f9392b1612e8.png">

