### PR TITLE
chore: update artwork filter order and visibility (FX-2627)

### DIFF
--- a/src/v2/Apps/Collect/collectRoutes.tsx
+++ b/src/v2/Apps/Collect/collectRoutes.tsx
@@ -84,7 +84,7 @@ function initializeVariablesWithFilterState(params, props) {
 
   // TODO: Do these aggregations accomplish much on /collect?
   const additionalAggregations = getENV("ENABLE_NEW_ARTWORK_FILTERS")
-    ? ["LOCATION_CITY", "ARTIST_NATIONALITY", "MATERIALS_TERMS"]
+    ? ["ARTIST_NATIONALITY", "LOCATION_CITY", "MATERIALS_TERMS", "PARTNER"]
     : []
   const collectionOnlyAggregations = collectionSlug
     ? ["MERCHANDISABLE_ARTISTS", "MEDIUM", "MAJOR_PERIOD"]

--- a/src/v2/Apps/Fair/Routes/FairArtworks.tsx
+++ b/src/v2/Apps/Fair/Routes/FairArtworks.tsx
@@ -18,9 +18,9 @@ import { useRouter } from "v2/Artsy/Router/useRouter"
 import { AttributionClassFilter } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/AttributionClassFilter"
 import { getENV } from "v2/Utils/getENV"
 import { PartnersFilter } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnersFilter"
-import { ArtworkLocationFilter } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter"
 import { ArtistNationalityFilter } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter"
 import { MaterialsFilter } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter"
+import { SizeFilter2 } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter2"
 
 interface FairArtworksFilterProps {
   fair: FairArtworks_fair
@@ -44,34 +44,29 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
   // TODO: You shouldn't have to pass `relayEnvironment` and `user` through below.
   // For some reason, they are undefined when `useSystemContext()` is referenced
   // in <ArtistsFilter />. So, pass as props for now.
-  const Filters = () => (
-    <Box pr={2}>
-      <ArtistsFilter
-        fairID={fair.internalID}
-        relayEnvironment={relayEnvironment}
-        user={user}
-      />
-      <MediumFilter />
-      {getENV("ENABLE_NEW_ARTWORK_FILTERS") && <MaterialsFilter />}
-      <AttributionClassFilter />
-      <PriceRangeFilter />
-      <WaysToBuyFilter />
-      {getENV("ENABLE_NEW_ARTWORK_FILTERS") ? (
-        <>
-          <PartnersFilter />
-          <ArtworkLocationFilter />
-          <ArtistNationalityFilter />
-        </>
-      ) : (
-        <>
-          <GalleryFilter />
-        </>
-      )}
-      <SizeFilter />
-      <TimePeriodFilter />
-      <ColorFilter />
-    </Box>
-  )
+  const Filters = () => {
+    const showNewFilters = getENV("ENABLE_NEW_ARTWORK_FILTERS")
+
+    return (
+      <Box pr={2}>
+        <ArtistsFilter
+          fairID={fair.internalID}
+          relayEnvironment={relayEnvironment}
+          user={user}
+        />
+        <MediumFilter expanded />
+        {showNewFilters && <MaterialsFilter expanded />}
+        <PriceRangeFilter />
+        <AttributionClassFilter expanded />
+        {showNewFilters ? <SizeFilter2 /> : <SizeFilter />}
+        <WaysToBuyFilter />
+        {showNewFilters && <ArtistNationalityFilter expanded />}
+        <TimePeriodFilter />
+        <ColorFilter />
+        {showNewFilters ? <PartnersFilter /> : <GalleryFilter />}
+      </Box>
+    )
+  }
 
   return (
     <ArtworkFilterContextProvider

--- a/src/v2/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
@@ -58,6 +58,7 @@ describe("FairArtworks", () => {
   it("includes the artist filter", async () => {
     const wrapper = await getWrapper()
     expect(wrapper.find("ArtistsFilter").length).toBe(1)
+    wrapper.find("ArtistsFilter").find("ChevronIcon").simulate("click")
     expect(wrapper.find("ArtistsFilter").text()).toMatch(
       "Artists I follow (10)"
     )

--- a/src/v2/Apps/Fair/fairRoutes.tsx
+++ b/src/v2/Apps/Fair/fairRoutes.tsx
@@ -133,7 +133,7 @@ function initializeVariablesWithFilterState({ slug }, props) {
   let aggregations: string[] = ["TOTAL", "MAJOR_PERIOD", "ARTIST"]
   if (props.context.user) aggregations = aggregations.concat("FOLLOWED_ARTISTS")
   const additionalAggregations = getENV("ENABLE_NEW_ARTWORK_FILTERS")
-    ? ["PARTNER", "ARTIST_NATIONALITY", "MATERIALS_TERMS"]
+    ? ["ARTIST_NATIONALITY", "MATERIALS_TERMS", "PARTNER"]
     : ["GALLERY"]
   const input = {
     sort: "-decayed_merch",

--- a/src/v2/Apps/Search/searchRoutes.tsx
+++ b/src/v2/Apps/Search/searchRoutes.tsx
@@ -17,7 +17,7 @@ import { SearchAppFragmentContainer } from "./SearchApp"
 const prepareVariables = (_params, { location }) => {
   const aggregations = ["TOTAL"]
   const additionalAggregations = getENV("ENABLE_NEW_ARTWORK_FILTERS")
-    ? ["ARTIST_NATIONALITY", "LOCATION_CITY", "MATERIALS_TERMS"]
+    ? ["ARTIST_NATIONALITY", "LOCATION_CITY", "MATERIALS_TERMS", "PARTNER"]
     : []
   return {
     ...paramsToCamelCase(omit(location.query, "term")),

--- a/src/v2/Apps/Show/Components/ShowArtworks.tsx
+++ b/src/v2/Apps/Show/Components/ShowArtworks.tsx
@@ -13,9 +13,9 @@ import { ColorFilter } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/Color
 import { Box, BoxProps } from "@artsy/palette"
 import { useRouter } from "v2/Artsy/Router/useRouter"
 import { getENV } from "v2/Utils/getENV"
-import { ArtistNationalityFilter } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter"
 import { MaterialsFilter } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter"
 import { omit } from "lodash"
+import { SizeFilter2 } from "v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter2"
 
 interface ShowArtworksFilterProps extends BoxProps {
   show: ShowArtworks_show
@@ -34,18 +34,21 @@ const ShowArtworksFilter: React.FC<ShowArtworksFilterProps> = ({
 
   if (!hasFilter) return null
 
-  const Filters = () => (
-    <Box pr={2}>
-      <MediumFilter />
-      {getENV("ENABLE_NEW_ARTWORK_FILTERS") && <MaterialsFilter />}
-      <PriceRangeFilter />
-      <WaysToBuyFilter />
-      {getENV("ENABLE_NEW_ARTWORK_FILTERS") && <ArtistNationalityFilter />}
-      <SizeFilter />
-      <TimePeriodFilter />
-      <ColorFilter />
-    </Box>
-  )
+  const Filters = () => {
+    const showNewFilters = getENV("ENABLE_NEW_ARTWORK_FILTERS")
+
+    return (
+      <Box pr={2}>
+        <MediumFilter expanded />
+        {showNewFilters && <MaterialsFilter expanded />}
+        <PriceRangeFilter />
+        {showNewFilters ? <SizeFilter2 /> : <SizeFilter />}
+        <WaysToBuyFilter />
+        <TimePeriodFilter />
+        <ColorFilter />
+      </Box>
+    )
+  }
 
   // Inject custom default sort into artwork filter.
   const filters = omit(

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter.tsx
@@ -1,14 +1,20 @@
 import React from "react"
 import { ResultsFilter } from "./ResultsFilter"
 
-export const ArtistNationalityFilter: React.FC = () => {
+export interface ArtistNationalityFilterProps {
+  expanded?: boolean
+}
+
+export const ArtistNationalityFilter: React.FC<ArtistNationalityFilterProps> = ({
+  expanded,
+}) => {
   return (
     <ResultsFilter
       facetName="artistNationalities"
       slice="ARTIST_NATIONALITY"
       label="Artist nationality or ethnicity"
       placeholder="Enter a nationality"
-      expanded
+      expanded={expanded}
     />
   )
 }

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
@@ -8,7 +8,8 @@ import {
 } from "../Utils/fetchFollowedArtists"
 import { ShowMore } from "./ShowMore"
 
-interface ArtistsFilterProps {
+export interface ArtistsFilterProps {
+  expanded?: boolean
   relayEnvironment?: any
   fairID?: string
   user?: User
@@ -62,6 +63,7 @@ const ArtistItem: React.FC<{
 }
 
 export const ArtistsFilter: FC<ArtistsFilterProps> = ({
+  expanded,
   fairID,
   relayEnvironment,
   user,
@@ -94,7 +96,7 @@ export const ArtistsFilter: FC<ArtistsFilterProps> = ({
   const followedArtistArtworkCount = filterContext?.counts?.followedArtists ?? 0
 
   return (
-    <Expandable mb={1} label="Artists" expanded>
+    <Expandable mb={1} label="Artists" expanded={expanded}>
       <Flex flexDirection="column">
         <Checkbox
           disabled={!followedArtistArtworkCount}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter.tsx
@@ -1,14 +1,20 @@
 import React from "react"
 import { ResultsFilter } from "./ResultsFilter"
 
-export const ArtworkLocationFilter: React.FC = () => {
+export interface ArtworkLocationFilterProps {
+  expanded?: boolean
+}
+
+export const ArtworkLocationFilter: React.FC<ArtworkLocationFilterProps> = ({
+  expanded,
+}) => {
   return (
     <ResultsFilter
       facetName="locationCities"
       slice="LOCATION_CITY"
       label="Artwork location"
       placeholder="Enter a city"
-      expanded
+      expanded={expanded}
     />
   )
 }

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/AttributionClassFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/AttributionClassFilter.tsx
@@ -21,7 +21,13 @@ const checkboxValues = [
   },
 ]
 
-export const AttributionClassFilter: React.FC = () => {
+export interface AttributionClassFilterProps {
+  expanded?: boolean
+}
+
+export const AttributionClassFilter: React.FC<AttributionClassFilterProps> = ({
+  expanded,
+}) => {
   const filterContext = useArtworkFilterContext()
 
   const toggleSelection = (selected, name) => {
@@ -42,7 +48,7 @@ export const AttributionClassFilter: React.FC = () => {
   })
 
   return (
-    <Expandable mb={1} label="Rarity" expanded>
+    <Expandable mb={1} label="Rarity" expanded={expanded}>
       <Flex flexDirection="column">
         {checkboxValues.map(({ name, value }, index) => {
           return (

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
@@ -108,13 +108,11 @@ const ColorFilterOption: React.FC<{ colorOption: ColorOption }> = ({
     </Checkbox>
   )
 }
-interface ColorFilterProps {
+export interface ColorFilterProps {
   expanded?: boolean // set to true to force expansion
 }
 
-export const ColorFilter: React.FC<ColorFilterProps> = ({
-  expanded = false,
-}) => {
+export const ColorFilter: React.FC<ColorFilterProps> = ({ expanded }) => {
   const { currentlySelectedFilters } = useArtworkFilterContext()
   const hasBelowTheFoldColorFilter =
     intersection(

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
@@ -1,14 +1,20 @@
 import React from "react"
 import { ResultsFilter } from "./ResultsFilter"
 
-export const MaterialsFilter: React.FC = () => {
+export interface MaterialsFilterProps {
+  expanded?: boolean
+}
+
+export const MaterialsFilter: React.FC<MaterialsFilterProps> = ({
+  expanded,
+}) => {
   return (
     <ResultsFilter
       facetName="materialsTerms"
       slice="MATERIALS_TERMS"
       label="Materials"
       placeholder="Enter a material"
-      expanded
+      expanded={expanded}
     />
   )
 }

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
@@ -5,7 +5,11 @@ import { ShowMore, INITIAL_ITEMS_TO_SHOW } from "./ShowMore"
 import { intersection } from "lodash"
 import { sortResults } from "./ResultsFilter"
 
-export const MediumFilter: FC = () => {
+export interface MediumFilterProps {
+  expanded?: boolean
+}
+
+export const MediumFilter: FC<MediumFilterProps> = ({ expanded }) => {
   const { aggregations, counts, ...filterContext } = useArtworkFilterContext()
   const mediums = aggregations.find(agg => agg.slice === "MEDIUM") || {
     slice: "",
@@ -13,8 +17,6 @@ export const MediumFilter: FC = () => {
   }
   const allowedMediums =
     mediums && mediums.counts.length ? mediums.counts : hardcodedMediums
-
-  const isExpanded = !counts.artworks || counts.artworks > 0
 
   const toggleMediumSelection = (selected, slug) => {
     let geneIDs = filterContext
@@ -45,7 +47,7 @@ export const MediumFilter: FC = () => {
   )
 
   return (
-    <Expandable mb={1} label="Medium" expanded={isExpanded}>
+    <Expandable mb={1} label="Medium" expanded={(!counts.artworks || counts.artworks > 0) && expanded}>
       <Flex flexDirection="column" alignItems="left">
         <ShowMore expanded={hasBelowTheFoldMediumFilter}>
           {resultsSorted.map(({ value: slug, name }, index) => {

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
@@ -1,14 +1,18 @@
 import React from "react"
 import { ResultsFilter } from "./ResultsFilter"
 
-export const PartnersFilter: React.FC = () => {
+export interface PartnersFilterProps {
+  expanded?: boolean
+}
+
+export const PartnersFilter: React.FC<PartnersFilterProps> = ({ expanded }) => {
   return (
     <ResultsFilter
       facetName="partnerIDs"
       slice="PARTNER"
       label="Galleries and institutions"
       placeholder="Enter a gallery"
-      expanded
+      expanded={expanded}
     />
   )
 }

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
@@ -60,7 +60,13 @@ const parseRange = (range?: string) => {
   })
 }
 
-export const PriceRangeFilter: React.FC = () => {
+export interface PriceRangeFilterProps {
+  expanded?: boolean
+}
+
+export const PriceRangeFilter: React.FC<PriceRangeFilterProps> = ({
+  expanded,
+}) => {
   const [mode, setMode] = useState<"resting" | "done">("resting")
 
   const { currentlySelectedFilters, setFilter } = useArtworkFilterContext()
@@ -122,7 +128,7 @@ export const PriceRangeFilter: React.FC = () => {
 
   return (
     <>
-      <Expandable mb={1} label="Price" expanded>
+      <Expandable mb={1} label="Price" expanded={expanded}>
         {mode === "done" && (
           <Media lessThan="sm">
             <Message variant="info" my={2}>

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ResultsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ResultsFilter.tsx
@@ -1,5 +1,5 @@
 import { Flex, Expandable } from "@artsy/palette"
-import { intersection, sortBy } from "lodash"
+import { intersection, orderBy } from "lodash"
 import React from "react"
 import {
   MultiSelectArtworkFilters,
@@ -38,7 +38,7 @@ export const ResultsFilter: React.FC<ResultsFilterProps> = ({
   slice,
   label,
   placeholder,
-  expanded = true,
+  expanded,
 }) => {
   const { aggregations, currentlySelectedFilters } = useArtworkFilterContext()
   const { isFiltered, handleFilterChange } = useFacetFilter()
@@ -51,10 +51,8 @@ export const ResultsFilter: React.FC<ResultsFilterProps> = ({
     return null
   }
 
-  const resultsSorted = sortResults(
-    selectedValues,
-    sortBy(results, ["count"]).reverse()
-  )
+  const resultsOrdered = orderBy(results, ["count", "name"], ["desc", "asc"])
+  const resultsSorted = sortResults(selectedValues, resultsOrdered)
 
   const isBelowTheFoldFilterSelected =
     intersection(

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
@@ -15,12 +15,16 @@ const sizeMap = [
   { displayName: "Large (over 100cm)", name: "LARGE" },
 ]
 
+export interface SizeFilterProps {
+  expanded?: boolean
+}
+
 /**
  * Note: This is a clone of the implementation at
  * src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SizeFilter.tsx
  * adapted to work with the common ArtworkFilter.
  */
-export const SizeFilter: React.FC = () => {
+export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
   const filterContext = useArtworkFilterContext()
 
   const toggleSelection = (selected, name) => {
@@ -39,7 +43,7 @@ export const SizeFilter: React.FC = () => {
   })
 
   return (
-    <Expandable mb={1} label="Size" expanded>
+    <Expandable mb={1} label="Size" expanded={expanded}>
       <Flex flexDirection="column" alignItems="left">
         <Text variant={tokens.secondaryVariant} color="black60" mb={1}>
           This is based on the artwork’s average dimension.

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter2.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter2.tsx
@@ -51,7 +51,11 @@ const hasValue = (size: CustomSize) => {
   return size.height || size.width
 }
 
-export const SizeFilter2: React.FC = () => {
+export interface SizeFilter2Props {
+  expanded?: boolean
+}
+
+export const SizeFilter2: React.FC<SizeFilter2Props> = ({ expanded }) => {
   const { currentlySelectedFilters, setFilters } = useArtworkFilterContext()
   const { height, width } = currentlySelectedFilters()
 
@@ -121,7 +125,7 @@ export const SizeFilter2: React.FC = () => {
   })
 
   return (
-    <Expandable mb={1} label="Size" expanded>
+    <Expandable mb={1} label="Size" expanded={expanded}>
       {mode === "done" && (
         <Media lessThan="sm">
           <Message variant="info" my={2}>

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
@@ -5,13 +5,11 @@ import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { INITIAL_ITEMS_TO_SHOW, ShowMore } from "./ShowMore"
 import { sortResults } from "./ResultsFilter"
 
-interface TimePeriodFilterProps {
+export interface TimePeriodFilterProps {
   expanded?: boolean // set to true to force expansion
 }
 
-export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({
-  expanded = false,
-}) => {
+export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({ expanded }) => {
   const { aggregations, ...filterContext } = useArtworkFilterContext()
   const timePeriods = aggregations.find(agg => agg.slice === "MAJOR_PERIOD")
 

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/WaysToBuyFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/WaysToBuyFilter.tsx
@@ -12,7 +12,11 @@ interface WayToBuy {
   state: keyof ArtworkFilters
 }
 
-export const WaysToBuyFilter: FC = () => {
+export interface WaysToBuyFilterProps {
+  expanded?: boolean
+}
+
+export const WaysToBuyFilter: FC<WaysToBuyFilterProps> = ({ expanded }) => {
   const filterContext = useArtworkFilterContext()
 
   /**
@@ -58,7 +62,7 @@ export const WaysToBuyFilter: FC = () => {
   })
 
   return (
-    <Expandable mb={1} label="Ways to buy" expanded>
+    <Expandable mb={1} label="Ways to buy" expanded={expanded}>
       <Flex flexDirection="column">
         {checkboxes.map((checkbox, index) => {
           return (

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ArtistNationalityFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ArtistNationalityFilter.jest.tsx
@@ -1,38 +1,47 @@
 import { mount } from "enzyme"
 import React from "react"
-import { ArtworkFilterContextProvider } from "../../ArtworkFilterContext"
-import { ArtistNationalityFilter } from "../ArtistNationalityFilter"
+import {
+  Aggregations,
+  ArtworkFilterContextProvider,
+} from "../../ArtworkFilterContext"
+import {
+  ArtistNationalityFilter,
+  ArtistNationalityFilterProps,
+} from "../ArtistNationalityFilter"
 
 describe("ArtworkLocationFilter", () => {
-  const getWrapper = (contextProps = {}) => {
+  const aggregations: Aggregations = [
+    {
+      slice: "ARTIST_NATIONALITY",
+      counts: [
+        {
+          name: "Cat",
+          count: 10,
+          value: "cat",
+        },
+        {
+          name: "Dog",
+          count: 5,
+          value: "dog",
+        },
+      ],
+    },
+  ]
+
+  const getWrapper = (
+    contextProps = {},
+    filterProps: ArtistNationalityFilterProps = { expanded: true }
+  ) => {
     return mount(
       <ArtworkFilterContextProvider {...contextProps}>
-        <ArtistNationalityFilter />
+        <ArtistNationalityFilter {...filterProps} />
       </ArtworkFilterContextProvider>
     )
   }
 
   describe("nationalities", () => {
-    it("renders nationalities", () => {
-      const wrapper = getWrapper({
-        aggregations: [
-          {
-            slice: "ARTIST_NATIONALITY",
-            counts: [
-              {
-                name: "Cat",
-                count: 10,
-                value: "cat",
-              },
-              {
-                name: "Dog",
-                count: 5,
-                value: "dog",
-              },
-            ],
-          },
-        ],
-      })
+    it("renders artist nationalities", () => {
+      const wrapper = getWrapper({ aggregations })
       expect(wrapper.find("Checkbox").first().text()).toContain("Cat")
       expect(wrapper.find("Checkbox").last().text()).toContain("Dog")
     })
@@ -47,6 +56,23 @@ describe("ArtworkLocationFilter", () => {
         ],
       })
       expect(wrapper.html()).not.toBeTruthy()
+    })
+  })
+
+  describe("the `expanded` prop", () => {
+    it("hides the filter controls when not set", () => {
+      const wrapper = getWrapper({ aggregations }, {})
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("hides the filter controls when `false`", () => {
+      const wrapper = getWrapper({ aggregations }, { expanded: false })
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("shows the filter controls when `true`", () => {
+      const wrapper = getWrapper({ aggregations }, { expanded: true })
+      expect(wrapper.find("Checkbox").length).not.toBe(0)
     })
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ArtistsFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ArtistsFilter.jest.tsx
@@ -1,58 +1,59 @@
 import { mount } from "enzyme"
 import React from "react"
 import {
+  Aggregations,
   ArtworkFilterContextProvider,
   useArtworkFilterContext,
 } from "../../ArtworkFilterContext"
-import { ArtistsFilter } from "../ArtistsFilter"
+import { ArtistsFilter, ArtistsFilterProps } from "../ArtistsFilter"
 
 describe("ArtistsFilter", () => {
   let context
 
-  const getWrapper = (contextProps = {}) => {
+  const aggregations: Aggregations = [
+    {
+      slice: "ARTIST",
+      counts: [
+        { name: "Percy A", count: 10, value: "percy-a" },
+        { name: "Percy B", count: 10, value: "percy-b" },
+        { name: "Percy C", count: 10, value: "percy-c" },
+        { name: "Percy D", count: 10, value: "percy-d" },
+        { name: "Percy E", count: 10, value: "percy-e" },
+        { name: "Percy F", count: 10, value: "percy-f" },
+        { name: "Percy G", count: 10, value: "percy-g" },
+      ],
+    },
+  ]
+
+  const getWrapper = (
+    contextProps = {},
+    filterProps: ArtistsFilterProps = { expanded: true }
+  ) => {
     return mount(
       <ArtworkFilterContextProvider {...contextProps}>
-        <ArtistsFilterTest />
+        <ArtistsFilterTest {...filterProps} />
       </ArtworkFilterContextProvider>
     )
   }
 
-  const ArtistsFilterTest = () => {
+  const ArtistsFilterTest = (props: ArtistsFilterProps) => {
     context = useArtworkFilterContext()
-    return <ArtistsFilter />
+    return <ArtistsFilter {...props} />
   }
 
   describe("artists", () => {
     it("renders artists", () => {
       const wrapper = getWrapper({
         counts: { followedArtists: 0 },
-        aggregations: [
-          {
-            slice: "ARTIST",
-            counts: [{ name: "Percy Z", count: 10, value: "percy-z" }],
-          },
-        ],
+        aggregations,
       })
-      expect(wrapper.find("Checkbox").last().text()).toContain("Percy Z")
+      expect(wrapper.find("Checkbox").last().text()).toContain("Percy F")
     })
 
     describe("show more", () => {
       const wrapper = getWrapper({
         counts: { followedArtists: 0 },
-        aggregations: [
-          {
-            slice: "ARTIST",
-            counts: [
-              { name: "Percy A", count: 10, value: "percy-a" },
-              { name: "Percy B", count: 10, value: "percy-b" },
-              { name: "Percy C", count: 10, value: "percy-c" },
-              { name: "Percy D", count: 10, value: "percy-d" },
-              { name: "Percy E", count: 10, value: "percy-e" },
-              { name: "Percy F", count: 10, value: "percy-f" },
-              { name: "Percy G", count: 10, value: "percy-g" },
-            ],
-          },
-        ],
+        aggregations,
       })
 
       it("renders the first 6 and includes a show more expand link", () => {
@@ -61,50 +62,60 @@ describe("ArtistsFilter", () => {
         expect(wrapper.text()).not.toContain("Percy G")
       })
 
-      it("reveals the rest of the list when 'Show more' is clicked, and can then hide the list again", done => {
+      it("reveals the rest of the list when 'Show more' is clicked, and can then hide the list again", () => {
         wrapper
           .findWhere(t => t.text() === "Show more")
           .first()
           .simulate("click")
 
-        setTimeout(() => {
-          expect(wrapper.text()).toContain("Percy G")
-          expect(wrapper.text()).toContain("Hide")
-          wrapper
-            .findWhere(t => t.text() === "Hide")
-            .first()
-            .simulate("click")
+        expect(wrapper.text()).toContain("Percy G")
+        expect(wrapper.text()).toContain("Hide")
 
-          setTimeout(() => {
-            expect(wrapper.text()).toContain("Show more")
-            expect(wrapper.text()).not.toContain("Percy G")
-            done()
-          }, 0)
-        }, 0)
+        wrapper
+          .findWhere(t => t.text() === "Hide")
+          .first()
+          .simulate("click")
+
+        expect(wrapper.text()).toContain("Show more")
+        expect(wrapper.text()).not.toContain("Percy G")
       })
     })
   })
 
   describe("followed artists", () => {
-    it("updates includeArtworksByFollowedArtists on filter change", done => {
+    it("updates includeArtworksByFollowedArtists on filter change", () => {
       const wrapper = getWrapper({
         counts: { followedArtists: 5 },
-        aggregations: [{ slice: "ARTIST", counts: [{}] }],
+        aggregations,
       })
       wrapper.find("Checkbox").first().simulate("click")
 
-      setTimeout(() => {
-        expect(context.filters.includeArtworksByFollowedArtists).toEqual(true)
-        done()
-      }, 0)
+      expect(context.filters.includeArtworksByFollowedArtists).toEqual(true)
     })
 
     it("is disabled if there are no results", () => {
       const wrapper = getWrapper({
         counts: { followedArtists: 0 },
-        aggregations: [{ slice: "ARTIST", counts: [{}] }],
+        aggregations,
       })
       expect(wrapper.find("Checkbox").first().props().disabled).toBeTruthy()
+    })
+  })
+
+  describe("the `expanded` prop", () => {
+    it("hides the filter controls when not set", () => {
+      const wrapper = getWrapper({ aggregations }, {})
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("hides the filter controls when `false`", () => {
+      const wrapper = getWrapper({ aggregations }, { expanded: false })
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("shows the filter controls when `true`", () => {
+      const wrapper = getWrapper({ aggregations }, { expanded: true })
+      expect(wrapper.find("Checkbox").length).not.toBe(0)
     })
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ArtworkLocationFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ArtworkLocationFilter.jest.tsx
@@ -1,36 +1,62 @@
 import { mount } from "enzyme"
 import React from "react"
-import { ArtworkFilterContextProvider } from "../../ArtworkFilterContext"
-import { ArtworkLocationFilter } from "../ArtworkLocationFilter"
+import {
+  Aggregations,
+  ArtworkFilterContextProvider,
+} from "../../ArtworkFilterContext"
+import {
+  ArtworkLocationFilter,
+  ArtworkLocationFilterProps,
+} from "../ArtworkLocationFilter"
 
 describe("ArtworkLocationFilter", () => {
-  const getWrapper = (contextProps = {}) => {
+  const aggregations: Aggregations = [
+    {
+      slice: "LOCATION_CITY",
+      counts: [
+        {
+          name: "Cattown, Cat City, Nowhere USA",
+          count: 10,
+          value: "percy-z",
+        },
+      ],
+    },
+  ]
+
+  const getWrapper = (
+    contextProps = {},
+    filterProps: ArtworkLocationFilterProps = { expanded: true }
+  ) => {
     return mount(
       <ArtworkFilterContextProvider {...contextProps}>
-        <ArtworkLocationFilter />
+        <ArtworkLocationFilter {...filterProps} />
       </ArtworkFilterContextProvider>
     )
   }
 
   describe("locations", () => {
     it("renders locations", () => {
-      const wrapper = getWrapper({
-        aggregations: [
-          {
-            slice: "LOCATION_CITY",
-            counts: [
-              {
-                name: "Cattown, Cat City, Nowhere USA",
-                count: 10,
-                value: "percy-z",
-              },
-            ],
-          },
-        ],
-      })
+      const wrapper = getWrapper({ aggregations })
       expect(wrapper.find("Checkbox").first().text()).toContain(
         "Cattown, Cat City, Nowhere USA"
       )
+    })
+  })
+
+  describe("the `expanded` prop", () => {
+    it("hides the filter controls when not set", () => {
+      const wrapper = getWrapper({ aggregations }, {})
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("hides the filter controls when `false`", () => {
+      const wrapper = getWrapper({ aggregations }, { expanded: false })
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("shows the filter controls when `true`", () => {
+      const wrapper = getWrapper({ aggregations }, { expanded: true })
+      expect(wrapper.find("Checkbox").length).not.toBe(0)
     })
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/AttributionClassFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/AttributionClassFilter.jest.tsx
@@ -5,22 +5,27 @@ import {
   ArtworkFilterContextProvider,
   useArtworkFilterContext,
 } from "v2/Components/v2/ArtworkFilter/ArtworkFilterContext"
-import { AttributionClassFilter } from "../AttributionClassFilter"
+import {
+  AttributionClassFilter,
+  AttributionClassFilterProps,
+} from "../AttributionClassFilter"
 
 describe("AttributionClassFilter", () => {
   let context: ArtworkFilterContextProps
 
-  const getWrapper = () => {
+  const getWrapper = (
+    props: AttributionClassFilterProps = { expanded: true }
+  ) => {
     return mount(
       <ArtworkFilterContextProvider>
-        <AttributionClassFilterTest />
+        <AttributionClassFilterTest {...props} />
       </ArtworkFilterContextProvider>
     )
   }
 
-  const AttributionClassFilterTest = () => {
+  const AttributionClassFilterTest = (props: AttributionClassFilterProps) => {
     context = useArtworkFilterContext()
-    return <AttributionClassFilter />
+    return <AttributionClassFilter {...props} />
   }
 
   it("updates context on filter change", async () => {
@@ -31,5 +36,22 @@ describe("AttributionClassFilter", () => {
 
     await wrapper.find("Checkbox").at(2).simulate("click")
     expect(context.filters.attributionClass).toEqual(["unique", "open edition"])
+  })
+
+  describe("the `expanded` prop", () => {
+    it("hides the filter controls when not set", () => {
+      const wrapper = getWrapper({})
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("hides the filter controls when `false`", () => {
+      const wrapper = getWrapper({ expanded: false })
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("shows the filter controls when `true`", () => {
+      const wrapper = getWrapper({ expanded: true })
+      expect(wrapper.find("Checkbox").length).not.toBe(0)
+    })
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ColorFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ColorFilter.jest.tsx
@@ -4,22 +4,22 @@ import {
   ArtworkFilterContextProvider,
   useArtworkFilterContext,
 } from "../../ArtworkFilterContext"
-import { ColorFilter } from "../ColorFilter"
+import { ColorFilter, ColorFilterProps } from "../ColorFilter"
 
 describe("ColorFilter", () => {
   let context
 
-  const getWrapper = () => {
+  const getWrapper = (filterProps: ColorFilterProps = { expanded: true }) => {
     return mount(
       <ArtworkFilterContextProvider>
-        <ColorFilterTest />
+        <ColorFilterTest {...filterProps} />
       </ArtworkFilterContextProvider>
     )
   }
 
-  const ColorFilterTest = () => {
+  const ColorFilterTest = (props: ColorFilterProps) => {
     context = useArtworkFilterContext()
-    return <ColorFilter expanded />
+    return <ColorFilter {...props} />
   }
 
   it("initially renders the primary colors", () => {
@@ -62,5 +62,22 @@ describe("ColorFilter", () => {
     wrapper.find("Checkbox").first().simulate("click")
 
     expect(context.filters.colors).toEqual(["violet"])
+  })
+
+  describe("the `expanded` prop", () => {
+    it("hides the filter controls when not set", () => {
+      const wrapper = getWrapper({})
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("hides the filter controls when `false`", () => {
+      const wrapper = getWrapper({ expanded: false })
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("shows the filter controls when `true`", () => {
+      const wrapper = getWrapper({ expanded: true })
+      expect(wrapper.find("Checkbox").length).not.toBe(0)
+    })
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/MaterialsTermFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/MaterialsTermFilter.jest.tsx
@@ -1,73 +1,58 @@
 import { mount } from "enzyme"
 import React from "react"
 import {
+  Aggregations,
   ArtworkFilterContextProps,
   ArtworkFilterContextProvider,
   useArtworkFilterContext,
 } from "../../ArtworkFilterContext"
-import { MaterialsFilter } from "../MaterialsFilter"
+import { MaterialsFilter, MaterialsFilterProps } from "../MaterialsFilter"
 
 describe("MaterialsTermFilter", () => {
   let context: ArtworkFilterContextProps
 
-  const getWrapper = (contextProps = {}) => {
+  const aggregations: Aggregations = [
+    {
+      slice: "MATERIALS_TERMS",
+      counts: [
+        { name: "Acrylic", value: "acrylic", count: 42 },
+        { name: "Brass", value: "brass", count: 42 },
+        { name: "Bronze", value: "bronze", count: 42 },
+        { name: "Canvas", value: "canvas", count: 42 },
+        { name: "Drypoint", value: "drypoint", count: 42 },
+        { name: "Enamel", value: "enamel", count: 42 },
+        { name: "Foam", value: "foam", count: 42 },
+        { name: "Glass", value: "glass", count: 42 },
+      ],
+    },
+  ]
+
+  const getWrapper = (
+    contextProps = {},
+    filterProps: MaterialsFilterProps = { expanded: true }
+  ) => {
     return mount(
       <ArtworkFilterContextProvider {...contextProps}>
-        <MaterialsFilterTest />
+        <MaterialsFilterTest {...filterProps} />
       </ArtworkFilterContextProvider>
     )
   }
 
-  const MaterialsFilterTest = () => {
+  const MaterialsFilterTest = (props: MaterialsFilterProps) => {
     context = useArtworkFilterContext()
-    return <MaterialsFilter />
+    return <MaterialsFilter {...props} />
   }
 
   describe("materials", () => {
-    it("renders material term names", () => {
-      const wrapper = getWrapper({
-        aggregations: [
-          {
-            slice: "MATERIALS_TERMS",
-            counts: [
-              {
-                name: "Oil",
-                count: 10,
-                value: "oil",
-              },
-              {
-                name: "Canvas",
-                count: 5,
-                value: "canvas",
-              },
-            ],
-          },
-        ],
-      })
-      expect(wrapper.find("Checkbox").first().text()).toContain("Oil")
-      expect(wrapper.find("Checkbox").last().text()).toContain("Canvas")
+    it("renders the first 6 material term names", () => {
+      const wrapper = getWrapper({ aggregations })
+
+      expect(wrapper.find("Checkbox").first().text()).toContain("Acrylic")
+      expect(wrapper.find("Checkbox").last().text()).toContain("Enamel")
     })
 
     it("acts on material term values", async () => {
-      const wrapper = getWrapper({
-        aggregations: [
-          {
-            slice: "MATERIALS_TERMS",
-            counts: [
-              {
-                name: "Oil",
-                count: 10,
-                value: "oil",
-              },
-              {
-                name: "Canvas",
-                count: 5,
-                value: "canvas",
-              },
-            ],
-          },
-        ],
-      })
+      const wrapper = getWrapper({ aggregations })
 
       expect(context.filters.materialsTerms).toHaveLength(0)
 
@@ -75,28 +60,12 @@ describe("MaterialsTermFilter", () => {
       await wrapper.find("Checkbox").last().simulate("click")
 
       expect(context.filters.materialsTerms).toHaveLength(2)
-      expect(context.filters.materialsTerms).toContain("oil")
-      expect(context.filters.materialsTerms).toContain("canvas")
+      expect(context.filters.materialsTerms).toContain("acrylic")
+      expect(context.filters.materialsTerms).toContain("enamel")
     })
 
     it("autocompletes available options", () => {
-      const wrapper = getWrapper({
-        aggregations: [
-          {
-            slice: "MATERIALS_TERMS",
-            counts: [
-              { name: "Acrylic", value: "acrylic", count: 42 },
-              { name: "Brass", value: "brass", count: 42 },
-              { name: "Bronze", value: "bronze", count: 42 },
-              { name: "Canvas", value: "canvas", count: 42 },
-              { name: "Drypoint", value: "drypoint", count: 42 },
-              { name: "Enamel", value: "enamel", count: 42 },
-              { name: "Foam", value: "foam", count: 42 },
-              { name: "Glass", value: "glass", count: 42 },
-            ],
-          },
-        ],
-      })
+      const wrapper = getWrapper({ aggregations })
 
       const input = wrapper.find("input")
       input.simulate("focus").simulate("change", { target: { value: "b" } })
@@ -110,6 +79,23 @@ describe("MaterialsTermFilter", () => {
       expect(wrapper.text()).not.toContain("Enamel")
       expect(wrapper.text()).not.toContain("Foam")
       expect(wrapper.text()).not.toContain("Glass")
+    })
+  })
+
+  describe("the `expanded` prop", () => {
+    it("hides the filter controls when not set", () => {
+      const wrapper = getWrapper({ aggregations }, {})
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("hides the filter controls when `false`", () => {
+      const wrapper = getWrapper({ aggregations }, { expanded: false })
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("shows the filter controls when `true`", () => {
+      const wrapper = getWrapper({ aggregations }, { expanded: true })
+      expect(wrapper.find("Checkbox").length).not.toBe(0)
     })
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/MediumFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/MediumFilter.jest.tsx
@@ -4,22 +4,25 @@ import {
   ArtworkFilterContextProvider,
   useArtworkFilterContext,
 } from "../../ArtworkFilterContext"
-import { MediumFilter } from "../MediumFilter"
+import { MediumFilter, MediumFilterProps } from "../MediumFilter"
 
 describe("MediumFilter", () => {
   let context
 
-  const getWrapper = (props = {}) => {
+  const getWrapper = (
+    contextProps = {},
+    filterProps: MediumFilterProps = { expanded: true }
+  ) => {
     return mount(
-      <ArtworkFilterContextProvider {...props}>
-        <MediumFilterTest />
+      <ArtworkFilterContextProvider {...contextProps}>
+        <MediumFilterTest {...filterProps} />
       </ArtworkFilterContextProvider>
     )
   }
 
-  const MediumFilterTest = () => {
+  const MediumFilterTest = (props: MediumFilterProps) => {
     context = useArtworkFilterContext()
-    return <MediumFilter />
+    return <MediumFilter {...props} />
   }
 
   it("shows custom mediums if aggregations passed to context", () => {
@@ -41,13 +44,29 @@ describe("MediumFilter", () => {
     expect(wrapper.html()).not.toContain("Painting")
   })
 
-  it("selects mediums", done => {
+  it("selects mediums", () => {
     const wrapper = getWrapper()
     wrapper.find("Checkbox").first().simulate("click")
+    expect(context.filters.additionalGeneIDs).toEqual(["painting"])
+  })
 
-    setTimeout(() => {
-      expect(context.filters.additionalGeneIDs).toEqual(["painting"])
-      done()
-    }, 0)
+  describe("the `expanded` prop", () => {
+    it("hides the filter controls when not set", () => {
+      const wrapper = getWrapper({}, {})
+
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("hides the filter controls when `false`", () => {
+      const wrapper = getWrapper({}, { expanded: false })
+
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("shows the filter controls when `true`", () => {
+      const wrapper = getWrapper({}, { expanded: true })
+
+      expect(wrapper.find("Checkbox").length).not.toBe(0)
+    })
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/PartnersFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/PartnersFilter.jest.tsx
@@ -1,28 +1,51 @@
 import { mount } from "enzyme"
 import React from "react"
-import { ArtworkFilterContextProvider } from "../../ArtworkFilterContext"
-import { PartnersFilter } from "../PartnersFilter"
+import {
+  Aggregations,
+  ArtworkFilterContextProvider,
+} from "../../ArtworkFilterContext"
+import { PartnersFilter, PartnersFilterProps } from "../PartnersFilter"
 
 describe("PartnersFilter", () => {
-  const getWrapper = (contextProps = {}) => {
+  const aggregations: Aggregations = [
+    {
+      slice: "PARTNER",
+      counts: [{ name: "Percy Z", count: 10, value: "percy-z" }],
+    },
+  ]
+
+  const getWrapper = (
+    contextProps = {},
+    filterProps: PartnersFilterProps = { expanded: true }
+  ) => {
     return mount(
       <ArtworkFilterContextProvider {...contextProps}>
-        <PartnersFilter />
+        <PartnersFilter {...filterProps} />
       </ArtworkFilterContextProvider>
     )
   }
 
   describe("partners", () => {
     it("renders partners", () => {
-      const wrapper = getWrapper({
-        aggregations: [
-          {
-            slice: "PARTNER",
-            counts: [{ name: "Percy Z", count: 10, value: "percy-z" }],
-          },
-        ],
-      })
+      const wrapper = getWrapper({ aggregations })
       expect(wrapper.find("Checkbox").first().text()).toContain("Percy Z")
+    })
+  })
+
+  describe("the `expanded` prop", () => {
+    it("hides the filter controls when not set", () => {
+      const wrapper = getWrapper({ aggregations }, {})
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("hides the filter controls when `false`", () => {
+      const wrapper = getWrapper({ aggregations }, { expanded: false })
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("shows the filter controls when `true`", () => {
+      const wrapper = getWrapper({ aggregations }, { expanded: true })
+      expect(wrapper.find("Checkbox").length).not.toBe(0)
     })
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/PriceRangeFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/PriceRangeFilter.jest.tsx
@@ -7,22 +7,22 @@ import {
   ArtworkFilterContextProvider,
   useArtworkFilterContext,
 } from "../../ArtworkFilterContext"
-import { PriceRangeFilter } from "../PriceRangeFilter"
+import { PriceRangeFilter, PriceRangeFilterProps } from "../PriceRangeFilter"
 
 describe("PriceRangeFilter", () => {
   let context: ArtworkFilterContextProps
 
-  const getWrapper = () => {
+  const getWrapper = (props: PriceRangeFilterProps = { expanded: true }) => {
     return mount(
       <ArtworkFilterContextProvider>
-        <PriceRangeFilterTest />
+        <PriceRangeFilterTest {...props} />
       </ArtworkFilterContextProvider>
     )
   }
 
-  const PriceRangeFilterTest = () => {
+  const PriceRangeFilterTest = (props: PriceRangeFilterProps) => {
     context = useArtworkFilterContext()
-    return <PriceRangeFilter />
+    return <PriceRangeFilter {...props} />
   }
 
   it("renders the options", () => {
@@ -130,5 +130,29 @@ describe("PriceRangeFilter", () => {
     wrapper.find("Button").last().prop("onClick")({} as any)
 
     expect(context.filters.priceRange).toEqual("*-*")
+  })
+
+  describe("the `expanded` prop", () => {
+    it("hides the filter controls when not set", () => {
+      const wrapper = getWrapper({})
+
+      expect(wrapper.find("RadioGroup").length).toBe(0)
+    })
+
+    it("hides the filter controls when `false`", () => {
+      const wrapper = getWrapper({
+        expanded: false,
+      })
+
+      expect(wrapper.find("RadioGroup").length).toBe(0)
+    })
+
+    it("shows the filter controls when `true`", () => {
+      const wrapper = getWrapper({
+        expanded: true,
+      })
+
+      expect(wrapper.find("RadioGroup").length).not.toBe(0)
+    })
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ResultsFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ResultsFilter.jest.tsx
@@ -12,6 +12,7 @@ describe("ArtworkLocationFilter", () => {
           slice="LOCATION_CITY"
           placeholder="Enter a city"
           label="Artwork location"
+          expanded
         />
       </ArtworkFilterContextProvider>
     )

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter.jest.tsx
@@ -5,22 +5,22 @@ import {
   ArtworkFilterContextProvider,
   useArtworkFilterContext,
 } from "v2/Components/v2/ArtworkFilter/ArtworkFilterContext"
-import { SizeFilter } from "../SizeFilter"
+import { SizeFilter, SizeFilterProps } from "../SizeFilter"
 
 describe("SizeFilter", () => {
   let context: ArtworkFilterContextProps
 
-  const getWrapper = () => {
+  const getWrapper = (props: SizeFilterProps = { expanded: true }) => {
     return mount(
       <ArtworkFilterContextProvider>
-        <SizeFilterTest />
+        <SizeFilterTest {...props} />
       </ArtworkFilterContextProvider>
     )
   }
 
-  const SizeFilterTest = () => {
+  const SizeFilterTest = (props: SizeFilterProps) => {
     context = useArtworkFilterContext()
-    return <SizeFilter />
+    return <SizeFilter {...props} />
   }
 
   it("updates context on filter change", async () => {
@@ -31,5 +31,22 @@ describe("SizeFilter", () => {
 
     await wrapper.find("Checkbox").at(2).simulate("click")
     expect(context.filters.sizes).toEqual(["SMALL", "LARGE"])
+  })
+
+  describe("the `expanded` prop", () => {
+    it("hides the filter controls when not set", () => {
+      const wrapper = getWrapper({})
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("hides the filter controls when `false`", () => {
+      const wrapper = getWrapper({ expanded: false })
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("shows the filter controls when `true`", () => {
+      const wrapper = getWrapper({ expanded: true })
+      expect(wrapper.find("Checkbox").length).not.toBe(0)
+    })
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter2.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter2.jest.tsx
@@ -6,22 +6,22 @@ import {
   ArtworkFilterContextProvider,
   useArtworkFilterContext,
 } from "v2/Components/v2/ArtworkFilter/ArtworkFilterContext"
-import { SizeFilter2 } from "../SizeFilter2"
+import { SizeFilter2, SizeFilter2Props } from "../SizeFilter2"
 
 describe("SizeFilter2", () => {
   let context: ArtworkFilterContextProps
 
-  const getWrapper = () => {
+  const getWrapper = (props: SizeFilter2Props = { expanded: true }) => {
     return mount(
       <ArtworkFilterContextProvider>
-        <SizeFilterTest />
+        <SizeFilterTest {...props} />
       </ArtworkFilterContextProvider>
     )
   }
 
-  const SizeFilterTest = () => {
+  const SizeFilterTest = (props: SizeFilter2Props) => {
     context = useArtworkFilterContext()
-    return <SizeFilter2 />
+    return <SizeFilter2 {...props} />
   }
 
   const simulateTyping = (
@@ -109,5 +109,22 @@ describe("SizeFilter2", () => {
     expect(context.filters.sizes).toEqual([])
     expect(context.filters.height).toEqual("12-24")
     expect(context.filters.width).toEqual("*-*")
+  })
+
+  describe("the `expanded` prop", () => {
+    it("hides the filter controls when not set", () => {
+      const wrapper = getWrapper({})
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("hides the filter controls when `false`", () => {
+      const wrapper = getWrapper({ expanded: false })
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("shows the filter controls when `true`", () => {
+      const wrapper = getWrapper({ expanded: true })
+      expect(wrapper.find("Checkbox").length).not.toBe(0)
+    })
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/TimePeriodFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/TimePeriodFilter.jest.tsx
@@ -4,46 +4,49 @@ import {
   ArtworkFilterContextProvider,
   useArtworkFilterContext,
 } from "../../ArtworkFilterContext"
-import { TimePeriodFilter } from "../TimePeriodFilter"
+import { TimePeriodFilter, TimePeriodFilterProps } from "../TimePeriodFilter"
 
 describe("TimePeriodFilter", () => {
   let context
 
-  const getWrapper = (props = {}) => {
+  const aggregations = [
+    {
+      slice: "MAJOR_PERIOD",
+      counts: [
+        {
+          name: "2000",
+          value: "2000-period",
+        },
+        {
+          name: "Late 19th Century",
+          value: "foo-period",
+        },
+        {
+          name: "18th Century & Earlier",
+          value: "bar-period",
+        },
+      ],
+    },
+  ]
+
+  const getWrapper = (
+    contextProps = {},
+    filterProps: TimePeriodFilterProps = { expanded: true }
+  ) => {
     return mount(
-      <ArtworkFilterContextProvider {...props}>
-        <TimePeriodFilterFilterTest />
+      <ArtworkFilterContextProvider {...contextProps}>
+        <TimePeriodFilterFilterTest {...filterProps} />
       </ArtworkFilterContextProvider>
     )
   }
 
-  const TimePeriodFilterFilterTest = () => {
+  const TimePeriodFilterFilterTest = (props: TimePeriodFilterProps) => {
     context = useArtworkFilterContext()
-    return <TimePeriodFilter expanded />
+    return <TimePeriodFilter {...props} />
   }
 
   it("shows specific time periods if aggregations passed to context", () => {
-    const wrapper = getWrapper({
-      aggregations: [
-        {
-          slice: "MAJOR_PERIOD",
-          counts: [
-            {
-              name: "2000",
-              value: "2000-period",
-            },
-            {
-              name: "Late 19th Century",
-              value: "foo-period",
-            },
-            {
-              name: "18th Century & Earlier",
-              value: "bar-period",
-            },
-          ],
-        },
-      ],
-    })
+    const wrapper = getWrapper({ aggregations })
 
     expect(wrapper.html()).toContain("Late 19th Century")
     expect(wrapper.html()).toContain("18th Century &amp; Earlier")
@@ -64,13 +67,27 @@ describe("TimePeriodFilter", () => {
     expect(wrapper.html()).not.toBeTruthy()
   })
 
-  it("updates context on filter change", done => {
+  it("updates context on filter change", () => {
     const wrapper = getWrapper()
     wrapper.find("Checkbox").first().simulate("click")
 
-    setTimeout(() => {
-      expect(context.filters.majorPeriods).toEqual(["2020"])
-      done()
-    }, 0)
+    expect(context.filters.majorPeriods).toEqual(["2020"])
+  })
+
+  describe("the `expanded` prop", () => {
+    it("hides the filter controls when not set", () => {
+      const wrapper = getWrapper({}, {})
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("hides the filter controls when `false`", () => {
+      const wrapper = getWrapper({}, { expanded: false })
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("shows the filter controls when `true`", () => {
+      const wrapper = getWrapper({}, { expanded: true })
+      expect(wrapper.find("Checkbox").length).not.toBe(0)
+    })
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/WaysToBuyFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/WaysToBuyFilter.jest.tsx
@@ -4,31 +4,45 @@ import {
   ArtworkFilterContextProvider,
   useArtworkFilterContext,
 } from "../../ArtworkFilterContext"
-import { WaysToBuyFilter } from "../WaysToBuyFilter"
+import { WaysToBuyFilter, WaysToBuyFilterProps } from "../WaysToBuyFilter"
 
 describe("WaysToBuyFilter", () => {
   let context
 
-  const getWrapper = () => {
+  const getWrapper = (props: WaysToBuyFilterProps = { expanded: true }) => {
     return mount(
       <ArtworkFilterContextProvider>
-        <WaysToBuyFilterFilterTest />
+        <WaysToBuyFilterFilterTest {...props} />
       </ArtworkFilterContextProvider>
     )
   }
 
-  const WaysToBuyFilterFilterTest = () => {
+  const WaysToBuyFilterFilterTest = (props: WaysToBuyFilterProps) => {
     context = useArtworkFilterContext()
-    return <WaysToBuyFilter />
+    return <WaysToBuyFilter {...props} />
   }
 
-  it("updates context on filter change", done => {
+  it("updates context on filter change", () => {
     const wrapper = getWrapper()
     wrapper.find("Checkbox").first().simulate("click")
 
-    setTimeout(() => {
-      expect(context.filters.acquireable).toEqual(true)
-      done()
-    }, 0)
+    expect(context.filters.acquireable).toEqual(true)
+  })
+
+  describe("the `expanded` prop", () => {
+    it("hides the filter controls when not set", () => {
+      const wrapper = getWrapper({})
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("hides the filter controls when `false`", () => {
+      const wrapper = getWrapper({ expanded: false })
+      expect(wrapper.find("Checkbox").length).toBe(0)
+    })
+
+    it("shows the filter controls when `true`", () => {
+      const wrapper = getWrapper({ expanded: true })
+      expect(wrapper.find("Checkbox").length).not.toBe(0)
+    })
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/index.tsx
@@ -12,34 +12,34 @@ import { TimePeriodFilter } from "./TimePeriodFilter"
 import { WaysToBuyFilter } from "./WaysToBuyFilter"
 import { AttributionClassFilter } from "./AttributionClassFilter"
 import { getENV } from "v2/Utils/getENV"
-import { PartnersFilter } from "./PartnersFilter"
 import { ArtworkLocationFilter } from "./ArtworkLocationFilter"
 import { ArtistNationalityFilter } from "./ArtistNationalityFilter"
 import { MaterialsFilter } from "./MaterialsFilter"
+import { PartnersFilter } from "./PartnersFilter"
 
 export const ArtworkFilters: React.FC = () => {
+  const showNewFilters = getENV("ENABLE_NEW_ARTWORK_FILTERS")
+
   return (
     <Box pr={2}>
-      <MediumFilter />
-      {getENV("ENABLE_NEW_ARTWORK_FILTERS") && <MaterialsFilter />}
-      <AttributionClassFilter />
+      <MediumFilter expanded />
+      {showNewFilters && <MaterialsFilter expanded />}
       <PriceRangeFilter />
+      <AttributionClassFilter expanded />
+      {showNewFilters ? <SizeFilter2 /> : <SizeFilter />}
       <WaysToBuyFilter />
-      {getENV("ENABLE_NEW_ARTWORK_FILTERS") ? (
-        <>
-          <PartnersFilter />
-          <ArtworkLocationFilter />
-          <ArtistNationalityFilter />
-        </>
+      {showNewFilters && <ArtworkLocationFilter expanded />}
+      {showNewFilters && <ArtistNationalityFilter expanded />}
+      <TimePeriodFilter />
+      <ColorFilter />
+      {showNewFilters ? (
+        <PartnersFilter />
       ) : (
         <>
           <GalleryFilter />
           <InstitutionFilter />
         </>
       )}
-      {getENV("ENABLE_NEW_ARTWORK_FILTERS") ? <SizeFilter2 /> : <SizeFilter />}
-      <TimePeriodFilter />
-      <ColorFilter />
     </Box>
   )
 }

--- a/src/v2/Components/v2/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
@@ -64,6 +64,8 @@ describe("ArtworkFilter", () => {
       const wrapper = await getWrapper("lg", {
         onFilterClick,
       })
+
+      wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
       wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
 
       expect(onFilterClick).toHaveBeenCalledWith("acquireable", true, {
@@ -107,6 +109,8 @@ describe("ArtworkFilter", () => {
       const wrapper = await getWrapper("lg", {
         onChange,
       })
+
+      wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
       wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
 
       expect(onChange).toHaveBeenCalledWith({
@@ -164,6 +168,8 @@ describe("ArtworkFilter", () => {
       const wrapper = await getWrapper("lg", {
         onFilterClick,
       })
+
+      wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
       wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
 
       expect(trackEvent).toHaveBeenCalledWith({

--- a/src/v2/Components/v2/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
@@ -76,6 +76,10 @@ describe("ArtworkFilterMobileActionSheet", () => {
   it("mutates staged filter state instead of 'real' filter state", () => {
     const wrapper = getWrapper()
 
+    // Expand the filters we want to make assertions about
+    wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
+    wrapper.find("SizeFilter").find("ChevronIcon").simulate("click")
+
     wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
     wrapper.find("SizeFilter").find("Checkbox").first().simulate("click")
 
@@ -96,6 +100,10 @@ describe("ArtworkFilterMobileActionSheet", () => {
     })
 
     expect(wrapper.find("ApplyButton").text()).toEqual("Apply (0)")
+
+    // Expand the filters we want to make assertions about
+    wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
+    wrapper.find("PriceRangeFilter").find("ChevronIcon").simulate("click")
 
     // Select another way to buy
     wrapper


### PR DESCRIPTION
This PR addresses [FX-2627](https://artsyproduct.atlassian.net/browse/FX-2627) by reshuffling the order of artwork filters, and making them expandable.

The changes made in this PR:

1. Added missing aggregations to collect and fair surfaces
2. Changed order of filters on the following surfaces:
  - collect
  - collection
  - artist artworks
  - artist series
  - fair artworks
  - show artworks 
3. Added `expanded` prop (and corresponding tests) to the following filters:
  - artist nationality
  - artist
  - artwork location
  - attribution class (rarity)
  - color
  - gallery
  - institution
  - material
  - medium
  - partners (gallery and institution)
  - price range
  - size
  - time period
  - ways to buy
4. Updated existing tests that failed as a result of filters being collapsed by default
