### PR TITLE
ci: Deploy storybooks via Circle orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,13 @@
 version: 2.1
 
 orbs:
+  artsy-remote-docker: artsy/remote-docker@0.1.10
+  aws-s3: circleci/aws-s3@2.0.0
   codecov: codecov/codecov@1.1.3
   hokusai: artsy/hokusai@0.8.0
   horizon: artsy/release@0.0.1
   node: artsy/node@1.0.0
   yarn: artsy/yarn@5.1.3
-  artsy-remote-docker: artsy/remote-docker@0.1.10
 
 jobs:
   run_deepcrawl_automator:
@@ -134,6 +135,15 @@ jobs:
     working_directory: /app
     steps:
       - run: /app/scripts/xvfb-run.sh /usr/local/bin/yarn test:smoke
+
+  upload-docs:
+    docker:
+      - image: "cimg/python:3.9"
+    steps:
+      - aws-s3/sync:
+          arguments: --acl public-read
+          from: storybook-static
+          to: "s3://artsy-static-sites/artsy-force-storybook"
 
 not_master_or_staging_or_release: &not_master_or_staging_or_release
   filters:
@@ -300,3 +310,22 @@ workflows:
           pre-steps:
             - run:
                 command: echo 'export DOCKER_BUILDKIT=1; export BUILDKIT_PROGRESS=plain; export COMPOSE_DOCKER_CLI_BUILD=1;' >> $BASH_ENV
+
+      # Docs / Storybooks
+      - yarn/run:
+          <<: *only_master
+          name: build-docs
+          script: "build-storybook"
+          post-steps:
+            - persist_to_workspace:
+                root: .
+                paths:
+                  - storybook-static
+      - upload-docs:
+          <<: *only_master
+          context: static-sites-uploader
+          requires:
+            - build-docs
+          pre-steps:
+            - attach_workspace:
+                at: .

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ yalc.lock
 /public
 /src/desktop/public/assets
 /src/mobile/public/assets
+/storybook-static
 node_modules
 
 # Compiled server code


### PR DESCRIPTION
Related: https://github.com/artsy/palette/pull/888

Adds a new storybook deploy step: 
https://artsy-static-sites.s3.amazonaws.com/artsy-force-storybook/index.html