### PR TITLE
fix(PX-4097): fix cover image

### DIFF
--- a/src/v2/Apps/Components/AppShell.tsx
+++ b/src/v2/Apps/Components/AppShell.tsx
@@ -103,11 +103,13 @@ export const AppShell: React.FC<AppShellProps> = props => {
           <NetworkOfflineMonitor />
 
           {showFooter && (
-            <AppContainer bg="white100">
-              <HorizontalPadding>
-                <Footer />
-              </HorizontalPadding>
-            </AppContainer>
+            <Flex bg="white100">
+              <AppContainer>
+                <HorizontalPadding>
+                  <Footer />
+                </HorizontalPadding>
+              </AppContainer>
+            </Flex>
           )}
         </>
       </Theme>


### PR DESCRIPTION
This PR fixes the cover image for the partner profile page. Used `Flex` to stretch the white background for the footer.

JIRA - https://artsyproduct.atlassian.net/browse/PX-4097

before:
![image](https://user-images.githubusercontent.com/79979820/119104896-78500b00-ba25-11eb-81e4-3d4aee184cd0.png)

now:
![image](https://user-images.githubusercontent.com/79979820/119104804-5ce50000-ba25-11eb-9125-72ef165807ed.png)
