### PR TITLE
Fix onboarding search results

### DIFF
--- a/src/v2/Components/Onboarding/Steps/Artists/ArtistSearchResults.tsx
+++ b/src/v2/Components/Onboarding/Steps/Artists/ArtistSearchResults.tsx
@@ -182,7 +182,12 @@ const ArtistSearchResultsContentContainer = createFragmentContainer(
   {
     viewer: graphql`
       fragment ArtistSearchResults_viewer on Viewer {
-        searchConnection(query: $term, mode: AUTOSUGGEST, entities: [ARTIST]) {
+        searchConnection(
+          query: $term
+          mode: AUTOSUGGEST
+          entities: [ARTIST]
+          first: 10
+        ) {
           edges {
             node {
               ... on SearchableItem {

--- a/src/v2/Components/Onboarding/Steps/Genes/GeneSearchResults.tsx
+++ b/src/v2/Components/Onboarding/Steps/Genes/GeneSearchResults.tsx
@@ -178,6 +178,7 @@ const GeneSearchResultsContentContainer = createFragmentContainer(
           query: $term
           mode: AUTOSUGGEST
           entities: [GENE]
+          first: 10
         ) {
           edges {
             node {

--- a/src/v2/__generated__/ArtistSearchResultsQuery.graphql.ts
+++ b/src/v2/__generated__/ArtistSearchResultsQuery.graphql.ts
@@ -28,7 +28,7 @@ query ArtistSearchResultsQuery(
 }
 
 fragment ArtistSearchResults_viewer on Viewer {
-  searchConnection(query: $term, mode: AUTOSUGGEST, entities: [ARTIST]) {
+  searchConnection(query: $term, mode: AUTOSUGGEST, entities: [ARTIST], first: 10) {
     edges {
       node {
         __typename
@@ -106,6 +106,11 @@ return {
                 "value": [
                   "ARTIST"
                 ]
+              },
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 10
               },
               {
                 "kind": "Literal",
@@ -206,7 +211,7 @@ return {
     "metadata": {},
     "name": "ArtistSearchResultsQuery",
     "operationKind": "query",
-    "text": "query ArtistSearchResultsQuery(\n  $term: String!\n) {\n  viewer {\n    ...ArtistSearchResults_viewer\n  }\n}\n\nfragment ArtistSearchResults_viewer on Viewer {\n  searchConnection(query: $term, mode: AUTOSUGGEST, entities: [ARTIST]) {\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          slug\n          internalID\n          displayLabel\n          imageUrl\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query ArtistSearchResultsQuery(\n  $term: String!\n) {\n  viewer {\n    ...ArtistSearchResults_viewer\n  }\n}\n\nfragment ArtistSearchResults_viewer on Viewer {\n  searchConnection(query: $term, mode: AUTOSUGGEST, entities: [ARTIST], first: 10) {\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          id\n          slug\n          internalID\n          displayLabel\n          imageUrl\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/ArtistSearchResults_viewer.graphql.ts
+++ b/src/v2/__generated__/ArtistSearchResults_viewer.graphql.ts
@@ -49,6 +49,11 @@ const node: ReaderFragment = {
         },
         {
           "kind": "Literal",
+          "name": "first",
+          "value": 10
+        },
+        {
+          "kind": "Literal",
           "name": "mode",
           "value": "AUTOSUGGEST"
         },
@@ -132,5 +137,5 @@ const node: ReaderFragment = {
   ],
   "type": "Viewer"
 };
-(node as any).hash = 'd6c4b99412cf4117f60a06e5297f433d';
+(node as any).hash = '5f174c02f7998df6fd09775b6226b837';
 export default node;

--- a/src/v2/__generated__/GeneSearchResultsQuery.graphql.ts
+++ b/src/v2/__generated__/GeneSearchResultsQuery.graphql.ts
@@ -28,7 +28,7 @@ query GeneSearchResultsQuery(
 }
 
 fragment GeneSearchResults_viewer on Viewer {
-  match_gene: searchConnection(query: $term, mode: AUTOSUGGEST, entities: [GENE]) {
+  match_gene: searchConnection(query: $term, mode: AUTOSUGGEST, entities: [GENE], first: 10) {
     edges {
       node {
         __typename
@@ -110,6 +110,11 @@ return {
                 "value": [
                   "GENE"
                 ]
+              },
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 10
               },
               {
                 "kind": "Literal",
@@ -243,7 +248,7 @@ return {
     "metadata": {},
     "name": "GeneSearchResultsQuery",
     "operationKind": "query",
-    "text": "query GeneSearchResultsQuery(\n  $term: String!\n) {\n  viewer {\n    ...GeneSearchResults_viewer\n  }\n}\n\nfragment GeneSearchResults_viewer on Viewer {\n  match_gene: searchConnection(query: $term, mode: AUTOSUGGEST, entities: [GENE]) {\n    edges {\n      node {\n        __typename\n        ... on Gene {\n          name\n          id\n          slug\n          internalID\n          image {\n            cropped(width: 100, height: 100) {\n              url\n            }\n          }\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query GeneSearchResultsQuery(\n  $term: String!\n) {\n  viewer {\n    ...GeneSearchResults_viewer\n  }\n}\n\nfragment GeneSearchResults_viewer on Viewer {\n  match_gene: searchConnection(query: $term, mode: AUTOSUGGEST, entities: [GENE], first: 10) {\n    edges {\n      node {\n        __typename\n        ... on Gene {\n          name\n          id\n          slug\n          internalID\n          image {\n            cropped(width: 100, height: 100) {\n              url\n            }\n          }\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/GeneSearchResults_viewer.graphql.ts
+++ b/src/v2/__generated__/GeneSearchResults_viewer.graphql.ts
@@ -53,6 +53,11 @@ const node: ReaderFragment = {
         },
         {
           "kind": "Literal",
+          "name": "first",
+          "value": 10
+        },
+        {
+          "kind": "Literal",
           "name": "mode",
           "value": "AUTOSUGGEST"
         },
@@ -169,5 +174,5 @@ const node: ReaderFragment = {
   ],
   "type": "Viewer"
 };
-(node as any).hash = '87a366c563b27a6b122d374b15ad6c54';
+(node as any).hash = '9d2ceaedd49be58a9d88754a1547e4a7';
 export default node;


### PR DESCRIPTION
This was such an irritating bug to track down, haha! 🤣 

I was seeing the results come back empty from MP so then I went up the stack and inspected what was going on there. I discovered that Gravity was returning 10 results but then `graphql-relay` was slicing it down to none because...well I'm not totally sure. I guess because a `page` argument was undefined where we didn't expect it, but this is right at the edge of my understanding of things.

Once I noticed that, then it occurred to me that I should try to send the `first` argument and see if that would fix things and sure enough it did. Sometimes you just have to try hard and believe in yourself!

This is the slicing code I was poking at:

https://github.com/graphql/graphql-relay-js/blob/8f4ed1ad35805ef233ad9fd1af33abb9c0cad35a/src/connection/arrayconnection.js#L80-L83

So, `arraySlice` had 10 items but then it had `slice` called on it with `NaN`s and things went to hell from there. 😈 

https://artsyproduct.atlassian.net/browse/GRO-55

/cc @artsy/grow-devs 