### PR TITLE
Set IS_MOBILE in common middleware, so page-load tracking can use it

### DIFF
--- a/src/lib/middleware/__tests__/sharifyLocals.jest.ts
+++ b/src/lib/middleware/__tests__/sharifyLocals.jest.ts
@@ -41,4 +41,20 @@ describe("locals middleware", () => {
     sharifyLocalsMiddleware(req, res, next)
     expect(res.locals.sd.EIGEN).toEqual(false)
   })
+
+  it("sets IS_MOBILE", () => {
+    req.get.mockReturnValueOnce(
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+    )
+    sharifyLocalsMiddleware(req, res, next)
+    expect(res.locals.sd.IS_MOBILE).toEqual(true)
+  })
+
+  it("sets IS_TABLET", () => {
+    req.get.mockReturnValueOnce(
+      "Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10"
+    )
+    sharifyLocalsMiddleware(req, res, next)
+    expect(res.locals.sd.IS_TABLET).toEqual(true)
+  })
 })

--- a/src/lib/middleware/locals.ts
+++ b/src/lib/middleware/locals.ts
@@ -56,22 +56,5 @@ export function localsMiddleware(
   res.locals.sd.USER_AGENT = res.locals.userAgent = escape(ua)
   res.locals.sd.REQUEST_ID = req.id
 
-  // Determines device type for non-responsive pages.
-  res.locals.sd.IS_MOBILE = Boolean(
-    (ua.match(/iPhone/i) && !ua.match(/iPad/i)) ||
-      (ua.match(/Android/i) && ua.match(/Mobile/i)) ||
-      ua.match(/Windows Phone/i) ||
-      ua.match(/BB10/i) ||
-      ua.match(/BlackBerry/i)
-  )
-
-  res.locals.sd.IS_TABLET = Boolean(
-    (ua.match(/iPad/i) && ua.match(/Mobile/i)) ||
-      // specifically targets Vivo
-      (ua.match(/vivo/i) && ua.match(/Mobile/i)) ||
-      // targets android devices that are not mobile
-      (ua.match(/Android/i) && ua.match(/Mobile/i))
-  )
-
   next()
 }

--- a/src/lib/middleware/sharifyLocals.ts
+++ b/src/lib/middleware/sharifyLocals.ts
@@ -28,5 +28,22 @@ export function sharifyLocalsMiddleware(
       : undefined
   res.locals.sd.ARTSY_XAPP_TOKEN = artsyXapp.token
 
+  // Determines device type for non-responsive pages.
+  res.locals.sd.IS_MOBILE = Boolean(
+    (ua.match(/iPhone/i) && !ua.match(/iPad/i)) ||
+      (ua.match(/Android/i) && ua.match(/Mobile/i)) ||
+      ua.match(/Windows Phone/i) ||
+      ua.match(/BB10/i) ||
+      ua.match(/BlackBerry/i)
+  )
+
+  res.locals.sd.IS_TABLET = Boolean(
+    (ua.match(/iPad/i) && ua.match(/Mobile/i)) ||
+      // specifically targets Vivo
+      (ua.match(/vivo/i) && ua.match(/Mobile/i)) ||
+      // targets android devices that are not mobile
+      (ua.match(/Android/i) && ua.match(/Mobile/i))
+  )
+
   next()
 }


### PR DESCRIPTION
### Problem:

Page performance data all arrived with the `device-type:desktop` tag once `/collect*` pages were switched to the novo template (https://github.com/artsy/force/pull/6905). It's helpful to [continue to] distinguish mobile performance data, since we're targeting mobile specifically and expect any improvements to be pronounced there.

### Solution:

I followed the pattern in https://github.com/artsy/force/pull/6917 and confirmed locally that the performance data is sent with either `device-type:mobile` or `...:desktop`. Added some tests while I was there.

Let me know what I'm missing!
