### PR TITLE
fix: add missing style to filter autosuggest (FX-2730)

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/FacetAutosuggest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/FacetAutosuggest.tsx
@@ -1,4 +1,4 @@
-import { BorderBox, Box, Checkbox } from "@artsy/palette"
+import { BorderBox, Box, Checkbox, Text } from "@artsy/palette"
 import { uniq } from "lodash"
 import React, { FC, useState } from "react"
 import Autosuggest from "react-autosuggest"
@@ -77,7 +77,7 @@ export const FacetAutosuggest: FC<{
     const noResults = suggestions.length === 0
 
     if (focused && noResults && value) {
-      return "No results found."
+      return <Text pt={0.5}>No results.</Text>
     }
 
     return noResults ? (

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/FacetAutosuggest.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/FacetAutosuggest.jest.tsx
@@ -52,6 +52,6 @@ describe("SearchBar", () => {
 
     simulateTyping(component, "magic")
 
-    expect(component.text()).toContain("No results found.")
+    expect(component.text()).toContain("No results.")
   })
 })


### PR DESCRIPTION
This PR addresses [FX-2730](https://artsyproduct.atlassian.net/browse/FX-2730) by adding style to the "No results found." text that is displayed under the filter search interface when a user's search term doesn't match any options. It also updates the copy to "No results." to match [the design spec](https://www.figma.com/file/zG9cduJdOaTQAw886QcOwn/Filters?node-id=856%3A2621).

<img width="847" alt="Screen Shot 2021-03-23 at 7 46 49 AM" src="https://user-images.githubusercontent.com/44589599/112141845-397c1100-8bac-11eb-87e1-337d6f2959d8.png">
