### PR TITLE
fix: add double bang to conditional render

### DIFF
--- a/src/v2/Apps/BuyerGuarantee/Components/Feature.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Components/Feature.tsx
@@ -67,7 +67,7 @@ export const Feature: React.FC<FeatureProps> = ({
           {title}
         </Text>
         <Text variant="text">{text}</Text>
-        {forcedSecondLine && <Text variant="text">{forcedSecondLine}</Text>}
+        {!!forcedSecondLine && <Text variant="text">{forcedSecondLine}</Text>}
       </Box>
       {!!onClick && <Box>{learnMore}</Box>}
     </Flex>


### PR DESCRIPTION
This PR adds a double bang in the condition render as a correction to this PR https://github.com/artsy/force/pull/7633.