### PR TITLE
fix(PX-3984): parent child margin collapsing

### DIFF
--- a/src/v2/Apps/Partner/PartnerApp.tsx
+++ b/src/v2/Apps/Partner/PartnerApp.tsx
@@ -17,7 +17,7 @@ export interface PartnerAppProps {
 const Foreground = styled(FullBleed)`
   background-color: white;
   z-index: 1;
-  display: inline-block;
+  display: flex;
 `
 
 export const PartnerApp: React.FC<PartnerAppProps> = ({


### PR DESCRIPTION
Initially, I used `inline-block` to fix margin collapsing on the partner profile page(https://github.com/artsy/force/pull/7403), but it looks like if the inline-block contains block with  `overflow: hidden` it adds some space after inline-block element. This PR uses `flex` instead of `inline-block`

JIRA - https://artsyproduct.atlassian.net/browse/PX-3984

![ezgif com-gif-maker (15)](https://user-images.githubusercontent.com/79979820/115868455-26778d80-a445-11eb-925c-9ed91fc47c8f.gif)

Before:
![image](https://user-images.githubusercontent.com/79979820/115867097-4d34c480-a443-11eb-8a56-f24404736ded.png)

Now:
![image](https://user-images.githubusercontent.com/79979820/115867049-3b532180-a443-11eb-820c-e07bd565849a.png)

