### PR TITLE
chore: Move my_active_bids and bid_history to MP V2

### DIFF
--- a/src/desktop/apps/user/components/bid_history/view.coffee
+++ b/src/desktop/apps/user/components/bid_history/view.coffee
@@ -1,5 +1,5 @@
 Backbone = require 'backbone'
-metaphysics = require '../../../../../lib/metaphysics.coffee'
+metaphysics2 = require '../../../../../lib/metaphysics2.coffee'
 query = require '../../../../components/my_active_bids/query.coffee'
 template = -> require('./index.jade') arguments...
 
@@ -10,7 +10,7 @@ module.exports = class BidHistoryView extends Backbone.View
     @me = {}
 
   fetch: ->
-    metaphysics
+    metaphysics2
       query: query
       variables: live: false
       req: user: @user

--- a/src/desktop/components/my_active_bids/query.coffee
+++ b/src/desktop/components/my_active_bids/query.coffee
@@ -1,27 +1,27 @@
 module.exports = """
   query MyActiveBidsQuery($live: Boolean!, $sale_id: String) {
     me {
-      lot_standings(live: $live, sale_id: $sale_id) {
-        active_bid {
-          id
+      lot_standings: lotStandings(live: $live, saleID: $sale_id) {
+        active_bid: activeBid {
+          id: internalID
         }
-        is_leading_bidder
-        sale_artwork {
-          id
-          lot_label
-          reserve_status
+        is_leading_bidder: isLeadingBidder
+        sale_artwork: saleArtwork {
+          id: internalID
+          lot_label: lotLabel
+          reserve_status: reserveStatus
           counts {
-            bidder_positions
+            bidder_positions: bidderPositions
           }
-          sale_id
-          highest_bid {
+          sale_id: saleID
+          highest_bid: highestBid {
             display
           }
           sale {
-            live_start_at
-            end_at
-            is_live_open
-            is_closed
+            live_start_at: liveStartAt
+            end_at: endAt
+            is_live_open: isLiveOpen
+            is_closed: isClosed
           }
           artwork {
             href

--- a/src/desktop/components/my_active_bids/view.coffee
+++ b/src/desktop/components/my_active_bids/view.coffee
@@ -1,7 +1,7 @@
 sd = require('sharify').data
 Backbone = require 'backbone'
 query = require './query.coffee'
-metaphysics = require '../../../lib/metaphysics.coffee'
+metaphysics2 = require '../../../lib/metaphysics2.coffee'
 CurrentUser = require '../../models/current_user'
 template = -> require('./template.jade') arguments...
 {getLiveAuctionUrl} = require('../../../utils/domain/auctions/urls')
@@ -23,7 +23,7 @@ module.exports = class MyActiveBids extends Backbone.View
     this
 
   fetch: ->
-    metaphysics(
+    metaphysics2(
       query: query
       variables: live: true, sale_id: @saleId
       req: user: @user


### PR DESCRIPTION
Fixes [PURCHASE-2188](https://artsyproduct.atlassian.net/browse/PURCHASE-2188)

The query is the same. I just changed 🐍 -> 🐫  case and `id -> internalID` conversion with aliases. 

`desktop/apps/user/components/bid_history` is also using the same query so moved that to MP V2. So it also fixes [PURCHASE-2184](https://artsyproduct.atlassian.net/browse/PURCHASE-2184)