### PR TITLE
HACK-8: track add to calendar clicks

### DIFF
--- a/src/desktop/apps/auction/components/Layout.tsx
+++ b/src/desktop/apps/auction/components/Layout.tsx
@@ -13,6 +13,8 @@ import React from "react"
 import block from "bem-cn-lite"
 import { connect } from "react-redux"
 import { showModal } from "../actions/app"
+import { AnalyticsContext } from "v2/Artsy/Analytics/AnalyticsContext"
+import { OwnerType } from "@artsy/cohesion"
 
 // FIXME: Rewire
 let Banner = _Banner
@@ -46,38 +48,46 @@ function Layout(props) {
   }
 
   return (
-    <div className={b()}>
-      {Modal && (
-        <Modal
-          auction={auction}
-          me={me}
-          onClose={() => {
-            dispatch(showModal(null))
-          }}
-        />
-      )}
-      <Banner />
-      <div className={b("container", "responsive-layout-container")}>
-        <AuctionInfoContainer />
-
-        {showAssociatedAuctions && (
-          <AuctionBlock sale={associatedSale} relatedAuction />
+    <AnalyticsContext.Provider
+      value={{
+        contextPageOwnerId: auction.get("_id"),
+        contextPageOwnerSlug: auction.id,
+        contextPageOwnerType: OwnerType.sale,
+      }}
+    >
+      <div className={b()}>
+        {Modal && (
+          <Modal
+            auction={auction}
+            me={me}
+            onClose={() => {
+              dispatch(showModal(null))
+            }}
+          />
         )}
+        <Banner />
+        <div className={b("container", "responsive-layout-container")}>
+          <AuctionInfoContainer />
 
-        {showMyActiveBids && <MyActiveBids />}
+          {showAssociatedAuctions && (
+            <AuctionBlock sale={associatedSale} relatedAuction />
+          )}
 
-        <PromotedSaleArtworks />
-        <ArtworksByFollowedArtists />
+          {showMyActiveBids && <MyActiveBids />}
 
-        {showFilter && !showInfoWindow && (
-          <div className="auction-main-page">
-            <ArtworkBrowser />
-          </div>
-        )}
+          <PromotedSaleArtworks />
+          <ArtworksByFollowedArtists />
 
-        {showFooter && <Footer />}
+          {showFilter && !showInfoWindow && (
+            <div className="auction-main-page">
+              <ArtworkBrowser />
+            </div>
+          )}
+
+          {showFooter && <Footer />}
+        </div>
       </div>
-    </div>
+    </AnalyticsContext.Provider>
   )
 }
 
@@ -86,9 +96,9 @@ Layout.propTypes = {
   me: PropTypes.object,
   showAssociatedAuctions: PropTypes.bool.isRequired,
   showFilter: PropTypes.bool.isRequired,
+  showFooter: PropTypes.bool.isRequired,
   showInfoWindow: PropTypes.bool.isRequired,
   showMyActiveBids: PropTypes.bool.isRequired,
-  showFooter: PropTypes.bool.isRequired,
 }
 
 const mapStateToProps = state => {
@@ -130,9 +140,9 @@ const mapStateToProps = state => {
     showAssociatedAuctions,
     showFilter,
     showFollowedArtistsRail,
+    showFooter,
     showInfoWindow,
     showMyActiveBids,
-    showFooter,
   }
 }
 

--- a/src/desktop/apps/auction/components/layout/auction_info/AuctionInfoDesktop.tsx
+++ b/src/desktop/apps/auction/components/layout/auction_info/AuctionInfoDesktop.tsx
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types"
 import React from "react"
 import Registration from "./Registration"
 import block from "bem-cn-lite"
@@ -6,86 +5,96 @@ import { connect } from "react-redux"
 import { AddToCalendar } from "v2/Components/AddToCalendar/AddToCalendar"
 import { data as sd } from "sharify"
 import { formatIsoDateNoZoneOffset } from "v2/Components/AddToCalendar/helpers"
+import { ContextModule } from "@artsy/cohesion"
+import track from "react-tracking"
+import Events from "v2/Utils/Events"
 
-function AuctionInfoDesktop(props) {
-  const {
-    description,
-    endAt,
-    href,
-    isAuctionPromo,
-    liveAuctionUrl,
-    liveStartAt,
-    name,
-    startAt,
-    showAddToCalendar,
-    upcomingLabel,
-  } = props
+interface AuctionInfoDesktopProps {
+  description: string
+  endAt?: string
+  href: string
+  isAuctionPromo?: boolean
+  liveAuctionUrl?: string
+  liveStartAt?: string
+  name: string
+  showAddToCalendar: boolean
+  startAt: string
+  upcomingLabel?: string
+}
+@track({}, { dispatch: data => Events.postEvent(data) })
+export class AuctionInfoDesktop extends React.Component<
+  AuctionInfoDesktopProps
+> {
+  render() {
+    const {
+      description,
+      endAt,
+      href,
+      isAuctionPromo,
+      liveAuctionUrl,
+      liveStartAt,
+      name,
+      startAt,
+      showAddToCalendar,
+      upcomingLabel,
+    } = this.props
 
-  const b = block("auction-AuctionInfo")
-  const endDate = liveStartAt
-    ? formatIsoDateNoZoneOffset(liveStartAt, 4)
-    : endAt
+    const b = block("auction-AuctionInfo")
+    const endDate = liveStartAt
+      ? formatIsoDateNoZoneOffset(liveStartAt, 4)
+      : endAt
 
-  return (
-    <header className={b()}>
-      <div className={b("primary")}>
-        {isAuctionPromo && <h4 className={b("sub-header")}>Sale Preview</h4>}
+    return (
+      <header className={b()}>
+        <div className={b("primary")}>
+          {isAuctionPromo && <h4 className={b("sub-header")}>Sale Preview</h4>}
 
-        <h1 className={b("title")}>{name}</h1>
+          <h1 className={b("title")}>{name}</h1>
 
-        <div className={b("callout")}>
-          <div className={b("time")}>
-            {upcomingLabel && (
-              <div className={b("upcomingLabel")}>{upcomingLabel}</div>
-            )}
+          <div className={b("callout")}>
+            <div className={b("time")}>
+              {upcomingLabel && (
+                <div className={b("upcomingLabel")}>{upcomingLabel}</div>
+              )}
 
-            {showAddToCalendar && (
-              <AddToCalendar
-                startDate={liveStartAt || startAt}
-                endDate={endDate}
-                title={name}
-                description={description}
-                href={`${sd.APP_URL}${href}`}
-                liveAuctionUrl={liveAuctionUrl}
-              />
+              {showAddToCalendar && (
+                <AddToCalendar
+                  startDate={liveStartAt || startAt}
+                  endDate={endDate}
+                  title={name}
+                  description={description}
+                  href={`${sd.APP_URL}${href}`}
+                  liveAuctionUrl={liveAuctionUrl}
+                  contextModule={ContextModule.auctionHome}
+                />
+              )}
+            </div>
+
+            {liveStartAt && (
+              <div className={b("callout-live-label")}>
+                <span className={b("live-label")}>Live auction</span>
+                <span
+                  className={b.builder()("live-tooltip").mix("help-tooltip")()}
+                  data-message="Participating in a live auction means you’ll be competing against bidders in real time on an auction room floor. You can place max bids which will be represented by Artsy in the auction room or you can bid live when the auction opens."
+                  data-anchor="top-left"
+                />
+              </div>
             )}
           </div>
-
-          {liveStartAt && (
-            <div className={b("callout-live-label")}>
-              <span className={b("live-label")}>Live auction</span>
-              <span
-                className={b.builder()("live-tooltip").mix("help-tooltip")()}
-                data-message="Participating in a live auction means you’ll be competing against bidders in real time on an auction room floor. You can place max bids which will be represented by Artsy in the auction room or you can bid live when the auction opens."
-                data-anchor="top-left"
-              />
-            </div>
-          )}
+          <div
+            className={b("description")}
+            dangerouslySetInnerHTML={{
+              __html: description,
+            }}
+          />
         </div>
-        <div
-          className={b("description")}
-          dangerouslySetInnerHTML={{
-            __html: description,
-          }}
-        />
-      </div>
 
-      <div className={b("metadata")}>
-        <Registration {...props} />
-      </div>
-    </header>
-  )
-}
-
-AuctionInfoDesktop.propTypes = {
-  description: PropTypes.string.isRequired,
-  endAt: PropTypes.string,
-  isAuctionPromo: PropTypes.bool,
-  liveStartAt: PropTypes.string,
-  name: PropTypes.string.isRequired,
-  startAt: PropTypes.string,
-  showAddToCalendar: PropTypes.bool.isRequired,
-  upcomingLabel: PropTypes.string.isRequired,
+        <div className={b("metadata")}>
+          <Registration {...this.props} />
+        </div>
+      </header>
+    )
+  }
 }
 
 const mapStateToProps = state => {
@@ -93,6 +102,7 @@ const mapStateToProps = state => {
 
   return {
     description: auction.mdToHtml("description"),
+    endAt: auction.get("end_at"),
     href: auction.href(),
     isAuctionPromo: auction.isAuctionPromo(),
     liveAuctionUrl,
@@ -100,7 +110,6 @@ const mapStateToProps = state => {
     name: auction.get("name"),
     showAddToCalendar: !(auction.isClosed() || auction.isLiveOpen()),
     startAt: auction.get("start_at"),
-    endAt: auction.get("end_at"),
     upcomingLabel: auction.upcomingLabel(),
   }
 }

--- a/src/v2/Components/AddToCalendar/AddToCalendar.tsx
+++ b/src/v2/Components/AddToCalendar/AddToCalendar.tsx
@@ -4,6 +4,13 @@ import {
   generateGoogleCalendarUrl,
   generateIcsCalendarUrl,
 } from "v2/Components/AddToCalendar/helpers"
+import {
+  AddToCalendar as AddToCalendarEvent,
+  addToCalendar,
+  ContextModule,
+} from "@artsy/cohesion"
+import { useTracking } from "v2/Artsy"
+import { useAnalyticsContext } from "v2/Artsy/Analytics/AnalyticsContext"
 
 export interface CalendarEventProps {
   title: string
@@ -13,13 +20,31 @@ export interface CalendarEventProps {
   address?: string
   href: string
   liveAuctionUrl?: string
+  contextModule: ContextModule
 }
 
 export const AddToCalendar: React.FC<CalendarEventProps> = props => {
   const [isVisible, setIsVisible] = useState(false)
-
+  const { trackEvent } = useTracking()
+  const {
+    contextPageOwnerId,
+    contextPageOwnerSlug,
+    contextPageOwnerType,
+  } = useAnalyticsContext()
   const googleUrl = generateGoogleCalendarUrl(props)
   const icsUrl = generateIcsCalendarUrl(props)
+
+  const trackClick = (subject: AddToCalendarEvent["subject"]) => {
+    trackEvent(
+      addToCalendar({
+        context_module: props.contextModule,
+        context_owner_id: contextPageOwnerId,
+        context_owner_slug: contextPageOwnerSlug,
+        context_owner_type: contextPageOwnerType,
+        subject,
+      })
+    )
+  }
 
   return (
     <Box display="inline-block">
@@ -38,11 +63,19 @@ export const AddToCalendar: React.FC<CalendarEventProps> = props => {
           onBlur={() => setIsVisible(false)}
         >
           <Menu>
-            <MenuItem href={googleUrl} target="_blank">
+            <MenuItem
+              href={googleUrl}
+              onClick={() => trackClick("google")}
+              target="_blank"
+            >
               Google
             </MenuItem>
-            <MenuItem href={icsUrl}>iCal</MenuItem>
-            <MenuItem href={icsUrl}>Outlook</MenuItem>
+            <MenuItem href={icsUrl} onClick={() => trackClick("iCal")}>
+              iCal
+            </MenuItem>
+            <MenuItem href={icsUrl} onClick={() => trackClick("outlook")}>
+              Outlook
+            </MenuItem>
           </Menu>
         </Box>
       )}

--- a/src/v2/Components/AddToCalendar/__tests__/helpers.jest.ts
+++ b/src/v2/Components/AddToCalendar/__tests__/helpers.jest.ts
@@ -1,4 +1,3 @@
-import { CalendarEventProps } from "../AddToCalendar"
 import {
   formatIsoDateNoZoneOffset,
   generateGoogleCalendarUrl,
@@ -6,15 +5,15 @@ import {
 } from "../helpers"
 
 describe("AddToCalendar date helpers", () => {
-  let event: CalendarEventProps
+  let event
 
   beforeEach(() => {
     event = {
+      description: "Artsy presents an auction.",
       endDate: new Date("2024-01-11").toISOString(),
       href: "http://artsy.net/auction/auction-slug",
       startDate: new Date("2024-01-10").toISOString(),
       title: "Heritage: Signature Urban Art",
-      description: "Artsy presents an auction.",
     }
   })
 

--- a/src/v2/Components/AddToCalendar/helpers.ts
+++ b/src/v2/Components/AddToCalendar/helpers.ts
@@ -1,6 +1,8 @@
 import { DateTime } from "luxon"
 import { stripTags } from "underscore.string"
-import { CalendarEventProps } from "v2/Components/AddToCalendar/AddToCalendar"
+import { CalendarEventProps as CalendarEventComponentProps } from "v2/Components/AddToCalendar/AddToCalendar"
+
+type CalendarEventProps = Omit<CalendarEventComponentProps, "contextModule">
 
 /** @returns URL to create a new Google Calendar event */
 export const generateGoogleCalendarUrl = ({


### PR DESCRIPTION
Follow up to #6639, track clicks on add to calendar component.

Addresses  https://artsyproduct.atlassian.net/browse/AUCT-725

- track clicks in `AddToCalendar` component
- add tracking context to auction app
- add analytics context props to auction app