### PR TITLE
fix(PX-3967): add max width to the carousel container

### DIFF
--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails.tsx
@@ -70,7 +70,7 @@ export const PartnerArtistDetails: React.FC<PartnerArtistDetailsProps> = ({
             </Text>
           )}
         </Column>
-        <Column span={12}>
+        <Column span={12} maxWidth="100%">
           <Carousel arrowHeight={160}>
             {filterArtworksConnection.edges.map((artwork, i) => {
               return (

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetailsPlaceholder.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetailsPlaceholder.tsx
@@ -45,7 +45,7 @@ export const PartnerArtistDetailsPlaceholder: React.FC<PartnerArtistDetailsPlace
             ullamcorper nunc.
           </SkeletonText>
         </Column>
-        <Column span={12}>
+        <Column span={12} maxWidth="100%">
           <Carousel arrowHeight={160}>
             {[...new Array(10)].map((_, i) => {
               return (


### PR DESCRIPTION
This PR fixes artwork carousel for Firefox.

JIRA - https://artsyproduct.atlassian.net/browse/PX-3967

Before: 
![image](https://user-images.githubusercontent.com/79979820/116375660-2c3feb00-a818-11eb-8f79-8fae73d2f38f.png)


Now:  
![image](https://user-images.githubusercontent.com/79979820/116375425-f13db780-a817-11eb-9803-75884293813a.png)
