### PR TITLE
dont-merge: Refactor sign up

### DIFF
--- a/src/lib/middleware/sharifyLocals.ts
+++ b/src/lib/middleware/sharifyLocals.ts
@@ -60,6 +60,8 @@ export function sharifyLocalsMiddleware(
 
   updateSharify(res, "IS_GOOGLEBOT", Boolean(ua.match(/Googlebot/i)))
 
+  updateSharify(res, "IP_ADDRESS", req.ip)
+
   // Required to know the hashed dll name.try
   updateSharify(res, "ASSET_LEGACY_ARTWORK_DLL", assetLegacyArtworkDllName())
   updateSharify(

--- a/src/typings/sharify.d.ts
+++ b/src/typings/sharify.d.ts
@@ -39,6 +39,7 @@ declare module "sharify" {
       readonly IMAGE_LAZY_LOADING: boolean
       IS_GOOGLEBOT: boolean
       IS_MOBILE: boolean
+      IP_ADDRESS: string
       readonly METAPHYSICS_ENDPOINT: string
       readonly NODE_ENV: string
       readonly NOTIFICATION_COUNT: string

--- a/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
@@ -52,16 +52,16 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
         validationSchema={SignUpValidator}
       >
         {({
-          values,
           errors,
-          touched,
-          handleChange: formikHandleChange,
           handleBlur,
+          handleChange: formikHandleChange,
           handleSubmit,
           isSubmitting,
-          status,
           setStatus,
           setTouched,
+          status,
+          touched,
+          values,
         }: FormikProps<InputValues>) => {
           const handleChange = e => {
             setStatus(null)

--- a/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
@@ -119,8 +119,6 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
                 name="accepted_terms_of_service"
                 onBlur={handleBlur}
                 onChange={handleChange}
-                type="checkbox"
-                value={values.accepted_terms_of_service}
               />
               <EmailSubscriptionCheckbox
                 checked={values.agreed_to_receive_emails}

--- a/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
@@ -70,12 +70,18 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
             formikHandleChange(e)
           }
 
+          const emailErrorMessage = touched.email ? errors.email : ""
+          const passwordErrorMessage = touched.password ? errors.password : ""
+          const nameErrorMessage = touched.name ? errors.name : ""
+          const termsErrorMessage = touched.accepted_terms_of_service
+            ? errors.accepted_terms_of_service
+            : ""
+
           return (
             <Form onSubmit={handleSubmit} data-test="SignUpForm">
               <QuickInput
                 block
-                // @ts-expect-error STRICT_NULL_CHECK
-                error={touched.email && errors.email}
+                error={emailErrorMessage}
                 placeholder="Enter your email address"
                 name="email"
                 label="Email"
@@ -87,8 +93,7 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
               />
               <PasswordInput
                 block
-                // @ts-expect-error STRICT_NULL_CHECK
-                error={touched.password && errors.password}
+                error={passwordErrorMessage}
                 placeholder="Enter a password"
                 name="password"
                 label="Password"
@@ -99,8 +104,7 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
               />
               <QuickInput
                 block
-                // @ts-expect-error STRICT_NULL_CHECK
-                error={touched.name && errors.name}
+                error={nameErrorMessage}
                 placeholder="Enter your full name"
                 name="name"
                 label="Name"
@@ -110,10 +114,7 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
                 onBlur={handleBlur}
               />
               <TermsOfServiceCheckbox
-                error={
-                  touched.accepted_terms_of_service &&
-                  errors.accepted_terms_of_service
-                }
+                error={termsErrorMessage}
                 checked={values.accepted_terms_of_service}
                 value={values.accepted_terms_of_service}
                 type="checkbox"

--- a/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
@@ -39,13 +39,15 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
   }
 
   render() {
+    const initialValues = {
+      accepted_terms_of_service: false,
+      agreed_to_receive_emails: false,
+      ...this.props.values,
+    }
+
     return (
       <Formik
-        initialValues={{
-          accepted_terms_of_service: false,
-          agreed_to_receive_emails: false,
-          ...this.props.values,
-        }}
+        initialValues={initialValues}
         onSubmit={this.onSubmit}
         validationSchema={SignUpValidator}
       >

--- a/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
@@ -80,55 +80,55 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
           return (
             <Form onSubmit={handleSubmit} data-test="SignUpForm">
               <QuickInput
+                autoFocus
                 block
                 error={emailErrorMessage}
-                placeholder="Enter your email address"
-                name="email"
                 label="Email"
+                name="email"
+                onBlur={handleBlur}
+                onChange={handleChange}
+                placeholder="Enter your email address"
                 type="email"
                 value={values.email}
-                onChange={handleChange}
-                onBlur={handleBlur}
-                autoFocus
               />
               <PasswordInput
                 block
                 error={passwordErrorMessage}
-                placeholder="Enter a password"
-                name="password"
                 label="Password"
-                value={values.password}
-                onChange={handleChange}
+                name="password"
                 onBlur={handleBlur}
+                onChange={handleChange}
+                placeholder="Enter a password"
                 showPasswordMessage
+                value={values.password}
               />
               <QuickInput
                 block
                 error={nameErrorMessage}
-                placeholder="Enter your full name"
-                name="name"
                 label="Name"
+                name="name"
+                onBlur={handleBlur}
+                onChange={handleChange}
+                placeholder="Enter your full name"
                 type="text"
                 value={values.name}
-                onChange={handleChange}
-                onBlur={handleBlur}
               />
               <TermsOfServiceCheckbox
-                error={termsErrorMessage}
                 checked={values.accepted_terms_of_service}
-                value={values.accepted_terms_of_service}
-                type="checkbox"
+                error={termsErrorMessage}
                 name="accepted_terms_of_service"
-                onChange={handleChange}
                 onBlur={handleBlur}
+                onChange={handleChange}
+                type="checkbox"
+                value={values.accepted_terms_of_service}
               />
               <EmailSubscriptionCheckbox
                 checked={values.agreed_to_receive_emails}
-                value={values.agreed_to_receive_emails}
-                type="checkbox"
                 name="agreed_to_receive_emails"
-                onChange={handleChange}
                 onBlur={handleBlur}
+                onChange={handleChange}
+                type="checkbox"
+                value={values.agreed_to_receive_emails}
               />
               {status && !status.success && <Error show>{status.error}</Error>}
               <SubmitButton loading={isSubmitting}>Sign up</SubmitButton>

--- a/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
@@ -20,7 +20,7 @@ import QuickInput from "v2/Components/QuickInput"
 import { Formik, FormikProps } from "formik"
 import React, { Component } from "react"
 import { recaptcha } from "v2/Utils/recaptcha"
-
+import { data as sd } from "sharify"
 import { SignUpForm_requestLocation } from "v2/__generated__/SignUpForm_requestLocation.graphql"
 
 const gdprCountries = [
@@ -222,12 +222,7 @@ const SignUpFormFragmentContainer = createFragmentContainer(SignUpForm, {
 
 export const SignUpFormQueryRenderer: React.FC<FormProps> = passedProps => {
   const { relayEnvironment } = useSystemContext()
-
-  // ultimately this will come in from express
-  // US ip address:
-  const variables = { ip: "162.211.217.130" }
-  // GDPR ip address:
-  // const variables = { ip: "213.142.96.69" }
+  const variables = { ip: sd.IP_ADDRESS }
 
   return (
     <QueryRenderer<SignUpFormLocationQuery>

--- a/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
@@ -125,8 +125,6 @@ export class SignUpForm extends Component<FormProps, SignUpFormState> {
                 name="agreed_to_receive_emails"
                 onBlur={handleBlur}
                 onChange={handleChange}
-                type="checkbox"
-                value={values.agreed_to_receive_emails}
               />
               {status && !status.success && <Error show>{status.error}</Error>}
               <SubmitButton loading={isSubmitting}>Sign up</SubmitButton>

--- a/src/v2/Components/Authentication/EmailSubscriptionCheckbox.tsx
+++ b/src/v2/Components/Authentication/EmailSubscriptionCheckbox.tsx
@@ -3,20 +3,21 @@ import Checkbox from "v2/Components/Checkbox"
 import React from "react"
 import styled from "styled-components"
 
-export const EmailSubscriptionCheckbox = ({
-  name,
-  onChange,
-  onBlur,
-  value,
-  ...props
-}) => {
-  const color = "black60"
+interface EmailSubscriptionCheckboxProps {
+  checked
+  name
+  onBlur
+  onChange
+}
+
+export const EmailSubscriptionCheckbox: React.FC<EmailSubscriptionCheckboxProps> = props => {
+  const labelText =
+    "Dive deeper into the art market with Artsy emails. Subscribe to hear about our products, services, editorials, and other promotional content. Unsubscribe at any time."
+
   return (
-    <StyledCheckbox {...{ checked: value, onChange, onBlur, name }}>
-      <Serif color={color} size="3t" ml={0.5}>
-        {
-          "Dive deeper into the art market with Artsy emails. Subscribe to hear about our products, services, editorials, and other promotional content. Unsubscribe at any time."
-        }
+    <StyledCheckbox {...props}>
+      <Serif color="black60" size="3t" ml={0.5}>
+        {labelText}
       </Serif>
     </StyledCheckbox>
   )

--- a/src/v2/Components/Authentication/FormSwitcher.tsx
+++ b/src/v2/Components/Authentication/FormSwitcher.tsx
@@ -8,7 +8,7 @@ import Events from "v2/Utils/Events"
 import { SystemContextProvider } from "v2/Artsy"
 import { ForgotPasswordForm } from "v2/Components/Authentication/Desktop/ForgotPasswordForm"
 import { LoginForm } from "v2/Components/Authentication/Desktop/LoginForm"
-import { SignUpForm } from "v2/Components/Authentication/Desktop/SignUpForm"
+import { SignUpFormQueryRenderer } from "v2/Components/Authentication/Desktop/SignUpForm"
 import {
   AfterSignUpAction,
   FormComponentType,
@@ -176,7 +176,7 @@ export class FormSwitcher extends React.Component<FormSwitcherProps, State> {
         Form = LoginForm
         break
       case ModalType.signup:
-        Form = SignUpForm
+        Form = SignUpFormQueryRenderer
         break
       case ModalType.forgot:
         Form = ForgotPasswordForm

--- a/src/v2/Components/Authentication/TermsOfServiceCheckbox.tsx
+++ b/src/v2/Components/Authentication/TermsOfServiceCheckbox.tsx
@@ -3,17 +3,19 @@ import Checkbox from "v2/Components/Checkbox"
 import React from "react"
 import styled from "styled-components"
 
-export const TermsOfServiceCheckbox = ({
-  error,
-  name,
-  onChange,
-  onBlur,
-  value,
-  ...props
-}) => {
-  const color = error && !value ? "red100" : "black60"
+interface TermsOfServiceCheckboxProps {
+  checked
+  error
+  name
+  onBlur
+  onChange
+}
+
+export const TermsOfServiceCheckbox: React.FC<TermsOfServiceCheckboxProps> = props => {
+  const color = props.error ? "red100" : "black60"
+
   return (
-    <StyledCheckbox {...{ checked: value, error, onChange, onBlur, name }}>
+    <StyledCheckbox {...props}>
       <Serif color={color} size="3t" ml={0.5}>
         {"By checking this box, you consent to our "}
         <Link

--- a/src/v2/Components/Authentication/TermsOfServiceCheckbox.tsx
+++ b/src/v2/Components/Authentication/TermsOfServiceCheckbox.tsx
@@ -13,6 +13,76 @@ interface TermsOfServiceCheckboxProps {
   setFieldValue
 }
 
+const GdprLabel = color => {
+  return (
+    <>
+      {"By checking this box, you consent to our "}
+      <Link
+        href="https://www.artsy.net/terms"
+        target="_blank"
+        color={color}
+        underlineBehavior="hover"
+      >
+        Terms of Use
+      </Link>
+      {", "}
+      <Link
+        href="https://www.artsy.net/privacy"
+        target="_blank"
+        color={color}
+        underlineBehavior="hover"
+      >
+        Privacy Policy
+      </Link>
+      {", and "}
+      <Link
+        href="https://www.artsy.net/conditions-of-sale"
+        target="_blank"
+        color={color}
+        underlineBehavior="hover"
+      >
+        Conditions of Sale
+      </Link>
+      {"."}
+    </>
+  )
+}
+
+const FallbackLabel = color => {
+  return (
+    <>
+      {"I agree to the "}
+      <Link
+        href="https://www.artsy.net/terms"
+        target="_blank"
+        color={color}
+        underlineBehavior="hover"
+      >
+        Terms of Use
+      </Link>
+      {", "}
+      <Link
+        href="https://www.artsy.net/privacy"
+        target="_blank"
+        color={color}
+        underlineBehavior="hover"
+      >
+        Privacy Policy
+      </Link>
+      {", and "}
+      <Link
+        href="https://www.artsy.net/conditions-of-sale"
+        target="_blank"
+        color={color}
+        underlineBehavior="hover"
+      >
+        Conditions of Sale
+      </Link>
+      {"and to receiving emails from Artsy."}
+    </>
+  )
+}
+
 export const TermsOfServiceCheckbox: React.FC<TermsOfServiceCheckboxProps> = props => {
   const { error, onChange, setEmailSubscribe, setFieldValue } = props
 
@@ -27,37 +97,12 @@ export const TermsOfServiceCheckbox: React.FC<TermsOfServiceCheckboxProps> = pro
     onChange(event)
   }
 
+  const Label = setEmailSubscribe ? FallbackLabel : GdprLabel
+
   return (
     <StyledCheckbox {...props} onChange={handleChange}>
       <Serif color={color} size="3t" ml={0.5}>
-        {"By checking this box, you consent to our "}
-        <Link
-          href="https://www.artsy.net/terms"
-          target="_blank"
-          color={color}
-          underlineBehavior="hover"
-        >
-          Terms of Use
-        </Link>
-        {", "}
-        <Link
-          href="https://www.artsy.net/privacy"
-          target="_blank"
-          color={color}
-          underlineBehavior="hover"
-        >
-          Privacy Policy
-        </Link>
-        {", and "}
-        <Link
-          href="https://www.artsy.net/conditions-of-sale"
-          target="_blanks"
-          color={color}
-          underlineBehavior="hover"
-        >
-          Conditions of Sale
-        </Link>
-        {"."}
+        <Label color={color} />
       </Serif>
     </StyledCheckbox>
   )

--- a/src/v2/Components/Authentication/TermsOfServiceCheckbox.tsx
+++ b/src/v2/Components/Authentication/TermsOfServiceCheckbox.tsx
@@ -9,13 +9,26 @@ interface TermsOfServiceCheckboxProps {
   name
   onBlur
   onChange
+  setEmailSubscribe
+  setFieldValue
 }
 
 export const TermsOfServiceCheckbox: React.FC<TermsOfServiceCheckboxProps> = props => {
-  const color = props.error ? "red100" : "black60"
+  const { error, onChange, setEmailSubscribe, setFieldValue } = props
+
+  const color = error ? "red100" : "black60"
+
+  const handleChange = event => {
+    if (setEmailSubscribe) {
+      const checked = event.currentTarget.checked
+      setFieldValue("agreed_to_receive_emails", checked)
+    }
+
+    onChange(event)
+  }
 
   return (
-    <StyledCheckbox {...props}>
+    <StyledCheckbox {...props} onChange={handleChange}>
       <Serif color={color} size="3t" ml={0.5}>
         {"By checking this box, you consent to our "}
         <Link

--- a/src/v2/Components/Authentication/__tests__/Desktop/SignUpForm.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/Desktop/SignUpForm.jest.tsx
@@ -1,204 +1,229 @@
-import { Link } from "@artsy/palette"
-import { SignUpForm } from "v2/Components/Authentication/Desktop/SignUpForm"
-import { mount } from "enzyme"
-import { Formik } from "formik"
 import React from "react"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { graphql } from "react-relay"
+import { tests } from "v2/Components/Authentication/Desktop/SignUpForm"
 import { SignupValues } from "../fixtures"
+import { ContextModule, Intent } from "@artsy/cohesion"
 
-const mockEnableRequestSignInWithApple = jest.fn()
+jest.unmock("react-relay")
 
 jest.mock("sharify", () => ({
   data: {
     RECAPTCHA_KEY: "recaptcha-api-key",
-    get ENABLE_SIGN_IN_WITH_APPLE() {
-      return mockEnableRequestSignInWithApple()
-    },
+    ENABLE_SIGN_IN_WITH_APPLE: true,
   },
 }))
 
-// FIXME: mock Formik async and remove setTimeout
 describe("SignUpForm", () => {
-  let props
+  let passedProps
+
+  const { getWrapper } = setupTestWrapper({
+    Component: (props: any) => {
+      return (
+        <tests.SignUpFormFragmentContainer
+          requestLocation={props.requestLocation}
+          {...passedProps}
+        />
+      )
+    },
+    query: graphql`
+      query SignUpFormLocation_tests_Query($ip: String!) {
+        requestLocation(ip: $ip) {
+          ...SignUpForm_requestLocation
+        }
+      }
+    `,
+  })
 
   beforeEach(() => {
-    props = {
+    jest.clearAllMocks()
+
+    passedProps = {
+      contextModule: ContextModule.consignSubmissionFlow,
       handleSubmit: jest.fn(),
-      onFacebookLogin: jest.fn(),
+      intent: Intent.consign,
       onAppleLogin: jest.fn(),
+      onFacebookLogin: jest.fn(),
+      showRecaptchaDisclaimer: false,
+      values: SignupValues,
     }
-    window.grecaptcha.execute.mockClear()
   })
 
-  const getWrapper = (passedProps = props) => {
-    return mount(<SignUpForm {...passedProps} />)
-  }
-
-  describe("onSubmit", () => {
-    it("calls handleSubmit with expected params", done => {
-      props.values = SignupValues
+  describe("general stuff", () => {
+    it("renders errors", done => {
+      passedProps.values.email = ""
       const wrapper = getWrapper()
-      const formik = wrapper.find("Formik")
-      formik.simulate("submit")
+      const button = wrapper.find(`input[name="email"]`)
+      button.simulate("blur")
 
       setTimeout(() => {
-        expect(props.handleSubmit).toBeCalledWith(
-          {
-            email: "foo@bar.com",
-            password: "password123",
-            name: "John Doe",
-            accepted_terms_of_service: true,
-            agreed_to_receive_emails: false,
-            recaptcha_token: "recaptcha-token",
-          },
-          expect.anything()
-        )
+        expect(wrapper.html()).toMatch("Please enter a valid email.")
         done()
       })
     })
 
-    it("sends email subscription agreement", done => {
-      props.values = SignupValues
+    it("clears error after input change", done => {
+      passedProps.error = "Some global server error"
       const wrapper = getWrapper()
-      const checkbox = wrapper.find("EmailSubscriptionCheckbox")
-      checkbox.simulate("click")
-      const formik = wrapper.find("Formik")
-      formik.simulate("submit")
+      const input = wrapper.find(`input[name="email"]`)
+      expect((wrapper.state() as any).error).toEqual("Some global server error")
+      input.simulate("change")
+      wrapper.update()
 
       setTimeout(() => {
-        expect(props.handleSubmit).toBeCalledWith(
-          {
-            email: "foo@bar.com",
-            password: "password123",
-            name: "John Doe",
-            accepted_terms_of_service: true,
-            agreed_to_receive_emails: false,
-            recaptcha_token: "recaptcha-token",
-          },
-          expect.anything()
-        )
-        done()
-      })
-    })
-
-    it("fires reCAPTCHA event", done => {
-      props.values = SignupValues
-      const wrapper = getWrapper()
-      const formik = wrapper.find("Formik")
-      formik.simulate("submit")
-
-      setTimeout(() => {
-        expect(window.grecaptcha.execute).toBeCalledWith("recaptcha-api-key", {
-          action: "signup_submit",
-        })
+        expect((wrapper.state() as any).error).toEqual(null)
         done()
       })
     })
   })
 
-  it("renders captcha disclaimer if showRecaptchaDisclaimer", () => {
-    props.showRecaptchaDisclaimer = true
-    const wrapper = getWrapper()
-    expect(wrapper.text()).toMatch(
-      "This site is protected by reCAPTCHA and the Google Privacy Policy Terms of Service apply."
-    )
-  })
+  describe("with a GDPR country code", () => {
+    const countryCode = "GB"
 
-  it("renders errors", done => {
-    const wrapper = getWrapper()
-    const button = wrapper.find(`input[name="email"]`)
-    button.simulate("blur")
-    wrapper.update()
+    it("uses the GDPR label and shows the email checkbox", () => {
+      const wrapper = getWrapper({
+        RequestLocation: () => ({ countryCode }),
+      })
 
-    setTimeout(() => {
-      expect(wrapper.html()).toMatch("Please enter a valid email.")
-      done()
+      expect(wrapper.find("GdprLabel")).toHaveLength(1)
+      expect(wrapper.find("EmailSubscriptionCheckbox")).toHaveLength(1)
+    })
+
+    it("leaves email flag alone when accepting terms", done => {
+      passedProps.values.accepted_terms_of_service = false
+      passedProps.values.agreed_to_receive_emails = false
+
+      const wrapper = getWrapper({
+        RequestLocation: () => ({ countryCode }),
+      })
+
+      const termsInput = wrapper.find("input[name='accepted_terms_of_service']")
+      termsInput.simulate("change", { currentTarget: { checked: true } })
+      const formik = wrapper.find("Formik")
+      formik.simulate("submit")
+
+      setTimeout(() => {
+        const calls = passedProps.handleSubmit.mock.calls
+        const {
+          accepted_terms_of_service,
+          agreed_to_receive_emails,
+        } = calls[0][0]
+
+        expect(accepted_terms_of_service).toEqual(true)
+        expect(agreed_to_receive_emails).toEqual(false)
+
+        done()
+      })
     })
   })
 
-  it("clears error after input change", done => {
-    props.error = "Some global server error"
-    const wrapper = getWrapper()
-    const input = wrapper.find(`input[name="email"]`)
-    expect((wrapper.state() as any).error).toEqual("Some global server error")
-    input.simulate("change")
-    wrapper.update()
+  describe("with a non-GDPR country code", () => {
+    const countryCode = "US"
 
-    setTimeout(() => {
-      expect((wrapper.state() as any).error).toEqual(null)
-      done()
+    it("uses the fallback label and hides the email checkbox", () => {
+      const wrapper = getWrapper({
+        RequestLocation: () => ({ countryCode }),
+      })
+
+      expect(wrapper.find("FallbackLabel")).toHaveLength(1)
+      expect(wrapper.find("EmailSubscriptionCheckbox")).toHaveLength(0)
+    })
+
+    it("sets email flag along with terms flag", done => {
+      passedProps.values.accepted_terms_of_service = false
+      passedProps.values.agreed_to_receive_emails = false
+
+      const wrapper = getWrapper({
+        RequestLocation: () => ({ countryCode }),
+      })
+
+      const termsInput = wrapper.find("input[name='accepted_terms_of_service']")
+      termsInput.simulate("change", { currentTarget: { checked: true } })
+      const formik = wrapper.find("Formik")
+      formik.simulate("submit")
+
+      setTimeout(() => {
+        const calls = passedProps.handleSubmit.mock.calls
+        const {
+          accepted_terms_of_service,
+          agreed_to_receive_emails,
+        } = calls[0][0]
+
+        expect(accepted_terms_of_service).toEqual(true)
+        expect(agreed_to_receive_emails).toEqual(true)
+
+        done()
+      })
     })
   })
 
-  it("renders spinner", done => {
-    props.values = SignupValues
-    const wrapper = getWrapper()
-    const input = wrapper.find(Formik)
+  describe("recaptcha", () => {
+    it("displays recaptcha warning", () => {
+      passedProps.showRecaptchaDisclaimer = true
+      const wrapper = getWrapper()
+      const warning =
+        "This site is protected by reCAPTCHA and the Google Privacy Policy Terms of Service apply."
 
-    input.simulate("submit")
-    wrapper.update()
+      expect(wrapper.text()).toMatch(warning)
+    })
 
-    setTimeout(() => {
-      const submitButton = wrapper.find(`SubmitButton`)
-      expect((submitButton.props() as any).loading).toEqual(true)
-      done()
+    it("mixes in the recaptcha token", done => {
+      const wrapper = getWrapper()
+      const formik = wrapper.find("Formik")
+      formik.simulate("submit")
+
+      setTimeout(() => {
+        const calls = passedProps.handleSubmit.mock.calls
+        const { recaptcha_token } = calls[0][0]
+
+        expect(recaptcha_token).toEqual("recaptcha-token")
+
+        done()
+      })
     })
   })
 
-  it("calls apple callback on tapping link", done => {
-    mockEnableRequestSignInWithApple.mockReturnValue(true)
-    props.values = SignupValues
-    const wrapper = getWrapper()
-    wrapper.find(Link).at(3).simulate("click")
+  describe("signup with Apple", () => {
+    it("calls apple callback on tapping link", done => {
+      passedProps.values.accepted_terms_of_service = true
+      const wrapper = getWrapper()
 
-    setTimeout(() => {
-      expect(props.onAppleLogin).toBeCalled()
-      done()
+      const appleLink = wrapper.find("Link").at(3)
+      expect(appleLink.text()).toEqual("Apple")
+      appleLink.simulate("click")
+
+      setTimeout(() => {
+        expect(passedProps.onAppleLogin).toHaveBeenCalled()
+        done()
+      })
     })
-  })
 
-  it("renders apple link with feature flag enabled", done => {
-    mockEnableRequestSignInWithApple.mockReturnValue(true)
-    props.onAppleLogin = jest.fn()
-    props.values = SignupValues
-    const wrapper = getWrapper()
-    expect(wrapper.text()).toContain("Apple")
-    done()
-  })
+    it("does not call apple callback without accepting terms", done => {
+      passedProps.values.accepted_terms_of_service = false
+      const wrapper = getWrapper()
 
-  it("does not render apple link with feature flag disabled", done => {
-    mockEnableRequestSignInWithApple.mockReturnValue(false)
-    props.onAppleLogin = jest.fn()
-    props.values = SignupValues
-    const wrapper = getWrapper()
-    expect(wrapper.text()).not.toContain("Apple")
-    done()
-  })
+      const appleLink = wrapper.find("Link").at(3)
+      expect(appleLink.text()).toEqual("Apple")
+      appleLink.simulate("click")
 
-  it("does not call apple callback without accepting terms of service", done => {
-    props.onAppleLogin = jest.fn()
-    props.values = SignupValues
-    props.values.accepted_terms_of_service = false
-    const wrapper = getWrapper()
-
-    wrapper.find(Link).at(1).simulate("click")
-
-    wrapper.update()
-
-    setTimeout(() => {
-      expect(props.onAppleLogin).not.toBeCalled()
-      done()
+      setTimeout(() => {
+        expect(passedProps.onAppleLogin).not.toHaveBeenCalled()
+        done()
+      })
     })
-  })
 
-  it("does not render email errors for social sign ups", done => {
-    const wrapper = getWrapper()
-    const socialLink = wrapper.find("Link").at(1)
-    socialLink.simulate("click")
-    wrapper.update()
+    it("does not render email errors for social sign ups", done => {
+      passedProps.values.accepted_terms_of_service = false
+      const wrapper = getWrapper()
 
-    setTimeout(() => {
-      expect(wrapper.html()).not.toMatch("Please enter a valid email.")
-      done()
+      const appleLink = wrapper.find("Link").at(3)
+      expect(appleLink.text()).toEqual("Apple")
+      appleLink.simulate("click")
+
+      setTimeout(() => {
+        expect(wrapper.html()).not.toMatch("Please enter a valid email.")
+        done()
+      })
     })
   })
 })

--- a/src/v2/__generated__/SignUpFormLocationQuery.graphql.ts
+++ b/src/v2/__generated__/SignUpFormLocationQuery.graphql.ts
@@ -1,0 +1,113 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SignUpFormLocationQueryVariables = {
+    ip: string;
+};
+export type SignUpFormLocationQueryResponse = {
+    readonly requestLocation: {
+        readonly " $fragmentRefs": FragmentRefs<"SignUpForm_requestLocation">;
+    } | null;
+};
+export type SignUpFormLocationQuery = {
+    readonly response: SignUpFormLocationQueryResponse;
+    readonly variables: SignUpFormLocationQueryVariables;
+};
+
+
+
+/*
+query SignUpFormLocationQuery(
+  $ip: String!
+) {
+  requestLocation(ip: $ip) {
+    ...SignUpForm_requestLocation
+  }
+}
+
+fragment SignUpForm_requestLocation on RequestLocation {
+  countryCode
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "ip",
+    "type": "String!"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "ip",
+    "variableName": "ip"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SignUpFormLocationQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "RequestLocation",
+        "kind": "LinkedField",
+        "name": "requestLocation",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SignUpForm_requestLocation"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SignUpFormLocationQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "RequestLocation",
+        "kind": "LinkedField",
+        "name": "requestLocation",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "countryCode",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "SignUpFormLocationQuery",
+    "operationKind": "query",
+    "text": "query SignUpFormLocationQuery(\n  $ip: String!\n) {\n  requestLocation(ip: $ip) {\n    ...SignUpForm_requestLocation\n  }\n}\n\nfragment SignUpForm_requestLocation on RequestLocation {\n  countryCode\n}\n"
+  }
+};
+})();
+(node as any).hash = 'f9d14ff83281a0d051c035554d6ea348';
+export default node;

--- a/src/v2/__generated__/SignUpFormLocation_tests_Query.graphql.ts
+++ b/src/v2/__generated__/SignUpFormLocation_tests_Query.graphql.ts
@@ -1,0 +1,113 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SignUpFormLocation_tests_QueryVariables = {
+    ip: string;
+};
+export type SignUpFormLocation_tests_QueryResponse = {
+    readonly requestLocation: {
+        readonly " $fragmentRefs": FragmentRefs<"SignUpForm_requestLocation">;
+    } | null;
+};
+export type SignUpFormLocation_tests_Query = {
+    readonly response: SignUpFormLocation_tests_QueryResponse;
+    readonly variables: SignUpFormLocation_tests_QueryVariables;
+};
+
+
+
+/*
+query SignUpFormLocation_tests_Query(
+  $ip: String!
+) {
+  requestLocation(ip: $ip) {
+    ...SignUpForm_requestLocation
+  }
+}
+
+fragment SignUpForm_requestLocation on RequestLocation {
+  countryCode
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "ip",
+    "type": "String!"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "ip",
+    "variableName": "ip"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SignUpFormLocation_tests_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "RequestLocation",
+        "kind": "LinkedField",
+        "name": "requestLocation",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SignUpForm_requestLocation"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SignUpFormLocation_tests_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "RequestLocation",
+        "kind": "LinkedField",
+        "name": "requestLocation",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "countryCode",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "SignUpFormLocation_tests_Query",
+    "operationKind": "query",
+    "text": "query SignUpFormLocation_tests_Query(\n  $ip: String!\n) {\n  requestLocation(ip: $ip) {\n    ...SignUpForm_requestLocation\n  }\n}\n\nfragment SignUpForm_requestLocation on RequestLocation {\n  countryCode\n}\n"
+  }
+};
+})();
+(node as any).hash = '2153ee92824b55469cfa43e08e1ccfbd';
+export default node;

--- a/src/v2/__generated__/SignUpForm_requestLocation.graphql.ts
+++ b/src/v2/__generated__/SignUpForm_requestLocation.graphql.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SignUpForm_requestLocation = {
+    readonly countryCode: string | null;
+    readonly " $refType": "SignUpForm_requestLocation";
+};
+export type SignUpForm_requestLocation$data = SignUpForm_requestLocation;
+export type SignUpForm_requestLocation$key = {
+    readonly " $data"?: SignUpForm_requestLocation$data;
+    readonly " $fragmentRefs": FragmentRefs<"SignUpForm_requestLocation">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SignUpForm_requestLocation",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "countryCode",
+      "storageKey": null
+    }
+  ],
+  "type": "RequestLocation"
+};
+(node as any).hash = '4e59fe8d3150617db26d33de4fac3bbe';
+export default node;


### PR DESCRIPTION
The purpose of this PR is to demonstrate how we could use Formik to conditionally set email preferences via the terms checkbox. There's some refactoring here that's coincidental so the important bits are:

* create a boolean called `collapseCheckboxes` that decides if we should collapse the checkboxes (I spoofed this!)
* suppress rendering `EmailSubscriptionCheckbox` with that boolean
* send that boolean to the `TermsOfServiceCheckbox` along with [`setFieldValue`][sfv] from Formik
* inside `TermsOfServiceCheckbox` intercept change events and use `setFieldValue` to imperatively update `agreed_to_receive_emails`

@The-Beez-Kneez next steps would be to blend these changes with the work we did with @damassi yesterday - happy to work together on this!

[sfv]: https://formik.org/docs/api/formik#setfieldvalue-field-string-value-any-shouldvalidate-boolean--void