### PR TITLE
Convert /feature/* pages to novo template

### DIFF
--- a/src/desktop/lib/webpackPublicPath.ts
+++ b/src/desktop/lib/webpackPublicPath.ts
@@ -28,6 +28,7 @@ if (process.env.NODE_ENV === "production") {
     "/collections",
     "/collection",
     "/collect",
+    "/feature/",
     "/show/",
     "/user/conversations",
   ]

--- a/src/v2/Apps/getAppNovoRoutes.tsx
+++ b/src/v2/Apps/getAppNovoRoutes.tsx
@@ -49,6 +49,7 @@ export function getAppNovoRoutes(): RouteConfig[] {
         routes: fairRoutes,
       },
       {
+        converted: true,
         routes: featureRoutes,
       },
       {

--- a/src/v2/Apps/getAppRoutes.tsx
+++ b/src/v2/Apps/getAppRoutes.tsx
@@ -11,7 +11,7 @@ import { debugRoutes } from "./Debug/debugRoutes"
 import { exampleRoutes } from "./Example/exampleRoutes"
 import { fairRoutes } from "v2/Apps/Fair/fairRoutes"
 import { fairsRoutes } from "v2/Apps/Fairs/fairsRoutes"
-import { featureRoutes } from "v2/Apps/Feature/featureRoutes"
+// import { featureRoutes } from "v2/Apps/Feature/featureRoutes"
 import { identityVerificationRoutes } from "v2/Apps/IdentityVerification/identityVerificationRoutes"
 import { orderRoutes } from "v2/Apps/Order/orderRoutes"
 import { purchaseRoutes } from "v2/Apps/Purchase/purchaseRoutes"
@@ -58,9 +58,10 @@ export function getAppRoutes(): RouteConfig[] {
     {
       routes: fairsRoutes,
     },
-    {
-      routes: featureRoutes,
-    },
+    // NOTE: Converted to use NOVO template.
+    // {
+    //   routes: featureRoutes,
+    // },
     {
       routes: identityVerificationRoutes,
     },


### PR DESCRIPTION
Could it be that simple?

* `feature/:slug` [link](https://novo.artsy.net/feature/alserkal-art-week)