### PR TITLE
Update modal text for pending auction reservation due to IDV

### DIFF
--- a/src/desktop/apps/auction/components/layout/ConfirmRegistrationModal.tsx
+++ b/src/desktop/apps/auction/components/layout/ConfirmRegistrationModal.tsx
@@ -5,7 +5,7 @@ import {
   ContentKey,
   PostRegistrationModal,
 } from "v2/Components/Auction/PostRegistrationModal"
-import { bidderNeedsIdentityVerification } from "v2/Utils/identityVerificationRequirements"
+import { bidderQualifications } from "v2/Utils/identityVerificationRequirements"
 
 const _ConfirmRegistrationModal = ({ me, modalType, onClose, sale }) => {
   useEffect(() => {
@@ -23,12 +23,16 @@ const _ConfirmRegistrationModal = ({ me, modalType, onClose, sale }) => {
 
   const bidder = me.bidders[0]
 
+  const { shouldPromptIdVerification } = bidderQualifications(sale, me, {
+    qualifiedForBidding: bidder.qualified_for_bidding,
+  })
+
   let contentKey: ContentKey
   if (bidder.qualified_for_bidding) {
     contentKey = "registrationConfirmed"
   } else if (modalType === "ConfirmBidAndRegistration") {
     contentKey = "bidPending"
-  } else if (bidderNeedsIdentityVerification({ sale, user: me })) {
+  } else if (shouldPromptIdVerification) {
     contentKey = "registrationPendingUnverified"
   } else {
     contentKey = "registrationPending"

--- a/src/desktop/apps/auction/components/layout/__tests__/ConfirmRegistrationModal.jest.tsx
+++ b/src/desktop/apps/auction/components/layout/__tests__/ConfirmRegistrationModal.jest.tsx
@@ -175,7 +175,7 @@ describe("Confirm Registration Modal", () => {
         expect(wrapper.text()).toContain("Artsy is reviewing your registration")
       })
 
-      it("shows an IDV registration pending message if the sale requires IDV but the user is not verified", () => {
+      it("shows a registration pending message if the sale requires IDV and the user is not verified but has no startable IDV flow", () => {
         const { wrapper } = renderTestComponent({
           Component: ConfirmRegistrationModal,
           options: { renderMode: "mount" },
@@ -189,6 +189,36 @@ describe("Confirm Registration Modal", () => {
                   },
                 ],
                 identityVerified: false,
+                pendingIdentityVerification: null,
+              },
+              sale: {
+                requireIdentityVerification: true,
+              },
+            },
+          },
+        })
+
+        expect(wrapper.text()).toContain("Registration pending")
+        expect(wrapper.text()).toContain("Artsy is reviewing your registration")
+      })
+
+      it("shows an 'please verify identity' message if the sale requires IDV but the user, who is not verified, has an available IDV flow", () => {
+        const { wrapper } = renderTestComponent({
+          Component: ConfirmRegistrationModal,
+          options: { renderMode: "mount" },
+          data: {
+            app: {
+              modalType: "ConfirmRegistration",
+              me: {
+                bidders: [
+                  {
+                    qualified_for_bidding: false,
+                  },
+                ],
+                identityVerified: false,
+                pendingIdentityVerification: {
+                  internalID: "whatever",
+                },
               },
               auction: {
                 requireIdentityVerification: true,
@@ -199,7 +229,7 @@ describe("Confirm Registration Modal", () => {
 
         expect(wrapper.text()).toContain("Registration pending")
         expect(wrapper.text()).toContain(
-          "This auction requires Artsy to verify your identity before bidding."
+          "To complete your registration and start bidding, please click the Verify identity button or follow the link sent to your email."
         )
       })
     })

--- a/src/v2/Components/Auction/PostRegistrationModal.tsx
+++ b/src/v2/Components/Auction/PostRegistrationModal.tsx
@@ -51,10 +51,12 @@ const RegistrationPendingUnverified: ModalContent = ({ onClick }) => {
         </a>{" "}
         or contact verification@artsy.net.
         <br />
-        <br />A link to complete identity verification has been sent to your
+        <br />
+        To complete your registration and start bidding, please click the{" "}
+        <strong>Verify identity</strong> button or follow the link sent to your
         email.
       </Serif>
-      <ViewWorksButton onClick={onClick} />
+      <OKButton onClick={onClick} />
     </>
   )
 }
@@ -131,6 +133,14 @@ const ViewWorksButton = props => {
   return (
     <Button width="100%" onClick={props.onClick}>
       View works in this sale
+    </Button>
+  )
+}
+
+const OKButton = props => {
+  return (
+    <Button width="100%" onClick={props.onClick}>
+      OK
     </Button>
   )
 }

--- a/src/v2/Components/Auction/PostRegistrationModal.tsx
+++ b/src/v2/Components/Auction/PostRegistrationModal.tsx
@@ -22,7 +22,9 @@ const BidPending: ModalContent = ({ onClick }) => {
         We're sorry, your bid could not be placed.
       </Serif>
       <ReviewingRegistrationContent />
-      <ViewWorksButton onClick={onClick} />
+      <Button width="100%" onClick={onClick}>
+        View works in this sale
+      </Button>
     </>
   )
 }
@@ -32,7 +34,9 @@ const RegistrationPending: ModalContent = ({ onClick }) => {
     <>
       <RegistrationPendingHeader />
       <ReviewingRegistrationContent />
-      <ViewWorksButton onClick={onClick} />
+      <Button width="100%" onClick={onClick}>
+        View works in this sale
+      </Button>
     </>
   )
 }
@@ -56,7 +60,9 @@ const RegistrationPendingUnverified: ModalContent = ({ onClick }) => {
         <strong>Verify identity</strong> button or follow the link sent to your
         email.
       </Serif>
-      <OKButton onClick={onClick} />
+      <Button width="100%" onClick={onClick}>
+        OK
+      </Button>
     </>
   )
 }
@@ -127,20 +133,4 @@ const ReviewingRegistrationContent = () => {
 
 const RegistrationPendingHeader = () => {
   return <Serif size="6">Registration pending</Serif>
-}
-
-const ViewWorksButton = props => {
-  return (
-    <Button width="100%" onClick={props.onClick}>
-      View works in this sale
-    </Button>
-  )
-}
-
-const OKButton = props => {
-  return (
-    <Button width="100%" onClick={props.onClick}>
-      OK
-    </Button>
-  )
 }

--- a/src/v2/Components/Auction/PostRegistrationModal.tsx
+++ b/src/v2/Components/Auction/PostRegistrationModal.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, CheckCircleIcon, Modal, Serif } from "@artsy/palette"
+import { Box, Button, CheckCircleIcon, Modal, Text } from "@artsy/palette"
 import React, { useEffect, useState } from "react"
 
 export type ContentKey =
@@ -18,9 +18,7 @@ const BidPending: ModalContent = ({ onClick }) => {
   return (
     <>
       <RegistrationPendingHeader />
-      <Serif my={3} size="3t">
-        We're sorry, your bid could not be placed.
-      </Serif>
+      <Text my={3}>We're sorry, your bid could not be placed.</Text>
       <ReviewingRegistrationContent />
       <Button width="100%" onClick={onClick}>
         View works in this sale
@@ -45,7 +43,7 @@ const RegistrationPendingUnverified: ModalContent = ({ onClick }) => {
   return (
     <>
       <RegistrationPendingHeader />
-      <Serif my={3} size="3t">
+      <Text my={3}>
         This auction requires Artsy to verify your identity before bidding.
         <br />
         <br />
@@ -59,7 +57,7 @@ const RegistrationPendingUnverified: ModalContent = ({ onClick }) => {
         To complete your registration and start bidding, please click the{" "}
         <strong>Verify identity</strong> button or follow the link sent to your
         email.
-      </Serif>
+      </Text>
       <Button width="100%" onClick={onClick}>
         OK
       </Button>
@@ -70,13 +68,13 @@ const RegistrationPendingUnverified: ModalContent = ({ onClick }) => {
 const RegistrationComplete: ModalContent = ({ onClick }) => {
   return (
     <>
-      <Serif size="6">Registration complete</Serif>
+      <Text variant="title">Registration complete</Text>
       <CheckCircleIcon mt={2} height="28px" width="28px" fill="green100" />
-      <Serif mt={2} mb={3} size="3t">
+      <Text mt={2} mb={3} size="3t">
         Thank you for registering.
         <br />
         You’re now eligible to bid on lots in this sale.
-      </Serif>
+      </Text>
       <Button width="100%" onClick={onClick}>
         Start bidding
       </Button>
@@ -120,17 +118,17 @@ export const PostRegistrationModal: React.FC<Props> = ({
 
 const ReviewingRegistrationContent = () => {
   return (
-    <Serif my={3} size="3t">
+    <Text my={3}>
       Artsy is reviewing your registration and you will receive an email when it
       has been confirmed. Please email specialist@artsy.net with any questions.
       <br />
       <br />
       In the meantime, you can still view works and watch lots you’re interested
       in.
-    </Serif>
+    </Text>
   )
 }
 
 const RegistrationPendingHeader = () => {
-  return <Serif size="6">Registration pending</Serif>
+  return <Text variant="title">Registration pending</Text>
 }


### PR DESCRIPTION
This PR updates the modal text for an auction registration that is blocked due to a user's pending identity verification. In the process I also updated the modal to user our preferred palette `<Text>` rather than `Serif` component.

Completes [AUCT-1142].

<img width="1088" alt="image" src="https://user-images.githubusercontent.com/9088720/94992901-34be9480-055b-11eb-956b-a5385e103b0f.png">



[AUCT-1142]: https://artsyproduct.atlassian.net/browse/AUCT-1142