### PR TITLE
feat(gene): roughs in gene route and header

### DIFF
--- a/src/v2/Apps/Components/AppContainer.tsx
+++ b/src/v2/Apps/Components/AppContainer.tsx
@@ -8,9 +8,9 @@ export const AppContainer: React.FC<AppContainerProps> = ({
   children,
   ...rest
 }) => {
-  const {
-    theme: { breakpoints },
-  } = useTheme<ThemeV2 & ThemeV3>()
+  const { theme: { breakpoints = { lg: null, xl: null } } = {} } = useTheme<
+    ThemeV2 & ThemeV3
+  >()
 
   const maxWidth = useThemeConfig({ v2: breakpoints.xl, v3: breakpoints.lg })
 

--- a/src/v2/Apps/Components/AppContainer.tsx
+++ b/src/v2/Apps/Components/AppContainer.tsx
@@ -1,17 +1,21 @@
-import { Box, breakpoints } from "@artsy/palette"
+import { Box, BoxProps, useTheme, useThemeConfig } from "@artsy/palette"
+import { ThemeV2, ThemeV3 } from "@artsy/palette/dist/themes"
 import React from "react"
 
-interface AppContainerProps {
-  children: React.ReactNode
-  maxWidth?: number | string
-}
+interface AppContainerProps extends BoxProps {}
 
 export const AppContainer: React.FC<AppContainerProps> = ({
   children,
-  maxWidth = breakpoints.xl,
+  ...rest
 }) => {
+  const {
+    theme: { breakpoints },
+  } = useTheme<ThemeV2 & ThemeV3>()
+
+  const maxWidth = useThemeConfig({ v2: breakpoints.xl, v3: breakpoints.lg })
+
   return (
-    <Box width="100%" maxWidth={maxWidth} m="auto">
+    <Box width="100%" m="auto" maxWidth={maxWidth} {...rest}>
       {children}
     </Box>
   )

--- a/src/v2/Apps/Gene/Components/GeneMeta.tsx
+++ b/src/v2/Apps/Gene/Components/GeneMeta.tsx
@@ -1,0 +1,50 @@
+import React from "react"
+import { Link, Meta, Title } from "react-head"
+import { createFragmentContainer, graphql } from "react-relay"
+import { GeneMeta_gene } from "v2/__generated__/GeneMeta_gene.graphql"
+import { getENV } from "v2/Utils/getENV"
+
+interface GeneMetaProps {
+  gene: GeneMeta_gene
+}
+
+const GeneMeta: React.FC<GeneMetaProps> = ({ gene }) => {
+  const title = `${gene.name} | Artsy`
+  const description = gene.description // TODO: meta { description }
+  const href = `${getENV("APP_URL")}/${gene.href}`
+  const image = gene.image?.cropped?.src
+
+  return (
+    <>
+      <Title>{title}</Title>
+      <Meta property="og:title" content={title} />
+      {description && (
+        <>
+          <Meta name="description" content={description} />
+          <Meta property="og:description" content={description} />
+          <Meta property="twitter:description" content={description} />
+        </>
+      )}
+      <Link rel="canonical" href={href} />
+      <Meta property="og:url" content={href} />
+      <Meta property="og:type" content="website" />
+      <Meta property="twitter:card" content="summary" />
+      {image && <Meta property="og:image" content={image} />}
+    </>
+  )
+}
+
+export const GeneMetaFragmentContainer = createFragmentContainer(GeneMeta, {
+  gene: graphql`
+    fragment GeneMeta_gene on Gene {
+      name
+      href
+      description
+      image {
+        cropped(width: 1200, height: 630) {
+          src
+        }
+      }
+    }
+  `,
+})

--- a/src/v2/Apps/Gene/GeneApp.tsx
+++ b/src/v2/Apps/Gene/GeneApp.tsx
@@ -1,0 +1,18 @@
+import React from "react"
+import { AppContainer } from "v2/Apps/Components/AppContainer"
+import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
+import { Footer } from "v2/Components/Footer"
+
+interface GeneAppProps {}
+
+export const GeneApp: React.FC<GeneAppProps> = ({ children }) => {
+  return (
+    <AppContainer>
+      <HorizontalPadding>
+        {children}
+
+        <Footer />
+      </HorizontalPadding>
+    </AppContainer>
+  )
+}

--- a/src/v2/Apps/Gene/GeneApp.tsx
+++ b/src/v2/Apps/Gene/GeneApp.tsx
@@ -1,3 +1,4 @@
+import { ThemeProviderV3 } from "@artsy/palette"
 import React from "react"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
@@ -7,12 +8,14 @@ interface GeneAppProps {}
 
 export const GeneApp: React.FC<GeneAppProps> = ({ children }) => {
   return (
-    <AppContainer>
-      <HorizontalPadding>
-        {children}
+    <ThemeProviderV3>
+      <AppContainer>
+        <HorizontalPadding>
+          {children}
 
-        <Footer />
-      </HorizontalPadding>
-    </AppContainer>
+          <Footer />
+        </HorizontalPadding>
+      </AppContainer>
+    </ThemeProviderV3>
   )
 }

--- a/src/v2/Apps/Gene/Routes/GeneShow.tsx
+++ b/src/v2/Apps/Gene/Routes/GeneShow.tsx
@@ -1,0 +1,105 @@
+import { Button, Column, GridColumns, Text } from "@artsy/palette"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { GeneShow_gene } from "v2/__generated__/GeneShow_gene.graphql"
+import { GeneMetaFragmentContainer } from "../Components/GeneMeta"
+
+interface GeneShowProps {
+  gene: GeneShow_gene
+}
+
+export const GeneShow: React.FC<GeneShowProps> = ({ gene }) => {
+  return (
+    <>
+      <GeneMetaFragmentContainer gene={gene} />
+
+      <GridColumns my={4}>
+        <Column span={6}>
+          <Text as="h1" variant="largeTitle" mb={2}>
+            {gene.name}
+          </Text>
+
+          <Button
+            variant="primaryBlack"
+            onClick={() => {
+              alert("TODO")
+            }}
+          >
+            Follow
+          </Button>
+        </Column>
+
+        <Column span={6}>
+          <Text as="h2" variant="subtitle">
+            About
+          </Text>
+
+          <Text>{gene.description}</Text>
+
+          {gene.similar?.edges.length > 0 && (
+            <>
+              <Text as="h2" variant="subtitle" mt={2}>
+                Related Categories
+              </Text>
+
+              <Text>
+                {gene.similar.edges.map(({ node }, i) => {
+                  return (
+                    <React.Fragment key={node.internalID}>
+                      <a href="#example">{node.name}</a>
+                      {i !== gene.similar.edges.length - 1 && ", "}
+                    </React.Fragment>
+                  )
+                })}
+              </Text>
+            </>
+          )}
+
+          {gene.artistsConnection?.edges.length > 0 && (
+            <>
+              <Text as="h2" variant="subtitle" mt={2}>
+                Related Artists
+              </Text>
+
+              <Text>
+                {gene.artistsConnection.edges.map(({ node }, i) => {
+                  return (
+                    <React.Fragment key={node.internalID}>
+                      <a href="#example">{node.name}</a>
+                      {i !== gene.artistsConnection.edges.length - 1 && ", "}
+                    </React.Fragment>
+                  )
+                })}
+              </Text>
+            </>
+          )}
+        </Column>
+      </GridColumns>
+    </>
+  )
+}
+export const GeneShowFragmentContainer = createFragmentContainer(GeneShow, {
+  gene: graphql`
+    fragment GeneShow_gene on Gene {
+      ...GeneMeta_gene
+      name
+      description
+      similar(first: 10) {
+        edges {
+          node {
+            internalID
+            name
+          }
+        }
+      }
+      artistsConnection(first: 10) {
+        edges {
+          node {
+            internalID
+            name
+          }
+        }
+      }
+    }
+  `,
+})

--- a/src/v2/Apps/Gene/Routes/GeneShow.tsx
+++ b/src/v2/Apps/Gene/Routes/GeneShow.tsx
@@ -14,13 +14,13 @@ export const GeneShow: React.FC<GeneShowProps> = ({ gene }) => {
       <GeneMetaFragmentContainer gene={gene} />
 
       <GridColumns my={4}>
-        <Column span={6}>
-          <Text as="h1" variant="largeTitle" mb={2}>
+        <Column span={6} mb={2}>
+          <Text as="h1" variant="xl" mb={2}>
             {gene.name}
           </Text>
 
           <Button
-            variant="primaryBlack"
+            variant="secondaryOutline"
             onClick={() => {
               alert("TODO")
             }}
@@ -29,20 +29,22 @@ export const GeneShow: React.FC<GeneShowProps> = ({ gene }) => {
           </Button>
         </Column>
 
-        <Column span={6}>
-          <Text as="h2" variant="subtitle">
+        <Column span={6} mb={2}>
+          <Text as="h2" variant="xs" textTransform="uppercase" mb={1}>
             About
           </Text>
 
-          <Text>{gene.description}</Text>
+          <Text variant="sm" mb={2}>
+            {gene.description}
+          </Text>
 
           {gene.similar?.edges.length > 0 && (
             <>
-              <Text as="h2" variant="subtitle" mt={2}>
+              <Text as="h2" variant="xs" textTransform="uppercase" mb={1}>
                 Related Categories
               </Text>
 
-              <Text>
+              <Text variant="sm" mb={2}>
                 {gene.similar.edges.map(({ node }, i) => {
                   return (
                     <React.Fragment key={node.internalID}>
@@ -57,11 +59,11 @@ export const GeneShow: React.FC<GeneShowProps> = ({ gene }) => {
 
           {gene.artistsConnection?.edges.length > 0 && (
             <>
-              <Text as="h2" variant="subtitle" mt={2}>
+              <Text as="h2" variant="xs" textTransform="uppercase" mb={1}>
                 Related Artists
               </Text>
 
-              <Text>
+              <Text variant="sm" mb={2}>
                 {gene.artistsConnection.edges.map(({ node }, i) => {
                   return (
                     <React.Fragment key={node.internalID}>
@@ -83,6 +85,7 @@ export const GeneShowFragmentContainer = createFragmentContainer(GeneShow, {
     fragment GeneShow_gene on Gene {
       ...GeneMeta_gene
       name
+      # TODO: use (format: HTML) once added in Metaphysics
       description
       similar(first: 10) {
         edges {

--- a/src/v2/Apps/Gene/Routes/__tests__/GeneShow.jest.tsx
+++ b/src/v2/Apps/Gene/Routes/__tests__/GeneShow.jest.tsx
@@ -1,0 +1,38 @@
+import React from "react"
+import { GeneShowFragmentContainer } from "../GeneShow"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { graphql } from "react-relay"
+import { GeneShow_Test_Query } from "v2/__generated__/GeneShow_Test_Query.graphql"
+import { MockBoot } from "v2/DevTools"
+
+jest.unmock("react-relay")
+
+const { getWrapper } = setupTestWrapper<GeneShow_Test_Query>({
+  Component: props => {
+    return (
+      <MockBoot>
+        <GeneShowFragmentContainer {...props} />
+      </MockBoot>
+    )
+  },
+  query: graphql`
+    query GeneShow_Test_Query {
+      gene(id: "example") {
+        ...GeneShow_gene
+      }
+    }
+  `,
+})
+
+describe("GeneShow", () => {
+  it("renders correctly", () => {
+    const wrapper = getWrapper({
+      Gene: () => ({
+        name: "Example Gene",
+      }),
+    })
+
+    expect(wrapper.find("h1")).toHaveLength(1)
+    expect(wrapper.find("h1").text()).toEqual("Example Gene")
+  })
+})

--- a/src/v2/Apps/Gene/geneRoutes.tsx
+++ b/src/v2/Apps/Gene/geneRoutes.tsx
@@ -1,0 +1,37 @@
+import loadable from "@loadable/component"
+import { graphql } from "react-relay"
+import { RouteConfig } from "found"
+
+const GeneApp = loadable(() => import("./GeneApp"), {
+  resolveComponent: component => component.GeneApp,
+})
+
+const GeneShowRoute = loadable(() => import("./Routes/GeneShow"), {
+  resolveComponent: component => component.GeneShowFragmentContainer,
+})
+
+export const geneRoutes: RouteConfig[] = [
+  {
+    path: "/gene2/:slug",
+    getComponent: () => GeneApp,
+    prepare: () => {
+      return GeneApp.preload()
+    },
+    children: [
+      {
+        path: "",
+        getComponent: () => GeneShowRoute,
+        prepare: () => {
+          return GeneShowRoute.preload()
+        },
+        query: graphql`
+          query geneRoutes_GeneShowQuery($slug: String!) {
+            gene(id: $slug) @principalField {
+              ...GeneShow_gene
+            }
+          }
+        `,
+      },
+    ],
+  },
+]

--- a/src/v2/Apps/getAppNovoRoutes.tsx
+++ b/src/v2/Apps/getAppNovoRoutes.tsx
@@ -13,6 +13,7 @@ import { exampleRoutes } from "./Example/exampleRoutes"
 import { fairRoutes } from "v2/Apps/Fair/fairRoutes"
 import { fairsRoutes } from "v2/Apps/Fairs/fairsRoutes"
 import { featureRoutes } from "v2/Apps/Feature/featureRoutes"
+import { geneRoutes } from "v2/Apps/Gene/geneRoutes"
 import { identityVerificationRoutes } from "v2/Apps/IdentityVerification/identityVerificationRoutes"
 import { orderRoutes } from "v2/Apps/Order/orderRoutes"
 import { purchaseRoutes } from "v2/Apps/Purchase/purchaseRoutes"
@@ -72,6 +73,10 @@ export function getAppNovoRoutes(): RouteConfig[] {
       {
         converted: true,
         routes: featureRoutes,
+      },
+      {
+        converted: true,
+        routes: geneRoutes,
       },
       {
         converted: true,

--- a/src/v2/__generated__/GeneMeta_gene.graphql.ts
+++ b/src/v2/__generated__/GeneMeta_gene.graphql.ts
@@ -1,0 +1,96 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type GeneMeta_gene = {
+    readonly name: string | null;
+    readonly href: string | null;
+    readonly description: string | null;
+    readonly image: {
+        readonly cropped: {
+            readonly src: string;
+        } | null;
+    } | null;
+    readonly " $refType": "GeneMeta_gene";
+};
+export type GeneMeta_gene$data = GeneMeta_gene;
+export type GeneMeta_gene$key = {
+    readonly " $data"?: GeneMeta_gene$data;
+    readonly " $fragmentRefs": FragmentRefs<"GeneMeta_gene">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "GeneMeta_gene",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "href",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "description",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "image",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 630
+            },
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 1200
+            }
+          ],
+          "concreteType": "CroppedImageUrl",
+          "kind": "LinkedField",
+          "name": "cropped",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "src",
+              "storageKey": null
+            }
+          ],
+          "storageKey": "cropped(height:630,width:1200)"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Gene"
+};
+(node as any).hash = '39b287fef5f18943388ab08ceabb3dee';
+export default node;

--- a/src/v2/__generated__/GeneShow_Test_Query.graphql.ts
+++ b/src/v2/__generated__/GeneShow_Test_Query.graphql.ts
@@ -1,0 +1,278 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type GeneShow_Test_QueryVariables = {};
+export type GeneShow_Test_QueryResponse = {
+    readonly gene: {
+        readonly " $fragmentRefs": FragmentRefs<"GeneShow_gene">;
+    } | null;
+};
+export type GeneShow_Test_Query = {
+    readonly response: GeneShow_Test_QueryResponse;
+    readonly variables: GeneShow_Test_QueryVariables;
+};
+
+
+
+/*
+query GeneShow_Test_Query {
+  gene(id: "example") {
+    ...GeneShow_gene
+    id
+  }
+}
+
+fragment GeneMeta_gene on Gene {
+  name
+  href
+  description
+  image {
+    cropped(width: 1200, height: 630) {
+      src
+    }
+  }
+}
+
+fragment GeneShow_gene on Gene {
+  ...GeneMeta_gene
+  name
+  description
+  similar(first: 10) {
+    edges {
+      node {
+        internalID
+        name
+        id
+      }
+    }
+  }
+  artistsConnection(first: 10) {
+    edges {
+      node {
+        internalID
+        name
+        id
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "internalID",
+    "storageKey": null
+  },
+  (v1/*: any*/),
+  (v3/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "GeneShow_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Gene",
+        "kind": "LinkedField",
+        "name": "gene",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "GeneShow_gene"
+          }
+        ],
+        "storageKey": "gene(id:\"example\")"
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "GeneShow_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Gene",
+        "kind": "LinkedField",
+        "name": "gene",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "href",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "description",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 630
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 1200
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "src",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "cropped(height:630,width:1200)"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "concreteType": "GeneConnection",
+            "kind": "LinkedField",
+            "name": "similar",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "GeneEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Gene",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": (v4/*: any*/),
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "similar(first:10)"
+          },
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "concreteType": "ArtistConnection",
+            "kind": "LinkedField",
+            "name": "artistsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArtistEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": (v4/*: any*/),
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "artistsConnection(first:10)"
+          },
+          (v3/*: any*/)
+        ],
+        "storageKey": "gene(id:\"example\")"
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "GeneShow_Test_Query",
+    "operationKind": "query",
+    "text": "query GeneShow_Test_Query {\n  gene(id: \"example\") {\n    ...GeneShow_gene\n    id\n  }\n}\n\nfragment GeneMeta_gene on Gene {\n  name\n  href\n  description\n  image {\n    cropped(width: 1200, height: 630) {\n      src\n    }\n  }\n}\n\nfragment GeneShow_gene on Gene {\n  ...GeneMeta_gene\n  name\n  description\n  similar(first: 10) {\n    edges {\n      node {\n        internalID\n        name\n        id\n      }\n    }\n  }\n  artistsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        name\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '1e4e6c508a6707447b71bad638f5197c';
+export default node;

--- a/src/v2/__generated__/GeneShow_gene.graphql.ts
+++ b/src/v2/__generated__/GeneShow_gene.graphql.ts
@@ -1,0 +1,149 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type GeneShow_gene = {
+    readonly name: string | null;
+    readonly description: string | null;
+    readonly similar: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string;
+                readonly name: string | null;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly artistsConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string;
+                readonly name: string | null;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $fragmentRefs": FragmentRefs<"GeneMeta_gene">;
+    readonly " $refType": "GeneShow_gene";
+};
+export type GeneShow_gene$data = GeneShow_gene;
+export type GeneShow_gene$key = {
+    readonly " $data"?: GeneShow_gene$data;
+    readonly " $fragmentRefs": FragmentRefs<"GeneShow_gene">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v2 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "internalID",
+    "storageKey": null
+  },
+  (v0/*: any*/)
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "GeneShow_gene",
+  "selections": [
+    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "description",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": (v1/*: any*/),
+      "concreteType": "GeneConnection",
+      "kind": "LinkedField",
+      "name": "similar",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "GeneEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Gene",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": (v2/*: any*/),
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "similar(first:10)"
+    },
+    {
+      "alias": null,
+      "args": (v1/*: any*/),
+      "concreteType": "ArtistConnection",
+      "kind": "LinkedField",
+      "name": "artistsConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArtistEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artist",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": (v2/*: any*/),
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "artistsConnection(first:10)"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "GeneMeta_gene"
+    }
+  ],
+  "type": "Gene"
+};
+})();
+(node as any).hash = '890e299763d636afde12a8e8c664b308';
+export default node;

--- a/src/v2/__generated__/geneRoutes_GeneShowQuery.graphql.ts
+++ b/src/v2/__generated__/geneRoutes_GeneShowQuery.graphql.ts
@@ -1,0 +1,290 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type geneRoutes_GeneShowQueryVariables = {
+    slug: string;
+};
+export type geneRoutes_GeneShowQueryResponse = {
+    readonly gene: {
+        readonly " $fragmentRefs": FragmentRefs<"GeneShow_gene">;
+    } | null;
+};
+export type geneRoutes_GeneShowQuery = {
+    readonly response: geneRoutes_GeneShowQueryResponse;
+    readonly variables: geneRoutes_GeneShowQueryVariables;
+};
+
+
+
+/*
+query geneRoutes_GeneShowQuery(
+  $slug: String!
+) {
+  gene(id: $slug) @principalField {
+    ...GeneShow_gene
+    id
+  }
+}
+
+fragment GeneMeta_gene on Gene {
+  name
+  href
+  description
+  image {
+    cropped(width: 1200, height: 630) {
+      src
+    }
+  }
+}
+
+fragment GeneShow_gene on Gene {
+  ...GeneMeta_gene
+  name
+  description
+  similar(first: 10) {
+    edges {
+      node {
+        internalID
+        name
+        id
+      }
+    }
+  }
+  artistsConnection(first: 10) {
+    edges {
+      node {
+        internalID
+        name
+        id
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "slug",
+    "type": "String!"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "slug"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "internalID",
+    "storageKey": null
+  },
+  (v2/*: any*/),
+  (v4/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "geneRoutes_GeneShowQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Gene",
+        "kind": "LinkedField",
+        "name": "gene",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "GeneShow_gene"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "geneRoutes_GeneShowQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Gene",
+        "kind": "LinkedField",
+        "name": "gene",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "href",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "description",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 630
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 1200
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "src",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "cropped(height:630,width:1200)"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": (v3/*: any*/),
+            "concreteType": "GeneConnection",
+            "kind": "LinkedField",
+            "name": "similar",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "GeneEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Gene",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": (v5/*: any*/),
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "similar(first:10)"
+          },
+          {
+            "alias": null,
+            "args": (v3/*: any*/),
+            "concreteType": "ArtistConnection",
+            "kind": "LinkedField",
+            "name": "artistsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArtistEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": (v5/*: any*/),
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "artistsConnection(first:10)"
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "geneRoutes_GeneShowQuery",
+    "operationKind": "query",
+    "text": "query geneRoutes_GeneShowQuery(\n  $slug: String!\n) {\n  gene(id: $slug) @principalField {\n    ...GeneShow_gene\n    id\n  }\n}\n\nfragment GeneMeta_gene on Gene {\n  name\n  href\n  description\n  image {\n    cropped(width: 1200, height: 630) {\n      src\n    }\n  }\n}\n\nfragment GeneShow_gene on Gene {\n  ...GeneMeta_gene\n  name\n  description\n  similar(first: 10) {\n    edges {\n      node {\n        internalID\n        name\n        id\n      }\n    }\n  }\n  artistsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        name\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'f0054fa7b90bc66c38eef2b99ba3247a';
+export default node;


### PR DESCRIPTION
Closes: [FX-2792](https://artsyproduct.atlassian.net/browse/FX-2792)

This should be fine to merge as a stub of the new app.

Some notes
* Jonathan is going to likely darken the secondaryOutline border style and tweak the rules for it's width in these 50/50 layouts
* Notice the footer: it looks like it's doing something kinda weird/complicated instead of just using the AppContainer. I'll have to update that in it's own PR.

![localhost_5000_gene2_contemporary-photography](https://user-images.githubusercontent.com/112297/112381769-59512900-8cc1-11eb-919c-b80c301907ff.png)
