### PR TITLE
fix: [Consign2] Cap header max-width

### DIFF
--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/Header.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/Header.tsx
@@ -62,6 +62,7 @@ const HeaderImageContainer = styled(Flex).attrs({
   height: 100%;
   position: absolute;
   margin: auto;
+  max-width: 1670px;
 `
 
 const LeftImage = styled(Box)`


### PR DESCRIPTION
So that the header images don't stretch too far on a wide screen 