### PR TITLE
[FX-2262] Renders hidden sub-menus to ensure they are crawlable

### DIFF
--- a/src/v2/Components/NavBar/NavItem.tsx
+++ b/src/v2/Components/NavBar/NavItem.tsx
@@ -191,8 +191,12 @@ export const NavItem: React.FC<NavItemProps> = ({
         </Text>
       </HitArea>
 
-      {showMenu && (
-        <NavItemPanel menuAnchor={menuAnchor} relativeTo={containerRef}>
+      {!!Menu && (
+        <NavItemPanel
+          menuAnchor={menuAnchor}
+          relativeTo={containerRef}
+          visible={showMenu}
+        >
           <Menu setIsVisible={setIsVisible} />
         </NavItemPanel>
       )}

--- a/src/v2/Components/NavBar/NavItemPanel.tsx
+++ b/src/v2/Components/NavBar/NavItemPanel.tsx
@@ -31,36 +31,34 @@ const AnimatedPanel = styled(animated.div)<{
 `
 
 const ANIMATION_STATES = {
-  in: {
+  hidden: {
+    display: "none",
     opacity: 0,
     transform: "translate3d(0, -25px, 0)",
   },
-  out: {
+  visible: {
+    display: "block",
     opacity: 1,
     transform: "translate3d(0, 0, 0)",
   },
 }
 
 interface NavItemPanelProps {
+  visible: boolean
   menuAnchor: MenuAnchor
   relativeTo: React.MutableRefObject<HTMLDivElement>
 }
 
 export const NavItemPanel: React.FC<NavItemPanelProps> = ({
+  visible,
   menuAnchor,
   relativeTo,
   children,
 }) => {
   const animation = useSpring({
-    ...ANIMATION_STATES.out,
-    from: ANIMATION_STATES.in,
+    ...(visible ? ANIMATION_STATES.visible : ANIMATION_STATES.hidden),
     config: name =>
-      name === "opacity"
-        ? config.stiff
-        : {
-            friction: 10,
-            mass: 0.1,
-          },
+      name === "opacity" ? config.stiff : { friction: 10, mass: 0.1 },
   })
 
   return (

--- a/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
@@ -73,10 +73,9 @@ describe("NavBar", () => {
 
       const links = wrapper.find("NavItem")
 
-      defaultLinks.forEach(([href, linkLabel], index) => {
+      defaultLinks.forEach(([href], index) => {
         const navLink = links.at(index)
         expect(href).toEqual(navLink.prop("href"))
-        expect(linkLabel).toEqual(navLink.text())
       })
     })
 
@@ -93,7 +92,7 @@ describe("NavBar", () => {
       expect(wrapper.html()).not.toContain("Log in")
       expect(wrapper.html()).not.toContain("Sign up")
       expect(wrapper.find(BellIcon).length).toEqual(1)
-      expect(wrapper.find(SoloIcon).length).toEqual(1)
+      expect(wrapper.find(SoloIcon).length).toEqual(2)
     })
 
     describe("lab features", () => {
@@ -103,6 +102,12 @@ describe("NavBar", () => {
         })
         expect(wrapper.find(EnvelopeIcon).length).toEqual(1)
       })
+    })
+
+    it("includes the sub-menus when rendering", () => {
+      const wrapper = getWrapper()
+      expect(wrapper.html()).toContain("View all artists")
+      expect(wrapper.html()).toContain("View all artworks")
     })
   })
 

--- a/src/v2/Components/NavBar/__tests__/NavItem.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavItem.jest.tsx
@@ -51,8 +51,12 @@ describe("NavItem", () => {
       </NavItem>
     )
     expect(wrapper.html()).toContain("Menu Item")
+    expect(wrapper.html()).toContain('aria-expanded="true"')
+    expect(wrapper.html()).not.toContain('aria-expanded="false"')
     toggle()
-    expect(wrapper.html()).not.toContain("Menu Item")
+    expect(wrapper.html()).toContain("Menu Item")
+    expect(wrapper.html()).toContain('aria-expanded="false"')
+    expect(wrapper.html()).not.toContain('aria-expanded="true"')
   })
 
   it("shows / hides Menu on mouse interactions", () => {
@@ -61,13 +65,13 @@ describe("NavItem", () => {
         hello how are you
       </NavItem>
     )
-    expect(wrapper.html()).not.toContain("Menu Item")
+    expect(wrapper.html()).toContain('aria-expanded="false"')
     wrapper.simulate("mouseenter")
     jest.runAllTimers()
-    expect(wrapper.html()).toContain("Menu Item")
+    expect(wrapper.html()).toContain('aria-expanded="true"')
     wrapper.simulate("mouseleave")
     jest.runAllTimers()
-    expect(wrapper.html()).not.toContain("Menu Item")
+    expect(wrapper.html()).toContain('aria-expanded="false"')
   })
 
   it("shows / hides Menu on button click", () => {
@@ -76,11 +80,11 @@ describe("NavItem", () => {
         hello how are you
       </NavItem>
     )
-    expect(wrapper.html()).not.toContain("Menu Item")
+    expect(wrapper.html()).toContain('aria-expanded="false"')
     wrapper.find("button").simulate("click")
-    expect(wrapper.html()).toContain("Menu Item")
+    expect(wrapper.html()).toContain('aria-expanded="true"')
     wrapper.find("button").simulate("click")
-    expect(wrapper.html()).not.toContain("Menu Item")
+    expect(wrapper.html()).toContain('aria-expanded="false"')
   })
 
   it("renders a Overlay", () => {


### PR DESCRIPTION
Closes: [FX-2262](https://artsyproduct.atlassian.net/browse/FX-2262)

Looks identical, just instead of rendering/not rendering we thread the boolean through to `useSpring` and `display: none|block`