### PR TITLE
fix(fx-2527): handles 404 in routes

### DIFF
--- a/src/v2/Apps/Artists/Routes/ArtistsByLetter.tsx
+++ b/src/v2/Apps/Artists/Routes/ArtistsByLetter.tsx
@@ -8,8 +8,6 @@ import { PaginationFragmentContainer } from "v2/Components/Pagination"
 import { ArtistsTopNav } from "../Components/ArtistsTopNav"
 import { ArtistsByLetter_viewer } from "v2/__generated__/ArtistsByLetter_viewer.graphql"
 import { ArtistsByLetterMeta } from "../Components/ArtistsByLetterMeta"
-import { LETTERS } from "../Components/ArtistsLetterNav"
-import { HttpError } from "found"
 
 const Columns = styled(Box)<{ isLoading: boolean }>`
   column-count: 4;
@@ -41,11 +39,6 @@ export const ArtistsByLetter: React.FC<ArtistsByLetterProps> = ({
 }) => {
   const { match } = useRouter()
   const [isLoading, setLoading] = useState(false)
-
-  // If the `letter` param isn't part of the nav, 404
-  if (!LETTERS.includes(match.params.letter?.toUpperCase())) {
-    throw new HttpError(404)
-  }
 
   if (!viewer.artistsConnection?.artists) {
     return null

--- a/src/v2/Apps/Artists/artistsRoutes.tsx
+++ b/src/v2/Apps/Artists/artistsRoutes.tsx
@@ -45,7 +45,7 @@ export const artistsRoutes: RouteConfig[] = [
       },
 
       {
-        path: "artists-starting-with-:letter",
+        path: "artists-starting-with-:letter([a-zA-Z])",
         getComponent: () => ArtistsByLetterRoute,
         prepare: () => {
           return ArtistsByLetterRoute.preload()


### PR DESCRIPTION
Closes: [FX-2527](https://artsyproduct.atlassian.net/browse/FX-2527)

Makes more sense to handle the 404 in the routes regardless. Handling it in the component like this was causing match to be undefined in the component, which, to me seems like a bug in the `useRouter` hook; though that's going unexamined for now (or is possibly reflected in the typings but I don't notice because of the non-strict null checking).