### PR TITLE
GRO-174: Adding H1 Tag on artsy.net/articles for SEO

### DIFF
--- a/src/desktop/apps/article/components/App.tsx
+++ b/src/desktop/apps/article/components/App.tsx
@@ -9,7 +9,11 @@ import { data as sd } from "sharify"
 import { ArticleProps } from "@artsy/reaction/dist/Components/Publishing/Article"
 import { ClassicArticleLayout } from "desktop/apps/article/components/layouts/Classic"
 import { mediator } from "lib/mediator"
+import styled from "styled-components"
 
+const StyledHeader = styled.h1`
+  visibility: hidden;
+`
 export interface AppProps extends ArticleProps {
   templates?: {
     SuperArticleFooter: string
@@ -50,10 +54,8 @@ export class App extends React.Component<AppProps> {
       }
     }
   }
-
   render() {
     const { article } = this.props
-
     return (
       <Fragment>
         <EditPortal article={article} />
@@ -61,7 +63,7 @@ export class App extends React.Component<AppProps> {
           user={sd.CURRENT_USER}
           mediator={mediator as Mediator}
         >
-          {this.getArticleLayout()}
+          <StyledHeader>{this.getArticleLayout()}</StyledHeader>
         </SystemContextProvider>
       </Fragment>
     )

--- a/src/desktop/apps/article/components/App.tsx
+++ b/src/desktop/apps/article/components/App.tsx
@@ -9,11 +9,7 @@ import { data as sd } from "sharify"
 import { ArticleProps } from "@artsy/reaction/dist/Components/Publishing/Article"
 import { ClassicArticleLayout } from "desktop/apps/article/components/layouts/Classic"
 import { mediator } from "lib/mediator"
-import styled from "styled-components"
 
-const StyledHeader = styled.h1`
-  visibility: hidden;
-`
 export interface AppProps extends ArticleProps {
   templates?: {
     SuperArticleFooter: string
@@ -63,7 +59,7 @@ export class App extends React.Component<AppProps> {
           user={sd.CURRENT_USER}
           mediator={mediator as Mediator}
         >
-          <StyledHeader>{this.getArticleLayout()}</StyledHeader>
+          {this.getArticleLayout()}
         </SystemContextProvider>
       </Fragment>
     )

--- a/src/desktop/apps/articles/templates/articles.jade
+++ b/src/desktop/apps/articles/templates/articles.jade
@@ -9,4 +9,6 @@ append locals
   - bodyClass = bodyClass + ' body-articles'
 
 block body
+  h1(style={visibility:"hidden"})
+    | Editorial | Artsy
   include full_feed


### PR DESCRIPTION
This is for ticket [GRO-174]: 

We were missing a H1 Tag on artsy.net/articles. Since no additional descriptive text on this page, the H1 is the same as the title tag **Editorial | Artsy**. Jenna also requested that the visibility be hidden for this H1 tag.

New Behavior:
<img width="1441" alt="Screen Shot 2021-02-17 at 1 43 34 PM" src="https://user-images.githubusercontent.com/30025439/108272681-71b0af80-7127-11eb-83ed-b6f086e32d89.png">


[GRO-174]: https://artsyproduct.atlassian.net/browse/GRO-174