### PR TITLE
chore: Fix prettier formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
-  "editor.rulers": [
-    80
-  ],
+  "editor.rulers": [80],
   "editor.tabSize": 2,
   "javascript.validate.enable": true,
   "search.exclude": {
@@ -28,6 +26,7 @@
     "**/*.snap",
     "**/*.story.tsx"
   ],
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true,


### PR DESCRIPTION
Follows recent change in MP: https://github.com/artsy/metaphysics/pull/2847

VSCode made a change recently where installing prettier-vscode isn't enough, one has to also set the formatter. This has caused a lot of confusion recently with @mzikherman, [see here](https://artsy.slack.com/archives/CP9P4KR35/p1606174797182000) for example, and @williardx got snagged by this too, as well as myself, which took a long time to track down. (This only recently started happening with newish vscode update.)

For those who would like to **not** autoformat their code while developing (which is rare) and instead rely on githooks when committing this can be locally disabled by updating `user` and `workspace`. cc/ @icirellik:
 
<img width="621" alt="Screen Shot 2020-12-04 at 11 38 04 AM" src="https://user-images.githubusercontent.com/236943/101207263-3a049200-3625-11eb-9992-e90cd884c2cd.png">
