### PR TITLE
feat: trim city name before taking unique values for partner profile header

### DIFF
--- a/src/v2/Apps/Partner/Components/PartnerHeader/PartnerHeaderAddress.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerHeader/PartnerHeaderAddress.tsx
@@ -11,8 +11,7 @@ export const PartnerHeaderAddress: React.FC<
 > = ({ edges }) => {
   return (
     <>
-      {uniq(edges.map(edge => edge.node.city))
-        .map(city => city.trim())
+      {uniq(edges.map(edge => edge.node.city.trim()))
         .map<React.ReactNode>((city, index) => (
           <TextWithNoWrap key={`${city}${index}`}>{city}</TextWithNoWrap>
         ))

--- a/src/v2/Apps/Partner/Components/__tests__/PartnerHeader.jest.tsx
+++ b/src/v2/Apps/Partner/Components/__tests__/PartnerHeader.jest.tsx
@@ -38,6 +38,29 @@ describe("PartnerHeader", () => {
           },
         },
         locations: {
+          totalCount: 1,
+          edges: [
+            {
+              node: {
+                city: "Jeddah",
+              },
+            },
+          ],
+        },
+      }),
+    })
+    const text = wrapper.text()
+
+    expect(wrapper.find(HeaderImage).length).toEqual(1)
+    expect(wrapper.find(FollowProfileButton).length).toEqual(1)
+    expect(text).toContain("White cube")
+    expect(text).toContain("Jeddah")
+  })
+
+  it("displays unique address value", () => {
+    const wrapper = getWrapper({
+      Partner: () => ({
+        locations: {
           totalCount: 4,
           edges: [
             {
@@ -64,13 +87,44 @@ describe("PartnerHeader", () => {
         },
       }),
     })
-    const text = wrapper.text()
 
-    expect(wrapper.find(HeaderImage).length).toEqual(1)
-    expect(wrapper.find(FollowProfileButton).length).toEqual(1)
-    expect(text).toContain("White cube")
-    expect(text).toContain(
-      "Jeddah\u00a0\u00a0•\u00a0 Jeddah\u00a0\u00a0•\u00a0 Jeddah"
+    const Address = wrapper.find(PartnerHeaderAddress)
+
+    expect(Address.length).toEqual(1)
+    expect(Address.text()).toContain("Jeddah")
+  })
+
+  it("displays few addresses", () => {
+    const wrapper = getWrapper({
+      Partner: () => ({
+        locations: {
+          totalCount: 4,
+          edges: [
+            {
+              node: {
+                city: "Jeddah",
+              },
+            },
+            {
+              node: {
+                city: "New York",
+              },
+            },
+            {
+              node: {
+                city: "San Francisco",
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    const Address = wrapper.find(PartnerHeaderAddress)
+
+    expect(Address.length).toEqual(1)
+    expect(Address.text()).toContain(
+      "Jeddah\u00a0\u00a0•\u00a0 New York\u00a0\u00a0•\u00a0 San Francisco"
     )
   })
 


### PR DESCRIPTION
This PR trim city name to show **only** unique values.

Discussed here - https://github.com/artsy/force/pull/7190#discussion_r598694527
JIRA - https://artsyproduct.atlassian.net/browse/PX-3824

Old:
![image](https://user-images.githubusercontent.com/79979820/112113789-56bed880-8bc8-11eb-8155-44ed4913d025.png)

New: 
![image](https://user-images.githubusercontent.com/79979820/112114306-f8462a00-8bc8-11eb-88a9-2f30660f298d.png)
 