### PR TITLE
fix: allow domestic-only shipping for non-US works [GALL-3293]

### DIFF
--- a/src/v2/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/v2/Apps/Order/Routes/Shipping/index.tsx
@@ -1,5 +1,6 @@
 import {
   BorderedRadio,
+  Box,
   Button,
   Col,
   Collapse,
@@ -8,7 +9,6 @@ import {
   Row,
   Sans,
   Spacer,
-  Box,
 } from "@artsy/palette"
 import { Shipping_order } from "v2/__generated__/Shipping_order.graphql"
 import {
@@ -99,7 +99,8 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
   get startingAddress() {
     return {
       ...emptyAddress,
-      country: "US",
+      country: this.props.order.lineItems.edges[0].node.artwork.shippingCountry,
+
       // We need to pull out _only_ the values specified by the Address type,
       // since our state will be used for Relay variables later on. The
       // easiest way to do this is with the emptyAddress.


### PR DESCRIPTION
Partners can list works in any country as "domestic only" by not adding an international shipping fee when editing the artwork in CMS. However, any "domestic only" work that is not in the US or continental Europe will trigger an error that says "This work can only be shipped to the continental United States" when a user attempting to purchases submits the shipping address form.

There's actually another subtle bug this fixes - if a user were to order a work (that will ship to anywhere) and not touch the shipping dropdown, we would actually assuming it's shipping to the US. Unlikely this has happened since our auto-selected option is Afghanistan, but better to fix!

Before: 
![Screen Recording 2020-09-29 at 05 33 25 PM](https://user-images.githubusercontent.com/5361806/94618919-f767b780-0279-11eb-90d3-d9f929d9c383.gif)

After:
![Screen Recording 2020-09-29 at 05 37 26 PM](https://user-images.githubusercontent.com/5361806/94619232-8379df00-027a-11eb-80d1-bffa28615ca5.gif)


Jira ticket: https://artsyproduct.atlassian.net/browse/GALL-3293