### PR TITLE
feat(materials filter): add autocomplete search UI

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
@@ -1,7 +1,8 @@
-import { Checkbox, Toggle } from "@artsy/palette"
 import { intersection } from "lodash"
+import { Checkbox, Flex, Toggle } from "@artsy/palette"
 import React from "react"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
+import { FacetAutosuggest } from "./FacetAutosuggest"
 import { OptionText } from "./OptionText"
 import { INITIAL_ITEMS_TO_SHOW, ShowMore } from "./ShowMore"
 
@@ -57,11 +58,18 @@ export const MaterialsFilter = () => {
 
   return (
     <Toggle label="Materials" expanded>
-      <ShowMore expanded={hasBelowTheFoldMaterialsFilter}>
-        {materialsTerms.counts.map(({ name, value }) => {
-          return <MaterialsTermOption key={value} name={name} value={value} />
-        })}
-      </ShowMore>
+      <Flex flexDirection="column">
+        <FacetAutosuggest
+          facetName="materialsTerms"
+          placeholder="Enter a material"
+          facets={materialsTerms.counts}
+        />
+        <ShowMore expanded={hasBelowTheFoldMaterialsFilter}>
+          {materialsTerms.counts.map(({ name, value }) => {
+            return <MaterialsTermOption key={value} name={name} value={value} />
+          })}
+        </ShowMore>
+      </Flex>
     </Toggle>
   )
 }

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/FacetAutosuggest.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/FacetAutosuggest.jest.tsx
@@ -17,11 +17,9 @@ const searchResults = [
 ]
 
 const simulateTyping = (wrapper: ReactWrapper, text: string) => {
-  const textArea = wrapper.find("input")
-  textArea.simulate("focus")
-  // @ts-ignore
-  textArea.getDOMNode().value = text
-  textArea.simulate("change")
+  const input = wrapper.find("input")
+  input.simulate("focus")
+  input.simulate("change", { target: { value: text } })
 }
 
 const getWrapper = suggestions => {

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/MaterialsTermFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/MaterialsTermFilter.jest.tsx
@@ -78,5 +78,38 @@ describe("MaterialsTermFilter", () => {
       expect(context.filters.materialsTerms).toContain("oil")
       expect(context.filters.materialsTerms).toContain("canvas")
     })
+
+    it("autocompletes available options", () => {
+      const wrapper = getWrapper({
+        aggregations: [
+          {
+            slice: "MATERIALS_TERMS",
+            counts: [
+              { name: "Acrylic", value: "acrylic", count: 42 },
+              { name: "Brass", value: "brass", count: 42 },
+              { name: "Bronze", value: "bronze", count: 42 },
+              { name: "Canvas", value: "canvas", count: 42 },
+              { name: "Drypoint", value: "drypoint", count: 42 },
+              { name: "Enamel", value: "enamel", count: 42 },
+              { name: "Foam", value: "foam", count: 42 },
+              { name: "Glass", value: "glass", count: 42 },
+            ],
+          },
+        ],
+      })
+
+      const input = wrapper.find("input")
+      input.simulate("focus").simulate("change", { target: { value: "b" } })
+
+      expect(wrapper.find("ItemsList").text()).toContain("Brass")
+      expect(wrapper.find("ItemsList").text()).toContain("Bronze")
+
+      expect(wrapper.find("ItemsList").text()).not.toContain("Acrylic")
+      expect(wrapper.find("ItemsList").text()).not.toContain("Canvas")
+      expect(wrapper.find("ItemsList").text()).not.toContain("Drypoint")
+      expect(wrapper.find("ItemsList").text()).not.toContain("Enamel")
+      expect(wrapper.find("ItemsList").text()).not.toContain("Foam")
+      expect(wrapper.find("ItemsList").text()).not.toContain("Glass")
+    })
   })
 })


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2645

This adds the autocomplete filtering of available aggregation options into the **Materials** filter:

<img src="https://user-images.githubusercontent.com/140521/112361414-bb059900-8ca9-11eb-9bdb-3941b092cc72.gif" width=500 />

~Tried to get a test around this, but Enzyme is not working for me — see below…~ solved