### PR TITLE
FX-2297: Adds analytics for new fair page

### DIFF
--- a/src/v2/Apps/Fair/Components/FairCollections/FairCollections.tsx
+++ b/src/v2/Apps/Fair/Components/FairCollections/FairCollections.tsx
@@ -16,8 +16,16 @@ export const FairCollections: React.FC<FairCollectionsProps> = ({
   return (
     <Box {...rest}>
       <Carousel>
-        {fair.marketingCollections.map(collection => {
-          return <FairCollection key={collection.id} collection={collection} />
+        {fair.marketingCollections.map((collection, index) => {
+          return (
+            <FairCollection
+              key={collection.id}
+              collection={collection}
+              carouselIndex={index}
+              fairSlug={fair.slug}
+              fairID={fair.internalID}
+            />
+          )
         })}
       </Carousel>
     </Box>
@@ -29,8 +37,11 @@ export const FairCollectionsFragmentContainer = createFragmentContainer(
   {
     fair: graphql`
       fragment FairCollections_fair on Fair {
+        internalID
+        slug
         marketingCollections(size: 4) {
           id
+          slug
           ...FairCollection_collection
         }
       }

--- a/src/v2/Apps/Fair/Components/FairEditorial/FairEditorial.tsx
+++ b/src/v2/Apps/Fair/Components/FairEditorial/FairEditorial.tsx
@@ -11,7 +11,14 @@ export const FairEditorial: React.FC<FairEditorialProps> = ({ fair }) => {
   return (
     <>
       {fair.articles.edges.map(({ node: article }) => {
-        return <FairEditorialItem key={article.id} article={article} />
+        return (
+          <FairEditorialItem
+            key={article.id}
+            article={article}
+            fairID={fair.internalID}
+            fairSlug={fair.slug}
+          />
+        )
       })}
     </>
   )
@@ -22,6 +29,8 @@ export const FairEditorialFragmentContainer = createFragmentContainer(
   {
     fair: graphql`
       fragment FairEditorial_fair on Fair {
+        internalID
+        slug
         articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {
           edges {
             node {

--- a/src/v2/Apps/Fair/Components/FairEditorial/FairEditorialItem.tsx
+++ b/src/v2/Apps/Fair/Components/FairEditorial/FairEditorialItem.tsx
@@ -4,6 +4,13 @@ import { FairEditorialItem_article } from "v2/__generated__/FairEditorialItem_ar
 import { Box, Text } from "@artsy/palette"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import styled from "styled-components"
+import { useTracking } from "react-tracking"
+import {
+  ActionType,
+  ClickedArticleGroup,
+  ContextModule,
+  OwnerType,
+} from "@artsy/cohesion"
 
 const Container = styled(RouterLink)`
   display: flex;
@@ -18,15 +25,34 @@ const Thumbnail = styled.img`
 
 interface FairEditorialItemProps {
   article: FairEditorialItem_article
+  fairID: string // needed for analytics
+  fairSlug: string // needed for analytics
 }
 
 export const FairEditorialItem: React.FC<FairEditorialItemProps> = ({
   article,
+  fairID,
+  fairSlug,
 }) => {
+  const tracking = useTracking()
+
+  const clickedArticleTrackingData: ClickedArticleGroup = {
+    context_module: ContextModule.relatedArticles,
+    context_page_owner_type: OwnerType.fair,
+    context_page_owner_id: fairID,
+    context_page_owner_slug: fairSlug,
+    destination_page_owner_type: OwnerType.article,
+    destination_page_owner_id: article.internalID,
+    destination_page_owner_slug: article.slug,
+    type: "thumbnail",
+    action: ActionType.clickedArticleGroup,
+  }
+
   return (
     <Container
       to={article.href}
       aria-label={`${article.title} (${article.publishedAt})`}
+      onClick={() => tracking.trackEvent(clickedArticleTrackingData)}
     >
       <Box flex="1" pr={3}>
         <Text variant="subtitle" as="h4" mb={0.5}>
@@ -63,6 +89,8 @@ export const FairEditorialItemFragmentContainer = createFragmentContainer(
     article: graphql`
       fragment FairEditorialItem_article on Article {
         id
+        internalID
+        slug
         title
         href
         publishedAt(format: "MMM Do, YY")

--- a/src/v2/Apps/Fair/FairApp.tsx
+++ b/src/v2/Apps/Fair/FairApp.tsx
@@ -13,6 +13,13 @@ import { FairMetaFragmentContainer as FairMeta } from "./Components/FairMeta"
 import { FairCollectionsFragmentContainer as FairCollections } from "./Components/FairCollections"
 import { FairFollowedArtistsFragmentContainer as FairFollowedArtists } from "./Components/FairFollowedArtists"
 import { useSystemContext } from "v2/Artsy"
+import { useTracking } from "react-tracking"
+import {
+  ActionType,
+  ClickedNavigationTab,
+  ContextModule,
+  OwnerType,
+} from "@artsy/cohesion"
 
 interface FairAppProps {
   fair: FairApp_fair
@@ -20,12 +27,33 @@ interface FairAppProps {
 
 const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
   const { user } = useSystemContext()
+  const tracking = useTracking()
 
   if (!fair) return <ErrorPage code={404} />
 
-  const hasArticles = fair.articles.edges.length > 0
-  const hasCollections = fair.marketingCollections.length > 0
+  const hasArticles = (fair.articles?.edges?.length ?? 0) > 0
+  const hasCollections = (fair.marketingCollections?.length ?? 0) > 0
   const columnCount = hasArticles && hasCollections ? 2 : 1
+
+  const clickedArtworksTabTrackingData: ClickedNavigationTab = {
+    context_module: ContextModule.exhibitorsTab,
+    context_page_owner_type: OwnerType.fair,
+    context_page_owner_id: fair.internalID,
+    context_page_owner_slug: fair.slug,
+    destination_path: `fair/${fair.slug}/artworks`,
+    subject: "Artworks",
+    action: ActionType.clickedNavigationTab,
+  }
+
+  const clickedExhibitorsTabTrackingData: ClickedNavigationTab = {
+    context_module: ContextModule.artworksTab,
+    context_page_owner_type: OwnerType.fair,
+    context_page_owner_id: fair.internalID,
+    context_page_owner_slug: fair.slug,
+    destination_path: `fair/${fair.slug}`,
+    subject: "Exhibitors",
+    action: ActionType.clickedNavigationTab,
+  }
 
   return (
     <>
@@ -76,11 +104,23 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
           )}
 
           <RouteTabs>
-            <RouteTab to={`/fair2/${fair.slug}`} exact>
+            <RouteTab
+              to={`/fair2/${fair.slug}`}
+              exact
+              onClick={() =>
+                tracking.trackEvent(clickedExhibitorsTabTrackingData)
+              }
+            >
               Exhibitors
             </RouteTab>
 
-            <RouteTab to={`/fair2/${fair.slug}/artworks`} exact>
+            <RouteTab
+              to={`/fair2/${fair.slug}/artworks`}
+              exact
+              onClick={() =>
+                tracking.trackEvent(clickedArtworksTabTrackingData)
+              }
+            >
               Artworks
             </RouteTab>
           </RouteTabs>
@@ -100,6 +140,7 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
 export default createFragmentContainer(FairApp, {
   fair: graphql`
     fragment FairApp_fair on Fair {
+      internalID
       slug
       ...FairMeta_fair
       ...FairHeader_fair

--- a/src/v2/Apps/Fair/Routes/FairArtworks.tsx
+++ b/src/v2/Apps/Fair/Routes/FairArtworks.tsx
@@ -15,6 +15,8 @@ import { ColorFilter } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/Color
 import { Box } from "@artsy/palette"
 import { FollowedArtistsFilter } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/FollowedArtistsFilter"
 import { useSystemContext } from "v2/Artsy"
+import { useTracking } from "react-tracking"
+import { OwnerType, clickedMainArtworkGrid } from "@artsy/cohesion"
 
 interface FairArtworksFilterProps {
   fair: FairArtworks_fair
@@ -24,8 +26,9 @@ interface FairArtworksFilterProps {
 
 const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
   const { match, relay, fair } = props
-  const { filtered_artworks } = fair
+  const { filtered_artworks, slug, internalID } = fair
   const { user } = useSystemContext()
+  const tracking = useTracking()
 
   const hasFilter = filtered_artworks && filtered_artworks.id
 
@@ -63,6 +66,17 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
         { value: "year", text: "Artwork year (asc.)" },
       ]}
       onChange={updateUrl}
+      onArtworkBrickClick={artwork => {
+        tracking.trackEvent(
+          clickedMainArtworkGrid({
+            contextPageOwnerType: OwnerType.fair,
+            contextPageOwnerSlug: slug,
+            contextPageOwnerId: internalID,
+            destinationPageOwnerId: artwork.internalID,
+            destinationPageOwnerSlug: artwork.slug,
+          })
+        )
+      }}
     >
       <BaseArtworkFilter
         relay={relay}
@@ -99,6 +113,8 @@ export const FairArtworksRefetchContainer = createRefetchContainer(
           sort: { type: "String", defaultValue: "-partner_updated_at" }
           shouldFetchCounts: { type: "Boolean", defaultValue: false }
         ) {
+        slug
+        internalID
         filtered_artworks: filterArtworksConnection(
           acquireable: $acquireable
           aggregations: $aggregations

--- a/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
+++ b/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
@@ -1,3 +1,9 @@
+import {
+  ActionType,
+  ClickedShowMore,
+  ContextModule,
+  OwnerType,
+} from "@artsy/cohesion"
 import { Button, Col, Grid, Row } from "@artsy/palette"
 import React, { useState } from "react"
 import {
@@ -5,6 +11,7 @@ import {
   createPaginationContainer,
   graphql,
 } from "react-relay"
+import { useTracking } from "react-tracking"
 import { FairExhibitors_fair } from "v2/__generated__/FairExhibitors_fair.graphql"
 import { FairExhibitorRailFragmentContainer as FairExhibitorRail } from "../Components/FairExhibitorRail"
 
@@ -15,9 +22,21 @@ interface FairExhibitorsProps {
 
 const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair, relay }) => {
   const [isLoading, setIsLoading] = useState(false)
+  const tracking = useTracking()
+
+  const clickShowMoreTrackingData: ClickedShowMore = {
+    context_module: ContextModule.exhibitorsTab,
+    context_page_owner_type: OwnerType.fair,
+    context_page_owner_id: fair.internalID,
+    context_page_owner_slug: fair.slug,
+    subject: "Show More",
+    action: ActionType.clickedShowMore,
+  }
 
   const handleClick = () => {
     if (!relay.hasMore() || relay.isLoading()) return
+
+    tracking.trackEvent(clickShowMoreTrackingData)
 
     setIsLoading(true)
 
@@ -38,7 +57,15 @@ const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair, relay }) => {
           return null
         }
 
-        return <FairExhibitorRail key={show.id} show={show} my={3} />
+        return (
+          <FairExhibitorRail
+            key={show.id}
+            show={show}
+            my={3}
+            fairID={fair.internalID}
+            fairSlug={fair.slug}
+          />
+        )
       })}
 
       <Grid my={6}>
@@ -70,6 +97,7 @@ export const FairExhibitorsFragmentContainer = createPaginationContainer(
           after: { type: "String" }
         ) {
         slug
+        internalID
         exhibitors: showsConnection(
           first: $first
           after: $after

--- a/src/v2/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
@@ -48,6 +48,8 @@ describe("FairArtworks", () => {
 const FAIR_ARTWORKS_FIXTURE: FairArtworks_QueryRawResponse = {
   fair: {
     id: "xxx",
+    slug: "cool-fair",
+    internalID: "bson-fair",
     filtered_artworks: {
       id: "filteredartworksabc123",
       counts: {

--- a/src/v2/Apps/Fair/Routes/__tests__/FairExhibitors.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairExhibitors.jest.tsx
@@ -54,6 +54,7 @@ describe("FairExhibitors", () => {
 const FAIR_EXHIBITORS_FIXTURE: FairExhibitors_QueryRawResponse = {
   fair: {
     id: "xxx",
+    internalID: "fair-ID",
     slug: "xxx",
     exhibitors: {
       pageInfo: {
@@ -67,6 +68,7 @@ const FAIR_EXHIBITORS_FIXTURE: FairExhibitors_QueryRawResponse = {
             __typename: "Show",
             id: "xxx-1",
             internalID: "xxx-1",
+            slug: "show-slug",
             counts: { artworks: 0 },
             href: "/show/example-1",
             partner: {
@@ -82,6 +84,7 @@ const FAIR_EXHIBITORS_FIXTURE: FairExhibitors_QueryRawResponse = {
             __typename: "Show",
             id: "xxx-2",
             internalID: "xxx-2",
+            slug: "show-slug",
             counts: { artworks: 10 },
             href: "/show/example-2",
             partner: {
@@ -97,6 +100,7 @@ const FAIR_EXHIBITORS_FIXTURE: FairExhibitors_QueryRawResponse = {
             __typename: "Show",
             id: "xxx-3",
             internalID: "xxx-3",
+            slug: "show-slug",
             counts: { artworks: 10 },
             href: "/show/example-3",
             partner: {

--- a/src/v2/__generated__/FairApp_Query.graphql.ts
+++ b/src/v2/__generated__/FairApp_Query.graphql.ts
@@ -13,6 +13,7 @@ export type FairApp_QueryResponse = {
 };
 export type FairApp_QueryRawResponse = {
     readonly fair: ({
+        readonly internalID: string;
         readonly slug: string;
         readonly name: string | null;
         readonly metaDescription: string | null;
@@ -51,6 +52,8 @@ export type FairApp_QueryRawResponse = {
             readonly edges: ReadonlyArray<({
                 readonly node: ({
                     readonly id: string;
+                    readonly internalID: string;
+                    readonly slug: string | null;
                     readonly title: string | null;
                     readonly href: string | null;
                     readonly publishedAt: string | null;
@@ -241,6 +244,7 @@ fragment Details_artwork on Artwork {
 }
 
 fragment FairApp_fair on Fair {
+  internalID
   slug
   ...FairMeta_fair
   ...FairHeader_fair
@@ -259,6 +263,7 @@ fragment FairApp_fair on Fair {
 }
 
 fragment FairCollection_collection on MarketingCollection {
+  id
   slug
   title
   category
@@ -276,14 +281,19 @@ fragment FairCollection_collection on MarketingCollection {
 }
 
 fragment FairCollections_fair on Fair {
+  internalID
+  slug
   marketingCollections(size: 4) {
     id
+    slug
     ...FairCollection_collection
   }
 }
 
 fragment FairEditorialItem_article on Article {
   id
+  internalID
+  slug
   title
   href
   publishedAt(format: "MMM Do, YY")
@@ -303,6 +313,8 @@ fragment FairEditorialItem_article on Article {
 }
 
 fragment FairEditorial_fair on Fair {
+  internalID
+  slug
   articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {
     edges {
       node {
@@ -416,92 +428,99 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "slug",
+  "name": "internalID",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "slug",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "summary",
+  "name": "name",
   "storageKey": null
 },
 v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "summary",
+  "storageKey": null
+},
+v6 = {
   "alias": "src",
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "width",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v9 = [
+v10 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "HTML"
   }
 ],
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v12 = [
-  (v7/*: any*/),
+v13 = [
   (v8/*: any*/),
-  (v5/*: any*/)
+  (v9/*: any*/),
+  (v6/*: any*/)
 ],
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v14 = [
+v15 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v15 = [
+v16 = [
   {
     "alias": null,
     "args": null,
@@ -552,6 +571,7 @@ return {
         "selections": [
           (v2/*: any*/),
           (v3/*: any*/),
+          (v4/*: any*/),
           {
             "alias": "metaDescription",
             "args": null,
@@ -590,7 +610,7 @@ return {
             "name": "about",
             "storageKey": null
           },
-          (v4/*: any*/),
+          (v5/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -638,14 +658,14 @@ return {
                     "name": "cropped",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/)
+                      (v6/*: any*/)
                     ],
                     "storageKey": "cropped(height:120,version:\"square140\",width:120)"
                   }
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/)
+              (v7/*: any*/)
             ],
             "storageKey": null
           },
@@ -681,9 +701,9 @@ return {
                 "name": "cropped",
                 "plural": false,
                 "selections": [
-                  (v5/*: any*/),
-                  (v7/*: any*/),
-                  (v8/*: any*/)
+                  (v6/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/)
                 ],
                 "storageKey": "cropped(height:1000,version:\"wide\",width:750)"
               }
@@ -705,8 +725,8 @@ return {
             "name": "location",
             "plural": false,
             "selections": [
-              (v4/*: any*/),
-              (v6/*: any*/)
+              (v5/*: any*/),
+              (v7/*: any*/)
             ],
             "storageKey": null
           },
@@ -719,28 +739,28 @@ return {
           },
           {
             "alias": null,
-            "args": (v9/*: any*/),
+            "args": (v10/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
             "storageKey": "hours(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v9/*: any*/),
+            "args": (v10/*: any*/),
             "kind": "ScalarField",
             "name": "links",
             "storageKey": "links(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v9/*: any*/),
+            "args": (v10/*: any*/),
             "kind": "ScalarField",
             "name": "tickets",
             "storageKey": "tickets(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v9/*: any*/),
+            "args": (v10/*: any*/),
             "kind": "ScalarField",
             "name": "contact",
             "storageKey": "contact(format:\"HTML\")"
@@ -780,9 +800,11 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
-                      (v10/*: any*/),
+                      (v7/*: any*/),
+                      (v2/*: any*/),
+                      (v3/*: any*/),
                       (v11/*: any*/),
+                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": [
@@ -829,7 +851,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v12/*: any*/),
+                            "selections": (v13/*: any*/),
                             "storageKey": "cropped(height:80,width:140)"
                           },
                           {
@@ -850,7 +872,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v12/*: any*/),
+                            "selections": (v13/*: any*/),
                             "storageKey": "cropped(height:160,width:280)"
                           }
                         ],
@@ -859,7 +881,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v13/*: any*/)
+                  (v14/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -880,9 +902,9 @@ return {
             "name": "marketingCollections",
             "plural": true,
             "selections": [
-              (v6/*: any*/),
-              (v2/*: any*/),
-              (v10/*: any*/),
+              (v7/*: any*/),
+              (v3/*: any*/),
+              (v11/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -944,18 +966,18 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v7/*: any*/)
                         ],
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
-                  (v6/*: any*/)
+                  (v7/*: any*/)
                 ],
                 "storageKey": "artworksConnection(first:3)"
               },
-              (v13/*: any*/)
+              (v14/*: any*/)
             ],
             "storageKey": "marketingCollections(size:4)"
           },
@@ -1032,8 +1054,8 @@ return {
                         "name": "imageTitle",
                         "storageKey": null
                       },
-                      (v10/*: any*/),
                       (v11/*: any*/),
+                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1057,15 +1079,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v14/*: any*/),
+                        "args": (v15/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v6/*: any*/),
-                          (v11/*: any*/),
-                          (v3/*: any*/)
+                          (v7/*: any*/),
+                          (v12/*: any*/),
+                          (v4/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -1078,15 +1100,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v14/*: any*/),
+                        "args": (v15/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/),
-                          (v11/*: any*/),
-                          (v6/*: any*/),
+                          (v4/*: any*/),
+                          (v12/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1119,7 +1141,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v6/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": "is_live_open",
                             "args": null,
@@ -1184,7 +1206,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v15/*: any*/),
+                            "selections": (v16/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1194,10 +1216,10 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v15/*: any*/),
+                            "selections": (v16/*: any*/),
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v7/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -1208,15 +1230,9 @@ return {
                         "name": "isInquireable",
                         "storageKey": null
                       },
-                      (v6/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "internalID",
-                        "storageKey": null
-                      },
+                      (v7/*: any*/),
                       (v2/*: any*/),
+                      (v3/*: any*/),
                       {
                         "alias": "is_saved",
                         "args": null,
@@ -1237,11 +1253,11 @@ return {
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/)
+              (v7/*: any*/)
             ],
             "storageKey": "filterArtworksConnection(first:20,includeArtworksByFollowedArtists:true)"
           },
-          (v6/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
@@ -1252,7 +1268,7 @@ return {
     "metadata": {},
     "name": "FairApp_Query",
     "operationKind": "query",
-    "text": "query FairApp_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairEditorial_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 4) {\n    __typename\n    id\n  }\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  slug\n  title\n  category\n  artworks: artworksConnection(first: 3) {\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 4) {\n    id\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  title\n  href\n  publishedAt(format: \"MMM Do, YY\")\n  thumbnailTitle\n  thumbnailImage {\n    _1x: cropped(width: 140, height: 80) {\n      width\n      height\n      src: url\n    }\n    _2x: cropped(width: 280, height: 160) {\n      width\n      height\n      src: url\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      artwork: node {\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  formattedOpeningHours\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query FairApp_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairEditorial_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 4) {\n    __typename\n    id\n  }\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  category\n  artworks: artworksConnection(first: 3) {\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  internalID\n  slug\n  marketingCollections(size: 4) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMM Do, YY\")\n  thumbnailTitle\n  thumbnailImage {\n    _1x: cropped(width: 140, height: 80) {\n      width\n      height\n      src: url\n    }\n    _2x: cropped(width: 280, height: 160) {\n      width\n      height\n      src: url\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  internalID\n  slug\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      artwork: node {\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  formattedOpeningHours\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairApp_fair.graphql.ts
+++ b/src/v2/__generated__/FairApp_fair.graphql.ts
@@ -4,6 +4,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type FairApp_fair = {
+    readonly internalID: string;
     readonly slug: string;
     readonly articles: {
         readonly edges: ReadonlyArray<{
@@ -40,6 +41,13 @@ return {
   "metadata": null,
   "name": "FairApp_fair",
   "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
     {
       "alias": null,
       "args": null,
@@ -124,5 +132,5 @@ return {
   "type": "Fair"
 };
 })();
-(node as any).hash = '676d31eff3db1901c747013245b0ebbf';
+(node as any).hash = 'e36e4e73c5f91ec2ea52e87d44b80161';
 export default node;

--- a/src/v2/__generated__/FairArtworksQuery.graphql.ts
+++ b/src/v2/__generated__/FairArtworksQuery.graphql.ts
@@ -179,6 +179,8 @@ fragment Details_artwork on Artwork {
 }
 
 fragment FairArtworks_fair_2QyA7m on Fair {
+  slug
+  internalID
   filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: "", sort: $sort) {
     id
     ...ArtworkFilterArtworkGrid2_filtered_artworks
@@ -424,33 +426,47 @@ v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "slug",
   "storageKey": null
 },
 v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "internalID",
   "storageKey": null
 },
 v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cursor",
+  "name": "id",
   "storageKey": null
 },
 v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v21 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v22 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v21 = [
-  (v19/*: any*/),
-  (v20/*: any*/),
+v23 = [
+  (v21/*: any*/),
+  (v22/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -459,21 +475,21 @@ v21 = [
     "storageKey": null
   }
 ],
-v22 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v23 = [
+v25 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v24 = [
+v26 = [
   {
     "alias": null,
     "args": null,
@@ -538,6 +554,8 @@ return {
         "name": "fair",
         "plural": false,
         "selections": [
+          (v17/*: any*/),
+          (v18/*: any*/),
           {
             "alias": "filtered_artworks",
             "args": [
@@ -572,7 +590,7 @@ return {
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              (v17/*: any*/),
+              (v19/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -603,7 +621,7 @@ return {
                         "name": "value",
                         "storageKey": null
                       },
-                      (v18/*: any*/),
+                      (v20/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -657,7 +675,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v21/*: any*/),
+                    "selections": (v23/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -667,7 +685,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v21/*: any*/),
+                    "selections": (v23/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -677,7 +695,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v21/*: any*/),
+                    "selections": (v23/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -688,8 +706,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v19/*: any*/),
-                      (v20/*: any*/)
+                      (v21/*: any*/),
+                      (v22/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -712,22 +730,10 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
+                      (v19/*: any*/),
                       (v17/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slug",
-                        "storageKey": null
-                      },
-                      (v22/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "internalID",
-                        "storageKey": null
-                      },
+                      (v24/*: any*/),
+                      (v18/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -803,15 +809,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v23/*: any*/),
+                        "args": (v25/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v17/*: any*/),
-                          (v22/*: any*/),
-                          (v18/*: any*/)
+                          (v19/*: any*/),
+                          (v24/*: any*/),
+                          (v20/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -824,15 +830,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v23/*: any*/),
+                        "args": (v25/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v18/*: any*/),
-                          (v22/*: any*/),
-                          (v17/*: any*/),
+                          (v20/*: any*/),
+                          (v24/*: any*/),
+                          (v19/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -865,7 +871,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v17/*: any*/),
+                          (v19/*: any*/),
                           {
                             "alias": "is_live_open",
                             "args": null,
@@ -930,7 +936,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v24/*: any*/),
+                            "selections": (v26/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -940,10 +946,10 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v24/*: any*/),
+                            "selections": (v26/*: any*/),
                             "storageKey": null
                           },
-                          (v17/*: any*/)
+                          (v19/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -971,14 +977,14 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v17/*: any*/)
+                  (v19/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": null
           },
-          (v17/*: any*/)
+          (v19/*: any*/)
         ],
         "storageKey": null
       }
@@ -989,7 +995,7 @@ return {
     "metadata": {},
     "name": "FairArtworksQuery",
     "operationKind": "query",
-    "text": "query FairArtworksQuery(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [TOTAL]\n  $slug: String!\n  $atAuction: Boolean\n  $color: String\n  $forSale: Boolean\n  $includeArtworksByFollowedArtists: Boolean\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sizes: [ArtworkSizes]\n  $sort: String\n) {\n  fair(id: $slug) {\n    ...FairArtworks_fair_2QyA7m\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairArtworks_fair_2QyA7m on Fair {\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: \"\", sort: $sort) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query FairArtworksQuery(\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [TOTAL]\n  $slug: String!\n  $atAuction: Boolean\n  $color: String\n  $forSale: Boolean\n  $includeArtworksByFollowedArtists: Boolean\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sizes: [ArtworkSizes]\n  $sort: String\n) {\n  fair(id: $slug) {\n    ...FairArtworks_fair_2QyA7m\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairArtworks_fair_2QyA7m on Fair {\n  slug\n  internalID\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: \"\", sort: $sort) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairArtworks_Query.graphql.ts
+++ b/src/v2/__generated__/FairArtworks_Query.graphql.ts
@@ -14,6 +14,8 @@ export type FairArtworks_QueryResponse = {
 };
 export type FairArtworks_QueryRawResponse = {
     readonly fair: ({
+        readonly slug: string;
+        readonly internalID: string;
         readonly filtered_artworks: ({
             readonly id: string;
             readonly counts: ({
@@ -248,6 +250,8 @@ fragment Details_artwork on Artwork {
 }
 
 fragment FairArtworks_fair_3Rrp9Z on Fair {
+  slug
+  internalID
   filtered_artworks: filterArtworksConnection(medium: "*", first: 20, after: "", sort: "-partner_updated_at") {
     id
     counts {
@@ -329,33 +333,47 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "slug",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "internalID",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cursor",
+  "name": "id",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v6 = [
-  (v4/*: any*/),
-  (v5/*: any*/),
+v8 = [
+  (v6/*: any*/),
+  (v7/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -364,21 +382,21 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v8 = [
+v10 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v9 = [
+v11 = [
   {
     "alias": null,
     "args": null,
@@ -433,6 +451,8 @@ return {
         "name": "fair",
         "plural": false,
         "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
           {
             "alias": "filtered_artworks",
             "args": [
@@ -462,7 +482,7 @@ return {
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
+              (v4/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -511,7 +531,7 @@ return {
                         "name": "value",
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -565,7 +585,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v6/*: any*/),
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -575,7 +595,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v6/*: any*/),
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -585,7 +605,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v6/*: any*/),
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -596,8 +616,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
-                      (v5/*: any*/)
+                      (v6/*: any*/),
+                      (v7/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -620,22 +640,10 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
+                      (v4/*: any*/),
                       (v2/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slug",
-                        "storageKey": null
-                      },
-                      (v7/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "internalID",
-                        "storageKey": null
-                      },
+                      (v9/*: any*/),
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -711,15 +719,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v8/*: any*/),
+                        "args": (v10/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v2/*: any*/),
-                          (v7/*: any*/),
-                          (v3/*: any*/)
+                          (v4/*: any*/),
+                          (v9/*: any*/),
+                          (v5/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -732,15 +740,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v8/*: any*/),
+                        "args": (v10/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/),
-                          (v7/*: any*/),
-                          (v2/*: any*/),
+                          (v5/*: any*/),
+                          (v9/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -773,7 +781,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v2/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": "is_live_open",
                             "args": null,
@@ -838,7 +846,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v11/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -848,10 +856,10 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v11/*: any*/),
                             "storageKey": null
                           },
-                          (v2/*: any*/)
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -879,14 +887,14 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v2/*: any*/)
+                  (v4/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": "filterArtworksConnection(after:\"\",first:20,medium:\"*\",sort:\"-partner_updated_at\")"
           },
-          (v2/*: any*/)
+          (v4/*: any*/)
         ],
         "storageKey": null
       }
@@ -897,7 +905,7 @@ return {
     "metadata": {},
     "name": "FairArtworks_Query",
     "operationKind": "query",
-    "text": "query FairArtworks_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairArtworks_fair_3Rrp9Z\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairArtworks_fair_3Rrp9Z on Fair {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-partner_updated_at\") {\n    id\n    counts {\n      followedArtists\n    }\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query FairArtworks_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairArtworks_fair_3Rrp9Z\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairArtworks_fair_3Rrp9Z on Fair {\n  slug\n  internalID\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-partner_updated_at\") {\n    id\n    counts {\n      followedArtists\n    }\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairArtworks_fair.graphql.ts
+++ b/src/v2/__generated__/FairArtworks_fair.graphql.ts
@@ -4,6 +4,8 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type FairArtworks_fair = {
+    readonly slug: string;
+    readonly internalID: string;
     readonly filtered_artworks: {
         readonly id: string;
         readonly counts?: {
@@ -124,6 +126,20 @@ const node: ReaderFragment = {
   "metadata": null,
   "name": "FairArtworks_fair",
   "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
     {
       "alias": "filtered_artworks",
       "args": [
@@ -261,5 +277,5 @@ const node: ReaderFragment = {
   ],
   "type": "Fair"
 };
-(node as any).hash = 'a6d10b9f523c42a0b3f9ff869ae1b431';
+(node as any).hash = 'e6d9b9af84777ffe5e0d7aea0a0cb4c3';
 export default node;

--- a/src/v2/__generated__/FairCollection_Query.graphql.ts
+++ b/src/v2/__generated__/FairCollection_Query.graphql.ts
@@ -13,6 +13,7 @@ export type FairCollection_QueryResponse = {
 };
 export type FairCollection_QueryRawResponse = {
     readonly marketingCollection: ({
+        readonly id: string;
         readonly slug: string;
         readonly title: string;
         readonly category: string;
@@ -27,7 +28,6 @@ export type FairCollection_QueryRawResponse = {
             }) | null> | null;
             readonly id: string | null;
         }) | null;
-        readonly id: string | null;
     }) | null;
 };
 export type FairCollection_Query = {
@@ -49,6 +49,7 @@ query FairCollection_Query(
 }
 
 fragment FairCollection_collection on MarketingCollection {
+  id
   slug
   title
   category
@@ -129,6 +130,7 @@ return {
         "name": "marketingCollection",
         "plural": false,
         "selections": [
+          (v2/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -214,8 +216,7 @@ return {
               (v2/*: any*/)
             ],
             "storageKey": "artworksConnection(first:3)"
-          },
-          (v2/*: any*/)
+          }
         ],
         "storageKey": null
       }
@@ -226,7 +227,7 @@ return {
     "metadata": {},
     "name": "FairCollection_Query",
     "operationKind": "query",
-    "text": "query FairCollection_Query(\n  $slug: String!\n) {\n  marketingCollection(slug: $slug) {\n    ...FairCollection_collection\n    id\n  }\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  slug\n  title\n  category\n  artworks: artworksConnection(first: 3) {\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query FairCollection_Query(\n  $slug: String!\n) {\n  marketingCollection(slug: $slug) {\n    ...FairCollection_collection\n    id\n  }\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  category\n  artworks: artworksConnection(first: 3) {\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairCollection_collection.graphql.ts
+++ b/src/v2/__generated__/FairCollection_collection.graphql.ts
@@ -4,6 +4,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type FairCollection_collection = {
+    readonly id: string;
     readonly slug: string;
     readonly title: string;
     readonly category: string;
@@ -32,6 +33,13 @@ const node: ReaderFragment = {
   "metadata": null,
   "name": "FairCollection_collection",
   "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
     {
       "alias": null,
       "args": null,
@@ -119,5 +127,5 @@ const node: ReaderFragment = {
   ],
   "type": "MarketingCollection"
 };
-(node as any).hash = '4f544c08fe9fea47619a607160bed74f';
+(node as any).hash = '9be90ef7795bbca6d5ca7b14a367ce72';
 export default node;

--- a/src/v2/__generated__/FairCollections_fair.graphql.ts
+++ b/src/v2/__generated__/FairCollections_fair.graphql.ts
@@ -4,8 +4,11 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type FairCollections_fair = {
+    readonly internalID: string;
+    readonly slug: string;
     readonly marketingCollections: ReadonlyArray<{
         readonly id: string;
+        readonly slug: string;
         readonly " $fragmentRefs": FragmentRefs<"FairCollection_collection">;
     } | null>;
     readonly " $refType": "FairCollections_fair";
@@ -18,12 +21,28 @@ export type FairCollections_fair$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+};
+return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
   "name": "FairCollections_fair",
   "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
+    (v0/*: any*/),
     {
       "alias": null,
       "args": [
@@ -45,6 +64,7 @@ const node: ReaderFragment = {
           "name": "id",
           "storageKey": null
         },
+        (v0/*: any*/),
         {
           "args": null,
           "kind": "FragmentSpread",
@@ -56,5 +76,6 @@ const node: ReaderFragment = {
   ],
   "type": "Fair"
 };
-(node as any).hash = 'e3bbcfd676e3a4e662ee093308eae546';
+})();
+(node as any).hash = 'fc352f1f661b21240d58e599f867208e';
 export default node;

--- a/src/v2/__generated__/FairEditorialItem_article.graphql.ts
+++ b/src/v2/__generated__/FairEditorialItem_article.graphql.ts
@@ -5,6 +5,8 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type FairEditorialItem_article = {
     readonly id: string;
+    readonly internalID: string;
+    readonly slug: string | null;
     readonly title: string | null;
     readonly href: string | null;
     readonly publishedAt: string | null;
@@ -66,6 +68,20 @@ return {
       "args": null,
       "kind": "ScalarField",
       "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
       "storageKey": null
     },
     {
@@ -159,5 +175,5 @@ return {
   "type": "Article"
 };
 })();
-(node as any).hash = '7ae77e7305447798221c7b205b4f0411';
+(node as any).hash = '6fb6b81da34bfb7cc785cf07c892e199';
 export default node;

--- a/src/v2/__generated__/FairEditorial_fair.graphql.ts
+++ b/src/v2/__generated__/FairEditorial_fair.graphql.ts
@@ -4,6 +4,8 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type FairEditorial_fair = {
+    readonly internalID: string;
+    readonly slug: string;
     readonly articles: {
         readonly edges: ReadonlyArray<{
             readonly node: {
@@ -28,6 +30,20 @@ const node: ReaderFragment = {
   "metadata": null,
   "name": "FairEditorial_fair",
   "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
     {
       "alias": "articles",
       "args": [
@@ -87,5 +103,5 @@ const node: ReaderFragment = {
   ],
   "type": "Fair"
 };
-(node as any).hash = '6c196cd86adf966b035c281f671b9c32';
+(node as any).hash = '55ee3fb0c18ecb8731e24cfa414bd604';
 export default node;

--- a/src/v2/__generated__/FairExhibitorRailArtworksQuery.graphql.ts
+++ b/src/v2/__generated__/FairExhibitorRailArtworksQuery.graphql.ts
@@ -106,6 +106,8 @@ fragment FairExhibitorRailArtworks_show on Show {
   artworks: artworksConnection(first: 20) {
     edges {
       artwork: node {
+        internalID
+        slug
         ...FillwidthItem_artwork
         id
       }
@@ -264,6 +266,20 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -486,20 +502,6 @@ return {
                       },
                       (v4/*: any*/),
                       {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "internalID",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slug",
-                        "storageKey": null
-                      },
-                      {
                         "alias": "is_saved",
                         "args": null,
                         "kind": "ScalarField",
@@ -533,7 +535,7 @@ return {
     "metadata": {},
     "name": "FairExhibitorRailArtworksQuery",
     "operationKind": "query",
-    "text": "query FairExhibitorRailArtworksQuery(\n  $id: String!\n) {\n  show(id: $id) {\n    ...FairExhibitorRailArtworks_show\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairExhibitorRailArtworks_show on Show {\n  artworks: artworksConnection(first: 20) {\n    edges {\n      artwork: node {\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query FairExhibitorRailArtworksQuery(\n  $id: String!\n) {\n  show(id: $id) {\n    ...FairExhibitorRailArtworks_show\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairExhibitorRailArtworks_show on Show {\n  artworks: artworksConnection(first: 20) {\n    edges {\n      artwork: node {\n        internalID\n        slug\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairExhibitorRailArtworks_show.graphql.ts
+++ b/src/v2/__generated__/FairExhibitorRailArtworks_show.graphql.ts
@@ -7,6 +7,8 @@ export type FairExhibitorRailArtworks_show = {
     readonly artworks: {
         readonly edges: ReadonlyArray<{
             readonly artwork: {
+                readonly internalID: string;
+                readonly slug: string;
                 readonly " $fragmentRefs": FragmentRefs<"FillwidthItem_artwork">;
             } | null;
         } | null> | null;
@@ -58,6 +60,20 @@ const node: ReaderFragment = {
               "plural": false,
               "selections": [
                 {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "slug",
+                  "storageKey": null
+                },
+                {
                   "args": null,
                   "kind": "FragmentSpread",
                   "name": "FillwidthItem_artwork"
@@ -74,5 +90,5 @@ const node: ReaderFragment = {
   ],
   "type": "Show"
 };
-(node as any).hash = '2cd0ef4a0f10392d01d89ff808d8de31';
+(node as any).hash = '30c2338aa32b73b3949ac6bfb1955657';
 export default node;

--- a/src/v2/__generated__/FairExhibitorRail_show.graphql.ts
+++ b/src/v2/__generated__/FairExhibitorRail_show.graphql.ts
@@ -5,6 +5,7 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type FairExhibitorRail_show = {
     readonly internalID: string;
+    readonly slug: string;
     readonly href: string | null;
     readonly partner: {
         readonly name?: string | null;
@@ -43,6 +44,13 @@ return {
       "args": null,
       "kind": "ScalarField",
       "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
       "storageKey": null
     },
     {
@@ -95,5 +103,5 @@ return {
   "type": "Show"
 };
 })();
-(node as any).hash = 'e71391c18cda1f56e8afd4c9ab7856ca';
+(node as any).hash = 'b5e285e71e922173d341f3f3c3c9c3be';
 export default node;

--- a/src/v2/__generated__/FairExhibitorsQuery.graphql.ts
+++ b/src/v2/__generated__/FairExhibitorsQuery.graphql.ts
@@ -34,6 +34,7 @@ query FairExhibitorsQuery(
 
 fragment FairExhibitorRail_show on Show {
   internalID
+  slug
   href
   partner {
     __typename
@@ -55,6 +56,7 @@ fragment FairExhibitorRail_show on Show {
 
 fragment FairExhibitors_fair_2HEEH6 on Fair {
   slug
+  internalID
   exhibitors: showsConnection(first: $first, after: $after, sort: FEATURED_ASC) {
     edges {
       node {
@@ -125,7 +127,21 @@ v3 = {
   "name": "first",
   "variableName": "first"
 },
-v4 = [
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v6 = [
   (v2/*: any*/),
   (v3/*: any*/),
   {
@@ -134,21 +150,21 @@ v4 = [
     "value": "FEATURED_ASC"
   }
 ],
-v5 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v6 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v7 = [
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -200,16 +216,11 @@ return {
         "name": "fair",
         "plural": false,
         "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "slug",
-            "storageKey": null
-          },
+          (v4/*: any*/),
+          (v5/*: any*/),
           {
             "alias": "exhibitors",
-            "args": (v4/*: any*/),
+            "args": (v6/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
@@ -231,7 +242,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
+                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -258,28 +269,23 @@ return {
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
-                          (v5/*: any*/),
+                          (v8/*: any*/),
+                          (v7/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v7/*: any*/),
+                            "selections": (v9/*: any*/),
                             "type": "Partner"
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v7/*: any*/),
+                            "selections": (v9/*: any*/),
                             "type": "ExternalPartner"
                           }
                         ],
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "internalID",
-                        "storageKey": null
-                      },
+                      (v5/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -287,7 +293,7 @@ return {
                         "name": "href",
                         "storageKey": null
                       },
-                      (v6/*: any*/)
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -331,7 +337,7 @@ return {
           },
           {
             "alias": "exhibitors",
-            "args": (v4/*: any*/),
+            "args": (v6/*: any*/),
             "filters": [
               "sort"
             ],
@@ -340,7 +346,7 @@ return {
             "kind": "LinkedHandle",
             "name": "showsConnection"
           },
-          (v5/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
@@ -351,7 +357,7 @@ return {
     "metadata": {},
     "name": "FairExhibitorsQuery",
     "operationKind": "query",
-    "text": "query FairExhibitorsQuery(\n  $id: String!\n  $first: Int!\n  $after: String\n) {\n  fair(id: $id) {\n    ...FairExhibitors_fair_2HEEH6\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair_2HEEH6 on Fair {\n  slug\n  exhibitors: showsConnection(first: $first, after: $after, sort: FEATURED_ASC) {\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query FairExhibitorsQuery(\n  $id: String!\n  $first: Int!\n  $after: String\n) {\n  fair(id: $id) {\n    ...FairExhibitors_fair_2HEEH6\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  slug\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair_2HEEH6 on Fair {\n  slug\n  internalID\n  exhibitors: showsConnection(first: $first, after: $after, sort: FEATURED_ASC) {\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairExhibitors_Query.graphql.ts
+++ b/src/v2/__generated__/FairExhibitors_Query.graphql.ts
@@ -14,6 +14,7 @@ export type FairExhibitors_QueryResponse = {
 export type FairExhibitors_QueryRawResponse = {
     readonly fair: ({
         readonly slug: string;
+        readonly internalID: string;
         readonly exhibitors: ({
             readonly edges: ReadonlyArray<({
                 readonly node: ({
@@ -34,6 +35,7 @@ export type FairExhibitors_QueryRawResponse = {
                         readonly id: string | null;
                     }) | null;
                     readonly internalID: string;
+                    readonly slug: string;
                     readonly href: string | null;
                     readonly __typename: "Show";
                 }) | null;
@@ -67,6 +69,7 @@ query FairExhibitors_Query(
 
 fragment FairExhibitorRail_show on Show {
   internalID
+  slug
   href
   partner {
     __typename
@@ -88,6 +91,7 @@ fragment FairExhibitorRail_show on Show {
 
 fragment FairExhibitors_fair on Fair {
   slug
+  internalID
   exhibitors: showsConnection(first: 15, sort: FEATURED_ASC) {
     edges {
       node {
@@ -136,7 +140,21 @@ v1 = [
     "variableName": "slug"
   }
 ],
-v2 = [
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -148,21 +166,21 @@ v2 = [
     "value": "FEATURED_ASC"
   }
 ],
-v3 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v5 = [
+v7 = [
   {
     "alias": null,
     "args": null,
@@ -211,16 +229,11 @@ return {
         "name": "fair",
         "plural": false,
         "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "slug",
-            "storageKey": null
-          },
+          (v2/*: any*/),
+          (v3/*: any*/),
           {
             "alias": "exhibitors",
-            "args": (v2/*: any*/),
+            "args": (v4/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
@@ -242,7 +255,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -269,28 +282,23 @@ return {
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v3/*: any*/),
+                          (v6/*: any*/),
+                          (v5/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v5/*: any*/),
+                            "selections": (v7/*: any*/),
                             "type": "Partner"
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v5/*: any*/),
+                            "selections": (v7/*: any*/),
                             "type": "ExternalPartner"
                           }
                         ],
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "internalID",
-                        "storageKey": null
-                      },
+                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -298,7 +306,7 @@ return {
                         "name": "href",
                         "storageKey": null
                       },
-                      (v4/*: any*/)
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -342,7 +350,7 @@ return {
           },
           {
             "alias": "exhibitors",
-            "args": (v2/*: any*/),
+            "args": (v4/*: any*/),
             "filters": [
               "sort"
             ],
@@ -351,7 +359,7 @@ return {
             "kind": "LinkedHandle",
             "name": "showsConnection"
           },
-          (v3/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": null
       }
@@ -362,7 +370,7 @@ return {
     "metadata": {},
     "name": "FairExhibitors_Query",
     "operationKind": "query",
-    "text": "query FairExhibitors_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  slug\n  exhibitors: showsConnection(first: 15, sort: FEATURED_ASC) {\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query FairExhibitors_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  slug\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  slug\n  internalID\n  exhibitors: showsConnection(first: 15, sort: FEATURED_ASC) {\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairExhibitors_fair.graphql.ts
+++ b/src/v2/__generated__/FairExhibitors_fair.graphql.ts
@@ -5,6 +5,7 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type FairExhibitors_fair = {
     readonly slug: string;
+    readonly internalID: string;
     readonly exhibitors: {
         readonly edges: ReadonlyArray<{
             readonly node: {
@@ -75,6 +76,13 @@ return {
       "args": null,
       "kind": "ScalarField",
       "name": "slug",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
       "storageKey": null
     },
     {
@@ -204,5 +212,5 @@ return {
   "type": "Fair"
 };
 })();
-(node as any).hash = '8bb4654633f1546d0d988ff4a49c1534';
+(node as any).hash = 'b5655aba0489958224062c9481bc02af';
 export default node;

--- a/src/v2/__generated__/routes_FairArtworksQuery.graphql.ts
+++ b/src/v2/__generated__/routes_FairArtworksQuery.graphql.ts
@@ -181,6 +181,8 @@ fragment Details_artwork on Artwork {
 }
 
 fragment FairArtworks_fair_314Ph3 on Fair {
+  slug
+  internalID
   filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: "", sort: $sort) {
     id
     counts @include(if: $shouldFetchCounts) {
@@ -433,33 +435,47 @@ v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "slug",
   "storageKey": null
 },
 v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "internalID",
   "storageKey": null
 },
 v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cursor",
+  "name": "id",
   "storageKey": null
 },
 v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v21 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v22 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v21 = [
-  (v19/*: any*/),
-  (v20/*: any*/),
+v23 = [
+  (v21/*: any*/),
+  (v22/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -468,21 +484,21 @@ v21 = [
     "storageKey": null
   }
 ],
-v22 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v23 = [
+v25 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v24 = [
+v26 = [
   {
     "alias": null,
     "args": null,
@@ -552,6 +568,8 @@ return {
         "name": "fair",
         "plural": false,
         "selections": [
+          (v17/*: any*/),
+          (v18/*: any*/),
           {
             "alias": "filtered_artworks",
             "args": [
@@ -586,7 +604,7 @@ return {
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              (v17/*: any*/),
+              (v19/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -617,7 +635,7 @@ return {
                         "name": "value",
                         "storageKey": null
                       },
-                      (v18/*: any*/),
+                      (v20/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -671,7 +689,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v21/*: any*/),
+                    "selections": (v23/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -681,7 +699,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v21/*: any*/),
+                    "selections": (v23/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -691,7 +709,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v21/*: any*/),
+                    "selections": (v23/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -702,8 +720,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v19/*: any*/),
-                      (v20/*: any*/)
+                      (v21/*: any*/),
+                      (v22/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -726,22 +744,10 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
+                      (v19/*: any*/),
                       (v17/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slug",
-                        "storageKey": null
-                      },
-                      (v22/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "internalID",
-                        "storageKey": null
-                      },
+                      (v24/*: any*/),
+                      (v18/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -817,15 +823,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v23/*: any*/),
+                        "args": (v25/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v17/*: any*/),
-                          (v22/*: any*/),
-                          (v18/*: any*/)
+                          (v19/*: any*/),
+                          (v24/*: any*/),
+                          (v20/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -838,15 +844,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v23/*: any*/),
+                        "args": (v25/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v18/*: any*/),
-                          (v22/*: any*/),
-                          (v17/*: any*/),
+                          (v20/*: any*/),
+                          (v24/*: any*/),
+                          (v19/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -879,7 +885,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v17/*: any*/),
+                          (v19/*: any*/),
                           {
                             "alias": "is_live_open",
                             "args": null,
@@ -944,7 +950,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v24/*: any*/),
+                            "selections": (v26/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -954,10 +960,10 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v24/*: any*/),
+                            "selections": (v26/*: any*/),
                             "storageKey": null
                           },
-                          (v17/*: any*/)
+                          (v19/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -985,7 +991,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v17/*: any*/)
+                  (v19/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -1017,7 +1023,7 @@ return {
             ],
             "storageKey": null
           },
-          (v17/*: any*/)
+          (v19/*: any*/)
         ],
         "storageKey": null
       }
@@ -1028,7 +1034,7 @@ return {
     "metadata": {},
     "name": "routes_FairArtworksQuery",
     "operationKind": "query",
-    "text": "query routes_FairArtworksQuery(\n  $slug: String!\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation]\n  $atAuction: Boolean\n  $color: String\n  $forSale: Boolean\n  $includeArtworksByFollowedArtists: Boolean\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sizes: [ArtworkSizes]\n  $sort: String\n  $shouldFetchCounts: Boolean!\n) {\n  fair(id: $slug) {\n    ...FairArtworks_fair_314Ph3\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairArtworks_fair_314Ph3 on Fair {\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: \"\", sort: $sort) {\n    id\n    counts @include(if: $shouldFetchCounts) {\n      followedArtists\n    }\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query routes_FairArtworksQuery(\n  $slug: String!\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation]\n  $atAuction: Boolean\n  $color: String\n  $forSale: Boolean\n  $includeArtworksByFollowedArtists: Boolean\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sizes: [ArtworkSizes]\n  $sort: String\n  $shouldFetchCounts: Boolean!\n) {\n  fair(id: $slug) {\n    ...FairArtworks_fair_314Ph3\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairArtworks_fair_314Ph3 on Fair {\n  slug\n  internalID\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: \"\", sort: $sort) {\n    id\n    counts @include(if: $shouldFetchCounts) {\n      followedArtists\n    }\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/routes_FairExhibitorsQuery.graphql.ts
+++ b/src/v2/__generated__/routes_FairExhibitorsQuery.graphql.ts
@@ -30,6 +30,7 @@ query routes_FairExhibitorsQuery(
 
 fragment FairExhibitorRail_show on Show {
   internalID
+  slug
   href
   partner {
     __typename
@@ -51,6 +52,7 @@ fragment FairExhibitorRail_show on Show {
 
 fragment FairExhibitors_fair on Fair {
   slug
+  internalID
   exhibitors: showsConnection(first: 15, sort: FEATURED_ASC) {
     edges {
       node {
@@ -99,7 +101,21 @@ v1 = [
     "variableName": "slug"
   }
 ],
-v2 = [
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -111,21 +127,21 @@ v2 = [
     "value": "FEATURED_ASC"
   }
 ],
-v3 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v5 = [
+v7 = [
   {
     "alias": null,
     "args": null,
@@ -174,16 +190,11 @@ return {
         "name": "fair",
         "plural": false,
         "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "slug",
-            "storageKey": null
-          },
+          (v2/*: any*/),
+          (v3/*: any*/),
           {
             "alias": "exhibitors",
-            "args": (v2/*: any*/),
+            "args": (v4/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
@@ -205,7 +216,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -232,28 +243,23 @@ return {
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v3/*: any*/),
+                          (v6/*: any*/),
+                          (v5/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v5/*: any*/),
+                            "selections": (v7/*: any*/),
                             "type": "Partner"
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v5/*: any*/),
+                            "selections": (v7/*: any*/),
                             "type": "ExternalPartner"
                           }
                         ],
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "internalID",
-                        "storageKey": null
-                      },
+                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -261,7 +267,7 @@ return {
                         "name": "href",
                         "storageKey": null
                       },
-                      (v4/*: any*/)
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -305,7 +311,7 @@ return {
           },
           {
             "alias": "exhibitors",
-            "args": (v2/*: any*/),
+            "args": (v4/*: any*/),
             "filters": [
               "sort"
             ],
@@ -314,7 +320,7 @@ return {
             "kind": "LinkedHandle",
             "name": "showsConnection"
           },
-          (v3/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": null
       }
@@ -325,7 +331,7 @@ return {
     "metadata": {},
     "name": "routes_FairExhibitorsQuery",
     "operationKind": "query",
-    "text": "query routes_FairExhibitorsQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  slug\n  exhibitors: showsConnection(first: 15, sort: FEATURED_ASC) {\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query routes_FairExhibitorsQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  slug\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  slug\n  internalID\n  exhibitors: showsConnection(first: 15, sort: FEATURED_ASC) {\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/routes_FairQuery.graphql.ts
+++ b/src/v2/__generated__/routes_FairQuery.graphql.ts
@@ -103,6 +103,7 @@ fragment Details_artwork on Artwork {
 }
 
 fragment FairApp_fair on Fair {
+  internalID
   slug
   ...FairMeta_fair
   ...FairHeader_fair
@@ -121,6 +122,7 @@ fragment FairApp_fair on Fair {
 }
 
 fragment FairCollection_collection on MarketingCollection {
+  id
   slug
   title
   category
@@ -138,14 +140,19 @@ fragment FairCollection_collection on MarketingCollection {
 }
 
 fragment FairCollections_fair on Fair {
+  internalID
+  slug
   marketingCollections(size: 4) {
     id
+    slug
     ...FairCollection_collection
   }
 }
 
 fragment FairEditorialItem_article on Article {
   id
+  internalID
+  slug
   title
   href
   publishedAt(format: "MMM Do, YY")
@@ -165,6 +172,8 @@ fragment FairEditorialItem_article on Article {
 }
 
 fragment FairEditorial_fair on Fair {
+  internalID
+  slug
   articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {
     edges {
       node {
@@ -278,92 +287,99 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "slug",
+  "name": "internalID",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "slug",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "summary",
+  "name": "name",
   "storageKey": null
 },
 v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "summary",
+  "storageKey": null
+},
+v6 = {
   "alias": "src",
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "width",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v9 = [
+v10 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "HTML"
   }
 ],
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v12 = [
-  (v7/*: any*/),
+v13 = [
   (v8/*: any*/),
-  (v5/*: any*/)
+  (v9/*: any*/),
+  (v6/*: any*/)
 ],
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v14 = [
+v15 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v15 = [
+v16 = [
   {
     "alias": null,
     "args": null,
@@ -414,6 +430,7 @@ return {
         "selections": [
           (v2/*: any*/),
           (v3/*: any*/),
+          (v4/*: any*/),
           {
             "alias": "metaDescription",
             "args": null,
@@ -452,7 +469,7 @@ return {
             "name": "about",
             "storageKey": null
           },
-          (v4/*: any*/),
+          (v5/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -500,14 +517,14 @@ return {
                     "name": "cropped",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/)
+                      (v6/*: any*/)
                     ],
                     "storageKey": "cropped(height:120,version:\"square140\",width:120)"
                   }
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/)
+              (v7/*: any*/)
             ],
             "storageKey": null
           },
@@ -543,9 +560,9 @@ return {
                 "name": "cropped",
                 "plural": false,
                 "selections": [
-                  (v5/*: any*/),
-                  (v7/*: any*/),
-                  (v8/*: any*/)
+                  (v6/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/)
                 ],
                 "storageKey": "cropped(height:1000,version:\"wide\",width:750)"
               }
@@ -567,8 +584,8 @@ return {
             "name": "location",
             "plural": false,
             "selections": [
-              (v4/*: any*/),
-              (v6/*: any*/)
+              (v5/*: any*/),
+              (v7/*: any*/)
             ],
             "storageKey": null
           },
@@ -581,28 +598,28 @@ return {
           },
           {
             "alias": null,
-            "args": (v9/*: any*/),
+            "args": (v10/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
             "storageKey": "hours(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v9/*: any*/),
+            "args": (v10/*: any*/),
             "kind": "ScalarField",
             "name": "links",
             "storageKey": "links(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v9/*: any*/),
+            "args": (v10/*: any*/),
             "kind": "ScalarField",
             "name": "tickets",
             "storageKey": "tickets(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v9/*: any*/),
+            "args": (v10/*: any*/),
             "kind": "ScalarField",
             "name": "contact",
             "storageKey": "contact(format:\"HTML\")"
@@ -642,9 +659,11 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
-                      (v10/*: any*/),
+                      (v7/*: any*/),
+                      (v2/*: any*/),
+                      (v3/*: any*/),
                       (v11/*: any*/),
+                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": [
@@ -691,7 +710,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v12/*: any*/),
+                            "selections": (v13/*: any*/),
                             "storageKey": "cropped(height:80,width:140)"
                           },
                           {
@@ -712,7 +731,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v12/*: any*/),
+                            "selections": (v13/*: any*/),
                             "storageKey": "cropped(height:160,width:280)"
                           }
                         ],
@@ -721,7 +740,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v13/*: any*/)
+                  (v14/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -742,9 +761,9 @@ return {
             "name": "marketingCollections",
             "plural": true,
             "selections": [
-              (v6/*: any*/),
-              (v2/*: any*/),
-              (v10/*: any*/),
+              (v7/*: any*/),
+              (v3/*: any*/),
+              (v11/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -806,18 +825,18 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v7/*: any*/)
                         ],
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
-                  (v6/*: any*/)
+                  (v7/*: any*/)
                 ],
                 "storageKey": "artworksConnection(first:3)"
               },
-              (v13/*: any*/)
+              (v14/*: any*/)
             ],
             "storageKey": "marketingCollections(size:4)"
           },
@@ -894,8 +913,8 @@ return {
                         "name": "imageTitle",
                         "storageKey": null
                       },
-                      (v10/*: any*/),
                       (v11/*: any*/),
+                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -919,15 +938,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v14/*: any*/),
+                        "args": (v15/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v6/*: any*/),
-                          (v11/*: any*/),
-                          (v3/*: any*/)
+                          (v7/*: any*/),
+                          (v12/*: any*/),
+                          (v4/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -940,15 +959,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v14/*: any*/),
+                        "args": (v15/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/),
-                          (v11/*: any*/),
-                          (v6/*: any*/),
+                          (v4/*: any*/),
+                          (v12/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -981,7 +1000,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v6/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": "is_live_open",
                             "args": null,
@@ -1046,7 +1065,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v15/*: any*/),
+                            "selections": (v16/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1056,10 +1075,10 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v15/*: any*/),
+                            "selections": (v16/*: any*/),
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v7/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -1070,15 +1089,9 @@ return {
                         "name": "isInquireable",
                         "storageKey": null
                       },
-                      (v6/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "internalID",
-                        "storageKey": null
-                      },
+                      (v7/*: any*/),
                       (v2/*: any*/),
+                      (v3/*: any*/),
                       {
                         "alias": "is_saved",
                         "args": null,
@@ -1099,11 +1112,11 @@ return {
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/)
+              (v7/*: any*/)
             ],
             "storageKey": "filterArtworksConnection(first:20,includeArtworksByFollowedArtists:true)"
           },
-          (v6/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
@@ -1114,7 +1127,7 @@ return {
     "metadata": {},
     "name": "routes_FairQuery",
     "operationKind": "query",
-    "text": "query routes_FairQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairEditorial_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 4) {\n    __typename\n    id\n  }\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  slug\n  title\n  category\n  artworks: artworksConnection(first: 3) {\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 4) {\n    id\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  title\n  href\n  publishedAt(format: \"MMM Do, YY\")\n  thumbnailTitle\n  thumbnailImage {\n    _1x: cropped(width: 140, height: 80) {\n      width\n      height\n      src: url\n    }\n    _2x: cropped(width: 280, height: 160) {\n      width\n      height\n      src: url\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      artwork: node {\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  formattedOpeningHours\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query routes_FairQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairEditorial_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 4) {\n    __typename\n    id\n  }\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  category\n  artworks: artworksConnection(first: 3) {\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  internalID\n  slug\n  marketingCollections(size: 4) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMM Do, YY\")\n  thumbnailTitle\n  thumbnailImage {\n    _1x: cropped(width: 140, height: 80) {\n      width\n      height\n      src: url\n    }\n    _2x: cropped(width: 280, height: 160) {\n      width\n      height\n      src: url\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  internalID\n  slug\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      artwork: node {\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  formattedOpeningHours\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Schema is [here](https://docs.google.com/spreadsheets/d/1_VDAmRJz2K87FXDq7oh_tQSgwBv4syuZjaaR3sfetcI/edit#gid=849940367).

This PR adds tracking for the new fair page:

- When clicking into an article from the related articles rail:
  <img width="600" alt="Screen Shot 2020-09-28 at 2 50 57 PM" src="https://user-images.githubusercontent.com/2081340/94492206-c4f58600-01b7-11eb-9a38-afbaa212e15c.png">

- When clicking into a curated highlights rail collection:
  <img width="410" alt="Screen Shot 2020-09-28 at 3 20 00 PM" src="https://user-images.githubusercontent.com/2081340/94492236-d63e9280-01b7-11eb-86b3-f885c05bd99e.png">

- When clicking into the artworks tab:
  <img width="412" alt="Screen Shot 2020-09-28 at 3 28 50 PM" src="https://user-images.githubusercontent.com/2081340/94492252-e2c2eb00-01b7-11eb-9f7d-c769d0415f37.png">

- When clicking into the exhibitors tab:
  <img width="381" alt="Screen Shot 2020-09-28 at 3 29 07 PM" src="https://user-images.githubusercontent.com/2081340/94492259-e7879f00-01b7-11eb-8200-c40a1eaae4aa.png">

- When clicking on an artwork in a show rail:
  <img width="402" alt="Screen Shot 2020-09-28 at 6 03 01 PM" src="https://user-images.githubusercontent.com/2081340/94492268-f0787080-01b7-11eb-9843-953c5bfb8dca.png">

- When clicking the "View" link on a show rail:
  <img width="643" alt="Screen Shot 2020-09-28 at 5 47 19 PM" src="https://user-images.githubusercontent.com/2081340/94492278-f79f7e80-01b7-11eb-8bc9-24f270341948.png">

- When clicking to "show more" in the exhibitors view:
  <img width="375" alt="Screen Shot 2020-09-28 at 3 57 32 PM" src="https://user-images.githubusercontent.com/2081340/94492286-fbcb9c00-01b7-11eb-8136-967b0bc4ecc6.png">

- When clicking the main grid under the artworks tab:
  <img width="527" alt="Screen Shot 2020-09-28 at 5 50 24 PM" src="https://user-images.githubusercontent.com/2081340/94492297-0128e680-01b8-11eb-8d06-e7bc8ab653db.png">
