### PR TITLE
chore: Only Load Openseadragon if Required

### DIFF
--- a/src/mobile/assets/mobile_openseadragon.ts
+++ b/src/mobile/assets/mobile_openseadragon.ts
@@ -1,1 +1,0 @@
-require("openseadragon")

--- a/webpack/envs/clientCommonConfig.js
+++ b/webpack/envs/clientCommonConfig.js
@@ -202,7 +202,7 @@ export const clientCommonConfig = {
           name: "common",
           chunks: "all",
           minSize: 0,
-          minChunks: 1,
+          minChunks: 2,
           reuseExistingChunk: true,
           enforce: true,
         },


### PR DESCRIPTION
We don't need to load the 200KB gzip archive for `openseadragon` on each
page, it is only used on the artwork page. This change updates the Webpack
minChunk property so that single use components are not included everywhere.

Also removes one unused file.