### PR TITLE
[FX-2325] Filter border

### DIFF
--- a/src/v2/Apps/Fair/FairApp.tsx
+++ b/src/v2/Apps/Fair/FairApp.tsx
@@ -34,7 +34,6 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
 
   const hasArticles = (fair.articles?.edges?.length ?? 0) > 0
   const hasCollections = (fair.marketingCollections?.length ?? 0) > 0
-  const columnCount = hasArticles && hasCollections ? 2 : 1
   const artworkCount = fair.counts.artworks
 
   const clickedArtworksTabTrackingData: ClickedNavigationTab = {
@@ -82,10 +81,7 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
                   gridAutoFlow="row"
                   gridColumnGap={3}
                   gridRowGap={2}
-                  gridTemplateColumns={[
-                    "repeat(1, 1fr)",
-                    `repeat(${columnCount}, 1fr)`,
-                  ]}
+                  gridTemplateColumns={["repeat(1, 1fr)", "repeat(2, 1fr)"]}
                 >
                   <FairEditorial fair={fair} />
                 </CSSGrid>

--- a/src/v2/Apps/Fair/Routes/FairArtworks.tsx
+++ b/src/v2/Apps/Fair/Routes/FairArtworks.tsx
@@ -85,6 +85,7 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
       }}
     >
       <BaseArtworkFilter
+        mt="-2px"
         relay={relay}
         viewer={fair}
         relayVariables={{

--- a/src/v2/Components/v2/ArtworkFilter/index.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/index.tsx
@@ -28,6 +28,7 @@ import { ArtworkFilters } from "./ArtworkFilters"
 
 import {
   Box,
+  BoxProps,
   Button,
   FilterIcon,
   Flex,
@@ -80,17 +81,19 @@ export const ArtworkFilter: React.FC<
   )
 }
 
-export const BaseArtworkFilter: React.FC<{
-  relay: RelayRefetchProp
-  relayVariables?: object
-  viewer:
-    | ArtworkFilter_viewer
-    | Collection_collection
-    | ArtistArtworkFilter_artist
-    | ArtistSeriesArtworksFilter_artistSeries
-    | FairArtworks_fair
-  Filters?: React.FC
-}> = ({ relay, viewer, Filters, relayVariables = {}, ...props }) => {
+export const BaseArtworkFilter: React.FC<
+  BoxProps & {
+    relay: RelayRefetchProp
+    relayVariables?: object
+    viewer:
+      | ArtworkFilter_viewer
+      | Collection_collection
+      | ArtistArtworkFilter_artist
+      | ArtistSeriesArtworksFilter_artistSeries
+      | FairArtworks_fair
+    Filters?: React.FC
+  }
+> = ({ relay, viewer, Filters, relayVariables = {}, children, ...rest }) => {
   const { filtered_artworks } = viewer
   const hasFilter = filtered_artworks && filtered_artworks.id
 
@@ -174,7 +177,7 @@ export const BaseArtworkFilter: React.FC<{
   }
 
   return (
-    <Box>
+    <Box mt={[0, 0.5]} {...rest}>
       <Box id="jump--artworkFilter" />
 
       {/*
@@ -213,18 +216,18 @@ export const BaseArtworkFilter: React.FC<{
       */}
       <Media greaterThan="xs">
         <Flex>
-          <Box width="25%" mr={2} mt={0.5}>
+          <Box width="25%" mr={2}>
             {Filters ? <Filters /> : <ArtworkFilters />}
           </Box>
           <Box width="75%">
             <Box mb={2}>
-              <Box pb={2} mt={0.5}>
+              <Box pb={2}>
                 <Separator />
               </Box>
               <SortFilter />
             </Box>
 
-            {props.children || <ArtworkGrid />}
+            {children || <ArtworkGrid />}
           </Box>
         </Flex>
       </Media>


### PR DESCRIPTION
Re: [FX-2325](https://artsyproduct.atlassian.net/browse/FX-2325)

This doesn't technically totally close out that issue. This is still an issue everywhere else that uses the artwork filter and tabs. So I suggest we merge this to deal with the immediate Q/A issue; and then resolve to fix this for real by leaving the ticket open/unresolved.

![](http://static.damonzucconi.com/_capture/dh9W5ng1aVFL.png)

There's a few problems compounding here and preventing me from fixing this the right way:

* The artwork filter has opinions about internal — this is easy enough to resolve: I removed the hardcoded spacing and mixed in box props, then set the default props to match the existing values for `mt`. (We can remove the borders as well and do the same thing but if we want to drop the split border.)
  * Re: border, that's why we're offsetting by the first `-1px`

* The tabs component [is complicated](https://palette.artsy.net/elements/navigation/tabs) and does a bunch of things unrelated to presentation. The complicated stuff (auto-centering) looks broken and unused. It happens to apply some positioning that also messes with how it would naturally sit on a page:
  * [Tabs.tsx#L242-L247](https://github.com/artsy/palette/blob/0bf6de00d2d660d06fa43bb536e550a86d13f466/packages/palette/src/elements/Tabs/Tabs.tsx#L242-L247) creates a 1px gap between it and everything else — that's the second `-1px`

I think the real solution is to just simplify the tabs and route tabs dramatically. And... I tried to do this, but I fall into a hole with `RouterLink`'s props being incorrect, updating found, and oh we can't update found easily even though there's no breaking changes because of a patch package, and on and on.

So... `-2px`