### PR TITLE
Refactor consign pages to use artworksConnection and add realized / estimate price multiplier to /consign recently sold artworks

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -1196,17 +1196,6 @@ type ArtistTargetSupply {
 }
 
 type ArtistTargetSupplyMicrofunnel {
-  artworks(
-    # Randomize the order of artworks for display purposes.
-    randomize: Boolean
-
-    # Number of artworks to return
-    size: Int
-  ): [ArtistTargetSupplyMicrofunnelArtwork]
-    @deprecated(
-      reason: "Prefer to use `artworksConnection`. [Will be removed in v2]"
-    )
-
   # A list of recently sold artworks.
   artworksConnection(
     after: String
@@ -1218,11 +1207,6 @@ type ArtistTargetSupplyMicrofunnel {
     randomize: Boolean
   ): ArtworkConnection
   metadata: TargetSupplyMicrofunnelMetadata
-}
-
-type ArtistTargetSupplyMicrofunnelArtwork {
-  artwork: Artwork
-  realizedPrice: String
 }
 
 type Artwork implements Node & Searchable & Sellable {
@@ -1403,6 +1387,7 @@ type Artwork implements Node & Searchable & Sellable {
   # in the target supply microfunnel and (currently) queries against hardcoded
   # spreadsheet data.
   realizedPrice: String
+  realizedToEstimate: String
   related(size: Int): [Artwork]
   sale: Sale
   saleArtwork(saleID: String = null): SaleArtwork

--- a/src/v2/Apps/Artist/Components/ArtistCollectionsRail/index.tsx
+++ b/src/v2/Apps/Artist/Components/ArtistCollectionsRail/index.tsx
@@ -20,9 +20,9 @@ export const ArtistCollectionsRailContent: React.SFC<Props> = passedProps => {
       <QueryRenderer<ArtistCollectionsRailQuery>
         environment={relayEnvironment}
         variables={{
+          artistID: passedProps.artistID,
           isFeaturedArtistContent: true,
           size: 16,
-          artistID: passedProps.artistID,
         }}
         query={graphql`
           query ArtistCollectionsRailQuery(

--- a/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignHeader/ArtistConsignHeaderImages.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignHeader/ArtistConsignHeaderImages.tsx
@@ -5,20 +5,22 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 
-type Artworks = ArtistConsignHeaderImages_artist["targetSupply"]["microfunnel"]["artworks"]
+type Artworks = ArtistConsignHeaderImages_artist["targetSupply"]["microfunnel"]["artworksConnection"]["edges"]
 
 interface HeaderImageProps {
   artist: ArtistConsignHeaderImages_artist
 }
 
 export const ArtistConsignHeaderImages: React.FC<HeaderImageProps> = props => {
-  const { error, leftImage, rightImage } = getImages(
-    props.artist.targetSupply.microfunnel.artworks
-  )
+  const leftImage =
+    props.artist.targetSupply.microfunnel?.artworksConnection?.edges?.[0]?.node
+  const rightImage = last(
+    props.artist.targetSupply.microfunnel?.artworksConnection?.edges
+  )?.node
+  const error = !(leftImage && rightImage)
   if (error) {
     return null
   }
-
   return (
     <HeaderImageContainer>
       <Flex width="100%" justifyContent="space-between" m="auto">
@@ -40,16 +42,18 @@ export const ArtistConsignHeaderImagesFragmentContainer = createFragmentContaine
       fragment ArtistConsignHeaderImages_artist on Artist {
         targetSupply {
           microfunnel {
-            artworks {
-              artwork {
-                image {
-                  resized(height: 395) {
-                    width
-                    height
-                    url
+            artworksConnection {
+              edges {
+                node {
+                  image {
+                    resized(height: 395) {
+                      width
+                      height
+                      url
+                    }
                   }
+                  ...FillwidthItem_artwork
                 }
-                ...FillwidthItem_artwork
               }
             }
           }
@@ -58,32 +62,8 @@ export const ArtistConsignHeaderImagesFragmentContainer = createFragmentContaine
     `,
   }
 )
-
-export const getImages = (artworks: Artworks) => {
-  try {
-    const leftImage = last(artworks)
-    const rightImage = artworks[1]
-    const foundImages = leftImage && rightImage
-
-    if (!foundImages) {
-      return {
-        error: true,
-      }
-    }
-
-    return {
-      leftImage: leftImage.artwork,
-      rightImage: rightImage.artwork,
-    }
-  } catch {
-    return {
-      error: true,
-    }
-  }
-}
-
 interface ImageProps {
-  image: Artworks[0]["artwork"]["image"]
+  image: Artworks[0]["node"]["image"]
 }
 const LeftImagePhoto: React.FC<ImageProps> = ({ image }) => {
   return (

--- a/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignMeta.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignMeta.tsx
@@ -17,7 +17,7 @@ export const ArtistConsignMeta: React.FC<ArtistConsignMeta> = props => {
 
   const imageURL = get(
     targetSupply,
-    p => p.microfunnel.artworks[0].artwork.image.imageURL
+    p => p.microfunnel.artworksConnection.edges[0].node.image.imageURL
   )
 
   const appURL = getENV("APP_URL")
@@ -50,10 +50,12 @@ export const ArtistConsignMetaFragmentContainer = createFragmentContainer(
         href
         targetSupply {
           microfunnel {
-            artworks {
-              artwork {
-                image {
-                  imageURL: url(version: "medium")
+            artworksConnection {
+              edges {
+                node {
+                  image {
+                    imageURL: url(version: "medium")
+                  }
                 }
               }
             }

--- a/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignRecentlySold.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignRecentlySold.tsx
@@ -16,7 +16,7 @@ interface ArtistConsignRecentlySoldProps {
 export const ArtistConsignRecentlySold: React.FC<ArtistConsignRecentlySoldProps> = ({
   artist,
 }) => {
-  if (!artist.targetSupply.microfunnel.artworks) {
+  if (artist.targetSupply.microfunnel.artworksConnection.edges.length === 0) {
     return null
   }
 
@@ -29,8 +29,8 @@ export const ArtistConsignRecentlySold: React.FC<ArtistConsignRecentlySoldProps>
           <Spacer my={4} />
 
           <Flex justifyContent={["center", "center"]} flexWrap="wrap">
-            {artist.targetSupply.microfunnel.artworks.map(
-              ({ artwork, realizedPrice }, key) => {
+            {artist.targetSupply.microfunnel.artworksConnection.edges.map(
+              ({ node }, key) => {
                 return (
                   <Flex
                     p={2}
@@ -39,14 +39,14 @@ export const ArtistConsignRecentlySold: React.FC<ArtistConsignRecentlySoldProps>
                     style={{ textAlign: "left" }}
                   >
                     <FillwidthItem
-                      artwork={artwork}
+                      artwork={node}
                       imageHeight={150}
                       showExtended={false}
                       contextModule={ContextModule.artistRecentlySold}
                     />
-                    {realizedPrice && (
+                    {node.realizedPrice && (
                       <Sans size="2" weight="medium">
-                        Sold for {realizedPrice}
+                        Sold for {node.realizedPrice}
                       </Sans>
                     )}
                   </Flex>
@@ -67,15 +67,16 @@ export const ArtistConsignRecentlySoldFragmentContainer = createFragmentContaine
       fragment ArtistConsignRecentlySold_artist on Artist {
         targetSupply {
           microfunnel {
-            artworks {
-              artwork {
-                ...FillwidthItem_artwork
+            artworksConnection {
+              edges {
+                node {
+                  ...FillwidthItem_artwork
+                  realizedPrice
+                }
               }
-              realizedPrice
             }
           }
         }
-
         name
       }
     `,

--- a/src/v2/Apps/Artist/Routes/Consign/Components/__tests__/ArtistConsignMeta.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/__tests__/ArtistConsignMeta.jest.tsx
@@ -10,19 +10,21 @@ jest.mock("v2/Utils/getENV", () => ({
 describe("ArtistConsignMeta", () => {
   const props = {
     artist: {
-      name: "Alex Katz",
       href: "/artist/alex-katz",
+      name: "Alex Katz",
       targetSupply: {
         microfunnel: {
-          artworks: [
-            {
-              artwork: {
-                image: {
-                  imageURL: "path/to/image.jpg",
+          artworksConnection: {
+            edges: [
+              {
+                node: {
+                  image: {
+                    imageURL: "path/to/image.jpg",
+                  },
                 },
               },
-            },
-          ],
+            ],
+          },
         },
       },
     },
@@ -107,15 +109,17 @@ describe("ArtistConsignMeta", () => {
         artist: {
           targetSupply: {
             microfunnel: {
-              artworks: [
-                {
-                  artwork: {
-                    image: {
-                      imageURL: null,
+              artworksConnection: {
+                edges: [
+                  {
+                    node: {
+                      image: {
+                        imageURL: null,
+                      },
                     },
                   },
-                },
-              ],
+                ],
+              },
             },
           },
         },

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/SoldRecently.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/SoldRecently.tsx
@@ -67,23 +67,37 @@ const SoldRecently: React.FC<SoldRecentlyProps> = ({ targetSupply }) => {
                   <>
                     <Media greaterThanOrEqual="sm">
                       <Flex flexDirection="row" alignItems="baseline">
+                        <Text variant="largeTitle">
+                          {artwork.realizedPrice}
+                        </Text>
+                        <Spacer ml={0.5} />
                         <Text variant="caption" color="black60">
                           Realized price
                         </Text>
-                        <Spacer ml={0.5} />
-                        <Text variant="largeTitle">
-                          {artwork.realizedPrice}
+                      </Flex>
+                      <Flex flexDirection="row" alignItems="baseline">
+                        <Text
+                          variant="caption"
+                          fontWeight="bold"
+                          color="#00A03E"
+                        >
+                          2.22x
+                        </Text>
+                        <Spacer ml={0.3} />
+                        <Text variant="caption" color="black60">
+                          estimate
                         </Text>
                       </Flex>
                     </Media>
                     <Media lessThan="sm">
                       <Flex flexDirection="column">
-                        <Text variant="caption" color="black60">
-                          Realized price
-                        </Text>
                         <Text variant="largeTitle">
                           {artwork.realizedPrice}
                         </Text>
+                        <Text variant="caption" color="black60">
+                          Realized price
+                        </Text>
+                        <Text variant="text">2.22x</Text>
                       </Flex>
                     </Media>
                   </>

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/SoldRecently.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/SoldRecently.tsx
@@ -11,6 +11,7 @@ import { SectionContainer } from "./SectionContainer"
 import { Media } from "v2/Utils/Responsive"
 import { useTracking } from "react-tracking"
 import { ContextModule, OwnerType, clickedArtworkGroup } from "@artsy/cohesion"
+import { flatten, shuffle } from "lodash"
 
 const HEIGHT = 300
 
@@ -25,9 +26,16 @@ const SoldRecently: React.FC<SoldRecentlyProps> = ({ targetSupply }) => {
     return null
   }
 
-  const recentlySoldArtworks = targetSupply.microfunnel.map(microfunnel => {
-    return extractNodes(microfunnel.artworksConnection)
-  })
+  const recentlySoldArtworks = shuffle(
+    flatten(
+      targetSupply.microfunnel.map(microfunnel => {
+        const artworks = extractNodes(microfunnel.artworksConnection)
+        return artworks.filter(
+          artwork => artwork.realizedPrice && artwork.realizedToEstimate
+        )
+      })
+    )
+  )
 
   const trackArtworkItemClick = (artwork, horizontalSlidePosition) => () => {
     tracking.trackEvent(
@@ -48,7 +56,7 @@ const SoldRecently: React.FC<SoldRecentlyProps> = ({ targetSupply }) => {
       </Text>
       <Flex flexDirection="column">
         <Carousel arrowHeight={HEIGHT}>
-          {recentlySoldArtworks.map(([artwork, _], index) => {
+          {recentlySoldArtworks.map((artwork, index) => {
             return (
               <Flex
                 key={index}
@@ -63,45 +71,47 @@ const SoldRecently: React.FC<SoldRecentlyProps> = ({ targetSupply }) => {
                   showExtended={false}
                   onClick={trackArtworkItemClick(artwork, index)}
                 />
-                {artwork.realizedPrice && (
-                  <>
-                    <Media greaterThanOrEqual="sm">
-                      <Flex flexDirection="row" alignItems="baseline">
-                        <Text variant="largeTitle">
-                          {artwork.realizedPrice}
-                        </Text>
-                        <Spacer ml={0.5} />
-                        <Text variant="caption" color="black60">
-                          Realized price
-                        </Text>
-                      </Flex>
+                <>
+                  <Media greaterThanOrEqual="sm">
+                    <Flex flexDirection="row" alignItems="baseline">
+                      <Text variant="largeTitle">{artwork.realizedPrice}</Text>
+                      <Spacer ml={0.5} />
+                      <Text variant="caption" color="black60">
+                        Realized price
+                      </Text>
+                    </Flex>
+                    <Flex flexDirection="row" alignItems="baseline">
+                      <Text variant="caption" fontWeight="bold" color="#00A03E">
+                        {artwork.realizedToEstimate + "x"}
+                      </Text>
+                      <Spacer ml={0.3} />
+                      <Text variant="caption" color="black60">
+                        estimate
+                      </Text>
+                    </Flex>
+                  </Media>
+                  <Media lessThan="sm">
+                    <Flex flexDirection="column">
+                      <Text variant="caption" color="black60" mt={0.5}>
+                        Realized price
+                      </Text>
+                      <Text variant="largeTitle">{artwork.realizedPrice}</Text>
                       <Flex flexDirection="row" alignItems="baseline">
                         <Text
                           variant="caption"
                           fontWeight="bold"
                           color="#00A03E"
                         >
-                          2.22x
+                          {artwork.realizedToEstimate + "x"}
                         </Text>
                         <Spacer ml={0.3} />
                         <Text variant="caption" color="black60">
                           estimate
                         </Text>
                       </Flex>
-                    </Media>
-                    <Media lessThan="sm">
-                      <Flex flexDirection="column">
-                        <Text variant="largeTitle">
-                          {artwork.realizedPrice}
-                        </Text>
-                        <Text variant="caption" color="black60">
-                          Realized price
-                        </Text>
-                        <Text variant="text">2.22x</Text>
-                      </Flex>
-                    </Media>
-                  </>
-                )}
+                    </Flex>
+                  </Media>
+                </>
               </Flex>
             )
           })}
@@ -115,11 +125,12 @@ const SoldRecentlyFragmentContainer = createFragmentContainer(SoldRecently, {
   targetSupply: graphql`
     fragment SoldRecently_targetSupply on TargetSupply {
       microfunnel {
-        artworksConnection(first: 1) {
+        artworksConnection {
           edges {
             node {
               ...FillwidthItem_artwork
               realizedPrice
+              realizedToEstimate
             }
           }
         }

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/__tests__/SoldRecently.jest.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/__tests__/SoldRecently.jest.tsx
@@ -39,5 +39,8 @@ describe("SoldRecently", () => {
   it("contains additional fields in the carousel artworks", () => {
     const wrapper = getWrapper()
     expect(wrapper.html()).toContain('mock-value-for-field-"realizedPrice"')
+    expect(wrapper.html()).toContain(
+      'mock-value-for-field-"realizedToEstimate"'
+    )
   })
 })

--- a/src/v2/Apps/__tests__/Fixtures/Artist/Routes/ConsignRouteFixture.ts
+++ b/src/v2/Apps/__tests__/Fixtures/Artist/Routes/ConsignRouteFixture.ts
@@ -2,246 +2,248 @@ import { ConsignRoute_Test_QueryRawResponse } from "v2/__generated__/ConsignRout
 
 export const ConsignRouteFixture: ConsignRoute_Test_QueryRawResponse = {
   artist: {
-    name: "Alex Katz",
     href: "/artist/alex-katz",
+    id: "QXJ0aXN0OjRkOGQxMjBjODc2YzY5N2FlMTAwMDA0Ng==",
+    name: "Alex Katz",
     targetSupply: {
+      isInMicrofunnel: true,
       microfunnel: {
-        artworks: [
-          {
-            artwork: {
-              imageTitle: "This Image Has a Title, A. Artist, 2020",
-              image: {
-                imageURL:
-                  "https://d32dm0rphc51dk.cloudfront.net/JB8GqSuSHtsDHDIQ9nyPUw/medium.jpg",
-                resized: {
-                  width: 296,
-                  height: 395,
+        artworksConnection: {
+          edges: [
+            {
+              node: {
+                artists: [
+                  {
+                    href: "/artist/alex-katz",
+                    id: "QXJ0aXN0OjRkOGQxMjBjODc2YzY5N2FlMTAwMDA0Ng==",
+                    name: "Alex Katz",
+                  },
+                ],
+                collecting_institution: null,
+                cultural_maker: null,
+                date: "1973",
+                href: "/artwork/alex-katz-luna-park-2-maravell-67-schroder-68",
+                id: "QXJ0d29yazo1ZDljYTZmZThmMWFlZTAwMTE0NzVjZjc=",
+                image: {
+                  aspectRatio: 0.75,
+                  imageURL:
+                    "https://d32dm0rphc51dk.cloudfront.net/JB8GqSuSHtsDHDIQ9nyPUw/medium.jpg",
+                  resized: {
+                    height: 395,
+                    url:
+                      "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=296&height=395&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FJB8GqSuSHtsDHDIQ9nyPUw%2Flarge.jpg",
+                    width: 296,
+                  },
                   url:
-                    "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=296&height=395&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FJB8GqSuSHtsDHDIQ9nyPUw%2Flarge.jpg",
+                    "https://d32dm0rphc51dk.cloudfront.net/JB8GqSuSHtsDHDIQ9nyPUw/large.jpg",
                 },
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/JB8GqSuSHtsDHDIQ9nyPUw/large.jpg",
-                aspectRatio: 0.75,
+                imageTitle: "This Image Has a Title, A. Artist, 2020",
+                internalID: "5d9ca6fe8f1aee0011475cf7",
+                is_biddable: false,
+                is_inquireable: false,
+                is_saved: false,
+                partner: {
+                  href: "/auction/partner-595e64cdcd530e765d529647",
+                  id: "UGFydG5lcjo1OTVlNjRjZGNkNTMwZTc2NWQ1Mjk2NDc=",
+                  name: "Doyle",
+                  type: "Auction House",
+                },
+                realizedPrice: "$1,300",
+                sale: {
+                  display_timely_at: "live 6M ago",
+                  id: "U2FsZTo1ZDliNjY2YjI4ZWVkYTAwMTJmZGQzMTc=",
+                  is_auction: true,
+                  is_closed: true,
+                  is_live_open: false,
+                  is_open: false,
+                  is_preview: false,
+                },
+                sale_artwork: {
+                  counts: {
+                    bidder_positions: 13,
+                  },
+                  highest_bid: {
+                    display: "$5,000",
+                  },
+                  id: "U2FsZUFydHdvcms6NWQ5Y2E3MDNiNjk1MmQwMDEyNzk5YmI2",
+                  opening_bid: {
+                    display: "$1,000",
+                  },
+                },
+                sale_message: null,
+                slug: "alex-katz-luna-park-2-maravell-67-schroder-68",
+                title: "Luna Park 2 (Maravell 67; Schröder 68)",
               },
-              id: "QXJ0d29yazo1ZDljYTZmZThmMWFlZTAwMTE0NzVjZjc=",
-              href: "/artwork/alex-katz-luna-park-2-maravell-67-schroder-68",
-              title: "Luna Park 2 (Maravell 67; Schröder 68)",
-              date: "1973",
-              sale_message: null,
-              cultural_maker: null,
-              artists: [
-                {
-                  id: "QXJ0aXN0OjRkOGQxMjBjODc2YzY5N2FlMTAwMDA0Ng==",
-                  href: "/artist/alex-katz",
-                  name: "Alex Katz",
-                },
-              ],
-              collecting_institution: null,
-              partner: {
-                name: "Doyle",
-                href: "/auction/partner-595e64cdcd530e765d529647",
-                id: "UGFydG5lcjo1OTVlNjRjZGNkNTMwZTc2NWQ1Mjk2NDc=",
-                type: "Auction House",
-              },
-              sale: {
-                is_auction: true,
-                is_closed: true,
-                id: "U2FsZTo1ZDliNjY2YjI4ZWVkYTAwMTJmZGQzMTc=",
-                is_live_open: false,
-                is_open: false,
-                is_preview: false,
-                display_timely_at: "live 6M ago",
-              },
-              sale_artwork: {
-                counts: {
-                  bidder_positions: 13,
-                },
-                highest_bid: {
-                  display: "$5,000",
-                },
-                opening_bid: {
-                  display: "$1,000",
-                },
-                id: "U2FsZUFydHdvcms6NWQ5Y2E3MDNiNjk1MmQwMDEyNzk5YmI2",
-              },
-              is_inquireable: false,
-              internalID: "5d9ca6fe8f1aee0011475cf7",
-              slug: "alex-katz-luna-park-2-maravell-67-schroder-68",
-              is_saved: false,
-              is_biddable: false,
             },
-            realizedPrice: "$1,300",
-          },
-          {
-            artwork: {
-              imageTitle: "This Image Has a Title, A. Artist, 2020",
-              image: {
-                imageURL:
-                  "https://d32dm0rphc51dk.cloudfront.net/NcjBjx9Xz_pTqQp1G0gXWQ/medium.jpg",
-                resized: {
-                  width: 294,
-                  height: 394,
+            {
+              node: {
+                artists: [
+                  {
+                    href: "/artist/alex-katz",
+                    id: "QXJ0aXN0OjRkOGQxMjBjODc2YzY5N2FlMTAwMDA0Ng==",
+                    name: "Alex Katz",
+                  },
+                ],
+                collecting_institution: null,
+                cultural_maker: null,
+                date: "2019",
+                href: "/artwork/alex-katz-rose-bud-30",
+                id: "QXJ0d29yazo1ZDEyNmY5YmJhNDZiYTAwMTJjMzEzNGY=",
+                image: {
+                  aspectRatio: 0.75,
+                  imageURL:
+                    "https://d32dm0rphc51dk.cloudfront.net/NcjBjx9Xz_pTqQp1G0gXWQ/medium.jpg",
+                  resized: {
+                    height: 394,
+                    url:
+                      "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=294&height=394&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FNcjBjx9Xz_pTqQp1G0gXWQ%2Flarge.jpg",
+                    width: 294,
+                  },
                   url:
-                    "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=294&height=394&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FNcjBjx9Xz_pTqQp1G0gXWQ%2Flarge.jpg",
+                    "https://d32dm0rphc51dk.cloudfront.net/NcjBjx9Xz_pTqQp1G0gXWQ/large.jpg",
                 },
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/NcjBjx9Xz_pTqQp1G0gXWQ/large.jpg",
-                aspectRatio: 0.75,
-              },
-              id: "QXJ0d29yazo1ZDEyNmY5YmJhNDZiYTAwMTJjMzEzNGY=",
-              href: "/artwork/alex-katz-rose-bud-30",
-              title: "Rose Bud",
-              date: "2019",
-              sale_message: "$11,000",
-              cultural_maker: null,
-              artists: [
-                {
-                  id: "QXJ0aXN0OjRkOGQxMjBjODc2YzY5N2FlMTAwMDA0Ng==",
-                  href: "/artist/alex-katz",
-                  name: "Alex Katz",
+                imageTitle: "This Image Has a Title, A. Artist, 2020",
+                internalID: "5d126f9bba46ba0012c3134f",
+                is_biddable: false,
+                is_inquireable: false,
+                is_saved: false,
+                partner: {
+                  href: "/adamar-fine-arts",
+                  id: "UGFydG5lcjo1NGI0MGEzNzc3NmY3MjBlNDU5ZDA1MDA=",
+                  name: "Adamar Fine Arts",
+                  type: "Gallery",
                 },
-              ],
-              collecting_institution: null,
-              partner: {
-                name: "Adamar Fine Arts",
-                href: "/adamar-fine-arts",
-                id: "UGFydG5lcjo1NGI0MGEzNzc3NmY3MjBlNDU5ZDA1MDA=",
-                type: "Gallery",
+                realizedPrice: "$5,000",
+                sale: null,
+                sale_artwork: null,
+                sale_message: "$11,000",
+                slug: "alex-katz-rose-bud-30",
+                title: "Rose Bud",
               },
-              sale: null,
-              sale_artwork: null,
-              is_inquireable: false,
-              internalID: "5d126f9bba46ba0012c3134f",
-              slug: "alex-katz-rose-bud-30",
-              is_saved: false,
-              is_biddable: false,
             },
-            realizedPrice: "$5,000",
-          },
-          {
-            artwork: {
-              imageTitle: "This Image Has a Title, A. Artist, 2020",
-              image: {
-                imageURL:
-                  "https://d32dm0rphc51dk.cloudfront.net/2PzNL_vTOOx3Py9zfe7upw/medium.jpg",
-                resized: {
-                  width: 672,
-                  height: 395,
+            {
+              node: {
+                artists: [
+                  {
+                    href: "/artist/alex-katz",
+                    id: "QXJ0aXN0OjRkOGQxMjBjODc2YzY5N2FlMTAwMDA0Ng==",
+                    name: "Alex Katz",
+                  },
+                ],
+                collecting_institution: null,
+                cultural_maker: null,
+                date: "1994",
+                href:
+                  "/artwork/alex-katz-fog-and-night-from-the-northern-landscapes-series",
+                id: "QXJ0d29yazo1Y2ZmZGRmZjQwNDkxODAwMGVjODliZWI=",
+                image: {
+                  aspectRatio: 1.7,
+                  imageURL:
+                    "https://d32dm0rphc51dk.cloudfront.net/2PzNL_vTOOx3Py9zfe7upw/medium.jpg",
+                  resized: {
+                    height: 395,
+                    url:
+                      "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=672&height=395&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F2PzNL_vTOOx3Py9zfe7upw%2Flarge.jpg",
+                    width: 672,
+                  },
                   url:
-                    "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=672&height=395&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F2PzNL_vTOOx3Py9zfe7upw%2Flarge.jpg",
+                    "https://d32dm0rphc51dk.cloudfront.net/2PzNL_vTOOx3Py9zfe7upw/large.jpg",
                 },
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/2PzNL_vTOOx3Py9zfe7upw/large.jpg",
-                aspectRatio: 1.7,
+                imageTitle: "This Image Has a Title, A. Artist, 2020",
+                internalID: "5cffddff404918000ec89beb",
+                is_biddable: false,
+                is_inquireable: false,
+                is_saved: false,
+                partner: {
+                  href: "/auction/partner-595e68c9275b24129e961234",
+                  id: "UGFydG5lcjo1OTVlNjhjOTI3NWIyNDEyOWU5NjEyMzQ=",
+                  name: "Rago",
+                  type: "Auction House",
+                },
+                realizedPrice: "$8,500",
+                sale: {
+                  display_timely_at: "ends in 10M",
+                  id: "U2FsZTo1Y2ZlOTk5ZDcwODY1ZTAwMGU5ODgxNzM=",
+                  is_auction: true,
+                  is_closed: true,
+                  is_live_open: false,
+                  is_open: false,
+                  is_preview: false,
+                },
+                sale_artwork: {
+                  counts: {
+                    bidder_positions: 3,
+                  },
+                  highest_bid: {
+                    display: "$1,300",
+                  },
+                  id: "U2FsZUFydHdvcms6NWNmZmRlMDE0MDQ5MTgwMDBlYzg5YmYy",
+                  opening_bid: {
+                    display: "$800",
+                  },
+                },
+                sale_message: null,
+                slug:
+                  "alex-katz-fog-and-night-from-the-northern-landscapes-series",
+                title: "Fog and Night from the Northern Landscapes series",
               },
-              id: "QXJ0d29yazo1Y2ZmZGRmZjQwNDkxODAwMGVjODliZWI=",
-              href:
-                "/artwork/alex-katz-fog-and-night-from-the-northern-landscapes-series",
-              title: "Fog and Night from the Northern Landscapes series",
-              date: "1994",
-              sale_message: null,
-              cultural_maker: null,
-              artists: [
-                {
-                  id: "QXJ0aXN0OjRkOGQxMjBjODc2YzY5N2FlMTAwMDA0Ng==",
-                  href: "/artist/alex-katz",
-                  name: "Alex Katz",
-                },
-              ],
-              collecting_institution: null,
-              partner: {
-                name: "Rago",
-                href: "/auction/partner-595e68c9275b24129e961234",
-                id: "UGFydG5lcjo1OTVlNjhjOTI3NWIyNDEyOWU5NjEyMzQ=",
-                type: "Auction House",
-              },
-              sale: {
-                is_auction: true,
-                is_closed: true,
-                id: "U2FsZTo1Y2ZlOTk5ZDcwODY1ZTAwMGU5ODgxNzM=",
-                is_live_open: false,
-                is_open: false,
-                is_preview: false,
-                display_timely_at: "ends in 10M",
-              },
-              sale_artwork: {
-                counts: {
-                  bidder_positions: 3,
-                },
-                highest_bid: {
-                  display: "$1,300",
-                },
-                opening_bid: {
-                  display: "$800",
-                },
-                id: "U2FsZUFydHdvcms6NWNmZmRlMDE0MDQ5MTgwMDBlYzg5YmYy",
-              },
-              is_inquireable: false,
-              internalID: "5cffddff404918000ec89beb",
-              slug:
-                "alex-katz-fog-and-night-from-the-northern-landscapes-series",
-              is_saved: false,
-              is_biddable: false,
             },
-            realizedPrice: "$8,500",
-          },
-          {
-            artwork: {
-              imageTitle: "This Image Has a Title, A. Artist, 2020",
-              image: {
-                imageURL:
-                  "https://d32dm0rphc51dk.cloudfront.net/WNHtB_gQLN3HxPW4nNGAjA/medium.jpg",
-                resized: {
-                  width: 261,
-                  height: 395,
+            {
+              node: {
+                artists: [
+                  {
+                    href: "/artist/alex-katz",
+                    id: "QXJ0aXN0OjRkOGQxMjBjODc2YzY5N2FlMTAwMDA0Ng==",
+                    name: "Alex Katz",
+                  },
+                ],
+                collecting_institution: null,
+                cultural_maker: null,
+                date: "2017",
+                href: "/artwork/alex-katz-laura-1-49",
+                id: "QXJ0d29yazo1YWEyZTkwZDc2MjJkZDQ5ZGM4YjM1NmM=",
+                image: {
+                  aspectRatio: 0.66,
+                  imageURL:
+                    "https://d32dm0rphc51dk.cloudfront.net/WNHtB_gQLN3HxPW4nNGAjA/medium.jpg",
+                  resized: {
+                    height: 395,
+                    url:
+                      "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=261&height=395&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWNHtB_gQLN3HxPW4nNGAjA%2Flarge.jpg",
+                    width: 261,
+                  },
                   url:
-                    "https://d196wkiy8qx2u5.cloudfront.net?resize_to=fit&width=261&height=395&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWNHtB_gQLN3HxPW4nNGAjA%2Flarge.jpg",
+                    "https://d32dm0rphc51dk.cloudfront.net/WNHtB_gQLN3HxPW4nNGAjA/large.jpg",
                 },
-                url:
-                  "https://d32dm0rphc51dk.cloudfront.net/WNHtB_gQLN3HxPW4nNGAjA/large.jpg",
-                aspectRatio: 0.66,
-              },
-              id: "QXJ0d29yazo1YWEyZTkwZDc2MjJkZDQ5ZGM4YjM1NmM=",
-              href: "/artwork/alex-katz-laura-1-49",
-              title: "Laura 1",
-              date: "2017",
-              sale_message: "$7,500",
-              cultural_maker: null,
-              artists: [
-                {
-                  id: "QXJ0aXN0OjRkOGQxMjBjODc2YzY5N2FlMTAwMDA0Ng==",
-                  href: "/artist/alex-katz",
-                  name: "Alex Katz",
+                imageTitle: "This Image Has a Title, A. Artist, 2020",
+                internalID: "5aa2e90d7622dd49dc8b356c",
+                is_biddable: false,
+                is_inquireable: false,
+                is_saved: false,
+                partner: {
+                  href: "/kenneth-a-friedman-and-co",
+                  id: "UGFydG5lcjo1NDFiMzU4ZjcyNjE2OTdiOTcyYTAwMDA=",
+                  name: "Kenneth A. Friedman & Co.",
+                  type: "Gallery",
                 },
-              ],
-              collecting_institution: null,
-              partner: {
-                name: "Kenneth A. Friedman & Co.",
-                href: "/kenneth-a-friedman-and-co",
-                id: "UGFydG5lcjo1NDFiMzU4ZjcyNjE2OTdiOTcyYTAwMDA=",
-                type: "Gallery",
+                realizedPrice: "$1,300",
+                sale: null,
+                sale_artwork: null,
+                sale_message: "$7,500",
+                slug: "alex-katz-laura-1-49",
+                title: "Laura 1",
               },
-              sale: null,
-              sale_artwork: null,
-              is_inquireable: false,
-              internalID: "5aa2e90d7622dd49dc8b356c",
-              slug: "alex-katz-laura-1-49",
-              is_saved: false,
-              is_biddable: false,
             },
-            realizedPrice: "$1,300",
-          },
-        ],
+          ],
+        },
         metadata: {
-          roundedViews: "3,500",
-          roundedUniqueVisitors: "1,200",
           highestRealized: "$4.17M",
-          str: "79%",
           realized: "177%",
+          roundedUniqueVisitors: "1,200",
+          roundedViews: "3,500",
+          str: "79%",
         },
       },
-      isInMicrofunnel: true,
     },
-    id: "QXJ0aXN0OjRkOGQxMjBjODc2YzY5N2FlMTAwMDA0Ng==",
   },
 }

--- a/src/v2/__generated__/ArtistConsignHeaderImages_artist.graphql.ts
+++ b/src/v2/__generated__/ArtistConsignHeaderImages_artist.graphql.ts
@@ -6,18 +6,20 @@ import { FragmentRefs } from "relay-runtime";
 export type ArtistConsignHeaderImages_artist = {
     readonly targetSupply: {
         readonly microfunnel: {
-            readonly artworks: ReadonlyArray<{
-                readonly artwork: {
-                    readonly image: {
-                        readonly resized: {
-                            readonly width: number | null;
-                            readonly height: number | null;
-                            readonly url: string;
+            readonly artworksConnection: {
+                readonly edges: ReadonlyArray<{
+                    readonly node: {
+                        readonly image: {
+                            readonly resized: {
+                                readonly width: number | null;
+                                readonly height: number | null;
+                                readonly url: string;
+                            } | null;
                         } | null;
+                        readonly " $fragmentRefs": FragmentRefs<"FillwidthItem_artwork">;
                     } | null;
-                    readonly " $fragmentRefs": FragmentRefs<"FillwidthItem_artwork">;
-                } | null;
-            } | null> | null;
+                } | null> | null;
+            } | null;
         } | null;
     } | null;
     readonly " $refType": "ArtistConsignHeaderImages_artist";
@@ -55,72 +57,83 @@ const node: ReaderFragment = {
             {
               "alias": null,
               "args": null,
-              "concreteType": "ArtistTargetSupplyMicrofunnelArtwork",
+              "concreteType": "ArtworkConnection",
               "kind": "LinkedField",
-              "name": "artworks",
-              "plural": true,
+              "name": "artworksConnection",
+              "plural": false,
               "selections": [
                 {
                   "alias": null,
                   "args": null,
-                  "concreteType": "Artwork",
+                  "concreteType": "ArtworkEdge",
                   "kind": "LinkedField",
-                  "name": "artwork",
-                  "plural": false,
+                  "name": "edges",
+                  "plural": true,
                   "selections": [
                     {
                       "alias": null,
                       "args": null,
-                      "concreteType": "Image",
+                      "concreteType": "Artwork",
                       "kind": "LinkedField",
-                      "name": "image",
+                      "name": "node",
                       "plural": false,
                       "selections": [
                         {
                           "alias": null,
-                          "args": [
-                            {
-                              "kind": "Literal",
-                              "name": "height",
-                              "value": 395
-                            }
-                          ],
-                          "concreteType": "ResizedImageUrl",
+                          "args": null,
+                          "concreteType": "Image",
                           "kind": "LinkedField",
-                          "name": "resized",
+                          "name": "image",
                           "plural": false,
                           "selections": [
                             {
                               "alias": null,
-                              "args": null,
-                              "kind": "ScalarField",
-                              "name": "width",
-                              "storageKey": null
-                            },
-                            {
-                              "alias": null,
-                              "args": null,
-                              "kind": "ScalarField",
-                              "name": "height",
-                              "storageKey": null
-                            },
-                            {
-                              "alias": null,
-                              "args": null,
-                              "kind": "ScalarField",
-                              "name": "url",
-                              "storageKey": null
+                              "args": [
+                                {
+                                  "kind": "Literal",
+                                  "name": "height",
+                                  "value": 395
+                                }
+                              ],
+                              "concreteType": "ResizedImageUrl",
+                              "kind": "LinkedField",
+                              "name": "resized",
+                              "plural": false,
+                              "selections": [
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "kind": "ScalarField",
+                                  "name": "width",
+                                  "storageKey": null
+                                },
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "kind": "ScalarField",
+                                  "name": "height",
+                                  "storageKey": null
+                                },
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "kind": "ScalarField",
+                                  "name": "url",
+                                  "storageKey": null
+                                }
+                              ],
+                              "storageKey": "resized(height:395)"
                             }
                           ],
-                          "storageKey": "resized(height:395)"
+                          "storageKey": null
+                        },
+                        {
+                          "args": null,
+                          "kind": "FragmentSpread",
+                          "name": "FillwidthItem_artwork"
                         }
                       ],
                       "storageKey": null
-                    },
-                    {
-                      "args": null,
-                      "kind": "FragmentSpread",
-                      "name": "FillwidthItem_artwork"
                     }
                   ],
                   "storageKey": null
@@ -137,5 +150,5 @@ const node: ReaderFragment = {
   ],
   "type": "Artist"
 };
-(node as any).hash = 'f7f772023dc79dc472421a1b53b4cffd';
+(node as any).hash = '64c51ded546f812a6837400f30c8ca29';
 export default node;

--- a/src/v2/__generated__/ArtistConsignMeta_artist.graphql.ts
+++ b/src/v2/__generated__/ArtistConsignMeta_artist.graphql.ts
@@ -8,13 +8,15 @@ export type ArtistConsignMeta_artist = {
     readonly href: string | null;
     readonly targetSupply: {
         readonly microfunnel: {
-            readonly artworks: ReadonlyArray<{
-                readonly artwork: {
-                    readonly image: {
-                        readonly imageURL: string | null;
+            readonly artworksConnection: {
+                readonly edges: ReadonlyArray<{
+                    readonly node: {
+                        readonly image: {
+                            readonly imageURL: string | null;
+                        } | null;
                     } | null;
-                } | null;
-            } | null> | null;
+                } | null> | null;
+            } | null;
         } | null;
     } | null;
     readonly " $refType": "ArtistConsignMeta_artist";
@@ -66,39 +68,50 @@ const node: ReaderFragment = {
             {
               "alias": null,
               "args": null,
-              "concreteType": "ArtistTargetSupplyMicrofunnelArtwork",
+              "concreteType": "ArtworkConnection",
               "kind": "LinkedField",
-              "name": "artworks",
-              "plural": true,
+              "name": "artworksConnection",
+              "plural": false,
               "selections": [
                 {
                   "alias": null,
                   "args": null,
-                  "concreteType": "Artwork",
+                  "concreteType": "ArtworkEdge",
                   "kind": "LinkedField",
-                  "name": "artwork",
-                  "plural": false,
+                  "name": "edges",
+                  "plural": true,
                   "selections": [
                     {
                       "alias": null,
                       "args": null,
-                      "concreteType": "Image",
+                      "concreteType": "Artwork",
                       "kind": "LinkedField",
-                      "name": "image",
+                      "name": "node",
                       "plural": false,
                       "selections": [
                         {
-                          "alias": "imageURL",
-                          "args": [
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "Image",
+                          "kind": "LinkedField",
+                          "name": "image",
+                          "plural": false,
+                          "selections": [
                             {
-                              "kind": "Literal",
-                              "name": "version",
-                              "value": "medium"
+                              "alias": "imageURL",
+                              "args": [
+                                {
+                                  "kind": "Literal",
+                                  "name": "version",
+                                  "value": "medium"
+                                }
+                              ],
+                              "kind": "ScalarField",
+                              "name": "url",
+                              "storageKey": "url(version:\"medium\")"
                             }
                           ],
-                          "kind": "ScalarField",
-                          "name": "url",
-                          "storageKey": "url(version:\"medium\")"
+                          "storageKey": null
                         }
                       ],
                       "storageKey": null
@@ -118,5 +131,5 @@ const node: ReaderFragment = {
   ],
   "type": "Artist"
 };
-(node as any).hash = 'cdb304af5dff2c7987ce5b9833fa7914';
+(node as any).hash = '70e6df5913a21146421466fe0a7e143d';
 export default node;

--- a/src/v2/__generated__/ArtistConsignRecentlySold_artist.graphql.ts
+++ b/src/v2/__generated__/ArtistConsignRecentlySold_artist.graphql.ts
@@ -6,12 +6,14 @@ import { FragmentRefs } from "relay-runtime";
 export type ArtistConsignRecentlySold_artist = {
     readonly targetSupply: {
         readonly microfunnel: {
-            readonly artworks: ReadonlyArray<{
-                readonly artwork: {
-                    readonly " $fragmentRefs": FragmentRefs<"FillwidthItem_artwork">;
-                } | null;
-                readonly realizedPrice: string | null;
-            } | null> | null;
+            readonly artworksConnection: {
+                readonly edges: ReadonlyArray<{
+                    readonly node: {
+                        readonly realizedPrice: string | null;
+                        readonly " $fragmentRefs": FragmentRefs<"FillwidthItem_artwork">;
+                    } | null;
+                } | null> | null;
+            } | null;
         } | null;
     } | null;
     readonly name: string | null;
@@ -50,32 +52,43 @@ const node: ReaderFragment = {
             {
               "alias": null,
               "args": null,
-              "concreteType": "ArtistTargetSupplyMicrofunnelArtwork",
+              "concreteType": "ArtworkConnection",
               "kind": "LinkedField",
-              "name": "artworks",
-              "plural": true,
+              "name": "artworksConnection",
+              "plural": false,
               "selections": [
                 {
                   "alias": null,
                   "args": null,
-                  "concreteType": "Artwork",
+                  "concreteType": "ArtworkEdge",
                   "kind": "LinkedField",
-                  "name": "artwork",
-                  "plural": false,
+                  "name": "edges",
+                  "plural": true,
                   "selections": [
                     {
+                      "alias": null,
                       "args": null,
-                      "kind": "FragmentSpread",
-                      "name": "FillwidthItem_artwork"
+                      "concreteType": "Artwork",
+                      "kind": "LinkedField",
+                      "name": "node",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "realizedPrice",
+                          "storageKey": null
+                        },
+                        {
+                          "args": null,
+                          "kind": "FragmentSpread",
+                          "name": "FillwidthItem_artwork"
+                        }
+                      ],
+                      "storageKey": null
                     }
                   ],
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "realizedPrice",
                   "storageKey": null
                 }
               ],
@@ -97,5 +110,5 @@ const node: ReaderFragment = {
   ],
   "type": "Artist"
 };
-(node as any).hash = '9554efc6c368bc6a4feebaeb434924ed';
+(node as any).hash = '4bb367f104df6c1ffe6a26b0eeb0555b';
 export default node;

--- a/src/v2/__generated__/ConsignRoute_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ConsignRoute_Test_Query.graphql.ts
@@ -20,66 +20,68 @@ export type ConsignRoute_Test_QueryRawResponse = {
         readonly href: string | null;
         readonly targetSupply: ({
             readonly microfunnel: ({
-                readonly artworks: ReadonlyArray<({
-                    readonly artwork: ({
-                        readonly image: ({
-                            readonly imageURL: string | null;
-                            readonly resized: ({
-                                readonly width: number | null;
-                                readonly height: number | null;
-                                readonly url: string;
+                readonly artworksConnection: ({
+                    readonly edges: ReadonlyArray<({
+                        readonly node: ({
+                            readonly image: ({
+                                readonly imageURL: string | null;
+                                readonly resized: ({
+                                    readonly width: number | null;
+                                    readonly height: number | null;
+                                    readonly url: string;
+                                }) | null;
+                                readonly url: string | null;
+                                readonly aspectRatio: number;
                             }) | null;
-                            readonly url: string | null;
-                            readonly aspectRatio: number;
-                        }) | null;
-                        readonly id: string | null;
-                        readonly imageTitle: string | null;
-                        readonly title: string | null;
-                        readonly href: string | null;
-                        readonly date: string | null;
-                        readonly sale_message: string | null;
-                        readonly cultural_maker: string | null;
-                        readonly artists: ReadonlyArray<({
-                            readonly id: string;
+                            readonly id: string | null;
+                            readonly imageTitle: string | null;
+                            readonly title: string | null;
                             readonly href: string | null;
-                            readonly name: string | null;
-                        }) | null> | null;
-                        readonly collecting_institution: string | null;
-                        readonly partner: ({
-                            readonly name: string | null;
-                            readonly href: string | null;
-                            readonly id: string | null;
-                            readonly type: string | null;
-                        }) | null;
-                        readonly sale: ({
-                            readonly is_auction: boolean | null;
-                            readonly is_closed: boolean | null;
-                            readonly id: string | null;
-                            readonly is_live_open: boolean | null;
-                            readonly is_open: boolean | null;
-                            readonly is_preview: boolean | null;
-                            readonly display_timely_at: string | null;
-                        }) | null;
-                        readonly sale_artwork: ({
-                            readonly counts: ({
-                                readonly bidder_positions: number | null;
+                            readonly date: string | null;
+                            readonly sale_message: string | null;
+                            readonly cultural_maker: string | null;
+                            readonly artists: ReadonlyArray<({
+                                readonly id: string;
+                                readonly href: string | null;
+                                readonly name: string | null;
+                            }) | null> | null;
+                            readonly collecting_institution: string | null;
+                            readonly partner: ({
+                                readonly name: string | null;
+                                readonly href: string | null;
+                                readonly id: string | null;
+                                readonly type: string | null;
                             }) | null;
-                            readonly highest_bid: ({
-                                readonly display: string | null;
+                            readonly sale: ({
+                                readonly is_auction: boolean | null;
+                                readonly is_closed: boolean | null;
+                                readonly id: string | null;
+                                readonly is_live_open: boolean | null;
+                                readonly is_open: boolean | null;
+                                readonly is_preview: boolean | null;
+                                readonly display_timely_at: string | null;
                             }) | null;
-                            readonly opening_bid: ({
-                                readonly display: string | null;
+                            readonly sale_artwork: ({
+                                readonly counts: ({
+                                    readonly bidder_positions: number | null;
+                                }) | null;
+                                readonly highest_bid: ({
+                                    readonly display: string | null;
+                                }) | null;
+                                readonly opening_bid: ({
+                                    readonly display: string | null;
+                                }) | null;
+                                readonly id: string | null;
                             }) | null;
-                            readonly id: string | null;
+                            readonly is_inquireable: boolean | null;
+                            readonly internalID: string;
+                            readonly slug: string;
+                            readonly is_saved: boolean | null;
+                            readonly is_biddable: boolean | null;
+                            readonly realizedPrice: string | null;
                         }) | null;
-                        readonly is_inquireable: boolean | null;
-                        readonly internalID: string;
-                        readonly slug: string;
-                        readonly is_saved: boolean | null;
-                        readonly is_biddable: boolean | null;
-                    }) | null;
-                    readonly realizedPrice: string | null;
-                }) | null> | null;
+                    }) | null> | null;
+                }) | null;
                 readonly metadata: ({
                     readonly roundedViews: string | null;
                     readonly roundedUniqueVisitors: string | null;
@@ -121,17 +123,19 @@ fragment ArtistConsignFAQ_artist on Artist {
 fragment ArtistConsignHeaderImages_artist on Artist {
   targetSupply {
     microfunnel {
-      artworks {
-        artwork {
-          image {
-            resized(height: 395) {
-              width
-              height
-              url
+      artworksConnection {
+        edges {
+          node {
+            image {
+              resized(height: 395) {
+                width
+                height
+                url
+              }
             }
+            ...FillwidthItem_artwork
+            id
           }
-          ...FillwidthItem_artwork
-          id
         }
       }
     }
@@ -166,12 +170,14 @@ fragment ArtistConsignMeta_artist on Artist {
   href
   targetSupply {
     microfunnel {
-      artworks {
-        artwork {
-          image {
-            imageURL: url(version: "medium")
+      artworksConnection {
+        edges {
+          node {
+            image {
+              imageURL: url(version: "medium")
+            }
+            id
           }
-          id
         }
       }
     }
@@ -193,12 +199,14 @@ fragment ArtistConsignPageViews_artist on Artist {
 fragment ArtistConsignRecentlySold_artist on Artist {
   targetSupply {
     microfunnel {
-      artworks {
-        artwork {
-          ...FillwidthItem_artwork
-          id
+      artworksConnection {
+        edges {
+          node {
+            ...FillwidthItem_artwork
+            realizedPrice
+            id
+          }
         }
-        realizedPrice
       }
     }
   }
@@ -455,327 +463,338 @@ return {
                   {
                     "alias": null,
                     "args": null,
-                    "concreteType": "ArtistTargetSupplyMicrofunnelArtwork",
+                    "concreteType": "ArtworkConnection",
                     "kind": "LinkedField",
-                    "name": "artworks",
-                    "plural": true,
+                    "name": "artworksConnection",
+                    "plural": false,
                     "selections": [
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "Artwork",
+                        "concreteType": "ArtworkEdge",
                         "kind": "LinkedField",
-                        "name": "artwork",
-                        "plural": false,
+                        "name": "edges",
+                        "plural": true,
                         "selections": [
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "Image",
+                            "concreteType": "Artwork",
                             "kind": "LinkedField",
-                            "name": "image",
+                            "name": "node",
                             "plural": false,
                             "selections": [
                               {
-                                "alias": "imageURL",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "medium"
-                                  }
-                                ],
-                                "kind": "ScalarField",
-                                "name": "url",
-                                "storageKey": "url(version:\"medium\")"
-                              },
-                              {
                                 "alias": null,
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "height",
-                                    "value": 395
-                                  }
-                                ],
-                                "concreteType": "ResizedImageUrl",
+                                "args": null,
+                                "concreteType": "Image",
                                 "kind": "LinkedField",
-                                "name": "resized",
+                                "name": "image",
                                 "plural": false,
                                 "selections": [
                                   {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "width",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "height",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
+                                    "alias": "imageURL",
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": "medium"
+                                      }
+                                    ],
                                     "kind": "ScalarField",
                                     "name": "url",
+                                    "storageKey": "url(version:\"medium\")"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "height",
+                                        "value": 395
+                                      }
+                                    ],
+                                    "concreteType": "ResizedImageUrl",
+                                    "kind": "LinkedField",
+                                    "name": "resized",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "width",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "height",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": "resized(height:395)"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": "large"
+                                      }
+                                    ],
+                                    "kind": "ScalarField",
+                                    "name": "url",
+                                    "storageKey": "url(version:\"large\")"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "aspectRatio",
                                     "storageKey": null
                                   }
                                 ],
-                                "storageKey": "resized(height:395)"
+                                "storageKey": null
+                              },
+                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "imageTitle",
+                                "storageKey": null
                               },
                               {
                                 "alias": null,
-                                "args": [
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "title",
+                                "storageKey": null
+                              },
+                              (v4/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "date",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "sale_message",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "saleMessage",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "cultural_maker",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "culturalMaker",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": (v6/*: any*/),
+                                "concreteType": "Artist",
+                                "kind": "LinkedField",
+                                "name": "artists",
+                                "plural": true,
+                                "selections": [
+                                  (v5/*: any*/),
+                                  (v4/*: any*/),
+                                  (v3/*: any*/)
+                                ],
+                                "storageKey": "artists(shallow:true)"
+                              },
+                              {
+                                "alias": "collecting_institution",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "collectingInstitution",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": (v6/*: any*/),
+                                "concreteType": "Partner",
+                                "kind": "LinkedField",
+                                "name": "partner",
+                                "plural": false,
+                                "selections": [
+                                  (v3/*: any*/),
+                                  (v4/*: any*/),
+                                  (v5/*: any*/),
                                   {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large"
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "type",
+                                    "storageKey": null
                                   }
                                 ],
-                                "kind": "ScalarField",
-                                "name": "url",
-                                "storageKey": "url(version:\"large\")"
+                                "storageKey": "partner(shallow:true)"
                               },
                               {
                                 "alias": null,
                                 "args": null,
-                                "kind": "ScalarField",
-                                "name": "aspectRatio",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          (v5/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "imageTitle",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "title",
-                            "storageKey": null
-                          },
-                          (v4/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "date",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "sale_message",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "saleMessage",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "cultural_maker",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "culturalMaker",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": (v6/*: any*/),
-                            "concreteType": "Artist",
-                            "kind": "LinkedField",
-                            "name": "artists",
-                            "plural": true,
-                            "selections": [
-                              (v5/*: any*/),
-                              (v4/*: any*/),
-                              (v3/*: any*/)
-                            ],
-                            "storageKey": "artists(shallow:true)"
-                          },
-                          {
-                            "alias": "collecting_institution",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "collectingInstitution",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": (v6/*: any*/),
-                            "concreteType": "Partner",
-                            "kind": "LinkedField",
-                            "name": "partner",
-                            "plural": false,
-                            "selections": [
-                              (v3/*: any*/),
-                              (v4/*: any*/),
-                              (v5/*: any*/),
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "type",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": "partner(shallow:true)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Sale",
-                            "kind": "LinkedField",
-                            "name": "sale",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": "is_auction",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isAuction",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": "is_closed",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isClosed",
-                                "storageKey": null
-                              },
-                              (v5/*: any*/),
-                              {
-                                "alias": "is_live_open",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isLiveOpen",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": "is_open",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isOpen",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": "is_preview",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isPreview",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": "display_timely_at",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "displayTimelyAt",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "sale_artwork",
-                            "args": null,
-                            "concreteType": "SaleArtwork",
-                            "kind": "LinkedField",
-                            "name": "saleArtwork",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "SaleArtworkCounts",
+                                "concreteType": "Sale",
                                 "kind": "LinkedField",
-                                "name": "counts",
+                                "name": "sale",
                                 "plural": false,
                                 "selections": [
                                   {
-                                    "alias": "bidder_positions",
+                                    "alias": "is_auction",
                                     "args": null,
                                     "kind": "ScalarField",
-                                    "name": "bidderPositions",
+                                    "name": "isAuction",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_closed",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isClosed",
+                                    "storageKey": null
+                                  },
+                                  (v5/*: any*/),
+                                  {
+                                    "alias": "is_live_open",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isLiveOpen",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_open",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isOpen",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_preview",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isPreview",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "display_timely_at",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "displayTimelyAt",
                                     "storageKey": null
                                   }
                                 ],
                                 "storageKey": null
                               },
                               {
-                                "alias": "highest_bid",
+                                "alias": "sale_artwork",
                                 "args": null,
-                                "concreteType": "SaleArtworkHighestBid",
+                                "concreteType": "SaleArtwork",
                                 "kind": "LinkedField",
-                                "name": "highestBid",
+                                "name": "saleArtwork",
                                 "plural": false,
-                                "selections": (v7/*: any*/),
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "SaleArtworkCounts",
+                                    "kind": "LinkedField",
+                                    "name": "counts",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "bidder_positions",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "bidderPositions",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "highest_bid",
+                                    "args": null,
+                                    "concreteType": "SaleArtworkHighestBid",
+                                    "kind": "LinkedField",
+                                    "name": "highestBid",
+                                    "plural": false,
+                                    "selections": (v7/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "opening_bid",
+                                    "args": null,
+                                    "concreteType": "SaleArtworkOpeningBid",
+                                    "kind": "LinkedField",
+                                    "name": "openingBid",
+                                    "plural": false,
+                                    "selections": (v7/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  (v5/*: any*/)
+                                ],
                                 "storageKey": null
                               },
                               {
-                                "alias": "opening_bid",
+                                "alias": "is_inquireable",
                                 "args": null,
-                                "concreteType": "SaleArtworkOpeningBid",
-                                "kind": "LinkedField",
-                                "name": "openingBid",
-                                "plural": false,
-                                "selections": (v7/*: any*/),
+                                "kind": "ScalarField",
+                                "name": "isInquireable",
                                 "storageKey": null
                               },
-                              (v5/*: any*/)
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "internalID",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "slug",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_saved",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isSaved",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_biddable",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isBiddable",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "realizedPrice",
+                                "storageKey": null
+                              }
                             ],
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "is_inquireable",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isInquireable",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "internalID",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "slug",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "is_saved",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isSaved",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "is_biddable",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isBiddable",
                             "storageKey": null
                           }
                         ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "realizedPrice",
                         "storageKey": null
                       }
                     ],
@@ -845,7 +864,7 @@ return {
     "metadata": {},
     "name": "ConsignRoute_Test_Query",
     "operationKind": "query",
-    "text": "query ConsignRoute_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...Consign_artist\n    targetSupply {\n      isInMicrofunnel\n    }\n    id\n  }\n}\n\nfragment ArtistConsignFAQ_artist on Artist {\n  href\n}\n\nfragment ArtistConsignHeaderImages_artist on Artist {\n  targetSupply {\n    microfunnel {\n      artworks {\n        artwork {\n          image {\n            resized(height: 395) {\n              width\n              height\n              url\n            }\n          }\n          ...FillwidthItem_artwork\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignHeader_artist on Artist {\n  ...ArtistConsignHeaderImages_artist\n  name\n  href\n}\n\nfragment ArtistConsignHowToSell_artist on Artist {\n  href\n}\n\nfragment ArtistConsignMarketTrends_artist on Artist {\n  href\n  targetSupply {\n    microfunnel {\n      metadata {\n        highestRealized\n        str\n        realized\n      }\n    }\n  }\n}\n\nfragment ArtistConsignMeta_artist on Artist {\n  name\n  href\n  targetSupply {\n    microfunnel {\n      artworks {\n        artwork {\n          image {\n            imageURL: url(version: \"medium\")\n          }\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignPageViews_artist on Artist {\n  name\n  targetSupply {\n    microfunnel {\n      metadata {\n        roundedViews\n        roundedUniqueVisitors\n      }\n    }\n  }\n}\n\nfragment ArtistConsignRecentlySold_artist on Artist {\n  targetSupply {\n    microfunnel {\n      artworks {\n        artwork {\n          ...FillwidthItem_artwork\n          id\n        }\n        realizedPrice\n      }\n    }\n  }\n  name\n}\n\nfragment ArtistConsignSellArt_artist on Artist {\n  href\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Consign_artist on Artist {\n  ...ArtistConsignMeta_artist\n  ...ArtistConsignHeader_artist\n  ...ArtistConsignRecentlySold_artist\n  ...ArtistConsignPageViews_artist\n  ...ArtistConsignMarketTrends_artist\n  ...ArtistConsignHowToSell_artist\n  ...ArtistConsignFAQ_artist\n  ...ArtistConsignSellArt_artist\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query ConsignRoute_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...Consign_artist\n    targetSupply {\n      isInMicrofunnel\n    }\n    id\n  }\n}\n\nfragment ArtistConsignFAQ_artist on Artist {\n  href\n}\n\nfragment ArtistConsignHeaderImages_artist on Artist {\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            image {\n              resized(height: 395) {\n                width\n                height\n                url\n              }\n            }\n            ...FillwidthItem_artwork\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignHeader_artist on Artist {\n  ...ArtistConsignHeaderImages_artist\n  name\n  href\n}\n\nfragment ArtistConsignHowToSell_artist on Artist {\n  href\n}\n\nfragment ArtistConsignMarketTrends_artist on Artist {\n  href\n  targetSupply {\n    microfunnel {\n      metadata {\n        highestRealized\n        str\n        realized\n      }\n    }\n  }\n}\n\nfragment ArtistConsignMeta_artist on Artist {\n  name\n  href\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            image {\n              imageURL: url(version: \"medium\")\n            }\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignPageViews_artist on Artist {\n  name\n  targetSupply {\n    microfunnel {\n      metadata {\n        roundedViews\n        roundedUniqueVisitors\n      }\n    }\n  }\n}\n\nfragment ArtistConsignRecentlySold_artist on Artist {\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            ...FillwidthItem_artwork\n            realizedPrice\n            id\n          }\n        }\n      }\n    }\n  }\n  name\n}\n\nfragment ArtistConsignSellArt_artist on Artist {\n  href\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Consign_artist on Artist {\n  ...ArtistConsignMeta_artist\n  ...ArtistConsignHeader_artist\n  ...ArtistConsignRecentlySold_artist\n  ...ArtistConsignPageViews_artist\n  ...ArtistConsignMarketTrends_artist\n  ...ArtistConsignHowToSell_artist\n  ...ArtistConsignFAQ_artist\n  ...ArtistConsignSellArt_artist\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/SoldRecentlyQuery.graphql.ts
+++ b/src/v2/__generated__/SoldRecentlyQuery.graphql.ts
@@ -126,11 +126,12 @@ fragment Save_artwork on Artwork {
 
 fragment SoldRecently_targetSupply on TargetSupply {
   microfunnel {
-    artworksConnection(first: 1) {
+    artworksConnection {
       edges {
         node {
           ...FillwidthItem_artwork
           realizedPrice
+          realizedToEstimate
           id
         }
       }
@@ -227,13 +228,7 @@ return {
             "selections": [
               {
                 "alias": null,
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "first",
-                    "value": 1
-                  }
-                ],
+                "args": null,
                 "concreteType": "ArtworkConnection",
                 "kind": "LinkedField",
                 "name": "artworksConnection",
@@ -510,6 +505,13 @@ return {
                             "kind": "ScalarField",
                             "name": "realizedPrice",
                             "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "realizedToEstimate",
+                            "storageKey": null
                           }
                         ],
                         "storageKey": null
@@ -518,7 +520,7 @@ return {
                     "storageKey": null
                   }
                 ],
-                "storageKey": "artworksConnection(first:1)"
+                "storageKey": null
               }
             ],
             "storageKey": null
@@ -533,7 +535,7 @@ return {
     "metadata": {},
     "name": "SoldRecentlyQuery",
     "operationKind": "query",
-    "text": "query SoldRecentlyQuery {\n  targetSupply {\n    ...SoldRecently_targetSupply\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SoldRecently_targetSupply on TargetSupply {\n  microfunnel {\n    artworksConnection(first: 1) {\n      edges {\n        node {\n          ...FillwidthItem_artwork\n          realizedPrice\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query SoldRecentlyQuery {\n  targetSupply {\n    ...SoldRecently_targetSupply\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SoldRecently_targetSupply on TargetSupply {\n  microfunnel {\n    artworksConnection {\n      edges {\n        node {\n          ...FillwidthItem_artwork\n          realizedPrice\n          realizedToEstimate\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/SoldRecently_targetSupply.graphql.ts
+++ b/src/v2/__generated__/SoldRecently_targetSupply.graphql.ts
@@ -9,6 +9,7 @@ export type SoldRecently_targetSupply = {
             readonly edges: ReadonlyArray<{
                 readonly node: {
                     readonly realizedPrice: string | null;
+                    readonly realizedToEstimate: string | null;
                     readonly " $fragmentRefs": FragmentRefs<"FillwidthItem_artwork">;
                 } | null;
             } | null> | null;
@@ -40,13 +41,7 @@ const node: ReaderFragment = {
       "selections": [
         {
           "alias": null,
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "first",
-              "value": 1
-            }
-          ],
+          "args": null,
           "concreteType": "ArtworkConnection",
           "kind": "LinkedField",
           "name": "artworksConnection",
@@ -76,6 +71,13 @@ const node: ReaderFragment = {
                       "storageKey": null
                     },
                     {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "realizedToEstimate",
+                      "storageKey": null
+                    },
+                    {
                       "args": null,
                       "kind": "FragmentSpread",
                       "name": "FillwidthItem_artwork"
@@ -87,7 +89,7 @@ const node: ReaderFragment = {
               "storageKey": null
             }
           ],
-          "storageKey": "artworksConnection(first:1)"
+          "storageKey": null
         }
       ],
       "storageKey": null
@@ -95,5 +97,5 @@ const node: ReaderFragment = {
   ],
   "type": "TargetSupply"
 };
-(node as any).hash = '078b6c58d241220af9fc51e433ca4fd7';
+(node as any).hash = '4f4f9bb3ce9930f44af7ff5436942d46';
 export default node;

--- a/src/v2/__generated__/SoldRecently_tests_Query.graphql.ts
+++ b/src/v2/__generated__/SoldRecently_tests_Query.graphql.ts
@@ -126,11 +126,12 @@ fragment Save_artwork on Artwork {
 
 fragment SoldRecently_targetSupply on TargetSupply {
   microfunnel {
-    artworksConnection(first: 1) {
+    artworksConnection {
       edges {
         node {
           ...FillwidthItem_artwork
           realizedPrice
+          realizedToEstimate
           id
         }
       }
@@ -227,13 +228,7 @@ return {
             "selections": [
               {
                 "alias": null,
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "first",
-                    "value": 1
-                  }
-                ],
+                "args": null,
                 "concreteType": "ArtworkConnection",
                 "kind": "LinkedField",
                 "name": "artworksConnection",
@@ -510,6 +505,13 @@ return {
                             "kind": "ScalarField",
                             "name": "realizedPrice",
                             "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "realizedToEstimate",
+                            "storageKey": null
                           }
                         ],
                         "storageKey": null
@@ -518,7 +520,7 @@ return {
                     "storageKey": null
                   }
                 ],
-                "storageKey": "artworksConnection(first:1)"
+                "storageKey": null
               }
             ],
             "storageKey": null
@@ -533,7 +535,7 @@ return {
     "metadata": {},
     "name": "SoldRecently_tests_Query",
     "operationKind": "query",
-    "text": "query SoldRecently_tests_Query {\n  targetSupply {\n    ...SoldRecently_targetSupply\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SoldRecently_targetSupply on TargetSupply {\n  microfunnel {\n    artworksConnection(first: 1) {\n      edges {\n        node {\n          ...FillwidthItem_artwork\n          realizedPrice\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query SoldRecently_tests_Query {\n  targetSupply {\n    ...SoldRecently_targetSupply\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SoldRecently_targetSupply on TargetSupply {\n  microfunnel {\n    artworksConnection {\n      edges {\n        node {\n          ...FillwidthItem_artwork\n          realizedPrice\n          realizedToEstimate\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/routes_ArtistConsignQuery.graphql.ts
+++ b/src/v2/__generated__/routes_ArtistConsignQuery.graphql.ts
@@ -41,17 +41,19 @@ fragment ArtistConsignFAQ_artist on Artist {
 fragment ArtistConsignHeaderImages_artist on Artist {
   targetSupply {
     microfunnel {
-      artworks {
-        artwork {
-          image {
-            resized(height: 395) {
-              width
-              height
-              url
+      artworksConnection {
+        edges {
+          node {
+            image {
+              resized(height: 395) {
+                width
+                height
+                url
+              }
             }
+            ...FillwidthItem_artwork
+            id
           }
-          ...FillwidthItem_artwork
-          id
         }
       }
     }
@@ -86,12 +88,14 @@ fragment ArtistConsignMeta_artist on Artist {
   href
   targetSupply {
     microfunnel {
-      artworks {
-        artwork {
-          image {
-            imageURL: url(version: "medium")
+      artworksConnection {
+        edges {
+          node {
+            image {
+              imageURL: url(version: "medium")
+            }
+            id
           }
-          id
         }
       }
     }
@@ -113,12 +117,14 @@ fragment ArtistConsignPageViews_artist on Artist {
 fragment ArtistConsignRecentlySold_artist on Artist {
   targetSupply {
     microfunnel {
-      artworks {
-        artwork {
-          ...FillwidthItem_artwork
-          id
+      artworksConnection {
+        edges {
+          node {
+            ...FillwidthItem_artwork
+            realizedPrice
+            id
+          }
         }
-        realizedPrice
       }
     }
   }
@@ -375,327 +381,338 @@ return {
                   {
                     "alias": null,
                     "args": null,
-                    "concreteType": "ArtistTargetSupplyMicrofunnelArtwork",
+                    "concreteType": "ArtworkConnection",
                     "kind": "LinkedField",
-                    "name": "artworks",
-                    "plural": true,
+                    "name": "artworksConnection",
+                    "plural": false,
                     "selections": [
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "Artwork",
+                        "concreteType": "ArtworkEdge",
                         "kind": "LinkedField",
-                        "name": "artwork",
-                        "plural": false,
+                        "name": "edges",
+                        "plural": true,
                         "selections": [
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "Image",
+                            "concreteType": "Artwork",
                             "kind": "LinkedField",
-                            "name": "image",
+                            "name": "node",
                             "plural": false,
                             "selections": [
                               {
-                                "alias": "imageURL",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "medium"
-                                  }
-                                ],
-                                "kind": "ScalarField",
-                                "name": "url",
-                                "storageKey": "url(version:\"medium\")"
-                              },
-                              {
                                 "alias": null,
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "height",
-                                    "value": 395
-                                  }
-                                ],
-                                "concreteType": "ResizedImageUrl",
+                                "args": null,
+                                "concreteType": "Image",
                                 "kind": "LinkedField",
-                                "name": "resized",
+                                "name": "image",
                                 "plural": false,
                                 "selections": [
                                   {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "width",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "height",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
+                                    "alias": "imageURL",
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": "medium"
+                                      }
+                                    ],
                                     "kind": "ScalarField",
                                     "name": "url",
+                                    "storageKey": "url(version:\"medium\")"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "height",
+                                        "value": 395
+                                      }
+                                    ],
+                                    "concreteType": "ResizedImageUrl",
+                                    "kind": "LinkedField",
+                                    "name": "resized",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "width",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "height",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": "resized(height:395)"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": "large"
+                                      }
+                                    ],
+                                    "kind": "ScalarField",
+                                    "name": "url",
+                                    "storageKey": "url(version:\"large\")"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "aspectRatio",
                                     "storageKey": null
                                   }
                                 ],
-                                "storageKey": "resized(height:395)"
+                                "storageKey": null
+                              },
+                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "imageTitle",
+                                "storageKey": null
                               },
                               {
                                 "alias": null,
-                                "args": [
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "title",
+                                "storageKey": null
+                              },
+                              (v4/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "date",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "sale_message",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "saleMessage",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "cultural_maker",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "culturalMaker",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": (v6/*: any*/),
+                                "concreteType": "Artist",
+                                "kind": "LinkedField",
+                                "name": "artists",
+                                "plural": true,
+                                "selections": [
+                                  (v5/*: any*/),
+                                  (v4/*: any*/),
+                                  (v3/*: any*/)
+                                ],
+                                "storageKey": "artists(shallow:true)"
+                              },
+                              {
+                                "alias": "collecting_institution",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "collectingInstitution",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": (v6/*: any*/),
+                                "concreteType": "Partner",
+                                "kind": "LinkedField",
+                                "name": "partner",
+                                "plural": false,
+                                "selections": [
+                                  (v3/*: any*/),
+                                  (v4/*: any*/),
+                                  (v5/*: any*/),
                                   {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "large"
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "type",
+                                    "storageKey": null
                                   }
                                 ],
-                                "kind": "ScalarField",
-                                "name": "url",
-                                "storageKey": "url(version:\"large\")"
+                                "storageKey": "partner(shallow:true)"
                               },
                               {
                                 "alias": null,
                                 "args": null,
-                                "kind": "ScalarField",
-                                "name": "aspectRatio",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          (v5/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "imageTitle",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "title",
-                            "storageKey": null
-                          },
-                          (v4/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "date",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "sale_message",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "saleMessage",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "cultural_maker",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "culturalMaker",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": (v6/*: any*/),
-                            "concreteType": "Artist",
-                            "kind": "LinkedField",
-                            "name": "artists",
-                            "plural": true,
-                            "selections": [
-                              (v5/*: any*/),
-                              (v4/*: any*/),
-                              (v3/*: any*/)
-                            ],
-                            "storageKey": "artists(shallow:true)"
-                          },
-                          {
-                            "alias": "collecting_institution",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "collectingInstitution",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": (v6/*: any*/),
-                            "concreteType": "Partner",
-                            "kind": "LinkedField",
-                            "name": "partner",
-                            "plural": false,
-                            "selections": [
-                              (v3/*: any*/),
-                              (v4/*: any*/),
-                              (v5/*: any*/),
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "type",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": "partner(shallow:true)"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Sale",
-                            "kind": "LinkedField",
-                            "name": "sale",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": "is_auction",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isAuction",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": "is_closed",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isClosed",
-                                "storageKey": null
-                              },
-                              (v5/*: any*/),
-                              {
-                                "alias": "is_live_open",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isLiveOpen",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": "is_open",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isOpen",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": "is_preview",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isPreview",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": "display_timely_at",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "displayTimelyAt",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "sale_artwork",
-                            "args": null,
-                            "concreteType": "SaleArtwork",
-                            "kind": "LinkedField",
-                            "name": "saleArtwork",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "SaleArtworkCounts",
+                                "concreteType": "Sale",
                                 "kind": "LinkedField",
-                                "name": "counts",
+                                "name": "sale",
                                 "plural": false,
                                 "selections": [
                                   {
-                                    "alias": "bidder_positions",
+                                    "alias": "is_auction",
                                     "args": null,
                                     "kind": "ScalarField",
-                                    "name": "bidderPositions",
+                                    "name": "isAuction",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_closed",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isClosed",
+                                    "storageKey": null
+                                  },
+                                  (v5/*: any*/),
+                                  {
+                                    "alias": "is_live_open",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isLiveOpen",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_open",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isOpen",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_preview",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isPreview",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "display_timely_at",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "displayTimelyAt",
                                     "storageKey": null
                                   }
                                 ],
                                 "storageKey": null
                               },
                               {
-                                "alias": "highest_bid",
+                                "alias": "sale_artwork",
                                 "args": null,
-                                "concreteType": "SaleArtworkHighestBid",
+                                "concreteType": "SaleArtwork",
                                 "kind": "LinkedField",
-                                "name": "highestBid",
+                                "name": "saleArtwork",
                                 "plural": false,
-                                "selections": (v7/*: any*/),
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "SaleArtworkCounts",
+                                    "kind": "LinkedField",
+                                    "name": "counts",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "bidder_positions",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "bidderPositions",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "highest_bid",
+                                    "args": null,
+                                    "concreteType": "SaleArtworkHighestBid",
+                                    "kind": "LinkedField",
+                                    "name": "highestBid",
+                                    "plural": false,
+                                    "selections": (v7/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "opening_bid",
+                                    "args": null,
+                                    "concreteType": "SaleArtworkOpeningBid",
+                                    "kind": "LinkedField",
+                                    "name": "openingBid",
+                                    "plural": false,
+                                    "selections": (v7/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  (v5/*: any*/)
+                                ],
                                 "storageKey": null
                               },
                               {
-                                "alias": "opening_bid",
+                                "alias": "is_inquireable",
                                 "args": null,
-                                "concreteType": "SaleArtworkOpeningBid",
-                                "kind": "LinkedField",
-                                "name": "openingBid",
-                                "plural": false,
-                                "selections": (v7/*: any*/),
+                                "kind": "ScalarField",
+                                "name": "isInquireable",
                                 "storageKey": null
                               },
-                              (v5/*: any*/)
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "internalID",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "slug",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_saved",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isSaved",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_biddable",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isBiddable",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "realizedPrice",
+                                "storageKey": null
+                              }
                             ],
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "is_inquireable",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isInquireable",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "internalID",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "slug",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "is_saved",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isSaved",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "is_biddable",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isBiddable",
                             "storageKey": null
                           }
                         ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "realizedPrice",
                         "storageKey": null
                       }
                     ],
@@ -765,7 +782,7 @@ return {
     "metadata": {},
     "name": "routes_ArtistConsignQuery",
     "operationKind": "query",
-    "text": "query routes_ArtistConsignQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...Consign_artist\n    targetSupply {\n      isInMicrofunnel\n    }\n    id\n  }\n}\n\nfragment ArtistConsignFAQ_artist on Artist {\n  href\n}\n\nfragment ArtistConsignHeaderImages_artist on Artist {\n  targetSupply {\n    microfunnel {\n      artworks {\n        artwork {\n          image {\n            resized(height: 395) {\n              width\n              height\n              url\n            }\n          }\n          ...FillwidthItem_artwork\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignHeader_artist on Artist {\n  ...ArtistConsignHeaderImages_artist\n  name\n  href\n}\n\nfragment ArtistConsignHowToSell_artist on Artist {\n  href\n}\n\nfragment ArtistConsignMarketTrends_artist on Artist {\n  href\n  targetSupply {\n    microfunnel {\n      metadata {\n        highestRealized\n        str\n        realized\n      }\n    }\n  }\n}\n\nfragment ArtistConsignMeta_artist on Artist {\n  name\n  href\n  targetSupply {\n    microfunnel {\n      artworks {\n        artwork {\n          image {\n            imageURL: url(version: \"medium\")\n          }\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignPageViews_artist on Artist {\n  name\n  targetSupply {\n    microfunnel {\n      metadata {\n        roundedViews\n        roundedUniqueVisitors\n      }\n    }\n  }\n}\n\nfragment ArtistConsignRecentlySold_artist on Artist {\n  targetSupply {\n    microfunnel {\n      artworks {\n        artwork {\n          ...FillwidthItem_artwork\n          id\n        }\n        realizedPrice\n      }\n    }\n  }\n  name\n}\n\nfragment ArtistConsignSellArt_artist on Artist {\n  href\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Consign_artist on Artist {\n  ...ArtistConsignMeta_artist\n  ...ArtistConsignHeader_artist\n  ...ArtistConsignRecentlySold_artist\n  ...ArtistConsignPageViews_artist\n  ...ArtistConsignMarketTrends_artist\n  ...ArtistConsignHowToSell_artist\n  ...ArtistConsignFAQ_artist\n  ...ArtistConsignSellArt_artist\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query routes_ArtistConsignQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...Consign_artist\n    targetSupply {\n      isInMicrofunnel\n    }\n    id\n  }\n}\n\nfragment ArtistConsignFAQ_artist on Artist {\n  href\n}\n\nfragment ArtistConsignHeaderImages_artist on Artist {\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            image {\n              resized(height: 395) {\n                width\n                height\n                url\n              }\n            }\n            ...FillwidthItem_artwork\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignHeader_artist on Artist {\n  ...ArtistConsignHeaderImages_artist\n  name\n  href\n}\n\nfragment ArtistConsignHowToSell_artist on Artist {\n  href\n}\n\nfragment ArtistConsignMarketTrends_artist on Artist {\n  href\n  targetSupply {\n    microfunnel {\n      metadata {\n        highestRealized\n        str\n        realized\n      }\n    }\n  }\n}\n\nfragment ArtistConsignMeta_artist on Artist {\n  name\n  href\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            image {\n              imageURL: url(version: \"medium\")\n            }\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ArtistConsignPageViews_artist on Artist {\n  name\n  targetSupply {\n    microfunnel {\n      metadata {\n        roundedViews\n        roundedUniqueVisitors\n      }\n    }\n  }\n}\n\nfragment ArtistConsignRecentlySold_artist on Artist {\n  targetSupply {\n    microfunnel {\n      artworksConnection {\n        edges {\n          node {\n            ...FillwidthItem_artwork\n            realizedPrice\n            id\n          }\n        }\n      }\n    }\n  }\n  name\n}\n\nfragment ArtistConsignSellArt_artist on Artist {\n  href\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Consign_artist on Artist {\n  ...ArtistConsignMeta_artist\n  ...ArtistConsignHeader_artist\n  ...ArtistConsignRecentlySold_artist\n  ...ArtistConsignPageViews_artist\n  ...ArtistConsignMarketTrends_artist\n  ...ArtistConsignHowToSell_artist\n  ...ArtistConsignFAQ_artist\n  ...ArtistConsignSellArt_artist\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"large\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Save_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GRO-54
Related Metaphysics PR: https://github.com/artsy/metaphysics/pull/2871

## Problem

We want to show users the value of consigning on Artsy by showing positive outcomes for works sold on Artsy. To do this, we want to show the ratio of the realized price to the estimate for a work.

## Solution

Add `realizedToEstimate` field on the `Artwork` type in Metaphysics and then display in Force.

As part of this work we refactored the `ArtistTargetSupplyMicrofunnel` type and related code in Metaphysics to only use `artworksConnection` instead of a separate `artworks` field. This PR continues that refactor and converts existing views that rely on `artworks` to only use `artworksConnection`.

## Release strategy

This change is tightly coupled to changes in Metaphysics and will result in a small amount of downtime for consign pages while we roll out both services.

## Screenshots

![Screen Shot 2020-12-10 at 4 33 57 PM](https://user-images.githubusercontent.com/4432348/101927664-bc9bcd00-3ba2-11eb-8a74-f24f9aa88435.png)

![Screen Shot 2020-12-10 at 4 34 20 PM](https://user-images.githubusercontent.com/4432348/101927686-c02f5400-3ba2-11eb-817d-29780c17fa59.png)
