### PR TITLE
feature: Convert Collection Routes

### DIFF
--- a/src/desktop/lib/webpackPublicPath.ts
+++ b/src/desktop/lib/webpackPublicPath.ts
@@ -22,9 +22,21 @@ if (process.env.NODE_ENV === "production") {
     cdnUrl = "https://d1rmpw1xlv9rxa.cloudfront.net"
   }
 
+  // TODO: Remove this as its temporary while routes are being converted.
+  const convertedRoutes = ["/collections", "/collection", "/collect"]
+
+  function beenConverted() {
+    for (const convertedRoute of convertedRoutes) {
+      if (window.location.pathname.startsWith(convertedRoute)) {
+        return true
+      }
+    }
+    return false
+  }
+
   // TODO: Ugh, this is a mess. Figure out a way to not relying on custom
   // webpack pathing client side.
-  if (window.location.pathname.startsWith("/novo")) {
+  if (window.location.pathname.startsWith("/novo") || beenConverted()) {
     __webpack_public_path__ = cdnUrl + "/assets-novo/"
   } else {
     __webpack_public_path__ = cdnUrl + "/assets/"

--- a/src/v2/Apps/getAppNovoRoutes.tsx
+++ b/src/v2/Apps/getAppNovoRoutes.tsx
@@ -34,6 +34,7 @@ export function getAppNovoRoutes(): RouteConfig[] {
         routes: artworkRoutes,
       },
       {
+        converted: true,
         routes: collectRoutes,
       },
       {
@@ -71,14 +72,25 @@ export function getAppNovoRoutes(): RouteConfig[] {
       {
         routes: debugRoutes,
       },
-    ].map((routeConfig: { disabled: boolean; routes: RouteConfig[] }) => {
-      return {
-        ...routeConfig,
-        routes: routeConfig.routes.map(route => ({
-          ...route,
-          path: `/novo${route.path}`,
-        })),
+    ].map(
+      (routeConfig: {
+        disabled?: boolean
+        routes: RouteConfig[]
+        converted?: boolean
+      }) => {
+        return {
+          ...routeConfig,
+          routes: routeConfig.routes.map(route => {
+            if (routeConfig.converted) {
+              return { ...route }
+            }
+            return {
+              ...route,
+              path: `/novo${route.path}`,
+            }
+          }),
+        }
       }
-    })
+    )
   )
 }

--- a/src/v2/Apps/getAppRoutes.tsx
+++ b/src/v2/Apps/getAppRoutes.tsx
@@ -4,7 +4,7 @@ import { artistRoutes } from "v2/Apps/Artist/artistRoutes"
 import { artistSeriesRoutes } from "./ArtistSeries/artistSeriesRoutes"
 import { artistsRoutes } from "v2/Apps/Artists/artistsRoutes"
 import { artworkRoutes } from "v2/Apps/Artwork/artworkRoutes"
-import { collectRoutes } from "v2/Apps/Collect/collectRoutes"
+// import { collectRoutes } from "v2/Apps/Collect/collectRoutes"
 import { consignRoutes } from "v2/Apps/Consign/consignRoutes"
 import { conversationRoutes } from "v2/Apps/Conversation/conversationRoutes"
 import { debugRoutes } from "./Debug/debugRoutes"
@@ -32,9 +32,10 @@ export function getAppRoutes(): RouteConfig[] {
     {
       routes: artworkRoutes,
     },
-    {
-      routes: collectRoutes,
-    },
+    // NOTE: Converted to use NOVO template.
+    // {
+    //   routes: collectRoutes,
+    // },
     {
       routes: consignRoutes,
     },


### PR DESCRIPTION
This is the first V2 app migration to the new minimal template and 
migrates: `/collections`, `/collect`, and `/collection`.

The migration is relatively straightforward and only requires a few steps
which are outlined below. There is one minor concern to be aware
of, the simplest migration (outlined below) moves all routes in a route
config for most pages I don't expect this to be an issue. However, when
migrating more complex pages would be possible to break the route
config apart to reduce the scope of the migration.

Review app ([here](https://novo.artsy.net))

* `/collections` ([here](https://novo.artsy.net/collections))
* `/collection` ([here](https://novo.artsy.net/collection/abstract-expressionism-works-on-paper))
* `/collect` ([here](https://novo.artsy.net/collect))
* `/collect/:medium` ([here](https://novo.artsy.net/collect/installation))

Migration Steps:

1. Enable the new template for the route ([here](https://github.com/artsy/force/blob/671fb10356854f57a9d20889093cabca387ceb52/src/v2/Apps/getAppNovoRoutes.tsx#L37))
2. Disable the current route ([here](https://github.com/artsy/force/blob/671fb10356854f57a9d20889093cabca387ceb52/src/v2/Apps/getAppRoutes.tsx#L36))
3. Enable asset routing ([here](https://github.com/artsy/force/blob/671fb10356854f57a9d20889093cabca387ceb52/src/desktop/lib/webpackPublicPath.ts#L26))
4. Ensure routes are being captured in Calibre