### PR TITLE
chore: add types for jwt-decode

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,6 +244,7 @@
     "@types/flickity": "2.2.2",
     "@types/isomorphic-fetch": "0.0.34",
     "@types/jest": "24.0.18",
+    "@types/jwt-decode": "2.2.0",
     "@types/loadable__component": "5.10.0",
     "@types/lodash": "4.14.111",
     "@types/memoize-one": "3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4428,6 +4428,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/jwt-decode@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/jwt-decode/-/jwt-decode-2.2.0.tgz#10c4945a1505f771e4c60d26838dd2d39024ae4c"
+  integrity sha512-iY8jTNNQtU+6msAbBP3KyiYvdWcT4oGBJJCKq5VTjMZDkhcz1PzXnbCYG/W/O6ntIm3IgbfBbFZj17FKh3pK7A==
+
 "@types/loadable__component@5.10.0":
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/@types/loadable__component/-/loadable__component-5.10.0.tgz#178fdc401983f4f93647fac778226da7b8c1e080"


### PR DESCRIPTION
A couple of us have had issues with the `jwt-decode` dependency not type-checking properly, though it seems to be very inconsistently affecting people. This PR adds the types as a dev dependency with the theory that (a) it shouldn't hurt anyone, and (b) if it prevents one more person from chasing their tail on this issue it's worth it. 