### PR TITLE
fix: spacing issue in BNMO messaging

### DIFF
--- a/src/v2/Apps/Order/Routes/Status/index.tsx
+++ b/src/v2/Apps/Order/Routes/Status/index.tsx
@@ -68,7 +68,7 @@ export class StatusRoute extends Component<StatusProps> {
                 <>
                   Thank you for your purchase. You will receive a confirmation
                   email by {stateExpiresAt}.
-                  <br />
+                  <Spacer mb={1} />
                   Disruptions caused by COVID-19 may cause delays — we
                   appreciate your understanding.
                 </>
@@ -81,7 +81,7 @@ export class StatusRoute extends Component<StatusProps> {
             <>
               Thank you for your purchase. You will be notified when the work
               has shipped, typically within 5–7 business days.
-              <br />
+              <Spacer mb={1} />
               Disruptions caused by COVID-19 may cause delays — we appreciate
               your understanding.
             </>
@@ -89,7 +89,7 @@ export class StatusRoute extends Component<StatusProps> {
             <>
               Thank you for your purchase. A specialist will contact you within
               2 business days to coordinate pickup.
-              <br />
+              <Spacer mb={1} />
               Disruptions caused by COVID-19 may cause delays — we appreciate
               your understanding.
             </>
@@ -148,8 +148,7 @@ export class StatusRoute extends Component<StatusProps> {
             <>
               Thank you for your response. The seller will be informed of your
               decision to end the negotiation process.
-              <br />
-              <br />
+              <Spacer mb={2} />
               We’d love to get your feedback. Contact{" "}
               <a href="mailto:orders@artsy.net">orders@artsy.net</a> with any
               comments you have.
@@ -216,18 +215,17 @@ export class StatusRoute extends Component<StatusProps> {
     return (
       <>
         Your work is on its way.
-        <br />
-        <br />
+        <Spacer mb={2} />
         {fulfillment.courier && (
           <>
             Shipper: {fulfillment.courier}
-            <br />
+            <Spacer mb={1} />
           </>
         )}
         {fulfillment.trackingId && (
           <>
             <>Tracking info: {fulfillment.trackingId}</>
-            <br />
+            <Spacer mb={1} />
           </>
         )}
         {fulfillment.estimatedDelivery && (


### PR DESCRIPTION
Address: [PURCHASE-2577](https://artsyproduct.atlassian.net/browse/PURCHASE-2577)

This addresses the spacing issue for by MO messaging in Eigen (inquiry checkout).

We were previously using `<br>` to create spacing in the MO messaging. This didn't translate well in eigen. This PR switches to use `<Spacer />` that provides the correct spacing.

Because this is a webview I don't think we will be able to verify this until it actually merged, but below is an example of the correct spacing we want with `<Spacer />` used in another place in eigen.

<img width="365" alt="Screen Shot 2021-04-22 at 2 38 37 PM" src="https://user-images.githubusercontent.com/5201004/115775468-e949c780-a380-11eb-8b63-ca95a158db32.png">

