### PR TITLE
feat: [Route config] Add `hideFooter` option

### DIFF
--- a/src/v2/Apps/Components/AppShell.tsx
+++ b/src/v2/Apps/Components/AppShell.tsx
@@ -26,9 +26,8 @@ export const AppShell: React.FC<AppShellProps> = props => {
 
   const { children, match } = props
   const routeConfig = findCurrentRoute(match)
-
   const { isEigen } = useSystemContext()
-  const showFooter = !isEigen
+  const showFooter = !isEigen && !routeConfig.hideFooter
   const appContainerMaxWidth = routeConfig.displayFullPage ? "100%" : null
 
   /**
@@ -89,11 +88,15 @@ export const AppShell: React.FC<AppShellProps> = props => {
 
           <NetworkOfflineMonitor />
 
-          <Flex backgroundColor="white100">
-            <AppContainer>
-              <HorizontalPadding>{showFooter && <Footer />}</HorizontalPadding>
-            </AppContainer>
-          </Flex>
+          {showFooter && (
+            <Flex backgroundColor="white100">
+              <AppContainer>
+                <HorizontalPadding>
+                  <Footer />
+                </HorizontalPadding>
+              </AppContainer>
+            </Flex>
+          )}
         </>
       </Theme>
     </Box>

--- a/src/v2/Apps/Conversation/conversationRoutes.tsx
+++ b/src/v2/Apps/Conversation/conversationRoutes.tsx
@@ -6,6 +6,7 @@ export const conversationRoutes: AppRouteConfig[] = [
   {
     path: "/user/conversations",
     displayFullPage: true,
+    hideFooter: true,
     getComponent: () =>
       loadable(() => import("./ConversationApp"), {
         resolveComponent: component =>
@@ -30,6 +31,7 @@ export const conversationRoutes: AppRouteConfig[] = [
   {
     path: "/user/conversations/:conversationID",
     displayFullPage: true,
+    hideFooter: true,
     Component: loadable(() => import("./Routes/Conversation"), {
       resolveComponent: component => component.ConversationPaginationContainer,
     }),

--- a/src/v2/Apps/Order/orderRoutes.tsx
+++ b/src/v2/Apps/Order/orderRoutes.tsx
@@ -28,6 +28,7 @@ export const orderRoutes: AppRouteConfig[] = [
   {
     // TODO: Still need order2?
     path: "/order(2|s)/:orderID",
+    hideFooter: true,
     Component: OrderApp,
     prepare: () => {
       OrderApp.preload()
@@ -81,6 +82,7 @@ export const orderRoutes: AppRouteConfig[] = [
         path: "respond",
         Component: RespondRoute,
         shouldWarnBeforeLeaving: true,
+        hideFooter: true,
         query: graphql`
           query orderRoutes_RespondQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -96,6 +98,7 @@ export const orderRoutes: AppRouteConfig[] = [
         path: "offer",
         Component: OfferRoute,
         shouldWarnBeforeLeaving: true,
+        hideFooter: true,
         query: graphql`
           query orderRoutes_OfferQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -111,6 +114,7 @@ export const orderRoutes: AppRouteConfig[] = [
         path: "shipping",
         Component: ShippingRoute,
         shouldWarnBeforeLeaving: true,
+        hideFooter: true,
         query: graphql`
           query orderRoutes_ShippingQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -129,6 +133,7 @@ export const orderRoutes: AppRouteConfig[] = [
         path: "payment",
         Component: PaymentRoute,
         shouldWarnBeforeLeaving: true,
+        hideFooter: true,
         query: graphql`
           query orderRoutes_PaymentQuery($orderID: ID!) {
             me {
@@ -147,6 +152,7 @@ export const orderRoutes: AppRouteConfig[] = [
         path: "payment/new",
         Component: NewPaymentRoute,
         shouldWarnBeforeLeaving: true,
+        hideFooter: true,
         query: graphql`
           query orderRoutes_NewPaymentQuery($orderID: ID!) {
             me {
@@ -165,6 +171,7 @@ export const orderRoutes: AppRouteConfig[] = [
         path: "review/counter",
         Component: CounterRoute,
         shouldWarnBeforeLeaving: true,
+        hideFooter: true,
         query: graphql`
           query orderRoutes_CounterQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -180,6 +187,7 @@ export const orderRoutes: AppRouteConfig[] = [
         path: "review",
         Component: ReviewRoute,
         shouldWarnBeforeLeaving: true,
+        hideFooter: true,
         query: graphql`
           query orderRoutes_ReviewQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -194,6 +202,7 @@ export const orderRoutes: AppRouteConfig[] = [
       {
         path: "review/accept",
         Component: AcceptRoute,
+        hideFooter: true,
         query: graphql`
           query orderRoutes_AcceptQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -208,6 +217,7 @@ export const orderRoutes: AppRouteConfig[] = [
       {
         path: "review/decline",
         Component: DeclineRoute,
+        hideFooter: true,
         query: graphql`
           query orderRoutes_RejectQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {
@@ -219,6 +229,7 @@ export const orderRoutes: AppRouteConfig[] = [
       {
         path: "status",
         Component: StatusRoute,
+        hideFooter: true,
         query: graphql`
           query orderRoutes_StatusQuery($orderID: ID!) {
             order: commerceOrder(id: $orderID) {

--- a/src/v2/Artsy/Router/Route.tsx
+++ b/src/v2/Artsy/Router/Route.tsx
@@ -17,6 +17,7 @@ interface RouteConfigProps extends RouteConfig {
   cacheConfig?: CacheConfig
   displayFullPage?: boolean
   fetchIndicator?: FetchIndicator
+  hideFooter?: true
   ignoreScrollBehavior?: boolean
   prepare?: () => void
   prepareVariables?: (params: any, props: any) => object

--- a/src/v2/Artsy/Router/Route.tsx
+++ b/src/v2/Artsy/Router/Route.tsx
@@ -16,12 +16,14 @@ type RemoveIndex<T> = {
 interface RouteConfigProps extends RouteConfig {
   cacheConfig?: CacheConfig
   displayFullPage?: boolean
+  displayNavigationTabs?: boolean
   fetchIndicator?: FetchIndicator
   hideFooter?: true
   ignoreScrollBehavior?: boolean
   prepare?: () => void
   prepareVariables?: (params: any, props: any) => object
   query?: GraphQLTaggedNode
+  shouldWarnBeforeLeaving?: boolean
   theme?: 'v2' | 'v3'
 }
 

--- a/src/v2/Artsy/Router/Utils/findCurrentRoute.tsx
+++ b/src/v2/Artsy/Router/Utils/findCurrentRoute.tsx
@@ -1,15 +1,16 @@
-import { Match, RouteConfig } from "found"
+import { Match } from "found"
+import { AppRouteConfig } from "../Route"
 
 export const findCurrentRoute = ({
   route: baseRoute,
   routes,
   routeIndices,
-}: Match & { route?: RouteConfig }) => {
+}: Match & { route?: AppRouteConfig }) => {
   if (!routeIndices || routeIndices.length === 0) {
     return baseRoute
   }
   let remainingRouteIndicies = [...routeIndices]
-  let route: RouteConfig = routes[remainingRouteIndicies.shift()]
+  let route: AppRouteConfig = routes[remainingRouteIndicies.shift()]
 
   while (remainingRouteIndicies.length > 0) {
     route = route.children[remainingRouteIndicies.shift()]


### PR DESCRIPTION
This addresses an issue [reported in slack](https://artsy.slack.com/archives/C9YNS4X32/p1620837973240300) around the footer appearing on the conversations screen.

#### Solution:

Add a new `hideFooter` prop to our route config that will hide the footer and apply it to /conversations and bnmo routes.

<img width="1252" alt="Screen Shot 2021-05-12 at 11 25 57 AM" src="https://user-images.githubusercontent.com/236943/118025566-d8073180-b314-11eb-97d2-c90abef5f424.png">

<img width="1259" alt="Screen Shot 2021-05-12 at 11 31 14 AM" src="https://user-images.githubusercontent.com/236943/118026411-9a56d880-b315-11eb-8bcf-32c004392a5d.png">
