### PR TITLE
chore: dont show filter toggles if there are no available filters in those facets

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter.tsx
@@ -41,7 +41,7 @@ export const ArtistNationalityFilter: FC = () => {
     agg => agg.slice === "ARTIST_NATIONALITY"
   )
 
-  if (!(nationalities && nationalities.counts)) {
+  if (!nationalities?.counts?.length) {
     return null
   }
 

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
@@ -84,7 +84,7 @@ export const ArtistsFilter: FC<ArtistsFilterProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  if (!(artists && artists.counts)) {
+  if (!artists?.counts?.length) {
     return null
   }
 

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter.tsx
@@ -39,7 +39,7 @@ export const ArtworkLocationFilter: FC = () => {
   const { aggregations, currentlySelectedFilters } = useArtworkFilterContext()
   const locations = aggregations.find(agg => agg.slice === "LOCATION_CITY")
 
-  if (!(locations && locations.counts)) {
+  if (!locations?.counts?.length) {
     return null
   }
 

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
@@ -44,7 +44,7 @@ export const MaterialsFilter = () => {
     agg => agg.slice === "MATERIALS_TERMS"
   )
 
-  if (!(materialsTerms && materialsTerms.counts)) {
+  if (!materialsTerms?.counts?.length) {
     return null
   }
 

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
@@ -42,7 +42,7 @@ export const PartnersFilter: FC = () => {
   const { aggregations, currentlySelectedFilters } = useArtworkFilterContext()
   const partners = aggregations.find(agg => agg.slice === "PARTNER")
 
-  if (!(partners && partners.counts)) {
+  if (!partners?.counts?.length) {
     return null
   }
 

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
@@ -24,6 +24,8 @@ export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({
     periods = allowedPeriods.map(name => ({ name }))
   }
 
+  if (!periods.length) return null
+
   const togglePeriodSelection = (selected, period) => {
     let majorPeriods = filterContext
       .currentlySelectedFilters()

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ArtistNationalityFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ArtistNationalityFilter.jest.tsx
@@ -12,8 +12,8 @@ describe("ArtworkLocationFilter", () => {
     )
   }
 
-  describe("locations", () => {
-    it("renders locations", () => {
+  describe("nationalities", () => {
+    it("renders nationalities", () => {
       const wrapper = getWrapper({
         aggregations: [
           {
@@ -35,6 +35,18 @@ describe("ArtworkLocationFilter", () => {
       })
       expect(wrapper.find("Checkbox").first().text()).toContain("Cat")
       expect(wrapper.find("Checkbox").last().text()).toContain("Dog")
+    })
+
+    it("renders nothing when there are no nationalities", () => {
+      const wrapper = getWrapper({
+        aggregations: [
+          {
+            slice: "ARTIST_NATIONALITY",
+            counts: [],
+          },
+        ],
+      })
+      expect(wrapper.html()).not.toBeTruthy()
     })
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ArtistsFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ArtistsFilter.jest.tsx
@@ -83,6 +83,18 @@ describe("ArtistsFilter", () => {
         }, 0)
       })
     })
+
+    it("renders nothing when there are no artists", () => {
+      const wrapper = getWrapper({
+        aggregations: [
+          {
+            slice: "ARTIST",
+            counts: [],
+          },
+        ],
+      })
+      expect(wrapper.html()).not.toBeTruthy()
+    })
   })
 
   describe("followed artists", () => {

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ArtworkLocationFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/ArtworkLocationFilter.jest.tsx
@@ -32,5 +32,17 @@ describe("ArtworkLocationFilter", () => {
         "Cattown, Cat City, Nowhere USA"
       )
     })
+
+    it("renders nothing when there are no locations", () => {
+      const wrapper = getWrapper({
+        aggregations: [
+          {
+            slice: "LOCATION_CITY",
+            counts: [],
+          },
+        ],
+      })
+      expect(wrapper.html()).not.toBeTruthy()
+    })
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/MaterialsTermFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/MaterialsTermFilter.jest.tsx
@@ -48,6 +48,18 @@ describe("MaterialsTermFilter", () => {
       expect(wrapper.find("Checkbox").last().text()).toContain("Canvas")
     })
 
+    it("renders nothing when there are no material terms", () => {
+      const wrapper = getWrapper({
+        aggregations: [
+          {
+            slice: "MATERIALS_TERMS",
+            counts: [],
+          },
+        ],
+      })
+      expect(wrapper.html()).not.toBeTruthy()
+    })
+
     it("acts on material term values", async () => {
       const wrapper = getWrapper({
         aggregations: [

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/MediumFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/MediumFilter.jest.tsx
@@ -41,6 +41,18 @@ describe("MediumFilter", () => {
     expect(wrapper.html()).not.toContain("Painting")
   })
 
+  it("renders the standard mediums when there are no medium aggregations", () => {
+    const wrapper = getWrapper({
+      aggregations: [
+        {
+          slice: "MEDIUM",
+          counts: [],
+        },
+      ],
+    })
+    expect(wrapper.html()).toContain("Painting")
+  })
+
   it("selects mediums", done => {
     const wrapper = getWrapper()
     wrapper.find("Checkbox").first().simulate("click")

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/PartnersFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/PartnersFilter.jest.tsx
@@ -24,5 +24,17 @@ describe("PartnersFilter", () => {
       })
       expect(wrapper.find("Checkbox").first().text()).toContain("Percy Z")
     })
+
+    it("renders nothing when there are no partners", () => {
+      const wrapper = getWrapper({
+        aggregations: [
+          {
+            slice: "PARTNER",
+            counts: [],
+          },
+        ],
+      })
+      expect(wrapper.html()).not.toBeTruthy()
+    })
   })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/TimePeriodFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/TimePeriodFilter.jest.tsx
@@ -51,6 +51,18 @@ describe("TimePeriodFilter", () => {
     expect(wrapper.html()).not.toContain("2010")
   })
 
+  it("renders nothing when there are no time periods", () => {
+    const wrapper = getWrapper({
+      aggregations: [
+        {
+          slice: "MAJOR_PERIOD",
+          counts: [],
+        },
+      ],
+    })
+    expect(wrapper.html()).not.toBeTruthy()
+  })
+
   it("updates context on filter change", done => {
     const wrapper = getWrapper()
     wrapper.find("Checkbox").first().simulate("click")


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/browse/FX-2801

The exist-y check wasn't enough, needs a better check on the length of available counts (which could be empty).