### PR TITLE
fix: use props max-width unless undefined

### DIFF
--- a/src/v2/Apps/Components/AppContainer.tsx
+++ b/src/v2/Apps/Components/AppContainer.tsx
@@ -6,6 +6,7 @@ interface AppContainerProps extends BoxProps {}
 
 export const AppContainer: React.FC<AppContainerProps> = ({
   children,
+  maxWidth: defaultMaxWidth,
   ...rest
 }) => {
   const { theme: { breakpoints = { lg: null, xl: null } } = {} } = useTheme<
@@ -15,7 +16,7 @@ export const AppContainer: React.FC<AppContainerProps> = ({
   const maxWidth = useThemeConfig({ v2: breakpoints.xl, v3: breakpoints.lg })
 
   return (
-    <Box width="100%" m="auto" maxWidth={maxWidth} {...rest}>
+    <Box width="100%" m="auto" maxWidth={defaultMaxWidth ?? maxWidth} {...rest}>
       {children}
     </Box>
   )


### PR DESCRIPTION
Thanks for catching this.

In a few places [we declare a `maxWidth` then sometimes define it](https://github.com/artsy/force/blob/523e3365d7af7313055143ba1a229176d6c3316f/src/v2/Apps/Artist/ArtistApp.tsx#L39-L44) — so this just works around this.