### PR TITLE
feature: Convert User Purchase Routes

### DIFF
--- a/src/desktop/lib/webpackPublicPath.ts
+++ b/src/desktop/lib/webpackPublicPath.ts
@@ -36,6 +36,7 @@ if (process.env.NODE_ENV === "production") {
     "/feature/",
     "/show/",
     "/user/conversations",
+    "/user/purchases",
     "/viewing-rooms",
     "/viewing-room/",
   ]

--- a/src/v2/Apps/getAppNovoRoutes.tsx
+++ b/src/v2/Apps/getAppNovoRoutes.tsx
@@ -66,6 +66,7 @@ export function getAppNovoRoutes(): RouteConfig[] {
         routes: orderRoutes,
       },
       {
+        converted: true,
         routes: purchaseRoutes,
       },
       {

--- a/src/v2/Apps/getAppRoutes.tsx
+++ b/src/v2/Apps/getAppRoutes.tsx
@@ -14,7 +14,7 @@ import { exampleRoutes } from "./Example/exampleRoutes"
 // import { featureRoutes } from "v2/Apps/Feature/featureRoutes"
 import { identityVerificationRoutes } from "v2/Apps/IdentityVerification/identityVerificationRoutes"
 import { orderRoutes } from "v2/Apps/Order/orderRoutes"
-import { purchaseRoutes } from "v2/Apps/Purchase/purchaseRoutes"
+// import { purchaseRoutes } from "v2/Apps/Purchase/purchaseRoutes"
 import { searchRoutes } from "v2/Apps/Search/searchRoutes"
 // import { showRoutes } from "v2/Apps/Show/showRoutes"
 // import { viewingRoomRoutes } from "./ViewingRoom/viewingRoomRoutes"
@@ -70,9 +70,10 @@ export function getAppRoutes(): RouteConfig[] {
     {
       routes: orderRoutes,
     },
-    {
-      routes: purchaseRoutes,
-    },
+    // NOTE: Converted to use NOVO template.
+    // {
+    //   routes: purchaseRoutes,
+    // },
     {
       routes: searchRoutes,
     },


### PR DESCRIPTION
This change converts the `/user/purchases` routes to the NOVO template.