### PR TITLE
fix(partner): fixes _ is not a function error

### DIFF
--- a/src/desktop/apps/partner2/components/fixed_cells_count_carousel/view.coffee
+++ b/src/desktop/apps/partner2/components/fixed_cells_count_carousel/view.coffee
@@ -29,10 +29,10 @@ module.exports = class FixedCellsCountCarousel extends Backbone.View
       _.map @fetchOptions, (options) =>
         @collection.fetch data: options, remove: false
     ).then (values) =>
-      objects = _(values).chain().pluck('value')
-      if objects.first().has('results').value() # For articles wrapped in results
-        objects = objects.pluck('results')
-      @collection.reset objects.flatten().value()
+      objects = _.pluck(values, 'value')
+      if _.has(objects[0], 'results') # For articles wrapped in results
+        objects = _.pluck(objects, 'results')
+      @collection.reset(_.flatten(objects))
       @collection
 
   # Only keep the first cellsCountPerPage * pagesCount items.


### PR DESCRIPTION
OK let this be a lesson to myself to actually look into errors that crop up in the smoke tests instead of dismissing them as spurious. I think this was sometimes passing because it was in the callback after an async action. I don't know _why_ this was actually undefined because this should be OK, but I'm not motivated enough to track down the root cause of an issue in a Backbone view that's going to get replaced in a week or two anyway.