### PR TITLE
fix: update apply button count when new filters are used (FX-2738)

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/Utils/countChangedFilters.ts
+++ b/src/v2/Components/v2/ArtworkFilter/Utils/countChangedFilters.ts
@@ -25,6 +25,11 @@ export const countChangedFilters = (
 
   // array-valued keys
   for (key of [
+    "additionalGeneIDs",
+    "artistNationalities",
+    "attributionClass",
+    "colors",
+    "locationCities",
     "sizes",
     "majorPeriods",
     "partnerIDs",

--- a/src/v2/Components/v2/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
@@ -119,4 +119,134 @@ describe("ArtworkFilterMobileActionSheet", () => {
 
     expect(wrapper.find("ApplyButton").text()).toEqual("Apply (2)")
   })
+
+  describe("the count on the `Apply` button", () => {
+    it("is 1 when 1 medium is selected", async () => {
+      const wrapper = getWrapper()
+
+      wrapper
+        .find("MediumFilter")
+        .find("div")
+        .findWhere(label => label.text() === "Painting")
+        .first()
+        .simulate("click")
+      await flushPromiseQueue()
+
+      expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
+    })
+
+    it("is 1 when 2 mediums are selected", async () => {
+      const wrapper = getWrapper()
+
+      wrapper
+        .find("MediumFilter")
+        .find("div")
+        .findWhere(label => label.text() === "Painting")
+        .first()
+        .simulate("click")
+      await flushPromiseQueue()
+
+      expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
+
+      wrapper
+        .find("MediumFilter")
+        .find("div")
+        .findWhere(label => label.text() === "Photography")
+        .first()
+        .simulate("click")
+      await flushPromiseQueue()
+
+      expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
+    })
+
+    it("is 1 when 1 rarity is selected", async () => {
+      const wrapper = getWrapper()
+
+      wrapper
+        .find("AttributionClassFilter")
+        .find("div")
+        .findWhere(label => label.text() === "Unique")
+        .first()
+        .simulate("click")
+      await flushPromiseQueue()
+
+      expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
+    })
+
+    it("is 1 when 2 rarities are selected", async () => {
+      const wrapper = getWrapper()
+
+      wrapper
+        .find("AttributionClassFilter")
+        .find("div")
+        .findWhere(label => label.text() === "Unique")
+        .first()
+        .simulate("click")
+      await flushPromiseQueue()
+
+      expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
+
+      wrapper
+        .find("AttributionClassFilter")
+        .find("div")
+        .findWhere(label => label.text() === "Limited Edition")
+        .first()
+        .simulate("click")
+      await flushPromiseQueue()
+
+      expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
+    })
+
+    it("is 1 when 1 color is selected", async () => {
+      const wrapper = getWrapper()
+
+      wrapper
+        .find("button")
+        .findWhere(label => label.text() === "Color")
+        .first()
+        .simulate("click")
+      await flushPromiseQueue()
+
+      wrapper
+        .find("ColorFilter")
+        .find("Checkbox")
+        .findWhere(label => label.text() === "Red")
+        .first()
+        .simulate("click")
+      await flushPromiseQueue()
+
+      expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
+    })
+
+    it("is 1 when 2 colors are selected", async () => {
+      const wrapper = getWrapper()
+
+      wrapper
+        .find("button")
+        .findWhere(label => label.text() === "Color")
+        .first()
+        .simulate("click")
+      await flushPromiseQueue()
+
+      wrapper
+        .find("ColorFilter")
+        .find("Checkbox")
+        .findWhere(label => label.text() === "Red")
+        .first()
+        .simulate("click")
+      await flushPromiseQueue()
+
+      expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
+
+      wrapper
+        .find("ColorFilter")
+        .find("Checkbox")
+        .findWhere(label => label.text() === "Black and white")
+        .first()
+        .simulate("click")
+      await flushPromiseQueue()
+
+      expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
+    })
+  })
 })

--- a/src/v2/Components/v2/ArtworkFilter/__tests__/NewArtworkFilterMobileActionSheet.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/__tests__/NewArtworkFilterMobileActionSheet.jest.tsx
@@ -1,0 +1,136 @@
+import { mount } from "enzyme"
+import React from "react"
+import { ArtworkFilterContextProvider } from "../ArtworkFilterContext"
+import { ArtworkFilterMobileActionSheet } from "../ArtworkFilterMobileActionSheet"
+import { ArtworkFilters } from "../ArtworkFilters"
+import { flushPromiseQueue } from "v2/DevTools"
+
+jest.mock("sharify", () => ({
+  data: {
+    ENABLE_NEW_ARTWORK_FILTERS: true,
+  },
+}))
+
+describe("the new artwork filters", () => {
+  const getWrapper = (props = {}) => {
+    return mount(
+      <ArtworkFilterContextProvider {...props}>
+        <ArtworkFilterMobileActionSheet onClose={jest.fn()}>
+          <ArtworkFilters />
+        </ArtworkFilterMobileActionSheet>
+      </ArtworkFilterContextProvider>
+    )
+  }
+
+  const aggregationsWithArtworkLocation = [
+    {
+      slice: "LOCATION_CITY",
+      counts: [
+        {
+          name: "Glens Falls, NY, USA",
+          count: 1,
+          value: "glens-falls",
+        },
+        {
+          name: "Schenectady, NY, USA",
+          count: 1,
+          value: "schenectady",
+        },
+      ],
+    },
+  ]
+
+  const aggregationsWithArtistNationality = [
+    {
+      slice: "ARTIST_NATIONALITY",
+      counts: [
+        {
+          name: "Glens Fallsian",
+          count: 1,
+          value: "glens-fallsian",
+        },
+        {
+          name: "Schenectadian",
+          count: 1,
+          value: "schenectadian",
+        },
+      ],
+    },
+  ]
+
+  describe("the count on the `Apply` button", () => {
+    it("is 1 when 1 artwork location is selected", async () => {
+      const wrapper = getWrapper({
+        aggregations: aggregationsWithArtworkLocation,
+      })
+
+      wrapper
+        .find("ArtworkLocationFilter")
+        .find("div")
+        .findWhere(label => label.text() === "Glens Falls, NY, USA")
+        .first()
+        .simulate("click")
+      await flushPromiseQueue()
+
+      expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
+    })
+
+    it("is 1 when 2 artwork locations are selected", async () => {
+      const wrapper = getWrapper({
+        aggregations: aggregationsWithArtworkLocation,
+      })
+
+      wrapper
+        .find("ArtworkLocationFilter")
+        .find("div")
+        .findWhere(label => label.text() === "Glens Falls, NY, USA")
+        .first()
+        .simulate("click")
+      await flushPromiseQueue()
+
+      expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
+
+      wrapper
+        .find("ArtworkLocationFilter")
+        .find("div")
+        .findWhere(label => label.text() === "Schenectady, NY, USA")
+        .first()
+        .simulate("click")
+      await flushPromiseQueue()
+
+      expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
+    })
+  })
+
+  it("is 1 when 1 artist nationality is selected", async () => {
+    const wrapper = getWrapper({
+      aggregations: aggregationsWithArtistNationality,
+    })
+
+    wrapper
+      .find("ArtistNationalityFilter")
+      .find("div")
+      .findWhere(label => label.text() === "Glens Fallsian")
+      .first()
+      .simulate("click")
+    await flushPromiseQueue()
+
+    expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
+  })
+
+  it("is 1 when 2 artist nationalities are selected", async () => {
+    const wrapper = getWrapper({
+      aggregations: aggregationsWithArtistNationality,
+    })
+
+    wrapper
+      .find("ArtistNationalityFilter")
+      .find("div")
+      .findWhere(label => label.text() === "Glens Fallsian")
+      .first()
+      .simulate("click")
+    await flushPromiseQueue()
+
+    expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
+  })
+})


### PR DESCRIPTION
This PR addresses [FX-2738](https://artsyproduct.atlassian.net/browse/FX-2738) by tracking changes that a user makes to the **artwork location**, **medium**, **rarity**, **color** and **artist nationality** filters so that the Apply button in the filter modal can show how many filters will be applied on-click.

The current behavior was that the Apply button showed 0 for any selections made on those four filters, but now the Apply button will add 1 to the count for any selections made in each filter.

**`~~~ before ~~~~~~~~~~~~~~~`**

![before](https://user-images.githubusercontent.com/44589599/112322548-62250900-8c87-11eb-865d-ce1c5136da66.gif)


**`~~~ after ~~~~~~~~~~~~~~~`**

![after](https://user-images.githubusercontent.com/44589599/112322561-651ff980-8c87-11eb-8295-532821213d1f.gif)

