### PR TITLE
fix: use SystemQueryRenderer instead of QueryRenderer

### DIFF
--- a/src/v2/Apps/Partner/Components/Overview/ArtworksRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/ArtworksRail.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react"
 import { Box, BoxProps, Flex, Text } from "@artsy/palette"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 import { ArtworksRail_partner } from "v2/__generated__/ArtworksRail_partner.graphql"
 import { flatten } from "lodash"
 import { Carousel } from "../Carousel"
@@ -11,6 +11,7 @@ import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import { ScrollToPartnerHeader } from "../ScrollToPartnerHeader"
 import { ArtworksRailPlaceholder } from "./ArtworkRailPlaceholder"
 import { ViewAllButton } from "./ViewAllButton"
+import { SystemQueryRenderer as QueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
 
 interface ArtworksRailProps extends BoxProps {
   partner: ArtworksRail_partner
@@ -116,7 +117,6 @@ export const ArtworksRailRenderer: React.FC<
 
   return (
     <QueryRenderer<ArtworksRailRendererQuery>
-      //  @ts-expect-error STRICT_NULL_CHECK
       environment={relayEnvironment}
       query={graphql`
         query ArtworksRailRendererQuery($partnerId: String!) {
@@ -130,7 +130,6 @@ export const ArtworksRailRenderer: React.FC<
         if (error || !props)
           return <ArtworksRailPlaceholder {...rest} count={15} />
 
-        // @ts-expect-error STRICT_NULL_CHECK
         return <ArtworksRailFragmentContainer {...rest} {...props} />
       }}
     />

--- a/src/v2/Apps/Partner/Components/Overview/ShowBannersRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/ShowBannersRail.tsx
@@ -10,7 +10,7 @@ import {
   SwiperCell,
   SwiperRail,
 } from "@artsy/palette"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 import { ShowBannersRail_partner } from "v2/__generated__/ShowBannersRail_partner.graphql"
 import { ShowBannersRailRendererQuery } from "v2/__generated__/ShowBannersRailRendererQuery.graphql"
 import { compact, take, uniqBy } from "lodash"
@@ -18,6 +18,7 @@ import { ShowBannerFragmentContainer } from "../PartnerShows"
 import { useSystemContext } from "v2/Artsy"
 import { ShowBannersRailPlaceholder } from "./ShowBannersRailPlaceholder"
 import { Media } from "v2/Utils/Responsive"
+import { SystemQueryRenderer as QueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
 
 interface ShowBannersRailProps extends BoxProps {
   partner: ShowBannersRail_partner
@@ -206,7 +207,6 @@ export const ShowBannersRailRenderer: React.FC<
 
   return (
     <QueryRenderer<ShowBannersRailRendererQuery>
-      // @ts-expect-error STRICT_NULL_CHECK
       environment={relayEnvironment}
       query={graphql`
         query ShowBannersRailRendererQuery($partnerId: String!) {
@@ -220,7 +220,6 @@ export const ShowBannersRailRenderer: React.FC<
         if (error || !props)
           return <ShowBannersRailPlaceholder count={10} {...rest} />
 
-        // @ts-expect-error STRICT_NULL_CHECK
         return <ShowBannersRailFragmentContainer {...rest} {...props} />
       }}
     />

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistDetails.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistDetails.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
+import { SystemQueryRenderer as QueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
 import { PartnerArtistDetails_partnerArtist } from "v2/__generated__/PartnerArtistDetails_partnerArtist.graphql"
 import { PartnerArtistDetailsQuery } from "v2/__generated__/PartnerArtistDetailsQuery.graphql"
 import { Carousel } from "v2/Components/Carousel"
@@ -137,7 +138,6 @@ export const PartnerArtistDetailsRenderer: React.FC<{
 
   return (
     <QueryRenderer<PartnerArtistDetailsQuery>
-      //  @ts-expect-error STRICT_NULL_CHECK
       environment={relayEnvironment}
       query={graphql`
         query PartnerArtistDetailsQuery(
@@ -160,7 +160,6 @@ export const PartnerArtistDetailsRenderer: React.FC<{
           <PartnerArtistDetailsFragmentContainer
             {...rest}
             {...props}
-            // @ts-expect-error STRICT_NULL_CHECK
             partnerArtist={props?.partner?.artistsConnection?.edges[0]}
           />
         )

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetailsList/PartnerArtistDetailsList.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetailsList/PartnerArtistDetailsList.tsx
@@ -4,13 +4,13 @@ import { useSystemContext } from "v2/Artsy"
 import {
   createPaginationContainer,
   graphql,
-  QueryRenderer,
   RelayPaginationProp,
 } from "react-relay"
 import { PartnerArtistDetailsList_partner } from "v2/__generated__/PartnerArtistDetailsList_partner.graphql"
 import { PartnerArtistDetailsListQuery } from "v2/__generated__/PartnerArtistDetailsListQuery.graphql"
 import { PartnerArtistDetailsListPlaceholder } from "./PartnerArtistDetailsListPlaceholder"
 import { PartnerArtistDetailsFragmentContainer } from "../PartnerArtistDetails"
+import { SystemQueryRenderer as QueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
 
 export interface PartnerArtistDetailsListProps {
   partner: PartnerArtistDetailsList_partner
@@ -137,7 +137,6 @@ export const PartnerArtistDetailsListRenderer: React.FC<{
 
   return (
     <QueryRenderer<PartnerArtistDetailsListQuery>
-      //  @ts-expect-error STRICT_NULL_CHECK
       environment={relayEnvironment}
       query={graphql`
         query PartnerArtistDetailsListRendererQuery($partnerId: String!) {
@@ -152,7 +151,6 @@ export const PartnerArtistDetailsListRenderer: React.FC<{
           return <PartnerArtistDetailsListPlaceholder count={PAGE_SIZE} />
 
         return (
-          // @ts-expect-error STRICT_NULL_CHECK
           <PartnerArtistDetailsListPaginationContainer {...rest} {...props} />
         )
       }}

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtists.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtists.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react"
 import { Box } from "@artsy/palette"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 import { PartnerArtists_partner } from "v2/__generated__/PartnerArtists_partner.graphql"
 import { PartnerArtistsQuery } from "v2/__generated__/PartnerArtistsQuery.graphql"
 import { ScrollIntoViewProps } from "v2/Utils/scrollHelpers"
@@ -8,6 +8,7 @@ import { useSystemContext } from "v2/Artsy"
 import { usePartnerArtistsLoadingContext } from "v2/Apps/Partner/Utils/PartnerArtistsLoadingContext"
 import { PartnerArtistListPlaceholder } from "./PartnerArtistListPlaceholder"
 import { PartnerArtistListFragmentContainer } from "./PartnerArtistList"
+import { SystemQueryRenderer as QueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
 
 export interface PartnerArtistsProps {
   partner: PartnerArtists_partner
@@ -78,7 +79,6 @@ export const PartnerArtistsRenderer: React.FC<{
 
   return (
     <QueryRenderer<PartnerArtistsQuery>
-      //  @ts-expect-error STRICT_NULL_CHECK
       environment={relayEnvironment}
       query={graphql`
         query PartnerArtistsQuery($partnerId: String!) {
@@ -90,7 +90,7 @@ export const PartnerArtistsRenderer: React.FC<{
       variables={{ partnerId }}
       render={({ error, props }) => {
         if (error || !props) return <PartnerArtistListPlaceholder />
-        // @ts-expect-error STRICT_NULL_CHECK
+
         return <PartnerArtistsFragmentContainer {...rest} {...props} />
       }}
     />

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarousel.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarousel.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react"
 import { Box, Text, Flex } from "@artsy/palette"
 import { flatten } from "lodash"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "v2/Artsy"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import { PartnerArtistsCarouselRendererQuery } from "v2/__generated__/PartnerArtistsCarouselRendererQuery.graphql"
@@ -13,6 +13,7 @@ import {
 import { PartnerArtistsCarouselPlaceholder } from "./PartnerArtistsCarouselPlaceholder"
 import { ScrollToPartnerHeader } from "../../ScrollToPartnerHeader"
 import { Carousel } from "../../Carousel"
+import { SystemQueryRenderer as QueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
 
 const PAGE_SIZE = 19
 
@@ -110,7 +111,6 @@ export const PartnerArtistsCarouselRenderer: React.FC<{
 
   return (
     <QueryRenderer<PartnerArtistsCarouselRendererQuery>
-      // @ts-expect-error STRICT_NULL_CHECK
       environment={relayEnvironment}
       query={graphql`
         query PartnerArtistsCarouselRendererQuery($partnerId: String!) {
@@ -124,7 +124,6 @@ export const PartnerArtistsCarouselRenderer: React.FC<{
         if (error || !props)
           return <PartnerArtistsCarouselPlaceholder count={PAGE_SIZE} />
 
-        // @ts-expect-error STRICT_NULL_CHECK
         return <PartnerArtistsCarouselFragmentContainer {...rest} {...props} />
       }}
     />

--- a/src/v2/Apps/Partner/Components/PartnerShows/ShowPaginatedEvents.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerShows/ShowPaginatedEvents.tsx
@@ -1,11 +1,6 @@
 import { Box } from "@artsy/palette"
 import React, { useState } from "react"
-import {
-  createRefetchContainer,
-  graphql,
-  QueryRenderer,
-  RelayRefetchProp,
-} from "react-relay"
+import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { PaginationFragmentContainer } from "v2/Components/Pagination"
 import { LoadingArea } from "v2/Components/LoadingArea"
 import { ShowEventsFragmentContainer } from "v2/Apps/Partner/Components/PartnerShows/ShowEvents"
@@ -14,6 +9,7 @@ import { useRouter } from "v2/Artsy/Router/useRouter"
 import { ShowPaginatedEventsRendererQuery } from "v2/__generated__/ShowPaginatedEventsRendererQuery.graphql"
 import { ShowPaginatedEvents_partner } from "v2/__generated__/ShowPaginatedEvents_partner.graphql"
 import { EventStatus } from "v2/__generated__/ShowPaginatedEventsRendererQuery.graphql"
+import { SystemQueryRenderer as QueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
 
 interface ShowEventsProps {
   relay: RelayRefetchProp
@@ -192,7 +188,6 @@ export const ShowPaginatedEventsRenderer: React.FC<ShowPaginatedEventsRendererPr
 
   return (
     <QueryRenderer<ShowPaginatedEventsRendererQuery>
-      // @ts-expect-error STRICT_NULL_CHECK
       environment={relayEnvironment}
       query={graphql`
         query ShowPaginatedEventsRendererQuery(
@@ -212,7 +207,6 @@ export const ShowPaginatedEventsRenderer: React.FC<ShowPaginatedEventsRendererPr
         if (error || !props) return null
 
         return (
-          // @ts-expect-error STRICT_NULL_CHECK
           <ShowEventsRefetchContainer {...rest} {...props} paramsPage={page} />
         )
       }}


### PR DESCRIPTION
This PR replaces all QueryRenderer components with SystemQueryRenderer for the Partner Profile page. From time to time we had some render issues that I think were related to `QueryRenderer` that runs on the server side.

Pay attention to progress dots:
![ezgif com-gif-maker (30)](https://user-images.githubusercontent.com/79979820/119007117-a12abe80-b999-11eb-9f89-13d97b835e79.gif)
