### PR TITLE
refactor: replace auth modal backbone requests with fetch

### DIFF
--- a/src/desktop/apps/authentication/routes.ts
+++ b/src/desktop/apps/authentication/routes.ts
@@ -180,7 +180,7 @@ export const getRedirectTo = req => {
     req.query["redirect_uri"] ||
     (!isStaticAuth ? referrer : undefined)
 
-  if (redirectTo === "/reset_password") {
+  if (redirectTo === ("/reset_password" || "/user/delete")) {
     return "/"
   } else {
     return redirectTo

--- a/src/typings/sharify.d.ts
+++ b/src/typings/sharify.d.ts
@@ -84,8 +84,10 @@ declare module "sharify" {
       PC_AUCTION_CHANNEL: string
       POSITRON_URL: string
       PROFILE?: any // mobile partner app data
+      RESET_PASSWORD_REDIRECT_TO: string
       SECTION?: { slug?: string } // FIXME: used only for /venice-biennale-2015
       SESSION_ID?: string
+      SET_PASSWORD: string
       SHOW_ANALYTICS_CALLS: boolean
       SUBMISSION: string
       SUBMISSION_ID: string


### PR DESCRIPTION
Our auth modals use the `LoggedOutUser` model to manage authentication requests, which adds unwanted dependencies for Backbone, jQuery and Underscore. 

This PR uses `fetch` to replicate request logic from `LoggedOutUser`'s `login`, `signup`, and `forgot` methods, and makes requests directly from the modal rather than relying on the backbone model.

https://artsyproduct.atlassian.net/browse/PLATFORM-2919

Review app: https://logged-out-user.artsy.net/

Old user logic (still used for inquiry flow) - https://github.com/artsy/force/blob/master/src/desktop/models/logged_out_user.coffee#L59-L101

TODO:
- [x] QA via review app
- [x] Ensure 2FA works as expected
- [x] Fix tests
- [x] Integrity passes against review app: https://app.circleci.com/pipelines/github/artsy/integrity/4050/workflows/c921acc2-5b09-4ab0-83ec-c5e3d579c67b
