### PR TITLE
toolchain: Add object keys sort lint autofixer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,9 +6,8 @@ module.exports = {
   plugins: [
     "react-hooks",
     "@typescript-eslint",
+    "sort-keys-fix",
     "styled-components-a11y",
-    // TODO: Add support for Graphql
-    /*, "graphql" */
   ],
   extends: [
     "eslint:recommended",
@@ -23,9 +22,6 @@ module.exports = {
       jsx: true,
     },
     ecmaVersion: 6,
-    // This significantly slows down linting and is needed for type-aware lint
-    // checks which we don't have atm.
-    // project: "./tsconfig.json",
     sourceType: "module",
   },
   settings: {
@@ -51,17 +47,17 @@ module.exports = {
     "@typescript-eslint/no-use-before-define": 0,
     "@typescript-eslint/no-unused-vars": 0,
     "@typescript-eslint/no-var-requires": 0,
+    "no-console": [
+      "error",
+      {
+        allow: ["warn", "error", "info", "group", "groupEnd", "groupCollapsed"],
+      },
+    ],
     "react/display-name": 0,
     "react/prop-types": 0,
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-    "sort-imports": [
-      "warn",
-      {
-        // Unfortunately there's no autofixer for this
-        ignoreDeclarationSort: true,
-      },
-    ],
+    "sort-keys-fix/sort-keys-fix": "warn",
 
     // FIXME: Investigate / reenable these rules. Disabled to introduce eslint
     // into codebase.
@@ -87,29 +83,6 @@ module.exports = {
     "@typescript-eslint/no-empty-function": 0,
     "@typescript-eslint/no-empty-interface": 0,
     "@typescript-eslint/no-non-null-assertion": 0,
-    // artsyPaletteCanonicalImport: 0,
-    // "@typescript-eslint/no-unused-vars": [
-    //   "error",
-    //   {
-    //     argsIgnorePattern: "^_",
-    //   },
-    // ],
-    "no-console": [
-      "error",
-      {
-        allow: ["warn", "error", "info", "group", "groupEnd", "groupCollapsed"],
-      },
-    ],
-
-    // TODO: Add support for Graphql, but first need to fetch .json schema
-    // "graphql/template-strings": [
-    //   "error",
-    //   {
-    //     env: "relay",
-    //     schemaJsonFilepath: path.resolve(__dirname, "./data/schema.json"),
-    //     tagName: "graphql",
-    //   },
-    // ],
   },
   overrides: [
     {

--- a/package.json
+++ b/package.json
@@ -299,6 +299,7 @@
     "eslint-plugin-graphql": "3.1.1",
     "eslint-plugin-react": "7.19.0",
     "eslint-plugin-react-hooks": "4.0.4",
+    "eslint-plugin-sort-keys-fix": "^1.1.1",
     "eslint-plugin-styled-components-a11y": "0.0.16",
     "fork-ts-checker-notifier-webpack-plugin": "0.4.0",
     "fork-ts-checker-webpack-plugin": "0.4.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7687,6 +7687,13 @@ eslint-plugin-react@^7.18.3:
     resolve "^1.17.0"
     string.prototype.matchall "^4.0.2"
 
+eslint-plugin-sort-keys-fix@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-keys-fix/-/eslint-plugin-sort-keys-fix-1.1.1.tgz#2ed201b53fd4a89552c6e2abd38933f330a4b62e"
+  integrity sha512-x02SLBg+8OEaoT9vvMbsgeInw17wjHLsa9cOieIVQY+xMNRiXBbyMWw+NiBoxYyJIR4QKDOPDofCjQdoSvltQg==
+  dependencies:
+    requireindex "~1.2.0"
+
 eslint-plugin-styled-components-a11y@0.0.16:
   version "0.0.16"
   resolved "https://registry.yarnpkg.com/eslint-plugin-styled-components-a11y/-/eslint-plugin-styled-components-a11y-0.0.16.tgz#ebf5313d8a5ae5a58d1e1b8c212c7b9af0eaf261"
@@ -16418,6 +16425,11 @@ require-package-name@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
   integrity sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=
+
+requireindex@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Follow-up to cohesion PR. Updated our ESlint config with an auto-fixer for sorting object keys: 
- [object keys](https://www.npmjs.com/package/eslint-plugin-sort-keys-fix)

