### PR TITLE
feat: Sync filter state with url params on gene page

### DIFF
--- a/src/v2/Apps/Gene/Components/GeneArtworkFilter.tsx
+++ b/src/v2/Apps/Gene/Components/GeneArtworkFilter.tsx
@@ -3,6 +3,7 @@ import { createRefetchContainer, RelayRefetchProp, graphql } from "react-relay"
 import { useRouter } from "v2/Artsy/Router/useRouter"
 import { BaseArtworkFilter } from "v2/Components/v2/ArtworkFilter"
 import { ArtworkFilterContextProvider } from "v2/Components/v2/ArtworkFilter/ArtworkFilterContext"
+import { updateUrl } from "v2/Components/v2/ArtworkFilter/Utils/urlBuilder"
 import { GeneArtworkFilter_gene } from "v2/__generated__/GeneArtworkFilter_gene.graphql"
 
 interface GeneArtworkFilterProps {
@@ -19,6 +20,7 @@ const GeneArtworkFilter: React.FC<GeneArtworkFilterProps> = ({
   return (
     <ArtworkFilterContextProvider
       filters={match && match.location.query}
+      onChange={updateUrl}
       sortOptions={[
         { text: "Default", value: "-decayed_merch" },
         { text: "Price (desc.)", value: "-has_price,-prices" },

--- a/src/v2/Apps/Gene/geneRoutes.tsx
+++ b/src/v2/Apps/Gene/geneRoutes.tsx
@@ -1,6 +1,9 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { RouteConfig } from "found"
+import { allowedFilters } from "v2/Components/v2/ArtworkFilter/Utils/allowedFilters"
+import { paramsToCamelCase } from "v2/Components/v2/ArtworkFilter/Utils/urlBuilder"
+import { initialArtworkFilterState } from "v2/Components/v2/ArtworkFilter/ArtworkFilterContext"
 
 const GeneApp = loadable(() => import("./GeneApp"), {
   resolveComponent: component => component.GeneApp,
@@ -24,6 +27,19 @@ export const geneRoutes: RouteConfig[] = [
         getComponent: () => GeneShowRoute,
         prepare: () => {
           return GeneShowRoute.preload()
+        },
+        prepareVariables: ({ slug }, props) => {
+          const urlFilterState = props.location ? props.location.query : {}
+
+          const filters = {
+            ...initialArtworkFilterState,
+            ...paramsToCamelCase(urlFilterState),
+          }
+
+          return {
+            input: allowedFilters(filters),
+            slug,
+          }
         },
         query: graphql`
           query geneRoutes_GeneShowQuery(


### PR DESCRIPTION
Addresses [FX-2893]

[FX-2893]: https://artsyproduct.atlassian.net/browse/FX-2893

## Description

This PR updates the address bar when the filter state changes on the Gene page and applies filters from the address bar when loading the page. 
