### PR TITLE
fix: partner profile page foreground

### DIFF
--- a/src/v2/Apps/Partner/PartnerApp.tsx
+++ b/src/v2/Apps/Partner/PartnerApp.tsx
@@ -15,10 +15,9 @@ export interface PartnerAppProps {
   partner: PartnerApp_partner
 }
 
-const Foreground = styled.div`
+const Foreground = styled(FullBleed)`
   background-color: white;
   z-index: 1;
-  width: 100%;
 `
 
 export const PartnerApp: React.FC<PartnerAppProps> = ({


### PR DESCRIPTION
This PR fixes foreground on the partner profile page.

JIRA - https://artsyproduct.atlassian.net/browse/PX-3884

Before:
![image](https://user-images.githubusercontent.com/79979820/112990531-d9b6d480-916e-11eb-997e-925f620d3c99.png)

Now:
![image](https://user-images.githubusercontent.com/79979820/112990393-aecc8080-916e-11eb-8fdc-dce16cf28c96.png)
