### PR TITLE
GRO-252 : Consolidate <Footer> into single location inside of <AppShell>

### DIFF
--- a/src/v2/Apps/Artist/ArtistApp.tsx
+++ b/src/v2/Apps/Artist/ArtistApp.tsx
@@ -8,7 +8,6 @@ import { useTracking } from "v2/Artsy"
 import { track } from "v2/Artsy/Analytics"
 import * as Schema from "v2/Artsy/Analytics/Schema"
 import { findCurrentRoute } from "v2/Artsy/Router/Utils/findCurrentRoute"
-import { Footer } from "v2/Components/Footer"
 import { RecentlyViewedQueryRenderer as RecentlyViewed } from "v2/Components/RecentlyViewed"
 import { Match } from "found"
 import React from "react"
@@ -117,12 +116,6 @@ export const ArtistApp: React.FC<ArtistAppProps> = props => {
             </LazyLoadComponent>
           </>
         )}
-
-        <Row>
-          <Col>
-            <Footer />
-          </Col>
-        </Row>
       </HorizontalPaddingArea>
     </AppContainer>
   )

--- a/src/v2/Apps/ArtistSeries/ArtistSeriesApp.tsx
+++ b/src/v2/Apps/ArtistSeries/ArtistSeriesApp.tsx
@@ -64,7 +64,6 @@ const ArtistSeriesApp: React.FC<ArtistSeriesAppProps> = ({ artistSeries }) => {
                   />
                 </LazyLoadComponent>
               )}
-              <Footer />
             </AppContainer>
           </Box>
         </AppContainer>

--- a/src/v2/Apps/ArtistSeries/ArtistSeriesApp.tsx
+++ b/src/v2/Apps/ArtistSeries/ArtistSeriesApp.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { Box, Separator, Spacer } from "@artsy/palette"
 
-import { Footer } from "v2/Components/Footer"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtistSeriesApp_artistSeries } from "v2/__generated__/ArtistSeriesApp_artistSeries.graphql"
 import { ArtistSeriesHeaderFragmentContainer as ArtistSeriesHeader } from "./Components/ArtistSeriesHeader"

--- a/src/v2/Apps/Artists/ArtistsApp.tsx
+++ b/src/v2/Apps/Artists/ArtistsApp.tsx
@@ -1,18 +1,13 @@
 import React from "react"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
-import { Footer } from "v2/Components/Footer"
 
 interface ArtistsAppProps {}
 
 export const ArtistsApp: React.FC<ArtistsAppProps> = ({ children }) => {
   return (
     <AppContainer>
-      <HorizontalPadding>
-        {children}
-
-        <Footer />
-      </HorizontalPadding>
+      <HorizontalPadding>{children}</HorizontalPadding>
     </AppContainer>
   )
 }

--- a/src/v2/Apps/Artwork/ArtworkApp.tsx
+++ b/src/v2/Apps/Artwork/ArtworkApp.tsx
@@ -23,7 +23,6 @@ import { PricingContextFragmentContainer as PricingContext } from "./Components/
 import { withSystemContext } from "v2/Artsy"
 import * as Schema from "v2/Artsy/Analytics/Schema"
 import { useRouteTracking } from "v2/Artsy/Analytics/useRouteTracking"
-import { Footer } from "v2/Components/Footer"
 import { RecentlyViewedQueryRenderer as RecentlyViewed } from "v2/Components/RecentlyViewed"
 import { RouterContext } from "found"
 import { TrackingProp } from "react-tracking"
@@ -295,13 +294,6 @@ export class ArtworkApp extends React.Component<Props> {
               </Row>
             </LazyLoadComponent>
           )}
-
-          <Row>
-            <Col>
-              <Footer />
-            </Col>
-          </Row>
-
           <div
             id="lightbox-container"
             style={{

--- a/src/v2/Apps/Auctions/AuctionsApp.tsx
+++ b/src/v2/Apps/Auctions/AuctionsApp.tsx
@@ -13,7 +13,6 @@ import {
   Text,
 } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
-import { Footer } from "v2/Components/Footer"
 import { HorizontalPadding } from "../Components/HorizontalPadding"
 import { LazyLoadComponent } from "react-lazy-load-image-component"
 import { RecentlyViewedQueryRenderer as RecentlyViewed } from "v2/Components/RecentlyViewed"

--- a/src/v2/Apps/Auctions/AuctionsApp.tsx
+++ b/src/v2/Apps/Auctions/AuctionsApp.tsx
@@ -101,7 +101,6 @@ const AuctionsApp: React.FC<AuctionsAppProps> = props => {
             </LazyLoadComponent>
           </>
         )}
-        <Footer />
       </HorizontalPadding>
     </AppContainer>
   )

--- a/src/v2/Apps/Components/AppShell.tsx
+++ b/src/v2/Apps/Components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { Box, Col, Row } from "@artsy/palette"
+import { Box } from "@artsy/palette"
 import { NetworkOfflineMonitor } from "v2/Artsy/Router/NetworkOfflineMonitor"
 import { findCurrentRoute } from "v2/Artsy/Router/Utils/findCurrentRoute"
 import { useMaybeReloadAfterInquirySignIn } from "v2/Artsy/Router/Utils/useMaybeReloadAfterInquirySignIn"
@@ -8,6 +8,8 @@ import { isFunction } from "lodash"
 import { Footer } from "v2/Components/Footer"
 import React, { useEffect } from "react"
 import createLogger from "v2/Utils/logger"
+import { useSystemContext } from "v2/Artsy"
+import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
 
 const logger = createLogger("Apps/Components/AppShell")
 
@@ -19,6 +21,8 @@ interface AppShellProps {
 export const AppShell: React.FC<AppShellProps> = props => {
   const { children, match } = props
   const routeConfig = findCurrentRoute(match)
+  const { isEigen } = useSystemContext()
+  const showFooter = !isEigen
 
   /**
    * Check to see if a route has a prepare key; if so call it. Used typically to
@@ -62,12 +66,7 @@ export const AppShell: React.FC<AppShellProps> = props => {
       </Box>
 
       <NetworkOfflineMonitor />
-
-      <Row>
-        <Col>
-          <Footer />
-        </Col>
-      </Row>
+      <HorizontalPadding>{showFooter && <Footer />}</HorizontalPadding>
     </Box>
   )
 }

--- a/src/v2/Apps/Components/AppShell.tsx
+++ b/src/v2/Apps/Components/AppShell.tsx
@@ -1,10 +1,11 @@
-import { Box } from "@artsy/palette"
+import { Box, Col, Row } from "@artsy/palette"
 import { NetworkOfflineMonitor } from "v2/Artsy/Router/NetworkOfflineMonitor"
 import { findCurrentRoute } from "v2/Artsy/Router/Utils/findCurrentRoute"
 import { useMaybeReloadAfterInquirySignIn } from "v2/Artsy/Router/Utils/useMaybeReloadAfterInquirySignIn"
 import { NAV_BAR_HEIGHT, NavBar, MOBILE_NAV_HEIGHT } from "v2/Components/NavBar"
 import { Match } from "found"
 import { isFunction } from "lodash"
+import { Footer } from "v2/Components/Footer"
 import React, { useEffect } from "react"
 import createLogger from "v2/Utils/logger"
 
@@ -61,6 +62,12 @@ export const AppShell: React.FC<AppShellProps> = props => {
       </Box>
 
       <NetworkOfflineMonitor />
+
+      <Row>
+        <Col>
+          <Footer />
+        </Col>
+      </Row>
     </Box>
   )
 }

--- a/src/v2/Apps/Fair/FairApp.tsx
+++ b/src/v2/Apps/Fair/FairApp.tsx
@@ -4,7 +4,6 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { FairApp_fair } from "v2/__generated__/FairApp_fair.graphql"
 import { Box, CSSGrid, Text } from "@artsy/palette"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
-import { Footer } from "v2/Components/Footer"
 import {
   FairEditorialFragmentContainer,
   FAIR_EDITORIAL_AMOUNT,
@@ -147,8 +146,6 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
           </RouteTabs>
 
           {children}
-
-          <Footer />
         </HorizontalPadding>
       </AppContainer>
     </>

--- a/src/v2/Apps/Fair/FairSubApp.tsx
+++ b/src/v2/Apps/Fair/FairSubApp.tsx
@@ -3,7 +3,6 @@ import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairSubApp_fair } from "v2/__generated__/FairSubApp_fair.graphql"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
-import { Footer } from "v2/Components/Footer"
 import { BackLink } from "v2/Components/Links/BackLink"
 import { FairMetaFragmentContainer as FairMeta } from "./Components/FairMeta"
 import { useSystemContext } from "v2/Artsy"
@@ -33,8 +32,6 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
           </BackLink>
 
           {children}
-
-          <Footer />
         </HorizontalPadding>
       </AppContainer>
     </>

--- a/src/v2/Apps/Fairs/FairsApp.tsx
+++ b/src/v2/Apps/Fairs/FairsApp.tsx
@@ -1,18 +1,13 @@
 import React from "react"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
-import { Footer } from "v2/Components/Footer"
 
 interface FairsAppProps {}
 
 export const FairsApp: React.FC<FairsAppProps> = ({ children }) => {
   return (
     <AppContainer>
-      <HorizontalPadding>
-        {children}
-
-        <Footer />
-      </HorizontalPadding>
+      <HorizontalPadding>{children}</HorizontalPadding>
     </AppContainer>
   )
 }

--- a/src/v2/Apps/Feature/FeatureApp.tsx
+++ b/src/v2/Apps/Feature/FeatureApp.tsx
@@ -7,7 +7,6 @@ import { FeatureApp_feature } from "v2/__generated__/FeatureApp_feature.graphql"
 import { Col, Grid, HTML, Join, Row, Spacer } from "@artsy/palette"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
 import { FeatureSetFragmentContainer as FeatureSet } from "./Components/FeatureSet"
-import { Footer } from "v2/Components/Footer"
 
 interface FeatureAppProps {
   feature: FeatureApp_feature
@@ -46,8 +45,6 @@ const FeatureApp: React.FC<FeatureAppProps> = ({ feature }) => {
             feature.sets.edges.map(
               ({ node: set }) => set && <FeatureSet key={set.id} set={set} />
             )}
-
-          <Footer />
         </HorizontalPadding>
       </AppContainer>
     </>

--- a/src/v2/Apps/Gene/GeneApp.tsx
+++ b/src/v2/Apps/Gene/GeneApp.tsx
@@ -2,7 +2,6 @@ import { ThemeProviderV3 } from "@artsy/palette"
 import React from "react"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
-import { Footer } from "v2/Components/Footer"
 
 interface GeneAppProps {}
 
@@ -10,11 +9,7 @@ export const GeneApp: React.FC<GeneAppProps> = ({ children }) => {
   return (
     <ThemeProviderV3>
       <AppContainer>
-        <HorizontalPadding>
-          {children}
-
-          <Footer />
-        </HorizontalPadding>
+        <HorizontalPadding>{children}</HorizontalPadding>
       </AppContainer>
     </ThemeProviderV3>
   )

--- a/src/v2/Apps/Partner/PartnerApp.tsx
+++ b/src/v2/Apps/Partner/PartnerApp.tsx
@@ -40,8 +40,6 @@ export const PartnerApp: React.FC<PartnerAppProps> = ({
             <NavigationTabs partner={partner} />
 
             {children}
-
-            <Footer />
           </HorizontalPadding>
         </AppContainer>
       </Foreground>

--- a/src/v2/Apps/Partner/PartnerApp.tsx
+++ b/src/v2/Apps/Partner/PartnerApp.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { Separator } from "@artsy/palette"
-import { Footer } from "v2/Components/Footer"
 import { AppContainer } from "../Components/AppContainer"
 import { HorizontalPadding } from "../Components/HorizontalPadding"
 import { createFragmentContainer, graphql } from "react-relay"

--- a/src/v2/Apps/Search/SearchApp.tsx
+++ b/src/v2/Apps/Search/SearchApp.tsx
@@ -8,7 +8,6 @@ import { withSystemContext } from "v2/Artsy"
 import { track } from "v2/Artsy/Analytics"
 import * as Schema from "v2/Artsy/Analytics/Schema"
 
-import { Footer } from "v2/Components/Footer"
 import { RecentlyViewedQueryRenderer as RecentlyViewed } from "v2/Components/RecentlyViewed"
 
 import { RouterState, withRouter } from "found"
@@ -86,12 +85,6 @@ export class SearchApp extends React.Component<Props> {
         <Row>
           <Col>
             <RecentlyViewed />
-          </Col>
-        </Row>
-
-        <Row>
-          <Col>
-            <Footer />
           </Col>
         </Row>
       </>

--- a/src/v2/Apps/Show/ShowApp.tsx
+++ b/src/v2/Apps/Show/ShowApp.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
-import { Footer } from "v2/Components/Footer"
 import { Column, GridColumns, Separator } from "@artsy/palette"
 import { ShowMetaFragmentContainer as ShowMeta } from "v2/Apps/Show/Components/ShowMeta"
 import { ShowHeaderFragmentContainer as ShowHeader } from "./Components/ShowHeader"
@@ -93,8 +92,6 @@ export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
             <Separator as="hr" my={3} />
 
             <ShowContextCard show={show} />
-
-            <Footer />
           </HorizontalPadding>
         </AnalyticsContext.Provider>
       </AppContainer>

--- a/src/v2/Apps/Show/ShowSubApp.tsx
+++ b/src/v2/Apps/Show/ShowSubApp.tsx
@@ -4,7 +4,6 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { Box } from "@artsy/palette"
 import { ShowSubApp_show } from "v2/__generated__/ShowSubApp_show.graphql"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
-import { Footer } from "v2/Components/Footer"
 import { BackLink } from "v2/Components/Links/BackLink"
 import { ShowMetaFragmentContainer as ShowMeta } from "./Components/ShowMeta"
 import {
@@ -40,8 +39,6 @@ const ShowApp: React.FC<ShowAppProps> = ({ children, show }) => {
             </BackLink>
 
             <Box minHeight="50vh">{children}</Box>
-
-            <Footer />
           </HorizontalPadding>
         </AnalyticsContext.Provider>
       </AppContainer>

--- a/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
+++ b/src/v2/Apps/ViewingRoom/ViewingRoomApp.tsx
@@ -8,7 +8,6 @@ import { createFragmentContainer, graphql } from "react-relay"
 
 import { ViewingRoomApp_viewingRoom } from "v2/__generated__/ViewingRoomApp_viewingRoom.graphql"
 import { ViewingRoomMetaFragmentContainer as ViewingRoomMeta } from "./Components/ViewingRoomMeta"
-import { Footer } from "v2/Components/Footer"
 import { ErrorPage } from "v2/Components/ErrorPage"
 import { openAuthModal } from "v2/Utils/openAuthModal"
 import { SystemContext } from "v2/Artsy"
@@ -86,9 +85,6 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
       <AppContainer maxWidth="100%">
         <ViewingRoomHeader viewingRoom={viewingRoom} />
         {user && getView()}
-        <Box mx={2}>
-          <Footer />
-        </Box>
       </AppContainer>
     </>
   )

--- a/src/v2/Apps/ViewingRoom/ViewingRoomsApp.tsx
+++ b/src/v2/Apps/ViewingRoom/ViewingRoomsApp.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import { AppContainer } from "v2/Apps/Components/AppContainer"
 import { Box, Sans, breakpoints } from "@artsy/palette"
 import { ViewingRoomsLatestGridFragmentContainer as ViewingRoomsLatestGrid } from "./Components/ViewingRoomsLatestGrid"
-import { Footer } from "v2/Components/Footer"
 import { ViewingRoomsMeta } from "./Components/ViewingRoomsMeta"
 import { ViewingRoomsApp_allViewingRooms } from "v2/__generated__/ViewingRoomsApp_allViewingRooms.graphql"
 import { ViewingRoomsApp_featuredViewingRooms } from "v2/__generated__/ViewingRoomsApp_featuredViewingRooms.graphql"
@@ -31,9 +30,6 @@ const ViewingRoomsApp: React.FC<ViewingRoomsAppProps> = props => {
             />
             <ViewingRoomsLatestGrid viewingRooms={allViewingRooms} />
           </Box>
-        </Box>
-        <Box mx={2}>
-          <Footer />
         </Box>
       </AppContainer>
     </>

--- a/src/v2/Components/FrameWithRecentlyViewed.tsx
+++ b/src/v2/Components/FrameWithRecentlyViewed.tsx
@@ -1,10 +1,9 @@
-import { Box, Flex } from "@artsy/palette"
+import { Flex } from "@artsy/palette"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
-import { useSystemContext } from "v2/Artsy"
+// import { useSystemContext } from "v2/Artsy"
 import React from "react"
 import { LazyLoadComponent } from "react-lazy-load-image-component"
 
-import { Footer } from "v2/Components/Footer"
 import { RecentlyViewedQueryRenderer as RecentlyViewed } from "v2/Components/RecentlyViewed"
 
 export interface Props {
@@ -12,8 +11,8 @@ export interface Props {
 }
 
 export const FrameWithRecentlyViewed: React.SFC<Props> = ({ children }) => {
-  const { isEigen } = useSystemContext()
-  const showFooter = !isEigen
+  // const { isEigen } = useSystemContext()
+  // const showFooter = !isEigen
 
   return (
     <HorizontalPadding>
@@ -24,12 +23,6 @@ export const FrameWithRecentlyViewed: React.SFC<Props> = ({ children }) => {
           <LazyLoadComponent threshold={1000}>
             <RecentlyViewed />
           </LazyLoadComponent>
-        )}
-
-        {showFooter && (
-          <Box>
-            <Footer />
-          </Box>
         )}
       </Flex>
     </HorizontalPadding>

--- a/src/v2/Components/FrameWithRecentlyViewed.tsx
+++ b/src/v2/Components/FrameWithRecentlyViewed.tsx
@@ -1,6 +1,5 @@
 import { Flex } from "@artsy/palette"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
-// import { useSystemContext } from "v2/Artsy"
 import React from "react"
 import { LazyLoadComponent } from "react-lazy-load-image-component"
 
@@ -11,9 +10,6 @@ export interface Props {
 }
 
 export const FrameWithRecentlyViewed: React.SFC<Props> = ({ children }) => {
-  // const { isEigen } = useSystemContext()
-  // const showFooter = !isEigen
-
   return (
     <HorizontalPadding>
       <Flex flexDirection="column">


### PR DESCRIPTION
[GRO-252] : This is to Consolidate `<Footer>` into single location inside of `<AppShell>`.

Currently a global search through force shows that we're importing the footer within every single `v2/Apps/<AppName>`. Since all of these apps share `<AppShell>`, the footer should live there, in one location, and all of the duplication can be removed. 

Went through and removed duplicated usage of `<Footer>` component, and verified that Footer component is still seen due to its inclusion in `<AppShell>`

[GRO-252]: https://artsyproduct.atlassian.net/browse/GRO-252