### PR TITLE
Fix CoffeeScript issue so "Page"s will render

### DIFF
--- a/src/desktop/apps/page/routes.coffee
+++ b/src/desktop/apps/page/routes.coffee
@@ -12,6 +12,6 @@ Page = require '../../models/page'
     return res.redirect(301, "/consign")
   else
     return new Page(id: req.params.id).fetch
-    cache: true
-    success: (page) -> res.render 'template', page: page
-    error: res.backboneError
+      cache: true
+      success: (page) -> res.render 'template', page: page
+      error: res.backboneError


### PR DESCRIPTION
Discovered today that `Page`s at the `/page/:id` route were not rendering properly.

Turns out it's due to a recent change that removed some necessary indentation from the routes file. (CoffeeScript! :shakes_fist: 😄)

This should fix it!

<img width="1572" alt="image" src="https://user-images.githubusercontent.com/2081340/106798598-2e851580-662c-11eb-9f10-0f5abca3f34e.png">
