### PR TITLE
FX-2296, FX-2309: Fix editorial byline + make descriptions proper html

### DIFF
--- a/src/v2/Apps/Fair/Components/FairEditorial/FairEditorialItem.tsx
+++ b/src/v2/Apps/Fair/Components/FairEditorial/FairEditorialItem.tsx
@@ -96,7 +96,7 @@ export const FairEditorialItemFragmentContainer = createFragmentContainer(
         slug
         title
         href
-        publishedAt(format: "MMM Do, YY")
+        publishedAt(format: "MMM Do, YYYY")
         thumbnailTitle
         thumbnailImage {
           _1x: cropped(width: 140, height: 80) {

--- a/src/v2/Apps/Fair/Components/FairHeader.tsx
+++ b/src/v2/Apps/Fair/Components/FairHeader.tsx
@@ -5,6 +5,7 @@ import {
   Col,
   Flex,
   Grid,
+  HTML,
   ResponsiveBox,
   ResponsiveBoxProps,
   Row,
@@ -100,9 +101,7 @@ const FairHeader: React.FC<FairHeaderProps> = ({ fair, ...rest }) => {
           </Col>
 
           <Col sm="6" mt={[3, 0]}>
-            <Text variant="subtitle" lineHeight="body">
-              {previewText}
-            </Text>
+            <HTML variant="subtitle" html={previewText} />
 
             {canShowMoreInfoLink && (
               <ForwardLink
@@ -120,8 +119,8 @@ const FairHeader: React.FC<FairHeaderProps> = ({ fair, ...rest }) => {
 export const FairHeaderFragmentContainer = createFragmentContainer(FairHeader, {
   fair: graphql`
     fragment FairHeader_fair on Fair {
-      about
-      summary
+      about(format: HTML)
+      summary(format: HTML)
       ...FairTiming_fair
       name
       slug

--- a/src/v2/Apps/Fair/Routes/FairInfo.tsx
+++ b/src/v2/Apps/Fair/Routes/FairInfo.tsx
@@ -23,13 +23,13 @@ const FairInfo: React.FC<FairInfoProps> = ({ fair }) => {
         <Col sm="9" pr={2}>
           {fair.summary && (
             <>
-              <TextWithNewlines variant="text">{fair.summary}</TextWithNewlines>
+              <HTML variant="text" html={fair.summary} />
               <Spacer my={3} />
             </>
           )}
           {fair.about && (
             <>
-              <TextWithNewlines variant="text">{fair.about}</TextWithNewlines>
+              <HTML variant="text" html={fair.about} />
               <Spacer my={3} />
             </>
           )}
@@ -98,7 +98,7 @@ const FairInfo: React.FC<FairInfoProps> = ({ fair }) => {
 export const FairInfoFragmentContainer = createFragmentContainer(FairInfo, {
   fair: graphql`
     fragment FairInfo_fair on Fair {
-      about
+      about(format: HTML)
       name
       slug
       tagline
@@ -109,7 +109,7 @@ export const FairInfoFragmentContainer = createFragmentContainer(FairInfo, {
       hours(format: HTML)
       links(format: HTML)
       tickets(format: HTML)
-      summary
+      summary(format: HTML)
       contact(format: HTML)
     }
   `,

--- a/src/v2/__generated__/FairApp_Query.graphql.ts
+++ b/src/v2/__generated__/FairApp_Query.graphql.ts
@@ -296,7 +296,7 @@ fragment FairEditorialItem_article on Article {
   slug
   title
   href
-  publishedAt(format: "MMM Do, YY")
+  publishedAt(format: "MMM Do, YYYY")
   thumbnailTitle
   thumbnailImage {
     _1x: cropped(width: 140, height: 80) {
@@ -337,8 +337,8 @@ fragment FairFollowedArtists_fair on Fair {
 }
 
 fragment FairHeader_fair on Fair {
-  about
-  summary
+  about(format: HTML)
+  summary(format: HTML)
   ...FairTiming_fair
   name
   slug
@@ -449,13 +449,13 @@ v4 = {
   "name": "name",
   "storageKey": null
 },
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "summary",
-  "storageKey": null
-},
+v5 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+],
 v6 = {
   "alias": "src",
   "args": null,
@@ -484,47 +484,40 @@ v9 = {
   "name": "height",
   "storageKey": null
 },
-v10 = [
-  {
-    "kind": "Literal",
-    "name": "format",
-    "value": "HTML"
-  }
-],
-v11 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v12 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v13 = [
+v12 = [
   (v8/*: any*/),
   (v9/*: any*/),
   (v6/*: any*/)
 ],
-v14 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v15 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v16 = [
+v15 = [
   {
     "alias": null,
     "args": null,
@@ -609,12 +602,18 @@ return {
           },
           {
             "alias": null,
-            "args": null,
+            "args": (v5/*: any*/),
             "kind": "ScalarField",
             "name": "about",
-            "storageKey": null
+            "storageKey": "about(format:\"HTML\")"
           },
-          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": (v5/*: any*/),
+            "kind": "ScalarField",
+            "name": "summary",
+            "storageKey": "summary(format:\"HTML\")"
+          },
           {
             "alias": null,
             "args": null,
@@ -743,7 +742,13 @@ return {
             "name": "location",
             "plural": false,
             "selections": [
-              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "summary",
+                "storageKey": null
+              },
               (v7/*: any*/)
             ],
             "storageKey": null
@@ -757,28 +762,28 @@ return {
           },
           {
             "alias": null,
-            "args": (v10/*: any*/),
+            "args": (v5/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
             "storageKey": "hours(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v10/*: any*/),
+            "args": (v5/*: any*/),
             "kind": "ScalarField",
             "name": "links",
             "storageKey": "links(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v10/*: any*/),
+            "args": (v5/*: any*/),
             "kind": "ScalarField",
             "name": "tickets",
             "storageKey": "tickets(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v10/*: any*/),
+            "args": (v5/*: any*/),
             "kind": "ScalarField",
             "name": "contact",
             "storageKey": "contact(format:\"HTML\")"
@@ -821,20 +826,20 @@ return {
                       (v7/*: any*/),
                       (v2/*: any*/),
                       (v3/*: any*/),
+                      (v10/*: any*/),
                       (v11/*: any*/),
-                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": [
                           {
                             "kind": "Literal",
                             "name": "format",
-                            "value": "MMM Do, YY"
+                            "value": "MMM Do, YYYY"
                           }
                         ],
                         "kind": "ScalarField",
                         "name": "publishedAt",
-                        "storageKey": "publishedAt(format:\"MMM Do, YY\")"
+                        "storageKey": "publishedAt(format:\"MMM Do, YYYY\")"
                       },
                       {
                         "alias": null,
@@ -869,7 +874,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v13/*: any*/),
+                            "selections": (v12/*: any*/),
                             "storageKey": "cropped(height:80,width:140)"
                           },
                           {
@@ -890,7 +895,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v13/*: any*/),
+                            "selections": (v12/*: any*/),
                             "storageKey": "cropped(height:160,width:280)"
                           }
                         ],
@@ -899,7 +904,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v14/*: any*/)
+                  (v13/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -922,7 +927,7 @@ return {
             "selections": [
               (v7/*: any*/),
               (v3/*: any*/),
-              (v11/*: any*/),
+              (v10/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -995,7 +1000,7 @@ return {
                 ],
                 "storageKey": "artworksConnection(first:3)"
               },
-              (v14/*: any*/)
+              (v13/*: any*/)
             ],
             "storageKey": "marketingCollections(size:4)"
           },
@@ -1072,8 +1077,8 @@ return {
                         "name": "imageTitle",
                         "storageKey": null
                       },
+                      (v10/*: any*/),
                       (v11/*: any*/),
-                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1097,14 +1102,14 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v15/*: any*/),
+                        "args": (v14/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
                           (v7/*: any*/),
-                          (v12/*: any*/),
+                          (v11/*: any*/),
                           (v4/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
@@ -1118,14 +1123,14 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v15/*: any*/),
+                        "args": (v14/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
                           (v4/*: any*/),
-                          (v12/*: any*/),
+                          (v11/*: any*/),
                           (v7/*: any*/),
                           {
                             "alias": null,
@@ -1224,7 +1229,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v16/*: any*/),
+                            "selections": (v15/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1234,7 +1239,7 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v16/*: any*/),
+                            "selections": (v15/*: any*/),
                             "storageKey": null
                           },
                           (v7/*: any*/)
@@ -1286,7 +1291,7 @@ return {
     "metadata": {},
     "name": "FairApp_Query",
     "operationKind": "query",
-    "text": "query FairApp_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairEditorial_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 4) {\n    __typename\n    id\n  }\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  category\n  artworks: artworksConnection(first: 3) {\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 4) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMM Do, YY\")\n  thumbnailTitle\n  thumbnailImage {\n    _1x: cropped(width: 140, height: 80) {\n      width\n      height\n      src: url\n    }\n    _2x: cropped(width: 280, height: 160) {\n      width\n      height\n      src: url\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      artwork: node {\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  ...FairTiming_fair\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query FairApp_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairEditorial_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 4) {\n    __typename\n    id\n  }\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  category\n  artworks: artworksConnection(first: 3) {\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 4) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMM Do, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    _1x: cropped(width: 140, height: 80) {\n      width\n      height\n      src: url\n    }\n    _2x: cropped(width: 280, height: 160) {\n      width\n      height\n      src: url\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      artwork: node {\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about(format: HTML)\n  summary(format: HTML)\n  ...FairTiming_fair\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairEditorialItem_article.graphql.ts
+++ b/src/v2/__generated__/FairEditorialItem_article.graphql.ts
@@ -104,12 +104,12 @@ return {
         {
           "kind": "Literal",
           "name": "format",
-          "value": "MMM Do, YY"
+          "value": "MMM Do, YYYY"
         }
       ],
       "kind": "ScalarField",
       "name": "publishedAt",
-      "storageKey": "publishedAt(format:\"MMM Do, YY\")"
+      "storageKey": "publishedAt(format:\"MMM Do, YYYY\")"
     },
     {
       "alias": null,
@@ -175,5 +175,5 @@ return {
   "type": "Article"
 };
 })();
-(node as any).hash = '6fb6b81da34bfb7cc785cf07c892e199';
+(node as any).hash = '9f2f76095c49af57942fadf67d481f63';
 export default node;

--- a/src/v2/__generated__/FairHeader_Query.graphql.ts
+++ b/src/v2/__generated__/FairHeader_Query.graphql.ts
@@ -67,8 +67,8 @@ query FairHeader_Query(
 }
 
 fragment FairHeader_fair on Fair {
-  about
-  summary
+  about(format: HTML)
+  summary(format: HTML)
   ...FairTiming_fair
   name
   slug
@@ -122,13 +122,13 @@ v1 = [
     "variableName": "slug"
   }
 ],
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "summary",
-  "storageKey": null
-},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+],
 v3 = {
   "alias": "src",
   "args": null,
@@ -142,14 +142,7 @@ v4 = {
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-},
-v5 = [
-  {
-    "kind": "Literal",
-    "name": "format",
-    "value": "HTML"
-  }
-];
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -192,12 +185,18 @@ return {
         "selections": [
           {
             "alias": null,
-            "args": null,
+            "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "about",
-            "storageKey": null
+            "storageKey": "about(format:\"HTML\")"
           },
-          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "kind": "ScalarField",
+            "name": "summary",
+            "storageKey": "summary(format:\"HTML\")"
+          },
           {
             "alias": null,
             "args": null,
@@ -352,7 +351,13 @@ return {
             "name": "location",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "summary",
+                "storageKey": null
+              },
               (v4/*: any*/)
             ],
             "storageKey": null
@@ -366,28 +371,28 @@ return {
           },
           {
             "alias": null,
-            "args": (v5/*: any*/),
+            "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
             "storageKey": "hours(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v5/*: any*/),
+            "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "links",
             "storageKey": "links(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v5/*: any*/),
+            "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "tickets",
             "storageKey": "tickets(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v5/*: any*/),
+            "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "contact",
             "storageKey": "contact(format:\"HTML\")"
@@ -403,7 +408,7 @@ return {
     "metadata": {},
     "name": "FairHeader_Query",
     "operationKind": "query",
-    "text": "query FairHeader_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairHeader_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  ...FairTiming_fair\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n"
+    "text": "query FairHeader_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairHeader_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about(format: HTML)\n  summary(format: HTML)\n  ...FairTiming_fair\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairHeader_fair.graphql.ts
+++ b/src/v2/__generated__/FairHeader_fair.graphql.ts
@@ -43,27 +43,20 @@ export type FairHeader_fair$key = {
 
 
 const node: ReaderFragment = (function(){
-var v0 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "summary",
-  "storageKey": null
-},
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+],
 v1 = {
   "alias": "src",
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
-},
-v2 = [
-  {
-    "kind": "Literal",
-    "name": "format",
-    "value": "HTML"
-  }
-];
+};
 return {
   "argumentDefinitions": [],
   "kind": "Fragment",
@@ -72,12 +65,18 @@ return {
   "selections": [
     {
       "alias": null,
-      "args": null,
+      "args": (v0/*: any*/),
       "kind": "ScalarField",
       "name": "about",
-      "storageKey": null
+      "storageKey": "about(format:\"HTML\")"
     },
-    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": (v0/*: any*/),
+      "kind": "ScalarField",
+      "name": "summary",
+      "storageKey": "summary(format:\"HTML\")"
+    },
     {
       "alias": null,
       "args": null,
@@ -210,7 +209,13 @@ return {
       "name": "location",
       "plural": false,
       "selections": [
-        (v0/*: any*/)
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "summary",
+          "storageKey": null
+        }
       ],
       "storageKey": null
     },
@@ -223,28 +228,28 @@ return {
     },
     {
       "alias": null,
-      "args": (v2/*: any*/),
+      "args": (v0/*: any*/),
       "kind": "ScalarField",
       "name": "hours",
       "storageKey": "hours(format:\"HTML\")"
     },
     {
       "alias": null,
-      "args": (v2/*: any*/),
+      "args": (v0/*: any*/),
       "kind": "ScalarField",
       "name": "links",
       "storageKey": "links(format:\"HTML\")"
     },
     {
       "alias": null,
-      "args": (v2/*: any*/),
+      "args": (v0/*: any*/),
       "kind": "ScalarField",
       "name": "tickets",
       "storageKey": "tickets(format:\"HTML\")"
     },
     {
       "alias": null,
-      "args": (v2/*: any*/),
+      "args": (v0/*: any*/),
       "kind": "ScalarField",
       "name": "contact",
       "storageKey": "contact(format:\"HTML\")"
@@ -258,5 +263,5 @@ return {
   "type": "Fair"
 };
 })();
-(node as any).hash = 'f639d9dfb1d75fe2c1d3e0b586ac6d89';
+(node as any).hash = '2d4af2250b9d6589b6629dac5d84cff5';
 export default node;

--- a/src/v2/__generated__/FairInfo_Query.graphql.ts
+++ b/src/v2/__generated__/FairInfo_Query.graphql.ts
@@ -49,7 +49,7 @@ query FairInfo_Query(
 }
 
 fragment FairInfo_fair on Fair {
-  about
+  about(format: HTML)
   name
   slug
   tagline
@@ -61,7 +61,7 @@ fragment FairInfo_fair on Fair {
   hours(format: HTML)
   links(format: HTML)
   tickets(format: HTML)
-  summary
+  summary(format: HTML)
   contact(format: HTML)
 }
 */
@@ -82,27 +82,20 @@ v1 = [
     "variableName": "slug"
   }
 ],
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "summary",
-  "storageKey": null
-},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+],
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-},
-v4 = [
-  {
-    "kind": "Literal",
-    "name": "format",
-    "value": "HTML"
-  }
-];
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -145,10 +138,10 @@ return {
         "selections": [
           {
             "alias": null,
-            "args": null,
+            "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "about",
-            "storageKey": null
+            "storageKey": "about(format:\"HTML\")"
           },
           {
             "alias": null,
@@ -179,7 +172,13 @@ return {
             "name": "location",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "summary",
+                "storageKey": null
+              },
               (v3/*: any*/)
             ],
             "storageKey": null
@@ -193,29 +192,35 @@ return {
           },
           {
             "alias": null,
-            "args": (v4/*: any*/),
+            "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
             "storageKey": "hours(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v4/*: any*/),
+            "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "links",
             "storageKey": "links(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v4/*: any*/),
+            "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "tickets",
             "storageKey": "tickets(format:\"HTML\")"
           },
-          (v2/*: any*/),
           {
             "alias": null,
-            "args": (v4/*: any*/),
+            "args": (v2/*: any*/),
+            "kind": "ScalarField",
+            "name": "summary",
+            "storageKey": "summary(format:\"HTML\")"
+          },
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "contact",
             "storageKey": "contact(format:\"HTML\")"
@@ -231,7 +236,7 @@ return {
     "metadata": {},
     "name": "FairInfo_Query",
     "operationKind": "query",
-    "text": "query FairInfo_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairInfo_fair\n    id\n  }\n}\n\nfragment FairInfo_fair on Fair {\n  about\n  name\n  slug\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  summary\n  contact(format: HTML)\n}\n"
+    "text": "query FairInfo_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairInfo_fair\n    id\n  }\n}\n\nfragment FairInfo_fair on Fair {\n  about(format: HTML)\n  name\n  slug\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  summary(format: HTML)\n  contact(format: HTML)\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairInfo_fair.graphql.ts
+++ b/src/v2/__generated__/FairInfo_fair.graphql.ts
@@ -28,14 +28,7 @@ export type FairInfo_fair$key = {
 
 
 const node: ReaderFragment = (function(){
-var v0 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "summary",
-  "storageKey": null
-},
-v1 = [
+var v0 = [
   {
     "kind": "Literal",
     "name": "format",
@@ -50,10 +43,10 @@ return {
   "selections": [
     {
       "alias": null,
-      "args": null,
+      "args": (v0/*: any*/),
       "kind": "ScalarField",
       "name": "about",
-      "storageKey": null
+      "storageKey": "about(format:\"HTML\")"
     },
     {
       "alias": null,
@@ -84,7 +77,13 @@ return {
       "name": "location",
       "plural": false,
       "selections": [
-        (v0/*: any*/)
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "summary",
+          "storageKey": null
+        }
       ],
       "storageKey": null
     },
@@ -97,29 +96,35 @@ return {
     },
     {
       "alias": null,
-      "args": (v1/*: any*/),
+      "args": (v0/*: any*/),
       "kind": "ScalarField",
       "name": "hours",
       "storageKey": "hours(format:\"HTML\")"
     },
     {
       "alias": null,
-      "args": (v1/*: any*/),
+      "args": (v0/*: any*/),
       "kind": "ScalarField",
       "name": "links",
       "storageKey": "links(format:\"HTML\")"
     },
     {
       "alias": null,
-      "args": (v1/*: any*/),
+      "args": (v0/*: any*/),
       "kind": "ScalarField",
       "name": "tickets",
       "storageKey": "tickets(format:\"HTML\")"
     },
-    (v0/*: any*/),
     {
       "alias": null,
-      "args": (v1/*: any*/),
+      "args": (v0/*: any*/),
+      "kind": "ScalarField",
+      "name": "summary",
+      "storageKey": "summary(format:\"HTML\")"
+    },
+    {
+      "alias": null,
+      "args": (v0/*: any*/),
       "kind": "ScalarField",
       "name": "contact",
       "storageKey": "contact(format:\"HTML\")"
@@ -128,5 +133,5 @@ return {
   "type": "Fair"
 };
 })();
-(node as any).hash = 'ea4f45ae63264ece824c15f339698eee';
+(node as any).hash = '82107962db8db75c38789a06702f0043';
 export default node;

--- a/src/v2/__generated__/routes_FairInfoQuery.graphql.ts
+++ b/src/v2/__generated__/routes_FairInfoQuery.graphql.ts
@@ -29,7 +29,7 @@ query routes_FairInfoQuery(
 }
 
 fragment FairInfo_fair on Fair {
-  about
+  about(format: HTML)
   name
   slug
   tagline
@@ -41,7 +41,7 @@ fragment FairInfo_fair on Fair {
   hours(format: HTML)
   links(format: HTML)
   tickets(format: HTML)
-  summary
+  summary(format: HTML)
   contact(format: HTML)
 }
 */
@@ -62,27 +62,20 @@ v1 = [
     "variableName": "slug"
   }
 ],
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "summary",
-  "storageKey": null
-},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+],
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-},
-v4 = [
-  {
-    "kind": "Literal",
-    "name": "format",
-    "value": "HTML"
-  }
-];
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -125,10 +118,10 @@ return {
         "selections": [
           {
             "alias": null,
-            "args": null,
+            "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "about",
-            "storageKey": null
+            "storageKey": "about(format:\"HTML\")"
           },
           {
             "alias": null,
@@ -159,7 +152,13 @@ return {
             "name": "location",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "summary",
+                "storageKey": null
+              },
               (v3/*: any*/)
             ],
             "storageKey": null
@@ -173,29 +172,35 @@ return {
           },
           {
             "alias": null,
-            "args": (v4/*: any*/),
+            "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
             "storageKey": "hours(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v4/*: any*/),
+            "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "links",
             "storageKey": "links(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v4/*: any*/),
+            "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "tickets",
             "storageKey": "tickets(format:\"HTML\")"
           },
-          (v2/*: any*/),
           {
             "alias": null,
-            "args": (v4/*: any*/),
+            "args": (v2/*: any*/),
+            "kind": "ScalarField",
+            "name": "summary",
+            "storageKey": "summary(format:\"HTML\")"
+          },
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "contact",
             "storageKey": "contact(format:\"HTML\")"
@@ -211,7 +216,7 @@ return {
     "metadata": {},
     "name": "routes_FairInfoQuery",
     "operationKind": "query",
-    "text": "query routes_FairInfoQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairInfo_fair\n    id\n  }\n}\n\nfragment FairInfo_fair on Fair {\n  about\n  name\n  slug\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  summary\n  contact(format: HTML)\n}\n"
+    "text": "query routes_FairInfoQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairInfo_fair\n    id\n  }\n}\n\nfragment FairInfo_fair on Fair {\n  about(format: HTML)\n  name\n  slug\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  summary(format: HTML)\n  contact(format: HTML)\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/routes_FairQuery.graphql.ts
+++ b/src/v2/__generated__/routes_FairQuery.graphql.ts
@@ -153,7 +153,7 @@ fragment FairEditorialItem_article on Article {
   slug
   title
   href
-  publishedAt(format: "MMM Do, YY")
+  publishedAt(format: "MMM Do, YYYY")
   thumbnailTitle
   thumbnailImage {
     _1x: cropped(width: 140, height: 80) {
@@ -194,8 +194,8 @@ fragment FairFollowedArtists_fair on Fair {
 }
 
 fragment FairHeader_fair on Fair {
-  about
-  summary
+  about(format: HTML)
+  summary(format: HTML)
   ...FairTiming_fair
   name
   slug
@@ -306,13 +306,13 @@ v4 = {
   "name": "name",
   "storageKey": null
 },
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "summary",
-  "storageKey": null
-},
+v5 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+],
 v6 = {
   "alias": "src",
   "args": null,
@@ -341,47 +341,40 @@ v9 = {
   "name": "height",
   "storageKey": null
 },
-v10 = [
-  {
-    "kind": "Literal",
-    "name": "format",
-    "value": "HTML"
-  }
-],
-v11 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v12 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v13 = [
+v12 = [
   (v8/*: any*/),
   (v9/*: any*/),
   (v6/*: any*/)
 ],
-v14 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v15 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v16 = [
+v15 = [
   {
     "alias": null,
     "args": null,
@@ -466,12 +459,18 @@ return {
           },
           {
             "alias": null,
-            "args": null,
+            "args": (v5/*: any*/),
             "kind": "ScalarField",
             "name": "about",
-            "storageKey": null
+            "storageKey": "about(format:\"HTML\")"
           },
-          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": (v5/*: any*/),
+            "kind": "ScalarField",
+            "name": "summary",
+            "storageKey": "summary(format:\"HTML\")"
+          },
           {
             "alias": null,
             "args": null,
@@ -600,7 +599,13 @@ return {
             "name": "location",
             "plural": false,
             "selections": [
-              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "summary",
+                "storageKey": null
+              },
               (v7/*: any*/)
             ],
             "storageKey": null
@@ -614,28 +619,28 @@ return {
           },
           {
             "alias": null,
-            "args": (v10/*: any*/),
+            "args": (v5/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
             "storageKey": "hours(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v10/*: any*/),
+            "args": (v5/*: any*/),
             "kind": "ScalarField",
             "name": "links",
             "storageKey": "links(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v10/*: any*/),
+            "args": (v5/*: any*/),
             "kind": "ScalarField",
             "name": "tickets",
             "storageKey": "tickets(format:\"HTML\")"
           },
           {
             "alias": null,
-            "args": (v10/*: any*/),
+            "args": (v5/*: any*/),
             "kind": "ScalarField",
             "name": "contact",
             "storageKey": "contact(format:\"HTML\")"
@@ -678,20 +683,20 @@ return {
                       (v7/*: any*/),
                       (v2/*: any*/),
                       (v3/*: any*/),
+                      (v10/*: any*/),
                       (v11/*: any*/),
-                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": [
                           {
                             "kind": "Literal",
                             "name": "format",
-                            "value": "MMM Do, YY"
+                            "value": "MMM Do, YYYY"
                           }
                         ],
                         "kind": "ScalarField",
                         "name": "publishedAt",
-                        "storageKey": "publishedAt(format:\"MMM Do, YY\")"
+                        "storageKey": "publishedAt(format:\"MMM Do, YYYY\")"
                       },
                       {
                         "alias": null,
@@ -726,7 +731,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v13/*: any*/),
+                            "selections": (v12/*: any*/),
                             "storageKey": "cropped(height:80,width:140)"
                           },
                           {
@@ -747,7 +752,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v13/*: any*/),
+                            "selections": (v12/*: any*/),
                             "storageKey": "cropped(height:160,width:280)"
                           }
                         ],
@@ -756,7 +761,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v14/*: any*/)
+                  (v13/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -779,7 +784,7 @@ return {
             "selections": [
               (v7/*: any*/),
               (v3/*: any*/),
-              (v11/*: any*/),
+              (v10/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -852,7 +857,7 @@ return {
                 ],
                 "storageKey": "artworksConnection(first:3)"
               },
-              (v14/*: any*/)
+              (v13/*: any*/)
             ],
             "storageKey": "marketingCollections(size:4)"
           },
@@ -929,8 +934,8 @@ return {
                         "name": "imageTitle",
                         "storageKey": null
                       },
+                      (v10/*: any*/),
                       (v11/*: any*/),
-                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -954,14 +959,14 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v15/*: any*/),
+                        "args": (v14/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
                           (v7/*: any*/),
-                          (v12/*: any*/),
+                          (v11/*: any*/),
                           (v4/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
@@ -975,14 +980,14 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v15/*: any*/),
+                        "args": (v14/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
                           (v4/*: any*/),
-                          (v12/*: any*/),
+                          (v11/*: any*/),
                           (v7/*: any*/),
                           {
                             "alias": null,
@@ -1081,7 +1086,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v16/*: any*/),
+                            "selections": (v15/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1091,7 +1096,7 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v16/*: any*/),
+                            "selections": (v15/*: any*/),
                             "storageKey": null
                           },
                           (v7/*: any*/)
@@ -1143,7 +1148,7 @@ return {
     "metadata": {},
     "name": "routes_FairQuery",
     "operationKind": "query",
-    "text": "query routes_FairQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairEditorial_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 4) {\n    __typename\n    id\n  }\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  category\n  artworks: artworksConnection(first: 3) {\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 4) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMM Do, YY\")\n  thumbnailTitle\n  thumbnailImage {\n    _1x: cropped(width: 140, height: 80) {\n      width\n      height\n      src: url\n    }\n    _2x: cropped(width: 280, height: 160) {\n      width\n      height\n      src: url\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      artwork: node {\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about\n  summary\n  ...FairTiming_fair\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query routes_FairQuery(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairApp_fair on Fair {\n  internalID\n  slug\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairEditorial_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 4) {\n    __typename\n    id\n  }\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  category\n  artworks: artworksConnection(first: 3) {\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 4) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMM Do, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    _1x: cropped(width: 140, height: 80) {\n      width\n      height\n      src: url\n    }\n    _2x: cropped(width: 280, height: 160) {\n      width\n      height\n      src: url\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      artwork: node {\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  about(format: HTML)\n  summary(format: HTML)\n  ...FairTiming_fair\n  name\n  slug\n  profile {\n    icon {\n      cropped(width: 120, height: 120, version: \"square140\") {\n        src: url\n      }\n    }\n    id\n  }\n  image {\n    cropped(width: 750, height: 1000, version: \"wide\") {\n      src: url\n      width\n      height\n    }\n  }\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Couple of minor fixes to the Fair2 page:
1. Updates the "about" and "summary" to support html/markdown:
  <img width="1503" alt="image" src="https://user-images.githubusercontent.com/2081340/94693217-705e2200-0301-11eb-8e94-02d939db87f4.png">
2. Same update as above, but on the info page:
  <img width="1174" alt="image" src="https://user-images.githubusercontent.com/2081340/94693273-7eac3e00-0301-11eb-91eb-21c4eb968b20.png">
3. Updates the editorial items to include the full year:
  <img width="1164" alt="image" src="https://user-images.githubusercontent.com/2081340/94693306-8bc92d00-0301-11eb-87e1-43e83c306793.png">
