### PR TITLE
feature: Enable Gene Routes

### DIFF
--- a/src/desktop/lib/webpackPublicPath.ts
+++ b/src/desktop/lib/webpackPublicPath.ts
@@ -40,6 +40,7 @@ if (process.env.NODE_ENV === "production") {
     "/fair/",
     "/fairs",
     "/feature/",
+    "/gene2",
     "/identity-verification",
     "/order",
     "/search",

--- a/src/v2/routes.tsx
+++ b/src/v2/routes.tsx
@@ -23,6 +23,13 @@ import { searchRoutes } from "v2/Apps/Search/searchRoutes"
 import { showRoutes } from "v2/Apps/Show/showRoutes"
 import { viewingRoomRoutes } from "v2/Apps/ViewingRoom/viewingRoomRoutes"
 
+/**
+ * **WARNING***
+ *
+ * When adding a new route to this file, be sure to add route to
+ * `src/desktop/lib/webpackPublicPath.ts` as well. This is temporary until the
+ * assets paths have stabilized.
+ */
 export function getAppRoutes(): RouteConfig[] {
   return buildAppRoutes([
     {


### PR DESCRIPTION
Add gene routes to `webpackPublicPath` so that the assets load from the
cdn properly.