### PR TITLE
bug: Add white space prewrap to subsection body

### DIFF
--- a/src/v2/Apps/ViewingRoom/Routes/Statement/Components/ViewingRoomSubsections.tsx
+++ b/src/v2/Apps/ViewingRoom/Routes/Statement/Components/ViewingRoomSubsections.tsx
@@ -36,7 +36,9 @@ const ViewingRoomSubsections: React.FC<ViewingRoomSubsectionsProps> = ({
                 <>
                   <Spacer my={1} />
                   <Box>
-                    <Serif size={["4", "5"]}>{body}</Serif>
+                    <Serif size={["4", "5"]} style={{ whiteSpace: "pre-wrap" }}>
+                      {body}
+                    </Serif>
                   </Box>
                 </>
               )}


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PX-3372

Add style `white-space: pre-wrap` to the body text of viewing room subsections