### PR TITLE
Added A-Z letters to artists nav bar on hover

### DIFF
--- a/src/v2/Apps/Artists/Components/ArtistsLetterNav.tsx
+++ b/src/v2/Apps/Artists/Components/ArtistsLetterNav.tsx
@@ -6,17 +6,13 @@ import { RouterLink, RouterLinkProps } from "v2/Artsy/Router/RouterLink"
 
 export const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("")
 
-interface ArtistsLetterNavProps extends BoxProps {
-  inDropDown?: boolean
-}
+interface ArtistsLetterNavProps extends BoxProps {}
 
 export const ArtistsLetterNav: React.FC<ArtistsLetterNavProps> = ({
-  inDropDown = false,
   ...rest
 }) => {
-  const justifyContent = inDropDown ? "flex-start" : ["flex-start", "flex-end"]
   return (
-    <Flex flexWrap="wrap" justifyContent={justifyContent}>
+    <Flex flexWrap="wrap" justifyContent={["flex-start", "flex-end"]} {...rest}>
       {LETTERS.map((letter, i) => {
         return (
           <Text key={letter} variant="md" color="black60">

--- a/src/v2/Apps/Artists/Components/ArtistsLetterNav.tsx
+++ b/src/v2/Apps/Artists/Components/ArtistsLetterNav.tsx
@@ -42,6 +42,7 @@ const Letter = styled(RouterLink)<RouterLinkProps>`
   text-align: center;
   text-decoration: none;
   transition: color 250ms;
+  color: ${themeGet("colors.black60")};
 
   &:hover {
     text-decoration: underline;

--- a/src/v2/Apps/Artists/Components/ArtistsLetterNav.tsx
+++ b/src/v2/Apps/Artists/Components/ArtistsLetterNav.tsx
@@ -6,13 +6,17 @@ import { RouterLink, RouterLinkProps } from "v2/Artsy/Router/RouterLink"
 
 export const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("")
 
-interface ArtistsLetterNavProps extends BoxProps {}
+interface ArtistsLetterNavProps extends BoxProps {
+  inDropDown?: boolean
+}
 
 export const ArtistsLetterNav: React.FC<ArtistsLetterNavProps> = ({
+  inDropDown = false,
   ...rest
 }) => {
+  const justifyContent = inDropDown ? "flex-start" : ["flex-start", "flex-end"]
   return (
-    <Flex flexWrap="wrap" justifyContent={["flex-start", "flex-end"]}>
+    <Flex flexWrap="wrap" justifyContent={justifyContent}>
       {LETTERS.map((letter, i) => {
         return (
           <Text key={letter} variant="md" color="black60">

--- a/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownMenu.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, color, breakpoints } from "@artsy/palette"
+import { Box, Flex, color, breakpoints, Text } from "@artsy/palette"
 import { AnalyticsSchema, ContextModule } from "v2/Artsy"
 import { useTracking } from "v2/Artsy/Analytics/useTracking"
 import React from "react"
@@ -6,6 +6,7 @@ import styled from "styled-components"
 import { DropDownSection } from "./DropDownSection"
 import { Menu, MenuItem } from "v2/Components/Menu"
 import { MenuData } from "../../menuData"
+import { ArtistsLetterNav } from "v2/Apps/Artists/Components/ArtistsLetterNav"
 
 interface DropDownNavMenuProps {
   width?: string
@@ -38,6 +39,10 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
       onClick()
     }
   }
+
+  const isArtistsDropdown =
+    contextModule === AnalyticsSchema.ContextModule.HeaderArtistsDropdown
+
   return (
     <Menu onClick={handleClick} width={width} py={0}>
       <Flex
@@ -75,11 +80,23 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
             </Box>
           </Links>
 
-          {menu.links.map(subMenu => {
-            if ("menu" in subMenu) {
-              return <DropDownSection key={subMenu.text} section={subMenu} />
-            }
-          })}
+          {isArtistsDropdown && (
+            <Flex flexDirection="column" border="solid 2px red">
+              <Flex>
+                {menu.links.map(subMenu => {
+                  if ("menu" in subMenu) {
+                    return (
+                      <DropDownSection key={subMenu.text} section={subMenu} />
+                    )
+                  }
+                })}
+              </Flex>
+              <LettersWrap>
+                <Text variant="small">Browse by name</Text>
+                <ArtistsLetterNav inDropDown />
+              </LettersWrap>
+            </Flex>
+          )}
         </Flex>
       </Flex>
     </Menu>
@@ -112,3 +129,10 @@ ViewAllMenuItem.displayName = "ViewAllMenuItem"
 const Links = styled(Box)`
   border-right: 1px solid ${color("black10")};
 `
+
+const LettersWrap = styled(Box).attrs({
+  px: 1,
+  py: 0.5,
+})``
+
+LettersWrap.displayName = "LettersWrap"

--- a/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownMenu.tsx
@@ -93,7 +93,7 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
               </Flex>
               <LettersWrap>
                 <Text variant="small">Browse by name</Text>
-                <ArtistsLetterNav inDropDown />
+                <ArtistsLetterNav justifyContent="flex-start" />
               </LettersWrap>
             </Flex>
           )}

--- a/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownMenu.tsx
@@ -99,7 +99,7 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
             {isArtistsDropdown && (
               <LettersWrap>
                 <Text variant="small">Browse by name</Text>
-                <Letters />
+                <StyledArtistsLetterNav />
               </LettersWrap>
             )}
           </Flex>
@@ -147,7 +147,7 @@ const LettersWrap = styled(Box).attrs({
 
 LettersWrap.displayName = "LettersWrap"
 
-const Letters = styled(ArtistsLetterNav).attrs({
+const StyledArtistsLetterNav = styled(ArtistsLetterNav).attrs({
   justifyContent: "flex-start",
 })`
   margin-left: -6px;
@@ -156,4 +156,4 @@ const Letters = styled(ArtistsLetterNav).attrs({
   }
 `
 
-Letters.displayName = "Letters"
+StyledArtistsLetterNav.displayName = "StyledArtistsLetterNav"

--- a/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownMenu.tsx
@@ -5,7 +5,7 @@ import React from "react"
 import styled from "styled-components"
 import { DropDownSection } from "./DropDownSection"
 import { Menu, MenuItem } from "v2/Components/Menu"
-import { MenuData } from "../../menuData"
+import { MenuData, SimpleLinkData } from "../../menuData"
 import { ArtistsLetterNav } from "v2/Apps/Artists/Components/ArtistsLetterNav"
 
 interface DropDownNavMenuProps {
@@ -43,6 +43,9 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
   const isArtistsDropdown =
     contextModule === AnalyticsSchema.ContextModule.HeaderArtistsDropdown
 
+  const lastMenuLinkIndex = menu.links.length - 1
+  const lastMenuItem = menu.links[lastMenuLinkIndex] as SimpleLinkData
+
   return (
     <Menu onClick={handleClick} width={width} py={0}>
       <Flex
@@ -54,49 +57,52 @@ export const DropDownNavMenu: React.FC<DropDownNavMenuProps> = ({
         ]}
       >
         <Flex width={breakpoints.xl} px={3}>
-          <Links py={3} mr={[3, 3, 5, 5]}>
+          <Links>
             <Box
+              flexGrow={1}
               display="flex"
               flexDirection="column"
-              height="100%"
               mr={[1, 1, 2, 2]}
               width={[110, 135, 135, 170, 170]}
             >
               {menu.links.map((menuItem, i) => {
                 if (!("menu" in menuItem)) {
-                  const isLast = menu.links.length - 1 === i
+                  const isLast = lastMenuLinkIndex === i
 
-                  return isLast ? (
-                    <ViewAllMenuItem key={menuItem.text} href={menuItem.href}>
-                      {menuItem.text}
-                    </ViewAllMenuItem>
-                  ) : (
-                    <LinkMenuItem key={menuItem.text} href={menuItem.href}>
-                      {menuItem.text}
-                    </LinkMenuItem>
+                  return (
+                    !isLast && (
+                      <LinkMenuItem key={menuItem.text} href={menuItem.href}>
+                        {menuItem.text}
+                      </LinkMenuItem>
+                    )
                   )
                 }
               })}
             </Box>
+            <Box height={isArtistsDropdown ? "90px" : "auto"}>
+              <ViewAllMenuItem key={lastMenuItem.text} href={lastMenuItem.href}>
+                {lastMenuItem.text}
+              </ViewAllMenuItem>
+            </Box>
           </Links>
 
-          {isArtistsDropdown && (
-            <Flex flexDirection="column" border="solid 2px red">
-              <Flex>
-                {menu.links.map(subMenu => {
-                  if ("menu" in subMenu) {
-                    return (
-                      <DropDownSection key={subMenu.text} section={subMenu} />
-                    )
-                  }
-                })}
-              </Flex>
+          <Flex flexDirection="column" pb={3}>
+            <Flex>
+              {menu.links.map(subMenu => {
+                if ("menu" in subMenu) {
+                  return (
+                    <DropDownSection key={subMenu.text} section={subMenu} />
+                  )
+                }
+              })}
+            </Flex>
+            {isArtistsDropdown && (
               <LettersWrap>
                 <Text variant="small">Browse by name</Text>
-                <ArtistsLetterNav justifyContent="flex-start" />
+                <Letters />
               </LettersWrap>
-            </Flex>
-          )}
+            )}
+          </Flex>
         </Flex>
       </Flex>
     </Menu>
@@ -126,13 +132,28 @@ const ViewAllMenuItem = styled(MenuItem).attrs({
 
 ViewAllMenuItem.displayName = "ViewAllMenuItem"
 
-const Links = styled(Box)`
+const Links = styled(Flex).attrs({
+  flexDirection: "column",
+  py: 3,
+  mr: [3, 3, 5, 5],
+})`
   border-right: 1px solid ${color("black10")};
 `
 
 const LettersWrap = styled(Box).attrs({
   px: 1,
-  py: 0.5,
+  height: "85px",
 })``
 
 LettersWrap.displayName = "LettersWrap"
+
+const Letters = styled(ArtistsLetterNav).attrs({
+  justifyContent: "flex-start",
+})`
+  margin-left: -6px;
+  > div {
+    width: 32px;
+  }
+`
+
+Letters.displayName = "Letters"

--- a/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownSection.tsx
+++ b/src/v2/Components/NavBar/Menus/DropDownMenu/DropDownSection.tsx
@@ -14,7 +14,7 @@ export const DropDownSection: React.FC<DropDownSectionProps> = ({
 
   return (
     <>
-      <Box width="100%" py={4} mr={[1, 1, 2, 2]}>
+      <Box width="100%" pt={4} pb={3} mr={[1, 1, 2, 2]}>
         <Text variant="small" mb={1} px={1}>
           {section.text}
         </Text>

--- a/src/v2/Components/NavBar/Menus/DropDownMenu/__tests__/DropDownMenu.jest.tsx
+++ b/src/v2/Components/NavBar/Menus/DropDownMenu/__tests__/DropDownMenu.jest.tsx
@@ -67,6 +67,22 @@ describe("DropDownMenu", () => {
     expect(dropDownSection.length).toBe(4)
   })
 
+  it("doesn't render ArtistsLetterNav inside artworks dropdown", () => {
+    const wrapper = getWrapper()
+    const artistsLetterNav = wrapper.find("StyledArtistsLetterNav")
+
+    expect(artistsLetterNav.exists()).toBeFalsy()
+  })
+
+  it("renders ArtistsLetterNav inside artists dropdown", () => {
+    const wrapper = getWrapper({
+      contextModule: ContextModule.HeaderArtistsDropdown,
+    })
+    const artistsLetterNav = wrapper.find("StyledArtistsLetterNav")
+
+    expect(artistsLetterNav.exists()).toBeTruthy()
+  })
+
   it("tracks analytics click events correctly", () => {
     const wrapper = getWrapper()
     const menuItem = wrapper.find(MenuItem).first()

--- a/src/v2/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
@@ -144,7 +144,7 @@ export const AnimatingMenuWrapper = styled.div<{
   `}
 `
 
-const Letters = styled(ArtistsLetterNav)`
+const StyledArtistsLetterNav = styled(ArtistsLetterNav)`
   max-width: 385px;
   > div {
     width: 55px;
@@ -178,10 +178,16 @@ const Menu: React.FC<MenuProps> = ({
       <ul>
         {[...links].map((link, i) => {
           const isLast = lastLinkIndex === i
-          return NavLink({ link, isLast, isArtistsMenu })
+          return (
+            <NavLink
+              link={link}
+              isLast={isLast}
+              isArtistsMenu={isArtistsMenu}
+            />
+          )
         })}
       </ul>
-      {isArtistsMenu && <Letters />}
+      {isArtistsMenu && <StyledArtistsLetterNav />}
     </AnimatingMenuWrapper>
   )
 }

--- a/src/v2/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
@@ -146,6 +146,7 @@ export const AnimatingMenuWrapper = styled.div<{
 
 const StyledArtistsLetterNav = styled(ArtistsLetterNav)`
   max-width: 385px;
+  margin-top: 10px;
   > div {
     width: 55px;
     height: 50px;

--- a/src/v2/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
@@ -33,6 +33,7 @@ import {
   useNavigation,
 } from "./NavigatorContextProvider"
 import { NAV_BAR_BORDER_OFFSET, MOBILE_NAV_HEIGHT } from "v2/Components/NavBar"
+import { ArtistsLetterNav } from "v2/Apps/Artists/Components/ArtistsLetterNav"
 
 const Close = styled(Clickable)`
   position: absolute;
@@ -141,9 +142,13 @@ export const AnimatingMenuWrapper = styled.div<{
     z-index: 0;
     transform: translate3d(100%, 0, 0);
   `}
+`
 
-  ul {
-    margin-bottom: 100px;
+const Letters = styled(ArtistsLetterNav)`
+  max-width: 385px;
+  > div {
+    width: 55px;
+    height: 50px;
   }
 `
 
@@ -160,6 +165,8 @@ const Menu: React.FC<MenuProps> = ({
   links,
   showBacknav = true,
 }) => {
+  const isArtistsMenu = title === "Artists"
+  const lastLinkIndex = links.length - 1
   return (
     <AnimatingMenuWrapper isOpen={isOpen}>
       <Flex position="relative">
@@ -168,7 +175,13 @@ const Menu: React.FC<MenuProps> = ({
           {title}
         </Sans>
       </Flex>
-      <ul>{[...links].map(link => NavLink({ link }))}</ul>
+      <ul>
+        {[...links].map((link, i) => {
+          const isLast = lastLinkIndex === i
+          return NavLink({ link, isLast, isArtistsMenu })
+        })}
+      </ul>
+      {isArtistsMenu && <Letters />}
     </AnimatingMenuWrapper>
   )
 }
@@ -225,7 +238,7 @@ const useTrackingContextModule = () => {
   return contextModule
 }
 
-const NavLink: React.FC<any> = ({ link }) => {
+const NavLink: React.FC<any> = ({ link, isLast, isArtistsMenu }) => {
   const isSubMenu = !!link.menu
   const contextModule = useTrackingContextModule()
 
@@ -245,6 +258,7 @@ const NavLink: React.FC<any> = ({ link }) => {
           onClick={link.onClick}
         >
           {link.text}
+          {isArtistsMenu && isLast && <> A &#8211; Z</>}
         </MobileLink>
         {link.dividerBelow && <Separator my={1} color={color("black10")} />}
       </React.Fragment>

--- a/src/v2/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
+++ b/src/v2/Components/NavBar/Menus/MobileNavMenu/MobileNavMenu.tsx
@@ -181,6 +181,7 @@ const Menu: React.FC<MenuProps> = ({
           const isLast = lastLinkIndex === i
           return (
             <NavLink
+              key={i}
               link={link}
               isLast={isLast}
               isArtistsMenu={isArtistsMenu}


### PR DESCRIPTION
This is a draft PR for https://artsyproduct.atlassian.net/browse/GRO-85


**Desktop**

Added letters and aligned _View all artists_ and _Browse by name_ lines

**Before**
![before](https://user-images.githubusercontent.com/44819355/119497196-f6394c80-bd6c-11eb-975d-39734928640c.png)

**After**
![after_lg](https://user-images.githubusercontent.com/44819355/119497207-fa656a00-bd6c-11eb-80ad-77d61f325fac.png)
![after_sm](https://user-images.githubusercontent.com/44819355/119497213-fc2f2d80-bd6c-11eb-992b-1e6b0500db91.png)


**Mobile**
https://www.figma.com/file/an2fT6dBetfEB7FaLUbpir/Navigation?node-id=174%3A0 

**Before**
![Screen Shot 2021-05-27 at 11 54 33 AM](https://user-images.githubusercontent.com/44819355/119796756-4ede2600-bee2-11eb-8d3f-4278405340b2.png)

**After**
![Screen Shot 2021-05-27 at 11 54 56 AM](https://user-images.githubusercontent.com/44819355/119796815-5d2c4200-bee2-11eb-935e-79b3722d9ae0.png)
![Screen Shot 2021-05-27 at 11 56 11 AM](https://user-images.githubusercontent.com/44819355/119797012-89e05980-bee2-11eb-8173-4aa55c7454bb.png)
![Screen Shot 2021-05-27 at 11 56 24 AM](https://user-images.githubusercontent.com/44819355/119797054-91076780-bee2-11eb-828b-e246ca62c207.png)
