### PR TITLE
chore: reason about some aggregations on /collect and collection pages

### DIFF
--- a/src/v2/Apps/Collect/Routes/Collection/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/index.tsx
@@ -219,9 +219,7 @@ export const CollectionRefetchContainer = createRefetchContainer(
           ...CollectionsHubRails_linkedCollections
         }
         fallbackHeaderImage: artworksConnection(
-          aggregations: $aggregations
           includeMediumFilterInAggregation: true
-          size: 1
           first: 1
           sort: "-decayed_merch"
         ) {
@@ -238,7 +236,6 @@ export const CollectionRefetchContainer = createRefetchContainer(
         artworksConnection(
           aggregations: $aggregations
           includeMediumFilterInAggregation: true
-          size: 20
           first: 20
           sort: "-decayed_merch"
         ) {
@@ -256,29 +253,22 @@ export const CollectionRefetchContainer = createRefetchContainer(
 
         #These two things are going to get highest price and lowest price of the artwork on the collection page.
         descending_artworks: artworksConnection(
-          aggregations: $aggregations
           includeMediumFilterInAggregation: true
           first: 1
-          size: 1
           sort: "sold,-has_price,-prices"
         ) {
           ...SeoProductsForCollections_descending_artworks
         }
 
         ascending_artworks: artworksConnection(
-          aggregations: $aggregations
           includeMediumFilterInAggregation: true
           first: 1
-          size: 1
           sort: "sold,-has_price,prices"
         ) {
           ...SeoProductsForCollections_ascending_artworks
         }
 
-        filtered_artworks: artworksConnection(
-          aggregations: $aggregations
-          input: $input
-        ) {
+        filtered_artworks: artworksConnection(input: $input) {
           id
           ...ArtworkFilterArtworkGrid_filtered_artworks
         }

--- a/src/v2/Apps/Collect/collectRoutes.tsx
+++ b/src/v2/Apps/Collect/collectRoutes.tsx
@@ -82,27 +82,27 @@ function initializeVariablesWithFilterState(params, props) {
 
   const collectionSlug = params.slug
 
-  const aggregations = ["TOTAL"]
-  // TODO: Does the `location_city` aggregation accomplish much on /collect, and
-  // should it be a hard-coded list of featured cities?
+  // TODO: Do these aggregations accomplish much on /collect?
   const additionalAggregations = getENV("ENABLE_NEW_ARTWORK_FILTERS")
     ? ["LOCATION_CITY", "ARTIST_NATIONALITY", "MATERIALS_TERMS"]
     : []
   const collectionOnlyAggregations = collectionSlug
     ? ["MERCHANDISABLE_ARTISTS", "MEDIUM", "MAJOR_PERIOD"]
     : []
+  const aggregations = ["TOTAL"]
+    .concat(additionalAggregations)
+    .concat(collectionOnlyAggregations)
 
   const input = {
     sort: "-decayed_merch",
     ...allowedFilters(paramsToCamelCase(initialFilterState)),
     first: 30,
+    aggregations,
   }
 
   return {
     input,
-    aggregations: aggregations
-      .concat(additionalAggregations)
-      .concat(collectionOnlyAggregations),
+    aggregations,
     slug: collectionSlug,
     sort: "-decayed_merch",
   }
@@ -111,18 +111,13 @@ function initializeVariablesWithFilterState(params, props) {
 function getArtworkFilterQuery() {
   return graphql`
     query collectRoutes_ArtworkFilterQuery(
-      $aggregations: [ArtworkAggregation]
       $sort: String
       $input: FilterArtworksInput
     ) {
       marketingHubCollections {
         ...Collect_marketingHubCollections
       }
-      filterArtworks: artworksConnection(
-        aggregations: $aggregations
-        sort: $sort
-        first: 30
-      ) {
+      filterArtworks: artworksConnection(sort: $sort, first: 30) {
         ...SeoProductsForArtworks_artworks
       }
       viewer {

--- a/src/v2/__generated__/CollectionAppQuery.graphql.ts
+++ b/src/v2/__generated__/CollectionAppQuery.graphql.ts
@@ -191,7 +191,7 @@ fragment Collection_collection_2p2tYs on MarketingCollection {
   linkedCollections {
     ...CollectionsHubRails_linkedCollections
   }
-  fallbackHeaderImage: artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, size: 1, first: 1, sort: "-decayed_merch") {
+  fallbackHeaderImage: artworksConnection(includeMediumFilterInAggregation: true, first: 1, sort: "-decayed_merch") {
     edges {
       node {
         image {
@@ -204,7 +204,7 @@ fragment Collection_collection_2p2tYs on MarketingCollection {
     }
     id
   }
-  artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, size: 20, first: 20, sort: "-decayed_merch") {
+  artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, first: 20, sort: "-decayed_merch") {
     ...Header_artworks
     ...SeoProductsForArtworks_artworks
     aggregations {
@@ -217,15 +217,15 @@ fragment Collection_collection_2p2tYs on MarketingCollection {
     }
     id
   }
-  descending_artworks: artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, first: 1, size: 1, sort: "sold,-has_price,-prices") {
+  descending_artworks: artworksConnection(includeMediumFilterInAggregation: true, first: 1, sort: "sold,-has_price,-prices") {
     ...SeoProductsForCollections_descending_artworks
     id
   }
-  ascending_artworks: artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, first: 1, size: 1, sort: "sold,-has_price,prices") {
+  ascending_artworks: artworksConnection(includeMediumFilterInAggregation: true, first: 1, sort: "sold,-has_price,prices") {
     ...SeoProductsForCollections_ascending_artworks
     id
   }
-  filtered_artworks: artworksConnection(aggregations: $aggregations, input: $input) {
+  filtered_artworks: artworksConnection(input: $input) {
     id
     ...ArtworkFilterArtworkGrid_filtered_artworks
   }
@@ -646,14 +646,11 @@ v2 = {
   "name": "aggregations",
   "variableName": "aggregations"
 },
-v3 = [
-  (v2/*: any*/),
-  {
-    "kind": "Variable",
-    "name": "input",
-    "variableName": "input"
-  }
-],
+v3 = {
+  "kind": "Variable",
+  "name": "input",
+  "variableName": "input"
+},
 v4 = {
   "alias": null,
   "args": null,
@@ -764,12 +761,7 @@ v19 = {
   "name": "includeMediumFilterInAggregation",
   "value": true
 },
-v20 = {
-  "kind": "Literal",
-  "name": "size",
-  "value": 1
-},
-v21 = [
+v20 = [
   {
     "alias": null,
     "args": null,
@@ -786,7 +778,7 @@ v21 = [
   },
   (v16/*: any*/)
 ],
-v22 = {
+v21 = {
   "alias": null,
   "args": [
     {
@@ -799,35 +791,35 @@ v22 = {
   "name": "url",
   "storageKey": "url(version:\"larger\")"
 },
-v23 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v24 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "availability",
   "storageKey": null
 },
-v25 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "date",
   "storageKey": null
 },
-v26 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v27 = [
+v26 = [
   {
     "alias": null,
     "args": null,
@@ -836,28 +828,28 @@ v27 = [
     "storageKey": null
   }
 ],
-v28 = [
+v27 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v29 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "type",
   "storageKey": null
 },
-v30 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v31 = {
+v30 = {
   "alias": null,
   "args": null,
   "concreteType": "ArtworksAggregationResults",
@@ -901,7 +893,7 @@ v31 = {
   ],
   "storageKey": null
 },
-v32 = [
+v31 = [
   {
     "alias": null,
     "args": [
@@ -923,7 +915,7 @@ v32 = [
     "storageKey": null
   }
 ],
-v33 = [
+v32 = [
   {
     "alias": null,
     "args": null,
@@ -941,7 +933,7 @@ v33 = [
         "plural": false,
         "selections": [
           (v7/*: any*/),
-          (v24/*: any*/),
+          (v23/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -950,7 +942,7 @@ v33 = [
             "name": "listPrice",
             "plural": false,
             "selections": [
-              (v26/*: any*/),
+              (v25/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -961,7 +953,7 @@ v33 = [
                     "kind": "LinkedField",
                     "name": "minPrice",
                     "plural": false,
-                    "selections": (v32/*: any*/),
+                    "selections": (v31/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -971,7 +963,7 @@ v33 = [
                     "kind": "LinkedField",
                     "name": "maxPrice",
                     "plural": false,
-                    "selections": (v32/*: any*/),
+                    "selections": (v31/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -979,7 +971,7 @@ v33 = [
               },
               {
                 "kind": "InlineFragment",
-                "selections": (v32/*: any*/),
+                "selections": (v31/*: any*/),
                 "type": "Money"
               }
             ],
@@ -993,23 +985,23 @@ v33 = [
   },
   (v7/*: any*/)
 ],
-v34 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v35 = {
+v34 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v36 = [
+v35 = [
+  (v33/*: any*/),
   (v34/*: any*/),
-  (v35/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -1034,7 +1026,10 @@ return {
         "plural": false,
         "selections": [
           {
-            "args": (v3/*: any*/),
+            "args": [
+              (v2/*: any*/),
+              (v3/*: any*/)
+            ],
             "kind": "FragmentSpread",
             "name": "Collection_collection"
           }
@@ -1304,10 +1299,8 @@ return {
           {
             "alias": "fallbackHeaderImage",
             "args": [
-              (v2/*: any*/),
               (v18/*: any*/),
               (v19/*: any*/),
-              (v20/*: any*/),
               (v11/*: any*/)
             ],
             "concreteType": "FilterArtworksConnection",
@@ -1367,7 +1360,7 @@ return {
               },
               (v7/*: any*/)
             ],
-            "storageKey": null
+            "storageKey": "artworksConnection(first:1,includeMediumFilterInAggregation:true,sort:\"-decayed_merch\")"
           },
           {
             "alias": null,
@@ -1379,11 +1372,6 @@ return {
                 "value": 20
               },
               (v19/*: any*/),
-              {
-                "kind": "Literal",
-                "name": "size",
-                "value": 20
-              },
               (v11/*: any*/)
             ],
             "concreteType": "FilterArtworksConnection",
@@ -1429,7 +1417,7 @@ return {
                             "kind": "LinkedField",
                             "name": "resized",
                             "plural": false,
-                            "selections": (v21/*: any*/),
+                            "selections": (v20/*: any*/),
                             "storageKey": "resized(height:230)"
                           },
                           {
@@ -1445,19 +1433,19 @@ return {
                             "kind": "LinkedField",
                             "name": "resized",
                             "plural": false,
-                            "selections": (v21/*: any*/),
+                            "selections": (v20/*: any*/),
                             "storageKey": "resized(height:160)"
                           },
-                          (v22/*: any*/)
+                          (v21/*: any*/)
                         ],
                         "storageKey": null
                       },
                       (v9/*: any*/),
-                      (v23/*: any*/),
+                      (v22/*: any*/),
                       (v8/*: any*/),
-                      (v24/*: any*/),
+                      (v23/*: any*/),
                       (v4/*: any*/),
-                      (v25/*: any*/),
+                      (v24/*: any*/),
                       {
                         "alias": "is_acquireable",
                         "args": null,
@@ -1480,15 +1468,15 @@ return {
                         "name": "listPrice",
                         "plural": false,
                         "selections": [
-                          (v26/*: any*/),
+                          (v25/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v27/*: any*/),
+                            "selections": (v26/*: any*/),
                             "type": "PriceRange"
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v27/*: any*/),
+                            "selections": (v26/*: any*/),
                             "type": "Money"
                           }
                         ],
@@ -1503,7 +1491,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v28/*: any*/),
+                        "args": (v27/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
@@ -1525,14 +1513,14 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v28/*: any*/),
+                        "args": (v27/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
                           (v13/*: any*/),
-                          (v29/*: any*/),
+                          (v28/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1549,7 +1537,7 @@ return {
                                 "name": "icon",
                                 "plural": false,
                                 "selections": [
-                                  (v22/*: any*/)
+                                  (v21/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -1560,7 +1548,11 @@ return {
                           {
                             "alias": null,
                             "args": [
-                              (v20/*: any*/)
+                              {
+                                "kind": "Literal",
+                                "name": "size",
+                                "value": 1
+                              }
                             ],
                             "concreteType": "Location",
                             "kind": "LinkedField",
@@ -1639,7 +1631,7 @@ return {
                 "plural": true,
                 "selections": [
                   (v8/*: any*/),
-                  (v30/*: any*/),
+                  (v29/*: any*/),
                   (v13/*: any*/),
                   {
                     "alias": null,
@@ -1721,7 +1713,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v31/*: any*/),
+              (v30/*: any*/),
               (v7/*: any*/)
             ],
             "storageKey": null
@@ -1729,10 +1721,8 @@ return {
           {
             "alias": "descending_artworks",
             "args": [
-              (v2/*: any*/),
               (v18/*: any*/),
               (v19/*: any*/),
-              (v20/*: any*/),
               {
                 "kind": "Literal",
                 "name": "sort",
@@ -1743,16 +1733,14 @@ return {
             "kind": "LinkedField",
             "name": "artworksConnection",
             "plural": false,
-            "selections": (v33/*: any*/),
-            "storageKey": null
+            "selections": (v32/*: any*/),
+            "storageKey": "artworksConnection(first:1,includeMediumFilterInAggregation:true,sort:\"sold,-has_price,-prices\")"
           },
           {
             "alias": "ascending_artworks",
             "args": [
-              (v2/*: any*/),
               (v18/*: any*/),
               (v19/*: any*/),
-              (v20/*: any*/),
               {
                 "kind": "Literal",
                 "name": "sort",
@@ -1763,19 +1751,21 @@ return {
             "kind": "LinkedField",
             "name": "artworksConnection",
             "plural": false,
-            "selections": (v33/*: any*/),
-            "storageKey": null
+            "selections": (v32/*: any*/),
+            "storageKey": "artworksConnection(first:1,includeMediumFilterInAggregation:true,sort:\"sold,-has_price,prices\")"
           },
           {
             "alias": "filtered_artworks",
-            "args": (v3/*: any*/),
+            "args": [
+              (v3/*: any*/)
+            ],
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "artworksConnection",
             "plural": false,
             "selections": [
               (v7/*: any*/),
-              (v31/*: any*/),
+              (v30/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1816,7 +1806,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v36/*: any*/),
+                    "selections": (v35/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1826,7 +1816,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v36/*: any*/),
+                    "selections": (v35/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1836,7 +1826,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v36/*: any*/),
+                    "selections": (v35/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1847,8 +1837,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v34/*: any*/),
-                      (v35/*: any*/)
+                      (v33/*: any*/),
+                      (v34/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1873,8 +1863,8 @@ return {
                     "selections": [
                       (v7/*: any*/),
                       (v8/*: any*/),
-                      (v23/*: any*/),
-                      (v30/*: any*/),
+                      (v22/*: any*/),
+                      (v29/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1921,7 +1911,7 @@ return {
                         "name": "imageTitle",
                         "storageKey": null
                       },
-                      (v25/*: any*/),
+                      (v24/*: any*/),
                       {
                         "alias": "sale_message",
                         "args": null,
@@ -1938,14 +1928,14 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v28/*: any*/),
+                        "args": (v27/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
                           (v7/*: any*/),
-                          (v23/*: any*/),
+                          (v22/*: any*/),
                           (v13/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
@@ -1959,16 +1949,16 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v28/*: any*/),
+                        "args": (v27/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
                           (v13/*: any*/),
-                          (v23/*: any*/),
+                          (v22/*: any*/),
                           (v7/*: any*/),
-                          (v29/*: any*/)
+                          (v28/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -2059,7 +2049,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v27/*: any*/),
+                            "selections": (v26/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -2069,7 +2059,7 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v27/*: any*/),
+                            "selections": (v26/*: any*/),
                             "storageKey": null
                           },
                           (v7/*: any*/)
@@ -2117,7 +2107,7 @@ return {
     "metadata": {},
     "name": "CollectionAppQuery",
     "operationKind": "query",
-    "text": "query CollectionAppQuery(\n  $input: FilterArtworksInput\n  $slug: String!\n  $aggregations: [ArtworkAggregation]\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...Collection_collection_2p2tYs\n    id\n  }\n}\n\nfragment ArtistSeriesEntity_member on MarketingCollection {\n  id\n  slug\n  headerImage\n  thumbnail\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          url(version: \"small\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    slug\n    ...ArtistSeriesEntity_member\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Collection_collection_2p2tYs on MarketingCollection {\n  ...Header_collection\n  description\n  headerImage\n  slug\n  id\n  title\n  query {\n    artist_id: artistID\n    gene_id: geneID\n    id\n  }\n  relatedCollections(size: 16) {\n    ...RelatedCollectionsRail_collections\n    id\n  }\n  linkedCollections {\n    ...CollectionsHubRails_linkedCollections\n  }\n  fallbackHeaderImage: artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, size: 1, first: 1, sort: \"-decayed_merch\") {\n    edges {\n      node {\n        image {\n          resized(width: 600) {\n            url\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n  artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, size: 20, first: 20, sort: \"-decayed_merch\") {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    aggregations {\n      slice\n      counts {\n        value\n        name\n        count\n      }\n    }\n    id\n  }\n  descending_artworks: artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, first: 1, size: 1, sort: \"sold,-has_price,-prices\") {\n    ...SeoProductsForCollections_descending_artworks\n    id\n  }\n  ascending_artworks: artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, first: 1, size: 1, sort: \"sold,-has_price,prices\") {\n    ...SeoProductsForCollections_ascending_artworks\n    id\n  }\n  filtered_artworks: artworksConnection(aggregations: $aggregations, input: $input) {\n    id\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {\n  groupType\n  ...FeaturedCollectionsRails_collectionGroup\n  ...OtherCollectionsRail_collectionGroup\n  ...ArtistSeriesRail_collectionGroup\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment DefaultHeaderArtwork_artwork on FilterArtworksEdge {\n  node {\n    id\n    title\n    href\n    slug\n    image {\n      large: resized(height: 230) {\n        url\n        width\n        height\n      }\n      small: resized(height: 160) {\n        url\n        width\n        height\n      }\n    }\n  }\n}\n\nfragment DefaultHeader_headerArtworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      image {\n        large: resized(height: 230) {\n          width\n          height\n        }\n        small: resized(height: 160) {\n          width\n          height\n        }\n      }\n    }\n    ...DefaultHeaderArtwork_artwork\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    id\n    slug\n    title\n    description\n    price_guidance: priceGuidance\n    thumbnail\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Header_artworks on FilterArtworksConnection {\n  ...DefaultHeader_headerArtworks\n  merchandisableArtists {\n    slug\n    internalID\n    name\n    image {\n      resized(width: 45, height: 45, version: \"square\") {\n        url\n      }\n    }\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment Header_collection on MarketingCollection {\n  category\n  credit\n  description\n  featuredArtistExclusionIds\n  headerImage\n  id\n  query {\n    artistIDs\n    id\n  }\n  slug\n  title\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment OtherCollectionEntity_member on MarketingCollection {\n  id\n  slug\n  thumbnail\n  title\n}\n\nfragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...OtherCollectionEntity_member\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment RelatedCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  id\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          resized(width: 262) {\n            url\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment RelatedCollectionsRail_collections on MarketingCollection {\n  ...RelatedCollectionEntity_collection\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      category\n      date\n      href\n      is_acquireable: isAcquireable\n      is_price_range: isPriceRange\n      listPrice {\n        __typename\n        ... on PriceRange {\n          display\n        }\n        ... on Money {\n          display\n        }\n      }\n      price_currency: priceCurrency\n      title\n      artists(shallow: true) {\n        name\n        id\n      }\n      image {\n        url(version: \"larger\")\n      }\n      meta {\n        description\n      }\n      partner(shallow: true) {\n        name\n        type\n        profile {\n          icon {\n            url(version: \"larger\")\n          }\n          id\n        }\n        locations(size: 1) {\n          address\n          address_2: address2\n          city\n          state\n          country\n          postal_code: postalCode\n          phone\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SeoProductsForCollections_ascending_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      listPrice {\n        __typename\n        ... on PriceRange {\n          minPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n          maxPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n        }\n        ... on Money {\n          major(convertTo: \"USD\")\n          currencyCode\n        }\n      }\n    }\n  }\n}\n\nfragment SeoProductsForCollections_descending_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      listPrice {\n        __typename\n        ... on PriceRange {\n          minPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n          maxPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n        }\n        ... on Money {\n          major(convertTo: \"USD\")\n          currencyCode\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query CollectionAppQuery(\n  $input: FilterArtworksInput\n  $slug: String!\n  $aggregations: [ArtworkAggregation]\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...Collection_collection_2p2tYs\n    id\n  }\n}\n\nfragment ArtistSeriesEntity_member on MarketingCollection {\n  id\n  slug\n  headerImage\n  thumbnail\n  title\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          url(version: \"small\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment ArtistSeriesRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    slug\n    ...ArtistSeriesEntity_member\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Collection_collection_2p2tYs on MarketingCollection {\n  ...Header_collection\n  description\n  headerImage\n  slug\n  id\n  title\n  query {\n    artist_id: artistID\n    gene_id: geneID\n    id\n  }\n  relatedCollections(size: 16) {\n    ...RelatedCollectionsRail_collections\n    id\n  }\n  linkedCollections {\n    ...CollectionsHubRails_linkedCollections\n  }\n  fallbackHeaderImage: artworksConnection(includeMediumFilterInAggregation: true, first: 1, sort: \"-decayed_merch\") {\n    edges {\n      node {\n        image {\n          resized(width: 600) {\n            url\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n  artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, first: 20, sort: \"-decayed_merch\") {\n    ...Header_artworks\n    ...SeoProductsForArtworks_artworks\n    aggregations {\n      slice\n      counts {\n        value\n        name\n        count\n      }\n    }\n    id\n  }\n  descending_artworks: artworksConnection(includeMediumFilterInAggregation: true, first: 1, sort: \"sold,-has_price,-prices\") {\n    ...SeoProductsForCollections_descending_artworks\n    id\n  }\n  ascending_artworks: artworksConnection(includeMediumFilterInAggregation: true, first: 1, sort: \"sold,-has_price,prices\") {\n    ...SeoProductsForCollections_ascending_artworks\n    id\n  }\n  filtered_artworks: artworksConnection(input: $input) {\n    id\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment CollectionsHubRails_linkedCollections on MarketingCollectionGroup {\n  groupType\n  ...FeaturedCollectionsRails_collectionGroup\n  ...OtherCollectionsRail_collectionGroup\n  ...ArtistSeriesRail_collectionGroup\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment DefaultHeaderArtwork_artwork on FilterArtworksEdge {\n  node {\n    id\n    title\n    href\n    slug\n    image {\n      large: resized(height: 230) {\n        url\n        width\n        height\n      }\n      small: resized(height: 160) {\n        url\n        width\n        height\n      }\n    }\n  }\n}\n\nfragment DefaultHeader_headerArtworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      image {\n        large: resized(height: 230) {\n          width\n          height\n        }\n        small: resized(height: 160) {\n          width\n          height\n        }\n      }\n    }\n    ...DefaultHeaderArtwork_artwork\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FeaturedCollectionsRails_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    id\n    slug\n    title\n    description\n    price_guidance: priceGuidance\n    thumbnail\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Header_artworks on FilterArtworksConnection {\n  ...DefaultHeader_headerArtworks\n  merchandisableArtists {\n    slug\n    internalID\n    name\n    image {\n      resized(width: 45, height: 45, version: \"square\") {\n        url\n      }\n    }\n    birthday\n    nationality\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment Header_collection on MarketingCollection {\n  category\n  credit\n  description\n  featuredArtistExclusionIds\n  headerImage\n  id\n  query {\n    artistIDs\n    id\n  }\n  slug\n  title\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment OtherCollectionEntity_member on MarketingCollection {\n  id\n  slug\n  thumbnail\n  title\n}\n\nfragment OtherCollectionsRail_collectionGroup on MarketingCollectionGroup {\n  groupType\n  name\n  members {\n    ...OtherCollectionEntity_member\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment RelatedCollectionEntity_collection on MarketingCollection {\n  headerImage\n  slug\n  title\n  id\n  price_guidance: priceGuidance\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        artist {\n          name\n          id\n        }\n        title\n        image {\n          resized(width: 262) {\n            url\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment RelatedCollectionsRail_collections on MarketingCollection {\n  ...RelatedCollectionEntity_collection\n  artworksConnection(first: 3, aggregations: [TOTAL], sort: \"-decayed_merch\") {\n    edges {\n      node {\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      category\n      date\n      href\n      is_acquireable: isAcquireable\n      is_price_range: isPriceRange\n      listPrice {\n        __typename\n        ... on PriceRange {\n          display\n        }\n        ... on Money {\n          display\n        }\n      }\n      price_currency: priceCurrency\n      title\n      artists(shallow: true) {\n        name\n        id\n      }\n      image {\n        url(version: \"larger\")\n      }\n      meta {\n        description\n      }\n      partner(shallow: true) {\n        name\n        type\n        profile {\n          icon {\n            url(version: \"larger\")\n          }\n          id\n        }\n        locations(size: 1) {\n          address\n          address_2: address2\n          city\n          state\n          country\n          postal_code: postalCode\n          phone\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SeoProductsForCollections_ascending_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      listPrice {\n        __typename\n        ... on PriceRange {\n          minPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n          maxPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n        }\n        ... on Money {\n          major(convertTo: \"USD\")\n          currencyCode\n        }\n      }\n    }\n  }\n}\n\nfragment SeoProductsForCollections_descending_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      listPrice {\n        __typename\n        ... on PriceRange {\n          minPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n          maxPrice {\n            major(convertTo: \"USD\")\n            currencyCode\n          }\n        }\n        ... on Money {\n          major(convertTo: \"USD\")\n          currencyCode\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/Collection_collection.graphql.ts
+++ b/src/v2/__generated__/Collection_collection.graphql.ts
@@ -72,26 +72,16 @@ var v0 = {
   "storageKey": null
 },
 v1 = {
-  "kind": "Variable",
-  "name": "aggregations",
-  "variableName": "aggregations"
-},
-v2 = {
   "kind": "Literal",
   "name": "first",
   "value": 1
 },
-v3 = {
+v2 = {
   "kind": "Literal",
   "name": "includeMediumFilterInAggregation",
   "value": true
 },
-v4 = {
-  "kind": "Literal",
-  "name": "size",
-  "value": 1
-},
-v5 = {
+v3 = {
   "kind": "Literal",
   "name": "sort",
   "value": "-decayed_merch"
@@ -212,9 +202,7 @@ return {
       "args": [
         (v1/*: any*/),
         (v2/*: any*/),
-        (v3/*: any*/),
-        (v4/*: any*/),
-        (v5/*: any*/)
+        (v3/*: any*/)
       ],
       "concreteType": "FilterArtworksConnection",
       "kind": "LinkedField",
@@ -279,24 +267,23 @@ return {
           "storageKey": null
         }
       ],
-      "storageKey": null
+      "storageKey": "artworksConnection(first:1,includeMediumFilterInAggregation:true,sort:\"-decayed_merch\")"
     },
     {
       "alias": null,
       "args": [
-        (v1/*: any*/),
+        {
+          "kind": "Variable",
+          "name": "aggregations",
+          "variableName": "aggregations"
+        },
         {
           "kind": "Literal",
           "name": "first",
           "value": 20
         },
-        (v3/*: any*/),
-        {
-          "kind": "Literal",
-          "name": "size",
-          "value": 20
-        },
-        (v5/*: any*/)
+        (v2/*: any*/),
+        (v3/*: any*/)
       ],
       "concreteType": "FilterArtworksConnection",
       "kind": "LinkedField",
@@ -371,8 +358,6 @@ return {
       "args": [
         (v1/*: any*/),
         (v2/*: any*/),
-        (v3/*: any*/),
-        (v4/*: any*/),
         {
           "kind": "Literal",
           "name": "sort",
@@ -390,15 +375,13 @@ return {
           "name": "SeoProductsForCollections_descending_artworks"
         }
       ],
-      "storageKey": null
+      "storageKey": "artworksConnection(first:1,includeMediumFilterInAggregation:true,sort:\"sold,-has_price,-prices\")"
     },
     {
       "alias": "ascending_artworks",
       "args": [
         (v1/*: any*/),
         (v2/*: any*/),
-        (v3/*: any*/),
-        (v4/*: any*/),
         {
           "kind": "Literal",
           "name": "sort",
@@ -416,12 +399,11 @@ return {
           "name": "SeoProductsForCollections_ascending_artworks"
         }
       ],
-      "storageKey": null
+      "storageKey": "artworksConnection(first:1,includeMediumFilterInAggregation:true,sort:\"sold,-has_price,prices\")"
     },
     {
       "alias": "filtered_artworks",
       "args": [
-        (v1/*: any*/),
         {
           "kind": "Variable",
           "name": "input",
@@ -451,5 +433,5 @@ return {
   "type": "MarketingCollection"
 };
 })();
-(node as any).hash = 'a996a7c392c99e9b03c946bf699aaaeb';
+(node as any).hash = '360adf1045a85a674a06328896cb0140';
 export default node;

--- a/src/v2/__generated__/collectRoutes_ArtworkFilterQuery.graphql.ts
+++ b/src/v2/__generated__/collectRoutes_ArtworkFilterQuery.graphql.ts
@@ -55,7 +55,6 @@ export type FilterArtworksInput = {
     width?: string | null;
 };
 export type collectRoutes_ArtworkFilterQueryVariables = {
-    aggregations?: Array<ArtworkAggregation | null> | null;
     sort?: string | null;
     input?: FilterArtworksInput | null;
 };
@@ -79,7 +78,6 @@ export type collectRoutes_ArtworkFilterQuery = {
 
 /*
 query collectRoutes_ArtworkFilterQuery(
-  $aggregations: [ArtworkAggregation]
   $sort: String
   $input: FilterArtworksInput
 ) {
@@ -87,7 +85,7 @@ query collectRoutes_ArtworkFilterQuery(
     ...Collect_marketingHubCollections
     id
   }
-  filterArtworks: artworksConnection(aggregations: $aggregations, sort: $sort, first: 30) {
+  filterArtworks: artworksConnection(sort: $sort, first: 30) {
     ...SeoProductsForArtworks_artworks
     id
   }
@@ -344,12 +342,6 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "aggregations",
-    "type": "[ArtworkAggregation]"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
     "name": "sort",
     "type": "String"
   },
@@ -361,11 +353,6 @@ var v0 = [
   }
 ],
 v1 = [
-  {
-    "kind": "Variable",
-    "name": "aggregations",
-    "variableName": "aggregations"
-  },
   {
     "kind": "Literal",
     "name": "first",
@@ -1227,9 +1214,9 @@ return {
     "metadata": {},
     "name": "collectRoutes_ArtworkFilterQuery",
     "operationKind": "query",
-    "text": "query collectRoutes_ArtworkFilterQuery(\n  $aggregations: [ArtworkAggregation]\n  $sort: String\n  $input: FilterArtworksInput\n) {\n  marketingHubCollections {\n    ...Collect_marketingHubCollections\n    id\n  }\n  filterArtworks: artworksConnection(aggregations: $aggregations, sort: $sort, first: 30) {\n    ...SeoProductsForArtworks_artworks\n    id\n  }\n  viewer {\n    ...ArtworkFilter_viewer_2VV6jB\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    id\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Collect_marketingHubCollections on MarketingCollection {\n  ...CollectionsHubsNav_marketingHubCollections\n}\n\nfragment CollectionsHubsNav_marketingHubCollections on MarketingCollection {\n  slug\n  title\n  thumbnail\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      category\n      date\n      href\n      is_acquireable: isAcquireable\n      is_price_range: isPriceRange\n      listPrice {\n        __typename\n        ... on PriceRange {\n          display\n        }\n        ... on Money {\n          display\n        }\n      }\n      price_currency: priceCurrency\n      title\n      artists(shallow: true) {\n        name\n        id\n      }\n      image {\n        url(version: \"larger\")\n      }\n      meta {\n        description\n      }\n      partner(shallow: true) {\n        name\n        type\n        profile {\n          icon {\n            url(version: \"larger\")\n          }\n          id\n        }\n        locations(size: 1) {\n          address\n          address_2: address2\n          city\n          state\n          country\n          postal_code: postalCode\n          phone\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query collectRoutes_ArtworkFilterQuery(\n  $sort: String\n  $input: FilterArtworksInput\n) {\n  marketingHubCollections {\n    ...Collect_marketingHubCollections\n    id\n  }\n  filterArtworks: artworksConnection(sort: $sort, first: 30) {\n    ...SeoProductsForArtworks_artworks\n    id\n  }\n  viewer {\n    ...ArtworkFilter_viewer_2VV6jB\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  aggregations {\n    slice\n    counts {\n      value\n      name\n      count\n    }\n  }\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    id\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Collect_marketingHubCollections on MarketingCollection {\n  ...CollectionsHubsNav_marketingHubCollections\n}\n\nfragment CollectionsHubsNav_marketingHubCollections on MarketingCollection {\n  slug\n  title\n  thumbnail\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworksConnection {\n  edges {\n    node {\n      id\n      availability\n      category\n      date\n      href\n      is_acquireable: isAcquireable\n      is_price_range: isPriceRange\n      listPrice {\n        __typename\n        ... on PriceRange {\n          display\n        }\n        ... on Money {\n          display\n        }\n      }\n      price_currency: priceCurrency\n      title\n      artists(shallow: true) {\n        name\n        id\n      }\n      image {\n        url(version: \"larger\")\n      }\n      meta {\n        description\n      }\n      partner(shallow: true) {\n        name\n        type\n        profile {\n          icon {\n            url(version: \"larger\")\n          }\n          id\n        }\n        locations(size: 1) {\n          address\n          address_2: address2\n          city\n          state\n          country\n          postal_code: postalCode\n          phone\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '5061f5837cb66fa4820f30b5c8d1da9b';
+(node as any).hash = '429d3b9cd624a7bae2e849a26e486d4a';
 export default node;


### PR DESCRIPTION
Looking through the fragments for the collect and collection pages, and it seems pretty clear some could be cleaned up. For instance, a bunch of requests on /collection pages are for calculating metadata, where their corresponding components don't reference any aggregation data. Some spurious `size`/`first` usage.

Also, this _re-adds_ the new aggregations back to /collect (lost in a recent refactor 🙈 ). We can keep them for QA and remove if needed.