### PR TITLE
feature: EJS Inject Chunks Automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -294,6 +294,7 @@
     "coffeescript": "1.11.1",
     "cypress": "5.1.0",
     "danger": "7.0.16",
+    "ejs-compiled-loader": "3.0.0",
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.14.0",
     "eslint": "6.8.0",

--- a/src/novo/src/index.ejs
+++ b/src/novo/src/index.ejs
@@ -5,36 +5,27 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <meta charset='utf-8' />
 
-  <link rel='apple-touch-icon' href="<%= icons.icon152 %>" />
-  <link rel='apple-touch-icon' sizes='120x120' href="<% icons.icon120 %>" />
-  <link rel='apple-touch-icon' sizes='152x152' href="<%= icons.icon152 %>" />
-  <link rel='apple-touch-icon' sizes='76x76' href="<%= icons.icon76 %>" />
-  <link rel='icon' type='image/png' href="<%= icons.favicon %>" />
+  <link rel='apple-touch-icon' href="<%%= icons.icon152 %>" />
+  <link rel='apple-touch-icon' sizes='120x120' href="<%%= icons.icon120 %>" />
+  <link rel='apple-touch-icon' sizes='152x152' href="<%%= icons.icon152 %>" />
+  <link rel='apple-touch-icon' sizes='76x76' href="<%%= icons.icon76 %>" />
+  <link rel='icon' type='image/png' href="<%%= icons.favicon %>" />
 
-  <link type="text/css" rel='stylesheet' href="<%= css.global %>" />
-  <%- content.head %>
-  <%- content.style %>
-  <%- content.data %>
+  <link type="text/css" rel='stylesheet' href="<%%= css.global %>" />
+
+  <!-- String concatenation is needed allow outputting a template tag -->
+  <%- htmlWebpackPlugin.tags.bodyTags.map((tag) => { tag.attributes['src'] = "<" + "%= cdnUrl %" + ">" + tag.attributes['src']; tag.attributes['async'] = true; return tag; }) %>
+
+  <%%- content.head %>
+  <%%- content.style %>
+  <%%- content.data %>
 </head>
 
 <body>
-  <% if (env === 'production') { %>
-  <script type="text/javascript" src="<%= manifest.runtime %>"></script>
-  <script type="text/javascript" src="<%= manifest.common %>"></script>
-  <script type="text/javascript" src="<%= manifest.artsyCommon %>"></script>
-  <script type="text/javascript" src="<%= manifest.commonReact %>"></script>
-  <script type="text/javascript" src="<%= manifest.commonUtility %>"></script>
-  <script type="text/javascript" src="<%= manifest.artsy %>"></script>
-  <% } %>
-
-  <%- content.scripts %>
+  <%%- content.scripts %>
 
   <div id="react-modal-container"></div>
-  <div id="react-root"><%- content.body %></div>
-
-  <% if (env === 'production') { %>
-  <script type="text/javascript" src="<%= manifest.artsyNovo %>"></script>
-  <% } %>
+  <div id="react-root"><%%- content.body %></div>
 </body>
 
 </html>

--- a/src/novo/src/server.ts
+++ b/src/novo/src/server.ts
@@ -8,8 +8,9 @@ import loadAssetManifest from "lib/manifest"
 import express from "express"
 import path from "path"
 
-const config = require("../../config")
-const { NODE_ENV } = config
+// TODO: Use the same variables as the asset middleware. Both config and sharify
+// have a default CDN_URL while this does not.
+const { CDN_URL, NODE_ENV } = process.env
 
 const PUBLIC_DIR = path.resolve(__dirname, "../../../public")
 const NOVO_MANIFEST = loadAssetManifest("manifest-novo.json")
@@ -92,6 +93,7 @@ function initializeNovo() {
         const sharifyData = res.locals.sharify.script()
 
         const options = {
+          cdnUrl: NODE_ENV === "production" ? CDN_URL : "",
           content: {
             body: bodyHTML,
             data: sharifyData,
@@ -122,6 +124,7 @@ function initializeNovo() {
             ),
             runtime: NOVO_MANIFEST.lookup("/assets-novo/runtime.js"),
           },
+          // TODO: Post-release review that sharify is still used in the template.
           sd: sharify.data,
         }
 

--- a/webpack/envs/clientNovoDevelopmentConfig.js
+++ b/webpack/envs/clientNovoDevelopmentConfig.js
@@ -70,6 +70,19 @@ export const clientNovoDevelopmentConfig = {
         type: "javascript/auto",
         use: [],
       },
+      // https://github.com/bazilio91/ejs-compiled-loader/issues/46
+      {
+        test: /\.ejs$/,
+        use: {
+          loader: "ejs-compiled-loader",
+          options: {
+            htmlmin: true,
+            htmlminOptions: {
+              removeComments: true,
+            },
+          },
+        },
+      },
     ],
   },
   name: "novo",
@@ -200,13 +213,8 @@ export const clientNovoDevelopmentConfig = {
     }),
     new HtmlWebpackPlugin({
       filename: path.resolve(basePath, "public", "index.ejs"),
-      template: `!!raw-loader!${path.resolve(
-        basePath,
-        "src",
-        "novo",
-        "src",
-        "index.ejs"
-      )}`,
+      inject: false,
+      template: path.resolve(basePath, "src", "novo", "src", "index.ejs"),
     }),
   ],
   resolve: {

--- a/webpack/envs/clientNovoProductionConfig.js
+++ b/webpack/envs/clientNovoProductionConfig.js
@@ -68,6 +68,19 @@ export const clientNovoProductionConfig = {
         type: "javascript/auto",
         use: [],
       },
+      // https://github.com/bazilio91/ejs-compiled-loader/issues/46
+      {
+        test: /\.ejs$/,
+        use: {
+          loader: "ejs-compiled-loader",
+          options: {
+            htmlmin: true,
+            htmlminOptions: {
+              removeComments: true,
+            },
+          },
+        },
+      },
     ],
   },
   optimization: {
@@ -212,13 +225,7 @@ export const clientNovoProductionConfig = {
         conservativeCollapse: true,
         removeComments: true,
       },
-      template: `!!raw-loader!${path.resolve(
-        basePath,
-        "src",
-        "novo",
-        "src",
-        "index.ejs"
-      )}`,
+      template: path.resolve(basePath, "src", "novo", "src", "index.ejs"),
     }),
   ],
   resolve: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5242,6 +5242,14 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camel-case@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
+  integrity sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=
+  dependencies:
+    no-case "^2.2.0"
+    upper-case "^1.1.1"
+
 camel-case@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.1.tgz#1fc41c854f00e2f7d0139dfeba1542d6896fe547"
@@ -5564,7 +5572,7 @@ clean-css@^4.1.11:
   dependencies:
     source-map "~0.6.0"
 
-clean-css@^4.2.3:
+clean-css@^4.2.1, clean-css@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"
   integrity sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==
@@ -5831,6 +5839,11 @@ commander@^2.18.0, commander@^2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
+commander@^2.19.0, commander@~2.20.3:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 commander@^2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
@@ -5845,11 +5858,6 @@ commander@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
-
-commander@~2.20.3:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 common-tags@^1.8.0:
   version "1.8.0"
@@ -7274,6 +7282,17 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
+ejs-compiled-loader@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ejs-compiled-loader/-/ejs-compiled-loader-3.0.0.tgz#a425b07f436d1bb2ad6f47e0fbfbb6b829d684b9"
+  integrity sha512-AR2y2TB2CdBO4cxSo2ZEqClL61NKgWa1fbB+r7z0MnC6pPjcSJgNL9ylMpDI/Olt1lAGifWw3ElX/t+x69RJUg==
+  dependencies:
+    ejs "^2"
+    html-minifier "^4"
+    loader-utils "^2"
+    merge "^1.2.1"
+    terser "^4.6"
+
 ejs@3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.5.tgz#aed723844dc20acb4b170cd9ab1017e476a0d93b"
@@ -7281,7 +7300,7 @@ ejs@3.1.5:
   dependencies:
     jake "^10.6.1"
 
-ejs@^2.6.1:
+ejs@^2, ejs@^2.6.1:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
@@ -9932,6 +9951,19 @@ html-minifier-terser@^5.0.1:
     param-case "^3.0.3"
     relateurl "^0.2.7"
     terser "^4.6.3"
+
+html-minifier@^4:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-4.0.0.tgz#cca9aad8bce1175e02e17a8c33e46d8988889f56"
+  integrity sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==
+  dependencies:
+    camel-case "^3.0.0"
+    clean-css "^4.2.1"
+    commander "^2.19.0"
+    he "^1.2.0"
+    param-case "^2.1.1"
+    relateurl "^0.2.7"
+    uglify-js "^3.5.1"
 
 html-webpack-plugin@4.5.0:
   version "4.5.0"
@@ -12613,6 +12645,15 @@ loader-utils@^1.2.3, loader-utils@^1.4.0:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
+loader-utils@^2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
+  integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -12977,6 +13018,11 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
+lower-case@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
+  integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
+
 lower-case@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.1.tgz#39eeb36e396115cc05e29422eaea9e692c9408c7"
@@ -13242,6 +13288,11 @@ merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+merge@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
+  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
 methods@1.x, methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
@@ -13676,6 +13727,13 @@ nightmare@2.10.0:
     rimraf "^2.4.3"
     sliced "1.0.1"
     split2 "^2.0.1"
+
+no-case@^2.2.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
+  integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
+  dependencies:
+    lower-case "^1.1.1"
 
 no-case@^3.0.3:
   version "3.0.3"
@@ -14486,6 +14544,13 @@ parallel-transform@^1.1.0:
     cyclist "~0.2.2"
     inherits "^2.0.3"
     readable-stream "^2.1.5"
+
+param-case@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
+  integrity sha1-35T9jPZTHs915r75oIWPvHK+Ikc=
+  dependencies:
+    no-case "^2.2.0"
 
 param-case@^3.0.3:
   version "3.0.3"
@@ -18531,7 +18596,7 @@ terser@^4.1.2:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^4.6.3:
+terser@^4.6, terser@^4.6.3:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
   integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
@@ -19029,6 +19094,11 @@ uglify-js@^3.1.4:
   dependencies:
     commander "~2.20.3"
 
+uglify-js@^3.5.1:
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.12.1.tgz#78307f539f7b9ca5557babb186ea78ad30cc0375"
+  integrity sha512-o8lHP20KjIiQe5b/67Rh68xEGRrc2SRsCuuoYclXXoC74AfSRGblU1HKzJWH3HxPZ+Ort85fWHpSX7KwBUC9CQ==
+
 uglify-js@~2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.2.5.tgz#a6e02a70d839792b9780488b7b8b184c095c99c7"
@@ -19284,6 +19354,11 @@ updeep@1.0.0:
   integrity sha1-5fSdkzMI+wJzD9TzIcs+Nr8EsPA=
   dependencies:
     lodash "^4.2.0"
+
+upper-case@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
+  integrity sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=
 
 uri-js@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
Automatically inject all chunks using the `html-webpack-plugin`. This
will allow us to iterate on chunk heuristics without needing to update
templates.

The ejs template is compiled once by Webpack to inject chunks and a
second time during rendering to inject dynamic variables.