### PR TITLE
chore: GRO-213: Adding LazyLoadComponent to FooterBanner

### DIFF
--- a/src/v2/Components/Footer.tsx
+++ b/src/v2/Components/Footer.tsx
@@ -68,14 +68,17 @@ const DownloadAppBanner = () => {
             </Text>
           </Flex>
         </Box>
-        <Box
-          height={320}
-          width="100%"
-          backgroundImage="url(https://files.artsy.net/consign/banner-large.jpg)"
-          backgroundSize="cover"
-          backgroundPosition="center"
-          backgroundRepeat="no-repeat"
-        ></Box>
+        <Box height={320} width="100%" textAlign="center">
+          <Image
+            height={320}
+            width="102%"
+            src="https://files.artsy.net/consign/banner-large.jpg"
+            mr={2}
+            style={{
+              objectFit: "cover",
+            }}
+          />
+        </Box>
       </Flex>
     </Flex>
   )
@@ -90,6 +93,7 @@ export const Footer: React.FC<Props> = props => {
       borderTop={flushWithContent ? "" : `1px solid ${color("black10")}`}
     >
       <Media greaterThan="xs">
+        <Box id="download-app-banner"></Box>
         <LazyLoadComponent threshold={1000}>
           <DownloadAppBanner />
         </LazyLoadComponent>

--- a/src/v2/Components/Footer.tsx
+++ b/src/v2/Components/Footer.tsx
@@ -21,6 +21,7 @@ import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import { DownloadAppBadge } from "v2/Components/DownloadAppBadge"
 import { ContextModule } from "@artsy/cohesion"
 import { CCPARequest } from "./CCPARequest"
+import { LazyLoadComponent } from "react-lazy-load-image-component"
 
 const Column = styled(Flex).attrs({
   flex: 1,
@@ -89,7 +90,9 @@ export const Footer: React.FC<Props> = props => {
       borderTop={flushWithContent ? "" : `1px solid ${color("black10")}`}
     >
       <Media greaterThan="xs">
-        <DownloadAppBanner />
+        <LazyLoadComponent threshold={1000}>
+          <DownloadAppBanner />
+        </LazyLoadComponent>
       </Media>
       <footer>
         <Flex

--- a/src/v2/Components/Footer.tsx
+++ b/src/v2/Components/Footer.tsx
@@ -41,7 +41,6 @@ const DownloadAppBanner = () => {
       borderBottom={`1px solid ${color("black10")}`}
       mb={3}
       overflow="hidden"
-      id="download-app-banner"
     >
       <Flex
         alignItems="center"

--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -24,6 +24,7 @@ import {
   NAV_BAR_TOP_TIER_HEIGHT,
   NAV_BAR_BOTTOM_TIER_HEIGHT,
 } from "./constants"
+import { ScrollIntoView } from "v2/Utils"
 
 /**
  * Old Force pages have the navbar height hardcoded in several places. If
@@ -243,7 +244,17 @@ export const NavBar: React.FC = track(
                 </NavItem>
               </NavSection>
               <NavSection alignItems="right" mr={2}>
-                <NavItem href="#download-app-banner">Download App</NavItem>
+                <ScrollIntoView
+                  selector="#download-app-banner"
+                  behavior="smooth"
+                >
+                  <NavItem
+                    href="#download-app-banner"
+                    onClick={event => event.preventDefault()}
+                  >
+                    Download App
+                  </NavItem>
+                </ScrollIntoView>
               </NavSection>
             </NavSection>
           </NavBarTier>

--- a/src/v2/Components/NavBar/NavItem.tsx
+++ b/src/v2/Components/NavBar/NavItem.tsx
@@ -65,7 +65,7 @@ export interface NavItemProps
   href?: string
   label?: string
   menuAnchor?: MenuAnchor
-  onClick?: () => void
+  onClick?: (event: React.MouseEvent<any>) => void
 }
 
 export const NavItem: React.FC<NavItemProps> = ({
@@ -118,9 +118,13 @@ export const NavItem: React.FC<NavItemProps> = ({
     }
   }, [isVisible])
 
-  const handleClick = () => {
-    onClick && onClick()
-    !!Menu && setIsVisible(prevIsVisible => !prevIsVisible)
+  const handleClick = event => {
+    if (onClick) {
+      onClick(event)
+    }
+    if (!!Menu) {
+      setIsVisible(prevIsVisible => !prevIsVisible)
+    }
     trackClick()
   }
 

--- a/src/v2/Utils/ScrollIntoView.tsx
+++ b/src/v2/Utils/ScrollIntoView.tsx
@@ -1,11 +1,7 @@
 import { Box } from "@artsy/palette"
 import React from "react"
-import { scrollIntoView } from "v2/Utils/scrollHelpers"
+import { scrollIntoView, ScrollIntoViewProps } from "v2/Utils/scrollHelpers"
 
-interface ScrollIntoViewProps {
-  selector: string
-  offset?: number
-}
 export class ScrollIntoView extends React.Component<ScrollIntoViewProps> {
   static defaultProps = {
     offset: 40,
@@ -16,7 +12,9 @@ export class ScrollIntoView extends React.Component<ScrollIntoViewProps> {
       <Box
         display="block"
         width={["100%"]}
-        onClick={() => scrollIntoView(this.props)}
+        onClick={() => {
+          scrollIntoView(this.props)
+        }}
       >
         {this.props.children}
       </Box>

--- a/src/v2/Utils/scrollHelpers.ts
+++ b/src/v2/Utils/scrollHelpers.ts
@@ -6,14 +6,21 @@ const getElementPosition = $element => {
   }
 }
 
-export const scrollIntoView = passedProps => {
-  const { selector, offset } = passedProps
+export interface ScrollIntoViewProps {
+  selector: string
+  offset?: number
+  behavior?: ScrollBehavior
+}
+
+export const scrollIntoView = (passedProps: ScrollIntoViewProps) => {
+  const { selector, offset, ...rest } = passedProps
   const $element = document.querySelector(selector)
 
   if ($element) {
     const { top } = getElementPosition($element)
     window.scrollTo({
       top: top - offset,
+      ...rest,
     })
   }
 }


### PR DESCRIPTION
Ticket: [GRO-213]
There were performance optimizations recommended by Damon for the footer.

The image in the footer should be lazy loaded and be a real `img` tag to increase accessibility.

New layout:
<img width="626" alt="Screen Shot 2021-02-23 at 2 12 13 PM" src="https://user-images.githubusercontent.com/30025439/108915189-5ccd9380-75e1-11eb-8913-75bbf5f9ae06.png">


[GRO-213]: https://artsyproduct.atlassian.net/browse/GRO-213