### PR TITLE
feat: 2FA respect after_update param.

### DIFF
--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -5,6 +5,7 @@ services:
 {% include 'templates/docker-compose-service.yml.j2' %}
     environment:
       - NODE_ENV=development
+      - REDIS_URL=redis://force-redis:6379/0
       - OPENREDIS_URL=redis://force-redis:6379/0
       - PORT=5000
       - S3_KEY

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -5,14 +5,21 @@ services:
 {% include 'templates/docker-compose-service.yml.j2' %}
     environment:
       - NODE_ENV=development
-      - REDIS_URL=redis://force-redis:6379/0
+      - OPENREDIS_URL=redis://force-redis:6379/0
       - PORT=5000
       - S3_KEY
       - S3_SECRET
       - DEPLOY_ENV
     env_file: ../.env
+    command: ["yarn", "start:dev"]
     ports:
       - 5000:5000
+    volumes:
+      - ../:/app
+      # prevents bind mount from overwriting node_modules in docker image.
+      - /app/node_modules
+    depends_on:
+      - force-redis
   force-redis:
     image: redis:3.2-alpine
     ports:

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
@@ -249,6 +249,7 @@ export const OnCompleteRedirModal: React.FC<OnCompleteRedirModalProps> = props =
       title="Set up with app"
       onClose={onClick}
       show={show}
+      hideCloseButton={true}
       FixedButton={
         <Button onClick={onClick} width="100%">
           OK

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
@@ -235,13 +235,13 @@ const InnerForm: React.FC<InnerFormProps> = ({
   )
 }
 
-interface OnCompleteRedirModalProps {
+interface OnCompleteRedirectModalProps {
   onClick: () => void
   redirectTo: string
   show: boolean
 }
 
-export const OnCompleteRedirModal: React.FC<OnCompleteRedirModalProps> = props => {
+export const OnCompleteRedirectModal: React.FC<OnCompleteRedirectModalProps> = props => {
   const { onClick, redirectTo, show } = props
 
   return (

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Input, Modal, Sans } from "@artsy/palette"
+import { Box, Button, Flex, Input, Modal, Sans, Serif } from "@artsy/palette"
 import { CreateAppSecondFactorMutationResponse } from "v2/__generated__/CreateAppSecondFactorMutation.graphql"
 import { useSystemContext } from "v2/Artsy"
 import { Formik, FormikHelpers as FormikActions, FormikProps } from "formik"
@@ -232,5 +232,35 @@ const InnerForm: React.FC<InnerFormProps> = ({
         </Button>
       </Flex>
     </Box>
+  )
+}
+
+interface OnCompleteRedirModalProps {
+  onClick: () => void
+  redirectTo: string
+  show: boolean
+}
+
+export const OnCompleteRedirModal: React.FC<OnCompleteRedirModalProps> = props => {
+  const { onClick, redirectTo, show } = props
+
+  return (
+    <Modal
+      title="Set up with app"
+      onClose={onClick}
+      show={show}
+      FixedButton={
+        <Button onClick={onClick} width="100%">
+          OK
+        </Button>
+      }
+    >
+      <Serif size="3t" color="black60">
+        You’ve successfully set up two-factor authentication!
+      </Serif>
+      <Serif mt={2} size="3t" color="black60">
+        You will be redirected to: {redirectTo}
+      </Serif>
+    </Modal>
   )
 }

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Flex, Input, Modal, Sans, Serif } from "@artsy/palette"
+import { getURLHost } from "v2/Utils/url"
 import { CreateAppSecondFactorMutationResponse } from "v2/__generated__/CreateAppSecondFactorMutation.graphql"
 import { useSystemContext } from "v2/Artsy"
 import { Formik, FormikHelpers as FormikActions, FormikProps } from "formik"
@@ -260,7 +261,7 @@ export const OnCompleteRedirectModal: React.FC<OnCompleteRedirectModalProps> = p
         You’ve successfully set up two-factor authentication!
       </Serif>
       <Serif mt={2} size="3t" color="black60">
-        You will be redirected to: {redirectTo}
+        You will be redirected to: {getURLHost(redirectTo)}
       </Serif>
     </Modal>
   )

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/Modal.tsx
@@ -1,5 +1,4 @@
 import { Box, Button, Flex, Input, Modal, Sans, Serif } from "@artsy/palette"
-import { getURLHost } from "v2/Utils/url"
 import { CreateAppSecondFactorMutationResponse } from "v2/__generated__/CreateAppSecondFactorMutation.graphql"
 import { useSystemContext } from "v2/Artsy"
 import { Formik, FormikHelpers as FormikActions, FormikProps } from "formik"
@@ -10,6 +9,7 @@ import { ApiError } from "../../ApiError"
 import { EnableSecondFactor } from "../Mutation/EnableSecondFactor"
 import { UpdateAppSecondFactor } from "./Mutation/UpdateAppSecondFactor"
 import { BackupSecondFactorReminder } from "../BackupSecondFactorReminder"
+import { redirectMessage } from "v2/Components/UserSettings/TwoFactorAuthentication/helpers"
 
 export interface FormValues {
   name: string
@@ -261,7 +261,7 @@ export const OnCompleteRedirectModal: React.FC<OnCompleteRedirectModalProps> = p
         You’ve successfully set up two-factor authentication!
       </Serif>
       <Serif mt={2} size="3t" color="black60">
-        You will be redirected to: {getURLHost(redirectTo)}
+        {redirectMessage(redirectTo)}
       </Serif>
     </Modal>
   )

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -84,7 +84,7 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
     if (props.me.hasSecondFactorEnabled) {
       setShowCompleteModal(false)
     } else {
-      setTimeout(() => window.location.assign(redirectTo), 500)
+      window.location.assign(redirectTo)
     }
   }
 

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -13,7 +13,7 @@ import { RelayRefetchProp, createFragmentContainer, graphql } from "react-relay"
 import request from "superagent"
 
 import { useSystemContext } from "v2/Artsy"
-import { AppSecondFactorModal, OnCompleteRedirModal } from "./Modal"
+import { AppSecondFactorModal, OnCompleteRedirectModal } from "./Modal"
 import { ApiError } from "../../ApiError"
 import { ApiErrorModal } from "../ApiErrorModal"
 import { CreateAppSecondFactor } from "./Mutation/CreateAppSecondFactor"
@@ -22,7 +22,7 @@ import { AppSecondFactor_me } from "v2/__generated__/AppSecondFactor_me.graphql"
 import { ConfirmPasswordModal } from "v2/Components/ConfirmPasswordModal"
 import { CreateAppSecondFactorInput } from "v2/__generated__/CreateAppSecondFactorMutation.graphql"
 
-import { afterUpdateRedir } from "v2/Components/UserSettings/TwoFactorAuthentication/helpers"
+import { afterUpdateRedirect } from "v2/Components/UserSettings/TwoFactorAuthentication/helpers"
 
 interface AppSecondFactorProps extends BorderBoxProps {
   me: AppSecondFactor_me
@@ -36,14 +36,14 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
   const [showSetupModal, setShowSetupModal] = useState(false)
   const [showCompleteModal, setShowCompleteModal] = useState(false)
-  const [showCompleteRedirModal, setShowCompleteRedirModal] = useState(false)
+  const [showCompleteRedirectModal, setShowCompleteRedirectModal] = useState(false)
   const [stagedSecondFactor, setStagedSecondFactor] = useState(null)
   const [isDisabling] = useState(false)
   const [isCreating, setCreating] = useState(false)
 
   const { relayEnvironment } = useSystemContext()
 
-  const redirectTo = afterUpdateRedir()
+  const redirectTo = afterUpdateRedirect()
 
   function onComplete() {
     const showCompleteModalCallback = () => {
@@ -51,9 +51,9 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
       setShowCompleteModal(true)
     }
 
-    const showCompleteRedirModalCallback = () => {
+    const showCompleteRedirectModalCallback = () => {
       setShowSetupModal(false)
-      setShowCompleteRedirModal(true)
+      setShowCompleteRedirectModal(true)
     }
 
     if (props.me.hasSecondFactorEnabled) {
@@ -61,7 +61,7 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
       relayRefetch.refetch({}, {}, showCompleteModalCallback)
     } else {
       if (redirectTo) {
-        showCompleteRedirModalCallback()
+        showCompleteRedirectModalCallback()
       } else {
         showCompleteModalCallback()
       }
@@ -80,7 +80,7 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
     }
   }
 
-  async function onCompleteRedir() {
+  async function onCompleteRedirect() {
     if (props.me.hasSecondFactorEnabled) {
       setShowCompleteModal(false)
     } else {
@@ -245,10 +245,10 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
           </Serif>
         )}
       </Modal>
-      <OnCompleteRedirModal
-        onClick={onCompleteRedir}
+      <OnCompleteRedirectModal
+        onClick={onCompleteRedirect}
         redirectTo={redirectTo}
-        show={showCompleteRedirModal}
+        show={showCompleteRedirectModal}
       />
     </BorderBox>
   )

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -80,7 +80,7 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
     }
   }
 
-  async function onCompleteRedirect() {
+  function onCompleteRedirect() {
     if (props.me.hasSecondFactorEnabled) {
       setShowCompleteModal(false)
     } else {

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -13,7 +13,7 @@ import { RelayRefetchProp, createFragmentContainer, graphql } from "react-relay"
 import request from "superagent"
 
 import { useSystemContext } from "v2/Artsy"
-import { AppSecondFactorModal } from "./Modal"
+import { AppSecondFactorModal, OnCompleteRedirModal } from "./Modal"
 import { ApiError } from "../../ApiError"
 import { ApiErrorModal } from "../ApiErrorModal"
 import { CreateAppSecondFactor } from "./Mutation/CreateAppSecondFactor"
@@ -21,6 +21,8 @@ import { DisableFactorConfirmation } from "../DisableFactorConfirmation"
 import { AppSecondFactor_me } from "v2/__generated__/AppSecondFactor_me.graphql"
 import { ConfirmPasswordModal } from "v2/Components/ConfirmPasswordModal"
 import { CreateAppSecondFactorInput } from "v2/__generated__/CreateAppSecondFactorMutation.graphql"
+
+import { afterUpdateRedir } from "v2/Components/UserSettings/TwoFactorAuthentication/helpers"
 
 interface AppSecondFactorProps extends BorderBoxProps {
   me: AppSecondFactor_me
@@ -34,11 +36,14 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
   const [showSetupModal, setShowSetupModal] = useState(false)
   const [showCompleteModal, setShowCompleteModal] = useState(false)
+  const [showCompleteRedirModal, setShowCompleteRedirModal] = useState(false)
   const [stagedSecondFactor, setStagedSecondFactor] = useState(null)
   const [isDisabling] = useState(false)
   const [isCreating, setCreating] = useState(false)
 
   const { relayEnvironment } = useSystemContext()
+
+  const redirectTo = afterUpdateRedir()
 
   function onComplete() {
     const showCompleteModalCallback = () => {
@@ -46,11 +51,20 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
       setShowCompleteModal(true)
     }
 
+    const showCompleteRedirModalCallback = () => {
+      setShowSetupModal(false)
+      setShowCompleteRedirModal(true)
+    }
+
     if (props.me.hasSecondFactorEnabled) {
       // @ts-expect-error STRICT_NULL_CHECK
       relayRefetch.refetch({}, {}, showCompleteModalCallback)
     } else {
-      showCompleteModalCallback()
+      if (redirectTo) {
+        showCompleteRedirModalCallback()
+      } else {
+        showCompleteModalCallback()
+      }
     }
   }
 
@@ -63,6 +77,14 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
         .set("X-Requested-With", "XMLHttpRequest")
 
       location.reload()
+    }
+  }
+
+  async function onCompleteRedir() {
+    if (props.me.hasSecondFactorEnabled) {
+      setShowCompleteModal(false)
+    } else {
+      setTimeout(() => window.location.assign(redirectTo), 500)
     }
   }
 
@@ -223,6 +245,11 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = props => {
           </Serif>
         )}
       </Modal>
+      <OnCompleteRedirModal
+        onClick={onCompleteRedir}
+        redirectTo={redirectTo}
+        show={showCompleteRedirModal}
+      />
     </BorderBox>
   )
 }

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
@@ -292,13 +292,13 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
   )
 }
 
-interface OnCompleteRedirModalProps {
+interface OnCompleteRedirectModalProps {
   onClick: () => void
   redirectTo: string
   show: boolean
 }
 
-export const OnCompleteRedirModal: React.FC<OnCompleteRedirModalProps> = props => {
+export const OnCompleteRedirectModal: React.FC<OnCompleteRedirectModalProps> = props => {
   const { onClick, redirectTo, show } = props
 
   return (

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
@@ -2,6 +2,7 @@ import { Box, Button, Flex, Input, Modal, Sans, Serif, Spacer } from "@artsy/pal
 import { FormikHelpers as FormikActions } from "formik"
 import React, { useState } from "react"
 import styled from "styled-components"
+import { getURLHost } from "v2/Utils/url"
 
 import * as Yup from "yup"
 
@@ -317,7 +318,7 @@ export const OnCompleteRedirectModal: React.FC<OnCompleteRedirectModalProps> = p
         You’ve successfully set up two-factor authentication!
       </Serif>
       <Serif mt={2} size="3t" color="black60">
-        You will be redirected to: {redirectTo}
+        You will be redirected to: {getURLHost(redirectTo)}
       </Serif>
     </Modal>
   )

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
@@ -306,6 +306,7 @@ export const OnCompleteRedirModal: React.FC<OnCompleteRedirModalProps> = props =
       title="Set up with text message"
       onClose={onClick}
       show={show}
+      hideCloseButton={true}
       FixedButton={
         <Button onClick={onClick} width="100%">
           OK

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
@@ -2,7 +2,6 @@ import { Box, Button, Flex, Input, Modal, Sans, Serif, Spacer } from "@artsy/pal
 import { FormikHelpers as FormikActions } from "formik"
 import React, { useState } from "react"
 import styled from "styled-components"
-import { getURLHost } from "v2/Utils/url"
 
 import * as Yup from "yup"
 
@@ -18,6 +17,7 @@ import { UpdateSmsSecondFactor } from "./Mutation/UpdateSmsSecondFactor"
 import { BackupSecondFactorReminder } from "../BackupSecondFactorReminder"
 
 import { CreateSmsSecondFactorMutationResponse } from "v2/__generated__/CreateSmsSecondFactorMutation.graphql"
+import { redirectMessage } from "v2/Components/UserSettings/TwoFactorAuthentication/helpers"
 
 interface SmsSecondFactorModalProps {
   onClose: () => void
@@ -318,7 +318,7 @@ export const OnCompleteRedirectModal: React.FC<OnCompleteRedirectModalProps> = p
         You’ve successfully set up two-factor authentication!
       </Serif>
       <Serif mt={2} size="3t" color="black60">
-        You will be redirected to: {getURLHost(redirectTo)}
+        {redirectMessage(redirectTo)}
       </Serif>
     </Modal>
   )

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/Modal.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Input, Modal, Sans, Spacer } from "@artsy/palette"
+import { Box, Button, Flex, Input, Modal, Sans, Serif, Spacer } from "@artsy/palette"
 import { FormikHelpers as FormikActions } from "formik"
 import React, { useState } from "react"
 import styled from "styled-components"
@@ -289,5 +289,35 @@ export const SmsSecondFactorModal: React.FC<SmsSecondFactorModalProps> = props =
         />
       </Modal>
     </>
+  )
+}
+
+interface OnCompleteRedirModalProps {
+  onClick: () => void
+  redirectTo: string
+  show: boolean
+}
+
+export const OnCompleteRedirModal: React.FC<OnCompleteRedirModalProps> = props => {
+  const { onClick, redirectTo, show } = props
+
+  return (
+    <Modal
+      title="Set up with text message"
+      onClose={onClick}
+      show={show}
+      FixedButton={
+        <Button onClick={onClick} width="100%">
+          OK
+        </Button>
+      }
+    >
+      <Serif size="3t" color="black60">
+        You’ve successfully set up two-factor authentication!
+      </Serif>
+      <Serif mt={2} size="3t" color="black60">
+        You will be redirected to: {redirectTo}
+      </Serif>
+    </Modal>
   )
 }

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
@@ -85,7 +85,7 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
     if (props.me.hasSecondFactorEnabled) {
       setShowCompleteModal(false)
     } else {
-      setTimeout(() => window.location.assign(redirectTo), 500)
+      window.location.assign(redirectTo)
     }
   }
 

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
@@ -14,7 +14,7 @@ import request from "superagent"
 import { useSystemContext } from "v2/Artsy"
 
 import { ApiError } from "../../ApiError"
-import { SmsSecondFactorModal, OnCompleteRedirModal } from "./Modal"
+import { SmsSecondFactorModal, OnCompleteRedirectModal } from "./Modal"
 import { CreateSmsSecondFactor } from "./Mutation/CreateSmsSecondFactor"
 import { CreateSmsSecondFactorInput } from "v2/__generated__/CreateSmsSecondFactorMutation.graphql"
 import { SmsSecondFactor_me } from "v2/__generated__/SmsSecondFactor_me.graphql"
@@ -22,7 +22,7 @@ import { ApiErrorModal } from "../ApiErrorModal"
 import { DisableFactorConfirmation } from "../DisableFactorConfirmation"
 import { ConfirmPasswordModal } from "v2/Components/ConfirmPasswordModal"
 
-import { afterUpdateRedir } from "v2/Components/UserSettings/TwoFactorAuthentication/helpers"
+import { afterUpdateRedirect } from "v2/Components/UserSettings/TwoFactorAuthentication/helpers"
 
 interface SmsSecondFactorProps extends BorderBoxProps {
   me: SmsSecondFactor_me
@@ -36,14 +36,14 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
   const [showSetupModal, setShowSetupModal] = useState(false)
   const [showCompleteModal, setShowCompleteModal] = useState(false)
-  const [showCompleteRedirModal, setShowCompleteRedirModal] = useState(false)
+  const [showCompleteRedirectModal, setShowCompleteRedirectModal] = useState(false)
   const [apiErrors, setApiErrors] = useState<ApiError[]>([])
   const [isDisabling] = useState(false)
   const [isCreating, setCreating] = useState(false)
 
   const [stagedSecondFactor, setStagedSecondFactor] = useState(null)
 
-  const redirectTo = afterUpdateRedir()
+  const redirectTo = afterUpdateRedirect()
 
   function onComplete() {
     const showCompleteModalCallback = () => {
@@ -51,9 +51,9 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
       setShowCompleteModal(true)
     }
 
-    const showCompleteRedirModalCallback = () => {
+    const showCompleteRedirectModalCallback = () => {
       setShowSetupModal(false)
-      setShowCompleteRedirModal(true)
+      setShowCompleteRedirectModal(true)
     }
 
     if (props.me.hasSecondFactorEnabled) {
@@ -62,7 +62,7 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
     } else {
       showCompleteModalCallback()
       if (redirectTo) {
-        showCompleteRedirModalCallback()
+        showCompleteRedirectModalCallback()
       } else {
         showCompleteModalCallback()
       }
@@ -81,7 +81,7 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
     }
   }
 
-  async function onCompleteRedir() {
+  async function onCompleteRedirect() {
     if (props.me.hasSecondFactorEnabled) {
       setShowCompleteModal(false)
     } else {
@@ -242,10 +242,10 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
           </Serif>
         )}
       </Modal>
-      <OnCompleteRedirModal
-        onClick={onCompleteRedir}
+      <OnCompleteRedirectModal
+        onClick={onCompleteRedirect}
         redirectTo={redirectTo}
-        show={showCompleteRedirModal}
+        show={showCompleteRedirectModal}
       />
     </BorderBox>
   )

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/Components/SmsSecondFactor/index.tsx
@@ -81,7 +81,7 @@ export const SmsSecondFactor: React.FC<SmsSecondFactorProps> = props => {
     }
   }
 
-  async function onCompleteRedirect() {
+  function onCompleteRedirect() {
     if (props.me.hasSecondFactorEnabled) {
       setShowCompleteModal(false)
     } else {

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/helpers.ts
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/helpers.ts
@@ -7,11 +7,7 @@ export const afterUpdateRedirect = () => {
 
   if (afterUpdateURL) {
     const sanitizedURL = sanitizeRedirect(afterUpdateURL)
-
-    // a '/' means URL is bad
-    if (sanitizedURL !== '/') {
-      return sanitizedURL
-    }
+    return sanitizedURL
   }
 
   return ''

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/helpers.ts
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/helpers.ts
@@ -1,4 +1,5 @@
 import { getClientParam } from "v2/Utils/getClientParam"
+import { getURLHost } from "v2/Utils/url"
 import sanitizeRedirect from "@artsy/passport/sanitize-redirect"
 
 export const afterUpdateRedirect = () => {
@@ -14,4 +15,13 @@ export const afterUpdateRedirect = () => {
   }
 
   return ''
+}
+
+export const redirectMessage = (url) => {
+  const urlHost = getURLHost(url)
+  if (urlHost) {
+    return 'You will be redirected to: ' + urlHost
+  } else {
+    return ''
+  }
 }

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/helpers.ts
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/helpers.ts
@@ -1,0 +1,17 @@
+import { getClientParam } from "v2/Utils/getClientParam"
+import sanitizeRedirect from "@artsy/passport/sanitize-redirect"
+
+export const afterUpdateRedir = () => {
+  const afterUpdateURL = getClientParam("after_update")
+
+  if (afterUpdateURL) {
+    const sanitizedURL = sanitizeRedirect(afterUpdateURL)
+
+    // a '/' means URL is bad
+    if (sanitizedURL !== '/') {
+      return sanitizedURL
+    }
+  }
+
+  return ''
+}

--- a/src/v2/Components/UserSettings/TwoFactorAuthentication/helpers.ts
+++ b/src/v2/Components/UserSettings/TwoFactorAuthentication/helpers.ts
@@ -1,7 +1,7 @@
 import { getClientParam } from "v2/Utils/getClientParam"
 import sanitizeRedirect from "@artsy/passport/sanitize-redirect"
 
-export const afterUpdateRedir = () => {
+export const afterUpdateRedirect = () => {
   const afterUpdateURL = getClientParam("after_update")
 
   if (afterUpdateURL) {

--- a/src/v2/Utils/url.ts
+++ b/src/v2/Utils/url.ts
@@ -1,0 +1,8 @@
+export const getURLHost = (url) => {
+  try {
+    const urlObject = new URL(url)
+    return urlObject.hostname
+  } catch (error) {
+    return ''
+  }
+}


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3340

We are going to redirect partners from CMS to Force to setup their 2FA (if they are required to but haven't yet) like so:

`https://www.artsy.net/user/edit?after_update=https%3A%2F%2Fcms.artsy.net%3A%2Fauth%2Fartsy#two-factor-authentication`

After they finish setting up 2FA, we would like them redirected to the URL encoded in `after_update` param (back to `https://cms.artsy.net/auth/artsy`).

This PR adds a 2FA setup completion modal specifically for these users. On completion, they are informed that they will be redirected to `after_update` URL.

The URL is sanitized to prevent rogue redirects (such as to www.evilsite.com, ...)

Changes to `hokusai/development.yml` are to get `hokusai dev` working.

Screenshots of new modal:

![Screenshot from 2021-05-25 16-42-09](https://user-images.githubusercontent.com/63004951/119565643-34883900-bd78-11eb-90a5-f4e38b1fa5ed.png)

![Screenshot from 2021-05-25 16-44-06](https://user-images.githubusercontent.com/63004951/119565844-76b17a80-bd78-11eb-954a-7d0190f29ba8.png)
