### PR TITLE
fix: use https over http for static image urls

### DIFF
--- a/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
@@ -29,7 +29,6 @@ import { scrollIntoView } from "v2/Utils/scrollHelpers"
 import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 import { BuyerGuaranteeMeta } from "../Components/BuyerGuaranteeMeta"
 
-
 export const BuyerGuaranteeIndex: React.FC = () => {
   const isMobile = useMatchMedia(themeProps.mediaQueries.xs)
 
@@ -49,20 +48,20 @@ export const BuyerGuaranteeIndex: React.FC = () => {
     "https://support.artsy.net/hc/en-us/articles/360048946973"
 
   const authenticityGuaranteeImageURL = resize(
-    "http://files.artsy.net/authenticityguaranteeartwork.jpg",
+    "https://files.artsy.net/authenticityguaranteeartwork.jpg",
     { width: 400, height: 600, convert_to: "jpg" }
   )
   const securePaymentImageURL = resize(
-    "http://files.artsy.net/securepaymentartwork.jpg",
+    "https://files.artsy.net/securepaymentartwork.jpg",
     { width: 400, height: 600, convert_to: "jpg" }
   )
   const moneyBackGuaranteeImageURL = resize(
-    "http://files.artsy.net/moneybackguaranteeartwork.jpg",
+    "https://files.artsy.net/moneybackguaranteeartwork.jpg",
     { width: 400, height: 600, convert_to: "jpg" }
   )
 
   const heroImageURL = resize(
-    "http://files.artsy.net/buyerGuaranteeHeroImage.jpg",
+    "https://files.artsy.net/buyerGuaranteeHeroImage.jpg",
     { width: 1600, height: 800, convert_to: "jpg" }
   )
 
@@ -88,7 +87,7 @@ export const BuyerGuaranteeIndex: React.FC = () => {
     imageTitle: "Sophie Treppendahl, ‘Swimming Hole’, 2019",
     image: {
       resized: {
-        srcSet: "http://files.artsy.net/images/normalizedheaderimage.jpeg 1x",
+        srcSet: "https://files.artsy.net/images/normalizedheaderimage.jpeg 1x",
       },
     },
   }
@@ -97,7 +96,7 @@ export const BuyerGuaranteeIndex: React.FC = () => {
     imageTitle: "Paul Wackers, ‘Constructing Planets’, 2018",
     image: {
       resized: {
-        srcSet: "http://files.artsy.net/authenticityguaranteeartwork.jpg 1x",
+        srcSet: "https://files.artsy.net/authenticityguaranteeartwork.jpg 1x",
       },
     },
     artist: {
@@ -109,7 +108,7 @@ export const BuyerGuaranteeIndex: React.FC = () => {
     imageTitle: "Alex Katz, ‘Blue Umbrella 2’, 2020",
     image: {
       resized: {
-        srcSet: "http://files.artsy.net/moneybackguaranteeartwork.jpg 1x",
+        srcSet: "https://files.artsy.net/moneybackguaranteeartwork.jpg 1x",
       },
     },
     artist: {
@@ -121,7 +120,7 @@ export const BuyerGuaranteeIndex: React.FC = () => {
     imageTitle: "Louise Belcourt, ‘Mound #26’, 2014-2015",
     image: {
       resized: {
-        srcSet: "http://files.artsy.net/securepaymentartwork.jpg 1x",
+        srcSet: "https://files.artsy.net/securepaymentartwork.jpg 1x",
       },
     },
     artist: {


### PR DESCRIPTION
Quick followup to #7661 to use `https` urls from Vanity instead of `http` as they caused the images to not render on Staging and Production.

cc @artsy/purchase-devs 

Bug:
<img width="693" alt="Screen Shot 2021-06-03 at 10 48 23 AM" src="https://user-images.githubusercontent.com/10385964/120690645-552c4f00-c45a-11eb-9079-307b5e4643e9.png">


Fix:
<img width="735" alt="Screen Shot 2021-06-03 at 10 48 42 AM" src="https://user-images.githubusercontent.com/10385964/120689901-750f4300-c459-11eb-8dec-d295739f0e6d.png">