### PR TITLE
toolchain: Add `yarn jest:debug` for debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "docker:force": "yarn docker -t force",
     "docker:clean": "docker rmi force force:builder force:electron",
     "jest": "node_modules/.bin/jest --config jest.config.js",
+    "jest:debug": "node --inspect node_modules/.bin/jest --runInBand",
     "lint": "eslint --cache --cache-location '.cache/eslint/' --ext ts,tsx --ignore-pattern 'src/v2/__generated__'",
     "mocha": "scripts/mocha.sh",
     "prepare": "patch-package",


### PR DESCRIPTION
Remembered [this blog post](https://artsy.github.io/blog/2018/08/24/How-to-debug-jest-tests), and have been doing the same in Metaphysics (via VSCode). Didn't realize it wasn't in force: 

![jest-debug](https://user-images.githubusercontent.com/236943/111374813-c7ab4100-865a-11eb-8388-0cb22d6b4b78.gif)


