### PR TITLE
Correct mutation file/module names to match

### DIFF
--- a/src/v2/Apps/Order/Components/AddressModal.tsx
+++ b/src/v2/Apps/Order/Components/AddressModal.tsx
@@ -9,7 +9,7 @@ import {
 } from "../Utils/formValidators"
 import { CountrySelect } from "v2/Components/CountrySelect"
 import { CommitMutation } from "../Utils/commitMutation"
-import { updateUserAddress } from "../Mutations/AddressModal"
+import { updateUserAddress } from "../Mutations/UpdateUserAddress"
 
 interface Props {
   show: boolean

--- a/src/v2/Apps/Order/Mutations/CreateUserAddress.ts
+++ b/src/v2/Apps/Order/Mutations/CreateUserAddress.ts
@@ -1,22 +1,20 @@
 import { graphql } from "react-relay"
-import { UserAddressAttributes } from "v2/__generated__/AddressModalMutation.graphql"
-import { ShippingCreateUserAddressMutation } from "v2/__generated__/ShippingCreateUserAddressMutation.graphql"
+import { UserAddressAttributes } from "v2/__generated__/UpdateUserAddressMutation.graphql"
+import { CreateUserAddressMutation } from "v2/__generated__/CreateUserAddressMutation.graphql"
 import { CommitMutation } from "../Utils/commitMutation"
 
-export const saveUserAddressMutation = (
+export const createUserAddress = (
   commitMutation: CommitMutation,
   address: UserAddressAttributes
 ) => {
-  return commitMutation<ShippingCreateUserAddressMutation>({
+  return commitMutation<CreateUserAddressMutation>({
     variables: {
       input: {
         attributes: address,
       },
     },
     mutation: graphql`
-      mutation ShippingCreateUserAddressMutation(
-        $input: CreateUserAddressInput!
-      ) {
+      mutation CreateUserAddressMutation($input: CreateUserAddressInput!) {
         createUserAddress(input: $input) {
           userAddressOrErrors {
             ... on UserAddress {

--- a/src/v2/Apps/Order/Mutations/SetShipping.ts
+++ b/src/v2/Apps/Order/Mutations/SetShipping.ts
@@ -1,18 +1,16 @@
 import { graphql } from "react-relay"
-import { ShippingOrderAddressUpdateMutation } from "v2/__generated__/ShippingOrderAddressUpdateMutation.graphql"
+import { SetShippingMutation } from "v2/__generated__/SetShippingMutation.graphql"
 import { CommitMutation } from "../Utils/commitMutation"
 
-export const setShippingMutation = (
+export const setShipping = (
   commitMutation: CommitMutation,
-  variables: ShippingOrderAddressUpdateMutation["variables"]
+  variables: SetShippingMutation["variables"]
 ) => {
-  return commitMutation<ShippingOrderAddressUpdateMutation>({
+  return commitMutation<SetShippingMutation>({
     variables,
     // TODO: Inputs to the mutation might have changed case of the keys!
     mutation: graphql`
-      mutation ShippingOrderAddressUpdateMutation(
-        $input: CommerceSetShippingInput!
-      ) {
+      mutation SetShippingMutation($input: CommerceSetShippingInput!) {
         commerceSetShipping(input: $input) {
           orderOrError {
             ... on CommerceOrderWithMutationSuccess {

--- a/src/v2/Apps/Order/Mutations/UpdateUserAddress.ts
+++ b/src/v2/Apps/Order/Mutations/UpdateUserAddress.ts
@@ -1,5 +1,5 @@
 import { graphql } from "react-relay"
-import { AddressModalMutation } from "v2/__generated__/AddressModalMutation.graphql"
+import { UpdateUserAddressMutation } from "v2/__generated__/UpdateUserAddressMutation.graphql"
 import { CommitMutation } from "../Utils/commitMutation"
 import {
   convertShippingAddressToMutationInput,
@@ -16,7 +16,7 @@ export const updateUserAddress = async (
 ) => {
   const useArtrubutes = convertShippingAddressToMutationInput(values)
 
-  const result = await commitMutation<AddressModalMutation>({
+  const result = await commitMutation<UpdateUserAddressMutation>({
     variables: {
       input: {
         userAddressID: userAddressID,
@@ -24,7 +24,7 @@ export const updateUserAddress = async (
       },
     },
     mutation: graphql`
-      mutation AddressModalMutation($input: UpdateUserAddressInput!) {
+      mutation UpdateUserAddressMutation($input: UpdateUserAddressInput!) {
         updateUserAddress(input: $input) {
           userAddressOrErrors {
             ... on UserAddress {

--- a/src/v2/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/v2/Apps/Order/Routes/Shipping/index.tsx
@@ -13,7 +13,7 @@ import {
   Text,
 } from "@artsy/palette"
 import { Shipping_order } from "v2/__generated__/Shipping_order.graphql"
-import { CommerceOrderFulfillmentTypeEnum } from "v2/__generated__/ShippingOrderAddressUpdateMutation.graphql"
+import { CommerceOrderFulfillmentTypeEnum } from "v2/__generated__/SetShippingMutation.graphql"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
 import { ArtworkSummaryItemFragmentContainer as ArtworkSummaryItem } from "v2/Apps/Order/Components/ArtworkSummaryItem"
 import {
@@ -67,8 +67,8 @@ import {
   SavedAddressesFragmentContainer as SavedAddresses,
 } from "../../Components/SavedAddresses"
 import { AddressModal } from "../../Components/AddressModal"
-import { saveUserAddressMutation } from "../../Mutations/ShippingCreateUserAddress"
-import { setShippingMutation } from "../../Mutations/ShippingOrderAddressUpdate"
+import { createUserAddress } from "../../Mutations/CreateUserAddress"
+import { setShipping } from "../../Mutations/SetShipping"
 
 export interface ShippingProps {
   order: Shipping_order
@@ -183,7 +183,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
         : this.getAddressList()[parseInt(this.state.selectedSavedAddress)].node
             .phoneNumber
       const orderOrError = (
-        await setShippingMutation(this.props.commitMutation, {
+        await setShipping(this.props.commitMutation, {
           input: {
             id: this.props.order.internalID,
             fulfillmentType: shippingOption,
@@ -199,7 +199,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
         this.isCreateNewAddress() &&
         this.state.saveAddress
       ) {
-        await saveUserAddressMutation(this.props.commitMutation, {
+        await createUserAddress(this.props.commitMutation, {
           ...address,
           phoneNumber: phoneNumber,
         })

--- a/src/v2/Apps/Order/Routes/__fixtures__/MutationResults/saveAddress.ts
+++ b/src/v2/Apps/Order/Routes/__fixtures__/MutationResults/saveAddress.ts
@@ -1,7 +1,7 @@
-import { AddressModalMutationResponse } from "v2/__generated__/AddressModalMutation.graphql"
-import { ShippingCreateUserAddressMutationResponse } from "v2/__generated__/ShippingCreateUserAddressMutation.graphql"
+import { UpdateUserAddressMutationResponse } from "v2/__generated__/UpdateUserAddressMutation.graphql"
+import { CreateUserAddressMutationResponse } from "v2/__generated__/CreateUserAddressMutation.graphql"
 
-export const saveAddressSuccess: ShippingCreateUserAddressMutationResponse = {
+export const saveAddressSuccess: CreateUserAddressMutationResponse = {
   createUserAddress: {
     userAddressOrErrors: {
       internalID: "address-id",
@@ -10,7 +10,7 @@ export const saveAddressSuccess: ShippingCreateUserAddressMutationResponse = {
   },
 }
 
-export const updateAddressSuccess: AddressModalMutationResponse = {
+export const updateAddressSuccess: UpdateUserAddressMutationResponse = {
   updateUserAddress: {
     userAddressOrErrors: {
       internalID: "address-id",

--- a/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -191,8 +191,8 @@ describe("Shipping", () => {
 
       expect(mutations.mockFetch).toHaveBeenCalledTimes(2)
       expect(mutations.mockFetch.mock.calls.map(call => call[0].name)).toEqual([
-        "ShippingOrderAddressUpdateMutation",
-        "ShippingCreateUserAddressMutation",
+        "SetShippingMutation",
+        "CreateUserAddressMutation",
       ])
       expect(mutations.mockFetch.mock.calls).toMatchSnapshot()
     })
@@ -598,7 +598,7 @@ describe("Shipping", () => {
 
       expect(mutations.mockFetch).toHaveBeenCalledTimes(1)
       expect(mutations.mockFetch.mock.calls[0][0].name).toEqual(
-        "ShippingOrderAddressUpdateMutation"
+        "SetShippingMutation"
       )
       expect(mutations.lastFetchVariables).toMatchInlineSnapshot(`
         Object {

--- a/src/v2/Apps/Order/Routes/__tests__/__snapshots__/Shipping.jest.tsx.snap
+++ b/src/v2/Apps/Order/Routes/__tests__/__snapshots__/Shipping.jest.tsx.snap
@@ -6,9 +6,9 @@ Array [
     Object {
       "id": null,
       "metadata": Object {},
-      "name": "ShippingOrderAddressUpdateMutation",
+      "name": "SetShippingMutation",
       "operationKind": "mutation",
-      "text": "mutation ShippingOrderAddressUpdateMutation(
+      "text": "mutation SetShippingMutation(
   $input: CommerceSetShippingInput!
 ) {
   commerceSetShipping(input: $input) {
@@ -70,9 +70,9 @@ Array [
     Object {
       "id": null,
       "metadata": Object {},
-      "name": "ShippingCreateUserAddressMutation",
+      "name": "CreateUserAddressMutation",
       "operationKind": "mutation",
-      "text": "mutation ShippingCreateUserAddressMutation(
+      "text": "mutation CreateUserAddressMutation(
   $input: CreateUserAddressInput!
 ) {
   createUserAddress(input: $input) {

--- a/src/v2/Apps/Order/Utils/shippingAddressUtils.ts
+++ b/src/v2/Apps/Order/Utils/shippingAddressUtils.ts
@@ -3,9 +3,9 @@ import { Shipping_me } from "v2/__generated__/Shipping_me.graphql"
 import { Shipping_order } from "v2/__generated__/Shipping_order.graphql"
 import { pick, omit } from "lodash"
 import {
-  AddressModalMutationResponse,
+  UpdateUserAddressMutationResponse,
   UserAddressAttributes,
-} from "v2/__generated__/AddressModalMutation.graphql"
+} from "v2/__generated__/UpdateUserAddressMutation.graphql"
 import { NEW_ADDRESS } from "../Components/SavedAddresses"
 
 export type SavedAddressType = Shipping_me["addressConnection"]["edges"][number]["node"]
@@ -42,7 +42,7 @@ export const startingAddress = (me: Shipping_me, order: Shipping_order) => {
   return initialAddress
 }
 
-type MutationAddressResponse = AddressModalMutationResponse["updateUserAddress"]["userAddressOrErrors"]
+type MutationAddressResponse = UpdateUserAddressMutationResponse["updateUserAddress"]["userAddressOrErrors"]
 
 // Gravity address has isDefault and addressLine3 but exchange does not
 export const convertShippingAddressForExchange = (

--- a/src/v2/__generated__/CreateUserAddressMutation.graphql.ts
+++ b/src/v2/__generated__/CreateUserAddressMutation.graphql.ts
@@ -2,10 +2,9 @@
 /* eslint-disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type UpdateUserAddressInput = {
+export type CreateUserAddressInput = {
     attributes: UserAddressAttributes;
     clientMutationId?: string | null;
-    userAddressID: string;
 };
 export type UserAddressAttributes = {
     addressLine1: string;
@@ -18,23 +17,14 @@ export type UserAddressAttributes = {
     postalCode?: string | null;
     region?: string | null;
 };
-export type AddressModalMutationVariables = {
-    input: UpdateUserAddressInput;
+export type CreateUserAddressMutationVariables = {
+    input: CreateUserAddressInput;
 };
-export type AddressModalMutationResponse = {
-    readonly updateUserAddress: {
+export type CreateUserAddressMutationResponse = {
+    readonly createUserAddress: {
         readonly userAddressOrErrors: {
             readonly id?: string;
             readonly internalID?: string;
-            readonly name?: string | null;
-            readonly addressLine1?: string;
-            readonly addressLine2?: string | null;
-            readonly isDefault?: boolean;
-            readonly phoneNumber?: string | null;
-            readonly city?: string;
-            readonly region?: string | null;
-            readonly postalCode?: string | null;
-            readonly country?: string;
             readonly errors?: ReadonlyArray<{
                 readonly code: string;
                 readonly message: string;
@@ -42,32 +32,23 @@ export type AddressModalMutationResponse = {
         };
     } | null;
 };
-export type AddressModalMutation = {
-    readonly response: AddressModalMutationResponse;
-    readonly variables: AddressModalMutationVariables;
+export type CreateUserAddressMutation = {
+    readonly response: CreateUserAddressMutationResponse;
+    readonly variables: CreateUserAddressMutationVariables;
 };
 
 
 
 /*
-mutation AddressModalMutation(
-  $input: UpdateUserAddressInput!
+mutation CreateUserAddressMutation(
+  $input: CreateUserAddressInput!
 ) {
-  updateUserAddress(input: $input) {
+  createUserAddress(input: $input) {
     userAddressOrErrors {
       __typename
       ... on UserAddress {
         id
         internalID
-        name
-        addressLine1
-        addressLine2
-        isDefault
-        phoneNumber
-        city
-        region
-        postalCode
-        country
       }
       ... on Errors {
         errors {
@@ -86,7 +67,7 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "input",
-    "type": "UpdateUserAddressInput!"
+    "type": "CreateUserAddressInput!"
   }
 ],
 v1 = [
@@ -111,69 +92,6 @@ v2 = {
       "args": null,
       "kind": "ScalarField",
       "name": "internalID",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "name",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "addressLine1",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "addressLine2",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "isDefault",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "phoneNumber",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "city",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "region",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "postalCode",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "country",
       "storageKey": null
     }
   ],
@@ -215,14 +133,14 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "AddressModalMutation",
+    "name": "CreateUserAddressMutation",
     "selections": [
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "UpdateUserAddressPayload",
+        "concreteType": "CreateUserAddressPayload",
         "kind": "LinkedField",
-        "name": "updateUserAddress",
+        "name": "createUserAddress",
         "plural": false,
         "selections": [
           {
@@ -248,14 +166,14 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "AddressModalMutation",
+    "name": "CreateUserAddressMutation",
     "selections": [
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "UpdateUserAddressPayload",
+        "concreteType": "CreateUserAddressPayload",
         "kind": "LinkedField",
-        "name": "updateUserAddress",
+        "name": "createUserAddress",
         "plural": false,
         "selections": [
           {
@@ -286,11 +204,11 @@ return {
   "params": {
     "id": null,
     "metadata": {},
-    "name": "AddressModalMutation",
+    "name": "CreateUserAddressMutation",
     "operationKind": "mutation",
-    "text": "mutation AddressModalMutation(\n  $input: UpdateUserAddressInput!\n) {\n  updateUserAddress(input: $input) {\n    userAddressOrErrors {\n      __typename\n      ... on UserAddress {\n        id\n        internalID\n        name\n        addressLine1\n        addressLine2\n        isDefault\n        phoneNumber\n        city\n        region\n        postalCode\n        country\n      }\n      ... on Errors {\n        errors {\n          code\n          message\n        }\n      }\n    }\n  }\n}\n"
+    "text": "mutation CreateUserAddressMutation(\n  $input: CreateUserAddressInput!\n) {\n  createUserAddress(input: $input) {\n    userAddressOrErrors {\n      __typename\n      ... on UserAddress {\n        id\n        internalID\n      }\n      ... on Errors {\n        errors {\n          code\n          message\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '2a9bfef04f8a6dd09c0a9dcd7dddebf3';
+(node as any).hash = 'd58253f3b92c3b1e89906b6212869648';
 export default node;

--- a/src/v2/__generated__/SetShippingMutation.graphql.ts
+++ b/src/v2/__generated__/SetShippingMutation.graphql.ts
@@ -21,10 +21,10 @@ export type CommerceShippingAttributes = {
     postalCode?: string | null;
     region?: string | null;
 };
-export type ShippingOrderAddressUpdateMutationVariables = {
+export type SetShippingMutationVariables = {
     input: CommerceSetShippingInput;
 };
-export type ShippingOrderAddressUpdateMutationResponse = {
+export type SetShippingMutationResponse = {
     readonly commerceSetShipping: {
         readonly orderOrError: {
             readonly __typename: "CommerceOrderWithMutationSuccess";
@@ -55,15 +55,15 @@ export type ShippingOrderAddressUpdateMutationResponse = {
         };
     } | null;
 };
-export type ShippingOrderAddressUpdateMutation = {
-    readonly response: ShippingOrderAddressUpdateMutationResponse;
-    readonly variables: ShippingOrderAddressUpdateMutationVariables;
+export type SetShippingMutation = {
+    readonly response: SetShippingMutationResponse;
+    readonly variables: SetShippingMutationVariables;
 };
 
 
 
 /*
-mutation ShippingOrderAddressUpdateMutation(
+mutation SetShippingMutation(
   $input: CommerceSetShippingInput!
 ) {
   commerceSetShipping(input: $input) {
@@ -257,7 +257,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "ShippingOrderAddressUpdateMutation",
+    "name": "SetShippingMutation",
     "selections": [
       {
         "alias": null,
@@ -310,7 +310,7 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "ShippingOrderAddressUpdateMutation",
+    "name": "SetShippingMutation",
     "selections": [
       {
         "alias": null,
@@ -370,11 +370,11 @@ return {
   "params": {
     "id": null,
     "metadata": {},
-    "name": "ShippingOrderAddressUpdateMutation",
+    "name": "SetShippingMutation",
     "operationKind": "mutation",
-    "text": "mutation ShippingOrderAddressUpdateMutation(\n  $input: CommerceSetShippingInput!\n) {\n  commerceSetShipping(input: $input) {\n    orderOrError {\n      __typename\n      ... on CommerceOrderWithMutationSuccess {\n        __typename\n        order {\n          __typename\n          internalID\n          state\n          requestedFulfillment {\n            __typename\n            ... on CommerceShip {\n              name\n              addressLine1\n              addressLine2\n              city\n              region\n              country\n              postalCode\n              phoneNumber\n            }\n          }\n          id\n        }\n      }\n      ... on CommerceOrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n"
+    "text": "mutation SetShippingMutation(\n  $input: CommerceSetShippingInput!\n) {\n  commerceSetShipping(input: $input) {\n    orderOrError {\n      __typename\n      ... on CommerceOrderWithMutationSuccess {\n        __typename\n        order {\n          __typename\n          internalID\n          state\n          requestedFulfillment {\n            __typename\n            ... on CommerceShip {\n              name\n              addressLine1\n              addressLine2\n              city\n              region\n              country\n              postalCode\n              phoneNumber\n            }\n          }\n          id\n        }\n      }\n      ... on CommerceOrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = 'b01b849a4040a3d42a3535fdc70caeef';
+(node as any).hash = '402fccfd9aeebd5393b111281e478735';
 export default node;

--- a/src/v2/__generated__/UpdateUserAddressMutation.graphql.ts
+++ b/src/v2/__generated__/UpdateUserAddressMutation.graphql.ts
@@ -2,9 +2,10 @@
 /* eslint-disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type CreateUserAddressInput = {
+export type UpdateUserAddressInput = {
     attributes: UserAddressAttributes;
     clientMutationId?: string | null;
+    userAddressID: string;
 };
 export type UserAddressAttributes = {
     addressLine1: string;
@@ -17,14 +18,23 @@ export type UserAddressAttributes = {
     postalCode?: string | null;
     region?: string | null;
 };
-export type ShippingCreateUserAddressMutationVariables = {
-    input: CreateUserAddressInput;
+export type UpdateUserAddressMutationVariables = {
+    input: UpdateUserAddressInput;
 };
-export type ShippingCreateUserAddressMutationResponse = {
-    readonly createUserAddress: {
+export type UpdateUserAddressMutationResponse = {
+    readonly updateUserAddress: {
         readonly userAddressOrErrors: {
             readonly id?: string;
             readonly internalID?: string;
+            readonly name?: string | null;
+            readonly addressLine1?: string;
+            readonly addressLine2?: string | null;
+            readonly isDefault?: boolean;
+            readonly phoneNumber?: string | null;
+            readonly city?: string;
+            readonly region?: string | null;
+            readonly postalCode?: string | null;
+            readonly country?: string;
             readonly errors?: ReadonlyArray<{
                 readonly code: string;
                 readonly message: string;
@@ -32,23 +42,32 @@ export type ShippingCreateUserAddressMutationResponse = {
         };
     } | null;
 };
-export type ShippingCreateUserAddressMutation = {
-    readonly response: ShippingCreateUserAddressMutationResponse;
-    readonly variables: ShippingCreateUserAddressMutationVariables;
+export type UpdateUserAddressMutation = {
+    readonly response: UpdateUserAddressMutationResponse;
+    readonly variables: UpdateUserAddressMutationVariables;
 };
 
 
 
 /*
-mutation ShippingCreateUserAddressMutation(
-  $input: CreateUserAddressInput!
+mutation UpdateUserAddressMutation(
+  $input: UpdateUserAddressInput!
 ) {
-  createUserAddress(input: $input) {
+  updateUserAddress(input: $input) {
     userAddressOrErrors {
       __typename
       ... on UserAddress {
         id
         internalID
+        name
+        addressLine1
+        addressLine2
+        isDefault
+        phoneNumber
+        city
+        region
+        postalCode
+        country
       }
       ... on Errors {
         errors {
@@ -67,7 +86,7 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "input",
-    "type": "CreateUserAddressInput!"
+    "type": "UpdateUserAddressInput!"
   }
 ],
 v1 = [
@@ -92,6 +111,69 @@ v2 = {
       "args": null,
       "kind": "ScalarField",
       "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "addressLine1",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "addressLine2",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isDefault",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "phoneNumber",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "city",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "region",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "postalCode",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "country",
       "storageKey": null
     }
   ],
@@ -133,14 +215,14 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "ShippingCreateUserAddressMutation",
+    "name": "UpdateUserAddressMutation",
     "selections": [
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "CreateUserAddressPayload",
+        "concreteType": "UpdateUserAddressPayload",
         "kind": "LinkedField",
-        "name": "createUserAddress",
+        "name": "updateUserAddress",
         "plural": false,
         "selections": [
           {
@@ -166,14 +248,14 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "ShippingCreateUserAddressMutation",
+    "name": "UpdateUserAddressMutation",
     "selections": [
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "CreateUserAddressPayload",
+        "concreteType": "UpdateUserAddressPayload",
         "kind": "LinkedField",
-        "name": "createUserAddress",
+        "name": "updateUserAddress",
         "plural": false,
         "selections": [
           {
@@ -204,11 +286,11 @@ return {
   "params": {
     "id": null,
     "metadata": {},
-    "name": "ShippingCreateUserAddressMutation",
+    "name": "UpdateUserAddressMutation",
     "operationKind": "mutation",
-    "text": "mutation ShippingCreateUserAddressMutation(\n  $input: CreateUserAddressInput!\n) {\n  createUserAddress(input: $input) {\n    userAddressOrErrors {\n      __typename\n      ... on UserAddress {\n        id\n        internalID\n      }\n      ... on Errors {\n        errors {\n          code\n          message\n        }\n      }\n    }\n  }\n}\n"
+    "text": "mutation UpdateUserAddressMutation(\n  $input: UpdateUserAddressInput!\n) {\n  updateUserAddress(input: $input) {\n    userAddressOrErrors {\n      __typename\n      ... on UserAddress {\n        id\n        internalID\n        name\n        addressLine1\n        addressLine2\n        isDefault\n        phoneNumber\n        city\n        region\n        postalCode\n        country\n      }\n      ... on Errors {\n        errors {\n          code\n          message\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '6acb5693bdd8fbbf5ce46a3e2d63d03e';
+(node as any).hash = 'c0b17f3129542653a592f68b76865ace';
 export default node;


### PR DESCRIPTION
Follow up to https://github.com/artsy/force/pull/7037 @damassi caught a problem that the module/file names are not consistent 🙌🏽 

Corrected the mutation module file names to match and make them consistent. The diff looks a bit crazy but basically, I did these changes to mutation files in `src/v2/Apps/Order/Mutations`:
```
ShippingCreateUserAddress -> CreateUserAddress
ShippingOrderAddressUpdate -> SetShipping
AddressModal -> UpdateUserAddress
```

The rest is updating references.
