### PR TITLE
fix: use resized logo instead of cropped

### DIFF
--- a/src/v2/Apps/Partner/Components/PartnerHeader/index.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerHeader/index.tsx
@@ -23,6 +23,7 @@ export interface PartnerHeaderProps {
 
 export const HeaderImage = styled(Image)`
   border: 1px solid ${color("black10")};
+  object-fit: contain;
 `
 
 export const PartnerHeader: React.FC<PartnerHeaderProps> = ({ partner }) => {
@@ -42,8 +43,8 @@ export const PartnerHeader: React.FC<PartnerHeaderProps> = ({ partner }) => {
                 style={{ display: "flex", textDecoration: "none" }}
               >
                 <HeaderImage
-                  src={partner.profile.icon.cropped.src}
-                  srcSet={partner.profile.icon.cropped.srcSet}
+                  src={partner.profile.icon.resized.src}
+                  srcSet={partner.profile.icon.resized.srcSet}
                   alt={partner.name}
                   width={[60, 80]}
                   height={[60, 80]}
@@ -97,7 +98,7 @@ export const PartnerHeaderFragmentContainer = createFragmentContainer(
         href
         profile {
           icon {
-            cropped(width: 80, height: 80, version: "square140") {
+            resized(width: 80, height: 80, version: "square140") {
               src
               srcSet
             }

--- a/src/v2/Apps/Partner/Components/__tests__/PartnerHeader.jest.tsx
+++ b/src/v2/Apps/Partner/Components/__tests__/PartnerHeader.jest.tsx
@@ -32,9 +32,11 @@ describe("PartnerHeader", () => {
       Partner: () => ({
         name: "White cube",
         profile: {
-          cropped: {
-            src: "/img.png",
-            srcSet: "/img.png",
+          icon: {
+            resized: {
+              src: "/img.png",
+              srcSet: "/img.png",
+            },
           },
         },
         locations: {
@@ -52,6 +54,7 @@ describe("PartnerHeader", () => {
     const text = wrapper.text()
 
     expect(wrapper.find(HeaderImage).length).toEqual(1)
+    expect(wrapper.find(HeaderImage).prop("src")).toEqual("/img.png")
     expect(wrapper.find(FollowProfileButton).length).toEqual(1)
     expect(text).toContain("White cube")
     expect(text).toContain("Jeddah")
@@ -134,9 +137,10 @@ describe("PartnerHeader", () => {
         name: "White cube",
         href: "/white-cube",
         profile: {
-          cropped: {
-            src: "/img.png",
-            srcSet: "/img.png",
+          icon: {
+            resized: {
+              src: "/img.png",
+            },
           },
         },
       }),
@@ -148,7 +152,11 @@ describe("PartnerHeader", () => {
 
     const PartnerIconLink = wrapper
       .find(RouterLink)
-      .filterWhere(c => c.children().find(HeaderImage).length > 0)
+      .filterWhere(
+        c =>
+          c.children().find(HeaderImage).length > 0 &&
+          c.children().find(HeaderImage).prop("src") === "/img.png"
+      )
 
     expect(PartnerNameLink.length).toEqual(1)
     expect(PartnerNameLink.first().prop("to")).toEqual("/white-cube")

--- a/src/v2/__generated__/PartnerApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PartnerApp_Test_Query.graphql.ts
@@ -47,7 +47,7 @@ fragment PartnerHeader_partner on Partner {
   href
   profile {
     icon {
-      cropped(width: 80, height: 80, version: "square140") {
+      resized(width: 80, height: 80, version: "square140") {
         src
         srcSet
       }
@@ -186,9 +186,9 @@ return {
                         "value": 80
                       }
                     ],
-                    "concreteType": "CroppedImageUrl",
+                    "concreteType": "ResizedImageUrl",
                     "kind": "LinkedField",
-                    "name": "cropped",
+                    "name": "resized",
                     "plural": false,
                     "selections": [
                       {
@@ -206,7 +206,7 @@ return {
                         "storageKey": null
                       }
                     ],
-                    "storageKey": "cropped(height:80,version:\"square140\",width:80)"
+                    "storageKey": "resized(height:80,version:\"square140\",width:80)"
                   }
                 ],
                 "storageKey": null
@@ -297,7 +297,7 @@ return {
     "metadata": {},
     "name": "PartnerApp_Test_Query",
     "operationKind": "query",
-    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n}\n\nfragment PartnerApp_partner on Partner {\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  href\n  profile {\n    icon {\n      cropped(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n}\n\nfragment PartnerApp_partner on Partner {\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  href\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnerHeader_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PartnerHeader_Test_Query.graphql.ts
@@ -16,7 +16,7 @@ export type PartnerHeader_Test_QueryRawResponse = {
         readonly href: string | null;
         readonly profile: ({
             readonly icon: ({
-                readonly cropped: ({
+                readonly resized: ({
                     readonly src: string;
                     readonly srcSet: string;
                 }) | null;
@@ -69,7 +69,7 @@ fragment PartnerHeader_partner on Partner {
   href
   profile {
     icon {
-      cropped(width: 80, height: 80, version: "square140") {
+      resized(width: 80, height: 80, version: "square140") {
         src
         srcSet
       }
@@ -201,9 +201,9 @@ return {
                         "value": 80
                       }
                     ],
-                    "concreteType": "CroppedImageUrl",
+                    "concreteType": "ResizedImageUrl",
                     "kind": "LinkedField",
-                    "name": "cropped",
+                    "name": "resized",
                     "plural": false,
                     "selections": [
                       {
@@ -221,7 +221,7 @@ return {
                         "storageKey": null
                       }
                     ],
-                    "storageKey": "cropped(height:80,version:\"square140\",width:80)"
+                    "storageKey": "resized(height:80,version:\"square140\",width:80)"
                   }
                 ],
                 "storageKey": null
@@ -317,7 +317,7 @@ return {
     "metadata": {},
     "name": "PartnerHeader_Test_Query",
     "operationKind": "query",
-    "text": "query PartnerHeader_Test_Query {\n  partner(id: \"white-cube\") {\n    ...PartnerHeader_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  href\n  profile {\n    icon {\n      cropped(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query PartnerHeader_Test_Query {\n  partner(id: \"white-cube\") {\n    ...PartnerHeader_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  href\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnerHeader_partner.graphql.ts
+++ b/src/v2/__generated__/PartnerHeader_partner.graphql.ts
@@ -9,7 +9,7 @@ export type PartnerHeader_partner = {
     readonly href: string | null;
     readonly profile: {
         readonly icon: {
-            readonly cropped: {
+            readonly resized: {
                 readonly src: string;
                 readonly srcSet: string;
             } | null;
@@ -96,9 +96,9 @@ const node: ReaderFragment = {
                   "value": 80
                 }
               ],
-              "concreteType": "CroppedImageUrl",
+              "concreteType": "ResizedImageUrl",
               "kind": "LinkedField",
-              "name": "cropped",
+              "name": "resized",
               "plural": false,
               "selections": [
                 {
@@ -116,7 +116,7 @@ const node: ReaderFragment = {
                   "storageKey": null
                 }
               ],
-              "storageKey": "cropped(height:80,version:\"square140\",width:80)"
+              "storageKey": "resized(height:80,version:\"square140\",width:80)"
             }
           ],
           "storageKey": null
@@ -185,5 +185,5 @@ const node: ReaderFragment = {
   ],
   "type": "Partner"
 };
-(node as any).hash = 'a7741b78c4d7da9422c10356dae26fad';
+(node as any).hash = '99d589f4b03544db5c03be1d2475f509';
 export default node;

--- a/src/v2/__generated__/partnerRoutes_PartnerQuery.graphql.ts
+++ b/src/v2/__generated__/partnerRoutes_PartnerQuery.graphql.ts
@@ -51,7 +51,7 @@ fragment PartnerHeader_partner on Partner {
   href
   profile {
     icon {
-      cropped(width: 80, height: 80, version: "square140") {
+      resized(width: 80, height: 80, version: "square140") {
         src
         srcSet
       }
@@ -198,9 +198,9 @@ return {
                         "value": 80
                       }
                     ],
-                    "concreteType": "CroppedImageUrl",
+                    "concreteType": "ResizedImageUrl",
                     "kind": "LinkedField",
-                    "name": "cropped",
+                    "name": "resized",
                     "plural": false,
                     "selections": [
                       {
@@ -218,7 +218,7 @@ return {
                         "storageKey": null
                       }
                     ],
-                    "storageKey": "cropped(height:80,version:\"square140\",width:80)"
+                    "storageKey": "resized(height:80,version:\"square140\",width:80)"
                   }
                 ],
                 "storageKey": null
@@ -309,7 +309,7 @@ return {
     "metadata": {},
     "name": "partnerRoutes_PartnerQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n}\n\nfragment PartnerApp_partner on Partner {\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  href\n  profile {\n    icon {\n      cropped(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n}\n\nfragment PartnerApp_partner on Partner {\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  href\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
This PR fixes the partner logo by using resized field instead of cropped.

JIRA - https://artsyproduct.atlassian.net/browse/PX-3866

Before:
![image](https://user-images.githubusercontent.com/79979820/112335021-ee0d5400-8ccc-11eb-9be9-6d3263b5d13e.png)

Now: 
![image](https://user-images.githubusercontent.com/79979820/112335673-7ab81200-8ccd-11eb-8c34-4265618a80bc.png)
