### PR TITLE
Erikdstock/buyer guarantee responsive header

### DIFF
--- a/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
@@ -99,6 +99,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
   return (
     <>
       <FullBleedHeader
+        {...headerImage.image.resized.srcSet}
         height={[283, 469]}
         src={heroImageURL}
         caption={
@@ -774,9 +775,6 @@ export const BuyerGuaranteeIndexFragmentContainer = createFragmentContainer(
         image {
           resized(version: "normalized") {
             srcSet
-          }
-          cropped(width: 1600, height: 600, version: "wide") {
-            src
           }
         }
       }

--- a/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
@@ -126,7 +126,6 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
           </Text>
         </Flex>
       </FullBleedHeader>
-      {/* First Row */}
       <Flex justifyContent="center" flexDirection="column">
         <Flex justifyContent="center" mx={["10%", "25%"]} textAlign="center">
           <Text variant="title" mt={5}>
@@ -136,81 +135,119 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
           </Text>
         </Flex>
 
-        {/* Second Row */}
-        <Flex justifyContent="center" mt={4} mx="20%">
-          <Flex flexDirection="column" mr={5} alignItems="center">
-            <Media greaterThanOrEqual="md">
-              <VerifiedIcon height={60} width={60} />
-            </Media>
-            <Media lessThan="md">
+        <Media lessThan="sm">
+          <Flex justifyContent="space-around" mt={4}>
+            <Flex flexDirection="column" alignItems="center">
               <VerifiedIcon height={50} width={50} />
-            </Media>
-            <Text
-              variant="mediumText"
-              my={[0, 2]}
-              style={{ whiteSpace: "nowrap" }}
-            >
-              Vetted Sellers
-            </Text>
-            <Media greaterThan="xs">
+              <Text
+                variant="mediumText"
+                my={2}
+                style={{ whiteSpace: "nowrap" }}
+              >
+                Vetted Sellers
+              </Text>
+            </Flex>
+
+            <Flex flexDirection="column" ml={0} alignItems="center">
+              <ChatIcon h={50} w={50} />
+              <Text
+                variant="mediumText"
+                my={2}
+                style={{ whiteSpace: "nowrap" }}
+              >
+                Dedicated Support
+              </Text>
+            </Flex>
+          </Flex>
+          <Flex justifyContent="space-around" mt={4}>
+            <Flex flexDirection="column" alignItems="center">
+              <CertificateIcon height={50} width={50} />
+              <Text
+                variant="mediumText"
+                my={2}
+                style={{ whiteSpace: "nowrap" }}
+              >
+                Authenticity Guarantee
+              </Text>
+            </Flex>
+
+            <Flex flexDirection="column" ml={0} alignItems="center">
+              <MoneyBackIcon h={50} w={50} />
+              <Text
+                variant="mediumText"
+                my={2}
+                style={{ whiteSpace: "nowrap" }}
+              >
+                Money-Back Guarantee
+              </Text>
+            </Flex>
+          </Flex>
+
+          <Flex justifyContent="space-around" mt={4}>
+            <Flex flexDirection="column" alignItems="center">
+              <LockIcon height={50} width={50} />
+              <Text
+                variant="mediumText"
+                my={2}
+                style={{ whiteSpace: "nowrap" }}
+              >
+                Secure Payment
+              </Text>
+            </Flex>
+          </Flex>
+        </Media>
+
+        <Media greaterThan="xs">
+          <Flex justifyContent="center" mt={4} mx="20%">
+            <Flex flexDirection="column" mr={5} alignItems="center">
+              <VerifiedIcon height={60} width={60} />
+
+              <Text
+                variant="mediumText"
+                my={2}
+                style={{ whiteSpace: "nowrap" }}
+              >
+                Vetted Sellers
+              </Text>
               <Text variant="text" textAlign="center" color={color("black80")}>
                 We partner with leading galleries, institutions, and auction
                 houses around the world in order to maintain the integrity of
                 our listings
               </Text>
-            </Media>
-          </Flex>
-          <Flex flexDirection="column" ml={[0, 5]} alignItems="center">
-            <Media greaterThanOrEqual="sm">
+            </Flex>
+
+            <Flex flexDirection="column" ml={[0, 5]} alignItems="center">
               <ChatIcon h={60} w={60} />
-            </Media>
-            <Media lessThan="sm">
-              <ChatIcon h={50} w={50} />
-            </Media>
-            <Text
-              variant="mediumText"
-              my={[0, 2]}
-              style={{ whiteSpace: "nowrap" }}
-            >
-              Dedicated Support
-            </Text>
-            <Media greaterThan="xs">
+              <Text
+                variant="mediumText"
+                my={2}
+                style={{ whiteSpace: "nowrap" }}
+              >
+                Dedicated Support
+              </Text>
               <Text variant="text" textAlign="center" color={color("black80")}>
                 Our global team of specialists is always here to answer your
                 questions and assist with any purchase-related needs.
               </Text>
-            </Media>
+            </Flex>
           </Flex>
-        </Flex>
 
-        {/* Third Row */}
-        <Flex
-          mb={[0, space(9)]}
-          flexWrap={["wrap", "nowrap"]}
-          alignItems="flex-start"
-        >
-          {/* Authenticity Guarantee */}
           <Flex
-            flexDirection="column"
-            mt={5}
-            height={300}
-            width="100%"
-            textAlign="center"
-            justifyContent="flex-end"
+            mb={[0, space(9)]}
+            flexWrap={["wrap", "nowrap"]}
+            alignItems="flex-start"
           >
-            <Box>
-              <Media greaterThanOrEqual="sm">
+            <Flex
+              flexDirection="column"
+              mt={5}
+              height={300}
+              width="100%"
+              textAlign="center"
+              justifyContent="flex-end"
+            >
+              <Box>
                 <CertificateIcon height={60} width={60} />
-              </Media>
-            </Box>
-            <Media lessThan="sm">
-              <CertificateIcon height={50} width={50} />
-              <Text my={2} variant="mediumText">
-                Authenticity Guarantee
-              </Text>
-            </Media>
-
-            <Media greaterThan="xs">
+              </Box>
               <Box>
                 <Text my={2} variant="mediumText">
                   Authenticity Guarantee
@@ -221,30 +258,18 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
                 </Text>
               </Box>
               <Box>{learnMoreIcon}</Box>
-            </Media>
-          </Flex>
-          {/* Money Back Guarantee */}
-          <Flex
-            flexDirection="column"
-            mt={5}
-            height={300}
-            width="100%"
-            textAlign="center"
-            justifyContent="flex-end"
-          >
-            <Box>
-              <Media greaterThanOrEqual="sm">
+            </Flex>
+            <Flex
+              flexDirection="column"
+              mt={5}
+              height={300}
+              width="100%"
+              textAlign="center"
+              justifyContent="flex-end"
+            >
+              <Box>
                 <MoneyBackIcon h={60} w={60} />
-              </Media>
-            </Box>
-            <Media lessThan="sm">
-              <MoneyBackIcon h={50} w={50} />
-              <Text my={4} variant="mediumText">
-                Money-Back Guarantee
-              </Text>
-            </Media>
-
-            <Media greaterThan="xs">
+              </Box>
               <Box>
                 <Text my={2} variant="mediumText">
                   Money-Back Guarantee
@@ -255,30 +280,19 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
                 </Text>
               </Box>
               <Box>{learnMoreIcon}</Box>
-            </Media>
-          </Flex>
-          {/* Secured Payment Guarantee */}
-          <Flex
-            flexDirection="column"
-            mt={5}
-            height={300}
-            width="100%"
-            textAlign="center"
-            justifyContent="flex-end"
-          >
-            <Box>
-              <Media greaterThanOrEqual="sm">
+            </Flex>
+            <Flex
+              flexDirection="column"
+              mt={5}
+              height={300}
+              width="100%"
+              textAlign="center"
+              justifyContent="flex-end"
+            >
+              <Box>
                 <LockIcon height={60} width={60} />
-              </Media>
-            </Box>
-            <Media lessThan="sm">
-              <LockIcon height={50} width={50} />
-              <Text my={2} variant="mediumText">
-                Authenticity Guarantee
-              </Text>
-            </Media>
+              </Box>
 
-            <Media greaterThan="xs">
               <Box>
                 <Text my={2} variant="mediumText">
                   Secure Payment
@@ -289,9 +303,9 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
                 </Text>
               </Box>
               <Box>{learnMoreIcon}</Box>
-            </Media>
+            </Flex>
           </Flex>
-        </Flex>
+        </Media>
       </Flex>
 
       {/*  Artsy Guarantee Sections desktop */}
@@ -390,7 +404,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
           <Text variant="text" my={2}>
             {securePaymentText}
           </Text>
-          <PoweredByStripeIcon w={500} mt={"-50px"} ml={"-30px"} />
+          <PoweredByStripeIcon w={200} ml={"-30px"} mt={0} />
         </Flex>
       </Media>
 

--- a/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
@@ -6,7 +6,6 @@ import {
   CertificateIcon,
   color,
   CSSGrid,
-  FullBleed,
   Flex,
   Image,
   Link,
@@ -25,6 +24,7 @@ import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import { useSystemContext } from "v2/Artsy"
 import styled from "styled-components"
 import { resize } from "v2/Utils/resizer"
+import { FullBleedHeader } from "v2/Components/FullBleedHeader"
 
 interface BuyerGuaranteeIndexProps {
   headerImage: BuyerGuaranteeIndex_headerImage
@@ -98,68 +98,33 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
 
   return (
     <>
-      <FullBleed>
-        {/* Header Block */}
-        <Flex justifyContent="center" alignContent="center">
-          <Media lessThan="sm">
-            <Box height={400}>
-              <Image
-                src={heroImageURL}
-                alt={headerImage.artist.name}
-                aria-label={headerImage.imageTitle}
-                srcSet={headerImage.image.resized.srcSet}
-                lazyLoad
-              />
-            </Box>
-            <Box position="absolute">
-              <Text
-                variant="largeTitle"
-                color={color("white100")}
-                position="relative"
-                mt={"60%"}
-                as="h1"
-              >
-                The Artsy Guarantee
-              </Text>
-            </Box>
-          </Media>
-          <Media greaterThanOrEqual="sm">
-            <Box height={400} overflow="hidden">
-              <Image
-                src={heroImageURL}
-                alt={headerImage.artist.name}
-                aria-label={headerImage.imageTitle}
-                srcSet={headerImage.image.resized.srcSet}
-                lazyLoad
-              />
-            </Box>
-            <Flex alignItems="center" justifyContent="center">
-              <Box position="absolute">
-                <Text
-                  fontSize={80}
-                  color={color("white100")}
-                  position="relative"
-                  mt={"-35%"}
-                  as="h1"
-                >
-                  The Artsy Guarantee
-                </Text>
-              </Box>
-            </Flex>
-          </Media>
-        </Flex>
-        <Flex justifyContent="flex-end" mt={["-40px", "-30px"]} mr={1}>
+      <FullBleedHeader
+        height={[283, 469]}
+        src={heroImageURL}
+        caption={
+          headerImage.imageTitle +
+          ". Courtesy of the artist and Kenise Barnes Fine Art. "
+        }
+      >
+        <Flex
+          position="absolute"
+          top={0}
+          right={0}
+          bottom={0}
+          left={0}
+          justifyContent="center"
+          alignItems="center"
+        >
           <Text
-            variant={["small", "text"]}
+            fontSize={[34, null, 80]}
             color={color("white100")}
-            textAlign="right"
+            position="relative"
+            as="h1"
           >
-            {headerImage.imageTitle +
-              ". Courtesy of the artist and Kenise Barnes Fine Art. "}
+            The Artsy Guarantee
           </Text>
         </Flex>
-      </FullBleed>
-
+      </FullBleedHeader>
       {/* First Row */}
       <Flex justifyContent="center" flexDirection="column">
         <Flex justifyContent="center" mx={["10%", "25%"]} textAlign="center">
@@ -803,13 +768,16 @@ export const BuyerGuaranteeIndexFragmentContainer = createFragmentContainer(
       fragment BuyerGuaranteeIndex_headerImage on Artwork {
         imageTitle
         imageUrl
+        artist {
+          name
+        }
         image {
           resized(version: "normalized") {
             srcSet
           }
-        }
-        artist {
-          name
+          cropped(width: 1600, height: 600, version: "wide") {
+            src
+          }
         }
       }
     `,
@@ -858,18 +826,8 @@ export const BuyerGuaranteeIndexFragmentContainer = createFragmentContainer(
   }
 )
 
-const PoweredByStripeIconContainer = styled(Box)<{
-  width?: string
-  marginTop?: string
-  marginLeft?: string
-}>`
-  width: ${props => props.width}};
-  margin-top: ${props => props.marginTop}};
-  margin-left: ${props => props.marginLeft}};
-`
-
 const PoweredByStripeIcon = ({ w, mt, ml }) => (
-  <PoweredByStripeIconContainer mt={mt} ml={ml}>
+  <Box mt={mt} ml={ml}>
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width={w}
@@ -888,7 +846,7 @@ const PoweredByStripeIcon = ({ w, mt, ml }) => (
         fillRule="evenodd"
       />
     </svg>
-  </PoweredByStripeIconContainer>
+  </Box>
 )
 
 const MoneyBackIcon = ({ h, w }) => (
@@ -928,8 +886,8 @@ const ChatIconContainer = styled.svg<{
   height: string | number
   width: string | number
 }>`
-  height: ${props => props.height}};
-  width: ${props => props.width}};
+  height: ${props => props.height};
+  width: ${props => props.width};
 `
 
 const ChatIcon = ({ h, w }) => (

--- a/src/v2/Apps/BuyerGuarantee/Routes/__tests__/BuyerGuaranteeIndex.jest.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Routes/__tests__/BuyerGuaranteeIndex.jest.tsx
@@ -43,7 +43,7 @@ describe("BuyerGuaranteeIndex when admin", () => {
 
     const html = wrapper.html()
 
-    expect(wrapper.find("h1")).toHaveLength(2)
+    expect(wrapper.find("h1")).toHaveLength(1)
     expect(html).toContain("The Artsy Guarantee")
   })
 })

--- a/src/v2/Apps/BuyerGuarantee/buyerGuaranteeRoutes.tsx
+++ b/src/v2/Apps/BuyerGuarantee/buyerGuaranteeRoutes.tsx
@@ -17,6 +17,7 @@ const BuyerGuaranteeIndexRoute = loadable(
 export const buyerGuaranteeRoutes: AppRouteConfig[] = [
   {
     path: "/buyer-guarantee",
+    theme: "v3",
     getComponent: () => BuyerGuaranteeApp,
     prepare: () => {
       BuyerGuaranteeApp.preload()

--- a/src/v2/__generated__/BuyerGuaranteeIndexNonAdmin_Test_Query.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndexNonAdmin_Test_Query.graphql.ts
@@ -62,14 +62,17 @@ fragment BuyerGuaranteeIndex_authenticityImage on Artwork {
 fragment BuyerGuaranteeIndex_headerImage on Artwork {
   imageTitle
   imageUrl
+  artist {
+    name
+    id
+  }
   image {
     resized(version: "normalized") {
       srcSet
     }
-  }
-  artist {
-    name
-    id
+    cropped(width: 1600, height: 600, version: "wide") {
+      src
+    }
   }
 }
 
@@ -145,23 +148,14 @@ v5 = {
   "name": "imageUrl",
   "storageKey": null
 },
-v6 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "srcSet",
-    "storageKey": null
-  }
-],
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
+v7 = {
   "alias": null,
   "args": null,
   "concreteType": "Artist",
@@ -176,10 +170,19 @@ v8 = {
       "name": "name",
       "storageKey": null
     },
-    (v7/*: any*/)
+    (v6/*: any*/)
   ],
   "storageKey": null
 },
+v8 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  }
+],
 v9 = [
   (v4/*: any*/),
   (v5/*: any*/),
@@ -204,14 +207,14 @@ v9 = [
         "kind": "LinkedField",
         "name": "resized",
         "plural": false,
-        "selections": (v6/*: any*/),
+        "selections": (v8/*: any*/),
         "storageKey": "resized(version:\"large_rectangle\")"
       }
     ],
     "storageKey": null
   },
-  (v8/*: any*/),
-  (v7/*: any*/)
+  (v7/*: any*/),
+  (v6/*: any*/)
 ];
 return {
   "fragment": {
@@ -303,6 +306,7 @@ return {
         "selections": [
           (v4/*: any*/),
           (v5/*: any*/),
+          (v7/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -324,14 +328,47 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v6/*: any*/),
+                "selections": (v8/*: any*/),
                 "storageKey": "resized(version:\"normalized\")"
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 600
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "wide"
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 1600
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "src",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "cropped(height:600,version:\"wide\",width:1600)"
               }
             ],
             "storageKey": null
           },
-          (v8/*: any*/),
-          (v7/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": "artwork(id:\"any-id1\")"
       },
@@ -372,7 +409,7 @@ return {
     "metadata": {},
     "name": "BuyerGuaranteeIndexNonAdmin_Test_Query",
     "operationKind": "query",
-    "text": "query BuyerGuaranteeIndexNonAdmin_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"normalized\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n"
+    "text": "query BuyerGuaranteeIndexNonAdmin_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      srcSet\n    }\n    cropped(width: 1600, height: 600, version: \"wide\") {\n      src\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/BuyerGuaranteeIndexNonAdmin_Test_Query.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndexNonAdmin_Test_Query.graphql.ts
@@ -70,9 +70,6 @@ fragment BuyerGuaranteeIndex_headerImage on Artwork {
     resized(version: "normalized") {
       srcSet
     }
-    cropped(width: 1600, height: 600, version: "wide") {
-      src
-    }
   }
 }
 
@@ -330,40 +327,6 @@ return {
                 "plural": false,
                 "selections": (v8/*: any*/),
                 "storageKey": "resized(version:\"normalized\")"
-              },
-              {
-                "alias": null,
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "height",
-                    "value": 600
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "wide"
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "width",
-                    "value": 1600
-                  }
-                ],
-                "concreteType": "CroppedImageUrl",
-                "kind": "LinkedField",
-                "name": "cropped",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "src",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": "cropped(height:600,version:\"wide\",width:1600)"
               }
             ],
             "storageKey": null
@@ -409,7 +372,7 @@ return {
     "metadata": {},
     "name": "BuyerGuaranteeIndexNonAdmin_Test_Query",
     "operationKind": "query",
-    "text": "query BuyerGuaranteeIndexNonAdmin_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      srcSet\n    }\n    cropped(width: 1600, height: 600, version: \"wide\") {\n      src\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n"
+    "text": "query BuyerGuaranteeIndexNonAdmin_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      srcSet\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/BuyerGuaranteeIndex_Test_Query.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndex_Test_Query.graphql.ts
@@ -62,14 +62,17 @@ fragment BuyerGuaranteeIndex_authenticityImage on Artwork {
 fragment BuyerGuaranteeIndex_headerImage on Artwork {
   imageTitle
   imageUrl
+  artist {
+    name
+    id
+  }
   image {
     resized(version: "normalized") {
       srcSet
     }
-  }
-  artist {
-    name
-    id
+    cropped(width: 1600, height: 600, version: "wide") {
+      src
+    }
   }
 }
 
@@ -145,23 +148,14 @@ v5 = {
   "name": "imageUrl",
   "storageKey": null
 },
-v6 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "srcSet",
-    "storageKey": null
-  }
-],
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
+v7 = {
   "alias": null,
   "args": null,
   "concreteType": "Artist",
@@ -176,10 +170,19 @@ v8 = {
       "name": "name",
       "storageKey": null
     },
-    (v7/*: any*/)
+    (v6/*: any*/)
   ],
   "storageKey": null
 },
+v8 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  }
+],
 v9 = [
   (v4/*: any*/),
   (v5/*: any*/),
@@ -204,14 +207,14 @@ v9 = [
         "kind": "LinkedField",
         "name": "resized",
         "plural": false,
-        "selections": (v6/*: any*/),
+        "selections": (v8/*: any*/),
         "storageKey": "resized(version:\"large_rectangle\")"
       }
     ],
     "storageKey": null
   },
-  (v8/*: any*/),
-  (v7/*: any*/)
+  (v7/*: any*/),
+  (v6/*: any*/)
 ];
 return {
   "fragment": {
@@ -303,6 +306,7 @@ return {
         "selections": [
           (v4/*: any*/),
           (v5/*: any*/),
+          (v7/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -324,14 +328,47 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v6/*: any*/),
+                "selections": (v8/*: any*/),
                 "storageKey": "resized(version:\"normalized\")"
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 600
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "wide"
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 1600
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "src",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "cropped(height:600,version:\"wide\",width:1600)"
               }
             ],
             "storageKey": null
           },
-          (v8/*: any*/),
-          (v7/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": "artwork(id:\"any-id1\")"
       },
@@ -372,7 +409,7 @@ return {
     "metadata": {},
     "name": "BuyerGuaranteeIndex_Test_Query",
     "operationKind": "query",
-    "text": "query BuyerGuaranteeIndex_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"normalized\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n"
+    "text": "query BuyerGuaranteeIndex_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      srcSet\n    }\n    cropped(width: 1600, height: 600, version: \"wide\") {\n      src\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/BuyerGuaranteeIndex_Test_Query.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndex_Test_Query.graphql.ts
@@ -70,9 +70,6 @@ fragment BuyerGuaranteeIndex_headerImage on Artwork {
     resized(version: "normalized") {
       srcSet
     }
-    cropped(width: 1600, height: 600, version: "wide") {
-      src
-    }
   }
 }
 
@@ -330,40 +327,6 @@ return {
                 "plural": false,
                 "selections": (v8/*: any*/),
                 "storageKey": "resized(version:\"normalized\")"
-              },
-              {
-                "alias": null,
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "height",
-                    "value": 600
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "wide"
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "width",
-                    "value": 1600
-                  }
-                ],
-                "concreteType": "CroppedImageUrl",
-                "kind": "LinkedField",
-                "name": "cropped",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "src",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": "cropped(height:600,version:\"wide\",width:1600)"
               }
             ],
             "storageKey": null
@@ -409,7 +372,7 @@ return {
     "metadata": {},
     "name": "BuyerGuaranteeIndex_Test_Query",
     "operationKind": "query",
-    "text": "query BuyerGuaranteeIndex_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      srcSet\n    }\n    cropped(width: 1600, height: 600, version: \"wide\") {\n      src\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n"
+    "text": "query BuyerGuaranteeIndex_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      srcSet\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/BuyerGuaranteeIndex_headerImage.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndex_headerImage.graphql.ts
@@ -13,9 +13,6 @@ export type BuyerGuaranteeIndex_headerImage = {
         readonly resized: {
             readonly srcSet: string;
         } | null;
-        readonly cropped: {
-            readonly src: string;
-        } | null;
     } | null;
     readonly " $refType": "BuyerGuaranteeIndex_headerImage";
 };
@@ -96,40 +93,6 @@ const node: ReaderFragment = {
             }
           ],
           "storageKey": "resized(version:\"normalized\")"
-        },
-        {
-          "alias": null,
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "height",
-              "value": 600
-            },
-            {
-              "kind": "Literal",
-              "name": "version",
-              "value": "wide"
-            },
-            {
-              "kind": "Literal",
-              "name": "width",
-              "value": 1600
-            }
-          ],
-          "concreteType": "CroppedImageUrl",
-          "kind": "LinkedField",
-          "name": "cropped",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "src",
-              "storageKey": null
-            }
-          ],
-          "storageKey": "cropped(height:600,version:\"wide\",width:1600)"
         }
       ],
       "storageKey": null
@@ -137,5 +100,5 @@ const node: ReaderFragment = {
   ],
   "type": "Artwork"
 };
-(node as any).hash = 'bea83da4bc0af11bbc94d6b90d65d58b';
+(node as any).hash = 'db01dc82a545e01ab10cb4d9e3aa3356';
 export default node;

--- a/src/v2/__generated__/BuyerGuaranteeIndex_headerImage.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndex_headerImage.graphql.ts
@@ -6,13 +6,16 @@ import { FragmentRefs } from "relay-runtime";
 export type BuyerGuaranteeIndex_headerImage = {
     readonly imageTitle: string | null;
     readonly imageUrl: string | null;
+    readonly artist: {
+        readonly name: string | null;
+    } | null;
     readonly image: {
         readonly resized: {
             readonly srcSet: string;
         } | null;
-    } | null;
-    readonly artist: {
-        readonly name: string | null;
+        readonly cropped: {
+            readonly src: string;
+        } | null;
     } | null;
     readonly " $refType": "BuyerGuaranteeIndex_headerImage";
 };
@@ -47,6 +50,24 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
+      "concreteType": "Artist",
+      "kind": "LinkedField",
+      "name": "artist",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
       "concreteType": "Image",
       "kind": "LinkedField",
       "name": "image",
@@ -75,24 +96,40 @@ const node: ReaderFragment = {
             }
           ],
           "storageKey": "resized(version:\"normalized\")"
-        }
-      ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "Artist",
-      "kind": "LinkedField",
-      "name": "artist",
-      "plural": false,
-      "selections": [
+        },
         {
           "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "name",
-          "storageKey": null
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 600
+            },
+            {
+              "kind": "Literal",
+              "name": "version",
+              "value": "wide"
+            },
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 1600
+            }
+          ],
+          "concreteType": "CroppedImageUrl",
+          "kind": "LinkedField",
+          "name": "cropped",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "src",
+              "storageKey": null
+            }
+          ],
+          "storageKey": "cropped(height:600,version:\"wide\",width:1600)"
         }
       ],
       "storageKey": null
@@ -100,5 +137,5 @@ const node: ReaderFragment = {
   ],
   "type": "Artwork"
 };
-(node as any).hash = '449113e08d06d4b54c81935abe8818c3';
+(node as any).hash = 'bea83da4bc0af11bbc94d6b90d65d58b';
 export default node;

--- a/src/v2/__generated__/buyerGuaranteeRoutes_BuyerGuaranteeQuery.graphql.ts
+++ b/src/v2/__generated__/buyerGuaranteeRoutes_BuyerGuaranteeQuery.graphql.ts
@@ -70,9 +70,6 @@ fragment BuyerGuaranteeIndex_headerImage on Artwork {
     resized(version: "normalized") {
       srcSet
     }
-    cropped(width: 1600, height: 600, version: "wide") {
-      src
-    }
   }
 }
 
@@ -330,40 +327,6 @@ return {
                 "plural": false,
                 "selections": (v8/*: any*/),
                 "storageKey": "resized(version:\"normalized\")"
-              },
-              {
-                "alias": null,
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "height",
-                    "value": 600
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "wide"
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "width",
-                    "value": 1600
-                  }
-                ],
-                "concreteType": "CroppedImageUrl",
-                "kind": "LinkedField",
-                "name": "cropped",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "src",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": "cropped(height:600,version:\"wide\",width:1600)"
               }
             ],
             "storageKey": null
@@ -409,7 +372,7 @@ return {
     "metadata": {},
     "name": "buyerGuaranteeRoutes_BuyerGuaranteeQuery",
     "operationKind": "query",
-    "text": "query buyerGuaranteeRoutes_BuyerGuaranteeQuery {\n  headerImage: artwork(id: \"5dd8084d257aaf000e4a0396\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"5fecdbfa19d5ae5bf95c1dd8\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"5fce729a212bcf54e2551f21\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"580fb7cd2a893a65c100086a\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      srcSet\n    }\n    cropped(width: 1600, height: 600, version: \"wide\") {\n      src\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n"
+    "text": "query buyerGuaranteeRoutes_BuyerGuaranteeQuery {\n  headerImage: artwork(id: \"5dd8084d257aaf000e4a0396\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"5fecdbfa19d5ae5bf95c1dd8\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"5fce729a212bcf54e2551f21\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"580fb7cd2a893a65c100086a\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      srcSet\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/buyerGuaranteeRoutes_BuyerGuaranteeQuery.graphql.ts
+++ b/src/v2/__generated__/buyerGuaranteeRoutes_BuyerGuaranteeQuery.graphql.ts
@@ -62,14 +62,17 @@ fragment BuyerGuaranteeIndex_authenticityImage on Artwork {
 fragment BuyerGuaranteeIndex_headerImage on Artwork {
   imageTitle
   imageUrl
+  artist {
+    name
+    id
+  }
   image {
     resized(version: "normalized") {
       srcSet
     }
-  }
-  artist {
-    name
-    id
+    cropped(width: 1600, height: 600, version: "wide") {
+      src
+    }
   }
 }
 
@@ -145,23 +148,14 @@ v5 = {
   "name": "imageUrl",
   "storageKey": null
 },
-v6 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "srcSet",
-    "storageKey": null
-  }
-],
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
+v7 = {
   "alias": null,
   "args": null,
   "concreteType": "Artist",
@@ -176,10 +170,19 @@ v8 = {
       "name": "name",
       "storageKey": null
     },
-    (v7/*: any*/)
+    (v6/*: any*/)
   ],
   "storageKey": null
 },
+v8 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  }
+],
 v9 = [
   (v4/*: any*/),
   (v5/*: any*/),
@@ -204,14 +207,14 @@ v9 = [
         "kind": "LinkedField",
         "name": "resized",
         "plural": false,
-        "selections": (v6/*: any*/),
+        "selections": (v8/*: any*/),
         "storageKey": "resized(version:\"large_rectangle\")"
       }
     ],
     "storageKey": null
   },
-  (v8/*: any*/),
-  (v7/*: any*/)
+  (v7/*: any*/),
+  (v6/*: any*/)
 ];
 return {
   "fragment": {
@@ -303,6 +306,7 @@ return {
         "selections": [
           (v4/*: any*/),
           (v5/*: any*/),
+          (v7/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -324,14 +328,47 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v6/*: any*/),
+                "selections": (v8/*: any*/),
                 "storageKey": "resized(version:\"normalized\")"
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 600
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "wide"
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 1600
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "src",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "cropped(height:600,version:\"wide\",width:1600)"
               }
             ],
             "storageKey": null
           },
-          (v8/*: any*/),
-          (v7/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": "artwork(id:\"5dd8084d257aaf000e4a0396\")"
       },
@@ -372,7 +409,7 @@ return {
     "metadata": {},
     "name": "buyerGuaranteeRoutes_BuyerGuaranteeQuery",
     "operationKind": "query",
-    "text": "query buyerGuaranteeRoutes_BuyerGuaranteeQuery {\n  headerImage: artwork(id: \"5dd8084d257aaf000e4a0396\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"5fecdbfa19d5ae5bf95c1dd8\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"5fce729a212bcf54e2551f21\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"580fb7cd2a893a65c100086a\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"normalized\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n"
+    "text": "query buyerGuaranteeRoutes_BuyerGuaranteeQuery {\n  headerImage: artwork(id: \"5dd8084d257aaf000e4a0396\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"5fecdbfa19d5ae5bf95c1dd8\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"5fce729a212bcf54e2551f21\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"580fb7cd2a893a65c100086a\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      srcSet\n    }\n    cropped(width: 1600, height: 600, version: \"wide\") {\n      src\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Includes commits from #7515 

This PR updates our image component in the Buyer Guarantee page to give us responsive sizes in the header. Using a plain styled `img` in the images below (plus `loading="lazy"` and `objectFit="cover"`) fixed image squishing issues but did not preserve aspect ratio - i'm not sure how to do that while continuing to accommodate text so I reverted that change.

Credit @dzucconi for the responsive header layout tips in https://github.com/artsy/force/pull/7074
-----
Tiny:
<img width="612" alt="image" src="https://user-images.githubusercontent.com/9088720/117877244-5232aa00-b272-11eb-809d-74a266fc6d23.png">

## Big:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/9088720/117877205-434bf780-b272-11eb-8d83-b326453b2e6f.png">
