### PR TITLE
[FX-2430] Fixes client-side artist page redirects

### DIFF
--- a/src/v2/Apps/Artist/__tests__/routes.jest.tsx
+++ b/src/v2/Apps/Artist/__tests__/routes.jest.tsx
@@ -5,7 +5,6 @@ import { Resolver } from "found-relay"
 import { FarceRedirectResult, getFarceResult } from "found/server"
 import React from "react"
 import { Environment, RecordSource, Store } from "relay-runtime"
-import { PermanentRedirectException } from "v2/Artsy/Router/PermanentRedirectException"
 
 describe("Artist/routes", () => {
   async function render(url, mockData: routes_ArtistTopLevelQueryRawResponse) {
@@ -44,13 +43,12 @@ describe("Artist/routes", () => {
   it("redirects trailing a trailing slash on the artist page back to the root", async () => {
     await expect(
       render("/artist/juan-gris/", mockResolver(overviewArtist))
-    ).rejects.toThrow(PermanentRedirectException)
-
-    try {
-      await render("/artist/juan-gris/", mockResolver(overviewArtist))
-    } catch (err) {
-      expect(err.pathname).toEqual("/artist/juan-gris")
-    }
+    ).resolves.toEqual({
+      redirect: {
+        url: "/artist/juan-gris",
+      },
+      status: 301,
+    })
   })
 
   it("doesn't redirect from /auction-results to /works-for-sale if auction-results", async () => {
@@ -106,8 +104,8 @@ describe("Artist/routes", () => {
   })
 
   it("redirects from / to the /works-for-sale page if there is no data", async () => {
-    const exec = async () =>
-      await render(
+    await expect(
+      render(
         "/artist/juan-gris",
         mockResolver({
           ...overviewArtist,
@@ -129,14 +127,12 @@ describe("Artist/routes", () => {
           },
         })
       )
-
-    await expect(exec()).rejects.toThrow(PermanentRedirectException)
-
-    try {
-      await exec()
-    } catch (err) {
-      expect(err.pathname).toEqual("/artist/juan-gris/works-for-sale")
-    }
+    ).resolves.toEqual({
+      redirect: {
+        url: "/artist/juan-gris/works-for-sale",
+      },
+      status: 301,
+    })
   })
 
   it("does not redirect from /cv", async () => {
@@ -167,8 +163,8 @@ describe("Artist/routes", () => {
   })
 
   it("redirects from /cv to the /works-for-sale page if there is no data", async () => {
-    const exec = async () =>
-      await render(
+    await expect(
+      render(
         "/artist/juan-gris/cv",
         mockResolver({
           ...overviewArtist,
@@ -187,14 +183,10 @@ describe("Artist/routes", () => {
           },
         })
       )
-
-    await expect(exec()).rejects.toThrow(PermanentRedirectException)
-
-    try {
-      await exec()
-    } catch (err) {
-      expect(err.pathname).toEqual("/artist/juan-gris/works-for-sale")
-    }
+    ).resolves.toEqual({
+      redirect: { url: "/artist/juan-gris/works-for-sale" },
+      status: 301,
+    })
   })
 })
 

--- a/src/v2/Apps/Artist/routes.tsx
+++ b/src/v2/Apps/Artist/routes.tsx
@@ -14,7 +14,6 @@ import {
   ArtworkFilters,
   initialArtworkFilterState,
 } from "v2/Components/v2/ArtworkFilter/ArtworkFilterContext"
-import { PermanentRedirectException } from "v2/Artsy/Router/PermanentRedirectException"
 
 graphql`
   fragment routes_Artist on Artist {
@@ -118,12 +117,13 @@ export const routes: RouteConfig[] = [
       const canShowOverview = showArtistInsights || hasArtistContent
 
       if (pathname === `/artist/${artist.slug}/`) {
-        throw new PermanentRedirectException(`/artist/${artist.slug}`)
+        throw new RedirectException(`/artist/${artist.slug}`, 301)
       }
 
       if (!canShowOverview && !alreadyAtWorksForSalePath) {
-        throw new PermanentRedirectException(
-          `/artist/${artist.slug}/works-for-sale`
+        throw new RedirectException(
+          `/artist/${artist.slug}/works-for-sale`,
+          301
         )
       }
 

--- a/src/v2/Artsy/Router/PermanentRedirectException.tsx
+++ b/src/v2/Artsy/Router/PermanentRedirectException.tsx
@@ -1,8 +1,0 @@
-export class PermanentRedirectException extends Error {
-  pathname: string
-
-  constructor(pathname: string) {
-    super()
-    this.pathname = pathname
-  }
-}

--- a/src/v2/Artsy/Router/buildServerApp.tsx
+++ b/src/v2/Artsy/Router/buildServerApp.tsx
@@ -30,7 +30,6 @@ import { queryStringParsing } from "./Utils/queryStringParsing"
 
 import { ChunkExtractor } from "@loadable/server"
 import { getENV } from "v2/Utils/getENV"
-import { PermanentRedirectException } from "v2/Artsy/Router/PermanentRedirectException"
 import RelayServerSSR from "react-relay-network-modern-ssr/lib/server"
 import { buildServerAppContext } from "desktop/lib/buildServerAppContext"
 import { RouteConfig } from "found"
@@ -92,7 +91,7 @@ export function buildServerApp(
       })
 
       if (isRedirect(farceResults)) {
-        resolve({ redirect: farceResults.redirect, status: 302 })
+        resolve(farceResults)
       } else {
         /**
          * An array that gets passed to `react-head`'s provider that will
@@ -253,12 +252,6 @@ export function buildServerApp(
         resolve(result)
       }
     } catch (error) {
-      // FIXME: https://github.com/artsy/force/pull/6013 once found is upgraded
-      if (error instanceof PermanentRedirectException) {
-        resolve({ redirect: { url: error.pathname }, status: 301 })
-        return
-      }
-
       logger.error(error)
       reject(error)
     }


### PR DESCRIPTION
Closes: [FX-2430](https://artsyproduct.atlassian.net/browse/FX-2430)

See https://artsy.slack.com/archives/C9SATFLUU/p1604595375485200 for more context.

The thrown `PermanentRedirectException` work-around was breaking client-side routing. Since we've upgraded to found 0.5.5 we can just use the status code support that I added there a while back when this became an issue, and remove this hack.