### PR TITLE
feat: Deprecate old bidderNeedsIdentityVerification in favor of more nuanced method for determining idv needs

### DIFF
--- a/src/desktop/apps/auction/components/layout/ConfirmRegistrationModal.tsx
+++ b/src/desktop/apps/auction/components/layout/ConfirmRegistrationModal.tsx
@@ -5,7 +5,7 @@ import {
   ContentKey,
   PostRegistrationModal,
 } from "v2/Components/Auction/PostRegistrationModal"
-import { bidderNeedsIdentityVerification } from "v2/Utils/identityVerificationRequirements"
+import { bidderQualifications } from "v2/Utils/identityVerificationRequirements"
 
 const _ConfirmRegistrationModal = ({ me, modalType, onClose, sale }) => {
   useEffect(() => {
@@ -23,12 +23,16 @@ const _ConfirmRegistrationModal = ({ me, modalType, onClose, sale }) => {
 
   const bidder = me.bidders[0]
 
+  const { shouldPromptIdVerification } = bidderQualifications(sale, me, {
+    qualifiedForBidding: bidder.qualified_for_bidding,
+  })
+
   let contentKey: ContentKey
   if (bidder.qualified_for_bidding) {
     contentKey = "registrationConfirmed"
   } else if (modalType === "ConfirmBidAndRegistration") {
     contentKey = "bidPending"
-  } else if (bidderNeedsIdentityVerification({ sale, user: me })) {
+  } else if (shouldPromptIdVerification) {
     contentKey = "registrationPendingUnverified"
   } else {
     contentKey = "registrationPending"

--- a/src/desktop/apps/auction/components/layout/__tests__/ConfirmRegistrationModal.jest.tsx
+++ b/src/desktop/apps/auction/components/layout/__tests__/ConfirmRegistrationModal.jest.tsx
@@ -175,7 +175,7 @@ describe("Confirm Registration Modal", () => {
         expect(wrapper.text()).toContain("Artsy is reviewing your registration")
       })
 
-      it("shows an IDV registration pending message if the sale requires IDV but the user is not verified", () => {
+      it("shows a registration pending message if the sale requires IDV and the user is not verified but has no startable IDV flow", () => {
         const { wrapper } = renderTestComponent({
           Component: ConfirmRegistrationModal,
           options: { renderMode: "mount" },
@@ -189,6 +189,36 @@ describe("Confirm Registration Modal", () => {
                   },
                 ],
                 identityVerified: false,
+                pendingIdentityVerification: null,
+              },
+              sale: {
+                requireIdentityVerification: true,
+              },
+            },
+          },
+        })
+
+        expect(wrapper.text()).toContain("Registration pending")
+        expect(wrapper.text()).toContain("Artsy is reviewing your registration")
+      })
+
+      it("shows an 'please verify identity' message if the sale requires IDV but the user, who is not verified, has an available IDV flow", () => {
+        const { wrapper } = renderTestComponent({
+          Component: ConfirmRegistrationModal,
+          options: { renderMode: "mount" },
+          data: {
+            app: {
+              modalType: "ConfirmRegistration",
+              me: {
+                bidders: [
+                  {
+                    qualified_for_bidding: false,
+                  },
+                ],
+                identityVerified: false,
+                pendingIdentityVerification: {
+                  internalID: "whatever",
+                },
               },
               auction: {
                 requireIdentityVerification: true,
@@ -199,7 +229,7 @@ describe("Confirm Registration Modal", () => {
 
         expect(wrapper.text()).toContain("Registration pending")
         expect(wrapper.text()).toContain(
-          "This auction requires Artsy to verify your identity before bidding."
+          "To complete your registration and start bidding, please click the Verify identity button or follow the link sent to your email."
         )
       })
     })

--- a/src/v2/Apps/Auction/Routes/Register/index.tsx
+++ b/src/v2/Apps/Auction/Routes/Register/index.tsx
@@ -19,7 +19,7 @@ import {
   graphql,
 } from "react-relay"
 import { TrackingProp } from "react-tracking"
-import { bidderNeedsIdentityVerification } from "v2/Utils/identityVerificationRequirements"
+import { bidderQualifications } from "v2/Utils/identityVerificationRequirements"
 import createLogger from "v2/Utils/logger"
 import {
   createStripeWrapper,
@@ -153,6 +153,8 @@ export const RegisterRoute: React.FC<RegisterProps> = props => {
     }
   }
 
+  const { userLacksIdentityVerification } = bidderQualifications(sale, me, null)
+
   return (
     <AppContainer>
       <Title>Auction Registration</Title>
@@ -163,10 +165,7 @@ export const RegisterRoute: React.FC<RegisterProps> = props => {
         <RegistrationForm
           onSubmit={createTokenAndSubmit}
           trackSubmissionErrors={trackRegistrationFailed}
-          needsIdentityVerification={bidderNeedsIdentityVerification({
-            sale,
-            user: me,
-          })}
+          needsIdentityVerification={userLacksIdentityVerification}
         />
       </Box>
     </AppContainer>

--- a/src/v2/Components/Auction/AuctionRegistrationModal.tsx
+++ b/src/v2/Components/Auction/AuctionRegistrationModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react"
 
 import { Box, Button, Flex, Modal, Sans, Serif } from "@artsy/palette"
-import { bidderNeedsIdentityVerification } from "v2/Utils/identityVerificationRequirements"
+import { bidderQualifications } from "v2/Utils/identityVerificationRequirements"
 import { ConditionsOfSaleCheckbox } from "./ConditionsOfSaleCheckbox"
 
 // For convenience even though sale is for now a single value
@@ -73,13 +73,18 @@ export const AuctionRegistrationModal: React.FC<Props> = ({
       handleSubmit(true)
     }
   }
+  const { userLacksIdentityVerification } = bidderQualifications(
+    auction,
+    me,
+    null
+  )
 
   return (
     <Modal show={show} onClose={closeModal}>
       <Box pt={[3, 0]} textAlign="center">
         <Serif size="6">Register for {auction.name}</Serif>
 
-        {bidderNeedsIdentityVerification({ sale: auction, user: me }) ? (
+        {userLacksIdentityVerification ? (
           <>
             <Serif my={3} size="4">
               This auction requires Artsy to verify your identity before

--- a/src/v2/Components/Auction/PostRegistrationModal.tsx
+++ b/src/v2/Components/Auction/PostRegistrationModal.tsx
@@ -51,10 +51,12 @@ const RegistrationPendingUnverified: ModalContent = ({ onClick }) => {
         </a>{" "}
         or contact verification@artsy.net.
         <br />
-        <br />A link to complete identity verification has been sent to your
+        <br />
+        To complete your registration and start bidding, please click the{" "}
+        <strong>Verify identity</strong> button or follow the link sent to your
         email.
       </Serif>
-      <ViewWorksButton onClick={onClick} />
+      <OKButton onClick={onClick} />
     </>
   )
 }
@@ -131,6 +133,14 @@ const ViewWorksButton = props => {
   return (
     <Button width="100%" onClick={props.onClick}>
       View works in this sale
+    </Button>
+  )
+}
+
+const OKButton = props => {
+  return (
+    <Button width="100%" onClick={props.onClick}>
+      OK
     </Button>
   )
 }

--- a/src/v2/Components/Auction/PostRegistrationModal.tsx
+++ b/src/v2/Components/Auction/PostRegistrationModal.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, CheckCircleIcon, Modal, Serif } from "@artsy/palette"
+import { Box, Button, CheckCircleIcon, Modal, Text } from "@artsy/palette"
 import React, { useEffect, useState } from "react"
 
 export type ContentKey =
@@ -18,9 +18,7 @@ const BidPending: ModalContent = ({ onClick }) => {
   return (
     <>
       <RegistrationPendingHeader />
-      <Serif my={3} size="3t">
-        We're sorry, your bid could not be placed.
-      </Serif>
+      <Text my={3}>We're sorry, your bid could not be placed.</Text>
       <ReviewingRegistrationContent />
       <ViewWorksButton onClick={onClick} />
     </>
@@ -41,7 +39,7 @@ const RegistrationPendingUnverified: ModalContent = ({ onClick }) => {
   return (
     <>
       <RegistrationPendingHeader />
-      <Serif my={3} size="3t">
+      <Text my={3}>
         This auction requires Artsy to verify your identity before bidding.
         <br />
         <br />
@@ -55,7 +53,7 @@ const RegistrationPendingUnverified: ModalContent = ({ onClick }) => {
         To complete your registration and start bidding, please click the{" "}
         <strong>Verify identity</strong> button or follow the link sent to your
         email.
-      </Serif>
+      </Text>
       <OKButton onClick={onClick} />
     </>
   )
@@ -64,13 +62,13 @@ const RegistrationPendingUnverified: ModalContent = ({ onClick }) => {
 const RegistrationComplete: ModalContent = ({ onClick }) => {
   return (
     <>
-      <Serif size="6">Registration complete</Serif>
+      <Text variant="title">Registration complete</Text>
       <CheckCircleIcon mt={2} height="28px" width="28px" fill="green100" />
-      <Serif mt={2} mb={3} size="3t">
+      <Text mt={2} mb={3} size="3t">
         Thank you for registering.
         <br />
         You’re now eligible to bid on lots in this sale.
-      </Serif>
+      </Text>
       <Button width="100%" onClick={onClick}>
         Start bidding
       </Button>
@@ -114,19 +112,19 @@ export const PostRegistrationModal: React.FC<Props> = ({
 
 const ReviewingRegistrationContent = () => {
   return (
-    <Serif my={3} size="3t">
+    <Text my={3}>
       Artsy is reviewing your registration and you will receive an email when it
       has been confirmed. Please email specialist@artsy.net with any questions.
       <br />
       <br />
       In the meantime, you can still view works and watch lots you’re interested
       in.
-    </Serif>
+    </Text>
   )
 }
 
 const RegistrationPendingHeader = () => {
-  return <Serif size="6">Registration pending</Serif>
+  return <Text variant="title">Registration pending</Text>
 }
 
 const ViewWorksButton = props => {


### PR DESCRIPTION
Blocked by #6404 because those commits are in here. https://github.com/artsy/force/pull/6405/commits/2c345b6704930bd971c5673d3a05bf39c0c46da5 is the relevant commit.

In the process of doing #6342, #6366 and https://github.com/artsy/force/pull/6404 I found our existing `bidderNeedsIdentityVerification` method confusing and ended up writing some duplicative logic for calculating a series of interdependent values. Eventually it these values came to live together in a new adjacent function which returns all of them in a sack:
```ts
interface BidderQualifications {
  /** Presence of bidder */
  registrationAttempted: boolean
  /** Bidder is qualified */
  qualifiedForBidding: boolean
  /** Sale requires identity verification but the user does not have it */
  userLacksIdentityVerification: boolean
  /** User's pending identity verification, if present */
  pendingIdentityVerification: {
    internalID: string
  } | null
  /** Whether user should be prompted to verify ID, that is:
   * - they are not qualified
   * - they are lacking idv for a sale that requires it
   * - they have an available pendingIdentityVerification
   */
  shouldPromptIdVerification: boolean
}
```

This PR removes the older method from the final places it was used. Current tests are still passing fine and the call signatures of the removed and new methods match (with the exception of the previously still snake-cased `bidder`, which is null since these call sites are for registration flows) so this should just be a refactor that removes ambiguity from a helper file..