### PR TITLE
fix(fx-2869): reset context to prevent stale filter state

### DIFF
--- a/src/v2/Apps/Artwork/ArtworkApp.tsx
+++ b/src/v2/Apps/Artwork/ArtworkApp.tsx
@@ -22,7 +22,6 @@ import { PricingContextFragmentContainer as PricingContext } from "./Components/
 
 import { withSystemContext } from "v2/Artsy"
 import * as Schema from "v2/Artsy/Analytics/Schema"
-import { useRouteTracking } from "v2/Artsy/Analytics/useRouteTracking"
 import { RecentlyViewedQueryRenderer as RecentlyViewed } from "v2/Components/RecentlyViewed"
 import { RouterContext } from "found"
 import { TrackingProp } from "react-tracking"
@@ -34,6 +33,7 @@ import {
 import { Mediator } from "lib/mediator"
 import { data } from "sharify"
 import { ReCaptchaContainer } from "v2/Utils/ReCaptchaContainer"
+import { useRouteComplete } from "v2/Utils/Hooks/useRouteComplete"
 
 export interface Props {
   artwork: ArtworkApp_artwork
@@ -322,7 +322,7 @@ const TrackingWrappedArtworkApp: React.FC<Props> = props => {
   // Check to see if referrer comes from link interception.
   // @see interceptLinks.ts
   const referrer = state && state.previousHref
-  const shouldTrackPageView = useRouteTracking()
+  const { isComplete } = useRouteComplete()
 
   return (
     <AnalyticsContext.Provider
@@ -336,7 +336,7 @@ const TrackingWrappedArtworkApp: React.FC<Props> = props => {
         {...props}
         routerPathname={pathname}
         referrer={referrer}
-        shouldTrackPageView={shouldTrackPageView}
+        shouldTrackPageView={isComplete}
       />
     </AnalyticsContext.Provider>
   )

--- a/src/v2/Apps/Collect/Routes/Collection/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/index.tsx
@@ -31,6 +31,7 @@ import {
 import { updateUrl } from "v2/Components/v2/ArtworkFilter/Utils/urlBuilder"
 import { TrackingProp } from "react-tracking"
 import { ErrorPage } from "v2/Components/ErrorPage"
+import { usePathnameComplete } from "v2/Utils/Hooks/usePathnameComplete"
 
 interface CollectionAppProps extends SystemContextProps, AnalyticsContextProps {
   collection: Collection_collection
@@ -45,6 +46,8 @@ export const CollectionApp: React.FC<CollectionAppProps> = props => {
     match: { location },
     relay,
   } = props
+
+  const { pathname } = usePathnameComplete()
 
   if (!collection) return <ErrorPage code={404} />
 
@@ -114,6 +117,9 @@ export const CollectionApp: React.FC<CollectionAppProps> = props => {
             )}
             <Box>
               <ArtworkFilterContextProvider
+                // Reset state of filter context without calling reset; which would
+                // affect analytics.
+                key={pathname}
                 filters={location.query}
                 sortOptions={[
                   { text: "Default", value: "-decayed_merch" },

--- a/src/v2/Utils/Hooks/usePathnameComplete.ts
+++ b/src/v2/Utils/Hooks/usePathnameComplete.ts
@@ -2,6 +2,12 @@ import { useState } from "react"
 import { useRouter } from "v2/Artsy/Router/useRouter"
 import { useRouteComplete } from "./useRouteComplete"
 
+/**
+ * Will return the active pathname *after*  the route completes.
+ * When a route change happens the route will immediately update even though
+ * the new route is still loading and hasn't been rendered. This waits until
+ * the render is complete and returns the next pathname.
+ */
 export const usePathnameComplete = () => {
   const { match } = useRouter()
   const [pathname, setPathname] = useState(match?.location?.pathname)

--- a/src/v2/Utils/Hooks/usePathnameComplete.ts
+++ b/src/v2/Utils/Hooks/usePathnameComplete.ts
@@ -1,0 +1,16 @@
+import { useState } from "react"
+import { useRouter } from "v2/Artsy/Router/useRouter"
+import { useRouteComplete } from "./useRouteComplete"
+
+export const usePathnameComplete = () => {
+  const { match } = useRouter()
+  const [pathname, setPathname] = useState(match?.location?.pathname)
+
+  useRouteComplete({
+    onComplete: () => {
+      setPathname(match?.location?.pathname)
+    },
+  })
+
+  return { pathname }
+}

--- a/src/v2/Utils/Hooks/usePrevious.ts
+++ b/src/v2/Utils/Hooks/usePrevious.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react"
 
-export function usePrevious(value) {
+export function usePrevious<T>(value: T) {
   const ref = useRef(value)
   useEffect(() => {
     ref.current = value

--- a/src/v2/Utils/Hooks/useRouteComplete.ts
+++ b/src/v2/Utils/Hooks/useRouteComplete.ts
@@ -3,25 +3,27 @@ import { useEffect, useState } from "react"
 import { usePrevious } from "v2/Utils/Hooks/usePrevious"
 
 /**
- * Checks to see if a route was previously fetching and has completed, in order
- * to track at the end of execution.
+ * Checks to see if a route was previously fetching and has completed.
  */
-export function useRouteTracking() {
-  const [shouldTrack, setShouldTrack] = useState(false)
+export const useRouteComplete = ({
+  onComplete,
+}: { onComplete?(): void } = {}) => {
+  const [isComplete, setIsComplete] = useState(false)
   const { isFetching } = useSystemContext()
   const prevFetching = usePrevious(isFetching)
 
   useEffect(() => {
     if (prevFetching && !isFetching) {
-      setShouldTrack(true)
+      setIsComplete(true)
+      onComplete && onComplete()
 
       // Wait till after the next tick to set to false, to give react tree
       // ability to execute related tracking handlers
       setImmediate(() => {
-        setShouldTrack(false)
+        setIsComplete(false)
       })
     }
-  }, [isFetching, prevFetching])
+  }, [isFetching, onComplete, prevFetching])
 
-  return shouldTrack
+  return { isComplete }
 }


### PR DESCRIPTION
Closes: [FX-2869](https://artsyproduct.atlassian.net/browse/FX-2869)

So this is a follow up on https://github.com/artsy/force/pull/7386

The problem with calling reset (or creating a new event for this), is that it triggers changes in the deep compare effect outside of just the reset (which is possibly a bug?). It also updates the URL, etc. I couldn't think of a way to ignore that call without altering the state since it is tracked outside of the context component itself. Just updating the key is fine to re-initialize it IMO.

