### PR TITLE
fix: prevent events duplications shows tab

### DIFF
--- a/src/v2/__generated__/Shows_partner.graphql.ts
+++ b/src/v2/__generated__/Shows_partner.graphql.ts
@@ -5,21 +5,28 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type Shows_partner = {
     readonly slug: string;
-    readonly featured: {
+    readonly featuredEvents: {
         readonly edges: ReadonlyArray<{
             readonly node: {
                 readonly isFeatured: boolean | null;
+                readonly internalID: string;
                 readonly " $fragmentRefs": FragmentRefs<"ShowBanner_show">;
             } | null;
         } | null> | null;
     } | null;
     readonly currentEvents: {
         readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string;
+            } | null;
             readonly " $fragmentRefs": FragmentRefs<"ShowEvents_edges">;
         } | null> | null;
     } | null;
     readonly upcomingEvents: {
         readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string;
+            } | null;
             readonly " $fragmentRefs": FragmentRefs<"ShowEvents_edges">;
         } | null> | null;
     } | null;
@@ -40,11 +47,18 @@ var v0 = {
   "value": true
 },
 v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v2 = {
   "kind": "Literal",
   "name": "first",
   "value": 12
 },
-v2 = [
+v3 = [
   {
     "alias": null,
     "args": null,
@@ -53,6 +67,18 @@ v2 = [
     "name": "edges",
     "plural": true,
     "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/)
+        ],
+        "storageKey": null
+      },
       {
         "args": null,
         "kind": "FragmentSpread",
@@ -76,7 +102,7 @@ return {
       "storageKey": null
     },
     {
-      "alias": "featured",
+      "alias": "featuredEvents",
       "args": [
         {
           "kind": "Literal",
@@ -123,6 +149,7 @@ return {
                   "name": "isFeatured",
                   "storageKey": null
                 },
+                (v1/*: any*/),
                 {
                   "args": null,
                   "kind": "FragmentSpread",
@@ -140,7 +167,7 @@ return {
     {
       "alias": "currentEvents",
       "args": [
-        (v1/*: any*/),
+        (v2/*: any*/),
         (v0/*: any*/),
         {
           "kind": "Literal",
@@ -152,13 +179,13 @@ return {
       "kind": "LinkedField",
       "name": "showsConnection",
       "plural": false,
-      "selections": (v2/*: any*/),
+      "selections": (v3/*: any*/),
       "storageKey": "showsConnection(first:12,isDisplayable:true,status:\"RUNNING\")"
     },
     {
       "alias": "upcomingEvents",
       "args": [
-        (v1/*: any*/),
+        (v2/*: any*/),
         (v0/*: any*/),
         {
           "kind": "Literal",
@@ -170,12 +197,12 @@ return {
       "kind": "LinkedField",
       "name": "showsConnection",
       "plural": false,
-      "selections": (v2/*: any*/),
+      "selections": (v3/*: any*/),
       "storageKey": "showsConnection(first:12,isDisplayable:true,status:\"UPCOMING\")"
     }
   ],
   "type": "Partner"
 };
 })();
-(node as any).hash = 'bab1be09c87841bf9381c9ff73d914f5';
+(node as any).hash = '0cd7aab15e111539c7884ec4b671d784';
 export default node;

--- a/src/v2/__generated__/partnerRoutes_ShowsQuery.graphql.ts
+++ b/src/v2/__generated__/partnerRoutes_ShowsQuery.graphql.ts
@@ -73,10 +73,11 @@ fragment ShowEvents_edges on ShowEdge {
 
 fragment Shows_partner on Partner {
   slug
-  featured: showsConnection(first: 1, status: ALL, sort: FEATURED_DESC_END_AT_DESC, isDisplayable: true) {
+  featuredEvents: showsConnection(first: 1, status: ALL, sort: FEATURED_DESC_END_AT_DESC, isDisplayable: true) {
     edges {
       node {
         isFeatured
+        internalID
         ...ShowBanner_show
         id
       }
@@ -84,11 +85,19 @@ fragment Shows_partner on Partner {
   }
   currentEvents: showsConnection(first: 12, status: RUNNING, isDisplayable: true) {
     edges {
+      node {
+        internalID
+        id
+      }
       ...ShowEvents_edges
     }
   }
   upcomingEvents: showsConnection(first: 12, status: UPCOMING, isDisplayable: true) {
     edges {
+      node {
+        internalID
+        id
+      }
       ...ShowEvents_edges
     }
   }
@@ -127,57 +136,64 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "internalID",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "href",
+  "name": "name",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "isFairBooth",
+  "name": "href",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "exhibitionPeriod",
+  "name": "isFairBooth",
   "storageKey": null
 },
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "exhibitionPeriod",
   "storageKey": null
 },
 v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "src",
+  "name": "id",
   "storageKey": null
 },
 v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "srcSet",
+  "name": "src",
   "storageKey": null
 },
 v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "srcSet",
+  "storageKey": null
+},
+v12 = {
   "kind": "Literal",
   "name": "first",
   "value": 12
 },
-v12 = [
+v13 = [
   {
     "alias": null,
     "args": null,
@@ -194,17 +210,12 @@ v12 = [
         "name": "node",
         "plural": false,
         "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "internalID",
-            "storageKey": null
-          },
-          (v5/*: any*/),
           (v4/*: any*/),
+          (v9/*: any*/),
           (v6/*: any*/),
+          (v5/*: any*/),
           (v7/*: any*/),
+          (v8/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -246,15 +257,14 @@ v12 = [
                     "name": "height",
                     "storageKey": null
                   },
-                  (v9/*: any*/),
-                  (v10/*: any*/)
+                  (v10/*: any*/),
+                  (v11/*: any*/)
                 ],
                 "storageKey": "cropped(height:222,width:263)"
               }
             ],
             "storageKey": null
-          },
-          (v8/*: any*/)
+          }
         ],
         "storageKey": null
       }
@@ -304,7 +314,7 @@ return {
         "selections": [
           (v2/*: any*/),
           {
-            "alias": "featured",
+            "alias": "featuredEvents",
             "args": [
               {
                 "kind": "Literal",
@@ -351,11 +361,12 @@ return {
                         "name": "isFeatured",
                         "storageKey": null
                       },
-                      (v2/*: any*/),
                       (v4/*: any*/),
+                      (v2/*: any*/),
                       (v5/*: any*/),
                       (v6/*: any*/),
                       (v7/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -385,7 +396,7 @@ return {
                             "name": "city",
                             "storageKey": null
                           },
-                          (v8/*: any*/)
+                          (v9/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -416,15 +427,15 @@ return {
                             "name": "cropped",
                             "plural": false,
                             "selections": [
-                              (v9/*: any*/),
-                              (v10/*: any*/)
+                              (v10/*: any*/),
+                              (v11/*: any*/)
                             ],
                             "storageKey": "cropped(height:480,width:600)"
                           }
                         ],
                         "storageKey": null
                       },
-                      (v8/*: any*/)
+                      (v9/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -437,7 +448,7 @@ return {
           {
             "alias": "currentEvents",
             "args": [
-              (v11/*: any*/),
+              (v12/*: any*/),
               (v3/*: any*/),
               {
                 "kind": "Literal",
@@ -449,13 +460,13 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v12/*: any*/),
+            "selections": (v13/*: any*/),
             "storageKey": "showsConnection(first:12,isDisplayable:true,status:\"RUNNING\")"
           },
           {
             "alias": "upcomingEvents",
             "args": [
-              (v11/*: any*/),
+              (v12/*: any*/),
               (v3/*: any*/),
               {
                 "kind": "Literal",
@@ -467,10 +478,10 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v12/*: any*/),
+            "selections": (v13/*: any*/),
             "storageKey": "showsConnection(first:12,isDisplayable:true,status:\"UPCOMING\")"
           },
-          (v8/*: any*/)
+          (v9/*: any*/)
         ],
         "storageKey": null
       }
@@ -481,7 +492,7 @@ return {
     "metadata": {},
     "name": "partnerRoutes_ShowsQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_ShowsQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...Shows_partner\n    id\n  }\n}\n\nfragment ShowBanner_show on Show {\n  slug\n  name\n  href\n  isFairBooth\n  exhibitionPeriod\n  status\n  description\n  location {\n    city\n    id\n  }\n  coverImage {\n    medium: cropped(width: 600, height: 480) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ShowCard_show on Show {\n  href\n  name\n  isFairBooth\n  exhibitionPeriod\n  coverImage {\n    medium: cropped(width: 263, height: 222) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ShowEvents_edges on ShowEdge {\n  node {\n    internalID\n    ...ShowCard_show\n    id\n  }\n}\n\nfragment Shows_partner on Partner {\n  slug\n  featured: showsConnection(first: 1, status: ALL, sort: FEATURED_DESC_END_AT_DESC, isDisplayable: true) {\n    edges {\n      node {\n        isFeatured\n        ...ShowBanner_show\n        id\n      }\n    }\n  }\n  currentEvents: showsConnection(first: 12, status: RUNNING, isDisplayable: true) {\n    edges {\n      ...ShowEvents_edges\n    }\n  }\n  upcomingEvents: showsConnection(first: 12, status: UPCOMING, isDisplayable: true) {\n    edges {\n      ...ShowEvents_edges\n    }\n  }\n}\n"
+    "text": "query partnerRoutes_ShowsQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...Shows_partner\n    id\n  }\n}\n\nfragment ShowBanner_show on Show {\n  slug\n  name\n  href\n  isFairBooth\n  exhibitionPeriod\n  status\n  description\n  location {\n    city\n    id\n  }\n  coverImage {\n    medium: cropped(width: 600, height: 480) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ShowCard_show on Show {\n  href\n  name\n  isFairBooth\n  exhibitionPeriod\n  coverImage {\n    medium: cropped(width: 263, height: 222) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ShowEvents_edges on ShowEdge {\n  node {\n    internalID\n    ...ShowCard_show\n    id\n  }\n}\n\nfragment Shows_partner on Partner {\n  slug\n  featuredEvents: showsConnection(first: 1, status: ALL, sort: FEATURED_DESC_END_AT_DESC, isDisplayable: true) {\n    edges {\n      node {\n        isFeatured\n        internalID\n        ...ShowBanner_show\n        id\n      }\n    }\n  }\n  currentEvents: showsConnection(first: 12, status: RUNNING, isDisplayable: true) {\n    edges {\n      node {\n        internalID\n        id\n      }\n      ...ShowEvents_edges\n    }\n  }\n  upcomingEvents: showsConnection(first: 12, status: UPCOMING, isDisplayable: true) {\n    edges {\n      node {\n        internalID\n        id\n      }\n      ...ShowEvents_edges\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
JIRA -> [PPP: Shows: "Current Show" card and "Current Events" cards represent the same show](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=36&projectKey=PX&modal=detail&selectedIssue=PX-4147&quickFilter=228)

**What was the issue:**
The shows page has a banner with a show which can be duplicated on upcoming/current/past events.

**What i've done:**
Removed the card with an event if the event displays in the banner.

**Before:**
![Screen Shot 2021-05-27 at 6 34 38 PM](https://user-images.githubusercontent.com/79980131/119855219-66390580-bf1a-11eb-91a7-e38f1e3afebd.png)

**After:**
![Screen Shot 2021-05-27 at 6 40 03 PM](https://user-images.githubusercontent.com/79980131/119855878-f7a87780-bf1a-11eb-9dcf-3b2508ab049e.png)
