### PR TITLE
fix(fx-2803): prevents input zoom

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@artsy/express-reloadable": "1.4.8",
     "@artsy/fresnel": "1.3.1",
     "@artsy/gemup": "0.1.0",
-    "@artsy/palette": "14.14.0",
+    "@artsy/palette": "14.15.0",
     "@artsy/passport": "1.8.0",
     "@artsy/reaction": "29.0.2",
     "@artsy/stitch": "6.2.0",

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
@@ -14,6 +14,7 @@ import {
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import styled from "styled-components"
 import { Media } from "v2/Utils/Responsive"
+import { themeGet } from "@styled-system/theme-get"
 
 // Disables arrows in numeric inputs
 export const NumericInput = styled(LabeledInput).attrs({ type: "number" })`
@@ -27,6 +28,14 @@ export const NumericInput = styled(LabeledInput).attrs({ type: "number" })`
   /* Firefox */
   input[type="number"] {
     -moz-appearance: textfield;
+  }
+
+  /* HACK: Setting the font-size to a minimum 16px prevents iOS from zooming on focus */
+  /* This won't be necessary when upgraded to Palette v3 */
+  @media ${themeGet("mediaQueries.xs")} {
+    input {
+      font-size: 16px;
+    }
   }
 `
 

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
@@ -47,7 +47,7 @@ export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({
 
   return (
     <Expandable
-      mb={2}
+      mb={1}
       label="Time period"
       expanded={hasMajorPeriodFilter || expanded}
     >

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,10 +65,10 @@
   dependencies:
     uuid "^8.3.0"
 
-"@artsy/palette@14.14.0":
-  version "14.14.0"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-14.14.0.tgz#0615ca7ceb26c7951f09a1b48593fc121dc78185"
-  integrity sha512-nuvoT9qXeNMh9wqGcGKcH1HzXbC4G9ccrZCWJHujwtTdycpCF/P3gY31PnVvtrnUtJt7EUEr3pInFOdBkl1JFw==
+"@artsy/palette@14.15.0":
+  version "14.15.0"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-14.15.0.tgz#7c872de4bbd75e9de29dc9972aa28a7c320e843c"
+  integrity sha512-2PljXrOmlVFekHgY5ltPCAth9jJLQaJW9//YZUmxBqc+zYVE2CphqsoyaVThlkMTVyWotoGzx+3x/gM8rzrEXg==
   dependencies:
     "@styled-system/theme-get" "^5.1.2"
     d3-interpolate "^1.3.2"


### PR DESCRIPTION
Obviously all other inputs will continue to zoom on focus (including search): which we don't really want... once we move to Palette v3 this will no longer be an issue. For now this handles this single input with a media query.

![](https://static.damonzucconi.com/_capture/t1HV3rSn.gif)