### PR TITLE
[FX-2192] Show header info

### DIFF
--- a/src/v2/Apps/Show/ShowApp.tsx
+++ b/src/v2/Apps/Show/ShowApp.tsx
@@ -1,15 +1,18 @@
 import React from "react"
-import { AppContainer } from "v2/Apps/Components/AppContainer"
+import styled from "styled-components"
 import { createFragmentContainer, graphql } from "react-relay"
-import { ShowApp_show } from "v2/__generated__/ShowApp_show.graphql"
+import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
 import { Footer } from "v2/Components/Footer"
 import { ErrorPage } from "v2/Components/ErrorPage"
-import { Box, Separator, Text } from "@artsy/palette"
+import { Box, Column, GridColumns, Separator } from "@artsy/palette"
 import { ShowMetaFragmentContainer as ShowMeta } from "v2/Apps/Show/components/ShowMeta"
+import { ShowHeaderFragmentContainer as ShowHeader } from "./components/ShowHeader"
+import { ShowAboutFragmentContainer as ShowAbout } from "./components/ShowAbout"
 import { ShowInstallShotsFragmentContainer as ShowInstallShots } from "./components/ShowInstallShots"
 import { ShowContextualLinkFragmentContainer as ShowContextualLink } from "./components/ShowContextualLink"
-import styled from "styled-components"
+import { ShowViewingRoom } from "./components/ShowViewingRoom"
+import { ShowApp_show } from "v2/__generated__/ShowApp_show.graphql"
 
 interface ShowAppProps {
   show: ShowApp_show
@@ -28,6 +31,11 @@ const FullScreenSeparator = styled(Separator)`
 export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
   if (!show) return <ErrorPage code={404} />
 
+  const hasViewingRoom = false // TODO
+  const hasAbout = !!show.about || !!show.pressRelease
+  const hasWideHeader =
+    (hasAbout && hasViewingRoom) || (!hasAbout && !hasViewingRoom)
+
   return (
     <>
       <ShowMeta show={show} />
@@ -41,9 +49,23 @@ export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
 
           <ShowInstallShots show={show} my={2} />
 
-          <Text as="h1" variant="largeTitle" my={4}>
-            {show.name}
-          </Text>
+          <GridColumns>
+            <Column span={hasWideHeader ? [12, 8, 6] : 6} wrap={hasWideHeader}>
+              <ShowHeader show={show} />
+            </Column>
+
+            {hasAbout && (
+              <Column span={6}>
+                <ShowAbout show={show} />
+              </Column>
+            )}
+
+            {hasViewingRoom && (
+              <Column span={5} start={8}>
+                <ShowViewingRoom />
+              </Column>
+            )}
+          </GridColumns>
 
           <Separator as="hr" my={3} />
 
@@ -59,7 +81,11 @@ export default createFragmentContainer(ShowApp, {
   show: graphql`
     fragment ShowApp_show on Show {
       name
+      about: description
+      pressRelease
       ...ShowContextualLink_show
+      ...ShowHeader_show
+      ...ShowAbout_show
       ...ShowMeta_show
       ...ShowInstallShots_show
     }

--- a/src/v2/Apps/Show/__tests__/ShowApp.jest.tsx
+++ b/src/v2/Apps/Show/__tests__/ShowApp.jest.tsx
@@ -1,6 +1,10 @@
 import React from "react"
 import { mount } from "enzyme"
-import { ShowApp } from "../ShowApp"
+import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
+import { QueryRenderer, graphql } from "react-relay"
+import ShowApp from "../ShowApp"
+
+jest.unmock("react-relay")
 
 jest.mock("v2/Apps/Show/components/ShowMeta", () => ({
   ShowMetaFragmentContainer: () => null,
@@ -10,16 +14,71 @@ jest.mock("v2/Apps/Show/components/ShowInstallShots", () => ({
   ShowInstallShotsFragmentContainer: () => null,
 }))
 
-const SHOW_FIXTURE = { name: "Example Show" }
-
 describe("ShowApp", () => {
-  const getWrapper = () => {
-    return mount(<ShowApp show={SHOW_FIXTURE as any} />)
+  const getWrapper = (response = {}) => {
+    const env = createMockEnvironment()
+
+    const TestRenderer = () => (
+      <QueryRenderer<any>
+        environment={env}
+        variables={{}}
+        query={graphql`
+          query ShowApp_Test_Query {
+            show(id: "xxx") {
+              ...ShowApp_show
+            }
+          }
+        `}
+        render={({ props, error }) => {
+          if (props?.show) {
+            return <ShowApp show={props.show} />
+          } else if (error) {
+            console.error(error)
+          }
+        }}
+      />
+    )
+
+    const wrapper = mount(<TestRenderer />)
+
+    env.mock.resolveMostRecentOperation(operation =>
+      MockPayloadGenerator.generate(operation, {
+        Show: () => {
+          return {
+            name: "Example Show",
+            ...response,
+          }
+        },
+      })
+    )
+    wrapper.update()
+    return wrapper
   }
 
   it("renders the title", () => {
     const wrapper = getWrapper()
     expect(wrapper.find("h1")).toHaveLength(1)
     expect(wrapper.find("h1").text()).toEqual("Example Show")
+  })
+
+  it("renders the appropriate info", () => {
+    const wrapper = getWrapper({
+      href: "/show/example-href",
+      metaDescription: "Information about the show",
+      pressRelease: "Press Release",
+      partner: {
+        name: "Example Partner",
+      },
+    })
+
+    expect(wrapper.text()).toContain("Information about the show")
+    expect(wrapper.text()).toContain("Example Partner")
+
+    // If a press release exists, link to the more info page
+    const moreInfoLink = wrapper
+      .find("a")
+      .findWhere(node => node.text() === "More info")
+      .first()
+    expect(moreInfoLink.prop("href")).toEqual("/show/example-href/info")
   })
 })

--- a/src/v2/Apps/Show/components/ShowAbout.tsx
+++ b/src/v2/Apps/Show/components/ShowAbout.tsx
@@ -1,0 +1,48 @@
+import React from "react"
+import { Box, BoxProps, Text } from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { ShowAbout_show } from "v2/__generated__/ShowAbout_show.graphql"
+import { ForwardLink } from "v2/Components/Links/ForwardLink"
+
+interface ShowAboutProps extends BoxProps {
+  show: ShowAbout_show
+}
+export const ShowAbout: React.FC<ShowAboutProps> = ({
+  show: { about, pressRelease, href },
+  ...rest
+}) => {
+  if (!about || !pressRelease) {
+    return null
+  }
+
+  return (
+    <Box {...rest}>
+      {about && (
+        <>
+          <Text variant="mediumText" as="h3" mb={1}>
+            About
+          </Text>
+
+          <Text variant="subtitle" as="p">
+            {about}
+          </Text>
+        </>
+      )}
+
+      {pressRelease && (
+        <ForwardLink to={`${href}/info`} mt={2}>
+          More info
+        </ForwardLink>
+      )}
+    </Box>
+  )
+}
+export const ShowAboutFragmentContainer = createFragmentContainer(ShowAbout, {
+  show: graphql`
+    fragment ShowAbout_show on Show {
+      about: description
+      pressRelease
+      href
+    }
+  `,
+})

--- a/src/v2/Apps/Show/components/ShowHeader.tsx
+++ b/src/v2/Apps/Show/components/ShowHeader.tsx
@@ -1,0 +1,58 @@
+import React from "react"
+import { Box, BoxProps, Text } from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { ShowHeader_show } from "v2/__generated__/ShowHeader_show.graphql"
+import { useCurrentTime } from "v2/Utils/Hooks/useCurrentTime"
+import { useEventTiming } from "v2/Utils/Hooks/useEventTiming"
+
+interface ShowHeaderProps extends BoxProps {
+  show: ShowHeader_show
+}
+export const ShowHeader: React.FC<ShowHeaderProps> = ({
+  show: { name, startAt, endAt, formattedStartAt, formattedEndAt, partner },
+  ...rest
+}) => {
+  const currentTime = useCurrentTime({ syncWithServer: true })
+  const { formattedTime } = useEventTiming({ currentTime, startAt, endAt })
+
+  return (
+    <Box {...rest}>
+      <Text as="h1" variant="largeTitle" mb={1.5}>
+        {name}
+      </Text>
+
+      <Text variant="mediumText">
+        {formattedStartAt} – {formattedEndAt}
+      </Text>
+
+      <Text variant="text" color="black60" mb={1}>
+        {formattedTime}
+      </Text>
+
+      {partner?.name && (
+        <Text variant="text" color="black60">
+          {partner.name}
+        </Text>
+      )}
+    </Box>
+  )
+}
+export const ShowHeaderFragmentContainer = createFragmentContainer(ShowHeader, {
+  show: graphql`
+    fragment ShowHeader_show on Show {
+      name
+      startAt
+      endAt
+      formattedStartAt: startAt(format: "MMMM D")
+      formattedEndAt: endAt(format: "MMMM D, YYYY")
+      partner {
+        ... on Partner {
+          name
+        }
+        ... on ExternalPartner {
+          name
+        }
+      }
+    }
+  `,
+})

--- a/src/v2/Apps/Show/components/ShowViewingRoom.tsx
+++ b/src/v2/Apps/Show/components/ShowViewingRoom.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import { Box, BoxProps, ResponsiveBox, Text } from "@artsy/palette"
+
+interface ShowViewingRoom extends BoxProps {}
+
+export const ShowViewingRoom = ({ ...rest }) => {
+  return (
+    <Box {...rest}>
+      <Text variant="mediumText" mb={1}>
+        Viewing Room
+      </Text>
+
+      <ResponsiveBox
+        bg="black10"
+        borderRadius={4}
+        maxWidth="100%"
+        aspectWidth={3}
+        aspectHeight={4}
+      />
+    </Box>
+  )
+}

--- a/src/v2/__generated__/ShowAbout_show.graphql.ts
+++ b/src/v2/__generated__/ShowAbout_show.graphql.ts
@@ -1,0 +1,51 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ShowAbout_show = {
+    readonly about: string | null;
+    readonly pressRelease: string | null;
+    readonly href: string | null;
+    readonly " $refType": "ShowAbout_show";
+};
+export type ShowAbout_show$data = ShowAbout_show;
+export type ShowAbout_show$key = {
+    readonly " $data"?: ShowAbout_show$data;
+    readonly " $fragmentRefs": FragmentRefs<"ShowAbout_show">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ShowAbout_show",
+  "selections": [
+    {
+      "alias": "about",
+      "args": null,
+      "kind": "ScalarField",
+      "name": "description",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "pressRelease",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "href",
+      "storageKey": null
+    }
+  ],
+  "type": "Show"
+};
+(node as any).hash = '2317727da9923f5d9e2bb0fd3492544d';
+export default node;

--- a/src/v2/__generated__/ShowApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ShowApp_Test_Query.graphql.ts
@@ -3,26 +3,22 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type routes_ShowQueryVariables = {
-    slug: string;
-};
-export type routes_ShowQueryResponse = {
+export type ShowApp_Test_QueryVariables = {};
+export type ShowApp_Test_QueryResponse = {
     readonly show: {
         readonly " $fragmentRefs": FragmentRefs<"ShowApp_show">;
     } | null;
 };
-export type routes_ShowQuery = {
-    readonly response: routes_ShowQueryResponse;
-    readonly variables: routes_ShowQueryVariables;
+export type ShowApp_Test_Query = {
+    readonly response: ShowApp_Test_QueryResponse;
+    readonly variables: ShowApp_Test_QueryVariables;
 };
 
 
 
 /*
-query routes_ShowQuery(
-  $slug: String!
-) {
-  show(id: $slug) {
+query ShowApp_Test_Query {
+  show(id: "xxx") {
     ...ShowApp_show
     id
   }
@@ -129,86 +125,78 @@ fragment ShowMeta_show on Show {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "slug",
-    "type": "String!"
-  }
-],
-v1 = [
-  {
-    "kind": "Variable",
+    "kind": "Literal",
     "name": "id",
-    "variableName": "slug"
+    "value": "xxx"
   }
 ],
-v2 = {
+v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "width",
   "storageKey": null
 },
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v7 = [
+v6 = [
   {
     "kind": "Literal",
     "name": "height",
     "value": 400
   }
 ],
-v8 = {
+v7 = {
   "alias": "src",
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v9 = [
-  (v8/*: any*/),
-  (v5/*: any*/),
-  (v6/*: any*/)
+v8 = [
+  (v7/*: any*/),
+  (v4/*: any*/),
+  (v5/*: any*/)
 ],
-v10 = [
-  (v8/*: any*/)
+v9 = [
+  (v7/*: any*/)
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "routes_ShowQuery",
+    "name": "ShowApp_Test_Query",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v0/*: any*/),
         "concreteType": "Show",
         "kind": "LinkedField",
         "name": "show",
@@ -220,26 +208,26 @@ return {
             "name": "ShowApp_show"
           }
         ],
-        "storageKey": null
+        "storageKey": "show(id:\"xxx\")"
       }
     ],
     "type": "Query"
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [],
     "kind": "Operation",
-    "name": "routes_ShowQuery",
+    "name": "ShowApp_Test_Query",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v0/*: any*/),
         "concreteType": "Show",
         "kind": "LinkedField",
         "name": "show",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
+          (v1/*: any*/),
           {
             "alias": "about",
             "args": null,
@@ -269,9 +257,9 @@ return {
             "name": "fair",
             "plural": false,
             "selections": [
-              (v3/*: any*/),
               (v2/*: any*/),
-              (v4/*: any*/)
+              (v1/*: any*/),
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
@@ -290,7 +278,7 @@ return {
                 "name": "__typename",
                 "storageKey": null
               },
-              (v4/*: any*/),
+              (v3/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -301,15 +289,15 @@ return {
                     "name": "isLinkable",
                     "storageKey": null
                   },
-                  (v2/*: any*/),
-                  (v3/*: any*/)
+                  (v1/*: any*/),
+                  (v2/*: any*/)
                 ],
                 "type": "Partner"
               },
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v2/*: any*/)
+                  (v1/*: any*/)
                 ],
                 "type": "ExternalPartner"
               }
@@ -356,7 +344,7 @@ return {
             "name": "endAt",
             "storageKey": "endAt(format:\"MMMM D, YYYY\")"
           },
-          (v3/*: any*/),
+          (v2/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -424,29 +412,29 @@ return {
                 "name": "resized",
                 "plural": false,
                 "selections": [
-                  (v5/*: any*/),
-                  (v6/*: any*/)
+                  (v4/*: any*/),
+                  (v5/*: any*/)
                 ],
                 "storageKey": "resized(height:300)"
               },
               {
                 "alias": "_1x",
-                "args": (v7/*: any*/),
+                "args": (v6/*: any*/),
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": (v8/*: any*/),
+                "storageKey": "resized(height:400)"
+              },
+              {
+                "alias": "_2x",
+                "args": (v6/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
                 "selections": (v9/*: any*/),
-                "storageKey": "resized(height:400)"
-              },
-              {
-                "alias": "_2x",
-                "args": (v7/*: any*/),
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": (v10/*: any*/),
                 "storageKey": "resized(height:400)"
               },
               {
@@ -467,7 +455,7 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v9/*: any*/),
+                "selections": (v8/*: any*/),
                 "storageKey": "resized(height:900,width:900)"
               },
               {
@@ -488,26 +476,26 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v10/*: any*/),
+                "selections": (v9/*: any*/),
                 "storageKey": "resized(height:1800,width:1800)"
               }
             ],
             "storageKey": null
           },
-          (v4/*: any*/)
+          (v3/*: any*/)
         ],
-        "storageKey": null
+        "storageKey": "show(id:\"xxx\")"
       }
     ]
   },
   "params": {
     "id": null,
     "metadata": {},
-    "name": "routes_ShowQuery",
+    "name": "ShowApp_Test_Query",
     "operationKind": "query",
-    "text": "query routes_ShowQuery(\n  $slug: String!\n) {\n  show(id: $slug) {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n  pressRelease\n  href\n}\n\nfragment ShowApp_show on Show {\n  name\n  about: description\n  pressRelease\n  ...ShowContextualLink_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images {\n    internalID\n    mobile1x: resized(height: 300) {\n      width\n      height\n    }\n    _1x: resized(height: 400) {\n      src: url\n      width\n      height\n    }\n    _2x: resized(height: 400) {\n      src: url\n    }\n    zoom1x: resized(width: 900, height: 900) {\n      src: url\n      width\n      height\n    }\n    zoom2x: resized(width: 1800, height: 1800) {\n      src: url\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n"
+    "text": "query ShowApp_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n  pressRelease\n  href\n}\n\nfragment ShowApp_show on Show {\n  name\n  about: description\n  pressRelease\n  ...ShowContextualLink_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images {\n    internalID\n    mobile1x: resized(height: 300) {\n      width\n      height\n    }\n    _1x: resized(height: 400) {\n      src: url\n      width\n      height\n    }\n    _2x: resized(height: 400) {\n      src: url\n    }\n    zoom1x: resized(width: 900, height: 900) {\n      src: url\n      width\n      height\n    }\n    zoom2x: resized(width: 1800, height: 1800) {\n      src: url\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = 'b6a500c743304c6db9a3cbaa7109e21f';
+(node as any).hash = '7fa78ef8909514aa70ba8bfff4a97dcd';
 export default node;

--- a/src/v2/__generated__/ShowApp_show.graphql.ts
+++ b/src/v2/__generated__/ShowApp_show.graphql.ts
@@ -5,7 +5,9 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ShowApp_show = {
     readonly name: string | null;
-    readonly " $fragmentRefs": FragmentRefs<"ShowContextualLink_show" | "ShowMeta_show" | "ShowInstallShots_show">;
+    readonly about: string | null;
+    readonly pressRelease: string | null;
+    readonly " $fragmentRefs": FragmentRefs<"ShowContextualLink_show" | "ShowHeader_show" | "ShowAbout_show" | "ShowMeta_show" | "ShowInstallShots_show">;
     readonly " $refType": "ShowApp_show";
 };
 export type ShowApp_show$data = ShowApp_show;
@@ -30,9 +32,33 @@ const node: ReaderFragment = {
       "storageKey": null
     },
     {
+      "alias": "about",
+      "args": null,
+      "kind": "ScalarField",
+      "name": "description",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "pressRelease",
+      "storageKey": null
+    },
+    {
       "args": null,
       "kind": "FragmentSpread",
       "name": "ShowContextualLink_show"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "ShowHeader_show"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "ShowAbout_show"
     },
     {
       "args": null,
@@ -47,5 +73,5 @@ const node: ReaderFragment = {
   ],
   "type": "Show"
 };
-(node as any).hash = '7fdc785a6024be96e72075cf08f34bca';
+(node as any).hash = '040a14bc6813179ea2b51f9c51c622db';
 export default node;

--- a/src/v2/__generated__/ShowHeader_show.graphql.ts
+++ b/src/v2/__generated__/ShowHeader_show.graphql.ts
@@ -1,0 +1,109 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ShowHeader_show = {
+    readonly name: string | null;
+    readonly startAt: string | null;
+    readonly endAt: string | null;
+    readonly formattedStartAt: string | null;
+    readonly formattedEndAt: string | null;
+    readonly partner: {
+        readonly name?: string | null;
+    } | null;
+    readonly " $refType": "ShowHeader_show";
+};
+export type ShowHeader_show$data = ShowHeader_show;
+export type ShowHeader_show$key = {
+    readonly " $data"?: ShowHeader_show$data;
+    readonly " $fragmentRefs": FragmentRefs<"ShowHeader_show">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v1 = [
+  (v0/*: any*/)
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ShowHeader_show",
+  "selections": [
+    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "startAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endAt",
+      "storageKey": null
+    },
+    {
+      "alias": "formattedStartAt",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "format",
+          "value": "MMMM D"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "startAt",
+      "storageKey": "startAt(format:\"MMMM D\")"
+    },
+    {
+      "alias": "formattedEndAt",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "format",
+          "value": "MMMM D, YYYY"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "endAt",
+      "storageKey": "endAt(format:\"MMMM D, YYYY\")"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "partner",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "InlineFragment",
+          "selections": (v1/*: any*/),
+          "type": "Partner"
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": (v1/*: any*/),
+          "type": "ExternalPartner"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Show"
+};
+})();
+(node as any).hash = '6c9b0c569a115533b876d48b3d3715ed';
+export default node;


### PR DESCRIPTION
This builds off the new grid component for layout in https://github.com/artsy/palette/pull/794

This is actually a weirdly complex conditional layout that becomes very easy with the new grid component.

### No about, no viewing room
![localhost_5000_show2_public-gallery-our-ashes-make-great-fertilizer](https://user-images.githubusercontent.com/112297/95514591-31c40980-098a-11eb-9135-a88b333fb1c7.png)

-----

### Has about, no viewing room
![localhost_5000_show2_public-gallery-our-ashes-make-great-fertilizer (1)](https://user-images.githubusercontent.com/112297/95514757-7a7bc280-098a-11eb-8f59-7d51e3322a65.png)

-----

### Has about and viewing room
![localhost_5000_show2_public-gallery-our-ashes-make-great-fertilizer (2)](https://user-images.githubusercontent.com/112297/95514595-32f53680-098a-11eb-8541-38e33469ccb9.png)

-----

### No about, has viewing room
![localhost_5000_show2_public-gallery-our-ashes-make-great-fertilizer (3)](https://user-images.githubusercontent.com/112297/95514607-35f02700-098a-11eb-9954-adae9021f9b6.png)

-----

### Everything stacks into single column on mobile
![localhost_5000_show2_public-gallery-our-ashes-make-great-fertilizer (4)](https://user-images.githubusercontent.com/112297/95514614-37215400-098a-11eb-80e2-b699de640b03.png)
