### PR TITLE
fix: [fair/:id] remove related articles header to remove whitespace

### DIFF
--- a/src/v2/Apps/Fair/FairApp.tsx
+++ b/src/v2/Apps/Fair/FairApp.tsx
@@ -73,12 +73,8 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
       <FairHeaderFragmentContainer fair={fair} />
 
       {hasArticles && (
-        <Box my={6} pt={4} borderTop="1px solid" borderColor="black10">
+        <Box my={4} pt={4} borderTop="1px solid" borderColor="black10">
           <Box display="flex" justifyContent="space-between">
-            <Text variant="lg" as="h3" mb={2}>
-              Related Reading
-            </Text>
-
             {/* @ts-expect-error STRICT_NULL_CHECK */}
             {fair.articlesConnection.totalCount > FAIR_EDITORIAL_AMOUNT && (
               <RouterLink to={`${fair.href}/articles`} noUnderline>
@@ -92,7 +88,7 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
       )}
 
       {hasCollections && (
-        <Box my={6} pt={4} borderTop="1px solid" borderColor="black10">
+        <Box my={4} pt={4} borderTop="1px solid" borderColor="black10">
           <Text variant="lg" as="h3" mb={2}>
             Curated Highlights
           </Text>

--- a/src/v2/Apps/Fair/__tests__/FairApp.jest.tsx
+++ b/src/v2/Apps/Fair/__tests__/FairApp.jest.tsx
@@ -62,7 +62,6 @@ describe("FairApp", () => {
 
     const html = wrapper.html()
 
-    expect(html).toContain("Related Reading")
     expect(html).toContain(
       "IFPDA Fine Art Print Fair 2019: Programming and Projects"
     )
@@ -75,7 +74,6 @@ describe("FairApp", () => {
 
     const html = wrapper.html()
 
-    expect(html).not.toContain("Related Reading")
     expect(html).not.toContain(
       "IFPDA Fine Art Print Fair 2019: Programming and Projects"
     )


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/FX-2921 

This removes the related articles header section on the page, as it was leading to strange whitespace issues. 