### PR TITLE
fix(sticky): works around overflow-x: hidden sticky interference

### DIFF
--- a/src/v2/Apps/Components/AppShell.tsx
+++ b/src/v2/Apps/Components/AppShell.tsx
@@ -45,7 +45,11 @@ export const AppShell: React.FC<AppShellProps> = props => {
   useMaybeReloadAfterInquirySignIn()
 
   return (
-    <Box width="100%" overflowX="hidden">
+    <Box
+      width="100%"
+      // Prevents horizontal scrollbars from `FullBleed` + persistent vertical scrollbars
+      overflowX="hidden"
+    >
       <Box pb={[MOBILE_NAV_HEIGHT, NAV_BAR_HEIGHT]}>
         <Box left={0} position="fixed" width="100%" zIndex={100}>
           <NavBar />

--- a/src/v2/Apps/Partner/Components/NavigationTabs/index.tsx
+++ b/src/v2/Apps/Partner/Components/NavigationTabs/index.tsx
@@ -1,31 +1,15 @@
 import { breakpoints, DROP_SHADOW } from "@artsy/palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import styled, { css } from "styled-components"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
 import { FullBleed } from "v2/Components/FullBleed"
 import { RouteTab, RouteTabs } from "v2/Components/RouteTabs"
-import { BaseContainer, StickyContainer } from "v2/Components/StickyContainer"
+import { StickyContainer } from "v2/Components/StickyContainer"
 import { NavigationTabs_partner } from "v2/__generated__/NavigationTabs_partner.graphql"
 
 interface NavigationTabsProps {
   partner: NavigationTabs_partner
 }
-
-export const Container = styled(BaseContainer)`
-  ${({ stuck }) =>
-    stuck
-      ? css`
-          & > div {
-            box-shadow: ${DROP_SHADOW};
-          }
-        `
-      : css`
-          & > div {
-            box-shadow: none;
-          }
-        `};
-`
 
 export const NavigationTabs: React.FC<NavigationTabsProps> = ({ partner }) => {
   const renderTabs = () => {
@@ -78,12 +62,19 @@ export const NavigationTabs: React.FC<NavigationTabsProps> = ({ partner }) => {
   }
 
   return (
-    <StickyContainer ContainerComponent={Container}>
-      <FullBleed py={2}>
-        <HorizontalPadding maxWidth={breakpoints.xl}>
-          <RouteTabs fill>{renderTabs()}</RouteTabs>
-        </HorizontalPadding>
-      </FullBleed>
+    <StickyContainer>
+      {({ stuck }) => {
+        return (
+          <FullBleed
+            py={2}
+            style={stuck ? { boxShadow: DROP_SHADOW } : undefined}
+          >
+            <HorizontalPadding maxWidth={breakpoints.xl}>
+              <RouteTabs fill>{renderTabs()}</RouteTabs>
+            </HorizontalPadding>
+          </FullBleed>
+        )
+      }}
     </StickyContainer>
   )
 }

--- a/src/v2/Components/v2/ArtworkFilter/index.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/index.tsx
@@ -211,15 +211,35 @@ export const BaseArtworkFilter: React.FC<
           )}
 
           <StickyContainer>
-            <Button size="small" onClick={() => toggleMobileActionSheet(true)}>
-              <Flex justifyContent="space-between" alignItems="center">
-                <FilterIcon fill="white100" />
-                <Spacer mr={0.5} />
-                Filter
-              </Flex>
-            </Button>
+            {({ stuck }) => {
+              return (
+                <Flex
+                  justifyContent="space-between"
+                  alignItems="center"
+                  py={1}
+                  {...(stuck
+                    ? {
+                        px: 2,
+                        borderBottom: "1px solid",
+                        borderColor: "black10",
+                      }
+                    : {})}
+                >
+                  <Button
+                    size="small"
+                    onClick={() => toggleMobileActionSheet(true)}
+                  >
+                    <Flex justifyContent="space-between" alignItems="center">
+                      <FilterIcon fill="white100" />
+                      <Spacer mr={0.5} />
+                      Filter
+                    </Flex>
+                  </Button>
 
-            <SortFilter />
+                  <SortFilter />
+                </Flex>
+              )
+            }}
           </StickyContainer>
 
           <Spacer mb={2} />


### PR DESCRIPTION
Closes: https://artsyproduct.atlassian.net/browse/FX-2809

Re: https://artsyproduct.atlassian.net/browse/FX-2796?focusedCommentId=36021

I always forget about [this issue](https://github.com/w3c/csswg-drafts/issues/865) which is a huge gotcha when using `position: sticky`. The thing that will finally fix this long-standing annoyance is `overflow: clip` but [that's not widely supported yet](https://caniuse.com/?search=overflow)
https://caniuse.com/?search=overflow

We're already tracking the intersection here so it's not much of a leap to just replicating what `position: sticky` does using `position: fixed` and a placeholder.

I've also refactored away having to pass in a `Container` prop in favor of just optionally supporting a function-as-prop. I was going to do a context + hook thing here but I think we'll only ever need it on the first level anyway so this simplifies things quite a bit.