### PR TITLE
chore: updates Image urls to Vanity generated ones

### DIFF
--- a/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
@@ -59,6 +59,14 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
   const supportArticleURL =
     "https://support.artsy.net/hc/en-us/articles/360048946973"
 
+  const authenticityGuaranteeImageURL =
+    "http://files.artsy.net/authenticityguaranteeartwork.jpg"
+  const securePaymentImageURL =
+    "http://files.artsy.net/securepaymentartwork.jpg"
+  const moneyBackGuaranteeImageURL =
+    "http://files.artsy.net/moneybackguaranteeartwork.jpg"
+  const heroImageURL = "http://files.artsy.net/buyerGuaranteeHeroImage.jpg"
+
   const learnMoreIcon = (
     <Flex pt={2} justifyContent="center">
       <Link href={supportArticleURL} mt="-2px" underlineBehavior="none">
@@ -86,7 +94,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
           <Media lessThan="sm">
             <Box height={400}>
               <Image
-                src={headerImage.image.resized.url}
+                src={heroImageURL}
                 alt={headerImage.artist.name}
                 aria-label={headerImage.imageTitle}
                 lazyLoad
@@ -109,7 +117,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
           <Media greaterThanOrEqual="sm">
             <Box height={400} overflow="hidden">
               <Image
-                src={headerImage.image.resized.url}
+                src={heroImageURL}
                 alt={headerImage.artist.name}
                 aria-label={headerImage.imageTitle}
                 lazyLoad
@@ -290,7 +298,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
       <Media greaterThanOrEqual="sm">
         <CSSGrid gridTemplateColumns="repeat(2, 1fr)">
           <Image
-            src={authenticityImage.image.resized.url}
+            src={authenticityGuaranteeImageURL}
             alt={authenticityImage.artist.name}
             lazyLoad
             width="100%"
@@ -312,7 +320,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
             {learnMoreButton("40%")}
           </Flex>
           <Image
-            src={moneyBackGuaranteeImage.image.resized.url}
+            src={moneyBackGuaranteeImageURL}
             alt={moneyBackGuaranteeImage.artist.name}
             lazyLoad
             aria-label={moneyBackGuaranteeImage.imageTitle}
@@ -320,7 +328,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
             height={400}
           />
           <Image
-            src={securePaymentImage.image.resized.url}
+            src={securePaymentImageURL}
             alt={securePaymentImage.artist.name}
             aria-label={securePaymentImage.imageTitle}
             lazyLoad
@@ -341,7 +349,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
       <Media lessThan="sm">
         <Flex flexDirection="column" mt={5} mx={2} mb={4}>
           <Image
-            src={authenticityImage.image.resized.url}
+            src={authenticityGuaranteeImageURL}
             alt={authenticityImage.artist.name}
             lazyLoad
             aria-label={authenticityImage.imageTitle}
@@ -356,7 +364,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
         </Flex>
         <Flex flexDirection="column" mt={5} mx={2} mb={4}>
           <Image
-            src={moneyBackGuaranteeImage.image.resized.url}
+            src={moneyBackGuaranteeImageURL}
             alt={moneyBackGuaranteeImage.artist.name}
             lazyLoad
             aria-label={moneyBackGuaranteeImage.imageTitle}
@@ -371,7 +379,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
         </Flex>
         <Flex flexDirection="column" mt={5} mx={2} mb={4}>
           <Image
-            src={securePaymentImage.image.resized.url}
+            src={securePaymentImageURL}
             alt={securePaymentImage.artist.name}
             lazyLoad
             aria-label={securePaymentImage.imageTitle}
@@ -778,11 +786,6 @@ export const BuyerGuaranteeIndexFragmentContainer = createFragmentContainer(
         artist {
           name
         }
-        image {
-          resized(version: "large_rectangle") {
-            url
-          }
-        }
       }
     `,
     moneyBackGuaranteeImage: graphql`
@@ -792,11 +795,6 @@ export const BuyerGuaranteeIndexFragmentContainer = createFragmentContainer(
         artist {
           name
         }
-        image {
-          resized(version: "large_rectangle") {
-            url
-          }
-        }
       }
     `,
     securePaymentImage: graphql`
@@ -805,11 +803,6 @@ export const BuyerGuaranteeIndexFragmentContainer = createFragmentContainer(
         imageUrl
         artist {
           name
-        }
-        image {
-          resized(version: "large_rectangle") {
-            url
-          }
         }
       }
     `,

--- a/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
@@ -24,6 +24,7 @@ import { Media } from "@artsy/reaction/dist/Utils/Responsive"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import { useSystemContext } from "v2/Artsy"
 import styled from "styled-components"
+import { resize } from "v2/Utils/resizer"
 
 interface BuyerGuaranteeIndexProps {
   headerImage: BuyerGuaranteeIndex_headerImage
@@ -59,13 +60,22 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
   const supportArticleURL =
     "https://support.artsy.net/hc/en-us/articles/360048946973"
 
-  const authenticityGuaranteeImageURL =
-    "http://files.artsy.net/authenticityguaranteeartwork.jpg"
-  const securePaymentImageURL =
-    "http://files.artsy.net/securepaymentartwork.jpg"
-  const moneyBackGuaranteeImageURL =
-    "http://files.artsy.net/moneybackguaranteeartwork.jpg"
-  const heroImageURL = "http://files.artsy.net/buyerGuaranteeHeroImage.jpg"
+  const authenticityGuaranteeImageURL = resize(
+    "http://files.artsy.net/authenticityguaranteeartwork.jpg",
+    { width: 400, height: 600, convert_to: "jpg" }
+  )
+  const securePaymentImageURL = resize(
+    "http://files.artsy.net/securepaymentartwork.jpg",
+    { width: 400, height: 600, convert_to: "jpg" }
+  )
+  const moneyBackGuaranteeImageURL = resize(
+    "http://files.artsy.net/moneybackguaranteeartwork.jpg",
+    { width: 400, height: 600, convert_to: "jpg" }
+  )
+  const heroImageURL = resize(
+    "http://files.artsy.net/buyerGuaranteeHeroImage.jpg",
+    { width: 1600, height: 800, convert_to: "jpg" }
+  )
 
   const learnMoreIcon = (
     <Flex pt={2} justifyContent="center">
@@ -97,9 +107,8 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
                 src={heroImageURL}
                 alt={headerImage.artist.name}
                 aria-label={headerImage.imageTitle}
+                srcSet={headerImage.image.resized.srcSet}
                 lazyLoad
-                width={1600}
-                height={800}
               />
             </Box>
             <Box position="absolute">
@@ -120,9 +129,8 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
                 src={heroImageURL}
                 alt={headerImage.artist.name}
                 aria-label={headerImage.imageTitle}
+                srcSet={headerImage.image.resized.srcSet}
                 lazyLoad
-                width={1600}
-                height={800}
               />
             </Box>
             <Flex alignItems="center" justifyContent="center">
@@ -265,7 +273,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
             </Box>
             <Media lessThan="sm">
               <MoneyBackIcon h={50} w={50} />
-              <Text my={2} variant="mediumText">
+              <Text my={4} variant="mediumText">
                 Money-Back Guarantee
               </Text>
             </Media>
@@ -326,9 +334,8 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
           <Image
             src={authenticityGuaranteeImageURL}
             alt={authenticityImage.artist.name}
+            srcSet={authenticityImage.image.resized.srcSet}
             lazyLoad
-            width="100%"
-            height={400}
             aria-label={authenticityImage.imageTitle}
           />
           <Flex flexDirection="column" p={space(9)}>
@@ -348,18 +355,16 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
           <Image
             src={moneyBackGuaranteeImageURL}
             alt={moneyBackGuaranteeImage.artist.name}
+            srcSet={moneyBackGuaranteeImage.image.resized.srcSet}
             lazyLoad
             aria-label={moneyBackGuaranteeImage.imageTitle}
-            width="100%"
-            height={400}
           />
           <Image
             src={securePaymentImageURL}
             alt={securePaymentImage.artist.name}
+            srcSet={securePaymentImage.image.resized.srcSet}
             aria-label={securePaymentImage.imageTitle}
             lazyLoad
-            width="100%"
-            height={400}
           />
           <Flex flexDirection="column" px={space(9)} pt={space(9)}>
             <Text variant="title">Secure Payment</Text>
@@ -377,6 +382,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
           <Image
             src={authenticityGuaranteeImageURL}
             alt={authenticityImage.artist.name}
+            srcSet={authenticityImage.image.resized.srcSet}
             lazyLoad
             aria-label={authenticityImage.imageTitle}
           />
@@ -392,6 +398,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
           <Image
             src={moneyBackGuaranteeImageURL}
             alt={moneyBackGuaranteeImage.artist.name}
+            srcSet={moneyBackGuaranteeImage.image.resized.srcSet}
             lazyLoad
             aria-label={moneyBackGuaranteeImage.imageTitle}
           />
@@ -407,6 +414,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
           <Image
             src={securePaymentImageURL}
             alt={securePaymentImage.artist.name}
+            srcSet={securePaymentImage.image.resized.srcSet}
             lazyLoad
             aria-label={securePaymentImage.imageTitle}
           />
@@ -795,6 +803,11 @@ export const BuyerGuaranteeIndexFragmentContainer = createFragmentContainer(
       fragment BuyerGuaranteeIndex_headerImage on Artwork {
         imageTitle
         imageUrl
+        image {
+          resized(version: "normalized") {
+            srcSet
+          }
+        }
         artist {
           name
         }
@@ -804,6 +817,11 @@ export const BuyerGuaranteeIndexFragmentContainer = createFragmentContainer(
       fragment BuyerGuaranteeIndex_authenticityImage on Artwork {
         imageTitle
         imageUrl
+        image {
+          resized(version: "large_rectangle") {
+            srcSet
+          }
+        }
         artist {
           name
         }
@@ -813,6 +831,11 @@ export const BuyerGuaranteeIndexFragmentContainer = createFragmentContainer(
       fragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {
         imageTitle
         imageUrl
+        image {
+          resized(version: "large_rectangle") {
+            srcSet
+          }
+        }
         artist {
           name
         }
@@ -822,6 +845,11 @@ export const BuyerGuaranteeIndexFragmentContainer = createFragmentContainer(
       fragment BuyerGuaranteeIndex_securePaymentImage on Artwork {
         imageTitle
         imageUrl
+        image {
+          resized(version: "large_rectangle") {
+            srcSet
+          }
+        }
         artist {
           name
         }

--- a/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
@@ -211,84 +211,110 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
 
         {/* Third Row */}
         <Flex
-          mt={[2, 3]}
           mb={[0, space(9)]}
           flexWrap={["wrap", "nowrap"]}
-          alignItems="flex-end"
+          alignItems="flex-start"
         >
+          {/* Authenticity Guarantee */}
           <Flex
             flexDirection="column"
             mt={5}
-            mx={[4, 9]}
-            width="30%"
+            height={300}
+            width="100%"
             textAlign="center"
-            border="solid 5px white"
+            justifyContent="flex-end"
           >
-            <Media greaterThanOrEqual="sm">
-              <CertificateIcon height={60} width={60} />
-            </Media>
+            <Box>
+              <Media greaterThanOrEqual="sm">
+                <CertificateIcon height={60} width={60} />
+              </Media>
+            </Box>
             <Media lessThan="sm">
               <CertificateIcon height={50} width={50} />
-            </Media>
-            <Text my={2} variant="mediumText">
-              Authenticity Guarantee
-            </Text>
-            <Media greaterThan="xs">
-              <Text variant="text">
-                In the rare occasion that your artwork is found to be
-                inauthentic, we'll help facilitate a refund.
+              <Text my={2} variant="mediumText">
+                Authenticity Guarantee
               </Text>
-              {learnMoreIcon}
+            </Media>
+
+            <Media greaterThan="xs">
+              <Box>
+                <Text my={2} variant="mediumText">
+                  Authenticity Guarantee
+                </Text>
+                <Text variant="text">
+                  In the rare occasion that your artwork is found to be
+                  inauthentic, we'll help facilitate a refund.
+                </Text>
+              </Box>
+              <Box>{learnMoreIcon}</Box>
             </Media>
           </Flex>
+          {/* Money Back Guarantee */}
           <Flex
             flexDirection="column"
             mt={5}
-            mx={[4, 9]}
-            width="30%"
+            height={300}
+            width="100%"
             textAlign="center"
-            border="solid 5px white"
+            justifyContent="flex-end"
           >
-            <Media greaterThanOrEqual="sm">
-              <MoneyBackIcon h={60} w={60} />
-            </Media>
+            <Box>
+              <Media greaterThanOrEqual="sm">
+                <MoneyBackIcon h={60} w={60} />
+              </Media>
+            </Box>
             <Media lessThan="sm">
               <MoneyBackIcon h={50} w={50} />
-            </Media>
-            <Text my={2} variant="mediumText">
-              Money-Back Guarantee
-            </Text>
-            <Media greaterThan="xs">
-              <Text variant="text" mb={2}>
-                If an item arrives not as described, we’ll work with you to make
-                it right.
+              <Text my={2} variant="mediumText">
+                Money-Back Guarantee
               </Text>
-              {learnMoreIcon}
+            </Media>
+
+            <Media greaterThan="xs">
+              <Box>
+                <Text my={2} variant="mediumText">
+                  Money-Back Guarantee
+                </Text>
+                <Text variant="text">
+                  If an item arrives not as described, we’ll work with you to
+                  make it right.
+                </Text>
+              </Box>
+              <Box>{learnMoreIcon}</Box>
             </Media>
           </Flex>
+          {/* Secured Payment Guarantee */}
           <Flex
             flexDirection="column"
             mt={5}
-            mx={[4, 9]}
-            width="30%"
+            height={300}
+            width="100%"
             textAlign="center"
-            border="solid 5px white"
+            justifyContent="flex-end"
           >
-            <Media greaterThanOrEqual="sm">
-              <LockIcon height={60} width={60} />
-            </Media>
+            <Box>
+              <Media greaterThanOrEqual="sm">
+                <LockIcon height={60} width={60} />
+              </Media>
+            </Box>
             <Media lessThan="sm">
               <LockIcon height={50} width={50} />
-            </Media>
-            <Text my={2} variant="mediumText">
-              Secure Payment
-            </Text>
-            <Media greaterThan="xs">
-              <Text variant="text">
-                Payments made through our secure checkout are protected with
-                trusted, industry-leading technology.
+              <Text my={2} variant="mediumText">
+                Authenticity Guarantee
               </Text>
-              {learnMoreIcon}
+            </Media>
+
+            <Media greaterThan="xs">
+              <Box>
+                <Text my={2} variant="mediumText">
+                  Secure Payment
+                </Text>
+                <Text variant="text">
+                  Payments made through our secure checkout are protected with
+                  trusted, industry-leading technology.
+                </Text>
+              </Box>
+              <Box>{learnMoreIcon}</Box>
             </Media>
           </Flex>
         </Flex>
@@ -771,11 +797,6 @@ export const BuyerGuaranteeIndexFragmentContainer = createFragmentContainer(
         imageUrl
         artist {
           name
-        }
-        image {
-          resized(version: "normalized") {
-            url
-          }
         }
       }
     `,

--- a/src/v2/__generated__/BuyerGuaranteeIndexNonAdmin_Test_Query.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndexNonAdmin_Test_Query.graphql.ts
@@ -61,11 +61,6 @@ fragment BuyerGuaranteeIndex_headerImage on Artwork {
     name
     id
   }
-  image {
-    resized(version: "normalized") {
-      url
-    }
-  }
 }
 
 fragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {
@@ -120,47 +115,44 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "imageTitle",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "imageUrl",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "Artist",
-  "kind": "LinkedField",
-  "name": "artist",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "name",
-      "storageKey": null
-    },
-    (v6/*: any*/)
-  ],
-  "storageKey": null
-},
-v8 = [
-  (v4/*: any*/),
-  (v5/*: any*/),
-  (v7/*: any*/),
-  (v6/*: any*/)
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "imageTitle",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "imageUrl",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "Artist",
+    "kind": "LinkedField",
+    "name": "artist",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "name",
+        "storageKey": null
+      },
+      (v4/*: any*/)
+    ],
+    "storageKey": null
+  },
+  (v4/*: any*/)
 ];
 return {
   "fragment": {
@@ -249,47 +241,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": [
-          (v4/*: any*/),
-          (v5/*: any*/),
-          (v7/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "Image",
-            "kind": "LinkedField",
-            "name": "image",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "normalized"
-                  }
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "url",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": "resized(version:\"normalized\")"
-              }
-            ],
-            "storageKey": null
-          },
-          (v6/*: any*/)
-        ],
+        "selections": (v5/*: any*/),
         "storageKey": "artwork(id:\"any-id1\")"
       },
       {
@@ -299,7 +251,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v8/*: any*/),
+        "selections": (v5/*: any*/),
         "storageKey": "artwork(id:\"any-id2\")"
       },
       {
@@ -309,7 +261,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v8/*: any*/),
+        "selections": (v5/*: any*/),
         "storageKey": "artwork(id:\"any-id3\")"
       },
       {
@@ -319,7 +271,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v8/*: any*/),
+        "selections": (v5/*: any*/),
         "storageKey": "artwork(id:\"any-id4\")"
       }
     ]
@@ -329,7 +281,7 @@ return {
     "metadata": {},
     "name": "BuyerGuaranteeIndexNonAdmin_Test_Query",
     "operationKind": "query",
-    "text": "query BuyerGuaranteeIndexNonAdmin_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      url\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n"
+    "text": "query BuyerGuaranteeIndexNonAdmin_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/BuyerGuaranteeIndexNonAdmin_Test_Query.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndexNonAdmin_Test_Query.graphql.ts
@@ -52,11 +52,6 @@ fragment BuyerGuaranteeIndex_authenticityImage on Artwork {
     name
     id
   }
-  image {
-    resized(version: "large_rectangle") {
-      url
-    }
-  }
 }
 
 fragment BuyerGuaranteeIndex_headerImage on Artwork {
@@ -80,11 +75,6 @@ fragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {
     name
     id
   }
-  image {
-    resized(version: "large_rectangle") {
-      url
-    }
-  }
 }
 
 fragment BuyerGuaranteeIndex_securePaymentImage on Artwork {
@@ -93,11 +83,6 @@ fragment BuyerGuaranteeIndex_securePaymentImage on Artwork {
   artist {
     name
     id
-  }
-  image {
-    resized(version: "large_rectangle") {
-      url
-    }
   }
 }
 */
@@ -172,45 +157,9 @@ v7 = {
   "storageKey": null
 },
 v8 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "url",
-    "storageKey": null
-  }
-],
-v9 = [
   (v4/*: any*/),
   (v5/*: any*/),
   (v7/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "Image",
-    "kind": "LinkedField",
-    "name": "image",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": [
-          {
-            "kind": "Literal",
-            "name": "version",
-            "value": "large_rectangle"
-          }
-        ],
-        "concreteType": "ResizedImageUrl",
-        "kind": "LinkedField",
-        "name": "resized",
-        "plural": false,
-        "selections": (v8/*: any*/),
-        "storageKey": "resized(version:\"large_rectangle\")"
-      }
-    ],
-    "storageKey": null
-  },
   (v6/*: any*/)
 ];
 return {
@@ -325,7 +274,15 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v8/*: any*/),
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "url",
+                    "storageKey": null
+                  }
+                ],
                 "storageKey": "resized(version:\"normalized\")"
               }
             ],
@@ -342,7 +299,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v9/*: any*/),
+        "selections": (v8/*: any*/),
         "storageKey": "artwork(id:\"any-id2\")"
       },
       {
@@ -352,7 +309,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v9/*: any*/),
+        "selections": (v8/*: any*/),
         "storageKey": "artwork(id:\"any-id3\")"
       },
       {
@@ -362,7 +319,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v9/*: any*/),
+        "selections": (v8/*: any*/),
         "storageKey": "artwork(id:\"any-id4\")"
       }
     ]
@@ -372,7 +329,7 @@ return {
     "metadata": {},
     "name": "BuyerGuaranteeIndexNonAdmin_Test_Query",
     "operationKind": "query",
-    "text": "query BuyerGuaranteeIndexNonAdmin_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"large_rectangle\") {\n      url\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      url\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"large_rectangle\") {\n      url\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"large_rectangle\") {\n      url\n    }\n  }\n}\n"
+    "text": "query BuyerGuaranteeIndexNonAdmin_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      url\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/BuyerGuaranteeIndexNonAdmin_Test_Query.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndexNonAdmin_Test_Query.graphql.ts
@@ -48,6 +48,11 @@ query BuyerGuaranteeIndexNonAdmin_Test_Query {
 fragment BuyerGuaranteeIndex_authenticityImage on Artwork {
   imageTitle
   imageUrl
+  image {
+    resized(version: "large_rectangle") {
+      srcSet
+    }
+  }
   artist {
     name
     id
@@ -57,6 +62,11 @@ fragment BuyerGuaranteeIndex_authenticityImage on Artwork {
 fragment BuyerGuaranteeIndex_headerImage on Artwork {
   imageTitle
   imageUrl
+  image {
+    resized(version: "normalized") {
+      srcSet
+    }
+  }
   artist {
     name
     id
@@ -66,6 +76,11 @@ fragment BuyerGuaranteeIndex_headerImage on Artwork {
 fragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {
   imageTitle
   imageUrl
+  image {
+    resized(version: "large_rectangle") {
+      srcSet
+    }
+  }
   artist {
     name
     id
@@ -75,6 +90,11 @@ fragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {
 fragment BuyerGuaranteeIndex_securePaymentImage on Artwork {
   imageTitle
   imageUrl
+  image {
+    resized(version: "large_rectangle") {
+      srcSet
+    }
+  }
   artist {
     name
     id
@@ -115,44 +135,83 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "imageTitle",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "imageUrl",
+  "storageKey": null
+},
+v6 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  }
+],
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = [
+v8 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Artist",
+  "kind": "LinkedField",
+  "name": "artist",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    (v7/*: any*/)
+  ],
+  "storageKey": null
+},
+v9 = [
+  (v4/*: any*/),
+  (v5/*: any*/),
   {
     "alias": null,
     "args": null,
-    "kind": "ScalarField",
-    "name": "imageTitle",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "imageUrl",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "Artist",
+    "concreteType": "Image",
     "kind": "LinkedField",
-    "name": "artist",
+    "name": "image",
     "plural": false,
     "selections": [
       {
         "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "name",
-        "storageKey": null
-      },
-      (v4/*: any*/)
+        "args": [
+          {
+            "kind": "Literal",
+            "name": "version",
+            "value": "large_rectangle"
+          }
+        ],
+        "concreteType": "ResizedImageUrl",
+        "kind": "LinkedField",
+        "name": "resized",
+        "plural": false,
+        "selections": (v6/*: any*/),
+        "storageKey": "resized(version:\"large_rectangle\")"
+      }
     ],
     "storageKey": null
   },
-  (v4/*: any*/)
+  (v8/*: any*/),
+  (v7/*: any*/)
 ];
 return {
   "fragment": {
@@ -241,7 +300,39 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v5/*: any*/),
+        "selections": [
+          (v4/*: any*/),
+          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "normalized"
+                  }
+                ],
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": (v6/*: any*/),
+                "storageKey": "resized(version:\"normalized\")"
+              }
+            ],
+            "storageKey": null
+          },
+          (v8/*: any*/),
+          (v7/*: any*/)
+        ],
         "storageKey": "artwork(id:\"any-id1\")"
       },
       {
@@ -251,7 +342,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v5/*: any*/),
+        "selections": (v9/*: any*/),
         "storageKey": "artwork(id:\"any-id2\")"
       },
       {
@@ -261,7 +352,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v5/*: any*/),
+        "selections": (v9/*: any*/),
         "storageKey": "artwork(id:\"any-id3\")"
       },
       {
@@ -271,7 +362,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v5/*: any*/),
+        "selections": (v9/*: any*/),
         "storageKey": "artwork(id:\"any-id4\")"
       }
     ]
@@ -281,7 +372,7 @@ return {
     "metadata": {},
     "name": "BuyerGuaranteeIndexNonAdmin_Test_Query",
     "operationKind": "query",
-    "text": "query BuyerGuaranteeIndexNonAdmin_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n"
+    "text": "query BuyerGuaranteeIndexNonAdmin_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"normalized\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/BuyerGuaranteeIndex_Test_Query.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndex_Test_Query.graphql.ts
@@ -48,6 +48,11 @@ query BuyerGuaranteeIndex_Test_Query {
 fragment BuyerGuaranteeIndex_authenticityImage on Artwork {
   imageTitle
   imageUrl
+  image {
+    resized(version: "large_rectangle") {
+      srcSet
+    }
+  }
   artist {
     name
     id
@@ -57,6 +62,11 @@ fragment BuyerGuaranteeIndex_authenticityImage on Artwork {
 fragment BuyerGuaranteeIndex_headerImage on Artwork {
   imageTitle
   imageUrl
+  image {
+    resized(version: "normalized") {
+      srcSet
+    }
+  }
   artist {
     name
     id
@@ -66,6 +76,11 @@ fragment BuyerGuaranteeIndex_headerImage on Artwork {
 fragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {
   imageTitle
   imageUrl
+  image {
+    resized(version: "large_rectangle") {
+      srcSet
+    }
+  }
   artist {
     name
     id
@@ -75,6 +90,11 @@ fragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {
 fragment BuyerGuaranteeIndex_securePaymentImage on Artwork {
   imageTitle
   imageUrl
+  image {
+    resized(version: "large_rectangle") {
+      srcSet
+    }
+  }
   artist {
     name
     id
@@ -115,44 +135,83 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "imageTitle",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "imageUrl",
+  "storageKey": null
+},
+v6 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  }
+],
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = [
+v8 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Artist",
+  "kind": "LinkedField",
+  "name": "artist",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    (v7/*: any*/)
+  ],
+  "storageKey": null
+},
+v9 = [
+  (v4/*: any*/),
+  (v5/*: any*/),
   {
     "alias": null,
     "args": null,
-    "kind": "ScalarField",
-    "name": "imageTitle",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "imageUrl",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "Artist",
+    "concreteType": "Image",
     "kind": "LinkedField",
-    "name": "artist",
+    "name": "image",
     "plural": false,
     "selections": [
       {
         "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "name",
-        "storageKey": null
-      },
-      (v4/*: any*/)
+        "args": [
+          {
+            "kind": "Literal",
+            "name": "version",
+            "value": "large_rectangle"
+          }
+        ],
+        "concreteType": "ResizedImageUrl",
+        "kind": "LinkedField",
+        "name": "resized",
+        "plural": false,
+        "selections": (v6/*: any*/),
+        "storageKey": "resized(version:\"large_rectangle\")"
+      }
     ],
     "storageKey": null
   },
-  (v4/*: any*/)
+  (v8/*: any*/),
+  (v7/*: any*/)
 ];
 return {
   "fragment": {
@@ -241,7 +300,39 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v5/*: any*/),
+        "selections": [
+          (v4/*: any*/),
+          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "normalized"
+                  }
+                ],
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": (v6/*: any*/),
+                "storageKey": "resized(version:\"normalized\")"
+              }
+            ],
+            "storageKey": null
+          },
+          (v8/*: any*/),
+          (v7/*: any*/)
+        ],
         "storageKey": "artwork(id:\"any-id1\")"
       },
       {
@@ -251,7 +342,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v5/*: any*/),
+        "selections": (v9/*: any*/),
         "storageKey": "artwork(id:\"any-id2\")"
       },
       {
@@ -261,7 +352,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v5/*: any*/),
+        "selections": (v9/*: any*/),
         "storageKey": "artwork(id:\"any-id3\")"
       },
       {
@@ -271,7 +362,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v5/*: any*/),
+        "selections": (v9/*: any*/),
         "storageKey": "artwork(id:\"any-id4\")"
       }
     ]
@@ -281,7 +372,7 @@ return {
     "metadata": {},
     "name": "BuyerGuaranteeIndex_Test_Query",
     "operationKind": "query",
-    "text": "query BuyerGuaranteeIndex_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n"
+    "text": "query BuyerGuaranteeIndex_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"normalized\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/BuyerGuaranteeIndex_Test_Query.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndex_Test_Query.graphql.ts
@@ -52,11 +52,6 @@ fragment BuyerGuaranteeIndex_authenticityImage on Artwork {
     name
     id
   }
-  image {
-    resized(version: "large_rectangle") {
-      url
-    }
-  }
 }
 
 fragment BuyerGuaranteeIndex_headerImage on Artwork {
@@ -80,11 +75,6 @@ fragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {
     name
     id
   }
-  image {
-    resized(version: "large_rectangle") {
-      url
-    }
-  }
 }
 
 fragment BuyerGuaranteeIndex_securePaymentImage on Artwork {
@@ -93,11 +83,6 @@ fragment BuyerGuaranteeIndex_securePaymentImage on Artwork {
   artist {
     name
     id
-  }
-  image {
-    resized(version: "large_rectangle") {
-      url
-    }
   }
 }
 */
@@ -172,45 +157,9 @@ v7 = {
   "storageKey": null
 },
 v8 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "url",
-    "storageKey": null
-  }
-],
-v9 = [
   (v4/*: any*/),
   (v5/*: any*/),
   (v7/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "Image",
-    "kind": "LinkedField",
-    "name": "image",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": [
-          {
-            "kind": "Literal",
-            "name": "version",
-            "value": "large_rectangle"
-          }
-        ],
-        "concreteType": "ResizedImageUrl",
-        "kind": "LinkedField",
-        "name": "resized",
-        "plural": false,
-        "selections": (v8/*: any*/),
-        "storageKey": "resized(version:\"large_rectangle\")"
-      }
-    ],
-    "storageKey": null
-  },
   (v6/*: any*/)
 ];
 return {
@@ -325,7 +274,15 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v8/*: any*/),
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "url",
+                    "storageKey": null
+                  }
+                ],
                 "storageKey": "resized(version:\"normalized\")"
               }
             ],
@@ -342,7 +299,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v9/*: any*/),
+        "selections": (v8/*: any*/),
         "storageKey": "artwork(id:\"any-id2\")"
       },
       {
@@ -352,7 +309,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v9/*: any*/),
+        "selections": (v8/*: any*/),
         "storageKey": "artwork(id:\"any-id3\")"
       },
       {
@@ -362,7 +319,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v9/*: any*/),
+        "selections": (v8/*: any*/),
         "storageKey": "artwork(id:\"any-id4\")"
       }
     ]
@@ -372,7 +329,7 @@ return {
     "metadata": {},
     "name": "BuyerGuaranteeIndex_Test_Query",
     "operationKind": "query",
-    "text": "query BuyerGuaranteeIndex_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"large_rectangle\") {\n      url\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      url\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"large_rectangle\") {\n      url\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"large_rectangle\") {\n      url\n    }\n  }\n}\n"
+    "text": "query BuyerGuaranteeIndex_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      url\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/BuyerGuaranteeIndex_Test_Query.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndex_Test_Query.graphql.ts
@@ -61,11 +61,6 @@ fragment BuyerGuaranteeIndex_headerImage on Artwork {
     name
     id
   }
-  image {
-    resized(version: "normalized") {
-      url
-    }
-  }
 }
 
 fragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {
@@ -120,47 +115,44 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "imageTitle",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "imageUrl",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "Artist",
-  "kind": "LinkedField",
-  "name": "artist",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "name",
-      "storageKey": null
-    },
-    (v6/*: any*/)
-  ],
-  "storageKey": null
-},
-v8 = [
-  (v4/*: any*/),
-  (v5/*: any*/),
-  (v7/*: any*/),
-  (v6/*: any*/)
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "imageTitle",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "imageUrl",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "Artist",
+    "kind": "LinkedField",
+    "name": "artist",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "name",
+        "storageKey": null
+      },
+      (v4/*: any*/)
+    ],
+    "storageKey": null
+  },
+  (v4/*: any*/)
 ];
 return {
   "fragment": {
@@ -249,47 +241,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": [
-          (v4/*: any*/),
-          (v5/*: any*/),
-          (v7/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "Image",
-            "kind": "LinkedField",
-            "name": "image",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "normalized"
-                  }
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "url",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": "resized(version:\"normalized\")"
-              }
-            ],
-            "storageKey": null
-          },
-          (v6/*: any*/)
-        ],
+        "selections": (v5/*: any*/),
         "storageKey": "artwork(id:\"any-id1\")"
       },
       {
@@ -299,7 +251,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v8/*: any*/),
+        "selections": (v5/*: any*/),
         "storageKey": "artwork(id:\"any-id2\")"
       },
       {
@@ -309,7 +261,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v8/*: any*/),
+        "selections": (v5/*: any*/),
         "storageKey": "artwork(id:\"any-id3\")"
       },
       {
@@ -319,7 +271,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v8/*: any*/),
+        "selections": (v5/*: any*/),
         "storageKey": "artwork(id:\"any-id4\")"
       }
     ]
@@ -329,7 +281,7 @@ return {
     "metadata": {},
     "name": "BuyerGuaranteeIndex_Test_Query",
     "operationKind": "query",
-    "text": "query BuyerGuaranteeIndex_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      url\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n"
+    "text": "query BuyerGuaranteeIndex_Test_Query {\n  headerImage: artwork(id: \"any-id1\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"any-id2\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"any-id3\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"any-id4\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/BuyerGuaranteeIndex_authenticityImage.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndex_authenticityImage.graphql.ts
@@ -9,11 +9,6 @@ export type BuyerGuaranteeIndex_authenticityImage = {
     readonly artist: {
         readonly name: string | null;
     } | null;
-    readonly image: {
-        readonly resized: {
-            readonly url: string;
-        } | null;
-    } | null;
     readonly " $refType": "BuyerGuaranteeIndex_authenticityImage";
 };
 export type BuyerGuaranteeIndex_authenticityImage$data = BuyerGuaranteeIndex_authenticityImage;
@@ -61,44 +56,9 @@ const node: ReaderFragment = {
         }
       ],
       "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "Image",
-      "kind": "LinkedField",
-      "name": "image",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "version",
-              "value": "large_rectangle"
-            }
-          ],
-          "concreteType": "ResizedImageUrl",
-          "kind": "LinkedField",
-          "name": "resized",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "url",
-              "storageKey": null
-            }
-          ],
-          "storageKey": "resized(version:\"large_rectangle\")"
-        }
-      ],
-      "storageKey": null
     }
   ],
   "type": "Artwork"
 };
-(node as any).hash = '5cc4ce2378155993610f625b3308dc41';
+(node as any).hash = '8ad049e322c1db7a7f29552493389321';
 export default node;

--- a/src/v2/__generated__/BuyerGuaranteeIndex_authenticityImage.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndex_authenticityImage.graphql.ts
@@ -6,6 +6,11 @@ import { FragmentRefs } from "relay-runtime";
 export type BuyerGuaranteeIndex_authenticityImage = {
     readonly imageTitle: string | null;
     readonly imageUrl: string | null;
+    readonly image: {
+        readonly resized: {
+            readonly srcSet: string;
+        } | null;
+    } | null;
     readonly artist: {
         readonly name: string | null;
     } | null;
@@ -42,6 +47,41 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "image",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "version",
+              "value": "large_rectangle"
+            }
+          ],
+          "concreteType": "ResizedImageUrl",
+          "kind": "LinkedField",
+          "name": "resized",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "srcSet",
+              "storageKey": null
+            }
+          ],
+          "storageKey": "resized(version:\"large_rectangle\")"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
       "concreteType": "Artist",
       "kind": "LinkedField",
       "name": "artist",
@@ -60,5 +100,5 @@ const node: ReaderFragment = {
   ],
   "type": "Artwork"
 };
-(node as any).hash = '8ad049e322c1db7a7f29552493389321';
+(node as any).hash = 'a929dd4f322adca6822fc4d4b9c8e2f5';
 export default node;

--- a/src/v2/__generated__/BuyerGuaranteeIndex_headerImage.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndex_headerImage.graphql.ts
@@ -6,6 +6,11 @@ import { FragmentRefs } from "relay-runtime";
 export type BuyerGuaranteeIndex_headerImage = {
     readonly imageTitle: string | null;
     readonly imageUrl: string | null;
+    readonly image: {
+        readonly resized: {
+            readonly srcSet: string;
+        } | null;
+    } | null;
     readonly artist: {
         readonly name: string | null;
     } | null;
@@ -42,6 +47,41 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "image",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "version",
+              "value": "normalized"
+            }
+          ],
+          "concreteType": "ResizedImageUrl",
+          "kind": "LinkedField",
+          "name": "resized",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "srcSet",
+              "storageKey": null
+            }
+          ],
+          "storageKey": "resized(version:\"normalized\")"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
       "concreteType": "Artist",
       "kind": "LinkedField",
       "name": "artist",
@@ -60,5 +100,5 @@ const node: ReaderFragment = {
   ],
   "type": "Artwork"
 };
-(node as any).hash = '5ab7113ebb770e6178cce9cbe9d0fc85';
+(node as any).hash = '449113e08d06d4b54c81935abe8818c3';
 export default node;

--- a/src/v2/__generated__/BuyerGuaranteeIndex_headerImage.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndex_headerImage.graphql.ts
@@ -9,11 +9,6 @@ export type BuyerGuaranteeIndex_headerImage = {
     readonly artist: {
         readonly name: string | null;
     } | null;
-    readonly image: {
-        readonly resized: {
-            readonly url: string;
-        } | null;
-    } | null;
     readonly " $refType": "BuyerGuaranteeIndex_headerImage";
 };
 export type BuyerGuaranteeIndex_headerImage$data = BuyerGuaranteeIndex_headerImage;
@@ -61,44 +56,9 @@ const node: ReaderFragment = {
         }
       ],
       "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "Image",
-      "kind": "LinkedField",
-      "name": "image",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "version",
-              "value": "normalized"
-            }
-          ],
-          "concreteType": "ResizedImageUrl",
-          "kind": "LinkedField",
-          "name": "resized",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "url",
-              "storageKey": null
-            }
-          ],
-          "storageKey": "resized(version:\"normalized\")"
-        }
-      ],
-      "storageKey": null
     }
   ],
   "type": "Artwork"
 };
-(node as any).hash = '452e71128a83f85a09937c23bcbbc413';
+(node as any).hash = '5ab7113ebb770e6178cce9cbe9d0fc85';
 export default node;

--- a/src/v2/__generated__/BuyerGuaranteeIndex_moneyBackGuaranteeImage.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndex_moneyBackGuaranteeImage.graphql.ts
@@ -6,6 +6,11 @@ import { FragmentRefs } from "relay-runtime";
 export type BuyerGuaranteeIndex_moneyBackGuaranteeImage = {
     readonly imageTitle: string | null;
     readonly imageUrl: string | null;
+    readonly image: {
+        readonly resized: {
+            readonly srcSet: string;
+        } | null;
+    } | null;
     readonly artist: {
         readonly name: string | null;
     } | null;
@@ -42,6 +47,41 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "image",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "version",
+              "value": "large_rectangle"
+            }
+          ],
+          "concreteType": "ResizedImageUrl",
+          "kind": "LinkedField",
+          "name": "resized",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "srcSet",
+              "storageKey": null
+            }
+          ],
+          "storageKey": "resized(version:\"large_rectangle\")"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
       "concreteType": "Artist",
       "kind": "LinkedField",
       "name": "artist",
@@ -60,5 +100,5 @@ const node: ReaderFragment = {
   ],
   "type": "Artwork"
 };
-(node as any).hash = '4ff4a314057b21480d1b55f1f20952b3';
+(node as any).hash = '26ba2ab8b1a4132a653089dbede44d92';
 export default node;

--- a/src/v2/__generated__/BuyerGuaranteeIndex_moneyBackGuaranteeImage.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndex_moneyBackGuaranteeImage.graphql.ts
@@ -9,11 +9,6 @@ export type BuyerGuaranteeIndex_moneyBackGuaranteeImage = {
     readonly artist: {
         readonly name: string | null;
     } | null;
-    readonly image: {
-        readonly resized: {
-            readonly url: string;
-        } | null;
-    } | null;
     readonly " $refType": "BuyerGuaranteeIndex_moneyBackGuaranteeImage";
 };
 export type BuyerGuaranteeIndex_moneyBackGuaranteeImage$data = BuyerGuaranteeIndex_moneyBackGuaranteeImage;
@@ -61,44 +56,9 @@ const node: ReaderFragment = {
         }
       ],
       "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "Image",
-      "kind": "LinkedField",
-      "name": "image",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "version",
-              "value": "large_rectangle"
-            }
-          ],
-          "concreteType": "ResizedImageUrl",
-          "kind": "LinkedField",
-          "name": "resized",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "url",
-              "storageKey": null
-            }
-          ],
-          "storageKey": "resized(version:\"large_rectangle\")"
-        }
-      ],
-      "storageKey": null
     }
   ],
   "type": "Artwork"
 };
-(node as any).hash = 'f44dfca209feebdeb22a88baca72ec2a';
+(node as any).hash = '4ff4a314057b21480d1b55f1f20952b3';
 export default node;

--- a/src/v2/__generated__/BuyerGuaranteeIndex_securePaymentImage.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndex_securePaymentImage.graphql.ts
@@ -6,6 +6,11 @@ import { FragmentRefs } from "relay-runtime";
 export type BuyerGuaranteeIndex_securePaymentImage = {
     readonly imageTitle: string | null;
     readonly imageUrl: string | null;
+    readonly image: {
+        readonly resized: {
+            readonly srcSet: string;
+        } | null;
+    } | null;
     readonly artist: {
         readonly name: string | null;
     } | null;
@@ -42,6 +47,41 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "image",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "version",
+              "value": "large_rectangle"
+            }
+          ],
+          "concreteType": "ResizedImageUrl",
+          "kind": "LinkedField",
+          "name": "resized",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "srcSet",
+              "storageKey": null
+            }
+          ],
+          "storageKey": "resized(version:\"large_rectangle\")"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
       "concreteType": "Artist",
       "kind": "LinkedField",
       "name": "artist",
@@ -60,5 +100,5 @@ const node: ReaderFragment = {
   ],
   "type": "Artwork"
 };
-(node as any).hash = 'cf4cd87f88fb95b072bc837e4a2903ff';
+(node as any).hash = '33d11abb3bb8f392307a007dc6984acf';
 export default node;

--- a/src/v2/__generated__/BuyerGuaranteeIndex_securePaymentImage.graphql.ts
+++ b/src/v2/__generated__/BuyerGuaranteeIndex_securePaymentImage.graphql.ts
@@ -9,11 +9,6 @@ export type BuyerGuaranteeIndex_securePaymentImage = {
     readonly artist: {
         readonly name: string | null;
     } | null;
-    readonly image: {
-        readonly resized: {
-            readonly url: string;
-        } | null;
-    } | null;
     readonly " $refType": "BuyerGuaranteeIndex_securePaymentImage";
 };
 export type BuyerGuaranteeIndex_securePaymentImage$data = BuyerGuaranteeIndex_securePaymentImage;
@@ -61,44 +56,9 @@ const node: ReaderFragment = {
         }
       ],
       "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "Image",
-      "kind": "LinkedField",
-      "name": "image",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "version",
-              "value": "large_rectangle"
-            }
-          ],
-          "concreteType": "ResizedImageUrl",
-          "kind": "LinkedField",
-          "name": "resized",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "url",
-              "storageKey": null
-            }
-          ],
-          "storageKey": "resized(version:\"large_rectangle\")"
-        }
-      ],
-      "storageKey": null
     }
   ],
   "type": "Artwork"
 };
-(node as any).hash = 'afd44fc813f2a747ef6d5348d6eb1950';
+(node as any).hash = 'cf4cd87f88fb95b072bc837e4a2903ff';
 export default node;

--- a/src/v2/__generated__/buyerGuaranteeRoutes_BuyerGuaranteeQuery.graphql.ts
+++ b/src/v2/__generated__/buyerGuaranteeRoutes_BuyerGuaranteeQuery.graphql.ts
@@ -48,6 +48,11 @@ query buyerGuaranteeRoutes_BuyerGuaranteeQuery {
 fragment BuyerGuaranteeIndex_authenticityImage on Artwork {
   imageTitle
   imageUrl
+  image {
+    resized(version: "large_rectangle") {
+      srcSet
+    }
+  }
   artist {
     name
     id
@@ -57,6 +62,11 @@ fragment BuyerGuaranteeIndex_authenticityImage on Artwork {
 fragment BuyerGuaranteeIndex_headerImage on Artwork {
   imageTitle
   imageUrl
+  image {
+    resized(version: "normalized") {
+      srcSet
+    }
+  }
   artist {
     name
     id
@@ -66,6 +76,11 @@ fragment BuyerGuaranteeIndex_headerImage on Artwork {
 fragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {
   imageTitle
   imageUrl
+  image {
+    resized(version: "large_rectangle") {
+      srcSet
+    }
+  }
   artist {
     name
     id
@@ -75,6 +90,11 @@ fragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {
 fragment BuyerGuaranteeIndex_securePaymentImage on Artwork {
   imageTitle
   imageUrl
+  image {
+    resized(version: "large_rectangle") {
+      srcSet
+    }
+  }
   artist {
     name
     id
@@ -115,44 +135,83 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "imageTitle",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "imageUrl",
+  "storageKey": null
+},
+v6 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  }
+],
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = [
+v8 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Artist",
+  "kind": "LinkedField",
+  "name": "artist",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    (v7/*: any*/)
+  ],
+  "storageKey": null
+},
+v9 = [
+  (v4/*: any*/),
+  (v5/*: any*/),
   {
     "alias": null,
     "args": null,
-    "kind": "ScalarField",
-    "name": "imageTitle",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "imageUrl",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "Artist",
+    "concreteType": "Image",
     "kind": "LinkedField",
-    "name": "artist",
+    "name": "image",
     "plural": false,
     "selections": [
       {
         "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "name",
-        "storageKey": null
-      },
-      (v4/*: any*/)
+        "args": [
+          {
+            "kind": "Literal",
+            "name": "version",
+            "value": "large_rectangle"
+          }
+        ],
+        "concreteType": "ResizedImageUrl",
+        "kind": "LinkedField",
+        "name": "resized",
+        "plural": false,
+        "selections": (v6/*: any*/),
+        "storageKey": "resized(version:\"large_rectangle\")"
+      }
     ],
     "storageKey": null
   },
-  (v4/*: any*/)
+  (v8/*: any*/),
+  (v7/*: any*/)
 ];
 return {
   "fragment": {
@@ -241,7 +300,39 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v5/*: any*/),
+        "selections": [
+          (v4/*: any*/),
+          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "normalized"
+                  }
+                ],
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": (v6/*: any*/),
+                "storageKey": "resized(version:\"normalized\")"
+              }
+            ],
+            "storageKey": null
+          },
+          (v8/*: any*/),
+          (v7/*: any*/)
+        ],
         "storageKey": "artwork(id:\"5dd8084d257aaf000e4a0396\")"
       },
       {
@@ -251,7 +342,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v5/*: any*/),
+        "selections": (v9/*: any*/),
         "storageKey": "artwork(id:\"5fecdbfa19d5ae5bf95c1dd8\")"
       },
       {
@@ -261,7 +352,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v5/*: any*/),
+        "selections": (v9/*: any*/),
         "storageKey": "artwork(id:\"5fce729a212bcf54e2551f21\")"
       },
       {
@@ -271,7 +362,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v5/*: any*/),
+        "selections": (v9/*: any*/),
         "storageKey": "artwork(id:\"580fb7cd2a893a65c100086a\")"
       }
     ]
@@ -281,7 +372,7 @@ return {
     "metadata": {},
     "name": "buyerGuaranteeRoutes_BuyerGuaranteeQuery",
     "operationKind": "query",
-    "text": "query buyerGuaranteeRoutes_BuyerGuaranteeQuery {\n  headerImage: artwork(id: \"5dd8084d257aaf000e4a0396\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"5fecdbfa19d5ae5bf95c1dd8\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"5fce729a212bcf54e2551f21\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"580fb7cd2a893a65c100086a\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n"
+    "text": "query buyerGuaranteeRoutes_BuyerGuaranteeQuery {\n  headerImage: artwork(id: \"5dd8084d257aaf000e4a0396\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"5fecdbfa19d5ae5bf95c1dd8\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"5fce729a212bcf54e2551f21\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"580fb7cd2a893a65c100086a\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"normalized\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  image {\n    resized(version: \"large_rectangle\") {\n      srcSet\n    }\n  }\n  artist {\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/buyerGuaranteeRoutes_BuyerGuaranteeQuery.graphql.ts
+++ b/src/v2/__generated__/buyerGuaranteeRoutes_BuyerGuaranteeQuery.graphql.ts
@@ -61,11 +61,6 @@ fragment BuyerGuaranteeIndex_headerImage on Artwork {
     name
     id
   }
-  image {
-    resized(version: "normalized") {
-      url
-    }
-  }
 }
 
 fragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {
@@ -120,47 +115,44 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "imageTitle",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "imageUrl",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "Artist",
-  "kind": "LinkedField",
-  "name": "artist",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "name",
-      "storageKey": null
-    },
-    (v6/*: any*/)
-  ],
-  "storageKey": null
-},
-v8 = [
-  (v4/*: any*/),
-  (v5/*: any*/),
-  (v7/*: any*/),
-  (v6/*: any*/)
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "imageTitle",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "imageUrl",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "Artist",
+    "kind": "LinkedField",
+    "name": "artist",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "name",
+        "storageKey": null
+      },
+      (v4/*: any*/)
+    ],
+    "storageKey": null
+  },
+  (v4/*: any*/)
 ];
 return {
   "fragment": {
@@ -249,47 +241,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": [
-          (v4/*: any*/),
-          (v5/*: any*/),
-          (v7/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "Image",
-            "kind": "LinkedField",
-            "name": "image",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "normalized"
-                  }
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "url",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": "resized(version:\"normalized\")"
-              }
-            ],
-            "storageKey": null
-          },
-          (v6/*: any*/)
-        ],
+        "selections": (v5/*: any*/),
         "storageKey": "artwork(id:\"5dd8084d257aaf000e4a0396\")"
       },
       {
@@ -299,7 +251,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v8/*: any*/),
+        "selections": (v5/*: any*/),
         "storageKey": "artwork(id:\"5fecdbfa19d5ae5bf95c1dd8\")"
       },
       {
@@ -309,7 +261,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v8/*: any*/),
+        "selections": (v5/*: any*/),
         "storageKey": "artwork(id:\"5fce729a212bcf54e2551f21\")"
       },
       {
@@ -319,7 +271,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v8/*: any*/),
+        "selections": (v5/*: any*/),
         "storageKey": "artwork(id:\"580fb7cd2a893a65c100086a\")"
       }
     ]
@@ -329,7 +281,7 @@ return {
     "metadata": {},
     "name": "buyerGuaranteeRoutes_BuyerGuaranteeQuery",
     "operationKind": "query",
-    "text": "query buyerGuaranteeRoutes_BuyerGuaranteeQuery {\n  headerImage: artwork(id: \"5dd8084d257aaf000e4a0396\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"5fecdbfa19d5ae5bf95c1dd8\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"5fce729a212bcf54e2551f21\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"580fb7cd2a893a65c100086a\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      url\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n"
+    "text": "query buyerGuaranteeRoutes_BuyerGuaranteeQuery {\n  headerImage: artwork(id: \"5dd8084d257aaf000e4a0396\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"5fecdbfa19d5ae5bf95c1dd8\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"5fce729a212bcf54e2551f21\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"580fb7cd2a893a65c100086a\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/buyerGuaranteeRoutes_BuyerGuaranteeQuery.graphql.ts
+++ b/src/v2/__generated__/buyerGuaranteeRoutes_BuyerGuaranteeQuery.graphql.ts
@@ -52,11 +52,6 @@ fragment BuyerGuaranteeIndex_authenticityImage on Artwork {
     name
     id
   }
-  image {
-    resized(version: "large_rectangle") {
-      url
-    }
-  }
 }
 
 fragment BuyerGuaranteeIndex_headerImage on Artwork {
@@ -80,11 +75,6 @@ fragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {
     name
     id
   }
-  image {
-    resized(version: "large_rectangle") {
-      url
-    }
-  }
 }
 
 fragment BuyerGuaranteeIndex_securePaymentImage on Artwork {
@@ -93,11 +83,6 @@ fragment BuyerGuaranteeIndex_securePaymentImage on Artwork {
   artist {
     name
     id
-  }
-  image {
-    resized(version: "large_rectangle") {
-      url
-    }
   }
 }
 */
@@ -172,45 +157,9 @@ v7 = {
   "storageKey": null
 },
 v8 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "url",
-    "storageKey": null
-  }
-],
-v9 = [
   (v4/*: any*/),
   (v5/*: any*/),
   (v7/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "Image",
-    "kind": "LinkedField",
-    "name": "image",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": [
-          {
-            "kind": "Literal",
-            "name": "version",
-            "value": "large_rectangle"
-          }
-        ],
-        "concreteType": "ResizedImageUrl",
-        "kind": "LinkedField",
-        "name": "resized",
-        "plural": false,
-        "selections": (v8/*: any*/),
-        "storageKey": "resized(version:\"large_rectangle\")"
-      }
-    ],
-    "storageKey": null
-  },
   (v6/*: any*/)
 ];
 return {
@@ -325,7 +274,15 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v8/*: any*/),
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "url",
+                    "storageKey": null
+                  }
+                ],
                 "storageKey": "resized(version:\"normalized\")"
               }
             ],
@@ -342,7 +299,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v9/*: any*/),
+        "selections": (v8/*: any*/),
         "storageKey": "artwork(id:\"5fecdbfa19d5ae5bf95c1dd8\")"
       },
       {
@@ -352,7 +309,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v9/*: any*/),
+        "selections": (v8/*: any*/),
         "storageKey": "artwork(id:\"5fce729a212bcf54e2551f21\")"
       },
       {
@@ -362,7 +319,7 @@ return {
         "kind": "LinkedField",
         "name": "artwork",
         "plural": false,
-        "selections": (v9/*: any*/),
+        "selections": (v8/*: any*/),
         "storageKey": "artwork(id:\"580fb7cd2a893a65c100086a\")"
       }
     ]
@@ -372,7 +329,7 @@ return {
     "metadata": {},
     "name": "buyerGuaranteeRoutes_BuyerGuaranteeQuery",
     "operationKind": "query",
-    "text": "query buyerGuaranteeRoutes_BuyerGuaranteeQuery {\n  headerImage: artwork(id: \"5dd8084d257aaf000e4a0396\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"5fecdbfa19d5ae5bf95c1dd8\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"5fce729a212bcf54e2551f21\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"580fb7cd2a893a65c100086a\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"large_rectangle\") {\n      url\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      url\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"large_rectangle\") {\n      url\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"large_rectangle\") {\n      url\n    }\n  }\n}\n"
+    "text": "query buyerGuaranteeRoutes_BuyerGuaranteeQuery {\n  headerImage: artwork(id: \"5dd8084d257aaf000e4a0396\") {\n    ...BuyerGuaranteeIndex_headerImage\n    id\n  }\n  authenticityImage: artwork(id: \"5fecdbfa19d5ae5bf95c1dd8\") {\n    ...BuyerGuaranteeIndex_authenticityImage\n    id\n  }\n  moneyBackGuaranteeImage: artwork(id: \"5fce729a212bcf54e2551f21\") {\n    ...BuyerGuaranteeIndex_moneyBackGuaranteeImage\n    id\n  }\n  securePaymentImage: artwork(id: \"580fb7cd2a893a65c100086a\") {\n    ...BuyerGuaranteeIndex_securePaymentImage\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_authenticityImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_headerImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n  image {\n    resized(version: \"normalized\") {\n      url\n    }\n  }\n}\n\nfragment BuyerGuaranteeIndex_moneyBackGuaranteeImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n\nfragment BuyerGuaranteeIndex_securePaymentImage on Artwork {\n  imageTitle\n  imageUrl\n  artist {\n    name\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Additional QA fixes on Buyer Guarantee page:
- uses Vanity's static urls for page images
- Fixes some text misalignment

https://artsyproduct.atlassian.net/browse/PURCHASE-2620
https://artsyproduct.atlassian.net/browse/PURCHASE-2637

cc @artsy/purchase-devs 

