### PR TITLE
feat(PX-3737): update COA copy in modal on Artwork Page

### DIFF
--- a/src/v2/Apps/Artwork/Components/TrustSignals/AuthenticityCertificate.tsx
+++ b/src/v2/Apps/Artwork/Components/TrustSignals/AuthenticityCertificate.tsx
@@ -1,4 +1,4 @@
-import { CertificateIcon, Flex, Modal, Text } from "@artsy/palette"
+import { CertificateIcon, Flex, Modal, Text, Link } from "@artsy/palette"
 import { AuthenticityCertificate_artwork } from "v2/__generated__/AuthenticityCertificate_artwork.graphql"
 import React, { useState } from "react"
 import { createFragmentContainer } from "react-relay"
@@ -55,6 +55,17 @@ export const AuthenticityCertificate: React.FC<AuthenticityCertificateProps> = (
               COAs typically include the name of the artist, the details (title,
               date, medium, dimensions) of the work in question, and whenever
               possible an image of the work.
+            </Text>
+            <Text variant="text" pb={2}>
+              Read more about artwork authenticity in our{" "}
+              <Link
+                href="https://support.artsy.net/hc/en-us/articles/360058123933-What-Counts-as-an-Artwork-s-Proof-of-Authenticity-"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Help Center
+              </Link>
+              .
             </Text>
           </Flex>
         </Modal>


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [PX-3737]

### Description

Added text and link to Help Center to the modal that displays when you click on "Certificate of Authenticity" to the right of the artwork.

![Screen Shot 2021-06-03 at 13 31 58](https://user-images.githubusercontent.com/83413732/120632274-72204c80-c471-11eb-95ca-061b7df6ffac.png)


[PX-3737]: https://artsyproduct.atlassian.net/browse/PX-3737