### PR TITLE
style(typography): remove Avant Garde from categories page #FF

### DIFF
--- a/src/desktop/apps/categories/components/App.js
+++ b/src/desktop/apps/categories/components/App.js
@@ -1,3 +1,4 @@
+import { Theme } from "@artsy/palette"
 import React, { Component } from "react"
 import PropTypes from "prop-types"
 import styled from "styled-components"
@@ -20,10 +21,12 @@ class App extends Component {
   render() {
     const { geneFamilies, allFeaturedGenesByFamily } = this.props
     return (
-      <Layout>
-        <GeneFamilyNav geneFamilies={geneFamilies} />
-        <TAGPContent geneFamilies={geneFamilies} />
-      </Layout>
+      <Theme>
+        <Layout>
+          <GeneFamilyNav geneFamilies={geneFamilies} />
+          <TAGPContent geneFamilies={geneFamilies} />
+        </Layout>
+      </Theme>
     )
   }
 }

--- a/src/desktop/apps/categories/components/FeaturedGene.js
+++ b/src/desktop/apps/categories/components/FeaturedGene.js
@@ -1,7 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import styled from "styled-components"
-import { avantgarde } from "v2/Assets/Fonts"
+import { Text } from "@artsy/palette"
 
 const propTypes = {
   title: PropTypes.string,
@@ -15,17 +15,14 @@ const Container = styled.div`
   overflow: hidden;
 `
 
-const GeneName = styled.span`
+const GeneName = styled(Text).attrs({ variant: "mediumText" })`
   position: absolute;
   left: 1em;
-  bottom: 1em;
+  bottom: 0.85em;
   text-decoration: none;
 
   color: white;
   text-shadow: 0 0 10px rgba(0, 0, 0, 0.7);
-
-  ${avantgarde("s13")};
-  font-weight: bold;
 `
 
 const GeneImage = styled.img`
@@ -37,7 +34,7 @@ const FeaturedGene = ({ title, href, image: { url: imageSrc } }) => {
     <a href={href}>
       <Container>
         <GeneName>{title}</GeneName>
-        <GeneImage src={imageSrc} />
+        <GeneImage src={imageSrc} alt={title} />
       </Container>
     </a>
   )

--- a/src/desktop/apps/categories/components/GeneFamilyNav.js
+++ b/src/desktop/apps/categories/components/GeneFamilyNav.js
@@ -3,8 +3,8 @@ import PropTypes from "prop-types"
 import styled from "styled-components"
 import Scrollspy from "react-scrollspy"
 
+import { Text } from "@artsy/palette"
 import colors from "v2/Assets/Colors"
-import { avantgarde } from "v2/Assets/Fonts"
 import FrameAnimator from "desktop/components/frame_animator"
 
 const propTypes = {
@@ -33,12 +33,10 @@ const GeneFamilyList = styled(Scrollspy)`
   padding-right: 2em;
   background: white;
   z-index: 1;
-
-  ${avantgarde("s13")};
 `
 
 const GeneFamilyItem = styled.li`
-  margin-bottom: 1em;
+  margin-bottom: 0.76em;
   &.is-current a {
     color: ${colors.purpleRegular};
   }
@@ -82,12 +80,14 @@ class GeneFamilyNav extends React.Component {
         >
           {geneFamilies.map(geneFamily => (
             <GeneFamilyItem key={geneFamily.slug}>
-              <GeneFamilyLink
-                href={`#${geneFamily.slug}`}
-                onClick={this.handleClick}
-              >
-                {geneFamily.name}
-              </GeneFamilyLink>
+              <Text variant="mediumText">
+                <GeneFamilyLink
+                  href={`#${geneFamily.slug}`}
+                  onClick={this.handleClick}
+                >
+                  {geneFamily.name}
+                </GeneFamilyLink>
+              </Text>
             </GeneFamilyItem>
           ))}
         </GeneFamilyList>

--- a/src/desktop/apps/categories/components/__tests__/GeneFamilyNav.test.js
+++ b/src/desktop/apps/categories/components/__tests__/GeneFamilyNav.test.js
@@ -9,14 +9,16 @@ describe("GeneFamilyNav", () => {
   beforeEach(() => {
     geneFamilies = [
       {
-        id: "materials",
+        id: 123,
+        slug: "materials",
         name: "Materials",
         genes: [
           /* … */
         ],
       },
       {
-        id: "styles",
+        id: 456,
+        slug: "styles",
         name: "Styles",
         genes: [
           /* … */
@@ -28,15 +30,7 @@ describe("GeneFamilyNav", () => {
 
   it("renders links for each family", () => {
     rendered.find("a").length.should.equal(2)
-    rendered
-      .find("a")
-      .eq(0)
-      .text()
-      .should.equal("Materials")
-    rendered
-      .find("a")
-      .eq(1)
-      .text()
-      .should.equal("Styles")
+    rendered.find("a").eq(0).text().should.equal("Materials")
+    rendered.find("a").eq(1).text().should.equal("Styles")
   })
 })


### PR DESCRIPTION
A small Future Friday typography conversion…

There is a generation of Force sub apps that were born after we switched to React but before we standardized on Relay/Reaction/Palette. I wanted to try updating one of those, so I went to my old friend `/categories`

The conversion was not too bad, just needed to wrap it in a Palette `<Theme />` and drop in a few `<Text>`s

I chose only to replace Avant Garde, leaving the rest as-is since that would require more substantial design input.

![cat2](https://user-images.githubusercontent.com/140521/94314166-fd922700-ff4d-11ea-8a13-e84f52c9dd04.gif)

