### PR TITLE
fix: add space between messages in checkout review

### DIFF
--- a/src/v2/Apps/Order/Routes/Review/index.tsx
+++ b/src/v2/Apps/Order/Routes/Review/index.tsx
@@ -343,7 +343,7 @@ export class ReviewRoute extends Component<ReviewProps> {
                     <Message p={[2, 3]} mb={[2, 3]}>
                       Disruptions caused by COVID-19 may cause delays — we
                       appreciate your understanding.
-                      <br />
+                      <Spacer mb={1} />
                       Please note that all offers are binding.
                     </Message>
                     {order.mode === "OFFER" && (


### PR DESCRIPTION
This addresses [https://artsyproduct.atlassian.net/browse/PURCHASE-2462] and adds some space between the two messages in the checkout review screen.