### PR TITLE
fix: Redirect about sub-sections GRO-212

### DIFF
--- a/src/desktop/apps/about/index.coffee
+++ b/src/desktop/apps/about/index.coffee
@@ -10,6 +10,15 @@ app.set 'view engine', 'jade'
 page = new JSONPage name: 'about', paths: show: '/about', edit: '/about/edit'
 { data, edit, upload } = require('../../components/json_page/routes')(page)
 
+sections = [
+  '/about/collecting',
+  '/about/education',
+  '/about/the-art-genome-project',
+  '/about/the-art-world-online',
+]
+sections.forEach (section) =>
+  app.get section, (_request, response) => response.redirect(301, '/about')
+
 app.get page.paths.show, routes.index
 app.get /^\/about((?!\/edit).)*$/, routes.index # Scroll routes
 app.get page.paths.show + '/data', data


### PR DESCRIPTION
While working through #7079 I failed to handle the sub-section URLs. This PR gobbles them up and redirects them to the main about page. More chatter here:

https://artsy.slack.com/archives/C9SATFLUU/p1614380046128900

https://artsyproduct.atlassian.net/browse/GRO-212

/cc @artsy/grow-devs @dblandin @joeyAghion @dzucconi 