### PR TITLE
feat: [Collect] Add collections link to header

### DIFF
--- a/src/v2/Apps/Collect/Routes/Collect/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collect/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Separator, Spacer, Text } from "@artsy/palette"
+import { Box, Separator, Spacer, Text, Flex } from "@artsy/palette"
 import { Match, Router } from "found"
 import React from "react"
 import { Link, Meta, Title } from "react-head"
@@ -18,6 +18,7 @@ import { Collect_marketingHubCollections } from "v2/__generated__/Collect_market
 import { collectRoutes_ArtworkFilterQueryResponse } from "v2/__generated__/collectRoutes_ArtworkFilterQuery.graphql"
 import { CollectionsHubsNavFragmentContainer as CollectionsHubsNav } from "v2/Components/CollectionsHubsNav"
 import { ArtworkFilter } from "v2/Components/v2/ArtworkFilter"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
 
 export interface CollectAppProps {
   match: Match
@@ -67,9 +68,18 @@ export const CollectApp: React.FC<CollectAppProps> = ({
         {filterArtworks && <SeoProductsForArtworks artworks={filterArtworks} />}
 
         <Box mt={3}>
-          <Text variant="largeTitle">
-            <h1>Collect art and design online</h1>
-          </Text>
+          <Flex
+            justifyContent="space-between"
+            alignItems={["left", "center"]}
+            flexDirection={["column", "row"]}
+          >
+            <Text variant="largeTitle">
+              <h1>Collect art and design online</h1>
+            </Text>
+            <Text variant="mediumText">
+              <RouterLink to="/collections">Browse by collection</RouterLink>
+            </Text>
+          </Flex>
           <Separator mt={2} mb={[2, 2, 2, 4]} />
 
           <CollectionsHubsNav

--- a/src/v2/Apps/Collect/Routes/Collections/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collections/index.tsx
@@ -4,13 +4,14 @@ import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { withSystemContext } from "v2/Artsy"
 import { FrameWithRecentlyViewed } from "v2/Components/FrameWithRecentlyViewed"
 import { BreadCrumbList } from "v2/Components/Seo"
-import { Link, Router } from "found"
+import { Router } from "found"
 import React, { Component, useState } from "react"
 import { Meta, Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { TrackingProp } from "react-tracking"
 import { data as sd } from "sharify"
 import { CollectionEntity, CollectionsGrid } from "./Components/CollectionsGrid"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
 
 interface CollectionsAppProps {
   marketingCategories: Collections_marketingCategories
@@ -45,15 +46,16 @@ export class CollectionsApp extends Component<CollectionsAppProps> {
               mt={3}
               mb={4}
               justifyContent="space-between"
-              alignItems="flex-end"
+              alignItems={["left", "center"]}
+              flexDirection={["column", "row"]}
             >
               <Text variant="largeTitle" as="h1">
                 Collections
               </Text>
 
-              <Box pb={0.3}>
+              <Box>
                 <Text variant="mediumText">
-                  <Link to="/collect">View works</Link>
+                  <RouterLink to="/collect">View works</RouterLink>
                 </Text>
               </Box>
             </Flex>


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GRO-25

Re-adds the "View collections" link to `/collect` and makes consistent with associated link on `/collections` 

<img width="934" alt="Screen Shot 2020-12-04 at 1 51 40 PM" src="https://user-images.githubusercontent.com/236943/101218631-4514ed80-3638-11eb-9a29-df6c0fa4a89f.png">

<img width="415" alt="Screen Shot 2020-12-04 at 1 51 44 PM" src="https://user-images.githubusercontent.com/236943/101218634-480fde00-3638-11eb-8a89-18d878f44ac3.png">

cc @artsy/grow-devs 
