### PR TITLE
fix: shows and articles refetch bugs

### DIFF
--- a/src/v2/Apps/Partner/Components/PartnerShows/ShowPaginatedEvents.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerShows/ShowPaginatedEvents.tsx
@@ -52,11 +52,11 @@ const ShowPaginatedEvents: React.FC<ShowEventsProps> = ({
   } = partner
 
   const handleClick = (cursor: string, page: number) => {
-    const refetchPage = paramsPage !== page
+    const canRefetch = paramsPage !== page
 
-    refetchPage && setIsLoading(true)
+    canRefetch && setIsLoading(true)
 
-    refetchPage &&
+    canRefetch &&
       relay.refetch(
         {
           first: 40,

--- a/src/v2/Apps/Partner/Routes/Articles/index.tsx
+++ b/src/v2/Apps/Partner/Routes/Articles/index.tsx
@@ -35,11 +35,11 @@ const Articles: React.FC<ArticlesProps> = ({ partner, relay }) => {
 
   const handleClick = (cursor: string, page: number) => {
     const paramsPage = +location.query.page || 1
-    const refetchPage = paramsPage !== page
+    const canRefetch = paramsPage !== page
 
-    refetchPage && setIsLoading(true)
+    canRefetch && setIsLoading(true)
 
-    refetchPage &&
+    canRefetch &&
       relay.refetch(
         {
           first: 18,

--- a/src/v2/Apps/Partner/Routes/Shows/index.tsx
+++ b/src/v2/Apps/Partner/Routes/Shows/index.tsx
@@ -29,6 +29,7 @@ export const Shows: React.FC<PartnerShowsProps> = ({
 
   const isCurrentEventsExist = !!currentEvents.edges.length
   const isUpcomingEventsExist = !!upcomingEvents.edges.length
+  const page = +query.page || 1
 
   return (
     <>
@@ -53,10 +54,10 @@ export const Shows: React.FC<PartnerShowsProps> = ({
         eventTitle="Past Events"
         partnerId={partner.slug}
         status="CLOSED"
-        first={24}
+        first={40}
         scrollTo="#jumpto--pastShowsGrid"
         offset={200}
-        page={+query?.page}
+        page={page}
       />
     </>
   )
@@ -79,12 +80,20 @@ export const ShowsFragmentContainer = createFragmentContainer(Shows, {
           }
         }
       }
-      currentEvents: showsConnection(first: 12, status: RUNNING) {
+      currentEvents: showsConnection(
+        first: 12
+        status: RUNNING
+        isDisplayable: true
+      ) {
         edges {
           ...ShowEvents_edges
         }
       }
-      upcomingEvents: showsConnection(first: 12, status: UPCOMING) {
+      upcomingEvents: showsConnection(
+        first: 12
+        status: UPCOMING
+        isDisplayable: true
+      ) {
         edges {
           ...ShowEvents_edges
         }

--- a/src/v2/__generated__/ShowPaginatedEventsQuery.graphql.ts
+++ b/src/v2/__generated__/ShowPaginatedEventsQuery.graphql.ts
@@ -86,7 +86,7 @@ fragment ShowEvents_edges on ShowEdge {
 
 fragment ShowPaginatedEvents_partner_qVb3U on Partner {
   slug
-  showsList: showsConnection(first: $first, last: $last, after: $after, before: $before, status: $status) {
+  showsList: showsConnection(first: $first, last: $last, after: $after, before: $before, status: $status, isDisplayable: true) {
     pageInfo {
       hasNextPage
       endCursor
@@ -147,50 +147,48 @@ v1 = [
     "variableName": "partnerId"
   }
 ],
-v2 = [
-  {
-    "kind": "Variable",
-    "name": "after",
-    "variableName": "after"
-  },
-  {
-    "kind": "Variable",
-    "name": "before",
-    "variableName": "before"
-  },
-  {
-    "kind": "Variable",
-    "name": "first",
-    "variableName": "first"
-  },
-  {
-    "kind": "Variable",
-    "name": "last",
-    "variableName": "last"
-  },
-  {
-    "kind": "Variable",
-    "name": "status",
-    "variableName": "status"
-  }
-],
+v2 = {
+  "kind": "Variable",
+  "name": "after",
+  "variableName": "after"
+},
 v3 = {
+  "kind": "Variable",
+  "name": "before",
+  "variableName": "before"
+},
+v4 = {
+  "kind": "Variable",
+  "name": "first",
+  "variableName": "first"
+},
+v5 = {
+  "kind": "Variable",
+  "name": "last",
+  "variableName": "last"
+},
+v6 = {
+  "kind": "Variable",
+  "name": "status",
+  "variableName": "status"
+},
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v4 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v5 = [
-  (v3/*: any*/),
-  (v4/*: any*/),
+v9 = [
+  (v7/*: any*/),
+  (v8/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -199,7 +197,7 @@ v5 = [
     "storageKey": null
   }
 ],
-v6 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -222,7 +220,13 @@ return {
         "plural": false,
         "selections": [
           {
-            "args": (v2/*: any*/),
+            "args": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/)
+            ],
             "kind": "FragmentSpread",
             "name": "ShowPaginatedEvents_partner"
           }
@@ -255,7 +259,18 @@ return {
           },
           {
             "alias": "showsList",
-            "args": (v2/*: any*/),
+            "args": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "isDisplayable",
+                "value": true
+              },
+              (v5/*: any*/),
+              (v6/*: any*/)
+            ],
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
@@ -301,7 +316,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v5/*: any*/),
+                    "selections": (v9/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -311,7 +326,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v9/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -321,7 +336,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v9/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -332,8 +347,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
-                      (v4/*: any*/)
+                      (v7/*: any*/),
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -452,7 +467,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v6/*: any*/)
+                      (v10/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -462,7 +477,7 @@ return {
             ],
             "storageKey": null
           },
-          (v6/*: any*/)
+          (v10/*: any*/)
         ],
         "storageKey": null
       }
@@ -473,7 +488,7 @@ return {
     "metadata": {},
     "name": "ShowPaginatedEventsQuery",
     "operationKind": "query",
-    "text": "query ShowPaginatedEventsQuery(\n  $partnerId: String!\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $status: EventStatus\n) {\n  partner(id: $partnerId) @principalField {\n    ...ShowPaginatedEvents_partner_qVb3U\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ShowCard_show on Show {\n  href\n  name\n  isFairBooth\n  exhibitionPeriod\n  coverImage {\n    medium: cropped(width: 263, height: 222) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ShowEvents_edges on ShowEdge {\n  node {\n    internalID\n    ...ShowCard_show\n    id\n  }\n}\n\nfragment ShowPaginatedEvents_partner_qVb3U on Partner {\n  slug\n  showsList: showsConnection(first: $first, last: $last, after: $after, before: $before, status: $status) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      ...ShowEvents_edges\n    }\n  }\n}\n"
+    "text": "query ShowPaginatedEventsQuery(\n  $partnerId: String!\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $status: EventStatus\n) {\n  partner(id: $partnerId) @principalField {\n    ...ShowPaginatedEvents_partner_qVb3U\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ShowCard_show on Show {\n  href\n  name\n  isFairBooth\n  exhibitionPeriod\n  coverImage {\n    medium: cropped(width: 263, height: 222) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ShowEvents_edges on ShowEdge {\n  node {\n    internalID\n    ...ShowCard_show\n    id\n  }\n}\n\nfragment ShowPaginatedEvents_partner_qVb3U on Partner {\n  slug\n  showsList: showsConnection(first: $first, last: $last, after: $after, before: $before, status: $status, isDisplayable: true) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      ...ShowEvents_edges\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/ShowPaginatedEventsRendererQuery.graphql.ts
+++ b/src/v2/__generated__/ShowPaginatedEventsRendererQuery.graphql.ts
@@ -82,7 +82,7 @@ fragment ShowEvents_edges on ShowEdge {
 
 fragment ShowPaginatedEvents_partner_JfDnP on Partner {
   slug
-  showsList: showsConnection(first: $first, status: $status, page: $page) {
+  showsList: showsConnection(first: $first, status: $status, page: $page, isDisplayable: true) {
     pageInfo {
       hasNextPage
       endCursor
@@ -131,40 +131,38 @@ v1 = [
     "variableName": "partnerId"
   }
 ],
-v2 = [
-  {
-    "kind": "Variable",
-    "name": "first",
-    "variableName": "first"
-  },
-  {
-    "kind": "Variable",
-    "name": "page",
-    "variableName": "page"
-  },
-  {
-    "kind": "Variable",
-    "name": "status",
-    "variableName": "status"
-  }
-],
+v2 = {
+  "kind": "Variable",
+  "name": "first",
+  "variableName": "first"
+},
 v3 = {
+  "kind": "Variable",
+  "name": "page",
+  "variableName": "page"
+},
+v4 = {
+  "kind": "Variable",
+  "name": "status",
+  "variableName": "status"
+},
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v4 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v5 = [
-  (v3/*: any*/),
-  (v4/*: any*/),
+v7 = [
+  (v5/*: any*/),
+  (v6/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -173,7 +171,7 @@ v5 = [
     "storageKey": null
   }
 ],
-v6 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -196,7 +194,11 @@ return {
         "plural": false,
         "selections": [
           {
-            "args": (v2/*: any*/),
+            "args": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/)
+            ],
             "kind": "FragmentSpread",
             "name": "ShowPaginatedEvents_partner"
           }
@@ -229,7 +231,16 @@ return {
           },
           {
             "alias": "showsList",
-            "args": (v2/*: any*/),
+            "args": [
+              (v2/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "isDisplayable",
+                "value": true
+              },
+              (v3/*: any*/),
+              (v4/*: any*/)
+            ],
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
@@ -275,7 +286,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v5/*: any*/),
+                    "selections": (v7/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -285,7 +296,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v7/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -295,7 +306,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v7/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -306,8 +317,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
-                      (v4/*: any*/)
+                      (v5/*: any*/),
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -426,7 +437,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v6/*: any*/)
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -436,7 +447,7 @@ return {
             ],
             "storageKey": null
           },
-          (v6/*: any*/)
+          (v8/*: any*/)
         ],
         "storageKey": null
       }
@@ -447,7 +458,7 @@ return {
     "metadata": {},
     "name": "ShowPaginatedEventsRendererQuery",
     "operationKind": "query",
-    "text": "query ShowPaginatedEventsRendererQuery(\n  $partnerId: String!\n  $first: Int\n  $page: Int\n  $status: EventStatus\n) {\n  partner(id: $partnerId) @principalField {\n    ...ShowPaginatedEvents_partner_JfDnP\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ShowCard_show on Show {\n  href\n  name\n  isFairBooth\n  exhibitionPeriod\n  coverImage {\n    medium: cropped(width: 263, height: 222) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ShowEvents_edges on ShowEdge {\n  node {\n    internalID\n    ...ShowCard_show\n    id\n  }\n}\n\nfragment ShowPaginatedEvents_partner_JfDnP on Partner {\n  slug\n  showsList: showsConnection(first: $first, status: $status, page: $page) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      ...ShowEvents_edges\n    }\n  }\n}\n"
+    "text": "query ShowPaginatedEventsRendererQuery(\n  $partnerId: String!\n  $first: Int\n  $page: Int\n  $status: EventStatus\n) {\n  partner(id: $partnerId) @principalField {\n    ...ShowPaginatedEvents_partner_JfDnP\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ShowCard_show on Show {\n  href\n  name\n  isFairBooth\n  exhibitionPeriod\n  coverImage {\n    medium: cropped(width: 263, height: 222) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ShowEvents_edges on ShowEdge {\n  node {\n    internalID\n    ...ShowCard_show\n    id\n  }\n}\n\nfragment ShowPaginatedEvents_partner_JfDnP on Partner {\n  slug\n  showsList: showsConnection(first: $first, status: $status, page: $page, isDisplayable: true) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      ...ShowEvents_edges\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/ShowPaginatedEvents_partner.graphql.ts
+++ b/src/v2/__generated__/ShowPaginatedEvents_partner.graphql.ts
@@ -30,7 +30,7 @@ export type ShowPaginatedEvents_partner$key = {
 const node: ReaderFragment = {
   "argumentDefinitions": [
     {
-      "defaultValue": 24,
+      "defaultValue": 40,
       "kind": "LocalArgument",
       "name": "first",
       "type": "Int"
@@ -64,6 +64,12 @@ const node: ReaderFragment = {
       "kind": "LocalArgument",
       "name": "status",
       "type": "EventStatus"
+    },
+    {
+      "defaultValue": true,
+      "kind": "LocalArgument",
+      "name": "isDisplayable",
+      "type": "Boolean"
     }
   ],
   "kind": "Fragment",
@@ -94,6 +100,11 @@ const node: ReaderFragment = {
           "kind": "Variable",
           "name": "first",
           "variableName": "first"
+        },
+        {
+          "kind": "Variable",
+          "name": "isDisplayable",
+          "variableName": "isDisplayable"
         },
         {
           "kind": "Variable",
@@ -179,5 +190,5 @@ const node: ReaderFragment = {
   ],
   "type": "Partner"
 };
-(node as any).hash = '0796f9ebb9c7906f547fb20143e880e6';
+(node as any).hash = '0af75016e048646a50556989af3d7c4e';
 export default node;

--- a/src/v2/__generated__/Shows_partner.graphql.ts
+++ b/src/v2/__generated__/Shows_partner.graphql.ts
@@ -36,10 +36,15 @@ export type Shows_partner$key = {
 const node: ReaderFragment = (function(){
 var v0 = {
   "kind": "Literal",
+  "name": "isDisplayable",
+  "value": true
+},
+v1 = {
+  "kind": "Literal",
   "name": "first",
   "value": 12
 },
-v1 = [
+v2 = [
   {
     "alias": null,
     "args": null,
@@ -78,11 +83,7 @@ return {
           "name": "first",
           "value": 1
         },
-        {
-          "kind": "Literal",
-          "name": "isDisplayable",
-          "value": true
-        },
+        (v0/*: any*/),
         {
           "kind": "Literal",
           "name": "sort",
@@ -139,6 +140,7 @@ return {
     {
       "alias": "currentEvents",
       "args": [
+        (v1/*: any*/),
         (v0/*: any*/),
         {
           "kind": "Literal",
@@ -150,12 +152,13 @@ return {
       "kind": "LinkedField",
       "name": "showsConnection",
       "plural": false,
-      "selections": (v1/*: any*/),
-      "storageKey": "showsConnection(first:12,status:\"RUNNING\")"
+      "selections": (v2/*: any*/),
+      "storageKey": "showsConnection(first:12,isDisplayable:true,status:\"RUNNING\")"
     },
     {
       "alias": "upcomingEvents",
       "args": [
+        (v1/*: any*/),
         (v0/*: any*/),
         {
           "kind": "Literal",
@@ -167,12 +170,12 @@ return {
       "kind": "LinkedField",
       "name": "showsConnection",
       "plural": false,
-      "selections": (v1/*: any*/),
-      "storageKey": "showsConnection(first:12,status:\"UPCOMING\")"
+      "selections": (v2/*: any*/),
+      "storageKey": "showsConnection(first:12,isDisplayable:true,status:\"UPCOMING\")"
     }
   ],
   "type": "Partner"
 };
 })();
-(node as any).hash = 'b62889efe000f4a90c736b7907655ee1';
+(node as any).hash = 'bab1be09c87841bf9381c9ff73d914f5';
 export default node;

--- a/src/v2/__generated__/partnerRoutes_ShowsQuery.graphql.ts
+++ b/src/v2/__generated__/partnerRoutes_ShowsQuery.graphql.ts
@@ -82,12 +82,12 @@ fragment Shows_partner on Partner {
       }
     }
   }
-  currentEvents: showsConnection(first: 12, status: RUNNING) {
+  currentEvents: showsConnection(first: 12, status: RUNNING, isDisplayable: true) {
     edges {
       ...ShowEvents_edges
     }
   }
-  upcomingEvents: showsConnection(first: 12, status: UPCOMING) {
+  upcomingEvents: showsConnection(first: 12, status: UPCOMING, isDisplayable: true) {
     edges {
       ...ShowEvents_edges
     }
@@ -119,60 +119,65 @@ v2 = {
   "storageKey": null
 },
 v3 = {
+  "kind": "Literal",
+  "name": "isDisplayable",
+  "value": true
+},
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isFairBooth",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "exhibitionPeriod",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "src",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "srcSet",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "Literal",
   "name": "first",
   "value": 12
 },
-v11 = [
+v12 = [
   {
     "alias": null,
     "args": null,
@@ -196,10 +201,10 @@ v11 = [
             "name": "internalID",
             "storageKey": null
           },
-          (v4/*: any*/),
-          (v3/*: any*/),
           (v5/*: any*/),
+          (v4/*: any*/),
           (v6/*: any*/),
+          (v7/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -241,15 +246,15 @@ v11 = [
                     "name": "height",
                     "storageKey": null
                   },
-                  (v8/*: any*/),
-                  (v9/*: any*/)
+                  (v9/*: any*/),
+                  (v10/*: any*/)
                 ],
                 "storageKey": "cropped(height:222,width:263)"
               }
             ],
             "storageKey": null
           },
-          (v7/*: any*/)
+          (v8/*: any*/)
         ],
         "storageKey": null
       }
@@ -306,11 +311,7 @@ return {
                 "name": "first",
                 "value": 1
               },
-              {
-                "kind": "Literal",
-                "name": "isDisplayable",
-                "value": true
-              },
+              (v3/*: any*/),
               {
                 "kind": "Literal",
                 "name": "sort",
@@ -351,10 +352,10 @@ return {
                         "storageKey": null
                       },
                       (v2/*: any*/),
-                      (v3/*: any*/),
                       (v4/*: any*/),
                       (v5/*: any*/),
                       (v6/*: any*/),
+                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -384,7 +385,7 @@ return {
                             "name": "city",
                             "storageKey": null
                           },
-                          (v7/*: any*/)
+                          (v8/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -415,15 +416,15 @@ return {
                             "name": "cropped",
                             "plural": false,
                             "selections": [
-                              (v8/*: any*/),
-                              (v9/*: any*/)
+                              (v9/*: any*/),
+                              (v10/*: any*/)
                             ],
                             "storageKey": "cropped(height:480,width:600)"
                           }
                         ],
                         "storageKey": null
                       },
-                      (v7/*: any*/)
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -436,7 +437,8 @@ return {
           {
             "alias": "currentEvents",
             "args": [
-              (v10/*: any*/),
+              (v11/*: any*/),
+              (v3/*: any*/),
               {
                 "kind": "Literal",
                 "name": "status",
@@ -447,13 +449,14 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v11/*: any*/),
-            "storageKey": "showsConnection(first:12,status:\"RUNNING\")"
+            "selections": (v12/*: any*/),
+            "storageKey": "showsConnection(first:12,isDisplayable:true,status:\"RUNNING\")"
           },
           {
             "alias": "upcomingEvents",
             "args": [
-              (v10/*: any*/),
+              (v11/*: any*/),
+              (v3/*: any*/),
               {
                 "kind": "Literal",
                 "name": "status",
@@ -464,10 +467,10 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v11/*: any*/),
-            "storageKey": "showsConnection(first:12,status:\"UPCOMING\")"
+            "selections": (v12/*: any*/),
+            "storageKey": "showsConnection(first:12,isDisplayable:true,status:\"UPCOMING\")"
           },
-          (v7/*: any*/)
+          (v8/*: any*/)
         ],
         "storageKey": null
       }
@@ -478,7 +481,7 @@ return {
     "metadata": {},
     "name": "partnerRoutes_ShowsQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_ShowsQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...Shows_partner\n    id\n  }\n}\n\nfragment ShowBanner_show on Show {\n  slug\n  name\n  href\n  isFairBooth\n  exhibitionPeriod\n  status\n  description\n  location {\n    city\n    id\n  }\n  coverImage {\n    medium: cropped(width: 600, height: 480) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ShowCard_show on Show {\n  href\n  name\n  isFairBooth\n  exhibitionPeriod\n  coverImage {\n    medium: cropped(width: 263, height: 222) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ShowEvents_edges on ShowEdge {\n  node {\n    internalID\n    ...ShowCard_show\n    id\n  }\n}\n\nfragment Shows_partner on Partner {\n  slug\n  featured: showsConnection(first: 1, status: ALL, sort: FEATURED_DESC_END_AT_DESC, isDisplayable: true) {\n    edges {\n      node {\n        isFeatured\n        ...ShowBanner_show\n        id\n      }\n    }\n  }\n  currentEvents: showsConnection(first: 12, status: RUNNING) {\n    edges {\n      ...ShowEvents_edges\n    }\n  }\n  upcomingEvents: showsConnection(first: 12, status: UPCOMING) {\n    edges {\n      ...ShowEvents_edges\n    }\n  }\n}\n"
+    "text": "query partnerRoutes_ShowsQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...Shows_partner\n    id\n  }\n}\n\nfragment ShowBanner_show on Show {\n  slug\n  name\n  href\n  isFairBooth\n  exhibitionPeriod\n  status\n  description\n  location {\n    city\n    id\n  }\n  coverImage {\n    medium: cropped(width: 600, height: 480) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ShowCard_show on Show {\n  href\n  name\n  isFairBooth\n  exhibitionPeriod\n  coverImage {\n    medium: cropped(width: 263, height: 222) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ShowEvents_edges on ShowEdge {\n  node {\n    internalID\n    ...ShowCard_show\n    id\n  }\n}\n\nfragment Shows_partner on Partner {\n  slug\n  featured: showsConnection(first: 1, status: ALL, sort: FEATURED_DESC_END_AT_DESC, isDisplayable: true) {\n    edges {\n      node {\n        isFeatured\n        ...ShowBanner_show\n        id\n      }\n    }\n  }\n  currentEvents: showsConnection(first: 12, status: RUNNING, isDisplayable: true) {\n    edges {\n      ...ShowEvents_edges\n    }\n  }\n  upcomingEvents: showsConnection(first: 12, status: UPCOMING, isDisplayable: true) {\n    edges {\n      ...ShowEvents_edges\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
JIRA:
- [PPP: Articles: empty page is opened when clicking the same page again being on the first/last page on pagination](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=36&projectKey=PX&modal=detail&selectedIssue=PX-4047&quickFilter=228)
- [PPP: Shows: infinite loading spinner is displayed when clicking any page on pagination](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=36&projectKey=PX&modal=detail&selectedIssue=PX-4046&quickFilter=228)
- [PPP: Shows: 24 items are displayed instead of 40 per page + "Next" button is clickable on the last page of pagination in mobile view](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=36&projectKey=PX&modal=detail&selectedIssue=PX-4039&quickFilter=228)

- Changed shows past events count to 40
- Prevented the refetching when a user clicks on the same page
- Removed the page params from the url when 1 page
- Removed a show card if it has no image via `isDisplayable`