### PR TITLE
fix: Fixes path to template

### DIFF
--- a/webpack/envs/clientDevelopmentConfig.js
+++ b/webpack/envs/clientDevelopmentConfig.js
@@ -56,7 +56,7 @@ export const clientDevelopmentConfig = {
     new webpack.HotModuleReplacementPlugin(),
     new LoadablePlugin({
       filename: "loadable-novo-stats.json",
-      path: path.resolve(basePath, "public/assets-novo"),
+      path: path.resolve(basePath, "public", "assets-novo"),
     }),
     new FriendlyErrorsWebpackPlugin({
       clearConsole: false,
@@ -71,7 +71,9 @@ export const clientDevelopmentConfig = {
       fileName: path.resolve(basePath, "manifest-novo.json"),
     }),
     new HtmlWebpackPlugin({
-      template: path.resolve(basePath, "src/v2/index.ejs"),
+      filename: path.resolve(basePath, "public", "index.ejs"),
+      inject: false,
+      template: path.resolve(basePath, "src", "v2", "index.ejs"),
     }),
     new ReactRefreshWebpackPlugin(),
   ],

--- a/webpack/envs/clientProductionConfig.js
+++ b/webpack/envs/clientProductionConfig.js
@@ -59,14 +59,14 @@ export const clientProductionConfig = {
       fileName: path.resolve(basePath, "manifest-novo.json"),
     }),
     new HtmlWebpackPlugin({
-      filename: path.resolve(basePath, "public/index.ejs"),
+      filename: path.resolve(basePath, "public", "index.ejs"),
       inject: false,
       minify: {
         collapseWhitespace: true,
         conservativeCollapse: true,
         removeComments: true,
       },
-      template: path.resolve(basePath, "src/v2/index.ejs"),
+      template: path.resolve(basePath, "src", "v2", "index.ejs"),
     }),
   ],
   resolve: standardResolve,


### PR DESCRIPTION
Quick fix for our `.ejs` template output. Was masked until I ran `yarn clean`, as we output the file to `public` during dev build. After folder was cleaned, realized the file wasn't outputting correctly anymore. 