### PR TITLE
fix: Add download iOS app badge to desktop footer

### DIFF
--- a/src/v2/Components/Footer.tsx
+++ b/src/v2/Components/Footer.tsx
@@ -129,6 +129,12 @@ const FooterContainer: React.FC<FlexDirectionProps & Props> = props => {
                 Buying on Artsy
               </Link>
             </Text>
+            <Media greaterThan="xs">
+              <Text variant="mediumText" mb={1} mt={3}>
+                Get the iOS app
+              </Text>
+              <DownloadAppBadge contextModule={ContextModule.footer} />
+            </Media>
           </Column>
 
           <Media at="xs">


### PR DESCRIPTION
Quick fix to add the iOS app badge to the desktop footer since https://github.com/artsy/force/pull/6941 inadvertently did not include it.