### PR TITLE
feat: [Router] Add types and intellisense to route configs

### DIFF
--- a/docs/adding_new_app.md
+++ b/docs/adding_new_app.md
@@ -10,7 +10,7 @@ To add a new app to force we can leverage our React-based SSR router.
 
 ```tsx
 // routes.tsx
-export const routes = [
+export const routes: AppRouteConfig[] = [
   {
     path: "/new-app",
     Component: props => {

--- a/src/v2/Apps/Artist/artistRoutes.tsx
+++ b/src/v2/Apps/Artist/artistRoutes.tsx
@@ -1,5 +1,5 @@
 import loadable from "@loadable/component"
-import { Redirect, RedirectException, RouteConfig } from "found"
+import { Redirect, RedirectException } from "found"
 import React from "react"
 import { graphql } from "react-relay"
 
@@ -12,6 +12,7 @@ import { hasOverviewContent } from "./Components/NavigationTabs"
 
 import { initialArtworkFilterState } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { allowedFilters } from "v2/Components/ArtworkFilter/Utils/allowedFilters"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 graphql`
   fragment artistRoutes_Artist on Artist {
@@ -89,7 +90,7 @@ if (typeof window !== "undefined") {
   ConsignRoute.preload()
 }
 
-export const artistRoutes: RouteConfig[] = [
+export const artistRoutes: AppRouteConfig[] = [
   {
     children: [
       // Routes in tabs

--- a/src/v2/Apps/ArtistSeries/artistSeriesRoutes.tsx
+++ b/src/v2/Apps/ArtistSeries/artistSeriesRoutes.tsx
@@ -1,6 +1,6 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import { paramsToCamelCase } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { getENV } from "v2/Utils/getENV"
 import { allowedFilters } from "v2/Components/ArtworkFilter/Utils/allowedFilters"
@@ -9,7 +9,7 @@ const ArtistSeriesApp = loadable(() => import("./ArtistSeriesApp"), {
   resolveComponent: component => component.ArtistSeriesAppFragmentContainer,
 })
 
-export const artistSeriesRoutes: RouteConfig[] = [
+export const artistSeriesRoutes: AppRouteConfig[] = [
   {
     path: "/artist-series/:slug",
     getComponent: () => ArtistSeriesApp,

--- a/src/v2/Apps/Artists/artistsRoutes.tsx
+++ b/src/v2/Apps/Artists/artistsRoutes.tsx
@@ -1,6 +1,6 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 const ArtistsApp = loadable(() => import("./ArtistsApp"), {
   resolveComponent: component => component.ArtistsApp,
@@ -17,7 +17,7 @@ const ArtistsByLetterRoute = loadable(
   }
 )
 
-export const artistsRoutes: RouteConfig[] = [
+export const artistsRoutes: AppRouteConfig[] = [
   {
     path: "/artists",
     getComponent: () => ArtistsApp,

--- a/src/v2/Apps/Artwork/artworkRoutes.tsx
+++ b/src/v2/Apps/Artwork/artworkRoutes.tsx
@@ -1,11 +1,12 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 const ArtworkApp = loadable(() => import("./ArtworkApp"), {
   resolveComponent: component => component.ArtworkAppFragmentContainer,
 })
 
-export const artworkRoutes = [
+export const artworkRoutes: AppRouteConfig[] = [
   {
     path: "/artwork/:artworkID/:optional?", // There's a `confirm-bid` nested route.
     getComponent: () => ArtworkApp,

--- a/src/v2/Apps/Auction/auctionRoutes.tsx
+++ b/src/v2/Apps/Auction/auctionRoutes.tsx
@@ -1,10 +1,11 @@
 import loadable from "@loadable/component"
 import { ErrorPage } from "v2/Components/ErrorPage"
-import { RedirectException, RouteConfig } from "found"
+import { RedirectException } from "found"
 import React from "react"
 import { graphql } from "react-relay"
 import createLogger from "v2/Utils/logger"
 import { Redirect, confirmBidRedirect, registerRedirect } from "./getRedirect"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 const logger = createLogger("Apps/Auction/routes")
 
@@ -18,7 +19,7 @@ const RegisterRoute = loadable(() => import("./Routes/Register"), {
   resolveComponent: component => component.RegisterRouteFragmentContainer,
 })
 
-export const auctionRoutes: RouteConfig[] = [
+export const auctionRoutes: AppRouteConfig[] = [
   {
     path: "/auction-faq",
     getComponent: () => AuctionFAQRoute,

--- a/src/v2/Apps/Auctions/auctionsRoutes.tsx
+++ b/src/v2/Apps/Auctions/auctionsRoutes.tsx
@@ -1,5 +1,6 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import { CurrentAuctionsPaginationContainer } from "./Routes/CurrentAuctions"
 import { PastAuctionsPaginationContainer } from "./Routes/PastAuctions"
 import { UpcomingAuctionsPaginationContainer } from "./Routes/UpcomingAuctions"
@@ -8,7 +9,7 @@ const AuctionsApp = loadable(() => import("./AuctionsApp"), {
   resolveComponent: component => component.AuctionsAppFragmentContainer,
 })
 
-export const auctionsRoutes = [
+export const auctionsRoutes: AppRouteConfig[] = [
   {
     path: "/auctions",
     theme: "v3",

--- a/src/v2/Apps/BuyerGuarantee/buyerGuaranteeRoutes.tsx
+++ b/src/v2/Apps/BuyerGuarantee/buyerGuaranteeRoutes.tsx
@@ -1,6 +1,6 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 const BuyerGuaranteeApp = loadable(() => import("./BuyerGuaranteeApp"), {
   resolveComponent: component => component.BuyerGuaranteeApp,
@@ -14,7 +14,7 @@ const BuyerGuaranteeIndexRoute = loadable(
   }
 )
 
-export const buyerGuaranteeRoutes: RouteConfig[] = [
+export const buyerGuaranteeRoutes: AppRouteConfig[] = [
   {
     path: "/buyer-guarantee",
     getComponent: () => BuyerGuaranteeApp,

--- a/src/v2/Apps/Collect/collectRoutes.tsx
+++ b/src/v2/Apps/Collect/collectRoutes.tsx
@@ -1,5 +1,5 @@
 import loadable from "@loadable/component"
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import { graphql } from "react-relay"
 import { allowedFilters } from "v2/Components/ArtworkFilter/Utils/allowedFilters"
 
@@ -17,7 +17,7 @@ const CollectionApp = loadable(() => import("./Routes/Collection"), {
   resolveComponent: component => component.CollectionRefetchContainer,
 })
 
-export const collectRoutes: RouteConfig[] = [
+export const collectRoutes: AppRouteConfig[] = [
   {
     path: "/collect/:medium?",
     getComponent: () => CollectApp,

--- a/src/v2/Apps/Consign/consignRoutes.tsx
+++ b/src/v2/Apps/Consign/consignRoutes.tsx
@@ -1,5 +1,6 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 const MarketingLandingApp = loadable(
   () => import("./Routes/MarketingLanding/MarketingLandingApp"),
@@ -11,7 +12,7 @@ const OfferDetailApp = loadable(() => import("./Routes/Offer/OfferDetailApp"), {
   resolveComponent: component => component.OfferDetailAppFragmentContainer,
 })
 
-export const consignRoutes = [
+export const consignRoutes: AppRouteConfig[] = [
   {
     path: "/consign",
     getComponent: () => MarketingLandingApp,

--- a/src/v2/Apps/Conversation/conversationRoutes.tsx
+++ b/src/v2/Apps/Conversation/conversationRoutes.tsx
@@ -1,8 +1,8 @@
 import loadable from "@loadable/component"
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import { graphql } from "react-relay"
 
-export const conversationRoutes: RouteConfig[] = [
+export const conversationRoutes: AppRouteConfig[] = [
   {
     path: "/user/conversations",
     displayFullPage: true,

--- a/src/v2/Apps/Debug/debugRoutes.tsx
+++ b/src/v2/Apps/Debug/debugRoutes.tsx
@@ -1,12 +1,13 @@
 import React from "react"
 import { Title } from "react-head"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 /**
  * This route is just for testing baseline page shell stuff -- Lighthouse,
  * Calibre, assets loaded on page, and other debugging things that might
  * impact global performance.
  */
-export const debugRoutes = [
+export const debugRoutes: AppRouteConfig[] = [
   {
     path: "/debug",
     Component: ({ children }) => children,

--- a/src/v2/Apps/Example/exampleRoutes.tsx
+++ b/src/v2/Apps/Example/exampleRoutes.tsx
@@ -1,5 +1,5 @@
 import loadable from "@loadable/component"
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import { graphql } from "react-relay"
 import { WelcomeRoute } from "./Routes/Welcome/WelcomeRoute"
 
@@ -28,7 +28,7 @@ const ArtworkFilterRoute = loadable(
   }
 )
 
-export const exampleRoutes: RouteConfig[] = [
+export const exampleRoutes: AppRouteConfig[] = [
   {
     path: "/example",
     getComponent: () => ExampleApp,

--- a/src/v2/Apps/Fair/fairRoutes.tsx
+++ b/src/v2/Apps/Fair/fairRoutes.tsx
@@ -1,6 +1,6 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import { paramsToCamelCase } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { getENV } from "v2/Utils/getENV"
 import { allowedFilters } from "v2/Components/ArtworkFilter/Utils/allowedFilters"
@@ -24,7 +24,7 @@ const FairArticlesRoute = loadable(() => import("./Routes/FairArticles"), {
   resolveComponent: component => component.FairArticlesPaginationContainer,
 })
 
-export const fairRoutes: RouteConfig[] = [
+export const fairRoutes: AppRouteConfig[] = [
   {
     path: "/fair/:slug",
     ignoreScrollBehavior: true,

--- a/src/v2/Apps/Fairs/fairsRoutes.tsx
+++ b/src/v2/Apps/Fairs/fairsRoutes.tsx
@@ -1,6 +1,7 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
-import { RedirectException, RouteConfig } from "found"
+import { RedirectException } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 const FairsApp = loadable(() => import("./FairsApp"), {
   resolveComponent: component => component.FairsApp,
@@ -10,7 +11,7 @@ const FairsIndexRoute = loadable(() => import("./Routes/FairsIndex"), {
   resolveComponent: component => component.FairsIndexFragmentContainer,
 })
 
-export const fairsRoutes: RouteConfig[] = [
+export const fairsRoutes: AppRouteConfig[] = [
   {
     path: "/fairs",
     render: _props => {

--- a/src/v2/Apps/Feature/featureRoutes.tsx
+++ b/src/v2/Apps/Feature/featureRoutes.tsx
@@ -1,12 +1,12 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 const FeatureApp = loadable(() => import("./FeatureApp"), {
   resolveComponent: component => component.FeatureAppFragmentContainer,
 })
 
-export const featureRoutes: RouteConfig[] = [
+export const featureRoutes: AppRouteConfig[] = [
   {
     path: "/feature/:slug",
     getComponent: () => FeatureApp,

--- a/src/v2/Apps/FeatureAKG/featureAKGRoutes.tsx
+++ b/src/v2/Apps/FeatureAKG/featureAKGRoutes.tsx
@@ -1,12 +1,12 @@
 import loadable from "@loadable/component"
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import { graphql } from "react-relay"
 
 const FeatureAKGApp = loadable(() => import("./FeatureAKGApp"), {
   resolveComponent: component => component.FeatureAKGAppFragmentContainer,
 })
 
-export const featureAKGRoutes: RouteConfig[] = [
+export const featureAKGRoutes: AppRouteConfig[] = [
   {
     path: "/campaign/art-keeps-going",
     getComponent: () => FeatureAKGApp,

--- a/src/v2/Apps/Gene/geneRoutes.tsx
+++ b/src/v2/Apps/Gene/geneRoutes.tsx
@@ -1,9 +1,10 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
-import { RedirectException, RouteConfig } from "found"
+import { RedirectException } from "found"
 import { allowedFilters } from "v2/Components/ArtworkFilter/Utils/allowedFilters"
 import { paramsToCamelCase } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { initialArtworkFilterState } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 const GeneApp = loadable(() => import("./GeneApp"), {
   resolveComponent: component => component.GeneApp,
@@ -13,7 +14,7 @@ const GeneShowRoute = loadable(() => import("./Routes/GeneShow"), {
   resolveComponent: component => component.GeneShowFragmentContainer,
 })
 
-export const geneRoutes: RouteConfig[] = [
+export const geneRoutes: AppRouteConfig[] = [
   {
     path: "/gene/:slug",
     getComponent: () => GeneApp,

--- a/src/v2/Apps/IdentityVerification/identityVerificationRoutes.tsx
+++ b/src/v2/Apps/IdentityVerification/identityVerificationRoutes.tsx
@@ -1,5 +1,5 @@
 import loadable from "@loadable/component"
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import { graphql } from "react-relay"
 
 const IdentityVerificationApp = loadable(
@@ -16,7 +16,7 @@ const Error = loadable(() => import("./Error"), {
   resolveComponent: component => component.Error,
 })
 
-export const identityVerificationRoutes: RouteConfig[] = [
+export const identityVerificationRoutes: AppRouteConfig[] = [
   {
     path: "/identity-verification/processing",
     getComponent: () => Processing,

--- a/src/v2/Apps/Order/orderRoutes.tsx
+++ b/src/v2/Apps/Order/orderRoutes.tsx
@@ -2,7 +2,7 @@ import loadable from "@loadable/component"
 import { getRedirect } from "v2/Apps/Order/getRedirect"
 import { redirects } from "v2/Apps/Order/redirects"
 import { ErrorPage } from "v2/Components/ErrorPage"
-import { Redirect, RedirectException, RouteConfig } from "found"
+import { Redirect, RedirectException } from "found"
 import React from "react"
 import { graphql } from "react-relay"
 
@@ -16,6 +16,7 @@ import { ReviewFragmentContainer as ReviewRoute } from "./Routes/Review"
 import { AcceptFragmentContainer as AcceptRoute } from "./Routes/Accept"
 import { RejectFragmentContainer as DeclineRoute } from "./Routes/Reject"
 import { StatusFragmentContainer as StatusRoute } from "./Routes/Status"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 const OrderApp = loadable(() => import("./OrderApp"), {
   resolveComponent: component => component.OrderApp,
@@ -23,7 +24,7 @@ const OrderApp = loadable(() => import("./OrderApp"), {
 
 // FIXME:
 // * `render` functions requires casting
-export const orderRoutes: RouteConfig[] = [
+export const orderRoutes: AppRouteConfig[] = [
   {
     // TODO: Still need order2?
     path: "/order(2|s)/:orderID",

--- a/src/v2/Apps/Partner/partnerRoutes.tsx
+++ b/src/v2/Apps/Partner/partnerRoutes.tsx
@@ -1,10 +1,11 @@
 import React from "react"
 import loadable from "@loadable/component"
-import { RedirectException, RouteConfig } from "found"
+import { RedirectException } from "found"
 import { graphql } from "react-relay"
 import { initialArtworkFilterState } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { paramsToCamelCase } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { allowedFilters } from "v2/Components/ArtworkFilter/Utils/allowedFilters"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 const PartnerApp = loadable(() => import("./PartnerApp"), {
   resolveComponent: component => component.PartnerAppFragmentContainer,
@@ -34,7 +35,7 @@ const ContactRoute = loadable(() => import("./Routes/Contact"), {
   resolveComponent: component => component.ContactRouteFragmentContainer,
 })
 
-export const partnerRoutes: RouteConfig[] = [
+export const partnerRoutes: AppRouteConfig[] = [
   {
     getComponent: () => PartnerApp,
     path: "/partner2/:partnerId",

--- a/src/v2/Apps/Payment/paymentRoutes.tsx
+++ b/src/v2/Apps/Payment/paymentRoutes.tsx
@@ -1,11 +1,12 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 const PaymentApp = loadable(() => import("./Routes/Payment/PaymentApp"), {
   resolveComponent: component => component.PaymentAppFragmentContainer,
 })
 
-export const paymentRoutes = [
+export const paymentRoutes: AppRouteConfig[] = [
   {
     // TODO: update route to /user/payments and remove stitched route to launch
     path: "/user/payments",

--- a/src/v2/Apps/Purchase/purchaseRoutes.tsx
+++ b/src/v2/Apps/Purchase/purchaseRoutes.tsx
@@ -1,12 +1,12 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 const PurchasesApp = loadable(() => import("./PurchaseApp"), {
   resolveComponent: component => component.PurchaseAppFragmentContainer,
 })
 
-export const purchaseRoutes: RouteConfig[] = [
+export const purchaseRoutes: AppRouteConfig[] = [
   {
     path: "/user/purchases",
     getComponent: () => PurchasesApp,

--- a/src/v2/Apps/Search/searchRoutes.tsx
+++ b/src/v2/Apps/Search/searchRoutes.tsx
@@ -1,4 +1,4 @@
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import { omit } from "lodash"
 import React from "react"
 import { graphql } from "react-relay"
@@ -73,7 +73,7 @@ const entityTabs = Object.entries(tabsToEntitiesMap).map(([key, entities]) => {
   }
 })
 
-export const searchRoutes: RouteConfig[] = [
+export const searchRoutes: AppRouteConfig[] = [
   {
     path: "/search",
     Component: SearchAppFragmentContainer,

--- a/src/v2/Apps/Show/showRoutes.tsx
+++ b/src/v2/Apps/Show/showRoutes.tsx
@@ -1,9 +1,10 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
-import { RedirectException, RouteConfig } from "found"
+import { RedirectException } from "found"
 import { paramsToCamelCase } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { getENV } from "v2/Utils/getENV"
 import { allowedFilters } from "v2/Components/ArtworkFilter/Utils/allowedFilters"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 const ShowApp = loadable(() => import("./ShowApp"), {
   resolveComponent: component => component.ShowAppFragmentContainer,
@@ -15,7 +16,7 @@ const ShowInfoRoute = loadable(() => import("./Routes/ShowInfo"), {
   resolveComponent: component => component.ShowInfoFragmentContainer,
 })
 
-export const showRoutes: RouteConfig[] = [
+export const showRoutes: AppRouteConfig[] = [
   {
     getComponent: () => ShowApp,
     path: "/show/:slug",

--- a/src/v2/Apps/Tag/tagRoutes.tsx
+++ b/src/v2/Apps/Tag/tagRoutes.tsx
@@ -1,5 +1,5 @@
 import loadable from "@loadable/component"
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import { graphql } from "relay-runtime"
 import { initialArtworkFilterState } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { allowedFilters } from "v2/Components/ArtworkFilter/Utils/allowedFilters"
@@ -9,7 +9,7 @@ const TagApp = loadable(() => import("./TagApp"), {
   resolveComponent: component => component.TagAppFragmentContainer,
 })
 
-export const tagRoutes: RouteConfig[] = [
+export const tagRoutes: AppRouteConfig[] = [
   {
     path: "/tag/:slug",
     getComponent: () => TagApp,

--- a/src/v2/Apps/ViewingRoom/viewingRoomRoutes.tsx
+++ b/src/v2/Apps/ViewingRoom/viewingRoomRoutes.tsx
@@ -1,6 +1,6 @@
 import loadable from "@loadable/component"
 import { graphql } from "react-relay"
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 import { ViewingRoomStatementRouteFragmentContainer as StatementRoute } from "./Routes/Statement/ViewingRoomStatementRoute"
 import { ViewingRoomWorksRouteFragmentContainer as WorksRoute } from "./Routes/Works/ViewingRoomWorksRoute"
@@ -12,7 +12,7 @@ const ViewingRoomsApp = loadable(() => import("./ViewingRoomsApp"), {
   resolveComponent: component => component.ViewingRoomsAppFragmentContainer,
 })
 
-export const viewingRoomRoutes: RouteConfig[] = [
+export const viewingRoomRoutes: AppRouteConfig[] = [
   {
     path: "/viewing-rooms",
     getComponent: () => ViewingRoomsApp,

--- a/src/v2/Artsy/Router/Boot.tsx
+++ b/src/v2/Artsy/Router/Boot.tsx
@@ -1,6 +1,6 @@
 import { Grid, Theme, injectGlobalStyles, themeProps } from "@artsy/palette"
 import { SystemContextProvider, track } from "v2/Artsy"
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import React, { useEffect } from "react"
 import { HeadProvider } from "react-head"
 import { Environment } from "relay-runtime"
@@ -29,7 +29,7 @@ export interface BootProps {
   headTags?: JSX.Element[]
   onlyMatchMediaQueries?: MatchingMediaQueries
   relayEnvironment: Environment
-  routes: RouteConfig
+  routes: AppRouteConfig[]
   user: User
 }
 

--- a/src/v2/Artsy/Router/Route.tsx
+++ b/src/v2/Artsy/Router/Route.tsx
@@ -4,9 +4,27 @@
  */
 
 import { RouteSpinner } from "v2/Artsy/Relay/renderWithLoadProgress"
-import { HttpError } from "found"
+import { RouteConfig, HttpError } from "found"
 import BaseRoute from "found/Route"
 import React from "react"
+import { CacheConfig, GraphQLTaggedNode } from "relay-runtime";
+
+type RemoveIndex<T> = {
+  [ P in keyof T as string extends P ? never : number extends P ? never : P ]: T[P]
+};
+
+interface RouteConfigProps extends RouteConfig {
+  cacheConfig?: CacheConfig
+  displayFullPage?: boolean
+  fetchIndicator?: FetchIndicator
+  ignoreScrollBehavior?: boolean
+  prepare?: () => void
+  prepareVariables?: (params: any, props: any) => object
+  query?: GraphQLTaggedNode
+  theme?: 'v2' | 'v3'
+}
+
+export type AppRouteConfig = RemoveIndex<RouteConfigProps>
 
 type FetchIndicator = "spinner" | "overlay"
 

--- a/src/v2/Artsy/Router/Utils/createRouteConfig.ts
+++ b/src/v2/Artsy/Router/Utils/createRouteConfig.ts
@@ -1,7 +1,7 @@
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import { Route } from "../Route"
 
-export function createRouteConfig(routes): RouteConfig[] {
+export function createRouteConfig(routes): AppRouteConfig[] {
   return routes.map(route => {
     if (route.__proto__ === Object.prototype) {
       return new Route({

--- a/src/v2/Artsy/Router/buildAppRoutes.tsx
+++ b/src/v2/Artsy/Router/buildAppRoutes.tsx
@@ -1,13 +1,14 @@
-import { Match, RouteConfig, Router, withRouter } from "found"
+import { Match, Router, withRouter } from "found"
 import { flatten } from "lodash"
 import React, { useEffect } from "react"
 
 import { AppShell } from "v2/Apps/Components/AppShell"
 import { useSystemContext } from "v2/Artsy/SystemContext"
 import { interceptLinks } from "./interceptLinks"
+import { AppRouteConfig } from "./Route"
 
 interface RouteList {
-  routes: RouteConfig
+  routes: AppRouteConfig[]
 
   /**
    * Disabled routes are not mounted within global route
@@ -15,7 +16,7 @@ interface RouteList {
   disabled?: boolean
 }
 
-export function buildAppRoutes(routeList: RouteList[]): RouteConfig[] {
+export function buildAppRoutes(routeList: RouteList[]): AppRouteConfig[] {
   const routes = getActiveRoutes(routeList)
 
   const Component: React.FC<{
@@ -64,7 +65,7 @@ function getActiveRoutes(routeList) {
   return routes
 }
 
-function createRouteConfiguration(route): RouteConfig {
+function createRouteConfiguration(route): AppRouteConfig {
   let path = route.path
   // FIXME: I'm certain this logic is incorrect. If the last character is a `/`
   // trim the first character of the path.

--- a/src/v2/Artsy/Router/buildServerApp.tsx
+++ b/src/v2/Artsy/Router/buildServerApp.tsx
@@ -32,7 +32,7 @@ import { ChunkExtractor } from "@loadable/server"
 import { getENV } from "v2/Utils/getENV"
 import RelayServerSSR from "react-relay-network-modern-ssr/lib/server"
 import { buildServerAppContext } from "desktop/lib/buildServerAppContext"
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 export interface ServerAppResolve {
   bodyHTML?: string
@@ -51,7 +51,7 @@ const logger = createLogger("Artsy/Router/buildServerApp.tsx")
 export interface ServerRouterConfig extends RouterConfig {
   req: Request
   res: Response
-  routes: RouteConfig[]
+  routes: AppRouteConfig[]
   context?: {
     injectedData?: any
   }

--- a/src/v2/Artsy/Router/index.ts
+++ b/src/v2/Artsy/Router/index.ts
@@ -1,6 +1,7 @@
 import { RelaySSREnvironment } from "v2/Artsy/Relay/createRelaySSREnvironment"
-import { FarceCreateRouterArgs, RouteConfig } from "found"
+import { FarceCreateRouterArgs } from "found"
 import { SystemContextProps } from "../SystemContext"
+import { AppRouteConfig } from "./Route"
 
 export { Link } from "found"
 export { Boot } from "./Boot"
@@ -35,7 +36,7 @@ export interface RouterConfig {
   /**
    * Array of routes to be passed to Found
    */
-  routes: RouteConfig[]
+  routes: AppRouteConfig[]
 
   /**
    * URL passed from server

--- a/src/v2/routes.tsx
+++ b/src/v2/routes.tsx
@@ -19,7 +19,7 @@ import { orderRoutes } from "v2/Apps/Order/orderRoutes"
 import { partnerRoutes } from "v2/Apps/Partner/partnerRoutes"
 import { paymentRoutes } from "v2/Apps/Payment/paymentRoutes"
 import { purchaseRoutes } from "v2/Apps/Purchase/purchaseRoutes"
-import { RouteConfig } from "found"
+import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import { searchRoutes } from "v2/Apps/Search/searchRoutes"
 import { showRoutes } from "v2/Apps/Show/showRoutes"
 import { viewingRoomRoutes } from "v2/Apps/ViewingRoom/viewingRoomRoutes"
@@ -32,7 +32,7 @@ import { tagRoutes } from "./Apps/Tag/tagRoutes"
  * `src/desktop/lib/webpackPublicPath.ts` as well. This is temporary until the
  * assets paths have stabilized.
  */
-export function getAppRoutes(): RouteConfig[] {
+export function getAppRoutes(): AppRouteConfig[] {
   return buildAppRoutes([
     {
       routes: artistRoutes,


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/WP-32 

This locks down our route config files by adding types, and requiring them. When adding new routes in the future, import our `AppRouteConfig` interface: 

```tsx
import { AppRouteConfig } from "v2/Artsy/Router/Route"

export const someAppRoutes: AppRouteConfig[] = [
  ...
]
```

Current options include: 

```tsx
  cacheConfig?: CacheConfig
  displayFullPage?: boolean
  fetchIndicator?: FetchIndicator
  ignoreScrollBehavior?: boolean
  prepare?: () => void
  prepareVariables?: (params: any, props: any) => object
  query?: GraphQLTaggedNode
  theme?: 'v2' | 'v3'
```