### PR TITLE
feature: Client Modal Bundle

### DIFF
--- a/src/v2/client.tsx
+++ b/src/v2/client.tsx
@@ -12,15 +12,15 @@ import { getClientParam } from "./Utils/getClientParam"
 async function setupClient() {
   const clientImports = await Promise.all([
     import(
-      /* webpackChunkName: "buildClientApp" */
+      /* webpackChunkName: "clientAppMain" */
       "v2/Artsy/Router/client"
     ),
     import(
-      /* webpackChunkName: "initModalManager" */
+      /* webpackChunkName: "clientAppModals" */
       "desktop/apps/authentication/client/initModalManager"
     ),
     import(
-      /* webpackChunkName: "setupArtistSignUpModal" */
+      /* webpackChunkName: "clientAppModals" */
       "desktop/components/artistSignupModal/artistSignupModal"
     ),
   ])


### PR DESCRIPTION
The client modal bundles have been merged together. Previously there were
two bundles, 22 KB and 2 KB. The 2 KB bundle was is unlikely to be beneficial
because the time to initiate a connection is similar to the time to download.

No specific speeds gains here however one less network request is always
preferable.