### PR TITLE
Add ability to selectively ignore some reflection pages for testing SEO

### DIFF
--- a/src/lib/middleware/proxy_to_reflection.js
+++ b/src/lib/middleware/proxy_to_reflection.js
@@ -6,14 +6,35 @@ const httpProxy = require("http-proxy")
 const request = require("superagent")
 const proxy = httpProxy.createProxyServer()
 const { parse } = require("url")
-const { REFLECTION_URL } = process.env
+
+let ignoreList = null
+
+/**
+ * Provides a set of paths to ignore from reflection for testing purposes. This
+ * is called only on the first middleware execution to avoid unnecessary
+ * recalculations.
+ */
+function setIgnoreList() {
+  // Destructured here so it can actually be mocked in tests
+  const { REFLECTION_IGNORE } = process.env
+  ignoreList =
+    typeof REFLECTION_IGNORE === "string" ? REFLECTION_IGNORE.split(",") : []
+}
 
 module.exports = function proxyToReflection(req, res, next) {
   if (req.query._escaped_fragment_ == null) {
     return next()
   }
 
-  const proxyUrl = reflectionProxyUrl(req)
+  // Initialize the ignore list if this hasn't already happened
+  if (!ignoreList) setIgnoreList()
+
+  const url = parse(req.url)
+  if (ignoreList.includes(url.pathname)) {
+    return next()
+  }
+
+  const proxyUrl = reflectionProxyUrl(url)
   request.head(proxyUrl).end(function (err) {
     if (err) {
       return next()
@@ -26,9 +47,8 @@ module.exports = function proxyToReflection(req, res, next) {
   })
 }
 
-const reflectionProxyUrl = function (req) {
-  const url = parse(req.url)
-  let dest = REFLECTION_URL + url.pathname
+const reflectionProxyUrl = function (url) {
+  let dest = process.env.REFLECTION_URL + url.pathname
   const query =
     url.query != null
       ? url.query.replace(/&?_escaped_fragment_=/, "")


### PR DESCRIPTION
This is part of the investigation into PURCHASE-2208. One of the tasks I'm working on is to test an see if some of the UI inconsistencies we've had reported to us by deepcrawl is when reflection comes into play. With this I'll selectively disable a small list of pages and we can test their state. 