### PR TITLE
fix: stop redirecting to individual fair edition before page is available

### DIFF
--- a/src/desktop/apps/fair_organizer/routes.coffee
+++ b/src/desktop/apps/fair_organizer/routes.coffee
@@ -48,8 +48,7 @@ representation = (fair) ->
     .then ->
       # find if we have a current fair
       current = fairs.find (fair)->
-        moment().utc().isBetween fair.get('autopublish_artworks_at'), fair.get('end_at')
-
+        moment().utc().isBetween fair.get('start_at'), fair.get('end_at')
       throw new Error() unless current?
       Promise.resolve(current.related().profile.fetch())
     .then (profile) ->

--- a/src/mobile/apps/fair_organizer/test/routes.test.js
+++ b/src/mobile/apps/fair_organizer/test/routes.test.js
@@ -16,6 +16,17 @@ const Fairs = require("../../../collections/fairs.coffee")
 const FairOrganizer = require("../../../models/fair_organizer.coffee")
 const Profile = require("../../../models/profile.coffee")
 
+class OrderedSetsFixture extends Backbone.Collection {
+  fetchAll() {
+    return {
+      then(cb) {
+        return cb()
+      },
+    }
+  }
+}
+routes.__set__("OrderedSets", OrderedSetsFixture)
+
 describe("Fair Organization routes", function () {
   beforeEach(function () {
     sinon.stub(Backbone, "sync")
@@ -35,10 +46,15 @@ describe("Fair Organization routes", function () {
         profile: new Profile(fabricate("fair_organizer_profile")),
       },
     }
-    return (this.next = sinon.stub())
+    this.next = sinon.stub()
+
+    return (this.clock = sinon.useFakeTimers())
   })
 
-  afterEach(() => Backbone.sync.restore())
+  afterEach(function () {
+    Backbone.sync.restore()
+    return this.clock.restore()
+  })
 
   describe("#overview", function () {
     it("next is called without a fair org", function () {
@@ -54,7 +70,7 @@ describe("Fair Organization routes", function () {
     })
   })
 
-  return describe("#fetchFairOrgData", function () {
+  describe("#fetchFairOrgData", function () {
     beforeEach(function () {
       return (this.fairs = new Fairs([
         fabricate("fair", {
@@ -75,7 +91,21 @@ describe("Fair Organization routes", function () {
       ]))
     })
 
-    return it("redirects to the fair if there is a current fair", function () {
+    it("fetches the fair organizer and associated fairs", function () {
+      let next
+      Backbone.sync.onCall(0).yieldsTo("success", this.fairs.models)
+      Backbone.sync.yieldsTo("success")
+      return routes
+        .fetchFairOrgData(this.req, this.res, (next = sinon.stub()))
+        .then(() => {
+          this.res.locals.sd.FAIR_IDS.should.eql(this.fairs.pluck("_id"))
+          return this.res.locals.sd.FAIR_ORGANIZER.should.eql(
+            this.fairOrg.toJSON()
+          )
+        })
+    })
+
+    it("redirects to the fair if there is a current fair with public profile", function () {
       let next
       const fair = this.fairs.first()
       fair.set({
@@ -83,9 +113,46 @@ describe("Fair Organization routes", function () {
         start_at: moment().utc().subtract(3, "days").format(),
         end_at: moment().utc().add(3, "days").format(),
       })
-      routes.fetchFairOrgData(this.req, this.res, (next = sinon.stub()))
-      Backbone.sync.args[0][2].success(this.fairs.models)
-      return this.res.redirect.args[0][0].should.equal("/the-armory-show")
+
+      Backbone.sync.onCall(0).yieldsTo("success", this.fairs.models)
+      Backbone.sync
+        .onCall(1)
+        .yieldsTo("success")
+        .returns(
+          new Promise((resolve, reject) => resolve(fabricate("fair_profile")))
+        )
+      Backbone.sync.yieldsTo("success")
+      return routes
+        .fetchFairOrgData(this.req, this.res, (next = sinon.stub()))
+        .then(() => {
+          return this.res.redirect.args[0][0].should.equal("/the-armory-show")
+        })
+    })
+
+    it("redirects to the fair if there is a current fair with private profile", function () {
+      let next
+      const fair = this.fairs.first()
+      fair.set({
+        autopublish_artworks_at: moment().utc().subtract(5, "days").format(),
+        start_at: moment().utc().subtract(3, "days").format(),
+        end_at: moment().utc().add(3, "days").format(),
+      })
+
+      Backbone.sync.onCall(0).yieldsTo("success", this.fairs.models)
+      Backbone.sync
+        .onCall(1)
+        .yieldsTo("error")
+        .returns(new Promise((resolve, reject) => reject()))
+      Backbone.sync.yieldsTo("success")
+      return routes
+        .fetchFairOrgData(this.req, this.res, (next = sinon.stub()))
+        .then(() => {
+          this.res.redirect.notCalled.should.be.ok()
+          this.res.locals.sd.FAIR_IDS.should.eql(this.fairs.pluck("_id"))
+          return this.res.locals.sd.FAIR_ORGANIZER.should.eql(
+            this.fairOrg.toJSON()
+          )
+        })
     })
   })
 })


### PR DESCRIPTION
This PR pulls heavily from https://github.com/artsy/force/pull/3780, doing essentially the same thing but for Force's mobile route.

The bug this fixes: when accessing a `fair_organizer` page **on mobile web**, (e.g. `artsy.net/the-armory-show`) after an iteration of that fair's autopublish date and before its start date, we redirect from fair organizer page to the individual fair page (e.g. `artsy.net/fair/the-armory-show-2020`) and the page 404s because it's not yet visible to the public.

For both mobile and desktop, I switched from checking `autopublish_at` to `start_at`. @starsirius mentions considering `active_start_at` in the last PR but opting not to because `active_start_at` is not always set.

That seems like a good choice - as we can see in `admin-fairs.artsy.net`, that field is effectively just used for a homepage banner and is therefore not always set: 
![Screen Shot 2020-10-20 at 12 03 50 PM](https://user-images.githubusercontent.com/5361806/96612940-614d0d00-12cc-11eb-99cf-db52062c9eb7.png)

However, `start_at` _is_ required, and to me seems like a more correct thing to check against when determining if we should redirect to the fair page. 
