### PR TITLE
New CTAs for user with pending identity verification

### DIFF
--- a/src/desktop/apps/auction/components/layout/auction_info/Registration.tsx
+++ b/src/desktop/apps/auction/components/layout/auction_info/Registration.tsx
@@ -86,14 +86,14 @@ const Registration: React.FC<RegistrationProps> = props => {
             // User is registered, not qualified
             if (
               userLacksIdentityVerification &&
-              Boolean(user.pendingIdentityVerificationId)
+              Boolean(user?.pendingIdentityVerification?.flowURL)
             ) {
               // User needs IDV and has one pending
               return (
                 <div className={b("wrapper")}>
                   <a
                     className={b("idv-link")}
-                    href={`/identity-verification/${user.pendingIdentityVerificationId}`}
+                    href={user.pendingIdentityVerification.flowURL}
                   >
                     <Button width="100%" size="large">
                       Verify identity

--- a/src/desktop/apps/auction/components/layout/auction_info/Registration.tsx
+++ b/src/desktop/apps/auction/components/layout/auction_info/Registration.tsx
@@ -37,7 +37,7 @@ interface RegistrationProps {
   isEcommerceSale?: boolean
   isMobile: boolean
   showContactInfo?: boolean
-  user: {
+  user?: {
     id: string
     identityVerified: boolean
 
@@ -58,8 +58,8 @@ const Registration: React.FC<RegistrationProps> = props => {
   } = props
 
   const userLacksIdentityVerification =
-    auction.requireIdentityVerification && !user.identityVerified
-  const { pendingIdentityVerification } = user
+    auction.requireIdentityVerification && !user?.identityVerified
+  const pendingIdentityVerification = user?.pendingIdentityVerification
 
   const b = block("auction-Registration")
   const trackClick = desc => e => {
@@ -67,7 +67,7 @@ const Registration: React.FC<RegistrationProps> = props => {
       context_type: "auctions landing",
       auction_slug: auction.id,
       auction_state: auction.auctionState,
-      user_id: user && user.id,
+      user_id: user?.id,
     })
   }
 
@@ -208,7 +208,7 @@ const mapStateToProps = (state): RegistrationProps => {
     },
     isEcommerceSale,
     isMobile,
-    userRegistration: {
+    userRegistration: userRegistration && {
       qualifiedForBidding: userRegistration.qualified_for_bidding,
     },
     showContactInfo,

--- a/src/desktop/apps/auction/components/layout/auction_info/__tests__/Registration.jest.js
+++ b/src/desktop/apps/auction/components/layout/auction_info/__tests__/Registration.jest.js
@@ -26,7 +26,7 @@ describe("auction/components/layout/auction_info/Registration.test", () => {
         Component: Registration,
         props: {
           isClosed: false,
-          userRegistration: { qualified_for_bidding: true },
+          userRegistration: { qualifiedForBidding: true },
           isRegistrationEnded: false,
           showContactInfo: true,
           user: {},
@@ -39,17 +39,15 @@ describe("auction/components/layout/auction_info/Registration.test", () => {
 
     describe("sale requires identity verification", () => {
       const auction = {
-        attributes: {
-          requireIdentityVerification: true,
-        },
+        isClosed: false,
+        requireIdentityVerification: true,
+        isRegistrationEnded: false,
       }
-      it("returns Registration Pending when not qualified for bidding and verified", () => {
+      it("returns Registration Pending when not qualified for bidding but verified", () => {
         const { wrapper } = renderTestComponent({
           Component: Registration,
           props: {
-            isClosed: false,
-            isRegistrationEnded: false,
-            userRegistration: { qualified_for_bidding: false },
+            userRegistration: { qualifiedForBidding: false },
             showContactInfo: true,
             auction,
             user: {
@@ -62,18 +60,18 @@ describe("auction/components/layout/auction_info/Registration.test", () => {
         wrapper.text().should.containEql("Reviewing submitted information")
       })
 
-      it("Has CTA with link for user to complete id verificaiton if that is blocking their registration", () => {
+      it("Has CTA with link for user to complete id verification if that is blocking their registration", () => {
         const { wrapper } = renderTestComponent({
           Component: Registration,
           props: {
-            isClosed: false,
-            isRegistrationEnded: false,
             showContactInfo: true,
-            userRegistration: { qualified_for_bidding: false },
+            userRegistration: { qualifiedForBidding: false },
             auction,
             user: {
               identityVerified: false,
-              pendingIdentityVerificationId: "idv-id",
+              pendingIdentityVerification: {
+                internalID: "idv-id",
+              },
             },
           },
         })
@@ -91,12 +89,13 @@ describe("auction/components/layout/auction_info/Registration.test", () => {
       const { wrapper } = renderTestComponent({
         Component: Registration,
         props: {
-          isClosed: false,
-          isRegistrationEnded: true,
           showContactInfo: true,
           userRegistration: undefined,
           user: {},
-          auction: { attributes: {} },
+          auction: {
+            isClosed: false,
+            isRegistrationEnded: true,
+          },
         },
       })
 
@@ -110,14 +109,12 @@ describe("auction/components/layout/auction_info/Registration.test", () => {
         const { wrapper } = renderTestComponent({
           Component: Registration,
           props: {
-            isClosed: false,
-            isRegistrationEnded: false,
             showContactInfo: true,
             userRegistration,
             auction: {
-              attributes: {
-                requireIdentityVerification: false,
-              },
+              isClosed: false,
+              isRegistrationEnded: false,
+              requireIdentityVerification: false,
             },
             user: {
               identityVerified: false,
@@ -133,12 +130,13 @@ describe("auction/components/layout/auction_info/Registration.test", () => {
         const { wrapper } = renderTestComponent({
           Component: Registration,
           props: {
-            isClosed: false,
-            isRegistrationEnded: false,
             userRegistration,
             showContactInfo: true,
-            numBidders: 0,
-            auction: { attributes: { requireIdentityVerification: true } },
+            auction: {
+              requireIdentityVerification: true,
+              isClosed: false,
+              isRegistrationEnded: false,
+            },
             user: { identityVerified: false },
           },
         })
@@ -153,12 +151,12 @@ describe("auction/components/layout/auction_info/Registration.test", () => {
         const { wrapper } = renderTestComponent({
           Component: Registration,
           props: {
-            isClosed: false,
-            isQualifiedForBidding: true,
             showContactInfo: false,
-            isRegistrationEnded: false,
-            numBidders: 0,
-            auction: { attributes: { requireIdentityVerification: false } },
+            auction: {
+              isClosed: false,
+              isRegistrationEnded: false,
+              requireIdentityVerification: false,
+            },
             user: {},
           },
         })
@@ -171,12 +169,13 @@ describe("auction/components/layout/auction_info/Registration.test", () => {
         const { wrapper } = renderTestComponent({
           Component: Registration,
           props: {
-            isClosed: false,
-            isQualifiedForBidding: true,
             showContactInfo: true,
-            isRegistrationEnded: false,
-            numBidders: 0,
-            auction: { attributes: { requireIdentityVerification: false } },
+            auction: {
+              isClosed: false,
+              isQualifiedForBidding: true,
+              requireIdentityVerification: false,
+              isRegistrationEnded: false,
+            },
             user: {},
           },
         })

--- a/src/desktop/apps/auction/components/layout/auction_info/__tests__/Registration.jest.js
+++ b/src/desktop/apps/auction/components/layout/auction_info/__tests__/Registration.jest.js
@@ -10,15 +10,13 @@ describe("auction/components/layout/auction_info/Registration.test", () => {
         Component: Registration,
         props: {
           isClosed: true,
-          isQualifiedForBidding: true,
           isRegistrationEnded: false,
           showContactInfo: true,
-          numBidders: 0,
           userNeedsIdentityVerification: false,
         },
       })
 
-      expect(wrapper.find(".auctino2-registration__wrapper").length).toBe(0)
+      expect(wrapper.find(".auction2-registration__wrapper").length).toBe(0)
     })
 
     it("returns Registration Pending when not qualified for bidding and verified", () => {
@@ -26,10 +24,9 @@ describe("auction/components/layout/auction_info/Registration.test", () => {
         Component: Registration,
         props: {
           isClosed: false,
-          isQualifiedForBidding: false,
           isRegistrationEnded: false,
+          userRegistration: { qualified_for_bidding: false },
           showContactInfo: true,
-          numBidders: 0,
           userNeedsIdentityVerification: false,
         },
       })
@@ -43,10 +40,9 @@ describe("auction/components/layout/auction_info/Registration.test", () => {
         Component: Registration,
         props: {
           isClosed: false,
-          isQualifiedForBidding: false,
           isRegistrationEnded: false,
           showContactInfo: true,
-          numBidders: 1,
+          userRegistration: { qualified_for_bidding: false },
           userNeedsIdentityVerification: true,
         },
       })
@@ -60,8 +56,7 @@ describe("auction/components/layout/auction_info/Registration.test", () => {
         Component: Registration,
         props: {
           isClosed: false,
-          isQualifiedForBidding: true,
-          numBidders: 1,
+          userRegistration: { qualified_for_bidding: true },
           isRegistrationEnded: false,
           showContactInfo: true,
           userNeedsIdentityVerification: false,
@@ -76,8 +71,7 @@ describe("auction/components/layout/auction_info/Registration.test", () => {
         Component: Registration,
         props: {
           isClosed: false,
-          isQualifiedForBidding: true,
-          numBidders: 1,
+          userRegistration: { qualified_for_bidding: true },
           isRegistrationEnded: false,
           showContactInfo: true,
           userNeedsIdentityVerification: true,
@@ -92,10 +86,9 @@ describe("auction/components/layout/auction_info/Registration.test", () => {
         Component: Registration,
         props: {
           isClosed: false,
-          isQualifiedForBidding: true,
           isRegistrationEnded: true,
           showContactInfo: true,
-          numBidders: 0,
+          userRegistration: undefined,
           userNeedsIdentityVerification: false,
         },
       })
@@ -109,10 +102,9 @@ describe("auction/components/layout/auction_info/Registration.test", () => {
         Component: Registration,
         props: {
           isClosed: false,
-          isQualifiedForBidding: true,
           isRegistrationEnded: false,
           showContactInfo: true,
-          numBidders: 0,
+          userRegistration: undefined,
           userNeedsIdentityVerification: false,
         },
       })

--- a/src/desktop/apps/auction/queries/v2/me.ts
+++ b/src/desktop/apps/auction/queries/v2/me.ts
@@ -5,7 +5,7 @@ export const meV2Query = `
       has_credit_cards: hasCreditCards
       identityVerified
       pendingIdentityVerification {
-        flowURL
+        internalID
       }
       bidders(saleID: $saleId) {
         qualified_for_bidding: qualifiedForBidding

--- a/src/desktop/apps/auction/queries/v2/me.ts
+++ b/src/desktop/apps/auction/queries/v2/me.ts
@@ -4,7 +4,9 @@ export const meV2Query = `
       id: internalID
       has_credit_cards: hasCreditCards
       identityVerified
-      pendingIdentityVerificationId
+      pendingIdentityVerification {
+        flowURL
+      }
       bidders(saleID: $saleId) {
         qualified_for_bidding: qualifiedForBidding
       }

--- a/src/desktop/apps/auction/queries/v2/me.ts
+++ b/src/desktop/apps/auction/queries/v2/me.ts
@@ -4,6 +4,7 @@ export const meV2Query = `
       id: internalID
       has_credit_cards: hasCreditCards
       identityVerified
+      pendingIdentityVerificationId
       bidders(saleID: $saleId) {
         qualified_for_bidding: qualifiedForBidding
       }


### PR DESCRIPTION
This PR creates new CTAs when a user has a pending identity verification blocking their registration in an auction. It is blocked by https://github.com/artsy/metaphysics/pull/2719.
Jira 🔒 [AUCT-1142]

Current specs for the `Registration` component, which contains logic for the button and info text on a sale:
  ```
auction/components/layout/auction_info/Registration.test
    <Registration />
      ✓ doesnt render when isClosed is true (13ms)
      ✓ returns Approved if user has a qualified bidder registration (4ms)
      ✓ returns Registration Closed if if registration is ended + not registered (3ms)
      sale requires identity verification
        ✓ returns Registration Pending when not qualified for bidding and verified (6ms)
        ✓ Has CTA with link for user to complete id verificaiton if that is blocking their registration (5ms)
      user not registered
        ✓ Button says 'Register to Bid' + 'registration required' by default (25ms)
        ✓ 'Register to bid' button plus ID verification message if applicable to that user+sale (5ms)
      contact info
        ✓ hides contact info if specified (4ms)
        ✓ displays contact info if specified (6ms)
```

User has a not-qualified registration, sale requires verification, and they have a pending (non-FINAL) identity verification (we can't tell if it is related to _this_ pending registration):
![image](https://user-images.githubusercontent.com/9088720/94347185-ba8c8e00-fff7-11ea-8983-2fa35795eb8b.png)

Same, but no pending idv:
![image](https://user-images.githubusercontent.com/9088720/94347201-e14ac480-fff7-11ea-8a4e-8c1c143e4643.png)


[AUCT-1142]: https://artsyproduct.atlassian.net/browse/AUCT-1142