### PR TITLE
fix(PX-4101): hide dots for if only one show visible

### DIFF
--- a/src/v2/Apps/Partner/Components/Overview/ShowBannersRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/ShowBannersRail.tsx
@@ -123,11 +123,13 @@ const ShowBannersRail: React.FC<ShowBannersRailProps> = ({
           )
         })}
       </ShowBannersRailContainer>
-      <ProgressDots
-        mt={[2, 6]}
-        activeIndex={currentCarouselPage}
-        amount={shows.length}
-      />
+      {shows.length > 1 && (
+        <ProgressDots
+          mt={[2, 6]}
+          activeIndex={currentCarouselPage}
+          amount={shows.length}
+        />
+      )}
     </Box>
   )
 }


### PR DESCRIPTION
This PR fixes showing progress dots for the partners with the only one available show.

JIRA - https://artsyproduct.atlassian.net/browse/PX-4101

Before
![image](https://user-images.githubusercontent.com/79979820/118789853-de118b00-b89d-11eb-88aa-f9be313b6ec8.png)

Now
![image](https://user-images.githubusercontent.com/79979820/118789748-c1755300-b89d-11eb-802e-9c9da83bc881.png)