### PR TITLE
fix: Add system context to FillwidthItem

### DIFF
--- a/src/v2/Components/Artwork/FillwidthItem.tsx
+++ b/src/v2/Components/Artwork/FillwidthItem.tsx
@@ -1,8 +1,7 @@
 import { AuthContextModule } from "@artsy/cohesion"
 import { Box, Image, space } from "@artsy/palette"
 import { FillwidthItem_artwork } from "v2/__generated__/FillwidthItem_artwork.graphql"
-import { SystemContextProps } from "v2/Artsy"
-import { Mediator } from "v2/Artsy"
+import { Mediator, SystemContextProps, withSystemContext } from "v2/Artsy"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
@@ -190,7 +189,7 @@ export const FillwidthItem = styled(FillwidthItemContainer)<
   }
 `
 
-export default createFragmentContainer(FillwidthItem, {
+export default createFragmentContainer(withSystemContext(FillwidthItem), {
   artwork: graphql`
     fragment FillwidthItem_artwork on Artwork {
       image {


### PR DESCRIPTION
Save artwork actions on the new fair pages were not opening the modal due to missing `mediator`. 
This PR wraps the `FillwidthItem` with `SystemContext`, ensuring the `mediator` will be present in all v2 apps by default. For non-v2 apps we can manually pass the mediator as a prop to launch the modal.

![save-artwork](https://user-images.githubusercontent.com/1497424/95374577-82653500-08ac-11eb-8e78-12e8cb3ac0c3.gif)
