### PR TITLE
Fix: Add guard for when sale_artwork is null to avoid crash

### DIFF
--- a/src/v2/Components/Artwork/Details.tsx
+++ b/src/v2/Components/Artwork/Details.tsx
@@ -203,7 +203,7 @@ const BidInfo: React.FC<DetailsProps> = ({
     return null
   }
 
-  const bidderPositionCounts = sale_artwork.counts.bidder_positions ?? 0
+  const bidderPositionCounts = sale_artwork?.counts.bidder_positions ?? 0
 
   if (bidderPositionCounts === 0) {
     return null


### PR DESCRIPTION
This _should_ prevent the crash we're currently seeing on the upcoming auctions tab on the `/auctions` page. 