### PR TITLE
feat: [SEO] Update /collect to support /color/red style url structure

### DIFF
--- a/src/v2/Apps/Collect/Routes/Collect/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collect/index.tsx
@@ -34,12 +34,19 @@ export const CollectApp: React.FC<CollectAppProps> = ({
   match: { location, params },
   viewer,
 }) => {
-  const medium = params && params.medium
+  const medium = params?.medium
+  const color = params?.color
   const { description, breadcrumbTitle, title } = getMetadataForMedium(medium)
 
-  const canonicalHref = medium
-    ? `${sd.APP_URL}/collect/${medium}`
-    : `${sd.APP_URL}/collect`
+  let canonicalHref
+  if (medium) {
+    canonicalHref = `${sd.APP_URL}/collect/${medium}`
+  } else if (color) {
+    canonicalHref = `${sd.APP_URL}/collect/color/${color}`
+    console.log("hi")
+  } else {
+    canonicalHref = `${sd.APP_URL}/collect`
+  }
 
   const items = [{ name: "Collect", path: "/collect" }]
   if (medium) {

--- a/src/v2/Apps/Collect/Routes/Collect/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collect/index.tsx
@@ -43,7 +43,6 @@ export const CollectApp: React.FC<CollectAppProps> = ({
     canonicalHref = `${sd.APP_URL}/collect/${medium}`
   } else if (color) {
     canonicalHref = `${sd.APP_URL}/collect/color/${color}`
-    console.log("hi")
   } else {
     canonicalHref = `${sd.APP_URL}/collect`
   }

--- a/src/v2/Apps/Collect/collectRoutes.tsx
+++ b/src/v2/Apps/Collect/collectRoutes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import loadable from "@loadable/component"
 import { RouteConfig } from "found"
 import { graphql } from "react-relay"
@@ -24,64 +23,16 @@ export const collectRoutes: RouteConfig[] = [
       CollectApp.preload()
     },
     prepareVariables: initializeVariablesWithFilterState,
-    query: graphql`
-      query collectRoutes_ArtworkFilterQuery(
-        $acquireable: Boolean
-        $aggregations: [ArtworkAggregation] = [TOTAL]
-        $artistID: String
-        $atAuction: Boolean
-        $attributionClass: [String]
-        $color: String
-        $forSale: Boolean
-        $height: String
-        $inquireableOnly: Boolean
-        $majorPeriods: [String]
-        $medium: String
-        $offerable: Boolean
-        $page: Int
-        $partnerID: ID
-        $priceRange: String
-        $sizes: [ArtworkSizes]
-        $sort: String
-        $keyword: String
-        $width: String
-      ) {
-        marketingHubCollections {
-          ...Collect_marketingHubCollections
-        }
-        filterArtworks: artworksConnection(
-          aggregations: $aggregations
-          sort: $sort
-          first: 30
-        ) {
-          ...SeoProductsForArtworks_artworks
-        }
-        viewer {
-          ...ArtworkFilter_viewer
-            @arguments(
-              acquireable: $acquireable
-              aggregations: $aggregations
-              artistID: $artistID
-              atAuction: $atAuction
-              attributionClass: $attributionClass
-              color: $color
-              forSale: $forSale
-              height: $height
-              inquireableOnly: $inquireableOnly
-              keyword: $keyword
-              majorPeriods: $majorPeriods
-              medium: $medium
-              offerable: $offerable
-              page: $page
-              partnerID: $partnerID
-              priceRange: $priceRange
-              sizes: $sizes
-              sort: $sort
-              width: $width
-            )
-        }
-      }
-    `,
+    query: getArtworkFilterQuery(),
+  },
+  {
+    path: "/collect/color/:color?",
+    getComponent: () => CollectApp,
+    prepare: () => {
+      CollectApp.preload()
+    },
+    prepareVariables: initializeVariablesWithFilterState,
+    query: getArtworkFilterQuery(),
   },
   {
     path: "/collections",
@@ -119,6 +70,14 @@ function initializeVariablesWithFilterState(params, props) {
     }
   }
 
+  if (params.color) {
+    initialFilterState.color = params.color
+
+    if (props.location.query) {
+      props.location.query.color = params.color
+    }
+  }
+
   const state = {
     sort: "-decayed_merch",
     ...paramsToCamelCase(initialFilterState),
@@ -126,4 +85,65 @@ function initializeVariablesWithFilterState(params, props) {
   }
 
   return state
+}
+
+function getArtworkFilterQuery() {
+  return graphql`
+    query collectRoutes_ArtworkFilterQuery(
+      $acquireable: Boolean
+      $aggregations: [ArtworkAggregation] = [TOTAL]
+      $artistID: String
+      $atAuction: Boolean
+      $attributionClass: [String]
+      $color: String
+      $forSale: Boolean
+      $height: String
+      $inquireableOnly: Boolean
+      $majorPeriods: [String]
+      $medium: String
+      $offerable: Boolean
+      $page: Int
+      $partnerID: ID
+      $priceRange: String
+      $sizes: [ArtworkSizes]
+      $sort: String
+      $keyword: String
+      $width: String
+    ) {
+      marketingHubCollections {
+        ...Collect_marketingHubCollections
+      }
+      filterArtworks: artworksConnection(
+        aggregations: $aggregations
+        sort: $sort
+        first: 30
+      ) {
+        ...SeoProductsForArtworks_artworks
+      }
+      viewer {
+        ...ArtworkFilter_viewer
+          @arguments(
+            acquireable: $acquireable
+            aggregations: $aggregations
+            artistID: $artistID
+            atAuction: $atAuction
+            attributionClass: $attributionClass
+            color: $color
+            forSale: $forSale
+            height: $height
+            inquireableOnly: $inquireableOnly
+            keyword: $keyword
+            majorPeriods: $majorPeriods
+            medium: $medium
+            offerable: $offerable
+            page: $page
+            partnerID: $partnerID
+            priceRange: $priceRange
+            sizes: $sizes
+            sort: $sort
+            width: $width
+          )
+      }
+    }
+  `
 }


### PR DESCRIPTION
Addresses: 
- https://artsyproduct.atlassian.net/browse/GRO-187 
- https://artsyproduct.atlassian.net/browse/GRO-184

This updates our URL structure for /collect to support direct url based color queries:

Example:
```
/collect/color/red
```

Once the client mounts things will convert into conventional query param for now, changing little of the underlying structure as FX is about to start a lot of work around filter architecture. 

cc @artsy/grow-devs 
