### PR TITLE
fix: Prevent nav items from remaining focused

### DIFF
--- a/src/v2/Components/NavBar/NavItem.tsx
+++ b/src/v2/Components/NavBar/NavItem.tsx
@@ -42,8 +42,8 @@ const HitArea = styled(Link)`
 `
 
 const UnfocusableAnchor = styled(RouterLink).attrs({
-  tabIndex: -1,
   role: "presentation",
+  tabIndex: -1,
 })`
   display: block;
   position: absolute;
@@ -84,14 +84,16 @@ export const NavItem: React.FC<NavItemProps> = ({
 
   const showMenu = Boolean(Menu && isVisible)
   const showOverlay = Boolean(Overlay)
+  const showFocusableAnchor = Boolean(Menu || !href)
   const color = isVisible ? "purple100" : "black100"
 
   const trackClick = () => {
     if (href && isString(children)) {
       trackEvent({
         action_type: AnalyticsSchema.ActionType.Click,
-        subject: children, // Text passed into the NavItem
+        // Text passed into the NavItem
         destination_path: href,
+        subject: children,
       })
     }
   }
@@ -165,9 +167,9 @@ export const NavItem: React.FC<NavItemProps> = ({
         ref={hitAreaRef as any}
         {...(!!Menu
           ? {
-              as: Clickable,
-              "aria-haspopup": true,
               "aria-expanded": showMenu,
+              "aria-haspopup": true,
+              as: Clickable,
             }
           : { as: RouterLink, to: href })}
         color={color}
@@ -178,7 +180,7 @@ export const NavItem: React.FC<NavItemProps> = ({
         role={role}
         onClick={handleClick}
       >
-        {!!Menu && href && <UnfocusableAnchor to={href} />}
+        {showFocusableAnchor && <UnfocusableAnchor to={href} />}
         <Text variant="text" lineHeight="solid" color={color}>
           <NavItemInner height={25}>
             {isFunction(children)


### PR DESCRIPTION
## Context

Fixes https://github.com/artsy/force/issues/6817

Although the solution doesn't seem to be ideal it's the best way I could think of without refactoring
the `NavItem` component.

## Proposed Change

This PR changes the logic on when `UnfocusableAnchor` is rendered inside of `NavItem` in
order to not focus the item itself when opening a menu. The change prevents the `HitArea` inside of `NavItem`
from being focused (and displaying a black border at the bottom) for all nav items without a link.

With this change, the `UnfocusableAnchor` is displayed whenever there is a `Menu` or **no** `href`
prop passed to `NavItem`.

If a `href` prop is provided, the item gets unfocused anyway after it is clicked due to the following page refresh.

## Testing Plan

- [ ] Test behavior wherever `NavItem` is used.
- [ ] Test navigation bar when logged in and when not logged in
- [ ] Test with different browsers and devices (especially mobile)
- [ ] Test if keyboard accessibility stays intact (e.g. navigating with the `tab` key)