### PR TITLE
feat: pin selected items to top of filters which are multi-select lists

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter.tsx
@@ -5,7 +5,7 @@ import React, { FC } from "react"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
 import { INITIAL_ITEMS_TO_SHOW, ShowMore } from "./ShowMore"
-import { FacetAutosuggest } from "./FacetAutosuggest"
+import { FacetAutosuggest, orderedFacets } from "./FacetAutosuggest"
 
 const ArtistNationalityOption: React.FC<{ name: string }> = ({ name }) => {
   const { currentlySelectedFilters, setFilter } = useArtworkFilterContext()
@@ -46,10 +46,14 @@ export const ArtistNationalityFilter: FC = () => {
   }
 
   const nationalitiesSorted = sortBy(nationalities.counts, ["count"]).reverse()
+  const items = orderedFacets(
+    currentlySelectedFilters().artistNationalities,
+    nationalitiesSorted
+  )
   const hasBelowTheFoldNationalityFilter =
     intersection(
       currentlySelectedFilters().artistNationalities,
-      nationalities.counts.slice(INITIAL_ITEMS_TO_SHOW).map(({ name }) => name)
+      items.slice(INITIAL_ITEMS_TO_SHOW).map(({ name }) => name)
     ).length > 0
 
   return (
@@ -61,7 +65,7 @@ export const ArtistNationalityFilter: FC = () => {
           facets={nationalities.counts}
         />
         <ShowMore expanded={hasBelowTheFoldNationalityFilter}>
-          {nationalitiesSorted.map(({ name }) => {
+          {items.map(({ name }) => {
             return <ArtistNationalityOption key={name} name={name} />
           })}
         </ShowMore>

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter.tsx
@@ -3,7 +3,7 @@ import { intersection, sortBy } from "lodash"
 import React, { FC } from "react"
 
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
-import { FacetAutosuggest } from "./FacetAutosuggest"
+import { FacetAutosuggest, orderedFacets } from "./FacetAutosuggest"
 import { OptionText } from "./OptionText"
 import { INITIAL_ITEMS_TO_SHOW, ShowMore } from "./ShowMore"
 
@@ -44,10 +44,16 @@ export const ArtworkLocationFilter: FC = () => {
   }
 
   const locationsSorted = sortBy(locations.counts, ["count"]).reverse()
+
+  const items = orderedFacets(
+    currentlySelectedFilters().locationCities,
+    locationsSorted
+  )
+
   const hasBelowTheFoldLocationFilter =
     intersection(
       currentlySelectedFilters().locationCities,
-      locations.counts.slice(INITIAL_ITEMS_TO_SHOW).map(({ name }) => name)
+      items.slice(INITIAL_ITEMS_TO_SHOW).map(({ name }) => name)
     ).length > 0
 
   return (
@@ -59,7 +65,7 @@ export const ArtworkLocationFilter: FC = () => {
           facets={locations.counts}
         />
         <ShowMore expanded={hasBelowTheFoldLocationFilter}>
-          {locationsSorted.map(({ name }) => {
+          {items.map(({ name }) => {
             return <ArtworkLocationOption key={name} name={name} />
           })}
         </ShowMore>

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/FacetAutosuggest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/FacetAutosuggest.tsx
@@ -18,6 +18,24 @@ type Facet = {
 const MAX_SUGGESTIONS = 10
 const MIN_ITEMS = 7
 
+// utility for constructing a full list of options
+// where selected items from the list will appear first,
+// followed by the remainining options.
+export const orderedFacets = (
+  selectedValues: Array<string>,
+  allItems: Array<Facet>
+) => {
+  const selectedFacets = allItems.filter(({ value }) => {
+    return selectedValues.includes(value)
+  })
+
+  return selectedFacets.concat(
+    allItems.filter(({ value }) => {
+      return !selectedValues.includes(value)
+    })
+  )
+}
+
 export const FacetAutosuggest: FC<{
   facets: Array<Facet>
   facetName: ArrayArtworkFilter
@@ -94,6 +112,7 @@ export const FacetAutosuggest: FC<{
   return (
     <Autosuggest
       suggestions={suggestions}
+      focusInputOnSuggestionClick={false}
       getSuggestionValue={getSuggestionValue}
       renderSuggestion={renderSuggestion}
       inputProps={inputProps}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
@@ -2,7 +2,7 @@ import { intersection } from "lodash"
 import { Checkbox, Flex, Toggle } from "@artsy/palette"
 import React from "react"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
-import { FacetAutosuggest } from "./FacetAutosuggest"
+import { FacetAutosuggest, orderedFacets } from "./FacetAutosuggest"
 import { OptionText } from "./OptionText"
 import { INITIAL_ITEMS_TO_SHOW, ShowMore } from "./ShowMore"
 
@@ -48,12 +48,15 @@ export const MaterialsFilter = () => {
     return null
   }
 
+  const items = orderedFacets(
+    currentlySelectedFilters().materialsTerms,
+    materialsTerms.counts
+  )
+
   const hasBelowTheFoldMaterialsFilter =
     intersection(
       currentlySelectedFilters().materialsTerms,
-      materialsTerms.counts
-        .slice(INITIAL_ITEMS_TO_SHOW)
-        .map(({ value }) => value)
+      items.slice(INITIAL_ITEMS_TO_SHOW).map(({ value }) => value)
     ).length > 0
 
   return (
@@ -65,7 +68,7 @@ export const MaterialsFilter = () => {
           facets={materialsTerms.counts}
         />
         <ShowMore expanded={hasBelowTheFoldMaterialsFilter}>
-          {materialsTerms.counts.map(({ name, value }) => {
+          {items.map(({ name, value }) => {
             return <MaterialsTermOption key={value} name={name} value={value} />
           })}
         </ShowMore>

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
@@ -4,7 +4,7 @@ import React, { FC } from "react"
 
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { OptionText } from "./OptionText"
-import { FacetAutosuggest } from "./FacetAutosuggest"
+import { FacetAutosuggest, orderedFacets } from "./FacetAutosuggest"
 import { INITIAL_ITEMS_TO_SHOW, ShowMore } from "./ShowMore"
 
 const PartnerOption: React.FC<{ name: string; slug: string }> = ({
@@ -47,10 +47,15 @@ export const PartnersFilter: FC = () => {
   }
 
   const partnersSorted = sortBy(partners.counts, ["count"]).reverse()
+
+  const items = orderedFacets(
+    currentlySelectedFilters().partnerIDs,
+    partnersSorted
+  )
   const hasBelowTheFoldPartnersFilter =
     intersection(
       currentlySelectedFilters().partnerIDs,
-      partners.counts.slice(INITIAL_ITEMS_TO_SHOW).map(({ value }) => value)
+      items.slice(INITIAL_ITEMS_TO_SHOW).map(({ value }) => value)
     ).length > 0
 
   return (
@@ -62,7 +67,7 @@ export const PartnersFilter: FC = () => {
           facets={partners.counts}
         />
         <ShowMore expanded={hasBelowTheFoldPartnersFilter}>
-          {partnersSorted.map(({ name, value }) => {
+          {items.map(({ name, value }) => {
             return <PartnerOption slug={value} key={name} name={name} />
           })}
         </ShowMore>

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/FacetAutosuggest.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/FacetAutosuggest.jest.tsx
@@ -1,4 +1,4 @@
-import { FacetAutosuggest } from "../FacetAutosuggest"
+import { FacetAutosuggest, orderedFacets } from "../FacetAutosuggest"
 import { ReactWrapper, mount } from "enzyme"
 import React from "react"
 import { ArtworkFilterContextProvider } from "../../ArtworkFilterContext"
@@ -51,5 +51,67 @@ describe("SearchBar", () => {
     simulateTyping(component, "magic")
 
     expect(component.text()).toContain("No results.")
+  })
+})
+
+describe("orderedFacets", () => {
+  it("returns the original list, but with selected items moved to the front", () => {
+    const results = [
+      {
+        value: "cat1",
+        name: "Cat 1",
+        count: 10,
+      },
+      {
+        value: "cat2",
+        name: "Cat 2",
+        count: 10,
+      },
+      {
+        value: "cat3",
+        name: "Cat 3",
+        count: 10,
+      },
+      {
+        value: "cat4",
+        name: "Cat 4",
+        count: 10,
+      },
+      {
+        value: "cat5",
+        name: "Cat 5",
+        count: 10,
+      },
+    ]
+
+    const selected = ["cat4", "cat5"]
+
+    expect(orderedFacets(selected, results)).toEqual([
+      {
+        value: "cat4",
+        name: "Cat 4",
+        count: 10,
+      },
+      {
+        value: "cat5",
+        name: "Cat 5",
+        count: 10,
+      },
+      {
+        value: "cat1",
+        name: "Cat 1",
+        count: 10,
+      },
+      {
+        value: "cat2",
+        name: "Cat 2",
+        count: 10,
+      },
+      {
+        value: "cat3",
+        name: "Cat 3",
+        count: 10,
+      },
+    ])
   })
 })


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/browse/FX-2723

This sort of winds up being relatively simple.

For each facet, we have the list of the available filter options. We also have the list of currently selected filter options for that facet. So, we create a new list of filter options, which is a reshuffle: selected items move to the front, and the rest of the options are concatenated (in their original order), with those selected items having been removed from the remaining list.

Looks like:


https://user-images.githubusercontent.com/1457859/113049099-40d58880-9171-11eb-841f-98fd416d72d8.mp4

