### PR TITLE
[WIP] feat: Stub out secondary fields for offer response

### DIFF
--- a/src/v2/Apps/Consign/OfferDetail/Operations/CreateOfferResponse.ts
+++ b/src/v2/Apps/Consign/OfferDetail/Operations/CreateOfferResponse.ts
@@ -7,7 +7,7 @@ import {
 
 type CreateOfferResponseValues = Pick<
   CreateOfferResponseMutationInput,
-  "intendedState"
+  "intendedState" | "phoneNumber" | "rejectionReason" | "comments"
 >
 
 export const CreateOfferResponse = (
@@ -26,6 +26,9 @@ export const CreateOfferResponse = (
           createConsignmentOfferResponse(input: $input) {
             consignmentOfferResponse {
               intendedState
+              phoneNumber
+              rejectionReason
+              comments
             }
           }
         }
@@ -34,6 +37,9 @@ export const CreateOfferResponse = (
         input: {
           offerId: offerID,
           intendedState: values.intendedState,
+          phoneNumber: values.phoneNumber,
+          rejectionReason: values.rejectionReason,
+          comments: values.comments,
         },
       },
     })

--- a/src/v2/__generated__/CreateOfferResponseMutation.graphql.ts
+++ b/src/v2/__generated__/CreateOfferResponseMutation.graphql.ts
@@ -18,6 +18,9 @@ export type CreateOfferResponseMutationResponse = {
     readonly createConsignmentOfferResponse: {
         readonly consignmentOfferResponse: {
             readonly intendedState: IntendedState;
+            readonly phoneNumber: string | null;
+            readonly rejectionReason: string | null;
+            readonly comments: string | null;
         } | null;
     } | null;
 };
@@ -35,6 +38,9 @@ mutation CreateOfferResponseMutation(
   createConsignmentOfferResponse(input: $input) {
     consignmentOfferResponse {
       intendedState
+      phoneNumber
+      rejectionReason
+      comments
       id
     }
   }
@@ -63,6 +69,27 @@ v2 = {
   "kind": "ScalarField",
   "name": "intendedState",
   "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "phoneNumber",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "rejectionReason",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "comments",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -87,7 +114,10 @@ return {
             "name": "consignmentOfferResponse",
             "plural": false,
             "selections": [
-              (v2/*: any*/)
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/)
             ],
             "storageKey": null
           }
@@ -120,6 +150,9 @@ return {
             "plural": false,
             "selections": [
               (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -140,9 +173,9 @@ return {
     "metadata": {},
     "name": "CreateOfferResponseMutation",
     "operationKind": "mutation",
-    "text": "mutation CreateOfferResponseMutation(\n  $input: CreateOfferResponseMutationInput!\n) {\n  createConsignmentOfferResponse(input: $input) {\n    consignmentOfferResponse {\n      intendedState\n      id\n    }\n  }\n}\n"
+    "text": "mutation CreateOfferResponseMutation(\n  $input: CreateOfferResponseMutationInput!\n) {\n  createConsignmentOfferResponse(input: $input) {\n    consignmentOfferResponse {\n      intendedState\n      phoneNumber\n      rejectionReason\n      comments\n      id\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = 'c62173b99e9ba5703c2630c0b0478681';
+(node as any).hash = '38225decca85af87db989478a5811786';
 export default node;


### PR DESCRIPTION
This is WIP. I'm setting this work aside to focus on sprint goals, and will return to this in the (hopefully not distant) future.

---

Associated with https://artsyproduct.atlassian.net/browse/CX-828. 

When finished, this work will add all secondary fields to the consignment offer response form - as documented in https://www.notion.so/artsy/Hackathon-Collectors-respond-to-offers-in-Artsy-net-b1e143118df04e27af9225fc7e882985. I also plan to introduce tests with this PR. 

In its current state, the PR displays some of the secondary fields, and they are connected to metaphysics. 

![secondary-fields](https://user-images.githubusercontent.com/1627089/99435688-1841a600-28d6-11eb-9553-9439e440424e.gif)

cc @sweir27 
