### PR TITLE
feat: add galleries/institutions auto-complete for filter

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnerAutosuggest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnerAutosuggest.tsx
@@ -1,0 +1,101 @@
+import { BorderBox, Box, Checkbox } from "@artsy/palette"
+import React, { FC, useState } from "react"
+import Autosuggest from "react-autosuggest"
+import { SearchInputContainer } from "v2/Components/Search/SearchInputContainer"
+import { useArtworkFilterContext } from "../ArtworkFilterContext"
+import { OptionText } from "./OptionText"
+
+type Partner = {
+  name: string
+  count: number
+  value: string
+}
+
+const MAX_SUGGESTIONS = 10
+
+export const PartnerAutosuggest: FC<{ partners: Array<Partner> }> = ({
+  partners,
+}) => {
+  const getSuggestions = ({ value }) => {
+    const inputValue = value.trim().toLowerCase()
+    const inputLength = inputValue.length
+
+    return inputLength === 0
+      ? []
+      : partners
+          .filter(
+            partner =>
+              !filterContext
+                .currentlySelectedFilters()
+                .partnerIDs.includes(partner.value) &&
+              partner.name.toLowerCase().slice(0, inputLength) === inputValue
+          )
+          .sort()
+          .slice(0, MAX_SUGGESTIONS)
+  }
+
+  const getSuggestionValue = ({ name }) => name
+
+  const renderSuggestion = ({ name }, { isHighlighted }) => {
+    return (
+      <Checkbox selected={isHighlighted}>
+        <OptionText>{name}</OptionText>
+      </Checkbox>
+    )
+  }
+
+  const [value, setValue] = useState("")
+  const [suggestions, setSuggestions] = useState([])
+  const [focused, setFocus] = useState(false)
+
+  const inputProps = {
+    placeholder: "Enter a gallery",
+    value,
+    onChange: (_e, { newValue }) => setValue(newValue),
+    onFocus: () => setFocus(true),
+    onBlur: () => setFocus(false),
+  }
+
+  const filterContext = useArtworkFilterContext()
+
+  const onSuggestionSelected = ({ suggestion: { value } }) => {
+    let partnerIDs = filterContext.currentlySelectedFilters().partnerIDs.slice()
+    partnerIDs.push(value)
+    filterContext.setFilter("partnerIDs", partnerIDs)
+  }
+
+  const renderInputComponent = props => <SearchInputContainer {...props} />
+
+  const renderSuggestionsContainer = ({ children, containerProps }) => {
+    const noResults = suggestions.length === 0
+
+    if (focused && noResults && value) {
+      return "No results found."
+    }
+
+    return noResults ? (
+      <Box>{children}</Box>
+    ) : (
+      <BorderBox {...containerProps}>{children}</BorderBox>
+    )
+  }
+
+  return (
+    <Autosuggest
+      suggestions={suggestions}
+      getSuggestionValue={getSuggestionValue}
+      renderSuggestion={renderSuggestion}
+      inputProps={inputProps}
+      onSuggestionsFetchRequested={val => setSuggestions(getSuggestions(val))}
+      onSuggestionsClearRequested={() => {
+        setSuggestions([])
+        setFocus(false)
+      }}
+      onSuggestionSelected={(_e, selection) => {
+        onSuggestionSelected(selection)
+      }}
+      renderInputComponent={renderInputComponent}
+      renderSuggestionsContainer={props => renderSuggestionsContainer(props)}
+    />
+  )
+}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components"
 
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
+import { PartnerAutosuggest } from "./PartnerAutosuggest"
 
 const ToggleLink = styled(Text)`
   cursor: pointer;
@@ -80,6 +81,7 @@ export const PartnersFilter: FC = () => {
   return (
     <Toggle label="Galleries and institutions" expanded>
       <Flex flexDirection="column">
+        <PartnerAutosuggest partners={partners.counts} />
         {renderPartnerGroup(initialPartnersGroup)}
 
         {!expanded && remainingPartnersGroup.length && <ExpandControl />}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/PartnerAutosuggest.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/PartnerAutosuggest.jest.tsx
@@ -1,0 +1,52 @@
+import { PartnerAutosuggest } from "../PartnerAutosuggest"
+import { ReactWrapper, mount } from "enzyme"
+import React from "react"
+import { ArtworkFilterContextProvider } from "../../ArtworkFilterContext"
+
+const searchResults = [
+  {
+    value: "doggy-gallery",
+    count: 12,
+    name: "Doggy Gallery",
+  },
+  {
+    value: "catty-gallery",
+    count: 12,
+    name: "Catty Gallery",
+  },
+]
+
+const simulateTyping = (wrapper: ReactWrapper, text: string) => {
+  const textArea = wrapper.find("input")
+  textArea.simulate("focus")
+  // @ts-ignore
+  textArea.getDOMNode().value = text
+  textArea.simulate("change")
+}
+
+const getWrapper = suggestions => {
+  return mount(
+    <ArtworkFilterContextProvider>
+      <PartnerAutosuggest partners={suggestions} />
+    </ArtworkFilterContextProvider>
+  )
+}
+
+describe("SearchBar", () => {
+  it("displays search results", () => {
+    const component = getWrapper(searchResults)
+
+    simulateTyping(component, "cat")
+
+    expect(component.text()).toContain("Catty Gallery")
+    expect(component.text()).not.toContain("Doggy Gallery")
+  })
+
+  it("displays empty state", () => {
+    const component = getWrapper(searchResults)
+
+    simulateTyping(component, "magic")
+
+    expect(component.text()).toContain("No results found.")
+  })
+})


### PR DESCRIPTION
![Feb-16-2021 15-44-14](https://user-images.githubusercontent.com/1457859/108121132-4d45cc00-7070-11eb-9d14-15eddd3814a3.gif)

Uses the `react-autosuggest` lib, I figure this might be good enough to merge and iterate on the behavior. This combined galleries/institutions filter itself is behind a feature flag, so should be safe to merge.