### PR TITLE
chore: cap show more to 6, and use for all long lists

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilterContext.tsx
@@ -332,6 +332,12 @@ interface ArtworkFiltersAction {
   payload: { name: keyof ArtworkFilters; value?: any }
 }
 
+export type ArrayArtworkFilter =
+  | "artistIDs"
+  | "partnerIDs"
+  | "locationCities"
+  | "artistNationalities"
+
 const artworkFilterReducer = (
   state: ArtworkFiltersState,
   action: ArtworkFiltersAction

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter.tsx
@@ -6,8 +6,6 @@ import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
 import { ShowMore } from "./ShowMore"
 
-const INITIAL_ITEMS_TO_SHOW = 6
-
 const ArtistNationalityOption: React.FC<{ name: string }> = ({ name }) => {
   const { currentlySelectedFilters, setFilter } = useArtworkFilterContext()
 
@@ -51,7 +49,7 @@ export const ArtistNationalityFilter: FC = () => {
   return (
     <Toggle label="Artist nationality or ethnicity" expanded>
       <Flex flexDirection="column">
-        <ShowMore initial={INITIAL_ITEMS_TO_SHOW}>
+        <ShowMore>
           {nationalitiesSorted.map(({ name }) => {
             return <ArtistNationalityOption key={name} name={name} />
           })}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter.tsx
@@ -5,6 +5,7 @@ import React, { FC } from "react"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
 import { ShowMore } from "./ShowMore"
+import { FacetAutosuggest } from "./FacetAutosuggest"
 
 const ArtistNationalityOption: React.FC<{ name: string }> = ({ name }) => {
   const { currentlySelectedFilters, setFilter } = useArtworkFilterContext()
@@ -49,6 +50,11 @@ export const ArtistNationalityFilter: FC = () => {
   return (
     <Toggle label="Artist nationality or ethnicity" expanded>
       <Flex flexDirection="column">
+        <FacetAutosuggest
+          facetName="artistNationalities"
+          placeholder="Enter a nationality"
+          facets={nationalities.counts}
+        />
         <ShowMore>
           {nationalitiesSorted.map(({ name }) => {
             return <ArtistNationalityOption key={name} name={name} />

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
@@ -47,18 +47,17 @@ const ArtistItem: React.FC<{
   }
 
   const isFollowedArtist = followedArtistSlugs.includes(slug)
-  const selected =
-    currentlySelectedFilters().artistIDs.includes(slug) ||
-    (isFollowedArtistCheckboxSelected && isFollowedArtist)
-  const props = {
-    onSelect: selected => {
-      toggleArtistSelection(selected, slug)
-    },
-    selected,
-  }
 
   return (
-    <Checkbox {...props}>
+    <Checkbox
+      selected={
+        currentlySelectedFilters().artistIDs.includes(slug) ||
+        (isFollowedArtistCheckboxSelected && isFollowedArtist)
+      }
+      onSelect={selected => {
+        return toggleArtistSelection(selected, slug)
+      }}
+    >
       <OptionText>{name}</OptionText>
     </Checkbox>
   )
@@ -94,11 +93,6 @@ export const ArtistsFilter: FC<ArtistsFilterProps> = ({
   const isFollowedArtistCheckboxSelected =
     !!user &&
     filterContext.currentlySelectedFilters()["includeArtworksByFollowedArtists"]
-  const followedArtistCheckboxProps = {
-    onSelect: value =>
-      filterContext.setFilter("includeArtworksByFollowedArtists", value),
-    selected: isFollowedArtistCheckboxSelected,
-  }
   const followedArtistArtworkCount = filterContext?.counts?.followedArtists ?? 0
 
   return (
@@ -106,7 +100,10 @@ export const ArtistsFilter: FC<ArtistsFilterProps> = ({
       <Flex flexDirection="column">
         <Checkbox
           disabled={!followedArtistArtworkCount}
-          {...followedArtistCheckboxProps}
+          selected={isFollowedArtistCheckboxSelected}
+          onSelect={value =>
+            filterContext.setFilter("includeArtworksByFollowedArtists", value)
+          }
         >
           <OptionText>
             Artists I follow ({followedArtistArtworkCount})

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter.tsx
@@ -3,6 +3,7 @@ import { sortBy } from "lodash"
 import React, { FC } from "react"
 
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
+import { FacetAutosuggest } from "./FacetAutosuggest"
 import { OptionText } from "./OptionText"
 import { ShowMore } from "./ShowMore"
 
@@ -47,6 +48,11 @@ export const ArtworkLocationFilter: FC = () => {
   return (
     <Toggle label="Artwork location" expanded>
       <Flex flexDirection="column">
+        <FacetAutosuggest
+          facetName="locationCities"
+          placeholder="Enter a location"
+          facets={locations.counts}
+        />
         <ShowMore>
           {locationsSorted.map(({ name }) => {
             return <ArtworkLocationOption key={name} name={name} />

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter.tsx
@@ -6,8 +6,6 @@ import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
 import { ShowMore } from "./ShowMore"
 
-const INITIAL_ITEMS_TO_SHOW = 6
-
 const ArtworkLocationOption: React.FC<{ name: string }> = ({ name }) => {
   const { currentlySelectedFilters, setFilter } = useArtworkFilterContext()
 
@@ -49,7 +47,7 @@ export const ArtworkLocationFilter: FC = () => {
   return (
     <Toggle label="Artwork location" expanded>
       <Flex flexDirection="column">
-        <ShowMore initial={INITIAL_ITEMS_TO_SHOW}>
+        <ShowMore>
           {locationsSorted.map(({ name }) => {
             return <ArtworkLocationOption key={name} name={name} />
           })}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
@@ -95,7 +95,7 @@ export const ColorFilter: React.FC<ColorFilterProps> = ({
 }) => {
   return (
     <Toggle label="Color" expanded={expanded}>
-      <ShowMore initial={7}>
+      <ShowMore>
         {COLOR_OPTIONS.map(colorOption => {
           return (
             <ColorFilterOption

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/FacetAutosuggest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/FacetAutosuggest.tsx
@@ -1,4 +1,5 @@
 import { BorderBox, Box, Checkbox } from "@artsy/palette"
+import { uniq } from "lodash"
 import React, { FC, useState } from "react"
 import Autosuggest from "react-autosuggest"
 import { SearchInputContainer } from "v2/Components/Search/SearchInputContainer"
@@ -15,12 +16,14 @@ type Facet = {
 }
 
 const MAX_SUGGESTIONS = 10
+const MIN_ITEMS = 7
 
 export const FacetAutosuggest: FC<{
   facets: Array<Facet>
   facetName: ArrayArtworkFilter
   placeholder: string
-}> = ({ facets, facetName, placeholder }) => {
+  alwaysShow?: boolean
+}> = ({ facets, facetName, placeholder, alwaysShow = false }) => {
   const getSuggestions = ({ value }) => {
     const inputValue = value.trim().toLowerCase()
     const inputLength = inputValue.length
@@ -30,9 +33,6 @@ export const FacetAutosuggest: FC<{
       : facets
           .filter(
             facet =>
-              !filterContext
-                .currentlySelectedFilters()
-                [facetName].includes(facet.value) &&
               facet.name.toLowerCase().slice(0, inputLength) === inputValue
           )
           .sort()
@@ -68,7 +68,7 @@ export const FacetAutosuggest: FC<{
       .currentlySelectedFilters()
       [facetName].slice()
     selectedValues.push(value)
-    filterContext.setFilter(facetName, selectedValues)
+    filterContext.setFilter(facetName, uniq(selectedValues))
   }
 
   const renderInputComponent = props => <SearchInputContainer {...props} />
@@ -86,6 +86,8 @@ export const FacetAutosuggest: FC<{
       <BorderBox {...containerProps}>{children}</BorderBox>
     )
   }
+
+  if (!alwaysShow && facets.length < MIN_ITEMS) return null
 
   return (
     <Autosuggest

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/FacetAutosuggest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/FacetAutosuggest.tsx
@@ -2,10 +2,13 @@ import { BorderBox, Box, Checkbox } from "@artsy/palette"
 import React, { FC, useState } from "react"
 import Autosuggest from "react-autosuggest"
 import { SearchInputContainer } from "v2/Components/Search/SearchInputContainer"
-import { useArtworkFilterContext } from "../ArtworkFilterContext"
+import {
+  ArrayArtworkFilter,
+  useArtworkFilterContext,
+} from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
 
-type Partner = {
+type Facet = {
   name: string
   count: number
   value: string
@@ -13,22 +16,24 @@ type Partner = {
 
 const MAX_SUGGESTIONS = 10
 
-export const PartnerAutosuggest: FC<{ partners: Array<Partner> }> = ({
-  partners,
-}) => {
+export const FacetAutosuggest: FC<{
+  facets: Array<Facet>
+  facetName: ArrayArtworkFilter
+  placeholder: string
+}> = ({ facets, facetName, placeholder }) => {
   const getSuggestions = ({ value }) => {
     const inputValue = value.trim().toLowerCase()
     const inputLength = inputValue.length
 
     return inputLength === 0
       ? []
-      : partners
+      : facets
           .filter(
-            partner =>
+            facet =>
               !filterContext
                 .currentlySelectedFilters()
-                .partnerIDs.includes(partner.value) &&
-              partner.name.toLowerCase().slice(0, inputLength) === inputValue
+                [facetName].includes(facet.value) &&
+              facet.name.toLowerCase().slice(0, inputLength) === inputValue
           )
           .sort()
           .slice(0, MAX_SUGGESTIONS)
@@ -49,7 +54,7 @@ export const PartnerAutosuggest: FC<{ partners: Array<Partner> }> = ({
   const [focused, setFocus] = useState(false)
 
   const inputProps = {
-    placeholder: "Enter a gallery",
+    placeholder,
     value,
     onChange: (_e, { newValue }) => setValue(newValue),
     onFocus: () => setFocus(true),
@@ -59,9 +64,11 @@ export const PartnerAutosuggest: FC<{ partners: Array<Partner> }> = ({
   const filterContext = useArtworkFilterContext()
 
   const onSuggestionSelected = ({ suggestion: { value } }) => {
-    let partnerIDs = filterContext.currentlySelectedFilters().partnerIDs.slice()
-    partnerIDs.push(value)
-    filterContext.setFilter("partnerIDs", partnerIDs)
+    let selectedValues = filterContext
+      .currentlySelectedFilters()
+      [facetName].slice()
+    selectedValues.push(value)
+    filterContext.setFilter(facetName, selectedValues)
   }
 
   const renderInputComponent = props => <SearchInputContainer {...props} />

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
@@ -33,18 +33,15 @@ export const MediumFilter: FC = () => {
       <Flex flexDirection="column" alignItems="left">
         <ShowMore>
           {allowedMediums.map(({ value: slug, name }, index) => {
-            const selected =
-              currentFilters.additionalGeneIDs.includes(slug) ||
-              currentFilters.medium === slug
-            const props = {
-              key: index,
-              onSelect: selected => {
-                toggleMediumSelection(selected, slug)
-              },
-              selected,
-            }
             return (
-              <Checkbox {...props}>
+              <Checkbox
+                selected={
+                  currentFilters.additionalGeneIDs.includes(slug) ||
+                  currentFilters.medium === slug
+                }
+                key={index}
+                onSelect={selected => toggleMediumSelection(selected, slug)}
+              >
                 <OptionText>{name}</OptionText>
               </Checkbox>
             )

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
@@ -2,6 +2,7 @@ import { Checkbox, Flex, Toggle } from "@artsy/palette"
 import React, { FC } from "react"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
+import { ShowMore } from "./ShowMore"
 
 export const MediumFilter: FC = () => {
   const { aggregations, counts, ...filterContext } = useArtworkFilterContext()
@@ -30,23 +31,25 @@ export const MediumFilter: FC = () => {
   return (
     <Toggle label="Medium" expanded={isExpanded}>
       <Flex flexDirection="column" alignItems="left">
-        {allowedMediums.map(({ value: slug, name }, index) => {
-          const selected =
-            currentFilters.additionalGeneIDs.includes(slug) ||
-            currentFilters.medium === slug
-          const props = {
-            key: index,
-            onSelect: selected => {
-              toggleMediumSelection(selected, slug)
-            },
-            selected,
-          }
-          return (
-            <Checkbox {...props}>
-              <OptionText>{name}</OptionText>
-            </Checkbox>
-          )
-        })}
+        <ShowMore>
+          {allowedMediums.map(({ value: slug, name }, index) => {
+            const selected =
+              currentFilters.additionalGeneIDs.includes(slug) ||
+              currentFilters.medium === slug
+            const props = {
+              key: index,
+              onSelect: selected => {
+                toggleMediumSelection(selected, slug)
+              },
+              selected,
+            }
+            return (
+              <Checkbox {...props}>
+                <OptionText>{name}</OptionText>
+              </Checkbox>
+            )
+          })}
+        </ShowMore>
       </Flex>
     </Toggle>
   )

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
@@ -4,7 +4,7 @@ import React, { FC } from "react"
 
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
-import { PartnerAutosuggest } from "./PartnerAutosuggest"
+import { FacetAutosuggest } from "./FacetAutosuggest"
 import { ShowMore } from "./ShowMore"
 
 const PartnerOption: React.FC<{ name: string }> = ({ name }) => {
@@ -48,7 +48,11 @@ export const PartnersFilter: FC = () => {
   return (
     <Toggle label="Galleries and institutions" expanded>
       <Flex flexDirection="column">
-        <PartnerAutosuggest partners={partners.counts} />
+        <FacetAutosuggest
+          facetName="partnerIDs"
+          placeholder="Enter a gallery"
+          facets={partners.counts}
+        />
         <ShowMore>
           {partnersSorted.map(({ name }) => {
             return <PartnerOption key={name} name={name} />

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
@@ -7,8 +7,6 @@ import { OptionText } from "./OptionText"
 import { PartnerAutosuggest } from "./PartnerAutosuggest"
 import { ShowMore } from "./ShowMore"
 
-const INITIAL_PARTNERS_TO_SHOW = 6
-
 const PartnerOption: React.FC<{ name: string }> = ({ name }) => {
   const { currentlySelectedFilters, setFilter } = useArtworkFilterContext()
 
@@ -51,7 +49,7 @@ export const PartnersFilter: FC = () => {
     <Toggle label="Galleries and institutions" expanded>
       <Flex flexDirection="column">
         <PartnerAutosuggest partners={partners.counts} />
-        <ShowMore initial={INITIAL_PARTNERS_TO_SHOW}>
+        <ShowMore>
           {partnersSorted.map(({ name }) => {
             return <PartnerOption key={name} name={name} />
           })}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ShowMore.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ShowMore.tsx
@@ -2,13 +2,15 @@ import { Clickable, Text } from "@artsy/palette"
 import React, { Children, isValidElement, useState } from "react"
 
 interface ShowMoreProps {
-  initial: number
+  initial?: number
   expanded?: boolean
   children: JSX.Element[]
 }
 
+const INITIAL_ITEMS_TO_SHOW = 6
+
 export const ShowMore: React.FC<ShowMoreProps> = ({
-  initial,
+  initial = INITIAL_ITEMS_TO_SHOW,
   children,
   expanded = false,
 }) => {

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
@@ -2,6 +2,7 @@ import { Checkbox, Flex, Toggle } from "@artsy/palette"
 import React, { FC } from "react"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
+import { ShowMore } from "./ShowMore"
 
 interface TimePeriodFilterProps {
   expanded?: boolean
@@ -39,21 +40,23 @@ export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({
   return (
     <Toggle label="Time period" expanded={expanded}>
       <Flex flexDirection="column">
-        {periods.map(({ name }, index) => {
-          const selected = currentFilters.majorPeriods.includes(name)
-          const props = {
-            key: index,
-            onSelect: selected => {
-              togglePeriodSelection(selected, name)
-            },
-            selected,
-          }
-          return (
-            <Checkbox {...props}>
-              <OptionText>{name}</OptionText>
-            </Checkbox>
-          )
-        })}
+        <ShowMore>
+          {periods.map(({ name }, index) => {
+            const selected = currentFilters.majorPeriods.includes(name)
+            const props = {
+              key: index,
+              onSelect: selected => {
+                togglePeriodSelection(selected, name)
+              },
+              selected,
+            }
+            return (
+              <Checkbox {...props}>
+                <OptionText>{name}</OptionText>
+              </Checkbox>
+            )
+          })}
+        </ShowMore>
       </Flex>
     </Toggle>
   )

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
@@ -42,16 +42,12 @@ export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({
       <Flex flexDirection="column">
         <ShowMore>
           {periods.map(({ name }, index) => {
-            const selected = currentFilters.majorPeriods.includes(name)
-            const props = {
-              key: index,
-              onSelect: selected => {
-                togglePeriodSelection(selected, name)
-              },
-              selected,
-            }
             return (
-              <Checkbox {...props}>
+              <Checkbox
+                selected={currentFilters.majorPeriods.includes(name)}
+                key={index}
+                onSelect={selected => togglePeriodSelection(selected, name)}
+              >
                 <OptionText>{name}</OptionText>
               </Checkbox>
             )

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ArtistsFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ArtistsFilter.jest.tsx
@@ -57,26 +57,26 @@ describe("ArtistsFilter", () => {
 
       it("renders the first 6 and includes a show more expand link", () => {
         expect(wrapper.text()).toContain("Percy F")
-        expect(wrapper.text()).toContain("Show 1 more")
+        expect(wrapper.text()).toContain("Show more")
         expect(wrapper.text()).not.toContain("Percy G")
       })
 
       it("reveals the rest of the list when 'Show more' is clicked, and can then hide the list again", done => {
         wrapper
-          .findWhere(t => t.text() === "Show 1 more")
+          .findWhere(t => t.text() === "Show more")
           .first()
           .simulate("click")
 
         setTimeout(() => {
           expect(wrapper.text()).toContain("Percy G")
-          expect(wrapper.text()).toContain("Hide list")
+          expect(wrapper.text()).toContain("Hide")
           wrapper
-            .findWhere(t => t.text() === "Hide list")
+            .findWhere(t => t.text() === "Hide")
             .first()
             .simulate("click")
 
           setTimeout(() => {
-            expect(wrapper.text()).toContain("Show 1 more")
+            expect(wrapper.text()).toContain("Show more")
             expect(wrapper.text()).not.toContain("Percy G")
             done()
           }, 0)

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ColorFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ColorFilter.jest.tsx
@@ -25,7 +25,7 @@ describe("ColorFilter", () => {
   it("initially renders the primary colors", () => {
     const wrapper = getWrapper()
 
-    expect(wrapper.find("Checkbox")).toHaveLength(7)
+    expect(wrapper.find("Checkbox")).toHaveLength(6)
   })
 
   it("selects a color when clicked", () => {
@@ -46,7 +46,7 @@ describe("ColorFilter", () => {
     wrapper.find("Checkbox").first().simulate("click")
     wrapper.find("Checkbox").last().simulate("click")
 
-    expect(context.filters.colors).toEqual(["black-and-white", "gold"])
+    expect(context.filters.colors).toEqual(["black-and-white", "violet"])
   })
 
   it("unselects a selected a color when clicked", () => {
@@ -57,7 +57,7 @@ describe("ColorFilter", () => {
     wrapper.find("Checkbox").first().simulate("click")
     wrapper.find("Checkbox").last().simulate("click")
 
-    expect(context.filters.colors).toEqual(["black-and-white", "gold"])
+    expect(context.filters.colors).toEqual(["black-and-white", "violet"])
 
     wrapper.find("Checkbox").last().simulate("click")
 

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/FacetAutosuggest.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/FacetAutosuggest.jest.tsx
@@ -1,4 +1,4 @@
-import { PartnerAutosuggest } from "../PartnerAutosuggest"
+import { FacetAutosuggest } from "../FacetAutosuggest"
 import { ReactWrapper, mount } from "enzyme"
 import React from "react"
 import { ArtworkFilterContextProvider } from "../../ArtworkFilterContext"
@@ -27,7 +27,11 @@ const simulateTyping = (wrapper: ReactWrapper, text: string) => {
 const getWrapper = suggestions => {
   return mount(
     <ArtworkFilterContextProvider>
-      <PartnerAutosuggest partners={suggestions} />
+      <FacetAutosuggest
+        placeholder="Enter a gallery"
+        facets={suggestions}
+        facetName="partnerIDs"
+      />
     </ArtworkFilterContextProvider>
   )
 }

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/FacetAutosuggest.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/FacetAutosuggest.jest.tsx
@@ -31,6 +31,7 @@ const getWrapper = suggestions => {
         placeholder="Enter a gallery"
         facets={suggestions}
         facetName="partnerIDs"
+        alwaysShow
       />
     </ArtworkFilterContextProvider>
   )


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=FX&modal=detail&selectedIssue=FX-2704

The commits tell the story. Capped 'show more' to 6, and added it to the artists filter (on fair page), and the medium and time period filters, as well as tweaking the color filter from 7 -> 6.

Also generalized the somewhat simple autosuggest widget and added it to artist nationality and artwork location (in addition to partners).