### PR TITLE
refactor(analytics): send JSON in filter change events

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "@artsy/backbone-mixins": "2.0.0",
-    "@artsy/cohesion": "1.85.0",
+    "@artsy/cohesion": "2.0.0",
     "@artsy/express-reloadable": "1.4.8",
     "@artsy/fresnel": "1.4.0",
     "@artsy/gemup": "0.1.0",

--- a/src/desktop/apps/auction/utils/__tests__/analyticsMiddleware.jest.ts
+++ b/src/desktop/apps/auction/utils/__tests__/analyticsMiddleware.jest.ts
@@ -33,13 +33,13 @@ describe("analytics middleware", () => {
         auction_slug: "auction-slug",
         sale_id: "123",
         user_id: "321",
-        current: [
+        current: JSON.stringify([
           { artists: [] },
           { medium: ["painting"] },
           { sort: "position" },
           { price: "" },
-        ],
-        changed: { medium: "painting" },
+        ]),
+        changed: JSON.stringify({ medium: "painting" }),
       }
     )
   })
@@ -58,13 +58,13 @@ describe("analytics middleware", () => {
         auction_slug: "auction-slug",
         sale_id: "123",
         user_id: "321",
-        current: [
+        current: JSON.stringify([
           { artists: ["andy-warhol"] },
           { medium: [] },
           { sort: "position" },
           { price: "" },
-        ],
-        changed: { artist: "andy-warhol" },
+        ]),
+        changed: JSON.stringify({ artist: "andy-warhol" }),
       }
     )
   })
@@ -83,13 +83,13 @@ describe("analytics middleware", () => {
         auction_slug: "auction-slug",
         sale_id: "123",
         user_id: "321",
-        current: [
+        current: JSON.stringify([
           { artists: ["artists-you-follow"] },
           { medium: [] },
           { sort: "position" },
           { price: "" },
-        ],
-        changed: { artist: "artists-you-follow" },
+        ]),
+        changed: JSON.stringify({ artist: "artists-you-follow" }),
       }
     )
   })
@@ -108,13 +108,13 @@ describe("analytics middleware", () => {
         auction_slug: "auction-slug",
         sale_id: "123",
         user_id: "321",
-        current: [
+        current: JSON.stringify([
           { artists: [] },
           { medium: [] },
           { sort: "position" },
           { price: "10000-*" },
-        ],
-        changed: { price: "10000-*" },
+        ]),
+        changed: JSON.stringify({ price: "10000-*" }),
       }
     )
   })
@@ -130,13 +130,13 @@ describe("analytics middleware", () => {
         auction_slug: "auction-slug",
         sale_id: "123",
         user_id: "321",
-        current: [
+        current: JSON.stringify([
           { artists: [] },
           { medium: [] },
           { sort: "lot_number" },
           { price: "" },
-        ],
-        changed: { sort: "lot_number" },
+        ]),
+        changed: JSON.stringify({ sort: "lot_number" }),
       }
     )
   })

--- a/src/desktop/apps/auction/utils/analyticsMiddleware.ts
+++ b/src/desktop/apps/auction/utils/analyticsMiddleware.ts
@@ -58,7 +58,7 @@ function trackParamChange(changed, newState) {
     sale_id: _id,
     auction_slug: id,
     user_id: USER_ID,
-    current,
-    changed,
+    current: JSON.stringify(current),
+    changed: JSON.stringify(changed),
   })
 }

--- a/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -97,11 +97,11 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
           tracking.trackEvent({
             action_type:
               AnalyticsSchema.ActionType.AuctionResultFilterParamChanged,
-            changed: {
+            changed: JSON.stringify({
               [filterKey]: filterContext.filters[filterKey],
-            },
+            }),
             context_page: AnalyticsSchema.PageName.ArtistAuctionResults,
-            current: filterContext.filters,
+            current: JSON.stringify(filterContext.filters),
           })
         }
       }

--- a/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResults.jest.tsx
@@ -218,22 +218,29 @@ describe("AuctionResults", () => {
               )
 
               expect(trackEvent).toHaveBeenCalledTimes(3)
-              expect(trackEvent.mock.calls[0][0]).toEqual({
+              expect(trackEvent.mock.calls[0][0]).toMatchObject({
                 action_type: "Auction results filter params changed",
                 context_page: "Artist Auction Results",
-                changed: { categories: ["Work on Paper"] },
-                current: {
-                  categories: ["Work on Paper"],
-                  pageAndCursor: { page: 1, cursor: null },
-                  sort: "DATE_DESC",
-                  organizations: [],
-                  sizes: [],
-                  createdAfterYear: 1880,
-                  createdBeforeYear: 1973,
-                  earliestCreatedYear: 1880,
-                  latestCreatedYear: 1973,
-                  allowEmptyCreatedDates: true,
-                },
+                // `changed` & `current` supplied as JSON blobs
+              })
+
+              const { changed, current } = trackEvent.mock.calls[0][0]
+
+              expect(JSON.parse(changed)).toMatchObject({
+                categories: ["Work on Paper"],
+              })
+
+              expect(JSON.parse(current)).toMatchObject({
+                categories: ["Work on Paper"],
+                organizations: [],
+                sizes: [],
+                pageAndCursor: { page: 1, cursor: null },
+                sort: "DATE_DESC",
+                allowEmptyCreatedDates: true,
+                earliestCreatedYear: 1880,
+                latestCreatedYear: 1973,
+                createdAfterYear: 1880,
+                createdBeforeYear: 1973,
               })
 
               wrapper.update()
@@ -321,22 +328,29 @@ describe("AuctionResults", () => {
               )
 
               expect(trackEvent).toHaveBeenCalledTimes(3)
-              expect(trackEvent.mock.calls[0][0]).toEqual({
+              expect(trackEvent.mock.calls[0][0]).toMatchObject({
                 action_type: "Auction results filter params changed",
                 context_page: "Artist Auction Results",
-                changed: { sizes: ["MEDIUM"] },
-                current: {
-                  sizes: ["MEDIUM"],
-                  pageAndCursor: { page: 1, cursor: null },
-                  sort: "DATE_DESC",
-                  organizations: [],
-                  categories: [],
-                  createdAfterYear: 1880,
-                  createdBeforeYear: 1973,
-                  earliestCreatedYear: 1880,
-                  latestCreatedYear: 1973,
-                  allowEmptyCreatedDates: true,
-                },
+                // `changed` & `current` supplied as JSON blobs
+              })
+
+              const { changed, current } = trackEvent.mock.calls[0][0]
+
+              expect(JSON.parse(changed)).toMatchObject({
+                sizes: ["MEDIUM"],
+              })
+
+              expect(JSON.parse(current)).toMatchObject({
+                sizes: ["MEDIUM"],
+                pageAndCursor: { page: 1, cursor: null },
+                sort: "DATE_DESC",
+                organizations: [],
+                categories: [],
+                createdAfterYear: 1880,
+                createdBeforeYear: 1973,
+                earliestCreatedYear: 1880,
+                latestCreatedYear: 1973,
+                allowEmptyCreatedDates: true,
               })
 
               wrapper.update()

--- a/src/v2/Components/v2/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
@@ -173,28 +173,38 @@ describe("ArtworkFilter", () => {
       wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
       wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
 
-      expect(trackEvent).toHaveBeenCalledWith({
-        action: "commercialFilterParamsChanged",
-        context_module: "artworkGrid",
-        context_owner_id: undefined,
-        context_owner_slug: undefined,
-        context_owner_type: "home",
-        changed: { acquireable: true },
-        current: {
-          acquireable: true,
-          majorPeriods: [],
-          page: 1,
-          sizes: [],
-          sort: "-decayed_merch",
-          artistIDs: [],
-          attributionClass: [],
-          partnerIDs: [],
-          additionalGeneIDs: [],
-          colors: [],
-          locationCities: [],
-          artistNationalities: [],
-          materialsTerms: [],
-        },
+      expect(trackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "commercialFilterParamsChanged",
+          context_module: "artworkGrid",
+          context_owner_id: undefined,
+          context_owner_slug: undefined,
+          context_owner_type: "home",
+          // `current` and `changed` are sent as
+          // JSON blobs, and verified below
+        })
+      )
+
+      const { current, changed } = trackEvent.mock.calls[0][0]
+
+      expect(JSON.parse(current)).toMatchObject({
+        acquireable: true,
+        majorPeriods: [],
+        page: 1,
+        sizes: [],
+        sort: "-decayed_merch",
+        artistIDs: [],
+        attributionClass: [],
+        partnerIDs: [],
+        additionalGeneIDs: [],
+        colors: [],
+        locationCities: [],
+        artistNationalities: [],
+        materialsTerms: [],
+      })
+
+      expect(JSON.parse(changed)).toMatchObject({
+        acquireable: true,
       })
     })
   })

--- a/src/v2/Components/v2/ArtworkFilter/index.tsx
+++ b/src/v2/Components/v2/ArtworkFilter/index.tsx
@@ -148,13 +148,13 @@ export const BaseArtworkFilter: React.FC<
 
           tracking.trackEvent(
             commercialFilterParamsChanged({
-              changed: {
+              changed: JSON.stringify({
                 [filterKey]: filterContext.filters[filterKey],
-              },
+              }),
               contextOwnerId: contextPageOwnerId,
               contextOwnerSlug: contextPageOwnerSlug,
               contextOwnerType: contextPageOwnerType,
-              current: filterContext.filters,
+              current: JSON.stringify(filterContext.filters),
             })
           )
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,10 +27,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-1.60.0.tgz#854db37b9f8643ed650f3cc9d14234a1b762fcc8"
   integrity sha512-GBfa0/AoiLtG/Mw0VBR0vCiEj1s8+eBMTtKSLQS82iFo41Z84Li8M0YrlHAmXUrK3oBOO/YvhVNFE40avgK8xQ==
 
-"@artsy/cohesion@1.85.0":
-  version "1.85.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-1.85.0.tgz#1108af9044af298c0b471b37f88b9705ac722a28"
-  integrity sha512-8FupGvgissHOIhXgv7HviiRYX1BVuQeCvbDS/1QXS6/K8ODLR0+Toh0p6VU6+xYNsbL9Ki1TEbpBa1+vIOgDYw==
+"@artsy/cohesion@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-2.0.0.tgz#9a8b661351094ec1d76fdc43504ea741ceb16323"
+  integrity sha512-hVMhLooiHq3k8yThXyopaGSoPWuhwFIJ7RDXDCWN12S2rIC3SpDwzTy+6pt1sa3q+CXH/LnHMr1Wn49GLfsWLw==
   dependencies:
     core-js "3"
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2850
↳ https://artsyproduct.atlassian.net/browse/FX-2913

Follow-up to https://github.com/artsy/cohesion/pull/184

Filter events on all artwork grids should now send their `current` and `changed` properties as JSON blobs, rather than as nested objects, which cause problems over in Redshift.

So this bumps Cohesion to v2 and —

- Uses the updated API for Cohesion's `commercialFilterParamsChanged` helper
- Update non-Cohesion events from auction results & auction artworks grid

This is how they look in Segment —

### Standard artwork grids, via Cohesion (artist, artist series, fair, show, etc)

![regular grid](https://user-images.githubusercontent.com/140521/116755447-6d7ef900-a9d8-11eb-8716-0dcb846f6fbd.png)

### Auction artworks grid

![auction grid](https://user-images.githubusercontent.com/140521/116755481-7a9be800-a9d8-11eb-9ec4-175d28f0b2d2.png)

### Auction results

![auction results](https://user-images.githubusercontent.com/140521/116755488-7ec80580-a9d8-11eb-84df-fdc24bc4328e.png)
