### PR TITLE
bugfix: check for missing analytics libs before firing

### DIFF
--- a/src/desktop/analytics/helpers.ts
+++ b/src/desktop/analytics/helpers.ts
@@ -76,14 +76,19 @@ const onClickedReadMore = data => {
     { path: pathname },
     { integrations: { Marketo: false } }
   )
-  if (window.PARSELY) {
+  // guard for aggressive ad blockers
+  if (
+    window.PARSELY &&
+    window.PARSELY.beacon &&
+    window.PARSELY.beacon.trackPageView
+  ) {
     window.PARSELY.beacon.trackPageView({
       url: href,
       js: 1,
       action_name: "infinite",
     })
   }
-  if (window.Sailthru) {
+  if (window.Sailthru && window.Sailthru.track) {
     window.Sailthru.track({
       domain: "horizon.artsy.net",
       spider: true,

--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -44,7 +44,10 @@ export const logoutEventHandler = (options?: LogoutEventOptions) => {
     url: "/users/sign_out",
     type: "DELETE",
     success() {
-      window.analytics.reset()
+      if (window.analytics && window.analytics.reset) {
+        // guard for aggressive ad blockers
+        window.analytics.reset()
+      }
       if (redirectPath) {
         location.assign(redirectPath)
       } else {


### PR DESCRIPTION
Follow up to https://github.com/artsy/force/pull/6545, checks if analytics libs are present on the window before firing events.
We are seeing issues with ad blockers on some clients selectively blocking functions from `window.analytics`.

Related sentry errors:
Cannot read property 'trackPageView' of undefined - https://sentry.io/organizations/artsynet/issues/1987311462/?project=28316
window.analytics.reset is not a function - https://sentry.io/organizations/artsynet/issues/1947334683/?project=28316
