### PR TITLE
fix: `Set price` and `Set size` are made as links instead of buttons

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/FilterLink.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/FilterLink.tsx
@@ -1,0 +1,36 @@
+import React, { ReactNode } from "react"
+import {
+  BoxProps,
+  Clickable,
+  Text,
+  TextVariant,
+  useThemeConfig,
+} from "@artsy/palette"
+
+interface FilterLinkProps extends BoxProps {
+  onClick: () => void
+  children: ReactNode
+}
+
+export const FilterLink: React.FC<FilterLinkProps> = ({
+  onClick,
+  children,
+  ...rest
+}) => {
+  const tokens = useThemeConfig({
+    v2: { variant: "small" as TextVariant },
+    v3: { variant: "xs" as TextVariant },
+  })
+
+  return (
+    <Clickable
+      mt={1}
+      textDecoration="underline"
+      textAlign="left"
+      onClick={onClick}
+      {...rest}
+    >
+      <Text variant={tokens.variant}>{children}</Text>
+    </Clickable>
+  )
+}

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react"
 import {
-  Button,
   Flex,
   LabeledInput,
   Message,
@@ -14,6 +13,7 @@ import styled from "styled-components"
 import { Media } from "v2/Utils/Responsive"
 import { themeGet } from "@styled-system/theme-get"
 import { FilterExpandable } from "./FilterExpandable"
+import { FilterLink } from "./FilterLink"
 
 // Disables arrows in numeric inputs
 export const NumericInput = styled(LabeledInput).attrs({ type: "number" })`
@@ -203,14 +203,9 @@ export const PriceRangeFilter: React.FC<PriceRangeFilterProps> = ({
             />
           </Flex>
 
-          <Button
-            mt={1}
-            variant="secondaryGray"
-            onClick={handleClick}
-            width="100%"
-          >
+          <FilterLink mt={1.5} onClick={handleClick}>
             Set price
-          </Button>
+          </FilterLink>
         </>
       )}
     </FilterExpandable>

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ShowMore.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ShowMore.tsx
@@ -1,5 +1,5 @@
-import { Clickable, Text, TextVariant, useThemeConfig } from "@artsy/palette"
 import React, { Children, isValidElement, useState } from "react"
+import { FilterLink } from "./FilterLink"
 
 interface ShowMoreProps {
   initial?: number
@@ -19,26 +19,14 @@ export const ShowMore: React.FC<ShowMoreProps> = ({
 
   const [isExpanded, setExpanded] = useState(expanded)
 
-  const tokens = useThemeConfig({
-    v2: { variant: "small" as TextVariant },
-    v3: { variant: "xs" as TextVariant },
-  })
-
   return (
     <>
       {isExpanded ? nodes : nodes.slice(0, initial)}
 
       {hasMore && (
-        <Clickable
-          mt={1}
-          textDecoration="underline"
-          textAlign="left"
-          onClick={() => setExpanded(visibility => !visibility)}
-        >
-          <Text variant={tokens.variant}>
-            {isExpanded ? "Hide" : "Show more"}
-          </Text>
-        </Clickable>
+        <FilterLink onClick={() => setExpanded(visibility => !visibility)}>
+          {isExpanded ? "Hide" : "Show more"}
+        </FilterLink>
       )}
     </>
   )

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter2.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter2.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect, useState } from "react"
 import {
-  Button,
   Text,
   Checkbox,
-  Clickable,
   Flex,
   Spacer,
   Message,
@@ -14,6 +12,7 @@ import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { NumericInput } from "./PriceRangeFilter"
 import { Media } from "v2/Utils/Responsive"
 import { FilterExpandable } from "./FilterExpandable"
+import { FilterLink } from "./FilterLink"
 
 const SIZES = [
   { displayName: "Small (under 40cm)", name: "SMALL" },
@@ -218,14 +217,11 @@ export const SizeFilter2: React.FC<SizeFilter2Props> = ({ expanded }) => {
 
       <Text></Text>
 
-      <Clickable
-        mt={1}
-        textDecoration="underline"
-        textAlign="left"
+      <FilterLink
         onClick={() => setShowCustom(prevShowCustom => !prevShowCustom)}
       >
-        <Text variant="small">{showCustom ? "Hide" : "Show"} custom size</Text>
-      </Clickable>
+        {showCustom ? "Hide" : "Show"} custom size
+      </FilterLink>
 
       {showCustom && (
         <>
@@ -289,14 +285,9 @@ export const SizeFilter2: React.FC<SizeFilter2Props> = ({ expanded }) => {
             />
           </Flex>
 
-          <Button
-            mt={1}
-            variant="secondaryGray"
-            onClick={handleClick}
-            width="100%"
-          >
+          <FilterLink mt={1.5} onClick={handleClick}>
             Set size
-          </Button>
+          </FilterLink>
         </>
       )}
     </FilterExpandable>

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/PriceRangeFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/PriceRangeFilter.jest.tsx
@@ -55,7 +55,7 @@ describe("PriceRangeFilter", () => {
     wrapper.update()
 
     expect(wrapper.find(Input)).toHaveLength(2)
-    expect(wrapper.find("Button").last().text()).toEqual("Set price")
+    expect(wrapper.find("FilterLink").text()).toEqual("Set price")
   })
 
   it("updates the input values when the radio selected option updates", async () => {
@@ -104,7 +104,7 @@ describe("PriceRangeFilter", () => {
     } as any)
 
     wrapper.update()
-    wrapper.find("Button").last().simulate("click")
+    wrapper.find("FilterLink").simulate("click")
 
     // @ts-expect-error STRICT_NULL_CHECK
     expect(context.filters.priceRange).toEqual("400-7500")
@@ -124,7 +124,7 @@ describe("PriceRangeFilter", () => {
 
     wrapper.update()
     // @ts-expect-error STRICT_NULL_CHECK
-    wrapper.find("Button").last().prop("onClick")({} as any)
+    wrapper.find("FilterLink").prop("onClick")()
 
     // @ts-expect-error STRICT_NULL_CHECK
     expect(context.filters.priceRange).toEqual("400-*")
@@ -136,7 +136,7 @@ describe("PriceRangeFilter", () => {
 
     wrapper.update()
     // @ts-expect-error STRICT_NULL_CHECK
-    wrapper.find("Button").last().prop("onClick")({} as any)
+    wrapper.find("FilterLink").prop("onClick")()
 
     // @ts-expect-error STRICT_NULL_CHECK
     expect(context.filters.priceRange).toEqual("*-*")


### PR DESCRIPTION
…ore' and 'Set price'

https://artsyproduct.atlassian.net/browse/FX-2846

**Before**
![Screen Shot 2021-06-02 at 4 38 25 PM](https://user-images.githubusercontent.com/44819355/120490304-f6ff5d80-c3c0-11eb-8807-3439deb98612.png)

**After**
![Screen Shot 2021-06-02 at 4 38 44 PM](https://user-images.githubusercontent.com/44819355/120490349-01b9f280-c3c1-11eb-99ef-8766894ff91a.png)
