### PR TITLE
feat: Add "How to Sell" section to consign2

### DIFF
--- a/src/v2/Apps/Consign/Components/HowToSell.tsx
+++ b/src/v2/Apps/Consign/Components/HowToSell.tsx
@@ -1,46 +1,67 @@
 import React from "react"
 import { Box, Button, EditIcon, Flex, Separator, Text } from "@artsy/palette"
+import { SectionContainer } from "v2/Apps/Artist/Routes/Consign/Components/SectionContainer"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
+import { Media } from "v2/Utils/Responsive"
 
 export const HowToSell: React.FC = () => {
+  const navigateTo = "/consign/submission"
   return (
-    <Box>
-      <Box>
-        <Text variant="title">
-          3 Simple Steps:
-          <br /> How to sell artwork from your collectiony
-        </Text>
-        <Separator />
-      </Box>
+    <SectionContainer>
+      <Text
+        width="100%"
+        textAlign={["center", "left"]}
+        mb={2}
+        variant="largeTitle"
+      >
+        3 Simple Steps:
+        <br /> How to sell artwork from your collection
+      </Text>
+      <Separator />
 
       <Flex
         flexDirection={["column", "row"]}
         alignItems="center"
-        justifyContent="center"
+        justifyContent="space-between"
+        pt={[1, 4]}
       >
         <Section
-          icon={<EditIcon width={30} height={30} />}
-          text="Submit once"
-          description="Submit your artwork details and images. Artsy will review and
-            approve qualified submissions for consignment."
+          icon={<EditIcon width={50} height={50} />}
+          text="Submit the Artwork"
+          description="Submit your artwork details and images. Artsy will review and approve qualified submissions."
         />
         <Section
-          icon={<EditIcon width={30} height={30} />}
-          text="Submit once"
-          description="Submit your artwork details and images. Artsy will review and
-            approve qualified submissions for consignment."
+          icon={<EditIcon width={50} height={50} />}
+          text="Receive Multiple Offers"
+          description="If your work is accepted, you’ll receive competitive consignment offers from auction houses, galleries, and collectors."
         />
         <Section
-          icon={<EditIcon width={30} height={30} />}
-          text="Submit once"
-          description="Submit your artwork details and images. Artsy will review and
-            approve qualified submissions for consignment."
+          icon={<EditIcon width={50} height={50} />}
+          text="Match and Sell"
+          description="With our specialists’ expert guidance, evaluate your offers, choose the best one for you, and sell your work. We’ll help you ship it safely."
         />
       </Flex>
-
-      <Box>
-        <Button size="large">Submit your artwork</Button>
+      <Box width="100%" textAlign="center">
+        <RouterLink to={navigateTo}>
+          <Media greaterThanOrEqual="sm">
+            <Button variant="primaryBlack" size="large" mt={6}>
+              Submit your artwork
+            </Button>
+          </Media>
+          <Media lessThan="sm">
+            <Button
+              variant="primaryBlack"
+              size="large"
+              mt={6}
+              block
+              width="100%"
+            >
+              Submit your artwork
+            </Button>
+          </Media>
+        </RouterLink>
       </Box>
-    </Box>
+    </SectionContainer>
   )
 }
 
@@ -50,13 +71,20 @@ const Section: React.FC<{
   description: string
 }> = ({ icon, text, description }) => {
   return (
-    <Box width={["100%", "25%"]} height={["100%", 170]} my={[3, 0]} mx={2}>
+    <Box
+      width={["100%", "25%"]}
+      height={["100%", 170]}
+      my={[1, 0]}
+      textAlign="center"
+    >
       <Box>{icon}</Box>
-      <Box mt={1} mb={2}>
-        <Text variant="mediumText">{text}</Text>
+      <Box mt={[0, 1]} mb={[0, 2]}>
+        <Text variant="subtitle">{text}</Text>
       </Box>
       <Box>
-        <Text variant="mediumText">{description}</Text>
+        <Text variant="text" color="black60">
+          {description}
+        </Text>
       </Box>
     </Box>
   )

--- a/src/v2/Apps/Consign/Components/SellArtDifferently.tsx
+++ b/src/v2/Apps/Consign/Components/SellArtDifferently.tsx
@@ -5,7 +5,12 @@ import { SectionContainer } from "v2/Apps/Artist/Routes/Consign/Components/Secti
 export const SellArtDifferently: React.FC = () => {
   return (
     <SectionContainer>
-      <Text textAlign={["center", "left"]} mb={2} variant="largeTitle">
+      <Text
+        width="100%"
+        textAlign={["center", "left"]}
+        mb={2}
+        variant="largeTitle"
+      >
         Selling Art Differently
       </Text>
       <Separator />

--- a/src/v2/Apps/Consign/ConsignApp.tsx
+++ b/src/v2/Apps/Consign/ConsignApp.tsx
@@ -29,11 +29,11 @@ const ConsignApp = props => {
 
         <AppContainer maxWidth="100%">
           <Header />
-          <GetPriceEstimate />
           <SellArtDifferently />
+          <GetPriceEstimate />
+          <HowToSell />
 
           <HorizontalPadding>
-            <HowToSell />
             <ConsignInDemandNow />
             <SoldRecently />
             <ReadMore />


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GRO-37

Adds the "How to Sell" section for the new consign2 page. The structure is almost identical to https://github.com/artsy/force/pull/6525.

### Screenshots
![Screen Shot 2020-10-26 at 10 40 36 AM](https://user-images.githubusercontent.com/4432348/97187013-63094b80-1778-11eb-9c86-71ecc6febea6.png)

![Screen Shot 2020-10-26 at 10 38 05 AM](https://user-images.githubusercontent.com/4432348/97187018-643a7880-1778-11eb-91c6-4e0f737b4b1c.png)
