### PR TITLE
fix: eigen context

### DIFF
--- a/src/desktop/lib/__tests__/buildServerAppContext.jest.ts
+++ b/src/desktop/lib/__tests__/buildServerAppContext.jest.ts
@@ -2,12 +2,15 @@ import { buildServerAppContext } from "../buildServerAppContext"
 
 describe("buildServerAppContext", () => {
   let req, res
+  let headers = {}
   beforeEach(() => {
+    headers = {}
     req = {
       user: {
         toJSON: () => ({ id: "user-id" }),
       },
       path: "/",
+      header: header => headers[header],
     }
     res = {
       locals: {
@@ -42,9 +45,20 @@ describe("buildServerAppContext", () => {
     expect(subject.isEigen).toBeFalsy()
   })
 
-  it("isEigen is true when specified", () => {
-    res.locals.sd.EIGEN = true
-    const subject = buildServerAppContext(req, res)
-    expect(subject.isEigen).toBeTruthy()
+  it("isEigen is true only when the user agent includes 'Artsy-Mobile'", () => {
+    headers["User-Agent"] = "blah blah blah Artsy-Mobile blah blah blah"
+    expect(buildServerAppContext(req, res).isEigen).toBeTruthy()
+
+    headers["User-Agent"] = "Artsy-Mobile blah blah blah"
+    expect(buildServerAppContext(req, res).isEigen).toBeTruthy()
+
+    headers["User-Agent"] = "blah blah blah Artsy-Mobile"
+    expect(buildServerAppContext(req, res).isEigen).toBeTruthy()
+
+    headers["User-Agent"] = "blah blah blah"
+    expect(buildServerAppContext(req, res).isEigen).toBeFalsy()
+
+    delete headers["User-Agent"]
+    expect(buildServerAppContext(req, res).isEigen).toBeFalsy()
   })
 })

--- a/src/desktop/lib/buildServerAppContext.ts
+++ b/src/desktop/lib/buildServerAppContext.ts
@@ -19,7 +19,7 @@ export const buildServerAppContext = (
   return {
     initialMatchingMediaQueries: res.locals.sd.IS_MOBILE ? ["xs"] : undefined,
     user: req.user && req.user.toJSON(),
-    isEigen: res.locals.sd.EIGEN,
+    isEigen: req.header("User-Agent")?.match("Artsy-Mobile") != null,
     mediator,
     analytics: {
       contextPageOwnerType: pageType,

--- a/src/v2/Artsy/SystemContext.tsx
+++ b/src/v2/Artsy/SystemContext.tsx
@@ -100,7 +100,7 @@ export const SystemContextProvider: SFC<SystemContextProps> = ({
     relayEnvironment,
     user,
     setUser,
-    isEigen: sd.EIGEN,
+    isEigen: sd.EIGEN || props.isEigen,
   }
 
   return (

--- a/src/v2/Artsy/__tests__/SystemContext.jest.tsx
+++ b/src/v2/Artsy/__tests__/SystemContext.jest.tsx
@@ -61,6 +61,25 @@ describe("Artsy context", () => {
     )
   })
 
+  describe("isEigen", () => {
+    it("does not get overwritten by sharify if truthy", () => {
+      jest.mock("sharify", () => ({
+        data: { EIGEN: false },
+      }))
+      render(
+        <Artsy.SystemContextProvider isEigen={true}>
+          <Artsy.SystemContextConsumer>
+            {props => {
+              expect(props.isEigen).toBe(true)
+              return null
+            }}
+          </Artsy.SystemContextConsumer>
+        </Artsy.SystemContextProvider>
+      )
+      expect.assertions(1)
+    })
+  })
+
   describe("concerning the current user", () => {
     let originalEnv = null
 

--- a/src/v2/Components/NavBar/MinimalNavBar.tsx
+++ b/src/v2/Components/NavBar/MinimalNavBar.tsx
@@ -2,6 +2,7 @@ import { ArtsyLogoBlackIcon, Box } from "@artsy/palette"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import React from "react"
+import { useSystemContext } from "v2/Artsy"
 
 interface MinimalNavBarProps {
   to: string
@@ -9,6 +10,7 @@ interface MinimalNavBarProps {
 }
 
 export const MinimalNavBar: React.FC<MinimalNavBarProps> = props => {
+  const { isEigen } = useSystemContext()
   return (
     <Box
       zIndex={1000}
@@ -19,19 +21,21 @@ export const MinimalNavBar: React.FC<MinimalNavBarProps> = props => {
       width="100%"
       pt={4}
     >
-      <AppContainer>
-        <Box height={70} px={[2, 4]}>
-          <RouterLink
-            to={props.to}
-            // TODO: figure out a minimal example of the underlying cause of this error
-            // and submit an issue to TS 😓
-            // @ts-ignore
-            data-test="logoLink"
-          >
-            <ArtsyLogoBlackIcon />
-          </RouterLink>
-        </Box>
-      </AppContainer>
+      {!isEigen && (
+        <AppContainer>
+          <Box height={70} px={[2, 4]}>
+            <RouterLink
+              to={props.to}
+              // TODO: figure out a minimal example of the underlying cause of this error
+              // and submit an issue to TS 😓
+              // @ts-ignore
+              data-test="logoLink"
+            >
+              <ArtsyLogoBlackIcon />
+            </RouterLink>
+          </Box>
+        </AppContainer>
+      )}
 
       {props.children}
     </Box>

--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -47,8 +47,11 @@ export const NavBar: React.FC = track(
     dispatch: data => Events.postEvent(data),
   }
 )(() => {
+  const { mediator, user, isEigen } = useSystemContext()
+  if (isEigen) {
+    return null
+  }
   const { trackEvent } = useTracking()
-  const { mediator, user } = useSystemContext()
   const [showMobileMenu, toggleMobileNav] = useState(false)
   const xs = useMatchMedia(themeProps.mediaQueries.xs)
   const sm = useMatchMedia(themeProps.mediaQueries.sm)

--- a/src/v2/Components/NavBar/__tests__/MinimalNavBar.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/MinimalNavBar.jest.tsx
@@ -1,0 +1,24 @@
+import { ArtsyLogoBlackIcon } from "@artsy/palette"
+import { mount } from "enzyme"
+import React from "react"
+import { SystemContextProvider } from "v2/Artsy"
+import { MinimalNavBar } from "../MinimalNavBar"
+
+const getWrapper = ({ isEigen }: { isEigen?: boolean } = {}) => {
+  return mount(
+    <SystemContextProvider isEigen={isEigen}>
+      <MinimalNavBar to="/">i am children</MinimalNavBar>
+    </SystemContextProvider>
+  )
+}
+
+describe("nav bar", () => {
+  it("shows the artsy logo", () => {
+    const tree = getWrapper()
+    expect(tree.find(ArtsyLogoBlackIcon).length).toBe(1)
+  })
+  it("hides the artsy logo on eigen", () => {
+    const tree = getWrapper({ isEigen: true })
+    expect(tree.find(ArtsyLogoBlackIcon).length).toBe(0)
+  })
+})

--- a/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
@@ -25,9 +25,9 @@ jest.mock("lib/isServer", () => ({
 describe("NavBar", () => {
   const trackEvent = jest.fn()
 
-  const getWrapper = ({ user = null } = {}) => {
+  const getWrapper = ({ user = null, isEigen = false } = {}) => {
     return mount(
-      <SystemContextProvider user={user}>
+      <SystemContextProvider user={user} isEigen={isEigen}>
         <NavBar />
       </SystemContextProvider>
     )
@@ -180,6 +180,17 @@ describe("NavBar", () => {
         user: { type: "NotAdmin", lab_features: ["User Conversations View"] },
       })
       expect(wrapper.find(InboxNotificationCount).length).toBe(1)
+    })
+  })
+
+  describe("eigen", () => {
+    it("renders null", () => {
+      expect(
+        getWrapper({ isEigen: false }).find(NavBar).isEmptyRender()
+      ).toBeFalsy()
+      expect(
+        getWrapper({ isEigen: true }).find(NavBar).isEmptyRender()
+      ).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
Web views in eigen have been slightly broken for some time. The root cause was that the `isEigen` system context value was not managed correctly. This PR fixes that while making sure that the main nav bars are hidden in eigen.

![image](https://user-images.githubusercontent.com/1242537/111352655-541a2b80-867c-11eb-937b-bc9251980890.png)
![image](https://user-images.githubusercontent.com/1242537/111352680-5d0afd00-867c-11eb-9064-34e39c3295ba.png)
