### PR TITLE
feat: converts recently viewed to v3

### DIFF
--- a/src/v2/Apps/Artist/ArtistApp.tsx
+++ b/src/v2/Apps/Artist/ArtistApp.tsx
@@ -7,10 +7,9 @@ import { useTracking } from "v2/Artsy"
 import { track } from "v2/Artsy/Analytics"
 import * as Schema from "v2/Artsy/Analytics/Schema"
 import { findCurrentRoute } from "v2/Artsy/Router/Utils/findCurrentRoute"
-import { RecentlyViewedQueryRenderer as RecentlyViewed } from "v2/Components/RecentlyViewed"
+import { RecentlyViewed } from "v2/Components/RecentlyViewed"
 import { Match } from "found"
 import React from "react"
-import { LazyLoadComponent } from "react-lazy-load-image-component"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtistHeaderFragmentContainer as ArtistHeader } from "./Components/ArtistHeader"
 import { StyledLink } from "./Components/StyledLink"
@@ -106,16 +105,12 @@ export const ArtistApp: React.FC<ArtistAppProps> = props => {
 
         {/* Fullpage is typically a stand-alone marketing page  */}
         {/* @ts-expect-error STRICT_NULL_CHECK */}
-        {!route.displayFullPage && typeof window !== "undefined" && (
-          <>
-            <LazyLoadComponent threshold={1000}>
-              <Row>
-                <Col>
-                  <RecentlyViewed />
-                </Col>
-              </Row>
-            </LazyLoadComponent>
-          </>
+        {!route.displayFullPage && (
+          <Row>
+            <Col>
+              <RecentlyViewed />
+            </Col>
+          </Row>
         )}
       </HorizontalPaddingArea>
     </>

--- a/src/v2/Apps/Artwork/ArtworkApp.tsx
+++ b/src/v2/Apps/Artwork/ArtworkApp.tsx
@@ -1,6 +1,5 @@
 import { Box, Col, Row, Spacer } from "@artsy/palette"
 import React, { useContext } from "react"
-import { LazyLoadComponent } from "react-lazy-load-image-component"
 import { createFragmentContainer, graphql } from "react-relay"
 import { data as sd } from "sharify"
 
@@ -20,7 +19,7 @@ import { PricingContextFragmentContainer as PricingContext } from "./Components/
 
 import { withSystemContext } from "v2/Artsy"
 import * as Schema from "v2/Artsy/Analytics/Schema"
-import { RecentlyViewedQueryRenderer as RecentlyViewed } from "v2/Components/RecentlyViewed"
+import { RecentlyViewed } from "v2/Components/RecentlyViewed"
 import { RouterContext } from "found"
 import { TrackingProp } from "react-tracking"
 import { Media } from "v2/Utils/Responsive"
@@ -287,15 +286,12 @@ export class ArtworkApp extends React.Component<Props> {
             </Row>
           )}
 
-          {typeof window !== "undefined" && (
-            <LazyLoadComponent threshold={1000}>
-              <Row>
-                <Col>
-                  <RecentlyViewed />
-                </Col>
-              </Row>
-            </LazyLoadComponent>
-          )}
+          <Row>
+            <Col>
+              <RecentlyViewed />
+            </Col>
+          </Row>
+
           <div
             id="lightbox-container"
             style={{

--- a/src/v2/Apps/Auctions/AuctionsApp.tsx
+++ b/src/v2/Apps/Auctions/AuctionsApp.tsx
@@ -4,8 +4,7 @@ import { AuctionsMeta } from "./Components/AuctionsMeta"
 import { MyBidsFragmentContainer } from "./Components/MyBids/MyBids"
 import { Box, Column, GridColumns, Join, Spacer, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
-import { LazyLoadComponent } from "react-lazy-load-image-component"
-import { RecentlyViewedQueryRenderer as RecentlyViewed } from "v2/Components/RecentlyViewed"
+import { RecentlyViewed } from "v2/Components/RecentlyViewed"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import { RouteTabs, RouteTab } from "v2/Components/RouteTabs"
 import { useSystemContext } from "v2/Artsy/useSystemContext"
@@ -77,13 +76,7 @@ const AuctionsApp: React.FC<AuctionsAppProps> = props => {
 
       <Box>{children}</Box>
 
-      {typeof window !== "undefined" && (
-        <>
-          <LazyLoadComponent threshold={1000}>
-            <RecentlyViewed />
-          </LazyLoadComponent>
-        </>
-      )}
+      <RecentlyViewed />
     </>
   )
 }

--- a/src/v2/Apps/Collect/Routes/Collect/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collect/index.tsx
@@ -104,9 +104,8 @@ export const CollectApp: React.FC<CollectAppProps> = ({
           <ArtworkFilter
             viewer={viewer}
             aggregations={
-              // @ts-expect-error STRICT_NULL_CHECK
-              viewer.artworksConnection
-                .aggregations as SharedArtworkFilterContextProps["aggregations"]
+              viewer?.artworksConnection
+                ?.aggregations as SharedArtworkFilterContextProps["aggregations"]
             }
             filters={location.query as any}
             sortOptions={[

--- a/src/v2/Apps/Search/SearchApp.tsx
+++ b/src/v2/Apps/Search/SearchApp.tsx
@@ -6,7 +6,7 @@ import { withSystemContext } from "v2/Artsy"
 import { track } from "v2/Artsy/Analytics"
 import * as Schema from "v2/Artsy/Analytics/Schema"
 
-import { RecentlyViewedQueryRenderer as RecentlyViewed } from "v2/Components/RecentlyViewed"
+import { RecentlyViewed } from "v2/Components/RecentlyViewed"
 
 import { RouterState, withRouter } from "found"
 import React, { useCallback, useEffect, useState } from "react"

--- a/src/v2/Components/Artwork/Details.tsx
+++ b/src/v2/Components/Artwork/Details.tsx
@@ -1,5 +1,4 @@
 import {
-  Flex,
   Link,
   Text,
   LinkProps,
@@ -156,28 +155,24 @@ const SaleInfoLine: React.FC<DetailsProps> = props => {
       variant: "text" as TextVariant,
       color: "black60",
       fontWeight: "normal",
-      mt: undefined,
     },
     v3: {
       variant: "xs" as TextVariant,
       color: "black100",
       fontWeight: "bold",
-      mt: "2px",
     },
   })
 
   return (
-    <Flex mt={tokens.mt}>
-      <TruncatedLine>
-        <Text
-          variant={tokens.variant}
-          color={tokens.color}
-          fontWeight={tokens.fontWeight}
-        >
-          <SaleMessage {...props} /> <BidInfo {...props} />
-        </Text>
-      </TruncatedLine>
-    </Flex>
+    <TruncatedLine>
+      <Text
+        variant={tokens.variant}
+        color={tokens.color}
+        fontWeight={tokens.fontWeight}
+      >
+        <SaleMessage {...props} /> <BidInfo {...props} />
+      </Text>
+    </TruncatedLine>
   )
 }
 

--- a/src/v2/Components/FrameWithRecentlyViewed.tsx
+++ b/src/v2/Components/FrameWithRecentlyViewed.tsx
@@ -1,24 +1,21 @@
-import { Flex } from "@artsy/palette"
+import { Flex, Spacer } from "@artsy/palette"
 import React from "react"
-import { LazyLoadComponent } from "react-lazy-load-image-component"
+import { RecentlyViewed } from "v2/Components/RecentlyViewed"
 
-import { RecentlyViewedQueryRenderer as RecentlyViewed } from "v2/Components/RecentlyViewed"
-
-export interface Props {
+export interface FrameWithRecentlyViewedProps {
   name?: string
 }
 
-export const FrameWithRecentlyViewed: React.FC<Props> = ({ children }) => {
+export const FrameWithRecentlyViewed: React.FC<FrameWithRecentlyViewedProps> = ({
+  children,
+}) => {
   return (
     <Flex flexDirection="column">
       {children}
 
-      {/* TODO */}
-      {typeof window !== "undefined" && (
-        <LazyLoadComponent threshold={1000}>
-          <RecentlyViewed />
-        </LazyLoadComponent>
-      )}
+      <Spacer mt={6} />
+
+      <RecentlyViewed />
     </Flex>
   )
 }

--- a/src/v2/Components/RecentlyViewed/RecentlyViewed.tsx
+++ b/src/v2/Components/RecentlyViewed/RecentlyViewed.tsx
@@ -1,0 +1,106 @@
+import { ContextModule } from "@artsy/cohesion"
+import { Shelf, Text } from "@artsy/palette"
+import { RecentlyViewed_me } from "v2/__generated__/RecentlyViewed_me.graphql"
+import { RecentlyViewedQuery } from "v2/__generated__/RecentlyViewedQuery.graphql"
+import { SystemContext } from "v2/Artsy"
+import { useTracking } from "v2/Artsy/Analytics"
+import * as Schema from "v2/Artsy/Analytics/Schema"
+import { SystemQueryRenderer as QueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
+import React, { useContext } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { extractNodes } from "v2/Utils/extractNodes"
+import { ShelfArtworkFragmentContainer } from "../Artwork/ShelfArtwork"
+import { RecentlyViewedPlaceholder } from "./RecentlyViewedPlaceholder"
+
+export interface RecentlyViewedProps {
+  me: RecentlyViewed_me
+}
+
+export const RecentlyViewed: React.FC<RecentlyViewedProps> = ({ me }) => {
+  const tracking = useTracking()
+
+  if (!me) return null
+
+  const trackClick = () => {
+    tracking.trackEvent({
+      type: Schema.Type.Thumbnail,
+      action_type: Schema.ActionType.Click,
+      context_module: Schema.ContextModule.RecentlyViewedArtworks,
+    })
+  }
+
+  const artworks = extractNodes(me.recentlyViewedArtworksConnection)
+
+  if (artworks.length === 0) return null
+
+  return (
+    <>
+      <Text variant="lg" mb={2}>
+        Recently viewed
+      </Text>
+
+      <Shelf showProgress={false}>
+        {artworks.map(artwork => {
+          return (
+            <ShelfArtworkFragmentContainer
+              key={artwork.id}
+              lazyLoad={true}
+              artwork={artwork}
+              onClick={trackClick}
+              contextModule={ContextModule.recentlyViewedRail}
+            />
+          )
+        })}
+      </Shelf>
+    </>
+  )
+}
+
+export const RecentlyViewedFragmentContainer = createFragmentContainer(
+  RecentlyViewed,
+  {
+    me: graphql`
+      fragment RecentlyViewed_me on Me {
+        recentlyViewedArtworksConnection(first: 20) {
+          edges {
+            node {
+              id
+              ...ShelfArtwork_artwork
+            }
+          }
+        }
+      }
+    `,
+  }
+)
+
+export const RecentlyViewedQueryRenderer = () => {
+  const { user, relayEnvironment } = useContext(SystemContext)
+
+  if (!user) return null
+
+  return (
+    <QueryRenderer<RecentlyViewedQuery>
+      environment={relayEnvironment}
+      query={graphql`
+        query RecentlyViewedQuery {
+          me {
+            ...RecentlyViewed_me
+          }
+        }
+      `}
+      render={({ error, props }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props) {
+          return <RecentlyViewedPlaceholder />
+        }
+
+        return <RecentlyViewedFragmentContainer {...props} />
+      }}
+    />
+  )
+}

--- a/src/v2/Components/RecentlyViewed/RecentlyViewedPlaceholder.tsx
+++ b/src/v2/Components/RecentlyViewed/RecentlyViewedPlaceholder.tsx
@@ -1,0 +1,49 @@
+import { Shelf, SkeletonBox, SkeletonText, Text } from "@artsy/palette"
+import React from "react"
+import { IMG_HEIGHT } from "../Artwork/ShelfArtwork"
+
+export const RecentlyViewedPlaceholder: React.FC = () => {
+  return (
+    <>
+      <Text variant="lg" mb={2}>
+        Recently viewed
+      </Text>
+
+      <Shelf showProgress={false}>
+        {[...new Array(10)].map((_, i) => {
+          return (
+            <React.Fragment key={i}>
+              <SkeletonBox
+                width={200}
+                height={[
+                  // Cycle through random-ish looking heights bounded by the
+                  // max IMG_HEIGHT for both mobile and desktop.
+                  [
+                    IMG_HEIGHT.mobile - 150,
+                    IMG_HEIGHT.mobile - 100,
+                    IMG_HEIGHT.mobile - 50,
+                    IMG_HEIGHT.mobile,
+                    IMG_HEIGHT.mobile - 33,
+                  ][i % 5],
+                  [
+                    IMG_HEIGHT.desktop - 150,
+                    IMG_HEIGHT.desktop - 100,
+                    IMG_HEIGHT.desktop - 50,
+                    IMG_HEIGHT.desktop,
+                    IMG_HEIGHT.desktop - 33,
+                  ][i % 5],
+                ]}
+                mb={1}
+              />
+
+              <SkeletonText variant="md">Artist Name</SkeletonText>
+              <SkeletonText variant="md">Artwork Title</SkeletonText>
+              <SkeletonText variant="xs">Partner Name</SkeletonText>
+              <SkeletonText variant="xs">Price</SkeletonText>
+            </React.Fragment>
+          )
+        })}
+      </Shelf>
+    </>
+  )
+}

--- a/src/v2/Components/RecentlyViewed/RecentlyViewedV2.tsx
+++ b/src/v2/Components/RecentlyViewed/RecentlyViewedV2.tsx
@@ -1,27 +1,27 @@
 import { ContextModule } from "@artsy/cohesion"
 import { Separator, Text } from "@artsy/palette"
-import { RecentlyViewed_me } from "v2/__generated__/RecentlyViewed_me.graphql"
-import { RecentlyViewedQuery } from "v2/__generated__/RecentlyViewedQuery.graphql"
+import { RecentlyViewedV2_me } from "v2/__generated__/RecentlyViewedV2_me.graphql"
+import { RecentlyViewedV2Query } from "v2/__generated__/RecentlyViewedV2Query.graphql"
 import { SystemContext, SystemContextConsumer } from "v2/Artsy"
 import { track } from "v2/Artsy/Analytics"
 import * as Schema from "v2/Artsy/Analytics/Schema"
-import { renderWithLoadProgress } from "v2/Artsy/Relay/renderWithLoadProgress"
 import { SystemQueryRenderer as QueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
 import { FillwidthItem } from "v2/Components/Artwork/FillwidthItem"
 import { Carousel } from "v2/Components/Carousel"
 import React, { useContext } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { RecentlyViewedV2Placeholder } from "./RecentlyViewedV2Placeholder"
 
-export interface RecentlyViewedProps {
-  me: RecentlyViewed_me
+export interface RecentlyViewedV2Props {
+  me: RecentlyViewedV2_me
 }
 
-const HEIGHT = 180
+export const HEIGHT = 180
 
 @track({
   context_module: Schema.ContextModule.RecentlyViewedArtworks,
 })
-export class RecentlyViewed extends React.Component<RecentlyViewedProps> {
+export class RecentlyViewedV2 extends React.Component<RecentlyViewedV2Props> {
   @track({
     type: Schema.Type.Thumbnail,
     action_type: Schema.ActionType.Click,
@@ -73,11 +73,11 @@ export class RecentlyViewed extends React.Component<RecentlyViewedProps> {
   }
 }
 
-export const RecentlyViewedFragmentContainer = createFragmentContainer(
-  RecentlyViewed,
+export const RecentlyViewedV2FragmentContainer = createFragmentContainer(
+  RecentlyViewedV2,
   {
     me: graphql`
-      fragment RecentlyViewed_me on Me {
+      fragment RecentlyViewedV2_me on Me {
         recentlyViewedArtworksConnection(first: 20) {
           edges {
             node {
@@ -91,23 +91,33 @@ export const RecentlyViewedFragmentContainer = createFragmentContainer(
   }
 )
 
-export const RecentlyViewedQueryRenderer = () => {
+export const RecentlyViewedV2QueryRenderer = () => {
   const { user, relayEnvironment } = useContext(SystemContext)
-  if (!user) {
-    return null
-  }
+
+  if (!user) return null
+
   return (
-    <QueryRenderer<RecentlyViewedQuery>
+    <QueryRenderer<RecentlyViewedV2Query>
       environment={relayEnvironment}
-      variables={{}}
       query={graphql`
-        query RecentlyViewedQuery {
+        query RecentlyViewedV2Query {
           me {
-            ...RecentlyViewed_me
+            ...RecentlyViewedV2_me
           }
         }
       `}
-      render={renderWithLoadProgress(RecentlyViewedFragmentContainer)}
+      render={({ error, props }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props) {
+          return <RecentlyViewedV2Placeholder />
+        }
+
+        return <RecentlyViewedV2FragmentContainer {...props} />
+      }}
     />
   )
 }

--- a/src/v2/Components/RecentlyViewed/RecentlyViewedV2Placeholder.tsx
+++ b/src/v2/Components/RecentlyViewed/RecentlyViewedV2Placeholder.tsx
@@ -1,0 +1,35 @@
+import { Separator, SkeletonBox, SkeletonText, Text } from "@artsy/palette"
+import React from "react"
+import { HEIGHT } from "./RecentlyViewedV2"
+import { Carousel } from "../Carousel"
+
+export const RecentlyViewedV2Placeholder: React.FC = () => {
+  return (
+    <>
+      <Separator my={6} />
+
+      <Text variant="subtitle" mb={3}>
+        Recently viewed
+      </Text>
+
+      <Carousel>
+        {[...new Array(10)].map((_, i) => {
+          return (
+            <React.Fragment key={i}>
+              <SkeletonBox
+                width={[200, 250, 333, 175, 222][i % 5]}
+                height={HEIGHT}
+                mb={1}
+              />
+
+              <SkeletonText variant="mediumText">Artist Name</SkeletonText>
+              <SkeletonText variant="text">Artwork Title</SkeletonText>
+              <SkeletonText variant="text">Partner Name</SkeletonText>
+              <SkeletonText variant="text">Price</SkeletonText>
+            </React.Fragment>
+          )
+        })}
+      </Carousel>
+    </>
+  )
+}

--- a/src/v2/Components/RecentlyViewed/index.tsx
+++ b/src/v2/Components/RecentlyViewed/index.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { useThemeConfig } from "@artsy/palette"
+import { RecentlyViewedV2QueryRenderer } from "./RecentlyViewedV2"
+import { RecentlyViewedQueryRenderer } from "./RecentlyViewed"
+import { useLazyLoadComponent } from "v2/Utils/Hooks/useLazyLoadComponent"
+import { RecentlyViewedV2Placeholder } from "./RecentlyViewedV2Placeholder"
+import { RecentlyViewedPlaceholder } from "./RecentlyViewedPlaceholder"
+import { useSystemContext } from "v2/Artsy"
+
+export const RecentlyViewed: React.FC = () => {
+  const { user } = useSystemContext()
+
+  const { Component, Placeholder } = useThemeConfig({
+    v2: {
+      Component: RecentlyViewedV2QueryRenderer,
+      Placeholder: RecentlyViewedV2Placeholder,
+    },
+    v3: {
+      Component: RecentlyViewedQueryRenderer,
+      Placeholder: RecentlyViewedPlaceholder,
+    },
+  })
+
+  const { isEnteredView, Waypoint } = useLazyLoadComponent({ threshold: 1000 })
+
+  if (!user) return null
+
+  return (
+    <>
+      <Waypoint />
+
+      {isEnteredView ? <Component /> : <Placeholder />}
+    </>
+  )
+}

--- a/src/v2/Components/__tests__/__snapshots__/Artwork.jest.tsx.snap
+++ b/src/v2/Components/__tests__/__snapshots__/Artwork.jest.tsx.snap
@@ -6,13 +6,6 @@ exports[`Artwork renders correctly 1`] = `
   margin-top: 4px;
 }
 
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
 .c5 {
   font-family: sans;
 }
@@ -23,7 +16,7 @@ exports[`Artwork renders correctly 1`] = `
   font-family: sans;
 }
 
-.c8 {
+.c7 {
   color: black60;
   color: black60;
   font-weight: normal;
@@ -154,21 +147,16 @@ exports[`Artwork renders correctly 1`] = `
         </div>
       </div>
       <div
-        className="c7"
-        display="flex"
+        className="c4"
       >
         <div
-          className="c4"
+          className="c7"
+          color="black60"
+          fontFamily="sans"
+          fontWeight="normal"
         >
-          <div
-            className="c8"
-            color="black60"
-            fontFamily="sans"
-            fontWeight="normal"
-          >
-            $875
-             
-          </div>
+          $875
+           
         </div>
       </div>
     </div>

--- a/src/v2/Utils/Hooks/useLazyLoadComponent.tsx
+++ b/src/v2/Utils/Hooks/useLazyLoadComponent.tsx
@@ -20,13 +20,22 @@ export const useLazyLoadComponent = ({
   const [isEnteredView, setIsEnteredView] = useState(false)
 
   const Waypoint = () => (
-    <LazyLoadComponent threshold={threshold} style={{ display: "inline" }}>
-      <Ready
-        onMount={() => {
-          setIsEnteredView(true)
-        }}
-      />
-    </LazyLoadComponent>
+    <>
+      {/*
+       * While although I have no reason to believe this client-side only check is necessary,
+       * it was wrapping every instance of this library, so it's been copied here.
+       * In the future we should replace this library with a simple intersection observer hook.
+       */}
+      {typeof window !== "undefined" && (
+        <LazyLoadComponent threshold={threshold} style={{ display: "inline" }}>
+          <Ready
+            onMount={() => {
+              setIsEnteredView(true)
+            }}
+          />
+        </LazyLoadComponent>
+      )}
+    </>
   )
 
   return { isEnteredView, Waypoint }

--- a/src/v2/__generated__/RecentlyViewedV2Query.graphql.ts
+++ b/src/v2/__generated__/RecentlyViewedV2Query.graphql.ts
@@ -3,23 +3,23 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type RecentlyViewedQueryVariables = {};
-export type RecentlyViewedQueryResponse = {
+export type RecentlyViewedV2QueryVariables = {};
+export type RecentlyViewedV2QueryResponse = {
     readonly me: {
-        readonly " $fragmentRefs": FragmentRefs<"RecentlyViewed_me">;
+        readonly " $fragmentRefs": FragmentRefs<"RecentlyViewedV2_me">;
     } | null;
 };
-export type RecentlyViewedQuery = {
-    readonly response: RecentlyViewedQueryResponse;
-    readonly variables: RecentlyViewedQueryVariables;
+export type RecentlyViewedV2Query = {
+    readonly response: RecentlyViewedV2QueryResponse;
+    readonly variables: RecentlyViewedV2QueryVariables;
 };
 
 
 
 /*
-query RecentlyViewedQuery {
+query RecentlyViewedV2Query {
   me {
-    ...RecentlyViewed_me
+    ...RecentlyViewedV2_me
     id
   }
 }
@@ -104,12 +104,21 @@ fragment Metadata_artwork on Artwork {
   href
 }
 
-fragment RecentlyViewed_me on Me {
+fragment RecentlyViewedV2_me on Me {
   recentlyViewedArtworksConnection(first: 20) {
     edges {
       node {
         id
-        ...ShelfArtwork_artwork
+        image {
+          url(version: "larger")
+          aspectRatio
+        }
+        imageTitle
+        title
+        href
+        ...Metadata_artwork
+        ...SaveButton_artwork
+        ...Badge_artwork
       }
     }
   }
@@ -121,25 +130,6 @@ fragment SaveButton_artwork on Artwork {
   slug
   is_saved: isSaved
   title
-}
-
-fragment ShelfArtwork_artwork on Artwork {
-  image {
-    resized(width: 200) {
-      src
-      srcSet
-      width
-      height
-    }
-    aspectRatio
-    height
-  }
-  imageTitle
-  title
-  href
-  ...Metadata_artwork
-  ...SaveButton_artwork
-  ...Badge_artwork
 }
 */
 
@@ -155,31 +145,24 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v3 = [
+v2 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = [
+v4 = [
   {
     "alias": null,
     "args": null,
@@ -193,7 +176,7 @@ return {
     "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "RecentlyViewedQuery",
+    "name": "RecentlyViewedV2Query",
     "selections": [
       {
         "alias": null,
@@ -206,7 +189,7 @@ return {
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "RecentlyViewed_me"
+            "name": "RecentlyViewedV2_me"
           }
         ],
         "storageKey": null
@@ -218,7 +201,7 @@ return {
   "operation": {
     "argumentDefinitions": [],
     "kind": "Operation",
-    "name": "RecentlyViewedQuery",
+    "name": "RecentlyViewedV2Query",
     "selections": [
       {
         "alias": null,
@@ -272,39 +255,13 @@ return {
                             "args": [
                               {
                                 "kind": "Literal",
-                                "name": "width",
-                                "value": 200
+                                "name": "version",
+                                "value": "larger"
                               }
                             ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "width",
-                                "storageKey": null
-                              },
-                              (v1/*: any*/)
-                            ],
-                            "storageKey": "resized(width:200)"
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:\"larger\")"
                           },
                           {
                             "alias": null,
@@ -312,8 +269,7 @@ return {
                             "kind": "ScalarField",
                             "name": "aspectRatio",
                             "storageKey": null
-                          },
-                          (v1/*: any*/)
+                          }
                         ],
                         "storageKey": null
                       },
@@ -331,7 +287,7 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v2/*: any*/),
+                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -355,15 +311,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v3/*: any*/),
+                        "args": (v2/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
                           (v0/*: any*/),
-                          (v2/*: any*/),
-                          (v4/*: any*/)
+                          (v1/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -376,14 +332,14 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v3/*: any*/),
+                        "args": (v2/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v2/*: any*/),
+                          (v3/*: any*/),
+                          (v1/*: any*/),
                           (v0/*: any*/),
                           {
                             "alias": null,
@@ -482,7 +438,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v5/*: any*/),
+                            "selections": (v4/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -492,7 +448,7 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v5/*: any*/),
+                            "selections": (v4/*: any*/),
                             "storageKey": null
                           },
                           (v0/*: any*/)
@@ -552,11 +508,11 @@ return {
   "params": {
     "id": null,
     "metadata": {},
-    "name": "RecentlyViewedQuery",
+    "name": "RecentlyViewedV2Query",
     "operationKind": "query",
-    "text": "query RecentlyViewedQuery {\n  me {\n    ...RecentlyViewed_me\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment RecentlyViewed_me on Me {\n  recentlyViewedArtworksConnection(first: 20) {\n    edges {\n      node {\n        id\n        ...ShelfArtwork_artwork\n      }\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+    "text": "query RecentlyViewedV2Query {\n  me {\n    ...RecentlyViewedV2_me\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment RecentlyViewedV2_me on Me {\n  recentlyViewedArtworksConnection(first: 20) {\n    edges {\n      node {\n        id\n        image {\n          url(version: \"larger\")\n          aspectRatio\n        }\n        imageTitle\n        title\n        href\n        ...Metadata_artwork\n        ...SaveButton_artwork\n        ...Badge_artwork\n      }\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();
-(node as any).hash = '7fd8678ce0ceade9e3f696b783d190df';
+(node as any).hash = '5fa60d1858fc413681e1e0aa38f9d31a';
 export default node;

--- a/src/v2/__generated__/RecentlyViewedV2_me.graphql.ts
+++ b/src/v2/__generated__/RecentlyViewedV2_me.graphql.ts
@@ -1,0 +1,155 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type RecentlyViewedV2_me = {
+    readonly recentlyViewedArtworksConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly id: string;
+                readonly image: {
+                    readonly url: string | null;
+                    readonly aspectRatio: number;
+                } | null;
+                readonly imageTitle: string | null;
+                readonly title: string | null;
+                readonly href: string | null;
+                readonly " $fragmentRefs": FragmentRefs<"Metadata_artwork" | "SaveButton_artwork" | "Badge_artwork">;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "RecentlyViewedV2_me";
+};
+export type RecentlyViewedV2_me$data = RecentlyViewedV2_me;
+export type RecentlyViewedV2_me$key = {
+    readonly " $data"?: RecentlyViewedV2_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"RecentlyViewedV2_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "RecentlyViewedV2_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 20
+        }
+      ],
+      "concreteType": "ArtworkConnection",
+      "kind": "LinkedField",
+      "name": "recentlyViewedArtworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArtworkEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "id",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Image",
+                  "kind": "LinkedField",
+                  "name": "image",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": [
+                        {
+                          "kind": "Literal",
+                          "name": "version",
+                          "value": "larger"
+                        }
+                      ],
+                      "kind": "ScalarField",
+                      "name": "url",
+                      "storageKey": "url(version:\"larger\")"
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "aspectRatio",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "imageTitle",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "title",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "href",
+                  "storageKey": null
+                },
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "Metadata_artwork"
+                },
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "SaveButton_artwork"
+                },
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "Badge_artwork"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "recentlyViewedArtworksConnection(first:20)"
+    }
+  ],
+  "type": "Me"
+};
+(node as any).hash = 'a4c716ef63b1780d43b571abdf51915b';
+export default node;

--- a/src/v2/__generated__/RecentlyViewed_me.graphql.ts
+++ b/src/v2/__generated__/RecentlyViewed_me.graphql.ts
@@ -8,14 +8,7 @@ export type RecentlyViewed_me = {
         readonly edges: ReadonlyArray<{
             readonly node: {
                 readonly id: string;
-                readonly image: {
-                    readonly url: string | null;
-                    readonly aspectRatio: number;
-                } | null;
-                readonly imageTitle: string | null;
-                readonly title: string | null;
-                readonly href: string | null;
-                readonly " $fragmentRefs": FragmentRefs<"Metadata_artwork" | "SaveButton_artwork" | "Badge_artwork">;
+                readonly " $fragmentRefs": FragmentRefs<"ShelfArtwork_artwork">;
             } | null;
         } | null> | null;
     } | null;
@@ -73,71 +66,9 @@ const node: ReaderFragment = {
                   "storageKey": null
                 },
                 {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "Image",
-                  "kind": "LinkedField",
-                  "name": "image",
-                  "plural": false,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": [
-                        {
-                          "kind": "Literal",
-                          "name": "version",
-                          "value": "larger"
-                        }
-                      ],
-                      "kind": "ScalarField",
-                      "name": "url",
-                      "storageKey": "url(version:\"larger\")"
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "aspectRatio",
-                      "storageKey": null
-                    }
-                  ],
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "imageTitle",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "title",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "href",
-                  "storageKey": null
-                },
-                {
                   "args": null,
                   "kind": "FragmentSpread",
-                  "name": "Metadata_artwork"
-                },
-                {
-                  "args": null,
-                  "kind": "FragmentSpread",
-                  "name": "SaveButton_artwork"
-                },
-                {
-                  "args": null,
-                  "kind": "FragmentSpread",
-                  "name": "Badge_artwork"
+                  "name": "ShelfArtwork_artwork"
                 }
               ],
               "storageKey": null
@@ -151,5 +82,5 @@ const node: ReaderFragment = {
   ],
   "type": "Me"
 };
-(node as any).hash = 'abeef15094294a706fc1c2aaad7c61a2';
+(node as any).hash = '54d03de051db4de38baaf24ffaca7866';
 export default node;


### PR DESCRIPTION
Closes: [DSWGW-58](https://artsyproduct.atlassian.net/browse/DSWGW-58)

Implements a V3 version of `RecentlyViewed` — also changes how we do the placeholder for these.

Previously we would have a weirdly placed loading spinner, then the component would pop in. Now there's an appropriately sized placeholder. One thing to note is that if you *haven't* recently viewed anything then you'll see the placeholder which will then pop _out_. Since we only show these to logged in users and a logged in viewer is pretty likely to have looked at at least one artwork, I figure that it's more appropriate to include the placeholder than not.

I also refactored the lazy-loading into the component itself since we lazy-load it in all cases that it appears.

![](https://static.damonzucconi.com/_capture/4gBnzCdw.png)