### PR TITLE
@dzucconi => [Show] Add context card for a fair

### DIFF
--- a/src/v2/Apps/Show/Components/ShowContextCard.tsx
+++ b/src/v2/Apps/Show/Components/ShowContextCard.tsx
@@ -1,0 +1,54 @@
+import { Box, Column, GridColumns, Spacer, Text } from "@artsy/palette"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { ShowContextCard_show } from "v2/__generated__/ShowContextCard_show.graphql"
+import { FairTimingFragmentContainer as FairTiming } from "v2/Apps/Fair/Components/FairHeader/FairTiming"
+import { FairCardFragmentContainer as FairCard } from "v2/Components/FairCard"
+import { StyledLink } from "v2/Components/Links/StyledLink"
+
+interface Props {
+  show: ShowContextCard_show
+}
+
+export const ShowContextCard: React.FC<Props> = ({ show }) => {
+  const { isFairBooth, fair } = show
+
+  if (!isFairBooth) return null
+
+  return (
+    <GridColumns>
+      <Column span={6}>
+        <Text variant="subtitle">Part of {fair.name}</Text>
+      </Column>
+      <Column span={6}>
+        <StyledLink noUnderline to={fair.href}>
+          <FairCard fair={fair} />
+
+          <Spacer mb={2} />
+          <Box>
+            <Text variant="largeTitle">{fair.name}</Text>
+
+            <FairTiming fair={fair} />
+          </Box>
+        </StyledLink>
+      </Column>
+    </GridColumns>
+  )
+}
+
+export const ShowContextCardFragmentContainer = createFragmentContainer(
+  ShowContextCard,
+  {
+    show: graphql`
+      fragment ShowContextCard_show on Show {
+        isFairBooth
+        fair {
+          href
+          name
+          ...FairTiming_fair
+          ...FairCard_fair
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Show/ShowApp.tsx
+++ b/src/v2/Apps/Show/ShowApp.tsx
@@ -15,6 +15,7 @@ import { ShowViewingRoom } from "./Components/ShowViewingRoom"
 import { ShowApp_show } from "v2/__generated__/ShowApp_show.graphql"
 import { ShowArtworksRefetchContainer as ShowArtworks } from "./Components/ShowArtworks"
 import { ForwardLink } from "v2/Components/Links/ForwardLink"
+import { ShowContextCardFragmentContainer as ShowContextCard } from "./Components/ShowContextCard"
 
 interface ShowAppProps {
   show: ShowApp_show
@@ -89,6 +90,14 @@ export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
 
           <Separator as="hr" my={3} />
 
+          {show.isFairBooth && (
+            <>
+              <ShowContextCard show={show} />
+
+              <Separator as="hr" my={3} />
+            </>
+          )}
+
           <Footer />
         </HorizontalPadding>
       </AppContainer>
@@ -141,6 +150,8 @@ export default createFragmentContainer(ShowApp, {
           sizes: $sizes
           sort: $sort
         )
+      isFairBooth
+      ...ShowContextCard_show
     }
   `,
 })

--- a/src/v2/Apps/Show/__tests__/ShowContextCard.jest.tsx
+++ b/src/v2/Apps/Show/__tests__/ShowContextCard.jest.tsx
@@ -1,0 +1,67 @@
+import { MockBoot } from "v2/DevTools"
+import { Breakpoint } from "@artsy/palette"
+import React from "react"
+import { ShowContextCardFragmentContainer } from "../Components/ShowContextCard"
+import { QueryRenderer, graphql } from "react-relay"
+import { ShowContextCard_Test_Query } from "v2/__generated__/ShowContextCard_Test_Query.graphql"
+import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
+import { mount } from "enzyme"
+
+jest.unmock("react-relay")
+
+describe("ShowContextCard", () => {
+  let env = createMockEnvironment() as ReturnType<typeof createMockEnvironment>
+
+  const getWrapper = (breakpoint = "xs") => {
+    const TestRenderer = () => (
+      <QueryRenderer<ShowContextCard_Test_Query>
+        environment={env}
+        query={graphql`
+          query ShowContextCard_Test_Query($slug: String!) {
+            show(id: $slug) {
+              ...ShowContextCard_show
+            }
+          }
+        `}
+        variables={{ slug: "show-id" }}
+        render={({ props, error }) => {
+          if (props?.show) {
+            return (
+              <MockBoot breakpoint={breakpoint as Breakpoint}>
+                <ShowContextCardFragmentContainer show={props.show} />
+              </MockBoot>
+            )
+          } else if (error) {
+            console.error(error)
+          }
+        }}
+      />
+    )
+
+    const wrapper = mount(<TestRenderer />)
+    env.mock.resolveMostRecentOperation(operation =>
+      MockPayloadGenerator.generate(operation, {
+        Fair: () => {
+          return {
+            name: "Catty Art Fair",
+          }
+        },
+      })
+    )
+    wrapper.update()
+    return wrapper
+  }
+
+  beforeEach(() => {
+    env = createMockEnvironment()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders correctly", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.text()).toContain("Part of Catty Art Fair")
+  })
+})

--- a/src/v2/Components/FairCard.tsx
+++ b/src/v2/Components/FairCard.tsx
@@ -1,0 +1,48 @@
+import React from "react"
+import { Image, ResponsiveBox } from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { FairCard_fair } from "v2/__generated__/FairCard_fair.graphql"
+
+interface FairHeaderImageProps {
+  fair: FairCard_fair
+}
+
+export const FairCard: React.FC<FairHeaderImageProps> = ({
+  fair: { name, image },
+}) => {
+  return (
+    <ResponsiveBox
+      aspectWidth={3}
+      aspectHeight={2}
+      maxWidth="100%"
+      bg="black60"
+    >
+      <Image
+        src={image._1x.src}
+        srcSet={`${image._1x.src} 1x, ${image._2x.src} 2x`}
+        alt={name}
+        lazyLoad
+        borderRadius="4px"
+      />
+    </ResponsiveBox>
+  )
+}
+
+export const FairCardFragmentContainer = createFragmentContainer(FairCard, {
+  fair: graphql`
+    fragment FairCard_fair on Fair {
+      name
+      image {
+        # Width = largest possible size, full width at 'xs' breakpoint.
+        # Height = Width / 1.5
+        _1x: cropped(width: 768, height: 512, version: "wide") {
+          src: url
+        }
+        # Above dimension multiplied by 2 for retina.
+        _2x: cropped(width: 1536, height: 1024, version: "wide") {
+          src: url
+        }
+      }
+    }
+  `,
+})

--- a/src/v2/__generated__/FairCard_fair.graphql.ts
+++ b/src/v2/__generated__/FairCard_fair.graphql.ts
@@ -1,0 +1,114 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type FairCard_fair = {
+    readonly name: string | null;
+    readonly image: {
+        readonly _1x: {
+            readonly src: string | null;
+        } | null;
+        readonly _2x: {
+            readonly src: string | null;
+        } | null;
+    } | null;
+    readonly " $refType": "FairCard_fair";
+};
+export type FairCard_fair$data = FairCard_fair;
+export type FairCard_fair$key = {
+    readonly " $data"?: FairCard_fair$data;
+    readonly " $fragmentRefs": FragmentRefs<"FairCard_fair">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "wide"
+},
+v1 = [
+  {
+    "alias": "src",
+    "args": null,
+    "kind": "ScalarField",
+    "name": "url",
+    "storageKey": null
+  }
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "FairCard_fair",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "image",
+      "plural": false,
+      "selections": [
+        {
+          "alias": "_1x",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 512
+            },
+            (v0/*: any*/),
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 768
+            }
+          ],
+          "concreteType": "CroppedImageUrl",
+          "kind": "LinkedField",
+          "name": "cropped",
+          "plural": false,
+          "selections": (v1/*: any*/),
+          "storageKey": "cropped(height:512,version:\"wide\",width:768)"
+        },
+        {
+          "alias": "_2x",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 1024
+            },
+            (v0/*: any*/),
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 1536
+            }
+          ],
+          "concreteType": "CroppedImageUrl",
+          "kind": "LinkedField",
+          "name": "cropped",
+          "plural": false,
+          "selections": (v1/*: any*/),
+          "storageKey": "cropped(height:1024,version:\"wide\",width:1536)"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Fair"
+};
+})();
+(node as any).hash = '6c6c9b44095ec228d128a0faa0ee1f2c';
+export default node;

--- a/src/v2/__generated__/ShowApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ShowApp_Test_Query.graphql.ts
@@ -142,6 +142,24 @@ fragment Details_artwork on Artwork {
   }
 }
 
+fragment FairCard_fair on Fair {
+  name
+  image {
+    _1x: cropped(width: 768, height: 512, version: "wide") {
+      src: url
+    }
+    _2x: cropped(width: 1536, height: 1024, version: "wide") {
+      src: url
+    }
+  }
+}
+
+fragment FairTiming_fair on Fair {
+  exhibitionPeriod
+  startAt
+  endAt
+}
+
 fragment GridItem_artwork on Artwork {
   internalID
   title
@@ -207,12 +225,25 @@ fragment ShowApp_show on Show {
   ...ShowMeta_show
   ...ShowInstallShots_show
   ...ShowArtworks_show_oju7O
+  isFairBooth
+  ...ShowContextCard_show
 }
 
 fragment ShowArtworks_show_oju7O on Show {
   filtered_artworks: filterArtworksConnection(medium: "*", first: 20, after: "", sort: "-decayed_merch") {
     id
     ...ArtworkFilterArtworkGrid2_filtered_artworks
+  }
+}
+
+fragment ShowContextCard_show on Show {
+  isFairBooth
+  fair {
+    href
+    name
+    ...FairTiming_fair
+    ...FairCard_fair
+    id
   }
 }
 
@@ -331,24 +362,53 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "startAt",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v6 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "wide"
+},
+v7 = {
+  "alias": "src",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "url",
+  "storageKey": null
+},
+v8 = [
+  (v7/*: any*/)
+],
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v5 = [
+v10 = [
   {
     "kind": "Literal",
     "name": "version",
     "value": "large"
   }
 ],
-v6 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v7 = {
+v12 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -356,60 +416,50 @@ v7 = {
     "large"
   ]
 },
-v8 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "width",
   "storageKey": null
 },
-v9 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v10 = [
+v15 = [
   {
     "kind": "Literal",
     "name": "height",
     "value": 400
   },
-  (v7/*: any*/)
+  (v12/*: any*/)
 ],
-v11 = {
-  "alias": "src",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "url",
-  "storageKey": null
-},
-v12 = [
-  (v11/*: any*/),
-  (v8/*: any*/),
-  (v9/*: any*/)
+v16 = [
+  (v7/*: any*/),
+  (v13/*: any*/),
+  (v14/*: any*/)
 ],
-v13 = [
-  (v11/*: any*/)
-],
-v14 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v15 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v16 = [
-  (v14/*: any*/),
-  (v15/*: any*/),
+v19 = [
+  (v17/*: any*/),
+  (v18/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -418,14 +468,14 @@ v16 = [
     "storageKey": null
   }
 ],
-v17 = [
+v20 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v18 = [
+v21 = [
   {
     "alias": null,
     "args": null,
@@ -500,7 +550,71 @@ return {
             "selections": [
               (v2/*: any*/),
               (v1/*: any*/),
-              (v3/*: any*/)
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "exhibitionPeriod",
+                "storageKey": null
+              },
+              (v4/*: any*/),
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "image",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": "_1x",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 512
+                      },
+                      (v6/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 768
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v8/*: any*/),
+                    "storageKey": "cropped(height:512,version:\"wide\",width:768)"
+                  },
+                  {
+                    "alias": "_2x",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 1024
+                      },
+                      (v6/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 1536
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v8/*: any*/),
+                    "storageKey": "cropped(height:1024,version:\"wide\",width:1536)"
+                  }
+                ],
+                "storageKey": null
+              }
             ],
             "storageKey": null
           },
@@ -545,20 +659,8 @@ return {
             ],
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "startAt",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "endAt",
-            "storageKey": null
-          },
+          (v4/*: any*/),
+          (v5/*: any*/),
           {
             "alias": "formattedStartAt",
             "args": [
@@ -585,7 +687,7 @@ return {
             "name": "endAt",
             "storageKey": "endAt(format:\"MMMM D, YYYY\")"
           },
-          (v4/*: any*/),
+          (v9/*: any*/),
           {
             "alias": "metaDescription",
             "args": null,
@@ -603,7 +705,7 @@ return {
             "selections": [
               {
                 "alias": "src",
-                "args": (v5/*: any*/),
+                "args": (v10/*: any*/),
                 "kind": "ScalarField",
                 "name": "url",
                 "storageKey": "url(version:\"large\")"
@@ -619,7 +721,7 @@ return {
             "name": "images",
             "plural": true,
             "selections": [
-              (v6/*: any*/),
+              (v11/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -635,36 +737,36 @@ return {
                     "name": "height",
                     "value": 300
                   },
-                  (v7/*: any*/)
+                  (v12/*: any*/)
                 ],
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
                 "selections": [
-                  (v8/*: any*/),
-                  (v9/*: any*/)
+                  (v13/*: any*/),
+                  (v14/*: any*/)
                 ],
                 "storageKey": "resized(height:300,version:[\"larger\",\"large\"])"
               },
               {
                 "alias": "_1x",
-                "args": (v10/*: any*/),
+                "args": (v15/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v12/*: any*/),
+                "selections": (v16/*: any*/),
                 "storageKey": "resized(height:400,version:[\"larger\",\"large\"])"
               },
               {
                 "alias": "_2x",
-                "args": (v10/*: any*/),
+                "args": (v15/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v13/*: any*/),
+                "selections": (v8/*: any*/),
                 "storageKey": "resized(height:400,version:[\"larger\",\"large\"])"
               },
               {
@@ -675,7 +777,7 @@ return {
                     "name": "height",
                     "value": 900
                   },
-                  (v7/*: any*/),
+                  (v12/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "width",
@@ -686,7 +788,7 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v12/*: any*/),
+                "selections": (v16/*: any*/),
                 "storageKey": "resized(height:900,version:[\"larger\",\"large\"],width:900)"
               },
               {
@@ -697,7 +799,7 @@ return {
                     "name": "height",
                     "value": 1800
                   },
-                  (v7/*: any*/),
+                  (v12/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "width",
@@ -708,7 +810,7 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v13/*: any*/),
+                "selections": (v8/*: any*/),
                 "storageKey": "resized(height:1800,version:[\"larger\",\"large\"],width:1800)"
               }
             ],
@@ -828,7 +930,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v16/*: any*/),
+                    "selections": (v19/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -838,7 +940,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v16/*: any*/),
+                    "selections": (v19/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -848,7 +950,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v16/*: any*/),
+                    "selections": (v19/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -859,8 +961,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v14/*: any*/),
-                      (v15/*: any*/)
+                      (v17/*: any*/),
+                      (v18/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -884,9 +986,9 @@ return {
                     "plural": false,
                     "selections": [
                       (v3/*: any*/),
-                      (v4/*: any*/),
+                      (v9/*: any*/),
                       (v2/*: any*/),
-                      (v6/*: any*/),
+                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -911,7 +1013,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v5/*: any*/),
+                            "args": (v10/*: any*/),
                             "kind": "ScalarField",
                             "name": "url",
                             "storageKey": "url(version:\"large\")"
@@ -956,7 +1058,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v17/*: any*/),
+                        "args": (v20/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
@@ -977,7 +1079,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v17/*: any*/),
+                        "args": (v20/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
@@ -1083,7 +1185,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v18/*: any*/),
+                            "selections": (v21/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1093,7 +1195,7 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v18/*: any*/),
+                            "selections": (v21/*: any*/),
                             "storageKey": null
                           },
                           (v3/*: any*/)
@@ -1142,7 +1244,7 @@ return {
     "metadata": {},
     "name": "ShowApp_Test_Query",
     "operationKind": "query",
-    "text": "query ShowApp_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show on Show {\n  name\n  href\n  about: description\n  ...ShowContextualLink_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowArtworks_show_oju7O\n}\n\nfragment ShowArtworks_show_oju7O on Show {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-decayed_merch\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images {\n    internalID\n    caption\n    mobile1x: resized(height: 300, version: [\"larger\", \"large\"]) {\n      width\n      height\n    }\n    _1x: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src: url\n      width\n      height\n    }\n    _2x: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src: url\n    }\n    zoom1x: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src: url\n      width\n      height\n    }\n    zoom2x: resized(width: 1800, height: 1800, version: [\"larger\", \"large\"]) {\n      src: url\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n"
+    "text": "query ShowApp_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    _1x: cropped(width: 768, height: 512, version: \"wide\") {\n      src: url\n    }\n    _2x: cropped(width: 1536, height: 1024, version: \"wide\") {\n      src: url\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show on Show {\n  name\n  href\n  about: description\n  ...ShowContextualLink_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowArtworks_show_oju7O\n  isFairBooth\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworks_show_oju7O on Show {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-decayed_merch\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images {\n    internalID\n    caption\n    mobile1x: resized(height: 300, version: [\"larger\", \"large\"]) {\n      width\n      height\n    }\n    _1x: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src: url\n      width\n      height\n    }\n    _2x: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src: url\n    }\n    zoom1x: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src: url\n      width\n      height\n    }\n    zoom2x: resized(width: 1800, height: 1800, version: [\"larger\", \"large\"]) {\n      src: url\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/ShowApp_show.graphql.ts
+++ b/src/v2/__generated__/ShowApp_show.graphql.ts
@@ -7,7 +7,8 @@ export type ShowApp_show = {
     readonly name: string | null;
     readonly href: string | null;
     readonly about: string | null;
-    readonly " $fragmentRefs": FragmentRefs<"ShowContextualLink_show" | "ShowHeader_show" | "ShowAbout_show" | "ShowMeta_show" | "ShowInstallShots_show" | "ShowArtworks_show">;
+    readonly isFairBooth: boolean | null;
+    readonly " $fragmentRefs": FragmentRefs<"ShowContextualLink_show" | "ShowHeader_show" | "ShowAbout_show" | "ShowMeta_show" | "ShowInstallShots_show" | "ShowArtworks_show" | "ShowContextCard_show">;
     readonly " $refType": "ShowApp_show";
 };
 export type ShowApp_show$data = ShowApp_show;
@@ -131,6 +132,13 @@ const node: ReaderFragment = {
       "storageKey": null
     },
     {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isFairBooth",
+      "storageKey": null
+    },
+    {
       "args": null,
       "kind": "FragmentSpread",
       "name": "ShowContextualLink_show"
@@ -230,9 +238,14 @@ const node: ReaderFragment = {
       ],
       "kind": "FragmentSpread",
       "name": "ShowArtworks_show"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "ShowContextCard_show"
     }
   ],
   "type": "Show"
 };
-(node as any).hash = '3680e942b082d51afb81c84ce0eab5da';
+(node as any).hash = '5322f51a90080340da4f33fc85285043';
 export default node;

--- a/src/v2/__generated__/ShowContextCard_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ShowContextCard_Test_Query.graphql.ts
@@ -1,0 +1,263 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ShowContextCard_Test_QueryVariables = {
+    slug: string;
+};
+export type ShowContextCard_Test_QueryResponse = {
+    readonly show: {
+        readonly " $fragmentRefs": FragmentRefs<"ShowContextCard_show">;
+    } | null;
+};
+export type ShowContextCard_Test_Query = {
+    readonly response: ShowContextCard_Test_QueryResponse;
+    readonly variables: ShowContextCard_Test_QueryVariables;
+};
+
+
+
+/*
+query ShowContextCard_Test_Query(
+  $slug: String!
+) {
+  show(id: $slug) {
+    ...ShowContextCard_show
+    id
+  }
+}
+
+fragment FairCard_fair on Fair {
+  name
+  image {
+    _1x: cropped(width: 768, height: 512, version: "wide") {
+      src: url
+    }
+    _2x: cropped(width: 1536, height: 1024, version: "wide") {
+      src: url
+    }
+  }
+}
+
+fragment FairTiming_fair on Fair {
+  exhibitionPeriod
+  startAt
+  endAt
+}
+
+fragment ShowContextCard_show on Show {
+  isFairBooth
+  fair {
+    href
+    name
+    ...FairTiming_fair
+    ...FairCard_fair
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "slug",
+    "type": "String!"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "slug"
+  }
+],
+v2 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "wide"
+},
+v3 = [
+  {
+    "alias": "src",
+    "args": null,
+    "kind": "ScalarField",
+    "name": "url",
+    "storageKey": null
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ShowContextCard_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ShowContextCard_show"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ShowContextCard_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isFairBooth",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Fair",
+            "kind": "LinkedField",
+            "name": "fair",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "href",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "exhibitionPeriod",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "startAt",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "endAt",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "image",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": "_1x",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 512
+                      },
+                      (v2/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 768
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v3/*: any*/),
+                    "storageKey": "cropped(height:512,version:\"wide\",width:768)"
+                  },
+                  {
+                    "alias": "_2x",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 1024
+                      },
+                      (v2/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 1536
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v3/*: any*/),
+                    "storageKey": "cropped(height:1024,version:\"wide\",width:1536)"
+                  }
+                ],
+                "storageKey": null
+              },
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "ShowContextCard_Test_Query",
+    "operationKind": "query",
+    "text": "query ShowContextCard_Test_Query(\n  $slug: String!\n) {\n  show(id: $slug) {\n    ...ShowContextCard_show\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    _1x: cropped(width: 768, height: 512, version: \"wide\") {\n      src: url\n    }\n    _2x: cropped(width: 1536, height: 1024, version: \"wide\") {\n      src: url\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'a7359cd327930945e900c214fa9d3907';
+export default node;

--- a/src/v2/__generated__/ShowContextCard_show.graphql.ts
+++ b/src/v2/__generated__/ShowContextCard_show.graphql.ts
@@ -1,0 +1,75 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ShowContextCard_show = {
+    readonly isFairBooth: boolean | null;
+    readonly fair: {
+        readonly href: string | null;
+        readonly name: string | null;
+        readonly " $fragmentRefs": FragmentRefs<"FairTiming_fair" | "FairCard_fair">;
+    } | null;
+    readonly " $refType": "ShowContextCard_show";
+};
+export type ShowContextCard_show$data = ShowContextCard_show;
+export type ShowContextCard_show$key = {
+    readonly " $data"?: ShowContextCard_show$data;
+    readonly " $fragmentRefs": FragmentRefs<"ShowContextCard_show">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ShowContextCard_show",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isFairBooth",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Fair",
+      "kind": "LinkedField",
+      "name": "fair",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "href",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "FairTiming_fair"
+        },
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "FairCard_fair"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Show"
+};
+(node as any).hash = 'ea85047a36b8c234f951d098a1f0218f';
+export default node;

--- a/src/v2/__generated__/routes_ShowQuery.graphql.ts
+++ b/src/v2/__generated__/routes_ShowQuery.graphql.ts
@@ -176,6 +176,24 @@ fragment Details_artwork on Artwork {
   }
 }
 
+fragment FairCard_fair on Fair {
+  name
+  image {
+    _1x: cropped(width: 768, height: 512, version: "wide") {
+      src: url
+    }
+    _2x: cropped(width: 1536, height: 1024, version: "wide") {
+      src: url
+    }
+  }
+}
+
+fragment FairTiming_fair on Fair {
+  exhibitionPeriod
+  startAt
+  endAt
+}
+
 fragment GridItem_artwork on Artwork {
   internalID
   title
@@ -241,12 +259,25 @@ fragment ShowApp_show_2jdisZ on Show {
   ...ShowMeta_show
   ...ShowInstallShots_show
   ...ShowArtworks_show_2jdisZ
+  isFairBooth
+  ...ShowContextCard_show
 }
 
 fragment ShowArtworks_show_2jdisZ on Show {
   filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: "", sort: $sort) {
     id
     ...ArtworkFilterArtworkGrid2_filtered_artworks
+  }
+}
+
+fragment ShowContextCard_show on Show {
+  isFairBooth
+  fair {
+    href
+    name
+    ...FairTiming_fair
+    ...FairCard_fair
+    id
   }
 }
 
@@ -531,24 +562,53 @@ v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "startAt",
+  "storageKey": null
+},
+v20 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v21 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "wide"
+},
+v22 = {
+  "alias": "src",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "url",
+  "storageKey": null
+},
+v23 = [
+  (v22/*: any*/)
+],
+v24 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v20 = [
+v25 = [
   {
     "kind": "Literal",
     "name": "version",
     "value": "large"
   }
 ],
-v21 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v22 = {
+v27 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -556,60 +616,50 @@ v22 = {
     "large"
   ]
 },
-v23 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "width",
   "storageKey": null
 },
-v24 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v25 = [
+v30 = [
   {
     "kind": "Literal",
     "name": "height",
     "value": 400
   },
-  (v22/*: any*/)
+  (v27/*: any*/)
 ],
-v26 = {
-  "alias": "src",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "url",
-  "storageKey": null
-},
-v27 = [
-  (v26/*: any*/),
-  (v23/*: any*/),
-  (v24/*: any*/)
+v31 = [
+  (v22/*: any*/),
+  (v28/*: any*/),
+  (v29/*: any*/)
 ],
-v28 = [
-  (v26/*: any*/)
-],
-v29 = {
+v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v30 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v31 = [
-  (v29/*: any*/),
-  (v30/*: any*/),
+v34 = [
+  (v32/*: any*/),
+  (v33/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -618,14 +668,14 @@ v31 = [
     "storageKey": null
   }
 ],
-v32 = [
+v35 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v33 = [
+v36 = [
   {
     "alias": null,
     "args": null,
@@ -715,7 +765,71 @@ return {
             "selections": [
               (v17/*: any*/),
               (v16/*: any*/),
-              (v18/*: any*/)
+              (v18/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "exhibitionPeriod",
+                "storageKey": null
+              },
+              (v19/*: any*/),
+              (v20/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "image",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": "_1x",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 512
+                      },
+                      (v21/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 768
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v23/*: any*/),
+                    "storageKey": "cropped(height:512,version:\"wide\",width:768)"
+                  },
+                  {
+                    "alias": "_2x",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 1024
+                      },
+                      (v21/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 1536
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v23/*: any*/),
+                    "storageKey": "cropped(height:1024,version:\"wide\",width:1536)"
+                  }
+                ],
+                "storageKey": null
+              }
             ],
             "storageKey": null
           },
@@ -760,20 +874,8 @@ return {
             ],
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "startAt",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "endAt",
-            "storageKey": null
-          },
+          (v19/*: any*/),
+          (v20/*: any*/),
           {
             "alias": "formattedStartAt",
             "args": [
@@ -800,7 +902,7 @@ return {
             "name": "endAt",
             "storageKey": "endAt(format:\"MMMM D, YYYY\")"
           },
-          (v19/*: any*/),
+          (v24/*: any*/),
           {
             "alias": "metaDescription",
             "args": null,
@@ -818,7 +920,7 @@ return {
             "selections": [
               {
                 "alias": "src",
-                "args": (v20/*: any*/),
+                "args": (v25/*: any*/),
                 "kind": "ScalarField",
                 "name": "url",
                 "storageKey": "url(version:\"large\")"
@@ -834,7 +936,7 @@ return {
             "name": "images",
             "plural": true,
             "selections": [
-              (v21/*: any*/),
+              (v26/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -850,36 +952,36 @@ return {
                     "name": "height",
                     "value": 300
                   },
-                  (v22/*: any*/)
+                  (v27/*: any*/)
                 ],
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
                 "selections": [
-                  (v23/*: any*/),
-                  (v24/*: any*/)
+                  (v28/*: any*/),
+                  (v29/*: any*/)
                 ],
                 "storageKey": "resized(height:300,version:[\"larger\",\"large\"])"
               },
               {
                 "alias": "_1x",
-                "args": (v25/*: any*/),
+                "args": (v30/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v27/*: any*/),
+                "selections": (v31/*: any*/),
                 "storageKey": "resized(height:400,version:[\"larger\",\"large\"])"
               },
               {
                 "alias": "_2x",
-                "args": (v25/*: any*/),
+                "args": (v30/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v28/*: any*/),
+                "selections": (v23/*: any*/),
                 "storageKey": "resized(height:400,version:[\"larger\",\"large\"])"
               },
               {
@@ -890,7 +992,7 @@ return {
                     "name": "height",
                     "value": 900
                   },
-                  (v22/*: any*/),
+                  (v27/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "width",
@@ -901,7 +1003,7 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v27/*: any*/),
+                "selections": (v31/*: any*/),
                 "storageKey": "resized(height:900,version:[\"larger\",\"large\"],width:900)"
               },
               {
@@ -912,7 +1014,7 @@ return {
                     "name": "height",
                     "value": 1800
                   },
-                  (v22/*: any*/),
+                  (v27/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "width",
@@ -923,7 +1025,7 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v28/*: any*/),
+                "selections": (v23/*: any*/),
                 "storageKey": "resized(height:1800,version:[\"larger\",\"large\"],width:1800)"
               }
             ],
@@ -1047,7 +1149,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v31/*: any*/),
+                    "selections": (v34/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1057,7 +1159,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v31/*: any*/),
+                    "selections": (v34/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1067,7 +1169,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v31/*: any*/),
+                    "selections": (v34/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1078,8 +1180,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v29/*: any*/),
-                      (v30/*: any*/)
+                      (v32/*: any*/),
+                      (v33/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1103,9 +1205,9 @@ return {
                     "plural": false,
                     "selections": [
                       (v18/*: any*/),
-                      (v19/*: any*/),
+                      (v24/*: any*/),
                       (v17/*: any*/),
-                      (v21/*: any*/),
+                      (v26/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1130,7 +1232,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v20/*: any*/),
+                            "args": (v25/*: any*/),
                             "kind": "ScalarField",
                             "name": "url",
                             "storageKey": "url(version:\"large\")"
@@ -1175,7 +1277,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v32/*: any*/),
+                        "args": (v35/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
@@ -1196,7 +1298,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v32/*: any*/),
+                        "args": (v35/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
@@ -1302,7 +1404,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v33/*: any*/),
+                            "selections": (v36/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1312,7 +1414,7 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v33/*: any*/),
+                            "selections": (v36/*: any*/),
                             "storageKey": null
                           },
                           (v18/*: any*/)
@@ -1361,7 +1463,7 @@ return {
     "metadata": {},
     "name": "routes_ShowQuery",
     "operationKind": "query",
-    "text": "query routes_ShowQuery(\n  $slug: String!\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MEDIUM, TOTAL, MAJOR_PERIOD]\n  $atAuction: Boolean\n  $color: String\n  $forSale: Boolean\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sizes: [ArtworkSizes]\n  $sort: String\n) {\n  show(id: $slug) {\n    ...ShowApp_show_2jdisZ\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show_2jdisZ on Show {\n  name\n  href\n  about: description\n  ...ShowContextualLink_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowArtworks_show_2jdisZ\n}\n\nfragment ShowArtworks_show_2jdisZ on Show {\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: \"\", sort: $sort) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images {\n    internalID\n    caption\n    mobile1x: resized(height: 300, version: [\"larger\", \"large\"]) {\n      width\n      height\n    }\n    _1x: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src: url\n      width\n      height\n    }\n    _2x: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src: url\n    }\n    zoom1x: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src: url\n      width\n      height\n    }\n    zoom2x: resized(width: 1800, height: 1800, version: [\"larger\", \"large\"]) {\n      src: url\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n"
+    "text": "query routes_ShowQuery(\n  $slug: String!\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MEDIUM, TOTAL, MAJOR_PERIOD]\n  $atAuction: Boolean\n  $color: String\n  $forSale: Boolean\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sizes: [ArtworkSizes]\n  $sort: String\n) {\n  show(id: $slug) {\n    ...ShowApp_show_2jdisZ\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    _1x: cropped(width: 768, height: 512, version: \"wide\") {\n      src: url\n    }\n    _2x: cropped(width: 1536, height: 1024, version: \"wide\") {\n      src: url\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show_2jdisZ on Show {\n  name\n  href\n  about: description\n  ...ShowContextualLink_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowArtworks_show_2jdisZ\n  isFairBooth\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworks_show_2jdisZ on Show {\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: \"\", sort: $sort) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images {\n    internalID\n    caption\n    mobile1x: resized(height: 300, version: [\"larger\", \"large\"]) {\n      width\n      height\n    }\n    _1x: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src: url\n      width\n      height\n    }\n    _2x: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src: url\n    }\n    zoom1x: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src: url\n      width\n      height\n    }\n    zoom2x: resized(width: 1800, height: 1800, version: [\"larger\", \"large\"]) {\n      src: url\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Looks like:

![Screen Shot 2020-10-12 at 5 36 56 PM](https://user-images.githubusercontent.com/1457859/95792462-8bda0d00-0cb1-11eb-8e3b-279a1276dd83.png)

This only implements the 'fair booth' version (ie- display info about and link back to the fair). Will follow up in a separate PR with the relevant info for the regular show version.