### PR TITLE
Require type check before deploying to staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,7 @@ workflows:
           name: push-staging-image
           <<: *only_master
           requires:
+            - yarn/type-check
             - yarn/jest
             - test:mocha
             - acceptance


### PR DESCRIPTION
The CircleCI [workflow](https://app.circleci.com/pipelines/github/artsy/force/9366/workflows/a725eb0b-7862-4143-b04b-630009bbbe9b) for the master branch seems off. The type check step is not doing anything but consumes container. We should probably either require it for staging deployment or remove it.

![Screen Shot 2020-09-25 at 10 56 31 AM](https://user-images.githubusercontent.com/796573/94283660-4a123e00-ff1f-11ea-9de2-e0de6af57b02.png)
