### PR TITLE
fix: Overview page. Scroll to top after clicking on gallery rail card

### DIFF
--- a/src/v2/Apps/Partner/partnerRoutes.tsx
+++ b/src/v2/Apps/Partner/partnerRoutes.tsx
@@ -100,7 +100,6 @@ export const partnerRoutes: AppRouteConfig[] = [
         prepare: () => {
           OverviewRoute.preload()
         },
-        ignoreScrollBehavior: true,
         query: graphql`
           query partnerRoutes_OverviewQuery($partnerId: String!) {
             partner(id: $partnerId) @principalField {


### PR DESCRIPTION
JIRA -> [PPP: Non-subscribers: Overview: partners page is opened without scrolling to the top when clicking any gallery from "Galleries nearby" section](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=36&projectKey=PX&modal=detail&selectedIssue=PX-4168&quickFilter=228)

before:

![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/79980131/120191467-a05c1d00-c222-11eb-97cf-4abdaf9df9a2.gif)


after: 

![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/79980131/120191800-0fd20c80-c223-11eb-89d1-53df68f7e76b.gif)
