### PR TITLE
Accommodates missing fair images

### DIFF
--- a/src/v2/Components/FairCard.tsx
+++ b/src/v2/Components/FairCard.tsx
@@ -15,15 +15,18 @@ export const FairCard: React.FC<FairHeaderImageProps> = ({
       aspectWidth={3}
       aspectHeight={2}
       maxWidth="100%"
-      bg="black60"
+      bg="black10"
+      borderRadius={4}
     >
-      <Image
-        src={image.cropped.src}
-        srcSet={image.cropped.srcSet}
-        alt={name}
-        lazyLoad
-        borderRadius="4px"
-      />
+      {image && (
+        <Image
+          src={image.cropped.src}
+          srcSet={image.cropped.srcSet}
+          alt={name}
+          lazyLoad
+          borderRadius={4}
+        />
+      )}
     </ResponsiveBox>
   )
 }


### PR DESCRIPTION
Related to [FX-2406](https://artsyproduct.atlassian.net/browse/FX-2406)

Previously was `500`ing. Now there's a missing image state:

![](http://static.damonzucconi.com/_capture/QIv24nGImlj7.png)

— unsure whether or not there should be a better missing image state?