### PR TITLE
chore: Update auction registrations to v2

### DIFF
--- a/src/desktop/apps/user/components/auction_registrations/query.coffee
+++ b/src/desktop/apps/user/components/auction_registrations/query.coffee
@@ -1,17 +1,21 @@
 module.exports = """
   query AuctionRegistrationsQuery {
     me {
-      sale_registrations(published: true, is_auction: true, sort: CREATED_AT_DESC) {
-        is_registered
-        sale {
-          id
-          name
-          href
-          start_at(format: "MMMM D, h:mmA")
-          is_closed
-          profile {
-            icon {
-              url
+      sale_registrations: saleRegistrationsConnection(published: true, isAuction: true, sort: CREATED_AT_DESC, first: 10 ) {
+        edges {
+          node {
+            is_registered: isRegistered
+            sale {
+              id
+              name
+              href
+              start_at: startAt(format: "MMMM D, h:mmA")
+              is_closed: isClosed
+              profile {
+                icon {
+                  url
+                }
+              }
             }
           }
         }

--- a/src/desktop/apps/user/components/auction_registrations/query.coffee
+++ b/src/desktop/apps/user/components/auction_registrations/query.coffee
@@ -6,7 +6,7 @@ module.exports = """
           node {
             is_registered: isRegistered
             sale {
-              id
+              id: internalID
               name
               href
               start_at: startAt(format: "MMMM D, h:mmA")

--- a/src/desktop/apps/user/components/auction_registrations/view.coffee
+++ b/src/desktop/apps/user/components/auction_registrations/view.coffee
@@ -1,5 +1,5 @@
 Backbone = require 'backbone'
-{ metaphysics } = require '../../../../../lib/metaphysics'
+metaphysics2 = require '../../../../../lib/metaphysics2.coffee'
 query = require './query.coffee'
 template = -> require('./index.jade') arguments...
 sd = require("sharify").data
@@ -14,7 +14,7 @@ module.exports = class AuctionRegistrationsView extends Backbone.View
     @me = {}
 
   fetch: ->
-    metaphysics query: query, req: user: @user
+    metaphysics2 query: query, req: user: @user
       .then ({ @me }) => @render()
       .catch console.error.bind(console)
 
@@ -30,5 +30,5 @@ module.exports = class AuctionRegistrationsView extends Backbone.View
 
   render: ->
     @$el.html template
-      sale_registrations: @me.sale_registrations
+      sale_registrations: @me.sale_registrations?.edges.map (e) -> e.node
     this


### PR DESCRIPTION
This PR relates to [PURCHASE-2185].

Updated auction registrations onto v2. It uses the fixed `saleRegistrationsConnection` merged on [this](https://github.com/artsy/metaphysics/pull/3072) PR.

cc: @artsy/purchase-devs 

[PURCHASE-2185]: https://artsyproduct.atlassian.net/browse/PURCHASE-2185