### PR TITLE
Rebuild User Settings Tabs in react and integrate into order history page

### DIFF
--- a/src/desktop/apps/user/stylesheets/index.styl
+++ b/src/desktop/apps/user/stylesheets/index.styl
@@ -36,6 +36,13 @@
       @media screen and (max-width: 550px)
         width 100%
 
+.settings-page.responsive-layout-container
+  margin 20px 0px
+  @media screen and (min-width: 941px)
+    margin -10px 0px
+  @media screen and (min-width: 1192px)
+    max-width 1112px
+    margin auto 0px
 
 .settings-subnav
   //

--- a/src/desktop/apps/user/stylesheets/index.styl
+++ b/src/desktop/apps/user/stylesheets/index.styl
@@ -42,7 +42,7 @@
     margin -10px 0px
   @media screen and (min-width: 1192px)
     max-width 1112px
-    margin auto 0px
+    margin 0px auto
 
 .settings-subnav
   //

--- a/src/desktop/apps/user/stylesheets/index.styl
+++ b/src/desktop/apps/user/stylesheets/index.styl
@@ -44,6 +44,11 @@
     max-width 1112px
     margin 0px auto
 
+#stitch-settings-tabs
+  @media screen and (max-width: 600px)
+    margin: 0px -10px
+
+
 .settings-subnav
   //
 

--- a/src/desktop/apps/user/templates/layout.jade
+++ b/src/desktop/apps/user/templates/layout.jade
@@ -12,12 +12,8 @@ block body
     class='js-settings-page'
   )
     .main-layout-container
-      header.settings-page__header
-        h1.settings-page__header__name
-          = user.get('name')
-
-        #stitch-settings-tabs
-          != stitch.components.UserSettingsTabs({ mountId: 'stitch-settings-tabs', route: sd.CURRENT_PATH })
+      #stitch-settings-tabs
+        != stitch.components.UserSettingsTabs({ mountId: 'stitch-settings-tabs', route: sd.CURRENT_PATH, username: user.get('name')})
 
       .settings-page__content
         .settings-page__content__main(

--- a/src/desktop/apps/user/templates/layout.jade
+++ b/src/desktop/apps/user/templates/layout.jade
@@ -16,7 +16,8 @@ block body
         h1.settings-page__header__name
           = user.get('name')
 
-        include ../components/tabs/index
+        #stitch-settings-tabs
+          != stitch.components.UserSettingsTabs({ mountId: 'stitch-settings-tabs', route: sd.CURRENT_PATH })
 
       .settings-page__content
         .settings-page__content__main(

--- a/src/desktop/components/react/stitch_components/index.tsx
+++ b/src/desktop/components/react/stitch_components/index.tsx
@@ -20,3 +20,4 @@ export {
   TwoFactorAuthenticationQueryRenderer as TwoFactorAuthentication,
 } from "v2/Components/UserSettings/TwoFactorAuthentication"
 export { ReactionCCPARequest as CCPARequest } from "./CCPARequest"
+export { UserSettingsTabs } from "v2/Components/UserSettings/UserSettingsTabs"

--- a/src/v2/Apps/Purchase/Components/PurchaseHistory.tsx
+++ b/src/v2/Apps/Purchase/Components/PurchaseHistory.tsx
@@ -15,12 +15,14 @@ import {
   Text,
   XCircleIcon,
 } from "@artsy/palette"
+import { data as sd } from "sharify"
 import { DateTime } from "luxon"
 import { PurchaseHistory_me } from "v2/__generated__/PurchaseHistory_me.graphql"
 import React, { useState } from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { Media } from "v2/Utils/Responsive"
+import { UserSettingsTabs } from "v2/components/UserSettings/UserSettingsTabs"
 
 interface OrderRowProps {
   order: PurchaseHistory_me["orders"]["edges"][number]["node"]
@@ -155,7 +157,7 @@ const OrderRow = (props: OrderRowProps) => {
         </Box>
       </Media>
       <Media greaterThanOrEqual="sm">
-        <BorderBox m={2} p={0} flexDirection="column">
+        <BorderBox my={2} mx="40px" p={0} flexDirection="column">
           <Flex
             bg="black5"
             width="100%"
@@ -310,10 +312,17 @@ const PurchaseHistory: React.FC<PurchaseHistoryProps> = (
   const myOrders = me.orders.edges && me.orders.edges.map(x => x.node)
   return !loading ? (
     <Box>
-      <Sans size="6" px={1} py={1.5}>
-        Order History
-      </Sans>
-      <Separator />
+      <Media greaterThanOrEqual="sm">
+        <Box mx="40px" mt="-5px">
+          <UserSettingsTabs route={sd.CURRENT_PATH} username={me.name} />
+        </Box>
+      </Media>
+      <Media lessThan="sm">
+        <Sans size="6" px={1} py={1.5}>
+          Order History
+        </Sans>
+        <Separator />
+      </Media>
       {myOrders.length ? (
         myOrders.map((order, i) => (
           <OrderRow
@@ -348,6 +357,7 @@ export const PurchaseHistoryFragmentContainer = createRefetchContainer(
           after: { type: "String" }
           before: { type: "String" }
         ) {
+        name
         orders(first: $first, last: $last, before: $before, after: $after) {
           edges {
             node {

--- a/src/v2/Apps/Purchase/Components/PurchaseHistory.tsx
+++ b/src/v2/Apps/Purchase/Components/PurchaseHistory.tsx
@@ -312,16 +312,16 @@ const PurchaseHistory: React.FC<PurchaseHistoryProps> = (
   const myOrders = me.orders.edges && me.orders.edges.map(x => x.node)
   return !loading ? (
     <Box>
-      <Media greaterThanOrEqual="sm">
-        <Box mx="40px" mt="-5px">
-          <UserSettingsTabs route={sd.CURRENT_PATH} username={me.name} />
-        </Box>
-      </Media>
-      <Media lessThan="sm">
+      <Media at="xs">
         <Sans size="6" px={1} py={1.5}>
           Order History
         </Sans>
         <Separator />
+      </Media>
+      <Media greaterThanOrEqual="sm">
+        <Box mx="40px" mt="-5px">
+          <UserSettingsTabs route={sd.CURRENT_PATH} username={me.name} />
+        </Box>
       </Media>
       {myOrders.length ? (
         myOrders.map((order, i) => (

--- a/src/v2/Apps/Purchase/Components/PurchaseHistory.tsx
+++ b/src/v2/Apps/Purchase/Components/PurchaseHistory.tsx
@@ -6,7 +6,6 @@ import {
   Flex,
   HelpIcon,
   Image,
-  LargePagination,
   Link,
   PendingCircleIcon,
   Sans,
@@ -16,6 +15,7 @@ import {
   XCircleIcon,
 } from "@artsy/palette"
 import { data as sd } from "sharify"
+import { PaginationFragmentContainer as Pagination } from "v2/Components/Pagination"
 import { DateTime } from "luxon"
 import { PurchaseHistory_me } from "v2/__generated__/PurchaseHistory_me.graphql"
 import React, { useState } from "react"
@@ -23,6 +23,7 @@ import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { Media } from "v2/Utils/Responsive"
 import { UserSettingsTabs } from "v2/components/UserSettings/UserSettingsTabs"
+import { themeGet } from "@styled-system/theme-get"
 
 interface OrderRowProps {
   order: PurchaseHistory_me["orders"]["edges"][number]["node"]
@@ -33,6 +34,18 @@ const StyledImage = styled(Image)`
   object-fit: cover;
   height: 50px;
   width: 50px;
+`
+const StyledBox = styled(Box)`
+  padding: 10px 40px 30px 40px;
+  svg {
+    top: 5px;
+  }
+  @media (max-width: ${themeGet("breakpoints.xs")}) {
+    padding: 10px 20px;
+    svg {
+      top: 0px;
+    }
+  }
 `
 const getIcon = status => {
   switch (status) {
@@ -313,17 +326,9 @@ const PurchaseHistory: React.FC<PurchaseHistoryProps> = (
   const myOrders = me.orders.edges && me.orders.edges.map(x => x.node)
   return !loading ? (
     <Box>
-      <Media greaterThanOrEqual="sm">
-        <Box mx="40px" mt="-5px">
-          <UserSettingsTabs route={sd.CURRENT_PATH} username={me.name} />
-        </Box>
-      </Media>
-      <Media lessThan="sm">
-        <Sans size="6" px={1} py={1.5}>
-          Order History
-        </Sans>
-        <Separator />
-      </Media>
+      <Box mx="40px" mt="-5px">
+        <UserSettingsTabs route={sd.CURRENT_PATH} username={me.name} />
+      </Box>
       {myOrders.length ? (
         myOrders.map((order, i) => (
           <OrderRow
@@ -335,12 +340,14 @@ const PurchaseHistory: React.FC<PurchaseHistoryProps> = (
       ) : (
         <Sans size="2">No Orders</Sans>
       )}
-      <LargePagination
-        pageCursors={me.orders.pageCursors}
-        hasNextPage
-        onClick={cursor => loadAfter(cursor, props.relay, setLoading)}
-        onNext={() => loadNext(pageInfo, props.relay, setLoading)}
-      />
+      <StyledBox>
+        <Pagination
+          pageCursors={me.orders.pageCursors}
+          hasNextPage
+          onClick={cursor => loadAfter(cursor, props.relay, setLoading)}
+          onNext={() => loadNext(pageInfo, props.relay, setLoading)}
+        />
+      </StyledBox>
     </Box>
   ) : (
     <Spinner />

--- a/src/v2/Apps/Purchase/Components/PurchaseHistory.tsx
+++ b/src/v2/Apps/Purchase/Components/PurchaseHistory.tsx
@@ -41,7 +41,7 @@ const StyledBox = styled(Box)`
     top: 5px;
   }
   @media (max-width: ${themeGet("breakpoints.xs")}) {
-    padding: 10px 20px;
+    padding: 20px;
     svg {
       top: 0px;
     }
@@ -288,7 +288,7 @@ const loadNext = (pageInfo, relay, setLoading) => {
   const { hasNextPage, endCursor } = pageInfo
 
   if (hasNextPage) {
-    this.loadAfter(endCursor, relay, setLoading)
+    loadAfter(endCursor, relay, setLoading)
   }
 }
 
@@ -326,7 +326,7 @@ const PurchaseHistory: React.FC<PurchaseHistoryProps> = (
   const myOrders = me.orders.edges && me.orders.edges.map(x => x.node)
   return !loading ? (
     <Box>
-      <Box mx="40px" mt="-5px">
+      <Box mx={["0px", "40px", "40px", "40px"]} mt="-5px">
         <UserSettingsTabs route={sd.CURRENT_PATH} username={me.name} />
       </Box>
       {myOrders.length ? (

--- a/src/v2/Apps/Purchase/Components/PurchaseHistory.tsx
+++ b/src/v2/Apps/Purchase/Components/PurchaseHistory.tsx
@@ -71,19 +71,20 @@ const getColor = status => {
 const OrderRow = (props: OrderRowProps) => {
   const { order } = props
   const artwork = order.lineItems.edges[0].node.artwork
-  const { partner } = artwork
 
   const orderCreatedAt = DateTime.fromISO(order.createdAt)
   if (!artwork || order.state === "ABANDONED") {
     return null
   }
 
+  const { partner } = artwork
+
   const { creditCard, requestedFulfillment } = order
 
   const orderIsInactive =
     order.state === "CANCELED" || order.state === "REFUNDED"
 
-  const partnerImageUrl = partner.profile.icon?.url
+  const partnerImageUrl = partner?.profile?.icon?.url
   const partnerInitials = partner?.initials
   const creditCardNumber = creditCard?.lastDigits
   const fulfillment = requestedFulfillment?.__typename
@@ -128,7 +129,7 @@ const OrderRow = (props: OrderRowProps) => {
                 </Text>
               )}
               <Text variant="text" color="black60" letterSpacing="tight">
-                {artwork.partner.name}
+                {artwork.partner?.name}
               </Text>
               <Text variant="text" color="black60" letterSpacing="tight">
                 {orderCreatedAt.toLocaleString(DateTime.DATE_SHORT)}
@@ -212,7 +213,7 @@ const OrderRow = (props: OrderRowProps) => {
                 initials={partnerInitials}
               />
               <Flex flexDirection="column" ml={1}>
-                <Text variant="text">{artwork.partner.name}</Text>
+                <Text variant="text">{artwork.partner?.name}</Text>
                 <Text variant="text" color="black60">
                   {artwork.shippingOrigin.replace(/, US/g, "")}
                 </Text>
@@ -312,16 +313,16 @@ const PurchaseHistory: React.FC<PurchaseHistoryProps> = (
   const myOrders = me.orders.edges && me.orders.edges.map(x => x.node)
   return !loading ? (
     <Box>
-      <Media at="xs">
-        <Sans size="6" px={1} py={1.5}>
-          Order History
-        </Sans>
-        <Separator />
-      </Media>
       <Media greaterThanOrEqual="sm">
         <Box mx="40px" mt="-5px">
           <UserSettingsTabs route={sd.CURRENT_PATH} username={me.name} />
         </Box>
+      </Media>
+      <Media lessThan="sm">
+        <Sans size="6" px={1} py={1.5}>
+          Order History
+        </Sans>
+        <Separator />
       </Media>
       {myOrders.length ? (
         myOrders.map((order, i) => (

--- a/src/v2/Apps/Purchase/__tests__/PurchaseApp.jest.tsx
+++ b/src/v2/Apps/Purchase/__tests__/PurchaseApp.jest.tsx
@@ -89,6 +89,7 @@ describe("Purchase app", () => {
         // TODO: revisit mocking and remove `artist_names` alias from PurchseHistory
         const mockMe = {
           id: "34343267",
+          name: "Moira Rose",
           orders: {
             edges: [{ node: UntouchedBuyOrder }],
             pageInfo,
@@ -98,7 +99,7 @@ describe("Purchase app", () => {
         const component = await render(mockMe, userType)
         const text = component.text()
         expect(text).toContain(
-          "Order History Dec 19, 2019pendingLisa BreslowGramercy Park SouthA GalleryNew York, NYOrder No.abcdefgTotal$12,000"
+          "Moira RoseSaves & FollowsCollector ProfileOrder HistoryBidsSettingsPayments Dec 19, 2019pendingLisa BreslowGramercy Park SouthA GalleryNew York, NYOrder No.abcdefgTotal$12,000"
         )
       })
     })
@@ -106,6 +107,7 @@ describe("Purchase app", () => {
       it("renders pagination component", async () => {
         const mockMe = {
           id: "111",
+          name: "Moira Rose",
           orders: {
             edges: [{ node: UntouchedBuyOrder }],
             pageInfo,
@@ -134,6 +136,7 @@ describe("Purchase app", () => {
       it("shows No orders", async () => {
         const mockMe = {
           id: "111",
+          name: "Moira Rose",
           orders: { edges: [], pageInfo, pageCursors },
         }
         const component = await render(mockMe, userType)
@@ -148,6 +151,7 @@ describe("Purchase app", () => {
     it("gives error", async () => {
       const mockMe = {
         id: "111",
+        name: "Moira Rose",
         orders: { edges: [{ node: UntouchedBuyOrder }], pageInfo, pageCursors },
       }
       const component = await render(mockMe, { type: "regular-user" })

--- a/src/v2/Components/UserSettings/UserSettingsTabs.tsx
+++ b/src/v2/Components/UserSettings/UserSettingsTabs.tsx
@@ -1,0 +1,51 @@
+import React from "react"
+import styled from "styled-components"
+import { Box, RouteTab, RouteTabs } from "v2/Components/RouteTabs"
+import { data as sd } from "sharify"
+
+interface UserSettingsTabsProps {
+  route: string
+}
+
+const isCurrentTab = (tabUrl, route) => {
+  const currentRoute =
+    typeof window === "undefined" ? route : window.location.pathname
+
+  return currentRoute === tabUrl ? "active" : undefined
+}
+
+export const UserSettingsTabs: React.FC<UserSettingsTabsProps> = ({
+  route,
+}) => {
+  return (
+    <RouteTabs>
+      <RouteTab class={isCurrentTab("/user/saves", route)} to="/user/saves">
+        Saves & Follows
+      </RouteTab>
+      <RouteTab class={isCurrentTab("/profile/edit", route)} to="/profile/edit">
+        Collector Profile
+      </RouteTab>
+      <RouteTab
+        class={isCurrentTab("/user/purchases", route)}
+        to="/user/purchases"
+      >
+        Order History
+      </RouteTab>
+      <RouteTab
+        class={isCurrentTab("/user/auctions", route)}
+        to="/user/auctions"
+      >
+        Bids
+      </RouteTab>
+      <RouteTab class={isCurrentTab("/user/edit", route)} to="/user/edit">
+        Settings
+      </RouteTab>
+      <RouteTab
+        class={isCurrentTab("/user/payments", route)}
+        to="/user/payments"
+      >
+        Payments
+      </RouteTab>
+    </RouteTabs>
+  )
+}

--- a/src/v2/Components/UserSettings/UserSettingsTabs.tsx
+++ b/src/v2/Components/UserSettings/UserSettingsTabs.tsx
@@ -1,13 +1,19 @@
 import React from "react"
 import styled from "styled-components"
 import { RouteTab, RouteTabs } from "v2/Components/RouteTabs"
-import { data as sd } from "sharify"
 import { Box, Text } from "@artsy/palette"
+import { themeGet } from "@styled-system/theme-get"
 
 interface UserSettingsTabsProps {
   route?: string
   username?: string
 }
+
+const StyledRouteTab = styled(RouteTab)`
+  @media (max-width: ${themeGet("breakpoints.xs")}) {
+    padding-right: 10px;
+  }
+`
 
 const isCurrentTab = (tabUrl, route) => {
   const currentRoute =
@@ -23,7 +29,7 @@ export const UserSettingsTabs: React.FC<UserSettingsTabsProps> = ({
   return (
     <Box pt={1}>
       <Box>
-        <Text variant="title" my={2}>
+        <Text variant="title" m={2}>
           {username}
         </Text>
       </Box>
@@ -52,12 +58,13 @@ export const UserSettingsTabs: React.FC<UserSettingsTabsProps> = ({
         <RouteTab class={isCurrentTab("/user/edit", route)} to="/user/edit">
           Settings
         </RouteTab>
-        <RouteTab
+        <StyledRouteTab
+          pr={1}
           class={isCurrentTab("/user/payments", route)}
           to="/user/payments"
         >
           Payments
-        </RouteTab>
+        </StyledRouteTab>
       </RouteTabs>
     </Box>
   )

--- a/src/v2/Components/UserSettings/UserSettingsTabs.tsx
+++ b/src/v2/Components/UserSettings/UserSettingsTabs.tsx
@@ -34,33 +34,35 @@ export const UserSettingsTabs: React.FC<UserSettingsTabsProps> = ({
         </Text>
       </Box>
       <RouteTabs>
-        <RouteTab class={isCurrentTab("/user/saves", route)} to="/user/saves">
+        <RouteTab
+          className={isCurrentTab("/user/saves", route)}
+          to="/user/saves"
+        >
           Saves & Follows
         </RouteTab>
         <RouteTab
-          class={isCurrentTab("/profile/edit", route)}
+          className={isCurrentTab("/profile/edit", route)}
           to="/profile/edit"
         >
           Collector Profile
         </RouteTab>
         <RouteTab
-          class={isCurrentTab("/user/purchases", route)}
+          className={isCurrentTab("/user/purchases", route)}
           to="/user/purchases"
         >
           Order History
         </RouteTab>
         <RouteTab
-          class={isCurrentTab("/user/auctions", route)}
+          className={isCurrentTab("/user/auctions", route)}
           to="/user/auctions"
         >
           Bids
         </RouteTab>
-        <RouteTab class={isCurrentTab("/user/edit", route)} to="/user/edit">
+        <RouteTab className={isCurrentTab("/user/edit", route)} to="/user/edit">
           Settings
         </RouteTab>
         <StyledRouteTab
-          pr={1}
-          class={isCurrentTab("/user/payments", route)}
+          className={isCurrentTab("/user/payments", route)}
           to="/user/payments"
         >
           Payments

--- a/src/v2/Components/UserSettings/UserSettingsTabs.tsx
+++ b/src/v2/Components/UserSettings/UserSettingsTabs.tsx
@@ -1,10 +1,12 @@
 import React from "react"
 import styled from "styled-components"
-import { Box, RouteTab, RouteTabs } from "v2/Components/RouteTabs"
+import { RouteTab, RouteTabs } from "v2/Components/RouteTabs"
 import { data as sd } from "sharify"
+import { Box, Text } from "@artsy/palette"
 
 interface UserSettingsTabsProps {
-  route: string
+  route?: string
+  username?: string
 }
 
 const isCurrentTab = (tabUrl, route) => {
@@ -16,36 +18,47 @@ const isCurrentTab = (tabUrl, route) => {
 
 export const UserSettingsTabs: React.FC<UserSettingsTabsProps> = ({
   route,
+  username,
 }) => {
   return (
-    <RouteTabs>
-      <RouteTab class={isCurrentTab("/user/saves", route)} to="/user/saves">
-        Saves & Follows
-      </RouteTab>
-      <RouteTab class={isCurrentTab("/profile/edit", route)} to="/profile/edit">
-        Collector Profile
-      </RouteTab>
-      <RouteTab
-        class={isCurrentTab("/user/purchases", route)}
-        to="/user/purchases"
-      >
-        Order History
-      </RouteTab>
-      <RouteTab
-        class={isCurrentTab("/user/auctions", route)}
-        to="/user/auctions"
-      >
-        Bids
-      </RouteTab>
-      <RouteTab class={isCurrentTab("/user/edit", route)} to="/user/edit">
-        Settings
-      </RouteTab>
-      <RouteTab
-        class={isCurrentTab("/user/payments", route)}
-        to="/user/payments"
-      >
-        Payments
-      </RouteTab>
-    </RouteTabs>
+    <Box pt={1}>
+      <Box>
+        <Text variant="title" my={2}>
+          {username}
+        </Text>
+      </Box>
+      <RouteTabs>
+        <RouteTab class={isCurrentTab("/user/saves", route)} to="/user/saves">
+          Saves & Follows
+        </RouteTab>
+        <RouteTab
+          class={isCurrentTab("/profile/edit", route)}
+          to="/profile/edit"
+        >
+          Collector Profile
+        </RouteTab>
+        <RouteTab
+          class={isCurrentTab("/user/purchases", route)}
+          to="/user/purchases"
+        >
+          Order History
+        </RouteTab>
+        <RouteTab
+          class={isCurrentTab("/user/auctions", route)}
+          to="/user/auctions"
+        >
+          Bids
+        </RouteTab>
+        <RouteTab class={isCurrentTab("/user/edit", route)} to="/user/edit">
+          Settings
+        </RouteTab>
+        <RouteTab
+          class={isCurrentTab("/user/payments", route)}
+          to="/user/payments"
+        >
+          Payments
+        </RouteTab>
+      </RouteTabs>
+    </Box>
   )
 }

--- a/src/v2/Components/UserSettings/__tests__/UserSettingsTabs.jest.tsx
+++ b/src/v2/Components/UserSettings/__tests__/UserSettingsTabs.jest.tsx
@@ -29,7 +29,6 @@ describe("UserSettingsTabs", () => {
 
     tabs.forEach(([href, tabLabel], index) => {
       const tabLink = links.at(index)
-      // console.log("HREF tablink", tabLink.)
       expect(href).toEqual(tabLink.prop("to"))
       expect(tabLabel).toEqual(tabLink.text())
     })

--- a/src/v2/Components/UserSettings/__tests__/UserSettingsTabs.jest.tsx
+++ b/src/v2/Components/UserSettings/__tests__/UserSettingsTabs.jest.tsx
@@ -1,0 +1,37 @@
+import { mount } from "enzyme"
+import React from "react"
+import { UserSettingsTabs } from "../UserSettingsTabs"
+
+describe("UserSettingsTabs", () => {
+  const getWrapper = () => {
+    return mount(<UserSettingsTabs route="/user/saves" username="Moira Rose" />)
+  }
+
+  const tabs = [
+    ["/user/saves", "Saves & Follows"],
+    ["/profile/edit", "Collector Profile"],
+    ["/user/purchases", "Order History"],
+    ["/user/auctions", "Bids"],
+    ["/user/edit", "Settings"],
+    ["/user/payments", "Payments"],
+  ]
+
+  it("renders user's name", () => {
+    const wrapper = getWrapper()
+    const name = wrapper.find("Text")
+
+    expect(name.text()).toContain("Moira Rose")
+  })
+
+  it("renders correct tabs", () => {
+    const wrapper = getWrapper()
+    const links = wrapper.find("RouteTab")
+
+    tabs.forEach(([href, tabLabel], index) => {
+      const tabLink = links.at(index)
+      // console.log("HREF tablink", tabLink.)
+      expect(href).toEqual(tabLink.prop("to"))
+      expect(tabLabel).toEqual(tabLink.text())
+    })
+  })
+})

--- a/src/v2/__generated__/PurchaseAppTestQuery.graphql.ts
+++ b/src/v2/__generated__/PurchaseAppTestQuery.graphql.ts
@@ -13,6 +13,7 @@ export type PurchaseAppTestQueryResponse = {
 };
 export type PurchaseAppTestQueryRawResponse = {
     readonly me: ({
+        readonly name: string | null;
         readonly orders: ({
             readonly edges: ReadonlyArray<({
                 readonly node: ({
@@ -122,6 +123,7 @@ fragment PurchaseApp_me on Me {
 }
 
 fragment PurchaseHistory_me on Me {
+  name
   orders(first: 10) {
     edges {
       node {
@@ -217,27 +219,34 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "__typename",
+  "name": "name",
   "storageKey": null
 },
 v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v2 = [
-  (v0/*: any*/)
+v3 = [
+  (v1/*: any*/)
 ],
-v3 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -300,6 +309,7 @@ return {
         "name": "me",
         "plural": false,
         "selections": [
+          (v0/*: any*/),
           {
             "alias": null,
             "args": [
@@ -330,8 +340,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v0/*: any*/),
                       (v1/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -361,15 +371,15 @@ return {
                         "name": "requestedFulfillment",
                         "plural": false,
                         "selections": [
-                          (v0/*: any*/),
+                          (v1/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v2/*: any*/),
+                            "selections": (v3/*: any*/),
                             "type": "CommerceShip"
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v2/*: any*/),
+                            "selections": (v3/*: any*/),
                             "type": "CommercePickup"
                           }
                         ],
@@ -390,7 +400,7 @@ return {
                             "name": "lastDigits",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -504,13 +514,7 @@ return {
                                             "name": "initials",
                                             "storageKey": null
                                           },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "name",
-                                            "storageKey": null
-                                          },
+                                          (v0/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -543,11 +547,11 @@ return {
                                                 ],
                                                 "storageKey": null
                                               },
-                                              (v3/*: any*/)
+                                              (v4/*: any*/)
                                             ],
                                             "storageKey": null
                                           },
-                                          (v3/*: any*/)
+                                          (v4/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
@@ -558,7 +562,7 @@ return {
                                         "name": "shippingOrigin",
                                         "storageKey": null
                                       },
-                                      (v1/*: any*/),
+                                      (v2/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -573,11 +577,11 @@ return {
                                         "name": "artistNames",
                                         "storageKey": null
                                       },
-                                      (v3/*: any*/)
+                                      (v4/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v3/*: any*/)
+                                  (v4/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -587,7 +591,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v3/*: any*/)
+                      (v4/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -609,7 +613,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v4/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -619,7 +623,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v4/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -629,7 +633,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v4/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -639,7 +643,7 @@ return {
                     "kind": "LinkedField",
                     "name": "previous",
                     "plural": false,
-                    "selections": (v4/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -687,7 +691,7 @@ return {
             ],
             "storageKey": "orders(first:10)"
           },
-          (v3/*: any*/)
+          (v4/*: any*/)
         ],
         "storageKey": null
       }
@@ -698,7 +702,7 @@ return {
     "metadata": {},
     "name": "PurchaseAppTestQuery",
     "operationKind": "query",
-    "text": "query PurchaseAppTestQuery {\n  me {\n    ...PurchaseApp_me\n    id\n  }\n}\n\nfragment PurchaseApp_me on Me {\n  ...PurchaseHistory_me\n}\n\nfragment PurchaseHistory_me on Me {\n  orders(first: 10) {\n    edges {\n      node {\n        __typename\n        internalID\n        code\n        state\n        mode\n        requestedFulfillment {\n          __typename\n          ... on CommerceShip {\n            __typename\n          }\n          ... on CommercePickup {\n            __typename\n          }\n        }\n        creditCard {\n          lastDigits\n          id\n        }\n        buyerTotal\n        createdAt\n        itemsTotal\n        lineItems {\n          edges {\n            node {\n              artwork {\n                date\n                image {\n                  resized(width: 55) {\n                    url\n                  }\n                }\n                partner {\n                  initials\n                  name\n                  profile {\n                    icon {\n                      url(version: \"square140\")\n                    }\n                    id\n                  }\n                  id\n                }\n                shippingOrigin\n                internalID\n                title\n                artist_names: artistNames\n                id\n              }\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
+    "text": "query PurchaseAppTestQuery {\n  me {\n    ...PurchaseApp_me\n    id\n  }\n}\n\nfragment PurchaseApp_me on Me {\n  ...PurchaseHistory_me\n}\n\nfragment PurchaseHistory_me on Me {\n  name\n  orders(first: 10) {\n    edges {\n      node {\n        __typename\n        internalID\n        code\n        state\n        mode\n        requestedFulfillment {\n          __typename\n          ... on CommerceShip {\n            __typename\n          }\n          ... on CommercePickup {\n            __typename\n          }\n        }\n        creditCard {\n          lastDigits\n          id\n        }\n        buyerTotal\n        createdAt\n        itemsTotal\n        lineItems {\n          edges {\n            node {\n              artwork {\n                date\n                image {\n                  resized(width: 55) {\n                    url\n                  }\n                }\n                partner {\n                  initials\n                  name\n                  profile {\n                    icon {\n                      url(version: \"square140\")\n                    }\n                    id\n                  }\n                  id\n                }\n                shippingOrigin\n                internalID\n                title\n                artist_names: artistNames\n                id\n              }\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PurchaseHistoryQuery.graphql.ts
+++ b/src/v2/__generated__/PurchaseHistoryQuery.graphql.ts
@@ -35,6 +35,7 @@ query PurchaseHistoryQuery(
 }
 
 fragment PurchaseHistory_me_pbnwq on Me {
+  name
   orders(first: $first, last: $last, before: $before, after: $after) {
     edges {
       node {
@@ -178,27 +179,34 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "__typename",
+  "name": "name",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v4 = [
-  (v2/*: any*/)
+v5 = [
+  (v3/*: any*/)
 ],
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v6 = [
+v7 = [
   {
     "alias": null,
     "args": null,
@@ -261,6 +269,7 @@ return {
         "name": "me",
         "plural": false,
         "selections": [
+          (v2/*: any*/),
           {
             "alias": null,
             "args": (v1/*: any*/),
@@ -285,8 +294,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v2/*: any*/),
                       (v3/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -316,15 +325,15 @@ return {
                         "name": "requestedFulfillment",
                         "plural": false,
                         "selections": [
-                          (v2/*: any*/),
+                          (v3/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v4/*: any*/),
+                            "selections": (v5/*: any*/),
                             "type": "CommerceShip"
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v4/*: any*/),
+                            "selections": (v5/*: any*/),
                             "type": "CommercePickup"
                           }
                         ],
@@ -345,7 +354,7 @@ return {
                             "name": "lastDigits",
                             "storageKey": null
                           },
-                          (v5/*: any*/)
+                          (v6/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -459,13 +468,7 @@ return {
                                             "name": "initials",
                                             "storageKey": null
                                           },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "name",
-                                            "storageKey": null
-                                          },
+                                          (v2/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -498,11 +501,11 @@ return {
                                                 ],
                                                 "storageKey": null
                                               },
-                                              (v5/*: any*/)
+                                              (v6/*: any*/)
                                             ],
                                             "storageKey": null
                                           },
-                                          (v5/*: any*/)
+                                          (v6/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
@@ -513,7 +516,7 @@ return {
                                         "name": "shippingOrigin",
                                         "storageKey": null
                                       },
-                                      (v3/*: any*/),
+                                      (v4/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -528,11 +531,11 @@ return {
                                         "name": "artistNames",
                                         "storageKey": null
                                       },
-                                      (v5/*: any*/)
+                                      (v6/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v6/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -542,7 +545,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v5/*: any*/)
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -564,7 +567,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v6/*: any*/),
+                    "selections": (v7/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -574,7 +577,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v6/*: any*/),
+                    "selections": (v7/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -584,7 +587,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v6/*: any*/),
+                    "selections": (v7/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -594,7 +597,7 @@ return {
                     "kind": "LinkedField",
                     "name": "previous",
                     "plural": false,
-                    "selections": (v6/*: any*/),
+                    "selections": (v7/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -642,7 +645,7 @@ return {
             ],
             "storageKey": null
           },
-          (v5/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
@@ -653,7 +656,7 @@ return {
     "metadata": {},
     "name": "PurchaseHistoryQuery",
     "operationKind": "query",
-    "text": "query PurchaseHistoryQuery(\n  $first: Int!\n  $last: Int\n  $after: String\n  $before: String\n) {\n  me {\n    ...PurchaseHistory_me_pbnwq\n    id\n  }\n}\n\nfragment PurchaseHistory_me_pbnwq on Me {\n  orders(first: $first, last: $last, before: $before, after: $after) {\n    edges {\n      node {\n        __typename\n        internalID\n        code\n        state\n        mode\n        requestedFulfillment {\n          __typename\n          ... on CommerceShip {\n            __typename\n          }\n          ... on CommercePickup {\n            __typename\n          }\n        }\n        creditCard {\n          lastDigits\n          id\n        }\n        buyerTotal\n        createdAt\n        itemsTotal\n        lineItems {\n          edges {\n            node {\n              artwork {\n                date\n                image {\n                  resized(width: 55) {\n                    url\n                  }\n                }\n                partner {\n                  initials\n                  name\n                  profile {\n                    icon {\n                      url(version: \"square140\")\n                    }\n                    id\n                  }\n                  id\n                }\n                shippingOrigin\n                internalID\n                title\n                artist_names: artistNames\n                id\n              }\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
+    "text": "query PurchaseHistoryQuery(\n  $first: Int!\n  $last: Int\n  $after: String\n  $before: String\n) {\n  me {\n    ...PurchaseHistory_me_pbnwq\n    id\n  }\n}\n\nfragment PurchaseHistory_me_pbnwq on Me {\n  name\n  orders(first: $first, last: $last, before: $before, after: $after) {\n    edges {\n      node {\n        __typename\n        internalID\n        code\n        state\n        mode\n        requestedFulfillment {\n          __typename\n          ... on CommerceShip {\n            __typename\n          }\n          ... on CommercePickup {\n            __typename\n          }\n        }\n        creditCard {\n          lastDigits\n          id\n        }\n        buyerTotal\n        createdAt\n        itemsTotal\n        lineItems {\n          edges {\n            node {\n              artwork {\n                date\n                image {\n                  resized(width: 55) {\n                    url\n                  }\n                }\n                partner {\n                  initials\n                  name\n                  profile {\n                    icon {\n                      url(version: \"square140\")\n                    }\n                    id\n                  }\n                  id\n                }\n                shippingOrigin\n                internalID\n                title\n                artist_names: artistNames\n                id\n              }\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PurchaseHistory_me.graphql.ts
+++ b/src/v2/__generated__/PurchaseHistory_me.graphql.ts
@@ -6,6 +6,7 @@ import { FragmentRefs } from "relay-runtime";
 export type CommerceOrderModeEnum = "BUY" | "OFFER" | "%future added value";
 export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "PENDING" | "REFUNDED" | "SUBMITTED" | "%future added value";
 export type PurchaseHistory_me = {
+    readonly name: string | null;
     readonly orders: {
         readonly edges: ReadonlyArray<{
             readonly node: {
@@ -101,10 +102,17 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v1 = [
+v2 = [
   {
     "alias": null,
     "args": null,
@@ -113,7 +121,7 @@ v1 = [
     "storageKey": null
   }
 ],
-v2 = [
+v3 = [
   {
     "alias": null,
     "args": null,
@@ -167,6 +175,7 @@ return {
   "metadata": null,
   "name": "PurchaseHistory_me",
   "selections": [
+    (v0/*: any*/),
     {
       "alias": null,
       "args": [
@@ -212,7 +221,7 @@ return {
               "name": "node",
               "plural": false,
               "selections": [
-                (v0/*: any*/),
+                (v1/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -244,12 +253,12 @@ return {
                   "selections": [
                     {
                       "kind": "InlineFragment",
-                      "selections": (v1/*: any*/),
+                      "selections": (v2/*: any*/),
                       "type": "CommerceShip"
                     },
                     {
                       "kind": "InlineFragment",
-                      "selections": (v1/*: any*/),
+                      "selections": (v2/*: any*/),
                       "type": "CommercePickup"
                     }
                   ],
@@ -383,13 +392,7 @@ return {
                                       "name": "initials",
                                       "storageKey": null
                                     },
-                                    {
-                                      "alias": null,
-                                      "args": null,
-                                      "kind": "ScalarField",
-                                      "name": "name",
-                                      "storageKey": null
-                                    },
+                                    (v0/*: any*/),
                                     {
                                       "alias": null,
                                       "args": null,
@@ -435,7 +438,7 @@ return {
                                   "name": "shippingOrigin",
                                   "storageKey": null
                                 },
-                                (v0/*: any*/),
+                                (v1/*: any*/),
                                 {
                                   "alias": null,
                                   "args": null,
@@ -483,7 +486,7 @@ return {
               "kind": "LinkedField",
               "name": "around",
               "plural": true,
-              "selections": (v2/*: any*/),
+              "selections": (v3/*: any*/),
               "storageKey": null
             },
             {
@@ -493,7 +496,7 @@ return {
               "kind": "LinkedField",
               "name": "first",
               "plural": false,
-              "selections": (v2/*: any*/),
+              "selections": (v3/*: any*/),
               "storageKey": null
             },
             {
@@ -503,7 +506,7 @@ return {
               "kind": "LinkedField",
               "name": "last",
               "plural": false,
-              "selections": (v2/*: any*/),
+              "selections": (v3/*: any*/),
               "storageKey": null
             },
             {
@@ -513,7 +516,7 @@ return {
               "kind": "LinkedField",
               "name": "previous",
               "plural": false,
-              "selections": (v2/*: any*/),
+              "selections": (v3/*: any*/),
               "storageKey": null
             }
           ],
@@ -565,5 +568,5 @@ return {
   "type": "Me"
 };
 })();
-(node as any).hash = '53a6e7088f1987cffe0d86d3378e52a0';
+(node as any).hash = '33653cd5785d2676b3c22ce9f3e0f1e7';
 export default node;

--- a/src/v2/__generated__/routes_PurchaseQuery.graphql.ts
+++ b/src/v2/__generated__/routes_PurchaseQuery.graphql.ts
@@ -29,6 +29,7 @@ fragment PurchaseApp_me on Me {
 }
 
 fragment PurchaseHistory_me on Me {
+  name
   orders(first: 10) {
     edges {
       node {
@@ -124,27 +125,34 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "__typename",
+  "name": "name",
   "storageKey": null
 },
 v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v2 = [
-  (v0/*: any*/)
+v3 = [
+  (v1/*: any*/)
 ],
-v3 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -207,6 +215,7 @@ return {
         "name": "me",
         "plural": false,
         "selections": [
+          (v0/*: any*/),
           {
             "alias": null,
             "args": [
@@ -237,8 +246,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v0/*: any*/),
                       (v1/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -268,15 +277,15 @@ return {
                         "name": "requestedFulfillment",
                         "plural": false,
                         "selections": [
-                          (v0/*: any*/),
+                          (v1/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v2/*: any*/),
+                            "selections": (v3/*: any*/),
                             "type": "CommerceShip"
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v2/*: any*/),
+                            "selections": (v3/*: any*/),
                             "type": "CommercePickup"
                           }
                         ],
@@ -297,7 +306,7 @@ return {
                             "name": "lastDigits",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -411,13 +420,7 @@ return {
                                             "name": "initials",
                                             "storageKey": null
                                           },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "name",
-                                            "storageKey": null
-                                          },
+                                          (v0/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -450,11 +453,11 @@ return {
                                                 ],
                                                 "storageKey": null
                                               },
-                                              (v3/*: any*/)
+                                              (v4/*: any*/)
                                             ],
                                             "storageKey": null
                                           },
-                                          (v3/*: any*/)
+                                          (v4/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
@@ -465,7 +468,7 @@ return {
                                         "name": "shippingOrigin",
                                         "storageKey": null
                                       },
-                                      (v1/*: any*/),
+                                      (v2/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -480,11 +483,11 @@ return {
                                         "name": "artistNames",
                                         "storageKey": null
                                       },
-                                      (v3/*: any*/)
+                                      (v4/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v3/*: any*/)
+                                  (v4/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -494,7 +497,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v3/*: any*/)
+                      (v4/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -516,7 +519,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v4/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -526,7 +529,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v4/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -536,7 +539,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v4/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -546,7 +549,7 @@ return {
                     "kind": "LinkedField",
                     "name": "previous",
                     "plural": false,
-                    "selections": (v4/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -594,7 +597,7 @@ return {
             ],
             "storageKey": "orders(first:10)"
           },
-          (v3/*: any*/)
+          (v4/*: any*/)
         ],
         "storageKey": null
       }
@@ -605,7 +608,7 @@ return {
     "metadata": {},
     "name": "routes_PurchaseQuery",
     "operationKind": "query",
-    "text": "query routes_PurchaseQuery {\n  me {\n    ...PurchaseApp_me\n    id\n  }\n}\n\nfragment PurchaseApp_me on Me {\n  ...PurchaseHistory_me\n}\n\nfragment PurchaseHistory_me on Me {\n  orders(first: 10) {\n    edges {\n      node {\n        __typename\n        internalID\n        code\n        state\n        mode\n        requestedFulfillment {\n          __typename\n          ... on CommerceShip {\n            __typename\n          }\n          ... on CommercePickup {\n            __typename\n          }\n        }\n        creditCard {\n          lastDigits\n          id\n        }\n        buyerTotal\n        createdAt\n        itemsTotal\n        lineItems {\n          edges {\n            node {\n              artwork {\n                date\n                image {\n                  resized(width: 55) {\n                    url\n                  }\n                }\n                partner {\n                  initials\n                  name\n                  profile {\n                    icon {\n                      url(version: \"square140\")\n                    }\n                    id\n                  }\n                  id\n                }\n                shippingOrigin\n                internalID\n                title\n                artist_names: artistNames\n                id\n              }\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
+    "text": "query routes_PurchaseQuery {\n  me {\n    ...PurchaseApp_me\n    id\n  }\n}\n\nfragment PurchaseApp_me on Me {\n  ...PurchaseHistory_me\n}\n\nfragment PurchaseHistory_me on Me {\n  name\n  orders(first: 10) {\n    edges {\n      node {\n        __typename\n        internalID\n        code\n        state\n        mode\n        requestedFulfillment {\n          __typename\n          ... on CommerceShip {\n            __typename\n          }\n          ... on CommercePickup {\n            __typename\n          }\n        }\n        creditCard {\n          lastDigits\n          id\n        }\n        buyerTotal\n        createdAt\n        itemsTotal\n        lineItems {\n          edges {\n            node {\n              artwork {\n                date\n                image {\n                  resized(width: 55) {\n                    url\n                  }\n                }\n                partner {\n                  initials\n                  name\n                  profile {\n                    icon {\n                      url(version: \"square140\")\n                    }\n                    id\n                  }\n                  id\n                }\n                shippingOrigin\n                internalID\n                title\n                artist_names: artistNames\n                id\n              }\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
[PURCHASE-2158]

This PR contains updates to the mobile view of the Order History page, a rebuild of the user settings tabs in react and styling to make the existing tabs fit with order history, tests, and fixes to some bugs on the order history page.

__Before:__
<img width="567" alt="Screen Shot 2020-10-06 at 2 37 37 PM" src="https://user-images.githubusercontent.com/5643895/95247022-53cf5780-07e3-11eb-8908-417bbc820a72.png">

__After:__
<img width="565" alt="Screen Shot 2020-10-06 at 2 37 17 PM" src="https://user-images.githubusercontent.com/5643895/95246992-4a45ef80-07e3-11eb-920a-44bd88f05bfd.png">

__Before:__
<img width="512" alt="Screen Shot 2020-10-06 at 2 38 08 PM" src="https://user-images.githubusercontent.com/5643895/95246913-2d112100-07e3-11eb-9b9d-708bb0a82342.png">

__After:__
<img width="512" alt="Screen Shot 2020-10-06 at 2 38 19 PM" src="https://user-images.githubusercontent.com/5643895/95246906-2a163080-07e3-11eb-8c64-f8a277cf5b25.png">


[PURCHASE-2158]: https://artsyproduct.atlassian.net/browse/PURCHASE-2158