### PR TITLE
(GRO-188): Updated unsubscribe redirect to anchor tag to Email Preferences

### DIFF
--- a/src/desktop/apps/unsubscribe/index.coffee
+++ b/src/desktop/apps/unsubscribe/index.coffee
@@ -8,4 +8,4 @@ routes = require './routes'
 app = module.exports = express()
 app.set 'views', __dirname + '/templates'
 app.set 'view engine', 'jade'
-app.get '/unsubscribe*', (req, res) => res.redirect(301, "/user/edit")
+app.get '/unsubscribe*', (req, res) => res.redirect(301, "/user/edit#stitch-user-email-preferences")


### PR DESCRIPTION
This is a subtask of the ticket [GRO-181].

After updating the unsubscribe redirect to `user/edit` it was noted that the redirect does not point users to an area with email unsubscription. Seemed to be in best interest for us to anchor that to the `Email Preferences` section to better point the user in the area of their email preferences and the ability to unsubscribe.

![image](https://user-images.githubusercontent.com/30025439/107416985-f9644180-6ac9-11eb-9f33-a7c6d454aea4.png)


[GRO-181]: https://artsyproduct.atlassian.net/browse/GRO-181