### PR TITLE
bugfix: Fix pagination bug with non-artworkgrid components

### DIFF
--- a/src/v2/Apps/Artist/Routes/Articles/ArtistArticles.tsx
+++ b/src/v2/Apps/Artist/Routes/Articles/ArtistArticles.tsx
@@ -29,7 +29,13 @@ export class ArtistArticles extends Component<
     isLoading: false,
   }
 
+  scrollToTop = () => {
+    window.scrollTo(0, 0)
+  }
+
   loadNext = () => {
+    this.scrollToTop()
+
     const {
       artist: {
         articlesConnection: {
@@ -44,6 +50,7 @@ export class ArtistArticles extends Component<
   }
 
   loadAfter = cursor => {
+    this.scrollToTop()
     this.toggleLoading(true)
 
     this.props.relay.refetch(

--- a/src/v2/Apps/Artist/Routes/Shows/ArtistShows.tsx
+++ b/src/v2/Apps/Artist/Routes/Shows/ArtistShows.tsx
@@ -31,7 +31,13 @@ class ArtistShows extends Component<ArtistShowsProps, LoadingAreaState> {
     isLoading: false,
   }
 
+  scrollToTop = () => {
+    window.scrollTo(0, 0)
+  }
+
   loadNext = () => {
+    this.scrollToTop()
+
     const {
       artist: {
         showsConnection: {
@@ -46,6 +52,7 @@ class ArtistShows extends Component<ArtistShowsProps, LoadingAreaState> {
   }
 
   loadAfter = cursor => {
+    this.scrollToTop()
     this.toggleLoading(true)
 
     this.props.relay.refetch(

--- a/src/v2/Apps/Artists/artistsRoutes.tsx
+++ b/src/v2/Apps/Artists/artistsRoutes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { RouteConfig } from "found"

--- a/src/v2/Apps/Search/searchRoutes.tsx
+++ b/src/v2/Apps/Search/searchRoutes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import { RouteConfig } from "found"
 import React from "react"
 import { graphql } from "react-relay"

--- a/src/v2/Components/Pagination/useComputeHref.ts
+++ b/src/v2/Components/Pagination/useComputeHref.ts
@@ -2,9 +2,18 @@ import { buildUrl } from "v2/Components/v2/ArtworkFilter/Utils/urlBuilder"
 import { useArtworkFilterContext } from "v2/Components/v2/ArtworkFilter/ArtworkFilterContext"
 import { useRouter } from "v2/Artsy/Router/useRouter"
 
+const NOOP = () => ""
+
 export function useComputeHref() {
+  // FIXME: This currently *only* only computes hrefs for artwork filter
+  // components. We'll need to update to work with other more generic
+  // usecases in the future
   const filterContext = useArtworkFilterContext()
   const routerContext = useRouter()
+
+  if (!filterContext.mountedContext) {
+    return NOOP
+  }
 
   const currentlySelectedFilters = filterContext.currentlySelectedFilters()
   const pathname = routerContext?.match?.location?.pathname

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilterContext.tsx
@@ -128,6 +128,9 @@ export interface ArtworkFilterContextProps {
   setShouldStageFilterChanges?: (value: boolean) => void
   setStagedFilters?: (state: ArtworkFilters) => void
   setFilters?: (state: ArtworkFilters) => void
+
+  // Has the ArtworkFilterContext been mounted in the tree
+  mountedContext?: boolean
 }
 
 /**
@@ -145,6 +148,7 @@ export const ArtworkFilterContext = React.createContext<
   sortOptions: [],
   unsetFilter: null,
   ZeroState: null,
+  mountedContext: false,
 })
 
 export type SortOptions = Array<{
@@ -217,6 +221,8 @@ export const ArtworkFilterContextProvider: React.FC<
   }
 
   const artworkFilterContext = {
+    mountedContext: true,
+
     filters: artworkFilterState,
     hasFilters: hasFilters(artworkFilterState),
     stagedFilters: stagedArtworkFilterState,


### PR DESCRIPTION
Quick fix for https://github.com/artsy/force/pull/6832.

Noticed that we were operating on a react context that doesn't exist, when using `<Pagination>` outside of an ArtworkFilter context. 

Most of the pages this applied to are actually old / hidden, so impact of bug not that wide, but it also raises the issue of making deep link href-based pagination work on components that aren't within the artwork filter (there are a few). The only reason this worked at all initially is because we build deep-linking into the artwork filter independent of pagination -- so wiring pagination into that was pretty seamless. Same can't be said about other components, however. 