### PR TITLE
feat: Add skeleton loading state when fetching price estimates on /consign2

### DIFF
--- a/src/v2/Apps/Consign/Components/GetPriceEstimate/ArtistInsightResult.tsx
+++ b/src/v2/Apps/Consign/Components/GetPriceEstimate/ArtistInsightResult.tsx
@@ -10,11 +10,20 @@ import {
   Separator,
   Spacer,
   Text,
+  color,
 } from "@artsy/palette"
 import styled from "styled-components"
 
 export const ArtistInsightResult: React.FC = () => {
-  const { artistInsights, selectedSuggestion } = usePriceEstimateContext()
+  const {
+    artistInsights,
+    isFetching,
+    selectedSuggestion,
+  } = usePriceEstimateContext()
+
+  if (isFetching) {
+    return <LoadingPlaceholder />
+  }
 
   if (!artistInsights?.priceInsights?.edges?.[0]?.node) {
     return <ZeroState />
@@ -121,3 +130,21 @@ const Container = styled(Box).attrs({
   background: white;
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
 `
+
+const PlaceholderText = styled(Box)`
+  background-color: ${color("black10")};
+  height: 20px;
+  width: 75%;
+  margin-bottom: 10px;
+`
+
+const LoadingPlaceholder: React.FC = () => {
+  return (
+    <Container>
+      <Box mb={2} height="80px" width="80px" bg="black10" />
+      <PlaceholderText />
+      <PlaceholderText />
+      <PlaceholderText />
+    </Container>
+  )
+}

--- a/src/v2/Apps/Consign/Components/GetPriceEstimate/EstimateResults.tsx
+++ b/src/v2/Apps/Consign/Components/GetPriceEstimate/EstimateResults.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { Box, Flex, Image, Join, Spacer, Text } from "@artsy/palette"
+import { Box, Flex, Image, Join, Spacer, Text, color } from "@artsy/palette"
 import { usePriceEstimateContext } from "./ConsignPriceEstimateContext"
 import { ArtistInsightResult } from "./ArtistInsightResult"
+import styled from "styled-components"
 
 export const EstimateResults: React.FC = () => {
   const { artistInsights, isFetching } = usePriceEstimateContext()
@@ -12,13 +13,18 @@ export const EstimateResults: React.FC = () => {
       alignItems="center"
       justifyContent="center"
     >
-      {isFetching && <Box>fetching...</Box>}
-      {artistInsights ? <ArtistInsightResult /> : <PlaceholderItems />}
+      {isFetching ? (
+        <LoadingPlaceholderItems />
+      ) : artistInsights ? (
+        <ArtistInsightResult />
+      ) : (
+        <ArtistInsightExample />
+      )}
     </Flex>
   )
 }
 
-const PlaceholderItems: React.FC = () => {
+const ArtistInsightExample: React.FC = () => {
   return (
     <>
       <Join separator={<Spacer mr={5} />}>
@@ -74,6 +80,24 @@ const ArtworkItem: React.FC<{
       <Text variant="small">{artistName}</Text>
       <Text variant="small">Average Sale Price:</Text>
       <Text variant="largeTitle">{salePrice}</Text>
+    </Box>
+  )
+}
+
+const PlaceholderText = styled(Box)`
+  background-color: ${color("black10")}
+  height: 20px
+  width: 75%
+  margin-bottom: 10px
+`
+
+const LoadingPlaceholderItems: React.FC = () => {
+  return (
+    <Box height="100%" width="100%">
+      <Box mb={2} height="80px" width="80px" bg="black10" />
+      <PlaceholderText />
+      <PlaceholderText />
+      <PlaceholderText />
     </Box>
   )
 }

--- a/src/v2/Apps/Consign/Components/GetPriceEstimate/EstimateResults.tsx
+++ b/src/v2/Apps/Consign/Components/GetPriceEstimate/EstimateResults.tsx
@@ -1,8 +1,7 @@
 import React from "react"
-import { Box, Flex, Image, Join, Spacer, Text, color } from "@artsy/palette"
+import { Box, Flex, Image, Join, Spacer, Text } from "@artsy/palette"
 import { usePriceEstimateContext } from "./ConsignPriceEstimateContext"
 import { ArtistInsightResult } from "./ArtistInsightResult"
-import styled from "styled-components"
 
 export const EstimateResults: React.FC = () => {
   const { artistInsights, isFetching } = usePriceEstimateContext()
@@ -13,9 +12,7 @@ export const EstimateResults: React.FC = () => {
       alignItems="center"
       justifyContent="center"
     >
-      {isFetching ? (
-        <LoadingPlaceholderItems />
-      ) : artistInsights ? (
+      {isFetching || artistInsights ? (
         <ArtistInsightResult />
       ) : (
         <ArtistInsightExample />
@@ -80,24 +77,6 @@ const ArtworkItem: React.FC<{
       <Text variant="small">{artistName}</Text>
       <Text variant="small">Average Sale Price:</Text>
       <Text variant="largeTitle">{salePrice}</Text>
-    </Box>
-  )
-}
-
-const PlaceholderText = styled(Box)`
-  background-color: ${color("black10")}
-  height: 20px
-  width: 75%
-  margin-bottom: 10px
-`
-
-const LoadingPlaceholderItems: React.FC = () => {
-  return (
-    <Box height="100%" width="100%">
-      <Box mb={2} height="80px" width="80px" bg="black10" />
-      <PlaceholderText />
-      <PlaceholderText />
-      <PlaceholderText />
     </Box>
   )
 }


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GRO-45

Adds a skeleton loading state when fetching price estimate results for an artist on `/consign2`.

![price-estimate-placeholder-2](https://user-images.githubusercontent.com/4432348/98159066-ee39be00-1ea9-11eb-9a31-d501ec094db9.gif)

![Screen Shot 2020-11-04 at 2 26 44 PM](https://user-images.githubusercontent.com/4432348/98159070-f134ae80-1ea9-11eb-9468-16b9f6db8bd7.png)
