### PR TITLE
@sweir27 => [Fair] Load followed artists clientside, and enable checkbox interaction with 'Artists I Follow' filter

### DIFF
--- a/src/v2/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
@@ -5,6 +5,13 @@ import { graphql } from "react-relay"
 import { FairArtworks_QueryRawResponse } from "v2/__generated__/FairArtworks_Query.graphql"
 
 jest.unmock("react-relay")
+jest.mock("v2/Artsy/Router/useRouter", () => ({
+  useRouter: () => ({
+    match: {
+      location: { query: {} },
+    },
+  }),
+}))
 
 describe("FairArtworks", () => {
   const getWrapper = async (
@@ -40,7 +47,7 @@ describe("FairArtworks", () => {
     const wrapper = await getWrapper()
     expect(wrapper.find("ArtistsFilter").length).toBe(1)
     expect(wrapper.find("ArtistsFilter").text()).toMatch(
-      "Artists I Follow (10)"
+      "Artists I follow (10)"
     )
   })
 })

--- a/src/v2/Apps/Fair/routes.tsx
+++ b/src/v2/Apps/Fair/routes.tsx
@@ -129,17 +129,23 @@ export const routes: RouteConfig[] = [
 ]
 
 function initializeVariablesWithFilterState(params, props) {
-  const initialFilterState = props.location ? props.location.query : {}
+  const initialFilterStateFromUrl = props.location ? props.location.query : {}
+  const camelCasedFilterStateFromUrl = paramsToCamelCase(
+    initialFilterStateFromUrl
+  )
 
   let aggregations: string[] = ["TOTAL", "GALLERY", "MAJOR_PERIOD", "ARTIST"]
   if (props.context.user) aggregations = aggregations.concat("FOLLOWED_ARTISTS")
 
   const state = {
     sort: "-decayed_merch",
-    ...paramsToCamelCase(initialFilterState),
+    ...camelCasedFilterStateFromUrl,
     ...params,
     aggregations,
     shouldFetchCounts: !!props.context.user,
+    includeArtworksByFollowedArtists:
+      !!props.context.user &&
+      camelCasedFilterStateFromUrl["includeArtworksByFollowedArtists"],
   }
 
   return state

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
@@ -1,9 +1,13 @@
 import { Checkbox, Flex, Text, Toggle } from "@artsy/palette"
 import { sortBy } from "lodash"
-import React, { FC, useState } from "react"
+import React, { FC, useEffect, useState } from "react"
 import styled from "styled-components"
 
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
+import {
+  FollowedArtistList,
+  fetchFollowedArtists,
+} from "../Utils/fetchFollowedArtists"
 import { OptionText } from "./OptionText"
 
 const ToggleLink = styled(Text)`
@@ -11,43 +15,75 @@ const ToggleLink = styled(Text)`
   text-decoration: underline;
 `
 
-export const ArtistsFilter: FC = () => {
-  const { aggregations, ...filterContext } = useArtworkFilterContext()
-  const [expanded, setExpanded] = useState(false)
+const INITIAL_ARTISTS_TO_SHOW = 6
 
+interface ArtistsFilterProps {
+  relayEnvironment?: any
+  fairID?: string
+  user?: User
+}
+
+export const ArtistsFilter: FC<ArtistsFilterProps> = ({
+  fairID,
+  relayEnvironment,
+  user,
+}) => {
+  const { aggregations, ...filterContext } = useArtworkFilterContext()
   const artists = aggregations.find(agg => agg.slice === "ARTIST")
+
+  const [expanded, setExpanded] = useState(
+    filterContext.currentlySelectedFilters().artistIDs.length > 0
+  )
+  const [followedArtists, setFollowedArtists] = useState<FollowedArtistList>([])
+  const followedArtistSlugs = followedArtists.map(({ slug }) => slug)
+
+  useEffect(() => {
+    if (relayEnvironment && user) {
+      fetchFollowedArtists({ relayEnvironment, fairID }).then(data => {
+        setFollowedArtists(data)
+      })
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   if (!(artists && artists.counts)) {
     return null
   }
 
   const artistsSorted = sortBy(artists.counts, ["name"])
-  const initialArtistsGroup = artistsSorted.slice(0, 6)
+  const initialArtistsGroup = artistsSorted.slice(0, INITIAL_ARTISTS_TO_SHOW)
   const remainingArtistsGroup =
-    artistsSorted.length > 6
-      ? artistsSorted.slice(6 - artistsSorted.length)
+    artistsSorted.length > INITIAL_ARTISTS_TO_SHOW
+      ? artistsSorted.slice(INITIAL_ARTISTS_TO_SHOW - artistsSorted.length)
       : []
 
   const toggle = () => setExpanded(!expanded)
 
+  const isFollowedArtistCheckboxSelected =
+    !!user &&
+    filterContext.currentlySelectedFilters()["includeArtworksByFollowedArtists"]
   const followedArtistCheckboxProps = {
     onSelect: value =>
       filterContext.setFilter("includeArtworksByFollowedArtists", value),
-    selected: Boolean(
-      filterContext.currentlySelectedFilters()[
-        "includeArtworksByFollowedArtists"
-      ]
-    ),
+    selected: isFollowedArtistCheckboxSelected,
   }
-
   const followedArtistArtworkCount = filterContext?.counts?.followedArtists ?? 0
 
-  const toggleSelection = (selected, name) => {
+  const toggleArtistSelection = (selected, slug) => {
     let artistIDs = filterContext.currentlySelectedFilters().artistIDs.slice()
     if (selected) {
-      artistIDs.push(name)
+      artistIDs.push(slug)
     } else {
-      artistIDs = artistIDs.filter(item => item !== name)
+      // When an artist is de-selected, if it is a followed artist _and_ that filter
+      // is also checked, we want to de-select it as well, and move remaining followed
+      // artists to the explicit `artistIDs` list.
+      artistIDs = artistIDs.filter(item => item !== slug)
+      if (followedArtistSlugs.includes(slug)) {
+        filterContext.setFilter("includeArtworksByFollowedArtists", false)
+        artistIDs = artistIDs.concat(followedArtistSlugs)
+        artistIDs = artistIDs.filter(item => item !== slug)
+      }
     }
     filterContext.setFilter("artistIDs", artistIDs)
   }
@@ -66,13 +102,14 @@ export const ArtistsFilter: FC = () => {
 
   const renderArtistGroup = artistGroup => {
     return artistGroup.map(({ value: slug, name }, index) => {
-      const selected = filterContext
-        .currentlySelectedFilters()
-        .artistIDs.includes(slug)
+      const isFollowedArtist = followedArtistSlugs.includes(slug)
+      const selected =
+        filterContext.currentlySelectedFilters().artistIDs.includes(slug) ||
+        (isFollowedArtistCheckboxSelected && isFollowedArtist)
       const props = {
         key: index,
         onSelect: selected => {
-          toggleSelection(selected, slug)
+          toggleArtistSelection(selected, slug)
         },
         selected,
       }
@@ -93,7 +130,7 @@ export const ArtistsFilter: FC = () => {
           {...followedArtistCheckboxProps}
         >
           <OptionText>
-            Artists I Follow ({followedArtistArtworkCount})
+            Artists I follow ({followedArtistArtworkCount})
           </OptionText>
         </Checkbox>
 
@@ -101,9 +138,12 @@ export const ArtistsFilter: FC = () => {
 
         {!expanded && remainingArtistsGroup.length && <ExpandControl />}
 
-        {expanded && renderArtistGroup(remainingArtistsGroup)}
-
-        {expanded && <HideControl />}
+        {expanded && (
+          <>
+            {renderArtistGroup(remainingArtistsGroup)}
+            <HideControl />
+          </>
+        )}
       </Flex>
     </Toggle>
   )

--- a/src/v2/Components/v2/ArtworkFilter/Utils/fetchFollowedArtists.ts
+++ b/src/v2/Components/v2/ArtworkFilter/Utils/fetchFollowedArtists.ts
@@ -1,0 +1,58 @@
+import { Environment, fetchQuery } from "relay-runtime"
+import { graphql } from "react-relay"
+import { fetchFollowedArtistsQuery } from "v2/__generated__/fetchFollowedArtistsQuery.graphql"
+
+export type FollowedArtistList = Array<{
+  slug: string
+  internalID: string
+}>
+
+// Expand support (in Gravity/MP as well), if needed
+// to further narrow down followed artists.
+export interface FetchFollowedArtistsArgs {
+  fairID: string
+}
+
+interface Args extends FetchFollowedArtistsArgs {
+  relayEnvironment: Environment
+}
+
+export async function fetchFollowedArtists(
+  args: Args
+): Promise<FollowedArtistList> {
+  const { relayEnvironment, ...props } = args
+
+  const query = graphql`
+    query fetchFollowedArtistsQuery($fairID: String) {
+      me {
+        followsAndSaves {
+          artistsConnection(first: 99, fairID: $fairID) {
+            edges {
+              node {
+                artist {
+                  slug
+                  internalID
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  try {
+    const data = await fetchQuery<fetchFollowedArtistsQuery>(
+      relayEnvironment,
+      query,
+      props
+    )
+
+    return data.me.followsAndSaves.artistsConnection.edges.map(
+      ({ node: { artist } }) => artist
+    )
+  } catch (error) {
+    console.error(error)
+    return []
+  }
+}

--- a/src/v2/__generated__/fetchFollowedArtistsQuery.graphql.ts
+++ b/src/v2/__generated__/fetchFollowedArtistsQuery.graphql.ts
@@ -1,0 +1,264 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type fetchFollowedArtistsQueryVariables = {
+    fairID?: string | null;
+};
+export type fetchFollowedArtistsQueryResponse = {
+    readonly me: {
+        readonly followsAndSaves: {
+            readonly artistsConnection: {
+                readonly edges: ReadonlyArray<{
+                    readonly node: {
+                        readonly artist: {
+                            readonly slug: string;
+                            readonly internalID: string;
+                        } | null;
+                    } | null;
+                } | null> | null;
+            } | null;
+        } | null;
+    } | null;
+};
+export type fetchFollowedArtistsQuery = {
+    readonly response: fetchFollowedArtistsQueryResponse;
+    readonly variables: fetchFollowedArtistsQueryVariables;
+};
+
+
+
+/*
+query fetchFollowedArtistsQuery(
+  $fairID: String
+) {
+  me {
+    followsAndSaves {
+      artistsConnection(first: 99, fairID: $fairID) {
+        edges {
+          node {
+            artist {
+              slug
+              internalID
+              id
+            }
+            id
+          }
+        }
+      }
+    }
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "fairID",
+    "type": "String"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "fairID",
+    "variableName": "fairID"
+  },
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 99
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "fetchFollowedArtistsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "FollowsAndSaves",
+            "kind": "LinkedField",
+            "name": "followsAndSaves",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": (v1/*: any*/),
+                "concreteType": "FollowArtistConnection",
+                "kind": "LinkedField",
+                "name": "artistsConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FollowArtistEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "FollowArtist",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Artist",
+                            "kind": "LinkedField",
+                            "name": "artist",
+                            "plural": false,
+                            "selections": [
+                              (v2/*: any*/),
+                              (v3/*: any*/)
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "fetchFollowedArtistsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "FollowsAndSaves",
+            "kind": "LinkedField",
+            "name": "followsAndSaves",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": (v1/*: any*/),
+                "concreteType": "FollowArtistConnection",
+                "kind": "LinkedField",
+                "name": "artistsConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FollowArtistEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "FollowArtist",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Artist",
+                            "kind": "LinkedField",
+                            "name": "artist",
+                            "plural": false,
+                            "selections": [
+                              (v2/*: any*/),
+                              (v3/*: any*/),
+                              (v4/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "fetchFollowedArtistsQuery",
+    "operationKind": "query",
+    "text": "query fetchFollowedArtistsQuery(\n  $fairID: String\n) {\n  me {\n    followsAndSaves {\n      artistsConnection(first: 99, fairID: $fairID) {\n        edges {\n          node {\n            artist {\n              slug\n              internalID\n              id\n            }\n            id\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '7d77bec8b2b55e8392884c9c418b8215';
+export default node;


### PR DESCRIPTION
This is kind of complex/nuanced! Basically, this tweaks the functionality and behavior of the current filter based on the spec:

![Screen Shot 2020-10-05 at 5 36 31 PM](https://user-images.githubusercontent.com/1457859/95134875-96385c00-0731-11eb-8b5a-76d444ffb436.png)

It feels a _bit_ odd, and I have a few questions about how it should exactly behave (is it even necessary?). But with Nicole gone, I'm not 100% sure how to clarify, or if we should revisit it.

This is nevertheless mergeable, and we can see how the behavior feels on staging/prod.


In a nutshell:
This loads artists you follow at the fair, client-side. Then, when checking on the 'Artists I follow' filter, those followed artists are checked on for you. As you select/de-select non followed artists, we maintain the `?include_artworks_by_followed_artists=true` param, and also construct the ad-hoc artists in `?artist_ids[]=...`. Once you de-select a followed artist however, we turn _off_ your 'Artists I follow' filter, and all of the followed artists which are still selected move over to the `?artist_ids[]=...` param.

See what I mean? 😅  It's a little...much. It does feel ok though, so I think we should merge and then QA/revisit on staging and prod and see how we feel, and if we can further tighten it up.