### PR TITLE
Only show displayable fair booths in news section on partner2 page

### DIFF
--- a/src/desktop/apps/partner2/components/news/test/view.test.js
+++ b/src/desktop/apps/partner2/components/news/test/view.test.js
@@ -44,7 +44,7 @@ describe("NewsView", function () {
       ]))
     })
 
-    it("makes proper requests to fetch partner artists", function () {
+    it("makes proper requests to fetch partner artists and shows", function () {
       let requests
       this.view.fetch()
       ;(requests = Backbone.sync.args).length.should.equal(2)
@@ -62,6 +62,7 @@ describe("NewsView", function () {
         sort: "start_at",
         size: 3,
         at_a_fair: true,
+        displayable: true,
       })
     })
 

--- a/src/desktop/apps/partner2/components/news/view.coffee
+++ b/src/desktop/apps/partner2/components/news/view.coffee
@@ -32,7 +32,7 @@ module.exports = class NewsView extends Backbone.View
 
     Promise.allSettled([
       showEvents.fetch data: data
-      fairBooths.fetch data: _.extend {}, data, at_a_fair: true
+      fairBooths.fetch data: _.extend {}, data, at_a_fair: true, displayable: true
     ])
     .then ->
       [showEvents, fairBooths]


### PR DESCRIPTION
## Problem
Currently, booths which are not yet "displayable" (have either been intentionally hidden or the fair hasn't opened yet) are visible in the "News" section on a gallery's profile page.

An example is [Goodman Gallery](https://staging.artsy.net/goodman-gallery):
<img width="1226" alt="image" src="https://user-images.githubusercontent.com/2081340/94148337-7dcc6580-fe44-11ea-96e6-2db08bad49af.png">

This was reported in slack [here](https://artsy.slack.com/archives/C9SATFLUU/p1600787460073000).

## Solution
Only fetch for shows which have `displayable: true`. This [follows the logic](https://github.com/artsy/force/blob/master/src/desktop/apps/partner2/client/overview_layout_factory.coffee#L183-L184) that we use elsewhere (such as on the "Shows" view on the same profile page).

<img width="1177" alt="Screen Shot 2020-09-24 at 8 57 22 AM" src="https://user-images.githubusercontent.com/2081340/94149311-b6b90a00-fe45-11ea-8068-b34081a6b7ef.png">
