### PR TITLE
feat: Add second contact block and update copy on /consign2

### DIFF
--- a/src/v2/Apps/Consign/Components/ContactUs.tsx
+++ b/src/v2/Apps/Consign/Components/ContactUs.tsx
@@ -1,20 +1,58 @@
 import React from "react"
-import { Button, Text } from "@artsy/palette"
+import { Button, Flex, Link, Text } from "@artsy/palette"
 import { SectionContainer } from "./SectionContainer"
+import { Media } from "v2/Utils/Responsive"
 
-export const ContactUs: React.FC = () => {
+export const ContactUs: React.FC<{ darkVariant?: boolean }> = ({
+  darkVariant,
+}) => {
   return (
-    <SectionContainer background="black5">
-      <Text width="100%" textAlign="left" mb={3} variant="largeTitle">
-        Need to speak to a specialist? Contact us.
+    <SectionContainer background={darkVariant ? "black100" : "black5"}>
+      <Text
+        width="100%"
+        textAlign="left"
+        mb={3}
+        variant="largeTitle"
+        color={darkVariant ? "white100" : "black100"}
+      >
+        Questions? Speak to an Artsy Specialist
       </Text>
-
-      <Text variant="text" color="black60" mb={4}>
-        Schedule a call with one of our specialist team members for <br />
-        more information on how Artsy can sell your artwork.
-      </Text>
-
-      <Button variant="secondaryOutline">Book an appointment</Button>
+      <Flex flexDirection="row" flexWrap="wrap" mb={3}>
+        <Text
+          variant="text"
+          color={darkVariant ? "black5" : "black60"}
+          mr={0.5}
+        >
+          Email us at
+        </Text>
+        <Text
+          variant="mediumText"
+          color={darkVariant ? "black5" : "black60"}
+          mr={0.5}
+        >
+          consign@artsy.net
+        </Text>
+        <Text
+          variant="text"
+          color={darkVariant ? "black5" : "black60"}
+          mr={0.5}
+        >
+          or call
+        </Text>
+        <Text variant="mediumText" color={darkVariant ? "black5" : "black60"}>
+          555-555-5555
+        </Text>
+      </Flex>
+      <Link href="mailto:consign@artsy.net">
+        <Media greaterThanOrEqual="sm">
+          <Button variant="secondaryOutline">Send an email</Button>
+        </Media>
+        <Media lessThan="sm">
+          <Button variant="secondaryOutline" size="large" block width="100%">
+            Send an email
+          </Button>
+        </Media>
+      </Link>
     </SectionContainer>
   )
 }

--- a/src/v2/Apps/Consign/ConsignApp.tsx
+++ b/src/v2/Apps/Consign/ConsignApp.tsx
@@ -32,9 +32,10 @@ const ConsignApp = props => {
           <SellArtDifferently />
           <GetPriceEstimate />
           <HowToSell />
+          <ContactUs />
           <ConsignInDemandNow />
           <ReadMore />
-          <ContactUs />
+          <ContactUs darkVariant />
           <FAQ />
           <SellWithArtsy />
           <SoldRecentlyQueryRenderer />


### PR DESCRIPTION
Adds a second contact block and updates `ContactUs` to have an optionally dark color scheme variant.

![Screen Shot 2020-11-03 at 3 57 46 PM](https://user-images.githubusercontent.com/4432348/98040123-c08f3f00-1ded-11eb-9996-f7f1fb41ecc6.png)

![Screen Shot 2020-11-03 at 3 50 20 PM](https://user-images.githubusercontent.com/4432348/98040125-c08f3f00-1ded-11eb-90f0-65c46dd19d80.png)
