### PR TITLE
fix(fx-2894): fixes after authentication intent on novo pages

### DIFF
--- a/src/v2/Apps/Components/AppShell.tsx
+++ b/src/v2/Apps/Components/AppShell.tsx
@@ -12,6 +12,7 @@ import { useSystemContext } from "v2/Artsy"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
 import { AppContainer } from "./AppContainer"
 import { useRouteComplete } from "v2/Utils/Hooks/useRouteComplete"
+import { useAuthIntent } from "v2/Utils/Hooks/useAuthIntent"
 
 const logger = createLogger("Apps/Components/AppShell")
 
@@ -21,6 +22,8 @@ interface AppShellProps {
 }
 
 export const AppShell: React.FC<AppShellProps> = props => {
+  useAuthIntent()
+
   const { children, match } = props
   const routeConfig = findCurrentRoute(match)
 

--- a/src/v2/Utils/Hooks/useAuthIntent/__tests__/useAuthIntent.jest.ts
+++ b/src/v2/Utils/Hooks/useAuthIntent/__tests__/useAuthIntent.jest.ts
@@ -1,0 +1,236 @@
+import { createMockEnvironment } from "relay-test-utils"
+import { runAuthIntent } from "../index"
+import Cookies from "cookies-js"
+import { followGeneMutation } from "../mutations/AuthIntentFollowGeneMutation"
+import { followArtistMutation } from "../mutations/AuthIntentFollowArtistMutation"
+import { followProfileMutation } from "../mutations/AuthIntentFollowProfileMutation"
+import { saveArtworkMutation } from "../mutations/AuthIntentSaveArtworkMutation"
+
+jest.mock("cookies-js", () => ({
+  get: jest.fn(),
+  expire: jest.fn(),
+}))
+
+jest.mock("../mutations/AuthIntentFollowGeneMutation", () => ({
+  followGeneMutation: jest.fn(),
+}))
+
+jest.mock("../mutations/AuthIntentFollowArtistMutation", () => ({
+  followArtistMutation: jest.fn(),
+}))
+
+jest.mock("../mutations/AuthIntentFollowProfileMutation", () => ({
+  followProfileMutation: jest.fn(),
+}))
+
+jest.mock("../mutations/AuthIntentSaveArtworkMutation", () => ({
+  saveArtworkMutation: jest.fn(),
+}))
+
+describe("runAuthIntent", () => {
+  const env = createMockEnvironment()
+
+  describe("following a gene", () => {
+    beforeEach(() => {
+      ;(Cookies.get as jest.Mock).mockImplementation(() =>
+        JSON.stringify({
+          action: "follow",
+          kind: "gene",
+          objectId: "representations-of-architecture",
+        })
+      )
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    describe("success", () => {
+      it("follows the gene and expires the cookie", async () => {
+        ;(followGeneMutation as jest.Mock).mockImplementation(() =>
+          Promise.resolve()
+        )
+
+        jest.spyOn(Cookies, "expire")
+
+        await runAuthIntent({}, env as any)
+
+        expect(followGeneMutation).toBeCalledWith(
+          env,
+          "representations-of-architecture"
+        )
+        expect(Cookies.expire).toBeCalledWith("afterSignUpAction")
+      })
+    })
+
+    describe("failure", () => {
+      it("tries to follow the gene; does not expire the cookie", async () => {
+        ;(followGeneMutation as jest.Mock).mockImplementation(() =>
+          Promise.reject()
+        )
+
+        jest.spyOn(Cookies, "expire")
+        jest.spyOn(global.console, "error").mockImplementation(jest.fn())
+
+        await runAuthIntent({}, env as any)
+
+        expect(followGeneMutation).toBeCalledWith(
+          env,
+          "representations-of-architecture"
+        )
+        expect(Cookies.expire).not.toBeCalled()
+        expect(global.console.error).toBeCalled()
+      })
+    })
+  })
+
+  describe("following an artist", () => {
+    beforeEach(() => {
+      ;(Cookies.get as jest.Mock).mockImplementation(() =>
+        JSON.stringify({
+          action: "follow",
+          kind: "artist",
+          objectId: "roni-horn",
+        })
+      )
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    describe("success", () => {
+      it("follows the artist and expires the cookie", async () => {
+        ;(followArtistMutation as jest.Mock).mockImplementation(() =>
+          Promise.resolve()
+        )
+
+        jest.spyOn(Cookies, "expire")
+
+        await runAuthIntent({}, env as any)
+
+        expect(followArtistMutation).toBeCalledWith(env, "roni-horn")
+        expect(Cookies.expire).toBeCalledWith("afterSignUpAction")
+      })
+    })
+
+    describe("failure", () => {
+      it("tries to follow the artist; does not expire the cookie", async () => {
+        ;(followArtistMutation as jest.Mock).mockImplementation(() =>
+          Promise.reject()
+        )
+
+        jest.spyOn(Cookies, "expire")
+        jest.spyOn(global.console, "error").mockImplementation(jest.fn())
+
+        await runAuthIntent({}, env as any)
+
+        expect(followArtistMutation).toBeCalledWith(env, "roni-horn")
+        expect(Cookies.expire).not.toBeCalled()
+        expect(global.console.error).toBeCalled()
+      })
+    })
+  })
+
+  describe("following a profile", () => {
+    beforeEach(() => {
+      ;(Cookies.get as jest.Mock).mockImplementation(() =>
+        JSON.stringify({
+          action: "follow",
+          kind: "profile",
+          objectId: "jtt-gallery",
+        })
+      )
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    describe("success", () => {
+      it("follows the artist and expires the cookie", async () => {
+        ;(followProfileMutation as jest.Mock).mockImplementation(() =>
+          Promise.resolve()
+        )
+
+        jest.spyOn(Cookies, "expire")
+
+        await runAuthIntent({}, env as any)
+
+        expect(followProfileMutation).toBeCalledWith(env, "jtt-gallery")
+        expect(Cookies.expire).toBeCalledWith("afterSignUpAction")
+      })
+    })
+
+    describe("failure", () => {
+      it("tries to follow the artist; does not expire the cookie", async () => {
+        ;(followProfileMutation as jest.Mock).mockImplementation(() =>
+          Promise.reject()
+        )
+
+        jest.spyOn(Cookies, "expire")
+        jest.spyOn(global.console, "error").mockImplementation(jest.fn())
+
+        await runAuthIntent({}, env as any)
+
+        expect(followProfileMutation).toBeCalledWith(env, "jtt-gallery")
+        expect(Cookies.expire).not.toBeCalled()
+        expect(global.console.error).toBeCalled()
+      })
+    })
+  })
+
+  describe("saving an artwork", () => {
+    beforeEach(() => {
+      ;(Cookies.get as jest.Mock).mockImplementation(() =>
+        JSON.stringify({
+          action: "save",
+          kind: "artworks",
+          objectId: "on-kawara-one-million-years",
+        })
+      )
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    describe("success", () => {
+      it("saves the artwork and expires the cookie", async () => {
+        ;(saveArtworkMutation as jest.Mock).mockImplementation(() =>
+          Promise.resolve()
+        )
+
+        jest.spyOn(Cookies, "expire")
+
+        await runAuthIntent({}, env as any)
+
+        expect(saveArtworkMutation).toBeCalledWith(
+          env,
+          "on-kawara-one-million-years"
+        )
+        expect(Cookies.expire).toBeCalledWith("afterSignUpAction")
+      })
+    })
+
+    describe("failure", () => {
+      it("tries to follow the artist; does not expire the cookie", async () => {
+        ;(saveArtworkMutation as jest.Mock).mockImplementation(() =>
+          Promise.reject()
+        )
+
+        jest.spyOn(Cookies, "expire")
+        jest.spyOn(global.console, "error").mockImplementation(jest.fn())
+
+        await runAuthIntent({}, env as any)
+
+        expect(saveArtworkMutation).toBeCalledWith(
+          env,
+          "on-kawara-one-million-years"
+        )
+        expect(Cookies.expire).not.toBeCalled()
+        expect(global.console.error).toBeCalled()
+      })
+    })
+  })
+})

--- a/src/v2/Utils/Hooks/useAuthIntent/index.ts
+++ b/src/v2/Utils/Hooks/useAuthIntent/index.ts
@@ -1,0 +1,85 @@
+import Cookies from "cookies-js"
+import { useEffect } from "react"
+import { Environment } from "react-relay"
+import { useSystemContext } from "v2/Artsy"
+import { followArtistMutation } from "./mutations/AuthIntentFollowArtistMutation"
+import { followGeneMutation } from "./mutations/AuthIntentFollowGeneMutation"
+import { followProfileMutation } from "./mutations/AuthIntentFollowProfileMutation"
+import { saveArtworkMutation } from "./mutations/AuthIntentSaveArtworkMutation"
+
+const AFTER_AUTH_ACTION_KEY = "afterSignUpAction"
+
+export type AfterAuthAction =
+  | { action: "follow"; kind: "artist"; objectId: string }
+  | { action: "follow"; kind: "profile"; objectId: string }
+  | { action: "follow"; kind: "gene"; objectId: string }
+  | { action: "save"; kind: "artworks"; objectId: string }
+
+const isValid = (value: any): value is AfterAuthAction => {
+  return (
+    typeof value === "object" &&
+    "action" in value &&
+    "kind" in value &&
+    "objectId" in value
+  )
+}
+
+const parse = (value: any): AfterAuthAction | null => {
+  try {
+    const parsed = JSON.parse(value)
+    if (!isValid(parsed)) return null
+    return parsed
+  } catch (err) {
+    return null
+  }
+}
+
+export const runAuthIntent = async (
+  user: User,
+  relayEnvironment: Environment
+) => {
+  if (!user) return
+
+  const afterAuthActionCookie = Cookies.get(AFTER_AUTH_ACTION_KEY)
+  if (!afterAuthActionCookie) return
+
+  const value = parse(afterAuthActionCookie)
+  if (value === null) return
+
+  try {
+    await (() => {
+      switch (value.action) {
+        case "follow":
+          switch (value.kind) {
+            case "artist":
+              return followArtistMutation(relayEnvironment, value.objectId)
+            case "gene":
+              return followGeneMutation(relayEnvironment, value.objectId)
+            case "profile":
+              return followProfileMutation(relayEnvironment, value.objectId)
+          }
+          break
+        case "save":
+          return saveArtworkMutation(relayEnvironment, value.objectId)
+      }
+    })()
+
+    Cookies.expire(AFTER_AUTH_ACTION_KEY)
+  } catch (err) {
+    console.error("Unable to run intent", err)
+  }
+}
+
+/**
+ * If someone is logged out and clicks a follow or save button we create a cookie
+ * specifying what action they were trying to take.
+ *
+ * This hook is what checks that cookie and runs that action after they are authenticated.
+ */
+export const useAuthIntent = () => {
+  const { user, relayEnvironment } = useSystemContext()
+
+  useEffect(() => {
+    runAuthIntent(user, relayEnvironment)
+  }, [relayEnvironment, user])
+}

--- a/src/v2/Utils/Hooks/useAuthIntent/mutations/AuthIntentFollowArtistMutation.ts
+++ b/src/v2/Utils/Hooks/useAuthIntent/mutations/AuthIntentFollowArtistMutation.ts
@@ -1,0 +1,44 @@
+import { commitMutation, Environment, graphql } from "relay-runtime"
+import { AuthIntentFollowArtistMutation } from "v2/__generated__/AuthIntentFollowArtistMutation.graphql"
+import { AuthIntentMutation } from "./types"
+
+export const followArtistMutation: AuthIntentMutation = (
+  relayEnvironment: Environment,
+  id: string
+) => {
+  return new Promise((resolve, reject) => {
+    commitMutation<AuthIntentFollowArtistMutation>(relayEnvironment, {
+      onCompleted: (res, errors) => {
+        if (errors !== null) {
+          reject(errors)
+          return
+        }
+
+        resolve(res)
+      },
+      mutation: graphql`
+        mutation AuthIntentFollowArtistMutation($input: FollowArtistInput!) {
+          followArtist(input: $input) {
+            artist {
+              id
+              isFollowed
+            }
+          }
+        }
+      `,
+      optimisticResponse: {
+        followArtist: {
+          artist: {
+            id,
+            isFollowed: true,
+          },
+        },
+      },
+      variables: {
+        input: {
+          artistID: id,
+        },
+      },
+    })
+  })
+}

--- a/src/v2/Utils/Hooks/useAuthIntent/mutations/AuthIntentFollowGeneMutation.ts
+++ b/src/v2/Utils/Hooks/useAuthIntent/mutations/AuthIntentFollowGeneMutation.ts
@@ -1,0 +1,43 @@
+import { commitMutation, Environment, graphql } from "relay-runtime"
+import { AuthIntentMutation } from "./types"
+
+export const followGeneMutation: AuthIntentMutation = (
+  relayEnvironment: Environment,
+  id: string
+) => {
+  return new Promise((resolve, reject) => {
+    commitMutation(relayEnvironment, {
+      onCompleted: (res, errors) => {
+        if (errors !== null) {
+          reject(errors)
+          return
+        }
+
+        resolve(res)
+      },
+      mutation: graphql`
+        mutation AuthIntentFollowGeneMutation($input: FollowGeneInput!) {
+          followGene(input: $input) {
+            gene {
+              id
+              isFollowed
+            }
+          }
+        }
+      `,
+      optimisticResponse: {
+        followGene: {
+          gene: {
+            id,
+            isFollowed: true,
+          },
+        },
+      },
+      variables: {
+        input: {
+          geneID: id,
+        },
+      },
+    })
+  })
+}

--- a/src/v2/Utils/Hooks/useAuthIntent/mutations/AuthIntentFollowProfileMutation.ts
+++ b/src/v2/Utils/Hooks/useAuthIntent/mutations/AuthIntentFollowProfileMutation.ts
@@ -1,0 +1,43 @@
+import { commitMutation, Environment, graphql } from "relay-runtime"
+import { AuthIntentMutation } from "./types"
+
+export const followProfileMutation: AuthIntentMutation = (
+  relayEnvironment: Environment,
+  id: string
+) => {
+  return new Promise((resolve, reject) => {
+    commitMutation(relayEnvironment, {
+      onCompleted: (res, errors) => {
+        if (errors !== null) {
+          reject(errors)
+          return
+        }
+
+        resolve(res)
+      },
+      mutation: graphql`
+        mutation AuthIntentFollowProfileMutation($input: FollowProfileInput!) {
+          followProfile(input: $input) {
+            profile {
+              id
+              isFollowed
+            }
+          }
+        }
+      `,
+      optimisticResponse: {
+        followProfile: {
+          profile: {
+            id,
+            isFollowed: true,
+          },
+        },
+      },
+      variables: {
+        input: {
+          profileID: id,
+        },
+      },
+    })
+  })
+}

--- a/src/v2/Utils/Hooks/useAuthIntent/mutations/AuthIntentSaveArtworkMutation.ts
+++ b/src/v2/Utils/Hooks/useAuthIntent/mutations/AuthIntentSaveArtworkMutation.ts
@@ -1,0 +1,43 @@
+import { commitMutation, Environment, graphql } from "relay-runtime"
+import { AuthIntentMutation } from "./types"
+
+export const saveArtworkMutation: AuthIntentMutation = (
+  relayEnvironment: Environment,
+  id: string
+) => {
+  return new Promise((resolve, reject) => {
+    commitMutation(relayEnvironment, {
+      onCompleted: (res, errors) => {
+        if (errors !== null) {
+          reject(errors)
+          return
+        }
+
+        resolve(res)
+      },
+      mutation: graphql`
+        mutation AuthIntentSaveArtworkMutation($input: SaveArtworkInput!) {
+          saveArtwork(input: $input) {
+            artwork {
+              id
+              isSaved
+            }
+          }
+        }
+      `,
+      optimisticResponse: {
+        saveArtwork: {
+          artwork: {
+            id,
+            isSaved: true,
+          },
+        },
+      },
+      variables: {
+        input: {
+          artworkID: id,
+        },
+      },
+    })
+  })
+}

--- a/src/v2/Utils/Hooks/useAuthIntent/mutations/types.ts
+++ b/src/v2/Utils/Hooks/useAuthIntent/mutations/types.ts
@@ -1,0 +1,6 @@
+import { Environment } from "relay-runtime"
+
+export type AuthIntentMutation = (
+  relayEnvironment: Environment,
+  id: string
+) => Promise<unknown>

--- a/src/v2/Utils/openAuthModal.ts
+++ b/src/v2/Utils/openAuthModal.ts
@@ -52,12 +52,19 @@ export const openAuthToFollowSave = (
   }
 }
 
+const FOLLOW_INTENTS = {
+  [Intent.followArtist]: "artist",
+  [Intent.followPartner]: "profile",
+  [Intent.followGene]: "gene",
+}
+
 function getDesktopIntentToFollow({
   contextModule,
   entity,
   intent,
 }: AuthModalOptions): ModalOptions {
-  const kind = intent === Intent.followArtist ? "artist" : "profile"
+  const kind = FOLLOW_INTENTS[intent]
+
   return {
     afterSignUpAction: {
       action: "follow",

--- a/src/v2/__generated__/AuthIntentFollowArtistMutation.graphql.ts
+++ b/src/v2/__generated__/AuthIntentFollowArtistMutation.graphql.ts
@@ -1,0 +1,120 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type FollowArtistInput = {
+    artistID: string;
+    clientMutationId?: string | null;
+    unfollow?: boolean | null;
+};
+export type AuthIntentFollowArtistMutationVariables = {
+    input: FollowArtistInput;
+};
+export type AuthIntentFollowArtistMutationResponse = {
+    readonly followArtist: {
+        readonly artist: {
+            readonly id: string;
+            readonly isFollowed: boolean | null;
+        } | null;
+    } | null;
+};
+export type AuthIntentFollowArtistMutation = {
+    readonly response: AuthIntentFollowArtistMutationResponse;
+    readonly variables: AuthIntentFollowArtistMutationVariables;
+};
+
+
+
+/*
+mutation AuthIntentFollowArtistMutation(
+  $input: FollowArtistInput!
+) {
+  followArtist(input: $input) {
+    artist {
+      id
+      isFollowed
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input",
+    "type": "FollowArtistInput!"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "FollowArtistPayload",
+    "kind": "LinkedField",
+    "name": "followArtist",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isFollowed",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuthIntentFollowArtistMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AuthIntentFollowArtistMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "AuthIntentFollowArtistMutation",
+    "operationKind": "mutation",
+    "text": "mutation AuthIntentFollowArtistMutation(\n  $input: FollowArtistInput!\n) {\n  followArtist(input: $input) {\n    artist {\n      id\n      isFollowed\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '7dbf0de1cae972b061dabe439ae5b14a';
+export default node;

--- a/src/v2/__generated__/AuthIntentFollowGeneMutation.graphql.ts
+++ b/src/v2/__generated__/AuthIntentFollowGeneMutation.graphql.ts
@@ -1,0 +1,120 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type FollowGeneInput = {
+    clientMutationId?: string | null;
+    geneID?: string | null;
+    unfollow?: boolean | null;
+};
+export type AuthIntentFollowGeneMutationVariables = {
+    input: FollowGeneInput;
+};
+export type AuthIntentFollowGeneMutationResponse = {
+    readonly followGene: {
+        readonly gene: {
+            readonly id: string;
+            readonly isFollowed: boolean | null;
+        } | null;
+    } | null;
+};
+export type AuthIntentFollowGeneMutation = {
+    readonly response: AuthIntentFollowGeneMutationResponse;
+    readonly variables: AuthIntentFollowGeneMutationVariables;
+};
+
+
+
+/*
+mutation AuthIntentFollowGeneMutation(
+  $input: FollowGeneInput!
+) {
+  followGene(input: $input) {
+    gene {
+      id
+      isFollowed
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input",
+    "type": "FollowGeneInput!"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "FollowGenePayload",
+    "kind": "LinkedField",
+    "name": "followGene",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Gene",
+        "kind": "LinkedField",
+        "name": "gene",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isFollowed",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuthIntentFollowGeneMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AuthIntentFollowGeneMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "AuthIntentFollowGeneMutation",
+    "operationKind": "mutation",
+    "text": "mutation AuthIntentFollowGeneMutation(\n  $input: FollowGeneInput!\n) {\n  followGene(input: $input) {\n    gene {\n      id\n      isFollowed\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '067e148f5eedd5e8193dadfce447ebbf';
+export default node;

--- a/src/v2/__generated__/AuthIntentFollowProfileMutation.graphql.ts
+++ b/src/v2/__generated__/AuthIntentFollowProfileMutation.graphql.ts
@@ -1,0 +1,120 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type FollowProfileInput = {
+    clientMutationId?: string | null;
+    profileID?: string | null;
+    unfollow?: boolean | null;
+};
+export type AuthIntentFollowProfileMutationVariables = {
+    input: FollowProfileInput;
+};
+export type AuthIntentFollowProfileMutationResponse = {
+    readonly followProfile: {
+        readonly profile: {
+            readonly id: string;
+            readonly isFollowed: boolean | null;
+        } | null;
+    } | null;
+};
+export type AuthIntentFollowProfileMutation = {
+    readonly response: AuthIntentFollowProfileMutationResponse;
+    readonly variables: AuthIntentFollowProfileMutationVariables;
+};
+
+
+
+/*
+mutation AuthIntentFollowProfileMutation(
+  $input: FollowProfileInput!
+) {
+  followProfile(input: $input) {
+    profile {
+      id
+      isFollowed
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input",
+    "type": "FollowProfileInput!"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "FollowProfilePayload",
+    "kind": "LinkedField",
+    "name": "followProfile",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Profile",
+        "kind": "LinkedField",
+        "name": "profile",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isFollowed",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuthIntentFollowProfileMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AuthIntentFollowProfileMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "AuthIntentFollowProfileMutation",
+    "operationKind": "mutation",
+    "text": "mutation AuthIntentFollowProfileMutation(\n  $input: FollowProfileInput!\n) {\n  followProfile(input: $input) {\n    profile {\n      id\n      isFollowed\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '567bc4b1dea32242bc6a8eb0d9b51f90';
+export default node;

--- a/src/v2/__generated__/AuthIntentSaveArtworkMutation.graphql.ts
+++ b/src/v2/__generated__/AuthIntentSaveArtworkMutation.graphql.ts
@@ -1,0 +1,120 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type SaveArtworkInput = {
+    artworkID?: string | null;
+    clientMutationId?: string | null;
+    remove?: boolean | null;
+};
+export type AuthIntentSaveArtworkMutationVariables = {
+    input: SaveArtworkInput;
+};
+export type AuthIntentSaveArtworkMutationResponse = {
+    readonly saveArtwork: {
+        readonly artwork: {
+            readonly id: string;
+            readonly isSaved: boolean | null;
+        } | null;
+    } | null;
+};
+export type AuthIntentSaveArtworkMutation = {
+    readonly response: AuthIntentSaveArtworkMutationResponse;
+    readonly variables: AuthIntentSaveArtworkMutationVariables;
+};
+
+
+
+/*
+mutation AuthIntentSaveArtworkMutation(
+  $input: SaveArtworkInput!
+) {
+  saveArtwork(input: $input) {
+    artwork {
+      id
+      isSaved
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input",
+    "type": "SaveArtworkInput!"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "SaveArtworkPayload",
+    "kind": "LinkedField",
+    "name": "saveArtwork",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isSaved",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuthIntentSaveArtworkMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AuthIntentSaveArtworkMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "AuthIntentSaveArtworkMutation",
+    "operationKind": "mutation",
+    "text": "mutation AuthIntentSaveArtworkMutation(\n  $input: SaveArtworkInput!\n) {\n  saveArtwork(input: $input) {\n    artwork {\n      id\n      isSaved\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '2f0e4b1d5370a41280441f06178aa7aa';
+export default node;


### PR DESCRIPTION
Closes: [FX-2894](https://artsyproduct.atlassian.net/browse/FX-2894)

This is a re-implementation of [this bit of code](https://github.com/artsy/force/blob/49b6a9b180398ae5a574a14902600bcf14f617a6/src/desktop/components/main_layout/client.coffee#L15-L35), which no longer runs on new pages post-novo.

A little on the verbose side — we should really just have a single polymorphic follow mutation? — but should be straightforward.