### PR TITLE
fix: deleted hiding of Museums tab in nav bar

### DIFF
--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -84,6 +84,8 @@ export const NavBar: React.FC = track(
     }
   }
 
+  const navItemsMargins = ["-2px", "-2px", "0", "0"]
+
   return (
     <>
       <NavBarSkipLink />
@@ -235,17 +237,22 @@ export const NavBar: React.FC = track(
                   Artworks
                 </NavItem>
 
-                <NavItem href="/auctions">Auctions</NavItem>
-                <NavItem href="/viewing-rooms">Viewing&nbsp;Rooms</NavItem>
-                <NavItem href="/galleries">Galleries</NavItem>
-                <NavItem href="/fairs">Fairs</NavItem>
-                <NavItem href="/Shows">Shows</NavItem>
-                <NavItem
-                  // Hide link at smaller viewports — corresponding display inside of `MoreNavMenu`
-                  // If we need to do this again, consider a more abstract solution
-                  display={["none", "none", "flex", "flex"]}
-                  href="/institutions"
-                >
+                <NavItem href="/auctions" marginX={navItemsMargins}>
+                  Auctions
+                </NavItem>
+                <NavItem href="/viewing-rooms" marginX={navItemsMargins}>
+                  Viewing&nbsp;Rooms
+                </NavItem>
+                <NavItem href="/galleries" marginX={navItemsMargins}>
+                  Galleries
+                </NavItem>
+                <NavItem href="/fairs" marginX={navItemsMargins}>
+                  Fairs
+                </NavItem>
+                <NavItem href="/Shows" marginX={navItemsMargins}>
+                  Shows
+                </NavItem>
+                <NavItem href="/institutions" marginX={navItemsMargins}>
                   Museums
                 </NavItem>
               </NavSection>


### PR DESCRIPTION
This fixes https://artsyproduct.atlassian.net/browse/GRO-247

**Before**
![nTab_before](https://user-images.githubusercontent.com/44819355/118654637-70a82080-b7f1-11eb-8c7c-2e467e01f6e0.gif)

**After**
![nTab_after](https://user-images.githubusercontent.com/44819355/118654663-756cd480-b7f1-11eb-9fe8-e5cdd2b96251.gif)

In order to avoid wrapping of "Download App" button text I added to nav items negative x-margin that decreases space between them. Without this change it looks like:
![wrap](https://user-images.githubusercontent.com/44819355/118655944-b44f5a00-b7f2-11eb-8311-33bfd37019cb.gif)

