### PR TITLE
Present API errors upon enabling second factors

### DIFF
--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
@@ -51,7 +51,7 @@ export const AppSecondFactorModal: React.FC<AppSecondFactorModalProps> = props =
     let statusMessage = ""
 
     errors.forEach(error => {
-      if (error.code === "invalid_otp") {
+      if (error.code === "invalid_otp" || error.code === "invalid") {
         actions.setFieldError("code", error.message)
       } else {
         statusMessage += `${error.message}\n`

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
@@ -70,9 +70,13 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
     let statusMessage = ""
 
     errors.forEach(error => {
-      if (error.code === "invalid" && error.data.key === "phone_number") {
+      if (
+        error.code === "invalid" &&
+        error.data &&
+        error.data.key === "phone_number"
+      ) {
         actions.setFieldError("phoneNumber", error.message)
-      } else if (error.code === "invalid_otp") {
+      } else if (error.code === "invalid_otp" || error.code === "invalid") {
         actions.setFieldError("code", error.message)
       } else {
         statusMessage += `${error.message}\n`


### PR DESCRIPTION
This follow up https://github.com/artsy/gravity/pull/13762 🔒 to expose back-end errors in the 2FA-enabling UI.

This doesn't break existing tests but could use a new one, hence "draft." I'm diving into the tests next, but could use a little help with that.

Looks like:

<img width="470" alt="Screen Shot 2021-01-19 at 12 23 52 PM" src="https://user-images.githubusercontent.com/28120/105070412-3f8d2e80-5a51-11eb-8976-68fffb0bc671.png">
