### PR TITLE
Ensure newly modernized /tag/* pages can load asset bundles in production

### DIFF
--- a/src/desktop/lib/webpackPublicPath.ts
+++ b/src/desktop/lib/webpackPublicPath.ts
@@ -45,6 +45,7 @@ if (process.env.NODE_ENV === "production") {
     "/order",
     "/search",
     "/show/",
+    "/tag/",
     "/partner2/",
     "/user/conversations",
     "/user/payments",


### PR DESCRIPTION
We observed that below-the-fold images failed to load, while requests for asset paths matching `.../assets/novo-*.js` were `403`-ing. Those same files _are_ available under `.../assets-novo/...`.

Similar issues have bitten us a few times now (proving that if _any_ code runs only in production, that's exactly where bugs will happen). We should eliminate this environment-sensitive path-munging somehow, as mentioned in code comments.