### PR TITLE
[chore] Show2 app specs clean up

### DIFF
--- a/package.json
+++ b/package.json
@@ -263,6 +263,7 @@
     "@types/react-transition-group": "2.0.11",
     "@types/redis": "2.8.22",
     "@types/relay-runtime": "9.1.6",
+    "@types/relay-test-utils": "6.0.3",
     "@types/styled-components": "4.0.3",
     "@types/styled-system": "5.1.9",
     "@types/styled-system__theme-get": "5.0.0",

--- a/src/v2/Apps/Show/__tests__/ShowApp.jest.tsx
+++ b/src/v2/Apps/Show/__tests__/ShowApp.jest.tsx
@@ -1,9 +1,8 @@
-import React from "react"
-import { mount } from "enzyme"
-import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
-import { QueryRenderer, graphql } from "react-relay"
+import { graphql } from "react-relay"
 import ShowApp from "../ShowApp"
 import { ShowViewingRoom } from "../Components/ShowViewingRoom"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { ShowApp_Test_Query } from "v2/__generated__/ShowApp_Test_Query.graphql"
 
 jest.unmock("react-relay")
 
@@ -19,40 +18,18 @@ jest.mock("v2/Apps/Show/Components/ShowInstallShots", () => ({
   ShowInstallShotsFragmentContainer: () => null,
 }))
 
+const { getWrapper } = setupTestWrapper<ShowApp_Test_Query>({
+  Component: ShowApp,
+  query: graphql`
+    query ShowApp_Test_Query {
+      show(id: "xxx") {
+        ...ShowApp_show
+      }
+    }
+  `,
+})
+
 describe("ShowApp", () => {
-  const getWrapper = (mocks = {}) => {
-    const env = createMockEnvironment()
-
-    const TestRenderer = () => (
-      <QueryRenderer<any>
-        environment={env}
-        variables={{}}
-        query={graphql`
-          query ShowApp_Test_Query {
-            show(id: "xxx") {
-              ...ShowApp_show
-            }
-          }
-        `}
-        render={({ props, error }) => {
-          if (props?.show) {
-            return <ShowApp show={props.show} />
-          } else if (error) {
-            console.error(error)
-          }
-        }}
-      />
-    )
-
-    const wrapper = mount(<TestRenderer />)
-
-    env.mock.resolveMostRecentOperation(operation =>
-      MockPayloadGenerator.generate(operation, mocks)
-    )
-    wrapper.update()
-    return wrapper
-  }
-
   it("renders the title", () => {
     const wrapper = getWrapper({
       Show: () => ({ name: "Example Show" }),

--- a/src/v2/Apps/Show/__tests__/ShowArtworks.jest.tsx
+++ b/src/v2/Apps/Show/__tests__/ShowArtworks.jest.tsx
@@ -1,68 +1,34 @@
-import { MockBoot } from "v2/DevTools"
-import { Breakpoint } from "@artsy/palette"
 import React from "react"
 import { ShowArtworksRefetchContainer } from "../Components/ShowArtworks"
-import { QueryRenderer, graphql } from "react-relay"
-import { ShowArtworks_Query } from "v2/__generated__/ShowArtworks_Query.graphql"
-import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
-import { mount } from "enzyme"
+import { graphql } from "react-relay"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { ShowArtworks_Test_Query } from "v2/__generated__/ShowArtworks_Test_Query.graphql"
+import { MockBoot } from "v2/DevTools"
 
 jest.unmock("react-relay")
 jest.mock("v2/Artsy/Router/useRouter", () => ({
-  useRouter: () => ({
-    match: {
-      location: { query: {} },
-    },
-  }),
+  useRouter: () => ({ match: { location: { query: {} } } }),
 }))
 
+const { getWrapper } = setupTestWrapper<ShowArtworks_Test_Query>({
+  Component: props => (
+    <MockBoot>
+      <ShowArtworksRefetchContainer {...props} />
+    </MockBoot>
+  ),
+  query: graphql`
+    query ShowArtworks_Test_Query {
+      show(id: "catty-show") {
+        ...ShowArtworks_show
+      }
+    }
+  `,
+})
+
 describe("ShowArtworks", () => {
-  let env = createMockEnvironment() as ReturnType<typeof createMockEnvironment>
+  it("renders correctly", () => {
+    const wrapper = getWrapper()
 
-  const getWrapper = (breakpoint = "xs") => {
-    const TestRenderer = () => (
-      <QueryRenderer<ShowArtworks_Query>
-        environment={env}
-        query={graphql`
-          query ShowArtworks_Query($slug: String!) {
-            show(id: $slug) {
-              ...ShowArtworks_show
-            }
-          }
-        `}
-        variables={{ slug: "show-id" }}
-        render={({ props, error }) => {
-          if (props?.show) {
-            return (
-              <MockBoot breakpoint={breakpoint as Breakpoint}>
-                <ShowArtworksRefetchContainer show={props.show} />
-              </MockBoot>
-            )
-          } else if (error) {
-            console.error(error)
-          }
-        }}
-      />
-    )
-
-    const wrapper = mount(<TestRenderer />)
-    env.mock.resolveMostRecentOperation(operation =>
-      MockPayloadGenerator.generate(operation)
-    )
-    wrapper.update()
-    return wrapper
-  }
-
-  beforeEach(() => {
-    env = createMockEnvironment()
-  })
-
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
-  it("renders correctly", async () => {
-    const wrapper = await getWrapper()
     expect(wrapper.find("ArtworkFilterArtworkGrid").length).toBe(1)
     expect(wrapper.find("GridItem__ArtworkGridItem").length).toBe(1)
   })

--- a/src/v2/Apps/Show/__tests__/ShowContextualLink.jest.tsx
+++ b/src/v2/Apps/Show/__tests__/ShowContextualLink.jest.tsx
@@ -1,51 +1,62 @@
-import React from "react"
-import { mount } from "enzyme"
-import { ContextualLink } from "../Components/ShowContextualLink"
+import { ShowContextualLinkFragmentContainer } from "../Components/ShowContextualLink"
 import { Link } from "@artsy/palette"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { graphql } from "react-relay"
+import { ShowContextualLink_Test_Query } from "v2/__generated__/ShowContextualLink_Test_Query.graphql"
 
-const SHOW_FIXTURE = {
-  name: "Example Show",
-  isFairBooth: true,
-  fair: {
-    name: "Catty Fair",
-    href: "/fair/catty-fair",
-  },
-  partner: {
-    isLinkable: true,
-    href: "/catty-partner",
-    name: "Catty Partner",
-  },
-  " $refType": null,
-}
+jest.unmock("react-relay")
+
+const { getWrapper } = setupTestWrapper<ShowContextualLink_Test_Query>({
+  Component: ShowContextualLinkFragmentContainer,
+  query: graphql`
+    query ShowContextualLink_Test_Query {
+      show(id: "catty-show") {
+        ...ShowContextualLink_show
+      }
+    }
+  `,
+})
 
 describe("ShowInstallShots", () => {
-  const getWrapper = (data = SHOW_FIXTURE) => {
-    return mount(<ContextualLink show={data} />)
-  }
+  describe("is a fair booth", () => {
+    it("renders the fair link", () => {
+      const wrapper = getWrapper({
+        Show: () => ({ isFairBooth: true }),
+        Fair: () => ({ name: "Catty Fair" }),
+      })
 
-  it("renders the fair link when a fair booth", () => {
-    const wrapper = getWrapper()
-    expect(wrapper.text()).toContain("Part of Catty Fair")
+      expect(wrapper.text()).toContain("Part of Catty Fair")
+    })
   })
 
   describe("when not a fair booth", () => {
-    let wrapper
-    afterEach(() => {
+    it("renders the partner link when the partner is linkable", () => {
+      const wrapper = getWrapper({
+        Show: () => ({ isFairBooth: false }),
+        Partner: () => ({
+          name: "Catty Partner",
+          href: "/catty-partner",
+          isLinkable: true,
+        }),
+      })
+
+      expect(wrapper.find(Link).length).toBeTruthy()
+      expect(wrapper.find(Link).first().props().href).toEqual("/catty-partner")
       expect(wrapper.text()).toContain("Presented by Catty Partner")
     })
 
-    it("renders the partner link when the partner is linkable", () => {
-      const data = { ...SHOW_FIXTURE, isFairBooth: false }
-      wrapper = getWrapper(data)
-      expect(wrapper.find(Link).length).toBeTruthy()
-      expect(wrapper.find(Link).props().href).toEqual("/catty-partner")
-    })
-
     it("does not render the partner link when the partner is not linkable", () => {
-      SHOW_FIXTURE.partner.isLinkable = false
-      const data = { ...SHOW_FIXTURE, isFairBooth: false }
-      wrapper = getWrapper(data)
+      const wrapper = getWrapper({
+        Show: () => ({ isFairBooth: false }),
+        Partner: () => ({
+          name: "Catty Partner",
+          href: "/catty-partner",
+          isLinkable: false,
+        }),
+      })
+
       expect(wrapper.find(Link).length).not.toBeTruthy()
+      expect(wrapper.text()).toContain("Presented by Catty Partner")
     })
   })
 })

--- a/src/v2/Apps/Show/__tests__/ShowInfo.jest.tsx
+++ b/src/v2/Apps/Show/__tests__/ShowInfo.jest.tsx
@@ -1,53 +1,24 @@
-import React from "react"
-import { mount } from "enzyme"
-import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
-import { QueryRenderer, graphql } from "react-relay"
+import { graphql } from "react-relay"
 import ShowInfo from "../Routes/ShowInfo"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
 
 jest.unmock("react-relay")
 
+const { getWrapper } = setupTestWrapper({
+  Component: ShowInfo,
+  query: graphql`
+    query ShowInfo_Test_Query {
+      show(id: "xxx") {
+        ...ShowInfo_show
+      }
+    }
+  `,
+})
+
 describe("ShowInfo", () => {
-  const getWrapper = (response = {}) => {
-    const env = createMockEnvironment()
-
-    const TestRenderer = () => (
-      <QueryRenderer<any>
-        environment={env}
-        variables={{}}
-        query={graphql`
-          query ShowInfo_Test_Query {
-            show(id: "xxx") {
-              ...ShowInfo_show
-            }
-          }
-        `}
-        render={({ props, error }) => {
-          if (props?.show) {
-            return <ShowInfo show={props.show} />
-          } else if (error) {
-            console.error(error)
-          }
-        }}
-      />
-    )
-
-    const wrapper = mount(<TestRenderer />)
-
-    env.mock.resolveMostRecentOperation(operation =>
-      MockPayloadGenerator.generate(operation, {
-        Show: () => response,
-      })
-    )
-    wrapper.update()
-    return wrapper
-  }
-
   it("renders the info page", () => {
-    const wrapper = getWrapper({
-      partner: {
-        type: "Gallery",
-      },
-    })
+    const wrapper = getWrapper({ Partner: () => ({ type: "Gallery" }) })
+
     expect(wrapper.find("h1")).toHaveLength(1)
     expect(wrapper.find("h1").text()).toEqual("About")
     expect(wrapper.find("h2").text()).toEqual("Gallery")

--- a/src/v2/Apps/Show/__tests__/ShowInstallShots.jest.tsx
+++ b/src/v2/Apps/Show/__tests__/ShowInstallShots.jest.tsx
@@ -1,6 +1,6 @@
-import React from "react"
-import { mount } from "enzyme"
-import { ShowInstallShots } from "../Components/ShowInstallShots"
+import { ShowInstallShotsFragmentContainer } from "../Components/ShowInstallShots"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { graphql } from "react-relay"
 
 jest.mock("v2/Components/Carousel", () => ({
   Carousel: ({ children }) => children,
@@ -13,62 +13,47 @@ jest.mock("@artsy/palette", () => {
   }
 })
 
-const SHOW_FIXTURE = {
-  name: "Example Show",
-  images: [
-    {
-      internalID: "example-image-0",
-      mobile: { width: 449, height: 300 },
-      desktop: {
-        src: "0_example1x.jpg",
-        srcSet: "0_example1x.jpg",
-        width: 599,
-        height: 400,
-      },
-      zoom: {
-        src: "0_zoomExample1x.jpg",
-        srcSet: "0_zoomExample1x.jpg",
-        width: 900,
-        height: 600,
-      },
-    },
-    {
-      internalID: "example-image-1",
-      mobile: { width: 449, height: 300 },
-      desktop: {
-        src: "1_example1x.jpg",
-        srcSet: "1_example1x.jpg",
-        width: 599,
-        height: 400,
-      },
-      zoom: {
-        src: "1_zoomExample1x.jpg",
-        srcSet: "1_zoomExample1x.jpg",
-        width: 900,
-        height: 600,
-      },
-    },
-  ],
-}
+jest.unmock("react-relay")
+
+const { getWrapper } = setupTestWrapper({
+  Component: ShowInstallShotsFragmentContainer,
+  query: graphql`
+    query ShowInstallShots_Test_Query {
+      show(id: "xxx") {
+        ...ShowInstallShots_show
+      }
+    }
+  `,
+})
 
 describe("ShowInstallShots", () => {
-  const getWrapper = (data = SHOW_FIXTURE) => {
-    return mount(<ShowInstallShots show={data as any} />)
-  }
+  it("renders empty string if there are no images", () => {
+    const wrapper = getWrapper({ Show: () => ({ images: [] }) })
 
-  it("renders null if there are no images", () => {
-    const wrapper = getWrapper({ ...SHOW_FIXTURE, images: [] })
-    expect(wrapper.html()).toBeNull()
+    expect(wrapper.html()).toBe("")
   })
 
   it("renders the images", () => {
-    const wrapper = getWrapper()
+    const wrapper = getWrapper({
+      Show: (_, generateID) => ({
+        images: [{ internalID: generateID() }, { internalID: generateID() }],
+      }),
+    })
+
     expect(wrapper.find("button")).toHaveLength(2)
     expect(wrapper.find("img")).toHaveLength(2)
   })
 
   it("zooms the second image when it is clicked", () => {
-    const wrapper = getWrapper()
+    const wrapper = getWrapper({
+      Show: (_, generateID) => ({
+        images: [
+          { internalID: generateID() },
+          { internalID: generateID(), zoom: { src: "1_zoomExample1x.jpg" } },
+        ],
+      }),
+    })
+
     expect(wrapper.html()).not.toContain("1_zoomExample1x.jpg")
     wrapper.find("button").at(1).simulate("click")
     expect(wrapper.html()).toContain("1_zoomExample1x.jpg")

--- a/src/v2/Apps/Show/__tests__/ShowViewingRoom.jest.tsx
+++ b/src/v2/Apps/Show/__tests__/ShowViewingRoom.jest.tsx
@@ -34,14 +34,14 @@ const { getWrapper } = setupTestWrapper<ShowViewingRoom_Test_Query>({
 })
 
 describe("ShowViewingRoom", () => {
-  let trackEvent
+  const trackEvent = jest.fn()
+
   beforeEach(() => {
-    trackEvent = jest.fn()
-    ;(useTracking as jest.Mock).mockImplementation(() => {
-      return {
-        trackEvent,
-      }
-    })
+    ;(useTracking as jest.Mock).mockImplementation(() => ({ trackEvent }))
+  })
+
+  afterEach(() => {
+    trackEvent.mockClear()
   })
 
   it("renders correctly", () => {
@@ -83,5 +83,7 @@ describe("ShowViewingRoom", () => {
       destination_page_owner_type: "viewingRoom",
       type: "thumbnail",
     })
+
+    expect(trackEvent).toBeCalledTimes(1)
   })
 })

--- a/src/v2/DevTools/setupTestWrapper.tsx
+++ b/src/v2/DevTools/setupTestWrapper.tsx
@@ -3,6 +3,7 @@ import { mount } from "enzyme"
 import { QueryRenderer } from "react-relay"
 import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
 import { GraphQLTaggedNode, OperationType } from "relay-runtime"
+import { MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator"
 
 type SetupTestWrapper<T extends OperationType> = {
   Component: React.ComponentType<T["response"]>
@@ -15,7 +16,7 @@ export const setupTestWrapper = <T extends OperationType>({
   query,
   variables = {},
 }: SetupTestWrapper<T>) => {
-  const getWrapper = (mocks = {}) => {
+  const getWrapper = (mockResolvers: MockResolvers = {}) => {
     const env = createMockEnvironment()
 
     const TestRenderer = () => (
@@ -36,7 +37,7 @@ export const setupTestWrapper = <T extends OperationType>({
     const wrapper = mount(<TestRenderer />)
 
     env.mock.resolveMostRecentOperation(operation => {
-      return MockPayloadGenerator.generate(operation, { ...mocks })
+      return MockPayloadGenerator.generate(operation, mockResolvers)
     })
 
     wrapper.update()

--- a/src/v2/__generated__/ShowArtworks_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ShowArtworks_Test_Query.graphql.ts
@@ -3,26 +3,22 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type ShowArtworks_QueryVariables = {
-    slug: string;
-};
-export type ShowArtworks_QueryResponse = {
+export type ShowArtworks_Test_QueryVariables = {};
+export type ShowArtworks_Test_QueryResponse = {
     readonly show: {
         readonly " $fragmentRefs": FragmentRefs<"ShowArtworks_show">;
     } | null;
 };
-export type ShowArtworks_Query = {
-    readonly response: ShowArtworks_QueryResponse;
-    readonly variables: ShowArtworks_QueryVariables;
+export type ShowArtworks_Test_Query = {
+    readonly response: ShowArtworks_Test_QueryResponse;
+    readonly variables: ShowArtworks_Test_QueryVariables;
 };
 
 
 
 /*
-query ShowArtworks_Query(
-  $slug: String!
-) {
-  show(id: $slug) {
+query ShowArtworks_Test_Query {
+  show(id: "catty-show") {
     ...ShowArtworks_show
     id
   }
@@ -208,50 +204,42 @@ fragment ShowArtworks_show on Show {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "slug",
-    "type": "String!"
-  }
-],
-v1 = [
-  {
-    "kind": "Variable",
+    "kind": "Literal",
     "name": "id",
-    "variableName": "slug"
+    "value": "catty-show"
   }
 ],
-v2 = {
+v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v6 = [
+v5 = [
+  (v3/*: any*/),
   (v4/*: any*/),
-  (v5/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -260,21 +248,21 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v8 = [
+v7 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v9 = [
+v8 = [
   {
     "alias": null,
     "args": null,
@@ -285,14 +273,14 @@ v9 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "ShowArtworks_Query",
+    "name": "ShowArtworks_Test_Query",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v0/*: any*/),
         "concreteType": "Show",
         "kind": "LinkedField",
         "name": "show",
@@ -304,20 +292,20 @@ return {
             "name": "ShowArtworks_show"
           }
         ],
-        "storageKey": null
+        "storageKey": "show(id:\"catty-show\")"
       }
     ],
     "type": "Query"
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [],
     "kind": "Operation",
-    "name": "ShowArtworks_Query",
+    "name": "ShowArtworks_Test_Query",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v0/*: any*/),
         "concreteType": "Show",
         "kind": "LinkedField",
         "name": "show",
@@ -352,7 +340,7 @@ return {
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
+              (v1/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -383,7 +371,7 @@ return {
                         "name": "value",
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -437,7 +425,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v6/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -447,7 +435,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v6/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -457,7 +445,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v6/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -468,8 +456,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
-                      (v5/*: any*/)
+                      (v3/*: any*/),
+                      (v4/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -492,7 +480,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v2/*: any*/),
+                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -500,7 +488,7 @@ return {
                         "name": "slug",
                         "storageKey": null
                       },
-                      (v7/*: any*/),
+                      (v6/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -583,15 +571,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v8/*: any*/),
+                        "args": (v7/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v2/*: any*/),
-                          (v7/*: any*/),
-                          (v3/*: any*/)
+                          (v1/*: any*/),
+                          (v6/*: any*/),
+                          (v2/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -604,15 +592,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v8/*: any*/),
+                        "args": (v7/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/),
-                          (v7/*: any*/),
                           (v2/*: any*/),
+                          (v6/*: any*/),
+                          (v1/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -645,7 +633,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v2/*: any*/),
+                          (v1/*: any*/),
                           {
                             "alias": "is_live_open",
                             "args": null,
@@ -710,7 +698,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -720,10 +708,10 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": null
                           },
-                          (v2/*: any*/)
+                          (v1/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -751,27 +739,27 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v2/*: any*/)
+                  (v1/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": "filterArtworksConnection(after:\"\",first:20,medium:\"*\",sort:\"-decayed_merch\")"
           },
-          (v2/*: any*/)
+          (v1/*: any*/)
         ],
-        "storageKey": null
+        "storageKey": "show(id:\"catty-show\")"
       }
     ]
   },
   "params": {
     "id": null,
     "metadata": {},
-    "name": "ShowArtworks_Query",
+    "name": "ShowArtworks_Test_Query",
     "operationKind": "query",
-    "text": "query ShowArtworks_Query(\n  $slug: String!\n) {\n  show(id: $slug) {\n    ...ShowArtworks_show\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowArtworks_show on Show {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-decayed_merch\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n"
+    "text": "query ShowArtworks_Test_Query {\n  show(id: \"catty-show\") {\n    ...ShowArtworks_show\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid2_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowArtworks_show on Show {\n  filtered_artworks: filterArtworksConnection(medium: \"*\", first: 20, after: \"\", sort: \"-decayed_merch\") {\n    id\n    ...ArtworkFilterArtworkGrid2_filtered_artworks\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '8ba162f245e5e47501352956d6fd8ba7';
+(node as any).hash = '48a4dcea82978aab2288472d66e8ab60';
 export default node;

--- a/src/v2/__generated__/ShowContextCard_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ShowContextCard_Test_Query.graphql.ts
@@ -3,9 +3,7 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type ShowContextCard_Test_QueryVariables = {
-    slug: string;
-};
+export type ShowContextCard_Test_QueryVariables = {};
 export type ShowContextCard_Test_QueryResponse = {
     readonly show: {
         readonly " $fragmentRefs": FragmentRefs<"ShowContextCard_show">;
@@ -19,10 +17,8 @@ export type ShowContextCard_Test_Query = {
 
 
 /*
-query ShowContextCard_Test_Query(
-  $slug: String!
-) {
-  show(id: $slug) {
+query ShowContextCard_Test_Query {
+  show(id: "xxx") {
     ...ShowContextCard_show
     id
   }
@@ -90,48 +86,40 @@ fragment ShowContextCard_show on Show {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "slug",
-    "type": "String!"
-  }
-],
-v1 = [
-  {
-    "kind": "Variable",
+    "kind": "Literal",
     "name": "id",
-    "variableName": "slug"
+    "value": "xxx"
   }
 ],
-v2 = {
+v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -140,14 +128,14 @@ v6 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
     "name": "ShowContextCard_Test_Query",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v0/*: any*/),
         "concreteType": "Show",
         "kind": "LinkedField",
         "name": "show",
@@ -159,20 +147,20 @@ return {
             "name": "ShowContextCard_show"
           }
         ],
-        "storageKey": null
+        "storageKey": "show(id:\"xxx\")"
       }
     ],
     "type": "Query"
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [],
     "kind": "Operation",
     "name": "ShowContextCard_Test_Query",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v0/*: any*/),
         "concreteType": "Show",
         "kind": "LinkedField",
         "name": "show",
@@ -200,14 +188,14 @@ return {
                 "name": "__typename",
                 "storageKey": null
               },
-              (v2/*: any*/),
+              (v1/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
+                  (v2/*: any*/),
                   (v3/*: any*/),
                   (v4/*: any*/),
                   (v5/*: any*/),
-                  (v6/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -223,7 +211,7 @@ return {
                         "name": "city",
                         "storageKey": null
                       },
-                      (v2/*: any*/)
+                      (v1/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -286,7 +274,7 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v2/*: any*/)
+                              (v1/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -310,10 +298,10 @@ return {
             "name": "fair",
             "plural": false,
             "selections": [
+              (v2/*: any*/),
               (v3/*: any*/),
               (v4/*: any*/),
               (v5/*: any*/),
-              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -387,13 +375,13 @@ return {
                 ],
                 "storageKey": null
               },
-              (v2/*: any*/)
+              (v1/*: any*/)
             ],
             "storageKey": null
           },
-          (v2/*: any*/)
+          (v1/*: any*/)
         ],
-        "storageKey": null
+        "storageKey": "show(id:\"xxx\")"
       }
     ]
   },
@@ -402,9 +390,9 @@ return {
     "metadata": {},
     "name": "ShowContextCard_Test_Query",
     "operationKind": "query",
-    "text": "query ShowContextCard_Test_Query(\n  $slug: String!\n) {\n  show(id: $slug) {\n    ...ShowContextCard_show\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n"
+    "text": "query ShowContextCard_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowContextCard_show\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = 'a7359cd327930945e900c214fa9d3907';
+(node as any).hash = '62c6d9dafbebe75585281066ca84ae6a';
 export default node;

--- a/src/v2/__generated__/ShowContextualLink_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ShowContextualLink_Test_Query.graphql.ts
@@ -1,0 +1,191 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ShowContextualLink_Test_QueryVariables = {};
+export type ShowContextualLink_Test_QueryResponse = {
+    readonly show: {
+        readonly " $fragmentRefs": FragmentRefs<"ShowContextualLink_show">;
+    } | null;
+};
+export type ShowContextualLink_Test_Query = {
+    readonly response: ShowContextualLink_Test_QueryResponse;
+    readonly variables: ShowContextualLink_Test_QueryVariables;
+};
+
+
+
+/*
+query ShowContextualLink_Test_Query {
+  show(id: "catty-show") {
+    ...ShowContextualLink_show
+    id
+  }
+}
+
+fragment ShowContextualLink_show on Show {
+  isFairBooth
+  fair {
+    href
+    name
+    id
+  }
+  partner {
+    __typename
+    ... on Partner {
+      isLinkable
+      name
+      href
+    }
+    ... on Node {
+      id
+    }
+    ... on ExternalPartner {
+      id
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "catty-show"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ShowContextualLink_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ShowContextualLink_show"
+          }
+        ],
+        "storageKey": "show(id:\"catty-show\")"
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ShowContextualLink_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isFairBooth",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Fair",
+            "kind": "LinkedField",
+            "name": "fair",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              (v2/*: any*/),
+              (v3/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "partner",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__typename",
+                "storageKey": null
+              },
+              (v3/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isLinkable",
+                    "storageKey": null
+                  },
+                  (v2/*: any*/),
+                  (v1/*: any*/)
+                ],
+                "type": "Partner"
+              }
+            ],
+            "storageKey": null
+          },
+          (v3/*: any*/)
+        ],
+        "storageKey": "show(id:\"catty-show\")"
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "ShowContextualLink_Test_Query",
+    "operationKind": "query",
+    "text": "query ShowContextualLink_Test_Query {\n  show(id: \"catty-show\") {\n    ...ShowContextualLink_show\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'c7eeb3a08f51b0007926acd0f3aaab09';
+export default node;

--- a/src/v2/__generated__/ShowInstallShots_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ShowInstallShots_Test_Query.graphql.ts
@@ -1,0 +1,258 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ShowInstallShots_Test_QueryVariables = {};
+export type ShowInstallShots_Test_QueryResponse = {
+    readonly show: {
+        readonly " $fragmentRefs": FragmentRefs<"ShowInstallShots_show">;
+    } | null;
+};
+export type ShowInstallShots_Test_Query = {
+    readonly response: ShowInstallShots_Test_QueryResponse;
+    readonly variables: ShowInstallShots_Test_QueryVariables;
+};
+
+
+
+/*
+query ShowInstallShots_Test_Query {
+  show(id: "xxx") {
+    ...ShowInstallShots_show
+    id
+  }
+}
+
+fragment ShowInstallShots_show on Show {
+  name
+  images(default: false) {
+    internalID
+    caption
+    mobile: resized(height: 300) {
+      width
+      height
+    }
+    desktop: resized(height: 400, version: ["larger", "large"]) {
+      src
+      srcSet
+      width
+      height
+    }
+    zoom: resized(width: 900, height: 900, version: ["larger", "large"]) {
+      src
+      srcSet
+      width
+      height
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "xxx"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "width",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "height",
+  "storageKey": null
+},
+v3 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": [
+    "larger",
+    "large"
+  ]
+},
+v4 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "src",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  },
+  (v1/*: any*/),
+  (v2/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ShowInstallShots_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ShowInstallShots_show"
+          }
+        ],
+        "storageKey": "show(id:\"xxx\")"
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ShowInstallShots_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "default",
+                "value": false
+              }
+            ],
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "images",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "internalID",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "caption",
+                "storageKey": null
+              },
+              {
+                "alias": "mobile",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 300
+                  }
+                ],
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": [
+                  (v1/*: any*/),
+                  (v2/*: any*/)
+                ],
+                "storageKey": "resized(height:300)"
+              },
+              {
+                "alias": "desktop",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 400
+                  },
+                  (v3/*: any*/)
+                ],
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": (v4/*: any*/),
+                "storageKey": "resized(height:400,version:[\"larger\",\"large\"])"
+              },
+              {
+                "alias": "zoom",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 900
+                  },
+                  (v3/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 900
+                  }
+                ],
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": (v4/*: any*/),
+                "storageKey": "resized(height:900,version:[\"larger\",\"large\"],width:900)"
+              }
+            ],
+            "storageKey": "images(default:false)"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "show(id:\"xxx\")"
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "ShowInstallShots_Test_Query",
+    "operationKind": "query",
+    "text": "query ShowInstallShots_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowInstallShots_show\n    id\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false) {\n    internalID\n    caption\n    mobile: resized(height: 300) {\n      width\n      height\n    }\n    desktop: resized(height: 400, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    zoom: resized(width: 900, height: 900, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '5e5440a7341ea09d022f5e312808c3f7';
+export default node;

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,7 +108,7 @@
     ip "1.1.5"
     mailcheck "1.1.1"
     passport "0.3.2"
-    passport-apple "git+https://github.com/artsy/passport-apple.git#f41adb7822c8344b72bc36a7d68312f6592cb14f"
+    passport-apple "https://github.com/artsy/passport-apple#f41adb7822c8344b72bc36a7d68312f6592cb14f"
     passport-facebook "2.1.1"
     superagent "1.8.4"
     underscore.string "3.3.4"
@@ -2993,6 +2993,14 @@
     "@types/react" "*"
     "@types/react-transition-group" "*"
 
+"@types/react-relay@*":
+  version "7.0.17"
+  resolved "https://registry.yarnpkg.com/@types/react-relay/-/react-relay-7.0.17.tgz#83f6b85c41b5fd3bb27d04d759fa4c0e4dd6a8d4"
+  integrity sha512-cJqOFIbp3M3/QkRpxlL4pwWRWB0lPGHevJFW8unuebkkITre8ptgknkGhAKe5IlA6ENTRJqVQXMuNdyLxl+0cQ==
+  dependencies:
+    "@types/react" "*"
+    "@types/relay-runtime" "*"
+
 "@types/react-relay@7.0.9":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/react-relay/-/react-relay-7.0.9.tgz#aae453888d5383dc13d7c5b55beb6b5933939ae8"
@@ -3063,6 +3071,15 @@
   version "9.1.6"
   resolved "https://registry.yarnpkg.com/@types/relay-runtime/-/relay-runtime-9.1.6.tgz#5a9afc37552d7e5b7966779d33ab26dce7da6771"
   integrity sha512-rdylQOGAoqjDjtzC2uKdjIqeDRcAvUsjONQB+FZld3cAP9qU4eEwTfMKJ7MdZSw2YbWRcTphczT4OpKKlLxY3Q==
+
+"@types/relay-test-utils@6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@types/relay-test-utils/-/relay-test-utils-6.0.3.tgz#aea2fa30e754c94f0d45b4abe78dfb2e35e2b45d"
+  integrity sha512-vVI8RcdnrP9pBaIN6Sg/ngni9Yh509WGbbX4tjPYlpNwsHGXs/O0e2Bjd4GZGQdInFvsrs/OOiGUG0dxoLscDQ==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-relay" "*"
+    "@types/relay-runtime" "*"
 
 "@types/serve-static@*":
   version "1.13.1"
@@ -14327,10 +14344,9 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
-"passport-apple@git+https://github.com/artsy/passport-apple.git#f41adb7822c8344b72bc36a7d68312f6592cb14f":
+"passport-apple@https://github.com/artsy/passport-apple#f41adb7822c8344b72bc36a7d68312f6592cb14f":
   version "1.1.2"
-  uid f41adb7822c8344b72bc36a7d68312f6592cb14f
-  resolved "git+https://github.com/artsy/passport-apple.git#f41adb7822c8344b72bc36a7d68312f6592cb14f"
+  resolved "https://github.com/artsy/passport-apple#f41adb7822c8344b72bc36a7d68312f6592cb14f"
   dependencies:
     jsonwebtoken "^8.5.1"
     passport-oauth2 "^1.5.0"


### PR DESCRIPTION
Cleaned up the rest of the specs in the show app directory — I know a lot of specs involve copy pasting, so at least there's a more consistent batch of specs using the mock generator, etc.

No real changes here. I added the relay-test-utils typings so that we can type the `getWrapper` argument for mocks resolvers.