### PR TITLE
fix: display auction result sale date without considering local time zone

### DIFF
--- a/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx
@@ -136,9 +136,7 @@ const LargeAuctionItem: SFC<Props> = props => {
   } = getProps(props)
 
   const imageUrl = get(images, i => i.thumbnail.url, "")
-  const dateOfSale = DateTime.fromISO(saleDate).toLocaleString(
-    DateTime.DATE_MED
-  )
+  const dateOfSale = getDisplaySaleDate(saleDate)
 
   return (
     <>
@@ -214,9 +212,7 @@ const ExtraSmallAuctionItem: SFC<Props> = props => {
     salePrice,
   } = getProps(props)
   const imageUrl = get(images, i => i.thumbnail.url, "")
-  const dateOfSale = DateTime.fromISO(saleDate).toLocaleString(
-    DateTime.DATE_MED
-  )
+  const dateOfSale = getDisplaySaleDate(saleDate)
 
   return (
     <Flex data-test={ContextModule.auctionResults} width="100%">
@@ -317,6 +313,12 @@ const getProps = (props: Props) => {
   }
 }
 
+const getDisplaySaleDate = saleDate => {
+  return DateTime.fromISO(saleDate, { zone: "utc" }).toLocaleString(
+    DateTime.DATE_MED
+  )
+}
+
 const renderPricing = (
   salePrice,
   saleDate,
@@ -330,7 +332,8 @@ const renderPricing = (
   // If user is logged in we show prices. Otherwise we show prices only when filters at default.
   if (user || filtersAtDefault) {
     const textAlign = size === "xs" ? "left" : "right"
-    const dateOfSale = DateTime.fromISO(saleDate)
+
+    const dateOfSale = DateTime.fromISO(saleDate, { zone: "utc" })
     const now = DateTime.local()
     const awaitingResults = dateOfSale > now
 
@@ -481,9 +484,7 @@ const renderLargeCollapse = (props, user, mediator, filtersAtDefault) => {
     estimatedPrice,
   } = getProps(props)
 
-  const dateOfSale = DateTime.fromISO(saleDate).toLocaleString(
-    DateTime.DATE_MED
-  )
+  const dateOfSale = getDisplaySaleDate(saleDate)
 
   return (
     <Collapse open={expanded}>
@@ -582,9 +583,7 @@ const renderSmallCollapse = (props, user, mediator, filtersAtDefault) => {
     estimatedPrice,
   } = getProps(props)
 
-  const dateOfSale = DateTime.fromISO(saleDate).toLocaleString(
-    DateTime.DATE_MED
-  )
+  const dateOfSale = getDisplaySaleDate(saleDate)
 
   return (
     <Collapse open={expanded}>

--- a/src/v2/Apps/__tests__/Fixtures/Artist/Routes/AuctionResultsFixture.ts
+++ b/src/v2/Apps/__tests__/Fixtures/Artist/Routes/AuctionResultsFixture.ts
@@ -42,7 +42,7 @@ export const AuctionResultsFixture: AuctionResults_Test_QueryRawResponse = {
             description:
               "Pablo Picasso (1881-1973)\n\nOiseau fantastique\n\nfelt-tip pen on paper\n\n10 ¾ x 8 3/8 in. (27.2 x 21.1 cm.)\n\nDrawn in 1952",
             date_text: "1881-1973",
-            saleDate: "2020-02-05T19:00:00-05:00",
+            saleDate: "2020-02-05T19:00:00Z",
             price_realized: { display: "$NaN", cents_usd: 0 },
             estimate: { display: "$40,000 - 60,000" },
             id: "QXVjdGlvblJlc3VsdDoyNDk2Nw==",
@@ -86,7 +86,7 @@ export const AuctionResultsFixture: AuctionResults_Test_QueryRawResponse = {
             description:
               "Pablo Picasso (1881-1973)\n\nTête d'homme\n\ninscribed and dated 'Boisgeloup 10 juillet XXXIV' (upper right)\n\npencil on paper\n\n20 1/8 x 13 ½ in. (51.2 x 34.2 cm.)\n\nDrawn in Boisgeloup on 10 July 1934",
             date_text: "1881-1973",
-            saleDate: "2020-02-05T19:00:00-05:00",
+            saleDate: "2020-02-05T19:00:00Z",
             price_realized: { display: "$NaN", cents_usd: 0 },
             estimate: { display: "$500,000 - 700,000" },
             id: "QXVjdGlvblJlc3VsdDoyNDc1Nw==",
@@ -108,7 +108,7 @@ export const AuctionResultsFixture: AuctionResults_Test_QueryRawResponse = {
             description:
               "PABLO PICASSO (1881-1973)\n\nPicador et taureau _(A.R. 197)_\n\ndated '25.9.53.' (in reverse; lower center); stamped and numbered 'Madoura Plein Feu/Empreinte Originale de Picasso/29/200' (underneath)\n\nwhite earthenware ceramic plate with black oxide, colored engobe and glaze\n\nDiameter: 9 ¼ in. (23.5 cm.)\n\nConceived on 25 September 1953 and executed in a numbered edition of 200",
             date_text: "1881-1973",
-            saleDate: "2020-02-05T19:00:00-05:00",
+            saleDate: "2020-02-05T19:00:00Z",
             price_realized: { display: "$NaN", cents_usd: 0 },
             estimate: { display: "$3,500 - 4,500" },
             id: "QXVjdGlvblJlc3VsdDoyNDY4Nw==",
@@ -130,7 +130,7 @@ export const AuctionResultsFixture: AuctionResults_Test_QueryRawResponse = {
             description:
               "PABLO PICASSO (1881-1973)\n\nColombe à la lucarne _(A.R. 78)_\n\nstamped, marked and numbered 'Madoura Plein Feu/Edition Picasso/193/200/Edition Picasso/Madoura' (underneath)\n\nwhite earthenware ceramic plate, partially engraved, with colored engobe and glaze\n\nLength: 15 3/8 in. (39 cm.)\n\nConceived in 1949 and executed in a numbered edition of 200",
             date_text: "1881-1973",
-            saleDate: "2020-02-05T19:00:00-05:00",
+            saleDate: "2020-02-05T19:00:00Z",
             price_realized: { display: "$NaN", cents_usd: 0 },
             estimate: { display: "$6,000 - 8,000" },
             id: "QXVjdGlvblJlc3VsdDoyNDY3Nw==",
@@ -152,7 +152,7 @@ export const AuctionResultsFixture: AuctionResults_Test_QueryRawResponse = {
             description:
               "PABLO PICASSO (1881-1973)\n\nScène de plage _(A.R. 391)_\n\nstamped 'Madoura Plein Feu/Empreinte Originale de Picasso' (on the reverse)\n\nwhite earthenware ceramic plaque with black engobe and white glaze\n\nDiameter: 10 in. (25.3 cm.)\n\nConceived in 1956 and executed in an edition of 450",
             date_text: "1881-1973",
-            saleDate: "2020-02-05T19:00:00-05:00",
+            saleDate: "2020-02-05T19:00:00Z",
             price_realized: { display: "$NaN", cents_usd: 0 },
             estimate: { display: "$2,500 - 3,500" },
             id: "QXVjdGlvblJlc3VsdDoyNDY2Nw==",
@@ -174,7 +174,7 @@ export const AuctionResultsFixture: AuctionResults_Test_QueryRawResponse = {
             description:
               "PABLO PICASSO (1881-1973)\n\nTête de femme couronnée de fleurs _(A.R. 236)_\n\nsigned and dated 'Picasso/20.3.54.' (on the side); numbered '18/50/6.' (underneath)\n\nwhite earthenware ceramic vase, partially engraved, with white engobe\n\nHeight: 9 1/8 in. (23 cm.)\n\nConceived on 20 March 1954 and executed in a numbered edition of 50",
             date_text: "1881-1973",
-            saleDate: "2020-02-05T19:00:00-05:00",
+            saleDate: "2020-02-05T19:00:00Z",
             price_realized: { display: "$NaN", cents_usd: 0 },
             estimate: { display: "$18,000 - 25,000" },
             id: "QXVjdGlvblJlc3VsdDoyNDY1Nw==",
@@ -196,7 +196,7 @@ export const AuctionResultsFixture: AuctionResults_Test_QueryRawResponse = {
             description:
               "PABLO PICASSO (1881-1973)\n\nFemme _(A.R. 297)_\n\nstamped 'Edition Picasso/Madoura Plein Feu/Edition Picasso' (underneath)\n\nwhite earthenware ceramic pitcher with colored engobe and glaze\n\nHeight: 13 in. (33 cm.)\n\nConceived in 1955 and executed in an edition of 100",
             date_text: "1881-1973",
-            saleDate: "2020-02-05T19:00:00-05:00",
+            saleDate: "2020-02-05T19:00:00Z",
             price_realized: { display: "$NaN", cents_usd: 0 },
             estimate: { display: "$10,000 - 15,000" },
             id: "QXVjdGlvblJlc3VsdDoyNDY0Nw==",
@@ -218,7 +218,7 @@ export const AuctionResultsFixture: AuctionResults_Test_QueryRawResponse = {
             description:
               "PABLO PICASSO (1881-1973)\n\n_Taureau dans l'arène _(A.R. 80)\n\nstamped and marked 'Madoura Plein Feu/D'Après Picasso/Edition Picasso /GR' (underneath)\n\nwhite earthenware ceramic plate, partially engraved, with colored engobe and glaze\n\nLength: 14 ¾ in. (37.6 cm.)\n\nConceived in 1948 and executed in an edition of 450",
             date_text: "1881-1973",
-            saleDate: "2020-02-05T19:00:00-05:00",
+            saleDate: "2020-02-05T19:00:00Z",
             price_realized: { display: "$NaN", cents_usd: 0 },
             estimate: { display: "$7,000 - 10,000" },
             id: "QXVjdGlvblJlc3VsdDoyNDYzNw==",
@@ -240,7 +240,7 @@ export const AuctionResultsFixture: AuctionResults_Test_QueryRawResponse = {
             description:
               "PABLO PICASSO (1881-1973)\n\nVisage de femme _(A.R. 192)_\n\nstamped, marked and numbered 'Edition Picasso/Madoura Plein Feu/Edition Picasso/99/200/Madoura' (underneath)\n\nwhite earthenware ceramic pitcher, partially engraved, with colored engobe and glaze\n\nHeight: 13 3/8 in. (34 cm.)\n\nConceived on 7 July 1953 and executed in a numbered edition of 200",
             date_text: "1881-1973",
-            saleDate: "2020-02-05T19:00:00-05:00",
+            saleDate: "2020-02-05T19:00:00Z",
             price_realized: { display: "$NaN", cents_usd: 0 },
             estimate: { display: "$7,000 - 10,000" },
             id: "QXVjdGlvblJlc3VsdDoyNDYyNw==",


### PR DESCRIPTION
Addresses [(CSGN-387)](https://artsyproduct.atlassian.net/browse/CSGN-387) 

Sale dates for auction lots were showing the correct date on server-render, but once the client took over they'd flip to the previous day. 

## Example before (ignore my cursor and focus on the auction sale dates):

![csgn-387-before](https://user-images.githubusercontent.com/1627089/94315613-77bfad00-ff48-11ea-9c26-6393ebd1e026.gif)

This PR modifies (and mostly centralizes) how we parse lot sale dates so that the correct date is displayed on the client. 

## Example after:
![csgn-387-after](https://user-images.githubusercontent.com/1627089/94316146-72169700-ff49-11ea-8983-8e9a0e47af17.gif)

## More details

Sale dates are stored in the diffusion Lot table without timezones. Metaphysics returns them to force in ISO format. For a sale that occurred on 2020-08-13, MP would return the `saleDate` field as `"2020-08-13T00:00:00.000Z"`. 

The luxon library, used in force, [assumes that we want the take the client's time zone into account when parsing dates](https://moment.github.io/luxon/docs/manual/zones.html#local-by-default). For a lot with the sale date `"2020-08-13T00:00:00.000Z"`, and for me in Central US time, by default luxon would parse this lot's sale date as `"2020-08-12T17:00:00.000-05:00"`. When the component renders that sale date, I'd see `Aug 12, 2020` instead of `Aug 13, 2020`. 

By telling luxon to use the `utc` time zone when parsing the lot's sale date, it ignores my time zone and parses as `"2020-08-13T00:00:00.000Z"`. Now when the component renders the sale date, it shows `Aug 13, 2020`. 

## But where are the tests??!!

I started writing some tests to ensure this functionality but [to quote the luxon docs](https://moment.github.io/luxon/docs/manual/zones.html#terminology),

> Time zones are pain in the ass.

And doubly so when trying to write robust unit tests, so I gave up on them.

cc @artsy/csgn-devs 