### PR TITLE
GRO-284: Added in meta description and canonical link

### DIFF
--- a/src/v2/Apps/Auctions/Components/AuctionsMeta.tsx
+++ b/src/v2/Apps/Auctions/Components/AuctionsMeta.tsx
@@ -1,10 +1,12 @@
 import React from "react"
-import { Meta, Title } from "react-head"
+import { Link, Meta, Title } from "react-head"
 import { getENV } from "v2/Utils/getENV"
 
 export const AuctionsMeta: React.FC = () => {
   const title = "Auctions | Artsy"
-  const description = ""
+  const description =
+    "Bid in live and online-only sales from the world’s leading auction houses. Browse paintings, sculptures, design, prints & multiples and more."
+  const href = `${getENV("APP_URL")}/auctions`
 
   return (
     <>
@@ -17,7 +19,8 @@ export const AuctionsMeta: React.FC = () => {
       <Meta property="twitter:card" content="summary" />
       <Meta property="twitter:description" content={description} />
 
-      <Meta property="og:url" href={`${getENV("APP_URL")}/auctions`} />
+      <Link rel="canonical" href={href} />
+      <Meta property="og:url" href={href} />
       <Meta property="og:image" href="/images/og_image.jpg" />
       <Meta property="og:type" href="website" />
     </>


### PR DESCRIPTION
This updates `/auctions2` with the following meta description and canonical link:

Meta Description: Bid in live and online-only sales from the world’s leading auction houses. Browse paintings, sculptures, design, prints & multiples and more.

Canonical (should be self referring): artsy.net/auctions 

New Behavior:
<img width="488" alt="Screen Shot 2021-04-08 at 2 24 28 PM" src="https://user-images.githubusercontent.com/30025439/114098776-b4188200-9876-11eb-9b7d-524ce34a7a84.png">
