### PR TITLE
fix(filters): artist nationality/ethnicity placeholder text

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter.tsx
@@ -13,7 +13,7 @@ export const ArtistNationalityFilter: React.FC<ArtistNationalityFilterProps> = (
       facetName="artistNationalities"
       slice="ARTIST_NATIONALITY"
       label="Artist nationality or ethnicity"
-      placeholder="Enter a nationality"
+      placeholder="Enter a nationality or ethnicity"
       expanded={expanded}
     />
   )


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2820

Trivial change, to bring the placeholder text in line with the facet name:

<img src="https://user-images.githubusercontent.com/140521/114060087-051e7b00-9863-11eb-9ada-9ea01bfc3be4.png" >
