### PR TITLE
toolchain: Add pull-lock for automatically yarn installing deps on pull

### DIFF
--- a/package.json
+++ b/package.json
@@ -323,6 +323,7 @@
     "prettier": "2.0.5",
     "promise.allsettled": "1.0.2",
     "pug-loader": "2.4.0",
+    "pull-lock": "^1.0.0",
     "raw-loader": "0.5.1",
     "react-test-renderer": "16.8.6",
     "react-use-dimensions": "1.2.1",
@@ -362,6 +363,7 @@
   },
   "husky": {
     "hooks": {
+      "post-merge": "pull-lock",
       "pre-commit": "lint-staged",
       "pre-push": "yarn type-check"
     }
@@ -399,5 +401,8 @@
     "semi": false,
     "singleQuote": false,
     "trailingComma": "es5"
+  },
+  "pull-lock": {
+    "yarn.lock": "yarn install"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6060,7 +6060,7 @@ cors@2.8.3:
     object-assign "^4"
     vary "^1"
 
-cosmiconfig@^5.0.5, cosmiconfig@^5.2.1:
+cosmiconfig@^5.0.5, cosmiconfig@^5.1.0, cosmiconfig@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
   integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
@@ -14969,6 +14969,15 @@ pug@2.0.3:
     pug-parser "^5.0.0"
     pug-runtime "^2.0.4"
     pug-strip-comments "^1.0.3"
+
+pull-lock@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pull-lock/-/pull-lock-1.0.0.tgz#6a0ab2719a3b7e6f49838b52168a30b8fdd84188"
+  integrity sha512-DKc72YeAuRSv9jEPMKoRA5xMs9THQ9kUExSR8WsZPhnLvBgnJ1evXxYPSIpQsmEA6yQYWSt9Uy1EX1/TNyvdXQ==
+  dependencies:
+    cosmiconfig "^5.1.0"
+    debug "^4.1.1"
+    execa "^1.0.0"
 
 pump@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
This adds [orta/pull-lock](https://github.com/orta/pull-lock) to force which will automatically run `yarn install` after `git pull` if it detects that our lockfile has changed. (Matching how things work on Eigen.)

This is especially useful for situations where a dev has sync'd up with master, opened a branch and did some work, pushes changes, but push fails because some kind of type error, etc, related to dev forgetting to run yarn install after master sync. 