### PR TITLE
fix: Fix consign2 jump

### DIFF
--- a/src/v2/Apps/Artist/routes.tsx
+++ b/src/v2/Apps/Artist/routes.tsx
@@ -236,7 +236,7 @@ export const routes: RouteConfig[] = [
           AuctionResultsRoute.preload()
         },
         displayNavigationTabs: true,
-        ignoreScrollBehavior: true,
+        ignoreScrollBehavior: false,
         query: graphql`
           query routes_AuctionResultsQuery($artistID: String!) {
             artist(id: $artistID) {

--- a/src/v2/Apps/Consign/Components/GetPriceEstimate/ArtistInsightResult.tsx
+++ b/src/v2/Apps/Consign/Components/GetPriceEstimate/ArtistInsightResult.tsx
@@ -75,10 +75,7 @@ export const ArtistInsightResult: React.FC = () => {
           </Text>
           <Spacer mb={2} />
           <Media greaterThanOrEqual="md">
-            <RouterLink
-              to={`/artist/${artistSlug}/auction-results`}
-              onClick={() => window.scrollTo(0, 0)}
-            >
+            <RouterLink to={`/artist/${artistSlug}/auction-results`}>
               <Button width={230} variant="secondaryOutline" mr={2}>
                 Explore auction data
               </Button>


### PR DESCRIPTION
Fixes the jump to top of page between consign -> artist/auction-results by moving behavior into artist app (which works now that we no longer have huge header) 