### PR TITLE
fix: add a trailing `s` for numeric time period filters

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
@@ -55,7 +55,7 @@ export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({
                 key={index}
                 onSelect={selected => togglePeriodSelection(selected, name)}
               >
-                <OptionText>{name}</OptionText>
+                <OptionText>{isNaN(name) ? name : `${name}s`}</OptionText>
               </Checkbox>
             )
           })}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/TimePeriodFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/TimePeriodFilter.jest.tsx
@@ -29,6 +29,10 @@ describe("TimePeriodFilter", () => {
           slice: "MAJOR_PERIOD",
           counts: [
             {
+              name: "2000",
+              value: "2000-period",
+            },
+            {
               name: "Late 19th Century",
               value: "foo-period",
             },
@@ -43,6 +47,7 @@ describe("TimePeriodFilter", () => {
 
     expect(wrapper.html()).toContain("Late 19th Century")
     expect(wrapper.html()).toContain("18th Century &amp; Earlier")
+    expect(wrapper.html()).toContain("2000s")
     expect(wrapper.html()).not.toContain("2010")
   })
 


### PR DESCRIPTION
Looks like

![Screen Shot 2021-03-31 at 12 14 46 PM](https://user-images.githubusercontent.com/1457859/113176632-b5183680-921a-11eb-88c1-f35c84499526.png)


Closes https://artsyproduct.atlassian.net/browse/FX-2800