### PR TITLE
feat(fx-2513): implements artists index

### DIFF
--- a/src/v2/Apps/Artists/ArtistsApp.tsx
+++ b/src/v2/Apps/Artists/ArtistsApp.tsx
@@ -1,0 +1,21 @@
+import React from "react"
+import { Separator } from "@artsy/palette"
+import { AppContainer } from "v2/Apps/Components/AppContainer"
+import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
+import { Footer } from "v2/Components/Footer"
+
+interface ArtistsAppProps {}
+
+export const ArtistsApp: React.FC<ArtistsAppProps> = ({ children }) => {
+  return (
+    <AppContainer>
+      <HorizontalPadding>
+        {children}
+
+        <Separator as="hr" my={3} />
+
+        <Footer />
+      </HorizontalPadding>
+    </AppContainer>
+  )
+}

--- a/src/v2/Apps/Artists/Components/ArtistsArtistCard.tsx
+++ b/src/v2/Apps/Artists/Components/ArtistsArtistCard.tsx
@@ -1,0 +1,105 @@
+import React from "react"
+import { Box, BoxProps, Image, ResponsiveBox, Text } from "@artsy/palette"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
+import { FollowArtistButtonFragmentContainer } from "v2/Components/FollowButton/FollowArtistButton"
+import { ContextModule } from "@artsy/cohesion"
+import { createFragmentContainer, graphql } from "react-relay"
+import { ArtistsArtistCard_artist } from "v2/__generated__/ArtistsArtistCard_artist.graphql"
+
+interface ArtistsArtistCardProps extends BoxProps {
+  artist: ArtistsArtistCard_artist
+}
+
+export const ArtistsArtistCard: React.FC<ArtistsArtistCardProps> = ({
+  artist,
+  ...rest
+}) => {
+  const { image, counts } = artist
+
+  if (!image) return null
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      justifyContent="space-between"
+      height="100%"
+      p={1}
+      border="1px solid"
+      borderColor="black10"
+      borderRadius={2}
+      flex="1"
+      {...rest}
+    >
+      <RouterLink to={artist.href} noUnderline style={{ display: "block" }}>
+        <ResponsiveBox
+          aspectWidth={image.thumb.width}
+          aspectHeight={image.thumb.height}
+          maxWidth="100%"
+        >
+          <Image
+            src={image.thumb.src}
+            srcSet={image.thumb.srcSet}
+            alt={artist.name}
+            width="100%"
+            height="100%"
+            lazyLoad
+          />
+        </ResponsiveBox>
+
+        <Box my={1}>
+          <Text variant="mediumText">{artist.name}</Text>
+
+          {artist.formattedNationalityAndBirthday && (
+            <Text color="black60">
+              {artist.formattedNationalityAndBirthday}
+            </Text>
+          )}
+
+          {counts && counts.artworks > 0 && (
+            <Text color="black60">
+              {counts.artworks} work
+              {counts.artworks === 1 ? "" : "s"}
+              {counts.forSaleArtworks > 0 &&
+                counts.forSaleArtworks !== counts.artworks && (
+                  <>, {counts.forSaleArtworks} for sale</>
+                )}
+            </Text>
+          )}
+        </Box>
+      </RouterLink>
+
+      <FollowArtistButtonFragmentContainer
+        artist={artist}
+        contextModule={ContextModule.featuredArtistsRail}
+        buttonProps={{ width: "100%" }}
+      />
+    </Box>
+  )
+}
+
+export const ArtistsArtistCardFragmentContainer = createFragmentContainer(
+  ArtistsArtistCard,
+  {
+    artist: graphql`
+      fragment ArtistsArtistCard_artist on Artist {
+        ...FollowArtistButton_artist
+        name
+        href
+        formattedNationalityAndBirthday
+        counts {
+          artworks
+          forSaleArtworks
+        }
+        image {
+          thumb: cropped(width: 270, height: 200) {
+            width
+            height
+            src
+            srcSet
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Artists/Components/ArtistsByLetterMeta.tsx
+++ b/src/v2/Apps/Artists/Components/ArtistsByLetterMeta.tsx
@@ -1,0 +1,32 @@
+import React from "react"
+import { Link, Meta, Title } from "react-head"
+import { useRouter } from "v2/Artsy/Router/useRouter"
+import { getENV } from "v2/Utils/getENV"
+
+const TITLE = "Modern and Contemporary Artists"
+
+export const ArtistsByLetterMeta: React.FC = () => {
+  const {
+    match: { params },
+  } = useRouter()
+
+  if (!params.letter) return <Title>{TITLE}</Title>
+
+  const title = `Artists Starting with ${params.letter.toUpperCase()} | ${TITLE}`
+  const description = `Research and discover artists starting with ${params.letter.toUpperCase()} on Artsy. Find works for sale, biographies, CVs, and auction results.`
+  const href = `${getENV("APP_URL")}/artists2/${params.letter}`
+
+  return (
+    <>
+      <Title>{title}</Title>
+      <Meta property="og:title" content={title} />
+      <Meta name="description" content={description} />
+      <Meta property="og:description" content={description} />
+      <Meta property="twitter:description" content={description} />
+      <Link rel="canonical" href={href} />
+      <Meta property="og:url" content={href} />
+      <Meta property="og:type" content="website" />
+      <Meta property="twitter:card" content="summary" />
+    </>
+  )
+}

--- a/src/v2/Apps/Artists/Components/ArtistsCarouselCell.tsx
+++ b/src/v2/Apps/Artists/Components/ArtistsCarouselCell.tsx
@@ -1,0 +1,80 @@
+import { ContextModule } from "@artsy/cohesion"
+import { Box, Image, Text } from "@artsy/palette"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
+import { FollowArtistButtonQueryRenderer } from "v2/Components/FollowButton/FollowArtistButton"
+import { ArtistsCarouselCell_featuredLink } from "v2/__generated__/ArtistsCarouselCell_featuredLink.graphql"
+
+const getSlug = (href: string) => {
+  const components = href.split("/")
+  return components[components.indexOf("artist") + 1]
+}
+
+interface ArtistsCarouselCellProps {
+  featuredLink: ArtistsCarouselCell_featuredLink
+  index: number
+}
+
+const ArtistsCarouselCell: React.FC<ArtistsCarouselCellProps> = ({
+  featuredLink,
+  index,
+}) => {
+  const { image } = featuredLink
+
+  if (!image) return null
+
+  const slug = getSlug(featuredLink.href)
+
+  return (
+    <RouterLink
+      key={featuredLink.internalID}
+      to={featuredLink.href}
+      style={{ display: "block", textDecoration: "none" }}
+      aria-label={featuredLink.title}
+    >
+      <Image
+        src={image.thumb.src}
+        srcSet={image.thumb.srcSet}
+        width={image.thumb.width}
+        height={image.thumb.height}
+        alt={featuredLink.title}
+        lazyLoad={index > 2}
+      />
+
+      <Box my={1} display="flex" justifyContent="space-between">
+        <Box>
+          <Text variant="mediumText">{featuredLink.title}</Text>
+          <Text color="black60">{featuredLink.subtitle}</Text>
+        </Box>
+
+        <FollowArtistButtonQueryRenderer
+          id={slug}
+          contextModule={ContextModule.featuredArtistsRail}
+        />
+      </Box>
+    </RouterLink>
+  )
+}
+
+export const ArtistsCarouselCellFragmentContainer = createFragmentContainer(
+  ArtistsCarouselCell,
+  {
+    featuredLink: graphql`
+      fragment ArtistsCarouselCell_featuredLink on FeaturedLink {
+        internalID
+        title
+        subtitle
+        href
+        image {
+          thumb: cropped(width: 546, height: 410, version: "wide") {
+            width
+            height
+            src
+            srcSet
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Artists/Components/ArtistsIndexMeta.tsx
+++ b/src/v2/Apps/Artists/Components/ArtistsIndexMeta.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import { Link, Meta, Title } from "react-head"
+import { getENV } from "v2/Utils/getENV"
+
+const TITLE = "Browse Artists on Artsy | Modern and Contemporary Artists"
+const DESCRIPTION =
+  "Research and discover more than 100,000 modern and contemporary artists on Artsy. Find works for sale, biographies, CVs, and auction results."
+
+export const ArtistsIndexMeta: React.FC = ({}) => {
+  const href = `${getENV("APP_URL")}/artists`
+
+  return (
+    <>
+      <Title>{TITLE}</Title>
+      <Meta property="og:title" content={TITLE} />
+      <Meta name="description" content={DESCRIPTION} />
+      <Meta property="og:description" content={DESCRIPTION} />
+      <Meta property="twitter:description" content={DESCRIPTION} />
+      <Link rel="canonical" href={href} />
+      <Meta property="og:url" content={href} />
+      <Meta property="og:type" content="website" />
+      <Meta property="twitter:card" content="summary" />
+    </>
+  )
+}

--- a/src/v2/Apps/Artists/Components/ArtistsLetterNav.tsx
+++ b/src/v2/Apps/Artists/Components/ArtistsLetterNav.tsx
@@ -1,0 +1,52 @@
+import { Box, BoxProps, color, space, Text } from "@artsy/palette"
+import React from "react"
+import styled from "styled-components"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
+
+export const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("")
+
+const Container = styled(Box)`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: flex-start;
+`
+
+const Letter = styled(RouterLink)`
+  display: block;
+  padding: ${space(0.5)}px ${space(1)}px;
+  text-align: center;
+  text-decoration: none;
+  border-radius: 2px;
+
+  &.active {
+    color: ${color("black100")};
+    background-color: ${color("black5")};
+    font-weight: bold;
+  }
+`
+
+interface ArtistsLetterNavProps extends BoxProps {}
+
+export const ArtistsLetterNav: React.FC<ArtistsLetterNavProps> = ({
+  ...rest
+}) => {
+  return (
+    <Container {...rest}>
+      {LETTERS.map(letter => {
+        return (
+          <Text key={letter} variant="text" color="black60">
+            <Letter
+              key={letter}
+              activeClassName="active"
+              to={`/artists2/artists-starting-with-${letter.toLowerCase()}`}
+              title={`View artists starting with “${letter}”`}
+            >
+              {letter}
+            </Letter>
+          </Text>
+        )
+      })}
+    </Container>
+  )
+}

--- a/src/v2/Apps/Artists/Components/ArtistsTopNav.tsx
+++ b/src/v2/Apps/Artists/Components/ArtistsTopNav.tsx
@@ -1,0 +1,34 @@
+import { Box, BoxProps } from "@artsy/palette"
+import React from "react"
+import { ArtistsLetterNav } from "./ArtistsLetterNav"
+
+interface ArtistsTopNavProps extends BoxProps {}
+
+export const ArtistsTopNav: React.FC<ArtistsTopNavProps> = ({
+  children,
+  ...rest
+}) => {
+  return (
+    <Box
+      // Compensate for vertical padding within ArtistsLetterNav items
+      mt={-0.5}
+    >
+      <Box
+        display="flex"
+        flexDirection={["column", "row"]}
+        alignItems="center"
+        justifyContent="space-between"
+        {...rest}
+      >
+        <Box mb={[1, 0]} pr={2} width={["100%", "auto"]}>
+          {children}
+        </Box>
+
+        <ArtistsLetterNav
+          // Compensate for first-item padding and align flush-left at mobile breakpoint
+          ml={[-1, 0]}
+        />
+      </Box>
+    </Box>
+  )
+}

--- a/src/v2/Apps/Artists/Routes/ArtistsByLetter.tsx
+++ b/src/v2/Apps/Artists/Routes/ArtistsByLetter.tsx
@@ -1,0 +1,155 @@
+import { Box, Text, media, space } from "@artsy/palette"
+import React, { useState } from "react"
+import { graphql, createRefetchContainer, RelayRefetchProp } from "react-relay"
+import styled, { css } from "styled-components"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
+import { useRouter } from "v2/Artsy/Router/useRouter"
+import { PaginationFragmentContainer } from "v2/Components/Pagination"
+import { ArtistsTopNav } from "../Components/ArtistsTopNav"
+import { ArtistsByLetter_viewer } from "v2/__generated__/ArtistsByLetter_viewer.graphql"
+import { ArtistsByLetterMeta } from "../Components/ArtistsByLetterMeta"
+import { LETTERS } from "../Components/ArtistsLetterNav"
+import { HttpError } from "found"
+
+const Columns = styled(Box)<{ isLoading: boolean }>`
+  column-count: 4;
+  ${media.md`column-count: 3;`}
+  ${media.xs`column-count: 1;`}
+
+  ${({ isLoading }) =>
+    isLoading &&
+    css`
+      opacity: 0.25;
+      pointer-events: none;
+    `}
+`
+
+const Name = styled(RouterLink)`
+  display: block;
+  text-decoration: none;
+  padding: ${space(0.5)}px 0;
+`
+
+interface ArtistsByLetterProps {
+  viewer: ArtistsByLetter_viewer
+  relay: RelayRefetchProp
+}
+
+export const ArtistsByLetter: React.FC<ArtistsByLetterProps> = ({
+  relay,
+  viewer,
+}) => {
+  const { match } = useRouter()
+  const [isLoading, setLoading] = useState(false)
+
+  // If the `letter` param isn't part of the nav, 404
+  if (!LETTERS.includes(match.params.letter?.toUpperCase())) {
+    throw new HttpError(404)
+  }
+
+  if (!viewer.artistsConnection?.artists) {
+    return null
+  }
+
+  const {
+    artistsConnection: {
+      artists,
+      pageCursors,
+      pageInfo: { endCursor, hasNextPage },
+    },
+  } = viewer
+
+  const handleNext = () => {
+    handleClick(endCursor)
+  }
+
+  const handleClick = (cursor: string) => {
+    setLoading(true)
+
+    relay.refetch({ after: cursor }, null, error => {
+      if (error) {
+        console.error(error)
+      }
+
+      setLoading(false)
+    })
+  }
+
+  return (
+    <>
+      <ArtistsByLetterMeta />
+
+      <Box>
+        <Text my={3}>
+          <RouterLink to="/artists2" noUnderline>
+            Artists
+          </RouterLink>{" "}
+          / Browse all 50,000 artists
+        </Text>
+
+        <ArtistsTopNav my={3}>
+          <Text as="h1" variant="largeTitle">
+            Artists
+            {match.params.letter && <> – {match.params.letter.toUpperCase()}</>}
+          </Text>
+        </ArtistsTopNav>
+
+        <Columns my={3} isLoading={isLoading}>
+          {artists.map(({ artist }) => {
+            return (
+              <Text key={artist.internalID}>
+                <Name to={artist.href}>{artist.name}</Name>
+              </Text>
+            )
+          })}
+        </Columns>
+
+        <PaginationFragmentContainer
+          hasNextPage={hasNextPage}
+          pageCursors={pageCursors}
+          onNext={handleNext}
+          onClick={handleClick}
+        />
+      </Box>
+    </>
+  )
+}
+
+export const ArtistsByLetterFragmentContainer = createRefetchContainer(
+  ArtistsByLetter,
+  {
+    viewer: graphql`
+      fragment ArtistsByLetter_viewer on Viewer
+        @argumentDefinitions(
+          letter: { type: "String", defaultValue: "a" }
+          first: { type: "Int", defaultValue: 100 }
+          after: { type: "String" }
+        ) {
+        artistsConnection(letter: $letter, first: $first, after: $after) {
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+          pageCursors {
+            ...Pagination_pageCursors
+          }
+          artists: edges {
+            artist: node {
+              internalID
+              name
+              href
+            }
+          }
+        }
+      }
+    `,
+  },
+  graphql`
+    query ArtistsByLetterQuery($letter: String!, $first: Int, $after: String) {
+      viewer {
+        ...ArtistsByLetter_viewer
+          @arguments(letter: $letter, first: $first, after: $after)
+      }
+    }
+  `
+)

--- a/src/v2/Apps/Artists/Routes/ArtistsIndex.tsx
+++ b/src/v2/Apps/Artists/Routes/ArtistsIndex.tsx
@@ -1,0 +1,166 @@
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { Box, GridColumns, Column, Text, Image } from "@artsy/palette"
+import { ArtistsIndex_featuredArtists } from "v2/__generated__/ArtistsIndex_featuredArtists.graphql"
+import { ArtistsIndex_featuredGenes } from "v2/__generated__/ArtistsIndex_featuredGenes.graphql"
+import { Media } from "v2/Utils/Responsive"
+import { Carousel } from "v2/Components/Carousel"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
+import { ArtistsIndexMeta } from "../Components/ArtistsIndexMeta"
+import { ArtistsTopNav } from "../Components/ArtistsTopNav"
+import { ArtistsArtistCardFragmentContainer } from "../Components/ArtistsArtistCard"
+import { ArtistsCarouselCellFragmentContainer } from "../Components/ArtistsCarouselCell"
+
+interface ArtistsIndexProps {
+  featuredArtists: ArtistsIndex_featuredArtists
+  featuredGenes: ArtistsIndex_featuredGenes
+}
+
+export const ArtistsIndex: React.FC<ArtistsIndexProps> = ({
+  featuredArtists,
+  featuredGenes,
+}) => {
+  const [{ name: headline, artists }] = featuredArtists
+  const [{ genes }] = featuredGenes
+
+  return (
+    <>
+      <ArtistsIndexMeta />
+
+      <ArtistsTopNav my={3}>
+        <Text>Browse all 50,000 artists</Text>
+      </ArtistsTopNav>
+
+      <Media greaterThanOrEqual="sm">
+        <Text as="h1" variant="largeTitle" my={2}>
+          {headline}
+        </Text>
+
+        {artists && (
+          <Carousel my={2} arrowHeight={410}>
+            {artists.map((featuredLink, index) => {
+              if (!featuredLink.internalID) return null
+
+              return (
+                <ArtistsCarouselCellFragmentContainer
+                  key={featuredLink.internalID}
+                  featuredLink={featuredLink}
+                  index={index}
+                />
+              )
+            })}
+          </Carousel>
+        )}
+      </Media>
+
+      <Media lessThan="sm">
+        <Text variant="largeTitle" as="h2" my={3}>
+          Artists by category
+        </Text>
+      </Media>
+
+      {genes?.map(gene => {
+        if (gene.trendingArtists?.length === 0) return null
+
+        return (
+          <React.Fragment key={gene.name}>
+            <Media greaterThanOrEqual="sm">
+              <Box my={4}>
+                <Box display="flex" justifyContent="space-between" my={2}>
+                  <RouterLink to={gene.href} noUnderline>
+                    <Text as="h2" variant="subtitle">
+                      {gene.name}
+                    </Text>
+                  </RouterLink>
+
+                  <RouterLink to={gene.href} noUnderline>
+                    <Text variant="subtitle" color="black60">
+                      View
+                    </Text>
+                  </RouterLink>
+                </Box>
+
+                <GridColumns>
+                  {gene.trendingArtists.map(artist => {
+                    return (
+                      <Column key={artist.internalID} span={[12, 6, 6, 3]}>
+                        <ArtistsArtistCardFragmentContainer artist={artist} />
+                      </Column>
+                    )
+                  })}
+                </GridColumns>
+              </Box>
+            </Media>
+
+            <Media lessThan="sm">
+              <RouterLink to={gene.href} noUnderline>
+                <Box
+                  borderTop="1px solid"
+                  borderColor="black10"
+                  py={1}
+                  display="flex"
+                  alignItems="center"
+                >
+                  {gene.image && (
+                    <Image
+                      src={gene.image.thumb.src}
+                      srcSet={gene.image.thumb.srcSet}
+                      width={gene.image.thumb.width}
+                      height={gene.image.thumb.height}
+                      alt={gene.name}
+                    />
+                  )}
+
+                  <Text ml={2} variant="subtitle">
+                    {gene.name}
+                  </Text>
+                </Box>
+              </RouterLink>
+            </Media>
+          </React.Fragment>
+        )
+      })}
+    </>
+  )
+}
+
+export const ArtistsIndexFragmentContainer = createFragmentContainer(
+  ArtistsIndex,
+  {
+    featuredArtists: graphql`
+      fragment ArtistsIndex_featuredArtists on OrderedSet @relay(plural: true) {
+        name
+        artists: items {
+          ... on FeaturedLink {
+            internalID
+          }
+          ...ArtistsCarouselCell_featuredLink
+        }
+      }
+    `,
+    featuredGenes: graphql`
+      fragment ArtistsIndex_featuredGenes on OrderedSet @relay(plural: true) {
+        name
+        genes: items {
+          ... on Gene {
+            internalID
+            name
+            href
+            image {
+              thumb: cropped(width: 80, height: 80) {
+                width
+                height
+                src
+                srcSet
+              }
+            }
+            trendingArtists(sample: 4) {
+              internalID
+              ...ArtistsArtistCard_artist
+            }
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Artists/__tests__/ArtistsArtistCard.jest.tsx
+++ b/src/v2/Apps/Artists/__tests__/ArtistsArtistCard.jest.tsx
@@ -1,0 +1,71 @@
+import { graphql } from "react-relay"
+import { ArtistsArtistCardFragmentContainer } from "../Components/ArtistsArtistCard"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { ArtistsArtistCard_Test_Query } from "v2/__generated__/ArtistsArtistCard_Test_Query.graphql"
+
+jest.unmock("react-relay")
+
+const { getWrapper } = setupTestWrapper<ArtistsArtistCard_Test_Query>({
+  Component: ArtistsArtistCardFragmentContainer,
+  query: graphql`
+    query ArtistsArtistCard_Test_Query {
+      artist(id: "example") {
+        ...ArtistsArtistCard_artist
+      }
+    }
+  `,
+})
+
+describe("ArtistsArtistCard", () => {
+  it("renders the counts correctly", () => {
+    const wrapper = getWrapper({
+      Artist: () => ({
+        counts: {
+          artworks: 10,
+          forSaleArtworks: 5,
+        },
+      }),
+    })
+
+    expect(wrapper.html()).toContain(">10 works, 5 for sale<")
+  })
+
+  it("renders the counts correctly (2)", () => {
+    const wrapper = getWrapper({
+      Artist: () => ({
+        counts: {
+          artworks: 10,
+          forSaleArtworks: 10,
+        },
+      }),
+    })
+
+    expect(wrapper.html()).toContain(">10 works<")
+  })
+
+  it("renders the counts correctly with a single work", () => {
+    const wrapper = getWrapper({
+      Artist: () => ({
+        counts: {
+          artworks: 1,
+          forSaleArtworks: 0,
+        },
+      }),
+    })
+
+    expect(wrapper.html()).toContain(">1 work<")
+  })
+
+  it("renders the counts correctly with a single for sale work", () => {
+    const wrapper = getWrapper({
+      Artist: () => ({
+        counts: {
+          artworks: 1,
+          forSaleArtworks: 1,
+        },
+      }),
+    })
+
+    expect(wrapper.html()).toContain(">1 work<")
+  })
+})

--- a/src/v2/Apps/Artists/__tests__/ArtistsByLetter.jest.tsx
+++ b/src/v2/Apps/Artists/__tests__/ArtistsByLetter.jest.tsx
@@ -1,0 +1,47 @@
+import React from "react"
+import { graphql } from "react-relay"
+import { ArtistsByLetterFragmentContainer } from "../Routes/ArtistsByLetter"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { ArtistsByLetter_Test_Query } from "v2/__generated__/ArtistsByLetter_Test_Query.graphql"
+import { MockBoot } from "v2/DevTools"
+
+jest.unmock("react-relay")
+
+jest.mock("v2/Artsy/Router/useRouter", () => ({
+  useRouter: () => ({ match: { params: { letter: "a" } } }),
+}))
+
+const { getWrapper } = setupTestWrapper<ArtistsByLetter_Test_Query>({
+  Component: props => {
+    return (
+      <MockBoot>
+        <ArtistsByLetterFragmentContainer {...props} />
+      </MockBoot>
+    )
+  },
+  query: graphql`
+    query ArtistsByLetter_Test_Query(
+      $letter: String!
+      $first: Int
+      $after: String
+    ) {
+      viewer {
+        ...ArtistsByLetter_viewer
+          @arguments(letter: $letter, first: $first, after: $after)
+      }
+    }
+  `,
+  variables: {
+    first: 100,
+    letter: "a",
+  },
+})
+
+describe("ArtistsByLetter", () => {
+  it("renders the page", () => {
+    const wrapper = getWrapper()
+
+    expect(wrapper.find("h1")).toHaveLength(1)
+    expect(wrapper.find("h1").text()).toEqual("Artists – A")
+  })
+})

--- a/src/v2/Apps/Artists/__tests__/ArtistsIndex.jest.tsx
+++ b/src/v2/Apps/Artists/__tests__/ArtistsIndex.jest.tsx
@@ -1,0 +1,39 @@
+import React from "react"
+import { graphql } from "react-relay"
+import { ArtistsIndexFragmentContainer } from "../Routes/ArtistsIndex"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { ArtistsIndexFragmentContainer_Test_Query } from "v2/__generated__/ArtistsIndexFragmentContainer_Test_Query.graphql"
+import { MockBoot } from "v2/DevTools"
+
+jest.unmock("react-relay")
+
+const { getWrapper } = setupTestWrapper<
+  ArtistsIndexFragmentContainer_Test_Query
+>({
+  Component: props => (
+    <MockBoot>
+      <ArtistsIndexFragmentContainer {...props} />
+    </MockBoot>
+  ),
+  query: graphql`
+    query ArtistsIndexFragmentContainer_Test_Query {
+      featuredArtists: orderedSets(key: "homepage:featured-artists") {
+        ...ArtistsIndex_featuredArtists
+      }
+      featuredGenes: orderedSets(key: "artists:featured-genes") {
+        ...ArtistsIndex_featuredGenes
+      }
+    }
+  `,
+})
+
+describe("ArtistsIndex", () => {
+  it("renders the page", () => {
+    const wrapper = getWrapper({
+      OrderedSet: () => ({ name: "Featured Artists" }),
+    })
+
+    expect(wrapper.find("h1")).toHaveLength(1)
+    expect(wrapper.find("h1").text()).toEqual("Featured Artists")
+  })
+})

--- a/src/v2/Apps/Artists/artistsRoutes.tsx
+++ b/src/v2/Apps/Artists/artistsRoutes.tsx
@@ -1,0 +1,75 @@
+/* eslint-disable sort-keys-fix/sort-keys-fix */
+import loadable from "@loadable/component"
+import { graphql } from "react-relay"
+import { RouteConfig } from "found"
+
+const ArtistsApp = loadable(() => import("./ArtistsApp"), {
+  resolveComponent: component => component.ArtistsApp,
+})
+
+const ArtistsIndexRoute = loadable(() => import("./Routes/ArtistsIndex"), {
+  resolveComponent: component => component.ArtistsIndexFragmentContainer,
+})
+
+const ArtistsByLetterRoute = loadable(
+  () => import("./Routes/ArtistsByLetter"),
+  {
+    resolveComponent: component => component.ArtistsByLetterFragmentContainer,
+  }
+)
+
+export const artistsRoutes: RouteConfig[] = [
+  {
+    path: "/artists2",
+    getComponent: () => ArtistsApp,
+    prepare: () => {
+      return ArtistsApp.preload()
+    },
+    children: [
+      {
+        path: "",
+        getComponent: () => ArtistsIndexRoute,
+        prepare: () => {
+          return ArtistsIndexRoute.preload()
+        },
+        query: graphql`
+          query artistsRoutes_ArtistsQuery {
+            featuredArtists: orderedSets(key: "homepage:featured-artists") {
+              ...ArtistsIndex_featuredArtists
+            }
+            featuredGenes: orderedSets(key: "artists:featured-genes") {
+              ...ArtistsIndex_featuredGenes
+            }
+          }
+        `,
+      },
+
+      {
+        path: "artists-starting-with-:letter",
+        getComponent: () => ArtistsByLetterRoute,
+        prepare: () => {
+          return ArtistsByLetterRoute.preload()
+        },
+        prepareVariables: (params, props) => {
+          return {
+            ...params,
+            ...props,
+            first: 100,
+          }
+        },
+        query: graphql`
+          query artistsRoutes_ArtistsByLetterQuery(
+            $letter: String!
+            $first: Int
+            $after: String
+          ) {
+            viewer {
+              ...ArtistsByLetter_viewer
+                @arguments(letter: $letter, first: $first, after: $after)
+            }
+          }
+        `,
+      },
+    ],
+  },
+]

--- a/src/v2/Apps/getAppRoutes.tsx
+++ b/src/v2/Apps/getAppRoutes.tsx
@@ -1,6 +1,7 @@
 import { buildAppRoutes } from "v2/Artsy/Router/buildAppRoutes"
 import { RouteConfig } from "found"
 import { routes as artistRoutes } from "v2/Apps/Artist/routes"
+import { artistsRoutes } from "v2/Apps/Artists/artistsRoutes"
 import { routes as artistSeriesRoutes } from "./ArtistSeries/routes"
 import { routes as artworkRoutes } from "v2/Apps/Artwork/routes"
 import { collectRoutes } from "v2/Apps/Collect/collectRoutes"
@@ -20,6 +21,9 @@ export function getAppRoutes(): RouteConfig[] {
   return buildAppRoutes([
     {
       routes: artistRoutes,
+    },
+    {
+      routes: artistsRoutes,
     },
     {
       routes: artistSeriesRoutes,

--- a/src/v2/Artsy/Router/RouterLink.tsx
+++ b/src/v2/Artsy/Router/RouterLink.tsx
@@ -54,7 +54,12 @@ export const RouterLink: React.ForwardRefExoticComponent<RouterLinkProps> = Reac
       ])
 
       return (
-        <Link ref={ref as any} to={to} {...allowedProps} style={styleProps}>
+        <Link
+          ref={ref as any}
+          to={to}
+          {...allowedProps}
+          style={{ ...styleProps, ...(props as LinkPropsSimple).style }}
+        >
           {children}
         </Link>
       )
@@ -64,7 +69,7 @@ export const RouterLink: React.ForwardRefExoticComponent<RouterLinkProps> = Reac
           ref={ref}
           href={to as string}
           className={(props as LinkPropsSimple).className}
-          style={Object.assign(styleProps, (props as LinkPropsSimple).style)}
+          style={{ ...styleProps, ...(props as LinkPropsSimple).style }}
           {...omit(props, [
             "activeClassName",
             "alignItems",

--- a/src/v2/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/v2/Components/FollowButton/FollowArtistButton.tsx
@@ -13,6 +13,7 @@ import React from "react"
 import track, { TrackingProp } from "react-tracking"
 import styled from "styled-components"
 import { FollowArtistButton_artist } from "../../__generated__/FollowArtistButton_artist.graphql"
+import { FollowArtistButtonQuery } from "../../__generated__/FollowArtistButtonQuery.graphql"
 import { FollowButton } from "./Button"
 import {
   RelayProp,
@@ -26,6 +27,8 @@ import {
   withAnalyticsContext,
 } from "v2/Artsy/Analytics/AnalyticsContext"
 import { Mediator } from "lib/mediator"
+import { useSystemContext } from "v2/Artsy"
+import { SystemQueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
 
 interface Props
   extends React.HTMLProps<FollowArtistButton>,
@@ -63,8 +66,8 @@ const Container = styled.span`
 @track()
 export class FollowArtistButton extends React.Component<Props, State> {
   static defaultProps = {
-    triggerSuggestions: false,
     buttonProps: {},
+    triggerSuggestions: false,
   }
 
   state = { openSuggestions: false }
@@ -80,12 +83,12 @@ export class FollowArtistButton extends React.Component<Props, State> {
     } = this.props
 
     const args: FollowedArgs = {
-      ownerId: artist.internalID,
-      ownerSlug: artist.slug,
       contextModule,
       contextOwnerId: contextPageOwnerId,
       contextOwnerSlug: contextPageOwnerSlug,
       contextOwnerType: contextPageOwnerType,
+      ownerId: artist.internalID,
+      ownerSlug: artist.slug,
     }
 
     const analyticsData = artist.is_followed
@@ -103,8 +106,8 @@ export class FollowArtistButton extends React.Component<Props, State> {
       this.followArtistForUser()
     } else {
       openAuthToFollowSave(mediator, {
-        entity: artist,
         contextModule,
+        entity: artist,
         intent: Intent.followArtist,
       })
     }
@@ -132,19 +135,13 @@ export class FollowArtistButton extends React.Component<Props, State> {
           }
         }
       `,
-      variables: {
-        input: {
-          artistID: artist.internalID,
-          unfollow: artist.is_followed,
-        },
-      },
       optimisticResponse: {
         followArtist: {
           artist: {
-            id: artist.id,
-            slug: artist.slug,
-            is_followed: !artist.is_followed,
             counts: { follows: newFollowCount },
+            id: artist.id,
+            is_followed: !artist.is_followed,
+            slug: artist.slug,
           },
         },
       },
@@ -154,6 +151,12 @@ export class FollowArtistButton extends React.Component<Props, State> {
         artistProxy
           .getLinkedRecord("counts")
           .setValue(newFollowCount, "follows")
+      },
+      variables: {
+        input: {
+          artistID: artist.internalID,
+          unfollow: artist.is_followed,
+        },
       },
     })
     this.trackFollow()
@@ -233,3 +236,32 @@ export const FollowArtistButtonFragmentContainer = createFragmentContainer(
     `,
   }
 )
+
+export const FollowArtistButtonQueryRenderer: React.FC<
+  {
+    id: string
+  } & Props
+> = ({ id, ...rest }) => {
+  const { relayEnvironment } = useSystemContext()
+
+  return (
+    <SystemQueryRenderer<FollowArtistButtonQuery>
+      environment={relayEnvironment}
+      query={graphql`
+        query FollowArtistButtonQuery($id: String!) {
+          artist(id: $id) {
+            ...FollowArtistButton_artist
+          }
+        }
+      `}
+      variables={{ id }}
+      render={({ error, props }) => {
+        if (error || !props) {
+          return <FollowArtistButtonFragmentContainer {...rest} artist={null} />
+        }
+
+        return <FollowArtistButtonFragmentContainer {...rest} {...props} />
+      }}
+    />
+  )
+}

--- a/src/v2/__generated__/ArtistsArtistCard_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ArtistsArtistCard_Test_Query.graphql.ts
@@ -1,0 +1,263 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistsArtistCard_Test_QueryVariables = {};
+export type ArtistsArtistCard_Test_QueryResponse = {
+    readonly artist: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtistsArtistCard_artist">;
+    } | null;
+};
+export type ArtistsArtistCard_Test_Query = {
+    readonly response: ArtistsArtistCard_Test_QueryResponse;
+    readonly variables: ArtistsArtistCard_Test_QueryVariables;
+};
+
+
+
+/*
+query ArtistsArtistCard_Test_Query {
+  artist(id: "example") {
+    ...ArtistsArtistCard_artist
+    id
+  }
+}
+
+fragment ArtistsArtistCard_artist on Artist {
+  ...FollowArtistButton_artist
+  name
+  href
+  formattedNationalityAndBirthday
+  counts {
+    artworks
+    forSaleArtworks
+  }
+  image {
+    thumb: cropped(width: 270, height: 200) {
+      width
+      height
+      src
+      srcSet
+    }
+  }
+}
+
+fragment FollowArtistButton_artist on Artist {
+  id
+  internalID
+  name
+  slug
+  is_followed: isFollowed
+  counts {
+    follows
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtistsArtistCard_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtistsArtistCard_artist"
+          }
+        ],
+        "storageKey": "artist(id:\"example\")"
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ArtistsArtistCard_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": "is_followed",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isFollowed",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistCounts",
+            "kind": "LinkedField",
+            "name": "counts",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "follows",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "artworks",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "forSaleArtworks",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "href",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "formattedNationalityAndBirthday",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": "thumb",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 200
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 270
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "width",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "height",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "src",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "srcSet",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "cropped(height:200,width:270)"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "artist(id:\"example\")"
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "ArtistsArtistCard_Test_Query",
+    "operationKind": "query",
+    "text": "query ArtistsArtistCard_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistsArtistCard_artist\n    id\n  }\n}\n\nfragment ArtistsArtistCard_artist on Artist {\n  ...FollowArtistButton_artist\n  name\n  href\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  image {\n    thumb: cropped(width: 270, height: 200) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '32c1312cba361f9de61e98eae76a1cb1';
+export default node;

--- a/src/v2/__generated__/ArtistsArtistCard_artist.graphql.ts
+++ b/src/v2/__generated__/ArtistsArtistCard_artist.graphql.ts
@@ -1,0 +1,155 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistsArtistCard_artist = {
+    readonly name: string | null;
+    readonly href: string | null;
+    readonly formattedNationalityAndBirthday: string | null;
+    readonly counts: {
+        readonly artworks: number | null;
+        readonly forSaleArtworks: number | null;
+    } | null;
+    readonly image: {
+        readonly thumb: {
+            readonly width: number;
+            readonly height: number;
+            readonly src: string;
+            readonly srcSet: string;
+        } | null;
+    } | null;
+    readonly " $fragmentRefs": FragmentRefs<"FollowArtistButton_artist">;
+    readonly " $refType": "ArtistsArtistCard_artist";
+};
+export type ArtistsArtistCard_artist$data = ArtistsArtistCard_artist;
+export type ArtistsArtistCard_artist$key = {
+    readonly " $data"?: ArtistsArtistCard_artist$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistsArtistCard_artist">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ArtistsArtistCard_artist",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "href",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "formattedNationalityAndBirthday",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ArtistCounts",
+      "kind": "LinkedField",
+      "name": "counts",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "artworks",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "forSaleArtworks",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "image",
+      "plural": false,
+      "selections": [
+        {
+          "alias": "thumb",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 200
+            },
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 270
+            }
+          ],
+          "concreteType": "CroppedImageUrl",
+          "kind": "LinkedField",
+          "name": "cropped",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "width",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "height",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "src",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "srcSet",
+              "storageKey": null
+            }
+          ],
+          "storageKey": "cropped(height:200,width:270)"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "FollowArtistButton_artist"
+    }
+  ],
+  "type": "Artist"
+};
+(node as any).hash = 'd0789d164d06cbbd47dba98cd4e2975e';
+export default node;

--- a/src/v2/__generated__/ArtistsByLetterQuery.graphql.ts
+++ b/src/v2/__generated__/ArtistsByLetterQuery.graphql.ts
@@ -1,0 +1,335 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistsByLetterQueryVariables = {
+    letter: string;
+    first?: number | null;
+    after?: string | null;
+};
+export type ArtistsByLetterQueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtistsByLetter_viewer">;
+    } | null;
+};
+export type ArtistsByLetterQuery = {
+    readonly response: ArtistsByLetterQueryResponse;
+    readonly variables: ArtistsByLetterQueryVariables;
+};
+
+
+
+/*
+query ArtistsByLetterQuery(
+  $letter: String!
+  $first: Int
+  $after: String
+) {
+  viewer {
+    ...ArtistsByLetter_viewer_1QQa5d
+  }
+}
+
+fragment ArtistsByLetter_viewer_1QQa5d on Viewer {
+  artistsConnection(letter: $letter, first: $first, after: $after) {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    pageCursors {
+      ...Pagination_pageCursors
+    }
+    artists: edges {
+      artist: node {
+        internalID
+        name
+        href
+        id
+      }
+    }
+  }
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "letter",
+    "type": "String!"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "first",
+    "type": "Int"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "after",
+    "type": "String"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "after"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  },
+  {
+    "kind": "Variable",
+    "name": "letter",
+    "variableName": "letter"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "page",
+  "storageKey": null
+},
+v4 = [
+  (v2/*: any*/),
+  (v3/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "isCurrent",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtistsByLetterQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": (v1/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "ArtistsByLetter_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ArtistsByLetterQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v1/*: any*/),
+            "concreteType": "ArtistConnection",
+            "kind": "LinkedField",
+            "name": "artistsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageCursors",
+                "kind": "LinkedField",
+                "name": "pageCursors",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "around",
+                    "plural": true,
+                    "selections": (v4/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "first",
+                    "plural": false,
+                    "selections": (v4/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "last",
+                    "plural": false,
+                    "selections": (v4/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "previous",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": "artists",
+                "args": null,
+                "concreteType": "ArtistEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": "artist",
+                    "args": null,
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "ArtistsByLetterQuery",
+    "operationKind": "query",
+    "text": "query ArtistsByLetterQuery(\n  $letter: String!\n  $first: Int\n  $after: String\n) {\n  viewer {\n    ...ArtistsByLetter_viewer_1QQa5d\n  }\n}\n\nfragment ArtistsByLetter_viewer_1QQa5d on Viewer {\n  artistsConnection(letter: $letter, first: $first, after: $after) {\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    artists: edges {\n      artist: node {\n        internalID\n        name\n        href\n        id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'd46dea583c01ba43ec3ef9c5efe6e5ec';
+export default node;

--- a/src/v2/__generated__/ArtistsByLetter_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ArtistsByLetter_Test_Query.graphql.ts
@@ -1,0 +1,335 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistsByLetter_Test_QueryVariables = {
+    letter: string;
+    first?: number | null;
+    after?: string | null;
+};
+export type ArtistsByLetter_Test_QueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtistsByLetter_viewer">;
+    } | null;
+};
+export type ArtistsByLetter_Test_Query = {
+    readonly response: ArtistsByLetter_Test_QueryResponse;
+    readonly variables: ArtistsByLetter_Test_QueryVariables;
+};
+
+
+
+/*
+query ArtistsByLetter_Test_Query(
+  $letter: String!
+  $first: Int
+  $after: String
+) {
+  viewer {
+    ...ArtistsByLetter_viewer_1QQa5d
+  }
+}
+
+fragment ArtistsByLetter_viewer_1QQa5d on Viewer {
+  artistsConnection(letter: $letter, first: $first, after: $after) {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    pageCursors {
+      ...Pagination_pageCursors
+    }
+    artists: edges {
+      artist: node {
+        internalID
+        name
+        href
+        id
+      }
+    }
+  }
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "letter",
+    "type": "String!"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "first",
+    "type": "Int"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "after",
+    "type": "String"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "after"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  },
+  {
+    "kind": "Variable",
+    "name": "letter",
+    "variableName": "letter"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "page",
+  "storageKey": null
+},
+v4 = [
+  (v2/*: any*/),
+  (v3/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "isCurrent",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtistsByLetter_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": (v1/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "ArtistsByLetter_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ArtistsByLetter_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v1/*: any*/),
+            "concreteType": "ArtistConnection",
+            "kind": "LinkedField",
+            "name": "artistsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageCursors",
+                "kind": "LinkedField",
+                "name": "pageCursors",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "around",
+                    "plural": true,
+                    "selections": (v4/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "first",
+                    "plural": false,
+                    "selections": (v4/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "last",
+                    "plural": false,
+                    "selections": (v4/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "previous",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": "artists",
+                "args": null,
+                "concreteType": "ArtistEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": "artist",
+                    "args": null,
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "ArtistsByLetter_Test_Query",
+    "operationKind": "query",
+    "text": "query ArtistsByLetter_Test_Query(\n  $letter: String!\n  $first: Int\n  $after: String\n) {\n  viewer {\n    ...ArtistsByLetter_viewer_1QQa5d\n  }\n}\n\nfragment ArtistsByLetter_viewer_1QQa5d on Viewer {\n  artistsConnection(letter: $letter, first: $first, after: $after) {\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    artists: edges {\n      artist: node {\n        internalID\n        name\n        href\n        id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '5f1520529918010a553111e2a42491d1';
+export default node;

--- a/src/v2/__generated__/ArtistsByLetter_viewer.graphql.ts
+++ b/src/v2/__generated__/ArtistsByLetter_viewer.graphql.ts
@@ -1,0 +1,173 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistsByLetter_viewer = {
+    readonly artistsConnection: {
+        readonly pageInfo: {
+            readonly endCursor: string | null;
+            readonly hasNextPage: boolean;
+        };
+        readonly pageCursors: {
+            readonly " $fragmentRefs": FragmentRefs<"Pagination_pageCursors">;
+        };
+        readonly artists: ReadonlyArray<{
+            readonly artist: {
+                readonly internalID: string;
+                readonly name: string | null;
+                readonly href: string | null;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "ArtistsByLetter_viewer";
+};
+export type ArtistsByLetter_viewer$data = ArtistsByLetter_viewer;
+export type ArtistsByLetter_viewer$key = {
+    readonly " $data"?: ArtistsByLetter_viewer$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistsByLetter_viewer">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [
+    {
+      "defaultValue": "a",
+      "kind": "LocalArgument",
+      "name": "letter",
+      "type": "String"
+    },
+    {
+      "defaultValue": 100,
+      "kind": "LocalArgument",
+      "name": "first",
+      "type": "Int"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "after",
+      "type": "String"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ArtistsByLetter_viewer",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "after",
+          "variableName": "after"
+        },
+        {
+          "kind": "Variable",
+          "name": "first",
+          "variableName": "first"
+        },
+        {
+          "kind": "Variable",
+          "name": "letter",
+          "variableName": "letter"
+        }
+      ],
+      "concreteType": "ArtistConnection",
+      "kind": "LinkedField",
+      "name": "artistsConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageCursors",
+          "kind": "LinkedField",
+          "name": "pageCursors",
+          "plural": false,
+          "selections": [
+            {
+              "args": null,
+              "kind": "FragmentSpread",
+              "name": "Pagination_pageCursors"
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": "artists",
+          "args": null,
+          "concreteType": "ArtistEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": "artist",
+              "args": null,
+              "concreteType": "Artist",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "href",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Viewer"
+};
+(node as any).hash = 'e724dc24a08c071997a89d5305202c36';
+export default node;

--- a/src/v2/__generated__/ArtistsCarouselCell_featuredLink.graphql.ts
+++ b/src/v2/__generated__/ArtistsCarouselCell_featuredLink.graphql.ts
@@ -1,0 +1,133 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistsCarouselCell_featuredLink = {
+    readonly internalID: string | null;
+    readonly title: string | null;
+    readonly subtitle: string | null;
+    readonly href: string | null;
+    readonly image: {
+        readonly thumb: {
+            readonly width: number;
+            readonly height: number;
+            readonly src: string;
+            readonly srcSet: string;
+        } | null;
+    } | null;
+    readonly " $refType": "ArtistsCarouselCell_featuredLink";
+};
+export type ArtistsCarouselCell_featuredLink$data = ArtistsCarouselCell_featuredLink;
+export type ArtistsCarouselCell_featuredLink$key = {
+    readonly " $data"?: ArtistsCarouselCell_featuredLink$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistsCarouselCell_featuredLink">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ArtistsCarouselCell_featuredLink",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "subtitle",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "href",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "image",
+      "plural": false,
+      "selections": [
+        {
+          "alias": "thumb",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 410
+            },
+            {
+              "kind": "Literal",
+              "name": "version",
+              "value": "wide"
+            },
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 546
+            }
+          ],
+          "concreteType": "CroppedImageUrl",
+          "kind": "LinkedField",
+          "name": "cropped",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "width",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "height",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "src",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "srcSet",
+              "storageKey": null
+            }
+          ],
+          "storageKey": "cropped(height:410,version:\"wide\",width:546)"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "FeaturedLink"
+};
+(node as any).hash = 'c899b9cc04b64439f4690caa7b9eb2ec';
+export default node;

--- a/src/v2/__generated__/ArtistsIndexFragmentContainer_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ArtistsIndexFragmentContainer_Test_Query.graphql.ts
@@ -1,0 +1,524 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistsIndexFragmentContainer_Test_QueryVariables = {};
+export type ArtistsIndexFragmentContainer_Test_QueryResponse = {
+    readonly featuredArtists: ReadonlyArray<{
+        readonly " $fragmentRefs": FragmentRefs<"ArtistsIndex_featuredArtists">;
+    } | null> | null;
+    readonly featuredGenes: ReadonlyArray<{
+        readonly " $fragmentRefs": FragmentRefs<"ArtistsIndex_featuredGenes">;
+    } | null> | null;
+};
+export type ArtistsIndexFragmentContainer_Test_Query = {
+    readonly response: ArtistsIndexFragmentContainer_Test_QueryResponse;
+    readonly variables: ArtistsIndexFragmentContainer_Test_QueryVariables;
+};
+
+
+
+/*
+query ArtistsIndexFragmentContainer_Test_Query {
+  featuredArtists: orderedSets(key: "homepage:featured-artists") {
+    ...ArtistsIndex_featuredArtists
+    id
+  }
+  featuredGenes: orderedSets(key: "artists:featured-genes") {
+    ...ArtistsIndex_featuredGenes
+    id
+  }
+}
+
+fragment ArtistsArtistCard_artist on Artist {
+  ...FollowArtistButton_artist
+  name
+  href
+  formattedNationalityAndBirthday
+  counts {
+    artworks
+    forSaleArtworks
+  }
+  image {
+    thumb: cropped(width: 270, height: 200) {
+      width
+      height
+      src
+      srcSet
+    }
+  }
+}
+
+fragment ArtistsCarouselCell_featuredLink on FeaturedLink {
+  internalID
+  title
+  subtitle
+  href
+  image {
+    thumb: cropped(width: 546, height: 410, version: "wide") {
+      width
+      height
+      src
+      srcSet
+    }
+  }
+}
+
+fragment ArtistsIndex_featuredArtists on OrderedSet {
+  name
+  artists: items {
+    __typename
+    ... on FeaturedLink {
+      internalID
+      id
+    }
+    ...ArtistsCarouselCell_featuredLink
+    ... on Node {
+      id
+    }
+  }
+}
+
+fragment ArtistsIndex_featuredGenes on OrderedSet {
+  name
+  genes: items {
+    __typename
+    ... on Gene {
+      internalID
+      name
+      href
+      image {
+        thumb: cropped(width: 80, height: 80) {
+          width
+          height
+          src
+          srcSet
+        }
+      }
+      trendingArtists(sample: 4) {
+        internalID
+        ...ArtistsArtistCard_artist
+        id
+      }
+    }
+    ... on Node {
+      id
+    }
+    ... on FeaturedLink {
+      id
+    }
+  }
+}
+
+fragment FollowArtistButton_artist on Artist {
+  id
+  internalID
+  name
+  slug
+  is_followed: isFollowed
+  counts {
+    follows
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "key",
+    "value": "homepage:featured-artists"
+  }
+],
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "key",
+    "value": "artists:featured-genes"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v7 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "width",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "height",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "src",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtistsIndexFragmentContainer_Test_Query",
+    "selections": [
+      {
+        "alias": "featuredArtists",
+        "args": (v0/*: any*/),
+        "concreteType": "OrderedSet",
+        "kind": "LinkedField",
+        "name": "orderedSets",
+        "plural": true,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtistsIndex_featuredArtists"
+          }
+        ],
+        "storageKey": "orderedSets(key:\"homepage:featured-artists\")"
+      },
+      {
+        "alias": "featuredGenes",
+        "args": (v1/*: any*/),
+        "concreteType": "OrderedSet",
+        "kind": "LinkedField",
+        "name": "orderedSets",
+        "plural": true,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtistsIndex_featuredGenes"
+          }
+        ],
+        "storageKey": "orderedSets(key:\"artists:featured-genes\")"
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ArtistsIndexFragmentContainer_Test_Query",
+    "selections": [
+      {
+        "alias": "featuredArtists",
+        "args": (v0/*: any*/),
+        "concreteType": "OrderedSet",
+        "kind": "LinkedField",
+        "name": "orderedSets",
+        "plural": true,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": "artists",
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "items",
+            "plural": true,
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  (v5/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "title",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "subtitle",
+                    "storageKey": null
+                  },
+                  (v6/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": "thumb",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "height",
+                            "value": 410
+                          },
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": "wide"
+                          },
+                          {
+                            "kind": "Literal",
+                            "name": "width",
+                            "value": 546
+                          }
+                        ],
+                        "concreteType": "CroppedImageUrl",
+                        "kind": "LinkedField",
+                        "name": "cropped",
+                        "plural": false,
+                        "selections": (v7/*: any*/),
+                        "storageKey": "cropped(height:410,version:\"wide\",width:546)"
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "FeaturedLink"
+              }
+            ],
+            "storageKey": null
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": "orderedSets(key:\"homepage:featured-artists\")"
+      },
+      {
+        "alias": "featuredGenes",
+        "args": (v1/*: any*/),
+        "concreteType": "OrderedSet",
+        "kind": "LinkedField",
+        "name": "orderedSets",
+        "plural": true,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": "genes",
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "items",
+            "plural": true,
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  (v5/*: any*/),
+                  (v2/*: any*/),
+                  (v6/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": "thumb",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "height",
+                            "value": 80
+                          },
+                          {
+                            "kind": "Literal",
+                            "name": "width",
+                            "value": 80
+                          }
+                        ],
+                        "concreteType": "CroppedImageUrl",
+                        "kind": "LinkedField",
+                        "name": "cropped",
+                        "plural": false,
+                        "selections": (v7/*: any*/),
+                        "storageKey": "cropped(height:80,width:80)"
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "sample",
+                        "value": 4
+                      }
+                    ],
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "trendingArtists",
+                    "plural": true,
+                    "selections": [
+                      (v5/*: any*/),
+                      (v4/*: any*/),
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_followed",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isFollowed",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtistCounts",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "follows",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "artworks",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "forSaleArtworks",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v6/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "formattedNationalityAndBirthday",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "thumb",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 200
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 270
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "cropped",
+                            "plural": false,
+                            "selections": (v7/*: any*/),
+                            "storageKey": "cropped(height:200,width:270)"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "trendingArtists(sample:4)"
+                  }
+                ],
+                "type": "Gene"
+              }
+            ],
+            "storageKey": null
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": "orderedSets(key:\"artists:featured-genes\")"
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "ArtistsIndexFragmentContainer_Test_Query",
+    "operationKind": "query",
+    "text": "query ArtistsIndexFragmentContainer_Test_Query {\n  featuredArtists: orderedSets(key: \"homepage:featured-artists\") {\n    ...ArtistsIndex_featuredArtists\n    id\n  }\n  featuredGenes: orderedSets(key: \"artists:featured-genes\") {\n    ...ArtistsIndex_featuredGenes\n    id\n  }\n}\n\nfragment ArtistsArtistCard_artist on Artist {\n  ...FollowArtistButton_artist\n  name\n  href\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  image {\n    thumb: cropped(width: 270, height: 200) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistsCarouselCell_featuredLink on FeaturedLink {\n  internalID\n  title\n  subtitle\n  href\n  image {\n    thumb: cropped(width: 546, height: 410, version: \"wide\") {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistsIndex_featuredArtists on OrderedSet {\n  name\n  artists: items {\n    __typename\n    ... on FeaturedLink {\n      internalID\n      id\n    }\n    ...ArtistsCarouselCell_featuredLink\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ArtistsIndex_featuredGenes on OrderedSet {\n  name\n  genes: items {\n    __typename\n    ... on Gene {\n      internalID\n      name\n      href\n      image {\n        thumb: cropped(width: 80, height: 80) {\n          width\n          height\n          src\n          srcSet\n        }\n      }\n      trendingArtists(sample: 4) {\n        internalID\n        ...ArtistsArtistCard_artist\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FeaturedLink {\n      id\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'c1eac90162d5a05fcf55a9199c545bc9';
+export default node;

--- a/src/v2/__generated__/ArtistsIndex_featuredArtists.graphql.ts
+++ b/src/v2/__generated__/ArtistsIndex_featuredArtists.graphql.ts
@@ -1,0 +1,70 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistsIndex_featuredArtists = ReadonlyArray<{
+    readonly name: string | null;
+    readonly artists: ReadonlyArray<{
+        readonly internalID?: string | null;
+        readonly " $fragmentRefs": FragmentRefs<"ArtistsCarouselCell_featuredLink">;
+    } | null> | null;
+    readonly " $refType": "ArtistsIndex_featuredArtists";
+}>;
+export type ArtistsIndex_featuredArtists$data = ArtistsIndex_featuredArtists;
+export type ArtistsIndex_featuredArtists$key = ReadonlyArray<{
+    readonly " $data"?: ArtistsIndex_featuredArtists$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistsIndex_featuredArtists">;
+}>;
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "ArtistsIndex_featuredArtists",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": "artists",
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "items",
+      "plural": true,
+      "selections": [
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "internalID",
+              "storageKey": null
+            }
+          ],
+          "type": "FeaturedLink"
+        },
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "ArtistsCarouselCell_featuredLink"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "OrderedSet"
+};
+(node as any).hash = 'ba28d063a2c65078e8213f2391fc2cd2';
+export default node;

--- a/src/v2/__generated__/ArtistsIndex_featuredGenes.graphql.ts
+++ b/src/v2/__generated__/ArtistsIndex_featuredGenes.graphql.ts
@@ -1,0 +1,174 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistsIndex_featuredGenes = ReadonlyArray<{
+    readonly name: string | null;
+    readonly genes: ReadonlyArray<{
+        readonly internalID?: string;
+        readonly name?: string | null;
+        readonly href?: string | null;
+        readonly image?: {
+            readonly thumb: {
+                readonly width: number;
+                readonly height: number;
+                readonly src: string;
+                readonly srcSet: string;
+            } | null;
+        } | null;
+        readonly trendingArtists?: ReadonlyArray<{
+            readonly internalID: string;
+            readonly " $fragmentRefs": FragmentRefs<"ArtistsArtistCard_artist">;
+        } | null> | null;
+    } | null> | null;
+    readonly " $refType": "ArtistsIndex_featuredGenes";
+}>;
+export type ArtistsIndex_featuredGenes$data = ArtistsIndex_featuredGenes;
+export type ArtistsIndex_featuredGenes$key = ReadonlyArray<{
+    readonly " $data"?: ArtistsIndex_featuredGenes$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistsIndex_featuredGenes">;
+}>;
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "ArtistsIndex_featuredGenes",
+  "selections": [
+    (v0/*: any*/),
+    {
+      "alias": "genes",
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "items",
+      "plural": true,
+      "selections": [
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            (v1/*: any*/),
+            (v0/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "href",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Image",
+              "kind": "LinkedField",
+              "name": "image",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": "thumb",
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "height",
+                      "value": 80
+                    },
+                    {
+                      "kind": "Literal",
+                      "name": "width",
+                      "value": 80
+                    }
+                  ],
+                  "concreteType": "CroppedImageUrl",
+                  "kind": "LinkedField",
+                  "name": "cropped",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "width",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "height",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "src",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "srcSet",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": "cropped(height:80,width:80)"
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "sample",
+                  "value": 4
+                }
+              ],
+              "concreteType": "Artist",
+              "kind": "LinkedField",
+              "name": "trendingArtists",
+              "plural": true,
+              "selections": [
+                (v1/*: any*/),
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "ArtistsArtistCard_artist"
+                }
+              ],
+              "storageKey": "trendingArtists(sample:4)"
+            }
+          ],
+          "type": "Gene"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "OrderedSet"
+};
+})();
+(node as any).hash = '412d57c2dda16f6c10773671737b1715';
+export default node;

--- a/src/v2/__generated__/FollowArtistButtonQuery.graphql.ts
+++ b/src/v2/__generated__/FollowArtistButtonQuery.graphql.ts
@@ -1,0 +1,167 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type FollowArtistButtonQueryVariables = {
+    id: string;
+};
+export type FollowArtistButtonQueryResponse = {
+    readonly artist: {
+        readonly " $fragmentRefs": FragmentRefs<"FollowArtistButton_artist">;
+    } | null;
+};
+export type FollowArtistButtonQuery = {
+    readonly response: FollowArtistButtonQueryResponse;
+    readonly variables: FollowArtistButtonQueryVariables;
+};
+
+
+
+/*
+query FollowArtistButtonQuery(
+  $id: String!
+) {
+  artist(id: $id) {
+    ...FollowArtistButton_artist
+    id
+  }
+}
+
+fragment FollowArtistButton_artist on Artist {
+  id
+  internalID
+  name
+  slug
+  is_followed: isFollowed
+  counts {
+    follows
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id",
+    "type": "String!"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "FollowArtistButtonQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "FollowArtistButton_artist"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "FollowArtistButtonQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": "is_followed",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isFollowed",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistCounts",
+            "kind": "LinkedField",
+            "name": "counts",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "follows",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "FollowArtistButtonQuery",
+    "operationKind": "query",
+    "text": "query FollowArtistButtonQuery(\n  $id: String!\n) {\n  artist(id: $id) {\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'ee43e11ac6bdf463ccdb4945e8bb663f';
+export default node;

--- a/src/v2/__generated__/artistsRoutes_ArtistsByLetterQuery.graphql.ts
+++ b/src/v2/__generated__/artistsRoutes_ArtistsByLetterQuery.graphql.ts
@@ -1,0 +1,335 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type artistsRoutes_ArtistsByLetterQueryVariables = {
+    letter: string;
+    first?: number | null;
+    after?: string | null;
+};
+export type artistsRoutes_ArtistsByLetterQueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtistsByLetter_viewer">;
+    } | null;
+};
+export type artistsRoutes_ArtistsByLetterQuery = {
+    readonly response: artistsRoutes_ArtistsByLetterQueryResponse;
+    readonly variables: artistsRoutes_ArtistsByLetterQueryVariables;
+};
+
+
+
+/*
+query artistsRoutes_ArtistsByLetterQuery(
+  $letter: String!
+  $first: Int
+  $after: String
+) {
+  viewer {
+    ...ArtistsByLetter_viewer_1QQa5d
+  }
+}
+
+fragment ArtistsByLetter_viewer_1QQa5d on Viewer {
+  artistsConnection(letter: $letter, first: $first, after: $after) {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    pageCursors {
+      ...Pagination_pageCursors
+    }
+    artists: edges {
+      artist: node {
+        internalID
+        name
+        href
+        id
+      }
+    }
+  }
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "letter",
+    "type": "String!"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "first",
+    "type": "Int"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "after",
+    "type": "String"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "after"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  },
+  {
+    "kind": "Variable",
+    "name": "letter",
+    "variableName": "letter"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "page",
+  "storageKey": null
+},
+v4 = [
+  (v2/*: any*/),
+  (v3/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "isCurrent",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "artistsRoutes_ArtistsByLetterQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": (v1/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "ArtistsByLetter_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "artistsRoutes_ArtistsByLetterQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v1/*: any*/),
+            "concreteType": "ArtistConnection",
+            "kind": "LinkedField",
+            "name": "artistsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageCursors",
+                "kind": "LinkedField",
+                "name": "pageCursors",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "around",
+                    "plural": true,
+                    "selections": (v4/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "first",
+                    "plural": false,
+                    "selections": (v4/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "last",
+                    "plural": false,
+                    "selections": (v4/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "previous",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": "artists",
+                "args": null,
+                "concreteType": "ArtistEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": "artist",
+                    "args": null,
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "artistsRoutes_ArtistsByLetterQuery",
+    "operationKind": "query",
+    "text": "query artistsRoutes_ArtistsByLetterQuery(\n  $letter: String!\n  $first: Int\n  $after: String\n) {\n  viewer {\n    ...ArtistsByLetter_viewer_1QQa5d\n  }\n}\n\nfragment ArtistsByLetter_viewer_1QQa5d on Viewer {\n  artistsConnection(letter: $letter, first: $first, after: $after) {\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    artists: edges {\n      artist: node {\n        internalID\n        name\n        href\n        id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'a49e41c56ee4b6760e6cdb78e8642262';
+export default node;

--- a/src/v2/__generated__/artistsRoutes_ArtistsQuery.graphql.ts
+++ b/src/v2/__generated__/artistsRoutes_ArtistsQuery.graphql.ts
@@ -1,0 +1,524 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type artistsRoutes_ArtistsQueryVariables = {};
+export type artistsRoutes_ArtistsQueryResponse = {
+    readonly featuredArtists: ReadonlyArray<{
+        readonly " $fragmentRefs": FragmentRefs<"ArtistsIndex_featuredArtists">;
+    } | null> | null;
+    readonly featuredGenes: ReadonlyArray<{
+        readonly " $fragmentRefs": FragmentRefs<"ArtistsIndex_featuredGenes">;
+    } | null> | null;
+};
+export type artistsRoutes_ArtistsQuery = {
+    readonly response: artistsRoutes_ArtistsQueryResponse;
+    readonly variables: artistsRoutes_ArtistsQueryVariables;
+};
+
+
+
+/*
+query artistsRoutes_ArtistsQuery {
+  featuredArtists: orderedSets(key: "homepage:featured-artists") {
+    ...ArtistsIndex_featuredArtists
+    id
+  }
+  featuredGenes: orderedSets(key: "artists:featured-genes") {
+    ...ArtistsIndex_featuredGenes
+    id
+  }
+}
+
+fragment ArtistsArtistCard_artist on Artist {
+  ...FollowArtistButton_artist
+  name
+  href
+  formattedNationalityAndBirthday
+  counts {
+    artworks
+    forSaleArtworks
+  }
+  image {
+    thumb: cropped(width: 270, height: 200) {
+      width
+      height
+      src
+      srcSet
+    }
+  }
+}
+
+fragment ArtistsCarouselCell_featuredLink on FeaturedLink {
+  internalID
+  title
+  subtitle
+  href
+  image {
+    thumb: cropped(width: 546, height: 410, version: "wide") {
+      width
+      height
+      src
+      srcSet
+    }
+  }
+}
+
+fragment ArtistsIndex_featuredArtists on OrderedSet {
+  name
+  artists: items {
+    __typename
+    ... on FeaturedLink {
+      internalID
+      id
+    }
+    ...ArtistsCarouselCell_featuredLink
+    ... on Node {
+      id
+    }
+  }
+}
+
+fragment ArtistsIndex_featuredGenes on OrderedSet {
+  name
+  genes: items {
+    __typename
+    ... on Gene {
+      internalID
+      name
+      href
+      image {
+        thumb: cropped(width: 80, height: 80) {
+          width
+          height
+          src
+          srcSet
+        }
+      }
+      trendingArtists(sample: 4) {
+        internalID
+        ...ArtistsArtistCard_artist
+        id
+      }
+    }
+    ... on Node {
+      id
+    }
+    ... on FeaturedLink {
+      id
+    }
+  }
+}
+
+fragment FollowArtistButton_artist on Artist {
+  id
+  internalID
+  name
+  slug
+  is_followed: isFollowed
+  counts {
+    follows
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "key",
+    "value": "homepage:featured-artists"
+  }
+],
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "key",
+    "value": "artists:featured-genes"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v7 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "width",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "height",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "src",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "artistsRoutes_ArtistsQuery",
+    "selections": [
+      {
+        "alias": "featuredArtists",
+        "args": (v0/*: any*/),
+        "concreteType": "OrderedSet",
+        "kind": "LinkedField",
+        "name": "orderedSets",
+        "plural": true,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtistsIndex_featuredArtists"
+          }
+        ],
+        "storageKey": "orderedSets(key:\"homepage:featured-artists\")"
+      },
+      {
+        "alias": "featuredGenes",
+        "args": (v1/*: any*/),
+        "concreteType": "OrderedSet",
+        "kind": "LinkedField",
+        "name": "orderedSets",
+        "plural": true,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtistsIndex_featuredGenes"
+          }
+        ],
+        "storageKey": "orderedSets(key:\"artists:featured-genes\")"
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "artistsRoutes_ArtistsQuery",
+    "selections": [
+      {
+        "alias": "featuredArtists",
+        "args": (v0/*: any*/),
+        "concreteType": "OrderedSet",
+        "kind": "LinkedField",
+        "name": "orderedSets",
+        "plural": true,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": "artists",
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "items",
+            "plural": true,
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  (v5/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "title",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "subtitle",
+                    "storageKey": null
+                  },
+                  (v6/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": "thumb",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "height",
+                            "value": 410
+                          },
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": "wide"
+                          },
+                          {
+                            "kind": "Literal",
+                            "name": "width",
+                            "value": 546
+                          }
+                        ],
+                        "concreteType": "CroppedImageUrl",
+                        "kind": "LinkedField",
+                        "name": "cropped",
+                        "plural": false,
+                        "selections": (v7/*: any*/),
+                        "storageKey": "cropped(height:410,version:\"wide\",width:546)"
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "FeaturedLink"
+              }
+            ],
+            "storageKey": null
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": "orderedSets(key:\"homepage:featured-artists\")"
+      },
+      {
+        "alias": "featuredGenes",
+        "args": (v1/*: any*/),
+        "concreteType": "OrderedSet",
+        "kind": "LinkedField",
+        "name": "orderedSets",
+        "plural": true,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": "genes",
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "items",
+            "plural": true,
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  (v5/*: any*/),
+                  (v2/*: any*/),
+                  (v6/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": "thumb",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "height",
+                            "value": 80
+                          },
+                          {
+                            "kind": "Literal",
+                            "name": "width",
+                            "value": 80
+                          }
+                        ],
+                        "concreteType": "CroppedImageUrl",
+                        "kind": "LinkedField",
+                        "name": "cropped",
+                        "plural": false,
+                        "selections": (v7/*: any*/),
+                        "storageKey": "cropped(height:80,width:80)"
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "sample",
+                        "value": 4
+                      }
+                    ],
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "trendingArtists",
+                    "plural": true,
+                    "selections": [
+                      (v5/*: any*/),
+                      (v4/*: any*/),
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_followed",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isFollowed",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtistCounts",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "follows",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "artworks",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "forSaleArtworks",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v6/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "formattedNationalityAndBirthday",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "thumb",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 200
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 270
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "cropped",
+                            "plural": false,
+                            "selections": (v7/*: any*/),
+                            "storageKey": "cropped(height:200,width:270)"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "trendingArtists(sample:4)"
+                  }
+                ],
+                "type": "Gene"
+              }
+            ],
+            "storageKey": null
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": "orderedSets(key:\"artists:featured-genes\")"
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "artistsRoutes_ArtistsQuery",
+    "operationKind": "query",
+    "text": "query artistsRoutes_ArtistsQuery {\n  featuredArtists: orderedSets(key: \"homepage:featured-artists\") {\n    ...ArtistsIndex_featuredArtists\n    id\n  }\n  featuredGenes: orderedSets(key: \"artists:featured-genes\") {\n    ...ArtistsIndex_featuredGenes\n    id\n  }\n}\n\nfragment ArtistsArtistCard_artist on Artist {\n  ...FollowArtistButton_artist\n  name\n  href\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  image {\n    thumb: cropped(width: 270, height: 200) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistsCarouselCell_featuredLink on FeaturedLink {\n  internalID\n  title\n  subtitle\n  href\n  image {\n    thumb: cropped(width: 546, height: 410, version: \"wide\") {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistsIndex_featuredArtists on OrderedSet {\n  name\n  artists: items {\n    __typename\n    ... on FeaturedLink {\n      internalID\n      id\n    }\n    ...ArtistsCarouselCell_featuredLink\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment ArtistsIndex_featuredGenes on OrderedSet {\n  name\n  genes: items {\n    __typename\n    ... on Gene {\n      internalID\n      name\n      href\n      image {\n        thumb: cropped(width: 80, height: 80) {\n          width\n          height\n          src\n          srcSet\n        }\n      }\n      trendingArtists(sample: 4) {\n        internalID\n        ...ArtistsArtistCard_artist\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n    ... on FeaturedLink {\n      id\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'e995ed1e0e3f670fa678146e605d76f8';
+export default node;


### PR DESCRIPTION
Closes: [FX-2513](https://artsyproduct.atlassian.net/browse/FX-2513)

This exposes the new artists index under the `/artists2` and `/artists2/artists-starting-with-:letter` routes. Once we have [pagination with real hrefs](https://artsyproduct.atlassian.net/browse/GRO-7) we'll be able to launch this under the proper path.

<del>Will move this off draft when https://github.com/artsy/metaphysics/pull/2842 is in production.</del>

### Desktop

![](http://static.damonzucconi.com/_capture/uvXtFAZg74CY.png)

![](http://static.damonzucconi.com/_capture/CvkBTcMrsCFK.png)

### Mobile

![](http://static.damonzucconi.com/_capture/vbrQJcET8GEM.png)

![](http://static.damonzucconi.com/_capture/QBScLvOjAipx.png)