### PR TITLE
@dzucconi => [Fair] Update timing display

### DIFF
--- a/src/v2/Apps/Fair/Components/FairHeader.tsx
+++ b/src/v2/Apps/Fair/Components/FairHeader.tsx
@@ -15,6 +15,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { FairHeader_fair } from "v2/__generated__/FairHeader_fair.graphql"
 import styled from "styled-components"
 import { ForwardLink } from "v2/Components/Links/ForwardLink"
+import { FairTimingFragmentContainer as FairTiming } from "./FairTiming"
 
 interface FairHeaderProps extends BoxProps {
   fair: FairHeader_fair
@@ -94,9 +95,8 @@ const FairHeader: React.FC<FairHeaderProps> = ({ fair, ...rest }) => {
             <Text as="h1" variant="largeTitle">
               {fair.name}
             </Text>
-            <Text variant="text" color="black60">
-              {fair.formattedOpeningHours}
-            </Text>
+
+            <FairTiming fair={fair} />
           </Col>
 
           <Col sm="6" mt={[3, 0]}>
@@ -122,7 +122,7 @@ export const FairHeaderFragmentContainer = createFragmentContainer(FairHeader, {
     fragment FairHeader_fair on Fair {
       about
       summary
-      formattedOpeningHours
+      ...FairTiming_fair
       name
       slug
       profile {

--- a/src/v2/Apps/Fair/Components/FairTiming.tsx
+++ b/src/v2/Apps/Fair/Components/FairTiming.tsx
@@ -1,0 +1,44 @@
+import React from "react"
+import { Text } from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { FairTiming_fair } from "v2/__generated__/FairTiming_fair.graphql"
+import { WithCurrentTime } from "v2/Components/WithCurrentTime"
+import { EventTiming } from "v2/Components/EventTiming"
+
+interface Props {
+  fair: FairTiming_fair
+}
+
+const FairTiming: React.FC<Props> = ({
+  fair: { exhibitionPeriod, startAt, endAt },
+}) => {
+  return (
+    <>
+      <Text variant="mediumText" color="black100">
+        {exhibitionPeriod}
+      </Text>
+      <Text variant="text" color="black60">
+        <WithCurrentTime syncWithServer>
+          {currentTime => {
+            const props = {
+              currentTime,
+              startAt,
+              endAt,
+            }
+            return <EventTiming {...props} />
+          }}
+        </WithCurrentTime>
+      </Text>
+    </>
+  )
+}
+
+export const FairTimingFragmentContainer = createFragmentContainer(FairTiming, {
+  fair: graphql`
+    fragment FairTiming_fair on Fair {
+      exhibitionPeriod
+      startAt
+      endAt
+    }
+  `,
+})

--- a/src/v2/Apps/Fair/Components/__tests__/FairHeader.jest.tsx
+++ b/src/v2/Apps/Fair/Components/__tests__/FairHeader.jest.tsx
@@ -106,6 +106,11 @@ describe("FairHeader", () => {
       .filterWhere(t => t.text() === "More info")
     expect(MoreInfoButton.length).toEqual(1)
   })
+
+  it("displays the relevant timing info", async () => {
+    const wrapper = await getWrapper()
+    expect(wrapper.text()).toContain("Closed")
+  })
 })
 
 const FairHeaderFixture: FairHeader_QueryRawResponse = {
@@ -113,8 +118,10 @@ const FairHeaderFixture: FairHeader_QueryRawResponse = {
     id: "fair12345",
     about: "This is the about.",
     name: "Miart 2020",
-    formattedOpeningHours: "Closes in 12 days",
+    exhibitionPeriod: "Aug 19 - Sep 19",
     slug: "miart-2020",
+    startAt: "2020-08-19T08:00:00+00:00",
+    endAt: "2020-09-19T08:00:00+00:00",
     image: {
       cropped: {
         src: "https://cloudfront.com/square.jpg",

--- a/src/v2/Apps/Fair/__tests__/FairApp.jest.tsx
+++ b/src/v2/Apps/Fair/__tests__/FairApp.jest.tsx
@@ -15,8 +15,10 @@ const FAIR_APP_FIXTURE: FairApp_QueryRawResponse = {
     internalID: "bson-fair",
     about: "Lorem ipsum",
     name: "Miart 2020",
-    formattedOpeningHours: "Closes in 12 days",
+    exhibitionPeriod: "Aug 19 - Sep 19",
     slug: "miart-2020",
+    startAt: "2020-08-19T08:00:00+00:00",
+    endAt: "2020-09-19T08:00:00+00:00",
     image: {
       cropped: {
         src: "https://cloudfront.com/square.jpg",

--- a/src/v2/Components/EventTiming.tsx
+++ b/src/v2/Components/EventTiming.tsx
@@ -1,0 +1,57 @@
+import React from "react"
+import { Text } from "@artsy/palette"
+import { DateTime, Duration } from "luxon"
+
+function padWithZero(num: number) {
+  return num.toString().padStart(2, "0")
+}
+
+interface Props {
+  startAt: string
+  endAt: string
+  currentTime: string
+}
+
+const SEPARATOR = <>&nbsp;:&nbsp;</>
+
+export const EventTiming: React.FC<Props> = ({
+  currentTime,
+  startAt,
+  endAt,
+}) => {
+  const durationTilEnd = Duration.fromISO(
+    DateTime.fromISO(endAt).diff(DateTime.fromISO(currentTime)).toString()
+  )
+  const daysTilEnd = durationTilEnd.as("days")
+  const secondsTilEnd = durationTilEnd.as("seconds")
+
+  const hasStarted =
+    Duration.fromISO(
+      DateTime.fromISO(startAt).diff(DateTime.fromISO(currentTime)).toString()
+    ).seconds < 0
+  const closesSoon = daysTilEnd <= 3 && daysTilEnd > 1
+  const hasEnded = Math.floor(secondsTilEnd) <= 0
+  const closesToday = daysTilEnd < 1 && !hasEnded
+
+  return (
+    <Text size="3" variant="mediumText">
+      {hasEnded && "Closed"}
+      {!hasStarted && "Opening Soon"}
+      {closesSoon && `Closes in ${Math.ceil(daysTilEnd)} days`}
+      {closesToday && (
+        <>
+          Closes in{" "}
+          {padWithZero(
+            Math.max(0, Math.floor(durationTilEnd.as("hours") % 24))
+          )}
+          {SEPARATOR}
+          {padWithZero(
+            Math.max(0, Math.floor(durationTilEnd.as("minutes") % 60))
+          )}
+          {SEPARATOR}
+          {padWithZero(Math.max(0, Math.floor(secondsTilEnd % 60)))}
+        </>
+      )}
+    </Text>
+  )
+}

--- a/src/v2/Components/__tests__/EventTimer.jest.tsx
+++ b/src/v2/Components/__tests__/EventTimer.jest.tsx
@@ -1,0 +1,40 @@
+import { mount } from "enzyme"
+import React from "react"
+import { EventTiming } from "../EventTiming"
+
+const currentTime = "2018-05-10T20:22:32.000Z"
+
+it("returns 'Closed' if the event is over", () => {
+  const timer = mount(
+    <EventTiming
+      startAt="2018-05-01T10:24:31+00:00"
+      currentTime={currentTime}
+      endAt="2018-05-08T10:24:31+00:00"
+    />
+  )
+  expect(timer.text()).toMatch("Closed")
+})
+
+it("returns a count of days if the event is closing soon", () => {
+  let timer
+  timer = mount(
+    <EventTiming
+      startAt="2018-05-01T10:24:31+00:00"
+      currentTime={currentTime}
+      endAt="2018-05-12T10:24:31+00:00"
+    />
+  )
+  expect(timer.text()).toMatch("Closes in 2 days")
+})
+
+it("returns a countdown if the event ends within 24 hours", () => {
+  let timer
+  timer = mount(
+    <EventTiming
+      startAt="2018-05-01T10:24:31+00:00"
+      currentTime={currentTime}
+      endAt="2018-05-10T23:24:31+00:00"
+    />
+  )
+  expect(timer.text()).toMatch("Closes in 03 : 01 : 59")
+})

--- a/src/v2/__generated__/FairApp_Query.graphql.ts
+++ b/src/v2/__generated__/FairApp_Query.graphql.ts
@@ -22,7 +22,9 @@ export type FairApp_QueryRawResponse = {
         }) | null;
         readonly about: string | null;
         readonly summary: string | null;
-        readonly formattedOpeningHours: string | null;
+        readonly exhibitionPeriod: string | null;
+        readonly startAt: string | null;
+        readonly endAt: string | null;
         readonly profile: ({
             readonly icon: ({
                 readonly cropped: ({
@@ -341,7 +343,7 @@ fragment FairFollowedArtists_fair on Fair {
 fragment FairHeader_fair on Fair {
   about
   summary
-  formattedOpeningHours
+  ...FairTiming_fair
   name
   slug
   profile {
@@ -378,6 +380,12 @@ fragment FairMeta_fair on Fair {
   metaImage: image {
     src: url(version: "large_rectangle")
   }
+}
+
+fragment FairTiming_fair on Fair {
+  exhibitionPeriod
+  startAt
+  endAt
 }
 
 fragment FillwidthItem_artwork on Artwork {
@@ -615,7 +623,21 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "formattedOpeningHours",
+            "name": "exhibitionPeriod",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "startAt",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "endAt",
             "storageKey": null
           },
           {
@@ -1268,7 +1290,7 @@ return {
     "metadata": {},
     "name": "FairApp_Query",
     "operationKind": "query",
-    "text": "query FairApp_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairEditorial_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 4) {\n    __typename\n    id\n  }\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  category\n  artworks: artworksConnection(first: 3) {\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  internalID\n  slug\n  marketingCollections(size: 4) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMM Do, YY\")\n  thumbnailTitle\n  thumbnailImage {\n    _1x: cropped(width: 140, height: 80) {\n      width\n      height\n      src: url\n    }\n    _2x: cropped(width: 280, height: 160) {\n      width\n      height\n      src: url\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  internalID\n  slug\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      artwork: node {\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  formattedOpeningHours\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query FairApp_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairEditorial_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 4) {\n    __typename\n    id\n  }\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  category\n  artworks: artworksConnection(first: 3) {\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  internalID\n  slug\n  marketingCollections(size: 4) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMM Do, YY\")\n  thumbnailTitle\n  thumbnailImage {\n    _1x: cropped(width: 140, height: 80) {\n      width\n      height\n      src: url\n    }\n    _2x: cropped(width: 280, height: 160) {\n      width\n      height\n      src: url\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  internalID\n  slug\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      artwork: node {\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  ...FairTiming_fair\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairHeader_Query.graphql.ts
+++ b/src/v2/__generated__/FairHeader_Query.graphql.ts
@@ -15,7 +15,9 @@ export type FairHeader_QueryRawResponse = {
     readonly fair: ({
         readonly about: string | null;
         readonly summary: string | null;
-        readonly formattedOpeningHours: string | null;
+        readonly exhibitionPeriod: string | null;
+        readonly startAt: string | null;
+        readonly endAt: string | null;
         readonly name: string | null;
         readonly slug: string;
         readonly profile: ({
@@ -67,7 +69,7 @@ query FairHeader_Query(
 fragment FairHeader_fair on Fair {
   about
   summary
-  formattedOpeningHours
+  ...FairTiming_fair
   name
   slug
   profile {
@@ -95,6 +97,12 @@ fragment FairHeader_fair on Fair {
   links(format: HTML)
   tickets(format: HTML)
   contact(format: HTML)
+}
+
+fragment FairTiming_fair on Fair {
+  exhibitionPeriod
+  startAt
+  endAt
 }
 */
 
@@ -194,7 +202,21 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "formattedOpeningHours",
+            "name": "exhibitionPeriod",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "startAt",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "endAt",
             "storageKey": null
           },
           {
@@ -381,7 +403,7 @@ return {
     "metadata": {},
     "name": "FairHeader_Query",
     "operationKind": "query",
-    "text": "query FairHeader_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairHeader_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  formattedOpeningHours\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n"
+    "text": "query FairHeader_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairHeader_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  ...FairTiming_fair\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairHeader_fair.graphql.ts
+++ b/src/v2/__generated__/FairHeader_fair.graphql.ts
@@ -6,7 +6,6 @@ import { FragmentRefs } from "relay-runtime";
 export type FairHeader_fair = {
     readonly about: string | null;
     readonly summary: string | null;
-    readonly formattedOpeningHours: string | null;
     readonly name: string | null;
     readonly slug: string;
     readonly profile: {
@@ -32,6 +31,7 @@ export type FairHeader_fair = {
     readonly links: string | null;
     readonly tickets: string | null;
     readonly contact: string | null;
+    readonly " $fragmentRefs": FragmentRefs<"FairTiming_fair">;
     readonly " $refType": "FairHeader_fair";
 };
 export type FairHeader_fair$data = FairHeader_fair;
@@ -78,13 +78,6 @@ return {
       "storageKey": null
     },
     (v0/*: any*/),
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "formattedOpeningHours",
-      "storageKey": null
-    },
     {
       "alias": null,
       "args": null,
@@ -255,10 +248,15 @@ return {
       "kind": "ScalarField",
       "name": "contact",
       "storageKey": "contact(format:\"HTML\")"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "FairTiming_fair"
     }
   ],
   "type": "Fair"
 };
 })();
-(node as any).hash = '602875de975ebad7d480faa41e409f8f';
+(node as any).hash = 'f639d9dfb1d75fe2c1d3e0b586ac6d89';
 export default node;

--- a/src/v2/__generated__/FairTiming_fair.graphql.ts
+++ b/src/v2/__generated__/FairTiming_fair.graphql.ts
@@ -1,0 +1,51 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type FairTiming_fair = {
+    readonly exhibitionPeriod: string | null;
+    readonly startAt: string | null;
+    readonly endAt: string | null;
+    readonly " $refType": "FairTiming_fair";
+};
+export type FairTiming_fair$data = FairTiming_fair;
+export type FairTiming_fair$key = {
+    readonly " $data"?: FairTiming_fair$data;
+    readonly " $fragmentRefs": FragmentRefs<"FairTiming_fair">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "FairTiming_fair",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "exhibitionPeriod",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "startAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endAt",
+      "storageKey": null
+    }
+  ],
+  "type": "Fair"
+};
+(node as any).hash = '69ccf3ea7b14916f83f88714796d542f';
+export default node;

--- a/src/v2/__generated__/routes_FairQuery.graphql.ts
+++ b/src/v2/__generated__/routes_FairQuery.graphql.ts
@@ -200,7 +200,7 @@ fragment FairFollowedArtists_fair on Fair {
 fragment FairHeader_fair on Fair {
   about
   summary
-  formattedOpeningHours
+  ...FairTiming_fair
   name
   slug
   profile {
@@ -237,6 +237,12 @@ fragment FairMeta_fair on Fair {
   metaImage: image {
     src: url(version: "large_rectangle")
   }
+}
+
+fragment FairTiming_fair on Fair {
+  exhibitionPeriod
+  startAt
+  endAt
 }
 
 fragment FillwidthItem_artwork on Artwork {
@@ -474,7 +480,21 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "formattedOpeningHours",
+            "name": "exhibitionPeriod",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "startAt",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "endAt",
             "storageKey": null
           },
           {
@@ -1127,7 +1147,7 @@ return {
     "metadata": {},
     "name": "routes_FairQuery",
     "operationKind": "query",
-    "text": "query routes_FairQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairEditorial_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 4) {\n    __typename\n    id\n  }\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  category\n  artworks: artworksConnection(first: 3) {\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  internalID\n  slug\n  marketingCollections(size: 4) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMM Do, YY\")\n  thumbnailTitle\n  thumbnailImage {\n    _1x: cropped(width: 140, height: 80) {\n      width\n      height\n      src: url\n    }\n    _2x: cropped(width: 280, height: 160) {\n      width\n      height\n      src: url\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  internalID\n  slug\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      artwork: node {\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  formattedOpeningHours\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query routes_FairQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairEditorial_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 4) {\n    __typename\n    id\n  }\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  category\n  artworks: artworksConnection(first: 3) {\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  internalID\n  slug\n  marketingCollections(size: 4) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMM Do, YY\")\n  thumbnailTitle\n  thumbnailImage {\n    _1x: cropped(width: 140, height: 80) {\n      width\n      height\n      src: url\n    }\n    _2x: cropped(width: 280, height: 160) {\n      width\n      height\n      src: url\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  internalID\n  slug\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      artwork: node {\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  ...FairTiming_fair\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Web version of:

<img width="892" alt="Screen Shot 2020-09-25 at 4 07 48 PM" src="https://user-images.githubusercontent.com/1457859/94311429-4693ac80-ff49-11ea-903f-09a8ce6038cc.png">


I made this a specific `Fair` component for now. It should be easily extracted into a more shareable `EventTiming` or something for use on the show page (it just needs the `startAt` and `endAt` basically).

For the first line of the display, I chose to use [`exhibitionPeriod`](https://github.com/artsy/metaphysics/blob/40e352176834ba79962d17dff51a94f9978dc71d/src/schema/v2/fair.ts#L157). That basically does what we want, and will include the year if it's different from the current year. The comp seems to always include the year, but the fair name (right above the timing info) will frequently include the year as well ('CHART 2020'), so this seems fine.

For the second line of the display, it's some dynamic text, but one of the dynamic possibilities is a countdown timer. I couldn't reuse our [existing one](https://github.com/artsy/force/blob/28d7e095aaa40ff0203fc0e2f8ec41795abb47bf/src/v2/Components/Timer.tsx) , but I think that's fine. It's basically a `<WithCurrentTime`> HOC and a duration calculation.

Updating with tests...