### PR TITLE
fix: Exclude `PaymentApp` route from analytics tracker

### DIFF
--- a/src/desktop/assets/analytics.ts
+++ b/src/desktop/assets/analytics.ts
@@ -26,6 +26,7 @@ const excludedRoutes = [
   "/user/conversations(.*)",
   "/user/purchases(.*)",
   "/viewing-room(.*)",
+  "/user/payments(.*)",
 ]
 
 beforeAnalyticsReady()


### PR DESCRIPTION
Because the tracking is handled by "SSR framework now via analyticsMiddleware" [[thread](https://artsy.slack.com/archives/C9YNS4X32/p1616088152046900)]

Caught by @damassi 🙏🏽 

cc: @icirellik 


