### PR TITLE
feat: Disable news on editorial landing page

### DIFF
--- a/src/desktop/apps/articles/client/magazine.coffee
+++ b/src/desktop/apps/articles/client/magazine.coffee
@@ -21,13 +21,16 @@ module.exports.init = ->
       sort: '-published_at'
   feedView.render()
 
-  ReactDOM.render(
-    React.createElement(
-      NewsPanel,
-      {articles: sd.NEWS_ARTICLES}
-    ),
-    document.getElementById('news-panel')
-  )
+  newsPanel = document.getElementById('news-panel')
+
+  if (newsPanel)
+    ReactDOM.render(
+      React.createElement(
+        NewsPanel,
+        {articles: sd.NEWS_ARTICLES}
+      ),
+      newsPanel
+    )
 
   ReactDOM.render(
     React.createElement(

--- a/src/desktop/apps/articles/routes.ts
+++ b/src/desktop/apps/articles/routes.ts
@@ -1,9 +1,6 @@
 import { stitch as _stitch } from "@artsy/stitch"
 import App from "desktop/apps/articles/components/App"
-import {
-  newsArticlesQuery,
-  newsPanelQuery,
-} from "./queries/news_articles_query"
+import { newsArticlesQuery } from "./queries/news_articles_query"
 import { positronql as _positronql } from "desktop/lib/positronql"
 import { first, last, map, reject, sortBy } from "lodash"
 const { crop } = require("desktop/components/resizer/index.coffee")
@@ -30,19 +27,7 @@ export const articles = (req, res, next) => {
       const articles = new Articles(result.articles)
       res.locals.sd.ARTICLES = articles.toJSON()
       res.locals.sd.PAGE = page
-
-      // Fetch News Panel Articles
-      positronql({ query: newsPanelQuery() }).then(result => {
-        const newsArticles = result.articles
-        res.locals.sd.NEWS_ARTICLES = newsArticles
-
-        res.render("articles", {
-          articles: articles,
-          crop,
-          newsArticles,
-          page,
-        })
-      })
+      res.render("articles", { articles, crop, page })
     })
     .catch(next)
 }

--- a/src/desktop/apps/articles/templates/full_feed.jade
+++ b/src/desktop/apps/articles/templates/full_feed.jade
@@ -5,9 +5,6 @@
         - article = featuredArticles[0]
         +article-figure(article, 1000, false, false)
 
-      #news-panel
-        //- renders reaction newsPanel via magazine.coffee
-
       #signup-modal
         //- renders AuthWrapper via magazine.coffee
 

--- a/src/desktop/apps/articles/test/templates.test.js
+++ b/src/desktop/apps/articles/test/templates.test.js
@@ -30,24 +30,6 @@ describe("article figure template", () =>
     return html.should.containEql("/article/foobar")
   }))
 
-describe("articles template", () =>
-  it("shows the news panel", function () {
-    const html = render("articles")({
-      articles: new Articles([
-        _.extend(fixtures.article, { slug: "foobar", tier: 1 }),
-      ]),
-      asset(url) {
-        return url
-      },
-      crop(url) {
-        return url
-      },
-      moment,
-      sd: {},
-    })
-    return html.should.containEql("news-panel")
-  }))
-
 describe("section template", function () {
   it("renders the section title", function () {
     const html = render("section")({

--- a/src/mobile/apps/articles/client/articles.coffee
+++ b/src/mobile/apps/articles/client/articles.coffee
@@ -81,10 +81,13 @@ module.exports.init = ->
     collection: sd.ARTICLES
     offset: 0
 
-  ReactDOM.render(
-    React.createElement(
-      NewsPanel,
-      {articles: sd.NEWS_ARTICLES}
-    ),
-    document.getElementById('news-panel')
-  )
+  newsPanel = document.getElementById('news-panel')
+
+  if (newsPanel)
+    ReactDOM.render(
+      React.createElement(
+        NewsPanel,
+        {articles: sd.NEWS_ARTICLES}
+      ),
+      newsPanel
+    )

--- a/src/mobile/apps/articles/routes.coffee
+++ b/src/mobile/apps/articles/routes.coffee
@@ -65,14 +65,6 @@ module.exports.articles = (req, res, next) ->
       }
     }
   """
-  newsQuery = """
-    {
-      articles(published: true, limit: 3, sort: "-published_at", layout: "news" ) {
-        title
-        slug
-      }
-    }
-  """
   # fetch recent articles
   request.post(sd.POSITRON_URL + '/api/graphql')
     .send(
@@ -81,17 +73,8 @@ module.exports.articles = (req, res, next) ->
       return next() if err
       articles = response.body.data?.articles
       email = res.locals.sd.CURRENT_USER?.email
-      # fetch news articles
-      request.post(sd.POSITRON_URL + '/api/graphql')
-        .send(
-          query: newsQuery
-        ).end (err, response) ->
-          newsArticles = response.body.data?.articles
-          res.locals.sd.ARTICLES = articles
-          res.locals.sd.NEWS_ARTICLES = newsArticles
-          res.render 'articles',
-            articles: articles,
-            newsArticles: newsArticles
+      res.locals.sd.ARTICLES = articles
+      res.render 'articles', articles: articles
 
 subscribedToEditorial = (email, cb) ->
   sailthru.apiGet 'user', { id: email }, (err, response) ->

--- a/src/mobile/apps/articles/templates/articles_feed.jade
+++ b/src/mobile/apps/articles/templates/articles_feed.jade
@@ -2,7 +2,5 @@ for article, i in articles
   if newsArticles && i == 0
       .article-item-first
         include ../../../components/article_figure/index
-        #news-panel
-        //- renders reaction NewsPanel via articles.coffee
   else
     include ../../../components/article_figure/index

--- a/src/mobile/apps/articles/test/routes.test.js
+++ b/src/mobile/apps/articles/test/routes.test.js
@@ -144,12 +144,4 @@ describe("#articles", function () {
     )
     return done()
   })
-
-  return it("fetches news articles", function (done) {
-    routes.articles(this.req, this.res, this.next)
-    this.res.render.args[0][1].newsArticles[0].title.should.containEql(
-      "News Article"
-    )
-    return done()
-  })
 })

--- a/src/mobile/apps/articles/test/templates.test.js
+++ b/src/mobile/apps/articles/test/templates.test.js
@@ -34,21 +34,6 @@ describe("articles feed template", function () {
     html.should.not.containEql("article-item-first")
     return html.should.not.containEql("news-panel")
   })
-
-  return it("renders the NewsPanel", function () {
-    const html = render("articles_feed")({
-      articles: [_.clone(fixtures.article)],
-      crop(url) {
-        return url
-      },
-      newsArticles: [{ layout: "news" }],
-      sd: {},
-    })
-
-    html.should.containEql("article-item-first")
-    html.should.containEql("article-item")
-    return html.should.containEql("news-panel")
-  })
 })
 
 describe("section template", function () {


### PR DESCRIPTION
We're going to be putting News on hiatus for the time being so this PR disables the news feed on the editorial landing pages.

<details>
<summary>before/after screenshots</summary>

<img width="1208" alt="Screen Shot 2021-01-06 at 2 04 56 PM" src="https://user-images.githubusercontent.com/79799/103815011-4ca92700-5028-11eb-8b26-9ee3214832c3.png">
<img width="1208" alt="Screen Shot 2021-01-06 at 2 04 58 PM" src="https://user-images.githubusercontent.com/79799/103815015-4f0b8100-5028-11eb-8144-df6e5d18534a.png">
<img width="685" alt="Screen Shot 2021-01-06 at 2 03 30 PM" src="https://user-images.githubusercontent.com/79799/103815023-516ddb00-5028-11eb-8512-0fdf32dcef3b.png">
<img width="685" alt="Screen Shot 2021-01-06 at 2 03 32 PM" src="https://user-images.githubusercontent.com/79799/103815030-53d03500-5028-11eb-9d06-9ac678b4e0d0.png">


</details>


https://artsyproduct.atlassian.net/browse/GRO-145

/cc @artsy/grow-devs