### PR TITLE
enhancement: Purchase history enhancements

### DIFF
--- a/src/v2/Apps/Purchase/Components/OrderRow.tsx
+++ b/src/v2/Apps/Purchase/Components/OrderRow.tsx
@@ -174,7 +174,7 @@ const OrderRow: React.FC<OrderRowProps> = props => {
               <Text variant="text" mx={1}>
                 &#8226;
               </Text>
-              <Link target="_blank" href={trackingURL}>
+              <Link target="_blank" rel="noopener noreferrer" href={trackingURL}>
                 <Text variant="text">Track order</Text>
               </Link>
             </>

--- a/src/v2/Apps/Purchase/Components/OrderRow.tsx
+++ b/src/v2/Apps/Purchase/Components/OrderRow.tsx
@@ -2,9 +2,11 @@ import {
   Avatar,
   BorderBox,
   Box,
+  Button,
   Flex,
   HelpIcon,
   Image,
+  Join,
   Link,
   Separator,
   Text,
@@ -61,9 +63,10 @@ const OrderRow: React.FC<OrderRowProps> = props => {
   const artworkURL = `/artwork/${artwork?.slug}`
   const artistURL = `/artist/${artwork?.artists?.[0]?.slug}`
   const partnerURL = `/${artwork?.partner?.slug}`
+  const trackingURL = `https://google.com/search?q=${trackingId}`
 
   const XSOrderRow = (
-    <Box px={2}>
+    <Flex px={2} flexDirection="column">
       <Flex
         py={1.5}
         flexDirection="row"
@@ -81,18 +84,9 @@ const OrderRow: React.FC<OrderRowProps> = props => {
         </Flex>
 
         <Flex flexDirection="column" justifyContent="center" width="100%">
-          {!orderIsInactive && (
-            <Link href={orderURL} underlineBehavior="hover">
-              <Text variant="text" letterSpacing="tight">
-                {artwork?.artist_names}
-              </Text>
-            </Link>
-          )}
-          {orderIsInactive && (
-            <Text variant="text" letterSpacing="tight">
-              {artwork?.artist_names}
-            </Text>
-          )}
+          <Text variant="text" letterSpacing="tight">
+            {artwork?.artist_names}
+          </Text>
           <Text variant="text" color="black60" letterSpacing="tight">
             {partnerName}
           </Text>
@@ -119,8 +113,37 @@ const OrderRow: React.FC<OrderRowProps> = props => {
           </Text>
         </Flex>
       </Flex>
-      {props.hasDivider && <Separator />}
-    </Box>
+      <Flex>
+        <Join separator={<Box ml={1} />}>
+          {!orderIsInactive && (
+            <Box flexGrow={1}>
+              <Button
+                width="100%"
+                onClick={() => {
+                  window.location.href = orderURL
+                }}
+                variant="secondaryGray"
+              >
+                View Order
+              </Button>
+            </Box>
+          )}
+          {trackingId && (
+            <Box flexGrow={1}>
+              <Button
+                width="100%"
+                onClick={() => {
+                  window.open(trackingURL)
+                }}
+              >
+                Track Order
+              </Button>
+            </Box>
+          )}
+        </Join>
+      </Flex>
+      {props.hasDivider && <Separator mt={2} />}
+    </Flex>
   )
 
   const SMOrderRow = (
@@ -151,7 +174,7 @@ const OrderRow: React.FC<OrderRowProps> = props => {
               <Text variant="text" mx={1}>
                 &#8226;
               </Text>
-              <Link href={`https://google.com?q=${trackingId}`}>
+              <Link target="_blank" href={trackingURL}>
                 <Text variant="text">Track order</Text>
               </Link>
             </>

--- a/src/v2/Apps/Purchase/Components/OrderRow.tsx
+++ b/src/v2/Apps/Purchase/Components/OrderRow.tsx
@@ -45,6 +45,9 @@ const OrderRow: React.FC<OrderRowProps> = props => {
   const partnerName = artwork?.partner?.name
   const creditCardNumber = creditCard?.lastDigits
   const fulfillment = requestedFulfillment?.__typename
+  const trackingId =
+    order?.lineItems?.edges?.[0]?.node?.fulfillments?.edges?.[0]?.node
+      ?.trackingId
 
   const isShip = fulfillment === "CommerceShip"
 
@@ -143,6 +146,16 @@ const OrderRow: React.FC<OrderRowProps> = props => {
           >
             {order.state.toLowerCase()}
           </Text>
+          {trackingId && (
+            <>
+              <Text variant="text" mx={1}>
+                &#8226;
+              </Text>
+              <Link href={`https://google.com?q=${trackingId}`}>
+                <Text variant="text">Track order</Text>
+              </Link>
+            </>
+          )}
         </Flex>
       </Flex>
       <Flex p={2} width="100%" alignItems="center">
@@ -287,6 +300,13 @@ export const OrderRowFragmentContainer = createFragmentContainer(
                 artist_names: artistNames
                 artists {
                   slug
+                }
+              }
+              fulfillments(first: 1) {
+                edges {
+                  node {
+                    trackingId
+                  }
                 }
               }
             }

--- a/src/v2/Apps/Purchase/Components/OrderRow.tsx
+++ b/src/v2/Apps/Purchase/Components/OrderRow.tsx
@@ -54,6 +54,11 @@ const OrderRow: React.FC<OrderRowProps> = props => {
     <Box width="50px" height="50px" backgroundColor="black10" />
   )
 
+  const orderURL = `/orders/${order.internalID}/status`
+  const artworkURL = `/artwork/${artwork?.slug}`
+  const artistURL = `/artist/${artwork?.artists?.[0]?.slug}`
+  const partnerURL = `/${artwork?.partner?.slug}`
+
   const XSOrderRow = (
     <Box px={2}>
       <Flex
@@ -74,10 +79,7 @@ const OrderRow: React.FC<OrderRowProps> = props => {
 
         <Flex flexDirection="column" justifyContent="center" width="100%">
           {!orderIsInactive && (
-            <Link
-              href={`/orders/${order.internalID}/status`}
-              underlineBehavior="hover"
-            >
+            <Link href={orderURL} underlineBehavior="hover">
               <Text variant="text" letterSpacing="tight">
                 {artwork?.artist_names}
               </Text>
@@ -89,7 +91,7 @@ const OrderRow: React.FC<OrderRowProps> = props => {
             </Text>
           )}
           <Text variant="text" color="black60" letterSpacing="tight">
-            {artwork?.partner?.name}
+            {partnerName}
           </Text>
           <Text variant="text" color="black60" letterSpacing="tight">
             {orderCreatedAt.toLocaleString(DateTime.DATE_SHORT)}
@@ -147,26 +149,24 @@ const OrderRow: React.FC<OrderRowProps> = props => {
         <Flex width="50%">
           {artworkImage}
           <Flex flexDirection="column" ml={1}>
-            {!orderIsInactive && (
-              <Link
-                href={`/orders/${order.internalID}/status`}
-                underlineBehavior="hover"
-              >
-                <Text variant="text">{artwork?.artist_names}</Text>
-              </Link>
-            )}
-            {orderIsInactive && (
+            <Link href={artistURL} underlineBehavior="hover">
               <Text variant="text">{artwork?.artist_names}</Text>
-            )}
-            <Text variant="text" color="black60">
-              {artwork?.title}
-            </Text>
+            </Link>
+            <Link href={artworkURL} underlineBehavior="hover">
+              <Text variant="text" color="black60">
+                {artwork?.title}
+              </Text>
+            </Link>
           </Flex>
         </Flex>
         <Flex width="50%">
           <Avatar size="xs" src={partnerImageUrl} initials={partnerInitials} />
           <Flex flexDirection="column" ml={1}>
-            <Text variant="text">{partnerName}</Text>
+            <Link href={partnerURL} underlineBehavior="hover">
+              <Text variant="text" color="black60" letterSpacing="tight">
+                {partnerName}
+              </Text>
+            </Link>{" "}
             <Text variant="text" color="black60">
               {artwork?.shippingOrigin &&
                 artwork?.shippingOrigin.replace(/, US/g, "")}
@@ -180,9 +180,18 @@ const OrderRow: React.FC<OrderRowProps> = props => {
       <Flex p={2}>
         <Flex flexDirection="column" width="25%">
           <Text variant="text">Order No.</Text>
-          <Text variant="text" color="black60">
-            {order.code}
-          </Text>
+          {!orderIsInactive && (
+            <Link href={orderURL} underlineBehavior="hover">
+              <Text variant="text" letterSpacing="tight">
+                {order.code}
+              </Text>
+            </Link>
+          )}
+          {orderIsInactive && (
+            <Text variant="text" letterSpacing="tight">
+              {order.code}
+            </Text>
+          )}
         </Flex>
         <Flex flexDirection="column" width="25%">
           <Text variant="text">Total</Text>
@@ -255,6 +264,7 @@ export const OrderRowFragmentContainer = createFragmentContainer(
           edges {
             node {
               artwork {
+                slug
                 date
                 image {
                   resized(width: 55) {
@@ -262,6 +272,7 @@ export const OrderRowFragmentContainer = createFragmentContainer(
                   }
                 }
                 partner {
+                  slug
                   initials
                   name
                   profile {
@@ -274,6 +285,9 @@ export const OrderRowFragmentContainer = createFragmentContainer(
                 internalID
                 title
                 artist_names: artistNames
+                artists {
+                  slug
+                }
               }
             }
           }

--- a/src/v2/Apps/Purchase/PurchaseApp.tsx
+++ b/src/v2/Apps/Purchase/PurchaseApp.tsx
@@ -1,11 +1,8 @@
 import { PurchaseApp_me } from "v2/__generated__/PurchaseApp_me.graphql"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
-import { SystemContext } from "v2/Artsy"
-import { ErrorPage } from "v2/Components/ErrorPage"
-import React, { useContext } from "react"
+import React from "react"
 import { Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
-import { userIsAdmin } from "v2/Utils/user"
 import { PurchaseHistoryFragmentContainer as PurchaseHistory } from "./Components/PurchaseHistory"
 import { Spacer } from "@artsy/palette"
 
@@ -15,20 +12,13 @@ export interface PurchaseAppProps {
 
 export const PurchaseApp = (props: any) => {
   const { me } = props
-  const { user } = useContext(SystemContext)
-  const isAdmin = userIsAdmin(user)
-  if (isAdmin) {
-    return (
-      <AppContainer>
-        <Title>My Orders | Artsy</Title>
-        <Spacer mt={2} />
-        <PurchaseHistory me={me} />
-      </AppContainer>
-    )
-  } else {
-    // not an admin
-    return <ErrorPage code={404} />
-  }
+  return (
+    <AppContainer>
+      <Title>My Orders | Artsy</Title>
+      <Spacer mt={2} />
+      <PurchaseHistory me={me} />
+    </AppContainer>
+  )
 }
 
 const PurchaseAppFragmentContainer = createFragmentContainer(PurchaseApp, {

--- a/src/v2/Apps/Purchase/__tests__/PurchaseApp.jest.tsx
+++ b/src/v2/Apps/Purchase/__tests__/PurchaseApp.jest.tsx
@@ -82,8 +82,8 @@ const render = (me: PurchaseAppTestQueryRawResponse["me"], user: User) =>
   })
 
 describe("Purchase app", () => {
-  describe("User with admin privilages", () => {
-    const userType = { type: "Admin" }
+  const userType = { type: "User" }
+  describe("A logged in use", () => {
     describe("having previous orders", () => {
       it("renders orders", async () => {
         // TODO: revisit mocking and remove `artist_names` alias from PurchseHistory
@@ -145,23 +145,6 @@ describe("Purchase app", () => {
         const btn = component.find("Button")
         expect(btn.length).toBe(0)
       })
-    })
-  })
-  describe("User without admin privileges", () => {
-    it("gives error", async () => {
-      const mockMe = {
-        id: "111",
-        name: "Moira Rose",
-        orders: { edges: [{ node: UntouchedBuyOrder }], pageInfo, pageCursors },
-      }
-      const component = await render(mockMe, { type: "regular-user" })
-      const text = component.text()
-      expect(text).not.toContain(
-        "PurchasesLisa BreslowGramercy Park South, 2016buypending"
-      )
-      expect(text).toContain(
-        "Sorry, the page you were looking for doesn’t exist at this URL."
-      )
     })
   })
 })

--- a/src/v2/Apps/Purchase/__tests__/PurchaseApp.jest.tsx
+++ b/src/v2/Apps/Purchase/__tests__/PurchaseApp.jest.tsx
@@ -99,7 +99,7 @@ describe("Purchase app", () => {
         const component = await render(mockMe, userType)
         const text = component.text()
         expect(text).toContain(
-          "Moira RoseSaves & FollowsCollector ProfileOrder HistoryBidsSettingsPayments Dec 19, 2019pendingLisa BreslowGramercy Park SouthA GalleryNew York, NYOrder No.abcdefgTotal$12,000"
+          "Moira RoseSaves & FollowsCollector ProfileOrder HistoryBidsSettingsPayments Dec 19, 2019pending•Track orderLisa BreslowGramercy Park SouthA Gallery New York, NYOrder No.abcdefgTotal$12,000Payment MethodN/AFulfillmentPickupMore infoNeed Help? Contact Us.1234...7Navigate left PrevNext Navigate right"
         )
       })
     })

--- a/src/v2/Apps/__tests__/Fixtures/Order.ts
+++ b/src/v2/Apps/__tests__/Fixtures/Order.ts
@@ -77,6 +77,7 @@ export const UntouchedOrder = {
               name: "A Gallery",
               id: "1234",
               initials: "AG",
+              slug: "a-g",
               profile: {
                 id: "12345",
                 icon: {

--- a/src/v2/Components/NavBar/Menus/MobileNavMenu/LoggedInLinks.tsx
+++ b/src/v2/Components/NavBar/Menus/MobileNavMenu/LoggedInLinks.tsx
@@ -20,6 +20,10 @@ export const LoggedInLinks: React.FC<
     title: "Account",
     links: [
       {
+        text: "Order history",
+        href: "/user/purchases",
+      },
+      {
         text: "Saves & Follows",
         href: "/user/saves",
       },

--- a/src/v2/Components/NavBar/Menus/UserMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/UserMenu.tsx
@@ -57,16 +57,14 @@ export const UserMenu: React.FC = () => {
         </>
       )}
 
-      {isAdmin && (
-        <MenuItem
-          variant="small"
-          aria-label="View your purchases"
-          href="/user/purchases"
-          onClick={trackClick}
-        >
-          <ReceiptIcon mr={1} aria-hidden="true" /> Order History
-        </MenuItem>
-      )}
+      <MenuItem
+        variant="small"
+        aria-label="View your purchases"
+        href="/user/purchases"
+        onClick={trackClick}
+      >
+        <ReceiptIcon mr={1} aria-hidden="true" /> Order History
+      </MenuItem>
 
       <MenuItem
         variant="small"

--- a/src/v2/Components/NavBar/Menus/__tests__/UserMenu.jest.tsx
+++ b/src/v2/Components/NavBar/Menus/__tests__/UserMenu.jest.tsx
@@ -26,6 +26,7 @@ describe("UserMenu", () => {
 
   // Label also includes SVG image title
   const defaultLinks = [
+    ["/user/purchases", "Pending Order History"],
     ["/user/saves", "Save Saves & Follows"],
     ["/profile/edit", "User Collector Profile"],
     ["/user/edit", "Settings Settings"],
@@ -59,11 +60,6 @@ describe("UserMenu", () => {
     it("shows admin button if admin", () => {
       const wrapper = getWrapper({ user: { type: "Admin" } })
       expect(wrapper.html()).toContain("Admin")
-    })
-
-    it("hides order history button if not admin", () => {
-      const wrapper = getWrapper({ user: { type: "NotAdmin" } })
-      expect(wrapper.html()).not.toContain("Order History")
     })
 
     it("shows order history button if admin", () => {

--- a/src/v2/Components/NavBar/__tests__/NavBarTracking.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBarTracking.jest.tsx
@@ -103,7 +103,7 @@ describe("NavBarTracking", () => {
       expect(trackEvent).toBeCalledWith({
         action_type: AnalyticsSchema.ActionType.Click,
         context_module: AnalyticsSchema.ContextModule.HeaderUserDropdown,
-        destination_path: "/user/saves",
+        destination_path: "/user/purchases",
       })
     })
   })

--- a/src/v2/__generated__/OrderRow_order.graphql.ts
+++ b/src/v2/__generated__/OrderRow_order.graphql.ts
@@ -54,6 +54,13 @@ export type OrderRow_order = {
                         readonly slug: string;
                     } | null> | null;
                 } | null;
+                readonly fulfillments: {
+                    readonly edges: ReadonlyArray<{
+                        readonly node: {
+                            readonly trackingId: string | null;
+                        } | null;
+                    } | null> | null;
+                } | null;
             } | null;
         } | null> | null;
     } | null;
@@ -351,6 +358,52 @@ return {
                     }
                   ],
                   "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "first",
+                      "value": 1
+                    }
+                  ],
+                  "concreteType": "CommerceFulfillmentConnection",
+                  "kind": "LinkedField",
+                  "name": "fulfillments",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "CommerceFulfillmentEdge",
+                      "kind": "LinkedField",
+                      "name": "edges",
+                      "plural": true,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "CommerceFulfillment",
+                          "kind": "LinkedField",
+                          "name": "node",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "trackingId",
+                              "storageKey": null
+                            }
+                          ],
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": "fulfillments(first:1)"
                 }
               ],
               "storageKey": null
@@ -365,5 +418,5 @@ return {
   "type": "CommerceOrder"
 };
 })();
-(node as any).hash = 'ba4ba2f29553a58567679cb06f07bac1';
+(node as any).hash = 'caf31ec76a2a0380704c38617ee2d129';
 export default node;

--- a/src/v2/__generated__/OrderRow_order.graphql.ts
+++ b/src/v2/__generated__/OrderRow_order.graphql.ts
@@ -29,6 +29,7 @@ export type OrderRow_order = {
         readonly edges: ReadonlyArray<{
             readonly node: {
                 readonly artwork: {
+                    readonly slug: string;
                     readonly date: string | null;
                     readonly image: {
                         readonly resized: {
@@ -36,6 +37,7 @@ export type OrderRow_order = {
                         } | null;
                     } | null;
                     readonly partner: {
+                        readonly slug: string;
                         readonly initials: string | null;
                         readonly name: string | null;
                         readonly profile: {
@@ -48,6 +50,9 @@ export type OrderRow_order = {
                     readonly internalID: string;
                     readonly title: string | null;
                     readonly artist_names: string | null;
+                    readonly artists: ReadonlyArray<{
+                        readonly slug: string;
+                    } | null> | null;
                 } | null;
             } | null;
         } | null> | null;
@@ -78,7 +83,14 @@ v1 = [
     "name": "__typename",
     "storageKey": null
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+};
 return {
   "argumentDefinitions": [],
   "kind": "Fragment",
@@ -199,6 +211,7 @@ return {
                   "name": "artwork",
                   "plural": false,
                   "selections": [
+                    (v2/*: any*/),
                     {
                       "alias": null,
                       "args": null,
@@ -249,6 +262,7 @@ return {
                       "name": "partner",
                       "plural": false,
                       "selections": [
+                        (v2/*: any*/),
                         {
                           "alias": null,
                           "args": null,
@@ -322,6 +336,18 @@ return {
                       "kind": "ScalarField",
                       "name": "artistNames",
                       "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "Artist",
+                      "kind": "LinkedField",
+                      "name": "artists",
+                      "plural": true,
+                      "selections": [
+                        (v2/*: any*/)
+                      ],
+                      "storageKey": null
                     }
                   ],
                   "storageKey": null
@@ -339,5 +365,5 @@ return {
   "type": "CommerceOrder"
 };
 })();
-(node as any).hash = '2114f408758d43e6e539f1dc1c6ab241';
+(node as any).hash = 'ba4ba2f29553a58567679cb06f07bac1';
 export default node;

--- a/src/v2/__generated__/PurchaseAppTestQuery.graphql.ts
+++ b/src/v2/__generated__/PurchaseAppTestQuery.graphql.ts
@@ -69,6 +69,14 @@ export type PurchaseAppTestQueryRawResponse = {
                                     }) | null> | null;
                                     readonly id: string | null;
                                 }) | null;
+                                readonly fulfillments: ({
+                                    readonly edges: ReadonlyArray<({
+                                        readonly node: ({
+                                            readonly trackingId: string | null;
+                                            readonly id: string | null;
+                                        }) | null;
+                                    }) | null> | null;
+                                }) | null;
                                 readonly id: string | null;
                             }) | null;
                         }) | null> | null;
@@ -177,6 +185,14 @@ fragment OrderRow_order on CommerceOrder {
             id
           }
           id
+        }
+        fulfillments(first: 1) {
+          edges {
+            node {
+              trackingId
+              id
+            }
+          }
         }
         id
       }
@@ -631,6 +647,53 @@ return {
                                     ],
                                     "storageKey": null
                                   },
+                                  {
+                                    "alias": null,
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "first",
+                                        "value": 1
+                                      }
+                                    ],
+                                    "concreteType": "CommerceFulfillmentConnection",
+                                    "kind": "LinkedField",
+                                    "name": "fulfillments",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "CommerceFulfillmentEdge",
+                                        "kind": "LinkedField",
+                                        "name": "edges",
+                                        "plural": true,
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "CommerceFulfillment",
+                                            "kind": "LinkedField",
+                                            "name": "node",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "trackingId",
+                                                "storageKey": null
+                                              },
+                                              (v4/*: any*/)
+                                            ],
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": "fulfillments(first:1)"
+                                  },
                                   (v4/*: any*/)
                                 ],
                                 "storageKey": null
@@ -752,7 +815,7 @@ return {
     "metadata": {},
     "name": "PurchaseAppTestQuery",
     "operationKind": "query",
-    "text": "query PurchaseAppTestQuery {\n  me {\n    ...PurchaseApp_me\n    id\n  }\n}\n\nfragment OrderRow_order on CommerceOrder {\n  internalID\n  code\n  state\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  creditCard {\n    lastDigits\n    id\n  }\n  buyerTotal\n  createdAt\n  itemsTotal\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          date\n          image {\n            resized(width: 55) {\n              url\n            }\n          }\n          partner {\n            slug\n            initials\n            name\n            profile {\n              icon {\n                url(version: \"square140\")\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          internalID\n          title\n          artist_names: artistNames\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PurchaseApp_me on Me {\n  ...PurchaseHistory_me\n}\n\nfragment PurchaseHistory_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED], first: 10) {\n    edges {\n      node {\n        __typename\n        code\n        ...OrderRow_order\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
+    "text": "query PurchaseAppTestQuery {\n  me {\n    ...PurchaseApp_me\n    id\n  }\n}\n\nfragment OrderRow_order on CommerceOrder {\n  internalID\n  code\n  state\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  creditCard {\n    lastDigits\n    id\n  }\n  buyerTotal\n  createdAt\n  itemsTotal\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          date\n          image {\n            resized(width: 55) {\n              url\n            }\n          }\n          partner {\n            slug\n            initials\n            name\n            profile {\n              icon {\n                url(version: \"square140\")\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          internalID\n          title\n          artist_names: artistNames\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PurchaseApp_me on Me {\n  ...PurchaseHistory_me\n}\n\nfragment PurchaseHistory_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED], first: 10) {\n    edges {\n      node {\n        __typename\n        code\n        ...OrderRow_order\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PurchaseAppTestQuery.graphql.ts
+++ b/src/v2/__generated__/PurchaseAppTestQuery.graphql.ts
@@ -40,6 +40,7 @@ export type PurchaseAppTestQueryRawResponse = {
                         readonly edges: ReadonlyArray<({
                             readonly node: ({
                                 readonly artwork: ({
+                                    readonly slug: string;
                                     readonly date: string | null;
                                     readonly image: ({
                                         readonly resized: ({
@@ -47,6 +48,7 @@ export type PurchaseAppTestQueryRawResponse = {
                                         }) | null;
                                     }) | null;
                                     readonly partner: ({
+                                        readonly slug: string;
                                         readonly initials: string | null;
                                         readonly name: string | null;
                                         readonly profile: ({
@@ -61,6 +63,10 @@ export type PurchaseAppTestQueryRawResponse = {
                                     readonly internalID: string;
                                     readonly title: string | null;
                                     readonly artist_names: string | null;
+                                    readonly artists: ReadonlyArray<({
+                                        readonly slug: string;
+                                        readonly id: string | null;
+                                    }) | null> | null;
                                     readonly id: string | null;
                                 }) | null;
                                 readonly id: string | null;
@@ -143,6 +149,7 @@ fragment OrderRow_order on CommerceOrder {
     edges {
       node {
         artwork {
+          slug
           date
           image {
             resized(width: 55) {
@@ -150,6 +157,7 @@ fragment OrderRow_order on CommerceOrder {
             }
           }
           partner {
+            slug
             initials
             name
             profile {
@@ -164,6 +172,10 @@ fragment OrderRow_order on CommerceOrder {
           internalID
           title
           artist_names: artistNames
+          artists {
+            slug
+            id
+          }
           id
         }
         id
@@ -251,7 +263,14 @@ v4 = {
   "name": "id",
   "storageKey": null
 },
-v5 = [
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v6 = [
   {
     "alias": null,
     "args": null,
@@ -473,6 +492,7 @@ return {
                                     "name": "artwork",
                                     "plural": false,
                                     "selections": [
+                                      (v5/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -523,6 +543,7 @@ return {
                                         "name": "partner",
                                         "plural": false,
                                         "selections": [
+                                          (v5/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -593,6 +614,19 @@ return {
                                         "name": "artistNames",
                                         "storageKey": null
                                       },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "Artist",
+                                        "kind": "LinkedField",
+                                        "name": "artists",
+                                        "plural": true,
+                                        "selections": [
+                                          (v5/*: any*/),
+                                          (v4/*: any*/)
+                                        ],
+                                        "storageKey": null
+                                      },
                                       (v4/*: any*/)
                                     ],
                                     "storageKey": null
@@ -629,7 +663,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v5/*: any*/),
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -639,7 +673,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -649,7 +683,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -659,7 +693,7 @@ return {
                     "kind": "LinkedField",
                     "name": "previous",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -718,7 +752,7 @@ return {
     "metadata": {},
     "name": "PurchaseAppTestQuery",
     "operationKind": "query",
-    "text": "query PurchaseAppTestQuery {\n  me {\n    ...PurchaseApp_me\n    id\n  }\n}\n\nfragment OrderRow_order on CommerceOrder {\n  internalID\n  code\n  state\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  creditCard {\n    lastDigits\n    id\n  }\n  buyerTotal\n  createdAt\n  itemsTotal\n  lineItems {\n    edges {\n      node {\n        artwork {\n          date\n          image {\n            resized(width: 55) {\n              url\n            }\n          }\n          partner {\n            initials\n            name\n            profile {\n              icon {\n                url(version: \"square140\")\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          internalID\n          title\n          artist_names: artistNames\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PurchaseApp_me on Me {\n  ...PurchaseHistory_me\n}\n\nfragment PurchaseHistory_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED], first: 10) {\n    edges {\n      node {\n        __typename\n        code\n        ...OrderRow_order\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
+    "text": "query PurchaseAppTestQuery {\n  me {\n    ...PurchaseApp_me\n    id\n  }\n}\n\nfragment OrderRow_order on CommerceOrder {\n  internalID\n  code\n  state\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  creditCard {\n    lastDigits\n    id\n  }\n  buyerTotal\n  createdAt\n  itemsTotal\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          date\n          image {\n            resized(width: 55) {\n              url\n            }\n          }\n          partner {\n            slug\n            initials\n            name\n            profile {\n              icon {\n                url(version: \"square140\")\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          internalID\n          title\n          artist_names: artistNames\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PurchaseApp_me on Me {\n  ...PurchaseHistory_me\n}\n\nfragment PurchaseHistory_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED], first: 10) {\n    edges {\n      node {\n        __typename\n        code\n        ...OrderRow_order\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PurchaseHistoryQuery.graphql.ts
+++ b/src/v2/__generated__/PurchaseHistoryQuery.graphql.ts
@@ -62,6 +62,7 @@ fragment OrderRow_order on CommerceOrder {
     edges {
       node {
         artwork {
+          slug
           date
           image {
             resized(width: 55) {
@@ -69,6 +70,7 @@ fragment OrderRow_order on CommerceOrder {
             }
           }
           partner {
+            slug
             initials
             name
             profile {
@@ -83,6 +85,10 @@ fragment OrderRow_order on CommerceOrder {
           internalID
           title
           artist_names: artistNames
+          artists {
+            slug
+            id
+          }
           id
         }
         id
@@ -225,7 +231,14 @@ v6 = {
   "name": "id",
   "storageKey": null
 },
-v7 = [
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v8 = [
   {
     "alias": null,
     "args": null,
@@ -430,6 +443,7 @@ return {
                                     "name": "artwork",
                                     "plural": false,
                                     "selections": [
+                                      (v7/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -480,6 +494,7 @@ return {
                                         "name": "partner",
                                         "plural": false,
                                         "selections": [
+                                          (v7/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -550,6 +565,19 @@ return {
                                         "name": "artistNames",
                                         "storageKey": null
                                       },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "Artist",
+                                        "kind": "LinkedField",
+                                        "name": "artists",
+                                        "plural": true,
+                                        "selections": [
+                                          (v7/*: any*/),
+                                          (v6/*: any*/)
+                                        ],
+                                        "storageKey": null
+                                      },
                                       (v6/*: any*/)
                                     ],
                                     "storageKey": null
@@ -586,7 +614,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v7/*: any*/),
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -596,7 +624,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v7/*: any*/),
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -606,7 +634,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v7/*: any*/),
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -616,7 +644,7 @@ return {
                     "kind": "LinkedField",
                     "name": "previous",
                     "plural": false,
-                    "selections": (v7/*: any*/),
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -675,7 +703,7 @@ return {
     "metadata": {},
     "name": "PurchaseHistoryQuery",
     "operationKind": "query",
-    "text": "query PurchaseHistoryQuery(\n  $states: [CommerceOrderStateEnum!]\n  $first: Int!\n  $last: Int\n  $after: String\n  $before: String\n) {\n  me {\n    ...PurchaseHistory_me_2dCEyL\n    id\n  }\n}\n\nfragment OrderRow_order on CommerceOrder {\n  internalID\n  code\n  state\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  creditCard {\n    lastDigits\n    id\n  }\n  buyerTotal\n  createdAt\n  itemsTotal\n  lineItems {\n    edges {\n      node {\n        artwork {\n          date\n          image {\n            resized(width: 55) {\n              url\n            }\n          }\n          partner {\n            initials\n            name\n            profile {\n              icon {\n                url(version: \"square140\")\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          internalID\n          title\n          artist_names: artistNames\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PurchaseHistory_me_2dCEyL on Me {\n  name\n  orders(states: $states, first: $first, last: $last, before: $before, after: $after) {\n    edges {\n      node {\n        __typename\n        code\n        ...OrderRow_order\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
+    "text": "query PurchaseHistoryQuery(\n  $states: [CommerceOrderStateEnum!]\n  $first: Int!\n  $last: Int\n  $after: String\n  $before: String\n) {\n  me {\n    ...PurchaseHistory_me_2dCEyL\n    id\n  }\n}\n\nfragment OrderRow_order on CommerceOrder {\n  internalID\n  code\n  state\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  creditCard {\n    lastDigits\n    id\n  }\n  buyerTotal\n  createdAt\n  itemsTotal\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          date\n          image {\n            resized(width: 55) {\n              url\n            }\n          }\n          partner {\n            slug\n            initials\n            name\n            profile {\n              icon {\n                url(version: \"square140\")\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          internalID\n          title\n          artist_names: artistNames\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PurchaseHistory_me_2dCEyL on Me {\n  name\n  orders(states: $states, first: $first, last: $last, before: $before, after: $after) {\n    edges {\n      node {\n        __typename\n        code\n        ...OrderRow_order\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PurchaseHistoryQuery.graphql.ts
+++ b/src/v2/__generated__/PurchaseHistoryQuery.graphql.ts
@@ -91,6 +91,14 @@ fragment OrderRow_order on CommerceOrder {
           }
           id
         }
+        fulfillments(first: 1) {
+          edges {
+            node {
+              trackingId
+              id
+            }
+          }
+        }
         id
       }
     }
@@ -582,6 +590,53 @@ return {
                                     ],
                                     "storageKey": null
                                   },
+                                  {
+                                    "alias": null,
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "first",
+                                        "value": 1
+                                      }
+                                    ],
+                                    "concreteType": "CommerceFulfillmentConnection",
+                                    "kind": "LinkedField",
+                                    "name": "fulfillments",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "CommerceFulfillmentEdge",
+                                        "kind": "LinkedField",
+                                        "name": "edges",
+                                        "plural": true,
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "CommerceFulfillment",
+                                            "kind": "LinkedField",
+                                            "name": "node",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "trackingId",
+                                                "storageKey": null
+                                              },
+                                              (v6/*: any*/)
+                                            ],
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": "fulfillments(first:1)"
+                                  },
                                   (v6/*: any*/)
                                 ],
                                 "storageKey": null
@@ -703,7 +758,7 @@ return {
     "metadata": {},
     "name": "PurchaseHistoryQuery",
     "operationKind": "query",
-    "text": "query PurchaseHistoryQuery(\n  $states: [CommerceOrderStateEnum!]\n  $first: Int!\n  $last: Int\n  $after: String\n  $before: String\n) {\n  me {\n    ...PurchaseHistory_me_2dCEyL\n    id\n  }\n}\n\nfragment OrderRow_order on CommerceOrder {\n  internalID\n  code\n  state\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  creditCard {\n    lastDigits\n    id\n  }\n  buyerTotal\n  createdAt\n  itemsTotal\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          date\n          image {\n            resized(width: 55) {\n              url\n            }\n          }\n          partner {\n            slug\n            initials\n            name\n            profile {\n              icon {\n                url(version: \"square140\")\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          internalID\n          title\n          artist_names: artistNames\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PurchaseHistory_me_2dCEyL on Me {\n  name\n  orders(states: $states, first: $first, last: $last, before: $before, after: $after) {\n    edges {\n      node {\n        __typename\n        code\n        ...OrderRow_order\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
+    "text": "query PurchaseHistoryQuery(\n  $states: [CommerceOrderStateEnum!]\n  $first: Int!\n  $last: Int\n  $after: String\n  $before: String\n) {\n  me {\n    ...PurchaseHistory_me_2dCEyL\n    id\n  }\n}\n\nfragment OrderRow_order on CommerceOrder {\n  internalID\n  code\n  state\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  creditCard {\n    lastDigits\n    id\n  }\n  buyerTotal\n  createdAt\n  itemsTotal\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          date\n          image {\n            resized(width: 55) {\n              url\n            }\n          }\n          partner {\n            slug\n            initials\n            name\n            profile {\n              icon {\n                url(version: \"square140\")\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          internalID\n          title\n          artist_names: artistNames\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PurchaseHistory_me_2dCEyL on Me {\n  name\n  orders(states: $states, first: $first, last: $last, before: $before, after: $after) {\n    edges {\n      node {\n        __typename\n        code\n        ...OrderRow_order\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/routes_PurchaseQuery.graphql.ts
+++ b/src/v2/__generated__/routes_PurchaseQuery.graphql.ts
@@ -78,6 +78,14 @@ fragment OrderRow_order on CommerceOrder {
           }
           id
         }
+        fulfillments(first: 1) {
+          edges {
+            node {
+              trackingId
+              id
+            }
+          }
+        }
         id
       }
     }
@@ -531,6 +539,53 @@ return {
                                     ],
                                     "storageKey": null
                                   },
+                                  {
+                                    "alias": null,
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "first",
+                                        "value": 1
+                                      }
+                                    ],
+                                    "concreteType": "CommerceFulfillmentConnection",
+                                    "kind": "LinkedField",
+                                    "name": "fulfillments",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "CommerceFulfillmentEdge",
+                                        "kind": "LinkedField",
+                                        "name": "edges",
+                                        "plural": true,
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "CommerceFulfillment",
+                                            "kind": "LinkedField",
+                                            "name": "node",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "trackingId",
+                                                "storageKey": null
+                                              },
+                                              (v4/*: any*/)
+                                            ],
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": "fulfillments(first:1)"
+                                  },
                                   (v4/*: any*/)
                                 ],
                                 "storageKey": null
@@ -652,7 +707,7 @@ return {
     "metadata": {},
     "name": "routes_PurchaseQuery",
     "operationKind": "query",
-    "text": "query routes_PurchaseQuery {\n  me {\n    ...PurchaseApp_me\n    id\n  }\n}\n\nfragment OrderRow_order on CommerceOrder {\n  internalID\n  code\n  state\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  creditCard {\n    lastDigits\n    id\n  }\n  buyerTotal\n  createdAt\n  itemsTotal\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          date\n          image {\n            resized(width: 55) {\n              url\n            }\n          }\n          partner {\n            slug\n            initials\n            name\n            profile {\n              icon {\n                url(version: \"square140\")\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          internalID\n          title\n          artist_names: artistNames\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PurchaseApp_me on Me {\n  ...PurchaseHistory_me\n}\n\nfragment PurchaseHistory_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED], first: 10) {\n    edges {\n      node {\n        __typename\n        code\n        ...OrderRow_order\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
+    "text": "query routes_PurchaseQuery {\n  me {\n    ...PurchaseApp_me\n    id\n  }\n}\n\nfragment OrderRow_order on CommerceOrder {\n  internalID\n  code\n  state\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  creditCard {\n    lastDigits\n    id\n  }\n  buyerTotal\n  createdAt\n  itemsTotal\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          date\n          image {\n            resized(width: 55) {\n              url\n            }\n          }\n          partner {\n            slug\n            initials\n            name\n            profile {\n              icon {\n                url(version: \"square140\")\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          internalID\n          title\n          artist_names: artistNames\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PurchaseApp_me on Me {\n  ...PurchaseHistory_me\n}\n\nfragment PurchaseHistory_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED], first: 10) {\n    edges {\n      node {\n        __typename\n        code\n        ...OrderRow_order\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/routes_PurchaseQuery.graphql.ts
+++ b/src/v2/__generated__/routes_PurchaseQuery.graphql.ts
@@ -49,6 +49,7 @@ fragment OrderRow_order on CommerceOrder {
     edges {
       node {
         artwork {
+          slug
           date
           image {
             resized(width: 55) {
@@ -56,6 +57,7 @@ fragment OrderRow_order on CommerceOrder {
             }
           }
           partner {
+            slug
             initials
             name
             profile {
@@ -70,6 +72,10 @@ fragment OrderRow_order on CommerceOrder {
           internalID
           title
           artist_names: artistNames
+          artists {
+            slug
+            id
+          }
           id
         }
         id
@@ -157,7 +163,14 @@ v4 = {
   "name": "id",
   "storageKey": null
 },
-v5 = [
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v6 = [
   {
     "alias": null,
     "args": null,
@@ -379,6 +392,7 @@ return {
                                     "name": "artwork",
                                     "plural": false,
                                     "selections": [
+                                      (v5/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -429,6 +443,7 @@ return {
                                         "name": "partner",
                                         "plural": false,
                                         "selections": [
+                                          (v5/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -499,6 +514,19 @@ return {
                                         "name": "artistNames",
                                         "storageKey": null
                                       },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "Artist",
+                                        "kind": "LinkedField",
+                                        "name": "artists",
+                                        "plural": true,
+                                        "selections": [
+                                          (v5/*: any*/),
+                                          (v4/*: any*/)
+                                        ],
+                                        "storageKey": null
+                                      },
                                       (v4/*: any*/)
                                     ],
                                     "storageKey": null
@@ -535,7 +563,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v5/*: any*/),
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -545,7 +573,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -555,7 +583,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -565,7 +593,7 @@ return {
                     "kind": "LinkedField",
                     "name": "previous",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -624,7 +652,7 @@ return {
     "metadata": {},
     "name": "routes_PurchaseQuery",
     "operationKind": "query",
-    "text": "query routes_PurchaseQuery {\n  me {\n    ...PurchaseApp_me\n    id\n  }\n}\n\nfragment OrderRow_order on CommerceOrder {\n  internalID\n  code\n  state\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  creditCard {\n    lastDigits\n    id\n  }\n  buyerTotal\n  createdAt\n  itemsTotal\n  lineItems {\n    edges {\n      node {\n        artwork {\n          date\n          image {\n            resized(width: 55) {\n              url\n            }\n          }\n          partner {\n            initials\n            name\n            profile {\n              icon {\n                url(version: \"square140\")\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          internalID\n          title\n          artist_names: artistNames\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PurchaseApp_me on Me {\n  ...PurchaseHistory_me\n}\n\nfragment PurchaseHistory_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED], first: 10) {\n    edges {\n      node {\n        __typename\n        code\n        ...OrderRow_order\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
+    "text": "query routes_PurchaseQuery {\n  me {\n    ...PurchaseApp_me\n    id\n  }\n}\n\nfragment OrderRow_order on CommerceOrder {\n  internalID\n  code\n  state\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommerceShip {\n      __typename\n    }\n    ... on CommercePickup {\n      __typename\n    }\n  }\n  creditCard {\n    lastDigits\n    id\n  }\n  buyerTotal\n  createdAt\n  itemsTotal\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          date\n          image {\n            resized(width: 55) {\n              url\n            }\n          }\n          partner {\n            slug\n            initials\n            name\n            profile {\n              icon {\n                url(version: \"square140\")\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          internalID\n          title\n          artist_names: artistNames\n          artists {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PurchaseApp_me on Me {\n  ...PurchaseHistory_me\n}\n\nfragment PurchaseHistory_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED], first: 10) {\n    edges {\n      node {\n        __typename\n        code\n        ...OrderRow_order\n        id\n      }\n    }\n    pageCursors {\n      around {\n        cursor\n        isCurrent\n        page\n      }\n      first {\n        cursor\n        isCurrent\n        page\n      }\n      last {\n        cursor\n        isCurrent\n        page\n      }\n      previous {\n        cursor\n        isCurrent\n        page\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Addresses [PURCHASE-2177] [PURCHASE-2178] [PURCHASE-2179]

* Add purchase history link to the mobile nav 
* Purchase history links 
* Add track order link 
* Mobile view/track button redesign
* Remove feature flag

<details><summary>Screenshots</summary>

Mobile

<img width="559" alt="Screen Shot 2020-10-14 at 10 02 05 PM" src="https://user-images.githubusercontent.com/687513/96068215-77d90b80-0e69-11eb-94a7-81f4a46d6ee9.png">

Desktop

<img width="1042" alt="Screen Shot 2020-10-14 at 10 02 25 PM" src="https://user-images.githubusercontent.com/687513/96068218-79a2cf00-0e69-11eb-963c-2245a5075740.png">

</details>

[PURCHASE-2177]: https://artsyproduct.atlassian.net/browse/PURCHASE-2177
[PURCHASE-2178]: https://artsyproduct.atlassian.net/browse/PURCHASE-2178
[PURCHASE-2179]: https://artsyproduct.atlassian.net/browse/PURCHASE-2179