### PR TITLE
fix: Improve onboarding routing

### DIFF
--- a/src/desktop/apps/personalize/index.coffee
+++ b/src/desktop/apps/personalize/index.coffee
@@ -3,11 +3,11 @@
 #
 
 express = require 'express'
-{ ensureLoggedInUser, index } = require './routes.js'
+{ ensureLoggedInUser, ensureValidStep, index } = require './routes.js'
 
 app = module.exports = express()
 app.set 'views', __dirname
 app.set 'view engine', 'jade'
 
 app.get '/personalize', (_, res) => res.redirect('/personalize/interests')
-app.get '/personalize/:slug', ensureLoggedInUser, index
+app.get '/personalize/:slug', ensureLoggedInUser, ensureValidStep, index

--- a/src/desktop/apps/personalize/routes.js
+++ b/src/desktop/apps/personalize/routes.js
@@ -4,7 +4,7 @@ import { App } from "desktop/apps/personalize/components/App"
 
 export const index = async (req, res, next) => {
   try {
-    const layout = await stitch({
+    const options = {
       basePath: req.app.get("views"),
       config: {
         styledComponents: true,
@@ -24,8 +24,9 @@ export const index = async (req, res, next) => {
         redirectTo: req.query.redirectTo,
         forceStep: req.params.slug,
       },
-    })
+    }
 
+    const layout = await stitch(options)
     res.send(layout)
   } catch (error) {
     next(error)

--- a/src/desktop/apps/personalize/routes.js
+++ b/src/desktop/apps/personalize/routes.js
@@ -45,7 +45,8 @@ export const index = async (req, res, next) => {
 }
 
 export const ensureLoggedInUser = (request, response, next) => {
+  const loginWithRedirect = "/login?redirect-to=/personalize/interests"
   const currentUser = response.locals.sd.CURRENT_USER
-  if (!currentUser) return response.redirect("/personalize")
+  if (!currentUser) return response.redirect(loginWithRedirect)
   next()
 }

--- a/src/desktop/apps/personalize/routes.js
+++ b/src/desktop/apps/personalize/routes.js
@@ -44,7 +44,8 @@ export const index = async (req, res, next) => {
   }
 }
 
-export const ensureLoggedInUser = (req, res, next) => {
-  if (!res.locals.sd.CURRENT_USER) return res.redirect("/personalize")
+export const ensureLoggedInUser = (request, response, next) => {
+  const currentUser = response.locals.sd.CURRENT_USER
+  if (!currentUser) return response.redirect("/personalize")
   next()
 }

--- a/src/desktop/apps/personalize/routes.js
+++ b/src/desktop/apps/personalize/routes.js
@@ -2,31 +2,37 @@ import * as _ from "underscore"
 import { stitch } from "@artsy/stitch"
 import { App } from "desktop/apps/personalize/components/App"
 
+const computeStitchOptions = (request, response) => {
+  const options = {
+    basePath: request.app.get("views"),
+    config: {
+      styledComponents: true,
+    },
+    layout: "../../components/main_layout/templates/react_blank_index.jade",
+    blocks: {
+      head: "./meta.jade",
+      body: App,
+    },
+    locals: {
+      ...response.locals,
+      assetPackage: "onboarding",
+    },
+    data: {
+      title: "Personalize | Artsy",
+      currentUser: response.locals.sd.CURRENT_USER,
+      redirectTo: request.query.redirectTo,
+      forceStep: request.params.slug,
+    },
+  }
+
+  return options
+}
+
 export const index = async (req, res, next) => {
   try {
-    const options = {
-      basePath: req.app.get("views"),
-      config: {
-        styledComponents: true,
-      },
-      layout: "../../components/main_layout/templates/react_blank_index.jade",
-      blocks: {
-        head: "./meta.jade",
-        body: App,
-      },
-      locals: {
-        ...res.locals,
-        assetPackage: "onboarding",
-      },
-      data: {
-        title: "Personalize | Artsy",
-        currentUser: res.locals.sd.CURRENT_USER,
-        redirectTo: req.query.redirectTo,
-        forceStep: req.params.slug,
-      },
-    }
-
+    const options = computeStitchOptions(req, res)
     const layout = await stitch(options)
+
     res.send(layout)
   } catch (error) {
     next(error)

--- a/src/desktop/apps/personalize/routes.js
+++ b/src/desktop/apps/personalize/routes.js
@@ -44,6 +44,14 @@ export const index = async (req, res, next) => {
   }
 }
 
+export const ensureValidStep = (request, response, next) => {
+  const validSteps = ["interests", "artists", "categories", "budget"]
+  const step = request.params.slug
+  const firstStep = "/personalize/interests"
+  if (!validSteps.includes(step)) return response.redirect(firstStep)
+  next()
+}
+
 export const ensureLoggedInUser = (request, response, next) => {
   const loginWithRedirect = "/login?redirect-to=/personalize/interests"
   const currentUser = response.locals.sd.CURRENT_USER

--- a/src/desktop/apps/personalize/routes.js
+++ b/src/desktop/apps/personalize/routes.js
@@ -3,8 +3,13 @@ import { stitch } from "@artsy/stitch"
 import { App } from "desktop/apps/personalize/components/App"
 
 const computeStitchOptions = (request, response) => {
+  const basePath = request.app.get("views")
+  const currentUser = response.locals.sd.CURRENT_USER
+  const redirectTo = request.query.redirectTo
+  const forceStep = request.params.slug
+
   const options = {
-    basePath: request.app.get("views"),
+    basePath,
     config: {
       styledComponents: true,
     },
@@ -18,10 +23,10 @@ const computeStitchOptions = (request, response) => {
       assetPackage: "onboarding",
     },
     data: {
+      currentUser,
+      forceStep,
+      redirectTo,
       title: "Personalize | Artsy",
-      currentUser: response.locals.sd.CURRENT_USER,
-      redirectTo: request.query.redirectTo,
-      forceStep: request.params.slug,
     },
   }
 

--- a/src/desktop/apps/personalize/test/routes.jest.ts
+++ b/src/desktop/apps/personalize/test/routes.jest.ts
@@ -46,7 +46,9 @@ describe("Personalize routes", () => {
 
       ensureLoggedInUser(request, response, mockNext)
 
-      expect(mockRedirect).toBeCalledWith("/personalize")
+      expect(mockRedirect).toBeCalledWith(
+        "/login?redirect-to=/personalize/interests"
+      )
       expect(mockNext).not.toHaveBeenCalled()
     })
 

--- a/src/desktop/apps/personalize/test/routes.jest.ts
+++ b/src/desktop/apps/personalize/test/routes.jest.ts
@@ -6,8 +6,13 @@ jest.mock("@artsy/stitch", () => ({
 const stichMock = require("@artsy/stitch").stitch as jest.Mock
 
 describe("Personalize routes", () => {
+  const mockNext = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe("index route", () => {
-    const mockNext = jest.fn()
     const request = {
       app: { get: jest.fn() },
       query: { redirectTo: "" },
@@ -28,7 +33,6 @@ describe("Personalize routes", () => {
   })
 
   describe("ensureLoggedInUser route", () => {
-    const mockNext = jest.fn()
     const mockRedirect = jest.fn()
 
     const request = {}
@@ -36,10 +40,6 @@ describe("Personalize routes", () => {
       locals: { sd: { CURRENT_USER: undefined } },
       redirect: mockRedirect,
     }
-
-    beforeEach(() => {
-      jest.clearAllMocks()
-    })
 
     it("redirects when there is no current user", () => {
       response.locals.sd.CURRENT_USER = undefined

--- a/src/desktop/apps/personalize/test/routes.jest.ts
+++ b/src/desktop/apps/personalize/test/routes.jest.ts
@@ -1,4 +1,4 @@
-import { index } from "../routes"
+import { index, ensureLoggedInUser } from "../routes"
 const CurrentUser = require("desktop/models/current_user")
 
 jest.mock("@artsy/stitch", () => ({
@@ -32,9 +32,44 @@ describe("Personalize routes", () => {
     }
   })
 
-  it("renders the personalize app", () => {
-    index(req, res, next)
-    expect(stichMock.mock.calls[0][0].data.title).toBe("Personalize | Artsy")
-    expect(stichMock.mock.calls[0][0].locals.assetPackage).toBe("onboarding")
+  describe("index route", () => {
+    it("renders the personalize app", () => {
+      index(req, res, next)
+      expect(stichMock.mock.calls[0][0].data.title).toBe("Personalize | Artsy")
+      expect(stichMock.mock.calls[0][0].locals.assetPackage).toBe("onboarding")
+    })
+  })
+
+  describe("ensureLoggedInUser route", () => {
+    const mockNext = jest.fn()
+    const mockRedirect = jest.fn()
+
+    const request = {}
+    const response = {
+      locals: { sd: { CURRENT_USER: undefined } },
+      redirect: mockRedirect,
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it("redirects when there is no current user", () => {
+      response.locals.sd.CURRENT_USER = undefined
+
+      ensureLoggedInUser(request, response, mockNext)
+
+      expect(mockRedirect).toBeCalledWith("/personalize")
+      expect(mockNext).not.toHaveBeenCalled()
+    })
+
+    it("calls next when there is a user", () => {
+      response.locals.sd.CURRENT_USER = {}
+
+      ensureLoggedInUser(request, response, mockNext)
+
+      expect(mockRedirect).not.toHaveBeenCalled()
+      expect(mockNext).toHaveBeenCalled()
+    })
   })
 })

--- a/src/desktop/apps/personalize/test/routes.jest.ts
+++ b/src/desktop/apps/personalize/test/routes.jest.ts
@@ -1,4 +1,4 @@
-import { index, ensureLoggedInUser } from "../routes"
+import { index, ensureLoggedInUser, ensureValidStep } from "../routes"
 
 jest.mock("@artsy/stitch", () => ({
   stitch: jest.fn(),
@@ -29,6 +29,33 @@ describe("Personalize routes", () => {
       expect(stichMock.mock.calls[0][0].data.title).toBe("Personalize | Artsy")
       expect(stichMock.mock.calls[0][0].locals.assetPackage).toBe("onboarding")
       expect(mockNext).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("ensureValidStep route", () => {
+    const mockRedirect = jest.fn()
+
+    const request = { params: { slug: "" } }
+    const response = {
+      redirect: mockRedirect,
+    }
+
+    it("redirects when there is no current user", () => {
+      request.params.slug = "invalid"
+
+      ensureValidStep(request, response, mockNext)
+
+      expect(mockRedirect).toBeCalledWith("/personalize/interests")
+      expect(mockNext).not.toHaveBeenCalled()
+    })
+
+    it("calls next when there is a user", () => {
+      request.params.slug = "artists"
+
+      ensureValidStep(request, response, mockNext)
+
+      expect(mockRedirect).not.toHaveBeenCalled()
+      expect(mockNext).toHaveBeenCalled()
     })
   })
 

--- a/src/desktop/apps/personalize/test/routes.jest.ts
+++ b/src/desktop/apps/personalize/test/routes.jest.ts
@@ -9,7 +9,7 @@ const stichMock = require("@artsy/stitch").stitch as jest.Mock
 describe("Personalize routes", () => {
   let req
   let res
-  let next
+  const next = jest.fn()
 
   beforeEach(() => {
     req = {
@@ -30,14 +30,11 @@ describe("Personalize routes", () => {
         sd: {},
       },
     }
-    next = jest.fn()
   })
 
-  it("renders the personalize app", done => {
-    index(req, res, next).then(() => {
-      expect(stichMock.mock.calls[0][0].data.title).toBe("Personalize | Artsy")
-      expect(stichMock.mock.calls[0][0].locals.assetPackage).toBe("onboarding")
-      done()
-    })
+  it("renders the personalize app", () => {
+    index(req, res, next)
+    expect(stichMock.mock.calls[0][0].data.title).toBe("Personalize | Artsy")
+    expect(stichMock.mock.calls[0][0].locals.assetPackage).toBe("onboarding")
   })
 })

--- a/src/desktop/apps/personalize/test/routes.jest.ts
+++ b/src/desktop/apps/personalize/test/routes.jest.ts
@@ -1,5 +1,4 @@
 import { index, ensureLoggedInUser } from "../routes"
-const CurrentUser = require("desktop/models/current_user")
 
 jest.mock("@artsy/stitch", () => ({
   stitch: jest.fn(),
@@ -7,36 +6,24 @@ jest.mock("@artsy/stitch", () => ({
 const stichMock = require("@artsy/stitch").stitch as jest.Mock
 
 describe("Personalize routes", () => {
-  let req
-  let res
-  const next = jest.fn()
-
-  beforeEach(() => {
-    req = {
-      body: {},
-      params: { slug: "interests" },
-      redirect: jest.fn(),
-      user: new CurrentUser({
-        name: "user",
-      }),
-      app: { get: jest.fn() },
-      query: {
-        redirectTo: "",
-      },
-    }
-    res = {
-      send: jest.fn(),
-      locals: {
-        sd: {},
-      },
-    }
-  })
-
   describe("index route", () => {
+    const mockNext = jest.fn()
+    const request = {
+      app: { get: jest.fn() },
+      query: { redirectTo: "" },
+      params: { slug: "interests" },
+    }
+    const response = {
+      send: jest.fn(),
+      locals: { sd: {} },
+    }
+
     it("renders the personalize app", () => {
-      index(req, res, next)
+      index(request, response, mockNext)
+
       expect(stichMock.mock.calls[0][0].data.title).toBe("Personalize | Artsy")
       expect(stichMock.mock.calls[0][0].locals.assetPackage).toBe("onboarding")
+      expect(mockNext).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
While tinkering with the onboarding code I noticed that the behavior to redirect wasn't working the way I expected. After some intense debugging in #dev-help (https://artsy.slack.com/archives/CP9P4KR35/p1613144682324000) it was discovered that artsy/passport was to blame. I opened artsy/artsy-passport#159 to remove that responsibility from that auth package.

So then this is the second part - this PR centralizes all the routing around `/personalize`. I have added some missing tests and did some extraction to make working with this part of the code a little nicer.

/cc @artsy/grow-devs @dzucconi @joeyAghion 