### PR TITLE
fix: Adjust margins on order flow screens

### DIFF
--- a/src/v2/Apps/Order/Components/OrderStepper.tsx
+++ b/src/v2/Apps/Order/Components/OrderStepper.tsx
@@ -26,7 +26,7 @@ export function OrderStepper<Steps extends string[]>({
   return (
     <>
       <Media between={["xs", "md"]}>
-        <Box pl={2} pr={2}>
+        <Box>
           <Stepper
             initialTabIndex={stepIndex}
             currentStepIndex={stepIndex}

--- a/src/v2/Apps/Order/OrderApp.tsx
+++ b/src/v2/Apps/Order/OrderApp.tsx
@@ -189,29 +189,27 @@ class OrderApp extends React.Component<OrderAppProps, {}> {
               */}
               <div id="main-layout-flash" />
               <MinimalNavBar to={artworkHref}>
-                <HorizontalPadding>
-                  <Title>Checkout | Artsy</Title>
-                  {isEigen ? (
-                    <Meta
-                      name="viewport"
-                      content="width=device-width, user-scalable=no"
-                    />
-                  ) : (
-                    <Meta
-                      name="viewport"
-                      content="width=device-width, initial-scale=1, maximum-scale=5 viewport-fit=cover"
-                    />
-                  )}
-                  <SafeAreaContainer>
-                    <Elements stripe={stripePromise}>
-                      <AppContainer>
-                        <HorizontalPadding>{children}</HorizontalPadding>
-                      </AppContainer>
-                    </Elements>
-                  </SafeAreaContainer>
-                  <StickyFooter orderType={order.mode} artworkId={artworkId} />
-                  <ConnectedModalDialog />
-                </HorizontalPadding>
+                <Title>Checkout | Artsy</Title>
+                {isEigen ? (
+                  <Meta
+                    name="viewport"
+                    content="width=device-width, user-scalable=no"
+                  />
+                ) : (
+                  <Meta
+                    name="viewport"
+                    content="width=device-width, initial-scale=1, maximum-scale=5 viewport-fit=cover"
+                  />
+                )}
+                <SafeAreaContainer>
+                  <Elements stripe={stripePromise}>
+                    <AppContainer>
+                      <HorizontalPadding>{children}</HorizontalPadding>
+                    </AppContainer>
+                  </Elements>
+                </SafeAreaContainer>
+                <StickyFooter orderType={order.mode} artworkId={artworkId} />
+                <ConnectedModalDialog />
               </MinimalNavBar>
             </Box>
           )


### PR DESCRIPTION
[PURCHASE-2682]

Recently the margins have changed in the web view of checkout. The content is far more squared and would like to use as much as the width of the phone screen. Confirmed with Arvind that the order stepper margins should be the same as the page content.

Pretty sure this regression was caused by [this PR](https://github.com/artsy/force/commit/4bea40764b1a9387a5a6514c8bfa8fd76015d72b)

_Before:_
<img width="356" alt="Screen Shot 2021-05-20 at 12 17 32 PM" src="https://user-images.githubusercontent.com/5643895/119013891-6c047900-b965-11eb-8f1c-42c8f70baf9d.png">

_After:_

<img width="357" alt="Screen Shot 2021-05-20 at 10 36 38 AM" src="https://user-images.githubusercontent.com/5643895/119013804-5727e580-b965-11eb-8467-77b74bf0d0bc.png">




[PURCHASE-2682]: https://artsyproduct.atlassian.net/browse/PURCHASE-2682