### PR TITLE
Convert fairs routes to novo template

### DIFF
--- a/src/desktop/lib/webpackPublicPath.ts
+++ b/src/desktop/lib/webpackPublicPath.ts
@@ -24,10 +24,12 @@ if (process.env.NODE_ENV === "production") {
 
   // TODO: Remove this as its temporary while routes are being converted.
   const convertedRoutes = [
+    "/art-fairs",
     "/artist-series",
-    "/collections",
-    "/collection",
     "/collect",
+    "/collection",
+    "/collections",
+    "/fairs",
     "/feature/",
     "/show/",
     "/user/conversations",

--- a/src/v2/Apps/getAppNovoRoutes.tsx
+++ b/src/v2/Apps/getAppNovoRoutes.tsx
@@ -9,6 +9,7 @@ import { consignRoutes } from "v2/Apps/Consign/consignRoutes"
 import { conversationRoutes } from "v2/Apps/Conversation/conversationRoutes"
 import { debugRoutes } from "./Debug/debugRoutes"
 import { fairRoutes } from "v2/Apps/Fair/fairRoutes"
+import { fairsRoutes } from "v2/Apps/Fairs/fairsRoutes"
 import { featureRoutes } from "v2/Apps/Feature/featureRoutes"
 import { identityVerificationRoutes } from "v2/Apps/IdentityVerification/identityVerificationRoutes"
 import { orderRoutes } from "v2/Apps/Order/orderRoutes"
@@ -47,6 +48,10 @@ export function getAppNovoRoutes(): RouteConfig[] {
       },
       {
         routes: fairRoutes,
+      },
+      {
+        converted: true,
+        routes: fairsRoutes,
       },
       {
         converted: true,

--- a/src/v2/Apps/getAppRoutes.tsx
+++ b/src/v2/Apps/getAppRoutes.tsx
@@ -10,7 +10,7 @@ import { consignRoutes } from "v2/Apps/Consign/consignRoutes"
 import { debugRoutes } from "./Debug/debugRoutes"
 import { exampleRoutes } from "./Example/exampleRoutes"
 import { fairRoutes } from "v2/Apps/Fair/fairRoutes"
-import { fairsRoutes } from "v2/Apps/Fairs/fairsRoutes"
+// import { fairsRoutes } from "v2/Apps/Fairs/fairsRoutes"
 // import { featureRoutes } from "v2/Apps/Feature/featureRoutes"
 import { identityVerificationRoutes } from "v2/Apps/IdentityVerification/identityVerificationRoutes"
 import { orderRoutes } from "v2/Apps/Order/orderRoutes"
@@ -55,9 +55,10 @@ export function getAppRoutes(): RouteConfig[] {
     {
       routes: fairRoutes,
     },
-    {
-      routes: fairsRoutes,
-    },
+    // NOTE: Converted to use NOVO template.
+    // {
+    //   routes: fairsRoutes,
+    // },
     // NOTE: Converted to use NOVO template.
     // {
     //   routes: featureRoutes,


### PR DESCRIPTION
Like https://github.com/artsy/force/pull/6971, but for the `/art-fairs` page and the `/fairs` route that redirects to it.

This is independent from the other route conversions, and can be merged later or as part of a separate release if it helps for tracking or risk-mitigation.

I created a new [ticket](https://artsyproduct.atlassian.net/browse/PLATFORM-3126) for this since it's separate from the other fair-related routes.