### PR TITLE
bugfix: send selected saved phone number to mutation

### DIFF
--- a/src/v2/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/v2/Apps/Order/Routes/Shipping/index.tsx
@@ -180,13 +180,17 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
             this.getAddressList()[parseInt(this.state.selectedSavedAddress)]
               .node
           )
+      const shipToPhoneNumber = this.isCreateNewAddress()
+        ? phoneNumber
+        : this.getAddressList()[parseInt(this.state.selectedSavedAddress)].node
+            .phoneNumber
       const orderOrError = (
         await setShippingMutation(this.props.commitMutation, {
           input: {
             id: this.props.order.internalID,
             fulfillmentType: shippingOption,
             shipping: shipToAddress,
-            phoneNumber,
+            phoneNumber: shipToPhoneNumber,
           },
         })
       ).commerceSetShipping.orderOrError

--- a/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -561,7 +561,7 @@ describe("Shipping", () => {
     it("saves the default address selection into state", async () => {
       expect(page.find(ShippingRoute).state().selectedSavedAddress).toEqual("1")
     })
-    it("commits the mutation with selected address", async () => {
+    it("commits the mutation with selected address and phone number", async () => {
       await page.clickSubmit()
 
       expect(mutations.mockFetch).toHaveBeenCalledTimes(1)
@@ -570,7 +570,7 @@ describe("Shipping", () => {
           "input": Object {
             "fulfillmentType": "SHIP",
             "id": "1234",
-            "phoneNumber": "",
+            "phoneNumber": "422-424-4242",
             "shipping": Object {
               "addressLine1": "401 Broadway",
               "addressLine2": "Floor 25",
@@ -585,7 +585,7 @@ describe("Shipping", () => {
         }
       `)
     })
-    it("changes the address and saves when another address is selected", async () => {
+    it("when another saved address is selected commits mutation with selected address and phone number", async () => {
       page
         .find(`Radio__BorderedRadio[data-test="savedAddress"]`)
         .first()
@@ -595,12 +595,15 @@ describe("Shipping", () => {
       await page.clickSubmit()
 
       expect(mutations.mockFetch).toHaveBeenCalledTimes(1)
+      expect(mutations.mockFetch.mock.calls[0][0].name).toEqual(
+        "ShippingOrderAddressUpdateMutation"
+      )
       expect(mutations.lastFetchVariables).toMatchInlineSnapshot(`
         Object {
           "input": Object {
             "fulfillmentType": "SHIP",
             "id": "1234",
-            "phoneNumber": "",
+            "phoneNumber": "555-555-5555",
             "shipping": Object {
               "addressLine1": "1 Main St",
               "addressLine2": "",


### PR DESCRIPTION
Problem:

When selecting a saved address the mutation was sending selected phone number along with the [shipping parameters](https://github.com/artsy/force/compare/sepans/fix-offer-checkout?expand=1#diff-1dc017ef4cac0c540b70784941eb16550eb06b8a495ad12edc5061812e14d9efR580) but not as the root `phoneNumber` param. Instead, it was trying to get it from the form which was empty.

Solution:
When not 'creating a new address', use the saved phone number