### PR TITLE
GRO-180: Fixing Spacing for Sign Up Flow

### DIFF
--- a/src/v2/Components/Authentication/TermsOfServiceCheckbox.tsx
+++ b/src/v2/Components/Authentication/TermsOfServiceCheckbox.tsx
@@ -78,7 +78,7 @@ const FallbackLabel = color => {
       >
         Conditions of Sale
       </Link>
-      {"and to receiving emails from Artsy."}
+      {" and to receiving emails from Artsy."}
     </>
   )
 }

--- a/src/v2/Components/Footer/Footer.tsx
+++ b/src/v2/Components/Footer/Footer.tsx
@@ -23,7 +23,7 @@ import { ContextModule } from "@artsy/cohesion"
 import { CCPARequest } from "../CCPARequest"
 import { FooterDownloadAppBanner } from "./FooterDownloadAppBanner"
 import { RouterLink, RouterLinkProps } from "v2/Artsy/Router/RouterLink"
-import { Device, useDeviceDetection } from "v2/Utils/Hooks/useDeviceDetection"
+import { useDeviceDetection } from "v2/Utils/Hooks/useDeviceDetection"
 
 interface FooterProps extends BoxProps {}
 


### PR DESCRIPTION
This is to address the bug that is being seen for Sign Up Flow in QA.

Seeing: `I agree to the Terms of Use, Privacy Policy, and Conditions of Saleand to receiving emails from Artsy.`