### PR TITLE
Fix: Use timely sorting instead of start_at

### DIFF
--- a/src/v2/Apps/Auctions/Routes/CurrentAuctions.tsx
+++ b/src/v2/Apps/Auctions/Routes/CurrentAuctions.tsx
@@ -96,7 +96,7 @@ export const CurrentAuctionsPaginationContainer = createPaginationContainer(
           after: $after
           live: true
           published: true
-          sort: START_AT_ASC
+          sort: TIMELY_AT_NAME_ASC
           auctionState: OPEN
         ) @connection(key: "CurrentAuctions_salesConnection") {
           totalCount

--- a/src/v2/Apps/Auctions/Routes/PastAuctions.tsx
+++ b/src/v2/Apps/Auctions/Routes/PastAuctions.tsx
@@ -95,7 +95,7 @@ export const PastAuctionsPaginationContainer = createPaginationContainer(
           first: $first
           after: $after
           live: false
-          sort: START_AT_DESC
+          sort: TIMELY_AT_NAME_DESC
           auctionState: CLOSED
         ) @connection(key: "PastAuctions_salesConnection") {
           totalCount

--- a/src/v2/Apps/Auctions/Routes/UpcomingAuctions.tsx
+++ b/src/v2/Apps/Auctions/Routes/UpcomingAuctions.tsx
@@ -97,7 +97,7 @@ export const UpcomingAuctionsPaginationContainer = createPaginationContainer(
         salesConnection(
           first: $first
           after: $after
-          sort: START_AT_ASC
+          sort: TIMELY_AT_NAME_ASC
           auctionState: UPCOMING
         ) @connection(key: "UpcomingAuctions_salesConnection") {
           totalCount

--- a/src/v2/__generated__/CurrentAuctionsQuery.graphql.ts
+++ b/src/v2/__generated__/CurrentAuctionsQuery.graphql.ts
@@ -38,7 +38,7 @@ fragment AuctionArtworksRail_sale on Sale {
 }
 
 fragment CurrentAuctions_viewer_2HEEH6 on Viewer {
-  salesConnection(first: $first, after: $after, live: true, published: true, sort: START_AT_ASC, auctionState: OPEN) {
+  salesConnection(first: $first, after: $after, live: true, published: true, sort: TIMELY_AT_NAME_ASC, auctionState: OPEN) {
     totalCount
     edges {
       node {
@@ -107,7 +107,7 @@ v3 = [
   {
     "kind": "Literal",
     "name": "sort",
-    "value": "START_AT_ASC"
+    "value": "TIMELY_AT_NAME_ASC"
   }
 ];
 return {
@@ -312,7 +312,7 @@ return {
     "metadata": {},
     "name": "CurrentAuctionsQuery",
     "operationKind": "query",
-    "text": "query CurrentAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...CurrentAuctions_viewer_2HEEH6\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment CurrentAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, live: true, published: true, sort: START_AT_ASC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query CurrentAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...CurrentAuctions_viewer_2HEEH6\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment CurrentAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, live: true, published: true, sort: TIMELY_AT_NAME_ASC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/CurrentAuctions_Test_Query.graphql.ts
+++ b/src/v2/__generated__/CurrentAuctions_Test_Query.graphql.ts
@@ -32,7 +32,7 @@ fragment AuctionArtworksRail_sale on Sale {
 }
 
 fragment CurrentAuctions_viewer on Viewer {
-  salesConnection(first: 30, live: true, published: true, sort: START_AT_ASC, auctionState: OPEN) {
+  salesConnection(first: 30, live: true, published: true, sort: TIMELY_AT_NAME_ASC, auctionState: OPEN) {
     totalCount
     edges {
       node {
@@ -80,7 +80,7 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "sort",
-    "value": "START_AT_ASC"
+    "value": "TIMELY_AT_NAME_ASC"
   }
 ];
 return {
@@ -256,7 +256,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "salesConnection(auctionState:\"OPEN\",first:30,live:true,published:true,sort:\"START_AT_ASC\")"
+            "storageKey": "salesConnection(auctionState:\"OPEN\",first:30,live:true,published:true,sort:\"TIMELY_AT_NAME_ASC\")"
           },
           {
             "alias": null,
@@ -282,7 +282,7 @@ return {
     "metadata": {},
     "name": "CurrentAuctions_Test_Query",
     "operationKind": "query",
-    "text": "query CurrentAuctions_Test_Query {\n  viewer {\n    ...CurrentAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment CurrentAuctions_viewer on Viewer {\n  salesConnection(first: 30, live: true, published: true, sort: START_AT_ASC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query CurrentAuctions_Test_Query {\n  viewer {\n    ...CurrentAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment CurrentAuctions_viewer on Viewer {\n  salesConnection(first: 30, live: true, published: true, sort: TIMELY_AT_NAME_ASC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/CurrentAuctions_viewer.graphql.ts
+++ b/src/v2/__generated__/CurrentAuctions_viewer.graphql.ts
@@ -78,7 +78,7 @@ const node: ReaderFragment = {
         {
           "kind": "Literal",
           "name": "sort",
-          "value": "START_AT_ASC"
+          "value": "TIMELY_AT_NAME_ASC"
         }
       ],
       "concreteType": "SaleConnection",
@@ -195,10 +195,10 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "__CurrentAuctions_salesConnection_connection(auctionState:\"OPEN\",live:true,published:true,sort:\"START_AT_ASC\")"
+      "storageKey": "__CurrentAuctions_salesConnection_connection(auctionState:\"OPEN\",live:true,published:true,sort:\"TIMELY_AT_NAME_ASC\")"
     }
   ],
   "type": "Viewer"
 };
-(node as any).hash = '5d9c81d9fb929219d3ae0c6ba7705f48';
+(node as any).hash = '9d7fbf0084329715051ce624d1758ea5';
 export default node;

--- a/src/v2/__generated__/PastAuctionsQuery.graphql.ts
+++ b/src/v2/__generated__/PastAuctionsQuery.graphql.ts
@@ -38,7 +38,7 @@ fragment AuctionArtworksRail_sale on Sale {
 }
 
 fragment PastAuctions_viewer_2HEEH6 on Viewer {
-  salesConnection(first: $first, after: $after, live: false, sort: START_AT_DESC, auctionState: CLOSED) {
+  salesConnection(first: $first, after: $after, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {
     totalCount
     edges {
       node {
@@ -101,7 +101,7 @@ v3 = [
   {
     "kind": "Literal",
     "name": "sort",
-    "value": "START_AT_DESC"
+    "value": "TIMELY_AT_NAME_DESC"
   }
 ];
 return {
@@ -298,7 +298,7 @@ return {
     "metadata": {},
     "name": "PastAuctionsQuery",
     "operationKind": "query",
-    "text": "query PastAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...PastAuctions_viewer_2HEEH6\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment PastAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, live: false, sort: START_AT_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query PastAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...PastAuctions_viewer_2HEEH6\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment PastAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PastAuctions_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PastAuctions_Test_Query.graphql.ts
@@ -32,7 +32,7 @@ fragment AuctionArtworksRail_sale on Sale {
 }
 
 fragment PastAuctions_viewer on Viewer {
-  salesConnection(first: 30, live: false, sort: START_AT_DESC, auctionState: CLOSED) {
+  salesConnection(first: 30, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {
     totalCount
     edges {
       node {
@@ -74,7 +74,7 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "sort",
-    "value": "START_AT_DESC"
+    "value": "TIMELY_AT_NAME_DESC"
   }
 ];
 return {
@@ -243,7 +243,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "salesConnection(auctionState:\"CLOSED\",first:30,live:false,sort:\"START_AT_DESC\")"
+            "storageKey": "salesConnection(auctionState:\"CLOSED\",first:30,live:false,sort:\"TIMELY_AT_NAME_DESC\")"
           },
           {
             "alias": null,
@@ -268,7 +268,7 @@ return {
     "metadata": {},
     "name": "PastAuctions_Test_Query",
     "operationKind": "query",
-    "text": "query PastAuctions_Test_Query {\n  viewer {\n    ...PastAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment PastAuctions_viewer on Viewer {\n  salesConnection(first: 30, live: false, sort: START_AT_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query PastAuctions_Test_Query {\n  viewer {\n    ...PastAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment PastAuctions_viewer on Viewer {\n  salesConnection(first: 30, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PastAuctions_viewer.graphql.ts
+++ b/src/v2/__generated__/PastAuctions_viewer.graphql.ts
@@ -72,7 +72,7 @@ const node: ReaderFragment = {
         {
           "kind": "Literal",
           "name": "sort",
-          "value": "START_AT_DESC"
+          "value": "TIMELY_AT_NAME_DESC"
         }
       ],
       "concreteType": "SaleConnection",
@@ -182,10 +182,10 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "__PastAuctions_salesConnection_connection(auctionState:\"CLOSED\",live:false,sort:\"START_AT_DESC\")"
+      "storageKey": "__PastAuctions_salesConnection_connection(auctionState:\"CLOSED\",live:false,sort:\"TIMELY_AT_NAME_DESC\")"
     }
   ],
   "type": "Viewer"
 };
-(node as any).hash = '70b3f5e1f742613058c27b6fb5a4217d';
+(node as any).hash = '897dce522364c5ce7cb8ee56f7dfaee3';
 export default node;

--- a/src/v2/__generated__/UpcomingAuctionsQuery.graphql.ts
+++ b/src/v2/__generated__/UpcomingAuctionsQuery.graphql.ts
@@ -38,7 +38,7 @@ fragment AuctionArtworksRail_sale on Sale {
 }
 
 fragment UpcomingAuctions_viewer_2HEEH6 on Viewer {
-  salesConnection(first: $first, after: $after, sort: START_AT_ASC, auctionState: UPCOMING) {
+  salesConnection(first: $first, after: $after, sort: TIMELY_AT_NAME_ASC, auctionState: UPCOMING) {
     totalCount
     edges {
       node {
@@ -99,7 +99,7 @@ v3 = [
   {
     "kind": "Literal",
     "name": "sort",
-    "value": "START_AT_ASC"
+    "value": "TIMELY_AT_NAME_ASC"
   }
 ];
 return {
@@ -309,7 +309,7 @@ return {
     "metadata": {},
     "name": "UpcomingAuctionsQuery",
     "operationKind": "query",
-    "text": "query UpcomingAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...UpcomingAuctions_viewer_2HEEH6\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment UpcomingAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query UpcomingAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...UpcomingAuctions_viewer_2HEEH6\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment UpcomingAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, sort: TIMELY_AT_NAME_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/UpcomingAuctions_Test_Query.graphql.ts
+++ b/src/v2/__generated__/UpcomingAuctions_Test_Query.graphql.ts
@@ -32,7 +32,7 @@ fragment AuctionArtworksRail_sale on Sale {
 }
 
 fragment UpcomingAuctions_viewer on Viewer {
-  salesConnection(first: 30, sort: START_AT_ASC, auctionState: UPCOMING) {
+  salesConnection(first: 30, sort: TIMELY_AT_NAME_ASC, auctionState: UPCOMING) {
     totalCount
     edges {
       node {
@@ -72,7 +72,7 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "sort",
-    "value": "START_AT_ASC"
+    "value": "TIMELY_AT_NAME_ASC"
   }
 ];
 return {
@@ -255,7 +255,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "salesConnection(auctionState:\"UPCOMING\",first:30,sort:\"START_AT_ASC\")"
+            "storageKey": "salesConnection(auctionState:\"UPCOMING\",first:30,sort:\"TIMELY_AT_NAME_ASC\")"
           },
           {
             "alias": null,
@@ -279,7 +279,7 @@ return {
     "metadata": {},
     "name": "UpcomingAuctions_Test_Query",
     "operationKind": "query",
-    "text": "query UpcomingAuctions_Test_Query {\n  viewer {\n    ...UpcomingAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment UpcomingAuctions_viewer on Viewer {\n  salesConnection(first: 30, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query UpcomingAuctions_Test_Query {\n  viewer {\n    ...UpcomingAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment UpcomingAuctions_viewer on Viewer {\n  salesConnection(first: 30, sort: TIMELY_AT_NAME_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/UpcomingAuctions_viewer.graphql.ts
+++ b/src/v2/__generated__/UpcomingAuctions_viewer.graphql.ts
@@ -70,7 +70,7 @@ const node: ReaderFragment = {
         {
           "kind": "Literal",
           "name": "sort",
-          "value": "START_AT_ASC"
+          "value": "TIMELY_AT_NAME_ASC"
         }
       ],
       "concreteType": "SaleConnection",
@@ -201,10 +201,10 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "__UpcomingAuctions_salesConnection_connection(auctionState:\"UPCOMING\",sort:\"START_AT_ASC\")"
+      "storageKey": "__UpcomingAuctions_salesConnection_connection(auctionState:\"UPCOMING\",sort:\"TIMELY_AT_NAME_ASC\")"
     }
   ],
   "type": "Viewer"
 };
-(node as any).hash = '8cd03baa48705295b46808427e67ab54';
+(node as any).hash = '1e31c8cc404fdce3f5e94d90cdf737e2';
 export default node;

--- a/src/v2/__generated__/auctionsRoutes_Current_AuctionsQuery.graphql.ts
+++ b/src/v2/__generated__/auctionsRoutes_Current_AuctionsQuery.graphql.ts
@@ -32,7 +32,7 @@ fragment AuctionArtworksRail_sale on Sale {
 }
 
 fragment CurrentAuctions_viewer on Viewer {
-  salesConnection(first: 30, live: true, published: true, sort: START_AT_ASC, auctionState: OPEN) {
+  salesConnection(first: 30, live: true, published: true, sort: TIMELY_AT_NAME_ASC, auctionState: OPEN) {
     totalCount
     edges {
       node {
@@ -80,7 +80,7 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "sort",
-    "value": "START_AT_ASC"
+    "value": "TIMELY_AT_NAME_ASC"
   }
 ];
 return {
@@ -256,7 +256,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "salesConnection(auctionState:\"OPEN\",first:30,live:true,published:true,sort:\"START_AT_ASC\")"
+            "storageKey": "salesConnection(auctionState:\"OPEN\",first:30,live:true,published:true,sort:\"TIMELY_AT_NAME_ASC\")"
           },
           {
             "alias": null,
@@ -282,7 +282,7 @@ return {
     "metadata": {},
     "name": "auctionsRoutes_Current_AuctionsQuery",
     "operationKind": "query",
-    "text": "query auctionsRoutes_Current_AuctionsQuery {\n  viewer {\n    ...CurrentAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment CurrentAuctions_viewer on Viewer {\n  salesConnection(first: 30, live: true, published: true, sort: START_AT_ASC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query auctionsRoutes_Current_AuctionsQuery {\n  viewer {\n    ...CurrentAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment CurrentAuctions_viewer on Viewer {\n  salesConnection(first: 30, live: true, published: true, sort: TIMELY_AT_NAME_ASC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/auctionsRoutes_Past_AuctionsQuery.graphql.ts
+++ b/src/v2/__generated__/auctionsRoutes_Past_AuctionsQuery.graphql.ts
@@ -32,7 +32,7 @@ fragment AuctionArtworksRail_sale on Sale {
 }
 
 fragment PastAuctions_viewer on Viewer {
-  salesConnection(first: 30, live: false, sort: START_AT_DESC, auctionState: CLOSED) {
+  salesConnection(first: 30, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {
     totalCount
     edges {
       node {
@@ -74,7 +74,7 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "sort",
-    "value": "START_AT_DESC"
+    "value": "TIMELY_AT_NAME_DESC"
   }
 ];
 return {
@@ -243,7 +243,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "salesConnection(auctionState:\"CLOSED\",first:30,live:false,sort:\"START_AT_DESC\")"
+            "storageKey": "salesConnection(auctionState:\"CLOSED\",first:30,live:false,sort:\"TIMELY_AT_NAME_DESC\")"
           },
           {
             "alias": null,
@@ -268,7 +268,7 @@ return {
     "metadata": {},
     "name": "auctionsRoutes_Past_AuctionsQuery",
     "operationKind": "query",
-    "text": "query auctionsRoutes_Past_AuctionsQuery {\n  viewer {\n    ...PastAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment PastAuctions_viewer on Viewer {\n  salesConnection(first: 30, live: false, sort: START_AT_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query auctionsRoutes_Past_AuctionsQuery {\n  viewer {\n    ...PastAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment PastAuctions_viewer on Viewer {\n  salesConnection(first: 30, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/auctionsRoutes_Upcoming_AuctionsQuery.graphql.ts
+++ b/src/v2/__generated__/auctionsRoutes_Upcoming_AuctionsQuery.graphql.ts
@@ -32,7 +32,7 @@ fragment AuctionArtworksRail_sale on Sale {
 }
 
 fragment UpcomingAuctions_viewer on Viewer {
-  salesConnection(first: 30, sort: START_AT_ASC, auctionState: UPCOMING) {
+  salesConnection(first: 30, sort: TIMELY_AT_NAME_ASC, auctionState: UPCOMING) {
     totalCount
     edges {
       node {
@@ -72,7 +72,7 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "sort",
-    "value": "START_AT_ASC"
+    "value": "TIMELY_AT_NAME_ASC"
   }
 ];
 return {
@@ -255,7 +255,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "salesConnection(auctionState:\"UPCOMING\",first:30,sort:\"START_AT_ASC\")"
+            "storageKey": "salesConnection(auctionState:\"UPCOMING\",first:30,sort:\"TIMELY_AT_NAME_ASC\")"
           },
           {
             "alias": null,
@@ -279,7 +279,7 @@ return {
     "metadata": {},
     "name": "auctionsRoutes_Upcoming_AuctionsQuery",
     "operationKind": "query",
-    "text": "query auctionsRoutes_Upcoming_AuctionsQuery {\n  viewer {\n    ...UpcomingAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment UpcomingAuctions_viewer on Viewer {\n  salesConnection(first: 30, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query auctionsRoutes_Upcoming_AuctionsQuery {\n  viewer {\n    ...UpcomingAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment UpcomingAuctions_viewer on Viewer {\n  salesConnection(first: 30, sort: TIMELY_AT_NAME_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Fixes: https://artsyproduct.atlassian.net/browse/GRO-296🔒 

We were sorting by started_at and that seemed to be pretty unintuitive. I'd asked on [#dev-help](https://artsy.slack.com/archives/CP9P4KR35/p1618428114451400)🔒 about `timely_at` which I found in [gravity](https://github.com/artsy/gravity/blob/a1e897656e368d142f0947d473f4346d7820c0ce/app/models/domain/sale.rb#L429)🔒. 

I just updated everything to reference that. This looks like what the [old page was doing](https://github.com/artsy/force/blob/2a20ca87f57f4ffcd0af6a3902f01baefe690900/src/mobile/apps/auctions/routes.coffee#L15). 