### PR TITLE
bugfix: Add 'roles' to passport's userKeys

### DIFF
--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -170,6 +170,7 @@ export default function (app) {
           "name",
           "paddle_number",
           "phone",
+          "roles",
           "type",
         ],
       })


### PR DESCRIPTION
Follow up to https://github.com/artsy/force/pull/6584, adds `roles` to artsy-passport's `userKeys` options.

