### PR TITLE
fix: [Auctions] add missing h1

### DIFF
--- a/src/v2/Apps/Auctions/AuctionsApp.tsx
+++ b/src/v2/Apps/Auctions/AuctionsApp.tsx
@@ -26,7 +26,9 @@ const AuctionsApp: React.FC<AuctionsAppProps> = props => {
 
       <GridColumns mt={4}>
         <Column span={6}>
-          <Text variant="xl">Auctions</Text>
+          <Text variant="xl" as="h1">
+            Auctions
+          </Text>
         </Column>
 
         <Column span={6}>


### PR DESCRIPTION
Accidentally deleted the `h1` tag yesterday when i was doing some cleanup: 

https://app.circleci.com/pipelines/github/artsy/integrity/6937/workflows/935452c4-e6f6-4de2-80c6-7ef6ffd84e76/jobs/33784