### PR TITLE
revert: Missed Artwork Files

### DIFF
--- a/src/desktop/lib/webpackPublicPath.ts
+++ b/src/desktop/lib/webpackPublicPath.ts
@@ -25,7 +25,6 @@ if (process.env.NODE_ENV === "production") {
   // TODO: Remove this as its temporary while routes are being converted.
   const convertedRoutes = [
     "/artist-series",
-    "/artwork",
     "/collections",
     "/collection",
     "/collect",


### PR DESCRIPTION
This files was missed as part of the revert due to how git handles
modified files.