### PR TITLE
GRO-183: Adding CCPA link back to footer

### DIFF
--- a/src/v2/Components/CCPARequest.tsx
+++ b/src/v2/Components/CCPARequest.tsx
@@ -5,10 +5,10 @@ import {
   Input,
   Link,
   Modal,
-  Sans,
   Separator,
   Serif,
   TextArea,
+  Text,
 } from "@artsy/palette"
 import { CCPARequestMutation } from "v2/__generated__/CCPARequestMutation.graphql"
 import { useSystemContext } from "v2/Artsy"
@@ -39,9 +39,7 @@ const IconContainer = styled(Box)`
 const Feedback = ({ setNotes, notes, triggeredValidation }) => {
   return (
     <>
-      <Sans weight="medium" size="3">
-        Your message
-      </Sans>
+      <Text variant="mediumText">Your message</Text>
       <FeedbackTextAreaContainer mt={1}>
         <TextArea
           onChange={({ value }) => {
@@ -312,7 +310,9 @@ export const CCPARequest: React.SFC<Props> = props => {
   return (
     <>
       <Box style={{ cursor: "pointer" }} onClick={() => setShowModal(true)}>
-        Do not sell my personal information
+        <Text variant="caption" color="black60">
+          Do not sell my personal information
+        </Text>
       </Box>
       <Modal
         title={title}

--- a/src/v2/Components/Footer.tsx
+++ b/src/v2/Components/Footer.tsx
@@ -266,6 +266,12 @@ const Link = styled(RouterLink)`
   align-items: center;
   padding: ${space(1)}px 0;
 `
+const CCPAWrapper = styled.p`
+  display: flex;
+  text-decoration: none;
+  align-items: center;
+  padding: ${space(1)}px 0;
+`
 
 const PolicyLinks = () => (
   <>
@@ -298,11 +304,13 @@ const PolicyLinks = () => (
     </Link>
 
     <Link to="/conditions-of-sale">
-      <Text variant="caption" color="black60">
+      <Text variant="caption" color="black60" mr={1}>
         Conditions of Sale
       </Text>
     </Link>
 
-    <CCPARequest />
+    <CCPAWrapper>
+      <CCPARequest />
+    </CCPAWrapper>
   </>
 )

--- a/src/v2/Components/Footer.tsx
+++ b/src/v2/Components/Footer.tsx
@@ -266,11 +266,8 @@ const Link = styled(RouterLink)`
   align-items: center;
   padding: ${space(1)}px 0;
 `
-const CCPAWrapper = styled.p`
-  display: flex;
+const CCPAWrapper = styled(Flex)`
   text-decoration: none;
-  align-items: center;
-  padding: ${space(1)}px 0;
 `
 
 const PolicyLinks = () => (
@@ -309,7 +306,7 @@ const PolicyLinks = () => (
       </Text>
     </Link>
 
-    <CCPAWrapper>
+    <CCPAWrapper py={1} justifyContent="center">
       <CCPARequest />
     </CCPAWrapper>
   </>

--- a/src/v2/Components/Footer.tsx
+++ b/src/v2/Components/Footer.tsx
@@ -23,6 +23,7 @@ import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import { DownloadAppBadge } from "v2/Components/DownloadAppBadge"
 import { Mediator } from "lib/mediator"
 import { ContextModule } from "@artsy/cohesion"
+import { CCPARequest } from "./CCPARequest"
 
 const Column = styled(Flex).attrs({
   flex: 1,
@@ -301,5 +302,7 @@ const PolicyLinks = () => (
         Conditions of Sale
       </Text>
     </Link>
+
+    <CCPARequest />
   </>
 )

--- a/src/v2/Components/__tests__/Footer.jest.tsx
+++ b/src/v2/Components/__tests__/Footer.jest.tsx
@@ -3,6 +3,7 @@ import { mount } from "enzyme"
 import React from "react"
 import { Footer, LargeFooter, SmallFooter } from "../Footer"
 import { DownloadAppBadge } from "v2/Components/DownloadAppBadge"
+import { CCPARequest } from "../CCPARequest"
 
 describe("Footer", () => {
   beforeAll(() => {
@@ -39,5 +40,13 @@ describe("Footer", () => {
     expect(large.find("DownloadAppBanner").length).toEqual(1)
     expect(small.find(DownloadAppBadge).length).toEqual(1)
     expect(large.find(DownloadAppBadge).length).toEqual(1)
+  })
+
+  it("renders CCPA Wrapper component", () => {
+    const small = getSmallFooterWrapper()
+    const large = getLargeFooterWrapper()
+
+    expect(small.find(CCPARequest).length).toEqual(1)
+    expect(large.find(CCPARequest).length).toEqual(1)
   })
 })


### PR DESCRIPTION
Our “Do Not Sell My Information” link that allows users to request their data or delete was not in the v2 footer, so when we updated web to only use the v2 footer we lost it. This PR is to add it back to be in compliance.

Previous Behavior:
<img width="1046" alt="Screen Shot 2021-02-18 at 2 10 57 PM" src="https://user-images.githubusercontent.com/30025439/108428451-72af1300-71f3-11eb-8e21-68254c11a08b.png">

New Behavior:
Desktop:
<img width="470" alt="Screen Shot 2021-02-18 at 1 56 36 PM" src="https://user-images.githubusercontent.com/30025439/108428480-7a6eb780-71f3-11eb-85c5-f44e8a73c4a8.png">

Mobile:
<img width="963" alt="Screen Shot 2021-02-18 at 1 56 10 PM" src="https://user-images.githubusercontent.com/30025439/108428482-7b9fe480-71f3-11eb-914d-f3d57193df5c.png">
