### PR TITLE
novo: Convert /orders routes

### DIFF
--- a/src/desktop/lib/webpackPublicPath.ts
+++ b/src/desktop/lib/webpackPublicPath.ts
@@ -29,6 +29,8 @@ if (process.env.NODE_ENV === "production") {
     "/collections",
     "/collection",
     "/collect",
+    "/order",
+    "/orders",
     "/show/",
   ]
 

--- a/src/v2/Apps/getAppNovoRoutes.tsx
+++ b/src/v2/Apps/getAppNovoRoutes.tsx
@@ -55,6 +55,7 @@ export function getAppNovoRoutes(): RouteConfig[] {
         routes: identityVerificationRoutes,
       },
       {
+        converted: true,
         routes: orderRoutes,
       },
       {

--- a/src/v2/Apps/getAppRoutes.tsx
+++ b/src/v2/Apps/getAppRoutes.tsx
@@ -13,7 +13,7 @@ import { fairRoutes } from "v2/Apps/Fair/fairRoutes"
 import { fairsRoutes } from "v2/Apps/Fairs/fairsRoutes"
 import { featureRoutes } from "v2/Apps/Feature/featureRoutes"
 import { identityVerificationRoutes } from "v2/Apps/IdentityVerification/identityVerificationRoutes"
-import { orderRoutes } from "v2/Apps/Order/orderRoutes"
+// import { orderRoutes } from "v2/Apps/Order/orderRoutes"
 import { purchaseRoutes } from "v2/Apps/Purchase/purchaseRoutes"
 import { searchRoutes } from "v2/Apps/Search/searchRoutes"
 // import { showRoutes } from "v2/Apps/Show/showRoutes"
@@ -64,9 +64,10 @@ export function getAppRoutes(): RouteConfig[] {
     {
       routes: identityVerificationRoutes,
     },
-    {
-      routes: orderRoutes,
-    },
+    // NOTE: Converted to use NOVO template.
+    // {
+    //   routes: orderRoutes,
+    // },
     {
       routes: purchaseRoutes,
     },

--- a/src/v2/Artsy/Router/Utils/shouldUpdateScroll.tsx
+++ b/src/v2/Artsy/Router/Utils/shouldUpdateScroll.tsx
@@ -7,7 +7,7 @@
 export function shouldUpdateScroll(_prevRenderArgs, { routes }) {
   try {
     // If true, don't reset scroll position on route change
-    if (routes.some(route => route.ignoreScrollBehavior)) {
+    if (routes?.some(route => route.ignoreScrollBehavior)) {
       return false
     }
   } catch (error) {


### PR DESCRIPTION
This was prompted by some [failures by integrity 🎉 ](https://artsy.slack.com/archives/C9YNS4X32/p1611868909222400), as well as a blind spot in our work.

#### Issue: 
We've been converting routes over to use the new novo template, which has been pretty straightforward. However, when converting the artwork page we ran into an error due to how we use 
```tsx
router.push('/orders/foo')
```
during BNMO interactions. 

Since the order app hadn't been moved yet, one can't push to a route that doesn't exist. This didn't come up before because in most places we use `<RouterLink to='/some-path'>` which has a fallback to a regular link if a route isn't found, performing a hard jump. This isn't the case with `router.push`. 

Doing a quick search around force, we don't use this function much outside of artwork / order apps, so moving order app over should be sufficient. 

![order](https://user-images.githubusercontent.com/236943/106203919-fa63ad80-6170-11eb-8903-6886be7af7fd.gif)


