### PR TITLE
chore: Add retry on status code cypress helper

### DIFF
--- a/cypress/helpers/visitWithStatusRetries.js
+++ b/cypress/helpers/visitWithStatusRetries.js
@@ -1,0 +1,3 @@
+export const visitWithStatusRetries = url => {
+  cy.visit(url, { retryOnStatusCodeFailure: true, retryOnNetworkFailure: true })
+}

--- a/cypress/integration/collection.spec.js
+++ b/cypress/integration/collection.spec.js
@@ -1,8 +1,9 @@
 import { artworkGridRenders } from "../helpers/artworkGridRenders"
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
 
 describe("/collection/:id", () => {
   before(() => {
-    cy.visit("/collection/emerging-photographers")
+    visitWithStatusRetries("/collection/emerging-photographers")
   })
 
   it("renders metadata", () => {
@@ -23,7 +24,7 @@ describe("/collection/:id", () => {
 
 describe("/collection/:id (a collection hub)", () => {
   before(() => {
-    cy.visit("/collection/contemporary")
+    visitWithStatusRetries("/collection/contemporary")
   })
   it("renders metadata", () => {
     cy.title().should("eq", "Contemporary Art - For Sale on Artsy")


### PR DESCRIPTION
The cypress test step has been failing somewhat regularly when a `visit` request returns a 500. Retries do not work on page visits that occur in the `before` block of a test.

Adds helper function `visitWithStatusRetries` (as we use in Integrity), to retry these requests. 

I added this to the `/collection/:id` spec for the moment, which is the one I have noticed failing. We can expand this to other tests if necessary. 

https://app.circleci.com/pipelines/github/artsy/force/10437/workflows/0e51ddb3-f580-4b73-8086-0bd6e07c7d63/jobs/72143