### PR TITLE
Remove unnecessary fragment meta tags

### DIFF
--- a/src/v2/Apps/Auctions/Components/AuctionsMeta.tsx
+++ b/src/v2/Apps/Auctions/Components/AuctionsMeta.tsx
@@ -11,7 +11,6 @@ export const AuctionsMeta: React.FC = () => {
       <Title>{title}</Title>
       <Meta property="og:title" content={title} />
 
-      <Meta name="fragment" content="!" />
       <Meta name="description" content={description} />
       <Meta property="og:description" content={description} />
 

--- a/src/v2/Apps/Feature/Components/FeatureMeta.tsx
+++ b/src/v2/Apps/Feature/Components/FeatureMeta.tsx
@@ -27,7 +27,6 @@ const FeatureMeta: React.FC<FeatureMetaProps> = ({
       <Meta property="og:url" content={href} />
       <Meta property="og:type" content="website" />
       <Meta property="twitter:card" content="summary" />
-      <Meta name="fragment" content="!" />
       {image && <Meta property="og:image" content={image} />}
     </>
   )


### PR DESCRIPTION
These tags are vestiges of the pre-rendering we needed to do for non-server-rendered pages in the past (according to [Google's deprecated AJaX crawling protocol](https://developers.google.com/search/docs/ajax-crawling/docs/specification)). Google may have deprecated it, but we've observed that other crawlers continue to respect this tag and make separate requests for the pre-rendered assets. In any case, it shouldn't be necessary for these server-rendered pages.

Once released, we can remove the [features sitemap](https://www.artsy.net/sitemap-features.xml) from the list that Reflection crawls and delete the corresponding pages:

```ruby
Sitemap.where(url: 'https://www.artsy.net/sitemap-features.xml').destroy_all
Page.where('url LIKE ?', 'https://www.artsy.net/feature/%').destroy_all
```