### PR TITLE
fix: adjust regex to not exclude analytics from /shows

### DIFF
--- a/src/desktop/assets/analytics.ts
+++ b/src/desktop/assets/analytics.ts
@@ -22,7 +22,7 @@ const excludedRoutes = [
   "/identity-verification(.*)",
   "/orders(.*)",
   "/search(.*)",
-  "/show(.*)",
+  "/show/(.*)",
   "/user/conversations(.*)",
   "/user/purchases(.*)",
   "/viewing-room(.*)",


### PR DESCRIPTION
We have a legacy page for shows (plural!), at http://www.artsy.net/shows .

It seems like an overeager regex to not record pageviews using the legacy stack for the rebuilt show (individual) page also suppressed them for /shows. This is the fix. Worth noting that while a data team member called out the anomalous data, no product team or KPI seems to particularly relate to this somewhat lost page.