### PR TITLE
fix: Mark all sales as auctions for seo GRO-210

### DIFF
--- a/src/desktop/apps/auction/components/layout/meta.jade
+++ b/src/desktop/apps/auction/components/layout/meta.jade
@@ -7,7 +7,7 @@ meta( name='description', content= description )
 meta( property='og:description', content= description )
 meta( property='twitter:description', content= description )
 meta( property='og:url', content='#{sd.APP_URL}#{app.auction.href()}' )
-link( rel='canonical', href='#{sd.APP_URL}#{app.auction.href()}' )
+link( rel='canonical', href='#{sd.APP_URL}/auction/#{app.auction.id}' )
 
 meta( property='og:type', content='website' )
 meta( property='og:event', content='auction' )


### PR DESCRIPTION
Rather than compute an href here I've opted to simply concatenate the canonical as `/auction/:id` so that we don't confuse Google with duplicate content.

More chatter here: https://artsy.slack.com/archives/C01ADJNCS5D/p1614874844237600

https://artsyproduct.atlassian.net/browse/GRO-210

/cc @artsy/grow-devs