### PR TITLE
fix: Fixes for scrolling issues related to address modal

### DIFF
--- a/src/v2/Apps/Order/Components/AddressModal.tsx
+++ b/src/v2/Apps/Order/Components/AddressModal.tsx
@@ -164,7 +164,6 @@ export const AddressModal: React.FC<Props> = ({
               disabled={Object.keys(formik.errors).length > 0}
               width="100%"
               mt={2}
-              onClick={() => formik.handleSubmit()}
             >
               Save changes
             </Button>

--- a/src/v2/Apps/Order/Components/AddressModal.tsx
+++ b/src/v2/Apps/Order/Components/AddressModal.tsx
@@ -59,7 +59,7 @@ export const AddressModal: React.FC<Props> = ({
   return (
     <Modal title={title} show={show} onClose={closeModal}>
       <Formik
-        initialValues={createAddressModalAction ? {} : address}
+        initialValues={createAddressModalAction ? { country: "US" } : address}
         validate={validator}
         onSubmit={values => {
           createAddressModalAction

--- a/src/v2/Apps/Order/Components/SavedAddresses.tsx
+++ b/src/v2/Apps/Order/Components/SavedAddresses.tsx
@@ -44,9 +44,6 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
 
   const { onSelect, handleClickEdit, me, inCollectorProfile, relay } = props
   const addressList = me?.addressConnection?.edges ?? []
-  const handleModal = () => {
-    setShowAddressModal(!showAddressModal)
-  }
   const collectorProfileAddressItems = addressList.map((address, index) => {
     if (!address.node) {
       return null
@@ -96,39 +93,37 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
         mt={addressList.length > 0 ? 3 : 0}
         variant="primaryBlack"
         size="large"
-        onClick={() => handleModal()}
+        onClick={() => setShowAddressModal(true)}
       >
         Add new address
       </Button>
-      {showAddressModal && (
-        <AddressModal
-          show={showAddressModal}
-          modalDetails={{
-            addressModalTitle: "Add new address",
-            addressModalAction: "createUserAddress",
-          }}
-          closeModal={() => handleModal()}
-          address={null}
-          onSuccess={() => {
-            relay.refetch(
-              {
-                first: PAGE_SIZE,
-              },
-              null,
-              error => {
-                if (error) {
-                  logger.error(error)
-                }
+      <AddressModal
+        show={showAddressModal}
+        modalDetails={{
+          addressModalTitle: "Add new address",
+          addressModalAction: "createUserAddress",
+        }}
+        closeModal={() => setShowAddressModal(false)}
+        address={null}
+        onSuccess={() => {
+          relay.refetch(
+            {
+              first: PAGE_SIZE,
+            },
+            null,
+            error => {
+              if (error) {
+                logger.error(error)
               }
-            )
-          }}
-          commitMutation={props.commitMutation}
-          onError={message => {
-            logger.error(message)
-          }}
-          me={me}
-        />
-      )}
+            }
+          )
+        }}
+        commitMutation={props.commitMutation}
+        onError={message => {
+          logger.error(message)
+        }}
+        me={me}
+      />
     </>
   )
 

--- a/src/v2/Apps/Order/Components/__tests__/SavedAddresses.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/SavedAddresses.jest.tsx
@@ -36,7 +36,7 @@ describe("SavedAddress button interactions", () => {
   it("renders modal when button is clicked", () => {
     const button = wrapper.find(Button)
     const modal = wrapper.find(AddressModal)
-    expect(modal).toHaveLength(0)
+    expect(modal.props().show).toBe(false)
     button.props().onClick({} as any)
 
     setTimeout(() => {
@@ -47,7 +47,7 @@ describe("SavedAddress button interactions", () => {
   it("opens Create Address modal when as expected", () => {
     const button = wrapper.find(Button)
     const modal = wrapper.find(AddressModal)
-    expect(modal).toHaveLength(0)
+    expect(modal.props().show).toBe(false)
     button.props().onClick({} as any)
 
     setTimeout(() => {

--- a/src/v2/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/v2/Apps/Order/Routes/Shipping/index.tsx
@@ -91,6 +91,7 @@ export interface ShippingState {
   selectedSavedAddress: string
   editAddressIndex: number
   saveAddress: boolean
+  showModal: boolean
 }
 
 const logger = createLogger("Order/Routes/Shipping/index.tsx")
@@ -110,6 +111,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
     selectedSavedAddress: defaultShippingAddressIndex(this.props.me),
     editAddressIndex: -1,
     saveAddress: true,
+    showModal: false,
   }
 
   get touchedAddress() {
@@ -212,7 +214,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
             }
           }, // onError
           this.props.me, // me
-          () => this.setState({ editAddressIndex: -1 }) // closeModal
+          () => this.setState({ showModal: false }) // closeModal
         )
       }
 
@@ -255,7 +257,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
   }
 
   handleClickEdit = (value: number) => {
-    this.setState({ editAddressIndex: value })
+    this.setState({ editAddressIndex: value, showModal: true })
   }
 
   onAddressChange: AddressChangeHandler = (address, key) => {
@@ -304,6 +306,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
       phoneNumber,
       phoneNumberError,
       phoneNumberTouched,
+      showModal,
     } = this.state
     const artwork = get(
       this.props,
@@ -323,30 +326,28 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
     const onSelectSavedAddress = (value: string) => {
       this.setState({ selectedSavedAddress: value })
     }
-    const showModal = this.state.editAddressIndex > -1
+
     return (
       <Box data-test="orderShipping">
-        {showModal && (
-          <AddressModal
-            modalDetails={{
-              addressModalTitle: "Edit address",
-              addressModalAction: "editUserAddress",
-            }}
-            show={showModal}
-            closeModal={() => this.setState({ editAddressIndex: -1 })}
-            address={addressList[this.state.editAddressIndex]?.node}
-            commitMutation={this.props.commitMutation}
-            onSuccess={() => {
-              // this.setState({ address: updatedAddress })
-            }}
-            onError={message => {
-              this.props.dialog.showErrorDialog({
-                title: "Address cannot be updated",
-                message: message,
-              })
-            }}
-          />
-        )}
+        <AddressModal
+          modalDetails={{
+            addressModalTitle: "Edit address",
+            addressModalAction: "editUserAddress",
+          }}
+          show={showModal}
+          closeModal={() => this.setState({ showModal: false })}
+          address={addressList[this.state.editAddressIndex]?.node}
+          commitMutation={this.props.commitMutation}
+          onSuccess={() => {
+            // this.setState({ address: updatedAddress })
+          }}
+          onError={message => {
+            this.props.dialog.showErrorDialog({
+              title: "Address cannot be updated",
+              message: message,
+            })
+          }}
+        />
         <HorizontalPadding px={[0, 4]}>
           <Row>
             <Col>

--- a/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -643,8 +643,10 @@ describe("Shipping", () => {
         const countrySelect = page.find("AddressModal").find("select")
         countrySelect.instance().value = `US`
         countrySelect.simulate("change")
-        const submit = page.find("AddressModal").find("button").at(0)
-        submit.simulate("click")
+
+        const form = page.find("form").first()
+        form.props().onSubmit()
+
         await page.update()
         expect(mutations.mockFetch.mock.calls[0][1]).toMatchInlineSnapshot(`
           Object {


### PR DESCRIPTION
This PR fixes scrolling issues that happened when using the address modal. It:

- Moves visibility of the modal to state on the payment/shipping flow.
- Changes modal visibility trigger to be explicit on saved addresses. 
- Removes conditional rendering of modal in parents.
- Removes redundant click handler on modal.