### PR TITLE
First pass for braze sdk integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@artsy/stitch": "6.2.0",
     "@artsy/xapp": "1.0.6",
     "@babel/runtime": "7.13.10",
+    "@braze/web-sdk": "^3.2.0",
     "@loadable/component": "5.14.1",
     "@loadable/server": "5.14.0",
     "@sentry/browser": "4.5.4",

--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -137,6 +137,9 @@ module.exports =
   APPLE_KEY_ID: null
   APPLE_PRIVATE_KEY: null
   ZENDESK_KEY: null
+  BRAZE_API_KEY: null
+  BRAZE_API_URL: null
+  BRAZE_LOGGING: false
 
 # Override any values with env variables if they exist.
 # You can set JSON-y values for env variables as well such as "true" or

--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -17,6 +17,9 @@ module.exports =
   ARTSY_EDITORIAL_CHANNEL: '5759e3efb5989e6f98f77993'
   BIDDER_INFO_COPY_P1: 'Please enter your credit card information below. The name on your Artsy account must match the name on the card, and a valid credit card is required in order to bid.'
   BIDDER_INFO_COPY_P2: 'Registration is free. Artsy will never charge this card without your permission, and you are not required to use this card to pay if you win.'
+  BRAZE_API_KEY: null
+  BRAZE_API_URL: null
+  BRAZE_LOGGING: false
   CDN_URL: 'https://d1s2w0upia4e9w.cloudfront.net'
   CLIENT_ID: null
   CLIENT_SECRET: null
@@ -137,9 +140,6 @@ module.exports =
   APPLE_KEY_ID: null
   APPLE_PRIVATE_KEY: null
   ZENDESK_KEY: null
-  BRAZE_API_KEY: null
-  BRAZE_API_URL: null
-  BRAZE_LOGGING: false
 
 # Override any values with env variables if they exist.
 # You can set JSON-y values for env variables as well such as "true" or

--- a/src/lib/braze.ts
+++ b/src/lib/braze.ts
@@ -1,12 +1,13 @@
-import { data as sd } from "sharify"
+import { getENV } from "v2/Utils/getENV"
 
-export const setup = async () => {
-  if (
-    typeof window === "undefined" ||
-    !sd.BRAZE_API_KEY ||
-    !sd.BRAZE_API_URL ||
-    process.env.NODE_ENV !== "production"
-  ) {
+export const setupBraze = async () => {
+  const isClient = typeof window === "undefined"
+  const BRAZE_API_KEY = getENV("BRAZE_API_KEY")
+  const BRAZE_API_URL = getENV("BRAZE_API_URL")
+  const BRAZE_LOGGING = Boolean(getENV("BRAZE_LOGGING"))
+
+  const shouldInit = Boolean(isClient && BRAZE_API_KEY && BRAZE_API_URL)
+  if (!shouldInit) {
     return
   }
 
@@ -15,9 +16,9 @@ export const setup = async () => {
     /* webpackChunkName: "brazeSDK" */
     "@braze/web-sdk"
   )
-  braze.initialize(process.env.BRAZE_API_KEY, {
-    baseUrl: process.env.BRAZE_API_URL,
-    enableLogging: Boolean(process.env.BRAZE_LOGGING),
+  braze.initialize(BRAZE_API_KEY, {
+    baseUrl: BRAZE_API_URL,
+    enableLogging: BRAZE_LOGGING,
   })
   braze.display.automaticallyShowNewInAppMessages()
 }

--- a/src/lib/braze.ts
+++ b/src/lib/braze.ts
@@ -1,0 +1,23 @@
+import { data as sd } from "sharify"
+
+export const setup = async () => {
+  if (
+    typeof window === "undefined" ||
+    !sd.BRAZE_API_KEY ||
+    !sd.BRAZE_API_URL ||
+    process.env.NODE_ENV !== "production"
+  ) {
+    return
+  }
+
+  // Load this async to not bloat our bundles or startup times
+  const { default: braze } = await import(
+    /* webpackChunkName: "brazeSDK" */
+    "@braze/web-sdk"
+  )
+  braze.initialize(process.env.BRAZE_API_KEY, {
+    baseUrl: process.env.BRAZE_API_URL,
+    enableLogging: Boolean(process.env.BRAZE_LOGGING),
+  })
+  braze.display.automaticallyShowNewInAppMessages()
+}

--- a/src/lib/setup_sharify.js
+++ b/src/lib/setup_sharify.js
@@ -100,7 +100,10 @@ sharify.data = _.extend(
     "TRACK_PAGELOAD_PATHS",
     "VOLLEY_ENDPOINT",
     "WEBFONT_URL",
-    "ZENDESK_KEY"
+    "ZENDESK_KEY",
+    "BRAZE_API_KEY",
+    "BRAZE_API_URL",
+    "BRAZE_LOGGING"
   ),
   {
     CSS_EXT: ["production", "staging"].includes(config.NODE_ENV)

--- a/src/typings/sharify.d.ts
+++ b/src/typings/sharify.d.ts
@@ -54,6 +54,9 @@ declare module "sharify" {
       readonly XAPP_TOKEN: string
       readonly GOOGLE_MAPS_API_KEY: string
       readonly ZENDESK_KEY: string
+      readonly BRAZE_API_KEY: string
+      readonly BRAZE_API_URL: string
+      readonly BRAZE_LOGGING: boolean
 
       // FORCE Tokens
       AP: {

--- a/src/v2/client.tsx
+++ b/src/v2/client.tsx
@@ -8,7 +8,7 @@ import { logoutEventHandler } from "desktop/lib/logoutHandler"
 import { mediator } from "lib/mediator"
 import { beforeAnalyticsReady, onAnalyticsReady } from "lib/analytics/helpers"
 import { getClientParam } from "./Utils/getClientParam"
-import { setup as setupMarketing } from "lib/braze"
+import { setupBraze } from "lib/braze"
 
 async function setupClient() {
   const clientImports = await Promise.all([
@@ -64,7 +64,7 @@ async function setupClient() {
     console.error("[v2/client.tsx] Error loading client:", error)
   }
   try {
-    setupMarketing()
+    await setupBraze()
   } catch (error) {
     console.error("Braze marketing sdk setup failed:", error)
   }

--- a/src/v2/client.tsx
+++ b/src/v2/client.tsx
@@ -8,6 +8,7 @@ import { logoutEventHandler } from "desktop/lib/logoutHandler"
 import { mediator } from "lib/mediator"
 import { beforeAnalyticsReady, onAnalyticsReady } from "lib/analytics/helpers"
 import { getClientParam } from "./Utils/getClientParam"
+import { setup as setupMarketing } from "lib/braze"
 
 async function setupClient() {
   const clientImports = await Promise.all([
@@ -61,6 +62,11 @@ async function setupClient() {
     await setupClient()
   } catch (error) {
     console.error("[v2/client.tsx] Error loading client:", error)
+  }
+  try {
+    setupMarketing()
+  } catch (error) {
+    console.error("Braze marketing sdk setup failed:", error)
   }
 })()
 

--- a/src/v2/client.tsx
+++ b/src/v2/client.tsx
@@ -66,7 +66,7 @@ async function setupClient() {
   try {
     await setupBraze()
   } catch (error) {
-    console.error("Braze marketing sdk setup failed:", error)
+    console.error("[v2/client.tsx] Braze marketing sdk setup failed:", error)
   }
 })()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1261,6 +1261,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@braze/web-sdk@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@braze/web-sdk/-/web-sdk-3.2.0.tgz#7b21cd62ee0f52a1387e3372990d4692b3c65756"
+  integrity sha512-tcAiO++9SsG5QgLSUOII1dwi7rbOgELnH/zJ6uJwsT3pBOKH2gbPOfS8hfr39AhezTuvsgeHITv2TLw/nds2aQ==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"


### PR DESCRIPTION
This isn't done.

Will address: https://artsyproduct.atlassian.net/browse/GRO-260

There's a few pending questions:
- Where do we ultimately set this up? I've went through a naive implementation and set it up in client. It's global, initializes after the client, imports dynamically. There are some real tradeoffs (like it only works on new pages). 
- How does marketing plan to use braze and how might that mean we need to set it up? I've got this `braze.display.automaticallyShowNewInAppMessages()` snippet that should automatically show any configured app messages, but it none of the other target types are enabled. 