### PR TITLE
Correctly prompt for password when updating email, even to original value

### DIFF
--- a/src/v2/Components/UserSettings/UserInformation/index.tsx
+++ b/src/v2/Components/UserSettings/UserInformation/index.tsx
@@ -61,6 +61,7 @@ export const UserInformation: React.FC<UserInformationProps> = ({
         }
       } else {
         formikBag.resetForm()
+        relay.refetch({})
       }
     } catch (err) {
       formikBag.setErrors(err)


### PR DESCRIPTION
We observed some email changes reaching the API _without_ the required password verification. This ended up being due to 2 possible conditions:
* the email mismatch is due to capitalization/normalization (fixed in https://github.com/artsy/gravity/pull/13776), and
* the email was being updated back to its original value at page-load

This change [that you suggested] mostly fixes the 2nd case. There's still a race condition somewhere that might allow form submission without a password prompt, but I couldn't reproduce it consistently.

https://artsyproduct.atlassian.net/browse/PLATFORM-3106