### PR TITLE
feature: Convert Show Routes

### DIFF
--- a/src/desktop/lib/webpackPublicPath.ts
+++ b/src/desktop/lib/webpackPublicPath.ts
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV === "production") {
   }
 
   // TODO: Remove this as its temporary while routes are being converted.
-  const convertedRoutes = ["/collections", "/collection", "/collect"]
+  const convertedRoutes = ["/collections", "/collection", "/collect", "/show/"]
 
   function beenConverted() {
     for (const convertedRoute of convertedRoutes) {

--- a/src/v2/Apps/Show/Components/ShowInstallShots.tsx
+++ b/src/v2/Apps/Show/Components/ShowInstallShots.tsx
@@ -97,7 +97,7 @@ export const ShowInstallShots: React.FC<ShowInstallShotsProps> = ({
                 width="100%"
                 height="100%"
                 alt={`${show.name}, installation view`}
-                style={{ position: "absolute" }}
+                style={{ position: "absolute", top: 0, left: 0 }}
               />
             </ResponsiveBox>
           </Clickable>

--- a/src/v2/Apps/Show/showRoutes.tsx
+++ b/src/v2/Apps/Show/showRoutes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { RedirectException, RouteConfig } from "found"

--- a/src/v2/Apps/getAppNovoRoutes.tsx
+++ b/src/v2/Apps/getAppNovoRoutes.tsx
@@ -62,6 +62,7 @@ export function getAppNovoRoutes(): RouteConfig[] {
         routes: searchRoutes,
       },
       {
+        converted: true,
         routes: showRoutes,
       },
       {

--- a/src/v2/Apps/getAppRoutes.tsx
+++ b/src/v2/Apps/getAppRoutes.tsx
@@ -16,7 +16,7 @@ import { identityVerificationRoutes } from "v2/Apps/IdentityVerification/identit
 import { orderRoutes } from "v2/Apps/Order/orderRoutes"
 import { purchaseRoutes } from "v2/Apps/Purchase/purchaseRoutes"
 import { searchRoutes } from "v2/Apps/Search/searchRoutes"
-import { showRoutes } from "v2/Apps/Show/showRoutes"
+// import { showRoutes } from "v2/Apps/Show/showRoutes"
 import { viewingRoomRoutes } from "./ViewingRoom/viewingRoomRoutes"
 import { auctionsRoutes } from "./Auctions/auctionsRoutes"
 
@@ -71,9 +71,10 @@ export function getAppRoutes(): RouteConfig[] {
     {
       routes: searchRoutes,
     },
-    {
-      routes: showRoutes,
-    },
+    // NOTE: Converted to use NOVO template.
+    // {
+    //   routes: showRoutes,
+    // },
     {
       routes: viewingRoomRoutes,
     },


### PR DESCRIPTION
This changed migrates the following routes: `/show/:slug`,
`/show/:slug/info`, and `/show/:slug/hours`.

Review app ([here](https://novo.artsy.net))

* `/show/:slug` ([here](https://novo.artsy.net/show/ross-sutton-gallery-black-voices-friend-of-my-mind))
* `/show/:slug/info` ([here](https://novo.artsy.net/show/ross-sutton-gallery-black-voices-friend-of-my-mind/info))