### PR TITLE
fix: fix collection type error in mobile browser

### DIFF
--- a/src/v2/Apps/Collect/Routes/Collection/Components/Header/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/Header/index.tsx
@@ -203,7 +203,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                               {smallerScreen ? (
                                 <ReadMore
                                   maxChars={chars}
-                                  content={htmlUnsafeDescription || ""}
+                                  content={collection.description || ""}
                                 />
                               ) : (
                                 htmlUnsafeDescription


### PR DESCRIPTION
**Description:**

Passing htmlUnsafeDescription to ReadMore was causing a type error/500 for mobile browsers. Not sure if this is the correct fix please advise if there is a better way 🙏  

Affected url:

`/collection/first-look-women-artists-to-watch-2021`

Reproduce locally:
```
curl -A "Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Mobile Safari/537.36" 'http://localhost:4000/collection/first-look-women-artists-to-watch-2021'
```

**Before:**
<img width="784" alt="Screen Shot 2021-04-02 at 11 06 31 AM" src="https://user-images.githubusercontent.com/49686530/113427686-811c4d00-93a3-11eb-897f-f39dcf5c40c8.png">

**After:**
<img width="823" alt="Screen Shot 2021-04-02 at 11 04 20 AM" src="https://user-images.githubusercontent.com/49686530/113427552-3ac6ee00-93a3-11eb-94ab-65de336574af.png">

See slack thread for more details:
https://artsy.slack.com/archives/CA8SANW3W/p1617292009246000
