### PR TITLE
bugfix: Fixes artist title tag for zero artworks

### DIFF
--- a/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignMeta.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignMeta.tsx
@@ -6,11 +6,11 @@ import { getENV } from "v2/Utils/getENV"
 import { ArtistConsignMeta_artist } from "v2/__generated__/ArtistConsignMeta_artist.graphql"
 import { get } from "v2/Utils/get"
 
-interface ArtistConsignMeta {
+interface ArtistConsignMetaProps {
   artist: ArtistConsignMeta_artist
 }
 
-export const ArtistConsignMeta: React.FC<ArtistConsignMeta> = props => {
+export const ArtistConsignMeta: React.FC<ArtistConsignMetaProps> = props => {
   const {
     artist: { name, href, targetSupply },
   } = props

--- a/src/v2/Apps/Artist/Routes/Overview/index.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/index.tsx
@@ -35,6 +35,7 @@ import { get } from "v2/Utils/get"
 import { Media } from "v2/Utils/Responsive"
 import { ArtistRecommendationsQueryRenderer as ArtistRecommendations } from "./Components/ArtistRecommendations"
 import { Title } from "react-head"
+import { computeTitle } from "v2/Apps/Artist/Utils/computeTitle"
 
 export interface OverviewRouteProps {
   artist: Overview_artist
@@ -181,7 +182,7 @@ export class OverviewRoute extends React.Component<OverviewRouteProps, {}> {
       get(artist, a => a.articlesConnection.edges.length) &&
       artist.articlesConnection.edges.map(({ node }) => node)
 
-    const titleString = `${artist.name} - ${artist.counts.artworks} Artworks, Bio & Shows on Artsy`
+    const titleString = computeTitle(artist.name, artist.counts.artworks)
 
     return (
       <>

--- a/src/v2/Apps/Artist/Routes/Works/index.tsx
+++ b/src/v2/Apps/Artist/Routes/Works/index.tsx
@@ -10,6 +10,7 @@ import { ArtistSeriesRailFragmentContainer as ArtistSeriesRail } from "v2/Compon
 import { ContextModule } from "@artsy/cohesion"
 import { ArtistCollectionsRailContent as ArtistCollectionsRail } from "v2/Apps/Artist/Components/ArtistCollectionsRail"
 import { Title } from "react-head"
+import { computeTitle } from "../../Utils/computeTitle"
 
 export interface WorksRouteProps {
   artist: Works_artist
@@ -27,7 +28,7 @@ export const WorksRoute: React.FC<WorksRouteProps> = props => {
   const hasArtistSeries =
     get(artist, a => a.artistSeriesConnection.edges.length, 0) > 0
 
-  const titleString = `${artist.name} - ${artist.counts.forSaleArtworks} Artworks for Sale on Artsy`
+  const titleString = computeTitle(artist.name, artist.counts.forSaleArtworks)
 
   return (
     <>

--- a/src/v2/Apps/Artist/Utils/__tests__/computeTitle.jest.tsx
+++ b/src/v2/Apps/Artist/Utils/__tests__/computeTitle.jest.tsx
@@ -1,0 +1,23 @@
+import { computeTitle } from "../computeTitle"
+
+describe("computeTitle", () => {
+  it("includes artworks when count > 0", () => {
+    const artist = {
+      name: "Artist Name",
+      count: 10,
+    }
+    expect(computeTitle(artist.name, artist.count)).toEqual(
+      "Artist Name - 10 Artworks, Bio & Shows on Artsy"
+    )
+  })
+
+  it("excludes artworks when count = 0", () => {
+    const artist = {
+      name: "Artist Name",
+      count: 0,
+    }
+    expect(computeTitle(artist.name, artist.count)).toEqual(
+      "Artist Name - Bio & Shows on Artsy"
+    )
+  })
+})

--- a/src/v2/Apps/Artist/Utils/computeTitle.tsx
+++ b/src/v2/Apps/Artist/Utils/computeTitle.tsx
@@ -1,0 +1,13 @@
+/**
+ * Computes title meta tage value for an artist
+ */
+export function computeTitle(name: string, count: number) {
+  const parts = [
+    name,
+    "-",
+    count ? count + " Artworks," : null,
+    "Bio & Shows on Artsy",
+  ]
+  const titleString = parts.filter(Boolean).join(" ")
+  return titleString
+}


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/GRO-241. 

Remove # of artworks from title tag on artist pages when 0.

cc @artsy/grow-devs 
