### PR TITLE
Fix: Call openSession to register a user's braze session

### DIFF
--- a/src/lib/braze.ts
+++ b/src/lib/braze.ts
@@ -21,4 +21,5 @@ export const setupBraze = async () => {
     enableLogging: BRAZE_LOGGING,
   })
   braze.display.automaticallyShowNewInAppMessages()
+  braze.openSession()
 }


### PR DESCRIPTION
cc @artsy/grow-devs 

I'd miss a call when initializing the braze SDK. Specifically you have to _manually_ indicate that a braze session is beginning. Given that we're currently invoking braze in [client.ts](https://github.com/artsy/force/blob/master/src/v2/client.tsx), that invocation will happen once and stay valid as they navigate between new pages in our routing infrastructure. If they navigate from a new page to an old page and back to a new page it'll re-activate their session, but so long as we have sane limits on how often we send messages they shouldn't get a retriggered in app message. 