### PR TITLE
chore: tweak custom size filter interaction when only one dimension is entered

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter2.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter2.tsx
@@ -43,8 +43,8 @@ const parseRange = (range?: string) => {
 
 const mapSizeToRange = (size: CustomSize) => {
   return {
-    height: size.height.join("-"),
-    width: size.width.join("-"),
+    height: size.height?.join("-"),
+    width: size.width?.join("-"),
   }
 }
 
@@ -61,7 +61,7 @@ export const SizeFilter2: React.FC = () => {
     width: parseRange(width),
   }
 
-  const [showCustom, setShowCustom] = useState(false)
+  const [showCustom, setShowCustom] = useState(!!hasValue(initialCustomSize))
   const [customSize, setCustomSize] = useState<CustomSize>(
     hasValue(initialCustomSize) ? initialCustomSize : DEFAULT_CUSTOM_SIZE
   )
@@ -166,7 +166,7 @@ export const SizeFilter2: React.FC = () => {
               name="width_min"
               min="0"
               step="1"
-              value={customSize.width[0]}
+              value={customSize.width && customSize.width[0]}
               onChange={handleInputChange("width", 0)}
             />
 
@@ -177,7 +177,7 @@ export const SizeFilter2: React.FC = () => {
               name="width_max"
               min="0"
               step="1"
-              value={customSize.width[1]}
+              value={customSize.width && customSize.width[1]}
               onChange={handleInputChange("width", 1)}
             />
           </Flex>
@@ -189,7 +189,7 @@ export const SizeFilter2: React.FC = () => {
               name="height_min"
               min="0"
               step="1"
-              value={customSize.height[0]}
+              value={customSize.height && customSize.height[0]}
               onChange={handleInputChange("height", 0)}
             />
 
@@ -200,7 +200,7 @@ export const SizeFilter2: React.FC = () => {
               name="height_max"
               min="0"
               step="1"
-              value={customSize.height[1]}
+              value={customSize.height && customSize.height[1]}
               onChange={handleInputChange("height", 1)}
             />
           </Flex>

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter2.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter2.jest.tsx
@@ -90,4 +90,24 @@ describe("SizeFilter2", () => {
     expect(context.filters.height).toEqual("12-16")
     expect(context.filters.width).toEqual("12-16")
   })
+
+  it("updates the filter values when only one dimension is added", async () => {
+    const wrapper = getWrapper()
+
+    wrapper
+      .find("button")
+      .filterWhere(n => n.text() === "Show custom size")
+      .simulate("click")
+
+    simulateTyping(wrapper, "height_min", "12")
+    simulateTyping(wrapper, "height_max", "24")
+
+    await wrapper
+      .find("button")
+      .filterWhere(n => n.text() === "Set size")
+      .simulate("click")
+    expect(context.filters.sizes).toEqual([])
+    expect(context.filters.height).toEqual("12-24")
+    expect(context.filters.width).toEqual("*-*")
+  })
 })


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/browse/FX-2804

No real change, besides handling the case of coming to a page with a URL like `?height=12-*` specified (only one dimension), and also expanding the 'custom' toggle if a custom range is present.