### PR TITLE
[FX-2402] Sets a minHeight for very short pages

### DIFF
--- a/src/v2/Apps/Show/ShowSubApp.tsx
+++ b/src/v2/Apps/Show/ShowSubApp.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { createFragmentContainer, graphql } from "react-relay"
-import { Separator } from "@artsy/palette"
+import { Box, Separator } from "@artsy/palette"
 import { ShowSubApp_show } from "v2/__generated__/ShowSubApp_show.graphql"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
 import { Footer } from "v2/Components/Footer"
@@ -39,7 +39,7 @@ const ShowApp: React.FC<ShowAppProps> = ({ children, show }) => {
               )}
             </BackLink>
 
-            {children}
+            <Box minHeight="50vh">{children}</Box>
 
             <Separator as="hr" my={3} />
 


### PR DESCRIPTION
Closes: [FX-2402](https://artsyproduct.atlassian.net/browse/FX-2402)

Initially my plan was to implement the [sticky footer pattern](https://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/), though this isn't as straight-forward as it seems for our case.

The situation is a rare enough thing that I don't feel too bad about adding a simple `minHeight` here.