### PR TITLE
[FX-2379] Forwards ref to RouterLink

### DIFF
--- a/src/v2/Artsy/Router/RouterLink.tsx
+++ b/src/v2/Artsy/Router/RouterLink.tsx
@@ -13,73 +13,70 @@ import { get } from "v2/Utils/get"
  *   ...
  * `
  */
-
-interface StyleProps {
-  noUnderline?: boolean
-}
-
-export type RouterLinkProps = StyleProps &
-  LinkProps &
-  React.HTMLAttributes<HTMLAnchorElement>
-
-export const RouterLink: React.FC<RouterLinkProps> = ({
-  to,
-  children,
-  ...props
-}) => {
-  const styleProps = props.noUnderline ? { textDecoration: "none" } : {}
-  const context = useContext(RouterContext)
-  const routes = get(context, c => c?.router?.matcher?.routeConfig, [])
-  const isSupportedInRouter = !!get(context, c =>
-    c?.router?.matcher?.matchRoutes(routes, to)
-  )
-
-  /**
-   * Only pass found-router specific props across, props that conform to the
-   * link API found here: https://github.com/4Catalyzer/found#links
-   */
-  const handlers = Object.keys(props).reduce((acc, prop) => {
-    if (prop.startsWith("on")) {
-      acc.push(prop)
-    }
-    return acc
-  }, [])
-
-  if (isSupportedInRouter) {
-    const allowedProps = pick(props, [
-      "aria-label",
-      "Component",
-      "activeClassName",
-      "className",
-      "data-test",
-      "exact",
-      "replace",
-      "role",
-      "style",
-      "tabIndex",
-      ...handlers,
-    ])
-
-    return (
-      <Link to={to} {...allowedProps} style={styleProps}>
-        {children}
-      </Link>
-    )
-  } else {
-    return (
-      <a
-        href={to as string}
-        className={(props as LinkPropsSimple).className}
-        style={Object.assign(styleProps, (props as LinkPropsSimple).style)}
-        {...omit(props, [
-          "activeClassName",
-          "alignItems",
-          "hasLighterTextColor",
-          "underlineBehavior",
-        ])}
-      >
-        {children}
-      </a>
-    )
+export type RouterLinkProps = LinkProps &
+  React.HTMLAttributes<HTMLAnchorElement> & {
+    noUnderline?: boolean
   }
-}
+
+export const RouterLink: React.ForwardRefExoticComponent<RouterLinkProps> = React.forwardRef(
+  ({ to, children, ...props }, ref) => {
+    const styleProps = props.noUnderline ? { textDecoration: "none" } : {}
+    const context = useContext(RouterContext)
+    const routes = get(context, c => c?.router?.matcher?.routeConfig, [])
+    const isSupportedInRouter = !!get(context, c =>
+      c?.router?.matcher?.matchRoutes(routes, to)
+    )
+
+    /**
+     * Only pass found-router specific props across, props that conform to the
+     * link API found here: https://github.com/4Catalyzer/found#links
+     */
+    const handlers = Object.keys(props).reduce((acc, prop) => {
+      if (prop.startsWith("on")) {
+        acc.push(prop)
+      }
+      return acc
+    }, [])
+
+    if (isSupportedInRouter) {
+      const allowedProps = pick(props, [
+        "aria-label",
+        "Component",
+        "activeClassName",
+        "className",
+        "data-test",
+        "exact",
+        "replace",
+        "role",
+        "style",
+        "tabIndex",
+        ...handlers,
+      ])
+
+      return (
+        <Link ref={ref as any} to={to} {...allowedProps} style={styleProps}>
+          {children}
+        </Link>
+      )
+    } else {
+      return (
+        <a
+          ref={ref}
+          href={to as string}
+          className={(props as LinkPropsSimple).className}
+          style={Object.assign(styleProps, (props as LinkPropsSimple).style)}
+          {...omit(props, [
+            "activeClassName",
+            "alignItems",
+            "hasLighterTextColor",
+            "underlineBehavior",
+          ])}
+        >
+          {children}
+        </a>
+      )
+    }
+  }
+)
+
+RouterLink.displayName = "RouterLink"

--- a/src/v2/Components/NavBar/NavItem.tsx
+++ b/src/v2/Components/NavBar/NavItem.tsx
@@ -60,7 +60,6 @@ interface NavItemProps extends BoxProps, React.HTMLAttributes<HTMLDivElement> {
   }>
   Overlay?: React.FC
   active?: boolean
-  className?: string
   href?: string
   label?: string
   menuAnchor?: MenuAnchor
@@ -72,8 +71,6 @@ export const NavItem: React.FC<NavItemProps> = ({
   Overlay,
   active = false,
   children,
-  className,
-  display = "block",
   href,
   label,
   menuAnchor = "left",
@@ -176,8 +173,6 @@ export const NavItem: React.FC<NavItemProps> = ({
         color={color}
         underlineBehavior="none"
         px={1}
-        display={display}
-        className={className}
         aria-label={label}
         tabIndex={tabIndex}
         role={role}


### PR DESCRIPTION
Closes: [FX-2379](https://artsyproduct.atlassian.net/browse/FX-2379)

[Diff without whitespace changes](https://github.com/artsy/force/pull/6501/files?diff=unified&w=1)

This wasn't manifesting in any visible bugs, but this fixes the issue and silences the error.

The `hitAreaRef` is specifically used when a sub-menu is opened: when the escape key is pressed, the sub-menu closes and focus is returned to that hit area, which is a `Clickable`. Since `NavItems` can be plain links without sub-menus using the `as` prop, this leads to a ref on a function component `RouterLink` that can't be used (but was never actually used).

It's a fine idea to forward the ref anyway, which is what this PR does.

(Also cleaned up some erroneous props which were present in a93e15a1c217995c20553a4e1bcdbaec4d61c8ab and are covered in the rest spread on the parent container.)