### PR TITLE
feat: Add Selling Art Differently section

### DIFF
--- a/src/v2/Apps/Consign/Components/SellArtDifferently.tsx
+++ b/src/v2/Apps/Consign/Components/SellArtDifferently.tsx
@@ -1,23 +1,13 @@
 import React from "react"
 import { Box, EditIcon, Flex, Separator, Text, color } from "@artsy/palette"
 import { SectionContainer } from "v2/Apps/Artist/Routes/Consign/Components/SectionContainer"
-import { Media } from "v2/Utils/Responsive"
 
 export const SellArtDifferently: React.FC = () => {
   return (
     <SectionContainer>
-      <Box>
-        <Media greaterThanOrEqual="md">
-          <Text textAlign={["center", "left"]} mb={2} variant={"title"}>
-            Selling Art Differently
-          </Text>
-        </Media>
-        <Media lessThan="md">
-          <Text textAlign={["center", "left"]} mb={2} variant={"largeTitle"}>
-            Selling Art Differently
-          </Text>
-        </Media>
-      </Box>
+      <Text textAlign={["center", "left"]} mb={2} variant={"largeTitle"}>
+        Selling Art Differently
+      </Text>
       <Separator />
 
       <Flex

--- a/src/v2/Apps/Consign/Components/SellArtDifferently.tsx
+++ b/src/v2/Apps/Consign/Components/SellArtDifferently.tsx
@@ -1,39 +1,48 @@
 import React from "react"
-import { Box, EditIcon, Flex, Separator, Text } from "@artsy/palette"
+import { Box, EditIcon, Flex, Separator, Text, color } from "@artsy/palette"
+import { SectionContainer } from "v2/Apps/Artist/Routes/Consign/Components/SectionContainer"
+import { Media } from "v2/Utils/Responsive"
 
 export const SellArtDifferently: React.FC = () => {
   return (
-    <Box>
+    <SectionContainer>
       <Box>
-        <Text variant="title">Selling Art Differently</Text>
-        <Separator />
+        <Media greaterThanOrEqual="md">
+          <Text textAlign={["center", "left"]} mb={2} variant={"title"}>
+            Selling Art Differently
+          </Text>
+        </Media>
+        <Media lessThan="md">
+          <Text textAlign={["center", "left"]} mb={2} variant={"largeTitle"}>
+            Selling Art Differently
+          </Text>
+        </Media>
       </Box>
+      <Separator />
 
       <Flex
         flexDirection={["column", "row"]}
         alignItems="center"
-        justifyContent="center"
+        justifyContent="space-between"
+        pt={[1, 4]}
       >
         <Section
-          icon={<EditIcon width={30} height={30} />}
-          text="Submit once"
-          description="Submit your artwork details and images. Artsy will review and
-            approve qualified submissions for consignment."
+          icon={<EditIcon width={50} height={50} />}
+          text="More selling options"
+          description="We’ll introduce your work to leading buyers around the world and help compare their offers to get you the best deal."
         />
         <Section
-          icon={<EditIcon width={30} height={30} />}
-          text="Submit once"
-          description="Submit your artwork details and images. Artsy will review and
-            approve qualified submissions for consignment."
+          icon={<EditIcon width={50} height={50} />}
+          text="Unique market insights"
+          description="Our expertise, primary and secondary art market data, and relationships with buyers provide a best-in-class reselling experience."
         />
         <Section
-          icon={<EditIcon width={30} height={30} />}
-          text="Submit once"
-          description="Submit your artwork details and images. Artsy will review and
-            approve qualified submissions for consignment."
+          icon={<EditIcon width={50} height={50} />}
+          text="Speed anad efficiency"
+          description="Guaranteed offer within 24 hours, and you’ll always be presented with a sales option to sell your work in a month. Plus, we’ll help you ship."
         />
       </Flex>
-    </Box>
+    </SectionContainer>
   )
 }
 
@@ -43,13 +52,22 @@ const Section: React.FC<{
   description: string
 }> = ({ icon, text, description }) => {
   return (
-    <Box width={["100%", "25%"]} height={["100%", 170]} my={[3, 0]} mx={2}>
+    <Box
+      width={["100%", "25%"]}
+      height={["100%", 170]}
+      my={[1, 0]}
+      textAlign="center"
+    >
       <Box>{icon}</Box>
-      <Box mt={1} mb={2}>
-        <Text variant="mediumText">{text}</Text>
+      <Box mt={[0, 1]} mb={[0, 2]}>
+        <Text variant="subtitle" color={color("black100")}>
+          {text}
+        </Text>
       </Box>
       <Box>
-        <Text variant="mediumText">{description}</Text>
+        <Text variant="text" color={color("black60")}>
+          {description}
+        </Text>
       </Box>
     </Box>
   )

--- a/src/v2/Apps/Consign/Components/SellArtDifferently.tsx
+++ b/src/v2/Apps/Consign/Components/SellArtDifferently.tsx
@@ -1,11 +1,11 @@
 import React from "react"
-import { Box, EditIcon, Flex, Separator, Text, color } from "@artsy/palette"
+import { Box, EditIcon, Flex, Separator, Text } from "@artsy/palette"
 import { SectionContainer } from "v2/Apps/Artist/Routes/Consign/Components/SectionContainer"
 
 export const SellArtDifferently: React.FC = () => {
   return (
     <SectionContainer>
-      <Text textAlign={["center", "left"]} mb={2} variant={"largeTitle"}>
+      <Text textAlign={["center", "left"]} mb={2} variant="largeTitle">
         Selling Art Differently
       </Text>
       <Separator />
@@ -50,12 +50,10 @@ const Section: React.FC<{
     >
       <Box>{icon}</Box>
       <Box mt={[0, 1]} mb={[0, 2]}>
-        <Text variant="subtitle" color={color("black100")}>
-          {text}
-        </Text>
+        <Text variant="subtitle">{text}</Text>
       </Box>
       <Box>
-        <Text variant="text" color={color("black60")}>
+        <Text variant="text" color="black60">
           {description}
         </Text>
       </Box>

--- a/src/v2/Apps/Consign/ConsignApp.tsx
+++ b/src/v2/Apps/Consign/ConsignApp.tsx
@@ -30,9 +30,9 @@ const ConsignApp = props => {
         <AppContainer maxWidth="100%">
           <Header />
           <GetPriceEstimate />
+          <SellArtDifferently />
 
           <HorizontalPadding>
-            <SellArtDifferently />
             <HowToSell />
             <ConsignInDemandNow />
             <SoldRecently />
@@ -41,8 +41,6 @@ const ConsignApp = props => {
             <FAQ />
             <SellWithArtsy />
             <Footer />
-
-            {/* hello hiii consign app {props.artist.name} */}
           </HorizontalPadding>
         </AppContainer>
       </>


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GRO-37

Adds the "Selling Art Differently" section for the new `/consign` page. This section will have to be updated once the new icons are available.

The separator is `black10` instead of `black60` pending confirmation from design that we do in fact want `black60`.

**Desktop viewports**
<img width="1008" alt="Screen Shot 2020-10-22 at 3 31 21 PM" src="https://user-images.githubusercontent.com/4432348/96921188-27bb0400-147c-11eb-9499-fc764bac1dbf.png">

**Mobile viewports** (overflow issue is unrelated)
<img width="321" alt="Screen Shot 2020-10-22 at 3 31 47 PM" src="https://user-images.githubusercontent.com/4432348/96921181-24c01380-147c-11eb-9791-b7f083ff3cc3.png">