### PR TITLE
chore: update description meta tag for new media type filters on collect page

### DIFF
--- a/src/v2/Apps/Collect/Routes/Collect/Components/CollectMediumMetadata.ts
+++ b/src/v2/Apps/Collect/Routes/Collect/Components/CollectMediumMetadata.ts
@@ -47,6 +47,14 @@ export function getMetadataForMedium(medium) {
       title = "Performance Art Works"
       mediumDescription = "3,000 performance art works"
       break
+    case "reproduction":
+      title = "Reproduction"
+      mediumDescription = "3,000 reproductions"
+      break
+    case "ephemera-or-merchandise":
+      title = "Ephemera or Merchandise"
+      mediumDescription = "5,000 ephemera or merchandise"
+      break
     default:
       null
   }


### PR DESCRIPTION
This PR addresses [FX-2486](https://artsyproduct.atlassian.net/browse/FX-2486)

**Description:**

This PR adds new options to a snippet of code on the `/collect` app that populates the `<title>` tag and a `<meta name="description">` tag with content to match the media type filter that is selected. I believe that this work will help crawlers better index the filtered pages for "Ephemera or Merchandise" and "Reproductions."

<img width="1676" alt="ephemera" src="https://user-images.githubusercontent.com/44589599/106665970-f8388f00-6574-11eb-81a8-cdb2c714a379.png">
