### PR TITLE
fix(PX-4015): use partnerArtist artwork connection for loading artist's artworks in the right order

### DIFF
--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistDetails.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistDetails.tsx
@@ -18,6 +18,7 @@ import { ContextModule } from "@artsy/cohesion"
 import { useSystemContext } from "v2/Artsy"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import { PartnerArtistDetailsPlaceholder } from "./PartnerArtistDetailsPlaceholder"
+import { compact } from "lodash"
 
 export interface PartnerArtistDetailsProps {
   partnerArtist: PartnerArtistDetails_partnerArtist
@@ -29,14 +30,12 @@ export const PartnerArtistDetails: React.FC<PartnerArtistDetailsProps> = ({
   if (!partnerArtist || !partnerArtist.node) return null
 
   const {
-    node: {
-      name,
-      filterArtworksConnection,
-      href,
-      formattedNationalityAndBirthday,
-    },
+    node: { name, href, formattedNationalityAndBirthday },
     biographyBlurb,
+    artworksConnection,
   } = partnerArtist
+
+  const artworks = compact(artworksConnection?.edges?.map(c => c?.node))
 
   return (
     <Box>
@@ -82,14 +81,11 @@ export const PartnerArtistDetails: React.FC<PartnerArtistDetailsProps> = ({
         </Column>
         <Column span={12} maxWidth="100%">
           <Carousel arrowHeight={160}>
-            {/* @ts-expect-error STRICT_NULL_CHECK */}
-            {filterArtworksConnection.edges.map((artwork, i) => {
+            {artworks.map(artwork => {
               return (
                 <FillwidthItem
-                  // @ts-expect-error STRICT_NULL_CHECK
-                  key={artwork.node.id}
-                  // @ts-expect-error STRICT_NULL_CHECK
-                  artwork={artwork.node}
+                  key={artwork.id}
+                  artwork={artwork}
                   imageHeight={160}
                   lazyLoad
                 />
@@ -111,19 +107,19 @@ export const PartnerArtistDetailsFragmentContainer = createFragmentContainer(
           text
           credit
         }
+        artworksConnection(first: 12) {
+          edges {
+            node {
+              id
+              ...FillwidthItem_artwork
+            }
+          }
+        }
         node {
           name
           href
           formattedNationalityAndBirthday
           ...FollowArtistButton_artist
-          filterArtworksConnection(first: 12, partnerIDs: [$partnerId]) {
-            edges {
-              node {
-                id
-                ...FillwidthItem_artwork
-              }
-            }
-          }
         }
       }
     `,

--- a/src/v2/__generated__/PartnerArtistDetailsListQuery.graphql.ts
+++ b/src/v2/__generated__/PartnerArtistDetailsListQuery.graphql.ts
@@ -164,20 +164,19 @@ fragment PartnerArtistDetails_partnerArtist on ArtistPartnerEdge {
     text
     credit
   }
+  artworksConnection(first: 12) {
+    edges {
+      node {
+        id
+        ...FillwidthItem_artwork
+      }
+    }
+  }
   node {
     name
     href
     formattedNationalityAndBirthday
     ...FollowArtistButton_artist
-    filterArtworksConnection(first: 12, partnerIDs: [$partnerId]) {
-      edges {
-        node {
-          id
-          ...FillwidthItem_artwork
-        }
-      }
-      id
-    }
     id
   }
 }
@@ -261,31 +260,24 @@ v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v10 = [
+v8 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v11 = [
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v10 = [
   {
     "alias": null,
     "args": null,
@@ -293,7 +285,14 @@ v11 = [
     "name": "display",
     "storageKey": null
   }
-];
+],
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -413,14 +412,290 @@ return {
                   },
                   {
                     "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "first",
+                        "value": 12
+                      }
+                    ],
+                    "concreteType": "ArtworkConnection",
+                    "kind": "LinkedField",
+                    "name": "artworksConnection",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Artwork",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v6/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "kind": "LinkedField",
+                                "name": "image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": "larger"
+                                      }
+                                    ],
+                                    "kind": "ScalarField",
+                                    "name": "url",
+                                    "storageKey": "url(version:\"larger\")"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "aspectRatio",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "imageTitle",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "title",
+                                "storageKey": null
+                              },
+                              (v7/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "date",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "sale_message",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "saleMessage",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "cultural_maker",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "culturalMaker",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": (v8/*: any*/),
+                                "concreteType": "Artist",
+                                "kind": "LinkedField",
+                                "name": "artists",
+                                "plural": true,
+                                "selections": [
+                                  (v6/*: any*/),
+                                  (v7/*: any*/),
+                                  (v9/*: any*/)
+                                ],
+                                "storageKey": "artists(shallow:true)"
+                              },
+                              {
+                                "alias": "collecting_institution",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "collectingInstitution",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": (v8/*: any*/),
+                                "concreteType": "Partner",
+                                "kind": "LinkedField",
+                                "name": "partner",
+                                "plural": false,
+                                "selections": [
+                                  (v9/*: any*/),
+                                  (v7/*: any*/),
+                                  (v6/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "type",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": "partner(shallow:true)"
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Sale",
+                                "kind": "LinkedField",
+                                "name": "sale",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": "is_auction",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isAuction",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_closed",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isClosed",
+                                    "storageKey": null
+                                  },
+                                  (v6/*: any*/),
+                                  {
+                                    "alias": "is_live_open",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isLiveOpen",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_open",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isOpen",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_preview",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isPreview",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "display_timely_at",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "displayTimelyAt",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "sale_artwork",
+                                "args": null,
+                                "concreteType": "SaleArtwork",
+                                "kind": "LinkedField",
+                                "name": "saleArtwork",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "SaleArtworkCounts",
+                                    "kind": "LinkedField",
+                                    "name": "counts",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "bidder_positions",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "bidderPositions",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "highest_bid",
+                                    "args": null,
+                                    "concreteType": "SaleArtworkHighestBid",
+                                    "kind": "LinkedField",
+                                    "name": "highestBid",
+                                    "plural": false,
+                                    "selections": (v10/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "opening_bid",
+                                    "args": null,
+                                    "concreteType": "SaleArtworkOpeningBid",
+                                    "kind": "LinkedField",
+                                    "name": "openingBid",
+                                    "plural": false,
+                                    "selections": (v10/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  (v6/*: any*/)
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_inquireable",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isInquireable",
+                                "storageKey": null
+                              },
+                              (v11/*: any*/),
+                              (v4/*: any*/),
+                              {
+                                "alias": "is_saved",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isSaved",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_biddable",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isBiddable",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "artworksConnection(first:12)"
+                  },
+                  {
+                    "alias": null,
                     "args": null,
                     "concreteType": "Artist",
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
                     "selections": [
+                      (v9/*: any*/),
                       (v7/*: any*/),
-                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -429,7 +704,7 @@ return {
                         "storageKey": null
                       },
                       (v6/*: any*/),
-                      (v9/*: any*/),
+                      (v11/*: any*/),
                       (v4/*: any*/),
                       {
                         "alias": "is_followed",
@@ -453,294 +728,6 @@ return {
                             "name": "follows",
                             "storageKey": null
                           }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "first",
-                            "value": 12
-                          },
-                          {
-                            "items": [
-                              {
-                                "kind": "Variable",
-                                "name": "partnerIDs.0",
-                                "variableName": "partnerId"
-                              }
-                            ],
-                            "kind": "ListValue",
-                            "name": "partnerIDs"
-                          }
-                        ],
-                        "concreteType": "FilterArtworksConnection",
-                        "kind": "LinkedField",
-                        "name": "filterArtworksConnection",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "FilterArtworksEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  (v6/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": "larger"
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:\"larger\")"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "title",
-                                    "storageKey": null
-                                  },
-                                  (v8/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "date",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_message",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "saleMessage",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "cultural_maker",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "culturalMaker",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v10/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artists",
-                                    "plural": true,
-                                    "selections": [
-                                      (v6/*: any*/),
-                                      (v8/*: any*/),
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": "artists(shallow:true)"
-                                  },
-                                  {
-                                    "alias": "collecting_institution",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "collectingInstitution",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v10/*: any*/),
-                                    "concreteType": "Partner",
-                                    "kind": "LinkedField",
-                                    "name": "partner",
-                                    "plural": false,
-                                    "selections": [
-                                      (v7/*: any*/),
-                                      (v8/*: any*/),
-                                      (v6/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "type",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": "partner(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Sale",
-                                    "kind": "LinkedField",
-                                    "name": "sale",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": "is_auction",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isAuction",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_closed",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isClosed",
-                                        "storageKey": null
-                                      },
-                                      (v6/*: any*/),
-                                      {
-                                        "alias": "is_live_open",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isLiveOpen",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_open",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isOpen",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_artwork",
-                                    "args": null,
-                                    "concreteType": "SaleArtwork",
-                                    "kind": "LinkedField",
-                                    "name": "saleArtwork",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "SaleArtworkCounts",
-                                        "kind": "LinkedField",
-                                        "name": "counts",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": "bidder_positions",
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidderPositions",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "highest_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkHighestBid",
-                                        "kind": "LinkedField",
-                                        "name": "highestBid",
-                                        "plural": false,
-                                        "selections": (v11/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "opening_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkOpeningBid",
-                                        "kind": "LinkedField",
-                                        "name": "openingBid",
-                                        "plural": false,
-                                        "selections": (v11/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v6/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "is_inquireable",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isInquireable",
-                                    "storageKey": null
-                                  },
-                                  (v9/*: any*/),
-                                  (v4/*: any*/),
-                                  {
-                                    "alias": "is_saved",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSaved",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "is_biddable",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          (v6/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -815,7 +802,7 @@ return {
     "metadata": {},
     "name": "PartnerArtistDetailsListQuery",
     "operationKind": "query",
-    "text": "query PartnerArtistDetailsListQuery(\n  $partnerId: String!\n  $first: Int!\n  $after: String\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerArtistDetailsList_partner_2HEEH6\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment PartnerArtistDetailsList_partner_2HEEH6 on Partner {\n  slug\n  artists: artistsConnection(first: $first, after: $after, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    edges {\n      id\n      representedBy\n      counts {\n        artworks\n      }\n      ...PartnerArtistDetails_partnerArtist\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PartnerArtistDetails_partnerArtist on ArtistPartnerEdge {\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  node {\n    name\n    href\n    formattedNationalityAndBirthday\n    ...FollowArtistButton_artist\n    filterArtworksConnection(first: 12, partnerIDs: [$partnerId]) {\n      edges {\n        node {\n          id\n          ...FillwidthItem_artwork\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query PartnerArtistDetailsListQuery(\n  $partnerId: String!\n  $first: Int!\n  $after: String\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerArtistDetailsList_partner_2HEEH6\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment PartnerArtistDetailsList_partner_2HEEH6 on Partner {\n  slug\n  artists: artistsConnection(first: $first, after: $after, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    edges {\n      id\n      representedBy\n      counts {\n        artworks\n      }\n      ...PartnerArtistDetails_partnerArtist\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PartnerArtistDetails_partnerArtist on ArtistPartnerEdge {\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  artworksConnection(first: 12) {\n    edges {\n      node {\n        id\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  node {\n    name\n    href\n    formattedNationalityAndBirthday\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnerArtistDetailsListRendererQuery.graphql.ts
+++ b/src/v2/__generated__/PartnerArtistDetailsListRendererQuery.graphql.ts
@@ -160,20 +160,19 @@ fragment PartnerArtistDetails_partnerArtist on ArtistPartnerEdge {
     text
     credit
   }
+  artworksConnection(first: 12) {
+    edges {
+      node {
+        id
+        ...FillwidthItem_artwork
+      }
+    }
+  }
   node {
     name
     href
     formattedNationalityAndBirthday
     ...FollowArtistButton_artist
-    filterArtworksConnection(first: 12, partnerIDs: [$partnerId]) {
-      edges {
-        node {
-          id
-          ...FillwidthItem_artwork
-        }
-      }
-      id
-    }
     id
   }
 }
@@ -238,31 +237,24 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v8 = [
+v6 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v9 = [
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v8 = [
   {
     "alias": null,
     "args": null,
@@ -270,7 +262,14 @@ v9 = [
     "name": "display",
     "storageKey": null
   }
-];
+],
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -387,14 +386,290 @@ return {
                   },
                   {
                     "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "first",
+                        "value": 12
+                      }
+                    ],
+                    "concreteType": "ArtworkConnection",
+                    "kind": "LinkedField",
+                    "name": "artworksConnection",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Artwork",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "kind": "LinkedField",
+                                "name": "image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": "larger"
+                                      }
+                                    ],
+                                    "kind": "ScalarField",
+                                    "name": "url",
+                                    "storageKey": "url(version:\"larger\")"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "aspectRatio",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "imageTitle",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "title",
+                                "storageKey": null
+                              },
+                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "date",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "sale_message",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "saleMessage",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "cultural_maker",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "culturalMaker",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": (v6/*: any*/),
+                                "concreteType": "Artist",
+                                "kind": "LinkedField",
+                                "name": "artists",
+                                "plural": true,
+                                "selections": [
+                                  (v4/*: any*/),
+                                  (v5/*: any*/),
+                                  (v7/*: any*/)
+                                ],
+                                "storageKey": "artists(shallow:true)"
+                              },
+                              {
+                                "alias": "collecting_institution",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "collectingInstitution",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": (v6/*: any*/),
+                                "concreteType": "Partner",
+                                "kind": "LinkedField",
+                                "name": "partner",
+                                "plural": false,
+                                "selections": [
+                                  (v7/*: any*/),
+                                  (v5/*: any*/),
+                                  (v4/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "type",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": "partner(shallow:true)"
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Sale",
+                                "kind": "LinkedField",
+                                "name": "sale",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": "is_auction",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isAuction",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_closed",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isClosed",
+                                    "storageKey": null
+                                  },
+                                  (v4/*: any*/),
+                                  {
+                                    "alias": "is_live_open",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isLiveOpen",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_open",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isOpen",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_preview",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isPreview",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "display_timely_at",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "displayTimelyAt",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "sale_artwork",
+                                "args": null,
+                                "concreteType": "SaleArtwork",
+                                "kind": "LinkedField",
+                                "name": "saleArtwork",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "SaleArtworkCounts",
+                                    "kind": "LinkedField",
+                                    "name": "counts",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "bidder_positions",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "bidderPositions",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "highest_bid",
+                                    "args": null,
+                                    "concreteType": "SaleArtworkHighestBid",
+                                    "kind": "LinkedField",
+                                    "name": "highestBid",
+                                    "plural": false,
+                                    "selections": (v8/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "opening_bid",
+                                    "args": null,
+                                    "concreteType": "SaleArtworkOpeningBid",
+                                    "kind": "LinkedField",
+                                    "name": "openingBid",
+                                    "plural": false,
+                                    "selections": (v8/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  (v4/*: any*/)
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_inquireable",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isInquireable",
+                                "storageKey": null
+                              },
+                              (v9/*: any*/),
+                              (v2/*: any*/),
+                              {
+                                "alias": "is_saved",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isSaved",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_biddable",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isBiddable",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "artworksConnection(first:12)"
+                  },
+                  {
+                    "alias": null,
                     "args": null,
                     "concreteType": "Artist",
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
                     "selections": [
+                      (v7/*: any*/),
                       (v5/*: any*/),
-                      (v6/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -403,7 +678,7 @@ return {
                         "storageKey": null
                       },
                       (v4/*: any*/),
-                      (v7/*: any*/),
+                      (v9/*: any*/),
                       (v2/*: any*/),
                       {
                         "alias": "is_followed",
@@ -427,294 +702,6 @@ return {
                             "name": "follows",
                             "storageKey": null
                           }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "first",
-                            "value": 12
-                          },
-                          {
-                            "items": [
-                              {
-                                "kind": "Variable",
-                                "name": "partnerIDs.0",
-                                "variableName": "partnerId"
-                              }
-                            ],
-                            "kind": "ListValue",
-                            "name": "partnerIDs"
-                          }
-                        ],
-                        "concreteType": "FilterArtworksConnection",
-                        "kind": "LinkedField",
-                        "name": "filterArtworksConnection",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "FilterArtworksEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  (v4/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": "larger"
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:\"larger\")"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "title",
-                                    "storageKey": null
-                                  },
-                                  (v6/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "date",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_message",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "saleMessage",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "cultural_maker",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "culturalMaker",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artists",
-                                    "plural": true,
-                                    "selections": [
-                                      (v4/*: any*/),
-                                      (v6/*: any*/),
-                                      (v5/*: any*/)
-                                    ],
-                                    "storageKey": "artists(shallow:true)"
-                                  },
-                                  {
-                                    "alias": "collecting_institution",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "collectingInstitution",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Partner",
-                                    "kind": "LinkedField",
-                                    "name": "partner",
-                                    "plural": false,
-                                    "selections": [
-                                      (v5/*: any*/),
-                                      (v6/*: any*/),
-                                      (v4/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "type",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": "partner(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Sale",
-                                    "kind": "LinkedField",
-                                    "name": "sale",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": "is_auction",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isAuction",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_closed",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isClosed",
-                                        "storageKey": null
-                                      },
-                                      (v4/*: any*/),
-                                      {
-                                        "alias": "is_live_open",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isLiveOpen",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_open",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isOpen",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_artwork",
-                                    "args": null,
-                                    "concreteType": "SaleArtwork",
-                                    "kind": "LinkedField",
-                                    "name": "saleArtwork",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "SaleArtworkCounts",
-                                        "kind": "LinkedField",
-                                        "name": "counts",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": "bidder_positions",
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidderPositions",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "highest_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkHighestBid",
-                                        "kind": "LinkedField",
-                                        "name": "highestBid",
-                                        "plural": false,
-                                        "selections": (v9/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "opening_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkOpeningBid",
-                                        "kind": "LinkedField",
-                                        "name": "openingBid",
-                                        "plural": false,
-                                        "selections": (v9/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v4/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "is_inquireable",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isInquireable",
-                                    "storageKey": null
-                                  },
-                                  (v7/*: any*/),
-                                  (v2/*: any*/),
-                                  {
-                                    "alias": "is_saved",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSaved",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "is_biddable",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -789,7 +776,7 @@ return {
     "metadata": {},
     "name": "PartnerArtistDetailsListRendererQuery",
     "operationKind": "query",
-    "text": "query PartnerArtistDetailsListRendererQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerArtistDetailsList_partner\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment PartnerArtistDetailsList_partner on Partner {\n  slug\n  artists: artistsConnection(first: 3, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    edges {\n      id\n      representedBy\n      counts {\n        artworks\n      }\n      ...PartnerArtistDetails_partnerArtist\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PartnerArtistDetails_partnerArtist on ArtistPartnerEdge {\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  node {\n    name\n    href\n    formattedNationalityAndBirthday\n    ...FollowArtistButton_artist\n    filterArtworksConnection(first: 12, partnerIDs: [$partnerId]) {\n      edges {\n        node {\n          id\n          ...FillwidthItem_artwork\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query PartnerArtistDetailsListRendererQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...PartnerArtistDetailsList_partner\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment PartnerArtistDetailsList_partner on Partner {\n  slug\n  artists: artistsConnection(first: 3, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    edges {\n      id\n      representedBy\n      counts {\n        artworks\n      }\n      ...PartnerArtistDetails_partnerArtist\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PartnerArtistDetails_partnerArtist on ArtistPartnerEdge {\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  artworksConnection(first: 12) {\n    edges {\n      node {\n        id\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  node {\n    name\n    href\n    formattedNationalityAndBirthday\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnerArtistDetailsQuery.graphql.ts
+++ b/src/v2/__generated__/PartnerArtistDetailsQuery.graphql.ts
@@ -148,20 +148,19 @@ fragment PartnerArtistDetails_partnerArtist on ArtistPartnerEdge {
     text
     credit
   }
+  artworksConnection(first: 12) {
+    edges {
+      node {
+        id
+        ...FillwidthItem_artwork
+      }
+    }
+  }
   node {
     name
     href
     formattedNationalityAndBirthday
     ...FollowArtistButton_artist
-    filterArtworksConnection(first: 12, partnerIDs: [$partnerId]) {
-      edges {
-        node {
-          id
-          ...FillwidthItem_artwork
-        }
-      }
-      id
-    }
     id
   }
 }
@@ -219,7 +218,7 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "id",
   "storageKey": null
 },
 v4 = {
@@ -229,35 +228,21 @@ v4 = {
   "name": "href",
   "storageKey": null
 },
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v8 = [
+v5 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v9 = [
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v7 = [
   {
     "alias": null,
     "args": null,
@@ -265,7 +250,21 @@ v9 = [
     "name": "display",
     "storageKey": null
   }
-];
+],
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -377,13 +376,289 @@ return {
                   },
                   {
                     "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "first",
+                        "value": 12
+                      }
+                    ],
+                    "concreteType": "ArtworkConnection",
+                    "kind": "LinkedField",
+                    "name": "artworksConnection",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Artwork",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "kind": "LinkedField",
+                                "name": "image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": "larger"
+                                      }
+                                    ],
+                                    "kind": "ScalarField",
+                                    "name": "url",
+                                    "storageKey": "url(version:\"larger\")"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "aspectRatio",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "imageTitle",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "title",
+                                "storageKey": null
+                              },
+                              (v4/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "date",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "sale_message",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "saleMessage",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "cultural_maker",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "culturalMaker",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": (v5/*: any*/),
+                                "concreteType": "Artist",
+                                "kind": "LinkedField",
+                                "name": "artists",
+                                "plural": true,
+                                "selections": [
+                                  (v3/*: any*/),
+                                  (v4/*: any*/),
+                                  (v6/*: any*/)
+                                ],
+                                "storageKey": "artists(shallow:true)"
+                              },
+                              {
+                                "alias": "collecting_institution",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "collectingInstitution",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": (v5/*: any*/),
+                                "concreteType": "Partner",
+                                "kind": "LinkedField",
+                                "name": "partner",
+                                "plural": false,
+                                "selections": [
+                                  (v6/*: any*/),
+                                  (v4/*: any*/),
+                                  (v3/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "type",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": "partner(shallow:true)"
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Sale",
+                                "kind": "LinkedField",
+                                "name": "sale",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": "is_auction",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isAuction",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_closed",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isClosed",
+                                    "storageKey": null
+                                  },
+                                  (v3/*: any*/),
+                                  {
+                                    "alias": "is_live_open",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isLiveOpen",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_open",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isOpen",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_preview",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isPreview",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "display_timely_at",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "displayTimelyAt",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "sale_artwork",
+                                "args": null,
+                                "concreteType": "SaleArtwork",
+                                "kind": "LinkedField",
+                                "name": "saleArtwork",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "SaleArtworkCounts",
+                                    "kind": "LinkedField",
+                                    "name": "counts",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "bidder_positions",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "bidderPositions",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "highest_bid",
+                                    "args": null,
+                                    "concreteType": "SaleArtworkHighestBid",
+                                    "kind": "LinkedField",
+                                    "name": "highestBid",
+                                    "plural": false,
+                                    "selections": (v7/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "opening_bid",
+                                    "args": null,
+                                    "concreteType": "SaleArtworkOpeningBid",
+                                    "kind": "LinkedField",
+                                    "name": "openingBid",
+                                    "plural": false,
+                                    "selections": (v7/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  (v3/*: any*/)
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_inquireable",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isInquireable",
+                                "storageKey": null
+                              },
+                              (v8/*: any*/),
+                              (v9/*: any*/),
+                              {
+                                "alias": "is_saved",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isSaved",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_biddable",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isBiddable",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "artworksConnection(first:12)"
+                  },
+                  {
+                    "alias": null,
                     "args": null,
                     "concreteType": "Artist",
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
+                      (v6/*: any*/),
                       (v4/*: any*/),
                       {
                         "alias": null,
@@ -392,9 +667,9 @@ return {
                         "name": "formattedNationalityAndBirthday",
                         "storageKey": null
                       },
-                      (v5/*: any*/),
-                      (v6/*: any*/),
-                      (v7/*: any*/),
+                      (v3/*: any*/),
+                      (v8/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": "is_followed",
                         "args": null,
@@ -419,306 +694,18 @@ return {
                           }
                         ],
                         "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "first",
-                            "value": 12
-                          },
-                          {
-                            "items": [
-                              {
-                                "kind": "Variable",
-                                "name": "partnerIDs.0",
-                                "variableName": "partnerId"
-                              }
-                            ],
-                            "kind": "ListValue",
-                            "name": "partnerIDs"
-                          }
-                        ],
-                        "concreteType": "FilterArtworksConnection",
-                        "kind": "LinkedField",
-                        "name": "filterArtworksConnection",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "FilterArtworksEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  (v5/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": "larger"
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:\"larger\")"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "aspectRatio",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "imageTitle",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "title",
-                                    "storageKey": null
-                                  },
-                                  (v4/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "date",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_message",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "saleMessage",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "cultural_maker",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "culturalMaker",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artists",
-                                    "plural": true,
-                                    "selections": [
-                                      (v5/*: any*/),
-                                      (v4/*: any*/),
-                                      (v3/*: any*/)
-                                    ],
-                                    "storageKey": "artists(shallow:true)"
-                                  },
-                                  {
-                                    "alias": "collecting_institution",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "collectingInstitution",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Partner",
-                                    "kind": "LinkedField",
-                                    "name": "partner",
-                                    "plural": false,
-                                    "selections": [
-                                      (v3/*: any*/),
-                                      (v4/*: any*/),
-                                      (v5/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "type",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": "partner(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Sale",
-                                    "kind": "LinkedField",
-                                    "name": "sale",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": "is_auction",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isAuction",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_closed",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isClosed",
-                                        "storageKey": null
-                                      },
-                                      (v5/*: any*/),
-                                      {
-                                        "alias": "is_live_open",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isLiveOpen",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_open",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isOpen",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_preview",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isPreview",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "display_timely_at",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "displayTimelyAt",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_artwork",
-                                    "args": null,
-                                    "concreteType": "SaleArtwork",
-                                    "kind": "LinkedField",
-                                    "name": "saleArtwork",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "SaleArtworkCounts",
-                                        "kind": "LinkedField",
-                                        "name": "counts",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": "bidder_positions",
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidderPositions",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "highest_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkHighestBid",
-                                        "kind": "LinkedField",
-                                        "name": "highestBid",
-                                        "plural": false,
-                                        "selections": (v9/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "opening_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkOpeningBid",
-                                        "kind": "LinkedField",
-                                        "name": "openingBid",
-                                        "plural": false,
-                                        "selections": (v9/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v5/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "is_inquireable",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isInquireable",
-                                    "storageKey": null
-                                  },
-                                  (v6/*: any*/),
-                                  (v7/*: any*/),
-                                  {
-                                    "alias": "is_saved",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSaved",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "is_biddable",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isBiddable",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          (v5/*: any*/)
-                        ],
-                        "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
-                  (v5/*: any*/)
+                  (v3/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": null
           },
-          (v5/*: any*/)
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
@@ -729,7 +716,7 @@ return {
     "metadata": {},
     "name": "PartnerArtistDetailsQuery",
     "operationKind": "query",
-    "text": "query PartnerArtistDetailsQuery(\n  $partnerId: String!\n  $artistId: String!\n) {\n  partner(id: $partnerId) {\n    artistsConnection(artistIDs: [$artistId], first: 1) {\n      edges {\n        ...PartnerArtistDetails_partnerArtist\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment PartnerArtistDetails_partnerArtist on ArtistPartnerEdge {\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  node {\n    name\n    href\n    formattedNationalityAndBirthday\n    ...FollowArtistButton_artist\n    filterArtworksConnection(first: 12, partnerIDs: [$partnerId]) {\n      edges {\n        node {\n          id\n          ...FillwidthItem_artwork\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query PartnerArtistDetailsQuery(\n  $partnerId: String!\n  $artistId: String!\n) {\n  partner(id: $partnerId) {\n    artistsConnection(artistIDs: [$artistId], first: 1) {\n      edges {\n        ...PartnerArtistDetails_partnerArtist\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  internalID\n  name\n  slug\n  is_followed: isFollowed\n  counts {\n    follows\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment PartnerArtistDetails_partnerArtist on ArtistPartnerEdge {\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  artworksConnection(first: 12) {\n    edges {\n      node {\n        id\n        ...FillwidthItem_artwork\n      }\n    }\n  }\n  node {\n    name\n    href\n    formattedNationalityAndBirthday\n    ...FollowArtistButton_artist\n    id\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnerArtistDetails_partnerArtist.graphql.ts
+++ b/src/v2/__generated__/PartnerArtistDetails_partnerArtist.graphql.ts
@@ -8,18 +8,18 @@ export type PartnerArtistDetails_partnerArtist = {
         readonly text: string | null;
         readonly credit: string | null;
     } | null;
+    readonly artworksConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly id: string;
+                readonly " $fragmentRefs": FragmentRefs<"FillwidthItem_artwork">;
+            } | null;
+        } | null> | null;
+    } | null;
     readonly node: {
         readonly name: string | null;
         readonly href: string | null;
         readonly formattedNationalityAndBirthday: string | null;
-        readonly filterArtworksConnection: {
-            readonly edges: ReadonlyArray<{
-                readonly node: {
-                    readonly id: string;
-                    readonly " $fragmentRefs": FragmentRefs<"FillwidthItem_artwork">;
-                } | null;
-            } | null> | null;
-        } | null;
         readonly " $fragmentRefs": FragmentRefs<"FollowArtistButton_artist">;
     } | null;
     readonly " $refType": "PartnerArtistDetails_partnerArtist";
@@ -33,13 +33,7 @@ export type PartnerArtistDetails_partnerArtist$key = {
 
 
 const node: ReaderFragment = {
-  "argumentDefinitions": [
-    {
-      "kind": "RootArgument",
-      "name": "partnerId",
-      "type": "String"
-    }
-  ],
+  "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
   "name": "PartnerArtistDetails_partnerArtist",
@@ -77,6 +71,57 @@ const node: ReaderFragment = {
     },
     {
       "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 12
+        }
+      ],
+      "concreteType": "ArtworkConnection",
+      "kind": "LinkedField",
+      "name": "artworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArtworkEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "id",
+                  "storageKey": null
+                },
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "FillwidthItem_artwork"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "artworksConnection(first:12)"
+    },
+    {
+      "alias": null,
       "args": null,
       "concreteType": "Artist",
       "kind": "LinkedField",
@@ -105,68 +150,6 @@ const node: ReaderFragment = {
           "storageKey": null
         },
         {
-          "alias": null,
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "first",
-              "value": 12
-            },
-            {
-              "items": [
-                {
-                  "kind": "Variable",
-                  "name": "partnerIDs.0",
-                  "variableName": "partnerId"
-                }
-              ],
-              "kind": "ListValue",
-              "name": "partnerIDs"
-            }
-          ],
-          "concreteType": "FilterArtworksConnection",
-          "kind": "LinkedField",
-          "name": "filterArtworksConnection",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "FilterArtworksEdge",
-              "kind": "LinkedField",
-              "name": "edges",
-              "plural": true,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "Artwork",
-                  "kind": "LinkedField",
-                  "name": "node",
-                  "plural": false,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "id",
-                      "storageKey": null
-                    },
-                    {
-                      "args": null,
-                      "kind": "FragmentSpread",
-                      "name": "FillwidthItem_artwork"
-                    }
-                  ],
-                  "storageKey": null
-                }
-              ],
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
-        },
-        {
           "args": null,
           "kind": "FragmentSpread",
           "name": "FollowArtistButton_artist"
@@ -177,5 +160,5 @@ const node: ReaderFragment = {
   ],
   "type": "ArtistPartnerEdge"
 };
-(node as any).hash = 'ba9c64f322825e146cd87ea5cd3c97ea';
+(node as any).hash = '962a53356d57ae9461a441f9fa9599cf';
 export default node;


### PR DESCRIPTION
This PR uses artworkConnection from the partnerArtist type for loading the artist's artworks in the right order.

JIRA - https://artsyproduct.atlassian.net/browse/PX-4015

![ezgif com-gif-maker (34)](https://user-images.githubusercontent.com/79979820/119789421-b775d480-bedb-11eb-9543-5f83231ae8bf.gif)
