### PR TITLE
@mzikherman => fix: include totalCount for fair exhibitors query

### DIFF
--- a/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
+++ b/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
@@ -104,6 +104,7 @@ export const FairExhibitorsFragmentContainer = createPaginationContainer(
           first: $first
           after: $after
           sort: FEATURED_DESC
+          totalCount: true
         ) @connection(key: "FairExhibitorsQuery_exhibitors") {
           edges {
             node {

--- a/src/v2/__generated__/FairExhibitorsQuery.graphql.ts
+++ b/src/v2/__generated__/FairExhibitorsQuery.graphql.ts
@@ -57,7 +57,7 @@ fragment FairExhibitorRail_show on Show {
 fragment FairExhibitors_fair_2HEEH6 on Fair {
   slug
   internalID
-  exhibitors: showsConnection(first: $first, after: $after, sort: FEATURED_DESC) {
+  exhibitors: showsConnection(first: $first, after: $after, sort: FEATURED_DESC, totalCount: true) {
     edges {
       node {
         id
@@ -148,6 +148,11 @@ v6 = [
     "kind": "Literal",
     "name": "sort",
     "value": "FEATURED_DESC"
+  },
+  {
+    "kind": "Literal",
+    "name": "totalCount",
+    "value": true
   }
 ],
 v7 = {
@@ -339,7 +344,8 @@ return {
             "alias": "exhibitors",
             "args": (v6/*: any*/),
             "filters": [
-              "sort"
+              "sort",
+              "totalCount"
             ],
             "handle": "connection",
             "key": "FairExhibitorsQuery_exhibitors",
@@ -357,7 +363,7 @@ return {
     "metadata": {},
     "name": "FairExhibitorsQuery",
     "operationKind": "query",
-    "text": "query FairExhibitorsQuery(\n  $id: String!\n  $first: Int!\n  $after: String\n) {\n  fair(id: $id) {\n    ...FairExhibitors_fair_2HEEH6\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  slug\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair_2HEEH6 on Fair {\n  slug\n  internalID\n  exhibitors: showsConnection(first: $first, after: $after, sort: FEATURED_DESC) {\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query FairExhibitorsQuery(\n  $id: String!\n  $first: Int!\n  $after: String\n) {\n  fair(id: $id) {\n    ...FairExhibitors_fair_2HEEH6\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  slug\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair_2HEEH6 on Fair {\n  slug\n  internalID\n  exhibitors: showsConnection(first: $first, after: $after, sort: FEATURED_DESC, totalCount: true) {\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairExhibitors_Query.graphql.ts
+++ b/src/v2/__generated__/FairExhibitors_Query.graphql.ts
@@ -92,7 +92,7 @@ fragment FairExhibitorRail_show on Show {
 fragment FairExhibitors_fair on Fair {
   slug
   internalID
-  exhibitors: showsConnection(first: 15, sort: FEATURED_DESC) {
+  exhibitors: showsConnection(first: 15, sort: FEATURED_DESC, totalCount: true) {
     edges {
       node {
         id
@@ -164,6 +164,11 @@ v4 = [
     "kind": "Literal",
     "name": "sort",
     "value": "FEATURED_DESC"
+  },
+  {
+    "kind": "Literal",
+    "name": "totalCount",
+    "value": true
   }
 ],
 v5 = {
@@ -346,13 +351,14 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "showsConnection(first:15,sort:\"FEATURED_DESC\")"
+            "storageKey": "showsConnection(first:15,sort:\"FEATURED_DESC\",totalCount:true)"
           },
           {
             "alias": "exhibitors",
             "args": (v4/*: any*/),
             "filters": [
-              "sort"
+              "sort",
+              "totalCount"
             ],
             "handle": "connection",
             "key": "FairExhibitorsQuery_exhibitors",
@@ -370,7 +376,7 @@ return {
     "metadata": {},
     "name": "FairExhibitors_Query",
     "operationKind": "query",
-    "text": "query FairExhibitors_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  slug\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  slug\n  internalID\n  exhibitors: showsConnection(first: 15, sort: FEATURED_DESC) {\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query FairExhibitors_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  slug\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  slug\n  internalID\n  exhibitors: showsConnection(first: 15, sort: FEATURED_DESC, totalCount: true) {\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairExhibitors_fair.graphql.ts
+++ b/src/v2/__generated__/FairExhibitors_fair.graphql.ts
@@ -92,6 +92,11 @@ return {
           "kind": "Literal",
           "name": "sort",
           "value": "FEATURED_DESC"
+        },
+        {
+          "kind": "Literal",
+          "name": "totalCount",
+          "value": true
         }
       ],
       "concreteType": "ShowConnection",
@@ -206,11 +211,11 @@ return {
           "storageKey": null
         }
       ],
-      "storageKey": "__FairExhibitorsQuery_exhibitors_connection(sort:\"FEATURED_DESC\")"
+      "storageKey": "__FairExhibitorsQuery_exhibitors_connection(sort:\"FEATURED_DESC\",totalCount:true)"
     }
   ],
   "type": "Fair"
 };
 })();
-(node as any).hash = '5fa0506fdcaa36c853a92b1655f8036a';
+(node as any).hash = '25b654a42281e69fef43b63319eb3b10';
 export default node;

--- a/src/v2/__generated__/routes_FairExhibitorsQuery.graphql.ts
+++ b/src/v2/__generated__/routes_FairExhibitorsQuery.graphql.ts
@@ -53,7 +53,7 @@ fragment FairExhibitorRail_show on Show {
 fragment FairExhibitors_fair on Fair {
   slug
   internalID
-  exhibitors: showsConnection(first: 15, sort: FEATURED_DESC) {
+  exhibitors: showsConnection(first: 15, sort: FEATURED_DESC, totalCount: true) {
     edges {
       node {
         id
@@ -125,6 +125,11 @@ v4 = [
     "kind": "Literal",
     "name": "sort",
     "value": "FEATURED_DESC"
+  },
+  {
+    "kind": "Literal",
+    "name": "totalCount",
+    "value": true
   }
 ],
 v5 = {
@@ -307,13 +312,14 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "showsConnection(first:15,sort:\"FEATURED_DESC\")"
+            "storageKey": "showsConnection(first:15,sort:\"FEATURED_DESC\",totalCount:true)"
           },
           {
             "alias": "exhibitors",
             "args": (v4/*: any*/),
             "filters": [
-              "sort"
+              "sort",
+              "totalCount"
             ],
             "handle": "connection",
             "key": "FairExhibitorsQuery_exhibitors",
@@ -331,7 +337,7 @@ return {
     "metadata": {},
     "name": "routes_FairExhibitorsQuery",
     "operationKind": "query",
-    "text": "query routes_FairExhibitorsQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  slug\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  slug\n  internalID\n  exhibitors: showsConnection(first: 15, sort: FEATURED_DESC) {\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query routes_FairExhibitorsQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  slug\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  slug\n  internalID\n  exhibitors: showsConnection(first: 15, sort: FEATURED_DESC, totalCount: true) {\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
This threads through the ability for the proper `endCursor` behavior to occur in Gravity (https://github.com/artsy/gravity/pull/13611)