### PR TITLE
fix: generalize error message for domstic shipping [GALL-3297]

### DIFF
--- a/src/v2/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/v2/Apps/Order/Routes/Shipping/index.tsx
@@ -250,8 +250,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
     ) {
       this.props.dialog.showErrorDialog({
         title: "Can't ship to that address",
-        message:
-          "This work can only be shipped to the continental United States.",
+        message: "This work can only be shipped domestically.",
       })
     } else {
       this.props.dialog.showErrorDialog()


### PR DESCRIPTION
Current state: if a work can only be shipped domestically and the user selects a non-domestic country (theoretically should not be possible because the shipping dropdown should always be locked to the country/countries a work can be shipped to) and submits, they're greeted with an error that says "This work can only be shipped to the continental United States," even if the work is shipping from a different country. 

After looking into this, it seems like we'd have to add a fair amount of logic to have a truly dynamic error message that says "...can only be shipped to [Country Name]/the continental US/continental Europe", and that didn't seem worth the effort to me. @ansor4 you think this is a reasonable way to go? 

Before: 
![Screen Shot 2020-10-01 at 4 45 11 PM](https://user-images.githubusercontent.com/5361806/94863852-1a74a180-0409-11eb-9da4-c062d1a29f66.png)

After:
![Screen Shot 2020-10-01 at 4 45 58 PM](https://user-images.githubusercontent.com/5361806/94863855-1a74a180-0409-11eb-850e-4b8f97e9e6e2.png)



Jira ticket: https://artsyproduct.atlassian.net/browse/GALL-3297