### PR TITLE
fix: Split getParams functions

### DIFF
--- a/src/v2/Utils/getClientParam.tsx
+++ b/src/v2/Utils/getClientParam.tsx
@@ -1,10 +1,3 @@
-export function getServerParam(req, name): string | null {
-  if (req.query && req.query.hasOwnProperty(name)) {
-    return req.query[name]
-  }
-  return null
-}
-
 export function getClientParam(name: string): string | null {
   const urlParams = new URLSearchParams(window.location.search)
   if (urlParams.has(name)) {

--- a/src/v2/Utils/getServerParam.tsx
+++ b/src/v2/Utils/getServerParam.tsx
@@ -1,0 +1,6 @@
+export function getServerParam(req, name): string | null {
+  if (req.query && req.query.hasOwnProperty(name)) {
+    return req.query[name]
+  }
+  return null
+}

--- a/src/v2/client.tsx
+++ b/src/v2/client.tsx
@@ -7,7 +7,7 @@ import { loadableReady } from "@loadable/component"
 import { logoutEventHandler } from "desktop/lib/logoutHandler"
 import { mediator } from "lib/mediator"
 import { beforeAnalyticsReady, onAnalyticsReady } from "lib/analytics/helpers"
-import { getClientParam } from "./Utils/getParam"
+import { getClientParam } from "./Utils/getClientParam"
 
 async function setupClient() {
   const clientImports = await Promise.all([

--- a/src/v2/server.ts
+++ b/src/v2/server.ts
@@ -7,7 +7,7 @@ import ReactDOM from "react-dom/server"
 import loadAssetManifest from "lib/manifest"
 import express from "express"
 import path from "path"
-import { getServerParam } from "./Utils/getParam"
+import { getServerParam } from "./Utils/getServerParam"
 
 // TODO: Use the same variables as the asset middleware. Both config and sharify
 // have a default CDN_URL while this does not.


### PR DESCRIPTION
Follow-up on https://github.com/artsy/force/pull/7294

Splits `getParams` function into server and client. 