### PR TITLE
bug: Add white-space: pre-wrap style to artwork details, exhitibion history, literature, and provenance

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/index.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/index.tsx
@@ -32,10 +32,10 @@ export interface ArtworkDetailsProps {
 export class ArtworkDetails extends Component<ArtworkDetailsProps> {
   @track((_props, _state, [{ data }]) => {
     return {
-      flow: Schema.Flow.ArtworkAboutTheArtist,
-      type: Schema.Type.Tab,
-      label: data.trackingLabel,
       action_type: Schema.ActionType.Click,
+      flow: Schema.Flow.ArtworkAboutTheArtist,
+      label: data.trackingLabel,
+      type: Schema.Type.Tab,
     }
   })
   trackTabChange() {
@@ -135,6 +135,7 @@ export const ArtworkDetailsQueryRenderer = ({
 const TabContainer = styled(Box)`
   > * {
     margin-block-start: 0;
+    white-space: pre-wrap;
   }
 `
 


### PR DESCRIPTION
Add a `white-space: pre-wrap` style certain Box elements on the artworks detail page.

**Before:**

<img width="261" alt=" 2020-12-11 at 4 57 44 PM" src="https://user-images.githubusercontent.com/1389948/101958780-ffc16480-3bd1-11eb-8414-c9e43bca20b6.png">

-----------

**After:**

<img width="277" alt=" 2020-12-11 at 4 57 39 PM" src="https://user-images.githubusercontent.com/1389948/101958812-15368e80-3bd2-11eb-82b2-6f6b6b4b19e7.png">

-----------

**CMS:**

<img width="715" alt=" 2020-12-11 at 5 02 25 PM" src="https://user-images.githubusercontent.com/1389948/101959091-a6a60080-3bd2-11eb-893f-59036548e628.png">
