### PR TITLE
fix: proper active state and routing for search page nav tabs

### DIFF
--- a/src/desktop/apps/artsy-v2/server.tsx
+++ b/src/desktop/apps/artsy-v2/server.tsx
@@ -4,6 +4,7 @@ import { buildServerApp } from "v2/Artsy/Router/server"
 import { getAppRoutes } from "v2/Apps/getAppRoutes"
 import { stitch } from "@artsy/stitch"
 import { flatten } from "lodash"
+import { stringify } from "qs"
 
 import { handleArtworkImageDownload } from "./apps/artwork/artworkMiddleware"
 import { artistMiddleware } from "./apps/artist/artistMiddleware"
@@ -36,6 +37,12 @@ const allRoutes = flatten(
  */
 app.get("/artwork/:artworkID/download/:filename", handleArtworkImageDownload)
 app.get("/collection/:collectionSlug", handleCollectionToArtistSeriesRedirect)
+
+// Redirect top-level /search?term=... style routes to /search/artworks?term=...
+app.get("/search", (req, res, next) => {
+  const queryParams = stringify(req.query)
+  return res.redirect(301, `/search/artworks?${queryParams}`)
+})
 
 /**
  * Mount routes that will connect to global SSR router

--- a/src/v2/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/v2/Apps/Search/Components/NavigationTabs.tsx
@@ -98,9 +98,8 @@ export class NavigationTabs extends React.Component<Props> {
 
     !!artworkCount &&
       tabs.push(
-        this.renderTab("Artworks", route(""), {
+        this.renderTab("Artworks", route("/artworks"), {
           count: artworkCount,
-          exact: true,
         })
       )
 

--- a/src/v2/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/v2/Apps/Search/Components/NavigationTabs.tsx
@@ -62,9 +62,7 @@ export class NavigationTabs extends React.Component<Props> {
       <RouteTab
         to={to}
         exact={exact}
-        onClick={event => {
-          event.preventDefault()
-          this.props.router.push(to)
+        onClick={() => {
           this.trackClick(tabName, to)
         }}
         key={to}

--- a/src/v2/Apps/Search/searchRoutes.tsx
+++ b/src/v2/Apps/Search/searchRoutes.tsx
@@ -33,7 +33,7 @@ const tabsToEntitiesMap = {
 
 const entityTabs = Object.entries(tabsToEntitiesMap).map(([key, entities]) => {
   return {
-    path: key,
+    path: `${key}(.*)?`,
     Component: SearchResultsEntityRouteFragmentContainer,
 
     // FIXME: We shouldn't overwrite our route functionality, as that breaks
@@ -79,13 +79,7 @@ export const searchRoutes: RouteConfig[] = [
     prepareVariables,
     children: [
       {
-        path: "/",
-        Component: SearchResultsArtworksRoute,
-        prepareVariables,
-        query: ArtworkQueryFilter,
-      },
-      {
-        path: "artists",
+        path: "artists(.*)?",
         Component: SearchResultsArtistsRouteFragmentContainer,
         prepareVariables,
         query: graphql`
@@ -101,6 +95,12 @@ export const searchRoutes: RouteConfig[] = [
         `,
       },
       ...entityTabs,
+      {
+        path: "artworks(.*)?",
+        Component: SearchResultsArtworksRoute,
+        prepareVariables,
+        query: ArtworkQueryFilter,
+      },
     ],
   },
 ]

--- a/src/v2/Apps/Search/searchRoutes.tsx
+++ b/src/v2/Apps/Search/searchRoutes.tsx
@@ -44,9 +44,9 @@ const entityTabs = Object.entries(tabsToEntitiesMap).map(([key, entities]) => {
       }
       return <Component {...props} tab={key} entities={entities} />
     },
-    prepareVariables: (params, { location }) => {
+    prepareVariables: (_params, { location }) => {
       return {
-        ...prepareVariables(params, { location }),
+        ...prepareVariables(_params, { location }),
         entities,
       }
     },

--- a/src/v2/Components/Search/SearchBar.tsx
+++ b/src/v2/Components/Search/SearchBar.tsx
@@ -375,7 +375,7 @@ export class SearchBar extends Component<Props, State> {
       node: {
         displayLabel: term,
         displayType: "FirstItem",
-        href: `/search?term=${term}`,
+        href: `/search/artworks?term=${term}`,
         isFirstItem: true,
       },
     }
@@ -410,12 +410,12 @@ export class SearchBar extends Component<Props, State> {
 
     return (
       <Form
-        action="/search"
+        action="/search/artworks"
         method="GET"
         onSubmit={event => {
           if (router) {
             event.preventDefault()
-            router.push(`/search?term=${this.state.term}`)
+            router.push(`/search/artworks?term=${this.state.term}`)
             this.onBlur(event)
           } else {
             console.error(


### PR DESCRIPTION
This fixes the active tab behavior + routing for the search results page.

However(!), this also changes the initial/default behavior from `/search?term=...(+ filter params)` to `/search/artworks?term=...`. I couldn't get the route matching to work w/ the nested child route being empty. I feel like the additional /artworks is actually better for SEO? There does need to be a middleware that redirects from `/search -> /search/artworks`, to account for any existing links and SEO equity.