### PR TITLE
feat: Let braze know the current user in the session

### DIFF
--- a/src/lib/braze.ts
+++ b/src/lib/braze.ts
@@ -21,5 +21,11 @@ export const setupBraze = async () => {
     enableLogging: BRAZE_LOGGING,
   })
   braze.display.automaticallyShowNewInAppMessages()
+
+  const userID = getENV("CURRENT_USER")?.id
+  if (userID) {
+    braze.changeUser(userID)
+  }
+
   braze.openSession()
 }


### PR DESCRIPTION
I'm not seeing activations in the test braze campaign I setup. As I was digging around, a comment in their [setup examples for cdn](https://github.com/Appboy/appboy-web-sdk#alternative-cdn-installation) had a note about this [changeUser](https://js.appboycdn.com/web-sdk/3.2/doc/modules/appboy.html#changeuser) method. From my understanding this is the mechanism required to de-anonymize a user. 

The one question I have is if this maps to the artsy user id or the braze user id. From their docs it sounds like the former:
> Use this method to identify a user with a unique ID