### PR TITLE
Guard against quotes being empty on auctions-partnerships page

### DIFF
--- a/src/desktop/apps/partnerships/templates/auction_sections.jade
+++ b/src/desktop/apps/partnerships/templates/auction_sections.jade
@@ -24,8 +24,9 @@ mixin auction_audience(section)
       img( src=section.images[0].src )
     .audience-quotes
       - q = section.quotes[0]
-      .quote
-        .text= q.quote
+      if q
+        .quote
+          .text= q.quote
 
 mixin access(section)
   .partnerships-section-header.access


### PR DESCRIPTION
The `/auctions-partnerships` page is giving a 500 due to this error: 

![image](https://user-images.githubusercontent.com/3087225/114214732-b3452600-9932-11eb-9049-43b83c76b3f8.png)

This is a fast fix to guard against that particular issue and get us back up and running. 