### PR TITLE
feat: [Consign2] Add In Demand section 

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@artsy/express-reloadable": "1.4.8",
     "@artsy/fresnel": "1.3.0",
     "@artsy/gemup": "0.1.0",
-    "@artsy/palette": "13.13.0",
+    "@artsy/palette": "13.15.0",
     "@artsy/passport": "1.5.0",
     "@artsy/reaction": "28.11.0",
     "@artsy/stitch": "6.1.6",

--- a/src/v2/Apps/Artist/Routes/Consign/Components/SectionContainer.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/SectionContainer.tsx
@@ -23,6 +23,7 @@ export const SectionContainer: React.FC<SectionContainerProps> = ({
       flexDirection="column"
       justifyContent="center"
       alignItems="center"
+      overflow="hidden"
       px={[2, 4]}
       py={6}
       position="relative"

--- a/src/v2/Apps/Components/HorizontalPadding.tsx
+++ b/src/v2/Apps/Components/HorizontalPadding.tsx
@@ -1,4 +1,4 @@
-import { media, space } from "@artsy/palette"
+import { Box, media, space } from "@artsy/palette"
 import styled, { css } from "styled-components"
 import { SpaceProps } from "styled-system"
 
@@ -6,7 +6,7 @@ export interface HorizontalPaddingProps {
   px?: SpaceProps["px"]
 }
 
-export const HorizontalPadding = styled.div<HorizontalPaddingProps>`
+export const HorizontalPadding = styled(Box)<HorizontalPaddingProps>`
   ${p =>
     media.xs`
       padding-right: ${(p.px[0] && space(p.px[0])) || 0}px;

--- a/src/v2/Apps/Consign/Components/GetPriceEstimate.tsx
+++ b/src/v2/Apps/Consign/Components/GetPriceEstimate.tsx
@@ -8,7 +8,6 @@ import {
   MagnifyingGlassIcon,
   Spacer,
   Text,
-  breakpoints,
 } from "@artsy/palette"
 import { SectionContainer } from "./SectionContainer"
 
@@ -16,8 +15,6 @@ export const GetPriceEstimate: React.FC = () => {
   return (
     <SectionContainer background="black5">
       <Flex
-        width="100%"
-        maxWidth={breakpoints.xl}
         flexDirection={["column", "column", "column", "row"]}
         justifyContent="center"
       >

--- a/src/v2/Apps/Consign/Components/Header.tsx
+++ b/src/v2/Apps/Consign/Components/Header.tsx
@@ -14,7 +14,7 @@ import { SectionContainer } from "./SectionContainer"
 
 export const Header: React.FC = () => {
   return (
-    <SectionContainer background="black5" height={[415, 546]}>
+    <SectionContainer background="black5" height={[415, 546]} constrain={false}>
       <HeaderImageContainer>
         <Flex width="100%" justifyContent="space-between" m="auto">
           <Media greaterThan="md">

--- a/src/v2/Apps/Consign/Components/HowToSell.tsx
+++ b/src/v2/Apps/Consign/Components/HowToSell.tsx
@@ -1,8 +1,8 @@
 import React from "react"
 import { Box, Button, EditIcon, Flex, Separator, Text } from "@artsy/palette"
-import { SectionContainer } from "v2/Apps/Artist/Routes/Consign/Components/SectionContainer"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import { Media } from "v2/Utils/Responsive"
+import { SectionContainer } from "./SectionContainer"
 
 export const HowToSell: React.FC = () => {
   const navigateTo = "/consign/submission"

--- a/src/v2/Apps/Consign/Components/InDemandNow/ConsignInDemandNow.tsx
+++ b/src/v2/Apps/Consign/Components/InDemandNow/ConsignInDemandNow.tsx
@@ -1,81 +1,383 @@
 import React from "react"
-import { Box, Separator, Text } from "@artsy/palette"
+import {
+  Text as BaseText,
+  BlueChipIcon,
+  Box,
+  Column,
+  Flex,
+  GridColumns,
+  Image,
+  Separator,
+  Spacer,
+} from "@artsy/palette"
 import { SystemQueryRenderer as QueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
 import { useSystemContext } from "v2/Artsy"
 import { graphql } from "react-relay"
 
 import { ConsignInDemandNowQuery } from "v2/__generated__/ConsignInDemandNowQuery.graphql"
 import { ConsignTopArtists } from "./ConsignTopArtists"
+import styled from "styled-components"
+import { DemandRank } from "./DemandRank"
+import { formatCentsToDollars } from "../../Utils/formatCentsToDollars"
+import { SectionContainer } from "../SectionContainer"
+import { Media } from "v2/Utils/Responsive"
 
-export const ConsignInDemandNow: React.FC = () => {
-  const { relayEnvironment } = useSystemContext()
-
+export const ConsignInDemandNow = () => {
   return (
-    <Box>
-      <Box>
-        <Text variant="title">In demand now</Text>
+    <SectionContainer background="black100">
+      <Box textAlign="left" width="100%">
+        <Text textAlign={"left"} mb={2} variant="largeTitle">
+          In Demand Now
+        </Text>
         <Separator />
       </Box>
 
-      <QueryRenderer<ConsignInDemandNowQuery>
-        environment={relayEnvironment}
-        variables={{
-          artistInternalId: "4d8b928b4eb68a1b2c0001f2", // Picasso
-          medium: "PAINTING",
-        }}
-        // FIXME: Must be logged in for diffusion data to work
-        query={graphql`
-          query ConsignInDemandNowQuery(
-            $artistInternalId: ID!
-            $medium: String!
-          ) {
-            marketPriceInsights(artistId: $artistInternalId, medium: $medium) {
-              annualLotsSold
-              annualValueSoldCents
-              artistId
-              artistName
-              artsyQInventory
-              createdAt
-              demandRank
-              demandTrend
-              highRangeCents
-              largeHighRangeCents
-              largeLowRangeCents
-              largeMidRangeCents
-              liquidityRank
-              lowRangeCents
-              medianSaleToEstimateRatio
-              medium
-              mediumHighRangeCents
-              mediumLowRangeCents
-              mediumMidRangeCents
-              midRangeCents
-              sellThroughRate
-              smallHighRangeCents
-              smallLowRangeCents
-              smallMidRangeCents
-              updatedAt
+      <Spacer my={3} />
+      <ConsignInDemandNowQueryRenderer />
+      <Spacer my={4} />
+      <ConsignTopArtists />
+    </SectionContainer>
+  )
+}
+
+const ConsignInDemandNowQueryRenderer: React.FC = () => {
+  const { relayEnvironment } = useSystemContext()
+
+  return (
+    <QueryRenderer<ConsignInDemandNowQuery>
+      environment={relayEnvironment}
+      variables={{
+        artistInternalId: "4ed901b755a41e0001000a9f", // Kehinde Wiley
+        artistSlug: "kehinde-wiley",
+        medium: "PAINTING",
+      }}
+      // FIXME: Must be logged in for diffusion data to work
+      query={graphql`
+        query ConsignInDemandNowQuery(
+          $artistInternalId: ID!
+          $artistSlug: String!
+          $medium: String!
+        ) {
+          artist(id: $artistSlug) {
+            birthday
+            nationality
+            auctionResultsConnection(first: 1, sort: DATE_DESC) {
+              edges {
+                node {
+                  internalID
+                  title
+                  dimensionText
+                  images {
+                    thumbnail {
+                      url
+                    }
+                  }
+                  description
+                  dateText
+                  organization
+                  saleDate
+                  priceRealized {
+                    display
+                    centsUSD
+                  }
+                }
+              }
             }
           }
-        `}
-        render={({ props, error }) => {
-          // FIXME: Error handling
-          if (error) {
-            return null
-          }
-          // FIXME: Add skeleton loading state
-          if (!props) {
-            return null
-          }
 
-          return (
-            <Box>
-              <Box>Artist name: {props.marketPriceInsights?.artistName}</Box>
-              <ConsignTopArtists />
-            </Box>
-          )
-        }}
-      />
-    </Box>
+          marketPriceInsights(artistId: $artistInternalId, medium: $medium) {
+            annualLotsSold
+            annualValueSoldCents
+            artistId
+            artistName
+            artsyQInventory
+            createdAt
+            demandRank
+            demandTrend
+            highRangeCents
+            largeHighRangeCents
+            largeLowRangeCents
+            largeMidRangeCents
+            liquidityRank
+            lowRangeCents
+            medianSaleToEstimateRatio
+            medium
+            mediumHighRangeCents
+            mediumLowRangeCents
+            mediumMidRangeCents
+            midRangeCents
+            sellThroughRate
+            smallHighRangeCents
+            smallLowRangeCents
+            smallMidRangeCents
+            updatedAt
+          }
+        }
+      `}
+      render={({ props, error }) => {
+        // FIXME: Error handling
+        if (error) {
+          return null
+        }
+
+        return (
+          <>
+            <Media greaterThanOrEqual="md">
+              <InDemandNowLarge {...props} />
+            </Media>
+            <Media lessThan="md">
+              <InDemandNowSmall {...props} />
+            </Media>
+          </>
+        )
+      }}
+    />
   )
+}
+
+const InDemandNowSmall: React.FC<
+  ConsignInDemandNowQuery["response"]
+> = props => {
+  // FIXME: Add skeleton loading state
+  if (!props?.marketPriceInsights || !props?.artist) {
+    return null
+  }
+
+  const {
+    artistName,
+    averageSalePrice,
+    birthday,
+    demandRank,
+    highRangeDollars,
+    lastAuctionResult,
+    medianSaleToEstimateRatio,
+    nationality,
+    sellThroughRate,
+  } = computeProps(props)
+
+  return (
+    <>
+      <Box>
+        <Text textAlign={"left"} variant="largeTitle">
+          {artistName}
+        </Text>
+        <Spacer mt={1} />
+        <Text variant="text">
+          {nationality}, b. {birthday}
+        </Text>
+        <Flex>
+          <BlueChipIcon width={15} height={15} fill="white100" mr={0.3} />{" "}
+          <Text variant="small">Blue Chip Representation</Text>
+        </Flex>
+
+        <Spacer mt={3} />
+      </Box>
+
+      <Flex justifyContent="space-between">
+        <Box>
+          <Box>
+            <Image
+              src={lastAuctionResult.images.thumbnail.url}
+              width={100}
+              height="auto"
+            />
+            <Spacer my={0.5} />
+            <Text variant="caption">
+              {lastAuctionResult.title}, {lastAuctionResult.dateText}
+            </Text>
+            <Text variant="caption">{lastAuctionResult.saleDate}</Text>
+            <Text variant="caption">{lastAuctionResult.organization}</Text>
+          </Box>
+          <Box>
+            <Text color="black30">Realized Price</Text>
+            <Text variant="largeTitle">
+              {lastAuctionResult.priceRealized.display}
+            </Text>
+          </Box>
+        </Box>
+        <Box>
+          <Box>
+            <Text>Highest Realized Price</Text>
+            <Text variant="largeTitle">{highRangeDollars}</Text>
+          </Box>
+
+          <Spacer my={1} />
+
+          <Box>
+            <Text>Sell-Through Rate</Text>
+            <Text variant="largeTitle">{sellThroughRate}</Text>
+          </Box>
+
+          <Spacer my={1} />
+
+          <Box>
+            <Text>Realized Price/Estimate</Text>
+            {/* TODO: Follow-up on how real diffusion number (1.84) maps to designs (184%) */}
+            <Text variant="largeTitle">{medianSaleToEstimateRatio * 100}%</Text>
+          </Box>
+        </Box>
+      </Flex>
+
+      <Spacer mt={5} />
+      <DemandRank demandRank={demandRank} />
+      <Spacer mt={5} />
+
+      <Box>
+        <Box>
+          <Text>Average Sale Price, 2010–2020</Text>
+          <Text variant="largeTitle">{averageSalePrice}</Text>
+        </Box>
+
+        <Image
+          width={370}
+          height="auto"
+          // FIXME: Move to vanity.artsy.net
+          src="https://user-images.githubusercontent.com/236943/97058779-9a42e700-1543-11eb-808d-654c0b2f7130.png"
+        />
+      </Box>
+    </>
+  )
+}
+
+const InDemandNowLarge: React.FC<
+  ConsignInDemandNowQuery["response"]
+> = props => {
+  // FIXME: Add skeleton loading state
+  if (!props?.marketPriceInsights || !props?.artist) {
+    return null
+  }
+
+  const {
+    artistName,
+    averageSalePrice,
+    birthday,
+    demandRank,
+    highRangeDollars,
+    lastAuctionResult,
+    medianSaleToEstimateRatio,
+    nationality,
+    sellThroughRate,
+  } = computeProps(props)
+
+  return (
+    <>
+      <Box>
+        <Text textAlign={"left"} variant="largeTitle">
+          {artistName}
+        </Text>
+        <Spacer mt={1} />
+        <Text variant="text">
+          {nationality}, b. {birthday}
+        </Text>
+        <Flex>
+          <BlueChipIcon width={15} height={15} fill="white100" mr={0.3} />{" "}
+          <Text variant="small">Blue Chip Representation</Text>
+        </Flex>
+
+        <Spacer mt={4} />
+      </Box>
+      <GridColumns>
+        <Column span={[12, 12, 4]}>
+          <DemandRank demandRank={demandRank} />
+
+          <Spacer mt={4} />
+
+          <Box>
+            <Text>Highest Realized Price</Text>
+            <Text variant="largeTitle">{highRangeDollars}</Text>
+          </Box>
+
+          <Spacer my={1} />
+
+          <Box>
+            <Text>Sell-Through Rate</Text>
+            <Text variant="largeTitle">{sellThroughRate}</Text>
+          </Box>
+
+          <Spacer my={1} />
+
+          <Box>
+            <Text>Realized Price/Estimate</Text>
+            {/* TODO: Follow-up on how real diffusion number (1.84) maps to designs (184%) */}
+            <Text variant="largeTitle">{medianSaleToEstimateRatio * 100}%</Text>
+          </Box>
+        </Column>
+        <Column span={[12, 12, 4]}>
+          <Flex alignItems="center" flexDirection="column">
+            <Box>
+              <Text>Recent Auction Result</Text>
+              <Text variant="largeTitle">
+                {lastAuctionResult.priceRealized.display}
+              </Text>
+            </Box>
+
+            <Box>
+              <Image
+                src={lastAuctionResult.images.thumbnail.url}
+                width={211}
+                height="auto"
+              />
+              <Spacer my={0.5} />
+              <Text variant="caption">
+                {lastAuctionResult.title}, {lastAuctionResult.dateText}
+              </Text>
+              <Text variant="caption">{lastAuctionResult.saleDate}</Text>
+              <Text variant="caption">{lastAuctionResult.organization}</Text>
+            </Box>
+          </Flex>
+        </Column>
+        <Column span={[12, 12, 4]}>
+          <Flex flexDirection="column">
+            <Box>
+              <Text>Average Sale Price, 2010–2020</Text>
+              <Text variant="largeTitle">{averageSalePrice}</Text>
+            </Box>
+
+            <Image
+              width={370}
+              height="auto"
+              // FIXME: Move to vanity.artsy.net
+              src="https://user-images.githubusercontent.com/236943/97058779-9a42e700-1543-11eb-808d-654c0b2f7130.png"
+            />
+          </Flex>
+        </Column>
+      </GridColumns>
+    </>
+  )
+}
+
+const Text = styled(BaseText)`
+  color: white;
+`
+
+const computeProps = ({ artist, marketPriceInsights }) => {
+  const {
+    artistName,
+    demandRank,
+    lowRangeCents,
+    highRangeCents,
+    medianSaleToEstimateRatio,
+    sellThroughRate,
+  } = marketPriceInsights
+
+  const { birthday, nationality, auctionResultsConnection } = artist
+  const lastAuctionResult = auctionResultsConnection?.edges?.[0].node
+
+  // TODO: Follow-up if this maps correctly to Highest Realized Price
+  const highRangeDollars = formatCentsToDollars(Number(highRangeCents))
+  const averageSalePrice = formatCentsToDollars(
+    (Number(lowRangeCents) + Number(highRangeCents)) / 2
+  )
+
+  return {
+    artistName,
+    averageSalePrice,
+    birthday,
+    demandRank,
+    highRangeDollars,
+    lastAuctionResult,
+    medianSaleToEstimateRatio,
+    nationality,
+    sellThroughRate,
+  }
 }

--- a/src/v2/Apps/Consign/Components/InDemandNow/ConsignTopArtists.tsx
+++ b/src/v2/Apps/Consign/Components/InDemandNow/ConsignTopArtists.tsx
@@ -1,81 +1,145 @@
 import React from "react"
-import { Box, Flex, Join, Separator, Spacer, Text } from "@artsy/palette"
 import { SystemQueryRenderer as QueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
 import { useSystemContext } from "v2/Artsy"
 import { graphql } from "react-relay"
-import { shuffle } from "lodash"
-
+import { chunk, shuffle } from "lodash"
 import { ConsignTopArtistsQuery } from "v2/__generated__/ConsignTopArtistsQuery.graphql"
+import styled from "styled-components"
+
+import {
+  Avatar,
+  Text as BaseText,
+  Box,
+  Flex,
+  Join,
+  Spacer,
+} from "@artsy/palette"
+
+type ArtworkProps = ConsignTopArtistsQuery["response"]["targetSupply"]["microfunnel"][0]["artworksConnection"]["edges"][0]["node"]
 
 export const ConsignTopArtists: React.FC = () => {
+  return (
+    <>
+      <Box>
+        <Text textAlign={"left"} mb={2} variant="largeTitle">
+          Top Artists
+        </Text>
+      </Box>
+
+      <ConsignTopArtistsQueryRenderer />
+    </>
+  )
+}
+
+const ConsignTopArtistsQueryRenderer: React.FC = () => {
   const { relayEnvironment } = useSystemContext()
 
   return (
-    <Box>
-      <Box>
-        <Text variant="title">Top artists</Text>
-        <Separator />
-      </Box>
-
-      <Box>
-        <QueryRenderer<ConsignTopArtistsQuery>
-          environment={relayEnvironment}
-          variables={{}}
-          query={graphql`
-            query ConsignTopArtistsQuery {
-              targetSupply {
-                microfunnel {
-                  artworksConnection(first: 1) {
-                    edges {
-                      node {
-                        slug
-                        internalID
-                        href
-                        artistNames
-                        image {
-                          imageURL
-                        }
-                        realizedPrice
-                      }
+    <QueryRenderer<ConsignTopArtistsQuery>
+      environment={relayEnvironment}
+      variables={{}}
+      query={graphql`
+        query ConsignTopArtistsQuery {
+          targetSupply {
+            microfunnel {
+              artworksConnection(first: 1) {
+                edges {
+                  node {
+                    slug
+                    internalID
+                    href
+                    artistNames
+                    image {
+                      imageURL
                     }
+
+                    # FIXME: Need to average up all artist artworks
+                    realizedPrice
                   }
                 }
               }
             }
-          `}
-          render={({ props, error }) => {
-            // FIXME: Error handling
-            if (error) {
-              return null
-            }
-            // FIXME: Add skeleton loading state
-            if (!props) {
-              return null
-            }
+          }
+        }
+      `}
+      render={({ props, error }) => {
+        // FIXME: Error handling
+        if (error) {
+          return null
+        }
 
-            const microfunnelItems = props.targetSupply.microfunnel || []
-            if (microfunnelItems.length === 0) {
-              return null
-            }
+        return <TopArtists {...props} />
+      }}
+    />
+  )
+}
 
-            const recentlySoldArtworks = shuffle(
-              microfunnelItems.map(x => x?.artworksConnection?.edges?.[0]?.node)
-            )
+const TopArtists: React.FC<ConsignTopArtistsQuery["response"]> = props => {
+  // FIXME: Add skeleton loading state
+  if (!props.targetSupply) {
+    return null
+  }
 
+  const microfunnelItems = props.targetSupply.microfunnel || []
+  if (microfunnelItems.length === 0) {
+    return null
+  }
+
+  const recentlySoldArtworks = chunk(
+    shuffle(
+      microfunnelItems.map(
+        artwork => artwork?.artworksConnection?.edges?.[0]?.node
+      )
+    ),
+    4
+  )
+
+  return (
+    <Box textAlign="left">
+      <Flex flexDirection="row" width="100%" overflow="scroll">
+        <Join separator={<Spacer mr={3} />}>
+          {recentlySoldArtworks.map((artworkSet, index) => {
             return (
               <Box>
-                <Flex flexDirection="row">
-                  <Join separator={<Spacer mr={0.5} />}>
-                    {recentlySoldArtworks.map((recentlySoldArtwork, index) => {
-                      return <Box key={index}>artwork</Box>
-                    })}
-                  </Join>
-                </Flex>
+                {artworkSet.map((recentlySoldArtwork: ArtworkProps, index) => {
+                  const {
+                    image,
+                    artistNames,
+                    realizedPrice,
+                  } = recentlySoldArtwork
+                  const imageUrl = image.imageURL.replace(":version", "small")
+
+                  return (
+                    <Box key={index}>
+                      <Flex
+                        mb={2}
+                        alignItems="center"
+                        style={{ whiteSpace: "nowrap" }}
+                      >
+                        <Box pr={1}>
+                          <Avatar src={imageUrl} size="xs" />
+                        </Box>
+                        <Box>
+                          <Text variant="text" fontWeight="bold">
+                            {artistNames}
+                          </Text>
+                          <Text variant="text">
+                            Average Sale Price: {realizedPrice}
+                          </Text>
+                        </Box>
+                      </Flex>
+                    </Box>
+                  )
+                })}
               </Box>
             )
-          }}
-        />
-      </Box>
+          })}
+        </Join>
+      </Flex>
     </Box>
   )
 }
+
+const Text = styled(BaseText)`
+  color: white;
+`

--- a/src/v2/Apps/Consign/Components/InDemandNow/DemandRank.tsx
+++ b/src/v2/Apps/Consign/Components/InDemandNow/DemandRank.tsx
@@ -1,0 +1,62 @@
+import React from "react"
+import {
+  Text as BaseText,
+  Box,
+  Flex,
+  Spacer,
+  TriangleDownIcon,
+} from "@artsy/palette"
+import styled from "styled-components"
+
+export const DemandRank: React.FC<{ demandRank: number }> = ({
+  demandRank,
+}) => {
+  let width = demandRank * 100
+  if (width > 100) {
+    width = 100
+  }
+
+  return (
+    <Box>
+      <Text>Demand Index</Text>
+      <Box>
+        <Text variant="largeTitle" color="white100">
+          {demandRank}
+        </Text>
+      </Box>
+      <ProgressBar width={width} />
+      <Spacer my={0.3} />
+      <Flex flexDirection="row" justifyContent="space-between">
+        <Text>0.0</Text>
+        <Text>{demandRank}</Text>
+      </Flex>
+    </Box>
+  )
+}
+
+const ProgressBar: React.FC<{ width: number }> = ({ width }) => {
+  const pctWidth = width + "%"
+
+  return (
+    <Box overflow="hidden">
+      <Box width="100%" position="relative" height={10} left={-6}>
+        <TriangleDownIcon fill="white100" left={pctWidth} position="absolute" />
+      </Box>
+      <Box height={20} width="100%" bg="black5">
+        <Box
+          width={pctWidth}
+          height={24}
+          className="card"
+          style={{
+            background:
+              "linear-gradient(to right, rgba(10, 26, 180, 0.1), #066AE0)",
+          }}
+        />
+      </Box>
+    </Box>
+  )
+}
+
+const Text = styled(BaseText)`
+  color: white;
+`

--- a/src/v2/Apps/Consign/Components/SectionContainer.tsx
+++ b/src/v2/Apps/Consign/Components/SectionContainer.tsx
@@ -1,13 +1,16 @@
-import { Color, Flex, FlexProps } from "@artsy/palette"
+import { Color, Flex, FlexProps, breakpoints } from "@artsy/palette"
 import React from "react"
+import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
 
 interface SectionContainerProps extends FlexProps {
   background?: Color
+  constrain?: boolean
 }
 
 export const SectionContainer: React.FC<SectionContainerProps> = ({
   children,
   background = "white100",
+  constrain = true,
   ...rest
 }) => {
   return (
@@ -22,7 +25,13 @@ export const SectionContainer: React.FC<SectionContainerProps> = ({
       top={-1}
       {...rest}
     >
-      {children}
+      {constrain ? (
+        <HorizontalPadding maxWidth={breakpoints.xl} width="100%">
+          {children}
+        </HorizontalPadding>
+      ) : (
+        <>{children}</>
+      )}
     </Flex>
   )
 }

--- a/src/v2/Apps/Consign/Components/SellArtDifferently.tsx
+++ b/src/v2/Apps/Consign/Components/SellArtDifferently.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Box, EditIcon, Flex, Separator, Text } from "@artsy/palette"
-import { SectionContainer } from "v2/Apps/Artist/Routes/Consign/Components/SectionContainer"
+import { SectionContainer } from "./SectionContainer"
 
 export const SellArtDifferently: React.FC = () => {
   return (

--- a/src/v2/Apps/Consign/ConsignApp.tsx
+++ b/src/v2/Apps/Consign/ConsignApp.tsx
@@ -32,9 +32,9 @@ const ConsignApp = props => {
           <SellArtDifferently />
           <GetPriceEstimate />
           <HowToSell />
+          <ConsignInDemandNow />
 
           <HorizontalPadding>
-            <ConsignInDemandNow />
             <SoldRecently />
             <ReadMore />
             <ContactUs />

--- a/src/v2/Apps/Consign/Utils/__tests__/formatCentsToDollars.jest.tsx
+++ b/src/v2/Apps/Consign/Utils/__tests__/formatCentsToDollars.jest.tsx
@@ -1,0 +1,12 @@
+import { formatCentsToDollars } from "../formatCentsToDollars"
+
+describe("formatCentsToDollars", () => {
+  it("ignores negative numbers", () => {
+    expect(formatCentsToDollars(-1)).toBe("$0")
+  })
+
+  it("formats inputs correctly", () => {
+    expect(formatCentsToDollars(200)).toBe("$2")
+    expect(formatCentsToDollars(200.013)).toBe("$2")
+  })
+})

--- a/src/v2/Apps/Consign/Utils/formatCentsToDollars.ts
+++ b/src/v2/Apps/Consign/Utils/formatCentsToDollars.ts
@@ -1,0 +1,17 @@
+export function formatCentsToDollars(value: number) {
+  if (value < 0) {
+    value = 0
+  }
+
+  const CENTS_IN_DOLLAR = 100
+
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+
+    // TODO: While artwork price insight stuff is all currently calculated
+    // in dollars, we might need to return to this later.
+    currency: "USD",
+  })
+    .format(Math.round(value / CENTS_IN_DOLLAR))
+    .replace(".00", "")
+}

--- a/src/v2/__generated__/ConsignInDemandNowQuery.graphql.ts
+++ b/src/v2/__generated__/ConsignInDemandNowQuery.graphql.ts
@@ -4,9 +4,36 @@
 import { ConcreteRequest } from "relay-runtime";
 export type ConsignInDemandNowQueryVariables = {
     artistInternalId: string;
+    artistSlug: string;
     medium: string;
 };
 export type ConsignInDemandNowQueryResponse = {
+    readonly artist: {
+        readonly birthday: string | null;
+        readonly nationality: string | null;
+        readonly auctionResultsConnection: {
+            readonly edges: ReadonlyArray<{
+                readonly node: {
+                    readonly internalID: string;
+                    readonly title: string | null;
+                    readonly dimensionText: string | null;
+                    readonly images: {
+                        readonly thumbnail: {
+                            readonly url: string | null;
+                        } | null;
+                    } | null;
+                    readonly description: string | null;
+                    readonly dateText: string | null;
+                    readonly organization: string | null;
+                    readonly saleDate: string | null;
+                    readonly priceRealized: {
+                        readonly display: string | null;
+                        readonly centsUSD: number | null;
+                    } | null;
+                } | null;
+            } | null> | null;
+        } | null;
+    } | null;
     readonly marketPriceInsights: {
         readonly annualLotsSold: number | null;
         readonly annualValueSoldCents: unknown | null;
@@ -45,8 +72,37 @@ export type ConsignInDemandNowQuery = {
 /*
 query ConsignInDemandNowQuery(
   $artistInternalId: ID!
+  $artistSlug: String!
   $medium: String!
 ) {
+  artist(id: $artistSlug) {
+    birthday
+    nationality
+    auctionResultsConnection(first: 1, sort: DATE_DESC) {
+      edges {
+        node {
+          internalID
+          title
+          dimensionText
+          images {
+            thumbnail {
+              url
+            }
+          }
+          description
+          dateText
+          organization
+          saleDate
+          priceRealized {
+            display
+            centsUSD
+          }
+          id
+        }
+      }
+    }
+    id
+  }
   marketPriceInsights(artistId: $artistInternalId, medium: $medium) {
     annualLotsSold
     annualValueSoldCents
@@ -88,216 +144,420 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
+    "name": "artistSlug",
+    "type": "String!"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
     "name": "medium",
     "type": "String!"
   }
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "artistId",
-        "variableName": "artistInternalId"
-      },
-      {
-        "kind": "Variable",
-        "name": "medium",
-        "variableName": "medium"
-      }
-    ],
-    "concreteType": "MarketPriceInsights",
-    "kind": "LinkedField",
-    "name": "marketPriceInsights",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "annualLotsSold",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "annualValueSoldCents",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "artistId",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "artistName",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "artsyQInventory",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "createdAt",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "demandRank",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "demandTrend",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "highRangeCents",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "largeHighRangeCents",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "largeLowRangeCents",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "largeMidRangeCents",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "liquidityRank",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "lowRangeCents",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "medianSaleToEstimateRatio",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "medium",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "mediumHighRangeCents",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "mediumLowRangeCents",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "mediumMidRangeCents",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "midRangeCents",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "sellThroughRate",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "smallHighRangeCents",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "smallLowRangeCents",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "smallMidRangeCents",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "updatedAt",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artistSlug"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "birthday",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "nationality",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 1
+  },
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "DATE_DESC"
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "dimensionText",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "AuctionLotImages",
+  "kind": "LinkedField",
+  "name": "images",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "thumbnail",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "url",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "dateText",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "organization",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "saleDate",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "AuctionResultPriceRealized",
+  "kind": "LinkedField",
+  "name": "priceRealized",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "display",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "centsUSD",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "artistId",
+      "variableName": "artistInternalId"
+    },
+    {
+      "kind": "Variable",
+      "name": "medium",
+      "variableName": "medium"
+    }
+  ],
+  "concreteType": "MarketPriceInsights",
+  "kind": "LinkedField",
+  "name": "marketPriceInsights",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "annualLotsSold",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "annualValueSoldCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "artistId",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "artistName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "artsyQInventory",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "createdAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "demandRank",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "demandTrend",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "highRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "largeHighRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "largeLowRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "largeMidRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "liquidityRank",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "lowRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "medianSaleToEstimateRatio",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "medium",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "mediumHighRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "mediumLowRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "mediumMidRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "midRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "sellThroughRate",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "smallHighRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "smallLowRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "smallMidRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "updatedAt",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "ConsignInDemandNowQuery",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
+            "concreteType": "AuctionResultConnection",
+            "kind": "LinkedField",
+            "name": "auctionResultsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "AuctionResultEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AuctionResult",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/),
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v9/*: any*/),
+                      (v10/*: any*/),
+                      (v11/*: any*/),
+                      (v12/*: any*/),
+                      (v13/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "auctionResultsConnection(first:1,sort:\"DATE_DESC\")"
+          }
+        ],
+        "storageKey": null
+      },
+      (v14/*: any*/)
+    ],
     "type": "Query"
   },
   "kind": "Request",
@@ -305,16 +565,75 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "ConsignInDemandNowQuery",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
+            "concreteType": "AuctionResultConnection",
+            "kind": "LinkedField",
+            "name": "auctionResultsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "AuctionResultEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AuctionResult",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/),
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v9/*: any*/),
+                      (v10/*: any*/),
+                      (v11/*: any*/),
+                      (v12/*: any*/),
+                      (v13/*: any*/),
+                      (v15/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "auctionResultsConnection(first:1,sort:\"DATE_DESC\")"
+          },
+          (v15/*: any*/)
+        ],
+        "storageKey": null
+      },
+      (v14/*: any*/)
+    ]
   },
   "params": {
     "id": null,
     "metadata": {},
     "name": "ConsignInDemandNowQuery",
     "operationKind": "query",
-    "text": "query ConsignInDemandNowQuery(\n  $artistInternalId: ID!\n  $medium: String!\n) {\n  marketPriceInsights(artistId: $artistInternalId, medium: $medium) {\n    annualLotsSold\n    annualValueSoldCents\n    artistId\n    artistName\n    artsyQInventory\n    createdAt\n    demandRank\n    demandTrend\n    highRangeCents\n    largeHighRangeCents\n    largeLowRangeCents\n    largeMidRangeCents\n    liquidityRank\n    lowRangeCents\n    medianSaleToEstimateRatio\n    medium\n    mediumHighRangeCents\n    mediumLowRangeCents\n    mediumMidRangeCents\n    midRangeCents\n    sellThroughRate\n    smallHighRangeCents\n    smallLowRangeCents\n    smallMidRangeCents\n    updatedAt\n  }\n}\n"
+    "text": "query ConsignInDemandNowQuery(\n  $artistInternalId: ID!\n  $artistSlug: String!\n  $medium: String!\n) {\n  artist(id: $artistSlug) {\n    birthday\n    nationality\n    auctionResultsConnection(first: 1, sort: DATE_DESC) {\n      edges {\n        node {\n          internalID\n          title\n          dimensionText\n          images {\n            thumbnail {\n              url\n            }\n          }\n          description\n          dateText\n          organization\n          saleDate\n          priceRealized {\n            display\n            centsUSD\n          }\n          id\n        }\n      }\n    }\n    id\n  }\n  marketPriceInsights(artistId: $artistInternalId, medium: $medium) {\n    annualLotsSold\n    annualValueSoldCents\n    artistId\n    artistName\n    artsyQInventory\n    createdAt\n    demandRank\n    demandTrend\n    highRangeCents\n    largeHighRangeCents\n    largeLowRangeCents\n    largeMidRangeCents\n    liquidityRank\n    lowRangeCents\n    medianSaleToEstimateRatio\n    medium\n    mediumHighRangeCents\n    mediumLowRangeCents\n    mediumMidRangeCents\n    midRangeCents\n    sellThroughRate\n    smallHighRangeCents\n    smallLowRangeCents\n    smallMidRangeCents\n    updatedAt\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = 'a7cf18943f14ee6fedccfdcd65ac9549';
+(node as any).hash = 'c0d0cbc29810b597927ea72f5dcaf098';
 export default node;

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,10 +58,10 @@
   dependencies:
     uuid "^8.3.0"
 
-"@artsy/palette@13.13.0":
-  version "13.13.0"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-13.13.0.tgz#7d503eae0db06fe4f2eb95e0b929494be673567d"
-  integrity sha512-mpkIHjrb9YNmb+KWUluQWP4ctQ4wHB6OYVLzpLqjRbhl4DFrHUtiv7gJQilOO6cRRPihhRc5LfG/9va/YlFrGw==
+"@artsy/palette@13.15.0":
+  version "13.15.0"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-13.15.0.tgz#968bfb0f836b4d0f021bc701cd8904fcf25dd862"
+  integrity sha512-LKXuqw9tom7hsQ9fm7+/lcuaHAq2XN9mWvH9J1DL9UpMmb7+md6ZwZUAfcxbpRBJMAJ+L5WqrwWtrU8cJrxI1w==
   dependencies:
     "@styled-system/theme-get" "^5.1.2"
     babel-plugin-styled-components "^1.10.0"


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GRO-34 

This gets a first pass of the the In Demand Now section in. 

Some follow-up items in next PR:
- Verify data (diffusion) fields are correct 
- Sum up average of all artists' artwork prices for average in top-artists section 
- Replace graph image with svg (?) 
- A little more precise design QA (margins) 

Also starts getting the overall page in shape, e.g., capping center content width for each section.

cc @artsy/grow-devs 

![screen](https://user-images.githubusercontent.com/236943/97245128-97e8c300-17b7-11eb-95db-781e86ff6833.gif)
