### PR TITLE
refactor: Gut onboarding wizard GRO-61

### DIFF
--- a/src/v2/Components/Onboarding/Steps/Artists/index.tsx
+++ b/src/v2/Components/Onboarding/Steps/Artists/index.tsx
@@ -1,7 +1,7 @@
 import { throttle } from "lodash"
 import React from "react"
 import styled from "styled-components"
-import { ProgressIndicator } from "../../../ProgressIndicator"
+import { ProgressIndicator } from "v2/Components/ProgressIndicator"
 import Colors from "../../../../Assets/Colors"
 import Input from "../../../Input"
 

--- a/src/v2/Components/Onboarding/Steps/Artists/index.tsx
+++ b/src/v2/Components/Onboarding/Steps/Artists/index.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components"
 import { ProgressIndicator } from "v2/Components/ProgressIndicator"
 import Colors from "../../../../Assets/Colors"
 import Input from "../../../Input"
-
+import { Spacer } from "@artsy/palette"
 import { MultiButtonState } from "../../../Buttons/MultiStateButton"
 import { media } from "../../../Helpers"
 import { StepProps } from "../../Types"
@@ -90,7 +90,7 @@ export default class Artists extends React.Component<StepProps, State> {
               onCut={this.searchTextChanged.bind(this)}
               autoFocus
             />
-            <div style={{ marginBottom: "35px" }} />
+            <Spacer my={2} />
             <ArtistList
               searchQuery={this.state.inputTextQuery}
               updateFollowCount={this.updateFollowCount.bind(this)}

--- a/src/v2/Components/Onboarding/Steps/Artists/index.tsx
+++ b/src/v2/Components/Onboarding/Steps/Artists/index.tsx
@@ -28,8 +28,6 @@ interface State {
 }
 
 export default class Artists extends React.Component<StepProps, State> {
-  static slug: "artists" = "artists"
-
   state = {
     inputText: "",
     inputTextQuery: "",

--- a/src/v2/Components/Onboarding/Steps/Artists/index.tsx
+++ b/src/v2/Components/Onboarding/Steps/Artists/index.tsx
@@ -1,7 +1,7 @@
 import { throttle } from "lodash"
 import React from "react"
 import styled from "styled-components"
-
+import { ProgressIndicator } from "../../../ProgressIndicator"
 import Colors from "../../../../Assets/Colors"
 import Input from "../../../Input"
 
@@ -71,32 +71,35 @@ export default class Artists extends React.Component<StepProps, State> {
 
   render() {
     return (
-      <Layout
-        title="Who are your favorite artists?"
-        subtitle="Follow one or more"
-        onNextButtonPressed={this.submit.bind(this)}
-        buttonState={
-          this.state.followCount > 0
-            ? MultiButtonState.Highlighted
-            : MultiButtonState.Default
-        }
-      >
-        <OnboardingSearchBox>
-          <Input
-            placeholder={"Search artists..."}
-            block
-            onInput={this.searchTextChanged.bind(this)}
-            onPaste={this.searchTextChanged.bind(this)}
-            onCut={this.searchTextChanged.bind(this)}
-            autoFocus
-          />
-          <div style={{ marginBottom: "35px" }} />
-          <ArtistList
-            searchQuery={this.state.inputTextQuery}
-            updateFollowCount={this.updateFollowCount.bind(this)}
-          />
-        </OnboardingSearchBox>
-      </Layout>
+      <>
+        <ProgressIndicator percentComplete={0.25} />
+        <Layout
+          title="Who are your favorite artists?"
+          subtitle="Follow one or more"
+          onNextButtonPressed={this.submit.bind(this)}
+          buttonState={
+            this.state.followCount > 0
+              ? MultiButtonState.Highlighted
+              : MultiButtonState.Default
+          }
+        >
+          <OnboardingSearchBox>
+            <Input
+              placeholder={"Search artists..."}
+              block
+              onInput={this.searchTextChanged.bind(this)}
+              onPaste={this.searchTextChanged.bind(this)}
+              onCut={this.searchTextChanged.bind(this)}
+              autoFocus
+            />
+            <div style={{ marginBottom: "35px" }} />
+            <ArtistList
+              searchQuery={this.state.inputTextQuery}
+              updateFollowCount={this.updateFollowCount.bind(this)}
+            />
+          </OnboardingSearchBox>
+        </Layout>
+      </>
     )
   }
 }

--- a/src/v2/Components/Onboarding/Steps/Artists/index.tsx
+++ b/src/v2/Components/Onboarding/Steps/Artists/index.tsx
@@ -43,8 +43,7 @@ export default class Artists extends React.Component<StepProps, State> {
   }
 
   submit() {
-    const increaseBy = this.state.followCount >= 4 ? 2 : 1
-    this.props.onNextButtonPressed(increaseBy)
+    this.props.history.push("/personalize/categories")
   }
 
   componentDidMount() {

--- a/src/v2/Components/Onboarding/Steps/Budget.tsx
+++ b/src/v2/Components/Onboarding/Steps/Budget.tsx
@@ -7,9 +7,12 @@ import { SystemContextProps, withSystemContext } from "v2/Artsy"
 import Colors from "../../../Assets/Colors"
 import { MultiButtonState } from "../../Buttons/MultiStateButton"
 import { media } from "../../Helpers"
+import { Props } from "../Wizard"
 import SelectableToggle from "../SelectableToggle"
 import { StepProps } from "../Types"
 import { Layout } from "./Layout"
+import track from "react-tracking"
+import Events from "../../../Utils/Events"
 
 const OptionsContainer = styled.div`
   width: 450px;
@@ -28,8 +31,9 @@ interface State {
   selection: number | null
 }
 
+@track({}, { dispatch: data => Events.postEvent(data) })
 export class BudgetComponent extends React.Component<
-  StepProps & SystemContextProps,
+  Props & StepProps & SystemContextProps,
   State
 > {
   static slug: "budget" = "budget"
@@ -80,7 +84,12 @@ export class BudgetComponent extends React.Component<
       }
     )
 
-    this.props.onNextButtonPressed()
+    const redirectTo = this.props.redirectTo || "/"
+    setTimeout(() => window.location.assign(redirectTo), 500)
+
+    this.props.tracking.trackEvent({
+      action: "Completed Onboarding",
+    })
   }
 
   render() {

--- a/src/v2/Components/Onboarding/Steps/Budget.tsx
+++ b/src/v2/Components/Onboarding/Steps/Budget.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { commitMutation, graphql } from "react-relay"
 import styled from "styled-components"
-import { ProgressIndicator } from "../../ProgressIndicator"
+import { ProgressIndicator } from "v2/Components/ProgressIndicator"
 import { BudgetUpdateMyUserProfileMutation } from "v2/__generated__/BudgetUpdateMyUserProfileMutation.graphql"
 import { SystemContextProps, withSystemContext } from "v2/Artsy"
 import Colors from "../../../Assets/Colors"

--- a/src/v2/Components/Onboarding/Steps/Budget.tsx
+++ b/src/v2/Components/Onboarding/Steps/Budget.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { commitMutation, graphql } from "react-relay"
 import styled from "styled-components"
-
+import { ProgressIndicator } from "../../ProgressIndicator"
 import { BudgetUpdateMyUserProfileMutation } from "v2/__generated__/BudgetUpdateMyUserProfileMutation.graphql"
 import { SystemContextProps, withSystemContext } from "v2/Artsy"
 import Colors from "../../../Assets/Colors"
@@ -103,19 +103,22 @@ export class BudgetComponent extends React.Component<
     ))
 
     return (
-      <Layout
-        title="What’s your maximum artwork budget?"
-        subtitle="Select one"
-        onNextButtonPressed={this.state.selection && this.submit.bind(this)}
-        isLastStep
-        buttonState={
-          this.state.selection
-            ? MultiButtonState.Highlighted
-            : MultiButtonState.Default
-        }
-      >
-        <OptionsContainer>{options}</OptionsContainer>
-      </Layout>
+      <>
+        <ProgressIndicator percentComplete={0.75} />
+        <Layout
+          title="What’s your maximum artwork budget?"
+          subtitle="Select one"
+          onNextButtonPressed={this.state.selection && this.submit.bind(this)}
+          isLastStep
+          buttonState={
+            this.state.selection
+              ? MultiButtonState.Highlighted
+              : MultiButtonState.Default
+          }
+        >
+          <OptionsContainer>{options}</OptionsContainer>
+        </Layout>
+      </>
     )
   }
 }

--- a/src/v2/Components/Onboarding/Steps/Budget.tsx
+++ b/src/v2/Components/Onboarding/Steps/Budget.tsx
@@ -36,8 +36,6 @@ export class BudgetComponent extends React.Component<
   Props & StepProps & SystemContextProps,
   State
 > {
-  static slug: "budget" = "budget"
-
   options = {
     "UNDER $500": 500,
     "UNDER $2,500": 2500,
@@ -124,7 +122,4 @@ export class BudgetComponent extends React.Component<
 }
 
 const Budget = withSystemContext(BudgetComponent)
-// tslint:disable:no-string-literal
-Budget["slug"] = BudgetComponent.slug
-
 export default Budget

--- a/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
+++ b/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { commitMutation, graphql } from "react-relay"
 import styled from "styled-components"
-
+import { ProgressIndicator } from "../../ProgressIndicator"
 import {
   CollectorIntentUpdateCollectorProfileMutation,
   Intents,
@@ -108,18 +108,21 @@ export class CollectorIntentComponent extends React.Component<Props, State> {
     ))
 
     return (
-      <Layout
-        title="How would you like to use Artsy?"
-        subtitle="Select all that apply"
-        onNextButtonPressed={this.submit.bind(this)}
-        buttonState={
-          this.selectedIntents().length > 0
-            ? MultiButtonState.Highlighted
-            : MultiButtonState.Default
-        }
-      >
-        <OptionsContainer>{options}</OptionsContainer>
-      </Layout>
+      <>
+        <ProgressIndicator percentComplete={0} />
+        <Layout
+          title="How would you like to use Artsy?"
+          subtitle="Select all that apply"
+          onNextButtonPressed={this.submit.bind(this)}
+          buttonState={
+            this.selectedIntents().length > 0
+              ? MultiButtonState.Highlighted
+              : MultiButtonState.Default
+          }
+        >
+          <OptionsContainer>{options}</OptionsContainer>
+        </Layout>
+      </>
     )
   }
 }

--- a/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
+++ b/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
@@ -109,7 +109,7 @@ export class CollectorIntentComponent extends React.Component<Props, State> {
 
     return (
       <>
-        <ProgressIndicator percentComplete={0} />
+        <ProgressIndicator />
         <Layout
           title="How would you like to use Artsy?"
           subtitle="Select all that apply"

--- a/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
+++ b/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
@@ -92,7 +92,7 @@ export class CollectorIntentComponent extends React.Component<Props, State> {
       }
     )
 
-    this.props.onNextButtonPressed()
+    this.props.history.push("/personalize/artists")
   }
 
   render() {

--- a/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
+++ b/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { commitMutation, graphql } from "react-relay"
 import styled from "styled-components"
-import { ProgressIndicator } from "../../ProgressIndicator"
+import { ProgressIndicator } from "v2/Components/ProgressIndicator"
 import {
   CollectorIntentUpdateCollectorProfileMutation,
   Intents,

--- a/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
+++ b/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
@@ -34,8 +34,6 @@ interface State {
 }
 
 export class CollectorIntentComponent extends React.Component<Props, State> {
-  static slug: "interests" = "interests"
-
   static intentEnum = {
     "buy art & design": "BUY_ART_AND_DESIGN",
     "sell art & design": "SELL_ART_AND_DESIGN",
@@ -128,7 +126,4 @@ export class CollectorIntentComponent extends React.Component<Props, State> {
 }
 
 const CollectorIntent = withSystemContext(CollectorIntentComponent)
-// tslint:disable:no-string-literal
-CollectorIntent["slug"] = CollectorIntentComponent.slug
-
 export default CollectorIntent

--- a/src/v2/Components/Onboarding/Steps/Genes/index.tsx
+++ b/src/v2/Components/Onboarding/Steps/Genes/index.tsx
@@ -60,8 +60,7 @@ export default class Genes extends React.Component<StepProps, State> {
   }
 
   handleNextButtonClick() {
-    const increaseBy = 1
-    this.props.onNextButtonPressed(increaseBy)
+    this.props.history.push("/personalize/budget")
   }
 
   render() {

--- a/src/v2/Components/Onboarding/Steps/Genes/index.tsx
+++ b/src/v2/Components/Onboarding/Steps/Genes/index.tsx
@@ -1,7 +1,7 @@
 import { throttle } from "lodash"
 import React from "react"
 import styled from "styled-components"
-import { ProgressIndicator } from "../../../ProgressIndicator"
+import { ProgressIndicator } from "v2/Components/ProgressIndicator"
 import Colors from "../../../../Assets/Colors"
 import Input from "../../../Input"
 

--- a/src/v2/Components/Onboarding/Steps/Genes/index.tsx
+++ b/src/v2/Components/Onboarding/Steps/Genes/index.tsx
@@ -28,8 +28,6 @@ interface State {
 }
 
 export default class Genes extends React.Component<StepProps, State> {
-  static slug = "categories"
-
   state = { inputText: "", inputTextQuery: "", followCount: 0 }
 
   updateFollowCount(count: number) {

--- a/src/v2/Components/Onboarding/Steps/Genes/index.tsx
+++ b/src/v2/Components/Onboarding/Steps/Genes/index.tsx
@@ -1,7 +1,7 @@
 import { throttle } from "lodash"
 import React from "react"
 import styled from "styled-components"
-
+import { ProgressIndicator } from "../../../ProgressIndicator"
 import Colors from "../../../../Assets/Colors"
 import Input from "../../../Input"
 
@@ -65,35 +65,38 @@ export default class Genes extends React.Component<StepProps, State> {
 
   render() {
     return (
-      <Layout
-        title="What categories most interest you?"
-        subtitle="Follow one or more"
-        onNextButtonPressed={this.handleNextButtonClick.bind(this)}
-        buttonState={
-          this.state.followCount > 0
-            ? MultiButtonState.Highlighted
-            : MultiButtonState.Default
-        }
-      >
-        <OnboardingSearchBox>
-          <Input
-            placeholder={"Search categories..."}
-            block
-            onInput={this.searchTextChanged}
-            onPaste={this.searchTextChanged}
-            onCut={this.searchTextChanged}
-            value={this.state.inputText}
-            autoFocus
-          />
-          <div style={{ marginBottom: "35px" }} />
-          {
-            <GeneList
-              searchQuery={this.state.inputTextQuery}
-              updateFollowCount={this.updateFollowCount.bind(this)}
-            />
+      <>
+        <ProgressIndicator percentComplete={0.5} />
+        <Layout
+          title="What categories most interest you?"
+          subtitle="Follow one or more"
+          onNextButtonPressed={this.handleNextButtonClick.bind(this)}
+          buttonState={
+            this.state.followCount > 0
+              ? MultiButtonState.Highlighted
+              : MultiButtonState.Default
           }
-        </OnboardingSearchBox>
-      </Layout>
+        >
+          <OnboardingSearchBox>
+            <Input
+              placeholder={"Search categories..."}
+              block
+              onInput={this.searchTextChanged}
+              onPaste={this.searchTextChanged}
+              onCut={this.searchTextChanged}
+              value={this.state.inputText}
+              autoFocus
+            />
+            <div style={{ marginBottom: "35px" }} />
+            {
+              <GeneList
+                searchQuery={this.state.inputTextQuery}
+                updateFollowCount={this.updateFollowCount.bind(this)}
+              />
+            }
+          </OnboardingSearchBox>
+        </Layout>
+      </>
     )
   }
 }

--- a/src/v2/Components/Onboarding/Types.ts
+++ b/src/v2/Components/Onboarding/Types.ts
@@ -1,8 +1,3 @@
-import Artists from "./Steps/Artists"
-import { BudgetComponent as Budget } from "./Steps/Budget"
-import { CollectorIntentComponent as CollectorIntent } from "./Steps/CollectorIntent"
-import Genes from "./Steps/Genes"
-
 /**
  * The props interface that the step needs to implement for the wizard.
  */
@@ -10,17 +5,6 @@ export interface StepProps {
   history
 }
 
-export interface StepComponent extends React.ComponentClass<StepProps> {
-  slug?: string
-}
-
 export interface FollowProps {
   updateFollowCount: (count: number) => void
 }
-
-export type StepSlugs =
-  | typeof Budget.slug
-  | typeof Artists.slug
-  | typeof Genes.slug
-  | typeof CollectorIntent.slug
-  | null

--- a/src/v2/Components/Onboarding/Types.ts
+++ b/src/v2/Components/Onboarding/Types.ts
@@ -7,7 +7,7 @@ import Genes from "./Steps/Genes"
  * The props interface that the step needs to implement for the wizard.
  */
 export interface StepProps {
-  onNextButtonPressed: (increaseBy?) => void
+  history
 }
 
 export interface StepComponent extends React.ComponentClass<StepProps> {

--- a/src/v2/Components/Onboarding/Wizard.jest.tsx
+++ b/src/v2/Components/Onboarding/Wizard.jest.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+import { MemoryRouter } from "react-router"
+import { mount } from "enzyme"
+import { Wizard } from "./Wizard"
+
+describe("Wizard", () => {
+  it("can render", () => {
+    const props = {}
+    const wrapper = mount(
+      <MemoryRouter>
+        <Wizard {...props} />
+      </MemoryRouter>
+    )
+    expect(wrapper.find("Route")).toHaveLength(4)
+  })
+})

--- a/src/v2/Components/Onboarding/Wizard.tsx
+++ b/src/v2/Components/Onboarding/Wizard.tsx
@@ -22,10 +22,6 @@ export interface Props {
 }
 
 export class Wizard extends React.Component<Props> {
-  onNextButtonPressed = (increaseBy: number, history) => {
-    history.push(STEPS[STEPS.indexOf(location.pathname) + increaseBy])
-  }
-
   render() {
     const percentComplete = STEPS.indexOf(location.pathname) / STEPS.length
 
@@ -35,36 +31,17 @@ export class Wizard extends React.Component<Props> {
 
         <Route
           path={`/personalize/${CollectorIntentComponent.slug}`}
-          render={props => (
-            <CollectorIntent
-              {...props}
-              onNextButtonPressed={(increaseBy = 1) =>
-                this.onNextButtonPressed(increaseBy, props.history)
-              }
-            />
+          render={routeProps => (
+            <CollectorIntent {...routeProps} {...this.props} />
           )}
         />
         <Route
           path={`/personalize/${Artists.slug}`}
-          render={props => (
-            <Artists
-              {...props}
-              onNextButtonPressed={(increaseBy = 1) =>
-                this.onNextButtonPressed(increaseBy, props.history)
-              }
-            />
-          )}
+          render={routeProps => <Artists {...routeProps} {...this.props} />}
         />
         <Route
           path={`/personalize/${Genes.slug}`}
-          render={props => (
-            <Genes
-              {...props}
-              onNextButtonPressed={(increaseBy = 1) =>
-                this.onNextButtonPressed(increaseBy, props.history)
-              }
-            />
-          )}
+          render={routeProps => <Genes {...routeProps} {...this.props} />}
         />
         <Route
           path={`/personalize/${BudgetComponent.slug}`}

--- a/src/v2/Components/Onboarding/Wizard.tsx
+++ b/src/v2/Components/Onboarding/Wizard.tsx
@@ -57,10 +57,7 @@ export class Wizard extends React.Component<Props, State> {
 
     return (
       <div>
-        <Route
-          path="/personalize/*"
-          render={() => <ProgressIndicator percentComplete={percentComplete} />}
-        />
+        <ProgressIndicator percentComplete={percentComplete} />
 
         <Route
           path={`/personalize/${CollectorIntentComponent.slug}`}

--- a/src/v2/Components/Onboarding/Wizard.tsx
+++ b/src/v2/Components/Onboarding/Wizard.tsx
@@ -1,10 +1,7 @@
 import React from "react"
 import { Route } from "react-router"
-
-import track, { TrackingProp } from "react-tracking"
-import Events from "../../Utils/Events"
+import { TrackingProp } from "react-tracking"
 import { ProgressIndicator } from "../ProgressIndicator"
-
 import Artists from "./Steps/Artists"
 import Budget, { BudgetComponent } from "./Steps/Budget"
 import CollectorIntent, {
@@ -24,37 +21,13 @@ export interface Props {
   tracking?: TrackingProp
 }
 
-export interface State {
-  finished: boolean
-}
-
-@track({}, { dispatch: data => Events.postEvent(data) })
-export class Wizard extends React.Component<Props, State> {
-  constructor(props) {
-    super(props)
-    this.state = {
-      finished: false,
-    }
-  }
-
+export class Wizard extends React.Component<Props> {
   onNextButtonPressed = (increaseBy: number, history) => {
     history.push(STEPS[STEPS.indexOf(location.pathname) + increaseBy])
   }
 
-  onFinish = () => {
-    this.setState({ finished: true })
-    const redirectTo = this.props.redirectTo || "/"
-    setTimeout(() => window.location.assign(redirectTo), 500)
-
-    this.props.tracking.trackEvent({
-      action: "Completed Onboarding",
-    })
-  }
-
   render() {
-    const percentComplete = this.state.finished
-      ? 1
-      : STEPS.indexOf(location.pathname) / STEPS.length
+    const percentComplete = STEPS.indexOf(location.pathname) / STEPS.length
 
     return (
       <div>
@@ -95,9 +68,7 @@ export class Wizard extends React.Component<Props, State> {
         />
         <Route
           path={`/personalize/${BudgetComponent.slug}`}
-          render={props => (
-            <Budget {...props} onNextButtonPressed={() => this.onFinish()} />
-          )}
+          render={routeProps => <Budget {...routeProps} {...this.props} />}
         />
       </div>
     )

--- a/src/v2/Components/Onboarding/Wizard.tsx
+++ b/src/v2/Components/Onboarding/Wizard.tsx
@@ -13,29 +13,25 @@ export interface Props {
   tracking?: TrackingProp
 }
 
-export class Wizard extends React.Component<Props> {
-  render() {
-    return (
-      <div>
-        <Route
-          path={`/personalize/${CollectorIntentComponent.slug}`}
-          render={routeProps => (
-            <CollectorIntent {...routeProps} {...this.props} />
-          )}
-        />
-        <Route
-          path={`/personalize/${Artists.slug}`}
-          render={routeProps => <Artists {...routeProps} {...this.props} />}
-        />
-        <Route
-          path={`/personalize/${Genes.slug}`}
-          render={routeProps => <Genes {...routeProps} {...this.props} />}
-        />
-        <Route
-          path={`/personalize/${BudgetComponent.slug}`}
-          render={routeProps => <Budget {...routeProps} {...this.props} />}
-        />
-      </div>
-    )
-  }
+export const Wizard: React.FC<Props> = props => {
+  return (
+    <div>
+      <Route
+        path={`/personalize/${CollectorIntentComponent.slug}`}
+        render={routeProps => <CollectorIntent {...routeProps} {...props} />}
+      />
+      <Route
+        path={`/personalize/${Artists.slug}`}
+        render={routeProps => <Artists {...routeProps} {...props} />}
+      />
+      <Route
+        path={`/personalize/${Genes.slug}`}
+        render={routeProps => <Genes {...routeProps} {...props} />}
+      />
+      <Route
+        path={`/personalize/${BudgetComponent.slug}`}
+        render={routeProps => <Budget {...routeProps} {...props} />}
+      />
+    </div>
+  )
 }

--- a/src/v2/Components/Onboarding/Wizard.tsx
+++ b/src/v2/Components/Onboarding/Wizard.tsx
@@ -2,10 +2,8 @@ import React from "react"
 import { Route } from "react-router"
 import { TrackingProp } from "react-tracking"
 import Artists from "./Steps/Artists"
-import Budget, { BudgetComponent } from "./Steps/Budget"
-import CollectorIntent, {
-  CollectorIntentComponent,
-} from "./Steps/CollectorIntent"
+import Budget from "./Steps/Budget"
+import CollectorIntent from "./Steps/CollectorIntent"
 import Genes from "./Steps/Genes"
 
 export interface Props {
@@ -17,19 +15,19 @@ export const Wizard: React.FC<Props> = props => {
   return (
     <div>
       <Route
-        path={`/personalize/${CollectorIntentComponent.slug}`}
+        path="/personalize/interests"
         render={routeProps => <CollectorIntent {...routeProps} {...props} />}
       />
       <Route
-        path={`/personalize/${Artists.slug}`}
+        path="/personalize/artists"
         render={routeProps => <Artists {...routeProps} {...props} />}
       />
       <Route
-        path={`/personalize/${Genes.slug}`}
+        path="/personalize/categories"
         render={routeProps => <Genes {...routeProps} {...props} />}
       />
       <Route
-        path={`/personalize/${BudgetComponent.slug}`}
+        path="/personalize/budget"
         render={routeProps => <Budget {...routeProps} {...props} />}
       />
     </div>

--- a/src/v2/Components/Onboarding/Wizard.tsx
+++ b/src/v2/Components/Onboarding/Wizard.tsx
@@ -1,20 +1,12 @@
 import React from "react"
 import { Route } from "react-router"
 import { TrackingProp } from "react-tracking"
-import { ProgressIndicator } from "../ProgressIndicator"
 import Artists from "./Steps/Artists"
 import Budget, { BudgetComponent } from "./Steps/Budget"
 import CollectorIntent, {
   CollectorIntentComponent,
 } from "./Steps/CollectorIntent"
 import Genes from "./Steps/Genes"
-
-const STEPS = [
-  `/personalize/${CollectorIntentComponent.slug}`,
-  `/personalize/${Artists.slug}`,
-  `/personalize/${Genes.slug}`,
-  `/personalize/${BudgetComponent.slug}`,
-]
 
 export interface Props {
   redirectTo?: string
@@ -23,12 +15,8 @@ export interface Props {
 
 export class Wizard extends React.Component<Props> {
   render() {
-    const percentComplete = STEPS.indexOf(location.pathname) / STEPS.length
-
     return (
       <div>
-        <ProgressIndicator percentComplete={percentComplete} />
-
         <Route
           path={`/personalize/${CollectorIntentComponent.slug}`}
           render={routeProps => (

--- a/src/v2/Components/Onboarding/Wizard.tsx
+++ b/src/v2/Components/Onboarding/Wizard.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Redirect, Route } from "react-router"
+import { Route } from "react-router"
 
 import track, { TrackingProp } from "react-tracking"
 import Events from "../../Utils/Events"
@@ -105,12 +105,6 @@ export class Wizard extends React.Component<Props, State> {
             <Budget {...props} onNextButtonPressed={() => this.onFinish()} />
           )}
         />
-
-        {new RegExp(
-          `^/personalize(?!(/${CollectorIntentComponent.slug}|/${Artists.slug}|/${Genes.slug}|/${BudgetComponent.slug})).*$`
-        ).exec(location.pathname) && (
-          <Redirect to={`/personalize/${CollectorIntentComponent.slug}`} />
-        )}
       </div>
     )
   }

--- a/src/v2/Components/Onboarding/Wizard.tsx
+++ b/src/v2/Components/Onboarding/Wizard.tsx
@@ -51,19 +51,15 @@ export class Wizard extends React.Component<Props, State> {
   }
 
   render() {
+    const percentComplete = this.state.finished
+      ? 1
+      : STEPS.indexOf(location.pathname) / STEPS.length
+
     return (
       <div>
         <Route
           path="/personalize/*"
-          render={() => (
-            <ProgressIndicator
-              percentComplete={
-                this.state.finished
-                  ? 1
-                  : STEPS.indexOf(location.pathname) / STEPS.length
-              }
-            />
-          )}
+          render={() => <ProgressIndicator percentComplete={percentComplete} />}
         />
 
         <Route

--- a/src/v2/Components/Onboarding/Wizard.tsx
+++ b/src/v2/Components/Onboarding/Wizard.tsx
@@ -43,7 +43,8 @@ export class Wizard extends React.Component<Props, State> {
 
   onFinish = () => {
     this.setState({ finished: true })
-    setTimeout(() => (window.location.href = this.props.redirectTo || "/"), 500)
+    const redirectTo = this.props.redirectTo || "/"
+    setTimeout(() => window.location.assign(redirectTo), 500)
 
     this.props.tracking.trackEvent({
       action: "Completed Onboarding",


### PR DESCRIPTION
This PR aims to drastically simplify the onboarding wizard component by pushing things down into its children. It was responsible for too many things and was more complicated than it had to be. Out of scope for this PR is improving the children - that's next. 😉 

The commits do a pretty good job of telling this refactoring story but I wanted to call out that prior to this work there were no tests for this onboarding code and that didn't feel great. I end up writing one sanity check test in the final commit so that's good but still not ideal. It meant that I did a lot of "refactor and then test in the browser"-type refactoring and sometimes that's just what you have to do to move something forward.

I expect to get more tests around this part of the code as I dive into the child components.

This is a part of this ticket: https://artsyproduct.atlassian.net/browse/GRO-61 but is just a first step to improve how we track onboarding. My ultimate goal is to move to our `useTracking` hooks and cohesion analytics schema. This PR sets me up for that.

/cc @artsy/grow-devs