### PR TITLE
fix: Add yarn relay to CI script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,16 @@ jobs:
     steps:
       - run: yarn type-check
 
+  relay-check:
+    docker:
+      - image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/force:$CIRCLE_SHA1-builder
+        aws_auth:
+          aws_access_key_id: $AWS_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+    working_directory: /app
+    steps:
+      - run: yarn relay
+
   acceptance:
     docker:
       - image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/force:$CIRCLE_SHA1-electron-runner
@@ -240,6 +250,12 @@ workflows:
           requires:
             - builder-image-push
 
+      - relay-check:
+          <<: *not_staging_or_release
+          context: hokusai
+          requires:
+            - builder-image-push
+
       - acceptance:
           <<: *not_staging_or_release
           context: hokusai
@@ -269,6 +285,7 @@ workflows:
             - jest-v1
             - jest-v2
             - type-check
+            - relay-check
             - acceptance
             - acceptance-cypress
             - production-image-build


### PR DESCRIPTION
Added yarn relay to check to ci script as a task under `jest-v1`. Does it make sense to include it there or is there a more intuitive place to add that check? I was debating running it under the type check?

To test if this worked, I ran the suite alone and it passed and then added a duplicate definition for a test query renderer (the problem we had run into in volt when CI was passing while relay was giving the error `Duplicate definition of...`) and it [failed and exited the test suite](https://app.circleci.com/pipelines/github/artsy/force/13571/workflows/c4f30079-c7e6-4dfe-a26c-a706eff4f2b2/jobs/97445). 

<img width="1107" alt="Screen Shot 2021-04-09 at 10 56 47 AM" src="https://user-images.githubusercontent.com/9466631/114215322-b506ed80-9922-11eb-82ca-9f1b7f9030bb.png">

[Jira ticket](https://artsyproduct.atlassian.net/browse/FP-20)
