### PR TITLE
bugfix: Guard against null edges

### DIFF
--- a/src/v2/Apps/Auctions/Components/AuctionArtworksRail/AuctionArtworksRailArtworks.tsx
+++ b/src/v2/Apps/Auctions/Components/AuctionArtworksRail/AuctionArtworksRailArtworks.tsx
@@ -10,6 +10,7 @@ import { useTracking } from "react-tracking"
 import { AuthContextModule, clickedArtworkGroup } from "@artsy/cohesion"
 import { tabTypeToContextModuleMap } from "../../Utils/tabTypeToContextModuleMap"
 import { ShelfArtworkFragmentContainer } from "v2/Components/Artwork/ShelfArtwork"
+import { extractNodes } from "v2/Utils/extractNodes"
 
 export interface AuctionArtworksRailArtworksProps {
   sale: AuctionArtworksRailArtworks_sale
@@ -24,13 +25,15 @@ const AuctionArtworksRailArtworks: React.FC<AuctionArtworksRailArtworksProps> = 
   const { contextPageOwnerType } = useAnalyticsContext()
   const contextModule = tabTypeToContextModuleMap[tabType] as AuthContextModule
 
-  if (sale.artworksConnection.edges.length === 0) {
+  const nodes = extractNodes(sale.artworksConnection)
+
+  if (nodes.length === 0) {
     return null
   }
 
   return (
     <Shelf>
-      {sale.artworksConnection.edges.map(({ node }, index) => {
+      {nodes.map((node, index) => {
         return (
           <ShelfArtworkFragmentContainer
             artwork={node}

--- a/src/v2/Apps/Auctions/Components/AuctionArtworksRail/__tests__/AuctionArtworksRailArtworks.jest.tsx
+++ b/src/v2/Apps/Auctions/Components/AuctionArtworksRail/__tests__/AuctionArtworksRailArtworks.jest.tsx
@@ -59,6 +59,16 @@ describe("AuctionArtworksRailArtworks", () => {
     expect(wrapper.find("FillwidthItem")).toBeDefined()
   })
 
+  it("guards against null data", () => {
+    expect(() =>
+      getWrapper({
+        ArtworkConnection: () => ({
+          edges: null,
+        }),
+      })
+    ).not.toThrowError()
+  })
+
   it("returns no artworks if there are no published artworks to return", () => {
     const wrapper = getWrapper({
       Sale: () => ({
@@ -70,7 +80,6 @@ describe("AuctionArtworksRailArtworks", () => {
       }),
     })
 
-    console.log(wrapper.find("Carousel").length)
     expect(wrapper.find("Carousel")).toHaveLength(0)
   })
 

--- a/src/v2/Apps/Auctions/Components/WorksByArtistsYouFollowRail/WorksByArtistsYouFollowRail.tsx
+++ b/src/v2/Apps/Auctions/Components/WorksByArtistsYouFollowRail/WorksByArtistsYouFollowRail.tsx
@@ -7,6 +7,7 @@ import { AuthContextModule, clickedArtworkGroup } from "@artsy/cohesion"
 import { tabTypeToContextModuleMap } from "../../Utils/tabTypeToContextModuleMap"
 import { Box, Shelf, Spacer, Text } from "@artsy/palette"
 import { ShelfArtworkFragmentContainer } from "v2/Components/Artwork/ShelfArtwork"
+import { extractNodes } from "v2/Utils/extractNodes"
 
 export interface WorksByArtistsYouFollowRailProps {
   viewer: WorksByArtistsYouFollowRail_viewer
@@ -19,7 +20,9 @@ const WorksByArtistsYouFollowRail: React.FC<WorksByArtistsYouFollowRailProps> = 
   const { contextPageOwnerType } = useAnalyticsContext()
   const contextModule = tabTypeToContextModuleMap.worksByArtistsYouFollow as AuthContextModule
 
-  if (viewer.saleArtworksConnection.edges.length === 0) {
+  const nodes = extractNodes(viewer.saleArtworksConnection)
+
+  if (nodes.length === 0) {
     return null
   }
 
@@ -43,7 +46,7 @@ const WorksByArtistsYouFollowRail: React.FC<WorksByArtistsYouFollowRailProps> = 
       <Spacer mb={4} />
 
       <Shelf>
-        {viewer.saleArtworksConnection.edges.map(({ node }, index) => {
+        {nodes.map((node, index) => {
           return (
             <ShelfArtworkFragmentContainer
               artwork={node}

--- a/src/v2/Apps/Auctions/Components/WorksByArtistsYouFollowRail/__tests__/WorksByArtistsYouFollowRail.jest.tsx
+++ b/src/v2/Apps/Auctions/Components/WorksByArtistsYouFollowRail/__tests__/WorksByArtistsYouFollowRail.jest.tsx
@@ -38,6 +38,16 @@ describe("WorksByArtistsYouFollowRail", () => {
     jest.clearAllMocks()
   })
 
+  it("guards against null data", () => {
+    expect(() =>
+      getWrapper({
+        SaleArtworksConnection: () => ({
+          edges: null,
+        }),
+      })
+    ).not.toThrowError()
+  })
+
   it("does not render if no followed artists", () => {
     const wrapper = getWrapper({
       SaleArtworksConnection: () => ({

--- a/src/v2/Apps/Auctions/Routes/CurrentAuctions.tsx
+++ b/src/v2/Apps/Auctions/Routes/CurrentAuctions.tsx
@@ -8,6 +8,7 @@ import {
 
 import { CurrentAuctions_viewer } from "v2/__generated__/CurrentAuctions_viewer.graphql"
 import { AuctionArtworksRailFragmentContainer } from "../Components/AuctionArtworksRail/AuctionArtworksRail"
+import { extractNodes } from "v2/Utils/extractNodes"
 
 export interface CurrentAuctionsProps {
   viewer: CurrentAuctions_viewer
@@ -40,7 +41,9 @@ const CurrentAuctions: React.FC<CurrentAuctionsProps> = ({ viewer, relay }) => {
     })
   }
 
-  if (viewer.salesConnection.edges.length === 0) {
+  const nodes = extractNodes(viewer.salesConnection)
+
+  if (nodes.length === 0) {
     return (
       <Box>
         <Text>No current auctions.</Text>
@@ -51,7 +54,7 @@ const CurrentAuctions: React.FC<CurrentAuctionsProps> = ({ viewer, relay }) => {
   return (
     <>
       <Box>
-        {viewer.salesConnection.edges.map(({ node }, index) => {
+        {nodes.map((node, index) => {
           return (
             <Box my={6} key={index}>
               <AuctionArtworksRailFragmentContainer

--- a/src/v2/Apps/Auctions/Routes/PastAuctions.tsx
+++ b/src/v2/Apps/Auctions/Routes/PastAuctions.tsx
@@ -8,6 +8,7 @@ import {
 
 import { PastAuctions_viewer } from "v2/__generated__/PastAuctions_viewer.graphql"
 import { AuctionArtworksRailFragmentContainer } from "../Components/AuctionArtworksRail/AuctionArtworksRail"
+import { extractNodes } from "v2/Utils/extractNodes"
 
 export interface PastAuctionsProps {
   viewer: PastAuctions_viewer
@@ -40,7 +41,9 @@ const PastAuctions: React.FC<PastAuctionsProps> = ({ viewer, relay }) => {
     })
   }
 
-  if (viewer.salesConnection.edges.length === 0) {
+  const nodes = extractNodes(viewer.salesConnection)
+
+  if (nodes.length === 0) {
     return (
       <Box>
         <Text>No past auctions.</Text>
@@ -51,7 +54,7 @@ const PastAuctions: React.FC<PastAuctionsProps> = ({ viewer, relay }) => {
   return (
     <>
       <Box>
-        {viewer.salesConnection.edges.map(({ node }, index) => {
+        {nodes.map((node, index) => {
           return (
             <Box my={6} key={index}>
               <AuctionArtworksRailFragmentContainer

--- a/src/v2/Apps/Auctions/Routes/UpcomingAuctions.tsx
+++ b/src/v2/Apps/Auctions/Routes/UpcomingAuctions.tsx
@@ -8,6 +8,7 @@ import {
 
 import { UpcomingAuctions_viewer } from "v2/__generated__/UpcomingAuctions_viewer.graphql"
 import { AuctionArtworksRailFragmentContainer } from "../Components/AuctionArtworksRail/AuctionArtworksRail"
+import { extractNodes } from "v2/Utils/extractNodes"
 
 export interface UpcomingAuctionsProps {
   viewer: UpcomingAuctions_viewer
@@ -43,7 +44,9 @@ const UpcomingAuctions: React.FC<UpcomingAuctionsProps> = ({
     })
   }
 
-  if (viewer.salesConnection.edges.length === 0) {
+  const nodes = extractNodes(viewer.salesConnection)
+
+  if (nodes.length === 0) {
     return (
       <Box>
         <Text>No upcoming auctions.</Text>
@@ -54,7 +57,7 @@ const UpcomingAuctions: React.FC<UpcomingAuctionsProps> = ({
   return (
     <>
       <Box>
-        {viewer.salesConnection.edges.map(({ node }, index) => {
+        {nodes.map((node, index) => {
           return (
             <Box my={6} key={index}>
               <AuctionArtworksRailFragmentContainer

--- a/src/v2/Apps/Auctions/Routes/__tests__/CurrentAuctions.jest.tsx
+++ b/src/v2/Apps/Auctions/Routes/__tests__/CurrentAuctions.jest.tsx
@@ -37,6 +37,16 @@ describe("CurrentAuctions", () => {
     })
   })
 
+  it("guards against null data", () => {
+    expect(() =>
+      getWrapper({
+        SaleConnection: () => ({
+          edges: null,
+        }),
+      })
+    ).not.toThrowError()
+  })
+
   it("renders zerostate if no auctions", () => {
     const wrapper = getWrapper({
       SaleConnection: () => ({

--- a/src/v2/Apps/Auctions/Routes/__tests__/PastAuctions.jest.tsx
+++ b/src/v2/Apps/Auctions/Routes/__tests__/PastAuctions.jest.tsx
@@ -37,6 +37,16 @@ describe("PastAuctions", () => {
     })
   })
 
+  it("guards against null data", () => {
+    expect(() =>
+      getWrapper({
+        SaleConnection: () => ({
+          edges: null,
+        }),
+      })
+    ).not.toThrowError()
+  })
+
   it("renders zerostate if no auctions", () => {
     const wrapper = getWrapper({
       SaleConnection: () => ({

--- a/src/v2/Apps/Auctions/Routes/__tests__/UpcomingAuctions.jest.tsx
+++ b/src/v2/Apps/Auctions/Routes/__tests__/UpcomingAuctions.jest.tsx
@@ -37,6 +37,16 @@ describe("UpcomingAuctions", () => {
     })
   })
 
+  it("guards against null data", () => {
+    expect(() =>
+      getWrapper({
+        SaleConnection: () => ({
+          edges: null,
+        }),
+      })
+    ).not.toThrowError()
+  })
+
   it("renders zerostate if no auctions", () => {
     const wrapper = getWrapper({
       SaleConnection: () => ({


### PR DESCRIPTION
Fixes https://sentry.io/organizations/artsynet/issues/2306340388/events/ee03fe7b10c54a41b87fd9c3c8e02d01/?project=28316&query=is%3Aunresolved+url%3A%22https%3A%2F%2Fwww.artsy.net%2Fauctions%22&statsPeriod=14d

Some users were reporting 500 errors. Not sure why, but a simple guard will protect against this. 