### PR TITLE
feat(materials filter): add Materials facet to artwork grids

### DIFF
--- a/src/v2/Apps/Artist/artistRoutes.tsx
+++ b/src/v2/Apps/Artist/artistRoutes.tsx
@@ -134,7 +134,7 @@ export const artistRoutes: RouteConfig[] = [
 
           const aggregations = ["MEDIUM", "TOTAL", "MAJOR_PERIOD"]
           const additionalAggregations = getENV("ENABLE_NEW_ARTWORK_FILTERS")
-            ? ["PARTNER", "LOCATION_CITY"]
+            ? ["PARTNER", "LOCATION_CITY", "MATERIALS_TERMS"]
             : ["GALLERY", "INSTITUTION"]
 
           return {

--- a/src/v2/Apps/ArtistSeries/artistSeriesRoutes.tsx
+++ b/src/v2/Apps/ArtistSeries/artistSeriesRoutes.tsx
@@ -34,7 +34,7 @@ function initializeVariablesWithFilterState({ slug }, props) {
 
   const aggregations = ["MEDIUM", "TOTAL", "MAJOR_PERIOD"]
   const additionalAggregations = getENV("ENABLE_NEW_ARTWORK_FILTERS")
-    ? ["PARTNER", "LOCATION_CITY"]
+    ? ["PARTNER", "LOCATION_CITY", "MATERIALS_TERMS"]
     : ["GALLERY", "INSTITUTION"]
 
   const input = {

--- a/src/v2/Apps/Collect/collectRoutes.tsx
+++ b/src/v2/Apps/Collect/collectRoutes.tsx
@@ -85,7 +85,7 @@ function initializeVariablesWithFilterState(params, props) {
   // TODO: Does the `location_city` aggregation accomplish much on /collect, and
   // should it be a hard-coded list of featured cities?
   const additionalAggregations = getENV("ENABLE_NEW_ARTWORK_FILTERS")
-    ? ["LOCATION_CITY", "ARTIST_NATIONALITY"]
+    ? ["LOCATION_CITY", "ARTIST_NATIONALITY", "MATERIALS_TERMS"]
     : []
   const collectionOnlyAggregations = collectionSlug
     ? ["MERCHANDISABLE_ARTISTS", "MEDIUM", "MAJOR_PERIOD"]

--- a/src/v2/Apps/Fair/Routes/FairArtworks.tsx
+++ b/src/v2/Apps/Fair/Routes/FairArtworks.tsx
@@ -20,6 +20,7 @@ import { getENV } from "v2/Utils/getENV"
 import { PartnersFilter } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnersFilter"
 import { ArtworkLocationFilter } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter"
 import { ArtistNationalityFilter } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter"
+import { MaterialsFilter } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter"
 
 interface FairArtworksFilterProps {
   fair: FairArtworks_fair
@@ -51,6 +52,7 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
         user={user}
       />
       <MediumFilter />
+      {getENV("ENABLE_NEW_ARTWORK_FILTERS") && <MaterialsFilter />}
       <AttributionClassFilter />
       <PriceRangeFilter />
       <WaysToBuyFilter />

--- a/src/v2/Apps/Fair/fairRoutes.tsx
+++ b/src/v2/Apps/Fair/fairRoutes.tsx
@@ -132,7 +132,7 @@ function initializeVariablesWithFilterState({ slug }, props) {
   let aggregations: string[] = ["TOTAL", "MAJOR_PERIOD", "ARTIST"]
   if (props.context.user) aggregations = aggregations.concat("FOLLOWED_ARTISTS")
   const additionalAggregations = getENV("ENABLE_NEW_ARTWORK_FILTERS")
-    ? ["PARTNER", "ARTIST_NATIONALITY"]
+    ? ["PARTNER", "ARTIST_NATIONALITY", "MATERIALS_TERMS"]
     : ["GALLERY"]
   const input = {
     sort: "-decayed_merch",

--- a/src/v2/Apps/Search/searchRoutes.tsx
+++ b/src/v2/Apps/Search/searchRoutes.tsx
@@ -16,7 +16,7 @@ import { SearchAppFragmentContainer } from "./SearchApp"
 const prepareVariables = (_params, { location }) => {
   const aggregations = ["TOTAL"]
   const additionalAggregations = getENV("ENABLE_NEW_ARTWORK_FILTERS")
-    ? ["ARTIST_NATIONALITY", "LOCATION_CITY"]
+    ? ["ARTIST_NATIONALITY", "LOCATION_CITY", "MATERIALS_TERMS"]
     : []
   return {
     ...paramsToCamelCase(omit(location.query, "term")),

--- a/src/v2/Apps/Show/Components/ShowArtworks.tsx
+++ b/src/v2/Apps/Show/Components/ShowArtworks.tsx
@@ -14,6 +14,7 @@ import { Box, BoxProps } from "@artsy/palette"
 import { useRouter } from "v2/Artsy/Router/useRouter"
 import { getENV } from "v2/Utils/getENV"
 import { ArtistNationalityFilter } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter"
+import { MaterialsFilter } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter"
 import { omit } from "lodash"
 
 interface ShowArtworksFilterProps extends BoxProps {
@@ -36,6 +37,7 @@ const ShowArtworksFilter: React.FC<ShowArtworksFilterProps> = ({
   const Filters = () => (
     <Box pr={2}>
       <MediumFilter />
+      {getENV("ENABLE_NEW_ARTWORK_FILTERS") && <MaterialsFilter />}
       <PriceRangeFilter />
       <WaysToBuyFilter />
       {getENV("ENABLE_NEW_ARTWORK_FILTERS") && <ArtistNationalityFilter />}

--- a/src/v2/Apps/Show/showRoutes.tsx
+++ b/src/v2/Apps/Show/showRoutes.tsx
@@ -75,7 +75,7 @@ function initializeVariablesWithFilterState({ slug }, props) {
   const initialFilterState = props.location ? props.location.query : {}
   const aggregations = ["MEDIUM", "TOTAL", "MAJOR_PERIOD"]
   const additionalAggregations = getENV("ENABLE_NEW_ARTWORK_FILTERS")
-    ? ["ARTIST_NATIONALITY"]
+    ? ["ARTIST_NATIONALITY", "MATERIALS_TERMS"]
     : []
   const input = {
     sort: "partner_show_position",

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilterContext.tsx
@@ -21,6 +21,7 @@ export const initialArtworkFilterState: ArtworkFilters = {
   colors: [],
   locationCities: [],
   artistNationalities: [],
+  materialsTerms: [],
 
   // TODO: Remove these unneeded default props
   // height: "*-*",
@@ -58,6 +59,7 @@ export interface ArtworkFilters {
   width?: string
   locationCities?: string[]
   artistNationalities?: string[]
+  materialsTerms?: string[]
 }
 
 interface ArtworkFiltersState extends ArtworkFilters {
@@ -84,6 +86,7 @@ export type Aggregations = Array<{
     | "PARTNER"
     | "LOCATION_CITY"
     | "ARTIST_NATIONALITY"
+    | "MATERIALS_TERMS"
   counts: Array<{
     count: number
     value: string
@@ -337,6 +340,7 @@ export type ArrayArtworkFilter =
   | "partnerIDs"
   | "locationCities"
   | "artistNationalities"
+  | "materialsTerms"
 
 const artworkFilterReducer = (
   state: ArtworkFiltersState,
@@ -352,6 +356,7 @@ const artworkFilterReducer = (
     "colors",
     "locationCities",
     "artistNationalities",
+    "materialsTerms",
   ]
 
   switch (action.type) {

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
@@ -1,0 +1,52 @@
+import { Checkbox, Toggle } from "@artsy/palette"
+import React from "react"
+import { useArtworkFilterContext } from "../ArtworkFilterContext"
+import { OptionText } from "./OptionText"
+import { ShowMore } from "./ShowMore"
+
+const MaterialsTermOption: React.FC<{ name: string }> = ({ name }) => {
+  const { currentlySelectedFilters, setFilter } = useArtworkFilterContext()
+
+  const toggleMaterialsTermSelection = (selected, name) => {
+    let materialsTerms = currentlySelectedFilters().materialsTerms.slice()
+    if (selected) {
+      materialsTerms.push(name)
+    } else {
+      materialsTerms = materialsTerms.filter(item => item !== name)
+    }
+    setFilter("materialsTerms", materialsTerms)
+  }
+
+  return (
+    <Checkbox
+      onSelect={selected => {
+        toggleMaterialsTermSelection(selected, name)
+      }}
+      selected={currentlySelectedFilters().materialsTerms.includes(name)}
+      key={name}
+    >
+      <OptionText>{name}</OptionText>
+    </Checkbox>
+  )
+}
+
+export const MaterialsFilter = () => {
+  const { aggregations } = useArtworkFilterContext()
+  const materialsTerms = aggregations.find(
+    agg => agg.slice === "MATERIALS_TERMS"
+  )
+
+  if (!(materialsTerms && materialsTerms.counts)) {
+    return null
+  }
+
+  return (
+    <Toggle label="Materials" expanded>
+      <ShowMore>
+        {materialsTerms.counts.map(({ name, value, count }) => {
+          return <MaterialsTermOption key={name} name={name} />
+        })}
+      </ShowMore>
+    </Toggle>
+  )
+}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/MaterialsTermFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/MaterialsTermFilter.jest.tsx
@@ -1,0 +1,39 @@
+import { mount } from "enzyme"
+import React from "react"
+import { ArtworkFilterContextProvider } from "../../ArtworkFilterContext"
+import { MaterialsFilter } from "../MaterialsFilter"
+
+describe("MaterialsTermFilter", () => {
+  const getWrapper = (contextProps = {}) => {
+    return mount(
+      <ArtworkFilterContextProvider {...contextProps}>
+        <MaterialsFilter />
+      </ArtworkFilterContextProvider>
+    )
+  }
+  describe("materials", () => {
+    it("renders materials", () => {
+      const wrapper = getWrapper({
+        aggregations: [
+          {
+            slice: "MATERIALS_TERMS",
+            counts: [
+              {
+                name: "Oil",
+                count: 10,
+                value: "oil",
+              },
+              {
+                name: "Canvas",
+                count: 5,
+                value: "canvas",
+              },
+            ],
+          },
+        ],
+      })
+      expect(wrapper.find("Checkbox").first().text()).toContain("Oil")
+      expect(wrapper.find("Checkbox").last().text()).toContain("Canvas")
+    })
+  })
+})

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/index.tsx
@@ -15,11 +15,13 @@ import { getENV } from "v2/Utils/getENV"
 import { PartnersFilter } from "./PartnersFilter"
 import { ArtworkLocationFilter } from "./ArtworkLocationFilter"
 import { ArtistNationalityFilter } from "./ArtistNationalityFilter"
+import { MaterialsFilter } from "./MaterialsFilter"
 
 export const ArtworkFilters: React.FC = () => {
   return (
     <Box pr={2}>
       <MediumFilter />
+      {getENV("ENABLE_NEW_ARTWORK_FILTERS") && <MaterialsFilter />}
       <AttributionClassFilter />
       <PriceRangeFilter />
       <WaysToBuyFilter />

--- a/src/v2/Components/v2/ArtworkFilter/Utils/countChangedFilters.ts
+++ b/src/v2/Components/v2/ArtworkFilter/Utils/countChangedFilters.ts
@@ -24,7 +24,14 @@ export const countChangedFilters = (
   }
 
   // array-valued keys
-  for (key of ["sizes", "majorPeriods", "partnerIDs", "geneIDs", "artistIDs"]) {
+  for (key of [
+    "sizes",
+    "majorPeriods",
+    "partnerIDs",
+    "geneIDs",
+    "artistIDs",
+    "materialsTerms",
+  ]) {
     if (!isEqual(filtersBefore[key], filtersAfter[key])) {
       changedCount++
     }

--- a/src/v2/Components/v2/ArtworkFilter/Utils/isDefaultFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/Utils/isDefaultFilter.tsx
@@ -17,7 +17,8 @@ export const isDefaultFilter: (
       name === "majorPeriods" ||
       name === "colors" ||
       name === "locationCities" ||
-      name === "artistNationalities":
+      name === "artistNationalities" ||
+      name === "materialsTerms":
       return value.length === 0
     case name === "sort":
       return value === "-decayed_merch"

--- a/src/v2/Components/v2/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
@@ -79,6 +79,7 @@ describe("ArtworkFilter", () => {
         colors: [],
         locationCities: [],
         artistNationalities: [],
+        materialsTerms: [],
       })
     })
 
@@ -121,6 +122,7 @@ describe("ArtworkFilter", () => {
         colors: [],
         locationCities: [],
         artistNationalities: [],
+        materialsTerms: [],
       })
     })
 
@@ -153,6 +155,7 @@ describe("ArtworkFilter", () => {
         colors: [],
         locationCities: [],
         artistNationalities: [],
+        materialsTerms: [],
       })
     })
 
@@ -183,6 +186,7 @@ describe("ArtworkFilter", () => {
           colors: [],
           locationCities: [],
           artistNationalities: [],
+          materialsTerms: [],
         },
       })
     })


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2631
↳ https://artsyproduct.atlassian.net/browse/FX-2742

- Creates a `MaterialsFilter` facet that renders the aggregation as multiple-select checkboxes
- Adds it to the following artwork grids:
  - [x] `/artist/:id`
  - [x] `/artist-series/:id`
  - [ ] ~~`/collect`~~ (none of the aggregation-based filters are showing up here 🤔)
  - [x] `/collection/:id`
  - [x] `/fair/:id`
  - [x] `/show/:id`
  - [x] `/search?term=:term`
- Updates the `Apply (n)` button logic on mobile

## Desktop 

<img height=600 src="https://user-images.githubusercontent.com/140521/111524424-c64d4780-8732-11eb-900e-9aa81c528bcb.gif" />

## Mobile

<img height=600 src="https://user-images.githubusercontent.com/140521/111528922-f519ec80-8737-11eb-93f9-747d0d32caca.gif" />

(btw noticed while updating ⬆️ that Apply button on mobile that we don't consistently do that with all the new facets. I'll PR something, hopefully with tests that make it easier to catch.)