### PR TITLE
feature: Convert Identity Verification Routes

### DIFF
--- a/src/desktop/lib/webpackPublicPath.ts
+++ b/src/desktop/lib/webpackPublicPath.ts
@@ -24,10 +24,10 @@ if (process.env.NODE_ENV === "production") {
 
   // TODO: Remove this as its temporary while routes are being converted.
   const convertedRoutes = [
-    "/artist/",
-    "/artists",
     "/art-fairs",
     "/artist-series",
+    "/artist/",
+    "/artists",
     "/collect",
     "/collection",
     "/collections",
@@ -37,12 +37,13 @@ if (process.env.NODE_ENV === "production") {
     "/fair/",
     "/fairs",
     "/feature/",
-    "/show/",
+    "/identity-verification",
     "/search",
+    "/show/",
     "/user/conversations",
     "/user/purchases",
-    "/viewing-rooms",
     "/viewing-room/",
+    "/viewing-rooms",
   ]
 
   function beenConverted() {

--- a/src/v2/Apps/getAppNovoRoutes.tsx
+++ b/src/v2/Apps/getAppNovoRoutes.tsx
@@ -72,6 +72,7 @@ export function getAppNovoRoutes(): RouteConfig[] {
         routes: featureRoutes,
       },
       {
+        converted: true,
         routes: identityVerificationRoutes,
       },
       {

--- a/src/v2/Apps/getAppRoutes.tsx
+++ b/src/v2/Apps/getAppRoutes.tsx
@@ -12,7 +12,7 @@ import { artworkRoutes } from "v2/Apps/Artwork/artworkRoutes"
 // import { fairRoutes } from "v2/Apps/Fair/fairRoutes"
 // import { fairsRoutes } from "v2/Apps/Fairs/fairsRoutes"
 // import { featureRoutes } from "v2/Apps/Feature/featureRoutes"
-import { identityVerificationRoutes } from "v2/Apps/IdentityVerification/identityVerificationRoutes"
+// import { identityVerificationRoutes } from "v2/Apps/IdentityVerification/identityVerificationRoutes"
 import { orderRoutes } from "v2/Apps/Order/orderRoutes"
 // import { purchaseRoutes } from "v2/Apps/Purchase/purchaseRoutes"
 // import { searchRoutes } from "v2/Apps/Search/searchRoutes"
@@ -64,9 +64,9 @@ export function getAppRoutes(): RouteConfig[] {
     // {
     //   routes: featureRoutes,
     // },
-    {
-      routes: identityVerificationRoutes,
-    },
+    // {
+    //   routes: identityVerificationRoutes,
+    // },
     {
       routes: orderRoutes,
     },


### PR DESCRIPTION
This change converts the `/identity-verification` routes to the NOVO template.