### PR TITLE
refactoring: partner carousel

### DIFF
--- a/src/v2/Apps/Partner/Components/Carousel/Carousel.tsx
+++ b/src/v2/Apps/Partner/Components/Carousel/Carousel.tsx
@@ -1,26 +1,23 @@
 import React from "react"
 import { Media } from "v2/Utils/Responsive"
-import { Swiper } from "@artsy/palette"
 import { DesktopCarousel } from "./DesktopCarousel"
+import { ResponsiveValue } from "styled-system"
+import { MobileCarousel } from "./MobileCarousel"
 
 export interface CarouselProps {
-  children: (itemsPerViewport: number) => JSX.Element | JSX.Element[]
+  children: JSX.Element | JSX.Element[]
+  onRailOverflowChange?: (value: boolean) => void
+  itemsPerViewport?: ResponsiveValue<number>
 }
 
-export const Carousel: React.FC<CarouselProps> = ({ children }) => {
+export const Carousel: React.FC<CarouselProps> = ({ children, ...rest }) => {
   return (
     <>
-      <Media greaterThan="md">
-        <DesktopCarousel itemsPerViewport={4}>{children(4)}</DesktopCarousel>
-      </Media>
-      <Media at="md">
-        <DesktopCarousel itemsPerViewport={3}>{children(3)}</DesktopCarousel>
-      </Media>
-      <Media at="sm">
-        <DesktopCarousel itemsPerViewport={2}>{children(2)}</DesktopCarousel>
+      <Media greaterThan="xs">
+        <DesktopCarousel {...rest}>{children}</DesktopCarousel>
       </Media>
       <Media at="xs">
-        <Swiper>{children(2)}</Swiper>
+        <MobileCarousel {...rest}>{children}</MobileCarousel>
       </Media>
     </>
   )

--- a/src/v2/Apps/Partner/Components/Carousel/DesktopCarousel.tsx
+++ b/src/v2/Apps/Partner/Components/Carousel/DesktopCarousel.tsx
@@ -1,23 +1,56 @@
-import React from "react"
-import { Carousel, CarouselCell, CarouselProps } from "@artsy/palette"
+import React, { useRef } from "react"
+import {
+  Carousel,
+  CarouselCell,
+  CarouselCellProps,
+  CarouselRail,
+} from "@artsy/palette"
+import { ResponsiveValue, system } from "styled-system"
+import styled from "styled-components"
+import { CarouselProps } from "./Carousel"
+import { useRailOverflow } from "./useRailOverflow"
 
-export const DesktopCarousel: React.FC<
-  CarouselProps & { itemsPerViewport: number }
-> = ({ children, itemsPerViewport, ...rest }) => {
+export interface DesktopCarouselCellProps extends CarouselCellProps {
+  itemsPerViewport?: ResponsiveValue<number>
+}
+
+const carouselCellFlexBasis = system({
+  itemsPerViewport: {
+    property: "flexBasis",
+    transform: n => `calc((100% - ${n - 1} * 20px) / ${n})`,
+  },
+})
+
+const DesktopCarouselCell = styled(CarouselCell)<DesktopCarouselCellProps>`
+  box-sizing: initial;
+  ${props =>
+    props.itemsPerViewport && {
+      ...carouselCellFlexBasis(props),
+    }};
+`
+
+export const DesktopCarousel: React.FC<CarouselProps> = ({
+  children,
+  itemsPerViewport,
+  onRailOverflowChange,
+  ...rest
+}) => {
+  const railRef = useRef<HTMLDivElement | null>(null)
+
+  useRailOverflow(railRef, showMore => {
+    onRailOverflowChange && onRailOverflowChange(showMore)
+  })
+
   return (
     <Carousel
+      Rail={props => <CarouselRail ref={railRef as any} {...props} />}
       Cell={React.forwardRef((props, ref) => {
         return (
-          <CarouselCell
+          <DesktopCarouselCell
             display="inline-flex"
             flexGrow={0}
             flexShrink={0}
-            style={{
-              boxSizing: "initial",
-              flexBasis: `calc((100% - ${
-                itemsPerViewport - 1
-              } * 20px) / ${itemsPerViewport})`,
-            }}
+            itemsPerViewport={itemsPerViewport}
             {...props}
             ref={ref as any}
           />

--- a/src/v2/Apps/Partner/Components/Carousel/MobileCarousel.tsx
+++ b/src/v2/Apps/Partner/Components/Carousel/MobileCarousel.tsx
@@ -1,0 +1,49 @@
+import React, { Children, useRef } from "react"
+import { Box, Swiper, SwiperRail } from "@artsy/palette"
+import { CarouselProps } from "./Carousel"
+import { useRailOverflow } from "./useRailOverflow"
+
+const CAROUSEL_MARGIN_SIZE = 2
+
+export const MobileCarousel: React.FC<CarouselProps> = ({
+  children,
+  onRailOverflowChange,
+  ...rest
+}) => {
+  const cells = Children.toArray(children)
+  const railRef = useRef<HTMLDivElement | null>(null)
+
+  useRailOverflow(railRef, showMore => {
+    onRailOverflowChange && onRailOverflowChange(showMore)
+  })
+
+  return (
+    <Swiper
+      Rail={props => <SwiperRail ref={railRef as any} {...props} />}
+      mx={-CAROUSEL_MARGIN_SIZE}
+      {...rest}
+    >
+      {cells.map((child, i) => {
+        // First cell
+        if (i === 0) {
+          return (
+            <Box key={i} pl={CAROUSEL_MARGIN_SIZE}>
+              {child}
+            </Box>
+          )
+        }
+
+        // Last cell
+        if (i === cells.length - 1) {
+          return (
+            <Box key={i} pr={CAROUSEL_MARGIN_SIZE}>
+              {child}
+            </Box>
+          )
+        }
+
+        return <React.Fragment key={i}>{child}</React.Fragment>
+      })}
+    </Swiper>
+  )
+}

--- a/src/v2/Apps/Partner/Components/Carousel/useRailOverflow.ts
+++ b/src/v2/Apps/Partner/Components/Carousel/useRailOverflow.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react"
+import { useWindowSize } from "v2/Utils/Hooks/useWindowSize"
+
+export const useRailOverflow = (
+  railRef: React.MutableRefObject<HTMLDivElement>,
+  callback: (val: boolean) => void
+) => {
+  const { width: viewportWidth } = useWindowSize()
+  const [showMore, setShowMore] = useState<boolean>(undefined)
+
+  useEffect(() => {
+    if (railRef.current) {
+      setShowMore(
+        railRef.current?.scrollWidth - 20 > railRef.current?.clientWidth
+      )
+    }
+  }, [viewportWidth])
+
+  useEffect(() => {
+    callback(showMore)
+  }, [showMore])
+}

--- a/src/v2/Apps/Partner/Components/Overview/ShowsRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/ShowsRail.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import { Box, BoxProps, Flex, ResponsiveBox, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ShowsRail_partner } from "v2/__generated__/ShowsRail_partner.graphql"
@@ -13,6 +13,7 @@ interface ShowsRailProps extends BoxProps {
 }
 
 const ShowsRail: React.FC<ShowsRailProps> = ({ partner, ...rest }) => {
+  const [isSeeAllAvaliable, setIsSeeAllAvaliable] = useState<boolean>(undefined)
   if (
     !partner ||
     !partner.showsConnection ||
@@ -37,42 +38,43 @@ const ShowsRail: React.FC<ShowsRailProps> = ({ partner, ...rest }) => {
         </RouterLink>
       </Flex>
 
-      <Carousel>
-        {itemsPerViewport => {
-          return flatten([
-            shows.map(edge => {
-              return (
-                <Box key={edge.node.id} width={[300, "100%"]}>
-                  <ShowCardFragmentContainer show={edge.node} />
-                </Box>
-              )
-            }),
-            shows.length > itemsPerViewport && (
-              <Box width={[300, "100%"]}>
-                <RouterLink to={`/partner2/${slug}/shows`}>
-                  <ScrollToPartnerHeader width="100%">
-                    <ResponsiveBox
-                      aspectWidth={263}
-                      aspectHeight={222}
-                      maxWidth="100%"
-                      bg="black10"
-                    >
-                      <Flex
-                        height="100%"
-                        alignItems="center"
-                        justifyContent="center"
-                      >
-                        <Text style={{ textDecoration: "underline" }}>
-                          See all shows
-                        </Text>
-                      </Flex>
-                    </ResponsiveBox>
-                  </ScrollToPartnerHeader>
-                </RouterLink>
+      <Carousel
+        onRailOverflowChange={setIsSeeAllAvaliable}
+        itemsPerViewport={[2, 2, 3, 4]}
+      >
+        {flatten([
+          shows.map(edge => {
+            return (
+              <Box key={edge.node.id} width={[300, "100%"]}>
+                <ShowCardFragmentContainer show={edge.node} />
               </Box>
-            ),
-          ])
-        }}
+            )
+          }),
+          isSeeAllAvaliable && (
+            <Box key="see-all-button" width={[300, "100%"]}>
+              <RouterLink to={`/partner2/${slug}/shows`}>
+                <ScrollToPartnerHeader width="100%">
+                  <ResponsiveBox
+                    aspectWidth={263}
+                    aspectHeight={222}
+                    maxWidth="100%"
+                    bg="black10"
+                  >
+                    <Flex
+                      height="100%"
+                      alignItems="center"
+                      justifyContent="center"
+                    >
+                      <Text style={{ textDecoration: "underline" }}>
+                        See all shows
+                      </Text>
+                    </Flex>
+                  </ResponsiveBox>
+                </ScrollToPartnerHeader>
+              </RouterLink>
+            </Box>
+          ),
+        ])}
       </Carousel>
     </Box>
   )

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarousel.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarousel.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import { Box, Text, Flex } from "@artsy/palette"
 import { flatten } from "lodash"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
@@ -11,8 +11,8 @@ import {
   ResponsiveImage,
 } from "./PartnerArtistsCarouselItem"
 import { PartnerArtistsCarouselPlaceholder } from "./PartnerArtistsCarouselPlaceholder"
-import { Carousel } from "../../Carousel"
 import { ScrollToPartnerHeader } from "../../ScrollToPartnerHeader"
+import { Carousel } from "../../Carousel"
 
 const PAGE_SIZE = 19
 
@@ -23,6 +23,8 @@ export interface PartnerArtistsCarouselProps {
 export const PartnerArtistsCarousel: React.FC<PartnerArtistsCarouselProps> = ({
   partner,
 }) => {
+  const [isSeeAllAvaliable, setIsSeeAllAvaliable] = useState<boolean>(undefined)
+
   if (!partner || !partner.artists || !partner.artists.edges) {
     return null
   }
@@ -30,41 +32,42 @@ export const PartnerArtistsCarousel: React.FC<PartnerArtistsCarouselProps> = ({
   const { artists, slug } = partner
 
   return (
-    <Carousel>
-      {itemsPerViewport => {
-        return flatten([
-          artists.edges
-            .filter(e => e.isDisplayOnPartnerProfile && e.counts.artworks > 0)
-            .map(edge => {
-              return (
-                <PartnerArtistsCarouselItemFragmentContainer
-                  key={edge.node.id}
-                  artist={edge.node}
-                  partnerArtistHref={`/partner2/${slug}/artists/${edge.node.slug}`}
-                />
-              )
-            }),
-          artists.edges.length > itemsPerViewport && (
-            <Box width={[300, "100%"]}>
-              <RouterLink to={`/partner2/${slug}/artists`}>
-                <ScrollToPartnerHeader width="100%">
-                  <ResponsiveImage>
-                    <Flex
-                      height="100%"
-                      alignItems="center"
-                      justifyContent="center"
-                    >
-                      <Text style={{ textDecoration: "underline" }}>
-                        See all artists
-                      </Text>
-                    </Flex>
-                  </ResponsiveImage>
-                </ScrollToPartnerHeader>
-              </RouterLink>
-            </Box>
-          ),
-        ])
-      }}
+    <Carousel
+      onRailOverflowChange={setIsSeeAllAvaliable}
+      itemsPerViewport={[2, 2, 3, 4]}
+    >
+      {flatten([
+        artists.edges
+          .filter(e => e.isDisplayOnPartnerProfile && e.counts.artworks > 0)
+          .map(edge => {
+            return (
+              <PartnerArtistsCarouselItemFragmentContainer
+                key={edge.node.id}
+                artist={edge.node}
+                partnerArtistHref={`/partner2/${slug}/artists/${edge.node.slug}`}
+              />
+            )
+          }),
+        isSeeAllAvaliable && (
+          <Box key="see-all-button" width={[300, "100%"]}>
+            <RouterLink to={`/partner2/${slug}/artists`}>
+              <ScrollToPartnerHeader width="100%">
+                <ResponsiveImage>
+                  <Flex
+                    height="100%"
+                    alignItems="center"
+                    justifyContent="center"
+                  >
+                    <Text style={{ textDecoration: "underline" }}>
+                      See all artists
+                    </Text>
+                  </Flex>
+                </ResponsiveImage>
+              </ScrollToPartnerHeader>
+            </RouterLink>
+          </Box>
+        ),
+      ])}
     </Carousel>
   )
 }

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarouselPlaceholder.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarouselPlaceholder.tsx
@@ -11,34 +11,27 @@ export const PartnerArtistsCarouselPlaceholder: React.FC<PartnerArtistsCarouselP
   count,
 }) => {
   return (
-    <Carousel>
-      {() =>
-        [...Array(count)].map((_, i) => {
-          return (
-            <Box width={[300, "100%"]} key={i}>
-              <ResponsiveImage>
-                <SkeletonBox height="100%" width="100%" />
-              </ResponsiveImage>
+    <Carousel itemsPerViewport={[2, 2, 3, 4]}>
+      {[...Array(count)].map((_, i) => {
+        return (
+          <Box width={[300, "100%"]} key={i}>
+            <ResponsiveImage>
+              <SkeletonBox height="100%" width="100%" />
+            </ResponsiveImage>
 
-              <Flex mt={1} justifyContent="space-between">
-                <Flex>
-                  <SkeletonBox
-                    mr={1}
-                    height={45}
-                    width={45}
-                    borderRadius="50%"
-                  />
-                  <Flex flexDirection="column">
-                    <SkeletonText>Artist Name</SkeletonText>
-                    <SkeletonText>Artist brief</SkeletonText>
-                  </Flex>
+            <Flex mt={1} justifyContent="space-between">
+              <Flex>
+                <SkeletonBox mr={1} height={45} width={45} borderRadius="50%" />
+                <Flex flexDirection="column">
+                  <SkeletonText>Artist Name</SkeletonText>
+                  <SkeletonText>Artist brief</SkeletonText>
                 </Flex>
-                <SkeletonBox height={30} width={60} />
               </Flex>
-            </Box>
-          )
-        })
-      }
+              <SkeletonBox height={30} width={60} />
+            </Flex>
+          </Box>
+        )
+      })}
     </Carousel>
   )
 }


### PR DESCRIPTION
This PR refactor carousel that we use for the partner page. 

The carousel supports:
-  showing defined items count by using the `itemsPerViewport` field
- `onRailOverflowChange` callback that indicates is carousel rail overflowed(needs to show **See all** button)

Figma - https://www.figma.com/file/x78XGXMM1LhOdQY8TxkXkR/Partner-Profile?node-id=1072%3A0