### PR TITLE
Includes artwork id in details key to force re-render

### DIFF
--- a/src/v2/Apps/Artwork/ArtworkApp.tsx
+++ b/src/v2/Apps/Artwork/ArtworkApp.tsx
@@ -206,7 +206,11 @@ export class ArtworkApp extends React.Component<Props> {
                 <Col>
                   <ArtworkImageBrowser artwork={artwork} />
                   <ArtworkSidebar artwork={artwork} me={me} />
-                  <ArtworkDetails artwork={artwork} />
+                  <ArtworkDetails
+                    // HACK: Forces component to re-render
+                    key={artwork.internalID}
+                    artwork={artwork}
+                  />
                   <PricingContext artwork={artwork} />
                   {this.renderArtists()}
                 </Col>
@@ -219,7 +223,11 @@ export class ArtworkApp extends React.Component<Props> {
                 <Col sm={8}>
                   <Box pr={4}>
                     <ArtworkImageBrowser artwork={artwork} />
-                    <ArtworkDetails artwork={artwork} />
+                    <ArtworkDetails
+                      // HACK: Forces component to re-render
+                      key={artwork.internalID}
+                      artwork={artwork}
+                    />
                     <PricingContext artwork={artwork} />
                     {this.renderArtists()}
                   </Box>


### PR DESCRIPTION
Re: https://artsy.slack.com/archives/CP9P4KR35/p1601507293104300

On client-side route changes the `ArtworkDetailsAboutTheWorkFromPartner` component doesn't re-render. I'd like to take a look in the morning see if this was introduced recently, but it appears unrelated to any of the cosmetic work that's been done on this page in the past week or so.

There's no danger in adding the key here — it's just treating the symptom and papering over the underlying issue.