### PR TITLE
Use border on text component instead of using a Separator on consign2

### DIFF
--- a/src/v2/Apps/Consign/Components/HowToSell.tsx
+++ b/src/v2/Apps/Consign/Components/HowToSell.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Box, Button, EditIcon, Flex, Separator, Text } from "@artsy/palette"
+import { Box, Button, EditIcon, Flex, Text, color } from "@artsy/palette"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import { Media } from "v2/Utils/Responsive"
 import { SectionContainer } from "./SectionContainer"
@@ -11,13 +11,13 @@ export const HowToSell: React.FC = () => {
       <Text
         width="100%"
         textAlign={["center", "left"]}
-        mb={2}
+        pb={3}
         variant="largeTitle"
+        borderBottom={`1px solid ${color("black60")}`}
       >
         3 Simple Steps:
         <br /> How to sell artwork from your collection
       </Text>
-      <Separator />
 
       <Flex
         flexDirection={["column", "row"]}

--- a/src/v2/Apps/Consign/Components/SellArtDifferently.tsx
+++ b/src/v2/Apps/Consign/Components/SellArtDifferently.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Box, EditIcon, Flex, Separator, Text } from "@artsy/palette"
+import { Box, EditIcon, Flex, Text, color } from "@artsy/palette"
 import { SectionContainer } from "./SectionContainer"
 
 export const SellArtDifferently: React.FC = () => {
@@ -8,12 +8,12 @@ export const SellArtDifferently: React.FC = () => {
       <Text
         width="100%"
         textAlign={["center", "left"]}
-        mb={2}
+        pb={3}
         variant="largeTitle"
+        borderBottom={`1px solid ${color("black60")}`}
       >
         Selling Art Differently
       </Text>
-      <Separator />
 
       <Flex
         flexDirection={["column", "row"]}


### PR DESCRIPTION
# Problem

The spec for `/consign2` calls for a black60 line that divides header text from body text in certain sections. Previously we were using a `Separator` component to do this and planned to add a `color` prop to change the color of the component to black60.

# Solution

Remove the `Separator` component in favor of a black60 border on the `Text` component since (1) it doesn't require updating Palette, (2) it's not clear that we should add a `color` prop to `Separator` anyway given our design system and (3) `Separator` isn't really designed for this use.

![Screen Shot 2020-11-03 at 2 50 35 PM](https://user-images.githubusercontent.com/4432348/98034153-89686000-1de4-11eb-9036-4991654acbe6.png)

![Screen Shot 2020-11-03 at 2 50 22 PM](https://user-images.githubusercontent.com/4432348/98034156-89686000-1de4-11eb-9ada-7817371f2060.png)
