### PR TITLE
chore: Add organizational structured data

### DIFF
--- a/src/desktop/apps/home/templates/index.jade
+++ b/src/desktop/apps/home/templates/index.jade
@@ -2,6 +2,31 @@ extends ../../../components/main_layout/templates/index
 
 block head
   include meta
+  script(type='application/ld+json')
+    | {
+    |   "@context": "http://schema.org",
+    |   "@type": "Organization",
+    |   "name": "Artsy",
+    |   "url": "https://www.artsy.net/",
+    |   "description": "Discover, buy, and sell art by the world’s leading artists.",
+    |   "sameAs": [
+    |     "https://www.instagram.com/artsy",
+    |     "https://www.facebook.com/artsy",
+    |     "https://twitter.com/artsy",
+    |     "https://www.linkedin.com/company/artsyinc",
+    |     "https://www.youtube.com/channel/UCN413ScKXGZAVTk5GOl4tgw"
+    |   ],
+    |   "address": {
+    |     "@type": "PostalAddress",
+    |     "addressRegion": "NY",
+    |     "postalCode": "10013",
+    |     "addressCountry": "USA",
+    |     "addressLocality": "New York"
+    |   },
+    |   "email": "support@artsy.net",
+    |   "founder": "Carter Cleveland",
+    |   "logo": "https://en.wikipedia.org/wiki/File:Art.sylogo_2.tiff"
+    | }
 
 append locals
   - assetPackage = 'home'

--- a/src/mobile/apps/home/templates/page.jade
+++ b/src/mobile/apps/home/templates/page.jade
@@ -1,5 +1,32 @@
 extends ../../../components/layout/templates/main
 
+block head
+  script(type='application/ld+json')
+    | {
+    |   "@context": "http://schema.org",
+    |   "@type": "Organization",
+    |   "name": "Artsy",
+    |   "url": "https://www.artsy.net/",
+    |   "description": "Discover, buy, and sell art by the world’s leading artists.",
+    |   "sameAs": [
+    |     "https://www.instagram.com/artsy",
+    |     "https://www.facebook.com/artsy",
+    |     "https://twitter.com/artsy",
+    |     "https://www.linkedin.com/company/artsyinc",
+    |     "https://www.youtube.com/channel/UCN413ScKXGZAVTk5GOl4tgw"
+    |   ],
+    |   "address": {
+    |     "@type": "PostalAddress",
+    |     "addressRegion": "NY",
+    |     "postalCode": "10013",
+    |     "addressCountry": "USA",
+    |     "addressLocality": "New York"
+    |   },
+    |   "email": "support@artsy.net",
+    |   "founder": "Carter Cleveland",
+    |   "logo": "https://en.wikipedia.org/wiki/File:Art.sylogo_2.tiff"
+    | }
+
 block content
   #home-page-hero-units.carousel
     if heroUnits && heroUnits.length > 0


### PR DESCRIPTION
It took a little investigation but I found the couple places where we draw the homepage and used what I think are the common practices to get something into the head of JUST the homepage.

So then I basically just copy/pasted from the Jira ticket and discovered that in Jade you have to do `|` in order to get this to work so I added that.

There's duplication here but it doesn't really offend me too much - happy to extract if there's a good pattern too. 🤷 

https://artsyproduct.atlassian.net/browse/GRO-24

/cc @artsy/grow-devs