### PR TITLE
feat: add placeholder for system query renderer

### DIFF
--- a/src/v2/Apps/Partner/Components/Overview/ArtworksRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/ArtworksRail.tsx
@@ -125,6 +125,7 @@ export const ArtworksRailRenderer: React.FC<
           }
         }
       `}
+      placeholder={<ArtworksRailPlaceholder {...rest} count={15} />}
       variables={{ partnerId }}
       render={({ error, props }) => {
         if (error || !props)

--- a/src/v2/Apps/Partner/Components/Overview/ShowBannersRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/ShowBannersRail.tsx
@@ -215,6 +215,7 @@ export const ShowBannersRailRenderer: React.FC<
           }
         }
       `}
+      placeholder={<ShowBannersRailPlaceholder count={10} {...rest} />}
       variables={{ partnerId }}
       render={({ error, props }) => {
         if (error || !props)

--- a/src/v2/Apps/Partner/Components/Overview/ShowBannersRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/ShowBannersRail.tsx
@@ -19,6 +19,7 @@ import { useSystemContext } from "v2/Artsy"
 import { ShowBannersRailPlaceholder } from "./ShowBannersRailPlaceholder"
 import { Media } from "v2/Utils/Responsive"
 import { SystemQueryRenderer as QueryRenderer } from "v2/Artsy/Relay/SystemQueryRenderer"
+import { usePrevious } from "v2/Utils/Hooks/usePrevious"
 
 interface ShowBannersRailProps extends BoxProps {
   partner: ShowBannersRail_partner
@@ -82,6 +83,7 @@ const ShowBannersRail: React.FC<ShowBannersRailProps> = ({
   ...rest
 }) => {
   const [currentCarouselPage, setCurrentCarouselPage] = useState(0)
+  const previousCarouselPage = usePrevious(currentCarouselPage)
 
   if (!partner) return null
 
@@ -116,7 +118,7 @@ const ShowBannersRail: React.FC<ShowBannersRailProps> = ({
         {shows.map((edge, i) => {
           return (
             <ShowBannerFragmentContainer
-              withAnimation
+              withAnimation={currentCarouselPage !== previousCarouselPage}
               selected={i === currentCarouselPage}
               key={edge.node.id}
               show={edge.node}

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistDetails.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistDetails.tsx
@@ -154,6 +154,7 @@ export const PartnerArtistDetailsRenderer: React.FC<{
         }
       `}
       variables={{ partnerId, artistId }}
+      placeholder={<PartnerArtistDetailsPlaceholder />}
       render={({ error, props }) => {
         if (error || !props) return <PartnerArtistDetailsPlaceholder />
         return (

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetailsList/PartnerArtistDetailsList.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetailsList/PartnerArtistDetailsList.tsx
@@ -145,6 +145,7 @@ export const PartnerArtistDetailsListRenderer: React.FC<{
           }
         }
       `}
+      placeholder={<PartnerArtistDetailsListPlaceholder count={PAGE_SIZE} />}
       variables={{ partnerId, first: PAGE_SIZE, after: undefined }}
       render={({ error, props }) => {
         if (error || !props)

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtists.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtists.tsx
@@ -88,6 +88,7 @@ export const PartnerArtistsRenderer: React.FC<{
         }
       `}
       variables={{ partnerId }}
+      placeholder={<PartnerArtistListPlaceholder />}
       render={({ error, props }) => {
         if (error || !props) return <PartnerArtistListPlaceholder />
 

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarousel.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarousel.tsx
@@ -120,6 +120,7 @@ export const PartnerArtistsCarouselRenderer: React.FC<{
         }
       `}
       variables={{ partnerId }}
+      placeholder={<PartnerArtistsCarouselPlaceholder count={PAGE_SIZE} />}
       render={({ error, props }) => {
         if (error || !props)
           return <PartnerArtistsCarouselPlaceholder count={PAGE_SIZE} />

--- a/src/v2/Artsy/Relay/SystemQueryRenderer.tsx
+++ b/src/v2/Artsy/Relay/SystemQueryRenderer.tsx
@@ -23,10 +23,12 @@ export class SystemQueryRenderer<
   }
 
   render() {
+    const { placeholder, ...rest } = this.props
+
     if (this.state.isMounted) {
-      return <QueryRenderer<T> {...this.props} />
+      return <QueryRenderer<T> {...rest} />
     } else {
-      return null
+      return placeholder ? placeholder : null
     }
   }
 }


### PR DESCRIPTION
This PR adds a placeholder for the system query renderer. The placeholder field uses for rendering skeleton spinners at the server time to prevent some content blinking. 

Before:
![119349967-739a8980-bca7-11eb-9dc8-d1a6fe9212db](https://user-images.githubusercontent.com/79979820/119492334-9ee4ad80-bd67-11eb-8665-01c8e7e9bff6.gif)

Now:
![ezgif com-gif-maker (32)](https://user-images.githubusercontent.com/79979820/119492767-20d4d680-bd68-11eb-8bf6-ba0625cbb94f.gif)
