### PR TITLE
fix(GRO-315): navigation button hit area size in MobileNavMenu panes

### DIFF
--- a/src/v2/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
@@ -191,7 +191,7 @@ export const BackLink: React.FC = () => {
         })
         pop()
       }}
-      width="30px"
+      width="60px"
       height="30px"
       style={{
         cursor: "pointer",


### PR DESCRIPTION
The type of this PR is: fix

This PR resolves [GRO-315.](https://artsyproduct.atlassian.net/browse/GRO-315).

**Description**

This PR fixes the hit area size of the backLink button in MobileNavMenu panes. Now the hit area of the button has a larger tap surface what is important for UX.

(https://user-images.githubusercontent.com/83413732/118157093-cc099580-b422-11eb-8cca-6b71a2cf0b0d.jpeg)
