### PR TITLE
fix: enable client-side-hot-reload

### DIFF
--- a/src/novo/src/client.tsx
+++ b/src/novo/src/client.tsx
@@ -18,7 +18,19 @@ import("v2/Artsy/Router/client")
       ReactDOM.hydrate(<ClientApp />, document.getElementById("react-root"))
     })
   })
-  .then(() => { return import("desktop/apps/authentication/client/initModalManager") })
-  .then(({ initModalManager }) => { initModalManager() })
-  .then(() => { mediator.on("auth:logout", logoutEventHandler) })
-  .catch(error => { console.error(error) })
+  .then(() => {
+    return import("desktop/apps/authentication/client/initModalManager")
+  })
+  .then(({ initModalManager }) => {
+    initModalManager()
+  })
+  .then(() => {
+    mediator.on("auth:logout", logoutEventHandler)
+  })
+  .catch(error => {
+    console.error(error)
+  })
+
+if (module.hot) {
+  module.hot.accept()
+}


### PR DESCRIPTION
This wasn't turned on before, which led to full-page reloads whenever client-side changes were made. We needed to add 

```tsx
if (module.hot) {
  module.hot.accept()
}
```
to our root `client.tsx` file. Now hot reloading is enabled throughout the entire client-side tree. 

#### Before:

![before](https://user-images.githubusercontent.com/236943/101712143-c0680c00-3a49-11eb-8b00-1f98fe835020.gif)

Notice that after the change is made, the console fully clears -- thats because the page has done a full reload and stuff isn't hot-reloaded.

#### After: 
![after](https://user-images.githubusercontent.com/236943/101712155-c5c55680-3a49-11eb-97f6-6524fb602e42.gif)

Now, after a change, the console is appended to and things are hot-reloaded successfully. No full page restart necessary. 