### PR TITLE
fix: allow works from 2020 to show up in that time period bucket

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
@@ -55,6 +55,7 @@ export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({
 }
 
 const allowedPeriods = [
+  "2020",
   "2010",
   "2000",
   "1990",

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/TimePeriodFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/TimePeriodFilter.jest.tsx
@@ -51,7 +51,7 @@ describe("TimePeriodFilter", () => {
     wrapper.find("Radio").first().find("Flex").first().simulate("click")
 
     setTimeout(() => {
-      expect(context.filters.majorPeriods).toEqual(["2010"])
+      expect(context.filters.majorPeriods).toEqual(["2020"])
       done()
     }, 0)
   })


### PR DESCRIPTION
Works from this year wouldn't be findable via the 'Time period' filtering (it only went up to '2010'). :(

Fixes https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=FX&modal=detail&selectedIssue=FX-2414
