### PR TITLE
fix: Removes Back to Artsy button in Eigen's Make Offer flow

### DIFF
--- a/src/v2/Apps/Order/Routes/Status/index.tsx
+++ b/src/v2/Apps/Order/Routes/Status/index.tsx
@@ -22,6 +22,7 @@ import createLogger from "v2/Utils/logger"
 import { ArtworkSummaryItemFragmentContainer as ArtworkSummaryItem } from "../../Components/ArtworkSummaryItem"
 import { CreditCardSummaryItemFragmentContainer as CreditCardSummaryItem } from "../../Components/CreditCardSummaryItem"
 import { ShippingSummaryItemFragmentContainer as ShippingSummaryItem } from "../../Components/ShippingSummaryItem"
+import { SystemContextConsumer } from "v2/Artsy/SystemContext"
 
 const logger = createLogger("Order/Routes/Status/index.tsx")
 
@@ -248,56 +249,62 @@ export class StatusRoute extends Component<StatusProps> {
     const showOfferNote = order.mode === "OFFER" && order.state === "SUBMITTED"
 
     return (
-      <>
-        <HorizontalPadding>
-          <Serif size="6" weight="regular" color="black100">
-            {title}
-          </Serif>
-          <Sans size="2" weight="regular" color="black60" mb={[2, 3]}>
-            {flowName} <span data-test="OrderCode">#{order.code}</span>
-          </Sans>
-          <TwoColumnLayout
-            Content={
-              <>
-                <Title>{flowName} status | Artsy</Title>
-                <Join separator={<Spacer mb={[2, 3]} />}>
-                  {description && <Message p={[2, 3]}>{description}</Message>}
-                  {showTransactionSummary ? (
+      <SystemContextConsumer>
+        {({ isEigen }) => {
+          return (
+            <HorizontalPadding>
+              <Serif size="6" weight="regular" color="black100">
+                {title}
+              </Serif>
+              <Sans size="2" weight="regular" color="black60" mb={[2, 3]}>
+                {flowName} <span data-test="OrderCode">#{order.code}</span>
+              </Sans>
+              <TwoColumnLayout
+                Content={
+                  <>
+                    <Title>{flowName} status | Artsy</Title>
+                    <Join separator={<Spacer mb={[2, 3]} />}>
+                      {description && (
+                        <Message p={[2, 3]}>{description}</Message>
+                      )}
+                      {showTransactionSummary ? (
+                        <Flex flexDirection="column">
+                          <ArtworkSummaryItem order={order} />
+                          <StyledTransactionDetailsSummaryItem
+                            order={order}
+                            useLastSubmittedOffer
+                            showOfferNote={showOfferNote}
+                          />
+                        </Flex>
+                      ) : isEigen ? null : (
+                        <Button
+                          onClick={() => {
+                            window.location.href = "/"
+                          }}
+                          size="large"
+                          width="100%"
+                        >
+                          Back to Artsy
+                        </Button>
+                      )}
+                    </Join>
+                  </>
+                }
+                Sidebar={
+                  showTransactionSummary && (
                     <Flex flexDirection="column">
-                      <ArtworkSummaryItem order={order} />
-                      <StyledTransactionDetailsSummaryItem
-                        order={order}
-                        useLastSubmittedOffer
-                        showOfferNote={showOfferNote}
-                      />
+                      <Flex flexDirection="column">
+                        <StyledShippingSummaryItem order={order} />
+                        <CreditCardSummaryItem order={order} />
+                      </Flex>
                     </Flex>
-                  ) : (
-                    <Button
-                      onClick={() => {
-                        window.location.href = "/"
-                      }}
-                      size="large"
-                      width="100%"
-                    >
-                      Back to Artsy
-                    </Button>
-                  )}
-                </Join>
-              </>
-            }
-            Sidebar={
-              showTransactionSummary && (
-                <Flex flexDirection="column">
-                  <Flex flexDirection="column">
-                    <StyledShippingSummaryItem order={order} />
-                    <CreditCardSummaryItem order={order} />
-                  </Flex>
-                </Flex>
-              )
-            }
-          />
-        </HorizontalPadding>
-      </>
+                  )
+                }
+              />
+            </HorizontalPadding>
+          )
+        }}
+      </SystemContextConsumer>
     )
   }
 }


### PR DESCRIPTION
Resolves [PURCHASE-2527](https://artsyproduct.atlassian.net/browse/PURCHASE-2527) to remove the "Back to Artsy" button from the webview in Eigen after a buyer has declined a counteroffer.

cc @artsy/purchase-devs 

Before:
<img width="293" alt="Screen Shot 2021-04-13 at 5 00 16 PM" src="https://user-images.githubusercontent.com/10385964/114621458-b74aae00-9c7a-11eb-82e8-6ac6e063b250.png">

After:
<img width="293" alt="Screen Shot 2021-04-13 at 4 59 55 PM" src="https://user-images.githubusercontent.com/10385964/114621482-bf0a5280-9c7a-11eb-9fc5-725fdc5ff22e.png">
