### PR TITLE
fix(PX-4080): partner page layout

### DIFF
--- a/src/v2/Apps/Partner/PartnerApp.tsx
+++ b/src/v2/Apps/Partner/PartnerApp.tsx
@@ -8,6 +8,8 @@ import { PartnerHeaderImageFragmentContainer as PartnerHeaderImage } from "./Com
 import styled from "styled-components"
 import { PartnerMetaFragmentContainer } from "./Components/PartnerMeta"
 import { StickyProvider } from "v2/Components/Sticky"
+import { AppContainer } from "../Components/AppContainer"
+import { HorizontalPadding } from "../Components/HorizontalPadding"
 
 export interface PartnerAppProps {
   partner: PartnerApp_partner
@@ -28,17 +30,21 @@ export const PartnerApp: React.FC<PartnerAppProps> = ({
       <PartnerHeaderImage profile={partner.profile} />
 
       <Foreground>
-        <PartnerMetaFragmentContainer partner={partner} />
+        <AppContainer>
+          <HorizontalPadding>
+            <PartnerMetaFragmentContainer partner={partner} />
 
-        <PartnerHeader partner={partner} />
+            <PartnerHeader partner={partner} />
 
-        <FullBleed mb={[2, 4]}>
-          <Separator />
-        </FullBleed>
+            <FullBleed mb={[2, 4]}>
+              <Separator />
+            </FullBleed>
 
-        <NavigationTabs partner={partner} />
+            <NavigationTabs partner={partner} />
 
-        {children}
+            {children}
+          </HorizontalPadding>
+        </AppContainer>
       </Foreground>
     </StickyProvider>
   )


### PR DESCRIPTION
This PR fixes the current partner page layout. The partner profile page has special scroll behavior for the header image, the solution described here: https://github.com/artsy/force/pull/7199#discussion_r600512091. In short, we use a fixed image and foreground which scrolls over it. As far as I see this PR https://github.com/artsy/force/pull/7497 broke partner page layout. To fix it I moved back `AppContainer` and `HorizontalPadding`. 

JIRA - https://artsyproduct.atlassian.net/browse/PX-4080

Before: 
![image](https://user-images.githubusercontent.com/79979820/117974450-3e507c00-b336-11eb-8860-154c1111da25.png)

Now:
![image](https://user-images.githubusercontent.com/79979820/117974506-4c060180-b336-11eb-938d-d686508dcf5d.png)
