### PR TITLE
Ensure stitch exists before attempting to use when stitching in footer

### DIFF
--- a/src/desktop/components/main_layout/footer/template.jade
+++ b/src/desktop/components/main_layout/footer/template.jade
@@ -1,3 +1,3 @@
 footer#main-layout-footer
   .responsive-layout-container: .mlf
-    != stitch.components.Footer()
+    != stitch && stitch.components && stitch.components.Footer()


### PR DESCRIPTION
Fixes issue where SSR errors were being masked by `stitch` being undefined.