### PR TITLE
fix: Update TemporaryOffer expiration date and add test

### DIFF
--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/TemporaryOffer.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/TemporaryOffer.tsx
@@ -3,8 +3,8 @@ import { Text } from "@artsy/palette"
 import { SectionContainer } from "./SectionContainer"
 
 export const TemporaryOffer: React.FC = () => {
-  const now = new Date()
-  const expirationDate = new Date(2020, 11, 1)
+  const now = new Date(Date.now())
+  const expirationDate = new Date(2021, 0, 1)
   if (now > expirationDate) {
     return null
   }

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/__tests__/TemporaryOffer.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/__tests__/TemporaryOffer.jest.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import { mount } from "enzyme"
+import { TemporaryOffer } from "../TemporaryOffer"
+import { Text } from "@artsy/palette"
+
+describe("TemporaryOffer", () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders the temporary offer before expiration date", () => {
+    global.Date.now = jest.fn(() => new Date(2020, 10, 23).getTime())
+    const component = mount(<TemporaryOffer />)
+    expect(component.find(Text).length).toBe(1)
+  })
+
+  it("does not render the temporary offer after it expires", () => {
+    global.Date.now = jest.fn(() => new Date(2021, 0, 1, 1).getTime())
+    const component = mount(<TemporaryOffer />)
+    expect(component.find(Text).length).toBe(0)
+  })
+})


### PR DESCRIPTION
Quick follow up to https://github.com/artsy/force/pull/6698. Sets the expiration date to the correct date on `TemporaryOffer` so that it does not render on the right date. Also adds a few quick tests.