### PR TITLE
feat: add profile page wireframe

### DIFF
--- a/src/v2/Apps/Partner/Components/NavigationTabs/index.tsx
+++ b/src/v2/Apps/Partner/Components/NavigationTabs/index.tsx
@@ -26,6 +26,26 @@ export class NavigationTabs extends React.Component<NavigationTabsProps> {
         href: route("/articles"),
         exact: false,
       },
+      {
+        name: "Shows",
+        href: route("/shows"),
+        exact: false,
+      },
+      {
+        name: "Works",
+        href: route("/works"),
+        exact: false,
+      },
+      {
+        name: "Artists",
+        href: route("/artists"),
+        exact: false,
+      },
+      {
+        name: "Contact",
+        href: route("/contact"),
+        exact: false,
+      },
     ]
 
     return routes.map(route => (

--- a/src/v2/Apps/Partner/Components/NavigationTabs/index.tsx
+++ b/src/v2/Apps/Partner/Components/NavigationTabs/index.tsx
@@ -1,15 +1,19 @@
 import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
 import { RouteTab, RouteTabs } from "v2/Components/RouteTabs"
+import { NavigationTabs_partner } from "v2/__generated__/NavigationTabs_partner.graphql"
 
 interface NavigationTabsProps {
-  partnerId: string
+  partner: NavigationTabs_partner
 }
 
 export class NavigationTabs extends React.Component<NavigationTabsProps> {
   renderTabs = () => {
-    const { partnerId } = this.props
-    const route = (path?: string) =>
-      `/novo/partner/${partnerId}${path ? path : ""}`
+    const {
+      partner: { slug },
+    } = this.props
+
+    const route = (path?: string) => `/novo/partner/${slug}${path ? path : ""}`
 
     const routes = [
       {
@@ -35,3 +39,14 @@ export class NavigationTabs extends React.Component<NavigationTabsProps> {
     return <RouteTabs fill>{this.renderTabs()}</RouteTabs>
   }
 }
+
+export const NavigationTabsFragmentContainer = createFragmentContainer(
+  NavigationTabs,
+  {
+    partner: graphql`
+      fragment NavigationTabs_partner on Partner {
+        slug
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Partner/Components/NavigationTabs/index.tsx
+++ b/src/v2/Apps/Partner/Components/NavigationTabs/index.tsx
@@ -22,11 +22,6 @@ export class NavigationTabs extends React.Component<NavigationTabsProps> {
         exact: true,
       },
       {
-        name: "Articles",
-        href: route("/articles"),
-        exact: true,
-      },
-      {
         name: "Shows",
         href: route("/shows"),
         exact: true,
@@ -39,6 +34,11 @@ export class NavigationTabs extends React.Component<NavigationTabsProps> {
       {
         name: "Artists",
         href: route("/artists"),
+        exact: true,
+      },
+      {
+        name: "Articles",
+        href: route("/articles"),
         exact: true,
       },
       {

--- a/src/v2/Apps/Partner/Components/NavigationTabs/index.tsx
+++ b/src/v2/Apps/Partner/Components/NavigationTabs/index.tsx
@@ -7,11 +7,9 @@ interface NavigationTabsProps {
   partner: NavigationTabs_partner
 }
 
-export class NavigationTabs extends React.Component<NavigationTabsProps> {
-  renderTabs = () => {
-    const {
-      partner: { slug },
-    } = this.props
+export const NavigationTabs: React.FC<NavigationTabsProps> = ({ partner }) => {
+  const renderTabs = () => {
+    const { slug } = partner
 
     const route = (path?: string) => `/partner2/${slug}${path ? path : ""}`
 
@@ -55,9 +53,7 @@ export class NavigationTabs extends React.Component<NavigationTabsProps> {
     ))
   }
 
-  render() {
-    return <RouteTabs fill>{this.renderTabs()}</RouteTabs>
-  }
+  return <RouteTabs fill>{renderTabs()}</RouteTabs>
 }
 
 export const NavigationTabsFragmentContainer = createFragmentContainer(

--- a/src/v2/Apps/Partner/Components/NavigationTabs/index.tsx
+++ b/src/v2/Apps/Partner/Components/NavigationTabs/index.tsx
@@ -1,0 +1,37 @@
+import React from "react"
+import { RouteTab, RouteTabs } from "v2/Components/RouteTabs"
+
+interface NavigationTabsProps {
+  partnerId: string
+}
+
+export class NavigationTabs extends React.Component<NavigationTabsProps> {
+  renderTabs = () => {
+    const { partnerId } = this.props
+    const route = (path?: string) =>
+      `/novo/partner/${partnerId}${path ? path : ""}`
+
+    const routes = [
+      {
+        name: "Overview",
+        href: route(),
+        exact: true,
+      },
+      {
+        name: "Articles",
+        href: route("/articles"),
+        exact: false,
+      },
+    ]
+
+    return routes.map(route => (
+      <RouteTab to={route.href} exact={route.exact} key={route.href}>
+        {route.name}
+      </RouteTab>
+    ))
+  }
+
+  render() {
+    return <RouteTabs fill>{this.renderTabs()}</RouteTabs>
+  }
+}

--- a/src/v2/Apps/Partner/Components/NavigationTabs/index.tsx
+++ b/src/v2/Apps/Partner/Components/NavigationTabs/index.tsx
@@ -13,7 +13,7 @@ export class NavigationTabs extends React.Component<NavigationTabsProps> {
       partner: { slug },
     } = this.props
 
-    const route = (path?: string) => `/novo/partner/${slug}${path ? path : ""}`
+    const route = (path?: string) => `/partner2/${slug}${path ? path : ""}`
 
     const routes = [
       {
@@ -24,27 +24,27 @@ export class NavigationTabs extends React.Component<NavigationTabsProps> {
       {
         name: "Articles",
         href: route("/articles"),
-        exact: false,
+        exact: true,
       },
       {
         name: "Shows",
         href: route("/shows"),
-        exact: false,
+        exact: true,
       },
       {
         name: "Works",
         href: route("/works"),
-        exact: false,
+        exact: true,
       },
       {
         name: "Artists",
         href: route("/artists"),
-        exact: false,
+        exact: true,
       },
       {
         name: "Contact",
         href: route("/contact"),
-        exact: false,
+        exact: true,
       },
     ]
 

--- a/src/v2/Apps/Partner/Components/__tests__/NavigationTabs.jest.tsx
+++ b/src/v2/Apps/Partner/Components/__tests__/NavigationTabs.jest.tsx
@@ -1,35 +1,30 @@
-import { NavigationTabs_Test_PartnerQueryRawResponse } from "v2/__generated__/NavigationTabs_Test_PartnerQuery.graphql"
-import { NavigationTabsFragmentContainer as NavigationTabs } from "v2/Apps/Partner/Components/NavigationTabs"
-import { renderRelayTree } from "v2/DevTools"
 import React from "react"
 import { graphql } from "react-relay"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { NavigationTabs_Test_PartnerQuery } from "v2/__generated__/NavigationTabs_Test_PartnerQuery.graphql"
+import { NavigationTabsFragmentContainer as NavigationTabs } from "v2/Apps/Partner/Components/NavigationTabs"
 
 jest.unmock("react-relay")
 jest.mock("v2/Components/RouteTabs")
 
-describe("PartnerNavigationTabs", () => {
-  const getWrapper = async (
-    response: NavigationTabs_Test_PartnerQueryRawResponse["partner"] = NavigationTabsFixture
-  ) => {
-    return await renderRelayTree({
-      Component: ({ partner }: any) => {
-        return <NavigationTabs partner={partner} />
-      },
-      query: graphql`
-        query NavigationTabs_Test_PartnerQuery @raw_response_type {
-          partner(id: "white-cube") {
-            ...NavigationTabs_partner
-          }
-        }
-      `,
-      mockData: {
-        partner: response,
-      } as NavigationTabs_Test_PartnerQueryRawResponse,
-    })
-  }
+const { getWrapper } = setupTestWrapper<NavigationTabs_Test_PartnerQuery>({
+  Component: ({ partner }: any) => {
+    return <NavigationTabs partner={partner} />
+  },
+  query: graphql`
+    query NavigationTabs_Test_PartnerQuery @raw_response_type {
+      partner(id: "white-cube") {
+        ...NavigationTabs_partner
+      }
+    }
+  `,
+})
 
+describe("PartnerNavigationTabs", () => {
   it("renders all tabs by default", async () => {
-    const wrapper = await getWrapper()
+    const wrapper = await getWrapper({
+      Partner: () => ({ id: "white-cube", slug: "white-cube" }),
+    })
     const html = wrapper.html()
 
     expect(html).toContain("Overview")
@@ -40,8 +35,3 @@ describe("PartnerNavigationTabs", () => {
     expect(html).toContain("Contact")
   })
 })
-
-const NavigationTabsFixture: NavigationTabs_Test_PartnerQueryRawResponse["partner"] = {
-  id: "white-cube",
-  slug: "white-cube",
-}

--- a/src/v2/Apps/Partner/Components/__tests__/NavigationTabs.jest.tsx
+++ b/src/v2/Apps/Partner/Components/__tests__/NavigationTabs.jest.tsx
@@ -1,0 +1,47 @@
+import { NavigationTabs_Test_PartnerQueryRawResponse } from "v2/__generated__/NavigationTabs_Test_PartnerQuery.graphql"
+import { NavigationTabsFragmentContainer as NavigationTabs } from "v2/Apps/Partner/Components/NavigationTabs"
+import { renderRelayTree } from "v2/DevTools"
+import React from "react"
+import { graphql } from "react-relay"
+
+jest.unmock("react-relay")
+jest.mock("v2/Components/RouteTabs")
+
+describe("PartnerNavigationTabs", () => {
+  const getWrapper = async (
+    response: NavigationTabs_Test_PartnerQueryRawResponse["partner"] = NavigationTabsFixture
+  ) => {
+    return await renderRelayTree({
+      Component: ({ partner }: any) => {
+        return <NavigationTabs partner={partner} />
+      },
+      query: graphql`
+        query NavigationTabs_Test_PartnerQuery @raw_response_type {
+          partner(id: "white-cube") {
+            ...NavigationTabs_partner
+          }
+        }
+      `,
+      mockData: {
+        partner: response,
+      } as NavigationTabs_Test_PartnerQueryRawResponse,
+    })
+  }
+
+  it("renders all tabs by default", async () => {
+    const wrapper = await getWrapper()
+    const html = wrapper.html()
+
+    expect(html).toContain("Overview")
+    expect(html).toContain("Shows")
+    expect(html).toContain("Works")
+    expect(html).toContain("Artists")
+    expect(html).toContain("Articles")
+    expect(html).toContain("Contact")
+  })
+})
+
+const NavigationTabsFixture: NavigationTabs_Test_PartnerQueryRawResponse["partner"] = {
+  id: "white-cube",
+  slug: "white-cube",
+}

--- a/src/v2/Apps/Partner/PartnerApp.tsx
+++ b/src/v2/Apps/Partner/PartnerApp.tsx
@@ -3,14 +3,24 @@ import { Box, Text } from "@artsy/palette"
 import { Footer } from "v2/Components/Footer"
 import { AppContainer } from "../Components/AppContainer"
 import { HorizontalPadding } from "../Components/HorizontalPadding"
+import { NavigationTabs } from "./Components/NavigationTabs"
+import { Match } from "found"
 
-export const PartnerApp: React.FC<any> = props => {
+export interface PartnerAppProps {
+  match: Match
+}
+
+export const PartnerApp: React.FC<PartnerAppProps> = props => {
   return (
     <AppContainer>
       <Box mx={[2, 4]}>
         <Text pt={2} pb={1} variant="largeTitle">
           Partner: {props.match.params.partnerId}
         </Text>
+
+        <NavigationTabs partnerId={props.match.params.partnerId} />
+
+        {props.children}
       </Box>
 
       <HorizontalPadding mt={4} mb={8}>

--- a/src/v2/Apps/Partner/PartnerApp.tsx
+++ b/src/v2/Apps/Partner/PartnerApp.tsx
@@ -6,7 +6,6 @@ import { HorizontalPadding } from "../Components/HorizontalPadding"
 import { NavigationTabsFragmentContainer as NavigationTabs } from "v2/Apps/Partner/Components/NavigationTabs"
 import { createFragmentContainer, graphql } from "react-relay"
 import { PartnerApp_partner } from "v2/__generated__/PartnerApp_partner.graphql"
-import { HttpError } from "found"
 
 export interface PartnerAppProps {
   partner: PartnerApp_partner
@@ -16,10 +15,6 @@ export const PartnerApp: React.FC<PartnerAppProps> = ({
   partner,
   children,
 }) => {
-  if (!partner) {
-    throw new HttpError(404)
-  }
-
   return (
     <AppContainer>
       <Box mx={[2, 4]}>

--- a/src/v2/Apps/Partner/PartnerApp.tsx
+++ b/src/v2/Apps/Partner/PartnerApp.tsx
@@ -4,10 +4,11 @@ import { Footer } from "v2/Components/Footer"
 import { AppContainer } from "../Components/AppContainer"
 import { HorizontalPadding } from "../Components/HorizontalPadding"
 import { NavigationTabs } from "./Components/NavigationTabs"
-import { Match } from "found"
+import { createFragmentContainer, graphql } from "react-relay"
+import { PartnerApp_partner } from "v2/__generated__/PartnerApp_partner.graphql"
 
 export interface PartnerAppProps {
-  match: Match
+  partner: PartnerApp_partner
 }
 
 export const PartnerApp: React.FC<PartnerAppProps> = props => {
@@ -15,10 +16,10 @@ export const PartnerApp: React.FC<PartnerAppProps> = props => {
     <AppContainer>
       <Box mx={[2, 4]}>
         <Text pt={2} pb={1} variant="largeTitle">
-          Partner: {props.match.params.partnerId}
+          Partner: {props.partner.name}
         </Text>
 
-        <NavigationTabs partnerId={props.match.params.partnerId} />
+        <NavigationTabs partnerId={props.partner.slug} />
 
         {props.children}
       </Box>
@@ -29,3 +30,13 @@ export const PartnerApp: React.FC<PartnerAppProps> = props => {
     </AppContainer>
   )
 }
+
+export const PartnerAppFragmentContainer = createFragmentContainer(PartnerApp, {
+  partner: graphql`
+    fragment PartnerApp_partner on Partner {
+      id
+      slug
+      name
+    }
+  `,
+})

--- a/src/v2/Apps/Partner/PartnerApp.tsx
+++ b/src/v2/Apps/Partner/PartnerApp.tsx
@@ -1,0 +1,21 @@
+import React from "react"
+import { Box, Text } from "@artsy/palette"
+import { Footer } from "v2/Components/Footer"
+import { AppContainer } from "../Components/AppContainer"
+import { HorizontalPadding } from "../Components/HorizontalPadding"
+
+export const PartnerApp: React.FC<any> = props => {
+  return (
+    <AppContainer>
+      <Box mx={[2, 4]}>
+        <Text pt={2} pb={1} variant="largeTitle">
+          Partner: {props.match.params.partnerId}
+        </Text>
+      </Box>
+
+      <HorizontalPadding mt={4} mb={8}>
+        <Footer />
+      </HorizontalPadding>
+    </AppContainer>
+  )
+}

--- a/src/v2/Apps/Partner/PartnerApp.tsx
+++ b/src/v2/Apps/Partner/PartnerApp.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "@artsy/palette"
 import { Footer } from "v2/Components/Footer"
 import { AppContainer } from "../Components/AppContainer"
 import { HorizontalPadding } from "../Components/HorizontalPadding"
-import { NavigationTabs } from "./Components/NavigationTabs"
+import { NavigationTabsFragmentContainer as NavigationTabs } from "v2/Apps/Partner/Components/NavigationTabs"
 import { createFragmentContainer, graphql } from "react-relay"
 import { PartnerApp_partner } from "v2/__generated__/PartnerApp_partner.graphql"
 
@@ -16,10 +16,10 @@ export const PartnerApp: React.FC<PartnerAppProps> = props => {
     <AppContainer>
       <Box mx={[2, 4]}>
         <Text pt={2} pb={1} variant="largeTitle">
-          Partner: {props.partner.name}
+          {props.partner.name}
         </Text>
 
-        <NavigationTabs partnerId={props.partner.slug} />
+        <NavigationTabs partner={props.partner} />
 
         {props.children}
       </Box>
@@ -34,9 +34,8 @@ export const PartnerApp: React.FC<PartnerAppProps> = props => {
 export const PartnerAppFragmentContainer = createFragmentContainer(PartnerApp, {
   partner: graphql`
     fragment PartnerApp_partner on Partner {
-      id
-      slug
       name
+      ...NavigationTabs_partner
     }
   `,
 })

--- a/src/v2/Apps/Partner/PartnerApp.tsx
+++ b/src/v2/Apps/Partner/PartnerApp.tsx
@@ -6,22 +6,30 @@ import { HorizontalPadding } from "../Components/HorizontalPadding"
 import { NavigationTabsFragmentContainer as NavigationTabs } from "v2/Apps/Partner/Components/NavigationTabs"
 import { createFragmentContainer, graphql } from "react-relay"
 import { PartnerApp_partner } from "v2/__generated__/PartnerApp_partner.graphql"
+import { HttpError } from "found"
 
 export interface PartnerAppProps {
   partner: PartnerApp_partner
 }
 
-export const PartnerApp: React.FC<PartnerAppProps> = props => {
+export const PartnerApp: React.FC<PartnerAppProps> = ({
+  partner,
+  children,
+}) => {
+  if (!partner) {
+    throw new HttpError(404)
+  }
+
   return (
     <AppContainer>
       <Box mx={[2, 4]}>
         <Text pt={2} pb={1} variant="largeTitle">
-          {props.partner.name}
+          {partner.name}
         </Text>
 
-        <NavigationTabs partner={props.partner} />
+        <NavigationTabs partner={partner} />
 
-        {props.children}
+        {children}
       </Box>
 
       <HorizontalPadding mt={4} mb={8}>

--- a/src/v2/Apps/Partner/Routes/Articles/index.tsx
+++ b/src/v2/Apps/Partner/Routes/Articles/index.tsx
@@ -1,0 +1,5 @@
+import React from "react"
+
+export const ArticlesRoute: React.FC = () => {
+  return <div>Articles</div>
+}

--- a/src/v2/Apps/Partner/Routes/Artists/index.tsx
+++ b/src/v2/Apps/Partner/Routes/Artists/index.tsx
@@ -1,0 +1,5 @@
+import React from "react"
+
+export const ArtistsRoute: React.FC = () => {
+  return <div>Artists</div>
+}

--- a/src/v2/Apps/Partner/Routes/Contact/index.tsx
+++ b/src/v2/Apps/Partner/Routes/Contact/index.tsx
@@ -1,0 +1,5 @@
+import React from "react"
+
+export const ContactRoute: React.FC = () => {
+  return <div>Contact</div>
+}

--- a/src/v2/Apps/Partner/Routes/Overview/index.tsx
+++ b/src/v2/Apps/Partner/Routes/Overview/index.tsx
@@ -1,0 +1,5 @@
+import React from "react"
+
+export const OverviewRoute: React.FC = () => {
+  return <div>Overview</div>
+}

--- a/src/v2/Apps/Partner/Routes/Shows/index.tsx
+++ b/src/v2/Apps/Partner/Routes/Shows/index.tsx
@@ -1,0 +1,5 @@
+import React from "react"
+
+export const ShowsRoute: React.FC = () => {
+  return <div>Shows</div>
+}

--- a/src/v2/Apps/Partner/Routes/Works/index.tsx
+++ b/src/v2/Apps/Partner/Routes/Works/index.tsx
@@ -1,0 +1,5 @@
+import React from "react"
+
+export const WorksRoute: React.FC = () => {
+  return <div>Works</div>
+}

--- a/src/v2/Apps/Partner/__tests__/PartnerApp.jest.tsx
+++ b/src/v2/Apps/Partner/__tests__/PartnerApp.jest.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+import { graphql } from "react-relay"
+import { PartnerApp_Test_Query } from "v2/__generated__/PartnerApp_Test_Query.graphql"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { PartnerAppFragmentContainer } from "../PartnerApp"
+
+jest.unmock("react-relay")
+jest.mock("react-tracking")
+
+const { getWrapper } = setupTestWrapper<PartnerApp_Test_Query>({
+  Component: props => {
+    return <PartnerAppFragmentContainer {...props} />
+  },
+  query: graphql`
+    query PartnerApp_Test_Query {
+      partner(id: "example") {
+        ...PartnerApp_partner
+      }
+    }
+  `,
+})
+
+describe("PartnerApp", () => {
+  it("displays navigation tabs for the partner page", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.find("NavigationTabs").length).toBe(1)
+  })
+})

--- a/src/v2/Apps/Partner/partnerRoutes.tsx
+++ b/src/v2/Apps/Partner/partnerRoutes.tsx
@@ -33,7 +33,7 @@ const ContactRoute = loadable(() => import("./Routes/Contact"), {
 export const partnerRoutes: RouteConfig[] = [
   {
     getComponent: () => PartnerApp,
-    path: "/partner/:partnerId",
+    path: "/partner2/:partnerId",
     prepare: () => {
       PartnerApp.preload()
     },

--- a/src/v2/Apps/Partner/partnerRoutes.tsx
+++ b/src/v2/Apps/Partner/partnerRoutes.tsx
@@ -5,6 +5,14 @@ const PartnerApp = loadable(() => import("./PartnerApp"), {
   resolveComponent: component => component.PartnerApp,
 })
 
+const ArticlesRoute = loadable(() => import("./Routes/Articles"), {
+  resolveComponent: component => component.ArticlesRoute,
+})
+
+const OverviewRoute = loadable(() => import("./Routes/Overview"), {
+  resolveComponent: component => component.OverviewRoute,
+})
+
 export const partnerRoutes: RouteConfig[] = [
   {
     getComponent: () => PartnerApp,
@@ -12,5 +20,21 @@ export const partnerRoutes: RouteConfig[] = [
     prepare: () => {
       PartnerApp.preload()
     },
+    children: [
+      {
+        getComponent: () => OverviewRoute,
+        path: "",
+        prepare: () => {
+          OverviewRoute.preload()
+        },
+      },
+      {
+        getComponent: () => ArticlesRoute,
+        path: "articles",
+        prepare: () => {
+          ArticlesRoute.preload()
+        },
+      },
+    ],
   },
 ]

--- a/src/v2/Apps/Partner/partnerRoutes.tsx
+++ b/src/v2/Apps/Partner/partnerRoutes.tsx
@@ -1,5 +1,5 @@
 import loadable from "@loadable/component"
-import { RouteConfig } from "found"
+import { RedirectException, RouteConfig } from "found"
 import { graphql } from "react-relay"
 
 const PartnerApp = loadable(() => import("./PartnerApp"), {
@@ -50,6 +50,15 @@ export const partnerRoutes: RouteConfig[] = [
         path: "",
         prepare: () => {
           OverviewRoute.preload()
+        },
+      },
+      {
+        path: "overview",
+        render: props => {
+          throw new RedirectException(
+            `/partner2/${props.match.params.partnerId}`,
+            302
+          )
         },
       },
       {

--- a/src/v2/Apps/Partner/partnerRoutes.tsx
+++ b/src/v2/Apps/Partner/partnerRoutes.tsx
@@ -14,6 +14,22 @@ const OverviewRoute = loadable(() => import("./Routes/Overview"), {
   resolveComponent: component => component.OverviewRoute,
 })
 
+const ShowsRoute = loadable(() => import("./Routes/Shows"), {
+  resolveComponent: component => component.ShowsRoute,
+})
+
+const WorksRoute = loadable(() => import("./Routes/Works"), {
+  resolveComponent: component => component.WorksRoute,
+})
+
+const ArtistsRoute = loadable(() => import("./Routes/Artists"), {
+  resolveComponent: component => component.ArtistsRoute,
+})
+
+const ContactRoute = loadable(() => import("./Routes/Contact"), {
+  resolveComponent: component => component.ContactRoute,
+})
+
 export const partnerRoutes: RouteConfig[] = [
   {
     getComponent: () => PartnerApp,
@@ -41,6 +57,34 @@ export const partnerRoutes: RouteConfig[] = [
         path: "articles",
         prepare: () => {
           ArticlesRoute.preload()
+        },
+      },
+      {
+        getComponent: () => ShowsRoute,
+        path: "shows",
+        prepare: () => {
+          ShowsRoute.preload()
+        },
+      },
+      {
+        getComponent: () => WorksRoute,
+        path: "works",
+        prepare: () => {
+          WorksRoute.preload()
+        },
+      },
+      {
+        getComponent: () => ArtistsRoute,
+        path: "artists",
+        prepare: () => {
+          ArtistsRoute.preload()
+        },
+      },
+      {
+        getComponent: () => ContactRoute,
+        path: "contact",
+        prepare: () => {
+          ContactRoute.preload()
         },
       },
     ],

--- a/src/v2/Apps/Partner/partnerRoutes.tsx
+++ b/src/v2/Apps/Partner/partnerRoutes.tsx
@@ -1,8 +1,9 @@
 import loadable from "@loadable/component"
 import { RouteConfig } from "found"
+import { graphql } from "react-relay"
 
 const PartnerApp = loadable(() => import("./PartnerApp"), {
-  resolveComponent: component => component.PartnerApp,
+  resolveComponent: component => component.PartnerAppFragmentContainer,
 })
 
 const ArticlesRoute = loadable(() => import("./Routes/Articles"), {
@@ -20,6 +21,13 @@ export const partnerRoutes: RouteConfig[] = [
     prepare: () => {
       PartnerApp.preload()
     },
+    query: graphql`
+      query partnerRoutes_PartnerQuery($partnerId: String!) {
+        partner(id: $partnerId) {
+          ...PartnerApp_partner
+        }
+      }
+    `,
     children: [
       {
         getComponent: () => OverviewRoute,

--- a/src/v2/Apps/Partner/partnerRoutes.tsx
+++ b/src/v2/Apps/Partner/partnerRoutes.tsx
@@ -39,7 +39,7 @@ export const partnerRoutes: RouteConfig[] = [
     },
     query: graphql`
       query partnerRoutes_PartnerQuery($partnerId: String!) {
-        partner(id: $partnerId) {
+        partner(id: $partnerId) @principalField {
           ...PartnerApp_partner
         }
       }

--- a/src/v2/Apps/Partner/partnerRoutes.tsx
+++ b/src/v2/Apps/Partner/partnerRoutes.tsx
@@ -1,0 +1,16 @@
+import loadable from "@loadable/component"
+import { RouteConfig } from "found"
+
+const PartnerApp = loadable(() => import("./PartnerApp"), {
+  resolveComponent: component => component.PartnerApp,
+})
+
+export const partnerRoutes: RouteConfig[] = [
+  {
+    getComponent: () => PartnerApp,
+    path: "/partner/:partnerId",
+    prepare: () => {
+      PartnerApp.preload()
+    },
+  },
+]

--- a/src/v2/Apps/getAppNovoRoutes.tsx
+++ b/src/v2/Apps/getAppNovoRoutes.tsx
@@ -102,7 +102,7 @@ export function getAppNovoRoutes(): RouteConfig[] {
         routes: paymentRoutes,
       },
       {
-        // converted: true,
+        converted: true,
         routes: partnerRoutes,
       },
 

--- a/src/v2/Apps/getAppNovoRoutes.tsx
+++ b/src/v2/Apps/getAppNovoRoutes.tsx
@@ -20,6 +20,7 @@ import { searchRoutes } from "v2/Apps/Search/searchRoutes"
 import { showRoutes } from "v2/Apps/Show/showRoutes"
 import { viewingRoomRoutes } from "./ViewingRoom/viewingRoomRoutes"
 import { paymentRoutes } from "v2/Apps/Payment/paymentRoutes"
+import { partnerRoutes } from "v2/Apps/Partner/partnerRoutes"
 
 export function getAppNovoRoutes(): RouteConfig[] {
   return buildAppRoutes(
@@ -99,6 +100,10 @@ export function getAppNovoRoutes(): RouteConfig[] {
       {
         converted: true,
         routes: paymentRoutes,
+      },
+      {
+        // converted: true,
+        routes: partnerRoutes,
       },
 
       // For debugging baseline app shell stuff

--- a/src/v2/__generated__/NavigationTabs_Test_PartnerQuery.graphql.ts
+++ b/src/v2/__generated__/NavigationTabs_Test_PartnerQuery.graphql.ts
@@ -1,0 +1,116 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type NavigationTabs_Test_PartnerQueryVariables = {};
+export type NavigationTabs_Test_PartnerQueryResponse = {
+    readonly partner: {
+        readonly " $fragmentRefs": FragmentRefs<"NavigationTabs_partner">;
+    } | null;
+};
+export type NavigationTabs_Test_PartnerQueryRawResponse = {
+    readonly partner: ({
+        readonly slug: string;
+        readonly id: string | null;
+    }) | null;
+};
+export type NavigationTabs_Test_PartnerQuery = {
+    readonly response: NavigationTabs_Test_PartnerQueryResponse;
+    readonly variables: NavigationTabs_Test_PartnerQueryVariables;
+    readonly rawResponse: NavigationTabs_Test_PartnerQueryRawResponse;
+};
+
+
+
+/*
+query NavigationTabs_Test_PartnerQuery {
+  partner(id: "white-cube") {
+    ...NavigationTabs_partner
+    id
+  }
+}
+
+fragment NavigationTabs_partner on Partner {
+  slug
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "white-cube"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "NavigationTabs_Test_PartnerQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Partner",
+        "kind": "LinkedField",
+        "name": "partner",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "NavigationTabs_partner"
+          }
+        ],
+        "storageKey": "partner(id:\"white-cube\")"
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "NavigationTabs_Test_PartnerQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Partner",
+        "kind": "LinkedField",
+        "name": "partner",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "partner(id:\"white-cube\")"
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "NavigationTabs_Test_PartnerQuery",
+    "operationKind": "query",
+    "text": "query NavigationTabs_Test_PartnerQuery {\n  partner(id: \"white-cube\") {\n    ...NavigationTabs_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n}\n"
+  }
+};
+})();
+(node as any).hash = 'c84bdc912b3f9fed0de3f5762759a1ed';
+export default node;

--- a/src/v2/__generated__/NavigationTabs_partner.graphql.ts
+++ b/src/v2/__generated__/NavigationTabs_partner.graphql.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type NavigationTabs_partner = {
+    readonly slug: string;
+    readonly " $refType": "NavigationTabs_partner";
+};
+export type NavigationTabs_partner$data = NavigationTabs_partner;
+export type NavigationTabs_partner$key = {
+    readonly " $data"?: NavigationTabs_partner$data;
+    readonly " $fragmentRefs": FragmentRefs<"NavigationTabs_partner">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "NavigationTabs_partner",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    }
+  ],
+  "type": "Partner"
+};
+(node as any).hash = '3888bb95277e684179a4f599ccb31044';
+export default node;

--- a/src/v2/__generated__/PartnerApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PartnerApp_Test_Query.graphql.ts
@@ -1,0 +1,121 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type PartnerApp_Test_QueryVariables = {};
+export type PartnerApp_Test_QueryResponse = {
+    readonly partner: {
+        readonly " $fragmentRefs": FragmentRefs<"PartnerApp_partner">;
+    } | null;
+};
+export type PartnerApp_Test_Query = {
+    readonly response: PartnerApp_Test_QueryResponse;
+    readonly variables: PartnerApp_Test_QueryVariables;
+};
+
+
+
+/*
+query PartnerApp_Test_Query {
+  partner(id: "example") {
+    ...PartnerApp_partner
+    id
+  }
+}
+
+fragment NavigationTabs_partner on Partner {
+  slug
+}
+
+fragment PartnerApp_partner on Partner {
+  name
+  ...NavigationTabs_partner
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "PartnerApp_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Partner",
+        "kind": "LinkedField",
+        "name": "partner",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "PartnerApp_partner"
+          }
+        ],
+        "storageKey": "partner(id:\"example\")"
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "PartnerApp_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Partner",
+        "kind": "LinkedField",
+        "name": "partner",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "partner(id:\"example\")"
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "PartnerApp_Test_Query",
+    "operationKind": "query",
+    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n}\n\nfragment PartnerApp_partner on Partner {\n  name\n  ...NavigationTabs_partner\n}\n"
+  }
+};
+})();
+(node as any).hash = '0c68d38f034c6d9a33a2e60062afa321';
+export default node;

--- a/src/v2/__generated__/PartnerApp_partner.graphql.ts
+++ b/src/v2/__generated__/PartnerApp_partner.graphql.ts
@@ -1,0 +1,51 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type PartnerApp_partner = {
+    readonly id: string;
+    readonly slug: string;
+    readonly name: string | null;
+    readonly " $refType": "PartnerApp_partner";
+};
+export type PartnerApp_partner$data = PartnerApp_partner;
+export type PartnerApp_partner$key = {
+    readonly " $data"?: PartnerApp_partner$data;
+    readonly " $fragmentRefs": FragmentRefs<"PartnerApp_partner">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "PartnerApp_partner",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "Partner"
+};
+(node as any).hash = '161bdf1b521d4e61aa5cae09a89b6a83';
+export default node;

--- a/src/v2/__generated__/PartnerApp_partner.graphql.ts
+++ b/src/v2/__generated__/PartnerApp_partner.graphql.ts
@@ -4,9 +4,8 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type PartnerApp_partner = {
-    readonly id: string;
-    readonly slug: string;
     readonly name: string | null;
+    readonly " $fragmentRefs": FragmentRefs<"NavigationTabs_partner">;
     readonly " $refType": "PartnerApp_partner";
 };
 export type PartnerApp_partner$data = PartnerApp_partner;
@@ -27,25 +26,16 @@ const node: ReaderFragment = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
-      "name": "id",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "slug",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
       "name": "name",
       "storageKey": null
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "NavigationTabs_partner"
     }
   ],
   "type": "Partner"
 };
-(node as any).hash = '161bdf1b521d4e61aa5cae09a89b6a83';
+(node as any).hash = '62a9f0389b78665c93b1bfdde852760f';
 export default node;

--- a/src/v2/__generated__/partnerRoutes_PartnerQuery.graphql.ts
+++ b/src/v2/__generated__/partnerRoutes_PartnerQuery.graphql.ts
@@ -1,0 +1,130 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type partnerRoutes_PartnerQueryVariables = {
+    partnerId: string;
+};
+export type partnerRoutes_PartnerQueryResponse = {
+    readonly partner: {
+        readonly " $fragmentRefs": FragmentRefs<"PartnerApp_partner">;
+    } | null;
+};
+export type partnerRoutes_PartnerQuery = {
+    readonly response: partnerRoutes_PartnerQueryResponse;
+    readonly variables: partnerRoutes_PartnerQueryVariables;
+};
+
+
+
+/*
+query partnerRoutes_PartnerQuery(
+  $partnerId: String!
+) {
+  partner(id: $partnerId) {
+    ...PartnerApp_partner
+    id
+  }
+}
+
+fragment PartnerApp_partner on Partner {
+  id
+  slug
+  name
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "partnerId",
+    "type": "String!"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "partnerId"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "partnerRoutes_PartnerQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Partner",
+        "kind": "LinkedField",
+        "name": "partner",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "PartnerApp_partner"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "partnerRoutes_PartnerQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Partner",
+        "kind": "LinkedField",
+        "name": "partner",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "partnerRoutes_PartnerQuery",
+    "operationKind": "query",
+    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  id\n  slug\n  name\n}\n"
+  }
+};
+})();
+(node as any).hash = '4aac554a98b73b85261806b9b20494e8';
+export default node;

--- a/src/v2/__generated__/partnerRoutes_PartnerQuery.graphql.ts
+++ b/src/v2/__generated__/partnerRoutes_PartnerQuery.graphql.ts
@@ -28,10 +28,13 @@ query partnerRoutes_PartnerQuery(
   }
 }
 
-fragment PartnerApp_partner on Partner {
-  id
+fragment NavigationTabs_partner on Partner {
   slug
+}
+
+fragment PartnerApp_partner on Partner {
   name
+  ...NavigationTabs_partner
 }
 */
 
@@ -95,7 +98,7 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "id",
+            "name": "name",
             "storageKey": null
           },
           {
@@ -109,7 +112,7 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "name",
+            "name": "id",
             "storageKey": null
           }
         ],
@@ -122,7 +125,7 @@ return {
     "metadata": {},
     "name": "partnerRoutes_PartnerQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  id\n  slug\n  name\n}\n"
+    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n}\n\nfragment PartnerApp_partner on Partner {\n  name\n  ...NavigationTabs_partner\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/partnerRoutes_PartnerQuery.graphql.ts
+++ b/src/v2/__generated__/partnerRoutes_PartnerQuery.graphql.ts
@@ -22,7 +22,7 @@ export type partnerRoutes_PartnerQuery = {
 query partnerRoutes_PartnerQuery(
   $partnerId: String!
 ) {
-  partner(id: $partnerId) {
+  partner(id: $partnerId) @principalField {
     ...PartnerApp_partner
     id
   }
@@ -125,9 +125,9 @@ return {
     "metadata": {},
     "name": "partnerRoutes_PartnerQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n}\n\nfragment PartnerApp_partner on Partner {\n  name\n  ...NavigationTabs_partner\n}\n"
+    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n}\n\nfragment PartnerApp_partner on Partner {\n  name\n  ...NavigationTabs_partner\n}\n"
   }
 };
 })();
-(node as any).hash = '4aac554a98b73b85261806b9b20494e8';
+(node as any).hash = 'b065b69c18af67164cd46d476357078f';
 export default node;


### PR DESCRIPTION
This PR adds a basic layout for the partner profile page. 

- adds new routes starts with `/partner2/:partnerId`
- adds navigation tabs
- includes 404 page handling

JIRA - https://artsyproduct.atlassian.net/browse/PX-3834

![image](https://user-images.githubusercontent.com/79979820/111627404-12b28900-8800-11eb-9779-2312250f6195.png)
