### PR TITLE
feat: Restore path to alpha artist list pages on mweb

### DIFF
--- a/src/desktop/apps/artists/index.styl
+++ b/src/desktop/apps/artists/index.styl
@@ -165,3 +165,35 @@ bumper-width = 40px
   > a
     display block
     padding 5px 10px 5px 0
+
+#artists-page.mobile
+  .alphabetical-index
+    flex-direction column
+    align-items flex-start
+    .alphabetical-index-label
+      text-align center
+      width 100%
+    .alphabetical-index-range
+      text-align left
+      width 100%
+      a
+        font-size 20px
+        padding: 10px
+  #letter-page
+    .contextual-return-link
+      margin-top 20px
+      position relative
+  .bordered-pagination
+    display flex
+    font-size 14px
+    flex-wrap wrap
+    justify-content space-between
+    ul
+      margin 0
+      padding 0
+    ul:first-child
+      order 1
+      margin-top 20px
+    ul:last-child
+      order 2
+      margin-top 20px

--- a/src/desktop/apps/artists/templates/index.jade
+++ b/src/desktop/apps/artists/templates/index.jade
@@ -10,7 +10,7 @@ block body
   #artists-page.main-layout-container
     nav.alphabetical-index
       .alphabetical-index-label
-        | Browse over 50,000 artists
+        | Browse over 100,000 artists
       .alphabetical-index-range
         for letter in letters
           a( href='/artists/artists-starting-with-#{letter}' )

--- a/src/desktop/apps/artists/templates/letter.jade
+++ b/src/desktop/apps/artists/templates/letter.jade
@@ -10,7 +10,7 @@ append locals
   - assetPackage = 'artists_artworks'
 
 block body
-  #artists-page.main-layout-container
+  #artists-page.main-layout-container(class=sd.IS_MOBILE ? "mobile" : "")
     nav.alphabetical-index
       .alphabetical-index-label
         | Browse 40,000 artists
@@ -20,12 +20,12 @@ block body
           a( href=href, class=activeClass(href) )= letter
 
     #letter-page
-      h1.avant-garde-header-center
-        | Artists &ndash; #{letter}
-
       a.contextual-return-link( href='/artists' )
         i.icon-chevron-small-left
         | Back to featured artists
+
+      h1.avant-garde-header-center
+        | Artists &ndash; #{letter}
 
       .artists-columns
         for artist in artists.models

--- a/src/desktop/apps/artists/templates/letter.jade
+++ b/src/desktop/apps/artists/templates/letter.jade
@@ -13,7 +13,7 @@ block body
   #artists-page.main-layout-container(class=sd.IS_MOBILE ? "mobile" : "")
     nav.alphabetical-index
       .alphabetical-index-label
-        | Browse 40,000 artists
+        | Browse 100,000 artists
       .alphabetical-index-range
         for letter in letterRange
           - var href = '/artists/artists-starting-with-' + letter;

--- a/src/desktop/apps/artists/templates/meta.jade
+++ b/src/desktop/apps/artists/templates/meta.jade
@@ -1,8 +1,8 @@
 title Browse Artists on Artsy | Modern and Contemporary Artists
 meta( property='og:title', content='Browse Artists on Artsy | Modern and Contemporary Artists' )
-meta( name='description', content='Research and discover more than 40,000 modern and contemporary artists on Artsy. Find works for sale, biographies, CVs, and auction results.' )
-meta( property='og:description', content='Research and discover more than 40,000 modern and contemporary artists on Artsy. Find works for sale, biographies, CVs, and auction results.' )
-meta( property='twitter:description', content='Research and discover more than 40,000 modern and contemporary artists on Artsy. Find works for sale, biographies, CVs, and auction results.' )
+meta( name='description', content='Research and discover more than 100,000 modern and contemporary artists on Artsy. Find works for sale, biographies, CVs, and auction results.' )
+meta( property='og:description', content='Research and discover more than 100,000 modern and contemporary artists on Artsy. Find works for sale, biographies, CVs, and auction results.' )
+meta( property='twitter:description', content='Research and discover more than 100,000 modern and contemporary artists on Artsy. Find works for sale, biographies, CVs, and auction results.' )
 link( rel='canonical', href=(sd.APP_URL + '/artists') )
 
 meta( property='og:url', content=(sd.APP_URL + '/artists') )

--- a/src/mobile/apps/artists/index.styl
+++ b/src/mobile/apps/artists/index.styl
@@ -25,3 +25,22 @@
   a
     &:last-child
       border-bottom none
+
+.alphabetical-index
+  display flex
+  flex-direction column
+  align-items flex-start
+
+  .alphabetical-index-label
+    text-align center
+    width 100%
+
+  .alphabetical-index-range
+    width 100%
+    display flex
+    flex-wrap wrap
+    a
+      text-transform uppercase
+      text-decoration none
+      font-size 20px
+      padding: 10px

--- a/src/mobile/apps/artists/routes.coffee
+++ b/src/mobile/apps/artists/routes.coffee
@@ -2,6 +2,7 @@ _ = require 'underscore'
 sd = require('sharify').data
 Backbone = require 'backbone'
 Genes = require '../../collections/genes'
+ArtistsByLetter = require '../../../desktop/apps/artists/collections/artists_by_letter'
 { Fetch } = require '@artsy/backbone-mixins'
 
 module.exports.index = (req, res, next) ->
@@ -18,4 +19,4 @@ module.exports.index = (req, res, next) ->
         cache: true
         error: res.backboneError
         success: (genes) ->
-          res.render 'index', { genes: genes.models }
+          res.render 'index', { genes: genes.models, letters: ArtistsByLetter::range }

--- a/src/mobile/apps/artists/templates/index.jade
+++ b/src/mobile/apps/artists/templates/index.jade
@@ -7,6 +7,14 @@ block head
   title Browse Artists on Artsy | Modern and Contemporary Artists
 
 block content
+  nav.alphabetical-index
+    .alphabetical-index-label
+      | Browse over 50,000 artists
+    .alphabetical-index-range
+      for letter in letters
+        a( href='/artists/artists-starting-with-#{letter}' )
+          = letter
+
   .main-side-margin
     header.avant-garde-header-center.artists-page-header Artists
 

--- a/src/mobile/apps/artists/templates/index.jade
+++ b/src/mobile/apps/artists/templates/index.jade
@@ -9,7 +9,7 @@ block head
 block content
   nav.alphabetical-index
     .alphabetical-index-label
-      | Browse over 50,000 artists
+      | Browse over 100,000 artists
     .alphabetical-index-range
       for letter in letters
         a( href='/artists/artists-starting-with-#{letter}' )


### PR DESCRIPTION
This PR does a few things:

* Improve the styling of the individual letter pages for artist lists
* Improve the styling of the pagination on these pages
* Restore a pathway to the individual letter pages from the artist landing page
* Settles on 100k as the number of artists one can browse

There is a ton of great chatter here if you want more context:

https://artsy.slack.com/archives/C01ADJNCS5D/p1604507472067500

The punchline from that thread was my desire to address the glaring problem that our alpha artist pages had been orphaned on mweb. This is bad because it's that version of the site that Google crawls.

What this PR does NOT do:

* match the delightful comps @deliciousnachos made for this page
* ensure a great user experience on these alpha pages nor on the list page

Frankly this PR is mostly about getting Google to these pages because that's got a ton of SEO value and we can come back around to other improvements as time permits!


<details>
<summary>Ok enough banter, let's see those screenshots!</summary>

<img width="377" alt="Screen Shot 2020-11-04 at 3 29 27 PM" src="https://user-images.githubusercontent.com/79799/98169882-aff4cc80-1eb2-11eb-949d-286ad0dded6c.png">

<img width="378" alt="Screen Shot 2020-11-04 at 3 28 56 PM" src="https://user-images.githubusercontent.com/79799/98169889-b420ea00-1eb2-11eb-93d0-fcb6825867eb.png">

<img width="376" alt="Screen Shot 2020-11-04 at 3 29 14 PM" src="https://user-images.githubusercontent.com/79799/98169900-b7b47100-1eb2-11eb-975f-4ff3b8b5d4b9.png">


</details>