### PR TITLE
fix: do not redirect to new fair exp via mobile routes if excluded

### DIFF
--- a/src/desktop/apps/fair/fairRedirection.ts
+++ b/src/desktop/apps/fair/fairRedirection.ts
@@ -22,7 +22,9 @@ const shouldRedirectToNewFairPage = req => {
 }
 
 const isNewFairPageDisabledForThisFair = req => {
-  return !!DISABLE_FAIRS_UPDATE_SLUGS?.split(/\s*,\s*/).includes(req.params.id)
+  // Comes in as `id` via desktop routes and `profileId` via mobile routes
+  const fairSlug = req.params.id || req.params.profileId
+  return !!DISABLE_FAIRS_UPDATE_SLUGS?.split(/\s*,\s*/).includes(fairSlug)
 }
 
 const shouldUserSeeNewFairPage = req => {

--- a/src/desktop/apps/fair/test/fairRedirection.jest.ts
+++ b/src/desktop/apps/fair/test/fairRedirection.jest.ts
@@ -117,6 +117,16 @@ describe("redirectFairRequests", () => {
       expect(res.redirect).not.toHaveBeenCalled()
       expect(next).toHaveBeenCalled()
     })
+
+    it("does not redirect, when loading via mobile routes", () => {
+      const { redirectFairRequests } = require("../fairRedirection")
+      req.params = { profileId: "foo-fair" }
+
+      redirectFairRequests(req, res, next)
+
+      expect(res.redirect).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalled()
+    })
   })
 
   describe("paths to redirect", () => {


### PR DESCRIPTION
The fair slug comes in as `profileId`, not `id`, when on mobile web so the desktop-oriented redirect rules would bypass the logic intended to keep a set of fairs on the old fair experience.

This commit adds handling of the mobile request param to trigger the same exclude behavior.