### PR TITLE
[FX-2428] Guards against nullable href

### DIFF
--- a/src/v2/Apps/Show/ShowApp.tsx
+++ b/src/v2/Apps/Show/ShowApp.tsx
@@ -69,7 +69,7 @@ export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
               >
                 <ShowHeader show={show} />
 
-                {!hasAbout && (
+                {!hasAbout && show.href && (
                   <ForwardLink
                     to={`${show.href.replace("/show", "/show2")}/info`}
                     mt={1}
@@ -83,12 +83,14 @@ export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
                 <Column span={6}>
                   <ShowAbout show={show} />
 
-                  <ForwardLink
-                    to={`${show.href.replace("/show", "/show2")}/info`}
-                    mt={2}
-                  >
-                    More info
-                  </ForwardLink>
+                  {show.href && (
+                    <ForwardLink
+                      to={`${show.href.replace("/show", "/show2")}/info`}
+                      mt={2}
+                    >
+                      More info
+                    </ForwardLink>
+                  )}
                 </Column>
               )}
 


### PR DESCRIPTION
Closes: [FX-2428](https://artsyproduct.atlassian.net/browse/FX-2428)

I was assuming that the nullable `href` was just a mistake in the schema — but no, it is the the case that you may have a displayable show that doesn't have an `href`. This matches the behavior that's currently in production.