### PR TITLE
feat: add assetlinks file for android deep links

### DIFF
--- a/src/desktop/public/.well-known/assetlinks.json
+++ b/src/desktop/public/.well-known/assetlinks.json
@@ -1,0 +1,9 @@
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "net.artsy.app",
+    "sha256_cert_fingerprints":
+    ["FA:C6:17:45:DC:09:03:78:6F:B9:ED:E6:2A:96:2B:39:9F:73:48:F0:BB:6F:89:9B:83:32:66:75:91:03:3B:9C"]
+  }
+}]


### PR DESCRIPTION
This file is needed in order to make artsy.net links open in the Android app