### PR TITLE
feat: Simplify user email preferences

### DIFF
--- a/src/desktop/apps/user/pages/settings/index.jade
+++ b/src/desktop/apps/user/pages/settings/index.jade
@@ -14,8 +14,9 @@ include ../../templates/mixins
 +settings-section('linked-accounts', 'Linked Accounts')
   include ../../components/linked_accounts/index
 
-+settings-section('email-preferences', 'Email Preferences')
-  include ../../components/email_preferences/index
++settings-section('user-email-preferences', '')
+  #stitch-user-email-preferences
+    != stitch.components.UserEmailPreferences({ mountId: 'stitch-user-email-preferences' })
 
 .settings-section
   .settings-section__main

--- a/src/desktop/components/react/stitch_components/index.tsx
+++ b/src/desktop/components/react/stitch_components/index.tsx
@@ -19,6 +19,7 @@ export {
 export {
   TwoFactorAuthenticationQueryRenderer as TwoFactorAuthentication,
 } from "v2/Components/UserSettings/TwoFactorAuthentication"
+export { UserEmailPreferencesQueryRenderer as UserEmailPreferences, } from "v2/Components/UserSettings/UserEmailPreferences"
 export { UserInformationQueryRenderer as UserInformation } from "v2/Components/UserSettings/UserInformation"
 export { ReactionCCPARequest as CCPARequest } from "./CCPARequest"
 export { UserSettingsTabs } from "v2/Components/UserSettings/UserSettingsTabs"

--- a/src/v2/Components/UserSettings/UserEmailPreferences/UserEmailPreferencesMutation.tsx
+++ b/src/v2/Components/UserSettings/UserEmailPreferences/UserEmailPreferencesMutation.tsx
@@ -1,0 +1,43 @@
+import { Environment, commitMutation, graphql } from "react-relay"
+import {
+  UpdateMyProfileInput,
+  UserEmailPreferencesMutation,
+  UserEmailPreferencesMutationResponse,
+} from "v2/__generated__/UserEmailPreferencesMutation.graphql.ts"
+
+export const UpdateUserEmailPreferencesMutation = (
+  environment: Environment,
+  input: UpdateMyProfileInput,
+  id: string
+) => {
+  return new Promise<UserEmailPreferencesMutationResponse>(
+    async (resolve, reject) => {
+      commitMutation<UserEmailPreferencesMutation>(environment, {
+        mutation: graphql`
+          mutation UserEmailPreferencesMutation($input: UpdateMyProfileInput!)
+            @raw_response_type {
+            updateMyUserProfile(input: $input) {
+              me {
+                id
+                emailFrequency
+              }
+            }
+          }
+        `,
+        onCompleted: resolve,
+        optimisticResponse: {
+          updateMyUserProfile: {
+            me: {
+              id,
+              emailFrequency: input.emailFrequency,
+            },
+          },
+        },
+        onError: reject,
+        variables: {
+          input,
+        },
+      })
+    }
+  )
+}

--- a/src/v2/Components/UserSettings/UserEmailPreferences/index.tsx
+++ b/src/v2/Components/UserSettings/UserEmailPreferences/index.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react"
 import { Banner, Box, Flex, SelectSmall, Serif } from "@artsy/palette"
 import { useSystemContext } from "v2/Artsy/SystemContext"
-import { QueryRenderer, graphql } from "react-relay"
+import { graphql } from "react-relay"
+import { SystemQueryRenderer as QueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
 import {
   UserEmailPreferencesQuery,
   UserEmailPreferencesQueryResponse,

--- a/src/v2/Components/UserSettings/UserEmailPreferences/index.tsx
+++ b/src/v2/Components/UserSettings/UserEmailPreferences/index.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from "react"
+import { Banner, Box, Flex, SelectSmall, Serif } from "@artsy/palette"
+import { useSystemContext } from "v2/Artsy/SystemContext"
+import { QueryRenderer, graphql } from "react-relay"
+import { UserInformationQuery } from "v2/__generated__/UserInformationQuery.graphql.ts"
+import { UpdateUserEmailPreferencesMutation } from "./UserEmailPreferencesMutation"
+import { renderWithLoadProgress } from "v2/Artsy/Relay/renderWithLoadProgress"
+
+const fallbackFrequency = "weekly"
+
+const options = [
+  { text: "None", value: "none" },
+  { text: "Daily", value: "daily" },
+  { text: "Weekly", value: "weekly" },
+]
+
+interface UserEmailPreferencesProps {
+  me: {
+    emailFrequency: string
+    id: string
+  }
+}
+
+export const UserEmailPreferences: React.FC<UserEmailPreferencesProps> = props => {
+  const { relayEnvironment } = useSystemContext()
+  const emailFrequency = props.me.emailFrequency || fallbackFrequency
+  const [updated, setUpdated] = useState(false)
+
+  const handleSelect = async newEmailFrequency => {
+    setUpdated(false)
+    const variables = { emailFrequency: newEmailFrequency }
+    await UpdateUserEmailPreferencesMutation(
+      relayEnvironment,
+      variables,
+      props.me.id
+    )
+    setUpdated(true)
+  }
+
+  return (
+    <>
+      <Serif color="black100" size="6">
+        Email Preferences
+      </Serif>
+      <Serif color="black60" mt="1" size="3">
+        Receive emails from Artsy with auctions, articles, curated collections,
+        and new works by artists you follow
+      </Serif>
+      {updated && (
+        <Box mt="2">
+          <Banner backgroundColor="green10" dismissable textColor="black100">
+            Preferences updated
+          </Banner>
+        </Box>
+      )}
+      <Flex mt="1" justifyContent="space-between">
+        <Serif color="black100" size="3">
+          Frequency
+        </Serif>
+        <Flex alignItems="center">
+          <SelectSmall
+            onSelect={handleSelect}
+            options={options}
+            selected={emailFrequency}
+          />
+        </Flex>
+      </Flex>
+    </>
+  )
+}
+
+export const UserEmailPreferencesQueryRenderer = () => {
+  const { user, relayEnvironment } = useSystemContext()
+
+  if (!user) {
+    return null
+  }
+
+  return (
+    <QueryRenderer<UserInformationQuery>
+      environment={relayEnvironment}
+      variables={{}}
+      query={graphql`
+        query UserEmailPreferencesQuery @raw_response_type {
+          me {
+            emailFrequency
+            id
+          }
+        }
+      `}
+      render={renderWithLoadProgress(UserEmailPreferences)}
+    />
+  )
+}

--- a/src/v2/Components/UserSettings/UserEmailPreferences/index.tsx
+++ b/src/v2/Components/UserSettings/UserEmailPreferences/index.tsx
@@ -2,7 +2,10 @@ import React, { useState } from "react"
 import { Banner, Box, Flex, SelectSmall, Serif } from "@artsy/palette"
 import { useSystemContext } from "v2/Artsy/SystemContext"
 import { QueryRenderer, graphql } from "react-relay"
-import { UserInformationQuery } from "v2/__generated__/UserInformationQuery.graphql.ts"
+import {
+  UserEmailPreferencesQuery,
+  UserEmailPreferencesQueryResponse,
+} from "v2/__generated__/UserEmailPreferencesQuery.graphql.ts"
 import { UpdateUserEmailPreferencesMutation } from "./UserEmailPreferencesMutation"
 import { renderWithLoadProgress } from "v2/Artsy/Relay/renderWithLoadProgress"
 
@@ -14,14 +17,7 @@ const options = [
   { text: "Weekly", value: "weekly" },
 ]
 
-interface UserEmailPreferencesProps {
-  me: {
-    emailFrequency: string
-    id: string
-  }
-}
-
-export const UserEmailPreferences: React.FC<UserEmailPreferencesProps> = props => {
+export const UserEmailPreferences: React.FC<UserEmailPreferencesQueryResponse> = props => {
   const { relayEnvironment } = useSystemContext()
   const emailFrequency = props.me.emailFrequency || fallbackFrequency
   const [updated, setUpdated] = useState(false)
@@ -77,18 +73,20 @@ export const UserEmailPreferencesQueryRenderer = () => {
   }
 
   return (
-    <QueryRenderer<UserInformationQuery>
+    <QueryRenderer<UserEmailPreferencesQuery>
       environment={relayEnvironment}
       variables={{}}
       query={graphql`
-        query UserEmailPreferencesQuery @raw_response_type {
+        query UserEmailPreferencesQuery {
           me {
             emailFrequency
             id
           }
         }
       `}
-      render={renderWithLoadProgress(UserEmailPreferences)}
+      render={renderWithLoadProgress<UserEmailPreferencesQueryResponse>(
+        UserEmailPreferences
+      )}
     />
   )
 }

--- a/src/v2/Components/UserSettings/UserInformation/index.tsx
+++ b/src/v2/Components/UserSettings/UserInformation/index.tsx
@@ -39,14 +39,16 @@ export const UserInformation: React.FC<UserInformationProps> = ({
   ) => {
     formikBag.setStatus({ error: undefined })
     try {
-      const {
-        updateMyUserProfile: { userOrError },
-      } = await UpdateUserInformation(relayEnvironment, {
+      const variables = {
         email,
         name,
         password,
         phone,
-      })
+      }
+
+      const response = await UpdateUserInformation(relayEnvironment, variables)
+      const userOrError = response.updateMyUserProfile.userOrError
+
       if (userOrError.mutationError) {
         const { message, fieldErrors } = userOrError.mutationError
         if (fieldErrors) {

--- a/src/v2/__generated__/UserEmailPreferencesMutation.graphql.ts
+++ b/src/v2/__generated__/UserEmailPreferencesMutation.graphql.ts
@@ -1,0 +1,153 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type UpdateMyProfileInput = {
+    clientMutationId?: string | null;
+    collectorLevel?: number | null;
+    email?: string | null;
+    emailFrequency?: string | null;
+    location?: EditableLocation | null;
+    name?: string | null;
+    password?: string | null;
+    phone?: string | null;
+    priceRangeMax?: number | null;
+    priceRangeMin?: number | null;
+    receiveLotOpeningSoonNotification?: boolean | null;
+    receiveNewSalesNotification?: boolean | null;
+    receiveNewWorksNotification?: boolean | null;
+    receiveOutbidNotification?: boolean | null;
+    receivePromotionNotification?: boolean | null;
+    receivePurchaseNotification?: boolean | null;
+    receiveSaleOpeningClosingNotification?: boolean | null;
+};
+export type EditableLocation = {
+    address?: string | null;
+    address2?: string | null;
+    city?: string | null;
+    country?: string | null;
+    postalCode?: string | null;
+    state?: string | null;
+    stateCode?: string | null;
+    summary?: string | null;
+};
+export type UserEmailPreferencesMutationVariables = {
+    input: UpdateMyProfileInput;
+};
+export type UserEmailPreferencesMutationResponse = {
+    readonly updateMyUserProfile: {
+        readonly me: {
+            readonly id: string;
+            readonly emailFrequency: string | null;
+        } | null;
+    } | null;
+};
+export type UserEmailPreferencesMutationRawResponse = {
+    readonly updateMyUserProfile: ({
+        readonly me: ({
+            readonly id: string;
+            readonly emailFrequency: string | null;
+        }) | null;
+    }) | null;
+};
+export type UserEmailPreferencesMutation = {
+    readonly response: UserEmailPreferencesMutationResponse;
+    readonly variables: UserEmailPreferencesMutationVariables;
+    readonly rawResponse: UserEmailPreferencesMutationRawResponse;
+};
+
+
+
+/*
+mutation UserEmailPreferencesMutation(
+  $input: UpdateMyProfileInput!
+) {
+  updateMyUserProfile(input: $input) {
+    me {
+      id
+      emailFrequency
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input",
+    "type": "UpdateMyProfileInput!"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpdateMyProfilePayload",
+    "kind": "LinkedField",
+    "name": "updateMyUserProfile",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "emailFrequency",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "UserEmailPreferencesMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "UserEmailPreferencesMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "UserEmailPreferencesMutation",
+    "operationKind": "mutation",
+    "text": "mutation UserEmailPreferencesMutation(\n  $input: UpdateMyProfileInput!\n) {\n  updateMyUserProfile(input: $input) {\n    me {\n      id\n      emailFrequency\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '49dee07154002a9bd194f4166baa9ee5';
+export default node;

--- a/src/v2/__generated__/UserEmailPreferencesQuery.graphql.ts
+++ b/src/v2/__generated__/UserEmailPreferencesQuery.graphql.ts
@@ -1,0 +1,89 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type UserEmailPreferencesQueryVariables = {};
+export type UserEmailPreferencesQueryResponse = {
+    readonly me: {
+        readonly emailFrequency: string | null;
+        readonly id: string;
+    } | null;
+};
+export type UserEmailPreferencesQueryRawResponse = {
+    readonly me: ({
+        readonly emailFrequency: string | null;
+        readonly id: string;
+    }) | null;
+};
+export type UserEmailPreferencesQuery = {
+    readonly response: UserEmailPreferencesQueryResponse;
+    readonly variables: UserEmailPreferencesQueryVariables;
+    readonly rawResponse: UserEmailPreferencesQueryRawResponse;
+};
+
+
+
+/*
+query UserEmailPreferencesQuery {
+  me {
+    emailFrequency
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "Me",
+    "kind": "LinkedField",
+    "name": "me",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "emailFrequency",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "UserEmailPreferencesQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "UserEmailPreferencesQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "UserEmailPreferencesQuery",
+    "operationKind": "query",
+    "text": "query UserEmailPreferencesQuery {\n  me {\n    emailFrequency\n    id\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '8a6606cd3574b35cb6067e12d4f1eca2';
+export default node;

--- a/src/v2/__generated__/UserEmailPreferencesQuery.graphql.ts
+++ b/src/v2/__generated__/UserEmailPreferencesQuery.graphql.ts
@@ -9,16 +9,9 @@ export type UserEmailPreferencesQueryResponse = {
         readonly id: string;
     } | null;
 };
-export type UserEmailPreferencesQueryRawResponse = {
-    readonly me: ({
-        readonly emailFrequency: string | null;
-        readonly id: string;
-    }) | null;
-};
 export type UserEmailPreferencesQuery = {
     readonly response: UserEmailPreferencesQueryResponse;
     readonly variables: UserEmailPreferencesQueryVariables;
-    readonly rawResponse: UserEmailPreferencesQueryRawResponse;
 };
 
 
@@ -85,5 +78,5 @@ return {
   }
 };
 })();
-(node as any).hash = '8a6606cd3574b35cb6067e12d4f1eca2';
+(node as any).hash = '40ba9b8060e5c7233e89cf00b348e15c';
 export default node;


### PR DESCRIPTION
This PR updates Force to use the email_frequency field on a user when updating their email preferences.

<details>
<summary>some screenshots</summary>

## before
<img width="1031" alt="Screen Shot 2021-01-07 at 4 34 46 PM" src="https://user-images.githubusercontent.com/79799/103952616-5903b180-5106-11eb-94a6-218a389fd09f.png">

## after
<img width="1031" alt="Screen Shot 2021-01-07 at 4 34 49 PM" src="https://user-images.githubusercontent.com/79799/103952622-5acd7500-5106-11eb-8d36-8848a147fb0a.png">
</details>

I worked pretty closely with @damassi on this so big thanks to him but I also brought this to a front-end practice office hours and got some great direction from @zephraph and @mdole so thanks to them as well.

Note: here's the tech plan - https://www.notion.so/Simplify-email-preferences-1cd2f7c320674032a1e3c0c73a19c54f and this is Milestone 4, the next one will see me deleting the legacy fields I cannot wait.

https://artsyproduct.atlassian.net/browse/GRO-133

/cc @artsy/grow-devs