### PR TITLE
Add 2FA recovery code display on enrollment

### DIFF
--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactorReminder.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactorReminder.tsx
@@ -1,0 +1,36 @@
+import { BorderBoxProps, Box, Flex, Sans } from "@artsy/palette"
+import React from "react"
+
+interface BackupSecondFactorReminderProps extends BorderBoxProps {
+  backupSecondFactors: string[]
+  factorTypeName: string
+}
+
+export const BackupSecondFactorReminder: React.FC<BackupSecondFactorReminderProps> = props => {
+  const { backupSecondFactors, factorTypeName } = props
+
+  return (
+    <Box minHeight="280px">
+      <Sans size="3" color="black60">
+        You can use these one-time codes to access your account if you lose
+        access to your{" "}
+        {factorTypeName === "AppSecondFactor"
+          ? "authenticator application"
+          : "phone"}
+        .
+      </Sans>
+      <Sans mt={2} size="3" color="black60">
+        Treat these codes like your password and store them in a safe place.
+      </Sans>
+      <Flex mt={3} flexDirection="row" flexWrap="wrap">
+        {backupSecondFactors.map((factor, index) => (
+          <Box width="50%" key={index}>
+            <Sans size="6" color="black60" textAlign="center" py={0.5}>
+              {factor}
+            </Sans>
+          </Box>
+        ))}
+      </Flex>
+    </Box>
+  )
+}

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactorReminder.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/BackupSecondFactorReminder.tsx
@@ -1,4 +1,4 @@
-import { BorderBoxProps, Box, Flex, Sans } from "@artsy/palette"
+import { BorderBoxProps, Box, Flex, Text } from "@artsy/palette"
 import React from "react"
 
 interface BackupSecondFactorReminderProps extends BorderBoxProps {
@@ -11,23 +11,28 @@ export const BackupSecondFactorReminder: React.FC<BackupSecondFactorReminderProp
 
   return (
     <Box minHeight="280px">
-      <Sans size="3" color="black60">
+      <Text color="black60">
         You can use these one-time codes to access your account if you lose
         access to your{" "}
         {factorTypeName === "AppSecondFactor"
           ? "authenticator application"
           : "phone"}
         .
-      </Sans>
-      <Sans mt={2} size="3" color="black60">
-        Treat these codes like your password and store them in a safe place.
-      </Sans>
+      </Text>
+      <Text mt={2} variant="mediumText" color="black80">
+        Treat these codes like a password and store them in a safe place.
+      </Text>
       <Flex mt={3} flexDirection="row" flexWrap="wrap">
         {backupSecondFactors.map((factor, index) => (
           <Box width="50%" key={index}>
-            <Sans size="6" color="black60" textAlign="center" py={0.5}>
+            <Text
+              variant="subtitle"
+              color="black60"
+              textAlign="center"
+              py={0.5}
+            >
               {factor}
-            </Sans>
+            </Text>
           </Box>
         ))}
       </Flex>

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/Mutation/EnableSecondFactor.ts
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/Mutation/EnableSecondFactor.ts
@@ -50,6 +50,7 @@ export const EnableSecondFactor = (
                   }
                 }
               }
+              recoveryCodes
             }
           }
         `,

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
@@ -55,8 +55,6 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
         code: values.code,
       })
 
-      console.log("RESPONSE", response)
-
       setRecoveryCodes(response.enableSecondFactor.recoveryCodes)
 
       setShowRecoveryCodes(true)
@@ -268,6 +266,7 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
         title="Recovery Codes"
         onClose={onComplete}
         show={showRecoveryCodes}
+        hideCloseButton={true}
         FixedButton={
           <Button onClick={handleRecoveryReminderNext} width="100%">
             next

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/__tests__/fixtures.ts
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/__tests__/fixtures.ts
@@ -22,6 +22,20 @@ export const BackupSecondFactors = [
   { code: "a9zmemiejs", __typename: "BackupSecondFactor" },
 ]
 
+export const RecoveryCodes = [
+  "d038183sj8",
+  "2494nzki4a",
+  "ze93hzna31",
+  "xfr93424b1",
+  "a93n5nziu3",
+  "asdf93nz81",
+  "8d300a5493",
+  "q0499zn411",
+  "fn3i1x239m",
+  "asd0893n2d",
+  "a9zmemiejs",
+]
+
 export const CreateBackupSecondFactorsMutationSuccessResponse: CreateBackupSecondFactorsMutationResponse = {
   createBackupSecondFactors: {
     secondFactorsOrErrors: {
@@ -153,6 +167,7 @@ export const EnableAppSecondFactorMutationSuccessResponse: EnableSecondFactorMut
     secondFactorOrErrors: {
       __typename: "AppSecondFactor",
     },
+    recoveryCodes: RecoveryCodes,
   },
 }
 
@@ -161,6 +176,7 @@ export const EnableSmsSecondFactorMutationSuccessResponse: EnableSecondFactorMut
     secondFactorOrErrors: {
       __typename: "SmsSecondFactor",
     },
+    recoveryCodes: RecoveryCodes,
   },
 }
 
@@ -176,6 +192,7 @@ export const EnableSmsSecondFactorMutationErrorResponse: EnableSecondFactorMutat
         },
       ],
     },
+    recoveryCodes: null,
   },
 }
 

--- a/src/v2/__generated__/EnableSecondFactorMutation.graphql.ts
+++ b/src/v2/__generated__/EnableSecondFactorMutation.graphql.ts
@@ -28,6 +28,7 @@ export type EnableSecondFactorMutationResponse = {
             value in case none of the concrete values match.*/
             readonly __typename: "%other";
         };
+        readonly recoveryCodes: ReadonlyArray<string> | null;
     } | null;
 };
 export type EnableSecondFactorMutationRawResponse = {
@@ -45,6 +46,7 @@ export type EnableSecondFactorMutationRawResponse = {
         } | {
             readonly __typename: string | null;
         };
+        readonly recoveryCodes: ReadonlyArray<string> | null;
     }) | null;
 };
 export type EnableSecondFactorMutation = {
@@ -76,6 +78,7 @@ mutation EnableSecondFactorMutation(
         }
       }
     }
+    recoveryCodes
   }
 }
 */
@@ -147,6 +150,13 @@ v6 = {
     }
   ],
   "type": "Errors"
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "recoveryCodes",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -176,7 +186,8 @@ return {
               (v6/*: any*/)
             ],
             "storageKey": null
-          }
+          },
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
@@ -211,7 +222,8 @@ return {
               (v6/*: any*/)
             ],
             "storageKey": null
-          }
+          },
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
@@ -222,9 +234,9 @@ return {
     "metadata": {},
     "name": "EnableSecondFactorMutation",
     "operationKind": "mutation",
-    "text": "mutation EnableSecondFactorMutation(\n  $input: EnableSecondFactorInput!\n) {\n  enableSecondFactor(input: $input) {\n    secondFactorOrErrors {\n      __typename\n      ... on SmsSecondFactor {\n        __typename\n      }\n      ... on AppSecondFactor {\n        __typename\n      }\n      ... on Errors {\n        __typename\n        errors {\n          message\n          code\n        }\n      }\n    }\n  }\n}\n"
+    "text": "mutation EnableSecondFactorMutation(\n  $input: EnableSecondFactorInput!\n) {\n  enableSecondFactor(input: $input) {\n    secondFactorOrErrors {\n      __typename\n      ... on SmsSecondFactor {\n        __typename\n      }\n      ... on AppSecondFactor {\n        __typename\n      }\n      ... on Errors {\n        __typename\n        errors {\n          message\n          code\n        }\n      }\n    }\n    recoveryCodes\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = 'deb895d4ddc2170a4c05725b6276fae4';
+(node as any).hash = 'e3165b7db63bdd9ed7fd8fcef2304f43';
 export default node;


### PR DESCRIPTION
Feature to automatically show 2FA backup recovery codes after successful enrollment. Discussed in PR https://github.com/artsy/gravity/pull/13099. 

**TO-DOs:** 
- Add copy/download functionality on display modal.

**Considerations for future:**
- When I removed all 2FA options and reenrolled, I received the same recovery codes as the prior enrollment. I would expect that if I removed all 2FA accounts that the previous recovery codes would be deleted automatically. @joeyAghion I saw your and @dblandin's discussion on the linked PR but I'm thinking of slightly different use case. Specifically if a user enrolled in 2FA, then at some point disables it and never reenroll's. I think it's worth considering the value of  holding onto potentially sensitive data for a feature the User has chosen not to use.

Jira: https://artsyproduct.atlassian.net/browse/PLATFORM-2412?atlOrigin=eyJpIjoiMmUyYjBkNWNmODVmNGM1MDgwNGRmYmJlM2QxOGRjN2QiLCJwIjoiaiJ9