### PR TITLE
@dzucconi => [Fair] Tweak route path regexp to handle linking to artworks tab w/ query params

### DIFF
--- a/src/v2/Apps/Fair/routes.tsx
+++ b/src/v2/Apps/Fair/routes.tsx
@@ -40,7 +40,7 @@ export const routes: RouteConfig[] = [
         `,
       },
       {
-        path: "artworks",
+        path: "artworks(.*)?",
         getComponent: () => FairArtworksRoute,
         prepare: () => {
           FairArtworksRoute.preload()


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=FX&modal=detail&selectedIssue=FX-2177

When you click the 'View All' link in the 'Works by Artists you Follow' rail, it should stay w/in the router and link you w/o a page reload.