### PR TITLE
feat: Disable infinite scroll on news page for googlebot

### DIFF
--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -1,4 +1,5 @@
 import { data as sd } from "sharify"
+import { getENV } from "v2/Utils/getENV"
 import moment from "moment"
 import styled from "styled-components"
 import React, { Component, Fragment } from "react"
@@ -129,11 +130,19 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
   }
 
   renderWaypoint = () => {
-    const { isEnabled, isLoading, error } = this.state
+    const { isLoading, error } = this.state
+    const isGooglebot = getENV("IS_GOOGLEBOT")
+    const isEnabled = !isGooglebot && this.state.isEnabled
 
     if (isEnabled) {
       if (!isLoading) {
-        return <Waypoint onEnter={this.fetchNextArticles} bottomOffset="-50%" />
+        return (
+          <Waypoint
+            data-test="news"
+            onEnter={this.fetchNextArticles}
+            bottomOffset="-50%"
+          />
+        )
       } else if (!error) {
         return (
           <LoadingSpinner>

--- a/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.jest.tsx
+++ b/src/desktop/apps/article/components/__tests__/InfiniteScrollNewsArticle.jest.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { getENV } from "v2/Utils/getENV"
 import { mount } from "enzyme"
 import { InfiniteScrollNewsArticle } from "../InfiniteScrollNewsArticle"
 import { NewsArticle } from "@artsy/reaction/dist/Components/Publishing/Fixtures/Articles"
@@ -37,9 +38,12 @@ jest.mock("sharify", () => {
 })
 const sd = require("sharify").data
 
+jest.mock("v2/Utils/getENV")
+
 describe("InfiniteScrollNewsArticle", () => {
   let props
   let nextArticle
+  let mockGetENV = getENV as jest.Mock
 
   const getWrapper = (passedProps = props) => {
     return mount(
@@ -69,6 +73,18 @@ describe("InfiniteScrollNewsArticle", () => {
     }
 
     sd.CURRENT_USER = { id: "123" }
+
+    mockGetENV.mockImplementation(() => {
+      return false
+    })
+  })
+
+  it("disables infinite scroll for googlebot", () => {
+    mockGetENV.mockImplementation(() => {
+      return true
+    })
+    const wrapper = getWrapper()
+    expect(wrapper.find("Waypoint[data-test='news']")).toHaveLength(0)
   })
 
   it("#hasNewDate returns true if article date is different from previous article", () => {
@@ -256,9 +272,8 @@ describe("InfiniteScrollNewsArticle", () => {
     })
   })
 
-  // FIXME: Reenable once scrolling date issue is resolved
   describe("#onDateChange", () => {
-    it("it sets date if it has a new one", () => {
+    it("sets date if it has a new one", () => {
       const component = getWrapper()
       const instance = component
         .find(InfiniteScrollNewsArticle)
@@ -267,7 +282,7 @@ describe("InfiniteScrollNewsArticle", () => {
       expect(instance.state.date).toBe("2018-07-20T17:19:55.909Z")
     })
 
-    it("it doesn't set date if it hasn't changed", () => {
+    it("doesn't set date if it hasn't changed", () => {
       const component = getWrapper()
       const instance = component
         .find(InfiniteScrollNewsArticle)

--- a/src/lib/middleware/sharifyLocals.ts
+++ b/src/lib/middleware/sharifyLocals.ts
@@ -45,5 +45,7 @@ export function sharifyLocalsMiddleware(
       (ua.match(/Android/i) && ua.match(/Mobile/i))
   )
 
+  res.locals.sd.IS_GOOGLEBOT = Boolean(ua.match(/Googlebot/i))
+
   next()
 }

--- a/src/typings/sharify.d.ts
+++ b/src/typings/sharify.d.ts
@@ -36,6 +36,7 @@ declare module "sharify" {
       readonly GENOME_URL: string
       readonly GOOGLE_ADWORDS_ID: string
       readonly IMAGE_LAZY_LOADING: boolean
+      IS_GOOGLEBOT: boolean
       IS_MOBILE: boolean
       readonly METAPHYSICS_ENDPOINT: string
       readonly NODE_ENV: string


### PR DESCRIPTION
This PR adds an `IS_GOOGLEBOT` boolean to our global data and then uses it to disable infinite scroll on news pages for Googlebot. I did some quick research and it appears `Googlebot` is the user agent to look for but wanted to ping @joeyAghion in case he has any info about this. Otherwise I think this is pretty good to go but it almost seems too easy - am I missing something? Also pretty hard to test this, I wonder how I will know if this fixes the problem? 🤔 

https://artsyproduct.atlassian.net/browse/GRO-63

/cc @artsy/grow-devs