### PR TITLE
fix: use focus visible selector in nav items

### DIFF
--- a/src/v2/Components/NavBar/NavItem.tsx
+++ b/src/v2/Components/NavBar/NavItem.tsx
@@ -34,7 +34,7 @@ const HitArea = styled(Link)`
   box-sizing: content-box;
   border-bottom: 1px solid transparent;
 
-  &:focus {
+  &:focus-visible {
     outline: 0;
     border-bottom-color: ${color("black100")};
     z-index: 1;
@@ -42,8 +42,8 @@ const HitArea = styled(Link)`
 `
 
 const UnfocusableAnchor = styled(RouterLink).attrs({
-  tabIndex: -1,
   role: "presentation",
+  tabIndex: -1,
 })`
   display: block;
   position: absolute;
@@ -90,8 +90,9 @@ export const NavItem: React.FC<NavItemProps> = ({
     if (href && isString(children)) {
       trackEvent({
         action_type: AnalyticsSchema.ActionType.Click,
-        subject: children, // Text passed into the NavItem
         destination_path: href,
+        // Text passed into the NavItem
+        subject: children,
       })
     }
   }
@@ -165,9 +166,9 @@ export const NavItem: React.FC<NavItemProps> = ({
         ref={hitAreaRef as any}
         {...(!!Menu
           ? {
-              as: Clickable,
-              "aria-haspopup": true,
               "aria-expanded": showMenu,
+              "aria-haspopup": true,
+              as: Clickable,
             }
           : { as: RouterLink, to: href })}
         color={color}


### PR DESCRIPTION
## Context

Fixes https://github.com/artsy/force/issues/6817

## Proposed Change

This PR changes the `focus` selector to `focus-visible` for the `HitArea` in `NavItem` to make the navigation items visually consistent and prevent the black bottom border from being visible when a user clicks on an item.

## Testing Plan

- [ ] Test behavior wherever `NavItem` is used.
- [ ] Test navigation bar when logged in and when not logged in
- [ ] Test with different browsers and devices (especially mobile)
- [ ] Test if keyboard accessibility stays intact (e.g. navigating with the `tab` key)