### PR TITLE
fix: [Novo] Add /auctions2 public path

### DIFF
--- a/src/desktop/lib/webpackPublicPath.ts
+++ b/src/desktop/lib/webpackPublicPath.ts
@@ -29,6 +29,8 @@ if (process.env.NODE_ENV === "production") {
     "/artist/",
     "/artists",
     "/artwork",
+    // FIXME: Swap with /auctions when new page launches
+    "/auctions2",
     "/collect",
     "/collection",
     "/collections",


### PR DESCRIPTION
Just noticed that I missed adding this to the `webpackPublicPath` a while back! 