### PR TITLE
fix: replace docker-compose extends keyword with Jinja2 template

### DIFF
--- a/hokusai/build.yml
+++ b/hokusai/build.yml
@@ -2,7 +2,4 @@
 version: "3.8"
 services:
   force:
-    image: "hokusai_force:${BUILD_TAG:-latest}"
-    build:
-      context: ../
-      target: "${BUILD_TARGET}"
+{% include 'templates/docker-compose-service.yml.j2' %}

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -2,9 +2,7 @@
 version: "3.8"
 services:
   force:
-    extends:
-      file: build.yml
-      service: force
+{% include 'templates/docker-compose-service.yml.j2' %}
     environment:
       - NODE_ENV=development
       - REDIS_URL=redis://force-redis:6379/0

--- a/hokusai/templates/docker-compose-service.yml.j2
+++ b/hokusai/templates/docker-compose-service.yml.j2
@@ -1,0 +1,4 @@
+    image: "hokusai_force:${BUILD_TAG:-latest}"
+    build:
+      context: ../
+      target: "${BUILD_TARGET}"

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -3,9 +3,7 @@ version: "3.8"
 services:
   force:
     command: yarn test
-    extends:
-      file: build.yml
-      service: force
+{% include 'templates/docker-compose-service.yml.j2' %}
     environment:
       - CI=true
       - CIRCLE_NODE_INDEX


### PR DESCRIPTION
Required for Docker Compose v3 / Hokusai >= v0.5.12 compatibility
