### PR TITLE
feature: Webpack Chunking

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test:ci:mocha": "NODE_ENV=test yarn mocha src/**/*.test.js src/**/*.test.ts",
     "type-check": "tsc",
     "unlink-all": "yalc remove --all && yarn --check-files",
-    "stats": "NODE_ENV=production BUILD_CLIENT=true node --max_old_space_size=4096 -r dotenv/config -r @babel/register node_modules/.bin/webpack --profile --json --config ./webpack > stats.json",
+    "stats:assets": "WEBPACK_STATS=normal NODE_ENV=production BUILD_CLIENT=true node --max_old_space_size=4096 -r dotenv/config -r @babel/register node_modules/.bin/webpack --profile --json --config ./webpack > stats.json",
     "storybook": "start-storybook -p 6006",
     "webpack": "node --max_old_space_size=4096 -r dotenv/config -r @babel/register node_modules/.bin/webpack --config ./webpack"
   },
@@ -110,7 +110,6 @@
     "cheerio": "0.22.0",
     "classnames": "2.2.6",
     "compression": "1.7.2",
-    "concurrently": "3.5.1",
     "connect-timeout": "1.9.0",
     "cookie-parser": "1.4.3",
     "cookie-session": "2.0.0-beta.3",

--- a/src/v2/Apps/Artist/artistRoutes.tsx
+++ b/src/v2/Apps/Artist/artistRoutes.tsx
@@ -59,30 +59,56 @@ graphql`
   }
 `
 
-const ArtistApp = loadable(() => import("./ArtistApp"), {
-  resolveComponent: component => component.ArtistAppFragmentContainer,
-})
-const OverviewRoute = loadable(() => import("./Routes/Overview"), {
-  resolveComponent: component => component.OverviewRouteFragmentContainer,
-})
-const WorksForSaleRoute = loadable(() => import("./Routes/Works"), {
-  resolveComponent: component => component.WorksRouteFragmentContainer,
-})
-const AuctionResultsRoute = loadable(() => import("./Routes/AuctionResults"), {
-  resolveComponent: component => component.AuctionResultsRouteFragmentContainer,
-})
-const ConsignRoute = loadable(() => import("./Routes/Consign"), {
-  resolveComponent: component => component.ConsignRouteFragmentContainer,
-})
-const CVRoute = loadable(() => import("./Routes/CV"), {
-  resolveComponent: component => component.CVRouteFragmentContainer,
-})
-const ArticlesRoute = loadable(() => import("./Routes/Articles"), {
-  resolveComponent: component => component.ArticlesRouteFragmentContainer,
-})
-const ShowsRoute = loadable(() => import("./Routes/Shows"), {
-  resolveComponent: component => component.ShowsRouteFragmentContainer,
-})
+const ArtistApp = loadable(
+  () => import(/* webpackChunkName: "artistBundle" */ "./ArtistApp"),
+  {
+    resolveComponent: component => component.ArtistAppFragmentContainer,
+  }
+)
+const OverviewRoute = loadable(
+  () => import(/* webpackChunkName: "artistBundle" */ "./Routes/Overview"),
+  {
+    resolveComponent: component => component.OverviewRouteFragmentContainer,
+  }
+)
+const WorksForSaleRoute = loadable(
+  () => import(/* webpackChunkName: "artistBundle" */ "./Routes/Works"),
+  {
+    resolveComponent: component => component.WorksRouteFragmentContainer,
+  }
+)
+const AuctionResultsRoute = loadable(
+  () =>
+    import(/* webpackChunkName: "artistBundle" */ "./Routes/AuctionResults"),
+  {
+    resolveComponent: component =>
+      component.AuctionResultsRouteFragmentContainer,
+  }
+)
+const ConsignRoute = loadable(
+  () => import(/* webpackChunkName: "artistBundle" */ "./Routes/Consign"),
+  {
+    resolveComponent: component => component.ConsignRouteFragmentContainer,
+  }
+)
+const CVRoute = loadable(
+  () => import(/* webpackChunkName: "artistBundle" */ "./Routes/CV"),
+  {
+    resolveComponent: component => component.CVRouteFragmentContainer,
+  }
+)
+const ArticlesRoute = loadable(
+  () => import(/* webpackChunkName: "artistBundle" */ "./Routes/Articles"),
+  {
+    resolveComponent: component => component.ArticlesRouteFragmentContainer,
+  }
+)
+const ShowsRoute = loadable(
+  () => import(/* webpackChunkName: "artistBundle" */ "./Routes/Shows"),
+  {
+    resolveComponent: component => component.ShowsRouteFragmentContainer,
+  }
+)
 
 // Artist pages tend to load almost instantly, so just preload it up front
 if (typeof window !== "undefined") {

--- a/src/v2/Apps/ArtistSeries/artistSeriesRoutes.tsx
+++ b/src/v2/Apps/ArtistSeries/artistSeriesRoutes.tsx
@@ -5,9 +5,12 @@ import { paramsToCamelCase } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { getENV } from "v2/Utils/getENV"
 import { allowedFilters } from "v2/Components/ArtworkFilter/Utils/allowedFilters"
 
-const ArtistSeriesApp = loadable(() => import("./ArtistSeriesApp"), {
-  resolveComponent: component => component.ArtistSeriesAppFragmentContainer,
-})
+const ArtistSeriesApp = loadable(
+  () => import(/* webpackChunkName: "artistBundle" */ "./ArtistSeriesApp"),
+  {
+    resolveComponent: component => component.ArtistSeriesAppFragmentContainer,
+  }
+)
 
 export const artistSeriesRoutes: AppRouteConfig[] = [
   {

--- a/src/v2/Apps/Artists/artistsRoutes.tsx
+++ b/src/v2/Apps/Artists/artistsRoutes.tsx
@@ -2,16 +2,23 @@ import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
-const ArtistsApp = loadable(() => import("./ArtistsApp"), {
-  resolveComponent: component => component.ArtistsApp,
-})
+const ArtistsApp = loadable(
+  () => import(/* webpackChunkName: "artistBundle" */ "./ArtistsApp"),
+  {
+    resolveComponent: component => component.ArtistsApp,
+  }
+)
 
-const ArtistsIndexRoute = loadable(() => import("./Routes/ArtistsIndex"), {
-  resolveComponent: component => component.ArtistsIndexFragmentContainer,
-})
+const ArtistsIndexRoute = loadable(
+  () => import(/* webpackChunkName: "artistBundle" */ "./Routes/ArtistsIndex"),
+  {
+    resolveComponent: component => component.ArtistsIndexFragmentContainer,
+  }
+)
 
 const ArtistsByLetterRoute = loadable(
-  () => import("./Routes/ArtistsByLetter"),
+  () =>
+    import(/* webpackChunkName: "artistBundle" */ "./Routes/ArtistsByLetter"),
   {
     resolveComponent: component => component.ArtistsByLetterFragmentContainer,
   }

--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/index.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/index.tsx
@@ -117,7 +117,6 @@ export const ArtworkDetailsQueryRenderer = ({
   artworkID: string
 }) => {
   const { relayEnvironment } = useContext(SystemContext)
-
   return (
     <QueryRenderer<ArtworkDetailsQuery>
       environment={relayEnvironment}

--- a/src/v2/Apps/Artwork/artworkRoutes.tsx
+++ b/src/v2/Apps/Artwork/artworkRoutes.tsx
@@ -2,9 +2,12 @@ import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
-const ArtworkApp = loadable(() => import("./ArtworkApp"), {
-  resolveComponent: component => component.ArtworkAppFragmentContainer,
-})
+const ArtworkApp = loadable(
+  () => import(/* webpackChunkName: "artworkBundle" */ "./ArtworkApp"),
+  {
+    resolveComponent: component => component.ArtworkAppFragmentContainer,
+  }
+)
 
 export const artworkRoutes: AppRouteConfig[] = [
   {

--- a/src/v2/Apps/Auction/auctionRoutes.tsx
+++ b/src/v2/Apps/Auction/auctionRoutes.tsx
@@ -9,15 +9,25 @@ import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 const logger = createLogger("Apps/Auction/routes")
 
-const AuctionFAQRoute = loadable(() => import("./Components/AuctionFAQ"), {
-  resolveComponent: component => component.AuctionFAQFragmentContainer,
-})
-const ConfirmBidRoute = loadable(() => import("./Routes/ConfirmBid"), {
-  resolveComponent: component => component.ConfirmBidRouteFragmentContainer,
-})
-const RegisterRoute = loadable(() => import("./Routes/Register"), {
-  resolveComponent: component => component.RegisterRouteFragmentContainer,
-})
+const AuctionFAQRoute = loadable(
+  () =>
+    import(/* webpackChunkName: "auctionBundle" */ "./Components/AuctionFAQ"),
+  {
+    resolveComponent: component => component.AuctionFAQFragmentContainer,
+  }
+)
+const ConfirmBidRoute = loadable(
+  () => import(/* webpackChunkName: "auctionBundle" */ "./Routes/ConfirmBid"),
+  {
+    resolveComponent: component => component.ConfirmBidRouteFragmentContainer,
+  }
+)
+const RegisterRoute = loadable(
+  () => import(/* webpackChunkName: "auctionBundle" */ "./Routes/Register"),
+  {
+    resolveComponent: component => component.RegisterRouteFragmentContainer,
+  }
+)
 
 export const auctionRoutes: AppRouteConfig[] = [
   {

--- a/src/v2/Apps/Auctions/auctionsRoutes.tsx
+++ b/src/v2/Apps/Auctions/auctionsRoutes.tsx
@@ -5,9 +5,12 @@ import { CurrentAuctionsPaginationContainer } from "./Routes/CurrentAuctions"
 import { PastAuctionsPaginationContainer } from "./Routes/PastAuctions"
 import { UpcomingAuctionsPaginationContainer } from "./Routes/UpcomingAuctions"
 
-const AuctionsApp = loadable(() => import("./AuctionsApp"), {
-  resolveComponent: component => component.AuctionsAppFragmentContainer,
-})
+const AuctionsApp = loadable(
+  () => import(/* webpackChunkName: "auctionBundle" */ "./AuctionsApp"),
+  {
+    resolveComponent: component => component.AuctionsAppFragmentContainer,
+  }
+)
 
 export const auctionsRoutes: AppRouteConfig[] = [
   {

--- a/src/v2/Apps/BuyerGuarantee/buyerGuaranteeRoutes.tsx
+++ b/src/v2/Apps/BuyerGuarantee/buyerGuaranteeRoutes.tsx
@@ -2,12 +2,18 @@ import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
-const BuyerGuaranteeApp = loadable(() => import("./BuyerGuaranteeApp"), {
-  resolveComponent: component => component.BuyerGuaranteeApp,
-})
+const BuyerGuaranteeApp = loadable(
+  () => import(/* webpackChunkName: "buyerBundle" */ "./BuyerGuaranteeApp"),
+  {
+    resolveComponent: component => component.BuyerGuaranteeApp,
+  }
+)
 
 const BuyerGuaranteeIndexRoute = loadable(
-  () => import("./Routes/BuyerGuaranteeIndex"),
+  () =>
+    import(
+      /* webpackChunkName: "buyerBundle" */ "./Routes/BuyerGuaranteeIndex"
+    ),
   {
     resolveComponent: component =>
       component.BuyerGuaranteeIndexFragmentContainer,

--- a/src/v2/Apps/Collect/collectRoutes.tsx
+++ b/src/v2/Apps/Collect/collectRoutes.tsx
@@ -7,15 +7,24 @@ import { paramsToCamelCase } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { getENV } from "v2/Utils/getENV"
 import { CollectionAppQuery } from "./Routes/Collection/CollectionAppQuery"
 
-const CollectApp = loadable(() => import("./Routes/Collect"), {
-  resolveComponent: component => component.CollectAppFragmentContainer,
-})
-const CollectionsApp = loadable(() => import("./Routes/Collections"), {
-  resolveComponent: component => component.CollectionsAppFragmentContainer,
-})
-const CollectionApp = loadable(() => import("./Routes/Collection"), {
-  resolveComponent: component => component.CollectionRefetchContainer,
-})
+const CollectApp = loadable(
+  () => import(/* webpackChunkName: "collectBundle" */ "./Routes/Collect"),
+  {
+    resolveComponent: component => component.CollectAppFragmentContainer,
+  }
+)
+const CollectionsApp = loadable(
+  () => import(/* webpackChunkName: "collectBundle" */ "./Routes/Collections"),
+  {
+    resolveComponent: component => component.CollectionsAppFragmentContainer,
+  }
+)
+const CollectionApp = loadable(
+  () => import(/* webpackChunkName: "collectBundle" */ "./Routes/Collection"),
+  {
+    resolveComponent: component => component.CollectionRefetchContainer,
+  }
+)
 
 export const collectRoutes: AppRouteConfig[] = [
   {

--- a/src/v2/Apps/Consign/consignRoutes.tsx
+++ b/src/v2/Apps/Consign/consignRoutes.tsx
@@ -3,14 +3,23 @@ import { graphql } from "react-relay"
 import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
 const MarketingLandingApp = loadable(
-  () => import("./Routes/MarketingLanding/MarketingLandingApp"),
+  () =>
+    import(
+      /* webpackChunkName: "consignBundle" */ "./Routes/MarketingLanding/MarketingLandingApp"
+    ),
   {
     resolveComponent: component => component.MarketingLandingApp,
   }
 )
-const OfferDetailApp = loadable(() => import("./Routes/Offer/OfferDetailApp"), {
-  resolveComponent: component => component.OfferDetailAppFragmentContainer,
-})
+const OfferDetailApp = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "consignBundle" */ "./Routes/Offer/OfferDetailApp"
+    ),
+  {
+    resolveComponent: component => component.OfferDetailAppFragmentContainer,
+  }
+)
 
 export const consignRoutes: AppRouteConfig[] = [
   {

--- a/src/v2/Apps/Conversation/conversationRoutes.tsx
+++ b/src/v2/Apps/Conversation/conversationRoutes.tsx
@@ -8,10 +8,16 @@ export const conversationRoutes: AppRouteConfig[] = [
     displayFullPage: true,
     hideFooter: true,
     getComponent: () =>
-      loadable(() => import("./ConversationApp"), {
-        resolveComponent: component =>
-          component.ConversationAppFragmentContainer,
-      }),
+      loadable(
+        () =>
+          import(
+            /* webpackChunkName: "conversationBundle" */ "./ConversationApp"
+          ),
+        {
+          resolveComponent: component =>
+            component.ConversationAppFragmentContainer,
+        }
+      ),
     query: graphql`
       query conversationRoutes_ConversationQuery {
         me {
@@ -32,7 +38,7 @@ export const conversationRoutes: AppRouteConfig[] = [
     path: "/user/conversations/:conversationID",
     displayFullPage: true,
     hideFooter: true,
-    Component: loadable(() => import("./Routes/Conversation"), {
+    Component: loadable(() => import(/* webpackChunkName: "conversationBundle" */ "./Routes/Conversation"), {
       resolveComponent: component => component.ConversationPaginationContainer,
     }),
     prepareVariables: (params, _props) => {

--- a/src/v2/Apps/Example/exampleRoutes.tsx
+++ b/src/v2/Apps/Example/exampleRoutes.tsx
@@ -3,18 +3,18 @@ import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import { graphql } from "react-relay"
 import { WelcomeRoute } from "./Routes/Welcome/WelcomeRoute"
 
-const ExampleApp = loadable(() => import("./ExampleApp"), {
+const ExampleApp = loadable(() => import(/* webpackChunkName: "exampleBundle" */ "./ExampleApp"), {
   resolveComponent: component => component.ExampleAppFragmentContainer,
 })
 const ArtistRoute = loadable(
-  () => import("./Routes/Artist/ExampleArtistRoute"),
+  () => import/* webpackChunkName: "exampleBundle" */ ("./Routes/Artist/ExampleArtistRoute"),
   {
     resolveComponent: component =>
       component.ExampleArtistRouteFragmentContainer,
   }
 )
 const ArtworkRoute = loadable(
-  () => import("./Routes/Artwork/ExampleArtworkRoute"),
+  () => import(/* webpackChunkName: "exampleBundle" */ "./Routes/Artwork/ExampleArtworkRoute"),
   {
     resolveComponent: component =>
       component.ExampleArtworkRouteFragmentContainer,

--- a/src/v2/Apps/Fair/fairRoutes.tsx
+++ b/src/v2/Apps/Fair/fairRoutes.tsx
@@ -5,24 +5,42 @@ import { paramsToCamelCase } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { getENV } from "v2/Utils/getENV"
 import { allowedFilters } from "v2/Components/ArtworkFilter/Utils/allowedFilters"
 
-const FairApp = loadable(() => import("./FairApp"), {
-  resolveComponent: component => component.FairAppFragmentContainer,
-})
-const FairSubApp = loadable(() => import("./FairSubApp"), {
-  resolveComponent: component => component.FairSubAppFragmentContainer,
-})
-const FairExhibitorsRoute = loadable(() => import("./Routes/FairExhibitors"), {
-  resolveComponent: component => component.FairExhibitorsFragmentContainer,
-})
-const FairArtworksRoute = loadable(() => import("./Routes/FairArtworks"), {
-  resolveComponent: component => component.FairArtworksRefetchContainer,
-})
-const FairInfoRoute = loadable(() => import("./Routes/FairInfo"), {
-  resolveComponent: component => component.FairInfoFragmentContainer,
-})
-const FairArticlesRoute = loadable(() => import("./Routes/FairArticles"), {
-  resolveComponent: component => component.FairArticlesPaginationContainer,
-})
+const FairApp = loadable(
+  () => import(/* webpackChunkName: "fairBundle" */ "./FairApp"),
+  {
+    resolveComponent: component => component.FairAppFragmentContainer,
+  }
+)
+const FairSubApp = loadable(
+  () => import(/* webpackChunkName: "fairBundle" */ "./FairSubApp"),
+  {
+    resolveComponent: component => component.FairSubAppFragmentContainer,
+  }
+)
+const FairExhibitorsRoute = loadable(
+  () => import(/* webpackChunkName: "fairBundle" */ "./Routes/FairExhibitors"),
+  {
+    resolveComponent: component => component.FairExhibitorsFragmentContainer,
+  }
+)
+const FairArtworksRoute = loadable(
+  () => import(/* webpackChunkName: "fairBundle" */ "./Routes/FairArtworks"),
+  {
+    resolveComponent: component => component.FairArtworksRefetchContainer,
+  }
+)
+const FairInfoRoute = loadable(
+  () => import(/* webpackChunkName: "fairBundle" */ "./Routes/FairInfo"),
+  {
+    resolveComponent: component => component.FairInfoFragmentContainer,
+  }
+)
+const FairArticlesRoute = loadable(
+  () => import(/* webpackChunkName: "fairBundle" */ "./Routes/FairArticles"),
+  {
+    resolveComponent: component => component.FairArticlesPaginationContainer,
+  }
+)
 
 export const fairRoutes: AppRouteConfig[] = [
   {

--- a/src/v2/Apps/Fairs/fairsRoutes.tsx
+++ b/src/v2/Apps/Fairs/fairsRoutes.tsx
@@ -3,13 +3,19 @@ import { graphql } from "react-relay"
 import { RedirectException } from "found"
 import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
-const FairsApp = loadable(() => import("./FairsApp"), {
-  resolveComponent: component => component.FairsApp,
-})
+const FairsApp = loadable(
+  () => import(/* webpackChunkName: "fairBundle" */ "./FairsApp"),
+  {
+    resolveComponent: component => component.FairsApp,
+  }
+)
 
-const FairsIndexRoute = loadable(() => import("./Routes/FairsIndex"), {
-  resolveComponent: component => component.FairsIndexFragmentContainer,
-})
+const FairsIndexRoute = loadable(
+  () => import(/* webpackChunkName: "fairBundle" */ "./Routes/FairsIndex"),
+  {
+    resolveComponent: component => component.FairsIndexFragmentContainer,
+  }
+)
 
 export const fairsRoutes: AppRouteConfig[] = [
   {

--- a/src/v2/Apps/Feature/featureRoutes.tsx
+++ b/src/v2/Apps/Feature/featureRoutes.tsx
@@ -2,9 +2,12 @@ import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
-const FeatureApp = loadable(() => import("./FeatureApp"), {
-  resolveComponent: component => component.FeatureAppFragmentContainer,
-})
+const FeatureApp = loadable(
+  () => import(/* webpackChunkName: "featureBundle" */ "./FeatureApp"),
+  {
+    resolveComponent: component => component.FeatureAppFragmentContainer,
+  }
+)
 
 export const featureRoutes: AppRouteConfig[] = [
   {

--- a/src/v2/Apps/FeatureAKG/featureAKGRoutes.tsx
+++ b/src/v2/Apps/FeatureAKG/featureAKGRoutes.tsx
@@ -2,9 +2,12 @@ import loadable from "@loadable/component"
 import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import { graphql } from "react-relay"
 
-const FeatureAKGApp = loadable(() => import("./FeatureAKGApp"), {
-  resolveComponent: component => component.FeatureAKGAppFragmentContainer,
-})
+const FeatureAKGApp = loadable(
+  () => import(/* webpackChunkName: "featureBundle" */ "./FeatureAKGApp"),
+  {
+    resolveComponent: component => component.FeatureAKGAppFragmentContainer,
+  }
+)
 
 export const featureAKGRoutes: AppRouteConfig[] = [
   {

--- a/src/v2/Apps/Gene/geneRoutes.tsx
+++ b/src/v2/Apps/Gene/geneRoutes.tsx
@@ -6,13 +6,19 @@ import { paramsToCamelCase } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { initialArtworkFilterState } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
-const GeneApp = loadable(() => import("./GeneApp"), {
-  resolveComponent: component => component.GeneApp,
-})
+const GeneApp = loadable(
+  () => import(/* webpackChunkName: "geneBundle" */ "./GeneApp"),
+  {
+    resolveComponent: component => component.GeneApp,
+  }
+)
 
-const GeneShowRoute = loadable(() => import("./Routes/GeneShow"), {
-  resolveComponent: component => component.GeneShowFragmentContainer,
-})
+const GeneShowRoute = loadable(
+  () => import(/* webpackChunkName: "geneBundle" */ "./Routes/GeneShow"),
+  {
+    resolveComponent: component => component.GeneShowFragmentContainer,
+  }
+)
 
 export const geneRoutes: AppRouteConfig[] = [
   {

--- a/src/v2/Apps/IdentityVerification/identityVerificationRoutes.tsx
+++ b/src/v2/Apps/IdentityVerification/identityVerificationRoutes.tsx
@@ -3,18 +3,28 @@ import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import { graphql } from "react-relay"
 
 const IdentityVerificationApp = loadable(
-  () => import("./IdentityVerificationApp"),
+  () =>
+    import(
+      /* webpackChunkName: "identityVerificationBundle" */ "./IdentityVerificationApp"
+    ),
   {
     resolveComponent: component =>
       component.IdentityVerificationAppFragmentContainer,
   }
 )
-const Processing = loadable(() => import("./Processing"), {
-  resolveComponent: component => component.Processing,
-})
-const Error = loadable(() => import("./Error"), {
-  resolveComponent: component => component.Error,
-})
+const Processing = loadable(
+  () =>
+    import(/* webpackChunkName: "identityVerificationBundle" */ "./Processing"),
+  {
+    resolveComponent: component => component.Processing,
+  }
+)
+const Error = loadable(
+  () => import(/* webpackChunkName: "identityVerificationBundle" */ "./Error"),
+  {
+    resolveComponent: component => component.Error,
+  }
+)
 
 export const identityVerificationRoutes: AppRouteConfig[] = [
   {

--- a/src/v2/Apps/Order/Utils/openAskSpecialistInquireableModal.ts
+++ b/src/v2/Apps/Order/Utils/openAskSpecialistInquireableModal.ts
@@ -1,0 +1,28 @@
+export const openAskSpecialistInquireableModal = (artworkId, sd) => {
+  const User = require("desktop/models/user.coffee")
+  const Artwork = require("desktop/models/artwork.coffee")
+  const ArtworkInquiry = require("desktop/models/artwork_inquiry.coffee")
+  const openInquiryQuestionnaireFor = require("desktop/components/inquiry_questionnaire/index.coffee")
+  const $ = require("jquery")
+
+  const user = User.instantiate()
+  const inquiry = new ArtworkInquiry({ notification_delay: 600 })
+
+  const artwork = new Artwork({
+    id: artworkId,
+  })
+
+  // Set token to be able to load user's collector profile later
+  $.ajaxSettings.headers = {
+    "X-ACCESS-TOKEN":
+      sd.CURRENT_USER != null ? sd.CURRENT_USER.accessToken : undefined,
+    "X-XAPP-TOKEN": sd.ARTSY_XAPP_TOKEN,
+  }
+
+  openInquiryQuestionnaireFor({
+    artwork,
+    ask_specialist: true,
+    inquiry,
+    user,
+  })
+}

--- a/src/v2/Apps/Order/orderRoutes.tsx
+++ b/src/v2/Apps/Order/orderRoutes.tsx
@@ -18,9 +18,12 @@ import { RejectFragmentContainer as DeclineRoute } from "./Routes/Reject"
 import { StatusFragmentContainer as StatusRoute } from "./Routes/Status"
 import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
-const OrderApp = loadable(() => import("./OrderApp"), {
-  resolveComponent: component => component.OrderApp,
-})
+const OrderApp = loadable(
+  () => import(/* webpackChunkName: "orderBundle" */ "./OrderApp"),
+  {
+    resolveComponent: component => component.OrderApp,
+  }
+)
 
 // FIXME:
 // * `render` functions requires casting

--- a/src/v2/Apps/Partner/partnerRoutes.tsx
+++ b/src/v2/Apps/Partner/partnerRoutes.tsx
@@ -7,33 +7,54 @@ import { paramsToCamelCase } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { allowedFilters } from "v2/Components/ArtworkFilter/Utils/allowedFilters"
 import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
-const PartnerApp = loadable(() => import("./PartnerApp"), {
-  resolveComponent: component => component.PartnerAppFragmentContainer,
-})
+const PartnerApp = loadable(
+  () => import(/* webpackChunkName: "partnerBundle" */ "./PartnerApp"),
+  {
+    resolveComponent: component => component.PartnerAppFragmentContainer,
+  }
+)
 
-const ArticlesRoute = loadable(() => import("./Routes/Articles"), {
-  resolveComponent: component => component.ArticlesPaginationContainer,
-})
+const ArticlesRoute = loadable(
+  () => import(/* webpackChunkName: "partnerBundle" */ "./Routes/Articles"),
+  {
+    resolveComponent: component => component.ArticlesPaginationContainer,
+  }
+)
 
-const OverviewRoute = loadable(() => import("./Routes/Overview"), {
-  resolveComponent: component => component.OverviewFragmentContainer,
-})
+const OverviewRoute = loadable(
+  () => import(/* webpackChunkName: "partnerBundle" */ "./Routes/Overview"),
+  {
+    resolveComponent: component => component.OverviewFragmentContainer,
+  }
+)
 
-const ShowsRoute = loadable(() => import("./Routes/Shows"), {
-  resolveComponent: component => component.ShowsFragmentContainer,
-})
+const ShowsRoute = loadable(
+  () => import(/* webpackChunkName: "partnerBundle" */ "./Routes/Shows"),
+  {
+    resolveComponent: component => component.ShowsFragmentContainer,
+  }
+)
 
-const WorksRoute = loadable(() => import("./Routes/Works"), {
-  resolveComponent: component => component.ArtworksRefetchContainer,
-})
+const WorksRoute = loadable(
+  () => import(/* webpackChunkName: "partnerBundle" */ "./Routes/Works"),
+  {
+    resolveComponent: component => component.ArtworksRefetchContainer,
+  }
+)
 
-const ArtistsRoute = loadable(() => import("./Routes/Artists"), {
-  resolveComponent: component => component.ArtistsRouteFragmentContainer,
-})
+const ArtistsRoute = loadable(
+  () => import(/* webpackChunkName: "partnerBundle" */ "./Routes/Artists"),
+  {
+    resolveComponent: component => component.ArtistsRouteFragmentContainer,
+  }
+)
 
-const ContactRoute = loadable(() => import("./Routes/Contact"), {
-  resolveComponent: component => component.ContactRouteFragmentContainer,
-})
+const ContactRoute = loadable(
+  () => import(/* webpackChunkName: "partnerBundle" */ "./Routes/Contact"),
+  {
+    resolveComponent: component => component.ContactRouteFragmentContainer,
+  }
+)
 
 export const partnerRoutes: AppRouteConfig[] = [
   {

--- a/src/v2/Apps/Payment/paymentRoutes.tsx
+++ b/src/v2/Apps/Payment/paymentRoutes.tsx
@@ -2,9 +2,15 @@ import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
-const PaymentApp = loadable(() => import("./Routes/Payment/PaymentApp"), {
-  resolveComponent: component => component.PaymentAppFragmentContainer,
-})
+const PaymentApp = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "paymentBundle" */ "./Routes/Payment/PaymentApp"
+    ),
+  {
+    resolveComponent: component => component.PaymentAppFragmentContainer,
+  }
+)
 
 export const paymentRoutes: AppRouteConfig[] = [
   {

--- a/src/v2/Apps/Purchase/purchaseRoutes.tsx
+++ b/src/v2/Apps/Purchase/purchaseRoutes.tsx
@@ -2,9 +2,12 @@ import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { AppRouteConfig } from "v2/Artsy/Router/Route"
 
-const PurchasesApp = loadable(() => import("./PurchaseApp"), {
-  resolveComponent: component => component.PurchaseAppFragmentContainer,
-})
+const PurchasesApp = loadable(
+  () => import(/* webpackChunkName: "pruchaseBundle" */ "./PurchaseApp"),
+  {
+    resolveComponent: component => component.PurchaseAppFragmentContainer,
+  }
+)
 
 export const purchaseRoutes: AppRouteConfig[] = [
   {

--- a/src/v2/Apps/ViewingRoom/viewingRoomRoutes.tsx
+++ b/src/v2/Apps/ViewingRoom/viewingRoomRoutes.tsx
@@ -5,12 +5,18 @@ import { AppRouteConfig } from "v2/Artsy/Router/Route"
 import { ViewingRoomStatementRouteFragmentContainer as StatementRoute } from "./Routes/Statement/ViewingRoomStatementRoute"
 import { ViewingRoomWorksRouteFragmentContainer as WorksRoute } from "./Routes/Works/ViewingRoomWorksRoute"
 
-const ViewingRoomApp = loadable(() => import("./ViewingRoomApp"), {
-  resolveComponent: component => component.ViewingRoomAppFragmentContainer,
-})
-const ViewingRoomsApp = loadable(() => import("./ViewingRoomsApp"), {
-  resolveComponent: component => component.ViewingRoomsAppFragmentContainer,
-})
+const ViewingRoomApp = loadable(
+  () => import(/* webpackChunkName: "viewingRoomBundle" */ "./ViewingRoomApp"),
+  {
+    resolveComponent: component => component.ViewingRoomAppFragmentContainer,
+  }
+)
+const ViewingRoomsApp = loadable(
+  () => import(/* webpackChunkName: "viewingRoomBundle" */ "./ViewingRoomsApp"),
+  {
+    resolveComponent: component => component.ViewingRoomsAppFragmentContainer,
+  }
+)
 
 export const viewingRoomRoutes: AppRouteConfig[] = [
   {

--- a/webpack/envs/clientDevelopmentConfig.js
+++ b/webpack/envs/clientDevelopmentConfig.js
@@ -28,7 +28,7 @@ import { clientChunks } from "./clientCommonConfig"
 export const clientDevelopmentConfig = {
   devtool: standardDevtool,
   entry: {
-    "artsy-novo": [
+    "artsy-entry": [
       "webpack-hot-middleware/client?name=novo&reload=true",
       path.resolve(process.cwd(), "src/v2/client.tsx"),
     ],

--- a/webpack/envs/clientProductionConfig.js
+++ b/webpack/envs/clientProductionConfig.js
@@ -27,7 +27,7 @@ import { clientChunks } from "./clientCommonConfig"
 export const clientProductionConfig = {
   devtool: productionDevtool,
   entry: {
-    "artsy-novo": [path.resolve(process.cwd(), "src/v2/client.tsx")],
+    "artsy-entry": [path.resolve(process.cwd(), "src/v2/client.tsx")],
   },
   externals: clientExternals,
   mode: standardMode,
@@ -36,14 +36,15 @@ export const clientProductionConfig = {
   },
   optimization: {
     concatenateModules: env.webpackConcatenate,
-    minimize: !env.webpackDebug,
+    minimize: !env.webpackDebug && !env.fastProductionBuild,
     minimizer: standardMinimizer,
     // Extract webpack runtime code into it's own file
     runtimeChunk: "single",
     splitChunks: clientChunks,
+    moduleIds: "hashed",
   },
   output: {
-    filename: "novo-[name].22820.[contenthash].js",
+    filename: "novo-[name].[contenthash].js",
     path: path.resolve(basePath, "public/assets-novo"),
     publicPath: "/assets-novo/",
   },

--- a/webpack/envs/legacyProductionConfig.js
+++ b/webpack/envs/legacyProductionConfig.js
@@ -11,11 +11,11 @@ import { standardMinimizer } from "./commonEnv"
 export const legacyProductionConfig = {
   entry: getEntrypoints(),
   optimization: {
-    minimize: !env.webpackDebug,
+    minimize: !env.webpackDebug && !env.fastProductionBuild,
     minimizer: standardMinimizer,
   },
   output: {
-    filename: "[name].22820.[contenthash].js",
+    filename: "[name].[contenthash].js",
     // NOTE: On the client, we're setting `publicPath` during runtime in order to
     // ensure that dynamically loaded split chunks are being pulled from CDN.
     // @see: https://github.com/artsy/force/blob/master/src/desktop/lib/global_client_setup.tsx#L7

--- a/webpack/envs/serverConfig.js
+++ b/webpack/envs/serverConfig.js
@@ -41,7 +41,7 @@ export const serverConfig = {
     __dirname: true,
   },
   optimization: {
-    minimize: env.isProduction && !env.webpackDebug,
+    minimize: env.isProduction && !env.webpackDebug && !env.fastProductionBuild,
     minimizer: standardMinimizer,
   },
   output: {

--- a/webpack/utils/env.js
+++ b/webpack/utils/env.js
@@ -31,55 +31,29 @@ const env = {
 
 const basePath = path.join(__dirname, "..", "..")
 
+// prettier-ignore
 if (env.onCi || env.logConfig) {
   console.log("\n[Webpack Environment]")
-  console.log("  cpus".padEnd(30), chalk.yellow(os.cpus().length))
-  console.log("  basePath".padEnd(30), chalk.yellow(basePath))
-  console.log(
-    "  BUILD_LEGACY_CLIENT".padEnd(30),
-    chalk.yellow(env.buildLegacyClient)
-  )
-  console.log("  BUILD_SERVER".padEnd(30), chalk.yellow(env.buildServer))
-  console.log("  BUILD_CLIENT".padEnd(30), chalk.yellow(env.buildClient))
-  console.log("  CI".padEnd(30), chalk.yellow(env.onCi))
-  console.log(
-    "  NODE_ENV == 'isDevelopment'".padEnd(30),
-    chalk.yellow(env.isDevelopment)
-  )
-  console.log(
-    "  NODE_ENV == 'isProduction'".padEnd(30),
-    chalk.yellow(env.isProduction)
-  )
-  console.log(
-    "  NODE_ENV == 'isStaging'".padEnd(30),
-    chalk.yellow(env.isStaging)
-  )
-  console.log("  NODE_ENV".padEnd(30), chalk.yellow(env.nodeEnv))
-  console.log("  PORT".padEnd(30), chalk.yellow(env.port))
-  console.log(
-    "  WEBPACK_ANALYZE".padEnd(30),
-    chalk.yellow(env.enableWebpackAnalyze)
-  )
-  console.log(
-    "  WEBPACK_CI_CPU_LIMIT".padEnd(30),
-    chalk.yellow(env.webpackCiCpuLimit)
-  )
-  console.log(
-    "  WEBPACK_CONCATENATE".padEnd(30),
-    chalk.yellow(env.webpackConcatenate)
-  )
-  console.log("  WEBPACK_DEBUG".padEnd(30), chalk.yellow(env.webpackDebug))
-  console.log("  WEBPACK_DEVTOOL".padEnd(30), chalk.yellow(env.webpackDevtool))
-  console.log(
-    "  WEBPACK_DUMP_CONFIG".padEnd(30),
-    chalk.yellow(env.enableWebpackDumpConfig)
-  )
-  console.log(
-    "  WEBPACK_FAST_PRODUCTION_BUILD".padEnd(30),
-    chalk.yellow(env.fastProductionBuild)
-  )
-  console.log("  WEBPACK_LOG_CONFIG".padEnd(30), chalk.yellow(env.logConfig))
-  console.log("  WEBPACK_STATS".padEnd(30), chalk.yellow(env.webpackStats))
+  console.log("  cpus".padEnd(35), chalk.yellow(os.cpus().length))
+  console.log("  basePath".padEnd(35), chalk.yellow(basePath))
+  console.log("  BUILD_LEGACY_CLIENT".padEnd(35), chalk.yellow(env.buildLegacyClient))
+  console.log("  BUILD_SERVER".padEnd(35), chalk.yellow(env.buildServer))
+  console.log("  BUILD_CLIENT".padEnd(35), chalk.yellow(env.buildClient))
+  console.log("  CI".padEnd(35), chalk.yellow(env.onCi))
+  console.log("  NODE_ENV == 'isDevelopment'".padEnd(35), chalk.yellow(env.isDevelopment))
+  console.log("  NODE_ENV == 'isProduction'".padEnd(35), chalk.yellow(env.isProduction))
+  console.log("  NODE_ENV == 'isStaging'".padEnd(35), chalk.yellow(env.isStaging))
+  console.log("  NODE_ENV".padEnd(35), chalk.yellow(env.nodeEnv))
+  console.log("  PORT".padEnd(35), chalk.yellow(env.port))
+  console.log("  WEBPACK_ANALYZE".padEnd(35), chalk.yellow(env.enableWebpackAnalyze))
+  console.log("  WEBPACK_CI_CPU_LIMIT".padEnd(35), chalk.yellow(env.webpackCiCpuLimit))
+  console.log("  WEBPACK_CONCATENATE".padEnd(35), chalk.yellow(env.webpackConcatenate))
+  console.log("  WEBPACK_DEBUG".padEnd(35), chalk.yellow(env.webpackDebug))
+  console.log("  WEBPACK_DEVTOOL".padEnd(35), chalk.yellow(env.webpackDevtool))
+  console.log("  WEBPACK_DUMP_CONFIG".padEnd(35), chalk.yellow(env.enableWebpackDumpConfig))
+  console.log("  WEBPACK_FAST_PRODUCTION_BUILD".padEnd(35), chalk.yellow(env.fastProductionBuild))
+  console.log("  WEBPACK_LOG_CONFIG".padEnd(35), chalk.yellow(env.logConfig))
+  console.log("  WEBPACK_STATS".padEnd(35), chalk.yellow(env.webpackStats))
   console.log("")
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4061,11 +4061,6 @@ ansi-html@0.0.7, ansi-html@^0.0.7:
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
   integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
 
-ansi-regex@^0.2.0, ansi-regex@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-0.2.1.tgz#0d8e946967a3d8143f93e24e298525fc1b2235f9"
-  integrity sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -4085,11 +4080,6 @@ ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
-
-ansi-styles@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.1.0.tgz#eaecbf66cd706882760b2f4691582b8f55d7a7de"
-  integrity sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -5654,17 +5644,6 @@ center-align@^0.1.1:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
-chalk@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.5.1.tgz#663b3a648b68b55d04690d49167aa837858f2174"
-  integrity sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=
-  dependencies:
-    ansi-styles "^1.1.0"
-    escape-string-regexp "^1.0.0"
-    has-ansi "^0.1.0"
-    strip-ansi "^0.3.0"
-    supports-color "^0.2.0"
-
 chalk@2.3.x:
   version "2.3.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
@@ -6115,11 +6094,6 @@ comma-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
-commander@2.6.0, commander@~2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.6.0.tgz#9df7e52fb2a0cb0fb89058ee80c3104225f37e1d"
-  integrity sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=
-
 commander@2.8.x:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
@@ -6153,6 +6127,11 @@ commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+
+commander@~2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.6.0.tgz#9df7e52fb2a0cb0fb89058ee80c3104225f37e1d"
+  integrity sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=
 
 common-tags@^1.8.0:
   version "1.8.0"
@@ -6244,20 +6223,6 @@ concat-stream@^1.4.7, concat-stream@^1.5.0, concat-stream@^1.6.2:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
-
-concurrently@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-3.5.1.tgz#ee8b60018bbe86b02df13e5249453c6ececd2521"
-  integrity sha512-689HrwGw8Rbk1xtV9C4dY6TPJAvIYZbRbnKSAtfJ7tHqICFGoZ0PCWYjxfmerRyxBG0o3sbG3pe7N8vqPwIHuQ==
-  dependencies:
-    chalk "0.5.1"
-    commander "2.6.0"
-    date-fns "^1.23.0"
-    lodash "^4.5.1"
-    rx "2.3.24"
-    spawn-command "^0.0.2-1"
-    supports-color "^3.2.3"
-    tree-kill "^1.1.0"
 
 configstore@^3.0.0:
   version "3.1.2"
@@ -7018,7 +6983,7 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@^1.23.0, date-fns@^1.27.2:
+date-fns@^1.27.2:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
   integrity sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==
@@ -7995,7 +7960,7 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -9960,13 +9925,6 @@ har-validator@~5.1.3:
   dependencies:
     ajv "^6.12.3"
     har-schema "^2.0.0"
-
-has-ansi@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-0.1.0.tgz#84f265aae8c0e6a88a12d7022894b7568894c62e"
-  integrity sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=
-  dependencies:
-    ansi-regex "^0.2.0"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -13316,7 +13274,7 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.15, lodash@4.17.21, "lodash@>=3.5 <5", lodash@^4.0.1, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@~3.10.1, lodash@~4.17.2:
+lodash@4.17.15, lodash@4.17.21, "lodash@>=3.5 <5", lodash@^4.0.1, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~3.10.1, lodash@~4.17.2:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -17481,11 +17439,6 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rx@2.3.24:
-  version "2.3.24"
-  resolved "https://registry.yarnpkg.com/rx/-/rx-2.3.24.tgz#14f950a4217d7e35daa71bbcbe58eff68ea4b2b7"
-  integrity sha1-FPlQpCF9fjXapxu8vljv9o6ksrc=
-
 rx@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
@@ -18195,11 +18148,6 @@ space-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
   integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
 
-spawn-command@^0.0.2-1:
-  version "0.0.2-1"
-  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
-  integrity sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=
-
 spawn-sync@^1.0.15:
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
@@ -18568,13 +18516,6 @@ strip-ansi@6.0.0, strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
-strip-ansi@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.3.0.tgz#25f48ea22ca79187f3174a4db8759347bb126220"
-  integrity sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=
-  dependencies:
-    ansi-regex "^0.2.1"
-
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -18766,22 +18707,10 @@ supports-color@3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-0.2.0.tgz#d92de2694eb3f67323973d7ae3d8b55b4c22190a"
-  integrity sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=
-
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
-
-supports-color@^3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
-  integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
-  dependencies:
-    has-flag "^1.0.0"
 
 supports-color@^5.0.0, supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
@@ -19239,11 +19168,6 @@ transformers@2.1.0:
     css "~1.0.8"
     promise "~2.0"
     uglify-js "~2.2.5"
-
-tree-kill@^1.1.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
-  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
 trim-right@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR modifies our Webpack bundling strategy to follow several common patterns used elsewhere in the industry.

Creates a minimal chunk for each App
Creates a minimal commons chunk for each App
Create a framework chunk for `@artsy` framework code to ensure that it will not be cache-invalidated
Create a framework chunk for core framework code to ensure that it will not be cache-invalidated
Creates library chunks for any large node_module dependencies
Creates shard chunks for any code used by multiple pages

Additional Optimizations

* Reduces the number of low KiB bundles by using naming common preloaded chunks
* Restricts bundles to 240 KiB unzipped
* Cleans up legacy code that was accidentally imported by the orders page

Notable Impacts:

Reduces the Artist page JS bundle payload by ~275 KiB compressed