### PR TITLE
fix: allow paginating on search results tab by passing the term thru

### DIFF
--- a/src/v2/Apps/Search/Routes/Entity/SearchResultsEntity.tsx
+++ b/src/v2/Apps/Search/Routes/Entity/SearchResultsEntity.tsx
@@ -63,6 +63,11 @@ export class SearchResultsEntityRoute extends React.Component<Props, State> {
 
   loadAfter = (cursor: string, page: number) => {
     this.toggleLoading(true)
+    const {
+      match: { location },
+    } = this.props
+    const { query } = location
+    const { term } = query
 
     this.props.relay.refetch(
       {
@@ -71,6 +76,7 @@ export class SearchResultsEntityRoute extends React.Component<Props, State> {
         first: PAGE_SIZE,
         last: null,
         page: null,
+        term,
       },
       null,
       error => {


### PR DESCRIPTION
this is an odd one b/c its one of these 'how did this ever work?' bugs. the answer is that it didn't, unless something was more recently changed (but I wasn't able to find anything spelunking in force and reaction, at least until the time of the merger, so it does seem likely this hasn't worked in 1+ years?).