### PR TITLE
feat: Add icons to /consign2 and fix minor QA issues

### DIFF
--- a/src/v2/Apps/Consign/Components/ContactUs.tsx
+++ b/src/v2/Apps/Consign/Components/ContactUs.tsx
@@ -43,16 +43,18 @@ export const ContactUs: React.FC<{ darkVariant?: boolean }> = ({
           555-555-5555
         </Text>
       </Flex>
-      <Link href="mailto:consign@artsy.net">
-        <Media greaterThanOrEqual="sm">
+      <Media greaterThanOrEqual="sm">
+        <Link href="mailto:consign@artsy.net">
           <Button variant="secondaryOutline">Send an email</Button>
-        </Media>
-        <Media lessThan="sm">
+        </Link>
+      </Media>
+      <Media lessThan="sm">
+        <Link href="mailto:consign@artsy.net">
           <Button variant="secondaryOutline" size="large" block width="100%">
             Send an email
           </Button>
-        </Media>
-      </Link>
+        </Link>
+      </Media>
     </SectionContainer>
   )
 }

--- a/src/v2/Apps/Consign/Components/HowToSell.tsx
+++ b/src/v2/Apps/Consign/Components/HowToSell.tsx
@@ -33,6 +33,7 @@ export const HowToSell: React.FC = () => {
         alignItems="center"
         justifyContent="space-between"
         pt={[1, 4]}
+        mb={[0, 4, 0, 0]}
       >
         <Section
           icon={<AddItemIcon width={50} height={50} />}
@@ -80,10 +81,12 @@ const Section: React.FC<{
   description: string
 }> = ({ icon, text, description }) => {
   return (
-    <Box
-      width={["100%", "25%"]}
+    <Flex
+      flexDirection="column"
+      width="100%"
       height={["100%", 170]}
       my={[1, 0]}
+      mx={1}
       textAlign="center"
     >
       <Box>{icon}</Box>
@@ -95,6 +98,6 @@ const Section: React.FC<{
           {description}
         </Text>
       </Box>
-    </Box>
+    </Flex>
   )
 }

--- a/src/v2/Apps/Consign/Components/HowToSell.tsx
+++ b/src/v2/Apps/Consign/Components/HowToSell.tsx
@@ -52,13 +52,15 @@ export const HowToSell: React.FC = () => {
         />
       </Flex>
       <Box width="100%" textAlign="center">
-        <RouterLink to={navigateTo}>
-          <Media greaterThanOrEqual="sm">
+        <Media greaterThanOrEqual="sm">
+          <RouterLink to={navigateTo}>
             <Button variant="primaryBlack" size="large" mt={6}>
               Submit your artwork
             </Button>
-          </Media>
-          <Media lessThan="sm">
+          </RouterLink>
+        </Media>
+        <Media lessThan="sm">
+          <RouterLink to={navigateTo}>
             <Button
               variant="primaryBlack"
               size="large"
@@ -68,8 +70,8 @@ export const HowToSell: React.FC = () => {
             >
               Submit your artwork
             </Button>
-          </Media>
-        </RouterLink>
+          </RouterLink>
+        </Media>
       </Box>
     </SectionContainer>
   )

--- a/src/v2/Apps/Consign/Components/HowToSell.tsx
+++ b/src/v2/Apps/Consign/Components/HowToSell.tsx
@@ -1,5 +1,14 @@
 import React from "react"
-import { Box, Button, EditIcon, Flex, Text, color } from "@artsy/palette"
+import {
+  AddItemIcon,
+  ArtworkWithCheckIcon,
+  Box,
+  Button,
+  Flex,
+  MultipleOffersIcon,
+  Text,
+  color,
+} from "@artsy/palette"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import { Media } from "v2/Utils/Responsive"
 import { SectionContainer } from "./SectionContainer"
@@ -26,19 +35,19 @@ export const HowToSell: React.FC = () => {
         pt={[1, 4]}
       >
         <Section
-          icon={<EditIcon width={50} height={50} />}
-          text="Submit the Artwork"
+          icon={<AddItemIcon width={50} height={50} />}
+          text="Submit your artwork"
           description="Submit your artwork details and images. Artsy will review and approve qualified submissions."
         />
         <Section
-          icon={<EditIcon width={50} height={50} />}
-          text="Receive Multiple Offers"
-          description="If your work is accepted, you’ll receive competitive consignment offers from auction houses, galleries, and collectors."
+          icon={<MultipleOffersIcon width={50} height={50} />}
+          text="Receive multiple offers"
+          description="If your work is accepted, you’ll receive competitive consignment offers from Artsy’s curated auctions, auction houses, and galleries."
         />
         <Section
-          icon={<EditIcon width={50} height={50} />}
-          text="Match and Sell"
-          description="With our specialists’ expert guidance, evaluate your offers, choose the best one for you, and sell your work. We’ll help you ship it safely."
+          icon={<ArtworkWithCheckIcon width={50} height={50} />}
+          text="Match and sell"
+          description="Our specialists will guide you in choosing the best option to sell your work."
         />
       </Flex>
       <Box width="100%" textAlign="center">

--- a/src/v2/Apps/Consign/Components/SellArtDifferently.tsx
+++ b/src/v2/Apps/Consign/Components/SellArtDifferently.tsx
@@ -28,6 +28,7 @@ export const SellArtDifferently: React.FC = () => {
         alignItems="center"
         justifyContent="space-between"
         pt={[1, 4]}
+        mb={[0, 4, 0, 0]}
       >
         <Section
           icon={<ArtworkWithBadgeIcon width={50} height={50} />}
@@ -41,7 +42,7 @@ export const SellArtDifferently: React.FC = () => {
         />
         <Section
           icon={<LightningBoltIcon width={50} height={50} />}
-          text="Speed anad efficiency"
+          text="Speed and efficiency"
           description="We will present you with a sales option that will allow you to sell your work quickly."
         />
       </Flex>
@@ -55,10 +56,12 @@ const Section: React.FC<{
   description: string
 }> = ({ icon, text, description }) => {
   return (
-    <Box
-      width={["100%", "25%"]}
+    <Flex
+      flexDirection="column"
+      width="100%"
       height={["100%", 170]}
       my={[1, 0]}
+      mx={1}
       textAlign="center"
     >
       <Box>{icon}</Box>
@@ -70,6 +73,6 @@ const Section: React.FC<{
           {description}
         </Text>
       </Box>
-    </Box>
+    </Flex>
   )
 }

--- a/src/v2/Apps/Consign/Components/SellArtDifferently.tsx
+++ b/src/v2/Apps/Consign/Components/SellArtDifferently.tsx
@@ -1,5 +1,13 @@
 import React from "react"
-import { Box, EditIcon, Flex, Text, color } from "@artsy/palette"
+import {
+  ArtworkWithBadgeIcon,
+  Box,
+  Flex,
+  LightningBoltIcon,
+  Text,
+  UserWithChartIcon,
+  color,
+} from "@artsy/palette"
 import { SectionContainer } from "./SectionContainer"
 
 export const SellArtDifferently: React.FC = () => {
@@ -22,19 +30,19 @@ export const SellArtDifferently: React.FC = () => {
         pt={[1, 4]}
       >
         <Section
-          icon={<EditIcon width={50} height={50} />}
-          text="More selling options"
-          description="We’ll introduce your work to leading buyers around the world and help compare their offers to get you the best deal."
+          icon={<ArtworkWithBadgeIcon width={50} height={50} />}
+          text="Risk-free sales"
+          description="We offer no upfront fees, our auctions are confidential, and best of all, you keep your artwork until it’s sold."
         />
         <Section
-          icon={<EditIcon width={50} height={50} />}
-          text="Unique market insights"
-          description="Our expertise, primary and secondary art market data, and relationships with buyers provide a best-in-class reselling experience."
+          icon={<UserWithChartIcon width={50} height={50} />}
+          text="Insights-driven matching"
+          description="Our proprietary data-driven insights and the largest global audience of collectors ensures better matchmaking to sell your work."
         />
         <Section
-          icon={<EditIcon width={50} height={50} />}
+          icon={<LightningBoltIcon width={50} height={50} />}
           text="Speed anad efficiency"
-          description="Guaranteed offer within 24 hours, and you’ll always be presented with a sales option to sell your work in a month. Plus, we’ll help you ship."
+          description="We will present you with a sales option that will allow you to sell your work quickly."
         />
       </Flex>
     </SectionContainer>

--- a/src/v2/Apps/Consign/ConsignApp.tsx
+++ b/src/v2/Apps/Consign/ConsignApp.tsx
@@ -34,11 +34,11 @@ const ConsignApp = props => {
           <HowToSell />
           <ContactUs />
           <ConsignInDemandNow />
+          <SoldRecentlyQueryRenderer />
           <ReadMore />
           <ContactUs darkVariant />
           <FAQ />
           <SellWithArtsy />
-          <SoldRecentlyQueryRenderer />
 
           <SectionContainer>
             <Footer />


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GRO-51

- Adds new icons to `/consign2` and updates copy based on current spec
- Fixes some minor layout issues at smaller viewports for "How to sell" and "Selling art differently" sections
- Fixes clickable area for some buttons to be just the button
- Moves "Sold recently on Artsy" up

![Screen Shot 2020-11-16 at 1 50 38 PM](https://user-images.githubusercontent.com/4432348/99294931-c2f09080-2812-11eb-94ba-80874df9cb38.png)
