### PR TITLE
chore: change copy for offer flow to include offer binding

### DIFF
--- a/src/v2/Apps/Order/Routes/Offer/index.tsx
+++ b/src/v2/Apps/Order/Routes/Offer/index.tsx
@@ -269,9 +269,8 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
                 )}
                 <Spacer mb={[2, 3]} />
                 <Message p={[2, 3]}>
-                  If your offer is accepted, your payment will be processed
-                  immediately. Keep in mind making an offer doesn’t guarantee
-                  you the work, as the seller might be receiving higher offers.
+                  Please note that all offers are binding. If your offer is
+                  accepted, your payment will be processed immediately.
                 </Message>
                 <Spacer mb={[2, 3]} />
                 <Media greaterThan="xs">

--- a/src/v2/Apps/Order/Routes/Review/index.tsx
+++ b/src/v2/Apps/Order/Routes/Review/index.tsx
@@ -343,6 +343,8 @@ export class ReviewRoute extends Component<ReviewProps> {
                     <Message p={[2, 3]} mb={[2, 3]}>
                       Disruptions caused by COVID-19 may cause delays — we
                       appreciate your understanding.
+                      <br />
+                      Please note that all offers are binding.
                     </Message>
                     {order.mode === "OFFER" && (
                       <OfferSummaryItem


### PR DESCRIPTION
This addresses [PURCHASE-2462]

## Context

Changes copy in two screens.

## Review Screen:

**Before:**
<img width="891" alt="Screenshot 2021-03-30 at 14 33 26" src="https://user-images.githubusercontent.com/4691889/112992858-dddff380-9168-11eb-8d41-069da9ad25d7.png">

**After:**

<img width="888" alt="Screenshot 2021-03-30 at 14 32 30" src="https://user-images.githubusercontent.com/4691889/112990494-6a3ce700-9166-11eb-871a-9d28d901dbb9.png">

## Offer Screen:

**Before:**
<img width="890" alt="Screenshot 2021-03-30 at 14 35 43" src="https://user-images.githubusercontent.com/4691889/112992696-b25d0900-9168-11eb-913e-bdf560738a91.png">


**After**
<img width="866" alt="Screenshot 2021-03-30 at 14 34 56" src="https://user-images.githubusercontent.com/4691889/112990510-7032c800-9166-11eb-9b55-4549ef26fc64.png">


[PURCHASE-2462]: https://artsyproduct.atlassian.net/browse/PURCHASE-2462

@artsy/purchase-devs 