### PR TITLE
fix: keep filters that are collapsed by default expanded after selection (FX-2830)

### DIFF
--- a/src/v2/Apps/Fair/Routes/FairArtworks.tsx
+++ b/src/v2/Apps/Fair/Routes/FairArtworks.tsx
@@ -39,33 +39,30 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
   if (!hasFilter) return null
 
   const { counts } = filtered_artworks
+  const showNewFilters = getENV("ENABLE_NEW_ARTWORK_FILTERS")
 
   // TODO: You shouldn't have to pass `relayEnvironment` and `user` through below.
   // For some reason, they are undefined when `useSystemContext()` is referenced
   // in <ArtistsFilter />. So, pass as props for now.
-  const Filters = () => {
-    const showNewFilters = getENV("ENABLE_NEW_ARTWORK_FILTERS")
-
-    return (
-      <>
-        <ArtistsFilter
-          fairID={fair.internalID}
-          relayEnvironment={relayEnvironment}
-          user={user}
-        />
-        <MediumFilter expanded />
-        {showNewFilters && <MaterialsFilter expanded />}
-        <PriceRangeFilter />
-        <AttributionClassFilter expanded />
-        {showNewFilters ? <SizeFilter2 /> : <SizeFilter />}
-        <WaysToBuyFilter />
-        {showNewFilters && <ArtistNationalityFilter expanded />}
-        <TimePeriodFilter />
-        <ColorFilter />
-        {showNewFilters ? <PartnersFilter /> : <GalleryFilter />}
-      </>
-    )
-  }
+  const Filters = (
+    <>
+      <ArtistsFilter
+        fairID={fair.internalID}
+        relayEnvironment={relayEnvironment}
+        user={user}
+      />
+      <MediumFilter expanded />
+      {showNewFilters && <MaterialsFilter expanded />}
+      <PriceRangeFilter />
+      <AttributionClassFilter expanded />
+      {showNewFilters ? <SizeFilter2 /> : <SizeFilter />}
+      <WaysToBuyFilter />
+      {showNewFilters && <ArtistNationalityFilter expanded />}
+      <TimePeriodFilter />
+      <ColorFilter />
+      {showNewFilters ? <PartnersFilter /> : <GalleryFilter />}
+    </>
+  )
 
   return (
     <ArtworkFilterContextProvider

--- a/src/v2/Apps/Show/Components/ShowArtworks.tsx
+++ b/src/v2/Apps/Show/Components/ShowArtworks.tsx
@@ -34,21 +34,18 @@ const ShowArtworksFilter: React.FC<ShowArtworksFilterProps> = ({
 
   if (!hasFilter) return null
 
-  const Filters = () => {
-    const showNewFilters = getENV("ENABLE_NEW_ARTWORK_FILTERS")
-
-    return (
-      <>
-        <MediumFilter expanded />
-        {showNewFilters && <MaterialsFilter expanded />}
-        <PriceRangeFilter />
-        {showNewFilters ? <SizeFilter2 /> : <SizeFilter />}
-        <WaysToBuyFilter />
-        <TimePeriodFilter />
-        <ColorFilter />
-      </>
-    )
-  }
+  const showNewFilters = getENV("ENABLE_NEW_ARTWORK_FILTERS")
+  const Filters = (
+    <>
+      <MediumFilter expanded />
+      {showNewFilters && <MaterialsFilter expanded />}
+      <PriceRangeFilter />
+      {showNewFilters ? <SizeFilter2 /> : <SizeFilter />}
+      <WaysToBuyFilter />
+      <TimePeriodFilter />
+      <ColorFilter />
+    </>
+  )
 
   // Inject custom default sort into artwork filter.
   const filters = omit(

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
@@ -96,8 +96,12 @@ export const ArtistsFilter: FC<ArtistsFilterProps> = ({
     filterContext.currentlySelectedFilters()["includeArtworksByFollowedArtists"]
   const followedArtistArtworkCount = filterContext?.counts?.followedArtists ?? 0
 
+  const selection = filterContext.currentlySelectedFilters().artistIDs
+  const hasSelection =
+    (selection && selection.length > 0) || isFollowedArtistCheckboxSelected
+
   return (
-    <FilterExpandable label="Artists" expanded={expanded}>
+    <FilterExpandable label="Artists" expanded={hasSelection || expanded}>
       <Flex flexDirection="column">
         <Checkbox
           disabled={!followedArtistArtworkCount}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
@@ -124,8 +124,11 @@ export const PriceRangeFilter: React.FC<PriceRangeFilterProps> = ({
     v3: { my: 1 },
   })
 
+  const selection = currentlySelectedFilters().priceRange
+  const hasSelection = selection && selection.length > 0
+
   return (
-    <FilterExpandable label="Price" expanded={expanded}>
+    <FilterExpandable label="Price" expanded={hasSelection || expanded}>
       {mode === "done" && (
         <Media lessThan="sm">
           <Message variant="info" my={2}>

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ResultsFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/ResultsFilter.tsx
@@ -61,8 +61,10 @@ export const ResultsFilter: React.FC<ResultsFilterProps> = ({
       resultsSorted.slice(INITIAL_ITEMS_TO_SHOW).map(({ value }) => value)
     ).length > 0
 
+  const hasSelection = selectedValues && selectedValues.length > 0
+
   return (
-    <FilterExpandable label={label} expanded={expanded}>
+    <FilterExpandable label={label} expanded={hasSelection || expanded}>
       <Flex flexDirection="column">
         <FacetFilter
           facetName={facetName}

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter2.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter2.tsx
@@ -128,8 +128,16 @@ export const SizeFilter2: React.FC<SizeFilter2Props> = ({ expanded }) => {
     v3: { my: 1, secondaryVariant: "xs" as TextVariant },
   })
 
+  const selection = currentlySelectedFilters().sizes
+  const customHeight = currentlySelectedFilters().height
+  const customWidth = currentlySelectedFilters().width
+  const hasSelection =
+    (selection && selection.length > 0) ||
+    (customHeight && customHeight !== "*-*") ||
+    (customWidth && customWidth !== "*-*")
+
   return (
-    <FilterExpandable label="Size" expanded={expanded}>
+    <FilterExpandable label="Size" expanded={hasSelection || expanded}>
       {mode === "done" && (
         <Media lessThan="sm">
           <Message variant="info" my={2}>

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/WaysToBuyFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/WaysToBuyFilter.tsx
@@ -62,8 +62,15 @@ export const WaysToBuyFilter: FC<WaysToBuyFilterProps> = ({ expanded }) => {
     v3: { my: 1 },
   })
 
+  const selection = filterContext.currentlySelectedFilters()
+  const hasSelection =
+    !!selection.acquireable ||
+    !!selection.offerable ||
+    !!selection.atAuction ||
+    !!selection.inquireableOnly
+
   return (
-    <FilterExpandable label="Ways to buy" expanded={expanded}>
+    <FilterExpandable label="Ways to buy" expanded={hasSelection || expanded}>
       <Flex flexDirection="column">
         {checkboxes.map((checkbox, index) => {
           return (

--- a/src/v2/Components/v2/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
@@ -101,10 +101,6 @@ describe("ArtworkFilterMobileActionSheet", () => {
 
     expect(wrapper.find("ApplyButton").text()).toEqual("Apply (0)")
 
-    // Expand the filters we want to make assertions about
-    wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
-    wrapper.find("PriceRangeFilter").find("ChevronIcon").simulate("click")
-
     // Select another way to buy
     wrapper
       .find("WaysToBuyFilter")
@@ -115,6 +111,9 @@ describe("ArtworkFilterMobileActionSheet", () => {
     await flushPromiseQueue()
 
     expect(wrapper.find("ApplyButton").text()).toEqual("Apply (1)")
+
+    // Expand the collapsed filters we want to make assertions about
+    wrapper.find("PriceRangeFilter").find("ChevronIcon").simulate("click")
 
     // Select a price range
     wrapper

--- a/src/v2/Components/v2/ArtworkFilter/index.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/index.tsx
@@ -92,7 +92,7 @@ export const BaseArtworkFilter: React.FC<
       | ArtistSeriesArtworksFilter_artistSeries
       | FairArtworks_fair
       | ShowArtworks_show
-    Filters?: React.FC
+    Filters?: JSX.Element
   }
 > = ({ relay, viewer, Filters, relayVariables = {}, children, ...rest }) => {
   const { filtered_artworks } = viewer
@@ -213,7 +213,7 @@ export const BaseArtworkFilter: React.FC<
             <ArtworkFilterMobileActionSheet
               onClose={() => toggleMobileActionSheet(false)}
             >
-              {Filters ? <Filters /> : <ArtworkFilters />}
+              {Filters ? Filters : <ArtworkFilters />}
             </ArtworkFilterMobileActionSheet>
           )}
 
@@ -269,7 +269,7 @@ export const BaseArtworkFilter: React.FC<
 
         <GridColumns>
           <Column span={3} pr={tokens.pr}>
-            {Filters ? <Filters /> : <ArtworkFilters />}
+            {Filters ? Filters : <ArtworkFilters />}
           </Column>
 
           <Column span={9}>


### PR DESCRIPTION
This PR addresses [FX-2830](https://artsyproduct.atlassian.net/browse/FX-2830) by:

1. Passing the filters that should appear on the fair and show artwork grids as a JSX element rather than as functional components.
1. Allowing filters that are collapsed by default to override their `expanded` prop if the user has selected one or more of their options.

**Buggy behavior**

![collapse](https://user-images.githubusercontent.com/44589599/114210122-64e15880-992d-11eb-9617-2e71dd12d2db.gif)
