### PR TITLE
fix: [Router] Add white border around loader for darkmode

### DIFF
--- a/src/v2/Artsy/Router/RenderStatus.tsx
+++ b/src/v2/Artsy/Router/RenderStatus.tsx
@@ -35,9 +35,10 @@ export const RenderPending = () => {
           showBackground={false}
           step={10} // speed of progress bar, randomized between 1/x to simulate variable progress
           style={{
+            borderTop: "1px solid white",
             position: "fixed",
             left: 0,
-            top: -6,
+            top: -5,
             zIndex: 1000,
           }}
         />


### PR DESCRIPTION
This adds a slight 1p white border to our top page transition loader so that we can see it in dark mode themes. This has always bothered me and just noticed this fix on another site, wanted to bring it here:

<img width="83" alt="Screen Shot 2021-03-03 at 2 15 04 PM" src="https://user-images.githubusercontent.com/236943/109880097-5c5d7a00-7c2b-11eb-8c61-ba7cfdd6b4da.png">
<img width="63" alt="Screen Shot 2021-03-03 at 2 12 03 PM" src="https://user-images.githubusercontent.com/236943/109880103-5d8ea700-7c2b-11eb-847e-727aeacf7bd5.png">
