### PR TITLE
fix: Set minimum 8 characters for password input fields

### DIFF
--- a/src/desktop/apps/authentication/templates/reset_password.jade
+++ b/src/desktop/apps/authentication/templates/reset_password.jade
@@ -21,8 +21,8 @@ block body
         name='password'
         placeholder='New Password'
         type='password'
-        pattern='.{6,}'
-        title='6 characters minimum'
+        pattern='.{8,}'
+        title='8 characters minimum'
         required
         autofocus
       )
@@ -30,8 +30,8 @@ block body
         name='password_confirmation'
         placeholder='Confirm New Password'
         type='password'
-        pattern='.{6,}'
-        title='6 characters minimum'
+        pattern='.{8,}'
+        title='8 characters minimum'
         required
         data-confirm='password'
       )

--- a/src/desktop/apps/user/components/password/index.jade
+++ b/src/desktop/apps/user/components/password/index.jade
@@ -30,8 +30,8 @@ form.settings-password__form.stacked-form(
     name='current_password'
     type='password'
     autocomplete='on'
-    pattern='.{6,}'
-    title='6 characters minimum'
+    pattern='.{8,}'
+    title='8 characters minimum'
     autofocus
     required
   )
@@ -43,8 +43,8 @@ form.settings-password__form.stacked-form(
     name='new_password'
     type='password'
     autocomplete='on'
-    pattern='.{6,}'
-    title='6 characters minimum'
+    pattern='.{8,}'
+    title='8 characters minimum'
     required
   )
 
@@ -55,8 +55,8 @@ form.settings-password__form.stacked-form(
     name='password_confirmation'
     type='password'
     autocomplete='on'
-    pattern='.{6,}'
-    title='6 characters minimum'
+    pattern='.{8,}'
+    title='8 characters minimum'
     required
   )
 

--- a/src/mobile/apps/user/models/password_edit.coffee
+++ b/src/mobile/apps/user/models/password_edit.coffee
@@ -17,14 +17,14 @@ module.exports = class PasswordEdit extends CurrentUser
     "#{super}/password"
 
   errorMessages:
-    new_password_min: "Minimum 6 characters."
+    new_password_min: "Minimum 8 characters."
     new_password_same: "Your new password must be different."
     password_confirmation: "Passwords don't match up. Please try again."
 
   validate: (attrs, options) ->
     errors = {}
 
-    if attrs.new_password and attrs.new_password.length < 6
+    if attrs.new_password and attrs.new_password.length < 8
       errors.new_password = @errorMessages.new_password_min
     else if attrs.new_password and attrs.new_password is attrs.current_password
       errors.new_password = @errorMessages.new_password_same

--- a/src/mobile/apps/user/test/models/password_edit.test.js
+++ b/src/mobile/apps/user/test/models/password_edit.test.js
@@ -25,28 +25,28 @@ describe("PasswordEdit", function () {
       return (this.values = {})
     })
 
-    it("ensures that the password is at least six chars long", function () {
-      this.values.new_password = "12345"
+    it("ensures that the password is at least eight chars long", function () {
+      this.values.new_password = "1234567"
       this.passwordEdit
         .validate(this.values)
         .new_password.should.equal(
           this.passwordEdit.errorMessages.new_password_min
         )
-      this.values.new_password = "123456"
+      this.values.new_password = "12345678"
       return _.isUndefined(
         this.passwordEdit.validate(this.values)
       ).should.be.true()
     })
 
     it("ensures the confirmation password matches the new", function () {
-      this.values.new_password = "123456"
-      this.values.password_confirmation = "654321"
+      this.values.new_password = "12345678"
+      this.values.password_confirmation = "87654321"
       this.passwordEdit
         .validate(this.values)
         .password_confirmation.should.equal(
           this.passwordEdit.errorMessages.password_confirmation
         )
-      this.values.password_confirmation = "123456"
+      this.values.password_confirmation = "12345678"
       return _.isUndefined(
         this.passwordEdit.validate(this.values)
       ).should.be.true()
@@ -54,16 +54,16 @@ describe("PasswordEdit", function () {
 
     return it("ensures the new isn't the old", function () {
       this.values = {
-        new_password: "123456",
-        password_confirmation: "123456",
-        current_password: "123456",
+        new_password: "12345678",
+        password_confirmation: "12345678",
+        current_password: "12345678",
       }
       this.passwordEdit
         .validate(this.values)
         .new_password.should.equal(
           this.passwordEdit.errorMessages.new_password_same
         )
-      this.values.current_password = "654321"
+      this.values.current_password = "87654321"
       return _.isUndefined(
         this.passwordEdit.validate(this.values)
       ).should.be.true()


### PR DESCRIPTION
On the password reset page and changing password in Settings, the user could enter in the password fields a minimum of 6 characters instead of the minimum of 8 characters, as it is written in another validation message. 

I changed the validation pattern that specifies a minimum of 8 characters and validation message