### PR TITLE
fix: Ensure self-referring canonicals on consign pages GRO-220

### DIFF
--- a/src/v2/Apps/Artist/Components/ArtistMetaCanonicalLink.tsx
+++ b/src/v2/Apps/Artist/Components/ArtistMetaCanonicalLink.tsx
@@ -8,32 +8,26 @@ import { hasOverviewContent } from "v2/Apps/Artist/Components/NavigationTabs"
 import { useRouter } from "v2/Artsy/Router/useRouter"
 
 export const computeCanonicalPath = (
-  artist: ArtistMetaCanonicalLink_artist,
-  path: string
+  appUrl: string,
+  artistSlug: string,
+  path: string,
+  canShowOverview: boolean
 ) => {
-  const basePath = `/artist/${artist.slug}`
-  const pathParts = [basePath]
+  const urlParts = [appUrl, "artist", artistSlug]
 
-  const isConsignPage = path === "consign"
+  const isConsignPage = path.endsWith("consign")
   const isWorksForSalePage = path.endsWith("works-for-sale")
   const isAuctionResultsPage = path.endsWith("auction-results")
 
-  const hasArtistInsights =
-    showMarketInsights(artist) ||
-    (artist.insights && artist.insights.length > 0)
-
-  const hasArtistContent = hasOverviewContent(artist)
-  const canShowOverview = hasArtistInsights || hasArtistContent
-
   if (isConsignPage) {
-    pathParts.push("/consign")
+    urlParts.push("consign")
   } else if (isWorksForSalePage || !canShowOverview) {
-    pathParts.push("/works-for-sale")
+    urlParts.push("works-for-sale")
   } else if (isAuctionResultsPage) {
-    pathParts.push("/auction-results")
+    urlParts.push("auction-results")
   }
 
-  return pathParts.join("")
+  return urlParts.join("/")
 }
 
 export type ArtistMetaCanonicalLinkProps = {
@@ -44,8 +38,20 @@ export const ArtistMetaCanonicalLink: React.FC<ArtistMetaCanonicalLinkProps> = (
   artist,
 }) => {
   const { pathname } = useRouter().match.location
-  const canonicalPath = computeCanonicalPath(artist, pathname)
-  const canonicalUrl = `${sd.APP_URL}${canonicalPath}`
+  const hasArtistInsights =
+    showMarketInsights(artist) ||
+    (artist.insights && artist.insights.length > 0)
+
+  const hasArtistContent = hasOverviewContent(artist)
+  const canShowOverview = hasArtistInsights || hasArtistContent
+
+  const canonicalUrl = computeCanonicalPath(
+    sd.APP_URL,
+    artist.slug,
+    pathname,
+    canShowOverview
+  )
+
   return <Link rel="canonical" href={canonicalUrl} />
 }
 

--- a/src/v2/Apps/Artist/Components/__tests__/ArtistMetaCanonical.jest.tsx
+++ b/src/v2/Apps/Artist/Components/__tests__/ArtistMetaCanonical.jest.tsx
@@ -2,7 +2,10 @@ import React from "react"
 import { mount } from "enzyme"
 import { HeadProvider } from "react-head"
 import { ArtistMetaCanonicalLink_artist } from "v2/__generated__/ArtistMetaCanonicalLink_artist.graphql"
-import { ArtistMetaCanonicalLink } from "../ArtistMetaCanonicalLink"
+import {
+  ArtistMetaCanonicalLink,
+  computeCanonicalPath,
+} from "../ArtistMetaCanonicalLink"
 
 jest.mock("v2/Artsy/Router/useRouter", () => ({
   useRouter: () => ({
@@ -178,8 +181,9 @@ describe("ArtistMetaCanonicalLink", () => {
       </HeadProvider>
     )
 
-    expect(wrapper.html()).toEqual(
-      '<link rel="canonical" href="https://www.artsy-test.net/artist/damon-zucconi">'
+    const canonicalUrl = wrapper.find("link[rel='canonical']").prop("href")
+    expect(canonicalUrl).toEqual(
+      "https://www.artsy-test.net/artist/damon-zucconi"
     )
   })
 
@@ -190,8 +194,27 @@ describe("ArtistMetaCanonicalLink", () => {
       </HeadProvider>
     )
 
-    expect(wrapper.html()).toEqual(
-      '<link rel="canonical" href="https://www.artsy-test.net/artist/gina-lombardi-bratter/works-for-sale">'
+    const canonicalUrl = wrapper.find("link[rel='canonical']").prop("href")
+    expect(canonicalUrl).toEqual(
+      "https://www.artsy-test.net/artist/gina-lombardi-bratter/works-for-sale"
     )
+  })
+})
+
+describe("computeCanonicalPath", () => {
+  it("appends consign for those pages", () => {
+    const appUrl = "https://www.artsy.net"
+    const artistSlug = "damon-zucconi"
+    const canShowOverview = true
+    const path = "/artist/damon-zucconi/consign"
+
+    const canonicalUrl = computeCanonicalPath(
+      appUrl,
+      artistSlug,
+      path,
+      canShowOverview
+    )
+
+    expect(canonicalUrl).toMatch("consign")
   })
 })


### PR DESCRIPTION
I took this work up after our SEO bug bash and did a little cleaning up. There's a function we use to compute the canonical tag and prior to this refactoring it was taking complex objects and that made it cumbersome to test so I changed that. I moved to that function taking only primitives which made it easier to spot and fix the bug. Props to @The-Beez-Kneez for finding it first so all I had to do was the clean-up part!! 🏆 

Anyway, this should be good and I'm hoping any future changes will be easier to make.

https://artsyproduct.atlassian.net/browse/GRO-220

/cc @artsy/grow-devs