### PR TITLE
feat: Redirect collector selling FAQ to /consign

### DIFF
--- a/src/desktop/apps/page/routes.coffee
+++ b/src/desktop/apps/page/routes.coffee
@@ -8,7 +8,10 @@ Page = require '../../models/page'
       error: res.backboneError
 
 @index = (req, res) ->
-  new Page(id: req.params.id).fetch
+  if req.params.id == "collector-faqs-selling-on-artsy"
+    return res.redirect(301, "/consign")
+  else
+    return new Page(id: req.params.id).fetch
     cache: true
     success: (page) -> res.render 'template', page: page
     error: res.backboneError

--- a/src/desktop/apps/page/test/routes.test.js
+++ b/src/desktop/apps/page/test/routes.test.js
@@ -1,0 +1,14 @@
+const sinon = require("sinon")
+const routes = require("../routes")
+
+describe("Page routes", () => {
+  describe("#index", () => {
+    it("redirects the collector selling FAQ to /consign", async () => {
+      const req = { params: { id: "collector-faqs-selling-on-artsy" } }
+      const res = { redirect: sinon.stub() }
+      await routes.index(req, res)
+      res.redirect.args[0][0].should.equal(301)
+      res.redirect.args[0][1].should.equal("/consign")
+    })
+  })
+})


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GRO-123
cc @artsy/grow-devs 

## Problem

Our `collector-faqs-selling-on-artsy` page ranks well on relevant Googles search queries but isn't a great user experience. We'd like for collectors who are searching for this information to go to `/consign` instead.

## Solution

301 redirect `/page/collector-faqs-selling-on-artsy` to `/consign`.