### PR TITLE
fix: added checking for article title existence and filling in the em…

### DIFF
--- a/src/desktop/apps/article/components/App.tsx
+++ b/src/desktop/apps/article/components/App.tsx
@@ -9,6 +9,7 @@ import { data as sd } from "sharify"
 import { ArticleProps } from "@artsy/reaction/dist/Components/Publishing/Article"
 import { ClassicArticleLayout } from "desktop/apps/article/components/layouts/Classic"
 import { mediator } from "lib/mediator"
+import { getArticleWithTitle } from "../helpers"
 
 export interface AppProps extends ArticleProps {
   templates?: {
@@ -20,7 +21,7 @@ export interface AppProps extends ArticleProps {
 
 export class App extends React.Component<AppProps> {
   getArticleLayout = () => {
-    const { article } = this.props
+    const article = getArticleWithTitle(this.props.article)
 
     switch (article.layout) {
       case "video": {

--- a/src/desktop/apps/article/components/InfiniteScrollArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollArticle.tsx
@@ -10,7 +10,10 @@ import {
 } from "@artsy/reaction/dist/Components/Publishing/Article"
 import { articlesQuery } from "desktop/apps/article/queries/articles"
 import { ArticleData } from "@artsy/reaction/dist/Components/Publishing/Typings"
-import { shouldAdRender } from "desktop/apps/article/helpers"
+import {
+  getArticleWithTitle,
+  shouldAdRender,
+} from "desktop/apps/article/helpers"
 
 const FETCH_TOP_OFFSET = 200
 
@@ -141,10 +144,12 @@ export class InfiniteScrollArticle extends React.Component<
         // @ts-expect-error STRICT_NULL_CHECK
         const renderAd = shouldAdRender(null, null, null, articleType)
 
+        const articleWithTitle = getArticleWithTitle(article)
+
         return (
           <div key={`article-${i}`}>
             <Article
-              article={article}
+              article={articleWithTitle}
               relatedArticlesForPanel={article.relatedArticlesPanel}
               relatedArticlesForCanvas={article.relatedArticlesCanvas}
               isTruncated={i !== 0}

--- a/src/desktop/apps/article/helpers.tsx
+++ b/src/desktop/apps/article/helpers.tsx
@@ -72,3 +72,11 @@ export const getJsonLd = article => {
   const articleModel = new Article(article)
   return stringifyJSONForWeb(articleModel.toJSONLD())
 }
+
+export const getArticleWithTitle = article => {
+  const articleWithTitle = { ...article }
+  if (!articleWithTitle.title || !articleWithTitle.title.trim()) {
+    articleWithTitle.title = articleWithTitle.thumbnail_title
+  }
+  return articleWithTitle
+}


### PR DESCRIPTION
…pty title

This is supposed to fix https://artsyproduct.atlassian.net/browse/GRO-324

Articles that had property `title` equal to `" "` didn't render `h1` tag so I check for `title` property existence and if it's missing set `thumbnail_title` value to it.

But I'm not sure whether it's got valid for SEO because, after all, `h1` tag was visible in elements tab, though I haven't found any other differences between articles which had `h1` tag and those hadn't
![Screen Shot 2021-05-17 at 5 05 51 PM](https://user-images.githubusercontent.com/44819355/118502199-27dd6280-b732-11eb-8571-8447bfe33990.png)

Before
![before](https://user-images.githubusercontent.com/44819355/118502975-dda8b100-b732-11eb-9fdc-8fa8fbe8116e.png)

After
![after](https://user-images.githubusercontent.com/44819355/118502997-e39e9200-b732-11eb-899e-722123d1b70b.png)

