### PR TITLE
fix: Remove eslint object sort plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,6 @@ module.exports = {
   plugins: [
     "react-hooks",
     "@typescript-eslint",
-    "sort-keys-fix",
     "styled-components-a11y",
     "jest",
   ],
@@ -59,7 +58,6 @@ module.exports = {
     "react/prop-types": 0,
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-    "sort-keys-fix/sort-keys-fix": "warn",
 
     // FIXME: Investigate / reenable these rules. Disabled to introduce eslint
     // into codebase.

--- a/package.json
+++ b/package.json
@@ -310,7 +310,6 @@
     "eslint-plugin-jest": "24.1.3",
     "eslint-plugin-react": "7.19.0",
     "eslint-plugin-react-hooks": "4.0.4",
-    "eslint-plugin-sort-keys-fix": "1.1.1",
     "eslint-plugin-styled-components-a11y": "0.0.16",
     "fork-ts-checker-notifier-webpack-plugin": "0.4.0",
     "fork-ts-checker-webpack-plugin": "0.4.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7750,13 +7750,6 @@ eslint-plugin-react@^7.18.3:
     resolve "^1.17.0"
     string.prototype.matchall "^4.0.2"
 
-eslint-plugin-sort-keys-fix@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-keys-fix/-/eslint-plugin-sort-keys-fix-1.1.1.tgz#2ed201b53fd4a89552c6e2abd38933f330a4b62e"
-  integrity sha512-x02SLBg+8OEaoT9vvMbsgeInw17wjHLsa9cOieIVQY+xMNRiXBbyMWw+NiBoxYyJIR4QKDOPDofCjQdoSvltQg==
-  dependencies:
-    requireindex "~1.2.0"
-
 eslint-plugin-styled-components-a11y@0.0.16:
   version "0.0.16"
   resolved "https://registry.yarnpkg.com/eslint-plugin-styled-components-a11y/-/eslint-plugin-styled-components-a11y-0.0.16.tgz#ebf5313d8a5ae5a58d1e1b8c212c7b9af0eaf261"
@@ -16555,11 +16548,6 @@ require-package-name@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
   integrity sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=
-
-requireindex@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
-  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This is leading to too much churn in our diffs, and attempting to fix everyting at once [here](https://github.com/artsy/force/pull/6827) mysteriously blows up our tests. Until https://github.com/artsy/force/pull/6827 can be fixed, just gonna opt to remove this plugin. 