### PR TITLE
fix(fullbleed): prevents persistent scrollbars from causing an overflow-x scroll on screens with fullbleed

### DIFF
--- a/src/v2/Apps/Components/AppShell.tsx
+++ b/src/v2/Apps/Components/AppShell.tsx
@@ -45,7 +45,7 @@ export const AppShell: React.FC<AppShellProps> = props => {
   useMaybeReloadAfterInquirySignIn()
 
   return (
-    <Box width="100%">
+    <Box width="100%" overflowX="hidden">
       <Box pb={[MOBILE_NAV_HEIGHT, NAV_BAR_HEIGHT]}>
         <Box left={0} position="fixed" width="100%" zIndex={100}>
           <NavBar />


### PR DESCRIPTION
Via: https://css-tricks.com/full-width-containers-limited-width-parents/

> The viewport-percentage lengths are relative to the size of the initial containing block. When the height or width of the initial containing block is changed, they are scaled accordingly. However, any scrollbars are assumed not to exist.
- https://www.w3.org/TR/css3-values/#viewport-relative-lengths

Which is: *interesting*.

Setting `overflow-x: hidden` on our app shell fixes this.