### PR TITLE
feat: Add auctions to robot

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,6 +84,13 @@ module.exports = {
   },
   overrides: [
     {
+      files: ["src/**/*.test.js", "src/**/*.test.ts"],
+      rules: {
+        "jest/expect-expect": "off",
+        "jest/valid-describe": "off",
+      },
+    },
+    {
       files: ["webpack/**/*"],
       rules: {
         "no-console": "off",

--- a/src/desktop/apps/sitemaps/routes.coffee
+++ b/src/desktop/apps/sitemaps/routes.coffee
@@ -30,6 +30,7 @@ sitemapProxy = httpProxy.createProxyServer(target: SITEMAP_BASE_URL)
     Sitemap: #{APP_URL}/sitemap-artist-images.xml
     Sitemap: #{APP_URL}/sitemap-artist-series.xml
     Sitemap: #{APP_URL}/sitemap-artworks.xml
+    Sitemap: #{APP_URL}/sitemap-auctions.xml
     Sitemap: #{APP_URL}/sitemap-cities.xml
     Sitemap: #{APP_URL}/sitemap-collect.xml
     Sitemap: #{APP_URL}/sitemap-fairs.xml

--- a/src/desktop/apps/sitemaps/test/routes.test.js
+++ b/src/desktop/apps/sitemaps/test/routes.test.js
@@ -53,6 +53,7 @@ Sitemap: https://www.artsy.net/sitemap-artists.xml
 Sitemap: https://www.artsy.net/sitemap-artist-images.xml
 Sitemap: https://www.artsy.net/sitemap-artist-series.xml
 Sitemap: https://www.artsy.net/sitemap-artworks.xml
+Sitemap: https://www.artsy.net/sitemap-auctions.xml
 Sitemap: https://www.artsy.net/sitemap-cities.xml
 Sitemap: https://www.artsy.net/sitemap-collect.xml
 Sitemap: https://www.artsy.net/sitemap-fairs.xml


### PR DESCRIPTION
This PR does a little bit of double duty and I can break it out if you want.

It's primary purpose is to just add the auctions sitemap to our robots.txt. Given that I had to update a mocha test, there were some lint failures (because jest lint config options are being ran on our mocha tests). To remove those failures, I added an override to categorically ignore those errors across our mocha test files. We'd talked about how to handle this [in slack](https://artsy.slack.com/archives/C2TQ4PT8R/p1616519353015800), but this seems to be the simplest, broad solution. 

We can't merge this until our sitemap deploy job is back up and running so I'll leave it in draft, but the work is technically done.