### PR TITLE
#DRAFT feat: filter sentry errors

### DIFF
--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -14,6 +14,7 @@ import syncAuth from "lib/syncAuth"
 import { mediator } from "lib/mediator"
 import { LogoutEventOptions } from "typings/mediator"
 import * as templateModules from "./template_modules"
+import { setupSentry } from "lib/setupSentry"
 
 const FlashMessage = require("../components/flash/index.coffee")
 const listenForInvert = require("../components/eggs/invert/index.coffee")
@@ -106,7 +107,7 @@ function setupJquery() {
 
 function setupErrorReporting() {
   if (sd.NODE_ENV === "production") {
-    Sentry.init({ dsn: sd.SENTRY_PUBLIC_DSN })
+    setupSentry(sd)
 
     const user = sd && sd.CURRENT_USER
 

--- a/src/lib/setupSentry.ts
+++ b/src/lib/setupSentry.ts
@@ -1,0 +1,24 @@
+import * as Sentry from "@sentry/browser"
+
+let INITIALIZED = false
+
+export function setupSentry(sd) {
+  if (INITIALIZED) {
+    return
+  }
+  Sentry.init(
+    {
+      dsn: sd.SENTRY_PUBLIC_DSN,
+      beforeSend(event, hint) {
+        const error = hint.originalException;
+        if (error && error.message) {
+          if (error.message.match(/pktAnnotationHighlighter/i)) {
+            return null;
+          }
+        }
+        return event;
+      }
+    }
+  )
+  INITIALIZED = true
+}

--- a/src/v2/Artsy/Router/Boot.tsx
+++ b/src/v2/Artsy/Router/Boot.tsx
@@ -45,7 +45,20 @@ export const Boot = track(null, {
     document.body.setAttribute("data-test", "AppReady") //
 
     if (getENV("NODE_ENV") === "production") {
-      Sentry.init({ dsn: sd.SENTRY_PUBLIC_DSN })
+      Sentry.init(
+        {
+          dsn: sd.SENTRY_PUBLIC_DSN,
+          beforeSend(event, hint) {
+            const error = hint.originalException;
+            if (error && error.message) {
+              if (error.message.match(/pktAnnotationHighlighter/i)) {
+                return null;
+              }
+            }
+            return event;
+          }
+        }
+      )
     }
   }, [])
 

--- a/src/v2/Artsy/Router/Boot.tsx
+++ b/src/v2/Artsy/Router/Boot.tsx
@@ -1,5 +1,4 @@
 import { Grid, Theme, injectGlobalStyles, themeProps } from "@artsy/palette"
-import * as Sentry from "@sentry/browser"
 import { SystemContextProvider, track } from "v2/Artsy"
 import { RouteConfig } from "found"
 import React, { useEffect } from "react"
@@ -21,6 +20,7 @@ import {
 import { AnalyticsContext } from "../Analytics/AnalyticsContext"
 import { ClientContext } from "desktop/lib/buildClientAppContext"
 import { FlashMessage } from "v2/Components/Modal/FlashModal"
+import { setupSentry } from "lib/setupSentry"
 
 export interface BootProps {
   children: React.ReactNode
@@ -45,20 +45,7 @@ export const Boot = track(null, {
     document.body.setAttribute("data-test", "AppReady") //
 
     if (getENV("NODE_ENV") === "production") {
-      Sentry.init(
-        {
-          dsn: sd.SENTRY_PUBLIC_DSN,
-          beforeSend(event, hint) {
-            const error = hint.originalException;
-            if (error && error.message) {
-              if (error.message.match(/pktAnnotationHighlighter/i)) {
-                return null;
-              }
-            }
-            return event;
-          }
-        }
-      )
+      setupSentry(sd)
     }
   }, [])
 


### PR DESCRIPTION
Use the `beforeSend` callback to filter and drop unwanted errors.  WIP.