### PR TITLE
Uses srcSet in viewing room cards

### DIFF
--- a/src/v2/Apps/Show/Components/ShowViewingRoom.tsx
+++ b/src/v2/Apps/Show/Components/ShowViewingRoom.tsx
@@ -3,8 +3,8 @@ import { Box, BoxProps, MediumCard, ResponsiveBox, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ShowViewingRoom_show } from "v2/__generated__/ShowViewingRoom_show.graphql"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
-import { crop } from "v2/Utils/resizer"
 import { getTagProps } from "v2/Components/ViewingRoomCard"
+import { cropped } from "v2/Utils/resized"
 
 interface ShowViewingRoomProps extends BoxProps {
   show: ShowViewingRoom_show
@@ -16,9 +16,9 @@ export const ShowViewingRoom: React.FC<ShowViewingRoomProps> = ({
 }) => {
   const [{ node: viewingRoom }] = show.viewingRoomsConnection.edges
 
-  const thumbnail = crop(viewingRoom.image.imageURLs.normalized, {
-    width: 900,
-    height: 1200,
+  const image = cropped(viewingRoom.image?.imageURLs?.normalized, {
+    width: 450,
+    height: 600,
   })
 
   return (
@@ -32,7 +32,7 @@ export const ShowViewingRoom: React.FC<ShowViewingRoomProps> = ({
           <MediumCard
             width="100%"
             height="100%"
-            image={thumbnail}
+            image={image}
             title={viewingRoom.title}
             subtitle={show.partner?.name}
             tag={getTagProps(

--- a/src/v2/Apps/ViewingRoom/Components/ViewingRoomsFeaturedRail.tsx
+++ b/src/v2/Apps/ViewingRoom/Components/ViewingRoomsFeaturedRail.tsx
@@ -4,7 +4,7 @@ import { ViewingRoomsFeaturedRail_featuredViewingRooms } from "v2/__generated__/
 import { createFragmentContainer, graphql } from "react-relay"
 import { ViewingRoomCarousel } from "./ViewingRoomCarousel"
 import { getTagProps } from "v2/Components/ViewingRoomCard"
-import { crop } from "v2/Utils/resizer"
+import { cropped } from "v2/Utils/resized"
 
 interface ViewingRoomsFeaturedRailProps {
   featuredViewingRooms: ViewingRoomsFeaturedRail_featuredViewingRooms
@@ -30,9 +30,9 @@ export const ViewingRoomsFeaturedRail: React.FC<ViewingRoomsFeaturedRailProps> =
     slideIndex: number
   ): React.ReactElement => {
     const tag = getTagProps(status, distanceToOpen, distanceToClose)
-    const heroImageURL = crop(image?.imageURLs?.normalized, {
-      height: 740,
-      width: 560,
+    const sized = cropped(image?.imageURLs?.normalized, {
+      width: 280,
+      height: 370,
     })
 
     return (
@@ -40,7 +40,7 @@ export const ViewingRoomsFeaturedRail: React.FC<ViewingRoomsFeaturedRailProps> =
         {slideIndex !== 0 && <Spacer ml="15px" />}
         <Link href={`/viewing-room/${slug}`} key={slug} noUnderline>
           <MediumCard
-            image={heroImageURL}
+            image={sized}
             title={title}
             subtitle={partner.name}
             tag={tag}

--- a/src/v2/Apps/ViewingRoom/Components/ViewingRoomsLatestGrid.tsx
+++ b/src/v2/Apps/ViewingRoom/Components/ViewingRoomsLatestGrid.tsx
@@ -7,9 +7,9 @@ import {
 } from "react-relay"
 import { scrollIntoView } from "v2/Utils/scrollHelpers"
 import { ViewingRoomsLatestGrid_viewingRooms } from "v2/__generated__/ViewingRoomsLatestGrid_viewingRooms.graphql"
-import { crop } from "v2/Utils/resizer"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import { getTagProps } from "v2/Components/ViewingRoomCard"
+import { cropped } from "v2/Utils/resized"
 
 export interface ViewingRoomsLatestGridProps {
   relay: RelayPaginationProp
@@ -88,14 +88,16 @@ export const ViewingRoomsLatestGrid: React.FC<ViewingRoomsLatestGridProps> = pro
               distanceToClose,
               artworksConnection,
             } = vr
-            const heroImageURL = crop(image?.imageURLs?.normalized, {
-              height: 800,
-              width: 800,
+            const heroImageURL = cropped(image?.imageURLs?.normalized, {
+              height: 490,
+              width: 490,
             })
             const artworksCount = artworksConnection.totalCount
-            const artworkImages = artworksConnection.edges.map(({ node }) =>
-              artworksCount < 2 ? node.image.regular : node.image.square
-            )
+            const artworkImages = artworksConnection.edges.map(({ node }) => {
+              const src =
+                artworksCount < 2 ? node.image.regular : node.image.square
+              return { src, srcSet: src }
+            })
             const tag = getTagProps(status, distanceToOpen, distanceToClose)
 
             return (

--- a/src/v2/Utils/__tests__/resized.jest.ts
+++ b/src/v2/Utils/__tests__/resized.jest.ts
@@ -1,0 +1,48 @@
+import { cropped, resized } from "../resized"
+
+describe("#cropped", () => {
+  it("uses width, height, and quality", () => {
+    const { src, srcSet } = cropped("https://media.artsy.net/img.jpg", {
+      width: 100,
+      height: 100,
+      quality: 80,
+    })
+
+    expect(src).toContain("d7hftxdivxxvm")
+    expect(src).toContain("&width=100&height=100&quality=80")
+    expect(srcSet).toContain("1x, ")
+    expect(srcSet).toContain("&width=100&height=100&quality=80")
+    expect(srcSet).toContain("2x")
+    expect(srcSet).toContain("&width=200&height=200&quality=80")
+  })
+})
+
+describe("#resized", () => {
+  it("resizeds to a width", () => {
+    const { src, srcSet } = resized("https://media.artsy.net/img.jpg", {
+      width: 100,
+    })
+
+    expect(src).toContain("d7hftxdivxxvm")
+    expect(src).toContain("&width=100&quality=80")
+    expect(src).toContain("resize_to=width")
+    expect(srcSet).toContain("1x, ")
+    expect(srcSet).toContain("&width=100&quality=80")
+    expect(srcSet).toContain("2x")
+    expect(srcSet).toContain("&width=200&quality=80")
+  })
+
+  it("resizeds to a height", () => {
+    const { src, srcSet } = resized("https://media.artsy.net/img.jpg", {
+      height: 100,
+    })
+
+    expect(src).toContain("d7hftxdivxxvm")
+    expect(src).toContain("&height=100&quality=80")
+    expect(src).toContain("resize_to=height")
+    expect(srcSet).toContain("1x, ")
+    expect(srcSet).toContain("&height=100&quality=80")
+    expect(srcSet).toContain("2x")
+    expect(srcSet).toContain("&height=200&quality=80")
+  })
+})

--- a/src/v2/Utils/resized.ts
+++ b/src/v2/Utils/resized.ts
@@ -1,0 +1,44 @@
+import { crop, resize } from "./resizer"
+
+type Sized = { src: string; srcSet: string }
+type Resize = Parameters<typeof resize>
+
+/**
+ * Same arguments as `resize`, but returns a `srcSet` with 2x support
+ * in addition to the 1x `src`.
+ */
+export const resized = (
+  src: Resize[0],
+  { width, height, ...rest }: Resize[1]
+): Sized => {
+  const _1x = resize(src, { width, height, ...rest })
+  const _2x = resize(src, {
+    ...(width ? { width: width * 2 } : {}),
+    ...(height ? { height: height * 2 } : {}),
+    ...rest,
+  })
+
+  return {
+    src: _1x,
+    srcSet: `${_1x} 1x, ${_2x} 2x`,
+  }
+}
+
+type Crop = Parameters<typeof crop>
+
+/**
+ * Same arguments as `crop`, but returns a `srcSet` with 2x support
+ * in addition to the 1x `src`.
+ */
+export const cropped = (
+  src: Crop[0],
+  { width, height, ...rest }: Crop[1]
+): Sized => {
+  const _1x = crop(src, { width, height, ...rest })
+  const _2x = crop(src, { width: width * 2, height: height * 2, ...rest })
+
+  return {
+    src: _1x,
+    srcSet: `${_1x} 1x, ${_2x} 2x`,
+  }
+}


### PR DESCRIPTION
Since we don't have the same helper fields that Metaphysics has, this PR adds two new functions `cropped` and `resized` which accept the same arguments as `crop` and `resize` but return `{ src: string, srcSet: string }` with a `srcSet` filled in for the `2x` version of the desired image.