### PR TITLE
GRO-228: Updated Copy Text for ToS and Subscription checkboxes

### DIFF
--- a/src/v2/Components/Authentication/EmailSubscriptionCheckbox.tsx
+++ b/src/v2/Components/Authentication/EmailSubscriptionCheckbox.tsx
@@ -15,7 +15,7 @@ export const EmailSubscriptionCheckbox = ({
     <StyledCheckbox {...{ checked: value, onChange, onBlur, name }}>
       <Serif color={color} size="3t" ml={0.5}>
         {
-          "Subscribe to Artsy emails and dive deeper into the art market with insights, auction alerts, and personalized updates."
+          "Dive deeper into the art market with Artsy emails. Subscribe to hear about our products, services, editorials, and other promotional content. Unsubscribe at any time."
         }
       </Serif>
     </StyledCheckbox>

--- a/src/v2/Components/Authentication/TermsOfServiceCheckbox.tsx
+++ b/src/v2/Components/Authentication/TermsOfServiceCheckbox.tsx
@@ -17,11 +17,30 @@ export const TermsOfServiceCheckbox = ({
       <Serif color={color} size="3t" ml={0.5}>
         {"By checking this box, you consent to our "}
         <Link
+          href="https://www.artsy.net/terms"
+          target="_blank"
+          color="blue100"
+          underlineBehavior="hover"
+        >
+          Terms of Use
+        </Link>
+        {", "}
+        <Link
           href="https://www.artsy.net/privacy"
           target="_blank"
-          color={color}
+          color="blue100"
+          underlineBehavior="hover"
         >
-          privacy policy
+          Privacy Policy
+        </Link>
+        {", and "}
+        <Link
+          href="https://www.artsy.net/conditions-of-sale"
+          target="_blanks"
+          color="blue100"
+          underlineBehavior="hover"
+        >
+          Conditions of Sale
         </Link>
         {"."}
       </Serif>

--- a/src/v2/Components/Authentication/TermsOfServiceCheckbox.tsx
+++ b/src/v2/Components/Authentication/TermsOfServiceCheckbox.tsx
@@ -19,7 +19,7 @@ export const TermsOfServiceCheckbox = ({
         <Link
           href="https://www.artsy.net/terms"
           target="_blank"
-          color="blue100"
+          color={color}
           underlineBehavior="hover"
         >
           Terms of Use
@@ -28,7 +28,7 @@ export const TermsOfServiceCheckbox = ({
         <Link
           href="https://www.artsy.net/privacy"
           target="_blank"
-          color="blue100"
+          color={color}
           underlineBehavior="hover"
         >
           Privacy Policy
@@ -37,7 +37,7 @@ export const TermsOfServiceCheckbox = ({
         <Link
           href="https://www.artsy.net/conditions-of-sale"
           target="_blanks"
-          color="blue100"
+          color={color}
           underlineBehavior="hover"
         >
           Conditions of Sale

--- a/src/v2/Components/Authentication/__tests__/Desktop/SignUpForm.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/Desktop/SignUpForm.jest.tsx
@@ -148,7 +148,7 @@ describe("SignUpForm", () => {
     mockEnableRequestSignInWithApple.mockReturnValue(true)
     props.values = SignupValues
     const wrapper = getWrapper()
-    wrapper.find(Link).at(1).simulate("click")
+    wrapper.find(Link).at(3).simulate("click")
 
     setTimeout(() => {
       expect(props.onAppleLogin).toBeCalled()


### PR DESCRIPTION
This is to update the Copy Script for the Onboarding Sign Up form [GRO-228].

Past behavior:
<img width="580" alt="Screen Shot 2021-04-21 at 12 00 59 PM" src="https://user-images.githubusercontent.com/30025439/115607041-4f5b1f80-a299-11eb-8f04-ffd009d95572.png">

New behavior:
<img width="638" alt="Screen Shot 2021-04-22 at 1 40 28 PM" src="https://user-images.githubusercontent.com/30025439/115783250-7ab13d80-a371-11eb-9978-4d5d52fec57c.png">


[GRO-228]: https://artsyproduct.atlassian.net/browse/GRO-228