### PR TITLE
[FX-2412] Show artwork filter empty state (and test helper)

### DIFF
--- a/src/v2/Apps/Show/Components/ShowArtworksEmptyState.tsx
+++ b/src/v2/Apps/Show/Components/ShowArtworksEmptyState.tsx
@@ -1,0 +1,40 @@
+import React from "react"
+import { Message } from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { ShowArtworksEmptyState_show } from "v2/__generated__/ShowArtworksEmptyState_show.graphql"
+
+interface ShowArtworksEmptyStateProps {
+  show: ShowArtworksEmptyState_show
+}
+
+export const ShowArtworksEmptyState: React.FC<ShowArtworksEmptyStateProps> = ({
+  show,
+}) => {
+  const message = [
+    `This ${
+      show.isFairBooth ? "fair booth" : "show"
+    } is currently unavailable.`,
+
+    ...(show.status !== "closed"
+      ? [
+          `Please check back closer to the ${
+            show.isFairBooth ? "fair" : "show"
+          } for artworks.`,
+        ]
+      : []),
+  ].join(" ")
+
+  return <Message>{message}</Message>
+}
+
+export const ShowArtworksEmptyStateFragmentContainer = createFragmentContainer(
+  ShowArtworksEmptyState,
+  {
+    show: graphql`
+      fragment ShowArtworksEmptyState_show on Show {
+        isFairBooth
+        status
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Show/ShowApp.tsx
+++ b/src/v2/Apps/Show/ShowApp.tsx
@@ -19,6 +19,7 @@ import {
   AnalyticsContext,
   useAnalyticsContext,
 } from "v2/Artsy/Analytics/AnalyticsContext"
+import { ShowArtworksEmptyStateFragmentContainer as ShowArtworksEmptyState } from "./Components/ShowArtworksEmptyState"
 
 interface ShowAppProps {
   show: ShowApp_show
@@ -99,7 +100,14 @@ export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
               )}
             </GridColumns>
 
-            <ShowArtworks show={show} my={3} />
+            {show.counts.eligibleArtworks > 0 ? (
+              <ShowArtworks show={show} my={3} />
+            ) : (
+              <>
+                <Separator my={3} />
+                <ShowArtworksEmptyState show={show} />
+              </>
+            )}
 
             <Separator as="hr" my={3} />
 
@@ -141,12 +149,16 @@ export default createFragmentContainer(ShowApp, {
       slug
       about: description
       viewingRoomIDs
+      counts {
+        eligibleArtworks
+      }
       ...ShowContextualLink_show
       ...ShowHeader_show
       ...ShowAbout_show
       ...ShowMeta_show
       ...ShowInstallShots_show
       ...ShowViewingRoom_show
+      ...ShowArtworksEmptyState_show
       ...ShowArtworks_show
         @arguments(
           acquireable: $acquireable

--- a/src/v2/Apps/Show/__tests__/ShowArtworksEmptyState.jest.tsx
+++ b/src/v2/Apps/Show/__tests__/ShowArtworksEmptyState.jest.tsx
@@ -1,0 +1,65 @@
+import { graphql } from "react-relay"
+import { ShowArtworksEmptyStateFragmentContainer } from "../Components/ShowArtworksEmptyState"
+import { ShowArtworksEmptyState_Test_Query } from "v2/__generated__/ShowArtworksEmptyState_Test_Query.graphql"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+
+jest.unmock("react-relay")
+
+const { getWrapper } = setupTestWrapper<ShowArtworksEmptyState_Test_Query>({
+  Component: ShowArtworksEmptyStateFragmentContainer,
+  query: graphql`
+    query ShowArtworksEmptyState_Test_Query {
+      show(id: "example-show-id") {
+        ...ShowArtworksEmptyState_show
+      }
+    }
+  `,
+})
+
+describe("ShowArtworksEmptyState", () => {
+  describe("fair booth", () => {
+    it("renders the correct message for non-closed fair booths", () => {
+      const wrapper = getWrapper({ Show: () => ({ isFairBooth: true }) })
+      const html = wrapper.html()
+
+      expect(html).toContain(
+        "This fair booth is currently unavailable. Please check back closer to the fair for artworks."
+      )
+    })
+
+    it("renders the correct message for closed fair booths", () => {
+      const wrapper = getWrapper({
+        Show: () => ({ isFairBooth: true, status: "closed" }),
+      })
+      const html = wrapper.html()
+
+      expect(html).toContain("This fair booth is currently unavailable.")
+      expect(html).not.toContain(
+        "Please check back closer to the fair for artworks."
+      )
+    })
+  })
+
+  describe("show", () => {
+    it("renders the correct message for non-closed shows", () => {
+      const wrapper = getWrapper({ Show: () => ({ isFairBooth: false }) })
+      const html = wrapper.html()
+
+      expect(html).toContain(
+        "This show is currently unavailable. Please check back closer to the show for artworks."
+      )
+    })
+
+    it("renders the correct message for closed shows", () => {
+      const wrapper = getWrapper({
+        Show: () => ({ isFairBooth: false, status: "closed" }),
+      })
+      const html = wrapper.html()
+
+      expect(html).toContain("This show is currently unavailable.")
+      expect(html).not.toContain(
+        "Please check back closer to the show for artworks."
+      )
+    })
+  })
+})

--- a/src/v2/Apps/Show/__tests__/ShowViewingRoom.jest.tsx
+++ b/src/v2/Apps/Show/__tests__/ShowViewingRoom.jest.tsx
@@ -1,21 +1,18 @@
 import React from "react"
-import { mount } from "enzyme"
-import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
-import { QueryRenderer, graphql } from "react-relay"
+import { graphql } from "react-relay"
 import { ShowViewingRoomFragmentContainer as ShowViewingRoom } from "../Components/ShowViewingRoom"
 import { ShowViewingRoom_Test_Query } from "v2/__generated__/ShowViewingRoom_Test_Query.graphql"
 import { useTracking } from "react-tracking"
 import { AnalyticsContext } from "v2/Artsy/Analytics/AnalyticsContext"
 import { OwnerType } from "@artsy/cohesion"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
 
-jest.unmock("react-relay")
 jest.mock("react-tracking")
+jest.unmock("react-relay")
 
-describe("ShowViewingRoom", () => {
-  const getWrapper = (mocks = {}) => {
-    const env = createMockEnvironment()
-
-    const TestRenderer = () => (
+const { getWrapper } = setupTestWrapper<ShowViewingRoom_Test_Query>({
+  Component: props => {
+    return (
       <AnalyticsContext.Provider
         value={{
           contextPageOwnerId: "example-show-id",
@@ -23,38 +20,20 @@ describe("ShowViewingRoom", () => {
           contextPageOwnerType: OwnerType.show,
         }}
       >
-        <QueryRenderer<ShowViewingRoom_Test_Query>
-          environment={env}
-          variables={{}}
-          query={graphql`
-            query ShowViewingRoom_Test_Query {
-              show(id: "example-show-id") {
-                ...ShowViewingRoom_show
-              }
-            }
-          `}
-          render={({ props, error }) => {
-            if (props?.show) {
-              return <ShowViewingRoom show={props.show} />
-            } else if (error) {
-              console.error(error)
-            }
-          }}
-        />
+        <ShowViewingRoom {...props} />
       </AnalyticsContext.Provider>
     )
+  },
+  query: graphql`
+    query ShowViewingRoom_Test_Query {
+      show(id: "example-show-id") {
+        ...ShowViewingRoom_show
+      }
+    }
+  `,
+})
 
-    const wrapper = mount(<TestRenderer />)
-
-    env.mock.resolveMostRecentOperation(operation =>
-      MockPayloadGenerator.generate(operation, {
-        ...mocks,
-      })
-    )
-    wrapper.update()
-    return wrapper
-  }
-
+describe("ShowViewingRoom", () => {
   let trackEvent
   beforeEach(() => {
     trackEvent = jest.fn()

--- a/src/v2/DevTools/setupTestWrapper.tsx
+++ b/src/v2/DevTools/setupTestWrapper.tsx
@@ -1,0 +1,48 @@
+import React from "react"
+import { mount } from "enzyme"
+import { QueryRenderer } from "react-relay"
+import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
+import { GraphQLTaggedNode, OperationType } from "relay-runtime"
+
+type SetupTestWrapper<T extends OperationType> = {
+  Component: React.ComponentType<T["response"]>
+  query: GraphQLTaggedNode
+  variables?: T["variables"]
+}
+
+export const setupTestWrapper = <T extends OperationType>({
+  Component,
+  query,
+  variables = {},
+}: SetupTestWrapper<T>) => {
+  const getWrapper = (mocks = {}) => {
+    const env = createMockEnvironment()
+
+    const TestRenderer = () => (
+      <QueryRenderer<T>
+        environment={env}
+        variables={variables}
+        query={query}
+        render={({ props, error }) => {
+          if (props) {
+            return <Component {...props} />
+          } else if (error) {
+            console.error(error)
+          }
+        }}
+      />
+    )
+
+    const wrapper = mount(<TestRenderer />)
+
+    env.mock.resolveMostRecentOperation(operation => {
+      return MockPayloadGenerator.generate(operation, { ...mocks })
+    })
+
+    wrapper.update()
+
+    return wrapper
+  }
+
+  return { getWrapper }
+}

--- a/src/v2/__generated__/ShowApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ShowApp_Test_Query.graphql.ts
@@ -220,14 +220,23 @@ fragment ShowApp_show on Show {
   slug
   about: description
   viewingRoomIDs
+  counts {
+    eligibleArtworks
+  }
   ...ShowContextualLink_show
   ...ShowHeader_show
   ...ShowAbout_show
   ...ShowMeta_show
   ...ShowInstallShots_show
   ...ShowViewingRoom_show
+  ...ShowArtworksEmptyState_show
   ...ShowArtworks_show_oju7O
   ...ShowContextCard_show
+}
+
+fragment ShowArtworksEmptyState_show on Show {
+  isFairBooth
+  status
 }
 
 fragment ShowArtworks_show_oju7O on Show {
@@ -497,37 +506,44 @@ v14 = [
   (v11/*: any*/),
   (v12/*: any*/)
 ],
-v15 = [
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "status",
+  "storageKey": null
+},
+v16 = [
   {
     "kind": "Literal",
     "name": "short",
     "value": true
   }
 ],
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v19 = [
-  (v17/*: any*/),
+v20 = [
   (v18/*: any*/),
+  (v19/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -536,14 +552,14 @@ v19 = [
     "storageKey": null
   }
 ],
-v20 = [
+v21 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v21 = [
+v22 = [
   {
     "alias": null,
     "args": null,
@@ -608,6 +624,24 @@ return {
             "args": null,
             "kind": "ScalarField",
             "name": "viewingRoomIDs",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ShowCounts",
+            "kind": "LinkedField",
+            "name": "counts",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "eligibleArtworks",
+                "storageKey": null
+              }
+            ],
             "storageKey": null
           },
           {
@@ -975,28 +1009,22 @@ return {
                     "selections": [
                       (v3/*: any*/),
                       (v4/*: any*/),
+                      (v15/*: any*/),
                       {
                         "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "status",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": (v15/*: any*/),
+                        "args": (v16/*: any*/),
                         "kind": "ScalarField",
                         "name": "distanceToOpen",
                         "storageKey": "distanceToOpen(short:true)"
                       },
                       {
                         "alias": null,
-                        "args": (v15/*: any*/),
+                        "args": (v16/*: any*/),
                         "kind": "ScalarField",
                         "name": "distanceToClose",
                         "storageKey": "distanceToClose(short:true)"
                       },
-                      (v16/*: any*/),
+                      (v17/*: any*/),
                       (v2/*: any*/),
                       {
                         "alias": null,
@@ -1036,6 +1064,7 @@ return {
             ],
             "storageKey": null
           },
+          (v15/*: any*/),
           {
             "alias": "filtered_artworks",
             "args": [
@@ -1150,7 +1179,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v19/*: any*/),
+                    "selections": (v20/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1160,7 +1189,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v19/*: any*/),
+                    "selections": (v20/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1170,7 +1199,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v19/*: any*/),
+                    "selections": (v20/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1181,8 +1210,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v17/*: any*/),
-                      (v18/*: any*/)
+                      (v18/*: any*/),
+                      (v19/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1241,7 +1270,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v16/*: any*/),
+                      (v17/*: any*/),
                       {
                         "alias": "image_title",
                         "args": null,
@@ -1272,7 +1301,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v20/*: any*/),
+                        "args": (v21/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
@@ -1293,7 +1322,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v20/*: any*/),
+                        "args": (v21/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
@@ -1399,7 +1428,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v21/*: any*/),
+                            "selections": (v22/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1409,7 +1438,7 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v21/*: any*/),
+                            "selections": (v22/*: any*/),
                             "storageKey": null
                           },
                           (v5/*: any*/)
@@ -1458,7 +1487,7 @@ return {
     "metadata": {},
     "name": "ShowApp_Test_Query",
     "operationKind": "query",
-    "text": "query ShowApp_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  viewingRoomIDs\n  ...ShowContextualLink_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowViewingRoom_show\n  ...ShowArtworks_show_oju7O\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworks_show_oju7O on Show {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-decayed_merch\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false) {\n    internalID\n    caption\n    mobile: resized(height: 300) {\n      width\n      height\n    }\n    desktop: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    zoom: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n\nfragment ShowViewingRoom_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  viewingRoomsConnection {\n    edges {\n      node {\n        internalID\n        slug\n        status\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        title\n        href\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query ShowApp_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  viewingRoomIDs\n  counts {\n    eligibleArtworks\n  }\n  ...ShowContextualLink_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowViewingRoom_show\n  ...ShowArtworksEmptyState_show\n  ...ShowArtworks_show_oju7O\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworksEmptyState_show on Show {\n  isFairBooth\n  status\n}\n\nfragment ShowArtworks_show_oju7O on Show {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-decayed_merch\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false) {\n    internalID\n    caption\n    mobile: resized(height: 300) {\n      width\n      height\n    }\n    desktop: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    zoom: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n\nfragment ShowViewingRoom_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  viewingRoomsConnection {\n    edges {\n      node {\n        internalID\n        slug\n        status\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        title\n        href\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/ShowApp_show.graphql.ts
+++ b/src/v2/__generated__/ShowApp_show.graphql.ts
@@ -10,7 +10,10 @@ export type ShowApp_show = {
     readonly slug: string;
     readonly about: string | null;
     readonly viewingRoomIDs: ReadonlyArray<string>;
-    readonly " $fragmentRefs": FragmentRefs<"ShowContextualLink_show" | "ShowHeader_show" | "ShowAbout_show" | "ShowMeta_show" | "ShowInstallShots_show" | "ShowViewingRoom_show" | "ShowArtworks_show" | "ShowContextCard_show">;
+    readonly counts: {
+        readonly eligibleArtworks: number | null;
+    } | null;
+    readonly " $fragmentRefs": FragmentRefs<"ShowContextualLink_show" | "ShowHeader_show" | "ShowAbout_show" | "ShowMeta_show" | "ShowInstallShots_show" | "ShowViewingRoom_show" | "ShowArtworksEmptyState_show" | "ShowArtworks_show" | "ShowContextCard_show">;
     readonly " $refType": "ShowApp_show";
 };
 export type ShowApp_show$data = ShowApp_show;
@@ -155,6 +158,24 @@ const node: ReaderFragment = {
       "storageKey": null
     },
     {
+      "alias": null,
+      "args": null,
+      "concreteType": "ShowCounts",
+      "kind": "LinkedField",
+      "name": "counts",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "eligibleArtworks",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
       "args": null,
       "kind": "FragmentSpread",
       "name": "ShowContextualLink_show"
@@ -183,6 +204,11 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "FragmentSpread",
       "name": "ShowViewingRoom_show"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "ShowArtworksEmptyState_show"
     },
     {
       "args": [
@@ -268,5 +294,5 @@ const node: ReaderFragment = {
   ],
   "type": "Show"
 };
-(node as any).hash = 'f52fc3659d5ac4437d1653283f2b0413';
+(node as any).hash = '960ba3e24d5c9206cc85e43b88cf06e8';
 export default node;

--- a/src/v2/__generated__/ShowArtworksEmptyState_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ShowArtworksEmptyState_Test_Query.graphql.ts
@@ -1,0 +1,117 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ShowArtworksEmptyState_Test_QueryVariables = {};
+export type ShowArtworksEmptyState_Test_QueryResponse = {
+    readonly show: {
+        readonly " $fragmentRefs": FragmentRefs<"ShowArtworksEmptyState_show">;
+    } | null;
+};
+export type ShowArtworksEmptyState_Test_Query = {
+    readonly response: ShowArtworksEmptyState_Test_QueryResponse;
+    readonly variables: ShowArtworksEmptyState_Test_QueryVariables;
+};
+
+
+
+/*
+query ShowArtworksEmptyState_Test_Query {
+  show(id: "example-show-id") {
+    ...ShowArtworksEmptyState_show
+    id
+  }
+}
+
+fragment ShowArtworksEmptyState_show on Show {
+  isFairBooth
+  status
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example-show-id"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ShowArtworksEmptyState_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ShowArtworksEmptyState_show"
+          }
+        ],
+        "storageKey": "show(id:\"example-show-id\")"
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ShowArtworksEmptyState_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isFairBooth",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "status",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "show(id:\"example-show-id\")"
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "ShowArtworksEmptyState_Test_Query",
+    "operationKind": "query",
+    "text": "query ShowArtworksEmptyState_Test_Query {\n  show(id: \"example-show-id\") {\n    ...ShowArtworksEmptyState_show\n    id\n  }\n}\n\nfragment ShowArtworksEmptyState_show on Show {\n  isFairBooth\n  status\n}\n"
+  }
+};
+})();
+(node as any).hash = 'f299977d77220a25cd3e2d1c38564cbf';
+export default node;

--- a/src/v2/__generated__/ShowArtworksEmptyState_show.graphql.ts
+++ b/src/v2/__generated__/ShowArtworksEmptyState_show.graphql.ts
@@ -1,0 +1,43 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ShowArtworksEmptyState_show = {
+    readonly isFairBooth: boolean | null;
+    readonly status: string | null;
+    readonly " $refType": "ShowArtworksEmptyState_show";
+};
+export type ShowArtworksEmptyState_show$data = ShowArtworksEmptyState_show;
+export type ShowArtworksEmptyState_show$key = {
+    readonly " $data"?: ShowArtworksEmptyState_show$data;
+    readonly " $fragmentRefs": FragmentRefs<"ShowArtworksEmptyState_show">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ShowArtworksEmptyState_show",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isFairBooth",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "status",
+      "storageKey": null
+    }
+  ],
+  "type": "Show"
+};
+(node as any).hash = 'be321818d2ec1658c3e5dfa05febe366';
+export default node;

--- a/src/v2/__generated__/routes_ShowQuery.graphql.ts
+++ b/src/v2/__generated__/routes_ShowQuery.graphql.ts
@@ -254,14 +254,23 @@ fragment ShowApp_show_2jdisZ on Show {
   slug
   about: description
   viewingRoomIDs
+  counts {
+    eligibleArtworks
+  }
   ...ShowContextualLink_show
   ...ShowHeader_show
   ...ShowAbout_show
   ...ShowMeta_show
   ...ShowInstallShots_show
   ...ShowViewingRoom_show
+  ...ShowArtworksEmptyState_show
   ...ShowArtworks_show_2jdisZ
   ...ShowContextCard_show
+}
+
+fragment ShowArtworksEmptyState_show on Show {
+  isFairBooth
+  status
 }
 
 fragment ShowArtworks_show_2jdisZ on Show {
@@ -697,37 +706,44 @@ v29 = [
   (v26/*: any*/),
   (v27/*: any*/)
 ],
-v30 = [
+v30 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "status",
+  "storageKey": null
+},
+v31 = [
   {
     "kind": "Literal",
     "name": "short",
     "value": true
   }
 ],
-v31 = {
+v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v32 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v33 = {
+v34 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v34 = [
-  (v32/*: any*/),
+v35 = [
   (v33/*: any*/),
+  (v34/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -736,14 +752,14 @@ v34 = [
     "storageKey": null
   }
 ],
-v35 = [
+v36 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v36 = [
+v37 = [
   {
     "alias": null,
     "args": null,
@@ -823,6 +839,24 @@ return {
             "args": null,
             "kind": "ScalarField",
             "name": "viewingRoomIDs",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ShowCounts",
+            "kind": "LinkedField",
+            "name": "counts",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "eligibleArtworks",
+                "storageKey": null
+              }
+            ],
             "storageKey": null
           },
           {
@@ -1190,28 +1224,22 @@ return {
                     "selections": [
                       (v18/*: any*/),
                       (v19/*: any*/),
+                      (v30/*: any*/),
                       {
                         "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "status",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": (v30/*: any*/),
+                        "args": (v31/*: any*/),
                         "kind": "ScalarField",
                         "name": "distanceToOpen",
                         "storageKey": "distanceToOpen(short:true)"
                       },
                       {
                         "alias": null,
-                        "args": (v30/*: any*/),
+                        "args": (v31/*: any*/),
                         "kind": "ScalarField",
                         "name": "distanceToClose",
                         "storageKey": "distanceToClose(short:true)"
                       },
-                      (v31/*: any*/),
+                      (v32/*: any*/),
                       (v17/*: any*/),
                       {
                         "alias": null,
@@ -1251,6 +1279,7 @@ return {
             ],
             "storageKey": null
           },
+          (v30/*: any*/),
           {
             "alias": "filtered_artworks",
             "args": [
@@ -1369,7 +1398,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v34/*: any*/),
+                    "selections": (v35/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1379,7 +1408,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v34/*: any*/),
+                    "selections": (v35/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1389,7 +1418,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v34/*: any*/),
+                    "selections": (v35/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1400,8 +1429,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v32/*: any*/),
-                      (v33/*: any*/)
+                      (v33/*: any*/),
+                      (v34/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1460,7 +1489,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v31/*: any*/),
+                      (v32/*: any*/),
                       {
                         "alias": "image_title",
                         "args": null,
@@ -1491,7 +1520,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v35/*: any*/),
+                        "args": (v36/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
@@ -1512,7 +1541,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v35/*: any*/),
+                        "args": (v36/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
@@ -1618,7 +1647,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v36/*: any*/),
+                            "selections": (v37/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1628,7 +1657,7 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v36/*: any*/),
+                            "selections": (v37/*: any*/),
                             "storageKey": null
                           },
                           (v20/*: any*/)
@@ -1677,7 +1706,7 @@ return {
     "metadata": {},
     "name": "routes_ShowQuery",
     "operationKind": "query",
-    "text": "query routes_ShowQuery(\n  $slug: String!\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MEDIUM, TOTAL, MAJOR_PERIOD]\n  $atAuction: Boolean\n  $color: String\n  $forSale: Boolean\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sizes: [ArtworkSizes]\n  $sort: String\n) {\n  show(id: $slug) @principalField {\n    ...ShowApp_show_2jdisZ\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show_2jdisZ on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  viewingRoomIDs\n  ...ShowContextualLink_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowViewingRoom_show\n  ...ShowArtworks_show_2jdisZ\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworks_show_2jdisZ on Show {\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: \"\", sort: $sort) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false) {\n    internalID\n    caption\n    mobile: resized(height: 300) {\n      width\n      height\n    }\n    desktop: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    zoom: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n\nfragment ShowViewingRoom_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  viewingRoomsConnection {\n    edges {\n      node {\n        internalID\n        slug\n        status\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        title\n        href\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query routes_ShowQuery(\n  $slug: String!\n  $acquireable: Boolean\n  $aggregations: [ArtworkAggregation] = [MEDIUM, TOTAL, MAJOR_PERIOD]\n  $atAuction: Boolean\n  $color: String\n  $forSale: Boolean\n  $inquireableOnly: Boolean\n  $majorPeriods: [String]\n  $medium: String\n  $offerable: Boolean\n  $page: Int\n  $partnerID: ID\n  $priceRange: String\n  $sizes: [ArtworkSizes]\n  $sort: String\n) {\n  show(id: $slug) @principalField {\n    ...ShowApp_show_2jdisZ\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show_2jdisZ on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  viewingRoomIDs\n  counts {\n    eligibleArtworks\n  }\n  ...ShowContextualLink_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowViewingRoom_show\n  ...ShowArtworksEmptyState_show\n  ...ShowArtworks_show_2jdisZ\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworksEmptyState_show on Show {\n  isFairBooth\n  status\n}\n\nfragment ShowArtworks_show_2jdisZ on Show {\n  filtered_artworks: filterArtworksConnection(acquireable: $acquireable, aggregations: $aggregations, atAuction: $atAuction, color: $color, forSale: $forSale, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, page: $page, partnerID: $partnerID, priceRange: $priceRange, sizes: $sizes, first: 20, after: \"\", sort: $sort) {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false) {\n    internalID\n    caption\n    mobile: resized(height: 300) {\n      width\n      height\n    }\n    desktop: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    zoom: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  slug\n  metaDescription: description\n  metaImage {\n    src: url(version: \"large\")\n  }\n}\n\nfragment ShowViewingRoom_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  viewingRoomsConnection {\n    edges {\n      node {\n        internalID\n        slug\n        status\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        title\n        href\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Closes: [FX-2412](https://artsyproduct.atlassian.net/browse/FX-2412)

![](http://static.damonzucconi.com/_capture/4KGuK6AvmLbC.png)

-----

I tried to wrap up the boilerplate for setting up a test renderer with mocks: b98dcf3eb2b9a769c5a369d01d202423565600e0

Not super necessary but the copy-pasting was getting me down a bit. I don't *think* we can get it any shorter?