### PR TITLE
fix: Add `payments2` to converted paths

### DIFF
--- a/src/desktop/lib/webpackPublicPath.ts
+++ b/src/desktop/lib/webpackPublicPath.ts
@@ -45,6 +45,7 @@ if (process.env.NODE_ENV === "production") {
     "/search",
     "/show/",
     "/user/conversations",
+    "/user/payments2", // TODO: change to payment to release the app
     "/user/purchases",
     "/viewing-room/",
     "/viewing-rooms",


### PR DESCRIPTION
Problem: 
Getting a bunch of ChunkLoadError: Loading chunk 29 failed.  from novo routes.

Discussion:
https://artsy.slack.com/archives/CA8SANW3W/p1614893500274200

After releasing the app to the public this will be changed to `user/payement`