### PR TITLE
chore: tweak custom size filter to match spec

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
@@ -17,7 +17,7 @@ import styled from "styled-components"
 import { Media } from "v2/Utils/Responsive"
 
 // Disables arrows in numeric inputs
-const NumericInput = styled(LabeledInput).attrs({ type: "number" })`
+export const NumericInput = styled(LabeledInput).attrs({ type: "number" })`
   /* Chrome, Safari, Edge, Opera */
   input::-webkit-outer-spin-button,
   input::-webkit-inner-spin-button {

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter2.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter2.tsx
@@ -6,13 +6,15 @@ import {
   Checkbox,
   Clickable,
   Flex,
-  Input,
   Sans,
   Spacer,
   Toggle,
+  Message,
 } from "@artsy/palette"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
+import { NumericInput } from "./PriceRangeFilter"
+import { Media } from "v2/Utils/Responsive"
 
 const sizeMap = [
   { displayName: "Small (under 40cm)", name: "SMALL" },
@@ -63,6 +65,7 @@ export const SizeFilter2: React.FC = () => {
   const [customSize, setCustomSize] = useState<CustomSize>(
     hasValue(initialCustomSize) ? initialCustomSize : DEFAULT_CUSTOM_SIZE
   )
+  const [mode, setMode] = useState<"resting" | "done">("resting")
 
   const handleInputChange = (dimension: "height" | "width", index: number) => ({
     currentTarget: { value },
@@ -110,10 +113,18 @@ export const SizeFilter2: React.FC = () => {
       ...mapSizeToRange(customSize),
     }
     setFilters(newFilters, { force: false })
+    setMode("done")
   }
 
   return (
     <Toggle label="Size" expanded>
+      {mode === "done" && (
+        <Media lessThan="sm">
+          <Message variant="info" my={2}>
+            Size set; select apply to see full results
+          </Message>
+        </Media>
+      )}
       <Flex flexDirection="column" alignItems="left">
         <Sans size="2" color="black60">
           This is based on the artwork’s average dimension.
@@ -150,10 +161,9 @@ export const SizeFilter2: React.FC = () => {
         <>
           <Text mt={1}>Width</Text>
           <Flex alignItems="flex-end">
-            <Input
-              placeholder="Inch Min"
+            <NumericInput
+              label="Inches"
               name="width_min"
-              type="number"
               min="0"
               step="1"
               value={customSize.width[0]}
@@ -162,10 +172,9 @@ export const SizeFilter2: React.FC = () => {
 
             <Spacer mx={0.5} />
 
-            <Input
-              placeholder="Inch Max"
+            <NumericInput
+              label="Inches"
               name="width_max"
-              type="number"
               min="0"
               step="1"
               value={customSize.width[1]}
@@ -175,10 +184,9 @@ export const SizeFilter2: React.FC = () => {
 
           <Text mt={1}>Height</Text>
           <Flex alignItems="flex-end">
-            <Input
-              placeholder="Inch Min"
+            <NumericInput
+              label="Inches"
               name="height_min"
-              type="number"
               min="0"
               step="1"
               value={customSize.height[0]}
@@ -187,10 +195,9 @@ export const SizeFilter2: React.FC = () => {
 
             <Spacer mx={0.5} />
 
-            <Input
-              placeholder="Inch Max"
+            <NumericInput
+              label="Inches"
               name="height_max"
-              type="number"
               min="0"
               step="1"
               value={customSize.height[1]}


### PR DESCRIPTION
![Screen Shot 2021-03-29 at 3 32 02 PM](https://user-images.githubusercontent.com/1457859/112891357-110d7e80-90a6-11eb-91b5-7814a1dccc3a.png)

Pretty light, tweaks the input a bit to match the spec, and also does the same "mode" thing as the price filter for the mobile case.