### PR TITLE
fix: Webpack Source Maps

### DIFF
--- a/webpack/envs/clientProductionConfig.js
+++ b/webpack/envs/clientProductionConfig.js
@@ -15,7 +15,7 @@ import {
 } from "./commonLoaders"
 import {
   clientExternals,
-  standardDevtool,
+  productionDevtool,
   standardMinimizer,
   standardMode,
   standardResolve,
@@ -25,7 +25,7 @@ import { standardPlugins } from "./commonPlugins"
 import { clientChunks } from "./clientCommonConfig"
 
 export const clientProductionConfig = {
-  devtool: standardDevtool,
+  devtool: productionDevtool,
   entry: {
     "artsy-novo": [path.resolve(process.cwd(), "src/v2/client.tsx")],
   },

--- a/webpack/envs/commonEnv.js
+++ b/webpack/envs/commonEnv.js
@@ -6,6 +6,8 @@ import { basePath, env } from "../utils/env"
 
 export const standardDevtool = env.webpackDevtool || "eval"
 
+export const productionDevtool = env.webpackDevtool || "source-map"
+
 export const standardMode = env.webpackDebug ? "development" : env.nodeEnv
 
 export const standardStats = env.webpackStats || "errors-only"

--- a/webpack/plugins/bundleAnalyzer.js
+++ b/webpack/plugins/bundleAnalyzer.js
@@ -10,7 +10,6 @@ export function bundleAnalyzer(config) {
   }
 
   return merge.smart(config, {
-    devtool: false,
     stats: "normal",
     optimization: {
       concatenateModules: false,


### PR DESCRIPTION
At some point, the production source maps were misconfigured causing
source maps to be inlined in our assets essentially doubling their size.

Also, ensure that the bundle report uses the correct source maps.