### PR TITLE
feat: Add new payment app to replace stitched user payments tab

### DIFF
--- a/src/desktop/apps/user/index.coffee
+++ b/src/desktop/apps/user/index.coffee
@@ -11,5 +11,6 @@ app.get '/profile/edit', routes.settings
 app.get '/user/edit', routes.settings
 app.get '/user/delete', routes.settings
 app.get '/user/saves', routes.settings
+# TODO remove after finishing new purchase app
 app.get '/user/payments', routes.settings
 app.get '/user/auctions', routes.settings

--- a/src/desktop/components/react/stitch_components/index.tsx
+++ b/src/desktop/components/react/stitch_components/index.tsx
@@ -13,6 +13,7 @@
 export { StitchWrapper } from "./StitchWrapper"
 export { NavBar } from "./NavBar"
 export { CollectionsHubsHomepageNav } from "./CollectionsHubsHomepageNav"
+// TODO remove after finishing new purchase app
 export {
   UserSettingsPaymentsQueryRenderer as UserSettingsPayments,
 } from "v2/Components/Payment/UserSettingsPayments"

--- a/src/v2/Apps/Payment/Routes/Payment/PaymentApp.tsx
+++ b/src/v2/Apps/Payment/Routes/Payment/PaymentApp.tsx
@@ -1,0 +1,42 @@
+import React from "react"
+import { AppContainer } from "v2/Apps/Components/AppContainer"
+import { createFragmentContainer, graphql } from "react-relay"
+import { Title } from "react-head"
+import { PaymentApp_me } from "v2/__generated__/PaymentApp_me.graphql"
+import { data as sd } from "sharify"
+import { Box } from "@artsy/palette"
+import { UserSettingsPaymentsFragmentContainer } from "v2/Components/Payment/UserSettingsPayments"
+import { UserSettingsTabs } from "v2/Components/UserSettings/UserSettingsTabs"
+
+export interface PaymentAppProps {
+  me: PaymentApp_me
+}
+
+const PaymentApp: React.FC<PaymentAppProps> = props => {
+  const { me } = props
+
+  // FIXME: the margins for Boxes below are added to make it consistent with
+  // the purchase app. We need to move these to a component when we move all tabs
+  // to apps
+  return (
+    <AppContainer>
+      <Title>My payments | Artsy</Title>
+      <Box mx={[1, 4]}>
+        <Box mb={2} mt={1}>
+          <UserSettingsTabs route={sd.CURRENT_PATH} username={me.name} />
+        </Box>
+
+        <UserSettingsPaymentsFragmentContainer me={me} />
+      </Box>
+    </AppContainer>
+  )
+}
+
+export const PaymentAppFragmentContainer = createFragmentContainer(PaymentApp, {
+  me: graphql`
+    fragment PaymentApp_me on Me {
+      name
+      ...UserSettingsPayments_me
+    }
+  `,
+})

--- a/src/v2/Apps/Payment/Routes/Payment/PaymentApp.tsx
+++ b/src/v2/Apps/Payment/Routes/Payment/PaymentApp.tsx
@@ -5,7 +5,7 @@ import { Title } from "react-head"
 import { PaymentApp_me } from "v2/__generated__/PaymentApp_me.graphql"
 import { data as sd } from "sharify"
 import { Box } from "@artsy/palette"
-import { UserSettingsPaymentsFragmentContainer } from "v2/Components/Payment/UserSettingsPayments"
+import { UserSettingsPaymentsFragmentContainer as UserSettingsPayments } from "v2/Components/Payment/UserSettingsPayments"
 import { UserSettingsTabs } from "v2/Components/UserSettings/UserSettingsTabs"
 
 export interface PaymentAppProps {
@@ -26,7 +26,7 @@ const PaymentApp: React.FC<PaymentAppProps> = props => {
           <UserSettingsTabs route={sd.CURRENT_PATH} username={me.name} />
         </Box>
 
-        <UserSettingsPaymentsFragmentContainer me={me} />
+        <UserSettingsPayments me={me} />
       </Box>
     </AppContainer>
   )

--- a/src/v2/Apps/Payment/__tests__/PaymentApp.jest.tsx
+++ b/src/v2/Apps/Payment/__tests__/PaymentApp.jest.tsx
@@ -1,0 +1,59 @@
+import React from "react"
+import { graphql } from "react-relay"
+import { PaymentApp_Test_Query } from "v2/__generated__/PaymentApp_Test_Query.graphql"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { PaymentAppFragmentContainer } from "../Routes/Payment/PaymentApp"
+import { HeadProvider } from "react-head"
+
+jest.mock("react-tracking")
+jest.unmock("react-relay")
+
+const { getWrapper } = setupTestWrapper<PaymentApp_Test_Query>({
+  Component: props => {
+    return (
+      <HeadProvider>
+        <PaymentAppFragmentContainer {...props} />
+      </HeadProvider>
+    )
+  },
+  query: graphql`
+    query PaymentApp_Test_Query {
+      me {
+        ...PaymentApp_me
+      }
+    }
+  `,
+})
+
+describe("PaymentApp", () => {
+  it("renders collector name and some menu routes", () => {
+    const wrapper = getWrapper({
+      Me: () => ({
+        name: "Rob Ross",
+      }),
+    })
+
+    const userSettingsTabs = wrapper.find("UserSettingsTabs")
+
+    expect(userSettingsTabs.text()).toContain("Rob Ross")
+    expect(userSettingsTabs.find("RouteTab").length).toBeGreaterThan(1)
+  })
+  it("renders saved credit cards and form", () => {
+    const wrapper = getWrapper({
+      Me: () => ({
+        name: "Rob Ross",
+      }),
+    })
+
+    const paymentSettings = wrapper.find("UserSettingsPayments")
+    const savedCreditCardText = paymentSettings.find("SavedCreditCards").text()
+
+    expect(savedCreditCardText).toContain(
+      'credit card•••• <mock-value-for-field-"lastDigits">'
+    )
+    expect(savedCreditCardText).toContain(
+      'Exp <mock-value-for-field-"expirationMonth">/">Remove'
+    )
+    expect(paymentSettings.find("PaymentFormWrapper").length).toBe(1)
+  })
+})

--- a/src/v2/Apps/Payment/paymentRoutes.tsx
+++ b/src/v2/Apps/Payment/paymentRoutes.tsx
@@ -1,0 +1,24 @@
+import loadable from "@loadable/component"
+import { graphql } from "react-relay"
+
+const PaymentApp = loadable(() => import("./Routes/Payment/PaymentApp"), {
+  resolveComponent: component => component.PaymentAppFragmentContainer,
+})
+
+export const paymentRoutes = [
+  {
+    // TODO: update route to /user/payments and remove stitched route to launch
+    path: "/user/payments2",
+    getComponent: () => PaymentApp,
+    prepare: () => {
+      PaymentApp.preload()
+    },
+    query: graphql`
+      query paymentRoutes_PaymentQuery {
+        me {
+          ...PaymentApp_me
+        }
+      }
+    `,
+  },
+]

--- a/src/v2/Apps/getAppNovoRoutes.tsx
+++ b/src/v2/Apps/getAppNovoRoutes.tsx
@@ -17,6 +17,7 @@ import { purchaseRoutes } from "v2/Apps/Purchase/purchaseRoutes"
 import { searchRoutes } from "v2/Apps/Search/searchRoutes"
 import { showRoutes } from "v2/Apps/Show/showRoutes"
 import { viewingRoomRoutes } from "./ViewingRoom/viewingRoomRoutes"
+import { paymentRoutes } from "v2/Apps/Payment/paymentRoutes"
 
 export function getAppNovoRoutes(): RouteConfig[] {
   return buildAppRoutes(
@@ -79,6 +80,10 @@ export function getAppNovoRoutes(): RouteConfig[] {
       {
         converted: true,
         routes: viewingRoomRoutes,
+      },
+      {
+        converted: true,
+        routes: paymentRoutes,
       },
 
       // For debugging baseline app shell stuff

--- a/src/v2/__generated__/PaymentApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PaymentApp_Test_Query.graphql.ts
@@ -1,0 +1,253 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type PaymentApp_Test_QueryVariables = {};
+export type PaymentApp_Test_QueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"PaymentApp_me">;
+    } | null;
+};
+export type PaymentApp_Test_Query = {
+    readonly response: PaymentApp_Test_QueryResponse;
+    readonly variables: PaymentApp_Test_QueryVariables;
+};
+
+
+
+/*
+query PaymentApp_Test_Query {
+  me {
+    ...PaymentApp_me
+    id
+  }
+}
+
+fragment PaymentApp_me on Me {
+  name
+  ...UserSettingsPayments_me
+}
+
+fragment UserSettingsPayments_me on Me {
+  id
+  internalID
+  creditCards(first: 100) {
+    edges {
+      node {
+        id
+        internalID
+        brand
+        lastDigits
+        expirationYear
+        expirationMonth
+        __typename
+      }
+      cursor
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "PaymentApp_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "PaymentApp_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "PaymentApp_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          (v0/*: any*/),
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "concreteType": "CreditCardConnection",
+            "kind": "LinkedField",
+            "name": "creditCards",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "CreditCardEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "CreditCard",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v0/*: any*/),
+                      (v1/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "brand",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lastDigits",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "expirationYear",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "expirationMonth",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__typename",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "cursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "creditCards(first:100)"
+          },
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "filters": [],
+            "handle": "connection",
+            "key": "UserSettingsPayments_creditCards",
+            "kind": "LinkedHandle",
+            "name": "creditCards"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "PaymentApp_Test_Query",
+    "operationKind": "query",
+    "text": "query PaymentApp_Test_Query {\n  me {\n    ...PaymentApp_me\n    id\n  }\n}\n\nfragment PaymentApp_me on Me {\n  name\n  ...UserSettingsPayments_me\n}\n\nfragment UserSettingsPayments_me on Me {\n  id\n  internalID\n  creditCards(first: 100) {\n    edges {\n      node {\n        id\n        internalID\n        brand\n        lastDigits\n        expirationYear\n        expirationMonth\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'c27c493fa90199a58d51c8f291ae80e8';
+export default node;

--- a/src/v2/__generated__/PaymentApp_me.graphql.ts
+++ b/src/v2/__generated__/PaymentApp_me.graphql.ts
@@ -1,0 +1,41 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type PaymentApp_me = {
+    readonly name: string | null;
+    readonly " $fragmentRefs": FragmentRefs<"UserSettingsPayments_me">;
+    readonly " $refType": "PaymentApp_me";
+};
+export type PaymentApp_me$data = PaymentApp_me;
+export type PaymentApp_me$key = {
+    readonly " $data"?: PaymentApp_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"PaymentApp_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "PaymentApp_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "UserSettingsPayments_me"
+    }
+  ],
+  "type": "Me"
+};
+(node as any).hash = '6a3e00b5cd28afc62f4db9675c9b0140';
+export default node;

--- a/src/v2/__generated__/paymentRoutes_PaymentQuery.graphql.ts
+++ b/src/v2/__generated__/paymentRoutes_PaymentQuery.graphql.ts
@@ -1,0 +1,253 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type paymentRoutes_PaymentQueryVariables = {};
+export type paymentRoutes_PaymentQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"PaymentApp_me">;
+    } | null;
+};
+export type paymentRoutes_PaymentQuery = {
+    readonly response: paymentRoutes_PaymentQueryResponse;
+    readonly variables: paymentRoutes_PaymentQueryVariables;
+};
+
+
+
+/*
+query paymentRoutes_PaymentQuery {
+  me {
+    ...PaymentApp_me
+    id
+  }
+}
+
+fragment PaymentApp_me on Me {
+  name
+  ...UserSettingsPayments_me
+}
+
+fragment UserSettingsPayments_me on Me {
+  id
+  internalID
+  creditCards(first: 100) {
+    edges {
+      node {
+        id
+        internalID
+        brand
+        lastDigits
+        expirationYear
+        expirationMonth
+        __typename
+      }
+      cursor
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "paymentRoutes_PaymentQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "PaymentApp_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "paymentRoutes_PaymentQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          (v0/*: any*/),
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "concreteType": "CreditCardConnection",
+            "kind": "LinkedField",
+            "name": "creditCards",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "CreditCardEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "CreditCard",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v0/*: any*/),
+                      (v1/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "brand",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lastDigits",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "expirationYear",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "expirationMonth",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__typename",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "cursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "creditCards(first:100)"
+          },
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "filters": [],
+            "handle": "connection",
+            "key": "UserSettingsPayments_creditCards",
+            "kind": "LinkedHandle",
+            "name": "creditCards"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "paymentRoutes_PaymentQuery",
+    "operationKind": "query",
+    "text": "query paymentRoutes_PaymentQuery {\n  me {\n    ...PaymentApp_me\n    id\n  }\n}\n\nfragment PaymentApp_me on Me {\n  name\n  ...UserSettingsPayments_me\n}\n\nfragment UserSettingsPayments_me on Me {\n  id\n  internalID\n  creditCards(first: 100) {\n    edges {\n      node {\n        id\n        internalID\n        brand\n        lastDigits\n        expirationYear\n        expirationMonth\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '991f781fb3d67ffa1c1094f5f2c98875';
+export default node;


### PR DESCRIPTION
[PURCHASE-2434]

This new app ultimately going to replace the `/user/payments` stitched component

For now, it creates the app skeleton. After we add the saved shipping addresses to it we will remove the old route and update the route to `/user/payments`

I assume adding  it to Novo routes is how we should add apps now  cc: @icirellik 

<details><summary>Screenshots</summary>

The stitched version (old):

<img width="870" alt="Screen Shot 2021-02-16 at 11 44 37 AM" src="https://user-images.githubusercontent.com/687513/108094588-f7abf800-704c-11eb-86e9-7c00bf64afaf.png">


The app (new):

<img width="867" alt="Screen Shot 2021-02-16 at 11 44 22 AM" src="https://user-images.githubusercontent.com/687513/108094618-009cc980-704d-11eb-8a6e-277585c5e7ef.png">

</details>

TODO:

- [x] tests

[PURCHASE-2434]: https://artsyproduct.atlassian.net/browse/PURCHASE-2434