### PR TITLE
Revert "Convert /viewing-rooms and /viewing-room/* routes to novo template (PLATFORM-3123)"

### DIFF
--- a/src/desktop/lib/webpackPublicPath.ts
+++ b/src/desktop/lib/webpackPublicPath.ts
@@ -34,8 +34,6 @@ if (process.env.NODE_ENV === "production") {
     "/feature/",
     "/show/",
     "/user/conversations",
-    "/viewing-rooms",
-    "/viewing-room/",
   ]
 
   function beenConverted() {

--- a/src/v2/Apps/getAppNovoRoutes.tsx
+++ b/src/v2/Apps/getAppNovoRoutes.tsx
@@ -75,7 +75,6 @@ export function getAppNovoRoutes(): RouteConfig[] {
         routes: showRoutes,
       },
       {
-        converted: true,
         routes: viewingRoomRoutes,
       },
 

--- a/src/v2/Apps/getAppRoutes.tsx
+++ b/src/v2/Apps/getAppRoutes.tsx
@@ -17,7 +17,7 @@ import { orderRoutes } from "v2/Apps/Order/orderRoutes"
 import { purchaseRoutes } from "v2/Apps/Purchase/purchaseRoutes"
 import { searchRoutes } from "v2/Apps/Search/searchRoutes"
 // import { showRoutes } from "v2/Apps/Show/showRoutes"
-// import { viewingRoomRoutes } from "./ViewingRoom/viewingRoomRoutes"
+import { viewingRoomRoutes } from "./ViewingRoom/viewingRoomRoutes"
 import { auctionsRoutes } from "./Auctions/auctionsRoutes"
 
 export function getAppRoutes(): RouteConfig[] {
@@ -78,9 +78,9 @@ export function getAppRoutes(): RouteConfig[] {
     // {
     //   routes: showRoutes,
     // },
-    // {
-    //   routes: viewingRoomRoutes,
-    // },
+    {
+      routes: viewingRoomRoutes,
+    },
 
     // For debugging baseline app shell stuff
     {


### PR DESCRIPTION
Integrity highlighted the fact that the sign-up prompt no longer opens consistently when freshly loading a viewing room page. (It _does_ open when following an internal link to a viewing room.) This PR reverts artsy/force#6993 while we debug.