### PR TITLE
fix: [Novo] Remove clone deep on routes

### DIFF
--- a/src/v2/Apps/getAppNovoRoutes.tsx
+++ b/src/v2/Apps/getAppNovoRoutes.tsx
@@ -2,21 +2,24 @@ import { buildAppRoutes } from "v2/Artsy/Router/buildAppRoutes"
 import { RouteConfig } from "found"
 import { routes as artistRoutes } from "v2/Apps/Artist/routes"
 import { debugRoutes } from "./Debug/debugRoutes"
-import { cloneDeep } from "lodash"
 
 export function getAppNovoRoutes(): RouteConfig[] {
   return buildAppRoutes([
     {
-      routes: cloneDeep(artistRoutes).map(route => {
-        route.path = `/novo${route.path}`
-        return route
+      routes: artistRoutes.map(route => {
+        return {
+          ...route,
+          path: `/novo${route.path}`,
+        }
       }),
     },
     // For debugging baseline app shell stuff
     {
-      routes: cloneDeep(debugRoutes).map(route => {
-        route.path = `/novo${route.path}`
-        return route
+      routes: debugRoutes.map(route => {
+        return {
+          ...route,
+          path: `/novo${route.path}`,
+        }
       }),
     },
   ])


### PR DESCRIPTION
No need to use cloneDeep, which will clone the whole tree, when we just need to assign a new path one level deep and shallowly copy other props. 