### PR TITLE
chore: Jest Three Workers

### DIFF
--- a/scripts/jest.sh
+++ b/scripts/jest.sh
@@ -3,7 +3,7 @@
 set -ex
 
 if [ "$1" == "v1" ]; then
-  node --expose-gc --max_old_space_size=4096 ./node_modules/.bin/jest  --logHeapUsage --maxWorkers 2 --config jest.config.v1.js
+  node --expose-gc --max_old_space_size=4096 ./node_modules/.bin/jest  --logHeapUsage --maxWorkers 3 --config jest.config.v1.js
 elif [ "$1" == "v2" ]; then
-  node --expose-gc --max_old_space_size=4096 ./node_modules/.bin/jest  --logHeapUsage --maxWorkers 2 --config jest.config.v2.js
+  node --expose-gc --max_old_space_size=4096 ./node_modules/.bin/jest  --logHeapUsage --maxWorkers 3 --config jest.config.v2.js
 fi


### PR DESCRIPTION
Jest has been stable with two workers and the memory usage is lower now
that we are running tests directly from the build container instead of
using docker in docker from the hokusai image. So let's see how three
workers goes.

This change speeds up the jest v2 build step by about 1m 10s. In other
words: from 4m 30s to 3m 20s.