### PR TITLE
Users with Team role can download images

### DIFF
--- a/src/desktop/components/prevent_right_click/index.jade
+++ b/src/desktop/components/prevent_right_click/index.jade
@@ -1,7 +1,7 @@
 script.
-  var isAdmin = #{!!(user && user.get('type') === 'Admin')};
+  var isTeam = #{!!(user && (user.get('roles') && user.get('roles').includes('team')))};
   document.addEventListener('contextmenu', function(e) {
-    if (isAdmin) return;
+    if (isTeam) return;
     if (['IMG', 'CANVAS'].indexOf(e.target.nodeName) < 0) return;
     var classes = e.target.className + ' ' + e.target.parentElement.className;
     if (classes.match('seadragon')) e.preventDefault();

--- a/src/desktop/models/additional_image.coffee
+++ b/src/desktop/models/additional_image.coffee
@@ -12,4 +12,4 @@ module.exports = class AdditionalImage extends Backbone.Model
   _.extend @prototype, DeepZoom(SECURE_IMAGES_URL)
 
   isDownloadable: (user) ->
-    (@get('downloadable') and @hasImage('larger')) or !!user?.isAdmin()
+    (@get('downloadable') and @hasImage('larger')) or !!user?.isTeam()

--- a/src/desktop/models/artwork.coffee
+++ b/src/desktop/models/artwork.coffee
@@ -50,7 +50,7 @@ module.exports = class Artwork extends Backbone.Model
     _s.slugify(@toOneLine()) + '.jpg'
 
   downloadableUrl: (user) ->
-    if user?.isAdmin()
+    if user?.isTeam()
       "#{@url()}/image/#{@defaultImage().id}/original.jpg"
     else
       @defaultImageUrl 'larger'
@@ -318,7 +318,7 @@ module.exports = class Artwork extends Backbone.Model
     not _.isFunction @saleMessage
 
   showActionsList: (user) ->
-    @get('website') or @isDownloadable() or (user and user.isAdmin())
+    @get('website') or @isDownloadable() or (user and user.isTeam())
 
   toJSONLD: ->
     creator =

--- a/src/desktop/test/models/artwork.test.js
+++ b/src/desktop/test/models/artwork.test.js
@@ -67,7 +67,7 @@ describe("Artwork", function () {
         this.artwork.downloadableUrl().should.containEql("larger.jpg")
         return this.artwork
           .downloadableUrl({
-            isAdmin() {
+            isTeam() {
               return false
             },
           })
@@ -78,7 +78,7 @@ describe("Artwork", function () {
       it('returns the URL to the "original" file', function () {
         return this.artwork
           .downloadableUrl({
-            isAdmin() {
+            isTeam() {
               return true
             },
           })
@@ -100,14 +100,14 @@ describe("Artwork", function () {
         this.artwork.isDownloadable().should.be.false()
         this.artwork
           .isDownloadable({
-            isAdmin() {
+            isTeam() {
               return false
             },
           })
           .should.be.false()
         return this.artwork
           .isDownloadable({
-            isAdmin() {
+            isTeam() {
               return true
             },
           })

--- a/src/lib/current_user.coffee
+++ b/src/lib/current_user.coffee
@@ -240,6 +240,9 @@ module.exports = class CurrentUser extends Backbone.Model
   isAdmin: ->
     (@get('type') is 'Admin') and ! @get('is_slumming')
 
+  isTeam: ->
+    @get('roles').includes('team')
+
   markNotifications: (status = 'read', options) ->
     request.put("#{@url()}/notifications")
       .set('X-ACCESS-TOKEN': @get 'accessToken')

--- a/src/typings/gravity.d.ts
+++ b/src/typings/gravity.d.ts
@@ -1,4 +1,5 @@
 interface User {
+  roles?: UserRole[]
   accessToken?: string
   appToken?: string
   email?: string
@@ -8,3 +9,21 @@ interface User {
   type?: string
   name?: string
 }
+
+/**
+ * Determinies permissions/access granted to CurrentUser.
+ * See https://github.com/artsy/gravity/blob/master/config/initializers/_user_roles.rb
+ */
+type UserRole =
+  | "admin"
+  | "billing_admin"
+  | "customer_support"
+  | "genomer"
+  | "metadata_admin"
+  | "partner_support"
+  | "role_manager"
+  | "sales_admin"
+  | "sales_observer"
+  | "team"
+  | "user"
+  | "verification_admin"

--- a/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
@@ -32,7 +32,7 @@ import {
   Text,
   color,
 } from "@artsy/palette"
-import { userIsAdmin } from "v2/Utils/user"
+import { userIsAdmin, userIsTeam } from "v2/Utils/user"
 import { ArtworkPopoutPanel } from "./ArtworkPopoutPanel"
 import { Mediator } from "lib/mediator"
 
@@ -81,12 +81,16 @@ export class ArtworkActions extends React.Component<
     return userIsAdmin(this.props.user)
   }
 
+  get isTeam() {
+    return userIsTeam(this.props.user)
+  }
+
   getDownloadableImageUrl() {
     const {
       artwork: { is_downloadable, href, artists, title, date },
     } = this.props
 
-    if (is_downloadable || this.isAdmin) {
+    if (is_downloadable || this.isTeam) {
       const artistNames = artists.map(({ name }) => name).join(", ")
       const filename = slugify(compact([artistNames, title, date]).join(" "))
       const downloadableImageUrl = `${href}/download/${filename}.jpg` // prettier-ignore

--- a/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActions.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActions.jest.tsx
@@ -51,16 +51,17 @@ describe("ArtworkActions", () => {
     })
   }
 
-  it("renders proper components for an admin", async () => {
+  it("renders proper components for a team user", async () => {
     const wrapper = await getWrapper()
     expect(wrapper.find(EditIcon).length).toBe(1)
     expect(wrapper.find(GenomeIcon).length).toBe(1)
     expect(wrapper.find(MoreIcon).length).toBe(0)
   })
 
-  it("renders proper components for a non-admin", async () => {
+  it("renders proper components for a non-team user", async () => {
     const data = cloneDeep(ArtworkActionsFixture)
     data.user.type = "User"
+    data.user.roles = ["user"]
     const wrapper = await getWrapper("lg", data)
     expect(wrapper.find(HeartFillIcon).length).toBe(1)
     expect(wrapper.find(ShareIcon).length).toBe(1)
@@ -197,6 +198,7 @@ describe("ArtworkActions", () => {
           user: {
             ...ArtworkActionsFixture.user,
             type: "User",
+            roles: [],
           },
         }
         const wrapper = await getWrapper("lg", data)
@@ -235,6 +237,7 @@ describe("ArtworkActions", () => {
         user: {
           ...ArtworkActionsFixture.user,
           type: "User",
+          roles: [],
         },
       }
       const wrapper = await getWrapper("xs", data)

--- a/src/v2/Apps/__tests__/Fixtures/Artwork/ArtworkActions.fixture.ts
+++ b/src/v2/Apps/__tests__/Fixtures/Artwork/ArtworkActions.fixture.ts
@@ -5,6 +5,7 @@ export const ArtworkActionsFixture: ArtworkActions_Test_QueryRawResponse & {
 } = {
   user: {
     type: "Admin",
+    roles: ["admin", "team"],
   },
   artwork: {
     id:

--- a/src/v2/Components/Artwork/FillwidthItem.tsx
+++ b/src/v2/Components/Artwork/FillwidthItem.tsx
@@ -8,7 +8,7 @@ import styled from "styled-components"
 import { get } from "v2/Utils/get"
 import { getENV } from "v2/Utils/getENV"
 import createLogger from "v2/Utils/logger"
-import { userIsAdmin } from "v2/Utils/user"
+import { userIsTeam } from "v2/Utils/user"
 import Badge from "./Badge"
 import Metadata from "./Metadata"
 import SaveButton from "./Save"
@@ -111,7 +111,7 @@ export class FillwidthItemContainer extends React.Component<
     if (user) {
       userSpread = { user }
     }
-    const isAdmin = userIsAdmin(user)
+    const isTeam = userIsTeam(user)
 
     const image = get(this.props, p => p.artwork.image)
 
@@ -140,7 +140,7 @@ export class FillwidthItemContainer extends React.Component<
               width="100%"
               height={imageHeight}
               lazyLoad={lazyLoad}
-              preventRightClick={!isAdmin}
+              preventRightClick={!isTeam}
               alt={artwork?.imageTitle}
             />
           </RouterLink>

--- a/src/v2/Components/Artwork/GridItem.tsx
+++ b/src/v2/Components/Artwork/GridItem.tsx
@@ -7,7 +7,7 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 import styled from "styled-components"
-import { userIsAdmin } from "v2/Utils/user"
+import { userIsTeam } from "v2/Utils/user"
 import Badge from "./Badge"
 import Metadata from "./Metadata"
 import SaveButton from "./Save"
@@ -106,7 +106,7 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
     if (user) {
       userSpread = { user }
     }
-    const isAdmin = userIsAdmin(user)
+    const isTeam = userIsTeam(user)
 
     // the 'artwork-item' className and data-id={artwork._id} are required to
     // track Artwork impressions
@@ -135,7 +135,7 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
               alt={artwork.image_title}
               src={this.getImageUrl()}
               lazyLoad={IMAGE_LAZY_LOADING && lazyLoad}
-              preventRightClick={!isAdmin}
+              preventRightClick={!isTeam}
             />
           </Link>
 

--- a/src/v2/Components/Lightbox/Lightbox.tsx
+++ b/src/v2/Components/Lightbox/Lightbox.tsx
@@ -7,7 +7,7 @@ import React from "react"
 import ReactDOM from "react-dom"
 import track from "react-tracking"
 import styled from "styled-components"
-import { userIsAdmin } from "v2/Utils/user"
+import { userIsTeam } from "v2/Utils/user"
 import { CloseButton } from "./CloseButton"
 import { Slider, SliderProps } from "./LightboxSlider"
 
@@ -292,7 +292,7 @@ class LightboxComponent extends React.Component<LightboxProps, LightboxState> {
       user,
     } = this.props
     const height = initialHeight || "auto"
-    const isAdmin = userIsAdmin(user)
+    const isTeam = userIsTeam(user)
 
     // Only render client-side
     if (!this.state.element) {
@@ -323,7 +323,7 @@ class LightboxComponent extends React.Component<LightboxProps, LightboxState> {
             alt={imageAlt}
             data-type="artwork-image"
             data-is-default={isDefault}
-            preventRightClick={!isAdmin}
+            preventRightClick={!isTeam}
           />
         </Flex>
       </>

--- a/src/v2/Utils/__tests__/user.jest.ts
+++ b/src/v2/Utils/__tests__/user.jest.ts
@@ -1,4 +1,4 @@
-import { userHasLabFeature, userIsAdmin } from "../user"
+import { userHasLabFeature, userIsAdmin, userIsTeam } from "../user"
 
 describe("user", () => {
   describe("userHasLabFeature", () => {
@@ -66,6 +66,36 @@ describe("user", () => {
       }
 
       const result = userIsAdmin(user)
+
+      expect(result).toEqual(true)
+    })
+  })
+
+  describe("userIsTeam", () => {
+    it("returns undefined if user is undefined", () => {
+      const user: User = undefined
+
+      const result = userIsTeam(user)
+
+      expect(result).toEqual(false)
+    })
+
+    it("returns false if user roles do not include 'team'", () => {
+      const user: User = {
+        roles: ["genomer"],
+      }
+
+      const result = userIsTeam(user)
+
+      expect(result).toEqual(false)
+    })
+
+    it("returns true if user is of type 'Team'", () => {
+      const user: User = {
+        roles: ["team"],
+      }
+
+      const result = userIsTeam(user)
 
       expect(result).toEqual(true)
     })

--- a/src/v2/Utils/user.ts
+++ b/src/v2/Utils/user.ts
@@ -37,6 +37,13 @@ export function userIsAdmin(user?: User): boolean {
   return isAdmin
 }
 
+export function userIsTeam(user?: User): boolean {
+  const isTeam = Boolean(
+    user && user.roles && user.roles.includes("team") ? true : false
+  )
+  return isTeam
+}
+
 export function userHasAccessToPartner(user: User, partnerId: string): boolean {
   const token = get(user, u => u.accessToken)
   if (!token) {


### PR DESCRIPTION
- Adds utils `userIsTeam` helper
- Updates all admin checks related to images to determine access by `team` role rather than `admin`
- Adds roles  to `User` typings

Addresses https://artsyproduct.atlassian.net/browse/PLATFORM-2492