### PR TITLE
chore: Update yarn clean to include cleaning out compiled CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bundle-report:assets": "WEBPACK_ANALYZE=true yarn build:assets",
     "bundle-report:assets:novo": "WEBPACK_ANALYZE=true yarn build:assets:novo",
     "bundle-report:server": "WEBPACK_ANALYZE=true yarn build:server",
-    "clean": "rm -rf .cache && rm -f manifest.json && rm -f manifest-novo.json && rm -rf public && mkdir public && rm -f src/mobile/public/assets/* src/desktop/public/assets/* && echo '[Force] Cleaned build directory'",
+    "clean": "scripts/clean.sh",
     "compile": "babel src/v2 --out-dir dist/v2 -s --source-map --extensions '.js,.jsx,.ts,.tsx' --ignore src/v2/**/__tests__",
     "cypress:run": "./node_modules/.bin/cypress run",
     "cypress": "./node_modules/.bin/cypress open",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bundle-report:assets": "WEBPACK_ANALYZE=true yarn build:assets",
     "bundle-report:assets:novo": "WEBPACK_ANALYZE=true yarn build:assets:novo",
     "bundle-report:server": "WEBPACK_ANALYZE=true yarn build:server",
-    "clean": "rm -rf .cache && rm -f manifest.json && rm -f manifest-novo.json && rm -rf public && mkdir public && echo '[Force] Cleaned build directory'",
+    "clean": "rm -rf .cache && rm -f manifest.json && rm -f manifest-novo.json && rm -rf public && mkdir public && rm -f src/mobile/public/assets/* src/desktop/public/assets/* && echo '[Force] Cleaned build directory'",
     "compile": "babel src/v2 --out-dir dist/v2 -s --source-map --extensions '.js,.jsx,.ts,.tsx' --ignore src/v2/**/__tests__",
     "cypress:run": "./node_modules/.bin/cypress run",
     "cypress": "./node_modules/.bin/cypress open",

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ex
+
+rm -rf .cache
+rm -f manifest.json
+rm -f manifest-novo.json
+rm -rf public
+mkdir public
+rm -f src/mobile/public/assets/* src/desktop/public/assets/*
+
+echo '[Force] Cleaned build directory'


### PR DESCRIPTION
## Problem

When working on old Force pages our toolchain doesn't always recompile CSS when we modify `styl` files. This results in stale CSS being served locally.

## Solution

Update `yarn clean` to delete compiled CSS assets. The assets get dynamically recreated on pages that need them and allow devs to see changes they've made.