### PR TITLE
chore: add buyer guarantee route to seo sitemap

### DIFF
--- a/src/desktop/apps/sitemaps/helpers.ts
+++ b/src/desktop/apps/sitemaps/helpers.ts
@@ -11,6 +11,7 @@ export const computeLandingPages = appUrl => {
     { loc: appUrl + "/auction-partnerships" },
     { loc: appUrl + "/auctions" },
     { loc: appUrl + "/buying-with-artsy" },
+    { loc: appUrl + "/buyer-guarantee" },
     { loc: appUrl + "/categories" },
     { loc: appUrl + "/collect", priority: 1 },
     { loc: appUrl + "/conditions-of-sale" },


### PR DESCRIPTION
Add Buyer Guarantee route to SEO sitemap.

https://artsyproduct.atlassian.net/browse/PURCHASE-2657