### PR TITLE
feat(fx-2845): directly stages custom filter input on mobile

### DIFF
--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/PriceRangeFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/PriceRangeFilter.jest.tsx
@@ -155,4 +155,27 @@ describe("PriceRangeFilter", () => {
       expect(wrapper.find("RadioGroup").length).not.toBe(0)
     })
   })
+
+  it("stages the filter changes", async () => {
+    const wrapper = getWrapper()
+    context.setShouldStageFilterChanges(true)
+
+    expect(wrapper.find("Button")).toHaveLength(0)
+
+    wrapper.find("Radio").last().simulate("click")
+    await flushPromiseQueue()
+    wrapper.update()
+
+    wrapper.find(Input).first().find("input").prop("onChange")({
+      currentTarget: { value: "400" },
+    } as any)
+
+    wrapper.find(Input).last().find("input").prop("onChange")({
+      currentTarget: { value: "7500" },
+    } as any)
+
+    await flushPromiseQueue()
+
+    expect(context.stagedFilters.priceRange).toEqual("400-7500")
+  })
 })

--- a/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter2.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter2.jest.tsx
@@ -129,4 +129,22 @@ describe("SizeFilter2", () => {
       expect(wrapper.find("Checkbox").length).not.toBe(0)
     })
   })
+
+  it("stages the filter changes", async () => {
+    const wrapper = getWrapper()
+    context.setShouldStageFilterChanges(true)
+
+    wrapper
+      .find("button")
+      .filterWhere(n => n.text() === "Show custom size")
+      .simulate("click")
+
+    simulateTyping(wrapper, "height_min", "12")
+    simulateTyping(wrapper, "height_max", "16")
+    simulateTyping(wrapper, "width_min", "12")
+    simulateTyping(wrapper, "width_max", "16")
+
+    expect(context.stagedFilters.height).toEqual("12-16")
+    expect(context.stagedFilters.width).toEqual("12-16")
+  })
 })


### PR DESCRIPTION
Closes: [FX-2845](https://artsyproduct.atlassian.net/browse/FX-2845)

We definitely need to ensure this is a usable experience on staging. It works but there may be some input lag as the context updates cause the entirety of filters to re-render on every keystroke. I wasn't able to fix this with memoization and there are a lot of issues with debouncing the input in this case. AFAIK the correct way to optimize this appears to be splitting the context which is what easy peasy should do out of the box.