### PR TITLE
fix: Disable react refresh overlay

### DIFF
--- a/webpack/envs/clientDevelopmentConfig.js
+++ b/webpack/envs/clientDevelopmentConfig.js
@@ -68,9 +68,7 @@ export const clientDevelopmentConfig = {
       template: path.resolve(basePath, "src", "v2", "index.ejs"),
     }),
     new ReactRefreshWebpackPlugin({
-      overlay: {
-        sockIntegration: "whm",
-      },
+      overlay: false,
     }),
   ],
   resolve: standardResolve,

--- a/webpack/envs/legacyDevelopmentConfig.js
+++ b/webpack/envs/legacyDevelopmentConfig.js
@@ -67,9 +67,7 @@ export const legacyDevelopmentConfig = {
     }),
     new WebpackNotifierPlugin(),
     new ReactRefreshWebpackPlugin({
-      overlay: {
-        sockIntegration: "whm",
-      },
+      overlay: false,
     }),
   ],
   stats: env.webpackStats || "errors-only",


### PR DESCRIPTION
We were getting some confusing behavior with the new react refresh plugin which masked errors during the server-render pass. Disabling for now in favor of what was there before. 

Problem:

<img width="384" alt="Screen Shot 2021-03-31 at 3 28 44 PM" src="https://user-images.githubusercontent.com/236943/113220335-dd625e00-9237-11eb-926b-c0692116eb0e.png">

Solution: 

<img width="977" alt="Screen Shot 2021-03-31 at 3 30 25 PM" src="https://user-images.githubusercontent.com/236943/113220346-e18e7b80-9237-11eb-9c3d-eeea8ec17e58.png">
 

