### PR TITLE
fix: change materials filter title to material again

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/MaterialsFilter.tsx
@@ -12,7 +12,7 @@ export const MaterialsFilter: React.FC<MaterialsFilterProps> = ({
     <ResultsFilter
       facetName="materialsTerms"
       slice="MATERIALS_TERMS"
-      label="Materials"
+      label="Material"
       placeholder="Enter a material"
       expanded={expanded}
     />


### PR DESCRIPTION
This is a follow-up to #7267 because that change got overwritten.