### PR TITLE
GRO-278: Add Artsy Curated Auction consignments agreement to front end.

### DIFF
--- a/src/v2/Components/Footer.tsx
+++ b/src/v2/Components/Footer.tsx
@@ -281,6 +281,12 @@ const PolicyLinks = () => (
       </Text>
     </Link>
 
+    <Link to="/page/artsy-curated-auctions-listing-agreement">
+      <Text variant="caption" color="black60" mr={1}>
+        ACA Seller’s Agreement
+      </Text>
+    </Link>
+
     <CCPAWrapper py={1} justifyContent="center">
       <CCPARequest />
     </CCPAWrapper>


### PR DESCRIPTION
This is to resolve [GRO-278] .

Added in ACA Seller’s Agreement and redirect to the universal Footer component with a redirect to https://www.artsy.net/page/artsy-curated-auctions-listing-agreement

New Behavior: 
<img width="1265" alt="Screen Shot 2021-04-22 at 10 20 21 AM" src="https://user-images.githubusercontent.com/30025439/115760852-880cfe80-a356-11eb-836b-1774d0a88cb4.png">


[GRO-278]: https://artsyproduct.atlassian.net/browse/GRO-278