### PR TITLE
bugfix: Fix hard reload on search tabs

### DIFF
--- a/src/v2/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/v2/Apps/Search/Components/NavigationTabs.tsx
@@ -62,7 +62,9 @@ export class NavigationTabs extends React.Component<Props> {
       <RouteTab
         to={to}
         exact={exact}
-        onClick={() => {
+        onClick={event => {
+          event.preventDefault()
+          this.props.router.push(to)
           this.trackClick(tabName, to)
         }}
         key={to}

--- a/src/v2/Apps/Search/searchRoutes.tsx
+++ b/src/v2/Apps/Search/searchRoutes.tsx
@@ -44,9 +44,9 @@ const entityTabs = Object.entries(tabsToEntitiesMap).map(([key, entities]) => {
       }
       return <Component {...props} tab={key} entities={entities} />
     },
-    prepareVariables: (_params, { location }) => {
+    prepareVariables: (params, { location }) => {
       return {
-        ...prepareVariables(_params, { location }),
+        ...prepareVariables(params, { location }),
         entities,
       }
     },


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/GRO-143 

Noticed recently that the tabs were doing full page hard reloads when clicked. This fixes that, while getting around a (seeming) limitation in found around `<RouterLink to='/some-path?with=params'>`; I've got a message out to the author about it, but in the meantime. 

![after](https://user-images.githubusercontent.com/236943/104255466-faa04100-542d-11eb-8628-05f9480e6251.gif)

cc @artsy/grow-devs 