### PR TITLE
feat: add header for partner profile

### DIFF
--- a/src/desktop/lib/webpackPublicPath.ts
+++ b/src/desktop/lib/webpackPublicPath.ts
@@ -44,6 +44,7 @@ if (process.env.NODE_ENV === "production") {
     "/order",
     "/search",
     "/show/",
+    "/partner2/",
     "/user/conversations",
     "/user/payments",
     "/user/purchases",

--- a/src/v2/Apps/Partner/Components/PartnerHeader/PartnerHeaderAddress.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerHeader/PartnerHeaderAddress.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+import styled from "styled-components"
+import { uniq } from "lodash"
+import { PartnerHeader_partner } from "v2/__generated__/PartnerHeader_partner.graphql"
+
+export const TextWithNoWrap = styled.span`
+  white-space: nowrap;
+`
+export const PartnerHeaderAddress: React.FC<
+  PartnerHeader_partner["locations"]
+> = ({ edges }) => {
+  return (
+    <>
+      {uniq(edges.map(edge => edge.node.city))
+        .map(city => city.trim())
+        .map<React.ReactNode>((city, index) => (
+          <TextWithNoWrap key={`${city}${index}`}>{city}</TextWithNoWrap>
+        ))
+        .reduce((prev, curr, index) => [
+          prev,
+          // The last space character is used instead of a non-breaking character
+          // for better text wrapping behavior.
+          <React.Fragment key={index}>&nbsp;&nbsp;•&nbsp; </React.Fragment>,
+          curr,
+        ])}
+    </>
+  )
+}

--- a/src/v2/Apps/Partner/Components/PartnerHeader/index.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerHeader/index.tsx
@@ -27,7 +27,6 @@ export const HeaderImage = styled(Image)`
 
 export const PartnerHeader: React.FC<PartnerHeaderProps> = ({ partner }) => {
   const { user } = useSystemContext()
-  const partnerIconUrl = partner.profile?.icon?.url
   const hasLocations = partner.locations?.totalCount > 0
   const canFollow =
     partner && partner.type !== "Auction House" && !!partner.profile
@@ -36,14 +35,15 @@ export const PartnerHeader: React.FC<PartnerHeaderProps> = ({ partner }) => {
     <GridColumns gridRowGap={2} my={[2, 4]}>
       <Column span={[12, 10]}>
         <Flex>
-          {partnerIconUrl && (
+          {partner.profile?.icon && (
             <Flex mr={2}>
               <RouterLink
                 to={partner.href}
                 style={{ display: "flex", textDecoration: "none" }}
               >
                 <HeaderImage
-                  src={partnerIconUrl}
+                  src={partner.profile.icon.cropped.src}
+                  srcSet={partner.profile.icon.cropped.srcSet}
                   alt={partner.name}
                   width={[60, 80]}
                   height={[60, 80]}
@@ -97,7 +97,10 @@ export const PartnerHeaderFragmentContainer = createFragmentContainer(
         href
         profile {
           icon {
-            url(version: "square140")
+            cropped(width: 80, height: 80, version: "square140") {
+              src
+              srcSet
+            }
           }
           ...FollowProfileButton_profile
         }

--- a/src/v2/Apps/Partner/Components/PartnerHeader/index.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerHeader/index.tsx
@@ -1,0 +1,115 @@
+import React from "react"
+import styled from "styled-components"
+import {
+  Box,
+  Text,
+  Image,
+  color,
+  GridColumns,
+  Column,
+  Flex,
+} from "@artsy/palette"
+import { PartnerHeaderAddress } from "./PartnerHeaderAddress"
+import { createFragmentContainer, graphql } from "react-relay"
+import { FollowProfileButtonFragmentContainer as FollowProfileButton } from "v2/Components/FollowButton/FollowProfileButton"
+import { useSystemContext } from "v2/Artsy"
+import { ContextModule } from "@artsy/cohesion"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
+import { PartnerHeader_partner } from "v2/__generated__/PartnerHeader_partner.graphql"
+
+export interface PartnerHeaderProps {
+  partner: PartnerHeader_partner
+}
+
+export const HeaderImage = styled(Image)`
+  border: 1px solid ${color("black10")};
+`
+
+export const PartnerHeader: React.FC<PartnerHeaderProps> = ({ partner }) => {
+  const { user } = useSystemContext()
+  const partnerIconUrl = partner.profile?.icon?.url
+  const hasLocations = partner.locations?.totalCount > 0
+  const canFollow =
+    partner && partner.type !== "Auction House" && !!partner.profile
+
+  return (
+    <GridColumns gridRowGap={2} my={[2, 4]}>
+      <Column span={[12, 10]}>
+        <Flex>
+          {partnerIconUrl && (
+            <Flex mr={2}>
+              <RouterLink
+                to={partner.href}
+                style={{ display: "flex", textDecoration: "none" }}
+              >
+                <HeaderImage
+                  src={partnerIconUrl}
+                  alt={partner.name}
+                  width={[60, 80]}
+                  height={[60, 80]}
+                />
+              </RouterLink>
+            </Flex>
+          )}
+          <Box>
+            <Text variant="largeTitle">
+              <RouterLink
+                style={{
+                  textDecoration: "none",
+                }}
+                to={partner.href}
+              >
+                {partner.name}
+              </RouterLink>
+            </Text>
+            {hasLocations && (
+              <Text color={color("black60")} variant="text">
+                <PartnerHeaderAddress {...partner.locations} />
+              </Text>
+            )}
+          </Box>
+        </Flex>
+      </Column>
+      <Column span={[12, 2]}>
+        {canFollow && (
+          <FollowProfileButton
+            profile={partner.profile}
+            user={user}
+            contextModule={ContextModule.partnerHeader}
+            buttonProps={{
+              variant: "secondaryOutline",
+              width: "100%",
+            }}
+          />
+        )}
+      </Column>
+    </GridColumns>
+  )
+}
+
+export const PartnerHeaderFragmentContainer = createFragmentContainer(
+  PartnerHeader,
+  {
+    partner: graphql`
+      fragment PartnerHeader_partner on Partner {
+        name
+        type
+        href
+        profile {
+          icon {
+            url(version: "square140")
+          }
+          ...FollowProfileButton_profile
+        }
+        locations: locationsConnection(first: 20) {
+          totalCount
+          edges {
+            node {
+              city
+            }
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Partner/Components/__tests__/NavigationTabs.jest.tsx
+++ b/src/v2/Apps/Partner/Components/__tests__/NavigationTabs.jest.tsx
@@ -22,7 +22,7 @@ const { getWrapper } = setupTestWrapper<NavigationTabs_Test_PartnerQuery>({
 
 describe("PartnerNavigationTabs", () => {
   it("renders all tabs by default", async () => {
-    const wrapper = await getWrapper({
+    const wrapper = getWrapper({
       Partner: () => ({ id: "white-cube", slug: "white-cube" }),
     })
     const html = wrapper.html()

--- a/src/v2/Apps/Partner/Components/__tests__/NavigationTabs.jest.tsx
+++ b/src/v2/Apps/Partner/Components/__tests__/NavigationTabs.jest.tsx
@@ -21,7 +21,7 @@ const { getWrapper } = setupTestWrapper<NavigationTabs_Test_PartnerQuery>({
 })
 
 describe("PartnerNavigationTabs", () => {
-  it("renders all tabs by default", async () => {
+  it("renders all tabs by default", () => {
     const wrapper = getWrapper({
       Partner: () => ({ id: "white-cube", slug: "white-cube" }),
     })

--- a/src/v2/Apps/Partner/Components/__tests__/PartnerHeader.jest.tsx
+++ b/src/v2/Apps/Partner/Components/__tests__/PartnerHeader.jest.tsx
@@ -1,0 +1,144 @@
+import React from "react"
+import { graphql } from "react-relay"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { PartnerHeader_Test_Query } from "v2/__generated__/PartnerHeader_Test_Query.graphql"
+import {
+  HeaderImage,
+  PartnerHeaderFragmentContainer as PartnerHeader,
+} from "v2/Apps/Partner/Components/PartnerHeader"
+import { RouterLink } from "v2/Artsy/Router/RouterLink"
+import { FollowProfileButtonFragmentContainer as FollowProfileButton } from "v2/Components/FollowButton/FollowProfileButton"
+import { PartnerHeaderAddress } from "../PartnerHeader/PartnerHeaderAddress"
+
+jest.unmock("react-relay")
+jest.mock("v2/Components/RouteTabs")
+
+const { getWrapper } = setupTestWrapper<PartnerHeader_Test_Query>({
+  Component: ({ partner }: any) => {
+    return <PartnerHeader partner={partner} />
+  },
+  query: graphql`
+    query PartnerHeader_Test_Query @raw_response_type {
+      partner(id: "white-cube") {
+        ...PartnerHeader_partner
+      }
+    }
+  `,
+})
+
+describe("PartnerHeader", () => {
+  it("displays basic information about partner profile", async () => {
+    const wrapper = getWrapper({
+      Partner: () => ({
+        name: "White cube",
+        profile: {
+          icon: {
+            url: "/img.png",
+          },
+        },
+        locations: {
+          totalCount: 4,
+          edges: [
+            {
+              node: {
+                city: "Jeddah",
+              },
+            },
+            {
+              node: {
+                city: "Jeddah",
+              },
+            },
+            {
+              node: {
+                city: " Jeddah",
+              },
+            },
+            {
+              node: {
+                city: "Jeddah ",
+              },
+            },
+          ],
+        },
+      }),
+    })
+    const text = wrapper.text()
+
+    expect(wrapper.find(HeaderImage).length).toEqual(1)
+    expect(wrapper.find(FollowProfileButton).length).toEqual(1)
+    expect(text).toContain("White cube")
+    expect(text).toContain(
+      "Jeddah\u00a0\u00a0•\u00a0 Jeddah\u00a0\u00a0•\u00a0 Jeddah"
+    )
+  })
+
+  it("displays links to partner profile page", () => {
+    const wrapper = getWrapper({
+      Partner: () => ({
+        name: "White cube",
+        href: "/white-cube",
+        profile: {
+          icon: {
+            url: "/img.png",
+          },
+        },
+      }),
+    })
+
+    const PartnerNameLink = wrapper
+      .find(RouterLink)
+      .filterWhere(t => t.text() === "White cube")
+
+    const PartnerIconLink = wrapper
+      .find(RouterLink)
+      .filterWhere(c => c.children().find(HeaderImage).length > 0)
+
+    expect(PartnerNameLink.length).toEqual(1)
+    expect(PartnerNameLink.first().prop("to")).toEqual("/white-cube")
+    expect(PartnerIconLink.length).toEqual(1)
+    expect(PartnerIconLink.first().prop("to")).toEqual("/white-cube")
+  })
+
+  it("doesn't display profile address if there is no info", () => {
+    const wrapper = getWrapper({
+      Partner: () => ({
+        locations: {
+          totalCount: 0,
+        },
+      }),
+    })
+
+    expect(wrapper.find(PartnerHeaderAddress).length).toEqual(0)
+  })
+
+  it("doesn't display profile icon if there is no info", () => {
+    const wrapper = getWrapper({
+      Partner: () => ({
+        profile: null,
+      }),
+    })
+
+    expect(wrapper.find(HeaderImage).length).toEqual(0)
+  })
+
+  it("doesn't display follow button if there is no info", () => {
+    const wrapper = getWrapper({
+      Partner: () => ({
+        profile: null,
+      }),
+    })
+
+    expect(wrapper.find(FollowProfileButton).length).toEqual(0)
+  })
+
+  it("doesn't display follow button if partner type is equal to Auction House", () => {
+    const wrapper = getWrapper({
+      Partner: () => ({
+        type: "Auction House",
+      }),
+    })
+
+    expect(wrapper.find(FollowProfileButton).length).toEqual(0)
+  })
+})

--- a/src/v2/Apps/Partner/Components/__tests__/PartnerHeader.jest.tsx
+++ b/src/v2/Apps/Partner/Components/__tests__/PartnerHeader.jest.tsx
@@ -32,8 +32,9 @@ describe("PartnerHeader", () => {
       Partner: () => ({
         name: "White cube",
         profile: {
-          icon: {
-            url: "/img.png",
+          cropped: {
+            src: "/img.png",
+            srcSet: "/img.png",
           },
         },
         locations: {
@@ -79,8 +80,9 @@ describe("PartnerHeader", () => {
         name: "White cube",
         href: "/white-cube",
         profile: {
-          icon: {
-            url: "/img.png",
+          cropped: {
+            src: "/img.png",
+            srcSet: "/img.png",
           },
         },
       }),

--- a/src/v2/Apps/Partner/Components/__tests__/PartnerHeader.jest.tsx
+++ b/src/v2/Apps/Partner/Components/__tests__/PartnerHeader.jest.tsx
@@ -27,7 +27,7 @@ const { getWrapper } = setupTestWrapper<PartnerHeader_Test_Query>({
 })
 
 describe("PartnerHeader", () => {
-  it("displays basic information about partner profile", async () => {
+  it("displays basic information about partner profile", () => {
     const wrapper = getWrapper({
       Partner: () => ({
         name: "White cube",

--- a/src/v2/Apps/Partner/PartnerApp.tsx
+++ b/src/v2/Apps/Partner/PartnerApp.tsx
@@ -1,11 +1,13 @@
 import React from "react"
-import { Box, Text } from "@artsy/palette"
+import { Box, Separator } from "@artsy/palette"
 import { Footer } from "v2/Components/Footer"
 import { AppContainer } from "../Components/AppContainer"
 import { HorizontalPadding } from "../Components/HorizontalPadding"
-import { NavigationTabsFragmentContainer as NavigationTabs } from "v2/Apps/Partner/Components/NavigationTabs"
 import { createFragmentContainer, graphql } from "react-relay"
+import { NavigationTabsFragmentContainer as NavigationTabs } from "v2/Apps/Partner/Components/NavigationTabs"
+import { PartnerHeaderFragmentContainer as PartnerHeader } from "./Components/PartnerHeader"
 import { PartnerApp_partner } from "v2/__generated__/PartnerApp_partner.graphql"
+import { FullBleed } from "v2/Components/FullBleed"
 
 export interface PartnerAppProps {
   partner: PartnerApp_partner
@@ -17,17 +19,19 @@ export const PartnerApp: React.FC<PartnerAppProps> = ({
 }) => {
   return (
     <AppContainer>
-      <Box mx={[2, 4]}>
-        <Text pt={2} pb={1} variant="largeTitle">
-          {partner.name}
-        </Text>
+      <HorizontalPadding mt={[2, 4]}>
+        <PartnerHeader partner={partner} />
 
-        <NavigationTabs partner={partner} />
+        <FullBleed>
+          <Separator />
+        </FullBleed>
+
+        <Box py={2} mt={[2, 4]}>
+          <NavigationTabs partner={partner} />
+        </Box>
 
         {children}
-      </Box>
 
-      <HorizontalPadding mt={4} mb={8}>
         <Footer />
       </HorizontalPadding>
     </AppContainer>
@@ -37,7 +41,7 @@ export const PartnerApp: React.FC<PartnerAppProps> = ({
 export const PartnerAppFragmentContainer = createFragmentContainer(PartnerApp, {
   partner: graphql`
     fragment PartnerApp_partner on Partner {
-      name
+      ...PartnerHeader_partner
       ...NavigationTabs_partner
     }
   `,

--- a/src/v2/__generated__/PartnerApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PartnerApp_Test_Query.graphql.ts
@@ -24,13 +24,43 @@ query PartnerApp_Test_Query {
   }
 }
 
+fragment FollowProfileButton_profile on Profile {
+  id
+  slug
+  name
+  internalID
+  is_followed: isFollowed
+}
+
 fragment NavigationTabs_partner on Partner {
   slug
 }
 
 fragment PartnerApp_partner on Partner {
-  name
+  ...PartnerHeader_partner
   ...NavigationTabs_partner
+}
+
+fragment PartnerHeader_partner on Partner {
+  name
+  type
+  href
+  profile {
+    icon {
+      url(version: "square140")
+    }
+    ...FollowProfileButton_profile
+    id
+  }
+  locations: locationsConnection(first: 20) {
+    totalCount
+    edges {
+      node {
+        city
+        id
+      }
+    }
+  }
 }
 */
 
@@ -41,7 +71,28 @@ var v0 = [
     "name": "id",
     "value": "example"
   }
-];
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [],
@@ -82,27 +133,129 @@ return {
         "name": "partner",
         "plural": false,
         "selections": [
+          (v1/*: any*/),
           {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "name",
+            "name": "type",
             "storageKey": null
           },
           {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "slug",
+            "name": "href",
             "storageKey": null
           },
           {
             "alias": null,
             "args": null,
-            "kind": "ScalarField",
-            "name": "id",
+            "concreteType": "Profile",
+            "kind": "LinkedField",
+            "name": "profile",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "icon",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "version",
+                        "value": "square140"
+                      }
+                    ],
+                    "kind": "ScalarField",
+                    "name": "url",
+                    "storageKey": "url(version:\"square140\")"
+                  }
+                ],
+                "storageKey": null
+              },
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "internalID",
+                "storageKey": null
+              },
+              {
+                "alias": "is_followed",
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isFollowed",
+                "storageKey": null
+              }
+            ],
             "storageKey": null
-          }
+          },
+          {
+            "alias": "locations",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 20
+              }
+            ],
+            "concreteType": "LocationConnection",
+            "kind": "LinkedField",
+            "name": "locationsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "totalCount",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "LocationEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Location",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "city",
+                        "storageKey": null
+                      },
+                      (v2/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "locationsConnection(first:20)"
+          },
+          (v3/*: any*/),
+          (v2/*: any*/)
         ],
         "storageKey": "partner(id:\"example\")"
       }
@@ -113,7 +266,7 @@ return {
     "metadata": {},
     "name": "PartnerApp_Test_Query",
     "operationKind": "query",
-    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n}\n\nfragment PartnerApp_partner on Partner {\n  name\n  ...NavigationTabs_partner\n}\n"
+    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n}\n\nfragment PartnerApp_partner on Partner {\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  href\n  profile {\n    icon {\n      url(version: \"square140\")\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnerApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PartnerApp_Test_Query.graphql.ts
@@ -47,7 +47,10 @@ fragment PartnerHeader_partner on Partner {
   href
   profile {
     icon {
-      url(version: "square140")
+      cropped(width: 80, height: 80, version: "square140") {
+        src
+        srcSet
+      }
     }
     ...FollowProfileButton_profile
     id
@@ -169,13 +172,41 @@ return {
                     "args": [
                       {
                         "kind": "Literal",
+                        "name": "height",
+                        "value": 80
+                      },
+                      {
+                        "kind": "Literal",
                         "name": "version",
                         "value": "square140"
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 80
                       }
                     ],
-                    "kind": "ScalarField",
-                    "name": "url",
-                    "storageKey": "url(version:\"square140\")"
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "src",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "srcSet",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "cropped(height:80,version:\"square140\",width:80)"
                   }
                 ],
                 "storageKey": null
@@ -266,7 +297,7 @@ return {
     "metadata": {},
     "name": "PartnerApp_Test_Query",
     "operationKind": "query",
-    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n}\n\nfragment PartnerApp_partner on Partner {\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  href\n  profile {\n    icon {\n      url(version: \"square140\")\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n}\n\nfragment PartnerApp_partner on Partner {\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  href\n  profile {\n    icon {\n      cropped(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnerApp_partner.graphql.ts
+++ b/src/v2/__generated__/PartnerApp_partner.graphql.ts
@@ -4,8 +4,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type PartnerApp_partner = {
-    readonly name: string | null;
-    readonly " $fragmentRefs": FragmentRefs<"NavigationTabs_partner">;
+    readonly " $fragmentRefs": FragmentRefs<"PartnerHeader_partner" | "NavigationTabs_partner">;
     readonly " $refType": "PartnerApp_partner";
 };
 export type PartnerApp_partner$data = PartnerApp_partner;
@@ -23,11 +22,9 @@ const node: ReaderFragment = {
   "name": "PartnerApp_partner",
   "selections": [
     {
-      "alias": null,
       "args": null,
-      "kind": "ScalarField",
-      "name": "name",
-      "storageKey": null
+      "kind": "FragmentSpread",
+      "name": "PartnerHeader_partner"
     },
     {
       "args": null,
@@ -37,5 +34,5 @@ const node: ReaderFragment = {
   ],
   "type": "Partner"
 };
-(node as any).hash = '62a9f0389b78665c93b1bfdde852760f';
+(node as any).hash = 'a08e8e56e66d826adfc080c2ea7f5ce3';
 export default node;

--- a/src/v2/__generated__/PartnerHeader_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PartnerHeader_Test_Query.graphql.ts
@@ -16,7 +16,10 @@ export type PartnerHeader_Test_QueryRawResponse = {
         readonly href: string | null;
         readonly profile: ({
             readonly icon: ({
-                readonly url: string | null;
+                readonly cropped: ({
+                    readonly src: string;
+                    readonly srcSet: string;
+                }) | null;
             }) | null;
             readonly id: string;
             readonly slug: string;
@@ -66,7 +69,10 @@ fragment PartnerHeader_partner on Partner {
   href
   profile {
     icon {
-      url(version: "square140")
+      cropped(width: 80, height: 80, version: "square140") {
+        src
+        srcSet
+      }
     }
     ...FollowProfileButton_profile
     id
@@ -181,13 +187,41 @@ return {
                     "args": [
                       {
                         "kind": "Literal",
+                        "name": "height",
+                        "value": 80
+                      },
+                      {
+                        "kind": "Literal",
                         "name": "version",
                         "value": "square140"
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 80
                       }
                     ],
-                    "kind": "ScalarField",
-                    "name": "url",
-                    "storageKey": "url(version:\"square140\")"
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "src",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "srcSet",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "cropped(height:80,version:\"square140\",width:80)"
                   }
                 ],
                 "storageKey": null
@@ -283,7 +317,7 @@ return {
     "metadata": {},
     "name": "PartnerHeader_Test_Query",
     "operationKind": "query",
-    "text": "query PartnerHeader_Test_Query {\n  partner(id: \"white-cube\") {\n    ...PartnerHeader_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  href\n  profile {\n    icon {\n      url(version: \"square140\")\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query PartnerHeader_Test_Query {\n  partner(id: \"white-cube\") {\n    ...PartnerHeader_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  href\n  profile {\n    icon {\n      cropped(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnerHeader_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PartnerHeader_Test_Query.graphql.ts
@@ -3,27 +3,51 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type partnerRoutes_PartnerQueryVariables = {
-    partnerId: string;
-};
-export type partnerRoutes_PartnerQueryResponse = {
+export type PartnerHeader_Test_QueryVariables = {};
+export type PartnerHeader_Test_QueryResponse = {
     readonly partner: {
-        readonly " $fragmentRefs": FragmentRefs<"PartnerApp_partner">;
+        readonly " $fragmentRefs": FragmentRefs<"PartnerHeader_partner">;
     } | null;
 };
-export type partnerRoutes_PartnerQuery = {
-    readonly response: partnerRoutes_PartnerQueryResponse;
-    readonly variables: partnerRoutes_PartnerQueryVariables;
+export type PartnerHeader_Test_QueryRawResponse = {
+    readonly partner: ({
+        readonly name: string | null;
+        readonly type: string | null;
+        readonly href: string | null;
+        readonly profile: ({
+            readonly icon: ({
+                readonly url: string | null;
+            }) | null;
+            readonly id: string;
+            readonly slug: string;
+            readonly name: string | null;
+            readonly internalID: string;
+            readonly is_followed: boolean | null;
+        }) | null;
+        readonly locations: ({
+            readonly totalCount: number | null;
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly city: string | null;
+                    readonly id: string | null;
+                }) | null;
+            }) | null> | null;
+        }) | null;
+        readonly id: string | null;
+    }) | null;
+};
+export type PartnerHeader_Test_Query = {
+    readonly response: PartnerHeader_Test_QueryResponse;
+    readonly variables: PartnerHeader_Test_QueryVariables;
+    readonly rawResponse: PartnerHeader_Test_QueryRawResponse;
 };
 
 
 
 /*
-query partnerRoutes_PartnerQuery(
-  $partnerId: String!
-) {
-  partner(id: $partnerId) @principalField {
-    ...PartnerApp_partner
+query PartnerHeader_Test_Query {
+  partner(id: "white-cube") {
+    ...PartnerHeader_partner
     id
   }
 }
@@ -34,15 +58,6 @@ fragment FollowProfileButton_profile on Profile {
   name
   internalID
   is_followed: isFollowed
-}
-
-fragment NavigationTabs_partner on Partner {
-  slug
-}
-
-fragment PartnerApp_partner on Partner {
-  ...PartnerHeader_partner
-  ...NavigationTabs_partner
 }
 
 fragment PartnerHeader_partner on Partner {
@@ -71,50 +86,35 @@ fragment PartnerHeader_partner on Partner {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "partnerId",
-    "type": "String!"
-  }
-],
-v1 = [
-  {
-    "kind": "Variable",
+    "kind": "Literal",
     "name": "id",
-    "variableName": "partnerId"
+    "value": "white-cube"
   }
 ],
-v2 = {
+v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
 };
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "partnerRoutes_PartnerQuery",
+    "name": "PartnerHeader_Test_Query",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v0/*: any*/),
         "concreteType": "Partner",
         "kind": "LinkedField",
         "name": "partner",
@@ -123,29 +123,29 @@ return {
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "PartnerApp_partner"
+            "name": "PartnerHeader_partner"
           }
         ],
-        "storageKey": null
+        "storageKey": "partner(id:\"white-cube\")"
       }
     ],
     "type": "Query"
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [],
     "kind": "Operation",
-    "name": "partnerRoutes_PartnerQuery",
+    "name": "PartnerHeader_Test_Query",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v0/*: any*/),
         "concreteType": "Partner",
         "kind": "LinkedField",
         "name": "partner",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
+          (v1/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -192,9 +192,15 @@ return {
                 ],
                 "storageKey": null
               },
-              (v3/*: any*/),
-              (v4/*: any*/),
               (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "slug",
+                "storageKey": null
+              },
+              (v1/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -256,7 +262,7 @@ return {
                         "name": "city",
                         "storageKey": null
                       },
-                      (v3/*: any*/)
+                      (v2/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -266,21 +272,20 @@ return {
             ],
             "storageKey": "locationsConnection(first:20)"
           },
-          (v4/*: any*/),
-          (v3/*: any*/)
+          (v2/*: any*/)
         ],
-        "storageKey": null
+        "storageKey": "partner(id:\"white-cube\")"
       }
     ]
   },
   "params": {
     "id": null,
     "metadata": {},
-    "name": "partnerRoutes_PartnerQuery",
+    "name": "PartnerHeader_Test_Query",
     "operationKind": "query",
-    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n}\n\nfragment PartnerApp_partner on Partner {\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  href\n  profile {\n    icon {\n      url(version: \"square140\")\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query PartnerHeader_Test_Query {\n  partner(id: \"white-cube\") {\n    ...PartnerHeader_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  href\n  profile {\n    icon {\n      url(version: \"square140\")\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = 'b065b69c18af67164cd46d476357078f';
+(node as any).hash = '6d448fea989962f873735f54cd4c8cc1';
 export default node;

--- a/src/v2/__generated__/PartnerHeader_partner.graphql.ts
+++ b/src/v2/__generated__/PartnerHeader_partner.graphql.ts
@@ -1,0 +1,158 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type PartnerHeader_partner = {
+    readonly name: string | null;
+    readonly type: string | null;
+    readonly href: string | null;
+    readonly profile: {
+        readonly icon: {
+            readonly url: string | null;
+        } | null;
+        readonly " $fragmentRefs": FragmentRefs<"FollowProfileButton_profile">;
+    } | null;
+    readonly locations: {
+        readonly totalCount: number | null;
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly city: string | null;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "PartnerHeader_partner";
+};
+export type PartnerHeader_partner$data = PartnerHeader_partner;
+export type PartnerHeader_partner$key = {
+    readonly " $data"?: PartnerHeader_partner$data;
+    readonly " $fragmentRefs": FragmentRefs<"PartnerHeader_partner">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "PartnerHeader_partner",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "type",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "href",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Profile",
+      "kind": "LinkedField",
+      "name": "profile",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Image",
+          "kind": "LinkedField",
+          "name": "icon",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "version",
+                  "value": "square140"
+                }
+              ],
+              "kind": "ScalarField",
+              "name": "url",
+              "storageKey": "url(version:\"square140\")"
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "FollowProfileButton_profile"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": "locations",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 20
+        }
+      ],
+      "concreteType": "LocationConnection",
+      "kind": "LinkedField",
+      "name": "locationsConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "totalCount",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "LocationEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Location",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "city",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "locationsConnection(first:20)"
+    }
+  ],
+  "type": "Partner"
+};
+(node as any).hash = '00027a53462c1123e368852d1bee7721';
+export default node;

--- a/src/v2/__generated__/PartnerHeader_partner.graphql.ts
+++ b/src/v2/__generated__/PartnerHeader_partner.graphql.ts
@@ -9,7 +9,10 @@ export type PartnerHeader_partner = {
     readonly href: string | null;
     readonly profile: {
         readonly icon: {
-            readonly url: string | null;
+            readonly cropped: {
+                readonly src: string;
+                readonly srcSet: string;
+            } | null;
         } | null;
         readonly " $fragmentRefs": FragmentRefs<"FollowProfileButton_profile">;
     } | null;
@@ -79,13 +82,41 @@ const node: ReaderFragment = {
               "args": [
                 {
                   "kind": "Literal",
+                  "name": "height",
+                  "value": 80
+                },
+                {
+                  "kind": "Literal",
                   "name": "version",
                   "value": "square140"
+                },
+                {
+                  "kind": "Literal",
+                  "name": "width",
+                  "value": 80
                 }
               ],
-              "kind": "ScalarField",
-              "name": "url",
-              "storageKey": "url(version:\"square140\")"
+              "concreteType": "CroppedImageUrl",
+              "kind": "LinkedField",
+              "name": "cropped",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "src",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "srcSet",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": "cropped(height:80,version:\"square140\",width:80)"
             }
           ],
           "storageKey": null
@@ -154,5 +185,5 @@ const node: ReaderFragment = {
   ],
   "type": "Partner"
 };
-(node as any).hash = '00027a53462c1123e368852d1bee7721';
+(node as any).hash = 'a7741b78c4d7da9422c10356dae26fad';
 export default node;

--- a/src/v2/__generated__/partnerRoutes_PartnerQuery.graphql.ts
+++ b/src/v2/__generated__/partnerRoutes_PartnerQuery.graphql.ts
@@ -51,7 +51,10 @@ fragment PartnerHeader_partner on Partner {
   href
   profile {
     icon {
-      url(version: "square140")
+      cropped(width: 80, height: 80, version: "square140") {
+        src
+        srcSet
+      }
     }
     ...FollowProfileButton_profile
     id
@@ -181,13 +184,41 @@ return {
                     "args": [
                       {
                         "kind": "Literal",
+                        "name": "height",
+                        "value": 80
+                      },
+                      {
+                        "kind": "Literal",
                         "name": "version",
                         "value": "square140"
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 80
                       }
                     ],
-                    "kind": "ScalarField",
-                    "name": "url",
-                    "storageKey": "url(version:\"square140\")"
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "src",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "srcSet",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "cropped(height:80,version:\"square140\",width:80)"
                   }
                 ],
                 "storageKey": null
@@ -278,7 +309,7 @@ return {
     "metadata": {},
     "name": "partnerRoutes_PartnerQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n}\n\nfragment PartnerApp_partner on Partner {\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  href\n  profile {\n    icon {\n      url(version: \"square140\")\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n}\n\nfragment PartnerApp_partner on Partner {\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  href\n  profile {\n    icon {\n      cropped(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
This PR adds header rail for the partner profile page.

- adds partner name and locations
- adds follow partner button
- adds partner icon

JIRA - https://artsyproduct.atlassian.net/browse/PX-3824

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/79979820/112026960-c80a7700-8b47-11eb-8b75-f49cbae0306b.png">
<img width="259" alt="image" src="https://user-images.githubusercontent.com/79979820/112027131-f38d6180-8b47-11eb-9cea-aa6f6c5659b3.png">
