### PR TITLE
feature: NOVO Chunk Preload

### DIFF
--- a/src/novo/src/index.ejs
+++ b/src/novo/src/index.ejs
@@ -5,6 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <meta charset='utf-8' />
 
+  <!-- Create preload tags for dynamic chunks -->
+  <%- htmlWebpackPlugin.tags.bodyTags.map((originalTag) => { const tag = { ...originalTag, attributes: { ...originalTag.attributes } }; tag.tagName = 'link'; tag.attributes['href'] = "<" + "%= cdnUrl %" + ">" + originalTag.attributes['src']; tag.attributes['rel'] = 'preload'; tag.attributes['as'] = 'script'; delete tag.attributes.src; return tag; }) %>
+
+  <!-- Create preload tags for most common fonts -->
   <link rel="preload" href="<%%= fontUrl %>/ll-unica77_regular.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="preload" href="<%%= fontUrl %>/ll-unica77_medium.woff2" as="font" type="font/woff2" crossorigin />
 
@@ -24,10 +28,7 @@
   <meta property="fb:app_id" content="308278682573501" />
   <meta property="fb:pages" content="342443413406" />
 
-  <link type='text/css', rel='stylesheet', href='<%%= fontUrl %>/all-webfonts.css' />
-
-  <!-- String concatenation is needed allow outputting a template tag -->
-  <%- htmlWebpackPlugin.tags.bodyTags.map((tag) => { tag.attributes['src'] = "<" + "%= cdnUrl %" + ">" + tag.attributes['src']; tag.attributes['async'] = true; return tag; }) %>
+  <link type='text/css' rel='stylesheet' href='<%%= fontUrl %>/all-webfonts.css' />
 
   <%%- content.head %>
   <%%- content.style %>
@@ -39,6 +40,9 @@
 
   <div id="react-modal-container"></div>
   <div id="react-root"><%%- content.body %></div>
+
+  <!-- String concatenation is needed allow outputting a template tag -->
+  <%- htmlWebpackPlugin.tags.bodyTags.map((originalTag) => { const tag = { ...originalTag, attributes: { ...originalTag.attributes } }; tag.attributes['src'] = "<" + "%= cdnUrl %" + ">" + originalTag.attributes['src']; tag.attributes['async'] = true; return tag; }) %>
 
   <%% if (!disable.segment && !sd.THIRD_PARTIES_DISABLED && sd.SEGMENT_WRITE_KEY) { %>
   <script type="text/javascript" defer>


### PR DESCRIPTION
This change adds preloading for the dynamically generated novo chunks
which has become necessary because the scripts must be included after
the react dom has been served to avoid visual glitches during rehydration.