### PR TITLE
fix(filters): ensure Clear All button clears custom inputs as well

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilterContext.tsx
@@ -116,13 +116,13 @@ interface Counts {
 // and `BaseFilterContext<AuctionResultFilters>`.
 export interface ArtworkFilterContextProps {
   /** The current artwork filter state (which determines the network request and the url querystring) */
-  filters?: ArtworkFilters
+  filters?: ArtworkFiltersState
 
   /** Interim filter state, to be manipulated before being applied to the current filter state */
-  stagedFilters?: ArtworkFilters
+  stagedFilters?: ArtworkFiltersState
 
   /** Getter for the appropriate source of truth to render in the filter UI */
-  currentlySelectedFilters?: () => ArtworkFilters
+  currentlySelectedFilters?: () => ArtworkFiltersState
 
   // Components
   ZeroState?: React.FC

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import {
   Button,
   Flex,
@@ -68,7 +68,7 @@ export const PriceRangeFilter: React.FC<PriceRangeFilterProps> = ({
   const [mode, setMode] = useState<"resting" | "done">("resting")
 
   const { currentlySelectedFilters, setFilter } = useArtworkFilterContext()
-  const { priceRange: initialRange } = currentlySelectedFilters()
+  const { priceRange: initialRange, reset } = currentlySelectedFilters()
 
   const numericInitialRange = parseRange(initialRange)
 
@@ -127,6 +127,13 @@ export const PriceRangeFilter: React.FC<PriceRangeFilterProps> = ({
   const selection = currentlySelectedFilters().priceRange
   const hasSelection = selection && selection.length > 0
 
+  useEffect(() => {
+    // if filter state is being reset, then also clear local input state
+    if (reset) {
+      setCustomRange(["*", "*"])
+    }
+  }, [reset])
+
   return (
     <FilterExpandable label="Price" expanded={hasSelection || expanded}>
       {mode === "done" && (
@@ -168,6 +175,7 @@ export const PriceRangeFilter: React.FC<PriceRangeFilterProps> = ({
           <Flex mt={1} alignItems="flex-end">
             <NumericInput
               label="$USD"
+              name="price_min"
               placeholder="Min"
               min="0"
               step="1"
@@ -179,6 +187,7 @@ export const PriceRangeFilter: React.FC<PriceRangeFilterProps> = ({
 
             <NumericInput
               label="$USD"
+              name="price_max"
               placeholder="Max"
               min="0"
               step="1"

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter2.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/SizeFilter2.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import {
   Button,
   Text,
@@ -57,7 +57,7 @@ export interface SizeFilter2Props {
 
 export const SizeFilter2: React.FC<SizeFilter2Props> = ({ expanded }) => {
   const { currentlySelectedFilters, setFilters } = useArtworkFilterContext()
-  const { height, width } = currentlySelectedFilters()
+  const { height, width, reset } = currentlySelectedFilters()
 
   const initialCustomSize = {
     height: parseRange(height),
@@ -127,6 +127,13 @@ export const SizeFilter2: React.FC<SizeFilter2Props> = ({ expanded }) => {
     v2: { my: 0.5, secondaryVariant: "small" as TextVariant },
     v3: { my: 1, secondaryVariant: "xs" as TextVariant },
   })
+
+  useEffect(() => {
+    // if filter state is being reset, then also clear local input state
+    if (reset) {
+      setCustomSize({ height: ["*", "*"], width: ["*", "*"] })
+    }
+  }, [reset])
 
   const selection = currentlySelectedFilters().sizes
   const customHeight = currentlySelectedFilters().height


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2819

In the case that custom filter inputs were currently supplied for **Size** or **Price**, those inputs were not being cleared in the UI when pressing the **Clear All** button. (They were cleared in the filter state, leading to a mismatch between actual artwork grid results and filter UI state.)

This adds a side effect to check that of the filter criteria have been reset, then local UI state should be cleared as well.

![clear gif 5 128](https://user-images.githubusercontent.com/140521/114596401-9c1d7580-9c5d-11eb-9790-b91db92e392b.gif)
