### PR TITLE
fix: add a missing assertion to artwork filter tests

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/__tests__/NewArtworkFilterMobileActionSheet.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/__tests__/NewArtworkFilterMobileActionSheet.jest.tsx
@@ -132,5 +132,15 @@ describe("the new artwork filters", () => {
     await flushPromiseQueue()
 
     expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
+
+    wrapper
+      .find("ArtistNationalityFilter")
+      .find("div")
+      .findWhere(label => label.text() === "Schenectadian")
+      .first()
+      .simulate("click")
+    await flushPromiseQueue()
+
+    expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
   })
 })


### PR DESCRIPTION
I forgot to add an assertion to one of the tests written in #7202.