### PR TITLE
trivial: Add data attrs for integrity to bid buttons

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarBidAction.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarBidAction.tsx
@@ -33,7 +33,7 @@ const RegisterToBidButton: React.FC<{ onClick: () => void }> = ({
   onClick,
 }) => {
   return (
-    <Button width="100%" size="large" mt={1} onClick={onClick}>
+    <Button width="100%" size="large" mt={1} onClick={onClick} data-test="bid">
       Register to bid
     </Button>
   )
@@ -279,6 +279,7 @@ export class ArtworkSidebarBidAction extends React.Component<
             <Button
               width="100%"
               size="large"
+              data-test="bid"
               onClick={() => this.redirectToBid(firstIncrement.cents)}
             >
               {hasMyBids ? "Increase max bid" : "Bid"}


### PR DESCRIPTION
Adds data attributes to bid-related buttons so that we can target them in Integrity without relying on the button text.

Related to https://github.com/artsy/integrity/pull/193

Related failure: https://app.circleci.com/pipelines/github/artsy/integrity/3779/workflows/7482c733-e4f4-404d-822e-321bb242604e/jobs/17858

