### PR TITLE
Add missing auctions sitemap reference

### DIFF
--- a/src/desktop/apps/sitemaps/index.coffee
+++ b/src/desktop/apps/sitemaps/index.coffee
@@ -19,6 +19,7 @@ standardSitemapRoutes = [
   '/sitemap-artists.xml',
   '/sitemap-artworks-:timestamp.xml',
   '/sitemap-artworks.xml',
+  '/sitemap-auctions.xml',
   '/sitemap-cities.xml',
   '/sitemap-collect.xml',
   '/sitemap-fairs-:timestamp.xml',


### PR DESCRIPTION
We correctly added the reference to robots.txt and routes.coffee in #7252, but missed this other place they're configured in the index.

Unfortunate.