### PR TITLE
fix: change "materials" filter title to "material" (FX-2802)

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
@@ -57,7 +57,7 @@ export const MaterialsFilter = () => {
     ).length > 0
 
   return (
-    <Toggle label="Materials" expanded>
+    <Toggle label="Material" expanded>
       <Flex flexDirection="column">
         <FacetAutosuggest
           facetName="materialsTerms"


### PR DESCRIPTION
This PR addresses [FX-2802](https://artsyproduct.atlassian.net/browse/FX-2802) by changing the label on the `MediumsFilter` from "Materials" to "Material."