### PR TITLE
chore: Address decaf/jquery issues in mocha tests

### DIFF
--- a/src/mobile/apps/fair/test/client/exhibitors.test.js
+++ b/src/mobile/apps/fair/test/client/exhibitors.test.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 const _ = require("underscore")
 const Backbone = require("backbone")
 const Fair = require("../../../../models/fair")
@@ -12,14 +7,14 @@ const sinon = require("sinon")
 const benv = require("benv")
 const { resolve } = require("path")
 
-describe("Exhibitors page client-side code", function () {
-  beforeEach(function (done) {
-    return benv.setup(() => {
+describe("Exhibitors page client-side code", () => {
+  let view
+  beforeEach(done => {
+    benv.setup(() => {
       benv.expose({ $: benv.require("jquery") })
-      Backbone.$ = $
       $.onInfiniteScroll = sinon.stub()
       sinon.stub(Backbone, "sync")
-      return benv.render(
+      benv.render(
         resolve(__dirname, "../../templates/exhibitors_page.jade"),
         {
           fair: new Fair(fabricate("fair")),
@@ -33,66 +28,67 @@ describe("Exhibitors page client-side code", function () {
             resolve(__dirname, "../../client/exhibitors"),
             ["exhibitorsTemplate", "artworkColumnsTemplate"]
           )
-          this.view = new FairExhibitorsView({
+          Backbone.$ = $
+          view = new FairExhibitorsView({
             el: $("body"),
             collection: new ShowsFeed([
               fabricate("show", { fair_location: { display: "booth 7" } }),
             ]),
             showParams: { foo: "bar" },
           })
-          return done()
+          done()
         }
       )
     })
   })
 
-  afterEach(function () {
+  afterEach(() => {
     benv.teardown()
-    return Backbone.sync.restore()
+    Backbone.sync.restore()
   })
 
   describe("init", () =>
-    xit("injects the showParams and shows into the view", function () {
+    xit("injects the showParams and shows into the view", () => {
       sd.SHOW_PARAMS = { foo: "baz" }
       sd.SHOWS = [fabricate("show", { fair_location: { display: "Dock 4" } })]
       const view = this.init()
       view.showParams.foo.should.equal("baz")
-      return view.collection.first().formattedLocation().should.equal("Dock 4")
+      view.collection.first().formattedLocation().should.equal("Dock 4")
     }))
 
-  return describe("FairMainPageView", function () {
+  describe("FairMainPageView", () => {
     describe("#initialize", () =>
-      it("attaches the show params", function () {
-        return this.view.showParams.foo.should.equal("bar")
+      it("attaches the show params", () => {
+        view.showParams.foo.should.equal("bar")
       }))
 
-    describe("#setupInfiniteScroll", function () {
-      xit("doesnt set up infinite scroll if in a partner scope", function () {
-        this.view.showParams.partner = { foo: "bar" }
-        this.view.setupInfiniteScroll()
-        return $.onInfiniteScroll.called.should.not.be.ok()
+    describe("#setupInfiniteScroll", () => {
+      xit("doesnt set up infinite scroll if in a partner scope", () => {
+        view.showParams.partner = { foo: "bar" }
+        view.setupInfiniteScroll()
+        $.onInfiniteScroll.called.should.not.be.ok()
       })
 
-      it("sets up infinite scroll for non-partner scope", function () {
-        this.view.setupInfiniteScroll()
-        return $.onInfiniteScroll.called.should.be.ok()
+      it("sets up infinite scroll for non-partner scope", () => {
+        view.setupInfiniteScroll()
+        $.onInfiniteScroll.called.should.be.ok()
       })
 
-      return it("fetches the next page on infinite scroll", function () {
-        this.view.collection.nextPage = sinon.stub()
-        this.view.setupInfiniteScroll()
+      it("fetches the next page on infinite scroll", () => {
+        view.collection.nextPage = sinon.stub()
+        view.setupInfiniteScroll()
         $.onInfiniteScroll.args[0][0]()
-        return this.view.collection.nextPage.called.should.be.ok()
+        view.collection.nextPage.called.should.be.ok()
       })
     })
 
-    return describe("#renderShows", () =>
-      it("renders the shows", function () {
-        this.view.collection.reset([
+    describe("#renderShows", () =>
+      it("renders the shows", () => {
+        view.collection.reset([
           fabricate("show", { fair_location: { display: "Pier FooBar" } }),
         ])
-        this.view.renderShows()
-        return this.view.$el.html().should.containEql("Pier FooBar")
+        view.renderShows()
+        view.$el.html().should.containEql("Pier FooBar")
       }))
   })
 })

--- a/src/mobile/apps/favorites_following/test/client/following.test.js
+++ b/src/mobile/apps/favorites_following/test/client/following.test.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 const _ = require("underscore")
 const benv = require("benv")
 const sinon = require("sinon")
@@ -14,41 +9,42 @@ const FollowingView = benv.requireWithJadeify(
   ["profilesTemplate"]
 )
 
-describe("Follows client-side code", function () {
-  beforeEach(function (done) {
-    return benv.setup(() => {
+describe("Follows client-side code", () => {
+  let view
+  beforeEach(done => {
+    benv.setup(() => {
       benv.expose({ $: benv.require("jquery") })
-      Backbone.$ = $
-      $.onInfiniteScroll = function () {}
-      return benv.render(
+      $.onInfiniteScroll = () => {}
+      benv.render(
         resolve(__dirname, "../../templates/index.jade"),
         { sd: {} },
         () => {
-          this.profiles = () =>
+          Backbone.$ = $
+          const profiles = () =>
             _.times(5, () => ({
               profile: fabricate("profile", { id: _.uniqueId() }),
             }))
-          sinon.stub(Backbone, "sync").yieldsTo("success", this.profiles())
-          this.view = new FollowingView({ el: $("body") })
-          return done()
+          sinon.stub(Backbone, "sync").yieldsTo("success", profiles())
+          view = new FollowingView({ el: $("body") })
+          done()
         }
       )
     })
   })
 
-  afterEach(function () {
+  afterEach(() => {
     benv.teardown()
-    return Backbone.sync.restore()
+    Backbone.sync.restore()
   })
 
-  it("fetches the following profiles and renders them immediately", function () {
-    this.view.$list.length.should.equal(1)
-    return this.view.$(".profile-item").length.should.equal(5)
+  it("fetches the following profiles and renders them immediately", () => {
+    view.$list.length.should.equal(1)
+    view.$(".profile-item").length.should.equal(5)
   })
 
-  return it("appends new profiles once they are fetched", function () {
-    this.view.following.fetch()
-    this.view.$list.length.should.equal(1)
-    return this.view.$(".profile-item").length.should.equal(10)
+  it("appends new profiles once they are fetched", () => {
+    view.following.fetch()
+    view.$list.length.should.equal(1)
+    view.$(".profile-item").length.should.equal(10)
   })
 })

--- a/src/mobile/apps/home/test/client_view.test.js
+++ b/src/mobile/apps/home/test/client_view.test.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 const _ = require("underscore")
 const Backbone = require("backbone")
 const { fabricate } = require("@artsy/antigravity")
@@ -10,23 +5,26 @@ const sinon = require("sinon")
 const benv = require("benv")
 const { resolve } = require("path")
 
-describe("HomePageView", function () {
-  beforeEach(function (done) {
-    return benv.setup(() => {
+describe("HomePageView", () => {
+  let view
+  let Flickity
+  let HomePageView
+  beforeEach(done => {
+    benv.setup(() => {
       benv.expose({
         $: benv.require("jquery"),
         analytics: { track: sinon.stub() },
         Element: window.Element,
       })
-      Backbone.$ = $
-      return benv.render(
+      benv.render(
         resolve(__dirname, "../templates/page.jade"),
         {
           heroUnits: [],
           sd: {},
         },
         () => {
-          this.HomePageView = benv.requireWithJadeify(
+          Backbone.$ = $
+          HomePageView = benv.requireWithJadeify(
             resolve(__dirname, "../client/view"),
             [
               "featuredItemsTemplate",
@@ -35,52 +33,52 @@ describe("HomePageView", function () {
             ]
           )
           sinon.stub(Backbone, "sync")
-          this.HomePageView.__set__("Flickity", (this.Flickity = sinon.stub()))
-          this.HomePageView.__set__("sd", {})
-          this.view = new this.HomePageView()
-          return done()
+          HomePageView.__set__("Flickity", (Flickity = sinon.stub()))
+          HomePageView.__set__("sd", {})
+          view = new HomePageView()
+          done()
         }
       )
     })
   })
 
-  afterEach(function () {
+  afterEach(() => {
     Backbone.sync.restore()
-    return benv.teardown()
+    benv.teardown()
   })
 
-  describe("#initialize", function () {
-    it("renders shows on sync", function () {
-      this.view.onSync = sinon.stub()
-      this.view.initialize()
-      this.view.collection.trigger("sync")
-      return this.view.onSync.called.should.be.ok()
+  describe("#initialize", () => {
+    it("renders shows on sync", () => {
+      view.onSync = sinon.stub()
+      view.initialize()
+      view.collection.trigger("sync")
+      view.onSync.called.should.be.ok()
     })
 
     xit("on infinite scroll calls next page on the collection with no arguments", function () {
-      this.view.shows.nextPage = sinon.stub()
+      view.shows.nextPage = sinon.stub()
       $(window).trigger("infiniteScroll")
-      return this.view.shows.nextPage.args[0].length.should.equal(0)
+      view.shows.nextPage.args[0].length.should.equal(0)
     })
 
-    return it("sets up hero units", function () {
-      this.view.onSync = sinon.stub()
-      this.view.initialize()
-      this.Flickity.args[0][0].should.equal("#carousel-track")
-      return this.Flickity.args[0][1].autoPlay.should.equal(10000)
+    it("sets up hero units", () => {
+      view.onSync = sinon.stub()
+      view.initialize()
+      Flickity.args[0][0].should.equal("#carousel-track")
+      Flickity.args[0][1].autoPlay.should.equal(10000)
     })
   })
 
   describe("#renderCurrentShows", () =>
-    it("renders the current shows", function () {
-      this.view.collection.reset([
+    it("renders the current shows", () => {
+      view.collection.reset([
         fabricate("show", { name: "Kittens on the wall" }),
       ])
-      this.view.onSync()
-      return this.view.$el.html().should.containEql("Kittens on the wall")
+      view.onSync()
+      view.$el.html().should.containEql("Kittens on the wall")
     }))
 
   xdescribe("#onSwipeStart", function () {})
 
-  return xdescribe("#onSwipeEnd", function () {})
+  xdescribe("#onSwipeEnd", function () {})
 })

--- a/src/mobile/apps/shows/test/view.test.js
+++ b/src/mobile/apps/shows/test/view.test.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 const benv = require("benv")
 const Backbone = require("backbone")
 const sinon = require("sinon")
@@ -11,9 +6,10 @@ const PartnerShows = require("../../../collections/partner_shows.coffee")
 const Show = require("../../../models/show.coffee")
 const { fabricate } = require("@artsy/antigravity")
 
-describe("ShowCityView", function () {
-  beforeEach(function (done) {
-    return benv.setup(() => {
+describe("ShowCityView", () => {
+  let view
+  beforeEach(done => {
+    benv.setup(() => {
       const partnerShows = new PartnerShows([
         fabricate("show", { status: "running" }),
         fabricate("show", { status: "running" }),
@@ -23,9 +19,8 @@ describe("ShowCityView", function () {
         $: benv.require("jquery"),
         jQuery: benv.require("jquery"),
       })
-      Backbone.$ = $
       sinon.stub(Backbone, "sync")
-      return benv.render(
+      benv.render(
         path.resolve(__dirname, "../templates/city.jade"),
         {
           sd: {},
@@ -43,36 +38,38 @@ describe("ShowCityView", function () {
             path.resolve(__dirname, "../client/shows.coffee"),
             ["showTemplate"]
           ))
-          this.view = new ShowCityView({
+          Backbone.$ = $
+          view = new ShowCityView({
             collection: partnerShows,
             el: $("body"),
             params: {},
           })
-          return done()
+          done()
         }
       )
     })
   })
 
-  afterEach(function () {
+  afterEach(() => {
     benv.teardown()
-    return Backbone.sync.restore()
+    Backbone.sync.restore()
   })
 
-  describe("#initialize", function () {
-    it("should start fetching at page 1", function () {
-      return this.view.page.should.equal(1)
+  describe("#initialize", () => {
+    it("should start fetching at page 1", () => {
+      view.page.should.equal(1)
     })
 
-    return it("should make the initial fetch", function () {
-      this.view.onInitialFetch()
-      return $("#running li").length.should.equal(3)
+    it("should make the initial fetch", () => {
+      view.onInitialFetch()
+      view.$("#running li").length.should.equal(3)
     })
   })
 
-  return describe("#onInfiniteScroll", () =>
-    it("fetches more shows", function () {
-      this.view.onInfiniteScroll()
-      return Backbone.sync.callCount.should.equal(2)
-    }))
+  describe("#onInfiniteScroll", () => {
+    it("fetches more shows", () => {
+      view.onInfiniteScroll()
+      Backbone.sync.callCount.should.equal(2)
+    })
+  })
 })

--- a/src/mobile/apps/unsubscribe/test/client.test.js
+++ b/src/mobile/apps/unsubscribe/test/client.test.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 const _ = require("underscore")
 const Backbone = require("backbone")
 const benv = require("benv")
@@ -10,13 +5,16 @@ const sinon = require("sinon")
 const { resolve } = require("path")
 const emailTypes = require("../email_types.coffee")
 
-describe("Unsubscribe View", function () {
-  beforeEach(function (done) {
-    return benv.setup(() => {
-      benv.expose({ $: benv.require("jquery") })
-      Backbone.$ = $
+describe("Unsubscribe View", () => {
+  let view
+  beforeEach(done => {
+    benv.setup(() => {
+      benv.expose({
+        $: benv.require("jquery"),
+        jQuery: benv.require("jquery"),
+      })
       sinon.stub(Backbone, "sync")
-      return benv.render(
+      benv.render(
         resolve(__dirname, "../templates/index.jade"),
         {
           sd: {},
@@ -24,67 +22,64 @@ describe("Unsubscribe View", function () {
         },
         () => {
           const UnsubscribeView = benv.require(resolve(__dirname, "../client"))
-          this.view = new UnsubscribeView({
+          Backbone.$ = $
+          view = new UnsubscribeView({
             el: $("#unsubscribe-content"),
             unsubToken: "cat",
           })
-          return done()
+          done()
         }
       )
     })
   })
 
-  afterEach(function () {
+  afterEach(() => {
     benv.teardown()
-    return Backbone.sync.restore()
+    Backbone.sync.restore()
   })
 
-  it("renders checkboxes for each email type, including a select all", function () {
+  it("renders checkboxes for each email type, including a select all", () => {
     _(_.keys(emailTypes)).each(type => {
-      return this.view.$el.find(`input[name='${type}']`).length.should.equal(1)
+      view.$el.find(`input[name='${type}']`).length.should.equal(1)
     })
-    return this.view.$el.find("input[name='selectAll']").length.should.equal(1)
+    view.$el.find("input[name='selectAll']").length.should.equal(1)
   })
 
-  return describe("posting to the API", function () {
-    it("correctly passes in the token and selected email types", function () {
-      this.view.$el
+  describe("posting to the API", () => {
+    it("correctly passes in the token and selected email types", () => {
+      view.$el
         .find("input[name='selectAll']")
         .prop("checked")
         .should.equal(false)
-      this.view.$el
-        .find("input[name='personalized_email']")
-        .prop("checked", true)
-      this.view.$el.find("button").click()
+      view.$el.find("input[name='personalized_email']").prop("checked", true)
+      view.$el.find("button").click()
       _.last(Backbone.sync.args)[1].attributes.type[0].should.equal(
         "personalized_email"
       )
-      return _.last(
+      _.last(
         Backbone.sync.args
       )[1].attributes.authentication_token.should.equal("cat")
     })
 
-    it('correctly passes email type "all" when selectAll has occurred', function () {
-      this.view.$el.find("input[name='selectAll']").prop("checked", true)
-      this.view.$el.find("button").click()
+    it('correctly passes email type "all" when selectAll has occurred', () => {
+      view.$el.find("input[name='selectAll']").prop("checked", true)
+      view.$el.find("button").click()
       _.last(Backbone.sync.args)[1].attributes.type[0].should.equal("all")
-      return _.last(
+      _.last(
         Backbone.sync.args
       )[1].attributes.authentication_token.should.equal("cat")
     })
 
-    it("renders success message on success", function () {
-      this.view.$el.find("button").click()
+    it("renders success message on success", () => {
+      view.$el.find("button").click()
       _.last(Backbone.sync.args)[2].success({})
-      return this.view.$el.html().should.containEql("You've been unsubscribed")
+      view.$el.html().should.containEql("You've been unsubscribed")
     })
 
-    return it("renders error message on error", function () {
-      this.view.$el.find("button").click()
+    it("renders error message on error", () => {
+      view.$el.find("button").click()
       _.last(Backbone.sync.args)[2].error({})
-      return this.view.$el
-        .html()
-        .should.containEql("Whoops, there was an error")
+      view.$el.html().should.containEql("Whoops, there was an error")
     })
   })
 })


### PR DESCRIPTION
Some changes in `mobile/bootstrap` (#6426) have introduced leak issues in mocha tests -- specifically that `Backbone.$ = $` should be defined inside the `benv.render` callback and after and view requires when used, otherwise `jQuery` will not be available.

Additionally fixed erroneously placed `return` statements and liberal use of `this`, which is not available in this context. 
