### PR TITLE
fix: [Auctions] v3 mobile updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@artsy/express-reloadable": "1.4.8",
     "@artsy/fresnel": "1.4.0",
     "@artsy/gemup": "0.1.0",
-    "@artsy/palette": "^14.25.0",
+    "@artsy/palette": "^14.27.0",
     "@artsy/passport": "1.8.0",
     "@artsy/reaction": "29.0.2",
     "@artsy/stitch": "6.2.0",

--- a/src/v2/Apps/Auctions/AuctionsApp.tsx
+++ b/src/v2/Apps/Auctions/AuctionsApp.tsx
@@ -28,7 +28,7 @@ const AuctionsApp: React.FC<AuctionsAppProps> = props => {
       <GridColumns>
         <Column span={[12, 6]}>
           <HorizontalPadding>
-            <Text mt={4} mb={[0, 1]} variant="xxl" as="h1">
+            <Text mt={4} mb={1} variant={["xl", "xxl"]} as="h1">
               Auctions
             </Text>
           </HorizontalPadding>
@@ -69,7 +69,7 @@ const AuctionsApp: React.FC<AuctionsAppProps> = props => {
         </>
       )}
 
-      <Spacer my={12} />
+      <Spacer my={[4, 12]} />
 
       <HorizontalPadding>
         <RouteTabs mb={2} fill>

--- a/src/v2/Apps/Auctions/Components/AuctionArtworksRail/AuctionArtworksRail.tsx
+++ b/src/v2/Apps/Auctions/Components/AuctionArtworksRail/AuctionArtworksRail.tsx
@@ -63,7 +63,7 @@ export const AuctionArtworksRail: React.FC<AuctionArtworksRailProps> = ({
       <Waypoint />
 
       <Box ref={ref as any} {...rest}>
-        <Box display="flex" mb={4}>
+        <Box display="flex" mb={[2, 4]} pr={[1, 0]}>
           <Box flex="1">
             <Text as="h3" variant="lg" color="black100">
               <RouterLink

--- a/src/v2/Apps/Auctions/Components/AuctionArtworksRailPlaceholder.tsx
+++ b/src/v2/Apps/Auctions/Components/AuctionArtworksRailPlaceholder.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Box, Shelf, SkeletonBox, SkeletonText } from "@artsy/palette"
-import { MAX_IMG_HEIGHT } from "v2/Components/Artwork/ShelfArtwork"
+import { IMG_HEIGHT } from "v2/Components/Artwork/ShelfArtwork"
 
 interface FairExhibitorRailPlaceholderProps {
   done?: boolean
@@ -13,7 +13,12 @@ export const AuctionArtworksRailPlaceholder: React.FC<FairExhibitorRailPlacehold
     {[...new Array(10)].map((_, i) => {
       return (
         <Box key={i}>
-          <SkeletonBox width={200} height={MAX_IMG_HEIGHT} mb={1} done={done} />
+          <SkeletonBox
+            width={200}
+            height={[IMG_HEIGHT.mobile, IMG_HEIGHT.desktop]}
+            mb={1}
+            done={done}
+          />
 
           <SkeletonText variant="mediumText" done={done}>
             Artist Name

--- a/src/v2/Components/Artwork/ShelfArtwork.tsx
+++ b/src/v2/Components/Artwork/ShelfArtwork.tsx
@@ -9,11 +9,15 @@ import Metadata from "./Metadata"
 import { AuthContextModule } from "@artsy/cohesion"
 import styled from "styled-components"
 import { Flex } from "@artsy/palette"
+import { Media } from "v2/Utils/Responsive"
 
 /**
  * The max height for an image in the carousel
  */
-export const MAX_IMG_HEIGHT = 320
+export const IMG_HEIGHT = {
+  mobile: 250,
+  desktop: 320,
+}
 
 interface ShelfArtworkProps {
   artwork: ShelfArtwork_artwork
@@ -39,10 +43,35 @@ const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
   showMetadata = true,
 }) => {
   const { mediator, user } = useSystemContext()
-  const imgHeight =
-    artwork.image.resized.height > MAX_IMG_HEIGHT
-      ? MAX_IMG_HEIGHT
+
+  const getHeight = (size: keyof typeof IMG_HEIGHT) => {
+    return artwork.image.resized.height > IMG_HEIGHT[size]
+      ? IMG_HEIGHT[size]
       : artwork.image.resized.height
+  }
+
+  const ResponsiveContainer = ({ children }) => {
+    return (
+      <>
+        <Media at="xs">
+          <Container
+            width={artwork.image.resized.width}
+            height={getHeight("mobile")}
+          >
+            {children}
+          </Container>
+        </Media>
+        <Media greaterThan="xs">
+          <Container
+            width={artwork.image.resized.width}
+            height={getHeight("desktop")}
+          >
+            {children}
+          </Container>
+        </Media>
+      </>
+    )
+  }
 
   return (
     <Box>
@@ -53,12 +82,12 @@ const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
           onClick && onClick()
         }}
       >
-        <Container width={artwork.image.resized.width} height={imgHeight}>
+        <ResponsiveContainer>
           <Image
             src={artwork.image.resized.src}
             srcSet={artwork.image.resized.srcSet}
             width={artwork.image.resized.width}
-            height={imgHeight}
+            maxHeight={[IMG_HEIGHT.mobile, IMG_HEIGHT.desktop]}
             lazyLoad={lazyLoad}
             style={{ objectFit: "contain" }}
           />
@@ -69,7 +98,7 @@ const ShelfArtwork: React.FC<ShelfArtworkProps> = ({
             contextModule={contextModule}
             artwork={artwork}
           />
-        </Container>
+        </ResponsiveContainer>
       </RouterLink>
 
       {showMetadata && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,10 +65,10 @@
   dependencies:
     uuid "^8.3.0"
 
-"@artsy/palette@^14.25.0":
-  version "14.25.0"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-14.25.0.tgz#1ffb3658f4e2174ea5ef4dfe934755c7bf14213f"
-  integrity sha512-OCElvnTDqR0k7Ls+yCTQUmMin6Mq4XW20R8eoCqFxTjQps4wBS80qhD6de4vAqA2haDjaMmnh24HobunAOl2Jg==
+"@artsy/palette@^14.27.0":
+  version "14.27.0"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-14.27.0.tgz#d0207faad5df94ddba9709b4d5a3640b33c83892"
+  integrity sha512-b9AlTdUyYkis2EKewxR7f2MoSOwVVaaiB5CqB5eRTFhYMco1p8w61kkriU71utPVas3ea9HAZk6zPnK3E0KIPg==
   dependencies:
     "@styled-system/theme-get" "^5.1.2"
     d3-interpolate "^1.3.2"


### PR DESCRIPTION
Various little mobile fixes:
- Make titles a bit smaller 
- Cap mobile image height at 250 
- Tighten up mobile carousel area to account for really tall images offscreen 
- Update palette so that carousel arrows don't show on mobile 

![auctions3](https://user-images.githubusercontent.com/236943/117399203-de308480-aeb4-11eb-991f-810644f83266.gif)
