### PR TITLE
feat(fx-2629): implements custom price range filter

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
@@ -1,11 +1,77 @@
-import React from "react"
-import { Flex, Radio, RadioGroup, Toggle } from "@artsy/palette"
+import React, { useState } from "react"
+import {
+  Button,
+  Clickable,
+  Flex,
+  Input,
+  Radio,
+  RadioGroup,
+  Spacer,
+  Text,
+  Toggle,
+} from "@artsy/palette"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
 
+const PRICE_RANGES = [
+  { name: "$50K+", value: "50000-*" },
+  { name: "$25K – $50K", value: "25000-50000" },
+  { name: "$10K – $25K", value: "10000-25000" },
+  { name: "$5K – $10K", value: "5000-10000" },
+  { name: "$1K – $5K", value: "1000-5000" },
+  { name: "$0 – $1,000", value: "0-1000" },
+]
+
+type CustomRange = (number | "*")[]
+
+const DEFAULT_CUSTOM_RANGE: CustomRange = ["*", "*"]
+
+const parseRange = (range?: string) => {
+  return range?.split("-").map(s => {
+    if (s === "*") return s
+    return parseInt(s, 10)
+  })
+}
+
 export const PriceRangeFilter: React.FC = () => {
-  const filterContext = useArtworkFilterContext()
-  const initialRange = filterContext.currentlySelectedFilters().priceRange
+  const { currentlySelectedFilters, setFilter } = useArtworkFilterContext()
+  const { priceRange: initialRange, atAuction } = currentlySelectedFilters()
+
+  const numericInitialRange = parseRange(initialRange)
+
+  const [showCustom, setShowCustom] = useState(false)
+  const [customRange, setCustomRange] = useState<CustomRange>(
+    numericInitialRange ?? DEFAULT_CUSTOM_RANGE
+  )
+
+  const handleClick = () => {
+    setFilter("priceRange", customRange.join("-"))
+  }
+
+  const handleChange = (index: number) => ({
+    currentTarget: { value },
+  }: React.FormEvent<HTMLInputElement>) => {
+    const isOpenEnded = value === "" || value === "0"
+    const isMin = index === 0
+    const isMax = index === 1
+
+    setCustomRange(prevCustomRange => {
+      if (isOpenEnded && isMin) {
+        prevCustomRange[index] = 0
+      } else if (isOpenEnded && isMax) {
+        prevCustomRange[index] = "*"
+      } else {
+        prevCustomRange[index] = parseInt(value, 10)
+      }
+
+      return [...prevCustomRange]
+    })
+  }
+
+  const handleSelect = (selectedOption: string) => {
+    setFilter("priceRange", selectedOption)
+    setCustomRange(parseRange(selectedOption))
+  }
 
   return (
     <Toggle label="Price" expanded>
@@ -13,13 +79,11 @@ export const PriceRangeFilter: React.FC = () => {
         <RadioGroup
           deselectable
           defaultValue={initialRange}
-          onSelect={selectedOption => {
-            filterContext.setFilter("priceRange", selectedOption)
-          }}
-          disabled={filterContext.currentlySelectedFilters().atAuction ?? false}
+          onSelect={handleSelect}
+          disabled={atAuction}
           disabledText="Disabled for biddable works"
         >
-          {priceRanges.map((range, index) => (
+          {PRICE_RANGES.map((range, index) => (
             <Radio
               key={`${index}`}
               my={0.3}
@@ -29,33 +93,45 @@ export const PriceRangeFilter: React.FC = () => {
           ))}
         </RadioGroup>
       </Flex>
+
+      <Clickable
+        mt={1}
+        textDecoration="underline"
+        textAlign="left"
+        onClick={() => setShowCustom(prevShowCustom => !prevShowCustom)}
+      >
+        <Text>{showCustom ? "Hide" : "Show"} custom price</Text>
+      </Clickable>
+
+      {showCustom && (
+        <>
+          <Flex mt={1} alignItems="flex-end">
+            <Input
+              placeholder="$ Min"
+              type="number"
+              min="0"
+              step="1"
+              value={customRange[0]}
+              onChange={handleChange(0)}
+            />
+
+            <Spacer mx={0.5} />
+
+            <Input
+              placeholder="$ Max"
+              type="number"
+              min="0"
+              step="1"
+              value={customRange[1]}
+              onChange={handleChange(1)}
+            />
+          </Flex>
+
+          <Button mt={1} variant="secondaryGray" onClick={handleClick}>
+            Set price
+          </Button>
+        </>
+      )}
     </Toggle>
   )
 }
-
-const priceRanges = [
-  {
-    name: "$50k+",
-    value: "50000-*",
-  },
-  {
-    name: "$25k – $50k",
-    value: "25000-50000",
-  },
-  {
-    name: "$10k – $25k",
-    value: "10000-25000",
-  },
-  {
-    name: "$5k – $10k",
-    value: "5000-10000",
-  },
-  {
-    name: "$1k – $5k",
-    value: "1000-5000",
-  },
-  {
-    name: "$0 – $1,000",
-    value: "0-1000",
-  },
-]

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/PriceRangeFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/PriceRangeFilter.jest.tsx
@@ -1,6 +1,7 @@
+import { Input } from "@artsy/palette"
 import { mount } from "enzyme"
 import React from "react"
-import { act } from "react-dom/test-utils"
+import { flushPromiseQueue } from "v2/DevTools"
 import {
   ArtworkFilterContextProps,
   ArtworkFilterContextProvider,
@@ -24,18 +25,93 @@ describe("PriceRangeFilter", () => {
     return <PriceRangeFilter />
   }
 
-  it("updates context on filter change", done => {
-    const wrapper = getWrapper() as any
-    act(() => {
-      wrapper
-        .find("Radio")
-        .filterWhere(n => n.text() === "$25k – $50k")
-        .simulate("click")
+  it("renders the options", () => {
+    const wrapper = getWrapper()
+    const options = wrapper.find("Radio")
 
-      setTimeout(() => {
-        expect(context.filters.priceRange).toEqual("25000-50000")
-        done()
-      }, 0)
-    })
+    expect(options).toHaveLength(6)
+  })
+
+  it("updates the filter on select", async () => {
+    const wrapper = getWrapper()
+    const option = wrapper
+      .find("Radio")
+      .filterWhere(n => n.text() === "$25K – $50K")
+
+    option.simulate("click")
+    await flushPromiseQueue()
+
+    expect(context.filters.priceRange).toEqual("25000-50000")
+  })
+
+  it("toggles the custom input", async () => {
+    const wrapper = getWrapper()
+
+    expect(wrapper.find(Input)).toHaveLength(0)
+
+    wrapper
+      .find("button")
+      .filterWhere(n => n.text() === "Show custom price")
+      .simulate("click")
+
+    expect(
+      wrapper.find("button").filterWhere(n => n.text() === "Hide custom price")
+    ).toHaveLength(1)
+
+    expect(wrapper.find(Input)).toHaveLength(2)
+  })
+
+  it("updates the input values when the radio selected option updates", async () => {
+    const wrapper = getWrapper()
+    const options = wrapper.find("Radio")
+
+    wrapper
+      .find("button")
+      .filterWhere(n => n.text() === "Show custom price")
+      .simulate("click")
+
+    expect(wrapper.find(Input).first().html()).toContain('value="*"')
+    expect(wrapper.find(Input).last().html()).toContain('value="*"')
+
+    options.first().simulate("click")
+    await flushPromiseQueue()
+
+    expect(wrapper.find(Input).first().html()).toContain('value="50000"')
+    expect(wrapper.find(Input).last().html()).toContain('value="*"')
+
+    options.last().simulate("click")
+    await flushPromiseQueue()
+
+    expect(wrapper.find(Input).first().html()).toContain('value="0"')
+    expect(wrapper.find(Input).last().html()).toContain('value="1000"')
+  })
+
+  // TODO: Unable to trigger this changes correctly
+  it.skip("updates the filter when the custom input is applied", async () => {
+    const wrapper = getWrapper()
+
+    wrapper
+      .find("button")
+      .filterWhere(n => n.text() === "Show custom price")
+      .simulate("click")
+
+    wrapper
+      .find(Input)
+      .first()
+      .find("input")
+      .simulate("change", { currentTarget: { value: "400" } })
+
+    wrapper
+      .find(Input)
+      .last()
+      .find("input")
+      .simulate("change", { currentTarget: { value: "7500" } })
+
+    await flushPromiseQueue()
+
+    wrapper.find("Button").last().simulate("click")
+    await flushPromiseQueue()
+
+    expect(context.filters.priceRange).toEqual("400-7500")
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
@@ -112,7 +112,7 @@ describe("ArtworkFilterMobileActionSheet", () => {
     wrapper
       .find("PriceRangeFilter")
       .find("label")
-      .findWhere(label => label.text() === "$10k – $25k")
+      .findWhere(label => label.text() === "$10K – $25K")
       .first()
       .simulate("click")
     await flushPromiseQueue()


### PR DESCRIPTION
Closes: [FX-2629](https://artsyproduct.atlassian.net/browse/FX-2629)

* The currently selected price range is always reflected in the inputs (so if selecting a radio or coming in from a link)
* You can only input positive integers into the inputs, left hand side has to be at a minimum of 0, right hand side can be empty which is `"*"`
* If the input changes to one not reflected in the radios; then no radios will be highlighted

There might be some subtleties to this interaction here that can be tweaked; so this needs some eyes on it; but this should work as a first-pass.

![](https://static.damonzucconi.com/_capture/CuWlrfVT.gif)