### PR TITLE
feat: Improve first and last onboarding step tracking GRO-61

### DIFF
--- a/src/v2/Components/Onboarding/SelectableToggle.tsx
+++ b/src/v2/Components/Onboarding/SelectableToggle.tsx
@@ -30,6 +30,7 @@ const Link = styled.a`
     padding: 0 5px;
   `};
 `
+Link.displayName = "Link"
 
 const FullWidthCol = styled.div`
   flex: 1;

--- a/src/v2/Components/Onboarding/Steps/Budget.jest.tsx
+++ b/src/v2/Components/Onboarding/Steps/Budget.jest.tsx
@@ -1,0 +1,67 @@
+import React from "react"
+import { mount } from "enzyme"
+import Budget from "./Budget"
+
+jest.useFakeTimers()
+
+describe("Budget", () => {
+  const mockRelay = {}
+  const mockTracking = { trackEvent: jest.fn() }
+  const mockUpdateProfile = jest.fn()
+
+  const defaultProps = {
+    relayEnvironment: mockRelay,
+    tracking: mockTracking,
+    updateUserProfile: mockUpdateProfile,
+  }
+
+  beforeEach(() => {
+    window.location.assign = jest.fn()
+    jest.clearAllMocks()
+  })
+
+  it("can render", () => {
+    const wrapper = mount(<Budget {...defaultProps} />)
+
+    expect(wrapper.find("ProgressIndicator")).toHaveLength(1)
+    expect(wrapper.find("Layout")).toHaveLength(1)
+  })
+
+  describe("with no budget selected", () => {
+    it("ignores the button click", () => {
+      const wrapper = mount(<Budget {...defaultProps} />)
+      wrapper.find("NextButton").simulate("click")
+      jest.runAllTimers()
+      expect(mockUpdateProfile).not.toHaveBeenCalled()
+      expect(mockTracking.trackEvent).not.toHaveBeenCalled()
+      expect(window.location.assign).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("with a budget selected", () => {
+    it("sends the update, tracks and redirects", () => {
+      const wrapper = mount(<Budget {...defaultProps} />)
+      wrapper.find("Link").first().simulate("click")
+      wrapper.find("NextButton").simulate("click")
+      jest.runAllTimers()
+      expect(mockUpdateProfile).toHaveBeenCalledWith(500, mockRelay)
+      expect(mockTracking.trackEvent).toHaveBeenCalled()
+      expect(window.location.assign).toHaveBeenCalledWith("/")
+    })
+  })
+
+  describe("with a budget selected and redirect location", () => {
+    it("redirects to that location", () => {
+      const redirectTo = "/some/other/path"
+      const props = {
+        ...defaultProps,
+        redirectTo,
+      }
+      const wrapper = mount(<Budget {...props} />)
+      wrapper.find("Link").first().simulate("click")
+      wrapper.find("NextButton").simulate("click")
+      jest.runAllTimers()
+      expect(window.location.assign).toHaveBeenCalledWith(redirectTo)
+    })
+  })
+})

--- a/src/v2/Components/Onboarding/Steps/Budget.jest.tsx
+++ b/src/v2/Components/Onboarding/Steps/Budget.jest.tsx
@@ -43,13 +43,13 @@ describe("Budget", () => {
   })
 
   describe("with a budget selected", () => {
-    it("sends the update, tracks and redirects", () => {
+    it("sends the update, tracks twice and redirects", () => {
       const wrapper = mount(<Budget {...defaultProps} />)
       wrapper.find("Link").first().simulate("click")
       wrapper.find("NextButton").simulate("click")
       jest.runAllTimers()
       expect(mockUpdateProfile).toHaveBeenCalledWith(500, mockRelay)
-      expect(mockTrackEvent).toHaveBeenCalled()
+      expect(mockTrackEvent.mock.calls.length).toEqual(2)
       expect(window.location.assign).toHaveBeenCalledWith("/")
     })
   })

--- a/src/v2/Components/Onboarding/Steps/Budget.jest.tsx
+++ b/src/v2/Components/Onboarding/Steps/Budget.jest.tsx
@@ -1,17 +1,21 @@
 import React from "react"
 import { mount } from "enzyme"
 import Budget from "./Budget"
+import { useTracking } from "v2/Artsy/Analytics/useTracking"
+
+jest.mock("v2/Artsy/Analytics/useTracking")
 
 jest.useFakeTimers()
 
 describe("Budget", () => {
   const mockRelay = {}
-  const mockTracking = { trackEvent: jest.fn() }
+  const mockTrackEvent = jest.fn()
+  const mockTracking = useTracking as jest.Mock
+  mockTracking.mockImplementation(() => ({ trackEvent: mockTrackEvent }))
   const mockUpdateProfile = jest.fn()
 
   const defaultProps = {
     relayEnvironment: mockRelay,
-    tracking: mockTracking,
     updateUserProfile: mockUpdateProfile,
   }
 
@@ -33,7 +37,7 @@ describe("Budget", () => {
       wrapper.find("NextButton").simulate("click")
       jest.runAllTimers()
       expect(mockUpdateProfile).not.toHaveBeenCalled()
-      expect(mockTracking.trackEvent).not.toHaveBeenCalled()
+      expect(mockTrackEvent).not.toHaveBeenCalled()
       expect(window.location.assign).not.toHaveBeenCalled()
     })
   })
@@ -45,7 +49,7 @@ describe("Budget", () => {
       wrapper.find("NextButton").simulate("click")
       jest.runAllTimers()
       expect(mockUpdateProfile).toHaveBeenCalledWith(500, mockRelay)
-      expect(mockTracking.trackEvent).toHaveBeenCalled()
+      expect(mockTrackEvent).toHaveBeenCalled()
       expect(window.location.assign).toHaveBeenCalledWith("/")
     })
   })

--- a/src/v2/Components/Onboarding/Steps/Budget.tsx
+++ b/src/v2/Components/Onboarding/Steps/Budget.tsx
@@ -1,18 +1,15 @@
-import React from "react"
+import React, { useState } from "react"
 import { commitMutation, graphql } from "react-relay"
 import styled from "styled-components"
 import { ProgressIndicator } from "v2/Components/ProgressIndicator"
 import { BudgetUpdateMyUserProfileMutation } from "v2/__generated__/BudgetUpdateMyUserProfileMutation.graphql"
-import { SystemContextProps, withSystemContext } from "v2/Artsy"
+import { withSystemContext } from "v2/Artsy"
 import Colors from "../../../Assets/Colors"
 import { MultiButtonState } from "../../Buttons/MultiStateButton"
 import { media } from "../../Helpers"
-import { Props } from "../Wizard"
 import SelectableToggle from "../SelectableToggle"
-import { StepProps } from "../Types"
 import { Layout } from "./Layout"
-import track from "react-tracking"
-import Events from "../../../Utils/Events"
+import { useTracking } from "v2/Artsy/Analytics/useTracking"
 
 const updateUserProfile = (priceRangeMax, relayEnvironment) => {
   const input = {
@@ -49,83 +46,69 @@ const OptionsContainer = styled.div`
   `};
 `
 
-type GeneralProps = Props & StepProps & SystemContextProps
-
-interface BudgetComponentProps extends GeneralProps {
-  updateUserProfile
+const budgetOptions = {
+  "UNDER $500": 500,
+  "UNDER $2,500": 2500,
+  "UNDER $5,000": 5000,
+  "UNDER $10,000": 10000,
+  "UNDER $25,000": 25000,
+  "UNDER $50,000": 50000,
+  "NO BUDGET IN MIND": 1000000000000,
 }
 
-interface State {
-  selection: number | null
-}
+export const BudgetComponent = props => {
+  const tracking = useTracking()
+  const updateProfile = props.updateUserProfile || updateUserProfile
+  const [selectedOption, setSelectedOption] = useState(null)
 
-@track({}, { dispatch: data => Events.postEvent(data) })
-export class BudgetComponent extends React.Component<
-  BudgetComponentProps,
-  State
-> {
-  static defaultProps = { updateUserProfile }
-
-  options = {
-    "UNDER $500": 500,
-    "UNDER $2,500": 2500,
-    "UNDER $5,000": 5000,
-    "UNDER $10,000": 10000,
-    "UNDER $25,000": 25000,
-    "UNDER $50,000": 50000,
-    "NO BUDGET IN MIND": 1000000000000,
+  const onOptionSelected = (index: number) => {
+    const selection = { selection: Object.values(budgetOptions)[index] }
+    setSelectedOption(selection)
   }
 
-  state = {
-    selection: null,
-  }
+  const options = Object.keys(budgetOptions).map((text, index) => (
+    <SelectableToggle
+      key={index}
+      text={text}
+      onSelect={() => onOptionSelected(index)}
+      selected={selectedOption?.selection === budgetOptions[text]}
+    />
+  ))
 
-  onOptionSelected = (index: number) => {
-    const selection = { selection: Object.values(this.options)[index] }
-    this.setState(selection)
-  }
+  const submit = () => {
+    const priceRangeMax = selectedOption?.selection
+    if (!priceRangeMax) return
 
-  submit() {
-    const priceRangeMax = this.state.selection
-    this.props.updateUserProfile(priceRangeMax, this.props.relayEnvironment)
+    updateProfile(priceRangeMax, props.relayEnvironment)
 
-    const redirectTo = this.props.redirectTo || "/"
+    const redirectTo = props.redirectTo || "/"
     setTimeout(() => window.location.assign(redirectTo), 500)
 
-    this.props.tracking.trackEvent({
+    const event: any = {
       action: "Completed Onboarding",
-    })
+    }
+
+    tracking.trackEvent(event)
   }
 
-  render() {
-    const options = Object.keys(this.options).map((text, index) => (
-      <SelectableToggle
-        key={index}
-        text={text}
-        onSelect={this.onOptionSelected.bind(this, index)}
-        selected={this.state.selection === this.options[text]}
-      />
-    ))
-
-    return (
-      <>
-        <ProgressIndicator percentComplete={0.75} />
-        <Layout
-          title="What’s your maximum artwork budget?"
-          subtitle="Select one"
-          onNextButtonPressed={this.state.selection && this.submit.bind(this)}
-          isLastStep
-          buttonState={
-            this.state.selection
-              ? MultiButtonState.Highlighted
-              : MultiButtonState.Default
-          }
-        >
-          <OptionsContainer>{options}</OptionsContainer>
-        </Layout>
-      </>
-    )
-  }
+  return (
+    <>
+      <ProgressIndicator percentComplete={0.75} />
+      <Layout
+        title="What’s your maximum artwork budget?"
+        subtitle="Select one"
+        onNextButtonPressed={submit}
+        isLastStep
+        buttonState={
+          selectedOption
+            ? MultiButtonState.Highlighted
+            : MultiButtonState.Default
+        }
+      >
+        <OptionsContainer>{options}</OptionsContainer>
+      </Layout>
+    </>
+  )
 }
 
 const Budget = withSystemContext(BudgetComponent)

--- a/src/v2/Components/Onboarding/Steps/Budget.tsx
+++ b/src/v2/Components/Onboarding/Steps/Budget.tsx
@@ -11,8 +11,14 @@ import { media } from "../../Helpers"
 import SelectableToggle from "../SelectableToggle"
 import { Layout } from "./Layout"
 import { useTracking } from "v2/Artsy/Analytics/useTracking"
+import { Environment } from "relay-runtime"
 
-const updateUserProfile = (priceRangeMax, relayEnvironment) => {
+type UserUpdater = (
+  priceRangeMax: number,
+  relayEnvironment: Environment
+) => void
+
+const updateUserProfile: UserUpdater = (priceRangeMax, relayEnvironment) => {
   const input = {
     priceRangeMin: -1,
     priceRangeMax,
@@ -57,7 +63,13 @@ const budgetOptions = {
   "NO BUDGET IN MIND": 1000000000000,
 }
 
-export const BudgetComponent = props => {
+interface Props {
+  redirectTo: string
+  relayEnvironment: Environment
+  updateUserProfile: UserUpdater
+}
+
+export const BudgetComponent: React.FC<Props> = props => {
   const tracking = useTracking()
   const updateProfile = props.updateUserProfile || updateUserProfile
   const [selectedOption, setSelectedOption] = useState(null)

--- a/src/v2/Components/Onboarding/Steps/Budget.tsx
+++ b/src/v2/Components/Onboarding/Steps/Budget.tsx
@@ -61,7 +61,7 @@ const budgetOptions = {
   "UNDER $25,000": 25000,
   "UNDER $50,000": 50000,
   "NO BUDGET IN MIND": 1000000000000,
-}
+} as const
 
 interface Props {
   redirectTo: string

--- a/src/v2/Components/Onboarding/Steps/Budget.tsx
+++ b/src/v2/Components/Onboarding/Steps/Budget.tsx
@@ -94,9 +94,6 @@ export const BudgetComponent: React.FC<Props> = props => {
 
     updateProfile(priceRangeMax, props.relayEnvironment)
 
-    const redirectTo = props.redirectTo || "/"
-    setTimeout(() => window.location.assign(redirectTo), 500)
-
     const event = {
       context_module: ContextModule.onboardingInterests,
       context_owner_type: OwnerType.onboarding,
@@ -108,6 +105,9 @@ export const BudgetComponent: React.FC<Props> = props => {
       action: "Completed Onboarding",
     }
     tracking.trackEvent(completedEvent)
+
+    const redirectTo = props.redirectTo || "/"
+    setTimeout(() => window.location.assign(redirectTo), 500)
   }
 
   return (

--- a/src/v2/Components/Onboarding/Steps/Budget.tsx
+++ b/src/v2/Components/Onboarding/Steps/Budget.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { commitMutation, graphql } from "react-relay"
 import styled from "styled-components"
 import { ProgressIndicator } from "v2/Components/ProgressIndicator"
@@ -84,11 +85,17 @@ export const BudgetComponent = props => {
     const redirectTo = props.redirectTo || "/"
     setTimeout(() => window.location.assign(redirectTo), 500)
 
-    const event: any = {
+    const event = {
+      context_module: ContextModule.onboardingInterests,
+      context_owner_type: OwnerType.onboarding,
+      data_input: selectedOption,
+    }
+    tracking.trackEvent(event)
+
+    const completedEvent: any = {
       action: "Completed Onboarding",
     }
-
-    tracking.trackEvent(event)
+    tracking.trackEvent(completedEvent)
   }
 
   return (

--- a/src/v2/Components/Onboarding/Steps/CollectorIntent.jest.tsx
+++ b/src/v2/Components/Onboarding/Steps/CollectorIntent.jest.tsx
@@ -1,0 +1,47 @@
+import React from "react"
+import { mount } from "enzyme"
+import CollectorIntent from "./CollectorIntent"
+
+describe("CollectorIntent", () => {
+  const mockRelay = {}
+  const mockHistory = {
+    push: jest.fn(),
+  }
+  const mockUpdateProfile = jest.fn()
+  const props = {
+    history: mockHistory,
+    relayEnvironment: mockRelay,
+    updateProfile: mockUpdateProfile,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("can render", () => {
+    const wrapper = mount(<CollectorIntent {...props} />)
+    expect(wrapper.find("ProgressIndicator")).toHaveLength(1)
+    expect(wrapper.find("Layout")).toHaveLength(1)
+  })
+
+  describe("with no selected intents", () => {
+    it("skips the update and advances to next step", () => {
+      const wrapper = mount(<CollectorIntent {...props} />)
+      wrapper.find("NextButton").simulate("click")
+      expect(mockUpdateProfile).not.toHaveBeenCalled()
+      expect(mockHistory.push).toHaveBeenCalledWith("/personalize/artists")
+    })
+  })
+
+  describe("with some selected intents", () => {
+    it("sends the update and advances to next step", () => {
+      const wrapper = mount(<CollectorIntent {...props} />)
+      wrapper.find("Link").first().simulate("click")
+      wrapper.find("Link").last().simulate("click")
+      wrapper.find("NextButton").simulate("click")
+      const expectedIntents = ["BUY_ART_AND_DESIGN", "READ_ART_MARKET_NEWS"]
+      expect(mockUpdateProfile).toHaveBeenCalledWith(expectedIntents, mockRelay)
+      expect(mockHistory.push).toHaveBeenCalledWith("/personalize/artists")
+    })
+  })
+})

--- a/src/v2/Components/Onboarding/Steps/CollectorIntent.jest.tsx
+++ b/src/v2/Components/Onboarding/Steps/CollectorIntent.jest.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { mount } from "enzyme"
 import CollectorIntent from "./CollectorIntent"
+import { MultiButtonState } from "../../Buttons/MultiStateButton"
 
 describe("CollectorIntent", () => {
   const mockRelay = {}
@@ -42,6 +43,21 @@ describe("CollectorIntent", () => {
       const expectedIntents = ["BUY_ART_AND_DESIGN", "READ_ART_MARKET_NEWS"]
       expect(mockUpdateProfile).toHaveBeenCalledWith(expectedIntents, mockRelay)
       expect(mockHistory.push).toHaveBeenCalledWith("/personalize/artists")
+    })
+  })
+
+  describe("button state", () => {
+    it("starts out with default state", () => {
+      const wrapper = mount(<CollectorIntent {...props} />)
+      const buttonState = wrapper.find("Layout").prop("buttonState")
+      expect(buttonState).toEqual(MultiButtonState.Default)
+    })
+
+    it("uses highlighted state after an option is selected", () => {
+      const wrapper = mount(<CollectorIntent {...props} />)
+      wrapper.find("Link").first().simulate("click")
+      const buttonState = wrapper.find("Layout").prop("buttonState")
+      expect(buttonState).toEqual(MultiButtonState.Highlighted)
     })
   })
 })

--- a/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
+++ b/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
@@ -119,18 +119,19 @@ export class CollectorIntentComponent extends React.Component<
       />
     ))
 
+    const buttonState =
+      this.selectedIntents().length > 0
+        ? MultiButtonState.Highlighted
+        : MultiButtonState.Default
+
     return (
       <>
         <ProgressIndicator />
         <Layout
-          title="How would you like to use Artsy?"
-          subtitle="Select all that apply"
+          buttonState={buttonState}
           onNextButtonPressed={this.submit.bind(this)}
-          buttonState={
-            this.selectedIntents().length > 0
-              ? MultiButtonState.Highlighted
-              : MultiButtonState.Default
-          }
+          subtitle="Select all that apply"
+          title="How would you like to use Artsy?"
         >
           <OptionsContainer>{options}</OptionsContainer>
         </Layout>

--- a/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
+++ b/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { commitMutation, graphql } from "react-relay"
 import styled from "styled-components"
 import { ProgressIndicator } from "v2/Components/ProgressIndicator"
@@ -12,6 +13,7 @@ import { MultiButtonState } from "../../Buttons/MultiStateButton"
 import { media } from "../../Helpers"
 import SelectableToggle from "../SelectableToggle"
 import { Layout } from "./Layout"
+import { useTracking } from "v2/Artsy/Analytics/useTracking"
 
 const intentEnum = {
   "buy art & design": "BUY_ART_AND_DESIGN",
@@ -53,6 +55,7 @@ const OptionsContainer = styled.div`
 `
 
 export const CollectorIntentComponent = props => {
+  const tracking = useTracking()
   const updateProfile = props.updateProfile || updateCollectorProfile
 
   const [selectedOptions, setSelectedOptions] = useState({})
@@ -68,6 +71,14 @@ export const CollectorIntentComponent = props => {
 
     if (selected.length > 0) {
       updateProfile(selected, props.relayEnvironment)
+
+      const dataInput = selected.join(" ")
+      const event = {
+        context_module: ContextModule.onboardingInterests,
+        context_owner_type: OwnerType.onboarding,
+        data_input: dataInput,
+      }
+      tracking.trackEvent(event)
     }
 
     props.history.push("/personalize/artists")

--- a/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
+++ b/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
@@ -14,6 +14,7 @@ import { media } from "../../Helpers"
 import SelectableToggle from "../SelectableToggle"
 import { Layout } from "./Layout"
 import { useTracking } from "v2/Artsy/Analytics/useTracking"
+import { Environment } from "relay-runtime"
 
 const intentEnum = {
   "buy art & design": "BUY_ART_AND_DESIGN",
@@ -24,7 +25,12 @@ const intentEnum = {
   "read art market news": "READ_ART_MARKET_NEWS",
 }
 
-const updateCollectorProfile = (intents, relayEnvironment) => {
+type ProfileUpdater = (
+  intents: Intents[],
+  relayEnvironment: Environment
+) => void
+
+const updateCollectorProfile: ProfileUpdater = (intents, relayEnvironment) => {
   commitMutation<CollectorIntentUpdateCollectorProfileMutation>(
     relayEnvironment,
     {
@@ -54,7 +60,13 @@ const OptionsContainer = styled.div`
   `};
 `
 
-export const CollectorIntentComponent = props => {
+interface Props {
+  history
+  relayEnvironment: Environment
+  updateProfile: ProfileUpdater
+}
+
+export const CollectorIntentComponent: React.FC<Props> = props => {
   const tracking = useTracking()
   const updateProfile = props.updateProfile || updateCollectorProfile
 

--- a/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
+++ b/src/v2/Components/Onboarding/Steps/CollectorIntent.tsx
@@ -23,7 +23,7 @@ const intentEnum = {
   "learn about art": "LEARN_ABOUT_ART",
   "find out about new exhibitions": "FIND_ART_EXHIBITS",
   "read art market news": "READ_ART_MARKET_NEWS",
-}
+} as const
 
 type ProfileUpdater = (
   intents: Intents[],

--- a/src/v2/Components/Onboarding/Steps/Layout.tsx
+++ b/src/v2/Components/Onboarding/Steps/Layout.tsx
@@ -89,6 +89,7 @@ const NextButton = styled(MultiStateButton)`
     margin: 25px 0 0;
   `};
 `
+NextButton.displayName = "NextButton"
 
 export class Layout extends React.Component<Props, null> {
   render() {

--- a/src/v2/Components/Onboarding/Wizard.tsx
+++ b/src/v2/Components/Onboarding/Wizard.tsx
@@ -5,13 +5,17 @@ import Artists from "./Steps/Artists"
 import Budget from "./Steps/Budget"
 import CollectorIntent from "./Steps/CollectorIntent"
 import Genes from "./Steps/Genes"
+import { track } from "v2/Artsy"
+import Events from "v2/Utils/Events"
 
 export interface Props {
   redirectTo?: string
   tracking?: TrackingProp
 }
 
-export const Wizard: React.FC<Props> = props => {
+export const Wizard = track(null, {
+  dispatch: Events.postEvent,
+})((props: Props) => {
   return (
     <div>
       <Route
@@ -32,4 +36,4 @@ export const Wizard: React.FC<Props> = props => {
       />
     </div>
   )
-}
+})


### PR DESCRIPTION
This PR adds two new onboarding tracking events for when a user picks interests and sets a budget. I followed some advice from this thread:

https://artsy.slack.com/archives/CP9P4KR35/p1613075517312100

And moved to wrapping the Wizard component in a `track` call so that I could use hooks in the child components. This worked great! The only exception was the existing event that was triggered and has not been migrated to cohesion. After chatting with @abhitip about it, we decided to leave it alone so I just marked it as `any` and moved on. We can come back to this if/when it makes sense.

I was really happy to add a bunch of tests in this PR so that we have some confidence as we move forward working on the onboarding code - more to come on this!

This PR only addresses the first and last steps because those were easy to do, haha. Next up I'll work on the artist and category steps using the patterns outlined here.

https://artsyproduct.atlassian.net/browse/GRO-61

/cc @artsy/grow-devs