### PR TITLE
chore: Do not log warning messages about cohesion in production

### DIFF
--- a/src/lib/getContextPage.ts
+++ b/src/lib/getContextPage.ts
@@ -71,7 +71,7 @@ export const formatOwnerTypes = (path: string) => {
       break
   }
 
-  if (!OwnerType[formattedType]) {
+  if (!OwnerType[formattedType] && sd.SHOW_ANALYTICS_CALLS) {
     console.warn(
       `OwnerType ${formattedType} is not part of @artsy/cohesion's schema.`
     )


### PR DESCRIPTION
We log warnings for page-type's that haven't been added to the cohesion schema, however we only need these in dev environments. Turns on the log only when `SHOW_ANALYTICS_CALLS` has been enabled.

Related conversation:
https://artsy.slack.com/archives/CA8SANW3W/p1605896540238700
