### PR TITLE
bugfix: [Auctions] Fix save on artwork

### DIFF
--- a/src/v2/Components/Artwork/SaveButton/index.tsx
+++ b/src/v2/Components/Artwork/SaveButton/index.tsx
@@ -137,7 +137,10 @@ export class SaveButton extends React.Component<
 
   mixinButtonActions() {
     return {
-      onClick: () => this.handleSave(),
+      onClick: event => {
+        event.preventDefault()
+        this.handleSave()
+      },
       onMouseEnter: () => {
         this.setState({
           isHovered: true,


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GRO-326 

The save button was passing click events down to the router link; it should stop the click on the save. 