### PR TITLE
fix: use exact value to define is active tab

### DIFF
--- a/src/v2/Components/RouteTabs.tsx
+++ b/src/v2/Components/RouteTabs.tsx
@@ -8,9 +8,18 @@ export const RouteTab: React.FC<BaseTabProps & RouterLinkProps> = ({
   to,
   ...rest
 }) => {
+  const options = {
+    exact: rest.exact !== undefined ? rest.exact : true,
+  }
+
   return (
-    // @ts-ignore
-    <BaseTab as={RouterLink} to={to} active={useIsRouteActive(to)} {...rest}>
+    <BaseTab
+      as={RouterLink}
+      // @ts-ignore
+      to={to}
+      active={useIsRouteActive(to, options)}
+      {...rest}
+    >
       {children}
     </BaseTab>
   )


### PR DESCRIPTION
This PR adds the use of the `exact` field value to determine the active tab.

Used `true` as a default value to support the same behavior. 