### PR TITLE
chore(merch): close the A/B experiment, again

### DIFF
--- a/src/desktop/components/split_test/running_tests.coffee
+++ b/src/desktop/components/split_test/running_tests.coffee
@@ -26,12 +26,4 @@
 # this should export empty Object
 # module.exports = {}
 
-module.exports = {
-  decayed_merch_v3:
-    key: "decayed_merch_v3"
-    outcomes: [
-      'control'
-      'experiment'
-    ]
-    weighting: 'equal'
-}
+module.exports = {}

--- a/src/desktop/components/split_test/splitTestMiddleware.ts
+++ b/src/desktop/components/split_test/splitTestMiddleware.ts
@@ -1,6 +1,5 @@
 import { NextFunction } from "express"
 import { ArtsyRequest, ArtsyResponse } from "lib/middleware/artsyExpress"
-import { updateSharifyAndContext } from "lib/middleware/bootstrapSharifyAndContextLocalsMiddleware"
 import qs from "qs"
 const runningTests = require("./running_tests.coffee")
 const SplitTest = require("./server_split_test.coffee")
@@ -15,9 +14,7 @@ export function splitTestMiddleware(
     const name = key.toUpperCase()
     if (!res.locals.sd[name]) {
       const test = new SplitTest(req, res, configuration)
-      const outcome = test.outcome()
-
-      updateSharifyAndContext(res, name, outcome)
+      res.locals.sd[name] = test.outcome()
     }
   }
 
@@ -29,8 +26,7 @@ export function splitTestMiddleware(
       const test = new SplitTest(req, res, runningTests[key])
       const value = params[key]
       test.set(value)
-
-      updateSharifyAndContext(res, key.toUpperCase(), value)
+      res.locals.sd[key.toUpperCase()] = value
     }
   }
 

--- a/src/desktop/config.coffee
+++ b/src/desktop/config.coffee
@@ -75,6 +75,7 @@ module.exports =
   MOBILE_MEDIA_QUERY: "only screen and (max-width: 640px)"
   NODE_ENV: 'development'
   OPENREDIS_URL: null
+  PAGE_CACHE_ENABLED: false
   PAGE_CACHE_TYPES: 'artist'
   PAGE_CACHE_NAMESPACE: 'page-cache'
   PAGE_CACHE_VERSION: '1'

--- a/src/lib/middleware/__tests__/pageCache.jest.ts
+++ b/src/lib/middleware/__tests__/pageCache.jest.ts
@@ -1,0 +1,64 @@
+import { pageCacheMiddleware } from "../pageCache"
+
+const { cache } = require("lib/cache")
+
+jest.mock("lib/cache", () => ({
+  cache: {
+    get: jest.fn().mockResolvedValue(true),
+    set: jest.fn(),
+  },
+}))
+
+jest.mock("config", () => ({
+  PAGE_CACHE_ENABLED: true,
+  PAGE_CACHE_TYPES: "artist",
+  PAGE_CACHE_NAMESPACE: "page-cache",
+  PAGE_CACHE_VERSION: "1",
+  PAGE_CACHE_EXPIRY_SECONDS: 600,
+  PAGE_CACHE_RETRIEVAL_TIMEOUT_MS: 400,
+}))
+
+describe("pageCacheMiddleware", () => {
+  let req
+  let res
+  let next
+  beforeEach(() => {
+    req = {
+      path: "/artist/test-artist",
+      url: "https://artsy.net/artist/test-artist",
+    }
+    res = {
+      once: jest.fn((_e, cb) => cb()),
+      locals: {
+        PAGE_CACHE: {
+          status: 200,
+          key: "key",
+          html: "html",
+        },
+      },
+    }
+    next = jest.fn()
+    cache.get.mockClear()
+    cache.set.mockClear()
+  })
+
+  it("sets up cache for valid pageTypes", async () => {
+    await pageCacheMiddleware(req, res, next)
+    expect(cache.set).toBeCalledWith("page-cache|1|key", "html", 600)
+    expect(cache.get.mock.calls[0][0]).toBe(
+      "page-cache|1|https://artsy.net/artist/test-artist"
+    )
+    expect(next).toBeCalled()
+  })
+
+  it("skips cache for invalid pageTypes", async () => {
+    req = {
+      path: "/artist-series/test-artist",
+      url: "https://artsy.net/artist-series/test-artist",
+    }
+    await pageCacheMiddleware(req, res, next)
+    expect(cache.set).not.toBeCalled()
+    expect(cache.get).not.toBeCalled()
+    expect(next).toBeCalled()
+  })
+})

--- a/src/lib/middleware/bootstrapSharifyAndContextLocalsMiddleware.ts
+++ b/src/lib/middleware/bootstrapSharifyAndContextLocalsMiddleware.ts
@@ -82,7 +82,7 @@ export function bootstrapSharifyAndContextLocalsMiddleware(
  * Updates both the sharify locals for template injection along with the context
  * globals for the request.
  */
-export function updateSharifyAndContext(res, key, value) {
+function updateSharifyAndContext(res, key, value) {
   res.locals.sd[key] = value
   const asyncLocalStorage = getAsyncLocalStorage()
   asyncLocalStorage.getStore()?.set(key, value)

--- a/src/lib/middleware/pageCache.ts
+++ b/src/lib/middleware/pageCache.ts
@@ -1,0 +1,115 @@
+import type { NextFunction } from "express"
+import type { ArtsyRequest, ArtsyResponse } from "./artsyExpress"
+
+import { getContextPageFromReq } from "lib/getContextPage"
+import { cache } from "lib/cache"
+import config from "../../config"
+
+const {
+  PAGE_CACHE_ENABLED,
+  PAGE_CACHE_EXPIRY_SECONDS,
+  PAGE_CACHE_NAMESPACE,
+  PAGE_CACHE_RETRIEVAL_TIMEOUT_MS,
+  PAGE_CACHE_TYPES,
+  PAGE_CACHE_VERSION,
+} = config
+
+const runningTests = Object.keys(
+  require("desktop/components/split_test/running_tests.coffee")
+).sort()
+const cacheablePageTypes: string[] = PAGE_CACHE_TYPES.split("|")
+
+// Middleware will `next` and do nothing if any of the following is true:
+//
+// * page cache feature is disabled.
+// * a user is signed in.
+// * this isnt a supported cacheable path (there is an allow-list set in ENV).
+// * the page content is uncached.
+// * the cache errors.
+export async function pageCacheMiddleware(
+  req: ArtsyRequest,
+  res: ArtsyResponse,
+  next: NextFunction
+) {
+  if (!PAGE_CACHE_ENABLED) return next()
+
+  // Returns true if the page type corresponding to `url` is configured cacheable.
+  const isCacheablePageType = (req: ArtsyRequest) => {
+    const { pageType } = getContextPageFromReq(req)
+
+    return cacheablePageTypes.includes(pageType)
+  }
+  if (!isCacheablePageType(req)) return next()
+
+  // @ts-ignore
+  const hasUser = !!req.user
+  if (hasUser) return next()
+
+  // Generate cache key that includes all currently running AB tests and outcomes.
+  const runningTestsCacheKey = runningTests
+    .map(test => {
+      const outcome = res.locals.sd[test.toUpperCase()]
+      return `${test}:${outcome}`
+    })
+    .join("|")
+
+  // `key` should be a full URL w/ query params, and not a path.
+  // This is to separate URL's like `/collect` and `/collect?acquireable=true`.
+  const cacheKey = (key: string) => {
+    return [PAGE_CACHE_NAMESPACE, runningTestsCacheKey, PAGE_CACHE_VERSION, key]
+      .filter(Boolean)
+      .join("|")
+  }
+
+  // `key` is the full URL.
+  const cacheHtmlForPage = ({ status, key, html }) => {
+    if (status !== 200) return
+
+    cache.set(cacheKey(key), html, PAGE_CACHE_EXPIRY_SECONDS)
+  }
+
+  const cacheKeyForRequest = cacheKey(req.url)
+
+  // Register callback to write rendered page data to cache.
+  res.once("finish", () => {
+    if (res.locals.PAGE_CACHE) {
+      // eslint-disable-next-line no-console
+      console.log(`[Page Cache]: Writing ${cacheKeyForRequest} to cache`)
+      cacheHtmlForPage(res.locals.PAGE_CACHE)
+    }
+  })
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      // Cache timeout handler, will reject if hit.
+      let timeoutId = setTimeout(() => {
+        // @ts-expect-error STRICT_NULL_CHECK
+        timeoutId = null
+        const error = new Error(
+          `Timeout of ${PAGE_CACHE_RETRIEVAL_TIMEOUT_MS}ms, skipping...`
+        )
+        reject(error)
+      }, PAGE_CACHE_RETRIEVAL_TIMEOUT_MS)
+
+      const handleCacheGet = (_err, html) => {
+        if (!timeoutId) return // Already timed out.
+
+        clearTimeout(timeoutId)
+
+        if (html) {
+          // eslint-disable-next-line no-console
+          console.log(`[Page Cache]: Reading ${cacheKeyForRequest} from cache`)
+          return res.send(html)
+        }
+
+        resolve()
+      }
+
+      cache.get(cacheKey(req.url), handleCacheGet)
+    })
+  } catch (e) {
+    console.error(`[Page Cache Middleware]: ${e.message}`)
+  } finally {
+    next()
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -38,6 +38,7 @@ import { escapedFragmentMiddleware } from "./lib/middleware/escapedFragment"
 import { hardcodedRedirectsMiddleware } from "./lib/middleware/hardcodedRedirects"
 import { localsMiddleware } from "./lib/middleware/locals"
 import { marketingModalsMiddleware } from "./lib/middleware/marketingModals"
+import { pageCacheMiddleware } from "./lib/middleware/pageCache"
 import { proxyReflectionMiddleware } from "./lib/middleware/proxyReflection"
 import { sameOriginMiddleware } from "./lib/middleware/sameOrigin"
 import { unsupportedBrowserMiddleware } from "./lib/middleware/unsupportedBrowser"
@@ -109,6 +110,7 @@ export function initializeMiddleware(app) {
   app.use(sameOriginMiddleware)
   app.use(escapedFragmentMiddleware)
   app.use(unsupportedBrowserMiddleware)
+  app.use(pageCacheMiddleware)
 
   /**
    * Blank page used by Eigen for caching web views.

--- a/src/typings/sharify.d.ts
+++ b/src/typings/sharify.d.ts
@@ -24,7 +24,6 @@ declare module "sharify" {
       readonly CMS_URL: string
       CURRENT_PATH: string
       CURRENT_USER: User
-      readonly DECAYED_MERCH_V3: string // TODO: Remove after A/B test
       readonly DEPLOY_ENV: string
       readonly EIGEN: boolean
       readonly ENABLE_NEW_ARTWORK_FILTERS: boolean

--- a/src/v2/Apps/Artist/Routes/Overview/Components/ArtistArtworkFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/Components/ArtistArtworkFilter.tsx
@@ -7,7 +7,6 @@ import { Match, RouterState, withRouter } from "found"
 import React from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import { ZeroState } from "./ZeroState"
-import { getENV } from "v2/Utils/getENV"
 
 interface ArtistArtworkFilterProps {
   artist: ArtistArtworkFilter_artist
@@ -25,31 +24,18 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
   // we still want to render the rest of the page.
   if (!hasFilter) return null
 
-  const sortOptions = [
-    { value: "-has_price,-prices", text: "Price (desc.)" },
-    { value: "-has_price,prices", text: "Price (asc.)" },
-    { value: "-partner_updated_at", text: "Recently updated" },
-    { value: "-published_at", text: "Recently added" },
-    { value: "-year", text: "Artwork year (desc.)" },
-    { value: "year", text: "Artwork year (asc.)" },
-  ]
-
-  const defaultSortValue =
-    getENV("DECAYED_MERCH_V3") === "experiment"
-      ? "-decayed_merch_v2"
-      : "-decayed_merch"
-
-  sortOptions.unshift({ value: defaultSortValue, text: "Default" })
-
-  const initialFilters = {
-    ...(match && match.location.query),
-    sort: defaultSortValue,
-  }
-
   return (
     <ArtworkFilterContextProvider
-      filters={initialFilters}
-      sortOptions={sortOptions}
+      filters={match && match.location.query}
+      sortOptions={[
+        { value: "-decayed_merch", text: "Default" },
+        { value: "-has_price,-prices", text: "Price (desc.)" },
+        { value: "-has_price,prices", text: "Price (asc.)" },
+        { value: "-partner_updated_at", text: "Recently updated" },
+        { value: "-published_at", text: "Recently added" },
+        { value: "-year", text: "Artwork year (desc.)" },
+        { value: "year", text: "Artwork year (asc.)" },
+      ]}
       // @ts-expect-error STRICT_NULL_CHECK
       aggregations={sidebarAggregations.aggregations as any}
       // @ts-expect-error STRICT_NULL_CHECK

--- a/src/v2/Apps/Artist/artistRoutes.tsx
+++ b/src/v2/Apps/Artist/artistRoutes.tsx
@@ -149,15 +149,9 @@ export const artistRoutes: AppRouteConfig[] = [
           // renders (such as tabbing back to this route in your browser) will not.
           const filterStateFromUrl = props.location ? props.location.query : {}
 
-          const sort =
-            getENV("DECAYED_MERCH_V3") === "experiment"
-              ? "-decayed_merch_v2"
-              : "-decayed_merch"
-
           const filterParams = {
             ...initialArtworkFilterState,
             ...paramsToCamelCase(filterStateFromUrl),
-            sort,
           }
 
           // filterParams.hasFilter = Object.entries(filterParams).some(

--- a/src/v2/Artsy/Analytics/__tests__/trackingMiddleware.jest.ts
+++ b/src/v2/Artsy/Analytics/__tests__/trackingMiddleware.jest.ts
@@ -6,7 +6,6 @@ declare const global: any
 jest.mock("sharify", () => ({
   data: {
     APP_URL: "http://testing.com",
-    ALL_ARTWORKS_AS_CATS: "experiment",
   },
 }))
 
@@ -20,7 +19,7 @@ describe("trackingMiddleware", () => {
   beforeEach(() => {
     // FIXME: reaction migration
     // @ts-ignore
-    window.analytics = { track: jest.fn(), page: jest.fn() }
+    window.analytics = { page: jest.fn() }
   })
 
   afterEach(() => {
@@ -144,32 +143,6 @@ describe("trackingMiddleware", () => {
           "http://testing.com/referrer?with=queryparams"
         )
       })
-    })
-  })
-
-  describe("triggering AB test experiment viewed events", () => {
-    it("triggers for a given route", () => {
-      trackingMiddleware({
-        abTestRouteMap: [
-          { abTest: "all_artworks_as_cats", routes: ["/artwork(.*)"] },
-        ],
-      })(store)(noop)({
-        type: ActionTypes.UPDATE_LOCATION,
-        payload: {
-          pathname: "/artwork/some-id",
-        },
-      })
-      expect(global.analytics.track).toBeCalledWith(
-        "Experiment Viewed",
-        {
-          experiment_id: "all_artworks_as_cats",
-          experiment_name: "all_artworks_as_cats",
-          variation_id: "experiment",
-          variation_name: "experiment",
-          nonInteraction: 1,
-        },
-        { page: {} }
-      )
     })
   })
 })

--- a/src/v2/Artsy/Analytics/trackExperimentViewed.tsx
+++ b/src/v2/Artsy/Analytics/trackExperimentViewed.tsx
@@ -1,7 +1,7 @@
 import * as Schema from "v2/Artsy/Analytics"
 import { data as sd } from "sharify"
 
-export const trackExperimentViewed = (name: string, trackingData = {}) => {
+export const trackExperimentViewed = (name: string, trackingData) => {
   if (typeof window.analytics !== "undefined") {
     const variation = sd[name.toUpperCase()]
     if (!Boolean(variation)) {

--- a/src/v2/Artsy/Analytics/trackingMiddleware.ts
+++ b/src/v2/Artsy/Analytics/trackingMiddleware.ts
@@ -1,4 +1,4 @@
-import { trackExperimentViewed } from "v2/Artsy/Analytics/trackExperimentViewed"
+// import { trackExperimentViewed } from "v2/Artsy/Analytics/trackExperimentViewed"
 import { ActionTypes } from "farce"
 import { data as sd } from "sharify"
 import { get } from "v2/Utils/get"
@@ -12,19 +12,13 @@ import { match } from "path-to-regexp"
  * @see https://github.com/4Catalyzer/farce/blob/master/src/ActionTypes.js
  */
 
-interface ABTestRouteMap {
-  abTest: string
-  routes: string[]
-}
-
 interface TrackingMiddlewareOptions {
   excludePaths?: string[]
-  abTestRouteMap?: ABTestRouteMap[]
 }
 
 export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
   return store => next => action => {
-    const { excludePaths = [], abTestRouteMap = [] } = options
+    const { excludePaths = [] } = options
     const { type, payload } = action
 
     switch (type) {
@@ -115,19 +109,6 @@ export function trackingMiddleware(options: TrackingMiddlewareOptions = {}) {
               }
             })
           }
-
-          // AB Test
-          abTestRouteMap.forEach(({ abTest, routes }) => {
-            routes.some(route => {
-              const matcher = match(route, { decode: decodeURIComponent })
-              const foundMatch = !!matcher(pathname)
-
-              if (foundMatch) {
-                trackExperimentViewed(abTest)
-                return true
-              }
-            })
-          })
         }
 
         return next(action)

--- a/src/v2/Artsy/Router/buildClientApp.tsx
+++ b/src/v2/Artsy/Router/buildClientApp.tsx
@@ -76,12 +76,6 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
             // @see https://github.com/artsy/force/blob/2c0db041fa6cb50e9f747ea95860ad5c38290653/src/v2/Apps/Artwork/ArtworkApp.tsx#L117-L121
             "/artwork(.*)",
           ],
-          abTestRouteMap: [
-            {
-              abTest: "decayed_merch_v3",
-              routes: ["/artist/:artistID/works-for-sale"],
-            },
-          ],
         }),
       ]
       const resolver = new Resolver(relayEnvironment)

--- a/src/v2/Components/ArtworkFilter/Utils/isDefaultFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/Utils/isDefaultFilter.tsx
@@ -1,5 +1,4 @@
 import { ArtworkFilters } from "../ArtworkFilterContext"
-import { getENV } from "v2/Utils/getENV"
 
 export const isDefaultFilter: (
   name: keyof ArtworkFilters,
@@ -8,11 +7,6 @@ export const isDefaultFilter: (
   if (!value) {
     return false
   }
-
-  const defaultSort =
-    getENV("DECAYED_MERCH_V3") === "experiment"
-      ? "-decayed_merch_v2"
-      : "-decayed_merch"
 
   switch (true) {
     case name === "sizes" ||
@@ -27,7 +21,7 @@ export const isDefaultFilter: (
       name === "materialsTerms":
       return value.length === 0
     case name === "sort":
-      return value === defaultSort
+      return value === "-decayed_merch"
     case name === "medium":
       return value === "*" || !value
     case name === "priceRange" || name === "height" || name === "width":


### PR DESCRIPTION
Reverts artsy/force#7635

Properly this time 😅 — see [thread](https://artsy.slack.com/archives/CP9P4KR35/p1622580534276900)

This is a follow-up to https://github.com/artsy/force/pull/7672 which 
- inadvertently reverted the Deploy PR rather than the feature-branch PR
- thus resulted in an immediate production deploy to close the the A/B (which is ok)
- resulted in `master`+`staging` being out of sync with `release` (which is not ok)