### PR TITLE
bugfix: Clear timeOnPage interval

### DIFF
--- a/src/desktop/analytics/main_layout.ts
+++ b/src/desktop/analytics/main_layout.ts
@@ -113,7 +113,6 @@ class PageTimeTracker {
   }
 }
 
-console.warn("here!!!!!!!!!!!!!!!!!!")
 window.desktopPageTimeTrackers = [
   new PageTimeTracker(sd.CURRENT_PATH, 15000, "15 seconds"),
 ]

--- a/src/desktop/analytics/main_layout.ts
+++ b/src/desktop/analytics/main_layout.ts
@@ -113,6 +113,7 @@ class PageTimeTracker {
   }
 }
 
+console.warn("here!!!!!!!!!!!!!!!!!!")
 window.desktopPageTimeTrackers = [
   new PageTimeTracker(sd.CURRENT_PATH, 15000, "15 seconds"),
 ]

--- a/src/desktop/analytics/timeOnPageListener.ts
+++ b/src/desktop/analytics/timeOnPageListener.ts
@@ -3,6 +3,7 @@ import { timeOnPage } from "@artsy/cohesion"
 import { getPageTypeFromClient } from "lib/getPageType"
 
 export const timeOnPageListener = (delay: number = 15000) => {
+  console.warn(".........................")
   setTimeout(() => {
     const { pageType, pageSlug } = getPageTypeFromClient()
     const pathname = new URL(window.location.href).pathname

--- a/src/desktop/analytics/timeOnPageListener.ts
+++ b/src/desktop/analytics/timeOnPageListener.ts
@@ -2,9 +2,14 @@ import { trackEvent } from "./helpers"
 import { timeOnPage } from "@artsy/cohesion"
 import { getPageTypeFromClient } from "lib/getPageType"
 
+let interval
+
 export const timeOnPageListener = (delay: number = 15000) => {
-  console.warn(".........................")
-  setTimeout(() => {
+  if (interval) {
+    clearInterval(interval)
+  }
+
+  interval = setTimeout(() => {
     const { pageType, pageSlug } = getPageTypeFromClient()
     const pathname = new URL(window.location.href).pathname
 

--- a/src/v2/Artsy/Analytics/trackingMiddleware.ts
+++ b/src/v2/Artsy/Analytics/trackingMiddleware.ts
@@ -92,18 +92,14 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
             })
           }
 
-          console.warn("firing here...'")
-
           // Reset timers that track time on page since we're tracking each order
           // checkout view as a separate page.
           const desktopPageTimeTrackers =
-            typeof window.desktopPageTimeTrackers !== "undefined" &&
-            window.desktopPageTimeTrackers
+            typeof window !== "undefined" && window.desktopPageTimeTrackers
 
           if (desktopPageTimeTrackers) {
             desktopPageTimeTrackers.forEach(tracker => {
               // No need to reset the tracker if we're on the same page.
-              console.log(pathname)
               if (pathname !== tracker.path) {
                 tracker.reset(pathname)
               }

--- a/src/v2/Artsy/Analytics/trackingMiddleware.ts
+++ b/src/v2/Artsy/Analytics/trackingMiddleware.ts
@@ -92,6 +92,8 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
             })
           }
 
+          console.warn("firing here...'")
+
           // Reset timers that track time on page since we're tracking each order
           // checkout view as a separate page.
           const desktopPageTimeTrackers =
@@ -101,6 +103,7 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
           if (desktopPageTimeTrackers) {
             desktopPageTimeTrackers.forEach(tracker => {
               // No need to reset the tracker if we're on the same page.
+              console.log(pathname)
               if (pathname !== tracker.path) {
                 tracker.reset(pathname)
               }

--- a/src/v2/Artsy/Router/RouterLink.tsx
+++ b/src/v2/Artsy/Router/RouterLink.tsx
@@ -71,7 +71,12 @@ export const RouterLink: React.FC<RouterLinkProps> = ({
         href={to as string}
         className={(props as LinkPropsSimple).className}
         style={Object.assign(styleProps, (props as LinkPropsSimple).style)}
-        {...omit(props, ["activeClassName", "hasLighterTextColor"])}
+        {...omit(props, [
+          "activeClassName",
+          "alignItems",
+          "hasLighterTextColor",
+          "underlineBehavior",
+        ])}
       >
         {children}
       </a>

--- a/src/v2/Components/NavBar/NavItemPanel.tsx
+++ b/src/v2/Components/NavBar/NavItemPanel.tsx
@@ -5,12 +5,12 @@ import styled, { css } from "styled-components"
 export type MenuAnchor = "left" | "right" | "center" | "full"
 
 const AnimatedPanel = styled(animated.div)<{
-  menuAnchor: MenuAnchor
-  offsetLeft?: number
+  "data-menuanchor": MenuAnchor
+  "data-offsetleft"?: number
 }>`
   position: absolute;
   top: 100%;
-  ${({ menuAnchor, offsetLeft = 0 }) =>
+  ${({ ...props }) =>
     ({
       right: css`
         right: 0;
@@ -25,9 +25,9 @@ const AnimatedPanel = styled(animated.div)<{
       full: css`
         left: 0;
         right: 0;
-        margin-left: -${offsetLeft}px;
+        margin-left: -${props["data-offsetleft"] ?? 0}px;
       `,
-    }[menuAnchor])}
+    }[props["data-menuanchor"]])}
 `
 
 const ANIMATION_STATES = {
@@ -66,8 +66,8 @@ export const NavItemPanel: React.FC<NavItemPanelProps> = ({
   return (
     <AnimatedPanel
       style={animation}
-      menuAnchor={menuAnchor}
-      offsetLeft={relativeTo.current?.offsetLeft}
+      data-menuanchor={menuAnchor}
+      data-offsetleft={relativeTo.current?.offsetLeft}
     >
       {children}
     </AnimatedPanel>


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/GRO-26

Noticed that we wern't clearing the timer and executing this function twice, if clicking through pages fast. This fixes that. 

Also fixes a few glaring react console errors related to props being improperly passed to the dom. 

cc @artsy/grow-devs 