### PR TITLE
fix(search): removes input clear after search

### DIFF
--- a/src/v2/Components/Search/SearchBar.tsx
+++ b/src/v2/Components/Search/SearchBar.tsx
@@ -96,6 +96,8 @@ export class SearchBar extends Component<Props, State> {
   // this behaviour  is acceptable.
   private userClickedOnDescendant: boolean
 
+  private removeNavigationListener: () => void
+
   state = {
     entityID: null,
     entityType: null,
@@ -158,11 +160,29 @@ export class SearchBar extends Component<Props, State> {
     this.throttledFetch = throttle(this.throttledFetch, 500, {
       leading: true,
     })
+
     this.throttledOnSuggestionHighlighted = throttle(
       this.throttledOnSuggestionHighlighted,
       500,
       { leading: true }
     )
+
+    // Clear the search term once you navigate away from search results
+    this.removeNavigationListener = this.props.router
+      ? this.props.router.addNavigationListener(location => {
+          if (!location.pathname.startsWith("/search")) {
+            this.setState({ term: "" })
+          }
+
+          return true
+        })
+      : () => {
+          // noop
+        }
+  }
+
+  componentWillUnmount() {
+    this.removeNavigationListener()
   }
 
   reportPerformanceMeasurement = performanceStart => {

--- a/src/v2/Components/Search/SearchBar.tsx
+++ b/src/v2/Components/Search/SearchBar.tsx
@@ -357,15 +357,6 @@ export class SearchBar extends Component<Props, State> {
         ) {
           event.preventDefault()
         }
-
-        // Clear input after submit
-        if (event.key === "Enter") {
-          setTimeout(() => {
-            this.setState({
-              term: "",
-            })
-          })
-        }
       },
       placeholder: xs ? PLACEHOLDER_XS : PLACEHOLDER,
       value: term,


### PR DESCRIPTION
Closes: [FX-2591](https://artsyproduct.atlassian.net/browse/FX-2591)

I noticed this bug this morning when trying to use the mobile site. The go button (which in mobile Safari simulates `<enter>`) clears the input without searching.

![](https://static.damonzucconi.com/_capture/Y7M1R0p4yOvA.gif)

This was introduced here as a feature not a bug: https://github.com/artsy/reaction/pull/3217

I think it makes sense not to clear the input because frequently one wants to edit the query to refine it — this is a pretty common pattern in most searches/search engines. I couldn't find any specific accessibility guidelines on this particular point, but it makes an intuitive kind of sense. So this PR just disables the clearing of the input, rather than fixing the submission with the addition of the input clear.

We also already populate the query when linking to search results directly, anyway.

![](https://static.damonzucconi.com/_capture/2zU7kJDpafXV.png)