### PR TITLE
[FX-2251] Utilizes `text` variant consistently across EntityHeaders

### DIFF
--- a/src/v2/Apps/Artist/Routes/Overview/Components/RecommendedArtist.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/Components/RecommendedArtist.tsx
@@ -1,5 +1,5 @@
 import { ContextModule, Intent } from "@artsy/cohesion"
-import { Box, EntityHeader, Sans } from "@artsy/palette"
+import { Box, EntityHeader, Text } from "@artsy/palette"
 import { RecommendedArtist_artist } from "v2/__generated__/RecommendedArtist_artist.graphql"
 import { SystemContext } from "v2/Artsy"
 import { track } from "v2/Artsy/Analytics"
@@ -79,10 +79,7 @@ const RecommendedArtist: FC<
             onOpenAuthModal={() => handleOpenAuth(mediator, artist)}
             render={({ is_followed }) => {
               return (
-                <Sans
-                  size="2"
-                  weight="medium"
-                  color="black"
+                <Text
                   data-test="followButton"
                   style={{
                     cursor: "pointer",
@@ -90,7 +87,7 @@ const RecommendedArtist: FC<
                   }}
                 >
                   {is_followed ? "Following" : "Follow"}
-                </Sans>
+                </Text>
               )
             }}
           />

--- a/src/v2/Apps/Artwork/Components/ArtistInfo.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtistInfo.tsx
@@ -138,8 +138,6 @@ export class ArtistInfo extends Component<ArtistInfoProps, ArtistInfoState> {
                     render={({ is_followed }) => {
                       return (
                         <Text
-                          variant="caption"
-                          color="black"
                           data-test="followButton"
                           style={{
                             cursor: "pointer",

--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAboutTheWorkFromPartner.tsx
@@ -128,8 +128,6 @@ export class ArtworkDetailsAboutTheWorkFromPartner extends React.Component<
                           const is_followed = profile.is_followed || false
                           return (
                             <Text
-                              variant="caption"
-                              color="black"
                               data-test="followButton"
                               style={{
                                 cursor: "pointer",

--- a/src/v2/Apps/Collect/Routes/Collection/Components/Header/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/Header/index.tsx
@@ -93,8 +93,6 @@ export const featuredArtistsEntityCollection: (
               render={({ is_followed }) => {
                 return (
                   <Text
-                    variant="caption"
-                    color="black"
                     data-test="followArtistButton"
                     style={{
                       cursor: "pointer",


### PR DESCRIPTION
Closes: [FX-2251](https://artsyproduct.atlassian.net/browse/FX-2251)

![](http://static.damonzucconi.com/_capture/x68kY5DYyZDi.png)