### PR TITLE
feat: Wrap collection/id header text in ReadMore

### DIFF
--- a/src/v2/Apps/Collect/Routes/Collection/Components/Header/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/Components/Header/index.tsx
@@ -7,6 +7,7 @@ import {
   Column,
   HTML,
   Spacer,
+  ReadMore,
 } from "@artsy/palette"
 import { Header_artworks } from "v2/__generated__/Header_artworks.graphql"
 import { Header_collection } from "v2/__generated__/Header_collection.graphql"
@@ -65,7 +66,9 @@ export const CollectionHeader: React.FC<CollectionHeaderProps> = ({
 
         {collection.description && (
           <Column span={6}>
-            <HTML html={collection.description} variant="sm" />
+            <HTML variant="sm">
+              <ReadMore maxChars={750} content={collection.description} />
+            </HTML>
           </Column>
         )}
       </GridColumns>


### PR DESCRIPTION
This wraps our `collection/id` header text in a read more component: 

<img width="1680" alt="Screen Shot 2021-05-19 at 12 40 07 PM" src="https://user-images.githubusercontent.com/236943/118874139-69d7e700-b89f-11eb-975f-8377c06ed374.png">
