### PR TITLE
fix: use the right SHA256 on release builds

### DIFF
--- a/src/desktop/public/.well-known/assetlinks.json
+++ b/src/desktop/public/.well-known/assetlinks.json
@@ -4,6 +4,6 @@
     "namespace": "android_app",
     "package_name": "net.artsy.app",
     "sha256_cert_fingerprints":
-    ["FA:C6:17:45:DC:09:03:78:6F:B9:ED:E6:2A:96:2B:39:9F:73:48:F0:BB:6F:89:9B:83:32:66:75:91:03:3B:9C"]
+    ["72:70:C3:1C:74:A4:86:D8:F7:31:08:E0:2E:72:D6:91:00:4D:57:35:16:8B:9C:DA:B1:65:5D:49:1D:33:2E:88"]
   }
 }]


### PR DESCRIPTION
Our current assetLinks.json file is using a debug sha256 and we should instead use a release sha256. It's safe to host this publicly as this is the standard for hosting assetLinks.json files. Similar files can be seen here https://digitalassetlinks.googleapis.com/v1/statements:list?source.web.site=https://youtube.com&relation=delegate_permission/common.handle_all_urls