### PR TITLE
fix: Artwork filter not showing followed artists for fairs

### DIFF
--- a/src/v2/Apps/Fair/fairRoutes.tsx
+++ b/src/v2/Apps/Fair/fairRoutes.tsx
@@ -136,7 +136,6 @@ function initializeVariablesWithFilterState({ slug }, props) {
   )
 
   let aggregations: string[] = ["TOTAL", "MAJOR_PERIOD", "ARTIST"]
-  if (props.context.user) aggregations = aggregations.concat("FOLLOWED_ARTISTS")
   const additionalAggregations = getENV("ENABLE_NEW_ARTWORK_FILTERS")
     ? ["ARTIST_NATIONALITY", "MATERIALS_TERMS", "PARTNER"]
     : ["GALLERY"]
@@ -147,6 +146,7 @@ function initializeVariablesWithFilterState({ slug }, props) {
     includeArtworksByFollowedArtists:
       !!props.context.user &&
       camelCasedFilterStateFromUrl["includeArtworksByFollowedArtists"],
+    aggregations: !!props.context.user ? ["FOLLOWED_ARTISTS"] : undefined,
   }
 
   return {


### PR DESCRIPTION
# Description

This PR moves the `FOLLOWED_ARTISTS` aggregation to inputs in order to make the followed artists available in the artists filter on the Fair Show page

### Screenshots

![image](https://user-images.githubusercontent.com/4691889/116722357-94d8c480-a9de-11eb-9b40-ba4d96cac2a8.png)
![image](https://user-images.githubusercontent.com/4691889/116722425-a91cc180-a9de-11eb-8c49-df24068828e4.png)
