### PR TITLE
fix(FX-2324): Move scrollY to previous position after content change

### DIFF
--- a/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
+++ b/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
@@ -41,8 +41,17 @@ const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair, relay }) => {
 
     setIsLoading(true)
 
+    const previousScrollY = window.scrollY
+
     relay.loadMore(15, err => {
       setIsLoading(false)
+
+      if (window.scrollY > previousScrollY) {
+        window.scrollTo({
+          top: previousScrollY,
+          behavior: "auto",
+        })
+      }
 
       if (err) {
         console.error(err)


### PR DESCRIPTION
This doesn't seem to affect all browsers but, on some versions of Chrome, the position is lost after a visitor clicks "Load more" and content is placed above the current scroll position.

To avoid the loss of position when new content loads in, snap back to the previous position if we're below where we were due to content appearing above the current scroll position.

### Screen Recordings

**Before**

![Peek 2020-10-14 15-29](https://user-images.githubusercontent.com/123595/96036743-e6e73d80-0e32-11eb-8e1e-389952447ed7.gif)

**After**

![Peek 2020-10-14 15-45](https://user-images.githubusercontent.com/123595/96037802-4bef6300-0e34-11eb-88be-9ede3e93f0b4.gif)



