### PR TITLE
feature: Reduce Novo Bundle Size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ cypress/videos
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Webpack stats
+stats*.json

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test:ci:mocha": "NODE_ENV=test yarn mocha src/**/*.test.js src/**/*.test.ts",
     "type-check": "tsc",
     "unlink-all": "yalc remove --all && yarn --check-files",
+    "stats:novo": "NODE_ENV=production BUILD_NOVO_CLIENT=true node --max_old_space_size=4096 -r dotenv/config -r @babel/register node_modules/.bin/webpack --profile --json --config ./webpack > stats.json",
     "webpack": "node --max_old_space_size=4096 -r dotenv/config -r @babel/register node_modules/.bin/webpack --config ./webpack"
   },
   "resolutions": {
@@ -146,7 +147,6 @@
     "http-shutdown": "1.2.1",
     "insane": "2.6.1",
     "invariant": "2.2.4",
-    "ip": "1.1.5",
     "jade": "1.11.0",
     "jquery": "2.2.4",
     "jquery-fillwidth-lite": "1.0.8",

--- a/src/desktop/components/cookies/index.coffee
+++ b/src/desktop/components/cookies/index.coffee
@@ -1,4 +1,4 @@
-_ = require 'underscore'
+_ = require 'lodash'
 IS_TEST_ENV = require('sharify').data.NODE_ENV not in ['production', 'staging', 'development']
 methods = ['get', 'set', 'expire']
 

--- a/src/desktop/components/split_test/setup.coffee
+++ b/src/desktop/components/split_test/setup.coffee
@@ -1,4 +1,4 @@
-_ = require 'underscore'
+_ = require 'lodash'
 runningTests = require './running_tests.coffee'
 SplitTest = require './split_test.coffee'
 

--- a/src/desktop/components/split_test/split_test.coffee
+++ b/src/desktop/components/split_test/split_test.coffee
@@ -1,4 +1,4 @@
-_ = require 'underscore'
+_ = require 'lodash'
 { CURRENT_USER, REFLECTION } = require('sharify').data
 IS_TEST_ENV = require('sharify').data.NODE_ENV not in ['production', 'staging', 'development']
 
@@ -60,7 +60,7 @@ module.exports = class SplitTest
     , 0
 
   outcome: ->
-    outcome = 
+    outcome =
       if (@admin() and @edge?)
         @edge
       else if @reflection()

--- a/src/lib/ip.ts
+++ b/src/lib/ip.ts
@@ -1,0 +1,5 @@
+const ipv6Regex = /^(::)?(((\d{1,3}\.){3}(\d{1,3}){1})?([0-9a-f]){0,4}:{0,2}){1,8}(::)?$/i
+
+export const isV6Format = ip => {
+  return ipv6Regex.test(ip)
+}

--- a/src/lib/metaphysics.ts
+++ b/src/lib/metaphysics.ts
@@ -1,14 +1,14 @@
 import qs from "qs"
 import request from "superagent"
 import { some } from "lodash"
-import ip from "ip"
 import { data as sd } from "sharify"
 import { Request } from "express"
+import { isV6Format } from "./ip"
 
 const { METAPHYSICS_ENDPOINT, API_REQUEST_TIMEOUT, REQUEST_ID } = sd
 
 const resolveIPv4 = function (ipAddress) {
-  if (ip.isV6Format(ipAddress) != null && ipAddress.indexOf("::ffff") >= 0) {
+  if (isV6Format(ipAddress) != null && ipAddress.indexOf("::ffff") >= 0) {
     ipAddress.split("::ffff:")[1]
   }
   return ipAddress

--- a/src/lib/metaphysics2.coffee
+++ b/src/lib/metaphysics2.coffee
@@ -1,12 +1,11 @@
 qs = require 'qs'
 request = require 'superagent'
-{ extend, some } = require 'underscore'
+{ extend, some } = require 'lodash'
 { METAPHYSICS_ENDPOINT, API_REQUEST_TIMEOUT, REQUEST_ID } = require('sharify').data
-ip = require 'ip'
-chalk = require 'chalk'
+{ isV6Format } = require './ip'
 
 resolveIPv4 = (ipAddress) ->
-  if ip.isV6Format(ipAddress)? and ipAddress.indexOf('::ffff') >= 0
+  if isV6Format(ipAddress)? and ipAddress.indexOf('::ffff') >= 0
     return ipAddress.split('::ffff:')[1]
   return ipAddress
 
@@ -45,10 +44,10 @@ metaphysics2 = ({ query, variables, req } = {}) ->
             try
               errorObject = JSON.parse(err?.response?.text)
             catch
-              console.error chalk.red('Failed to JSON.parse `err.response.text`')
+              console.error 'Failed to JSON.parse `err.response.text`'
 
           formattedError = JSON.stringify(errorObject, null, 2)
-          console.error chalk.red(formattedError)
+          console.error formattedError
           return reject err
 
         if response.body.errors?

--- a/webpack/envs/clientNovoProductionConfig.js
+++ b/webpack/envs/clientNovoProductionConfig.js
@@ -85,7 +85,6 @@ export const clientNovoProductionConfig = {
   },
   optimization: {
     minimize: !env.webpackDebug,
-
     minimizer: [
       new TerserPlugin({
         cache: false,
@@ -254,4 +253,7 @@ export const clientNovoProductionConfig = {
     symlinks: false,
   },
   stats: "normal",
+  node: {
+    global: true,
+  },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,7 +105,7 @@
     ip "1.1.5"
     mailcheck "1.1.1"
     passport "0.3.2"
-    passport-apple "git+https://github.com/artsy/passport-apple.git#f41adb7822c8344b72bc36a7d68312f6592cb14f"
+    passport-apple "https://github.com/artsy/passport-apple#f41adb7822c8344b72bc36a7d68312f6592cb14f"
     passport-facebook "2.1.1"
     superagent "1.8.4"
     underscore.string "3.3.4"
@@ -14451,10 +14451,9 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
-"passport-apple@git+https://github.com/artsy/passport-apple.git#f41adb7822c8344b72bc36a7d68312f6592cb14f":
+"passport-apple@https://github.com/artsy/passport-apple#f41adb7822c8344b72bc36a7d68312f6592cb14f":
   version "1.1.2"
-  uid f41adb7822c8344b72bc36a7d68312f6592cb14f
-  resolved "git+https://github.com/artsy/passport-apple.git#f41adb7822c8344b72bc36a7d68312f6592cb14f"
+  resolved "https://github.com/artsy/passport-apple#f41adb7822c8344b72bc36a7d68312f6592cb14f"
   dependencies:
     jsonwebtoken "^8.5.1"
     passport-oauth2 "^1.5.0"


### PR DESCRIPTION
Strategically cleans up several `underscore`/`chalk` imports that were causing them
to be included in Novo bundles.

Pulls the one function we used from `ip` into lib, we don't need a whole
library for a single ipv6 regex.

The bundle size is reduced from 1.07 MiB to 1.02 MiB 