### PR TITLE
feat: [SEO] Add /auctions meta description text

### DIFF
--- a/src/desktop/apps/auctions/templates/meta.jade
+++ b/src/desktop/apps/auctions/templates/meta.jade
@@ -1,5 +1,5 @@
 - var title = 'Auctions | Artsy'
-- var description = ''
+- var description = 'Bid in live and online-only sales from the world’s leading auction houses. Browse paintings, sculptures, design, prints & multiples and more.'
 
 title= title
 meta( property="og:title", content= title )


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GRO-176 

Adds a meta description to /auctions pages (old, non-react section of the app).

@artsy/grow-devs 