### PR TITLE
feat: make sure to expand toggle and show more appropriately

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter.tsx
@@ -1,10 +1,10 @@
 import { Checkbox, Flex, Toggle } from "@artsy/palette"
-import { sortBy } from "lodash"
+import { intersection, sortBy } from "lodash"
 import React, { FC } from "react"
 
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
-import { ShowMore } from "./ShowMore"
+import { INITIAL_ITEMS_TO_SHOW, ShowMore } from "./ShowMore"
 import { FacetAutosuggest } from "./FacetAutosuggest"
 
 const ArtistNationalityOption: React.FC<{ name: string }> = ({ name }) => {
@@ -36,7 +36,7 @@ const ArtistNationalityOption: React.FC<{ name: string }> = ({ name }) => {
 }
 
 export const ArtistNationalityFilter: FC = () => {
-  const { aggregations } = useArtworkFilterContext()
+  const { aggregations, currentlySelectedFilters } = useArtworkFilterContext()
   const nationalities = aggregations.find(
     agg => agg.slice === "ARTIST_NATIONALITY"
   )
@@ -46,6 +46,11 @@ export const ArtistNationalityFilter: FC = () => {
   }
 
   const nationalitiesSorted = sortBy(nationalities.counts, ["count"]).reverse()
+  const hasBelowTheFoldNationalityFilter =
+    intersection(
+      currentlySelectedFilters().artistNationalities,
+      nationalities.counts.slice(INITIAL_ITEMS_TO_SHOW).map(({ name }) => name)
+    ).length > 0
 
   return (
     <Toggle label="Artist nationality or ethnicity" expanded>
@@ -55,7 +60,7 @@ export const ArtistNationalityFilter: FC = () => {
           placeholder="Enter a nationality"
           facets={nationalities.counts}
         />
-        <ShowMore>
+        <ShowMore expanded={hasBelowTheFoldNationalityFilter}>
           {nationalitiesSorted.map(({ name }) => {
             return <ArtistNationalityOption key={name} name={name} />
           })}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter.tsx
@@ -1,11 +1,11 @@
 import { Checkbox, Flex, Toggle } from "@artsy/palette"
-import { sortBy } from "lodash"
+import { intersection, sortBy } from "lodash"
 import React, { FC } from "react"
 
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { FacetAutosuggest } from "./FacetAutosuggest"
 import { OptionText } from "./OptionText"
-import { ShowMore } from "./ShowMore"
+import { INITIAL_ITEMS_TO_SHOW, ShowMore } from "./ShowMore"
 
 const ArtworkLocationOption: React.FC<{ name: string }> = ({ name }) => {
   const { currentlySelectedFilters, setFilter } = useArtworkFilterContext()
@@ -36,7 +36,7 @@ const ArtworkLocationOption: React.FC<{ name: string }> = ({ name }) => {
 }
 
 export const ArtworkLocationFilter: FC = () => {
-  const { aggregations } = useArtworkFilterContext()
+  const { aggregations, currentlySelectedFilters } = useArtworkFilterContext()
   const locations = aggregations.find(agg => agg.slice === "LOCATION_CITY")
 
   if (!(locations && locations.counts)) {
@@ -44,6 +44,11 @@ export const ArtworkLocationFilter: FC = () => {
   }
 
   const locationsSorted = sortBy(locations.counts, ["count"]).reverse()
+  const hasBelowTheFoldLocationFilter =
+    intersection(
+      currentlySelectedFilters().locationCities,
+      locations.counts.slice(INITIAL_ITEMS_TO_SHOW).map(({ name }) => name)
+    ).length > 0
 
   return (
     <Toggle label="Artwork location" expanded>
@@ -53,7 +58,7 @@ export const ArtworkLocationFilter: FC = () => {
           placeholder="Enter a city"
           facets={locations.counts}
         />
-        <ShowMore>
+        <ShowMore expanded={hasBelowTheFoldLocationFilter}>
           {locationsSorted.map(({ name }) => {
             return <ArtworkLocationOption key={name} name={name} />
           })}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
@@ -1,9 +1,10 @@
 import { Checkbox, space, color, Toggle, Box } from "@artsy/palette"
+import { intersection } from "lodash"
 import React from "react"
 import styled from "styled-components"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
-import { ShowMore } from "./ShowMore"
+import { INITIAL_ITEMS_TO_SHOW, ShowMore } from "./ShowMore"
 
 const COLOR_OPTIONS = [
   { hex: "#ffffff", value: "black-and-white", name: "Black and white" },
@@ -85,17 +86,24 @@ const ColorFilterOption: React.FC<{ colorOption: ColorOption }> = ({
     </Checkbox>
   )
 }
-
 interface ColorFilterProps {
-  expanded?: boolean
+  expanded?: boolean // set to true to force expansion
 }
 
 export const ColorFilter: React.FC<ColorFilterProps> = ({
   expanded = false,
 }) => {
+  const { currentlySelectedFilters } = useArtworkFilterContext()
+  const hasBelowTheFoldColorFilter =
+    intersection(
+      currentlySelectedFilters().colors,
+      COLOR_OPTIONS.slice(INITIAL_ITEMS_TO_SHOW).map(({ value }) => value)
+    ).length > 0
+  const hasColorFilter = currentlySelectedFilters().colors.length > 0
+
   return (
-    <Toggle label="Color" expanded={expanded}>
-      <ShowMore>
+    <Toggle label="Color" expanded={hasColorFilter || expanded}>
+      <ShowMore expanded={hasBelowTheFoldColorFilter}>
         {COLOR_OPTIONS.map(colorOption => {
           return (
             <ColorFilterOption

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
@@ -1,8 +1,9 @@
 import { Checkbox, Toggle } from "@artsy/palette"
+import { intersection } from "lodash"
 import React from "react"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
-import { ShowMore } from "./ShowMore"
+import { INITIAL_ITEMS_TO_SHOW, ShowMore } from "./ShowMore"
 
 const MaterialsTermOption: React.FC<{
   /** Display value (capitalized) for this term */
@@ -37,7 +38,7 @@ const MaterialsTermOption: React.FC<{
 }
 
 export const MaterialsFilter = () => {
-  const { aggregations } = useArtworkFilterContext()
+  const { aggregations, currentlySelectedFilters } = useArtworkFilterContext()
   const materialsTerms = aggregations.find(
     agg => agg.slice === "MATERIALS_TERMS"
   )
@@ -46,9 +47,17 @@ export const MaterialsFilter = () => {
     return null
   }
 
+  const hasBelowTheFoldMaterialsFilter =
+    intersection(
+      currentlySelectedFilters().materialsTerms,
+      materialsTerms.counts
+        .slice(INITIAL_ITEMS_TO_SHOW)
+        .map(({ value }) => value)
+    ).length > 0
+
   return (
     <Toggle label="Materials" expanded>
-      <ShowMore>
+      <ShowMore expanded={hasBelowTheFoldMaterialsFilter}>
         {materialsTerms.counts.map(({ name, value }) => {
           return <MaterialsTermOption key={value} name={name} value={value} />
         })}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
@@ -2,7 +2,8 @@ import { Checkbox, Flex, Toggle } from "@artsy/palette"
 import React, { FC } from "react"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
-import { ShowMore } from "./ShowMore"
+import { ShowMore, INITIAL_ITEMS_TO_SHOW } from "./ShowMore"
+import { intersection } from "lodash"
 
 export const MediumFilter: FC = () => {
   const { aggregations, counts, ...filterContext } = useArtworkFilterContext()
@@ -28,10 +29,16 @@ export const MediumFilter: FC = () => {
   }
 
   const currentFilters = filterContext.currentlySelectedFilters()
+  const hasBelowTheFoldMediumFilter =
+    intersection(
+      currentFilters.additionalGeneIDs,
+      allowedMediums.slice(INITIAL_ITEMS_TO_SHOW).map(({ value }) => value)
+    ).length > 0
+
   return (
     <Toggle label="Medium" expanded={isExpanded}>
       <Flex flexDirection="column" alignItems="left">
-        <ShowMore>
+        <ShowMore expanded={hasBelowTheFoldMediumFilter}>
           {allowedMediums.map(({ value: slug, name }, index) => {
             return (
               <Checkbox

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
@@ -1,11 +1,11 @@
 import { Checkbox, Flex, Toggle } from "@artsy/palette"
-import { sortBy } from "lodash"
+import { intersection, sortBy } from "lodash"
 import React, { FC } from "react"
 
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
 import { FacetAutosuggest } from "./FacetAutosuggest"
-import { ShowMore } from "./ShowMore"
+import { INITIAL_ITEMS_TO_SHOW, ShowMore } from "./ShowMore"
 
 const PartnerOption: React.FC<{ name: string; slug: string }> = ({
   name,
@@ -39,7 +39,7 @@ const PartnerOption: React.FC<{ name: string; slug: string }> = ({
 }
 
 export const PartnersFilter: FC = () => {
-  const { aggregations } = useArtworkFilterContext()
+  const { aggregations, currentlySelectedFilters } = useArtworkFilterContext()
   const partners = aggregations.find(agg => agg.slice === "PARTNER")
 
   if (!(partners && partners.counts)) {
@@ -47,6 +47,11 @@ export const PartnersFilter: FC = () => {
   }
 
   const partnersSorted = sortBy(partners.counts, ["count"]).reverse()
+  const hasBelowTheFoldPartnersFilter =
+    intersection(
+      currentlySelectedFilters().partnerIDs,
+      partners.counts.slice(INITIAL_ITEMS_TO_SHOW).map(({ value }) => value)
+    ).length > 0
 
   return (
     <Toggle label="Galleries and institutions" expanded>
@@ -56,7 +61,7 @@ export const PartnersFilter: FC = () => {
           placeholder="Enter a gallery"
           facets={partners.counts}
         />
-        <ShowMore>
+        <ShowMore expanded={hasBelowTheFoldPartnersFilter}>
           {partnersSorted.map(({ name, value }) => {
             return <PartnerOption slug={value} key={name} name={name} />
           })}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ShowMore.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ShowMore.tsx
@@ -7,7 +7,7 @@ interface ShowMoreProps {
   children: JSX.Element[]
 }
 
-const INITIAL_ITEMS_TO_SHOW = 6
+export const INITIAL_ITEMS_TO_SHOW = 6
 
 export const ShowMore: React.FC<ShowMoreProps> = ({
   initial = INITIAL_ITEMS_TO_SHOW,

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
@@ -1,11 +1,12 @@
 import { Checkbox, Flex, Toggle } from "@artsy/palette"
 import React, { FC } from "react"
+import { intersection } from "underscore"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
-import { ShowMore } from "./ShowMore"
+import { INITIAL_ITEMS_TO_SHOW, ShowMore } from "./ShowMore"
 
 interface TimePeriodFilterProps {
-  expanded?: boolean
+  expanded?: boolean // set to true to force expansion
 }
 
 export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({
@@ -36,11 +37,17 @@ export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({
   }
 
   const currentFilters = filterContext.currentlySelectedFilters()
+  const hasBelowTheFoldMajorPeriodFilter =
+    intersection(
+      currentFilters.majorPeriods,
+      periods.slice(INITIAL_ITEMS_TO_SHOW).map(({ name }) => name)
+    ).length > 0
+  const hasMajorPeriodFilter = currentFilters.majorPeriods.length > 0
 
   return (
-    <Toggle label="Time period" expanded={expanded}>
+    <Toggle label="Time period" expanded={hasMajorPeriodFilter || expanded}>
       <Flex flexDirection="column">
-        <ShowMore>
+        <ShowMore expanded={hasBelowTheFoldMajorPeriodFilter}>
           {periods.map(({ name }, index) => {
             return (
               <Checkbox


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/browse/FX-2786

This is an odd one! I wasn't sure what to account for the desired behavior in some cases: ie, interactions with the filter remain, so if you've expanded or toggled, it doesn't 're-render'. That seemed possibly larger in scope, due to how the components are structured.

So, what this does, is actually check whether there is a currently selected filter in the list of options that would be visible when 'Show More' is pressed. If so, the 'expanded' state is set there directly. This has the affect of working like we'd like: if you've expanded and selected an item, that expanded state will remain irrespective of re-renders.