### PR TITLE
feat: offer a gallery curated default sort on show artwork filter

### DIFF
--- a/src/v2/Apps/Show/Components/ShowArtworks.tsx
+++ b/src/v2/Apps/Show/Components/ShowArtworks.tsx
@@ -41,17 +41,23 @@ const ShowArtworksFilter: React.FC<ShowArtworksFilterProps> = ({
     </Box>
   )
 
+  // Inject custom default sort into artwork filter.
+  const filters = {
+    sort: "partner_show_position",
+    ...(match && match.location.query),
+  }
+
   return (
     <ArtworkFilterContextProvider
-      filters={match && match.location.query}
+      filters={filters}
       sortOptions={[
-        { value: "-decayed_merch", text: "Default" },
-        { value: "-has_price,-prices", text: "Price (desc.)" },
-        { value: "-has_price,prices", text: "Price (asc.)" },
-        { value: "-partner_updated_at", text: "Recently updated" },
-        { value: "-published_at", text: "Recently added" },
-        { value: "-year", text: "Artwork year (desc.)" },
-        { value: "year", text: "Artwork year (asc.)" },
+        { text: "Gallery Curated", value: "partner_show_position" },
+        { text: "Price (desc.)", value: "-has_price,-prices" },
+        { text: "Price (asc.)", value: "-has_price,prices" },
+        { text: "Recently updated", value: "-partner_updated_at" },
+        { text: "Recently added", value: "-published_at" },
+        { text: "Artwork year (desc.)", value: "-year" },
+        { text: "Artwork year (asc.)", value: "year" },
       ]}
       onChange={updateUrl}
     >

--- a/src/v2/Apps/Show/routes.tsx
+++ b/src/v2/Apps/Show/routes.tsx
@@ -9,8 +9,8 @@ const ShowInfoRoute = loadable(() => import("./Routes/ShowInfo"))
 
 export const routes: RouteConfig[] = [
   {
-    path: "/show/:slug",
     getComponent: () => ShowApp,
+    path: "/show/:slug",
     prepare: () => {
       ShowApp.preload()
     },
@@ -58,22 +58,10 @@ export const routes: RouteConfig[] = [
   // NOTE: Nested sub-apps are mounted under the same top-level path as above.
   // The root `path: ""` matches the `ShowApp` route.
   {
-    path: "/show/:slug",
-    getComponent: () => ShowSubApp,
-    prepare: () => {
-      ShowSubApp.preload()
-    },
-    query: graphql`
-      query routes_ShowSubAppQuery($slug: String!) {
-        show(id: $slug) @principalField {
-          ...ShowSubApp_show
-        }
-      }
-    `,
     children: [
       {
-        path: "info",
         getComponent: () => ShowInfoRoute,
+        path: "info",
         prepare: () => {
           ShowInfoRoute.preload()
         },
@@ -92,6 +80,18 @@ export const routes: RouteConfig[] = [
         },
       },
     ],
+    getComponent: () => ShowSubApp,
+    path: "/show/:slug",
+    prepare: () => {
+      ShowSubApp.preload()
+    },
+    query: graphql`
+      query routes_ShowSubAppQuery($slug: String!) {
+        show(id: $slug) @principalField {
+          ...ShowSubApp_show
+        }
+      }
+    `,
   },
 ]
 
@@ -99,7 +99,7 @@ function initializeVariablesWithFilterState(params, props) {
   const initialFilterState = props.location ? props.location.query : {}
 
   const state = {
-    sort: "-decayed_merch",
+    sort: "partner_show_position",
     ...paramsToCamelCase(initialFilterState),
     ...params,
   }


### PR DESCRIPTION
Pretty straightforward, one less repo needed to be touched (MP), since we don't model possible sorts as an enum, they're just free-form strings 😅 