### PR TITLE
feat(materials filter): use proper capitalization

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
@@ -4,15 +4,21 @@ import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
 import { ShowMore } from "./ShowMore"
 
-const MaterialsTermOption: React.FC<{ name: string }> = ({ name }) => {
+const MaterialsTermOption: React.FC<{
+  /** Display value (capitalized) for this term */
+  name: string
+
+  /** Database value for this term */
+  value: string
+}> = ({ name, value }) => {
   const { currentlySelectedFilters, setFilter } = useArtworkFilterContext()
 
-  const toggleMaterialsTermSelection = (selected, name) => {
+  const toggleMaterialsTermSelection = (selected, value) => {
     let materialsTerms = currentlySelectedFilters().materialsTerms.slice()
     if (selected) {
-      materialsTerms.push(name)
+      materialsTerms.push(value)
     } else {
-      materialsTerms = materialsTerms.filter(item => item !== name)
+      materialsTerms = materialsTerms.filter(item => item !== value)
     }
     setFilter("materialsTerms", materialsTerms)
   }
@@ -20,10 +26,10 @@ const MaterialsTermOption: React.FC<{ name: string }> = ({ name }) => {
   return (
     <Checkbox
       onSelect={selected => {
-        toggleMaterialsTermSelection(selected, name)
+        toggleMaterialsTermSelection(selected, value)
       }}
-      selected={currentlySelectedFilters().materialsTerms.includes(name)}
-      key={name}
+      selected={currentlySelectedFilters().materialsTerms.includes(value)}
+      key={value}
     >
       <OptionText>{name}</OptionText>
     </Checkbox>
@@ -43,8 +49,8 @@ export const MaterialsFilter = () => {
   return (
     <Toggle label="Materials" expanded>
       <ShowMore>
-        {materialsTerms.counts.map(({ name, value, count }) => {
-          return <MaterialsTermOption key={name} name={name} />
+        {materialsTerms.counts.map(({ name, value }) => {
+          return <MaterialsTermOption key={value} name={name} value={value} />
         })}
       </ShowMore>
     </Toggle>

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/MaterialsTermFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/MaterialsTermFilter.jest.tsx
@@ -1,18 +1,30 @@
 import { mount } from "enzyme"
 import React from "react"
-import { ArtworkFilterContextProvider } from "../../ArtworkFilterContext"
+import {
+  ArtworkFilterContextProps,
+  ArtworkFilterContextProvider,
+  useArtworkFilterContext,
+} from "../../ArtworkFilterContext"
 import { MaterialsFilter } from "../MaterialsFilter"
 
 describe("MaterialsTermFilter", () => {
+  let context: ArtworkFilterContextProps
+
   const getWrapper = (contextProps = {}) => {
     return mount(
       <ArtworkFilterContextProvider {...contextProps}>
-        <MaterialsFilter />
+        <MaterialsFilterTest />
       </ArtworkFilterContextProvider>
     )
   }
+
+  const MaterialsFilterTest = () => {
+    context = useArtworkFilterContext()
+    return <MaterialsFilter />
+  }
+
   describe("materials", () => {
-    it("renders materials", () => {
+    it("renders material term names", () => {
       const wrapper = getWrapper({
         aggregations: [
           {
@@ -34,6 +46,37 @@ describe("MaterialsTermFilter", () => {
       })
       expect(wrapper.find("Checkbox").first().text()).toContain("Oil")
       expect(wrapper.find("Checkbox").last().text()).toContain("Canvas")
+    })
+
+    it("acts on material term values", async () => {
+      const wrapper = getWrapper({
+        aggregations: [
+          {
+            slice: "MATERIALS_TERMS",
+            counts: [
+              {
+                name: "Oil",
+                count: 10,
+                value: "oil",
+              },
+              {
+                name: "Canvas",
+                count: 5,
+                value: "canvas",
+              },
+            ],
+          },
+        ],
+      })
+
+      expect(context.filters.materialsTerms).toHaveLength(0)
+
+      await wrapper.find("Checkbox").first().simulate("click")
+      await wrapper.find("Checkbox").last().simulate("click")
+
+      expect(context.filters.materialsTerms).toHaveLength(2)
+      expect(context.filters.materialsTerms).toContain("oil")
+      expect(context.filters.materialsTerms).toContain("canvas")
     })
   })
 })


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2744

This update teaches the filters how to properly use the `name` _and_ `value` of the upstream aggregations:

- Use the (capitalized) `name` for user-facing display
- Use the `value` for twiddling filter state

This relies on the upstream work in Gravity (https://github.com/artsy/gravity/pull/13919), but should continue to work fine even before that lands.