### PR TITLE
ShowPartnerEntityHeader follow button uses typesafe props

### DIFF
--- a/src/v2/Apps/Show/Components/ShowPartnerEntityHeader.tsx
+++ b/src/v2/Apps/Show/Components/ShowPartnerEntityHeader.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { ContextModule } from "@artsy/cohesion"
 import { createFragmentContainer, graphql } from "react-relay"
-import { Clickable, EntityHeader, Text } from "@artsy/palette"
+import { EntityHeader, Text } from "@artsy/palette"
 import { useSystemContext } from "v2/Artsy"
 import { filterLocations } from "v2/Apps/Artwork/Utils/filterLocations"
 import { limitWithCount } from "v2/Apps/Artwork/Utils/limitWithCount"
@@ -45,9 +45,14 @@ const ShowPartnerEntityHeader: React.FC<ShowPartnerEntityHeaderProps> = ({
             contextModule={ContextModule.partnerHeader}
             render={profile => {
               return (
-                <Clickable textDecoration="underline" data-test="followButton">
-                  <Text>{profile.is_followed ? "Following" : "Follow"}</Text>
-                </Clickable>
+                <Text
+                  style={{
+                    cursor: "pointer",
+                    textDecoration: "underline",
+                  }}
+                >
+                  {profile.is_followed ? "Following" : "Follow"}
+                </Text>
               )
             }}
           />

--- a/src/v2/Apps/Show/Components/ShowPartnerEntityHeader.tsx
+++ b/src/v2/Apps/Show/Components/ShowPartnerEntityHeader.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { ContextModule, Intent } from "@artsy/cohesion"
+import { ContextModule } from "@artsy/cohesion"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Clickable, EntityHeader, Text } from "@artsy/palette"
 import { useSystemContext } from "v2/Artsy"
@@ -7,7 +7,6 @@ import { filterLocations } from "v2/Apps/Artwork/Utils/filterLocations"
 import { limitWithCount } from "v2/Apps/Artwork/Utils/limitWithCount"
 import { FollowProfileButtonFragmentContainer as FollowProfileButton } from "v2/Components/FollowButton/FollowProfileButton"
 import { ShowPartnerEntityHeader_partner } from "v2/__generated__/ShowPartnerEntityHeader_partner.graphql"
-import { openAuthToFollowSave } from "v2/Utils/openAuthModal"
 
 interface ShowPartnerEntityHeaderProps {
   partner: ShowPartnerEntityHeader_partner
@@ -16,7 +15,7 @@ interface ShowPartnerEntityHeaderProps {
 const ShowPartnerEntityHeader: React.FC<ShowPartnerEntityHeaderProps> = ({
   partner,
 }) => {
-  const { user, mediator } = useSystemContext()
+  const { user } = useSystemContext()
 
   if (!partner) {
     return null
@@ -31,14 +30,6 @@ const ShowPartnerEntityHeader: React.FC<ShowPartnerEntityHeaderProps> = ({
     2
   ).join(", ")
 
-  const handleOpenAuthModal = () => {
-    openAuthToFollowSave(mediator, {
-      intent: Intent.followPartner,
-      entity: { slug: partner.slug, name: partner.name },
-      contextModule: ContextModule.partnerHeader, // ?
-    })
-  }
-
   return (
     <EntityHeader
       name={partner.name}
@@ -51,7 +42,7 @@ const ShowPartnerEntityHeader: React.FC<ShowPartnerEntityHeaderProps> = ({
           <FollowProfileButton
             user={user}
             profile={partner.profile}
-            onOpenAuthModal={handleOpenAuthModal}
+            contextModule={ContextModule.partnerHeader}
             render={profile => {
               return (
                 <Clickable textDecoration="underline" data-test="followButton">

--- a/src/v2/Apps/Show/ShowApp.tsx
+++ b/src/v2/Apps/Show/ShowApp.tsx
@@ -16,6 +16,8 @@ import { ShowApp_show } from "v2/__generated__/ShowApp_show.graphql"
 import { ShowArtworksRefetchContainer as ShowArtworks } from "./Components/ShowArtworks"
 import { ForwardLink } from "v2/Components/Links/ForwardLink"
 import { ShowContextCardFragmentContainer as ShowContextCard } from "./Components/ShowContextCard"
+import { AnalyticsContext } from "v2/Artsy/Analytics/AnalyticsContext"
+import { OwnerType } from "@artsy/cohesion"
 
 interface ShowAppProps {
   show: ShowApp_show
@@ -44,58 +46,69 @@ export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
       <ShowMeta show={show} />
 
       <AppContainer>
-        <HorizontalPadding>
-          <Box my={2}>
-            <ShowContextualLink show={show} />
-            <FullScreenSeparator as="hr" my={2} />
-          </Box>
+        <AnalyticsContext.Provider
+          value={{
+            contextPageOwnerId: show.internalID,
+            contextPageOwnerSlug: show.slug,
+            contextPageOwnerType: OwnerType.show,
+          }}
+        >
+          <HorizontalPadding>
+            <Box my={2}>
+              <ShowContextualLink show={show} />
+              <FullScreenSeparator as="hr" my={2} />
+            </Box>
 
-          <ShowInstallShots show={show} my={2} />
+            <ShowInstallShots show={show} my={2} />
 
-          <GridColumns>
-            <Column span={hasWideHeader ? [12, 8, 6] : 6} wrap={hasWideHeader}>
-              <ShowHeader show={show} />
+            <GridColumns>
+              <Column
+                span={hasWideHeader ? [12, 8, 6] : 6}
+                wrap={hasWideHeader}
+              >
+                <ShowHeader show={show} />
 
-              {!hasAbout && (
-                <ForwardLink
-                  to={`${show.href.replace("/show", "/show2")}/info`}
-                  mt={1}
-                >
-                  More info
-                </ForwardLink>
+                {!hasAbout && (
+                  <ForwardLink
+                    to={`${show.href.replace("/show", "/show2")}/info`}
+                    mt={1}
+                  >
+                    More info
+                  </ForwardLink>
+                )}
+              </Column>
+
+              {hasAbout && (
+                <Column span={6}>
+                  <ShowAbout show={show} />
+
+                  <ForwardLink
+                    to={`${show.href.replace("/show", "/show2")}/info`}
+                    mt={2}
+                  >
+                    More info
+                  </ForwardLink>
+                </Column>
               )}
-            </Column>
 
-            {hasAbout && (
-              <Column span={6}>
-                <ShowAbout show={show} />
+              {hasViewingRoom && (
+                <Column span={5} start={8}>
+                  <ShowViewingRoom />
+                </Column>
+              )}
+            </GridColumns>
 
-                <ForwardLink
-                  to={`${show.href.replace("/show", "/show2")}/info`}
-                  mt={2}
-                >
-                  More info
-                </ForwardLink>
-              </Column>
-            )}
+            <ShowArtworks show={show} my={3} />
 
-            {hasViewingRoom && (
-              <Column span={5} start={8}>
-                <ShowViewingRoom />
-              </Column>
-            )}
-          </GridColumns>
+            <Separator as="hr" my={3} />
 
-          <ShowArtworks show={show} my={3} />
+            <ShowContextCard show={show} />
 
-          <Separator as="hr" my={3} />
+            <Separator as="hr" my={3} />
 
-          <ShowContextCard show={show} />
-
-          <Separator as="hr" my={3} />
-
-          <Footer />
-        </HorizontalPadding>
+            <Footer />
+          </HorizontalPadding>
+        </AnalyticsContext.Provider>
       </AppContainer>
     </>
   )
@@ -123,6 +136,8 @@ export default createFragmentContainer(ShowApp, {
       ) {
       name
       href
+      internalID
+      slug
       about: description
       ...ShowContextualLink_show
       ...ShowHeader_show

--- a/src/v2/Apps/Show/ShowSubApp.tsx
+++ b/src/v2/Apps/Show/ShowSubApp.tsx
@@ -8,6 +8,8 @@ import { Footer } from "v2/Components/Footer"
 import { ErrorPage } from "v2/Components/ErrorPage"
 import { BackLink } from "v2/Components/Links/BackLink"
 import { ShowMetaFragmentContainer as ShowMeta } from "./Components/ShowMeta"
+import { AnalyticsContext } from "v2/Artsy/Analytics/AnalyticsContext"
+import { OwnerType } from "@artsy/cohesion"
 
 interface ShowAppProps {
   show: ShowSubApp_show
@@ -21,18 +23,26 @@ const ShowApp: React.FC<ShowAppProps> = ({ children, show }) => {
       <ShowMeta show={show} />
 
       <AppContainer>
-        <HorizontalPadding>
-          <BackLink my={3} to={show.href.replace("/show", "/show2")}>
-            Back to {show.name}
-            {show.partner?.name && <> at {show.partner.name}</>}
-          </BackLink>
+        <AnalyticsContext.Provider
+          value={{
+            contextPageOwnerId: show.internalID,
+            contextPageOwnerSlug: show.slug,
+            contextPageOwnerType: OwnerType.show,
+          }}
+        >
+          <HorizontalPadding>
+            <BackLink my={3} to={show.href.replace("/show", "/show2")}>
+              Back to {show.name}
+              {show.partner?.name && <> at {show.partner.name}</>}
+            </BackLink>
 
-          {children}
+            {children}
 
-          <Separator as="hr" my={3} />
+            <Separator as="hr" my={3} />
 
-          <Footer />
-        </HorizontalPadding>
+            <Footer />
+          </HorizontalPadding>
+        </AnalyticsContext.Provider>
       </AppContainer>
     </>
   )
@@ -43,6 +53,8 @@ export default createFragmentContainer(ShowApp, {
   show: graphql`
     fragment ShowSubApp_show on Show {
       id
+      internalID
+      slug
       name
       href
       partner {

--- a/src/v2/Components/FollowButton/FollowProfileButton.tsx
+++ b/src/v2/Components/FollowButton/FollowProfileButton.tsx
@@ -124,7 +124,9 @@ export class FollowProfileButton extends React.Component<Props> {
     // Custom button renderer
     if (render) {
       return (
-        <Clickable onClick={this.handleFollow}>{render(profile)}</Clickable>
+        <Clickable onClick={this.handleFollow} data-test="followButton">
+          {render(profile)}
+        </Clickable>
       )
     } else {
       return (

--- a/src/v2/__generated__/ShowApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ShowApp_Test_Query.graphql.ts
@@ -218,6 +218,8 @@ fragment ShowAbout_show on Show {
 fragment ShowApp_show on Show {
   name
   href
+  internalID
+  slug
   about: description
   ...ShowContextualLink_show
   ...ShowHeader_show
@@ -381,59 +383,59 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "internalID",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "startAt",
+  "name": "slug",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "endAt",
+  "name": "id",
   "storageKey": null
 },
 v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "startAt",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v8 = {
   "kind": "Literal",
   "name": "version",
   "value": "wide"
 },
-v7 = {
+v9 = {
   "alias": "src",
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v8 = [
-  (v7/*: any*/)
-],
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
 v10 = [
+  (v9/*: any*/)
+],
+v11 = [
   {
     "kind": "Literal",
     "name": "version",
     "value": "large"
   }
 ],
-v11 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
 v12 = {
   "kind": "Literal",
   "name": "version",
@@ -465,7 +467,7 @@ v15 = [
   (v12/*: any*/)
 ],
 v16 = [
-  (v7/*: any*/),
+  (v9/*: any*/),
   (v13/*: any*/),
   (v14/*: any*/)
 ],
@@ -552,6 +554,8 @@ return {
         "selections": [
           (v1/*: any*/),
           (v2/*: any*/),
+          (v3/*: any*/),
+          (v4/*: any*/),
           {
             "alias": "about",
             "args": null,
@@ -576,7 +580,7 @@ return {
             "selections": [
               (v2/*: any*/),
               (v1/*: any*/),
-              (v3/*: any*/),
+              (v5/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -584,8 +588,8 @@ return {
                 "name": "exhibitionPeriod",
                 "storageKey": null
               },
-              (v4/*: any*/),
-              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -602,7 +606,7 @@ return {
                         "name": "height",
                         "value": 512
                       },
-                      (v6/*: any*/),
+                      (v8/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
@@ -613,7 +617,7 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v8/*: any*/),
+                    "selections": (v10/*: any*/),
                     "storageKey": "cropped(height:512,version:\"wide\",width:768)"
                   },
                   {
@@ -624,7 +628,7 @@ return {
                         "name": "height",
                         "value": 1024
                       },
-                      (v6/*: any*/),
+                      (v8/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
@@ -635,7 +639,7 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v8/*: any*/),
+                    "selections": (v10/*: any*/),
                     "storageKey": "cropped(height:1024,version:\"wide\",width:1536)"
                   }
                 ],
@@ -659,7 +663,7 @@ return {
                 "name": "__typename",
                 "storageKey": null
               },
-              (v3/*: any*/),
+              (v5/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -687,7 +691,7 @@ return {
                         "name": "city",
                         "storageKey": null
                       },
-                      (v3/*: any*/)
+                      (v5/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -750,7 +754,7 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v3/*: any*/)
+                              (v5/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -773,8 +777,8 @@ return {
             ],
             "storageKey": null
           },
-          (v4/*: any*/),
-          (v5/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
           {
             "alias": "formattedStartAt",
             "args": [
@@ -801,7 +805,6 @@ return {
             "name": "endAt",
             "storageKey": "endAt(format:\"MMMM D, YYYY\")"
           },
-          (v9/*: any*/),
           {
             "alias": "metaDescription",
             "args": null,
@@ -819,7 +822,7 @@ return {
             "selections": [
               {
                 "alias": "src",
-                "args": (v10/*: any*/),
+                "args": (v11/*: any*/),
                 "kind": "ScalarField",
                 "name": "url",
                 "storageKey": "url(version:\"large\")"
@@ -835,7 +838,7 @@ return {
             "name": "images",
             "plural": true,
             "selections": [
-              (v11/*: any*/),
+              (v3/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -880,7 +883,7 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v8/*: any*/),
+                "selections": (v10/*: any*/),
                 "storageKey": "resized(height:400,version:[\"larger\",\"large\"])"
               },
               {
@@ -924,7 +927,7 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v8/*: any*/),
+                "selections": (v10/*: any*/),
                 "storageKey": "resized(height:1800,version:[\"larger\",\"large\"],width:1800)"
               }
             ],
@@ -959,7 +962,7 @@ return {
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              (v3/*: any*/),
+              (v5/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1099,10 +1102,10 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
-                      (v9/*: any*/),
+                      (v5/*: any*/),
+                      (v4/*: any*/),
                       (v2/*: any*/),
-                      (v11/*: any*/),
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1127,7 +1130,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v10/*: any*/),
+                            "args": (v11/*: any*/),
                             "kind": "ScalarField",
                             "name": "url",
                             "storageKey": "url(version:\"large\")"
@@ -1178,7 +1181,7 @@ return {
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v3/*: any*/),
+                          (v5/*: any*/),
                           (v2/*: any*/),
                           (v1/*: any*/)
                         ],
@@ -1201,7 +1204,7 @@ return {
                         "selections": [
                           (v1/*: any*/),
                           (v2/*: any*/),
-                          (v3/*: any*/),
+                          (v5/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1234,7 +1237,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v3/*: any*/),
+                          (v5/*: any*/),
                           {
                             "alias": "is_live_open",
                             "args": null,
@@ -1312,7 +1315,7 @@ return {
                             "selections": (v21/*: any*/),
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v5/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -1340,14 +1343,14 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v3/*: any*/)
+                  (v5/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": "filterArtworksConnection(after:\"\",first:20,medium:\"*\",sort:\"-decayed_merch\")"
           },
-          (v3/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": "show(id:\"xxx\")"
       }
@@ -1358,7 +1361,7 @@ return {
     "metadata": {},
     "name": "ShowApp_Test_Query",
     "operationKind": "query",
-    "text": "query ShowApp_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    _1x: cropped(width: 768, height: 512, version: \"wide\") {\n      src: url\n    }\n    _2x: cropped(width: 1536, height: 1024, version: \"wide\") {\n      src: url\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show on Show {\n  name\n  href\n  about: description\n  ...ShowContextualLink_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowArtworks_show_oju7O\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworks_show_oju7O on Show {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-decayed_merch\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images {\n    internalID\n    caption\n    mobile1x: resized(height: 300, version: [\"larger\", \"large\"]) {\n      width\n      height\n    }\n    _1x: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src: url\n      width\n      height\n    }\n    _2x: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src: url\n    }\n    zoom1x: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src: url\n      width\n      height\n    }\n    zoom2x: resized(width: 1800, height: 1800, version: [\"larger\", \"large\"]) {\n      src: url\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n"
+    "text": "query ShowApp_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    _1x: cropped(width: 768, height: 512, version: \"wide\") {\n      src: url\n    }\n    _2x: cropped(width: 1536, height: 1024, version: \"wide\") {\n      src: url\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  ...ShowContextualLink_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowArtworks_show_oju7O\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworks_show_oju7O on Show {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-decayed_merch\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images {\n    internalID\n    caption\n    mobile1x: resized(height: 300, version: [\"larger\", \"large\"]) {\n      width\n      height\n    }\n    _1x: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src: url\n      width\n      height\n    }\n    _2x: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src: url\n    }\n    zoom1x: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src: url\n      width\n      height\n    }\n    zoom2x: resized(width: 1800, height: 1800, version: [\"larger\", \"large\"]) {\n      src: url\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/ShowApp_show.graphql.ts
+++ b/src/v2/__generated__/ShowApp_show.graphql.ts
@@ -6,6 +6,8 @@ import { FragmentRefs } from "relay-runtime";
 export type ShowApp_show = {
     readonly name: string | null;
     readonly href: string | null;
+    readonly internalID: string;
+    readonly slug: string;
     readonly about: string | null;
     readonly " $fragmentRefs": FragmentRefs<"ShowContextualLink_show" | "ShowHeader_show" | "ShowAbout_show" | "ShowMeta_show" | "ShowInstallShots_show" | "ShowArtworks_show" | "ShowContextCard_show">;
     readonly " $refType": "ShowApp_show";
@@ -124,6 +126,20 @@ const node: ReaderFragment = {
       "storageKey": null
     },
     {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
+    {
       "alias": "about",
       "args": null,
       "kind": "ScalarField",
@@ -239,5 +255,5 @@ const node: ReaderFragment = {
   ],
   "type": "Show"
 };
-(node as any).hash = '44a6eda6f952169cc33f678f11431002';
+(node as any).hash = '63efbbcfebe108fa0b87c36f3c08ce5b';
 export default node;

--- a/src/v2/__generated__/ShowInfo_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ShowInfo_Test_Query.graphql.ts
@@ -26,6 +26,8 @@ query ShowInfo_Test_Query {
 
 fragment FollowProfileButton_profile on Profile {
   id
+  slug
+  name
   internalID
   is_followed: isFollowed
 }
@@ -159,6 +161,13 @@ v8 = {
   "args": null,
   "kind": "ScalarField",
   "name": "name",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
   "storageKey": null
 };
 return {
@@ -310,13 +319,7 @@ return {
                     "name": "type",
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "slug",
-                    "storageKey": null
-                  },
+                  (v9/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -361,6 +364,8 @@ return {
                     "plural": false,
                     "selections": [
                       (v7/*: any*/),
+                      (v9/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -419,7 +424,7 @@ return {
     "metadata": {},
     "name": "ShowInfo_Test_Query",
     "operationKind": "query",
-    "text": "query ShowInfo_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowInfo_show\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  internalID\n  is_followed: isFollowed\n}\n\nfragment ShowInfoLocation_show on Show {\n  fair {\n    location {\n      address\n      address2\n      city\n      state\n      country\n      summary\n      id\n    }\n    id\n  }\n  location {\n    display\n    address\n    address2\n    city\n    state\n    country\n    summary\n    id\n  }\n}\n\nfragment ShowInfo_show on Show {\n  ...ShowInfoLocation_show\n  name\n  about: description\n  pressRelease(format: HTML)\n  hasLocation\n  partner {\n    __typename\n    ... on Partner {\n      ...ShowPartnerEntityHeader_partner\n      type\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowPartnerEntityHeader_partner on Partner {\n  type\n  slug\n  href\n  name\n  initials\n  locations {\n    city\n    id\n  }\n  isDefaultProfilePublic\n  profile {\n    ...FollowProfileButton_profile\n    icon {\n      url(version: \"square140\")\n    }\n    id\n  }\n}\n"
+    "text": "query ShowInfo_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowInfo_show\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment ShowInfoLocation_show on Show {\n  fair {\n    location {\n      address\n      address2\n      city\n      state\n      country\n      summary\n      id\n    }\n    id\n  }\n  location {\n    display\n    address\n    address2\n    city\n    state\n    country\n    summary\n    id\n  }\n}\n\nfragment ShowInfo_show on Show {\n  ...ShowInfoLocation_show\n  name\n  about: description\n  pressRelease(format: HTML)\n  hasLocation\n  partner {\n    __typename\n    ... on Partner {\n      ...ShowPartnerEntityHeader_partner\n      type\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowPartnerEntityHeader_partner on Partner {\n  type\n  slug\n  href\n  name\n  initials\n  locations {\n    city\n    id\n  }\n  isDefaultProfilePublic\n  profile {\n    ...FollowProfileButton_profile\n    icon {\n      url(version: \"square140\")\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/ShowSubApp_show.graphql.ts
+++ b/src/v2/__generated__/ShowSubApp_show.graphql.ts
@@ -5,6 +5,8 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ShowSubApp_show = {
     readonly id: string;
+    readonly internalID: string;
+    readonly slug: string;
     readonly name: string | null;
     readonly href: string | null;
     readonly partner: {
@@ -45,6 +47,20 @@ return {
       "name": "id",
       "storageKey": null
     },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
     (v0/*: any*/),
     {
       "alias": null,
@@ -83,5 +99,5 @@ return {
   "type": "Show"
 };
 })();
-(node as any).hash = '54f298f8f04dbca856c6bad4e4041e8e';
+(node as any).hash = 'd249d36ed8cf73dc9f2331be62de2c15';
 export default node;

--- a/src/v2/__generated__/routes_ShowInfoQuery.graphql.ts
+++ b/src/v2/__generated__/routes_ShowInfoQuery.graphql.ts
@@ -30,6 +30,8 @@ query routes_ShowInfoQuery(
 
 fragment FollowProfileButton_profile on Profile {
   id
+  slug
+  name
   internalID
   is_followed: isFollowed
 }
@@ -171,6 +173,13 @@ v9 = {
   "args": null,
   "kind": "ScalarField",
   "name": "name",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
   "storageKey": null
 };
 return {
@@ -322,13 +331,7 @@ return {
                     "name": "type",
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "slug",
-                    "storageKey": null
-                  },
+                  (v10/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -373,6 +376,8 @@ return {
                     "plural": false,
                     "selections": [
                       (v8/*: any*/),
+                      (v10/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -431,7 +436,7 @@ return {
     "metadata": {},
     "name": "routes_ShowInfoQuery",
     "operationKind": "query",
-    "text": "query routes_ShowInfoQuery(\n  $slug: String!\n) {\n  show(id: $slug) {\n    ...ShowInfo_show\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  internalID\n  is_followed: isFollowed\n}\n\nfragment ShowInfoLocation_show on Show {\n  fair {\n    location {\n      address\n      address2\n      city\n      state\n      country\n      summary\n      id\n    }\n    id\n  }\n  location {\n    display\n    address\n    address2\n    city\n    state\n    country\n    summary\n    id\n  }\n}\n\nfragment ShowInfo_show on Show {\n  ...ShowInfoLocation_show\n  name\n  about: description\n  pressRelease(format: HTML)\n  hasLocation\n  partner {\n    __typename\n    ... on Partner {\n      ...ShowPartnerEntityHeader_partner\n      type\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowPartnerEntityHeader_partner on Partner {\n  type\n  slug\n  href\n  name\n  initials\n  locations {\n    city\n    id\n  }\n  isDefaultProfilePublic\n  profile {\n    ...FollowProfileButton_profile\n    icon {\n      url(version: \"square140\")\n    }\n    id\n  }\n}\n"
+    "text": "query routes_ShowInfoQuery(\n  $slug: String!\n) {\n  show(id: $slug) {\n    ...ShowInfo_show\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment ShowInfoLocation_show on Show {\n  fair {\n    location {\n      address\n      address2\n      city\n      state\n      country\n      summary\n      id\n    }\n    id\n  }\n  location {\n    display\n    address\n    address2\n    city\n    state\n    country\n    summary\n    id\n  }\n}\n\nfragment ShowInfo_show on Show {\n  ...ShowInfoLocation_show\n  name\n  about: description\n  pressRelease(format: HTML)\n  hasLocation\n  partner {\n    __typename\n    ... on Partner {\n      ...ShowPartnerEntityHeader_partner\n      type\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowPartnerEntityHeader_partner on Partner {\n  type\n  slug\n  href\n  name\n  initials\n  locations {\n    city\n    id\n  }\n  isDefaultProfilePublic\n  profile {\n    ...FollowProfileButton_profile\n    icon {\n      url(version: \"square140\")\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/routes_ShowQuery.graphql.ts
+++ b/src/v2/__generated__/routes_ShowQuery.graphql.ts
@@ -252,6 +252,8 @@ fragment ShowAbout_show on Show {
 fragment ShowApp_show_2jdisZ on Show {
   name
   href
+  internalID
+  slug
   about: description
   ...ShowContextualLink_show
   ...ShowHeader_show
@@ -581,59 +583,59 @@ v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "internalID",
   "storageKey": null
 },
 v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "startAt",
+  "name": "slug",
   "storageKey": null
 },
 v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "endAt",
+  "name": "id",
   "storageKey": null
 },
 v21 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "startAt",
+  "storageKey": null
+},
+v22 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v23 = {
   "kind": "Literal",
   "name": "version",
   "value": "wide"
 },
-v22 = {
+v24 = {
   "alias": "src",
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v23 = [
-  (v22/*: any*/)
-],
-v24 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
 v25 = [
+  (v24/*: any*/)
+],
+v26 = [
   {
     "kind": "Literal",
     "name": "version",
     "value": "large"
   }
 ],
-v26 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
 v27 = {
   "kind": "Literal",
   "name": "version",
@@ -665,7 +667,7 @@ v30 = [
   (v27/*: any*/)
 ],
 v31 = [
-  (v22/*: any*/),
+  (v24/*: any*/),
   (v28/*: any*/),
   (v29/*: any*/)
 ],
@@ -767,6 +769,8 @@ return {
         "selections": [
           (v16/*: any*/),
           (v17/*: any*/),
+          (v18/*: any*/),
+          (v19/*: any*/),
           {
             "alias": "about",
             "args": null,
@@ -791,7 +795,7 @@ return {
             "selections": [
               (v17/*: any*/),
               (v16/*: any*/),
-              (v18/*: any*/),
+              (v20/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -799,8 +803,8 @@ return {
                 "name": "exhibitionPeriod",
                 "storageKey": null
               },
-              (v19/*: any*/),
-              (v20/*: any*/),
+              (v21/*: any*/),
+              (v22/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -817,7 +821,7 @@ return {
                         "name": "height",
                         "value": 512
                       },
-                      (v21/*: any*/),
+                      (v23/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
@@ -828,7 +832,7 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v23/*: any*/),
+                    "selections": (v25/*: any*/),
                     "storageKey": "cropped(height:512,version:\"wide\",width:768)"
                   },
                   {
@@ -839,7 +843,7 @@ return {
                         "name": "height",
                         "value": 1024
                       },
-                      (v21/*: any*/),
+                      (v23/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
@@ -850,7 +854,7 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v23/*: any*/),
+                    "selections": (v25/*: any*/),
                     "storageKey": "cropped(height:1024,version:\"wide\",width:1536)"
                   }
                 ],
@@ -874,7 +878,7 @@ return {
                 "name": "__typename",
                 "storageKey": null
               },
-              (v18/*: any*/),
+              (v20/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -902,7 +906,7 @@ return {
                         "name": "city",
                         "storageKey": null
                       },
-                      (v18/*: any*/)
+                      (v20/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -965,7 +969,7 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v18/*: any*/)
+                              (v20/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -988,8 +992,8 @@ return {
             ],
             "storageKey": null
           },
-          (v19/*: any*/),
-          (v20/*: any*/),
+          (v21/*: any*/),
+          (v22/*: any*/),
           {
             "alias": "formattedStartAt",
             "args": [
@@ -1016,7 +1020,6 @@ return {
             "name": "endAt",
             "storageKey": "endAt(format:\"MMMM D, YYYY\")"
           },
-          (v24/*: any*/),
           {
             "alias": "metaDescription",
             "args": null,
@@ -1034,7 +1037,7 @@ return {
             "selections": [
               {
                 "alias": "src",
-                "args": (v25/*: any*/),
+                "args": (v26/*: any*/),
                 "kind": "ScalarField",
                 "name": "url",
                 "storageKey": "url(version:\"large\")"
@@ -1050,7 +1053,7 @@ return {
             "name": "images",
             "plural": true,
             "selections": [
-              (v26/*: any*/),
+              (v18/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1095,7 +1098,7 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v23/*: any*/),
+                "selections": (v25/*: any*/),
                 "storageKey": "resized(height:400,version:[\"larger\",\"large\"])"
               },
               {
@@ -1139,7 +1142,7 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v23/*: any*/),
+                "selections": (v25/*: any*/),
                 "storageKey": "resized(height:1800,version:[\"larger\",\"large\"],width:1800)"
               }
             ],
@@ -1178,7 +1181,7 @@ return {
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              (v18/*: any*/),
+              (v20/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1318,10 +1321,10 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v18/*: any*/),
-                      (v24/*: any*/),
+                      (v20/*: any*/),
+                      (v19/*: any*/),
                       (v17/*: any*/),
-                      (v26/*: any*/),
+                      (v18/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1346,7 +1349,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v25/*: any*/),
+                            "args": (v26/*: any*/),
                             "kind": "ScalarField",
                             "name": "url",
                             "storageKey": "url(version:\"large\")"
@@ -1397,7 +1400,7 @@ return {
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v18/*: any*/),
+                          (v20/*: any*/),
                           (v17/*: any*/),
                           (v16/*: any*/)
                         ],
@@ -1420,7 +1423,7 @@ return {
                         "selections": [
                           (v16/*: any*/),
                           (v17/*: any*/),
-                          (v18/*: any*/),
+                          (v20/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1453,7 +1456,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v18/*: any*/),
+                          (v20/*: any*/),
                           {
                             "alias": "is_live_open",
                             "args": null,
@@ -1531,7 +1534,7 @@ return {
                             "selections": (v36/*: any*/),
                             "storageKey": null
                           },
-                          (v18/*: any*/)
+                          (v20/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -1559,14 +1562,14 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v18/*: any*/)
+                  (v20/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": null
           },
-          (v18/*: any*/)
+          (v20/*: any*/)
         ],
         "storageKey": null
       }
@@ -1577,7 +1580,7 @@ return {
     "metadata": {},
     "name": "routes_ShowQuery",
     "operationKind": "query",
-    "text": "query routes_ShowQuery(\n  $slug: String!\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MEDIUM, TOTAL, MAJOR_PERIOD]\n  $atAuction: Boolean\n  $color: String\n  $forSale: Boolean\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sizes: [ArtworkSizes]\n  $sort: String\n) {\n  show(id: $slug) {\n    ...ShowApp_show_2jdisZ\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    _1x: cropped(width: 768, height: 512, version: \"wide\") {\n      src: url\n    }\n    _2x: cropped(width: 1536, height: 1024, version: \"wide\") {\n      src: url\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show_2jdisZ on Show {\n  name\n  href\n  about: description\n  ...ShowContextualLink_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowArtworks_show_2jdisZ\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworks_show_2jdisZ on Show {\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: \"\", sort: $sort) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images {\n    internalID\n    caption\n    mobile1x: resized(height: 300, version: [\"larger\", \"large\"]) {\n      width\n      height\n    }\n    _1x: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src: url\n      width\n      height\n    }\n    _2x: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src: url\n    }\n    zoom1x: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src: url\n      width\n      height\n    }\n    zoom2x: resized(width: 1800, height: 1800, version: [\"larger\", \"large\"]) {\n      src: url\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n"
+    "text": "query routes_ShowQuery(\n  $slug: String!\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MEDIUM, TOTAL, MAJOR_PERIOD]\n  $atAuction: Boolean\n  $color: String\n  $forSale: Boolean\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sizes: [ArtworkSizes]\n  $sort: String\n) {\n  show(id: $slug) {\n    ...ShowApp_show_2jdisZ\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    _1x: cropped(width: 768, height: 512, version: \"wide\") {\n      src: url\n    }\n    _2x: cropped(width: 1536, height: 1024, version: \"wide\") {\n      src: url\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show_2jdisZ on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  ...ShowContextualLink_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowArtworks_show_2jdisZ\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworks_show_2jdisZ on Show {\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: \"\", sort: $sort) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images {\n    internalID\n    caption\n    mobile1x: resized(height: 300, version: [\"larger\", \"large\"]) {\n      width\n      height\n    }\n    _1x: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src: url\n      width\n      height\n    }\n    _2x: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src: url\n    }\n    zoom1x: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src: url\n      width\n      height\n    }\n    zoom2x: resized(width: 1800, height: 1800, version: [\"larger\", \"large\"]) {\n      src: url\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/routes_ShowSubAppQuery.graphql.ts
+++ b/src/v2/__generated__/routes_ShowSubAppQuery.graphql.ts
@@ -39,6 +39,8 @@ fragment ShowMeta_show on Show {
 
 fragment ShowSubApp_show on Show {
   id
+  internalID
+  slug
   name
   href
   partner {
@@ -132,6 +134,20 @@ return {
         "plural": false,
         "selections": [
           (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
           (v3/*: any*/),
           {
             "alias": null,
@@ -167,13 +183,6 @@ return {
                 "type": "ExternalPartner"
               }
             ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "slug",
             "storageKey": null
           },
           {
@@ -217,7 +226,7 @@ return {
     "metadata": {},
     "name": "routes_ShowSubAppQuery",
     "operationKind": "query",
-    "text": "query routes_ShowSubAppQuery(\n  $slug: String!\n) {\n  show(id: $slug) {\n    ...ShowSubApp_show\n    id\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n\nfragment ShowSubApp_show on Show {\n  id\n  name\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  ...ShowMeta_show\n}\n"
+    "text": "query routes_ShowSubAppQuery(\n  $slug: String!\n) {\n  show(id: $slug) {\n    ...ShowSubApp_show\n    id\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n\nfragment ShowSubApp_show on Show {\n  id\n  internalID\n  slug\n  name\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  ...ShowMeta_show\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Follow up to #6388, update props for `ShowPartnerEntityHeader` to handle new proptypes
- remove deprecated prop `onOpenAuthModal`.
- remove extra `Clickable` (causes errors for nested buttons)
- adds analytics context to app 