### PR TITLE
fix: Use shipping address as billing

### DIFF
--- a/src/v2/Apps/Order/Components/PaymentPicker.tsx
+++ b/src/v2/Apps/Order/Components/PaymentPicker.tsx
@@ -42,6 +42,7 @@ import {
   SystemContextProps,
 } from "v2/Artsy/SystemContext"
 import { createStripeWrapper } from "v2/Utils/createStripeWrapper"
+import { isNull, mergeWith } from "lodash"
 
 export interface StripeProps {
   stripe: Stripe
@@ -364,9 +365,16 @@ export class PaymentPicker extends React.Component<
   }
 
   private getStripeBillingAddress(): CreateTokenCardData {
+    // replace null items in requestedFulfillment with empty string to keep stripe happy
+    const shippingAddress = mergeWith(
+      {},
+      emptyAddress,
+      this.props.order.requestedFulfillment,
+      (o, s) => (isNull(s) ? o : s)
+    )
     const selectedBillingAddress = (this.needsAddress()
       ? this.state.address
-      : this.props.order.requestedFulfillment) as Address
+      : shippingAddress) as Address
     const {
       name,
       addressLine1,

--- a/src/v2/Apps/Order/Components/SavedAddresses.tsx
+++ b/src/v2/Apps/Order/Components/SavedAddresses.tsx
@@ -7,7 +7,8 @@ import {
   Flex,
   Text,
   Separator,
-  StackableBorderBox,
+  BorderBox,
+  Join,
 } from "@artsy/palette"
 import React, { useState } from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
@@ -103,7 +104,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
     const isDefaultAddress = address.node.isDefault
 
     return (
-      <StackableBorderBox
+      <BorderBox
         p={2}
         width="100%"
         flexDirection="column"
@@ -156,7 +157,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
             </Text>
           </Box>
         </ModifyAddressWrapper>
-      </StackableBorderBox>
+      </BorderBox>
     )
   })
 
@@ -214,7 +215,11 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
 
   return inCollectorProfile ? (
     <>
-      <Flex flexDirection="column">{collectorProfileAddressItems}</Flex>
+      <Flex flexDirection="column">
+        <Join separator={<Spacer mb="1" />}>
+          {collectorProfileAddressItems}
+        </Join>
+      </Flex>
       {addAddressButton}
     </>
   ) : (


### PR DESCRIPTION
Fixes [PURCHASE-2485]

Making sure all the `null` address item values are changed to the empty string the way stripe expects them to be.

Also adds margin between saved shipping addresses in collector profile.

<details><summary>Screenshots</summary>

<img width="978" alt="Screen Shot 2021-03-17 at 1 36 40 PM" src="https://user-images.githubusercontent.com/687513/111513198-eaa32700-8726-11eb-9cc5-2810efa02d9e.png">

</details>

[PURCHASE-2485]: https://artsyproduct.atlassian.net/browse/PURCHASE-2485