### PR TITLE
fix: add padding and line break to buyer guarantee page

### DIFF
--- a/src/v2/Apps/BuyerGuarantee/Components/Feature.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Components/Feature.tsx
@@ -11,6 +11,7 @@ import {
 interface FeatureProps {
   title: string
   text?: string
+  forcedSecondLine?: string
   icon: React.FC<IconProps>
   sm?: boolean
   onClick?: () => void
@@ -19,6 +20,7 @@ interface FeatureProps {
 export const Feature: React.FC<FeatureProps> = ({
   title,
   text,
+  forcedSecondLine,
   icon,
   sm,
   onClick,
@@ -65,6 +67,7 @@ export const Feature: React.FC<FeatureProps> = ({
           {title}
         </Text>
         <Text variant="text">{text}</Text>
+        {forcedSecondLine && <Text variant="text">{forcedSecondLine}</Text>}
       </Box>
       {!!onClick && <Box>{learnMore}</Box>}
     </Flex>

--- a/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
@@ -209,7 +209,8 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
             />
             <Feature
               title="Money-Back Guarantee"
-              text="If an item arrives not as described, we’ll work with you to make it right."
+              text="If an item arrives not as described,"
+              forcedSecondLine="we’ll work with you to make it right."
               icon={MoneyBackIcon}
               onClick={() => {
                 scrollTo("moneyBack")
@@ -385,6 +386,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
             backgroundColor={color("black5")}
             gridTemplateColumns="repeat(3, 1fr)"
             mt={2}
+            px={2}
           >
             <Box borderBottom={`solid 1px ${color("black10")}`}>{""}</Box>
             <Text
@@ -574,7 +576,7 @@ export const BuyerGuaranteeIndex: React.FC<BuyerGuaranteeIndexProps> = ({
         <CSSGrid
           backgroundColor={color("black5")}
           gridTemplateColumns="repeat(6, 1fr)"
-          px={0}
+          px={2}
           pt={0}
           pb={space(9)}
         >


### PR DESCRIPTION
This PR addresses two issues from [PURCHASE-2699]:

1. It adds 20 pixels of padding on either side of the Artsy Guarantee Table so that it does not edge to the grey borders.

<img width="387" alt="Screen Shot 2021-05-27 at 5 20 36 PM" src="https://user-images.githubusercontent.com/38149304/119898537-fd4c9000-bf0f-11eb-9a77-3d892ea382ee.png">
<img width="206" alt="Screen Shot 2021-05-27 at 5 20 24 PM" src="https://user-images.githubusercontent.com/38149304/119898549-0178ad80-bf10-11eb-833e-17fb159d19fd.png">

2. On Desktop it forces a line break for the Money-Back Guarantee passage. ‘we’ll work with you to make it right.'

<img width="640" alt="Screen Shot 2021-05-27 at 5 20 44 PM" src="https://user-images.githubusercontent.com/38149304/119898631-19e8c800-bf10-11eb-809f-4a1e335c9231.png">


[PURCHASE-2699]: https://artsyproduct.atlassian.net/browse/PURCHASE-2699