### PR TITLE
fix: use an allowlist for filter params coming from URL

### DIFF
--- a/src/v2/Apps/Artist/artistRoutes.tsx
+++ b/src/v2/Apps/Artist/artistRoutes.tsx
@@ -11,6 +11,7 @@ import { getENV } from "v2/Utils/getENV"
 import { hasOverviewContent } from "./Components/NavigationTabs"
 
 import { initialArtworkFilterState } from "v2/Components/v2/ArtworkFilter/ArtworkFilterContext"
+import { allowedFilters } from "v2/Components/v2/ArtworkFilter/Utils/allowedFilters"
 
 graphql`
   fragment artistRoutes_Artist on Artist {
@@ -139,7 +140,7 @@ export const artistRoutes: RouteConfig[] = [
 
           return {
             input: {
-              ...filterParams,
+              ...allowedFilters(filterParams),
               aggregations: aggregations.concat(additionalAggregations),
             },
             artistID,

--- a/src/v2/Apps/ArtistSeries/artistSeriesRoutes.tsx
+++ b/src/v2/Apps/ArtistSeries/artistSeriesRoutes.tsx
@@ -3,6 +3,7 @@ import { graphql } from "react-relay"
 import { RouteConfig } from "found"
 import { paramsToCamelCase } from "v2/Components/v2/ArtworkFilter/Utils/urlBuilder"
 import { getENV } from "v2/Utils/getENV"
+import { allowedFilters } from "v2/Components/v2/ArtworkFilter/Utils/allowedFilters"
 
 const ArtistSeriesApp = loadable(() => import("./ArtistSeriesApp"), {
   resolveComponent: component => component.ArtistSeriesAppFragmentContainer,
@@ -39,7 +40,7 @@ function initializeVariablesWithFilterState({ slug }, props) {
 
   const input = {
     sort: "-decayed_merch",
-    ...paramsToCamelCase(initialFilterState),
+    ...allowedFilters(paramsToCamelCase(initialFilterState)),
     aggregations: aggregations.concat(additionalAggregations),
     first: 20,
   }

--- a/src/v2/Apps/Collect/collectRoutes.tsx
+++ b/src/v2/Apps/Collect/collectRoutes.tsx
@@ -1,6 +1,7 @@
 import loadable from "@loadable/component"
 import { RouteConfig } from "found"
 import { graphql } from "react-relay"
+import { allowedFilters } from "v2/Components/v2/ArtworkFilter/Utils/allowedFilters"
 
 import { paramsToCamelCase } from "v2/Components/v2/ArtworkFilter/Utils/urlBuilder"
 import { getENV } from "v2/Utils/getENV"
@@ -93,7 +94,7 @@ function initializeVariablesWithFilterState(params, props) {
 
   const input = {
     sort: "-decayed_merch",
-    ...paramsToCamelCase(initialFilterState),
+    ...allowedFilters(paramsToCamelCase(initialFilterState)),
     first: 30,
   }
 

--- a/src/v2/Apps/Fair/fairRoutes.tsx
+++ b/src/v2/Apps/Fair/fairRoutes.tsx
@@ -3,6 +3,7 @@ import { graphql } from "react-relay"
 import { RouteConfig } from "found"
 import { paramsToCamelCase } from "v2/Components/v2/ArtworkFilter/Utils/urlBuilder"
 import { getENV } from "v2/Utils/getENV"
+import { allowedFilters } from "v2/Components/v2/ArtworkFilter/Utils/allowedFilters"
 
 const FairApp = loadable(() => import("./FairApp"), {
   resolveComponent: component => component.FairAppFragmentContainer,
@@ -136,7 +137,7 @@ function initializeVariablesWithFilterState({ slug }, props) {
     : ["GALLERY"]
   const input = {
     sort: "-decayed_merch",
-    ...camelCasedFilterStateFromUrl,
+    ...allowedFilters(camelCasedFilterStateFromUrl),
     includeArtworksByFollowedArtists:
       !!props.context.user &&
       camelCasedFilterStateFromUrl["includeArtworksByFollowedArtists"],

--- a/src/v2/Apps/Search/searchRoutes.tsx
+++ b/src/v2/Apps/Search/searchRoutes.tsx
@@ -5,6 +5,7 @@ import { graphql } from "react-relay"
 
 import { RouteSpinner } from "v2/Artsy/Relay/renderWithLoadProgress"
 import { ArtworkQueryFilter } from "v2/Components/v2/ArtworkFilter/ArtworkQueryFilter"
+import { allowedFilters } from "v2/Components/v2/ArtworkFilter/Utils/allowedFilters"
 import { paramsToCamelCase } from "v2/Components/v2/ArtworkFilter/Utils/urlBuilder"
 import { getENV } from "v2/Utils/getENV"
 
@@ -90,7 +91,10 @@ export const searchRoutes: RouteConfig[] = [
         Component: SearchResultsArtworksRoute,
         prepareVariables: (params, { location }) => {
           return {
-            input: { ...prepareVariables(params, { location }), first: 20 },
+            input: {
+              ...allowedFilters(prepareVariables(params, { location })),
+              first: 20,
+            },
           }
         },
         query: ArtworkQueryFilter,

--- a/src/v2/Apps/Show/showRoutes.tsx
+++ b/src/v2/Apps/Show/showRoutes.tsx
@@ -3,7 +3,7 @@ import { graphql } from "react-relay"
 import { RedirectException, RouteConfig } from "found"
 import { paramsToCamelCase } from "v2/Components/v2/ArtworkFilter/Utils/urlBuilder"
 import { getENV } from "v2/Utils/getENV"
-import { omit } from "lodash"
+import { allowedFilters } from "v2/Components/v2/ArtworkFilter/Utils/allowedFilters"
 
 const ShowApp = loadable(() => import("./ShowApp"), {
   resolveComponent: component => component.ShowAppFragmentContainer,
@@ -79,7 +79,7 @@ function initializeVariablesWithFilterState({ slug }, props) {
     : []
   const input = {
     sort: "partner_show_position",
-    ...omit(paramsToCamelCase(initialFilterState), "fromShowGuide"), // TODO: Investigate if this param is needed.
+    ...allowedFilters(paramsToCamelCase(initialFilterState)),
     aggregations: aggregations.concat(additionalAggregations),
   }
 

--- a/src/v2/Components/v2/ArtworkFilter/Utils/__tests__/allowedFilters.jest.ts
+++ b/src/v2/Components/v2/ArtworkFilter/Utils/__tests__/allowedFilters.jest.ts
@@ -1,0 +1,24 @@
+import { allowedFilters } from "../allowedFilters"
+
+describe("allowedFilters", () => {
+  it("returns only supported params", () => {
+    expect(
+      allowedFilters({
+        height: "*-*",
+        majorPeriods: [],
+        page: 1,
+        priceRange: "*-*",
+        sort: "-decayed_merch",
+        width: "*-*",
+        blah: 1,
+      })
+    ).toEqual({
+      height: "*-*",
+      majorPeriods: [],
+      page: 1,
+      priceRange: "*-*",
+      sort: "-decayed_merch",
+      width: "*-*",
+    })
+  })
+})

--- a/src/v2/Components/v2/ArtworkFilter/Utils/allowedFilters.ts
+++ b/src/v2/Components/v2/ArtworkFilter/Utils/allowedFilters.ts
@@ -1,0 +1,61 @@
+export const allowedFilters = filterParams => {
+  return Object.keys(filterParams)
+    .filter(key => supportedInputArgs.includes(key))
+    .reduce((obj, key) => {
+      obj[key] = filterParams[key]
+      return obj
+    }, {})
+}
+
+// This corresponds to all the allowed inputs to the
+// filtered artworks connection. This can be used as an
+// allow-list when passing filter state from a URL.
+const supportedInputArgs = [
+  "acquireable",
+  "additionalGeneIDs",
+  "after",
+  "aggregationPartnerCities",
+  "aggregations",
+  "artistID",
+  "artistIDs",
+  "artistNationalities",
+  "artistSeriesID",
+  "atAuction",
+  "attributionClass",
+  "before",
+  "color",
+  "colors",
+  "dimensionRange",
+  "excludeArtworkIDs",
+  "extraAggregationGeneIDs",
+  "first",
+  "forSale",
+  "geneID",
+  "geneIDs",
+  "height",
+  "includeArtworksByFollowedArtists",
+  "includeMediumFilterInAggregation",
+  "inquireableOnly",
+  "keyword",
+  "keywordMatchExact",
+  "last",
+  "locationCities",
+  "majorPeriods",
+  "marketable",
+  "materialsTerms",
+  "medium",
+  "offerable",
+  "page",
+  "partnerCities",
+  "partnerID",
+  "partnerIDs",
+  "period",
+  "periods",
+  "priceRange",
+  "saleID",
+  "size",
+  "sizes",
+  "sort",
+  "tagID",
+  "width",
+]

--- a/src/v2/Components/v2/ArtworkFilter/index.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/index.tsx
@@ -1,4 +1,4 @@
-import { isEqual, omit } from "lodash"
+import { isEqual } from "lodash"
 import React, { useEffect, useState } from "react"
 import useDeepCompareEffect from "use-deep-compare-effect"
 
@@ -45,6 +45,7 @@ import { FairArtworks_fair } from "v2/__generated__/FairArtworks_fair.graphql"
 import { ShowArtworks_show } from "v2/__generated__/ShowArtworks_show.graphql"
 import { useAnalyticsContext } from "v2/Artsy/Analytics/AnalyticsContext"
 import { commercialFilterParamsChanged } from "@artsy/cohesion"
+import { allowedFilters } from "./Utils/allowedFilters"
 
 /**
  * Primary ArtworkFilter which is wrapped with a context and refetch container.
@@ -165,7 +166,7 @@ export const BaseArtworkFilter: React.FC<
 
     const relayRefetchVariables = {
       first: 30,
-      ...omit(filterContext.filters, "term", "fromShowGuide"),
+      ...allowedFilters(filterContext.filters),
       keyword: filterContext.filters.term,
     }
 


### PR DESCRIPTION
This adds an allow list on the initial request, as well as the same allow list on any refetches. So going to a filter page with `?blah=..` should just work, and the URL itself remains (as in, we're not scrubbing the URL to remove that erroneous param, as I'm sure that'll do something funky with stuff that tracks UTM params in the URL...).