### PR TITLE
Improve pagination with hrefs

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@artsy/express-reloadable": "1.4.8",
     "@artsy/fresnel": "1.3.1",
     "@artsy/gemup": "0.1.0",
-    "@artsy/palette": "13.26.4",
+    "@artsy/palette": "13.27.0",
     "@artsy/passport": "1.7.0",
     "@artsy/reaction": "29.0.1",
     "@artsy/stitch": "6.2.0",

--- a/src/v2/Apps/Artist/Routes/Articles/__tests__/Articles.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/Articles/__tests__/Articles.jest.tsx
@@ -8,6 +8,7 @@ import { graphql } from "react-relay"
 import { Breakpoint } from "v2/Utils/Responsive"
 
 jest.unmock("react-relay")
+jest.mock("v2/Components/Pagination/useComputeHref")
 
 describe("Articles Route", () => {
   let wrapper: ReactWrapper
@@ -40,7 +41,7 @@ describe("Articles Route", () => {
     it("renders proper elements", () => {
       expect(wrapper.find("ArticleItem").length).toBe(10)
       expect(wrapper.find("Pagination").length).toBe(1)
-      expect(wrapper.find("Pagination").find("button").length).toBe(4)
+      expect(wrapper.find("Pagination").find("a").length).toBe(6)
     })
 
     it("renders proper article contents", () => {

--- a/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.jest.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-done-callback */
 import { AuctionResults_Test_QueryRawResponse } from "v2/__generated__/AuctionResults_Test_Query.graphql"
 import { AuctionResultsFixture } from "v2/Apps/__tests__/Fixtures/Artist/Routes/AuctionResultsFixture"
 import { AuctionResultsRouteFragmentContainer as AuctionResultsRoute } from "v2/Apps/Artist/Routes/AuctionResults"
@@ -13,6 +14,7 @@ import { openAuthModal } from "v2/Utils/openAuthModal"
 jest.unmock("react-relay")
 jest.mock("react-tracking")
 jest.mock("v2/Utils/openAuthModal")
+jest.mock("v2/Components/Pagination/useComputeHref")
 
 describe("AuctionResults", () => {
   let wrapper: ReactWrapper
@@ -64,13 +66,13 @@ describe("AuctionResults", () => {
 
     it("calls auth modal for 1st pagination but not for 2nd", done => {
       const pagination = wrapper.find("Pagination")
-      pagination.find("button").at(1).simulate("click")
+      pagination.find("a").at(1).simulate("click")
 
       setTimeout(() => {
         expect(mockOpenAuthModal).toHaveBeenCalledTimes(1)
       })
 
-      pagination.find("button").at(2).simulate("click")
+      pagination.find("a").at(2).simulate("click")
 
       setTimeout(() => {
         // expect no new call
@@ -158,7 +160,7 @@ describe("AuctionResults", () => {
         it("triggers relay refetch with after, and re-shows sign up to see price", done => {
           const pagination = wrapper.find("Pagination")
 
-          pagination.find("button").at(1).simulate("click")
+          pagination.find("a").at(1).simulate("click")
 
           setTimeout(() => {
             expect(refetchSpy).toHaveBeenCalledTimes(1)

--- a/src/v2/Apps/Artist/Routes/Shows/__tests__/Shows.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/Shows/__tests__/Shows.jest.tsx
@@ -8,6 +8,7 @@ import { graphql } from "react-relay"
 import { Breakpoint } from "v2/Utils/Responsive"
 
 jest.unmock("react-relay")
+jest.mock("v2/Components/Pagination/useComputeHref")
 
 describe("Shows Route", () => {
   let wrapper: ReactWrapper
@@ -69,11 +70,11 @@ describe("Shows Route", () => {
 
     it("renders the correct number of pages", () => {
       const getPaginationAt = index =>
-        wrapper.find("Pagination").at(index).find("button")
+        wrapper.find("Pagination").at(index).find("a")
 
-      expect(getPaginationAt(0).length).toBe(2)
-      expect(getPaginationAt(1).length).toBe(3)
-      expect(getPaginationAt(2).length).toBe(5)
+      expect(getPaginationAt(0).length).toBe(4)
+      expect(getPaginationAt(1).length).toBe(5)
+      expect(getPaginationAt(2).length).toBe(7)
     })
   })
 })

--- a/src/v2/Apps/Artist/Routes/Works/__tests__/Works.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/Works/__tests__/Works.jest.tsx
@@ -9,6 +9,7 @@ import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
 
 jest.mock("v2/Artsy/Analytics/useTracking")
 jest.unmock("react-relay")
+jest.mock("v2/Components/Pagination/useComputeHref")
 
 jest.mock("v2/Components/Artwork/FillwidthItem", () => () => {
   const FillwidthItem = () => <div />

--- a/src/v2/Apps/Artists/__tests__/ArtistsByLetter.jest.tsx
+++ b/src/v2/Apps/Artists/__tests__/ArtistsByLetter.jest.tsx
@@ -6,6 +6,7 @@ import { ArtistsByLetter_Test_Query } from "v2/__generated__/ArtistsByLetter_Tes
 import { MockBoot } from "v2/DevTools"
 
 jest.unmock("react-relay")
+jest.mock("v2/Components/Pagination/useComputeHref")
 
 jest.mock("v2/Artsy/Router/useRouter", () => ({
   useRouter: () => ({ match: { params: { letter: "a" } } }),

--- a/src/v2/Apps/Purchase/Components/PurchaseHistory.tsx
+++ b/src/v2/Apps/Purchase/Components/PurchaseHistory.tsx
@@ -109,6 +109,10 @@ const PurchaseHistory: React.FC<PurchaseHistoryProps> = (
           {props.me.orders.pageCursors && (
             <SmallPagination
               {...paginationProps}
+              getHref={x => {
+                // FIXME: wire this up properly
+                return ""
+              }}
               pageCursors={paginationProps.pageCursors as any}
             />
           )}
@@ -119,6 +123,10 @@ const PurchaseHistory: React.FC<PurchaseHistoryProps> = (
             {props.me.orders.pageCursors && (
               <LargePagination
                 {...paginationProps}
+                getHref={x => {
+                  // FIXME: wire this up properly
+                  return ""
+                }}
                 pageCursors={paginationProps.pageCursors as any}
               />
             )}

--- a/src/v2/Apps/Purchase/__tests__/PurchaseApp.jest.tsx
+++ b/src/v2/Apps/Purchase/__tests__/PurchaseApp.jest.tsx
@@ -12,6 +12,7 @@ import { PurchaseHistoryProps } from "../Components/PurchaseHistory"
 import { PurchaseAppFragmentContainer } from "../PurchaseApp"
 
 jest.unmock("react-relay")
+jest.mock("v2/Components/Pagination/useComputeHref")
 
 const pageInfo: PurchaseAppTestQueryRawResponse["me"]["orders"]["pageInfo"] = {
   endCursor: "MQ",
@@ -99,7 +100,7 @@ describe("Purchase app", () => {
         const component = await render(mockMe, userType)
         const text = component.text()
         expect(text).toContain(
-          "Moira RoseSaves & FollowsCollector ProfileOrder HistoryBidsSettingsPayments Dec 19, 2019pending•Track orderLisa BreslowGramercy Park SouthA Gallery New York, NYOrder No.abcdefgTotal$12,000Payment MethodN/AFulfillmentPickupMore infoNeed Help? Contact Us.1234...7Navigate left PrevNext Navigate right"
+          "pending•Track orderLisa BreslowGramercy Park SouthA Gallery New York, NYOrder No.abcdefgTotal$12,000Payment MethodN/AFulfillmentPickupMore infoNeed Help? Contact Us.1234...7Navigate leftPrevNextNavigate right"
         )
       })
     })
@@ -125,7 +126,7 @@ describe("Purchase app", () => {
         const pagination = component.find("LargePagination")
         expect(pagination.length).toBe(1)
         expect(pagination.text()).toContain("1234...7")
-        pagination.find("button").at(1).simulate("click")
+        pagination.find("a").at(1).simulate("click")
         expect(refetchSpy).toHaveBeenCalledTimes(1)
         expect(refetchSpy.mock.calls[0][0]).toEqual(
           expect.objectContaining({ after: "NQ", first: 10 })

--- a/src/v2/Apps/Search/Routes/Artists/__tests__/SearchResultsArtists.jest.tsx
+++ b/src/v2/Apps/Search/Routes/Artists/__tests__/SearchResultsArtists.jest.tsx
@@ -1,34 +1,20 @@
 import { ZeroState } from "v2/Apps/Search/Components/ZeroState"
+import { SystemContextProvider } from "v2/Artsy"
 import { PaginationFragmentContainer as Pagination } from "v2/Components/Pagination"
 import { MockBoot } from "v2/DevTools"
 import { mount } from "enzyme"
 import React from "react"
 import { SearchResultsArtistsRoute as SearchResultsArtists } from "../SearchResultsArtists"
 
-jest.mock("v2/Artsy/Router/useRouter", () => ({
-  useRouter: () => ({
-    match: {
-      location: {
-        pathname: "anything",
-      },
-    },
-  }),
-}))
-
-jest.mock("v2/Components/v2/ArtworkFilter/ArtworkFilterContext", () => ({
-  useArtworkFilterContext: () => ({
-    currentlySelectedFilters: () => ({}),
-    filters: {
-      term: "andy",
-    },
-  }),
-}))
+jest.mock("v2/Components/Pagination/useComputeHref")
 
 describe("SearchResultsArtworks", () => {
   const getWrapper = (searchProps: any) => {
     return mount(
       <MockBoot>
-        <SearchResultsArtists {...searchProps} />
+        <SystemContextProvider>
+          <SearchResultsArtists {...searchProps} />
+        </SystemContextProvider>
       </MockBoot>
     )
   }

--- a/src/v2/Apps/Search/Routes/Artists/__tests__/SearchResultsArtists.jest.tsx
+++ b/src/v2/Apps/Search/Routes/Artists/__tests__/SearchResultsArtists.jest.tsx
@@ -1,18 +1,34 @@
 import { ZeroState } from "v2/Apps/Search/Components/ZeroState"
-import { SystemContextProvider } from "v2/Artsy"
 import { PaginationFragmentContainer as Pagination } from "v2/Components/Pagination"
 import { MockBoot } from "v2/DevTools"
 import { mount } from "enzyme"
 import React from "react"
 import { SearchResultsArtistsRoute as SearchResultsArtists } from "../SearchResultsArtists"
 
+jest.mock("v2/Artsy/Router/useRouter", () => ({
+  useRouter: () => ({
+    match: {
+      location: {
+        pathname: "anything",
+      },
+    },
+  }),
+}))
+
+jest.mock("v2/Components/v2/ArtworkFilter/ArtworkFilterContext", () => ({
+  useArtworkFilterContext: () => ({
+    currentlySelectedFilters: () => ({}),
+    filters: {
+      term: "andy",
+    },
+  }),
+}))
+
 describe("SearchResultsArtworks", () => {
   const getWrapper = (searchProps: any) => {
     return mount(
       <MockBoot>
-        <SystemContextProvider>
-          <SearchResultsArtists {...searchProps} />
-        </SystemContextProvider>
+        <SearchResultsArtists {...searchProps} />
       </MockBoot>
     )
   }

--- a/src/v2/Apps/Search/Routes/Entity/__tests__/SearchResultsEntity.jest.tsx
+++ b/src/v2/Apps/Search/Routes/Entity/__tests__/SearchResultsEntity.jest.tsx
@@ -1,18 +1,34 @@
 import { ZeroState } from "v2/Apps/Search/Components/ZeroState"
-import { SystemContextProvider } from "v2/Artsy"
 import { PaginationFragmentContainer as Pagination } from "v2/Components/Pagination"
 import { MockBoot } from "v2/DevTools"
 import { mount } from "enzyme"
 import React from "react"
 import { SearchResultsEntityRoute as SearchResultsEntity } from "../SearchResultsEntity"
 
+jest.mock("v2/Artsy/Router/useRouter", () => ({
+  useRouter: () => ({
+    match: {
+      location: {
+        pathname: "anything",
+      },
+    },
+  }),
+}))
+
+jest.mock("v2/Components/v2/ArtworkFilter/ArtworkFilterContext", () => ({
+  useArtworkFilterContext: () => ({
+    currentlySelectedFilters: () => ({}),
+    filters: {
+      term: "andy",
+    },
+  }),
+}))
+
 describe("SearchResultsEntity", () => {
   const getWrapper = searchProps => {
     return mount(
       <MockBoot>
-        <SystemContextProvider>
-          <SearchResultsEntity {...searchProps} />
-        </SystemContextProvider>
+        <SearchResultsEntity {...searchProps} />
       </MockBoot>
     )
   }

--- a/src/v2/Components/Pagination.tsx
+++ b/src/v2/Components/Pagination.tsx
@@ -14,10 +14,10 @@ import {
 } from "@artsy/palette"
 
 interface Props {
+  hasNextPage: boolean
   onClick?: (cursor: string, page: number) => void
   onNext?: () => void
   pageCursors: Pagination_pageCursors
-  hasNextPage: boolean
   scrollTo?: string
 }
 
@@ -29,15 +29,18 @@ export class Pagination extends React.Component<Props> {
   }
 
   render() {
-    const { pageCursors, scrollTo } = this.props
+    const { hasNextPage, onClick, onNext, pageCursors, scrollTo } = this.props
 
     if (pageCursors.around.length === 1) {
       return null
     }
 
     const paginationProps: PaginationProps = {
-      ...this.props,
+      hasNextPage,
+      onClick,
+      onNext,
       pageCursors: pageCursors as any,
+      scrollTo,
     }
 
     return (

--- a/src/v2/Components/Pagination.tsx
+++ b/src/v2/Components/Pagination.tsx
@@ -21,42 +21,38 @@ interface Props {
   scrollTo?: string
 }
 
-export class Pagination extends React.Component<Props> {
-  static defaultProps = {
-    onClick: _cursor => ({}),
-    onNext: () => ({}),
-    scrollTo: null,
+export const Pagination: React.FC<Props> = ({
+  hasNextPage,
+  onClick = _cursor => ({}),
+  onNext = () => ({}),
+  pageCursors,
+  scrollTo = null,
+}) => {
+  if (pageCursors.around.length === 1) {
+    return null
   }
 
-  render() {
-    const { hasNextPage, onClick, onNext, pageCursors, scrollTo } = this.props
-
-    if (pageCursors.around.length === 1) {
-      return null
-    }
-
-    const paginationProps: PaginationProps = {
-      hasNextPage,
-      onClick,
-      onNext,
-      pageCursors: pageCursors as any,
-      scrollTo,
-    }
-
-    return (
-      <ScrollIntoView selector={scrollTo}>
-        <Media at="xs">
-          <SmallPagination {...paginationProps} />
-        </Media>
-        <Media greaterThan="xs">
-          <Box>
-            <Separator mb={3} pr={2} />
-            <LargePagination {...paginationProps} />
-          </Box>
-        </Media>
-      </ScrollIntoView>
-    )
+  const paginationProps: PaginationProps = {
+    hasNextPage,
+    onClick,
+    onNext,
+    pageCursors: pageCursors as any,
+    scrollTo,
   }
+
+  return (
+    <ScrollIntoView selector={scrollTo}>
+      <Media at="xs">
+        <SmallPagination {...paginationProps} />
+      </Media>
+      <Media greaterThan="xs">
+        <Box>
+          <Separator mb={3} pr={2} />
+          <LargePagination {...paginationProps} />
+        </Box>
+      </Media>
+    </ScrollIntoView>
+  )
 }
 
 export const PaginationFragmentContainer = createFragmentContainer(Pagination, {

--- a/src/v2/Components/Pagination.tsx
+++ b/src/v2/Components/Pagination.tsx
@@ -28,25 +28,21 @@ export class Pagination extends React.Component<Props> {
   }
 
   render() {
-    if (this.props.pageCursors.around.length === 1) {
+    const { pageCursors, scrollTo } = this.props
+
+    if (pageCursors.around.length === 1) {
       return null
     }
 
     return (
-      <ScrollIntoView selector={this.props.scrollTo}>
+      <ScrollIntoView selector={scrollTo}>
         <Media at="xs">
-          <SmallPagination
-            {...this.props}
-            pageCursors={this.props.pageCursors as any}
-          />
+          <SmallPagination {...this.props} pageCursors={pageCursors as any} />
         </Media>
         <Media greaterThan="xs">
           <Box>
             <Separator mb={3} pr={2} />
-            <LargePagination
-              {...this.props}
-              pageCursors={this.props.pageCursors as any}
-            />
+            <LargePagination {...this.props} pageCursors={pageCursors as any} />
           </Box>
         </Media>
       </ScrollIntoView>

--- a/src/v2/Components/Pagination.tsx
+++ b/src/v2/Components/Pagination.tsx
@@ -10,6 +10,7 @@ import {
   LargePagination,
   Separator,
   SmallPagination,
+  PaginationProps,
 } from "@artsy/palette"
 
 interface Props {
@@ -34,15 +35,20 @@ export class Pagination extends React.Component<Props> {
       return null
     }
 
+    const paginationProps: PaginationProps = {
+      ...this.props,
+      pageCursors: pageCursors as any,
+    }
+
     return (
       <ScrollIntoView selector={scrollTo}>
         <Media at="xs">
-          <SmallPagination {...this.props} pageCursors={pageCursors as any} />
+          <SmallPagination {...paginationProps} />
         </Media>
         <Media greaterThan="xs">
           <Box>
             <Separator mb={3} pr={2} />
-            <LargePagination {...this.props} pageCursors={pageCursors as any} />
+            <LargePagination {...paginationProps} />
           </Box>
         </Media>
       </ScrollIntoView>

--- a/src/v2/Components/Pagination.tsx
+++ b/src/v2/Components/Pagination.tsx
@@ -32,9 +32,14 @@ export const Pagination: React.FC<Props> = ({
     return null
   }
 
+  const handleClick = (cursor, page, event) => {
+    event.preventDefault()
+    onClick(cursor, page)
+  }
+
   const paginationProps: PaginationProps = {
     hasNextPage,
-    onClick,
+    onClick: handleClick,
     onNext,
     pageCursors: pageCursors as any,
     scrollTo,

--- a/src/v2/Components/Pagination.tsx
+++ b/src/v2/Components/Pagination.tsx
@@ -55,11 +55,16 @@ export const Pagination: React.FC<Props> = ({
     onClick(cursor, page)
   }
 
+  const handleNext = event => {
+    event.preventDefault()
+    onNext()
+  }
+
   const paginationProps: PaginationProps = {
     getHref,
     hasNextPage,
     onClick: handleClick,
-    onNext,
+    onNext: handleNext,
     pageCursors: pageCursors as any,
     scrollTo,
   }

--- a/src/v2/Components/Pagination.tsx
+++ b/src/v2/Components/Pagination.tsx
@@ -2,8 +2,10 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Media } from "v2/Utils/Responsive"
 import { ScrollIntoView } from "v2/Utils/ScrollIntoView"
-
+import { useArtworkFilterContext } from "v2/Components/v2/ArtworkFilter/ArtworkFilterContext"
+import { useRouter } from "v2/Artsy/Router/useRouter"
 import { Pagination_pageCursors } from "v2/__generated__/Pagination_pageCursors.graphql"
+import { buildUrl } from "v2/Components/v2/ArtworkFilter/Utils/urlBuilder"
 
 import {
   Box,
@@ -28,8 +30,24 @@ export const Pagination: React.FC<Props> = ({
   pageCursors,
   scrollTo = null,
 }) => {
+  const filterContext = useArtworkFilterContext()
+  const routerContext = useRouter()
+
   if (pageCursors.around.length === 1) {
     return null
+  }
+
+  const currentlySelectedFilters = filterContext.currentlySelectedFilters()
+  const pathname = routerContext?.match?.location?.pathname
+
+  const getHref = page => {
+    const filterState = {
+      ...currentlySelectedFilters,
+      page,
+    }
+
+    const href = buildUrl(filterState, pathname)
+    return href
   }
 
   const handleClick = (cursor, page, event) => {
@@ -38,6 +56,7 @@ export const Pagination: React.FC<Props> = ({
   }
 
   const paginationProps: PaginationProps = {
+    getHref,
     hasNextPage,
     onClick: handleClick,
     onNext,

--- a/src/v2/Components/Pagination/__mocks__/useComputeHref.ts
+++ b/src/v2/Components/Pagination/__mocks__/useComputeHref.ts
@@ -1,0 +1,3 @@
+exports.useComputeHref = () => {
+  return () => ""
+}

--- a/src/v2/Components/Pagination/index.tsx
+++ b/src/v2/Components/Pagination/index.tsx
@@ -2,10 +2,7 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Media } from "v2/Utils/Responsive"
 import { ScrollIntoView } from "v2/Utils/ScrollIntoView"
-import { useArtworkFilterContext } from "v2/Components/v2/ArtworkFilter/ArtworkFilterContext"
-import { useRouter } from "v2/Artsy/Router/useRouter"
 import { Pagination_pageCursors } from "v2/__generated__/Pagination_pageCursors.graphql"
-import { buildUrl } from "v2/Components/v2/ArtworkFilter/Utils/urlBuilder"
 
 import {
   Box,
@@ -14,6 +11,7 @@ import {
   SmallPagination,
   PaginationProps,
 } from "@artsy/palette"
+import { useComputeHref } from "./useComputeHref"
 
 interface Props {
   hasNextPage: boolean
@@ -30,24 +28,10 @@ export const Pagination: React.FC<Props> = ({
   pageCursors,
   scrollTo = null,
 }) => {
-  const filterContext = useArtworkFilterContext()
-  const routerContext = useRouter()
+  const getHref = useComputeHref()
 
   if (pageCursors.around.length === 1) {
     return null
-  }
-
-  const currentlySelectedFilters = filterContext.currentlySelectedFilters()
-  const pathname = routerContext?.match?.location?.pathname
-
-  const getHref = page => {
-    const filterState = {
-      ...currentlySelectedFilters,
-      page,
-    }
-
-    const href = buildUrl(filterState, pathname)
-    return href
   }
 
   const handleClick = (cursor, page, event) => {

--- a/src/v2/Components/Pagination/useComputeHref.ts
+++ b/src/v2/Components/Pagination/useComputeHref.ts
@@ -1,0 +1,23 @@
+import { buildUrl } from "v2/Components/v2/ArtworkFilter/Utils/urlBuilder"
+import { useArtworkFilterContext } from "v2/Components/v2/ArtworkFilter/ArtworkFilterContext"
+import { useRouter } from "v2/Artsy/Router/useRouter"
+
+export function useComputeHref() {
+  const filterContext = useArtworkFilterContext()
+  const routerContext = useRouter()
+
+  const currentlySelectedFilters = filterContext.currentlySelectedFilters()
+  const pathname = routerContext?.match?.location?.pathname
+
+  const computeHref = page => {
+    const filterState = {
+      ...currentlySelectedFilters,
+      page,
+    }
+
+    const href = buildUrl(filterState, pathname)
+    return href
+  }
+
+  return computeHref
+}

--- a/src/v2/Components/v2/ArtworkFilter/Utils/urlBuilder.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/Utils/urlBuilder.tsx
@@ -35,7 +35,12 @@ export const paramsToCamelCase = params => {
 export const buildUrl = (state: ArtworkFilters): string => {
   const params = removeDefaultValues(state)
   const queryString = qs.stringify(paramsToSnakeCase(params))
-  const pathname = window.location.pathname
+  let pathname = ""
+
+  if (typeof window !== "undefined") {
+    pathname = window.location.pathname
+  }
+
   const url = queryString ? `${pathname}?${queryString}` : pathname
 
   return url

--- a/src/v2/Components/v2/ArtworkFilter/Utils/urlBuilder.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/Utils/urlBuilder.tsx
@@ -34,11 +34,9 @@ export const paramsToCamelCase = params => {
 
 export const buildUrl = (state: ArtworkFilters): string => {
   const params = removeDefaultValues(state)
-
   const queryString = qs.stringify(paramsToSnakeCase(params))
-  const url = queryString
-    ? `${window.location.pathname}?${queryString}`
-    : window.location.pathname
+  const pathname = window.location.pathname
+  const url = queryString ? `${pathname}?${queryString}` : pathname
 
   return url
 }

--- a/src/v2/Components/v2/ArtworkFilter/Utils/urlBuilder.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/Utils/urlBuilder.tsx
@@ -32,12 +32,11 @@ export const paramsToCamelCase = params => {
   }, {})
 }
 
-export const buildUrl = (state: ArtworkFilters): string => {
+export const buildUrl = (state: ArtworkFilters, pathname?: string): string => {
   const params = removeDefaultValues(state)
   const queryString = qs.stringify(paramsToSnakeCase(params))
-  let pathname = ""
 
-  if (typeof window !== "undefined") {
+  if (!pathname && typeof window !== "undefined") {
     pathname = window.location.pathname
   }
 

--- a/src/v2/Components/v2/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
@@ -12,6 +12,7 @@ import { ArtworkFilterFixture } from "./fixtures/ArtworkFilter.fixture"
 
 jest.unmock("react-relay")
 jest.mock("v2/Artsy/Analytics/useTracking")
+jest.mock("v2/Components/Pagination/useComputeHref")
 
 describe("ArtworkFilter", () => {
   const getWrapper = async (

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,10 +63,10 @@
   dependencies:
     uuid "^8.3.0"
 
-"@artsy/palette@13.26.4":
-  version "13.26.4"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-13.26.4.tgz#fae942473562f9879722de2094a716b3cac32be4"
-  integrity sha512-qH8S5wN2w8NUv/tdJWX+B55l1hw+LGZ99ej//xgJ1RgBRSyrj/wCgjUqIHoqWsNASDMILguGN99s1JKMMGZpSg==
+"@artsy/palette@13.27.0":
+  version "13.27.0"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-13.27.0.tgz#e34aedb440a88949e842fc044e8ca079a55ac35b"
+  integrity sha512-m/yaF568xRrZCUbT961mSGRvSv5jfoYW99YtEM+g079i8BCufL0QInMFA+mSD/vZyBEfCTZXqGBtaypXj9xN2w==
   dependencies:
     "@styled-system/theme-get" "^5.1.2"
     d3-interpolate "^1.3.2"


### PR DESCRIPTION
Sibling here: artsy/force#6832

This work started as a collab with @damassi and he's graciously offered to help get it over the finish line. What we did was run force and palette locally with the latter linked to the former. That allowed us to tinker with the contract between force's pagination wrapper and the large/small components in palette.

Our approach to getting hrefs populated has been to pass a function called `getHref` that can collaborate with the url builder helper function in force. That allows us to have each pagination link set the page number but also not break any existing filtering or whatever.

This worked great for the individual page number links, but not quite for the prev/next buttons and I have not been able to get to the small breakpoint to see about how things work there. This is important because this is what Google will ultimately spider through.

todo: fix
 src/v2/Apps/Purchase/__tests__/PurchaseApp.jest.tsx