### PR TITLE
fix: PPP overview about section

### DIFF
--- a/src/v2/Apps/Partner/Components/Overview/AboutPartner.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/AboutPartner.tsx
@@ -12,7 +12,9 @@ export interface AboutPartnerProps {
 export const AboutPartner: React.FC<AboutPartnerProps> = ({
   partner: { profile, vatNumber, website, fullProfileEligible },
 }) => {
-  const isEmpty = !profile?.fullBio && !vatNumber && !website
+  const fullBio = profile?.fullBio
+  const limitedBio = profile?.bio
+  const isEmpty = !fullBio && !limitedBio && !vatNumber && !website
 
   if (isEmpty) {
     return null
@@ -20,8 +22,7 @@ export const AboutPartner: React.FC<AboutPartnerProps> = ({
 
   const canRenderWebsite = website && fullProfileEligible
   const canRenderVatNumber = vatNumber && fullProfileEligible
-  const fullBio = profile?.fullBio
-  const limitedBio = profile?.bio
+  const bioDisplayable = fullBio || limitedBio
 
   return (
     <GridColumns mb={12} gridRowGap={2}>
@@ -31,16 +32,16 @@ export const AboutPartner: React.FC<AboutPartnerProps> = ({
 
       <Column span={6}>
         <Media at="xs">
-          {limitedBio && (
+          {bioDisplayable && (
             <Text mb={2} variant="text">
-              {limitedBio}
+              {limitedBio ? limitedBio : fullBio}
             </Text>
           )}
         </Media>
         <Media greaterThan="xs">
-          {fullBio && (
+          {bioDisplayable && (
             <Text mb={2} variant="text">
-              {fullBio}
+              {fullBio ? fullBio : limitedBio}
             </Text>
           )}
         </Media>

--- a/src/v2/Apps/Partner/Components/Overview/SubscriberBanner.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/SubscriberBanner.tsx
@@ -14,7 +14,7 @@ export const SubscriberBanner: React.FC<SubscriberBannerProps> = ({
   const fairPartner = `${name} participates in Artsy’s art fair coverage but does not have a full profile.`
   const churnedPartner = `${name} is not currently an Artsy partner and does not have a full profile.`
   return (
-    <Message title={hasFairPartnership ? fairPartner : churnedPartner}>
+    <Message mb={4} title={hasFairPartnership ? fairPartner : churnedPartner}>
       <Text display="inline">{`Do you represent ${name}?`}</Text>
       <RouterLink to="https://partners.artsy.net/gallery-partnerships/">
         <Text display="inline">

--- a/src/v2/Apps/Partner/Components/__tests__/Overview/AboutPartner.jest.tsx
+++ b/src/v2/Apps/Partner/Components/__tests__/Overview/AboutPartner.jest.tsx
@@ -22,10 +22,14 @@ describe("AboutPartner", () => {
   it("renders correctly", () => {
     const website = "http://www.theunitldn.com"
     const vatNumber = "GB204716728"
-    const limitedBio =
+    let limitedBio =
       "Our core mission is the identification, development and exposure of talented and innovative artists for a contemporary audience."
-    const fullBio =
+    let fullBio =
       "Since the brand’s inception in 2013, Unit London has established a global artistic platform for the world’s most distinctive emerging talent. In an often opaque and impenetrable art world, Unit London seeks to identify, cultivate and expose works of art on a purely meritocratic basis. The gallery has successfully launched and advanced the careers of numerous important contemporary artists and remains a bastion of equity, innovation and sustainability."
+
+    limitedBio = limitedBio ? limitedBio : fullBio
+    fullBio = fullBio ? fullBio : limitedBio
+
     const wrapper = getWrapper({
       Partner: () => ({
         website,
@@ -57,6 +61,7 @@ describe("AboutPartner", () => {
     expect(wrapper.find("Text").at(1).length).toEqual(0)
     expect(wrapper.find("Text").at(2).length).toEqual(0)
     expect(wrapper.find("Text").at(3).length).toEqual(0)
+    expect(wrapper.find("Text").at(4).length).toEqual(0)
   })
 
   it("doesn't render the component if all data is empty", () => {


### PR DESCRIPTION
JIRA -> [Displayed only `About` title in about section of overview page](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=36&projectKey=PX&modal=detail&selectedIssue=PX-4121&quickFilter=228)

We have a logic of displaying partners bio in about section:
- `bio` field - shorted version of partners bio for displaying on mobile version
- `full_bio` field - full version for displaying on PC

This PR adjusted the logic of displaying bio and full_bio in about section in the following way:
- display `bio` version on PC if `full_bio` is null
- display `full_bio` version on mobile if `bio` is null
