### PR TITLE
chore: Electron Runner Slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -156,7 +156,7 @@ COPY --from=builder-server /app/server.dist.js.map .
 # ---------------------------------------------------------
 # Image with xvfb to run Electron with a virtual display
 # ---------------------------------------------------------
-FROM node:12.18.4-stretch as electron-runner
+FROM node:12.18.4-stretch-slim as electron-runner
 
 WORKDIR /app
 


### PR DESCRIPTION
Switching the electron-runner container to use a slim Debian base shaves
off ~600MiB (300MB gzip) from the image size. This will decrease push time and pull
time in CI decreasing the average execution time for the cypress steps.

```
force-test-electron-runner                           latest                                     66dcf71af3e3        27 minutes ago      2.64GB
force-test-electron-runner-slim                      latest                                     0d9ab8417dfc        37 minutes ago      2.02GB
```