### PR TITLE
feat: Add canonicals to auth paths

### DIFF
--- a/src/desktop/apps/authentication/__tests__/routes.jest.ts
+++ b/src/desktop/apps/authentication/__tests__/routes.jest.ts
@@ -1,0 +1,158 @@
+import { redirectLoggedInHome, resetPassword } from "../routes"
+
+describe("Routes", () => {
+  let req
+  let res
+  const next = jest.fn()
+
+  describe("#resetPassword", () => {
+    beforeEach(() => {
+      res = {
+        locals: {
+          sd: {},
+        },
+        redirect: jest.fn(),
+        render: jest.fn(),
+      }
+      req = {
+        query: {},
+        session: {},
+      }
+    })
+
+    describe("Has reset_password_token", () => {
+      beforeEach(() => {
+        req.query = {
+          reset_password_redirect_to: "/articles",
+          reset_password_token: "foobar",
+          set_password: "set password",
+        }
+      })
+
+      it("matches session params to query params", () => {
+        const {
+          reset_password_token,
+          reset_password_redirect_to,
+          set_password,
+        } = req.query
+        resetPassword(req, res)
+
+        expect(req.session.reset_password_token).toBe(reset_password_token)
+        expect(req.session.reset_password_redirect_to).toBe(
+          reset_password_redirect_to
+        )
+        expect(req.session.set_password).toBe(set_password)
+      })
+
+      it("redirects to /reset_password", () => {
+        resetPassword(req, res)
+        expect(res.redirect.mock.calls[0][0]).toBe("/reset_password")
+      })
+    })
+
+    describe("Without reset_password_token", () => {
+      beforeEach(() => {
+        req.session = {
+          reset_password_redirect_to: "/articles",
+          reset_password_token: "foobar",
+          set_password: "set password",
+        }
+      })
+
+      it("sets sd.RESET_PASWORD_REDIRECT_TO", () => {
+        resetPassword(req, res)
+        expect(res.locals.sd.RESET_PASWORD_REDIRECT_TO).toBe("/articles")
+      })
+
+      it("renders reset_password with expected args", () => {
+        resetPassword(req, res)
+        expect(res.render.mock.calls[0][0]).toBe("reset_password")
+        expect(res.render.mock.calls[0][1].reset_password_token).toBe("foobar")
+        expect(res.render.mock.calls[0][1].set_password).toBe("set password")
+      })
+    })
+  })
+
+  describe("#redirectLoggedInHome", () => {
+    beforeEach(() => {
+      res = {
+        locals: {
+          sd: {},
+        },
+        redirect: jest.fn(),
+        render: jest.fn(),
+      }
+      req = {
+        body: {},
+        get: jest.fn(),
+        header: () => "referrer",
+        query: {},
+        session: {},
+      }
+    })
+
+    it("Calls next if no user", () => {
+      redirectLoggedInHome(req, res, next)
+      expect(next).toBeCalled()
+    })
+
+    it("redirects logged in users home", () => {
+      req.user = {}
+      redirectLoggedInHome(req, res, next)
+      expect(res.redirect).toBeCalledWith("/")
+    })
+
+    it("redirects logged in users (with a redirect_uri query param) to redirect location", () => {
+      req.user = {}
+      req.query["redirect_uri"] = "/awesome-fair"
+      redirectLoggedInHome(req, res, next)
+      expect(res.redirect).toBeCalledWith("/awesome-fair")
+    })
+
+    it("redirects logged in users (with a redirect-to query param) to redirect location", () => {
+      req.user = {}
+      req.query["redirect-to"] = "/awesome-fair"
+      redirectLoggedInHome(req, res, next)
+      expect(res.redirect).toBeCalledWith("/awesome-fair")
+    })
+
+    it("redirects logged in users (with redirect-to in the POST params) to redirect location", () => {
+      req.user = {}
+      req.body["redirect-to"] = "/awesome-fair"
+      redirectLoggedInHome(req, res, next)
+      expect(res.redirect).toBeCalledWith("/awesome-fair")
+    })
+
+    it("redirects logged in users to home if they log in from /log_in", () => {
+      req.get.mockReturnValueOnce("/log_in")
+      req.url = "/log_in"
+      req.user = {}
+      redirectLoggedInHome(req, res, next)
+      expect(res.redirect).toBeCalledWith("/")
+    })
+
+    it("redirects logged in users to home if they log in from /login", () => {
+      req.get.mockReturnValueOnce("/login")
+      req.url = "/login"
+      req.user = {}
+      redirectLoggedInHome(req, res, next)
+      expect(res.redirect).toBeCalledWith("/")
+    })
+
+    it("redirects logged in users to home if they log in from /sign_up", () => {
+      req.get.mockReturnValueOnce("/sign_up")
+      req.url = "/sign_up"
+      req.user = {}
+      redirectLoggedInHome(req, res, next)
+      expect(res.redirect).toBeCalledWith("/")
+    })
+
+    it("redirects logged in users to home if they log in from /signup", () => {
+      req.get.mockReturnValueOnce("/signup")
+      req.url = "/signup"
+      req.user = {}
+      redirectLoggedInHome(req, res, next)
+      expect(res.redirect).toBeCalledWith("/")
+    })
+  })
+})

--- a/src/desktop/apps/authentication/components/meta.tsx
+++ b/src/desktop/apps/authentication/components/meta.tsx
@@ -2,6 +2,7 @@ import React from "react"
 
 interface MetaProps {
   meta: {
+    canonical?: string
     title: string
     description: string
   }
@@ -9,7 +10,7 @@ interface MetaProps {
 
 export const AuthenticationMeta: React.SFC<MetaProps> = props => {
   const {
-    meta: { description, title },
+    meta: { canonical, description, title },
   } = props
 
   return (
@@ -19,6 +20,7 @@ export const AuthenticationMeta: React.SFC<MetaProps> = props => {
       <meta property="description" content={description} />
       <meta property="og:description" content={description} />
       <meta property="twitter:description" content={description} />
+      {canonical && <link rel="canonical" href={canonical} />}
       {/* Don't index or follow links on this page */}
       <meta name="robots" content="none" />
     </>

--- a/src/desktop/apps/authentication/routeHelpers.ts
+++ b/src/desktop/apps/authentication/routeHelpers.ts
@@ -35,7 +35,13 @@ export const computeCopy = ({ intent, pageTitle, req, res, type }) => {
   return req.query.copy || title
 }
 
-export const computeStitchOptions = ({ pageTitle, req, res, type }) => {
+export const computeStitchOptions = ({
+  canonical,
+  pageTitle,
+  req,
+  res,
+  type,
+}) => {
   const {
     action,
     afterSignUpAction,
@@ -57,6 +63,7 @@ export const computeStitchOptions = ({ pageTitle, req, res, type }) => {
   }
 
   const meta = {
+    canonical,
     description: "",
     title: pageTitle,
   }

--- a/src/desktop/apps/authentication/routeHelpers.ts
+++ b/src/desktop/apps/authentication/routeHelpers.ts
@@ -3,7 +3,7 @@ import { parse } from "url"
 import { FullPageAuthStatic } from "./components/FullPageAuthStatic"
 import { AuthenticationMeta } from "./components/meta"
 
-export const computeCopy = (req, intent, pageTitle, type, res) => {
+export const computeCopy = ({ intent, pageTitle, req, res, type }) => {
   let title
 
   switch (intent) {
@@ -35,7 +35,7 @@ export const computeCopy = (req, intent, pageTitle, type, res) => {
   return req.query.copy || title
 }
 
-export const computeStitchOptions = (pageTitle, req, res, type) => {
+export const computeStitchOptions = ({ pageTitle, req, res, type }) => {
   const {
     action,
     afterSignUpAction,
@@ -47,7 +47,7 @@ export const computeStitchOptions = (pageTitle, req, res, type) => {
     trigger,
   } = req.query
 
-  const copy = computeCopy(req, intent, pageTitle, type, res)
+  const copy = computeCopy({ intent, pageTitle, req, res, type })
   const redirectTo = getRedirectTo(req)
   const destination = req.query.destination || (isStaticAuthRoute && "/")
   const signupReferer = req.header("Referer") || req.hostname

--- a/src/desktop/apps/authentication/routeHelpers.ts
+++ b/src/desktop/apps/authentication/routeHelpers.ts
@@ -35,26 +35,26 @@ export const computeCopy = (req, intent, pageTitle, type, res) => {
   return req.query.copy || title
 }
 
-export const computeStitchOptions = (
-  pageTitle,
-  copy,
-  destination,
-  redirectTo,
-  signupReferer,
-  type,
-  req,
-  res
-) => {
+export const computeStitchOptions = (pageTitle, req, res, type) => {
   const {
     action,
     afterSignUpAction,
     contextModule,
     error,
+    intent,
     kind,
     objectId,
-    intent,
     trigger,
   } = req.query
+
+  const copy = computeCopy(req, intent, pageTitle, type, res)
+  const redirectTo = getRedirectTo(req)
+  const destination = req.query.destination || (isStaticAuthRoute && "/")
+  const signupReferer = req.header("Referer") || req.hostname
+
+  if (action) {
+    res.cookie("afterSignUpAction", JSON.stringify({ action, kind, objectId }))
+  }
 
   const meta = {
     description: "",

--- a/src/desktop/apps/authentication/routes.ts
+++ b/src/desktop/apps/authentication/routes.ts
@@ -11,7 +11,7 @@ export const login = async (req, res, next) => {
   const pageTitle = "Login to Artsy"
 
   try {
-    const options = computeStitchOptions(pageTitle, req, res, type)
+    const options = computeStitchOptions({ pageTitle, req, res, type })
     const layout = await stitch(options)
     res.send(layout)
   } catch (error) {
@@ -24,7 +24,7 @@ export const signup = async (req, res, next) => {
   const pageTitle = "Signup for Artsy"
 
   try {
-    const options = computeStitchOptions(pageTitle, req, res, type)
+    const options = computeStitchOptions({ pageTitle, req, res, type })
     const layout = await stitch(options)
     res.send(layout)
   } catch (error) {
@@ -37,7 +37,7 @@ export const forgotPassword = async (req, res, next) => {
   const pageTitle = "Reset your password"
 
   try {
-    const options = computeStitchOptions(pageTitle, req, res, type)
+    const options = computeStitchOptions({ pageTitle, req, res, type })
     const layout = await stitch(options)
     res.send(layout)
   } catch (error) {

--- a/src/desktop/apps/authentication/routes.ts
+++ b/src/desktop/apps/authentication/routes.ts
@@ -1,7 +1,6 @@
 import { stitch } from "@artsy/stitch"
 import { ModalType } from "v2/Components/Authentication/Types"
 import {
-  computeCopy,
   computeStitchOptions,
   getRedirectTo,
   isStaticAuthRoute,
@@ -11,29 +10,8 @@ export const login = async (req, res, next) => {
   const type = ModalType.login
   const pageTitle = "Login to Artsy"
 
-  const { action, kind, objectId, intent } = req.query
-
-  const copy = computeCopy(req, intent, pageTitle, type, res)
-  const redirectTo = getRedirectTo(req)
-  const destination = req.query.destination || (isStaticAuthRoute && "/")
-  const signupReferer = req.header("Referer") || req.hostname
-
-  if (action) {
-    res.cookie("afterSignUpAction", JSON.stringify({ action, kind, objectId }))
-  }
-
   try {
-    const options = computeStitchOptions(
-      pageTitle,
-      copy,
-      destination,
-      redirectTo,
-      signupReferer,
-      type,
-      req,
-      res
-    )
-
+    const options = computeStitchOptions(pageTitle, req, res, type)
     const layout = await stitch(options)
     res.send(layout)
   } catch (error) {
@@ -45,28 +23,8 @@ export const signup = async (req, res, next) => {
   const type = ModalType.signup
   const pageTitle = "Signup for Artsy"
 
-  const { action, kind, objectId, intent } = req.query
-  const copy = computeCopy(req, intent, pageTitle, type, res)
-  const redirectTo = getRedirectTo(req)
-  const destination = req.query.destination || (isStaticAuthRoute && "/")
-  const signupReferer = req.header("Referer") || req.hostname
-
-  if (action) {
-    res.cookie("afterSignUpAction", JSON.stringify({ action, kind, objectId }))
-  }
-
   try {
-    const options = computeStitchOptions(
-      pageTitle,
-      copy,
-      destination,
-      redirectTo,
-      signupReferer,
-      type,
-      req,
-      res
-    )
-
+    const options = computeStitchOptions(pageTitle, req, res, type)
     const layout = await stitch(options)
     res.send(layout)
   } catch (error) {
@@ -78,28 +36,8 @@ export const forgotPassword = async (req, res, next) => {
   const type = ModalType.forgot
   const pageTitle = "Reset your password"
 
-  const { action, kind, objectId, intent } = req.query
-  const copy = computeCopy(req, intent, pageTitle, type, res)
-  const redirectTo = getRedirectTo(req)
-  const destination = req.query.destination || (isStaticAuthRoute && "/")
-  const signupReferer = req.header("Referer") || req.hostname
-
-  if (action) {
-    res.cookie("afterSignUpAction", JSON.stringify({ action, kind, objectId }))
-  }
-
   try {
-    const options = computeStitchOptions(
-      pageTitle,
-      copy,
-      destination,
-      redirectTo,
-      signupReferer,
-      type,
-      req,
-      res
-    )
-
+    const options = computeStitchOptions(pageTitle, req, res, type)
     const layout = await stitch(options)
     res.send(layout)
   } catch (error) {

--- a/src/desktop/apps/authentication/routes.ts
+++ b/src/desktop/apps/authentication/routes.ts
@@ -1,5 +1,6 @@
 import { stitch } from "@artsy/stitch"
 import { ModalType } from "v2/Components/Authentication/Types"
+import { data as sd } from "sharify"
 import {
   computeStitchOptions,
   getRedirectTo,
@@ -9,9 +10,16 @@ import {
 export const login = async (req, res, next) => {
   const type = ModalType.login
   const pageTitle = "Login to Artsy"
+  const canonical = `${sd.APP_URL}/login`
 
   try {
-    const options = computeStitchOptions({ pageTitle, req, res, type })
+    const options = computeStitchOptions({
+      canonical,
+      pageTitle,
+      req,
+      res,
+      type,
+    })
     const layout = await stitch(options)
     res.send(layout)
   } catch (error) {
@@ -22,9 +30,16 @@ export const login = async (req, res, next) => {
 export const signup = async (req, res, next) => {
   const type = ModalType.signup
   const pageTitle = "Signup for Artsy"
+  const canonical = `${sd.APP_URL}/signup`
 
   try {
-    const options = computeStitchOptions({ pageTitle, req, res, type })
+    const options = computeStitchOptions({
+      canonical,
+      pageTitle,
+      req,
+      res,
+      type,
+    })
     const layout = await stitch(options)
     res.send(layout)
   } catch (error) {
@@ -35,9 +50,16 @@ export const signup = async (req, res, next) => {
 export const forgotPassword = async (req, res, next) => {
   const type = ModalType.forgot
   const pageTitle = "Reset your password"
+  const canonical = `${sd.APP_URL}/forgot`
 
   try {
-    const options = computeStitchOptions({ pageTitle, req, res, type })
+    const options = computeStitchOptions({
+      canonical,
+      pageTitle,
+      req,
+      res,
+      type,
+    })
     const layout = await stitch(options)
     res.send(layout)
   } catch (error) {


### PR DESCRIPTION
This PR updates our auth pages to include canonical links per the recommendations from DeepCrawl. It closes that Jira ticket.

In order to do this, I followed the pattern I established in #6969 and updated each auth handler to declare the canonical path and then passed it down the stack. I found the meta component and added an optional canonical string property. That property, if present will draw the link tag and tell Google that the auth page is for real.

## Prefer Objects Over Positional Arguments

Looking at this `computeStitchOptions` with fresh eyes this morning I realized that I was breaking a best practice that @damassi is really good at reminding me of: positional arguments are fragile, prefer an object as a function's argument. So I started down that path first and then pushed some more stuff down. That left me with just the essentials in the trio of route handlers: `type`, `pageTitle` and `canonical`. Those are sent to the `computeStitchOptions` along with the request and response and it takes it from there.

Note: I mistakenly removed tests over on #6969 for `redirectLoggedInHome` and `resetPassword` so this PR restores them.

https://artsyproduct.atlassian.net/browse/GRO-18

/cc @artsy/grow-devs