### PR TITLE
fix: ensure spacing is consistent above continue button

### DIFF
--- a/src/v2/Apps/Order/Routes/Accept/index.tsx
+++ b/src/v2/Apps/Order/Routes/Accept/index.tsx
@@ -234,7 +234,6 @@ export class Accept extends Component<AcceptProps> {
               </Media>
               <Media at="xs">
                 <>
-                  <Spacer mb={2} />
                   <Button
                     onClick={this.onSubmit}
                     loading={isCommittingMutation}

--- a/src/v2/Apps/Order/Routes/NewPayment/index.tsx
+++ b/src/v2/Apps/Order/Routes/NewPayment/index.tsx
@@ -194,7 +194,6 @@ export class NewPaymentRoute extends Component<
               <Spacer mb={[2, 3]} />
               <Media at="xs">
                 <>
-                  <Spacer mb={3} />
                   <ContinueButton
                     onClick={this.onContinue}
                     loading={isLoading}

--- a/src/v2/Apps/Order/Routes/Offer/index.tsx
+++ b/src/v2/Apps/Order/Routes/Offer/index.tsx
@@ -304,7 +304,6 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
               <Spacer mb={[2, 3]} />
               <Media at="xs">
                 <>
-                  <Spacer mb={3} />
                   <Button
                     onClick={this.onContinueButtonPressed}
                     loading={isCommittingMutation}

--- a/src/v2/Apps/Order/Routes/Payment/index.tsx
+++ b/src/v2/Apps/Order/Routes/Payment/index.tsx
@@ -161,7 +161,6 @@ export class PaymentRoute extends Component<
               <Spacer mb={[2, 3]} />
               <Media at="xs">
                 <>
-                  <Spacer mb={3} />
                   <ContinueButton
                     onClick={this.onContinue}
                     loading={isLoading}

--- a/src/v2/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/v2/Apps/Order/Routes/Shipping/index.tsx
@@ -487,7 +487,6 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
               <BuyerGuarantee />
               <Spacer mb={[2, 3]} />
               <Media at="xs">
-                <Spacer mb={3} />
                 <Button
                   onClick={this.onContinueButtonPressed}
                   loading={isCommittingMutation}


### PR DESCRIPTION
Addresses: [https://artsyproduct.atlassian.net/browse/PURCHASE-2671](https://artsyproduct.atlassian.net/browse/PURCHASE-2671)

This ensures the margin about the "Continue" button is consistent.

**Shipping**
<img width="332" alt="Screen Shot 2021-05-17 at 5 35 43 PM" src="https://user-images.githubusercontent.com/5201004/118559724-5a895a00-b736-11eb-8082-49bf31797be5.png">

**Payment**
<img width="331" alt="Screen Shot 2021-05-17 at 5 36 45 PM" src="https://user-images.githubusercontent.com/5201004/118560105-f87d2480-b736-11eb-8fc8-0c719cc877ff.png">
