### PR TITLE
fix: artwork location autosuggest placeholder copy (FX-2733)

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter.tsx
@@ -50,7 +50,7 @@ export const ArtworkLocationFilter: FC = () => {
       <Flex flexDirection="column">
         <FacetAutosuggest
           facetName="locationCities"
-          placeholder="Enter a location"
+          placeholder="Enter a city"
           facets={locations.counts}
         />
         <ShowMore>


### PR DESCRIPTION
This PR addresses [FX-2733](https://artsyproduct.atlassian.net/browse/FX-2733) by changing the copy of the placeholder text in the artwork location filter's search field from "Enter a location" to "Enter a city" because it only filters on city name and not on state or country names.

<img width="838" alt="Screen Shot 2021-03-23 at 8 39 55 AM" src="https://user-images.githubusercontent.com/44589599/112148291-13f30580-8bb4-11eb-9f82-eaf9ea5baf6b.png">
