### PR TITLE
[FX-2424] Uses https to pass validation

### DIFF
--- a/src/desktop/apps/home/routes.coffee
+++ b/src/desktop/apps/home/routes.coffee
@@ -34,7 +34,7 @@ fetchMetaphysicsData = (req, showHeroUnits, showCollectionsHubs)->
   featuredLinks = new Items [], id: '529939e2275b245e290004a0', item_type: 'FeaturedLink'
 
   jsonLD = {
-    "@context": "http://schema.org",
+    "@context": "https://schema.org",
     "@type": "WebSite",
     "url": "https://www.artsy.net/",
     "potentialAction": {


### PR DESCRIPTION
Closes: [FX-2424](https://artsyproduct.atlassian.net/browse/FX-2424) (Maybe)

According to JSON-LD Playground, with the `http` URL, validation fails with:

> jsonld.InvalidUrl: Dereferencing a URL did not result in a valid JSON-LD object. Possible causes are an inaccessible URL perhaps due to a same-origin policy (ensure the server uses CORS if you are using client-side JavaScript), too many redirects, a non-JSON response, or more than one HTTP Link Header was provided for a remote context.

So changing this to https allows it to pass validation.

That said; if you run artsy.net through https://search.google.com/test/rich-results

You get:

![](http://static.damonzucconi.com/_capture/jNBzz8JmWjqH.png)
![](http://static.damonzucconi.com/_capture/gKQxMQrBYuiy.png)

It's not clear to me if updating the JSON-LD markup will fix this. So, will have to deploy and re-test and go from there.




