### PR TITLE
fix: [Auctions2] More spacing QA

### DIFF
--- a/src/v2/Apps/Auctions/AuctionsApp.tsx
+++ b/src/v2/Apps/Auctions/AuctionsApp.tsx
@@ -8,6 +8,7 @@ import {
   ChevronIcon,
   Column,
   GridColumns,
+  Join,
   Separator,
   Text,
 } from "@artsy/palette"
@@ -71,16 +72,16 @@ const AuctionsApp: React.FC<AuctionsAppProps> = props => {
       </GridColumns>
 
       {user && (
-        <HorizontalPadding>
-          <Box mt={[2, 4]}>
-            <MyBidsFragmentContainer me={viewer.me} />
-          </Box>
+        <HorizontalPadding pb={2} my={[2, 4]}>
+          <Join separator={<Separator my={[2, 4]} />}>
+            <Box>
+              <MyBidsFragmentContainer me={viewer.me} />
+            </Box>
 
-          <Separator />
-
-          <Box my={[2]} pb={2}>
-            <WorksByArtistsYouFollowRailFragmentContainer viewer={viewer} />
-          </Box>
+            <Box>
+              <WorksByArtistsYouFollowRailFragmentContainer viewer={viewer} />
+            </Box>
+          </Join>
         </HorizontalPadding>
       )}
       <HorizontalPadding mt={4}>

--- a/src/v2/Apps/Auctions/auctionsRoutes.tsx
+++ b/src/v2/Apps/Auctions/auctionsRoutes.tsx
@@ -1,20 +1,11 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
+import { CurrentAuctionsPaginationContainer } from "./Routes/CurrentAuctions"
+import { PastAuctionsPaginationContainer } from "./Routes/PastAuctions"
+import { UpcomingAuctionsPaginationContainer } from "./Routes/UpcomingAuctions"
 
 const AuctionsApp = loadable(() => import("./AuctionsApp"), {
   resolveComponent: component => component.AuctionsAppFragmentContainer,
-})
-
-const CurrentAuctions = loadable(() => import("./Routes/CurrentAuctions"), {
-  resolveComponent: component => component.CurrentAuctionsPaginationContainer,
-})
-
-const UpcomingAuctions = loadable(() => import("./Routes/UpcomingAuctions"), {
-  resolveComponent: component => component.UpcomingAuctionsPaginationContainer,
-})
-
-const PastAuctions = loadable(() => import("./Routes/PastAuctions"), {
-  resolveComponent: component => component.PastAuctionsPaginationContainer,
 })
 
 export const auctionsRoutes = [
@@ -35,11 +26,8 @@ export const auctionsRoutes = [
     children: [
       {
         path: "", // represents current auctions aka /auctions/current
-        getComponent: () => CurrentAuctions,
+        Component: CurrentAuctionsPaginationContainer,
         ignoreScrollBehavior: true,
-        prepare: () => {
-          CurrentAuctions.preload()
-        },
         query: graphql`
           query auctionsRoutes_Current_AuctionsQuery {
             viewer {
@@ -50,11 +38,8 @@ export const auctionsRoutes = [
       },
       {
         path: "upcoming",
-        getComponent: () => UpcomingAuctions,
+        Component: UpcomingAuctionsPaginationContainer,
         ignoreScrollBehavior: true,
-        prepare: () => {
-          UpcomingAuctions.preload()
-        },
         query: graphql`
           query auctionsRoutes_Upcoming_AuctionsQuery {
             viewer {
@@ -65,11 +50,8 @@ export const auctionsRoutes = [
       },
       {
         path: "past",
-        getComponent: () => PastAuctions,
+        Component: PastAuctionsPaginationContainer,
         ignoreScrollBehavior: true,
-        prepare: () => {
-          PastAuctions.preload()
-        },
         query: graphql`
           query auctionsRoutes_Past_AuctionsQuery {
             viewer {


### PR DESCRIPTION
Noticed a few other little things with the spacing, and realized we don't need to bundle split the sub-routes as the chunk sizes are so minuscule that even with js preloading they load so fast that there's still some layout thrashing, and are basically all identical -- only pulling in a couple rails. 

Before: 

<img width="635" alt="Screen Shot 2021-04-10 at 12 48 16 PM" src="https://user-images.githubusercontent.com/236943/114283881-1d2c0100-9a01-11eb-8c51-0b441aab1d99.png">


After: 

<img width="817" alt="Screen Shot 2021-04-10 at 1 29 48 PM" src="https://user-images.githubusercontent.com/236943/114283886-23ba7880-9a01-11eb-8d07-375e0e0917a3.png">


