### PR TITLE
fix: Decaffeination Export Error

### DIFF
--- a/src/mobile/collections/install_shots.coffee
+++ b/src/mobile/collections/install_shots.coffee
@@ -1,6 +1,6 @@
 _ = require 'underscore'
 Backbone = require 'backbone'
-InstallShot = require '../models/install_shot'
+{ InstallShot } = require '../models/install_shot'
 { Fetch } = require '@artsy/backbone-mixins'
 { API_URL } = require('sharify').data
 

--- a/src/mobile/models/install_shot.ts
+++ b/src/mobile/models/install_shot.ts
@@ -1,4 +1,3 @@
-let InstallShot
 const AdditionalImage = require("./additional_image.coffee")
 
-module.exports = InstallShot = class InstallShot extends AdditionalImage {}
+export class InstallShot extends AdditionalImage {}


### PR DESCRIPTION
While decaffeinating files the following export needed to be updated to
prevent a mismatch between `module.exports` and es6 style exports. I'm
still investigating to see if there is a way this type of mismatch can
be identified more easily while decaffeinating files.