### PR TITLE
chore: Remove Invalid Lint Rule Ignore

### DIFF
--- a/src/v2/Apps/Artwork/artworkRoutes.tsx
+++ b/src/v2/Apps/Artwork/artworkRoutes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 

--- a/src/v2/Apps/Auction/auctionRoutes.tsx
+++ b/src/v2/Apps/Auction/auctionRoutes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import loadable from "@loadable/component"
 import { ErrorPage } from "v2/Components/ErrorPage"
 import { RedirectException, RouteConfig } from "found"

--- a/src/v2/Apps/Consign/consignRoutes.tsx
+++ b/src/v2/Apps/Consign/consignRoutes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 

--- a/src/v2/Apps/Debug/debugRoutes.tsx
+++ b/src/v2/Apps/Debug/debugRoutes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import React from "react"
 import { Title } from "react-head"
 

--- a/src/v2/Apps/Feature/featureRoutes.tsx
+++ b/src/v2/Apps/Feature/featureRoutes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { RouteConfig } from "found"

--- a/src/v2/Apps/FeatureAKG/featureAKGRoutes.tsx
+++ b/src/v2/Apps/FeatureAKG/featureAKGRoutes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import loadable from "@loadable/component"
 import { RouteConfig } from "found"
 import { graphql } from "react-relay"

--- a/src/v2/Apps/IdentityVerification/identityVerificationRoutes.tsx
+++ b/src/v2/Apps/IdentityVerification/identityVerificationRoutes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import loadable from "@loadable/component"
 import { RouteConfig } from "found"
 import { graphql } from "react-relay"

--- a/src/v2/Apps/Order/orderRoutes.tsx
+++ b/src/v2/Apps/Order/orderRoutes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import loadable from "@loadable/component"
 import { getRedirect } from "v2/Apps/Order/getRedirect"
 import { redirects } from "v2/Apps/Order/redirects"

--- a/src/v2/Apps/Purchase/purchaseRoutes.tsx
+++ b/src/v2/Apps/Purchase/purchaseRoutes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { RouteConfig } from "found"


### PR DESCRIPTION
Removes and old lint rule ignore that is currently invalid because hte
plugin is no longer installed.