### PR TITLE
Upgrade @artsy/passport to pass X-Forwarded-For through from clients to API

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@artsy/express-reloadable": "1.4.8",
     "@artsy/gemup": "0.1.0",
     "@artsy/palette": "13.7.3",
-    "@artsy/passport": "1.3.2",
+    "@artsy/passport": "^1.4.0",
     "@artsy/reaction": "28.7.0",
     "@artsy/stitch": "6.1.6",
     "@artsy/xapp": "1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,10 +83,10 @@
   dependencies:
     passport-strategy "1.x.x"
 
-"@artsy/passport@1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@artsy/passport/-/passport-1.3.2.tgz#2393f6130808eb7432278126ac35666f028bf3e0"
-  integrity sha512-+t1YSvMbyCyeRC+Td/h6E7fN1Q6Y69bwG9rhqysadfsAQ6Stsqpbd68ZUWXMAN+pDcCqh8mev/DhvsLM5BfSJQ==
+"@artsy/passport@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@artsy/passport/-/passport-1.4.0.tgz#095b504b9941c755b15bd6af00833ae27bfe2679"
+  integrity sha512-htOaR+EF2yqgoWkxTpvW/gp5pmNg0ndYlLsDAtzm1m2MXAXxhzeFQ6ytpzJQEQm7ngngl58YdSum9/Uhjn/38w==
   dependencies:
     "@artsy/passport-local-with-otp" "^0.3.0"
     "@artsy/xapp" "^1.0.6"


### PR DESCRIPTION
Follows up https://github.com/artsy/artsy-passport/pull/149.

This seems to work locally. At least, it works as well as any local development works for me--it bumps into a Recaptcha-validation error, but that's pre-existing. (The local problem I had with xapp-loading went away when using this properly-released version of `@artsy/passport`. It must have been related to pointing to a local version of the library.)