### PR TITLE
feature: Convert Artist Series

### DIFF
--- a/src/desktop/lib/webpackPublicPath.ts
+++ b/src/desktop/lib/webpackPublicPath.ts
@@ -23,7 +23,13 @@ if (process.env.NODE_ENV === "production") {
   }
 
   // TODO: Remove this as its temporary while routes are being converted.
-  const convertedRoutes = ["/collections", "/collection", "/collect", "/show/"]
+  const convertedRoutes = [
+    "/arist-series",
+    "/collections",
+    "/collection",
+    "/collect",
+    "/show/",
+  ]
 
   function beenConverted() {
     for (const convertedRoute of convertedRoutes) {

--- a/src/v2/Apps/ArtistSeries/artistSeriesRoutes.tsx
+++ b/src/v2/Apps/ArtistSeries/artistSeriesRoutes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { RouteConfig } from "found"

--- a/src/v2/Apps/getAppNovoRoutes.tsx
+++ b/src/v2/Apps/getAppNovoRoutes.tsx
@@ -28,6 +28,7 @@ export function getAppNovoRoutes(): RouteConfig[] {
         routes: artistsRoutes,
       },
       {
+        converted: true,
         routes: artistSeriesRoutes,
       },
       {

--- a/src/v2/Apps/getAppRoutes.tsx
+++ b/src/v2/Apps/getAppRoutes.tsx
@@ -1,7 +1,7 @@
 import { buildAppRoutes } from "v2/Artsy/Router/buildAppRoutes"
 import { RouteConfig } from "found"
 import { artistRoutes } from "v2/Apps/Artist/artistRoutes"
-import { artistSeriesRoutes } from "./ArtistSeries/artistSeriesRoutes"
+// import { artistSeriesRoutes } from "./ArtistSeries/artistSeriesRoutes"
 import { artistsRoutes } from "v2/Apps/Artists/artistsRoutes"
 import { artworkRoutes } from "v2/Apps/Artwork/artworkRoutes"
 // import { collectRoutes } from "v2/Apps/Collect/collectRoutes"
@@ -28,9 +28,10 @@ export function getAppRoutes(): RouteConfig[] {
     {
       routes: artistsRoutes,
     },
-    {
-      routes: artistSeriesRoutes,
-    },
+    // NOTE: Converted to use NOVO template.
+    // {
+    //   routes: artistSeriesRoutes,
+    // },
     {
       routes: artworkRoutes,
     },


### PR DESCRIPTION
This change migrates the following routes: `/artist-series/:slug`

Review app ([here](https://novo.artsy.net))

* `/artist-series/:slug` ([here](https://novo.artsy.net/artist-series/damien-hirst-butterflies))