### PR TITLE
feat: Remove stale news sitemap GRO-226

### DIFF
--- a/src/desktop/apps/sitemaps/index.coffee
+++ b/src/desktop/apps/sitemaps/index.coffee
@@ -6,6 +6,7 @@ app.set 'views', __dirname + '/templates'
 app.set 'view engine', 'jade'
 
 app.get '/robots.txt', routes.robots
+app.get '/sitemap-misc.xml', routes.misc
 
 app.get ['/sitemap-articles.xml', '/sitemap-articles-:timestamp.xml'], routes.sitemaps
 app.get ['/sitemap-artists.xml', '/sitemap-artists-:timestamp.xml'], routes.sitemaps
@@ -18,7 +19,6 @@ app.get ['/sitemap-fairs.xml', '/sitemap-fairs-:timestamp.xml'], routes.sitemaps
 app.get ['/sitemap-features.xml', '/sitemap-features-:timestamp.xml'], routes.sitemaps
 app.get '/sitemap-genes.xml', routes.sitemaps
 app.get ['/sitemap-images.xml', '/sitemap-images-:timestamp.xml'], routes.sitemaps
-app.get '/sitemap-misc.xml', routes.misc
 app.get ['/sitemap-partners.xml', '/sitemap-partners-:timestamp.xml'], routes.sitemaps
 app.get ['/sitemap-shows.xml', '/sitemap-shows-:timestamp.xml'], routes.sitemaps
 app.get '/sitemap-tags.xml', routes.sitemaps

--- a/src/desktop/apps/sitemaps/index.coffee
+++ b/src/desktop/apps/sitemaps/index.coffee
@@ -8,18 +8,33 @@ app.set 'view engine', 'jade'
 app.get '/robots.txt', routes.robots
 app.get '/sitemap-misc.xml', routes.misc
 
-app.get ['/sitemap-articles.xml', '/sitemap-articles-:timestamp.xml'], routes.sitemaps
-app.get ['/sitemap-artists.xml', '/sitemap-artists-:timestamp.xml'], routes.sitemaps
-app.get ['/sitemap-artist-images.xml', '/sitemap-artist-images-:slug.xml'], routes.sitemaps
-app.get ['/sitemap-artist-series.xml', '/sitemap-artist-series-:timestamp.xml'], routes.sitemaps
-app.get ['/sitemap-artworks.xml', '/sitemap-artworks-:timestamp.xml'], routes.sitemaps
-app.get '/sitemap-cities.xml', routes.sitemaps
-app.get '/sitemap-collect.xml', routes.sitemaps
-app.get ['/sitemap-fairs.xml', '/sitemap-fairs-:timestamp.xml'], routes.sitemaps
-app.get ['/sitemap-features.xml', '/sitemap-features-:timestamp.xml'], routes.sitemaps
-app.get '/sitemap-genes.xml', routes.sitemaps
-app.get ['/sitemap-images.xml', '/sitemap-images-:timestamp.xml'], routes.sitemaps
-app.get ['/sitemap-partners.xml', '/sitemap-partners-:timestamp.xml'], routes.sitemaps
-app.get ['/sitemap-shows.xml', '/sitemap-shows-:timestamp.xml'], routes.sitemaps
-app.get '/sitemap-tags.xml', routes.sitemaps
-app.get ['/sitemap-videos.xml', '/sitemap-videos-:timestamp.xml'], routes.sitemaps
+standardSitemapRoutes = [
+  '/sitemap-articles-:timestamp.xml',
+  '/sitemap-articles.xml',
+  '/sitemap-artist-images-:slug.xml',
+  '/sitemap-artist-images.xml',
+  '/sitemap-artist-series-:timestamp.xml',
+  '/sitemap-artist-series.xml',
+  '/sitemap-artists-:timestamp.xml',
+  '/sitemap-artists.xml',
+  '/sitemap-artworks-:timestamp.xml',
+  '/sitemap-artworks.xml',
+  '/sitemap-cities.xml',
+  '/sitemap-collect.xml',
+  '/sitemap-fairs-:timestamp.xml',
+  '/sitemap-fairs.xml',
+  '/sitemap-features-:timestamp.xml',
+  '/sitemap-features.xml',
+  '/sitemap-genes.xml',
+  '/sitemap-images-:timestamp.xml',
+  '/sitemap-images.xml',
+  '/sitemap-partners-:timestamp.xml',
+  '/sitemap-partners.xml',
+  '/sitemap-shows-:timestamp.xml',
+  '/sitemap-shows.xml',
+  '/sitemap-tags.xml',
+  '/sitemap-videos-:timestamp.xml',
+  '/sitemap-videos.xml',
+]
+
+app.get standardSitemapRoutes, routes.sitemaps

--- a/src/desktop/apps/sitemaps/index.coffee
+++ b/src/desktop/apps/sitemaps/index.coffee
@@ -19,7 +19,6 @@ app.get ['/sitemap-features.xml', '/sitemap-features-:timestamp.xml'], routes.si
 app.get '/sitemap-genes.xml', routes.sitemaps
 app.get ['/sitemap-images.xml', '/sitemap-images-:timestamp.xml'], routes.sitemaps
 app.get '/sitemap-misc.xml', routes.misc
-app.get '/sitemap-news.xml', routes.news
 app.get ['/sitemap-partners.xml', '/sitemap-partners-:timestamp.xml'], routes.sitemaps
 app.get ['/sitemap-shows.xml', '/sitemap-shows-:timestamp.xml'], routes.sitemaps
 app.get '/sitemap-tags.xml', routes.sitemaps

--- a/src/desktop/apps/sitemaps/routes.coffee
+++ b/src/desktop/apps/sitemaps/routes.coffee
@@ -1,32 +1,8 @@
 _ = require 'underscore'
-Articles = require '../../collections/articles'
-request = require 'superagent'
-moment = require 'moment'
-async = require 'async'
-PartnerFeaturedCities = require '../../collections/partner_featured_cities'
-{ API_URL, POSITRON_URL, APP_URL, ARTSY_EDITORIAL_CHANNEL, ENABLE_WEB_CRAWLING, SITEMAP_BASE_URL } = require('sharify').data
-artsyXapp = require '@artsy/xapp'
-PAGE_SIZE = 100
+{ APP_URL, ENABLE_WEB_CRAWLING, SITEMAP_BASE_URL } = require('sharify').data
 { parse } = require 'url'
-sd = require 'sharify'
 httpProxy = require 'http-proxy'
 sitemapProxy = httpProxy.createProxyServer(target: SITEMAP_BASE_URL)
-getFullEditorialHref = require("@artsy/reaction/dist/Components/Publishing/Constants").getFullEditorialHref
-
-@news = (req, res, next) ->
-  new Articles().fetch
-    data:
-      channel_id: sd.ARTSY_EDITORIAL_CHANNEL
-      published: true
-      sort: '-published_at'
-      exclude_google_news: false
-      limit: PAGE_SIZE
-    error: res.backboneError
-    success: (articles) ->
-      recentArticles = articles.filter (article) ->
-        moment(article.get 'published_at').isAfter(moment().subtract(2, 'days')) && article.get("layout") != 'classic'
-      res.set 'Content-Type', 'text/xml'
-      res.render('news', { pretty: true, articles: recentArticles, getFullEditorialHref: getFullEditorialHref })
 
 @misc = (req, res, next) ->
   res.set 'Content-Type', 'text/xml'
@@ -60,7 +36,6 @@ getFullEditorialHref = require("@artsy/reaction/dist/Components/Publishing/Const
     Sitemap: #{APP_URL}/sitemap-genes.xml
     Sitemap: #{APP_URL}/sitemap-images.xml
     Sitemap: #{APP_URL}/sitemap-misc.xml
-    Sitemap: #{APP_URL}/sitemap-news.xml
     Sitemap: #{APP_URL}/sitemap-partners.xml
     Sitemap: #{APP_URL}/sitemap-shows.xml
     Sitemap: #{APP_URL}/sitemap-tags.xml

--- a/src/desktop/apps/sitemaps/test/routes.test.js
+++ b/src/desktop/apps/sitemaps/test/routes.test.js
@@ -66,7 +66,6 @@ Sitemap: https://www.artsy.net/sitemap-features.xml
 Sitemap: https://www.artsy.net/sitemap-genes.xml
 Sitemap: https://www.artsy.net/sitemap-images.xml
 Sitemap: https://www.artsy.net/sitemap-misc.xml
-Sitemap: https://www.artsy.net/sitemap-news.xml
 Sitemap: https://www.artsy.net/sitemap-partners.xml
 Sitemap: https://www.artsy.net/sitemap-shows.xml
 Sitemap: https://www.artsy.net/sitemap-tags.xml
@@ -78,49 +77,6 @@ Sitemap: https://www.artsy.net/sitemap-videos.xml
       return it("includes a CR/LF at the end of robots.txt", function () {
         return this.res.send.args[0][0].slice(-1).should.eql("\n")
       })
-    })
-  })
-
-  describe("#news", function () {
-    it("displays the sitemap for articles that are < 2 days old", function () {
-      const today = new Date()
-      const oneDayAgo = new Date()
-      const twoDaysAgo = new Date()
-
-      oneDayAgo.setDate(today.getDate() - 1)
-      twoDaysAgo.setDate(today.getDate() - 2)
-
-      routes.news(this.req, this.res)
-      Backbone.sync.args[0][2].success({
-        total: 16088,
-        count: 12,
-        results: [
-          fabricate("article", {
-            layout: "standard",
-            published_at: today.toISOString(),
-          }),
-          fabricate("article", {
-            layout: "news",
-            published_at: oneDayAgo.toISOString(),
-          }),
-          fabricate("article", {
-            layout: "classic",
-            published_at: oneDayAgo.toISOString(),
-          }),
-          fabricate("article", { published_at: twoDaysAgo.toISOString() }),
-        ],
-      })
-
-      this.res.render.args[0][0].should.equal("news")
-      return this.res.render.args[0][1].articles.length.should.equal(2)
-    })
-
-    return it("fetches with correct news data", function () {
-      routes.news(this.req, this.res)
-      Backbone.sync.args[0][2].data.published.should.be.true()
-      Backbone.sync.args[0][2].data.sort.should.equal("-published_at")
-      Backbone.sync.args[0][2].data.exclude_google_news.should.be.false()
-      return Backbone.sync.args[0][2].data.limit.should.equal(100)
     })
   })
 

--- a/src/desktop/apps/sitemaps/test/templates.test.js
+++ b/src/desktop/apps/sitemaps/test/templates.test.js
@@ -42,28 +42,3 @@ describe("misc sitemap template", () =>
     xml.should.containEql("/sign_up")
     return xml.should.containEql("/terms")
   }))
-
-describe("news sitemap template", () =>
-  it("renders article info", function () {
-    const articles = [
-      new Article(fabricate("article", { layout: "standard" })),
-      new Article(
-        fabricate("article", {
-          layout: "news",
-          slug: "banksys-half-shredded-painting-will-view-german-museum",
-        })
-      ),
-    ]
-
-    const xml = render("news")({ articles, getFullEditorialHref })
-
-    xml.should.containEql("/article/editorial-on-the-heels-of-a-stellar-year")
-    xml.should.containEql(
-      "/news/banksys-half-shredded-painting-will-view-german-museum"
-    )
-    xml.should.containEql("<news:name>Artsy</news:name>")
-    xml.should.containEql("2014-09-24T23:24:54.000Z")
-    return xml.should.containEql(
-      "On The Heels of A Stellar Year in the West, Sterling Ruby Makes His Vivid Mark on Asia"
-    )
-  }))


### PR DESCRIPTION
We aren't publishing news like we used to so this sitemap is stale. When this is merged I'll update Google Search Console to remove the sitemap from there as well. Note that these news items ARE in the corresponding article sitemap so they were sorta dupes.

https://artsyproduct.atlassian.net/browse/GRO-226

/cc @artsy/grow-devs