### PR TITLE
feature: Smoke Test Order

### DIFF
--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -16,6 +16,9 @@ fi
 # start server in the background in production mode
 NODE_ENV=production nohup yarn start &
 
+# Leverage the server boot time to begin the cypress install.
+./node_modules/.bin/cypress install
+
 # wait for it to accept connections
 while ! curl --output /dev/null --silent --head --fail http://localhost:5000; do
     sleep 1
@@ -24,7 +27,6 @@ done
 export ELECTRON_EXTRA_LAUNCH_ARGS=disable-dev-shm-usage
 
 # run ./cypress/integration/* tests in headless mode
-./node_modules/.bin/cypress install
 ./node_modules/.bin/cypress run
 
 # Kill the server


### PR DESCRIPTION
We spend several seconds on each cypress test run waiting for the server
to start. Let's use this time to begin downloading an installing cypress.