### PR TITLE
fix: [NavBar] Space items better at breakpoints

### DIFF
--- a/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownMenu.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, color } from "@artsy/palette"
+import { Box, Flex, color, breakpoints } from "@artsy/palette"
 import { AnalyticsSchema, ContextModule } from "v2/Artsy"
 import { useTracking } from "v2/Artsy/Analytics/useTracking"
 import React from "react"
@@ -6,33 +6,6 @@ import styled from "styled-components"
 import { DropDownSection } from "./DropDownSection"
 import { Menu, MenuItem } from "v2/Components/Menu"
 import { MenuData } from "../../menuData"
-
-const LinkMenuItem = styled(MenuItem).attrs({
-  px: 1,
-  py: 0.5,
-  color: "black60",
-  variant: "text",
-  hasLighterTextColor: true,
-})``
-
-LinkMenuItem.displayName = "LinkMenuItem"
-
-const ViewAllMenuItem = styled(MenuItem).attrs({
-  px: 1,
-  py: 0.5,
-  color: "black100",
-  variant: "text",
-  hasLighterTextColor: true,
-})`
-  margin-top: auto;
-  text-decoration: underline;
-`
-
-ViewAllMenuItem.displayName = "ViewAllMenuItem"
-
-const Links = styled(Box)`
-  border-right: 1px solid ${color("black10")};
-`
 
 interface DropDownNavMenuProps {
   width?: string
@@ -75,38 +48,67 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
           "center",
         ]}
       >
-        <Links py={3} mr={[3, 3, "50px", "50px"]}>
-          <Box
-            display="flex"
-            flexDirection="column"
-            height="100%"
-            mr={[1, 1, 2, 2]}
-            width={[110, 135, 135, 170, 170]}
-          >
-            {menu.links.map((menuItem, i) => {
-              if (!("menu" in menuItem)) {
-                const isLast = menu.links.length - 1 === i
+        <Flex width={breakpoints.xl} px={3}>
+          <Links py={3} mr={[3, 3, 5, 5]}>
+            <Box
+              display="flex"
+              flexDirection="column"
+              height="100%"
+              mr={[1, 1, 2, 2]}
+              width={[110, 135, 135, 170, 170]}
+            >
+              {menu.links.map((menuItem, i) => {
+                if (!("menu" in menuItem)) {
+                  const isLast = menu.links.length - 1 === i
 
-                return isLast ? (
-                  <ViewAllMenuItem key={menuItem.text} href={menuItem.href}>
-                    {menuItem.text}
-                  </ViewAllMenuItem>
-                ) : (
-                  <LinkMenuItem key={menuItem.text} href={menuItem.href}>
-                    {menuItem.text}
-                  </LinkMenuItem>
-                )
-              }
-            })}
-          </Box>
-        </Links>
+                  return isLast ? (
+                    <ViewAllMenuItem key={menuItem.text} href={menuItem.href}>
+                      {menuItem.text}
+                    </ViewAllMenuItem>
+                  ) : (
+                    <LinkMenuItem key={menuItem.text} href={menuItem.href}>
+                      {menuItem.text}
+                    </LinkMenuItem>
+                  )
+                }
+              })}
+            </Box>
+          </Links>
 
-        {menu.links.map(subMenu => {
-          if ("menu" in subMenu) {
-            return <DropDownSection key={subMenu.text} section={subMenu} />
-          }
-        })}
+          {menu.links.map(subMenu => {
+            if ("menu" in subMenu) {
+              return <DropDownSection key={subMenu.text} section={subMenu} />
+            }
+          })}
+        </Flex>
       </Flex>
     </Menu>
   )
 }
+
+const LinkMenuItem = styled(MenuItem).attrs({
+  px: 1,
+  py: 0.5,
+  color: "black60",
+  variant: "text",
+  hasLighterTextColor: true,
+})``
+
+LinkMenuItem.displayName = "LinkMenuItem"
+
+const ViewAllMenuItem = styled(MenuItem).attrs({
+  px: 1,
+  py: 0.5,
+  color: "black100",
+  variant: "text",
+  hasLighterTextColor: true,
+})`
+  margin-top: auto;
+  text-decoration: underline;
+`
+
+ViewAllMenuItem.displayName = "ViewAllMenuItem"
+
+const Links = styled(Box)`
+  border-right: 1px solid ${color("black10")};
+`

--- a/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownSection.tsx
+++ b/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownSection.tsx
@@ -14,7 +14,7 @@ export const DropDownSection: React.FC<DropDownSectionProps> = ({
 
   return (
     <>
-      <Box width={[110, 135, 135, 170, 170]} py={4} mr={[1, 1, 2, 2]}>
+      <Box width="100%" py={4} mr={[1, 1, 2, 2]}>
         <Text variant="small" mb={1} px={1}>
           {section.text}
         </Text>

--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -37,36 +37,6 @@ import {
  * https://github.com/artsy/force/pull/6991
  */
 
-const NavBarContainer = styled(Flex)`
-  position: relative;
-  background-color: ${color("white100")};
-  flex-direction: column;
-`
-
-export const NavBarTier = styled(Flex)`
-  position: relative;
-  border-bottom: 1px solid ${color("black10")};
-`
-
-const NavSection: React.FC<FlexProps> = ({
-  children,
-  justifyContent,
-  ...rest
-}) => {
-  return (
-    <Flex alignItems="stretch" height="100%" bg={rest.bg} {...rest}>
-      <Flex
-        width="100%"
-        height="100%"
-        alignItems="center"
-        justifyContent={justifyContent}
-      >
-        {children}
-      </Flex>
-    </Flex>
-  )
-}
-
 export const NavBar: React.FC = track(
   {
     flow: AnalyticsSchema.Flow.Header,
@@ -292,3 +262,33 @@ export const NavBar: React.FC = track(
     </>
   )
 })
+
+const NavBarContainer = styled(Flex)`
+  position: relative;
+  background-color: ${color("white100")};
+  flex-direction: column;
+`
+
+export const NavBarTier = styled(Flex)`
+  position: relative;
+  border-bottom: 1px solid ${color("black10")};
+`
+
+const NavSection: React.FC<FlexProps> = ({
+  children,
+  justifyContent,
+  ...rest
+}) => {
+  return (
+    <Flex alignItems="stretch" height="100%" bg={rest.bg} {...rest}>
+      <Flex
+        width="100%"
+        height="100%"
+        alignItems="center"
+        justifyContent={justifyContent}
+      >
+        {children}
+      </Flex>
+    </Flex>
+  )
+}

--- a/src/v2/Components/NavBar/NavBarPrimaryLogo.tsx
+++ b/src/v2/Components/NavBar/NavBarPrimaryLogo.tsx
@@ -3,6 +3,19 @@ import { ArtsyMarkIcon, color, space } from "@artsy/palette"
 import styled from "styled-components"
 import { RouterLink, RouterLinkProps } from "v2/Artsy/Router/RouterLink"
 
+export const NavBarPrimaryLogo: React.FC<Omit<
+  Partial<RouterLinkProps>,
+  "children"
+>> = props => {
+  return (
+    <HitArea to="/" {...props}>
+      <ArtsyMarkIcon height={40} width={40} name="Artsy" />
+    </HitArea>
+  )
+}
+
+NavBarPrimaryLogo.displayName = "NavBarPrimaryLogo"
+
 const HitArea = styled(RouterLink)`
   display: flex;
   align-items: center;
@@ -21,16 +34,3 @@ const HitArea = styled(RouterLink)`
     }
   }
 `
-
-export const NavBarPrimaryLogo: React.FC<Omit<
-  Partial<RouterLinkProps>,
-  "children"
->> = props => {
-  return (
-    <HitArea to="/" {...props}>
-      <ArtsyMarkIcon height={40} width={40} name="Artsy" />
-    </HitArea>
-  )
-}
-
-NavBarPrimaryLogo.displayName = "NavBarPrimaryLogo"

--- a/src/v2/Components/NavBar/NavBarSkipLink.tsx
+++ b/src/v2/Components/NavBar/NavBarSkipLink.tsx
@@ -2,6 +2,16 @@ import React from "react"
 import styled from "styled-components"
 import { Text, color, space } from "@artsy/palette"
 
+export const NavBarSkipLink: React.FC = () => {
+  return (
+    <Container href="#main">
+      <Text variant="text">Skip to Main Content</Text>
+    </Container>
+  )
+}
+
+NavBarSkipLink.displayName = "NavBarSkipLink"
+
 const Container = styled.a`
   display: block;
   position: absolute;
@@ -16,13 +26,3 @@ const Container = styled.a`
     top: 0;
   }
 `
-
-export const NavBarSkipLink: React.FC = () => {
-  return (
-    <Container href="#main">
-      <Text variant="text">Skip to Main Content</Text>
-    </Container>
-  )
-}
-
-NavBarSkipLink.displayName = "NavBarSkipLink"

--- a/src/v2/Components/NavBar/NavItemPanel.tsx
+++ b/src/v2/Components/NavBar/NavItemPanel.tsx
@@ -4,6 +4,35 @@ import styled, { css } from "styled-components"
 
 export type MenuAnchor = "left" | "right" | "center" | "full"
 
+interface NavItemPanelProps {
+  visible: boolean
+  menuAnchor: MenuAnchor
+  relativeTo: React.MutableRefObject<HTMLDivElement>
+}
+
+export const NavItemPanel: React.FC<NavItemPanelProps> = ({
+  visible,
+  menuAnchor,
+  relativeTo,
+  children,
+}) => {
+  const animation = useSpring({
+    ...(visible ? ANIMATION_STATES.visible : ANIMATION_STATES.hidden),
+    config: name =>
+      name === "opacity" ? config.stiff : { friction: 10, mass: 0.1 },
+  })
+
+  return (
+    <AnimatedPanel
+      style={animation}
+      data-menuanchor={menuAnchor}
+      data-offsetleft={relativeTo.current?.offsetLeft}
+    >
+      {children}
+    </AnimatedPanel>
+  )
+}
+
 const AnimatedPanel = styled(animated.div)<{
   "data-menuanchor": MenuAnchor
   "data-offsetleft"?: number
@@ -42,33 +71,4 @@ const ANIMATION_STATES = {
     opacity: 1,
     transform: "translate3d(0, 0, 0)",
   },
-}
-
-interface NavItemPanelProps {
-  visible: boolean
-  menuAnchor: MenuAnchor
-  relativeTo: React.MutableRefObject<HTMLDivElement>
-}
-
-export const NavItemPanel: React.FC<NavItemPanelProps> = ({
-  visible,
-  menuAnchor,
-  relativeTo,
-  children,
-}) => {
-  const animation = useSpring({
-    ...(visible ? ANIMATION_STATES.visible : ANIMATION_STATES.hidden),
-    config: name =>
-      name === "opacity" ? config.stiff : { friction: 10, mass: 0.1 },
-  })
-
-  return (
-    <AnimatedPanel
-      style={animation}
-      data-menuanchor={menuAnchor}
-      data-offsetleft={relativeTo.current?.offsetLeft}
-    >
-      {children}
-    </AnimatedPanel>
-  )
 }


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GRO-215

This fixes an issue where the nav didn't stretch to the full width of the content area.

Also does a light refactor, moving the styled-components related components in a few files from the top of the file to the bottom, after the main component definition, since CSS is rarely returned to by future devs; however, main component code often is. Reduces the signal to noise ratio around contributing changes and increases readability. 

cc @artsy/grow-devs 

Before: 

<img width="1612" alt="Screen Shot 2021-02-18 at 4 57 55 PM" src="https://user-images.githubusercontent.com/236943/108441684-831eb800-720a-11eb-9d7e-7f295523893e.png">

After: 

<img width="1529" alt="Screen Shot 2021-02-18 at 4 52 35 PM" src="https://user-images.githubusercontent.com/236943/108441698-89149900-720a-11eb-9a0f-e60bff909696.png">
