### PR TITLE
fix: resizes buttons on md breakpoints + open link in new tab

### DIFF
--- a/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
@@ -351,14 +351,16 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
             <Text variant="text" my={2}>
               {authenticityText}
             </Text>
-            {learnMoreButton("40%")}
+            <Media greaterThanOrEqual="lg">{learnMoreButton("40%")}</Media>
+            <Media lessThan="lg">{learnMoreButton("80%")}</Media>
           </Flex>
           <Flex flexDirection="column" p={space(9)}>
             <Text variant="title">Money-Back Guarantee</Text>
             <Text variant="text" my={2}>
               {moneyBackGuaranteeText}
             </Text>
-            {learnMoreButton("40%")}
+            <Media greaterThanOrEqual="lg">{learnMoreButton("40%")}</Media>
+            <Media lessThan="lg">{learnMoreButton("80%")}</Media>
           </Flex>
           {moneyBackGuaranteeImageURL && (
             <Image

--- a/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
@@ -94,7 +94,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
   )
 
   const learnMoreButton = (width: string) => (
-    <RouterLink to={supportArticleURL}>
+    <RouterLink to={supportArticleURL} target="_blank">
       <Button width={width} variant="secondaryOutline">
         Learn More
       </Button>


### PR DESCRIPTION
Fixes the width of the Learn More button in iPad sized screens and opens page in new tab instead.


Before:
<img width="811" alt="Screen Shot 2021-05-19 at 3 37 49 PM" src="https://user-images.githubusercontent.com/10385964/118875819-83d2f300-b8ba-11eb-9071-59f9da9cf065.png">

After:
<img width="864" alt="Screen Shot 2021-05-19 at 3 51 03 PM" src="https://user-images.githubusercontent.com/10385964/118875798-7d447b80-b8ba-11eb-9fe3-dc32d740bc1c.png">

https://artsyproduct.atlassian.net/browse/PURCHASE-2694
https://artsyproduct.atlassian.net/browse/PURCHASE-2654
