### PR TITLE
feat: Update iPhone image on about GRO-249

### DIFF
--- a/src/desktop/apps/about/client/view.coffee
+++ b/src/desktop/apps/about/client/view.coffee
@@ -18,7 +18,6 @@ module.exports = class AboutView extends Backbone.View
 
   initialize: ->
     @$window = $(window)
-    @$window.on 'scroll', _.throttle(@iphoneScroll, 200)
 
     @cacheSelectors()
     @setupStickyNav()
@@ -54,8 +53,6 @@ module.exports = class AboutView extends Backbone.View
     @$heroUnitNav = @$('.about-nav')
     @$genes = @$('.about-genome-work-gene')
     @$spinner = @$('#about-spinner')
-    @$iphone = @$('.about-section1-phone-container')
-    @$iphoneBg = @$('.about-section1-phone-bg')
 
   setupStickyNav: ->
     @$nav.waypoint 'sticky'
@@ -141,10 +138,3 @@ module.exports = class AboutView extends Backbone.View
   contactSpecialistModal: (e) ->
     e.preventDefault()
     openFeedback()
-
-  iphoneScroll: =>
-    windowBottom = @$window.scrollTop() + @$window.height()
-    iphoneTop = @$iphone.offset().top
-    return unless windowBottom > iphoneTop
-    offset = (windowBottom - iphoneTop) * 0.4
-    @$iphoneBg.css transform: "translateY(-#{offset}px)"

--- a/src/desktop/apps/about/stylesheets/the_art_world_online.styl
+++ b/src/desktop/apps/about/stylesheets/the_art_world_online.styl
@@ -31,53 +31,6 @@ ease-in-out-quart = cubic-bezier(0.770, 0.000, 0.175, 1.000)
     opacity 1
     transform rotateX(0deg)
 
-.about-section1-phone-error
-  color red-color
-  display none
-  margin 5px 0 15px 0
-  line-height 1.2em
-  font-size 16px
-
-.about-section1-phone-success
-  color green-color
-  display none
-  margin 5px 0 15px 0
-  line-height 1.2em
-  font-size 16px
-
-.about-section1-phone-plate
-.about-section1-phone-bg
-  width 100%
-  height 800px
-  background-size contain
-
-.about-section1-phone-plate
-  z-index 2
-  height 674px
-  background-image url("/images/about_iphone_plate.png")
-
-.about-section1-phone-container
-  position relative
-
-.about-section1-phone-img-wrapper
-  overflow hidden
-  position absolute
-  top iphone-top-margin
-  left 0
-  padding 0 23px 0 28px
-  width 100%
-  height calc(100% \- (iphone-top-margin * 2))
-  z-index -1
-
-.about-section1-phone-bg
-  width 100%
-  height 1544px
-  width 100%
-  position relative
-  force-hardware-acceleration()
-  background-image url("/images/about_iphone_bg.jpg")
-  transition transform 0.25s
-
 .about-section1-cta
   margin 0
   span(2)

--- a/src/desktop/apps/about/templates/sections/the_art_world_online.jade
+++ b/src/desktop/apps/about/templates/sections/the_art_world_online.jade
@@ -42,7 +42,4 @@
   .span2
     +pull-blurb(section.pullBlurb4)
   .span2
-    .about-section1-phone-container
-      .about-section1-phone-plate
-      .about-section1-phone-img-wrapper
-        .about-section1-phone-bg
+    img( src= "https://artsy-media-uploads.s3.amazonaws.com/PiE_1gCyYvs3IKWiWjHo3g%2FFrame+14.png" )


### PR DESCRIPTION
All I did for this was track down where we were setting up that iPhone image on the about page and then cut out all the fancy stuff, haha. Then I just dropped in a static asset. Simple enough? 🤷 

Looks like this:

<img width="1577" alt="Screen Shot 2021-05-06 at 11 12 47 AM" src="https://user-images.githubusercontent.com/79799/117331125-0cce4100-ae5c-11eb-9911-7dba95147da1.png">


https://artsyproduct.atlassian.net/browse/GRO-249

/cc @artsy/grow-devs