### PR TITLE
fix: refactor address mutations

### DIFF
--- a/src/v2/Apps/Order/Components/AddressModal.tsx
+++ b/src/v2/Apps/Order/Components/AddressModal.tsx
@@ -7,17 +7,16 @@ import {
   validateAddress,
   validatePhoneNumber,
 } from "../Utils/formValidators"
-import { CommitMutation } from "../Utils/commitMutation"
 import { updateUserAddress } from "../Mutations/UpdateUserAddress"
 import { createUserAddress } from "v2/Apps/Order/Mutations/CreateUserAddress"
 import { SavedAddresses_me } from "v2/__generated__/SavedAddresses_me.graphql"
 import { AddressModalFields } from "v2/Components/Address/AddressModalFields"
+import { useSystemContext } from "v2/Artsy/SystemContext"
 
 interface Props {
   show: boolean
   closeModal: () => void
   address?: SavedAddressType
-  commitMutation: CommitMutation
   onSuccess: (address) => void
   onError: (message: string) => void
   modalDetails?: {
@@ -33,7 +32,6 @@ export const AddressModal: React.FC<Props> = ({
   show,
   closeModal,
   address,
-  commitMutation,
   onSuccess,
   onError,
   modalDetails,
@@ -51,7 +49,8 @@ export const AddressModal: React.FC<Props> = ({
     const errorsTrimmed = removeEmptyKeys(errors)
     return errorsTrimmed
   }
-
+  const { relayEnvironment } = useSystemContext()
+  console.log("relay", relayEnvironment)
   return (
     <Modal title={title} show={show} onClose={closeModal}>
       <Formik
@@ -60,7 +59,7 @@ export const AddressModal: React.FC<Props> = ({
         onSubmit={values => {
           createMutation
             ? createUserAddress(
-                commitMutation,
+                relayEnvironment,
                 values,
                 onSuccess,
                 onError,
@@ -68,7 +67,7 @@ export const AddressModal: React.FC<Props> = ({
                 closeModal
               )
             : updateUserAddress(
-                commitMutation,
+                relayEnvironment,
                 address.internalID,
                 values,
                 closeModal,

--- a/src/v2/Apps/Order/Components/SavedAddresses.tsx
+++ b/src/v2/Apps/Order/Components/SavedAddresses.tsx
@@ -73,7 +73,6 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
   }
 
   const onError = (message: string) => {
-    // TODO: actually handle error
     logger.error(message)
   }
 

--- a/src/v2/Apps/Order/Components/SavedAddresses.tsx
+++ b/src/v2/Apps/Order/Components/SavedAddresses.tsx
@@ -23,6 +23,7 @@ import createLogger from "v2/Utils/logger"
 import { SavedAddressItem } from "v2/Apps/Order/Components/SavedAddressItem"
 import { deleteUserAddress } from "v2/Apps/Order/Mutations/DeleteUserAddress"
 import { updateUserDefaultAddress } from "v2/Apps/Order/Mutations/UpdateUserDefaultAddress"
+import { useSystemContext } from "v2/Artsy/SystemContext"
 
 export const NEW_ADDRESS = "NEW_ADDRESS"
 const PAGE_SIZE = 30
@@ -55,6 +56,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
   const logger = createLogger("SavedAddresses.tsx")
   const { onSelect, handleClickEdit, me, inCollectorProfile, relay } = props
   const addressList = me?.addressConnection?.edges ?? []
+  const { relayEnvironment } = useSystemContext()
 
   const onSuccess = () => {
     relay.refetch(
@@ -75,7 +77,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
   }
 
   const handleDeleteAddress = (addressID: string) => {
-    deleteUserAddress(props.commitMutation, addressID, onSuccess, onError)
+    deleteUserAddress(relayEnvironment, addressID, onSuccess, onError)
   }
 
   const handleEditAddress = (address: Address) => {
@@ -88,12 +90,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
   }
 
   const handleSetDefaultAddress = (addressID: string) => {
-    updateUserDefaultAddress(
-      props.commitMutation,
-      addressID,
-      onSuccess,
-      onError
-    )
+    updateUserDefaultAddress(relayEnvironment, addressID, onSuccess, onError)
   }
 
   const collectorProfileAddressItems = addressList.map((address, index) => {
@@ -183,7 +180,6 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
         closeModal={() => setShowAddressModal(false)}
         address={address}
         onSuccess={() => onSuccess()}
-        commitMutation={props.commitMutation}
         onError={onError}
         me={me}
       />

--- a/src/v2/Apps/Order/Components/SavedAddresses.tsx
+++ b/src/v2/Apps/Order/Components/SavedAddresses.tsx
@@ -73,6 +73,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
   }
 
   const onError = (message: string) => {
+    // TODO: actually handle error
     logger.error(message)
   }
 

--- a/src/v2/Apps/Order/Components/__tests__/AddressModal.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/AddressModal.jest.tsx
@@ -1,0 +1,150 @@
+import React from "react"
+import { commitMutation as _commitMutation } from "react-relay"
+import { AddressModal, Props } from "../AddressModal"
+import { mount } from "enzyme"
+import { validAddress } from "v2/Components/__tests__/Utils/addressForm"
+import {
+  updateAddressSuccess,
+  updateAddressFailure,
+} from "v2/Apps/Order/Routes/__fixtures__/MutationResults"
+import { SavedAddressType } from "../../Utils/shippingAddressUtils"
+
+const errorBoxQuery = "Text[data-test='credit-card-error']"
+
+// needed for modal contentAnimation
+const tick = () => new Promise(resolve => setTimeout(resolve, 0))
+
+const commitMutation = _commitMutation as jest.Mock<any>
+
+const savedAddress: SavedAddressType = {
+  ...validAddress,
+  id: "id",
+  internalID: "internal-id",
+  addressLine3: null,
+  isDefault: false,
+}
+
+const testAddressModalProps: Props = {
+  show: true,
+  address: savedAddress,
+  onSuccess: jest.fn(),
+  onError: jest.fn(),
+  modalDetails: {
+    addressModalTitle: "Modal title",
+    addressModalAction: "editUserAddress",
+  },
+  me: {
+    id: "1234",
+    addressConnection: {
+      edges: [],
+    },
+    " $refType": "SavedAddresses_me",
+  },
+  closeModal: jest.fn(),
+}
+
+function getWrapper(props: Props) {
+  return mount(<AddressModal {...props} />)
+}
+
+describe("AddressModal", () => {
+  beforeEach(() => {
+    commitMutation.mockReset()
+  })
+  it("renders Modal with the title and input fields", () => {
+    const wrapper = getWrapper(testAddressModalProps)
+    expect(wrapper.text()).toContain("Modal title")
+    expect(wrapper.find("input").length).toBe(7)
+    expect(wrapper.find("select").length).toBe(1)
+  })
+  describe("update mode", () => {
+    it("creates address when form is submitted with valid values", async () => {
+      const wrapper = getWrapper(testAddressModalProps)
+
+      commitMutation.mockImplementationOnce((_environment, { onCompleted }) => {
+        onCompleted(updateAddressSuccess)
+      })
+
+      const formik = wrapper.find("Formik").first()
+      formik.props().onSubmit(validAddress as any)
+
+      await wrapper.update()
+
+      expect(
+        commitMutation.mock.calls[0][1].mutation.default.params.name
+      ).toEqual("UpdateUserAddressMutation")
+
+      expect(commitMutation.mock.calls[0][1]).toMatchObject({
+        variables: {
+          input: {
+            attributes: {
+              ...validAddress,
+            },
+          },
+        },
+      })
+
+      expect(wrapper.find(AddressModal).props().onSuccess).toHaveBeenCalled()
+      expect(wrapper.find(AddressModal).props().closeModal).toHaveBeenCalled()
+    })
+
+    it("shows generic error when mutation fails", async () => {
+      let wrapper = getWrapper(testAddressModalProps)
+
+      commitMutation.mockImplementationOnce((_, { onError }) =>
+        onError(new TypeError("Network request failed"))
+      )
+
+      const formik = wrapper.find("Formik").first()
+      formik.props().onSubmit(validAddress as any)
+
+      await wrapper.update()
+
+      expect(commitMutation.mock.calls[0][1]).toMatchObject({
+        variables: {
+          input: {
+            attributes: {
+              ...validAddress,
+            },
+          },
+        },
+      })
+
+      await tick()
+
+      expect(wrapper.find(AddressModal).props().onError).toHaveBeenCalled()
+
+      expect(wrapper.find(errorBoxQuery).text()).toContain(
+        "Network request failed"
+      )
+    })
+    it("shows error when mutation returns error", async () => {
+      let wrapper = getWrapper(testAddressModalProps)
+
+      commitMutation.mockImplementationOnce((_, { onCompleted }) =>
+        onCompleted(updateAddressFailure)
+      )
+
+      const formik = wrapper.find("Formik").first()
+      formik.props().onSubmit(validAddress as any)
+
+      await wrapper.update()
+
+      expect(commitMutation.mock.calls[0][1]).toMatchObject({
+        variables: {
+          input: {
+            attributes: {
+              ...validAddress,
+            },
+          },
+        },
+      })
+
+      await tick()
+
+      expect(wrapper.find(errorBoxQuery).text()).toContain(
+        "Invalid phone number"
+      )
+    })
+  })
+})

--- a/src/v2/Apps/Order/Mutations/CreateUserAddress.ts
+++ b/src/v2/Apps/Order/Mutations/CreateUserAddress.ts
@@ -80,6 +80,7 @@ export const createUserAddress = async (
       onAddressAdded(me, store, data)
     },
     onCompleted: (data, e) => {
+      console.log("//// complete")
       const errors = data.createUserAddress.userAddressOrErrors.errors
       if (errors) {
         onError(errors.map(error => error.message).join(", "))

--- a/src/v2/Apps/Order/Mutations/CreateUserAddress.ts
+++ b/src/v2/Apps/Order/Mutations/CreateUserAddress.ts
@@ -80,7 +80,6 @@ export const createUserAddress = async (
       onAddressAdded(me, store, data)
     },
     onCompleted: (data, e) => {
-      console.log("//// complete")
       const errors = data.createUserAddress.userAddressOrErrors.errors
       if (errors) {
         onError(errors.map(error => error.message).join(", "))

--- a/src/v2/Apps/Order/Mutations/CreateUserAddress.ts
+++ b/src/v2/Apps/Order/Mutations/CreateUserAddress.ts
@@ -4,10 +4,14 @@ import {
   CreateUserAddressMutationResponse,
   UserAddressAttributes,
 } from "v2/__generated__/CreateUserAddressMutation.graphql"
-import { CommitMutation } from "../Utils/commitMutation"
-import { RecordSourceSelectorProxy, ConnectionHandler } from "relay-runtime"
+import {
+  RecordSourceSelectorProxy,
+  ConnectionHandler,
+  Environment,
+} from "relay-runtime"
 import { SavedAddresses_me } from "v2/__generated__/SavedAddresses_me.graphql"
 import { Shipping_me } from "v2/__generated__/Shipping_me.graphql"
+import { commitMutation } from "relay-runtime"
 
 const onAddressAdded = (
   me: SavedAddresses_me | Shipping_me,
@@ -32,14 +36,14 @@ const onAddressAdded = (
 }
 
 export const createUserAddress = async (
-  commitMutation: CommitMutation,
+  environment: Environment,
   address: UserAddressAttributes,
   onSuccess: (address: CreateUserAddressMutationResponse | null) => void,
   onError: (message: string | null) => void,
   me: SavedAddresses_me | Shipping_me,
   closeModal: () => void
 ) => {
-  const response = await commitMutation<CreateUserAddressMutation>({
+  commitMutation<CreateUserAddressMutation>(environment, {
     variables: {
       input: {
         attributes: address,
@@ -75,12 +79,17 @@ export const createUserAddress = async (
     updater: (store, data: CreateUserAddressMutationResponse) => {
       onAddressAdded(me, store, data)
     },
+    onCompleted: (data, e) => {
+      const errors = data.createUserAddress.userAddressOrErrors.errors
+      if (errors) {
+        onError(errors.map(error => error.message).join(", "))
+      } else {
+        onSuccess(data)
+        closeModal()
+      }
+    },
+    onError: e => {
+      onError(e.message)
+    },
   })
-  const errors = response.createUserAddress.userAddressOrErrors.errors
-  if (errors) {
-    onError(errors.map(error => error.message).join(", "))
-  } else {
-    onSuccess(response)
-  }
-  closeModal()
 }

--- a/src/v2/Apps/Order/Mutations/DeleteUserAddress.ts
+++ b/src/v2/Apps/Order/Mutations/DeleteUserAddress.ts
@@ -1,14 +1,13 @@
-import { graphql } from "react-relay"
+import { commitMutation, Environment, graphql } from "react-relay"
 import { DeleteUserAddressMutation } from "v2/__generated__/DeleteUserAddressMutation.graphql"
-import { CommitMutation } from "../Utils/commitMutation"
 
 export const deleteUserAddress = async (
-  commitMutation: CommitMutation,
+  environment: Environment,
   userAddressID: string,
   onSuccess: () => void,
   onError: (message: string) => void
 ) => {
-  const result = await commitMutation<DeleteUserAddressMutation>({
+  await commitMutation<DeleteUserAddressMutation>(environment, {
     variables: {
       input: {
         userAddressID: userAddressID,
@@ -41,11 +40,16 @@ export const deleteUserAddress = async (
         }
       }
     `,
+    onError: e => {
+      onError(e.message)
+    },
+    onCompleted: (data, e) => {
+      const errors = data.deleteUserAddress.userAddressOrErrors.errors
+      if (errors) {
+        onError(errors.map(error => error.message).join(", "))
+      } else {
+        onSuccess()
+      }
+    },
   })
-  const errors = result.deleteUserAddress.userAddressOrErrors.errors
-  if (errors) {
-    onError(errors.map(error => error.message).join(", "))
-  } else {
-    onSuccess()
-  }
 }

--- a/src/v2/Apps/Order/Mutations/UpdateUserAddress.ts
+++ b/src/v2/Apps/Order/Mutations/UpdateUserAddress.ts
@@ -1,16 +1,18 @@
 import { commitMutation, Environment, graphql } from "react-relay"
+import { Address } from "v2/Components/AddressForm"
 import { UpdateUserAddressMutation } from "v2/__generated__/UpdateUserAddressMutation.graphql"
 import {
   convertShippingAddressToMutationInput,
   convertShippingAddressForExchange,
+  SavedAddressType,
 } from "../Utils/shippingAddressUtils"
 
 export const updateUserAddress = async (
   environment: Environment,
   userAddressID: string,
-  values: any,
+  values: SavedAddressType,
   closeModal: () => void,
-  onSuccess: (address) => void,
+  onSuccess: (address: Address) => void,
   onError: (message: string) => void
 ) => {
   const useAttributes = convertShippingAddressToMutationInput(values)

--- a/src/v2/Apps/Order/Mutations/UpdateUserAddress.ts
+++ b/src/v2/Apps/Order/Mutations/UpdateUserAddress.ts
@@ -58,8 +58,8 @@ export const updateUserAddress = async (
           data.updateUserAddress.userAddressOrErrors
         )
         onSuccess(address)
+        closeModal()
       }
-      closeModal()
     },
     onError: e => {
       onError(e.message)

--- a/src/v2/Apps/Order/Mutations/UpdateUserDefaultAddress.ts
+++ b/src/v2/Apps/Order/Mutations/UpdateUserDefaultAddress.ts
@@ -1,14 +1,13 @@
-import { graphql } from "react-relay"
+import { commitMutation, Environment, graphql } from "react-relay"
 import { UpdateUserDefaultAddressMutation } from "v2/__generated__/UpdateUserDefaultAddressMutation.graphql"
-import { CommitMutation } from "../Utils/commitMutation"
 
 export const updateUserDefaultAddress = async (
-  commitMutation: CommitMutation,
+  environment: Environment,
   userAddressID: string,
   onSuccess: () => void,
   onError: (message: string) => void
 ) => {
-  const result = await commitMutation<UpdateUserDefaultAddressMutation>({
+  commitMutation<UpdateUserDefaultAddressMutation>(environment, {
     variables: {
       input: {
         userAddressID: userAddressID,
@@ -43,11 +42,16 @@ export const updateUserDefaultAddress = async (
         }
       }
     `,
+    onError: e => {
+      onError(e.message)
+    },
+    onCompleted: (data, e) => {
+      const errors = data.updateUserDefaultAddress.userAddressOrErrors.errors
+      if (errors) {
+        onError(errors.map(error => error.message).join(", "))
+      } else {
+        onSuccess()
+      }
+    },
   })
-  const errors = result.updateUserDefaultAddress.userAddressOrErrors.errors
-  if (errors) {
-    onError(errors.map(error => error.message).join(", "))
-  } else {
-    onSuccess()
-  }
 }

--- a/src/v2/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/v2/Apps/Order/Routes/Shipping/index.tsx
@@ -69,8 +69,9 @@ import {
 import { AddressModal } from "../../Components/AddressModal"
 import { createUserAddress } from "../../Mutations/CreateUserAddress"
 import { setShipping } from "../../Mutations/SetShipping"
+import { SystemContextProps, withSystemContext } from "v2/Artsy/SystemContext"
 
-export interface ShippingProps {
+export interface ShippingProps extends SystemContextProps {
   order: Shipping_order
   me: Shipping_me
   relay?: RelayProp
@@ -201,8 +202,9 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
         this.isCreateNewAddress() &&
         this.state.saveAddress
       ) {
+        const { relayEnvironment } = this.props
         await createUserAddress(
-          this.props.commitMutation,
+          relayEnvironment,
           {
             ...address,
             phoneNumber: phoneNumber,
@@ -312,6 +314,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
       this.props,
       props => props.order.lineItems.edges[0].node.artwork
     )
+    console.log(this.props.relayEnvironment)
     const addressList = this.getAddressList()
 
     const shippingSelected =
@@ -337,7 +340,6 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
           show={showModal}
           closeModal={() => this.setState({ showModal: false })}
           address={addressList[this.state.editAddressIndex]?.node}
-          commitMutation={this.props.commitMutation}
           onSuccess={() => {
             // this.setState({ address: updatedAddress })
           }}
@@ -495,7 +497,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
 }
 
 export const ShippingFragmentContainer = createFragmentContainer(
-  injectCommitMutation(injectDialog(ShippingRoute)),
+  withSystemContext(injectCommitMutation(injectDialog(ShippingRoute))),
   {
     order: graphql`
       fragment Shipping_order on CommerceOrder {

--- a/src/v2/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/v2/Apps/Order/Routes/Shipping/index.tsx
@@ -314,7 +314,6 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
       this.props,
       props => props.order.lineItems.edges[0].node.artwork
     )
-    console.log(this.props.relayEnvironment)
     const addressList = this.getAddressList()
 
     const shippingSelected =

--- a/src/v2/Apps/Order/Routes/__fixtures__/MutationResults/saveAddress.ts
+++ b/src/v2/Apps/Order/Routes/__fixtures__/MutationResults/saveAddress.ts
@@ -44,7 +44,7 @@ export const updateAddressFailure: UpdateUserAddressMutationResponse = {
       errors: [
         {
           code: "100",
-          message: "Invalid phone number",
+          message: "Invalid address",
         },
       ],
     },

--- a/src/v2/Apps/Order/Routes/__fixtures__/MutationResults/saveAddress.ts
+++ b/src/v2/Apps/Order/Routes/__fixtures__/MutationResults/saveAddress.ts
@@ -37,3 +37,16 @@ export const updateAddressSuccess: UpdateUserAddressMutationResponse = {
     },
   },
 }
+
+export const updateAddressFailure: UpdateUserAddressMutationResponse = {
+  updateUserAddress: {
+    userAddressOrErrors: {
+      errors: [
+        {
+          code: "100",
+          message: "Invalid phone number",
+        },
+      ],
+    },
+  },
+}


### PR DESCRIPTION
[PURCHASE-2484](https://artsyproduct.atlassian.net/browse/PURCHASE-2484)

Handles server errors gracefully.

Before:
When a mutation returned errors, it was being handled by `Order/Utils/commitMutation` and the errors were not properly surfaced in the UI.

After:
Now the errors are being handled and if there is a known server error, it is being displayed next to the corresponding field.

<img width="444" alt="Screen Shot 2021-03-25 at 2 31 49 PM" src="https://user-images.githubusercontent.com/687513/112531548-143efc80-8d7e-11eb-87b4-53b5ef139843.png">

TODO:
- [x] More QA
