### PR TITLE
chore [a11y]: replace auction result anchors with buttons

### DIFF
--- a/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
@@ -419,7 +419,7 @@ const renderEstimate = (estimatedPrice, user, mediator) => {
 }
 
 const renderRealizedPrice = (
-  estimatedPrice,
+  realizedPrice,
   user,
   mediator,
   filtersAtDefault
@@ -427,8 +427,8 @@ const renderRealizedPrice = (
   // Show prices if user is logged in. Otherwise, show prices only when filters at default.
   let body: JSX.Element
   if (user || filtersAtDefault) {
-    if (estimatedPrice) {
-      body = <Sans size="2">{estimatedPrice}</Sans>
+    if (realizedPrice) {
+      body = <Sans size="2">{realizedPrice}</Sans>
     } else {
       body = <Sans size="2">Price not available</Sans>
     }

--- a/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
@@ -3,9 +3,9 @@ import {
   ArrowDownIcon,
   ArrowUpIcon,
   BorderBox,
+  Clickable,
   Col,
   Collapse,
-  Link,
   Row,
   Sans,
 } from "@artsy/palette"
@@ -388,26 +388,17 @@ const renderPricing = (
   }
 }
 
-const renderEstimate = (estimatedPrice, user, mediator, size) => {
-  const justifyContent = size === "xs" ? "flex-start" : "flex-end"
+const renderEstimate = (estimatedPrice, user, mediator) => {
+  let body: JSX.Element
   if (user) {
-    return (
-      <Flex justifyContent={justifyContent}>
-        {estimatedPrice && (
-          <>
-            <Sans size="2">{estimatedPrice}</Sans>
-          </>
-        )}
-        {!estimatedPrice && (
-          <>
-            <Sans size="2">Estimate not available</Sans>
-          </>
-        )}
-      </Flex>
-    )
+    if (estimatedPrice) {
+      body = <Sans size="2">{estimatedPrice}</Sans>
+    } else {
+      body = <Sans size="2">Estimate not available</Sans>
+    }
   } else {
-    return (
-      <Link
+    body = (
+      <Clickable
         onClick={() => {
           mediator &&
             openAuthModal(mediator, {
@@ -417,40 +408,33 @@ const renderEstimate = (estimatedPrice, user, mediator, size) => {
               intent: Intent.seeEstimateAuctionRecords,
             })
         }}
+        textDecoration="underline"
       >
         <Sans size="2">Sign up to see estimate</Sans>
-      </Link>
+      </Clickable>
     )
   }
+
+  return <Flex justifyContent="flex-start">{body}</Flex>
 }
 
 const renderRealizedPrice = (
   estimatedPrice,
   user,
   mediator,
-  size,
   filtersAtDefault
 ) => {
-  const justifyContent = size === "xs" ? "flex-start" : "flex-end"
   // Show prices if user is logged in. Otherwise, show prices only when filters at default.
+  let body: JSX.Element
   if (user || filtersAtDefault) {
-    return (
-      <Flex justifyContent={justifyContent}>
-        {estimatedPrice && (
-          <>
-            <Sans size="2">{estimatedPrice}</Sans>
-          </>
-        )}
-        {!estimatedPrice && (
-          <>
-            <Sans size="2">Price not available</Sans>
-          </>
-        )}
-      </Flex>
-    )
+    if (estimatedPrice) {
+      body = <Sans size="2">{estimatedPrice}</Sans>
+    } else {
+      body = <Sans size="2">Price not available</Sans>
+    }
   } else {
-    return (
-      <Link
+    body = (
+      <Clickable
         onClick={() => {
           mediator &&
             openAuthModal(mediator, {
@@ -460,11 +444,14 @@ const renderRealizedPrice = (
               intent: Intent.seeRealizedPriceAuctionRecords,
             })
         }}
+        textDecoration="underline"
       >
         <Sans size="2">Sign up to see realized price</Sans>
-      </Link>
+      </Clickable>
     )
   }
+
+  return <Flex justifyContent="flex-start">{body}</Flex>
 }
 
 const renderLargeCollapse = (props, user, mediator, filtersAtDefault) => {
@@ -510,9 +497,7 @@ const renderLargeCollapse = (props, user, mediator, filtersAtDefault) => {
             </Box>
           </Col>
           <Col sm={4} pr="4.5%">
-            <Sans size="2">
-              {renderEstimate(estimatedPrice, user, mediator, "lg")}
-            </Sans>
+            {renderEstimate(estimatedPrice, user, mediator)}
           </Col>
         </Row>
 
@@ -538,13 +523,7 @@ const renderLargeCollapse = (props, user, mediator, filtersAtDefault) => {
             </Box>
           </Col>
           <Col sm={4} pr="4.5%">
-            {renderRealizedPrice(
-              salePrice,
-              user,
-              mediator,
-              "lg",
-              filtersAtDefault
-            )}
+            {renderRealizedPrice(salePrice, user, mediator, filtersAtDefault)}
           </Col>
         </Row>
 
@@ -612,9 +591,7 @@ const renderSmallCollapse = (props, user, mediator, filtersAtDefault) => {
               Estimate
             </Sans>
           </Col>
-          <Col xs={8}>
-            {renderEstimate(estimatedPrice, user, mediator, "xs")}
-          </Col>
+          <Col xs={8}>{renderEstimate(estimatedPrice, user, mediator)}</Col>
         </Row>
 
         <Row mb={2}>
@@ -624,13 +601,7 @@ const renderSmallCollapse = (props, user, mediator, filtersAtDefault) => {
             </Sans>
           </Col>
           <Col xs={8}>
-            {renderRealizedPrice(
-              salePrice,
-              user,
-              mediator,
-              "xs",
-              filtersAtDefault
-            )}
+            {renderRealizedPrice(salePrice, user, mediator, filtersAtDefault)}
           </Col>
         </Row>
 


### PR DESCRIPTION
While making a change in how the auction result sale dates are rendered, I found that eslint was complaining about us using anchors with `onClick` handlers. This PR replaces them with `<Clickable>` text (which is effectively text wrapped in a `<Button>`). I also refactored the component to better separate (I think) the logical decisions from the display rendering.

There are some visual changes as a result. The fields that needed a11y help were inconsistently aligned, so I made the alignment consistent.

## On desktop

| Logical branch  | Before  | After |
|---|---|---|
| logged out, unfiltered | ![image](https://user-images.githubusercontent.com/1627089/94305164-62da1e00-ff36-11ea-8f0e-555a59c3a915.png) | ![image](https://user-images.githubusercontent.com/1627089/94308803-b2234d00-ff3c-11ea-931a-dfcdf0003fbd.png) |
| logged out, filtered | ![image](https://user-images.githubusercontent.com/1627089/94305353-a03eab80-ff36-11ea-90ff-01c16e67bdfc.png) | ![image](https://user-images.githubusercontent.com/1627089/94308886-d121df00-ff3c-11ea-9f1d-af2db1e3d534.png)|
| logged in | ![image](https://user-images.githubusercontent.com/1627089/94308969-f6165200-ff3c-11ea-97ef-3a47f1127124.png) | ![image](https://user-images.githubusercontent.com/1627089/94309013-062e3180-ff3d-11ea-880b-ffc485d0e6a3.png)|

## On mobile


| Logical branch  | Before  | After |
|---|---|---|
| logged out, unfiltered | ![image](https://user-images.githubusercontent.com/1627089/94304454-3540a500-ff35-11ea-8bd0-c72b374385d1.png)|![image](https://user-images.githubusercontent.com/1627089/94304708-95cfe200-ff35-11ea-97a6-ab0c940813bd.png)|
| logged out, filtered | ![image](https://user-images.githubusercontent.com/1627089/94304545-56a19100-ff35-11ea-980c-36488d7acf95.png) | ![image](https://user-images.githubusercontent.com/1627089/94304750-ab450c00-ff35-11ea-8c82-46a6dcde26c3.png)|
| logged in | ![image](https://user-images.githubusercontent.com/1627089/94309266-67560500-ff3d-11ea-93a1-90b15446a0e7.png) | ![image](https://user-images.githubusercontent.com/1627089/94309287-72109a00-ff3d-11ea-85a8-8c59deb5ec55.png)|

cc @artsy/csgn-devs 

