### PR TITLE
Defer openAuthModal call to avoid apparent race condition

### DIFF
--- a/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
+++ b/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
@@ -44,7 +44,7 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
         mode: ModalType.signup,
         redirectTo: window.location.href,
       })
-    }, 0)
+    }, 1000)
 
     return () => clearTimeout(timeoutID)
   }, [user, router, mediator])


### PR DESCRIPTION
This follows up https://github.com/artsy/force/pull/6993 which switched `/viewing-room*` routes to use the novo template. [Integrity caught](https://app.circleci.com/pipelines/github/artsy/integrity/5570/workflows/ce8745f6-130b-475d-8bb6-6d99829f71e8/jobs/26893) that the registration prompt wasn't consistently appearing on viewing room pages.

The issue seems related to `ModalContainer` not being mounted when `open:auth` is triggered, as is already [mentioned in a comment](https://github.com/artsy/force/blob/dae1001ce074dbccedcc909fa82917adac2fbca1/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx#L33-L34). Deferring the event for another second worked locally.

Apologies to future developers encountering this work-around. It may be gross, but at least it's green.

Related aborted revert: https://github.com/artsy/force/pull/7008