### PR TITLE
Update COA language on artwork page

### DIFF
--- a/src/v2/Apps/Artwork/Components/TrustSignals/AuthenticityCertificate.tsx
+++ b/src/v2/Apps/Artwork/Components/TrustSignals/AuthenticityCertificate.tsx
@@ -43,7 +43,7 @@ export const AuthenticityCertificate: React.FC<AuthenticityCertificateProps> = (
         >
           <Flex flexGrow={1} flexDirection="column">
             <Text variant="text" pb={2}>
-              A certificate of authenticity (COA) is a signed document from an
+              A certificate of authenticity (COA) is a document from an
               authoritative source that verifies the artwork’s authenticity.
               While many COAs are signed by the artist, others will be signed by
               the representing gallery or the printmaker who collaborated with


### PR DESCRIPTION
[PURCHASE-2254]

Context:

The current language for COAs that appears on the artwork page defines a COA as a signed document, and while this is best practice, there are some rare exceptions where a COA is not signed, but is from an authoritative body. 

We want to allow for this exception (though not encourage it) to avoid confusion on the part of collectors.

Request:

Amend the first sentence of the langue to remove "signed," so that it will read: "A certificate of authenticity (COA) is a document from an authoritative source that verifies the artwork’s authenticity."

[PURCHASE-2254]: https://artsyproduct.atlassian.net/browse/PURCHASE-2254