### PR TITLE
chore: move WIP fairs page from /fair2 to /fair

### DIFF
--- a/src/v2/Apps/Fair/Components/FairFollowedArtists.tsx
+++ b/src/v2/Apps/Fair/Components/FairFollowedArtists.tsx
@@ -28,7 +28,7 @@ export const FairFollowedArtists: React.FC<FairFollowedArtistsProps> = ({
 
         <Text variant="subtitle" color="black60">
           <RouterLink
-            to={`/fair2/${fair.slug}/artworks?include_artworks_by_followed_artists=true`}
+            to={`/fair/${fair.slug}/artworks?include_artworks_by_followed_artists=true`}
             noUnderline
           >
             View all

--- a/src/v2/Apps/Fair/Components/FairHeader.tsx
+++ b/src/v2/Apps/Fair/Components/FairHeader.tsx
@@ -107,7 +107,7 @@ const FairHeader: React.FC<FairHeaderProps> = ({ fair, ...rest }) => {
             {canShowMoreInfoLink && (
               <ForwardLink
                 linkText="More info"
-                path={`/fair2/${fair.slug}/info`}
+                path={`/fair/${fair.slug}/info`}
               />
             )}
           </Col>

--- a/src/v2/Apps/Fair/Components/__tests__/FairHeader.jest.tsx
+++ b/src/v2/Apps/Fair/Components/__tests__/FairHeader.jest.tsx
@@ -58,7 +58,7 @@ describe("FairHeader", () => {
       .find(RouterLink)
       .filterWhere(t => t.text() === "More info")
     expect(MoreInfoButton.length).toEqual(1)
-    expect(MoreInfoButton.first().prop("to")).toEqual("/fair2/miart-2020/info")
+    expect(MoreInfoButton.first().prop("to")).toEqual("/fair/miart-2020/info")
   })
 
   it("doesn't display the More info link if there is no info", async () => {

--- a/src/v2/Apps/Fair/FairApp.tsx
+++ b/src/v2/Apps/Fair/FairApp.tsx
@@ -113,7 +113,7 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
 
             <RouteTabs>
               <RouteTab
-                to={`/fair2/${fair.slug}`}
+                to={`/fair/${fair.slug}`}
                 exact
                 onClick={() =>
                   tracking.trackEvent(clickedExhibitorsTabTrackingData)
@@ -123,7 +123,7 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
               </RouteTab>
 
               <RouteTab
-                to={`/fair2/${fair.slug}/artworks`}
+                to={`/fair/${fair.slug}/artworks`}
                 exact
                 onClick={() =>
                   tracking.trackEvent(clickedArtworksTabTrackingData)

--- a/src/v2/Apps/Fair/FairSubApp.tsx
+++ b/src/v2/Apps/Fair/FairSubApp.tsx
@@ -22,7 +22,7 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
 
       <AppContainer>
         <HorizontalPadding>
-          <BackLink my={3} to={`/fair2/${fair.slug}`}>
+          <BackLink my={3} to={`/fair/${fair.slug}`}>
             Back to {fair.name}
           </BackLink>
 

--- a/src/v2/Apps/Fair/routes.tsx
+++ b/src/v2/Apps/Fair/routes.tsx
@@ -11,7 +11,7 @@ const FairInfoRoute = loadable(() => import("./Routes/FairInfo"))
 
 export const routes: RouteConfig[] = [
   {
-    path: "/fair2/:slug",
+    path: "/fair/:slug",
     ignoreScrollBehavior: true,
     getComponent: () => FairApp,
     prepare: () => {
@@ -95,7 +95,7 @@ export const routes: RouteConfig[] = [
   // NOTE: Nested sub-apps are mounted under the same top-level path as above.
   // The root `path: ""` matches the `FairExhibitorsRoute`.
   {
-    path: "/fair2/:slug",
+    path: "/fair/:slug",
     getComponent: () => FairSubApp,
     prepare: () => {
       FairSubApp.preload()


### PR DESCRIPTION
Addresses: [FX-2300]

Following discussion on [FX-2291] and in our launch chat, we want to move the `/fair2` routing for the new Fair page over to `/fair`, which is currently unused.



[FX-2300]: https://artsyproduct.atlassian.net/browse/FX-2300
[FX-2291]: https://artsyproduct.atlassian.net/browse/FX-2291