### PR TITLE
[FX-2192] [WIP] Show header info

### DIFF
--- a/src/v2/Apps/Fair/Components/FairHeader/FairHeader.tsx
+++ b/src/v2/Apps/Fair/Components/FairHeader/FairHeader.tsx
@@ -63,11 +63,12 @@ const FairHeader: React.FC<FairHeaderProps> = ({ fair, ...rest }) => {
 
           {canShowMoreInfoLink && (
             <ForwardLink
-              linkText="More info"
-              path={`/fair/${fair.slug}/info`}
+              to={`/fair/${fair.slug}/info`}
               mt={previewText ? 1 : undefined}
               justifyContent={columnCount === 1 ? "center" : undefined}
-            />
+            >
+              More info
+            </ForwardLink>
           )}
         </Box>
       </CSSGrid>

--- a/src/v2/Apps/Show/ShowApp.tsx
+++ b/src/v2/Apps/Show/ShowApp.tsx
@@ -1,13 +1,17 @@
 import React from "react"
-import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { createFragmentContainer, graphql } from "react-relay"
-import { ShowApp_show } from "v2/__generated__/ShowApp_show.graphql"
+import { Separator } from "@artsy/palette"
+import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
 import { Footer } from "v2/Components/Footer"
 import { ErrorPage } from "v2/Components/ErrorPage"
-import { Separator, Text } from "@artsy/palette"
+import { ShowApp_show } from "v2/__generated__/ShowApp_show.graphql"
 import { ShowMetaFragmentContainer as ShowMeta } from "v2/Apps/Show/components/ShowMeta"
+import { ShowHeaderFragmentContainer as ShowHeader } from "./components/ShowHeader"
+import { ShowAboutFragmentContainer as ShowAbout } from "./components/ShowAbout"
 import { ShowInstallShotsFragmentContainer as ShowInstallShots } from "./components/ShowInstallShots"
+import { ShowViewingRoom } from "./components/ShowViewingRoom"
+import { Break, Col, Grid } from "v2/Components/FluidGrid"
 
 interface ShowAppProps {
   show: ShowApp_show
@@ -15,6 +19,9 @@ interface ShowAppProps {
 
 export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
   if (!show) return <ErrorPage code={404} />
+
+  const hasViewingRoom = true // TODO
+  const hasAbout = !!show.about || !!show.pressRelease
 
   return (
     <>
@@ -24,9 +31,61 @@ export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
         <HorizontalPadding>
           <ShowInstallShots show={show} my={2} />
 
-          <Text as="h1" variant="largeTitle" my={4}>
-            {show.name}
-          </Text>
+          <Grid>
+            {!hasAbout && !hasViewingRoom && (
+              <Col span={[12, 8, 6]}>
+                <ShowHeader show={show} />
+              </Col>
+            )}
+
+            {hasAbout && !hasViewingRoom && (
+              <>
+                <Col span={6}>
+                  <ShowHeader show={show} />
+                </Col>
+
+                <Col span={6}>
+                  <ShowAbout show={show} />
+                </Col>
+              </>
+            )}
+
+            {!hasAbout && hasViewingRoom && (
+              <>
+                <Col span={6}>
+                  <ShowHeader show={show} />
+                </Col>
+
+                <Col span={1} display={["none", "block"]} />
+
+                <Col span={5}>
+                  <ShowViewingRoom />
+                </Col>
+              </>
+            )}
+
+            {hasAbout && hasViewingRoom && (
+              <>
+                <Col span={[12, 8, 6]}>
+                  <ShowHeader show={show} />
+                </Col>
+
+                <Break />
+
+                <>
+                  <Col span={6}>
+                    <ShowAbout show={show} />
+                  </Col>
+
+                  <Col span={1} display={["none", "block"]} />
+
+                  <Col span={5}>
+                    <ShowViewingRoom />
+                  </Col>
+                </>
+              </>
+            )}
+          </Grid>
 
           <Separator as="hr" my={3} />
 
@@ -41,7 +100,10 @@ export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
 export default createFragmentContainer(ShowApp, {
   show: graphql`
     fragment ShowApp_show on Show {
-      name
+      about: description
+      pressRelease
+      ...ShowHeader_show
+      ...ShowAbout_show
       ...ShowMeta_show
       ...ShowInstallShots_show
     }

--- a/src/v2/Apps/Show/components/ShowAbout.tsx
+++ b/src/v2/Apps/Show/components/ShowAbout.tsx
@@ -1,0 +1,43 @@
+import React from "react"
+import { Box, BoxProps, Text } from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { ShowAbout_show } from "v2/__generated__/ShowAbout_show.graphql"
+import { ForwardLink } from "v2/Components/Links/ForwardLink"
+
+interface ShowAboutProps extends BoxProps {
+  show: ShowAbout_show
+}
+export const ShowAbout: React.FC<ShowAboutProps> = ({
+  show: { about, pressRelease },
+  ...rest
+}) => {
+  return (
+    <Box {...rest}>
+      {about && (
+        <>
+          <Text variant="mediumText" as="h3" mb={1}>
+            About
+          </Text>
+
+          <Text variant="subtitle" as="p">
+            {about}
+          </Text>
+        </>
+      )}
+
+      {pressRelease && (
+        <ForwardLink to="#todo" mt={2}>
+          More info
+        </ForwardLink>
+      )}
+    </Box>
+  )
+}
+export const ShowAboutFragmentContainer = createFragmentContainer(ShowAbout, {
+  show: graphql`
+    fragment ShowAbout_show on Show {
+      about: description
+      pressRelease
+    }
+  `,
+})

--- a/src/v2/Apps/Show/components/ShowHeader.tsx
+++ b/src/v2/Apps/Show/components/ShowHeader.tsx
@@ -1,0 +1,58 @@
+import React from "react"
+import { Box, BoxProps, Text } from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { ShowHeader_show } from "v2/__generated__/ShowHeader_show.graphql"
+import { useCurrentTime } from "v2/Utils/Hooks/useCurrentTime"
+import { useEventTiming } from "v2/Utils/Hooks/useEventTiming"
+
+interface ShowHeaderProps extends BoxProps {
+  show: ShowHeader_show
+}
+export const ShowHeader: React.FC<ShowHeaderProps> = ({
+  show: { name, startAt, endAt, formattedStartAt, formattedEndAt, partner },
+  ...rest
+}) => {
+  const currentTime = useCurrentTime({ syncWithServer: true })
+  const { formattedTime } = useEventTiming({ currentTime, startAt, endAt })
+
+  return (
+    <Box {...rest}>
+      <Text as="h1" variant="largeTitle" mb={1.5}>
+        {name}
+      </Text>
+
+      <Text variant="mediumText">
+        {formattedStartAt} – {formattedEndAt}
+      </Text>
+
+      <Text variant="text" color="black60" mb={1}>
+        {formattedTime}
+      </Text>
+
+      {partner?.name && (
+        <Text variant="text" color="black60">
+          {partner.name}
+        </Text>
+      )}
+    </Box>
+  )
+}
+export const ShowHeaderFragmentContainer = createFragmentContainer(ShowHeader, {
+  show: graphql`
+    fragment ShowHeader_show on Show {
+      name
+      startAt
+      endAt
+      formattedStartAt: startAt(format: "MMMM D")
+      formattedEndAt: endAt(format: "MMMM D, YYYY")
+      partner {
+        ... on Partner {
+          name
+        }
+        ... on ExternalPartner {
+          name
+        }
+      }
+    }
+  `,
+})

--- a/src/v2/Apps/Show/components/ShowViewingRoom.tsx
+++ b/src/v2/Apps/Show/components/ShowViewingRoom.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import { Box, BoxProps, ResponsiveBox, Text } from "@artsy/palette"
+
+interface ShowViewingRoom extends BoxProps {}
+
+export const ShowViewingRoom = ({ ...rest }) => {
+  return (
+    <Box {...rest}>
+      <Text variant="mediumText" mb={1}>
+        Viewing Room
+      </Text>
+
+      <ResponsiveBox
+        bg="black10"
+        borderRadius={4}
+        maxWidth="100%"
+        aspectWidth={3}
+        aspectHeight={4}
+      />
+    </Box>
+  )
+}

--- a/src/v2/Components/EventTiming.tsx
+++ b/src/v2/Components/EventTiming.tsx
@@ -1,57 +1,24 @@
 import React from "react"
-import { Text } from "@artsy/palette"
-import { DateTime, Duration } from "luxon"
+import { Text, TextProps } from "@artsy/palette"
+import { useEventTiming } from "v2/Utils/Hooks/useEventTiming"
 
-function padWithZero(num: number) {
-  return num.toString().padStart(2, "0")
-}
-
-interface Props {
+interface EventTimingProps extends TextProps {
   startAt: string
   endAt: string
   currentTime: string
 }
 
-const SEPARATOR = <>&nbsp;:&nbsp;</>
-
-export const EventTiming: React.FC<Props> = ({
+export const EventTiming: React.FC<EventTimingProps> = ({
   currentTime,
   startAt,
   endAt,
+  ...rest
 }) => {
-  const durationTilEnd = Duration.fromISO(
-    DateTime.fromISO(endAt).diff(DateTime.fromISO(currentTime)).toString()
-  )
-  const daysTilEnd = durationTilEnd.as("days")
-  const secondsTilEnd = durationTilEnd.as("seconds")
-
-  const hasStarted =
-    Duration.fromISO(
-      DateTime.fromISO(startAt).diff(DateTime.fromISO(currentTime)).toString()
-    ).seconds < 0
-  const closesSoon = daysTilEnd <= 3 && daysTilEnd > 1
-  const hasEnded = Math.floor(secondsTilEnd) <= 0
-  const closesToday = daysTilEnd < 1 && !hasEnded
+  const { formattedTime } = useEventTiming({ currentTime, startAt, endAt })
 
   return (
-    <Text size="3" variant="mediumText">
-      {hasEnded && "Closed"}
-      {!hasStarted && "Opening Soon"}
-      {closesSoon && `Closes in ${Math.ceil(daysTilEnd)} days`}
-      {closesToday && (
-        <>
-          Closes in{" "}
-          {padWithZero(
-            Math.max(0, Math.floor(durationTilEnd.as("hours") % 24))
-          )}
-          {SEPARATOR}
-          {padWithZero(
-            Math.max(0, Math.floor(durationTilEnd.as("minutes") % 60))
-          )}
-          {SEPARATOR}
-          {padWithZero(Math.max(0, Math.floor(secondsTilEnd % 60)))}
-        </>
-      )}
+    <Text variant="mediumText" {...rest}>
+      {formattedTime}
     </Text>
   )
 }

--- a/src/v2/Components/FluidGrid.tsx
+++ b/src/v2/Components/FluidGrid.tsx
@@ -1,0 +1,60 @@
+import React from "react"
+import styled from "styled-components"
+import { Box, BoxProps, CSSGrid } from "@artsy/palette"
+import {
+  GridColumnProps,
+  ResponsiveValue,
+  gridColumn,
+  system,
+} from "styled-system"
+
+/**
+ * A 12-column fluid grid. Collapses to a single column at mobile breakpoints.
+ */
+export const Grid = styled(CSSGrid)``
+
+Grid.defaultProps = {
+  gridColumnGap: 2,
+  gridRowGap: 2,
+  gridTemplateColumns: "repeat(12, 1fr)",
+}
+
+const colSpan = system({
+  span: {
+    property: "gridColumn",
+    transform: value => value && `span ${value}`,
+  },
+})
+
+type ColSpanProps = { span?: ResponsiveValue<number> } & GridColumnProps
+
+const __Col__ = styled(Box)<ColSpanProps>`
+  ${colSpan}
+  ${gridColumn}
+  outline: 1px dotted red;
+`
+
+export const Col: React.FC<BoxProps & ColSpanProps> = ({ span, ...rest }) => {
+  if (typeof span === "number") {
+    return (
+      <__Col__
+        span={[undefined, span]}
+        gridColumn={["1 / -1", undefined]}
+        {...rest}
+      />
+    )
+  }
+
+  return <__Col__ span={span} {...rest} />
+}
+
+/**
+ * Utility for breaking after a non full-width column.
+ * Fills until the end of the row.
+ */
+export const Break = styled(Col)``
+
+Break.defaultProps = {
+  display: ["none", "block"],
+  gridColumn: "auto / -1",
+}

--- a/src/v2/Components/Links/ForwardLink.tsx
+++ b/src/v2/Components/Links/ForwardLink.tsx
@@ -4,8 +4,7 @@ import { StyledLink } from "./StyledLink"
 import styled from "styled-components"
 
 interface ForwardLinkProps extends BoxProps {
-  linkText: string
-  path: string
+  to: string
 }
 
 const Link = styled(StyledLink)<BoxProps>`
@@ -23,20 +22,20 @@ const Link = styled(StyledLink)<BoxProps>`
 `
 
 export const ForwardLink: React.FC<ForwardLinkProps> = ({
-  linkText,
-  path,
+  children,
+  to,
   ...rest
 }) => {
   return (
     <Link
-      to={path}
+      to={to}
       display="flex"
       flexDirection="row"
       alignItems="center"
       {...rest}
     >
       <Text variant="mediumText" mr={0.3}>
-        {linkText}
+        {children}
       </Text>
 
       <ChevronIcon

--- a/src/v2/Components/WithCurrentTime.tsx
+++ b/src/v2/Components/WithCurrentTime.tsx
@@ -1,8 +1,5 @@
-import { useSystemContext } from "v2/Artsy"
-import { DateTime } from "luxon"
-import React, { useEffect, useState } from "react"
-import { getCurrentTimeAsIsoString } from "v2/Utils/getCurrentTimeAsIsoString"
-import { getOffsetBetweenGravityClock } from "v2/Utils/time"
+import React from "react"
+import { useCurrentTime } from "v2/Utils/Hooks/useCurrentTime"
 
 /**
  * Render prop component to provide the current time as an ISO string, and
@@ -36,32 +33,6 @@ export const WithCurrentTime: React.FC<WithCurrentTimeProps> = ({
   interval = 1000,
   syncWithServer,
 }) => {
-  const { relayEnvironment } = useSystemContext()
-  const [currentTime, setCurrentTime] = useState(getCurrentTimeAsIsoString())
-  const [timeOffsetInMilliseconds, setTimeOffsetInMilliseconds] = useState(0)
-  let intervalId
-
-  function updateCurrentTime() {
-    setCurrentTime(getCurrentTimeAsIsoString())
-  }
-
-  useEffect(() => {
-    if (syncWithServer) {
-      getOffsetBetweenGravityClock(relayEnvironment).then(offset => {
-        setTimeOffsetInMilliseconds(offset)
-      })
-    }
-
-    intervalId = setInterval(updateCurrentTime, interval || 1000)
-
-    return () => {
-      clearInterval(intervalId)
-    }
-  }, [])
-
-  return children(
-    DateTime.fromISO(currentTime)
-      .minus({ millisecond: timeOffsetInMilliseconds })
-      .toString()
-  )
+  const time = useCurrentTime({ interval, syncWithServer })
+  return children(time)
 }

--- a/src/v2/Utils/Hooks/useCurrentTime.tsx
+++ b/src/v2/Utils/Hooks/useCurrentTime.tsx
@@ -1,0 +1,57 @@
+import { useSystemContext } from "v2/Artsy"
+import { DateTime } from "luxon"
+import { useEffect, useRef, useState } from "react"
+import { getCurrentTimeAsIsoString } from "v2/Utils/getCurrentTimeAsIsoString"
+import { getOffsetBetweenGravityClock } from "v2/Utils/time"
+
+/**
+ * Hook to provide the current time as an ISO string, and
+ * an offset from the current time to the server time (in milliseconds).
+ *
+ * If the `syncWithServer` prop is provided the offset is calculated and included
+ * with the current time. Any errors in offset calculation, or if that prop is not
+ * provided, will result in the offset being calculated as 0.
+ *
+ * @param interval The interval (in ms) with which to update the time.
+ *                 The default value is 1000, i.e. the time is updated once
+ *                 every second.
+ */
+
+interface UseCurrentTimeProps {
+  interval?: number
+  syncWithServer?: boolean
+}
+
+export const useCurrentTime = ({
+  interval = 1000,
+  syncWithServer = false,
+}: UseCurrentTimeProps = {}) => {
+  const { relayEnvironment } = useSystemContext()
+
+  const [currentTime, setCurrentTime] = useState(getCurrentTimeAsIsoString())
+  const [timeOffsetInMilliseconds, setTimeOffsetInMilliseconds] = useState(0)
+
+  const intervalId = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  function updateCurrentTime() {
+    setCurrentTime(getCurrentTimeAsIsoString())
+  }
+
+  useEffect(() => {
+    if (syncWithServer) {
+      getOffsetBetweenGravityClock(relayEnvironment).then(offset => {
+        setTimeOffsetInMilliseconds(offset)
+      })
+    }
+
+    intervalId.current = setInterval(updateCurrentTime, interval || 1000)
+
+    return () => {
+      clearInterval(intervalId.current)
+    }
+  }, [interval, relayEnvironment, syncWithServer])
+
+  return DateTime.fromISO(currentTime)
+    .minus({ millisecond: timeOffsetInMilliseconds })
+    .toString()
+}

--- a/src/v2/Utils/Hooks/useEventTiming.tsx
+++ b/src/v2/Utils/Hooks/useEventTiming.tsx
@@ -1,0 +1,86 @@
+import { DateTime, Duration } from "luxon"
+import { useMemo } from "react"
+
+const NBSP = " "
+const SEPARATOR = `${NBSP}:${NBSP}`
+
+const padWithZero = (n: number) => {
+  return n.toString().padStart(2, "0")
+}
+
+interface UseEventTiming {
+  startAt: string
+  endAt: string
+  currentTime: string
+}
+
+export const useEventTiming = ({
+  currentTime,
+  startAt,
+  endAt,
+}: UseEventTiming) => {
+  const durationTilEnd = Duration.fromISO(
+    DateTime.fromISO(endAt).diff(DateTime.fromISO(currentTime)).toString()
+  )
+  const daysTilEnd = durationTilEnd.as("days")
+  const secondsTilEnd = durationTilEnd.as("seconds")
+
+  const hasStarted =
+    Duration.fromISO(
+      DateTime.fromISO(startAt).diff(DateTime.fromISO(currentTime)).toString()
+    ).seconds < 0
+
+  const hasEnded = Math.floor(secondsTilEnd) <= 0
+  const closesSoon = daysTilEnd <= 3 && daysTilEnd > 1
+  const closesToday = daysTilEnd < 1 && !hasEnded
+  const hours = padWithZero(
+    Math.max(0, Math.floor(durationTilEnd.as("hours") % 24))
+  )
+  const minutes = padWithZero(
+    Math.max(0, Math.floor(durationTilEnd.as("minutes") % 60))
+  )
+  const seconds = padWithZero(Math.max(0, Math.floor(secondsTilEnd % 60)))
+
+  const formattedTime = useMemo(() => {
+    if (hasEnded) {
+      return "Closed"
+    }
+
+    if (!hasStarted) {
+      return "Opening Soon"
+    }
+
+    if (closesSoon) {
+      return `Closes in ${Math.ceil(daysTilEnd)} days`
+    }
+
+    if (closesToday) {
+      return `Closes in ${[hours, minutes, seconds].join(SEPARATOR)}`
+    }
+
+    return null
+  }, [
+    closesSoon,
+    closesToday,
+    daysTilEnd,
+    hasEnded,
+    hasStarted,
+    hours,
+    minutes,
+    seconds,
+  ])
+
+  return {
+    formattedTime,
+    durationTilEnd,
+    daysTilEnd,
+    secondsTilEnd,
+    hasStarted,
+    hasEnded,
+    closesSoon,
+    closesToday,
+    hours,
+    minutes,
+    seconds,
+  }
+}

--- a/src/v2/__generated__/ShowAbout_show.graphql.ts
+++ b/src/v2/__generated__/ShowAbout_show.graphql.ts
@@ -1,0 +1,43 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ShowAbout_show = {
+    readonly about: string | null;
+    readonly pressRelease: string | null;
+    readonly " $refType": "ShowAbout_show";
+};
+export type ShowAbout_show$data = ShowAbout_show;
+export type ShowAbout_show$key = {
+    readonly " $data"?: ShowAbout_show$data;
+    readonly " $fragmentRefs": FragmentRefs<"ShowAbout_show">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ShowAbout_show",
+  "selections": [
+    {
+      "alias": "about",
+      "args": null,
+      "kind": "ScalarField",
+      "name": "description",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "pressRelease",
+      "storageKey": null
+    }
+  ],
+  "type": "Show"
+};
+(node as any).hash = '19ef21a17eb8b4afafa25582ece2ed52';
+export default node;

--- a/src/v2/__generated__/ShowApp_show.graphql.ts
+++ b/src/v2/__generated__/ShowApp_show.graphql.ts
@@ -4,8 +4,9 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ShowApp_show = {
-    readonly name: string | null;
-    readonly " $fragmentRefs": FragmentRefs<"ShowMeta_show" | "ShowInstallShots_show">;
+    readonly about: string | null;
+    readonly pressRelease: string | null;
+    readonly " $fragmentRefs": FragmentRefs<"ShowHeader_show" | "ShowAbout_show" | "ShowMeta_show" | "ShowInstallShots_show">;
     readonly " $refType": "ShowApp_show";
 };
 export type ShowApp_show$data = ShowApp_show;
@@ -23,11 +24,28 @@ const node: ReaderFragment = {
   "name": "ShowApp_show",
   "selections": [
     {
+      "alias": "about",
+      "args": null,
+      "kind": "ScalarField",
+      "name": "description",
+      "storageKey": null
+    },
+    {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
-      "name": "name",
+      "name": "pressRelease",
       "storageKey": null
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "ShowHeader_show"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "ShowAbout_show"
     },
     {
       "args": null,
@@ -42,5 +60,5 @@ const node: ReaderFragment = {
   ],
   "type": "Show"
 };
-(node as any).hash = '56e700b805c8dd260c5f9f984e9c97a6';
+(node as any).hash = 'bc21491cc2300b8d2a8c46920f892de6';
 export default node;

--- a/src/v2/__generated__/ShowHeader_show.graphql.ts
+++ b/src/v2/__generated__/ShowHeader_show.graphql.ts
@@ -1,0 +1,109 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ShowHeader_show = {
+    readonly name: string | null;
+    readonly startAt: string | null;
+    readonly endAt: string | null;
+    readonly formattedStartAt: string | null;
+    readonly formattedEndAt: string | null;
+    readonly partner: {
+        readonly name?: string | null;
+    } | null;
+    readonly " $refType": "ShowHeader_show";
+};
+export type ShowHeader_show$data = ShowHeader_show;
+export type ShowHeader_show$key = {
+    readonly " $data"?: ShowHeader_show$data;
+    readonly " $fragmentRefs": FragmentRefs<"ShowHeader_show">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v1 = [
+  (v0/*: any*/)
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ShowHeader_show",
+  "selections": [
+    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "startAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endAt",
+      "storageKey": null
+    },
+    {
+      "alias": "formattedStartAt",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "format",
+          "value": "MMMM D"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "startAt",
+      "storageKey": "startAt(format:\"MMMM D\")"
+    },
+    {
+      "alias": "formattedEndAt",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "format",
+          "value": "MMMM D, YYYY"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "endAt",
+      "storageKey": "endAt(format:\"MMMM D, YYYY\")"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "partner",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "InlineFragment",
+          "selections": (v1/*: any*/),
+          "type": "Partner"
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": (v1/*: any*/),
+          "type": "ExternalPartner"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Show"
+};
+})();
+(node as any).hash = '6c9b0c569a115533b876d48b3d3715ed';
+export default node;

--- a/src/v2/__generated__/routes_ShowQuery.graphql.ts
+++ b/src/v2/__generated__/routes_ShowQuery.graphql.ts
@@ -28,10 +28,39 @@ query routes_ShowQuery(
   }
 }
 
+fragment ShowAbout_show on Show {
+  about: description
+  pressRelease
+}
+
 fragment ShowApp_show on Show {
-  name
+  about: description
+  pressRelease
+  ...ShowHeader_show
+  ...ShowAbout_show
   ...ShowMeta_show
   ...ShowInstallShots_show
+}
+
+fragment ShowHeader_show on Show {
+  name
+  startAt
+  endAt
+  formattedStartAt: startAt(format: "MMMM D")
+  formattedEndAt: endAt(format: "MMMM D, YYYY")
+  partner {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on ExternalPartner {
+      name
+      id
+    }
+    ... on Node {
+      id
+    }
+  }
 }
 
 fragment ShowInstallShots_show on Show {
@@ -91,37 +120,54 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "width",
+  "name": "name",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
+  "name": "id",
   "storageKey": null
 },
 v4 = [
+  (v2/*: any*/)
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "width",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "height",
+  "storageKey": null
+},
+v7 = [
   {
     "kind": "Literal",
     "name": "height",
     "value": 400
   }
 ],
-v5 = {
+v8 = {
   "alias": "src",
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v6 = [
+v9 = [
+  (v8/*: any*/),
   (v5/*: any*/),
-  (v2/*: any*/),
-  (v3/*: any*/)
+  (v6/*: any*/)
 ],
-v7 = [
-  (v5/*: any*/)
+v10 = [
+  (v8/*: any*/)
 ];
 return {
   "fragment": {
@@ -164,10 +210,87 @@ return {
         "plural": false,
         "selections": [
           {
+            "alias": "about",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "description",
+            "storageKey": null
+          },
+          {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "name",
+            "name": "pressRelease",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "startAt",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "endAt",
+            "storageKey": null
+          },
+          {
+            "alias": "formattedStartAt",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "format",
+                "value": "MMMM D"
+              }
+            ],
+            "kind": "ScalarField",
+            "name": "startAt",
+            "storageKey": "startAt(format:\"MMMM D\")"
+          },
+          {
+            "alias": "formattedEndAt",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "format",
+                "value": "MMMM D, YYYY"
+              }
+            ],
+            "kind": "ScalarField",
+            "name": "endAt",
+            "storageKey": "endAt(format:\"MMMM D, YYYY\")"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "partner",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__typename",
+                "storageKey": null
+              },
+              (v3/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": (v4/*: any*/),
+                "type": "Partner"
+              },
+              {
+                "kind": "InlineFragment",
+                "selections": (v4/*: any*/),
+                "type": "ExternalPartner"
+              }
+            ],
             "storageKey": null
           },
           {
@@ -237,29 +360,29 @@ return {
                 "name": "resized",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
-                  (v3/*: any*/)
+                  (v5/*: any*/),
+                  (v6/*: any*/)
                 ],
                 "storageKey": "resized(height:300)"
               },
               {
                 "alias": "_1x",
-                "args": (v4/*: any*/),
+                "args": (v7/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v6/*: any*/),
+                "selections": (v9/*: any*/),
                 "storageKey": "resized(height:400)"
               },
               {
                 "alias": "_2x",
-                "args": (v4/*: any*/),
+                "args": (v7/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v7/*: any*/),
+                "selections": (v10/*: any*/),
                 "storageKey": "resized(height:400)"
               },
               {
@@ -280,7 +403,7 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v6/*: any*/),
+                "selections": (v9/*: any*/),
                 "storageKey": "resized(height:900,width:900)"
               },
               {
@@ -301,19 +424,13 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v7/*: any*/),
+                "selections": (v10/*: any*/),
                 "storageKey": "resized(height:1800,width:1800)"
               }
             ],
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          }
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
@@ -324,7 +441,7 @@ return {
     "metadata": {},
     "name": "routes_ShowQuery",
     "operationKind": "query",
-    "text": "query routes_ShowQuery(\n  $slug: String!\n) {\n  show(id: $slug) {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment ShowApp_show on Show {\n  name\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images {\n    internalID\n    mobile1x: resized(height: 300) {\n      width\n      height\n    }\n    _1x: resized(height: 400) {\n      src: url\n      width\n      height\n    }\n    _2x: resized(height: 400) {\n      src: url\n    }\n    zoom1x: resized(width: 900, height: 900) {\n      src: url\n      width\n      height\n    }\n    zoom2x: resized(width: 1800, height: 1800) {\n      src: url\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n"
+    "text": "query routes_ShowQuery(\n  $slug: String!\n) {\n  show(id: $slug) {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n  pressRelease\n}\n\nfragment ShowApp_show on Show {\n  about: description\n  pressRelease\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images {\n    internalID\n    mobile1x: resized(height: 300) {\n      width\n      height\n    }\n    _1x: resized(height: 400) {\n      src: url\n      width\n      height\n    }\n    _2x: resized(height: 400) {\n      src: url\n    }\n    zoom1x: resized(width: 900, height: 900) {\n      src: url\n      width\n      height\n    }\n    zoom2x: resized(width: 1800, height: 1800) {\n      src: url\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Re: [FX-2192](https://artsyproduct.atlassian.net/browse/FX-2192)

[Figma spec here](https://www.figma.com/file/I5sz0m16SiW7F3tsSoLRxK/Fair-Page?node-id=0%3A1) — in particular note the  "[Web, Desktop Only] Show header, with variable data" section. This broke my brain a little bit.

* First problem: Our existing grid, based on styled-bootstrap-grid, doesn't have gutters/column gaps.
* Second problem: if we were to add column gaps and then set the `noGutter` property on `Col`, this actually doesn't even work how you'd expect it to.
* [Possible solution: a light wrapper around CSS grid](https://github.com/artsy/force/commit/094502d2f57814e09c1ef453c426af0422d31b8d) with the assumption that we have a 12 column grid, with gutters, and assume it collapses into a single column at mobile breakpoints — this could be extracted to Palette as a possible replacement for our current Grid? The question I have is whether or not it's intuitive enough or if there's a better solution we can/should use here.

![](http://static.damonzucconi.com/_capture/RyMN52iNtmue.png)

![](https://static.damonzucconi.com/_capture/EUF0KbdwWrGW.gif)