### PR TITLE
chore: Cleanup Sentry Imports

### DIFF
--- a/src/desktop/apps/authentication/helpers.ts
+++ b/src/desktop/apps/authentication/helpers.ts
@@ -2,8 +2,7 @@ import Cookies from "cookies-js"
 import { ModalOptions, ModalType } from "v2/Components/Authentication/Types"
 import { data as sd } from "sharify"
 import * as qs from "query-string"
-import { Response } from "express"
-import { captureException } from "@sentry/browser"
+import type { Response } from "express"
 import {
   AuthService,
   createdAccount,
@@ -12,6 +11,7 @@ import {
 } from "@artsy/cohesion"
 import { omit, pick } from "lodash"
 import { mediator } from "lib/mediator"
+import { reportError } from "v2/Utils/errors"
 
 export const handleSubmit = async (
   type: ModalType,
@@ -154,7 +154,7 @@ export async function apiAuthWithRedirectUrl(
       return appRedirectURL
     }
   } catch (error) {
-    captureException(error)
+    reportError(error)
     return appRedirectURL
   }
 }
@@ -212,7 +212,7 @@ const loginUser = async (
         options.error(data)
       }
     })
-    .catch(e => captureException(e))
+    .catch(e => reportError(e))
 }
 
 const signupUser = async (
@@ -254,7 +254,7 @@ const signupUser = async (
         options.error(data)
       }
     })
-    .catch(e => captureException(e))
+    .catch(e => reportError(e))
 }
 
 const forgotUserPassword = async (
@@ -294,5 +294,5 @@ const forgotUserPassword = async (
         options.error(data)
       }
     })
-    .catch(e => captureException(e))
+    .catch(e => reportError(e))
 }

--- a/src/desktop/lib/global_client_setup.tsx
+++ b/src/desktop/lib/global_client_setup.tsx
@@ -3,7 +3,7 @@ import $ from "jquery"
 import Backbone from "backbone"
 import _ from "underscore"
 import Cookies from "cookies-js"
-import * as Sentry from "@sentry/browser"
+import { configureScope } from "@sentry/browser"
 import { data as sd } from "sharify"
 import * as globalReactModules from "./global_react_modules"
 import { hydrate as hydrateStitch } from "@artsy/stitch/dist/internal/hydrate"
@@ -112,7 +112,7 @@ function setupErrorReporting() {
     const user = sd && sd.CURRENT_USER
 
     if (sd.CURRENT_USER) {
-      Sentry.configureScope(scope => {
+      configureScope(scope => {
         scope.setUser(_.pick(user, "id", "email"))
       })
     }

--- a/src/lib/setupSentry.ts
+++ b/src/lib/setupSentry.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/browser"
+import { init } from "@sentry/browser"
 
 let INITIALIZED = false
 
@@ -24,7 +24,7 @@ export function setupSentry(sd) {
   if (INITIALIZED) {
     return
   }
-  Sentry.init({
+  init({
     dsn: sd.SENTRY_PUBLIC_DSN,
     beforeSend(event, hint) {
       const error = hint.originalException

--- a/src/mobile/components/layout/bootstrap.coffee
+++ b/src/mobile/components/layout/bootstrap.coffee
@@ -18,7 +18,7 @@ Cookies = require 'cookies-js'
 doc = window.document
 sharify = require('sharify')
 CurrentUser = require '../../models/current_user'
-Sentry = require("@sentry/browser")
+{ init } = require("@sentry/browser")
 globalReactModules = require('../../../desktop/lib/global_react_modules.tsx')
 hydrateStitch = require('@artsy/stitch/dist/internal/hydrate').hydrate
 { mediator } = require('../../../lib/mediator')
@@ -63,7 +63,7 @@ mountStitch = ->
   })
 
 setupErrorReporting = ->
-  Sentry.init({ dsn: sd.SENTRY_PUBLIC_DSN })
+  init({ dsn: sd.SENTRY_PUBLIC_DSN })
 
 operations =
   save: (currentUser, objectId) ->

--- a/src/v2/Utils/__tests__/errors.jest.ts
+++ b/src/v2/Utils/__tests__/errors.jest.ts
@@ -1,5 +1,5 @@
-import * as Sentry from "@sentry/browser"
-import { ErrorWithMetadata, reportError } from "v2/Utils/errors"
+import { captureException } from "@sentry/browser"
+import { ErrorWithMetadata, reportErrorWithScope } from "v2/Utils/errors"
 
 jest.mock("@sentry/browser")
 
@@ -16,18 +16,18 @@ describe("errors", () => {
     })
 
     it("does not call setExtra on scope if the error has no metadata", () => {
-      reportError(err)(scope)
+      reportErrorWithScope(err)(scope)
       expect(scope.setExtra).not.toBeCalled()
     })
 
     it("calls setExtra on scope for errors with metadata", () => {
-      reportError(errWithMetadata)(scope)
+      reportErrorWithScope(errWithMetadata)(scope)
       expect(scope.setExtra).toBeCalledWith("foo", "bar")
     })
 
     it("sends the error to Sentry", () => {
-      reportError(errWithMetadata)(scope)
-      expect(Sentry.captureException).toBeCalledWith(err)
+      reportErrorWithScope(errWithMetadata)(scope)
+      expect(captureException).toBeCalledWith(err)
     })
   })
 })

--- a/src/v2/Utils/errors.tsx
+++ b/src/v2/Utils/errors.tsx
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/browser"
+import { captureException, withScope } from "@sentry/browser"
 
 export class NetworkError extends Error {
   response: any
@@ -16,15 +16,21 @@ export class ErrorWithMetadata extends Error {
   }
 }
 
-export const reportError = error => scope => {
+export const reportError = (error: Error | ErrorWithMetadata) => {
+  captureException(error)
+}
+
+export const reportErrorWithScope = (
+  error: Error | ErrorWithMetadata
+) => scope => {
   if (error instanceof ErrorWithMetadata) {
     Object.entries(error.metadata).forEach(([key, value]) => {
       scope.setExtra(key, value)
     })
   }
-  Sentry.captureException(error)
+  captureException(error)
 }
 
 export const sendErrorToService = (error: Error | ErrorWithMetadata) => {
-  Sentry.withScope(reportError(error))
+  withScope(reportErrorWithScope(error))
 }


### PR DESCRIPTION
This cleans up the Sentry imports to better support tree shaking and
moves error reporting to a single module.