### PR TITLE
feat(PX-4058): partner profile page transition

### DIFF
--- a/src/desktop/apps/partner/index.coffee
+++ b/src/desktop/apps/partner/index.coffee
@@ -5,15 +5,15 @@ app = module.exports = express()
 app.set 'views', __dirname + '/templates'
 app.set 'view engine', 'jade'
 
-app.get '/:id', routes.requirePartner, routes.overview
-app.get '/:id/overview', routes.requirePartner, routes.redirectToOverview
-app.get '/:id/contact', routes.requirePartner, routes.contact
-app.get '/:id/about', routes.requirePartner, routes.about
-app.get '/:id/collection', routes.requirePartner, routes.collection
-app.get '/:id/shop', routes.requirePartner, routes.shop
-app.get '/:id/works', routes.requirePartner, routes.works
-app.get '/:id/shows', routes.requirePartner, routes.shows
-app.get '/:id/artists', routes.requirePartner, routes.artists
-app.get '/:id/artist/:artistId', routes.requirePartner, routes.artist
-app.get '/:id/articles', routes.requirePartner, routes.articles
+# app.get '/:id', routes.requirePartner, routes.overview
+# app.get '/:id/overview', routes.requirePartner, routes.overview
+# app.get '/:id/contact', routes.requirePartner, routes.contact
+# app.get '/:id/about', routes.requirePartner, routes.about
+# app.get '/:id/collection', routes.requirePartner, routes.collection
+# app.get '/:id/shop', routes.requirePartner, routes.shop
+# app.get '/:id/works', routes.requirePartner, routes.works
+# app.get '/:id/shows', routes.requirePartner, routes.shows
+# app.get '/:id/artists', routes.requirePartner, routes.artists
+# app.get '/:id/artist/:artistId', routes.requirePartner, routes.artist
+# app.get '/:id/articles', routes.requirePartner, routes.articles
 app.get '/:id/article/:articleId', routes.requirePartner, routes.articles

--- a/src/desktop/apps/partner2/index.coffee
+++ b/src/desktop/apps/partner2/index.coffee
@@ -5,15 +5,15 @@ app = module.exports = express()
 app.set 'views', __dirname + '/templates'
 app.set 'view engine', 'jade'
 
-app.get '/:id', routes.requireNewLayout, routes.overview
-app.get '/:id/overview', routes.requireNewLayout, routes.redirectToOverview
-app.get '/:id/shows', routes.requireNewLayout, routes.shows
-app.get '/:id/works', routes.requireNewLayout, routes.works
-app.get '/:id/collection', routes.requireNewLayout, routes.collection
-app.get '/:id/shop', routes.requireNewLayout, routes.shop
-app.get '/:id/artists', routes.requireNewLayout, routes.artists
-app.get '/:id/artist/:artistId', routes.requireNewLayout, routes.artist
-app.get '/:id/articles', routes.requireNewLayout, routes.articles
-app.get '/:id/contact', routes.requireNewLayout, routes.contact
-app.get '/:id/about', routes.requireNewLayout, routes.about
+# app.get '/:id', routes.requireNewLayout, routes.overview
+# app.get '/:id/overview', routes.requireNewLayout, routes.overview
+# app.get '/:id/shows', routes.requireNewLayout, routes.shows
+# app.get '/:id/works', routes.requireNewLayout, routes.works
+# app.get '/:id/collection', routes.requireNewLayout, routes.collection
+# app.get '/:id/shop', routes.requireNewLayout, routes.shop
+# app.get '/:id/artists', routes.requireNewLayout, routes.artists
+# app.get '/:id/artist/:artistId', routes.requireNewLayout, routes.artist
+# app.get '/:id/articles', routes.requireNewLayout, routes.articles
+# app.get '/:id/contact', routes.requireNewLayout, routes.contact
+# app.get '/:id/about', routes.requireNewLayout, routes.about
 app.get '/:id/article/:articleId', routes.requireNewLayout, routes.articles

--- a/src/desktop/apps/partner_redirect/__tests__/partnerRedirectionMiddleware.jest.ts
+++ b/src/desktop/apps/partner_redirect/__tests__/partnerRedirectionMiddleware.jest.ts
@@ -1,0 +1,99 @@
+import { NextFunction } from "express"
+import { ArtsyRequest, ArtsyResponse } from "lib/middleware/artsyExpress"
+import { partnerRedirectionMiddleware } from "../partnerRedirectionMiddleware"
+
+describe("partnerRedirectionMiddleware", () => {
+  let req: Partial<ArtsyRequest>
+  let res: Partial<ArtsyResponse>
+  let next: jest.Mock<NextFunction>
+
+  beforeEach(() => {
+    jest.resetModules()
+
+    res = {
+      locals: {
+        profile: {
+          isPartner: jest.fn(() => {
+            return true
+          }),
+        },
+      },
+      redirect: jest.fn(),
+    }
+
+    next = jest.fn()
+  })
+
+  it.each([
+    ["/:id", "/partner/white-cube", "/white-cube", { id: "white-cube" }],
+    [
+      "/:id/overview",
+      "/partner/white-cube",
+      "/white-cube/overview",
+      { id: "white-cube" },
+    ],
+    [
+      "/:id/shows",
+      "/partner/white-cube/shows",
+      "/white-cube/shows",
+      { id: "white-cube" },
+    ],
+    [
+      "/:id/works",
+      "/partner/white-cube/works",
+      "/white-cube/works",
+      { id: "white-cube" },
+    ],
+    [
+      "/:id/artists",
+      "/partner/white-cube/artists",
+      "/white-cube/artists",
+      { id: "white-cube" },
+    ],
+    [
+      "/:id/artist/:artistId",
+      "/partner/white-cube/artists/artist_slug",
+      "/white-cube/artist/artist_slug",
+      { artistId: "artist_slug", id: "white-cube" },
+    ],
+    [
+      "/:id/articles",
+      "/partner/white-cube/articles",
+      "/white-cube/articles",
+      { id: "white-cube" },
+    ],
+    [
+      "/:id/contact",
+      "/partner/white-cube/contact",
+      "/white-cube/contact",
+      { id: "white-cube" },
+    ],
+  ])(
+    "redirects %s to %s",
+    (route: string, result: string, path: string, params: any) => {
+      req = { route: { path: route }, path, params }
+
+      partnerRedirectionMiddleware(req, res, next)
+
+      expect(res.redirect).toHaveBeenCalledWith(301, result)
+    }
+  )
+
+  it("does not redirect is not a partner", () => {
+    res = {
+      locals: {
+        profile: {
+          isPartner: jest.fn(() => {
+            return false
+          }),
+        },
+      },
+      redirect: jest.fn(),
+    }
+
+    partnerRedirectionMiddleware(req, res, next)
+
+    expect(res.redirect).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/src/desktop/apps/partner_redirect/index.ts
+++ b/src/desktop/apps/partner_redirect/index.ts
@@ -1,0 +1,17 @@
+import express from "express"
+import { partnerRedirectionMiddleware } from "./partnerRedirectionMiddleware"
+
+export const app = express()
+
+app
+  .get("/:id", partnerRedirectionMiddleware)
+  .get("/:id/overview", partnerRedirectionMiddleware)
+  .get("/:id/shows", partnerRedirectionMiddleware)
+  .get("/:id/works", partnerRedirectionMiddleware)
+  .get("/:id/artists", partnerRedirectionMiddleware)
+  .get("/:id/artist/:artistId", partnerRedirectionMiddleware)
+  .get("/:id/articles", partnerRedirectionMiddleware)
+  .get("/:id/contact", partnerRedirectionMiddleware)
+// .get("/:id/collection", partnerRedirectionMiddleware)
+// .get("/:id/shop", partnerRedirectionMiddleware)
+// .get("/:id/about", partnerRedirectionMiddleware)

--- a/src/desktop/apps/partner_redirect/partnerRedirectionMiddleware.ts
+++ b/src/desktop/apps/partner_redirect/partnerRedirectionMiddleware.ts
@@ -1,0 +1,27 @@
+import { NextFunction } from "express"
+import { ArtsyRequest, ArtsyResponse } from "lib/middleware/artsyExpress"
+
+export const partnerRedirectionMiddleware = (
+  req: Partial<ArtsyRequest>,
+  res: Partial<ArtsyResponse>,
+  next: NextFunction
+) => {
+  if (!res.locals?.profile?.isPartner() || !res.redirect) return next()
+
+  const href: string | null = `/partner${req.path}`
+
+  // /:id/overview -> /partner/:id
+  if (req.route.path === "/:id/overview") {
+    return res.redirect(301, `/partner/${req.params.id}`)
+  }
+
+  // /:id/artist/:artistId -> /partner/:id/artists/:artistId
+  if (req.route.path === "/:id/artist/:artistId" && req.params?.artistId) {
+    return res.redirect(
+      301,
+      `/partner/${req.params.id}/artists/${req.params.artistId}`
+    )
+  }
+
+  return res.redirect(301, href)
+}

--- a/src/desktop/index.ts
+++ b/src/desktop/index.ts
@@ -95,6 +95,7 @@ app.use(require("./apps/ssr-experiments/server").app)
 // it's best to keep them last. Otherwise it's easy for these to unexpectedly
 // catch conventional app routes.
 app.use(require("./apps/profile"))
+app.use(require("./apps/partner_redirect").app)
 app.use(require("./apps/partner2"))
 app.use(require("./apps/partner"))
 app.use(require("./apps/fair_redirect").app)

--- a/src/mobile/apps/partner_profile/index.coffee
+++ b/src/mobile/apps/partner_profile/index.coffee
@@ -9,13 +9,13 @@ app = module.exports = express()
 app.set 'views', __dirname + '/templates'
 app.set 'view engine', 'jade'
 
-app.get '/:profileId', routes.requirePartner, routes.index
-app.get '/:profileId/overview', routes.requirePartner, routes.index
-app.get '/:profileId/artists', routes.requirePartner, routes.artists
-app.get '/:profileId/artist/:artistId', routes.requirePartner, routes.artist
-app.get '/:profileId/collection', routes.requirePartner, routes.fetchArtworksAndRender('Works')
-app.get '/:profileId/contact', routes.requirePartner, routes.contact
-app.get '/:profileId/articles', routes.requirePartner, routes.articles
+# app.get '/:profileId', routes.requirePartner, routes.index
+# app.get '/:profileId/overview', routes.requirePartner, routes.index
+# app.get '/:profileId/artists', routes.requirePartner, routes.artists
+# app.get '/:profileId/artist/:artistId', routes.requirePartner, routes.artist
+# app.get '/:profileId/collection', routes.requirePartner, routes.fetchArtworksAndRender('Works')
+# app.get '/:profileId/contact', routes.requirePartner, routes.contact
+# app.get '/:profileId/articles', routes.requirePartner, routes.articles
+# app.get '/:profileId/shop', routes.requirePartner, routes.fetchArtworksAndRender('Shop')
+# app.get '/:profileId/shows', routes.requirePartner, routes.shows
 app.get '/:profileId/article/:articleId', routes.requirePartner, routes.article
-app.get '/:profileId/shop', routes.requirePartner, routes.fetchArtworksAndRender('Shop')
-app.get '/:profileId/shows', routes.requirePartner, routes.shows


### PR DESCRIPTION
### This PR is just a migrating plan from partner2 to partner. We'll start to implement it after its approval. Please take a look into.

- [X] **1. New partner profile page** https://github.com/artsy/force/pull/7682
  - replace /partner2 with /partner

- [X] **2. Add redirects for the old routes** https://github.com/artsy/force/pull/7677

  We have to implement a middleware to manage an overlapping redirection logic to the new routes in these files: [partner2 routes](https://github.com/artsy/force/blob/master/src/desktop/apps/partner2/index.coffee#L8) and [partner](https://github.com/artsy/force/blob/master/src/desktop/apps/partner/index.coffee#L8) routes.

  The current routes desktop should be redirected in accordance with the next schema:

/:id                              ->  /partner/:id
/:id/overview              ->  /partner/:id/overview -> /partner/:id/       
/:id/contact                ->  /partner/:id/contact
/:id/works                   ->  /partner/:id/works
/:id/shows                  ->  /partner/:id/shows
/:id/artists                  ->  /partner/:id/artists
/:id/artist/:artistId      ->  /partner/:id/artists/:artistId
/:id/articles                ->  /partner/:id/articles
/:id/about                   ->  /partner/:id
/:id/collection            ->  /partner/:id/works
/:id/shop                    ->  /partner/:id/works
/:id/article/:articleId  ->  _It is shouldn't be redirected. Should be used the current version of the page_

  [Mobile routes](https://github.com/artsy/force/blob/master/src/mobile/apps/partner_profile/index.coffee#L12):

/:profileId                            ->  /partner/:id/
/:profileId/overview            ->  /partner/:id/overview -> /partner/:id/ 
/:profileId/artists                 ->  /partner/:id/artists
/:profileId/artist/:artistId     ->  /partner/:id/artists/:artistId
/:profileId/contact               ->  /partner/:id/contact
/:profileId/articles               ->  /partner/:id/articles
/:profileId/shows                 ->  /partner/:id/shows
/:profileId/collection            ->  /partner/:id/works
/:profileId/shop                    ->  /partner/:id/works
/:profileId/article/:articleId -> _It is shouldn't be redirected. Should be used the current version of the page_
 
- [ ] **3. Metaphisics** https://github.com/artsy/metaphysics/pull/3193
   - update href field for Partner, Profile and maybe https://github.com/artsy/metaphysics/blob/master/src/lib/routing.ts


 - [x] **4. Update links to the partner page** https://github.com/artsy/force/pull/7685
We would like all links to the partner page in the current version of app to use updated routes instead of current to avoid the future redirect logic. We found several places we could update but we're not completely sure if they have to be updated.

    - desktop: 
      https://github.com/artsy/force/blob/master/src/desktop/components/article/templates/mixins.jade#L109
      https://github.com/artsy/force/blob/master/src/desktop/models/partner.coffee#L31

      ?? https://github.com/artsy/force/blob/master/src/desktop/models/artwork.coffee#L214 
      ?? https://github.com/artsy/force/blob/master/src/desktop/models/partner_artist.coffee#L12

    - mobile:
      https://github.com/artsy/force/blob/master/src/mobile/components/article/templates/sections/images.jade#L39
      https://github.com/artsy/force/blob/master/src/mobile/components/artist_list/template.jade#L5
      https://github.com/artsy/force/blob/master/src/mobile/models/show.coffee#L50
      https://github.com/artsy/force/blob/master/src/mobile/models/partner.coffee#L32

      ?? https://github.com/artsy/force/blob/master/src/mobile/apps/articles/routes.coffee#L20
      ?? https://github.com/artsy/force/blob/master/src/mobile/apps/home/templates/current_shows.jade#L5
      ?? https://github.com/artsy/force/blob/master/src/mobile/models/artwork.coffee#L58

    - v2:
      https://github.com/artsy/force/blob/master/src/v2/Apps/Purchase/Components/OrderRow.tsx#L68

 - [x] **5. Remove profile page header and footer** https://github.com/artsy/force/pull/7688
 We want to remove the header and footer from the _old_ partner page to prevent the possibility of old tabs navigating.
    Header:
![image](https://user-images.githubusercontent.com/79979820/119521696-0e689600-bd84-11eb-872a-c7c1c1ec0433.png)
     
    Footer:
![image](https://user-images.githubusercontent.com/79979820/119521966-47086f80-bd84-11eb-982f-6c9c2cafa659.png)

- [ ] **6. Remove unused code**