### PR TITLE
fix: Collection Artwork Aggregations

### DIFF
--- a/src/v2/Apps/Collect/Routes/Collection/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/index.tsx
@@ -134,7 +134,9 @@ export const CollectionApp: React.FC<CollectionAppProps> = props => {
                   { text: "Artwork year (asc.)", value: "year" },
                 ]}
                 aggregations={
-                  artworksConnection.aggregations as SharedArtworkFilterContextProps["aggregations"]
+                  artworksConnection !== null
+                    ? (artworksConnection?.aggregations as SharedArtworkFilterContextProps["aggregations"])
+                    : null
                 }
                 onChange={updateUrl}
               >


### PR DESCRIPTION
The `artworksConnection` can sometime be null. This is one of the reasons
that collection specs have been failing periodically.