### PR TITLE
fix(filters): ensure consistent button styles for custom fields

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
@@ -1,14 +1,12 @@
 import React, { useState } from "react"
 import {
   Button,
-  Clickable,
   Flex,
   LabeledInput,
   Message,
   Radio,
   RadioGroup,
   Spacer,
-  Text,
   useThemeConfig,
 } from "@artsy/palette"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
@@ -188,22 +186,14 @@ export const PriceRangeFilter: React.FC<PriceRangeFilterProps> = ({
             />
           </Flex>
 
-          <Media lessThan="sm">
-            <Clickable mt={2} textDecoration="underline" onClick={handleClick}>
-              <Text>Set price</Text>
-            </Clickable>
-          </Media>
-
-          <Media greaterThanOrEqual="sm">
-            <Button
-              mt={1}
-              variant="secondaryGray"
-              onClick={handleClick}
-              width="100%"
-            >
-              Set price
-            </Button>
-          </Media>
+          <Button
+            mt={1}
+            variant="secondaryGray"
+            onClick={handleClick}
+            width="100%"
+          >
+            Set price
+          </Button>
         </>
       )}
     </FilterExpandable>

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter2.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter2.tsx
@@ -211,7 +211,12 @@ export const SizeFilter2: React.FC<SizeFilter2Props> = ({ expanded }) => {
             />
           </Flex>
 
-          <Button mt={1} variant="secondaryGray" onClick={handleClick}>
+          <Button
+            mt={1}
+            variant="secondaryGray"
+            onClick={handleClick}
+            width="100%"
+          >
             Set size
           </Button>
         </>


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2823

The ticketed is change is highlighted in red.

Based on the design [spec](https://www.figma.com/file/zG9cduJdOaTQAw886QcOwn/Filters?node-id=856%3A1600) I also smuggled in another change for consistency, highlighted in blue.

## mWeb before vs after

![mweb](https://user-images.githubusercontent.com/140521/114077980-613eca80-9876-11eb-9bf0-f43f0776bffb.png)

## Web before vs after

![web](https://user-images.githubusercontent.com/140521/114077979-613eca80-9876-11eb-8914-63c0cf82d4c8.png)
