### PR TITLE
feat(fx-2508): roughs in fair articles route

### DIFF
--- a/src/v2/Apps/Fair/Routes/FairArticles.tsx
+++ b/src/v2/Apps/Fair/Routes/FairArticles.tsx
@@ -1,0 +1,154 @@
+import React from "react"
+import {
+  ResponsiveBox,
+  Text,
+  GridColumns,
+  Column,
+  Box,
+  Image,
+} from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { FairArticles_fair } from "v2/__generated__/FairArticles_fair.graphql"
+import { Masonry } from "v2/Components/Masonry"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
+
+interface FairArticlesProps {
+  fair: FairArticles_fair
+}
+
+const FairArticles: React.FC<FairArticlesProps> = ({ fair }) => {
+  const {
+    articlesConnection: { articles },
+  } = fair
+
+  const [{ article: heroArticle }, ...remainingArticles] = articles
+
+  return (
+    <>
+      <Text as="h1" variant="largeTitle" fontSize={60} my={2}>
+        Articles
+      </Text>
+
+      <GridColumns>
+        <Column
+          span={6}
+          start={4}
+          borderBottom="1px solid"
+          borderColor="black10"
+        >
+          <RouterLink
+            to={heroArticle.href}
+            style={{ display: "block", textDecoration: "none" }}
+          >
+            <ResponsiveBox
+              aspectWidth={1}
+              aspectHeight={1}
+              maxWidth="100%"
+              bg="black10"
+            >
+              <Image
+                src={heroArticle.thumbnailImage.large.src}
+                srcSet={heroArticle.thumbnailImage.large.srcSet}
+                alt={heroArticle.thumbnailTitle}
+                width="100%"
+                height="100%"
+              />
+            </ResponsiveBox>
+
+            <Text as="h3" mt={2} mb={1.5} variant="largeTitle">
+              {heroArticle.title}
+            </Text>
+
+            {heroArticle.author && (
+              <Text mt={1} variant="mediumText">
+                {heroArticle.author.name}
+              </Text>
+            )}
+
+            <Text mb={2} color="black60">
+              {heroArticle.publishedAt}
+            </Text>
+          </RouterLink>
+        </Column>
+      </GridColumns>
+
+      <Masonry columnCount={[1, 3]} gridColumnGap={20} my={4}>
+        {remainingArticles.map(({ article }) => {
+          return (
+            <Box key={article.internalID} mb={4}>
+              <RouterLink
+                to={article.href}
+                style={{ display: "block", textDecoration: "none" }}
+              >
+                {article.thumbnailImage && (
+                  <ResponsiveBox
+                    aspectWidth={article.thumbnailImage.medium.width}
+                    aspectHeight={article.thumbnailImage.medium.height}
+                    maxWidth="100%"
+                  >
+                    <Image
+                      src={article.thumbnailImage.medium.src}
+                      srcSet={article.thumbnailImage.medium.srcSet}
+                      alt={article.thumbnailTitle}
+                      width="100%"
+                      height="100%"
+                      lazyLoad
+                    />
+                  </ResponsiveBox>
+                )}
+
+                <Text as="h3" mt={1.5} mb={1} variant="subtitle">
+                  {article.title}
+                </Text>
+
+                {article.author && (
+                  <Text variant="mediumText">{article.author.name}</Text>
+                )}
+
+                <Text color="black60">{article.publishedAt}</Text>
+              </RouterLink>
+            </Box>
+          )
+        })}
+      </Masonry>
+    </>
+  )
+}
+
+export const FairArticlesFragmentContainer = createFragmentContainer(
+  FairArticles,
+  {
+    fair: graphql`
+      fragment FairArticles_fair on Fair {
+        articlesConnection(first: 10) {
+          articles: edges {
+            article: node {
+              internalID
+              title
+              href
+              author {
+                name
+              }
+              publishedAt(format: "MMM Do, YYYY")
+              thumbnailTitle
+              thumbnailImage {
+                large: cropped(width: 546, height: 546) {
+                  width
+                  height
+                  src
+                  srcSet
+                }
+                medium: cropped(width: 360, height: 270) {
+                  width
+                  height
+                  src
+                  srcSet
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Fair/Routes/__tests__/FairArticles.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairArticles.jest.tsx
@@ -1,0 +1,32 @@
+import { graphql } from "react-relay"
+import { FairArticlesFragmentContainer } from "../FairArticles"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+
+jest.unmock("react-relay")
+
+const { getWrapper } = setupTestWrapper({
+  Component: FairArticlesFragmentContainer,
+  query: graphql`
+    query FairArticles_Test_Query {
+      fair(id: "example") {
+        ...FairArticles_fair
+      }
+    }
+  `,
+})
+
+describe("FairArticles", () => {
+  it("renders correctly", () => {
+    const wrapper = getWrapper({
+      Article: () => ({ title: "Example Article" }),
+      Author: () => ({ name: "Example Author" }),
+    })
+
+    expect(wrapper.find("h1")).toHaveLength(1)
+
+    const html = wrapper.html()
+
+    expect(html).toContain("Example Article")
+    expect(html).toContain("Example Author")
+  })
+})

--- a/src/v2/Apps/Fair/fairRoutes.tsx
+++ b/src/v2/Apps/Fair/fairRoutes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { RouteConfig } from "found"
@@ -18,6 +17,9 @@ const FairArtworksRoute = loadable(() => import("./Routes/FairArtworks"), {
 })
 const FairInfoRoute = loadable(() => import("./Routes/FairInfo"), {
   resolveComponent: component => component.FairInfoFragmentContainer,
+})
+const FairArticlesRoute = loadable(() => import("./Routes/FairArticles"), {
+  resolveComponent: component => component.FairArticlesFragmentContainer,
 })
 
 export const fairRoutes: RouteConfig[] = [
@@ -131,6 +133,20 @@ export const fairRoutes: RouteConfig[] = [
           query fairRoutes_FairInfoQuery($slug: String!) {
             fair(id: $slug) @principalField {
               ...FairInfo_fair
+            }
+          }
+        `,
+      },
+      {
+        path: "articles",
+        getComponent: () => FairArticlesRoute,
+        prepare: () => {
+          FairArticlesRoute.preload()
+        },
+        query: graphql`
+          query fairRoutes_FaiArticlesQuery($slug: String!) {
+            fair(id: $slug) @principalField {
+              ...FairArticles_fair
             }
           }
         `,

--- a/src/v2/__generated__/FairArticles_Test_Query.graphql.ts
+++ b/src/v2/__generated__/FairArticles_Test_Query.graphql.ts
@@ -1,0 +1,315 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type FairArticles_Test_QueryVariables = {};
+export type FairArticles_Test_QueryResponse = {
+    readonly fair: {
+        readonly " $fragmentRefs": FragmentRefs<"FairArticles_fair">;
+    } | null;
+};
+export type FairArticles_Test_Query = {
+    readonly response: FairArticles_Test_QueryResponse;
+    readonly variables: FairArticles_Test_QueryVariables;
+};
+
+
+
+/*
+query FairArticles_Test_Query {
+  fair(id: "example") {
+    ...FairArticles_fair
+    id
+  }
+}
+
+fragment FairArticles_fair on Fair {
+  articlesConnection(first: 10) {
+    articles: edges {
+      article: node {
+        internalID
+        title
+        href
+        author {
+          name
+          id
+        }
+        publishedAt(format: "MMM Do, YYYY")
+        thumbnailTitle
+        thumbnailImage {
+          large: cropped(width: 546, height: 546) {
+            width
+            height
+            src
+            srcSet
+          }
+          medium: cropped(width: 360, height: 270) {
+            width
+            height
+            src
+            srcSet
+          }
+        }
+        id
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "width",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "height",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "src",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "FairArticles_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "FairArticles_fair"
+          }
+        ],
+        "storageKey": "fair(id:\"example\")"
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "FairArticles_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 10
+              }
+            ],
+            "concreteType": "ArticleConnection",
+            "kind": "LinkedField",
+            "name": "articlesConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": "articles",
+                "args": null,
+                "concreteType": "ArticleEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": "article",
+                    "args": null,
+                    "concreteType": "Article",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Author",
+                        "kind": "LinkedField",
+                        "name": "author",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "name",
+                            "storageKey": null
+                          },
+                          (v1/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "format",
+                            "value": "MMM Do, YYYY"
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "publishedAt",
+                        "storageKey": "publishedAt(format:\"MMM Do, YYYY\")"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "thumbnailTitle",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "thumbnailImage",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "large",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 546
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 546
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "cropped",
+                            "plural": false,
+                            "selections": (v2/*: any*/),
+                            "storageKey": "cropped(height:546,width:546)"
+                          },
+                          {
+                            "alias": "medium",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 270
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 360
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "cropped",
+                            "plural": false,
+                            "selections": (v2/*: any*/),
+                            "storageKey": "cropped(height:270,width:360)"
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v1/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "articlesConnection(first:10)"
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": "fair(id:\"example\")"
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "FairArticles_Test_Query",
+    "operationKind": "query",
+    "text": "query FairArticles_Test_Query {\n  fair(id: \"example\") {\n    ...FairArticles_fair\n    id\n  }\n}\n\nfragment FairArticles_fair on Fair {\n  articlesConnection(first: 10) {\n    articles: edges {\n      article: node {\n        internalID\n        title\n        href\n        author {\n          name\n          id\n        }\n        publishedAt(format: \"MMM Do, YYYY\")\n        thumbnailTitle\n        thumbnailImage {\n          large: cropped(width: 546, height: 546) {\n            width\n            height\n            src\n            srcSet\n          }\n          medium: cropped(width: 360, height: 270) {\n            width\n            height\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '042e0e9ffb29ab964cfda270febbb5d9';
+export default node;

--- a/src/v2/__generated__/FairArticles_fair.graphql.ts
+++ b/src/v2/__generated__/FairArticles_fair.graphql.ts
@@ -1,0 +1,238 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type FairArticles_fair = {
+    readonly articlesConnection: {
+        readonly articles: ReadonlyArray<{
+            readonly article: {
+                readonly internalID: string;
+                readonly title: string | null;
+                readonly href: string | null;
+                readonly author: {
+                    readonly name: string | null;
+                } | null;
+                readonly publishedAt: string | null;
+                readonly thumbnailTitle: string | null;
+                readonly thumbnailImage: {
+                    readonly large: {
+                        readonly width: number;
+                        readonly height: number;
+                        readonly src: string;
+                        readonly srcSet: string;
+                    } | null;
+                    readonly medium: {
+                        readonly width: number;
+                        readonly height: number;
+                        readonly src: string;
+                        readonly srcSet: string;
+                    } | null;
+                } | null;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "FairArticles_fair";
+};
+export type FairArticles_fair$data = FairArticles_fair;
+export type FairArticles_fair$key = {
+    readonly " $data"?: FairArticles_fair$data;
+    readonly " $fragmentRefs": FragmentRefs<"FairArticles_fair">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "width",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "height",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "src",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  }
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "FairArticles_fair",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 10
+        }
+      ],
+      "concreteType": "ArticleConnection",
+      "kind": "LinkedField",
+      "name": "articlesConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": "articles",
+          "args": null,
+          "concreteType": "ArticleEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": "article",
+              "args": null,
+              "concreteType": "Article",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "title",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "href",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Author",
+                  "kind": "LinkedField",
+                  "name": "author",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "name",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "format",
+                      "value": "MMM Do, YYYY"
+                    }
+                  ],
+                  "kind": "ScalarField",
+                  "name": "publishedAt",
+                  "storageKey": "publishedAt(format:\"MMM Do, YYYY\")"
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "thumbnailTitle",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Image",
+                  "kind": "LinkedField",
+                  "name": "thumbnailImage",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": "large",
+                      "args": [
+                        {
+                          "kind": "Literal",
+                          "name": "height",
+                          "value": 546
+                        },
+                        {
+                          "kind": "Literal",
+                          "name": "width",
+                          "value": 546
+                        }
+                      ],
+                      "concreteType": "CroppedImageUrl",
+                      "kind": "LinkedField",
+                      "name": "cropped",
+                      "plural": false,
+                      "selections": (v0/*: any*/),
+                      "storageKey": "cropped(height:546,width:546)"
+                    },
+                    {
+                      "alias": "medium",
+                      "args": [
+                        {
+                          "kind": "Literal",
+                          "name": "height",
+                          "value": 270
+                        },
+                        {
+                          "kind": "Literal",
+                          "name": "width",
+                          "value": 360
+                        }
+                      ],
+                      "concreteType": "CroppedImageUrl",
+                      "kind": "LinkedField",
+                      "name": "cropped",
+                      "plural": false,
+                      "selections": (v0/*: any*/),
+                      "storageKey": "cropped(height:270,width:360)"
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "articlesConnection(first:10)"
+    }
+  ],
+  "type": "Fair"
+};
+})();
+(node as any).hash = '76fdd578bfca0274f7878441721cba44';
+export default node;

--- a/src/v2/__generated__/fairRoutes_FaiArticlesQuery.graphql.ts
+++ b/src/v2/__generated__/fairRoutes_FaiArticlesQuery.graphql.ts
@@ -1,0 +1,327 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type fairRoutes_FaiArticlesQueryVariables = {
+    slug: string;
+};
+export type fairRoutes_FaiArticlesQueryResponse = {
+    readonly fair: {
+        readonly " $fragmentRefs": FragmentRefs<"FairArticles_fair">;
+    } | null;
+};
+export type fairRoutes_FaiArticlesQuery = {
+    readonly response: fairRoutes_FaiArticlesQueryResponse;
+    readonly variables: fairRoutes_FaiArticlesQueryVariables;
+};
+
+
+
+/*
+query fairRoutes_FaiArticlesQuery(
+  $slug: String!
+) {
+  fair(id: $slug) @principalField {
+    ...FairArticles_fair
+    id
+  }
+}
+
+fragment FairArticles_fair on Fair {
+  articlesConnection(first: 10) {
+    articles: edges {
+      article: node {
+        internalID
+        title
+        href
+        author {
+          name
+          id
+        }
+        publishedAt(format: "MMM Do, YYYY")
+        thumbnailTitle
+        thumbnailImage {
+          large: cropped(width: 546, height: 546) {
+            width
+            height
+            src
+            srcSet
+          }
+          medium: cropped(width: 360, height: 270) {
+            width
+            height
+            src
+            srcSet
+          }
+        }
+        id
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "slug",
+    "type": "String!"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "slug"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "width",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "height",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "src",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "fairRoutes_FaiArticlesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "FairArticles_fair"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "fairRoutes_FaiArticlesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 10
+              }
+            ],
+            "concreteType": "ArticleConnection",
+            "kind": "LinkedField",
+            "name": "articlesConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": "articles",
+                "args": null,
+                "concreteType": "ArticleEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": "article",
+                    "args": null,
+                    "concreteType": "Article",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Author",
+                        "kind": "LinkedField",
+                        "name": "author",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "name",
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "format",
+                            "value": "MMM Do, YYYY"
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "publishedAt",
+                        "storageKey": "publishedAt(format:\"MMM Do, YYYY\")"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "thumbnailTitle",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "thumbnailImage",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "large",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 546
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 546
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "cropped",
+                            "plural": false,
+                            "selections": (v3/*: any*/),
+                            "storageKey": "cropped(height:546,width:546)"
+                          },
+                          {
+                            "alias": "medium",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 270
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 360
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "cropped",
+                            "plural": false,
+                            "selections": (v3/*: any*/),
+                            "storageKey": "cropped(height:270,width:360)"
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v2/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "articlesConnection(first:10)"
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "fairRoutes_FaiArticlesQuery",
+    "operationKind": "query",
+    "text": "query fairRoutes_FaiArticlesQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairArticles_fair\n    id\n  }\n}\n\nfragment FairArticles_fair on Fair {\n  articlesConnection(first: 10) {\n    articles: edges {\n      article: node {\n        internalID\n        title\n        href\n        author {\n          name\n          id\n        }\n        publishedAt(format: \"MMM Do, YYYY\")\n        thumbnailTitle\n        thumbnailImage {\n          large: cropped(width: 546, height: 546) {\n            width\n            height\n            src\n            srcSet\n          }\n          medium: cropped(width: 360, height: 270) {\n            width\n            height\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '3a804b0eed7cc5ae52329dc763f9773a';
+export default node;


### PR DESCRIPTION
Re: [FX-2508](https://artsyproduct.atlassian.net/browse/FX-2508)

This isn't meant to close the ticket, but rather just merge something that @artsy/design can look at on staging. There's some display corner cases that I didn't handle, but will once the layout is final.

Some notes:

* The “Articles” header text size is outside of the design system. According to the initial typographic guidelines, these instances should probably be reserved for bespoke editorial content.
* We don’t store thumbnail dimensions for article thumbnails. Due to this we can only display thumbnails with a specific aspect ratio crop
    * This makes the masonry weird because of how it looks with uniform content, ie: the masonry will try to lay out thumbnails in strange fashions when everything is even (like 2 even rows, then a centered thumbnail hanging off the bottom) — we can swap this out for just a n-up column view, unless we want to fix and backfill the thumbnail geometry.
* In general thumbnails are pretty low quality — though this varies a great deal. (Perhaps writer could have better guidelines.)
* I made some alterations vs the Figma spec to better match artwork bricks (bold + `black100` author, regular `black60` metadata)
* I imagine we won’t link to unless a fair has more than 6 articles?

-----

### Desktop
![localhost_5000_fair_intersect-chicago-2020_articles](https://user-images.githubusercontent.com/112297/102928408-a4f7fa80-4466-11eb-813d-456478f6fa77.jpg)

### Mobile
![localhost_5000_fair_intersect-chicago-2020_articles (1)](https://user-images.githubusercontent.com/112297/102928327-7f6af100-4466-11eb-9646-bd186c96943e.png)
