### PR TITLE
toolchain: Remove --inspect from default `yarn start`

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -15,16 +15,6 @@ if [ "${NODE_ENV}" != "production" ]; then
   fi
   OPT+=(--preserve-symlinks)
 
-  # If is another node process being debugged do not add the inspect-brk flag to force.
-  if (nc -z 127.0.0.1 9229) &> /dev/null; then
-    echo
-    echo "WARNING! You are already debugging another node process!"
-    echo
-    echo "    force will start without --inspect unless you kill the other process"
-  else
-    OPT+=(--inspect)
-  fi
-
   yarn relay --watch & BUILD_CLIENT=true exec node "${OPT[@]}" ./src/index.dev.js
 else
   exec node "${OPT[@]}" ./server.dist.js


### PR DESCRIPTION
Per convo the other day, this removes the `--inspect` command from default `yarn start` dev flow, which should improve perf for many on the team developing on less performant computers. 

cc @zephraph 