### PR TITLE
GRO-277: Update /auctions header layout

### DIFF
--- a/src/v2/Apps/Auctions/AuctionsApp.tsx
+++ b/src/v2/Apps/Auctions/AuctionsApp.tsx
@@ -3,7 +3,14 @@ import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { AuctionsApp_viewer } from "v2/__generated__/AuctionsApp_viewer.graphql"
 import { AuctionsMeta } from "./Components/AuctionsMeta"
 import { MyBidsFragmentContainer } from "./Components/MyBids/MyBids"
-import { ChevronIcon, Box, Text } from "@artsy/palette"
+import {
+  Box,
+  ChevronIcon,
+  Column,
+  GridColumns,
+  Separator,
+  Text,
+} from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Footer } from "v2/Components/Footer"
 import { HorizontalPadding } from "../Components/HorizontalPadding"
@@ -13,7 +20,6 @@ import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import { RouteTabs, RouteTab } from "v2/Components/RouteTabs"
 import { useSystemContext } from "v2/Artsy/useSystemContext"
 import { WorksByArtistsYouFollowRailFragmentContainer } from "./Components/WorksByArtistsYouFollowRail/WorksByArtistsYouFollowRail"
-import { Separator } from "@artsy/palette"
 export interface AuctionsAppProps {
   viewer: AuctionsApp_viewer
 }
@@ -25,36 +31,44 @@ const AuctionsApp: React.FC<AuctionsAppProps> = props => {
   return (
     <AppContainer>
       <AuctionsMeta />
-      <HorizontalPadding>
-        <Text mt={3} mb={1} variant="largeTitle">
-          Auctions
-        </Text>
-        <Text py={1}>
-          Bid on works you love with auctions on Artsy. With bidding opening
-          daily, Artsy connects collectors like you to art from leading auction
-          houses, nonprofit organizations, and sellers across the globe. We
-          feature premium artworks including modern, contemporary, and street
-          art, so you can find works by your favorite artists—and discover new
-          ones—all in one place.
-        </Text>
-        <RouterLink
-          to="https://support.artsy.net/hc/en-us/sections/360008298773-Bid-at-Auction"
-          noUnderline
-        >
-          <Text variant="mediumText" py={1}>
-            Learn more about bidding on Artsy{" "}
-            <ChevronIcon
-              title={null}
-              direction="right"
-              color="black"
-              height="15px"
-              width="14px"
-              top="3px"
-              left="3px"
-            />
-          </Text>
-        </RouterLink>
-      </HorizontalPadding>
+      <GridColumns>
+        <Column span={6}>
+          <HorizontalPadding>
+            <Text mt={3} mb={1} variant="largeTitle">
+              Auctions
+            </Text>
+          </HorizontalPadding>
+        </Column>
+        <Column span={6}>
+          <HorizontalPadding>
+            <Text mt={3} py={1}>
+              Bid on works you love with auctions on Artsy. With bidding opening
+              daily, Artsy connects collectors like you to art from leading
+              auction houses, nonprofit organizations, and sellers across the
+              globe. We feature premium artworks including modern, contemporary,
+              and street art, so you can find works by your favorite artists—and
+              discover new ones—all in one place.
+            </Text>
+            <RouterLink
+              to="https://support.artsy.net/hc/en-us/sections/360008298773-Bid-at-Auction"
+              noUnderline
+            >
+              <Text variant="mediumText" py={1}>
+                Learn more about bidding on Artsy{" "}
+                <ChevronIcon
+                  title={null}
+                  direction="right"
+                  color="black"
+                  height="15px"
+                  width="14px"
+                  top="3px"
+                  left="3px"
+                />
+              </Text>
+            </RouterLink>
+          </HorizontalPadding>
+        </Column>
+      </GridColumns>
 
       {user && (
         <HorizontalPadding>

--- a/src/v2/Apps/Auctions/AuctionsApp.tsx
+++ b/src/v2/Apps/Auctions/AuctionsApp.tsx
@@ -32,14 +32,14 @@ const AuctionsApp: React.FC<AuctionsAppProps> = props => {
     <AppContainer>
       <AuctionsMeta />
       <GridColumns>
-        <Column span={6}>
+        <Column span={[12, 6]}>
           <HorizontalPadding>
             <Text mt={3} mb={1} variant="largeTitle">
               Auctions
             </Text>
           </HorizontalPadding>
         </Column>
-        <Column span={6}>
+        <Column span={[12, 6]}>
           <HorizontalPadding>
             <Text mt={3} py={1}>
               Bid on works you love with auctions on Artsy. With bidding opening


### PR DESCRIPTION
This is for JIRA ticket [GRO-277]

Since the new copy text is rather long we wanted to  use this 50/50 header layout.

New Behavior:
<img width="1455" alt="Screen Shot 2021-04-07 at 2 40 11 PM" src="https://user-images.githubusercontent.com/30025439/113938490-8b798500-97af-11eb-8da9-8159683bd536.png">


[GRO-277]: https://artsyproduct.atlassian.net/browse/GRO-277