### PR TITLE
Preserve querystrings when redirecting to /login or /signup paths (PLATFORM-3341)

### DIFF
--- a/src/desktop/apps/auction_support/routes.coffee
+++ b/src/desktop/apps/auction_support/routes.coffee
@@ -38,7 +38,7 @@ registerAndRedirect = (sale, req, res, next) ->
 
 @modalAuctionRegistration = (req, res, next) ->
   unless req.user
-    return res.redirect "/log_in?redirect_uri=/auction-registration/#{req.params.id}"
+    return res.redirect "/login?redirectTo=/auction-registration/#{req.params.id}"
 
   new Sale(id: req.params.id).fetch
     error: res.backboneError

--- a/src/desktop/apps/auction_support/test/routes.test.js
+++ b/src/desktop/apps/auction_support/test/routes.test.js
@@ -67,7 +67,7 @@ describe("#modalAuctionRegistration", function () {
   it("redirects to login without user", function () {
     routes.modalAuctionRegistration(this.req, this.res)
     return this.res.redirect.args[0][0].should.equal(
-      "/log_in?redirect_uri=/auction-registration/awesome-sale"
+      "/login?redirectTo=/auction-registration/awesome-sale"
     )
   })
 

--- a/src/desktop/apps/authentication/client/reset_password.coffee
+++ b/src/desktop/apps/authentication/client/reset_password.coffee
@@ -31,7 +31,7 @@ module.exports.PasswordResetView = class PasswordResetView extends Backbone.View
 
     @model.save @serializeForm(),
       success: ->
-        window.location = RESET_PASWORD_REDIRECT_TO || '/log_in'
+        window.location = RESET_PASWORD_REDIRECT_TO || '/login'
       error: (model, response, options) =>
         @reenableForm()
         @$errors.html @errorMessage(response)

--- a/src/desktop/apps/authentication/index.ts
+++ b/src/desktop/apps/authentication/index.ts
@@ -1,4 +1,5 @@
 import express from "express"
+import { parse } from "url"
 import {
   forgotPassword,
   login,
@@ -17,9 +18,11 @@ app.get("/signup", redirectLoggedInHome, signup)
 app.get("/forgot", forgotPassword)
 app.get("/reset_password", resetPassword)
 
-app.get("/log_in", (_req, res) => {
-  res.redirect(301, "/login")
+app.get("/log_in", (req, res) => {
+  const parsedUrl = parse(req.url)
+  res.redirect(301, `/login?${parsedUrl.query}`)
 })
-app.get("/sign_up", (_req, res) => {
-  res.redirect(301, "/signup")
+app.get("/sign_up", (req, res) => {
+  const parsedUrl = parse(req.url)
+  res.redirect(301, `/signup?${parsedUrl.query}`)
 })

--- a/src/desktop/apps/notifications/routes.coffee
+++ b/src/desktop/apps/notifications/routes.coffee
@@ -3,11 +3,11 @@ sd = require('sharify').data
 qs = require 'qs'
 
 @worksForYou = (req, res) ->
-  # If the user is logged-out, redirect to /log_in unless they are coming from email.
+  # If the user is logged-out, redirect to /login unless they are coming from email.
   # If they are coming from email, redirect to artist works page.
   unless req.user
     { artist_id, from_email } = req.query
-    return res.redirect("/log_in?redirect_uri=#{req.url}") unless artist_id and from_email
+    return res.redirect("/login?redirectTo=#{encodeURIComponent(req.url)}") unless artist_id and from_email
     params = _.extend sort: '-published_at', _.pick req.query, 'utm_content', 'utm_medium', 'utm_source', 'utm_campaign'
     queryString = qs.stringify params
     return res.redirect("/artist/#{artist_id}/works-for-sale?#{queryString}")

--- a/src/desktop/apps/notifications/test/routes.test.js
+++ b/src/desktop/apps/notifications/test/routes.test.js
@@ -33,7 +33,7 @@ describe("Notification Routing", function () {
     it("redirect to login without a user", function () {
       routes.worksForYou(this.req, this.res)
       return this.res.redirect.args[0][0].should.equal(
-        "/log_in?redirect_uri=/works-for-you"
+        "/login?redirectTo=%2Fworks-for-you"
       )
     })
 
@@ -55,7 +55,7 @@ describe("Notification Routing", function () {
       }
       routes.worksForYou(this.req, this.res)
       return this.res.redirect.args[0][0].should.equal(
-        "/log_in?redirect_uri=/works-for-you"
+        "/login?redirectTo=%2Fworks-for-you"
       )
     })
 

--- a/src/desktop/apps/user/components/password/view.coffee
+++ b/src/desktop/apps/user/components/password/view.coffee
@@ -30,7 +30,7 @@ module.exports = class SettingsPasswordView extends GenericFormView
       method: "DELETE"
       url: "/users/sign_out",
       complete: ->
-        return location.assign '/log_in?redirect_uri=/user/edit'
+        return location.assign '/login?redirectTo=/user/edit'
   , 300
 
   render: ->

--- a/src/desktop/apps/user/routes.coffee
+++ b/src/desktop/apps/user/routes.coffee
@@ -15,7 +15,7 @@
 @settings = (req, res, next) ->
   user = req.user
 
-  return res.redirect "/log_in?redirect_uri=#{req.url}" unless user
+  return res.redirect "/login?redirectTo=#{encodeURIComponent(req.url)}" unless user
   return res.redirect '/' if req.url is '/user/delete' and user.isAdmin()
 
   user.fetch()

--- a/src/desktop/apps/user/test/routes.test.js
+++ b/src/desktop/apps/user/test/routes.test.js
@@ -57,7 +57,7 @@ describe("/user", function () {
     it("redirects to the home page without a current user", function () {
       routes.settings(this.req, this.res)
       return this.res.redirect.args[0][0].should.equal(
-        "/log_in?redirect_uri=/user/edit"
+        "/login?redirectTo=%2Fuser%2Fedit"
       )
     })
 

--- a/src/desktop/components/fair_layout/templates/user.jade
+++ b/src/desktop/components/fair_layout/templates/user.jade
@@ -23,5 +23,5 @@
           | Log out
 
   else
-    a.avant-garde-button-white.mlh-login( href='/log_in', rel='nofollow' ) Log in
-    a.avant-garde-button-black.mlh-signup( href='/sign_up', rel='nofollow' ) Sign up
+    a.avant-garde-button-white.mlh-login( href='/login', rel='nofollow' ) Log in
+    a.avant-garde-button-black.mlh-signup( href='/signup', rel='nofollow' ) Sign up

--- a/src/desktop/components/fair_layout/test/templates/nav.test.js
+++ b/src/desktop/components/fair_layout/test/templates/nav.test.js
@@ -91,7 +91,7 @@ describe("Header template", function () {
     return it("works with out user", function () {
       const user = undefined
 
-      return this.$template.html().should.containEql("/log_in")
+      return this.$template.html().should.containEql("/login")
     })
   })
 })

--- a/src/desktop/components/main_layout/footer/mobile_footer_menu.jade
+++ b/src/desktop/components/main_layout/footer/mobile_footer_menu.jade
@@ -15,8 +15,8 @@
       a( href='/user/edit' ) Account
   else
     .mlf-login-signup
-      a.mlf-signup.avant-garde-button-dark( href='/sign_up', rel='nofollow' ) Sign up
-      a.mlf-login.avant-garde-button-dark( href='/log_in', rel='nofollow') Log in
+      a.mlf-signup.avant-garde-button-dark( href='/signup', rel='nofollow' ) Sign up
+      a.mlf-login.avant-garde-button-dark( href='/login', rel='nofollow') Log in
   .mlf-lower
       nav#main-layout-footer-internal
         span.mlf-links

--- a/src/mobile/apps/favorites_following/routes.coffee
+++ b/src/mobile/apps/favorites_following/routes.coffee
@@ -14,7 +14,7 @@ module.exports.following = (req, res, next) ->
   if (route = req.params.type) in _.keys(typeMap)
     kind = res.locals.sd.KIND = typeMap[route] or 'artist'
     if _.contains implemented, kind
-      return res.redirect "/log_in?redirect-to=#{encodeURIComponent(req.url)}" unless req.user
+      return res.redirect "/login?redirectTo=#{encodeURIComponent(req.url)}" unless req.user
       res.render 'index', type: route
     else
       res.render 'placeholder'

--- a/src/mobile/apps/favorites_following/test/routes.test.js
+++ b/src/mobile/apps/favorites_following/test/routes.test.js
@@ -33,7 +33,7 @@ describe("favorites_following", function () {
           )
           this.renderStub.called.should.be.false()
           return this.redirectStub.args[0][0].should.equal(
-            "/log_in?redirect-to=%2Ffollowing%2Fgalleries"
+            "/login?redirectTo=%2Ffollowing%2Fgalleries"
           )
         }))
 

--- a/src/mobile/apps/user/routes.coffee
+++ b/src/mobile/apps/user/routes.coffee
@@ -14,7 +14,7 @@ module.exports.refresh = (req, res, next) ->
           res.json req.user.attributes
 
 module.exports.settings = (req, res) ->
-  return res.redirect("/log_in?redirect_uri=#{req.url}") unless req.user
+  return res.redirect("/login?redirectTo=#{encodeURIComponent(req.url)}") unless req.user
 
   user = new CurrentUser req.user.attributes
 

--- a/src/mobile/apps/user/test/routes.test.js
+++ b/src/mobile/apps/user/test/routes.test.js
@@ -50,7 +50,7 @@ describe("/user", function () {
     it("redirects to the home page without a current user", function () {
       routes.settings(this.req, this.res)
       return this.res.redirect.args[0][0].should.equal(
-        "/log_in?redirect_uri=/user/edit"
+        "/login?redirectTo=%2Fuser%2Fedit"
       )
     }))
 })

--- a/src/mobile/components/layout/templates/login-signup.jade
+++ b/src/mobile/components/layout/templates/login-signup.jade
@@ -1,6 +1,6 @@
 mixin login-signup(template)
   .login-signup
     .login-signup-button-container
-      a.avant-garde-box-button.avant-garde-box-button-gray( href="/sign_up?intent=signup&contextModule=#{template}&destination=#{sd.CURRENT_PATH}", data-test="mobileSignUpCTA", rel="nofollow" ) Sign up
+      a.avant-garde-box-button.avant-garde-box-button-gray( href="/signup?intent=signup&contextModule=#{template}&destination=#{sd.CURRENT_PATH}", data-test="mobileSignUpCTA", rel="nofollow" ) Sign up
     .login-signup-button-container
-      a.avant-garde-box-button.avant-garde-box-button-gray( href="/log_in?intent=login&contextModule=#{template}&destination=#{sd.CURRENT_PATH}", data-test="mobileLogInCTA", rel="nofollow" ) Log in
+      a.avant-garde-box-button.avant-garde-box-button-gray( href="/login?intent=login&contextModule=#{template}&destination=#{sd.CURRENT_PATH}", data-test="mobileLogInCTA", rel="nofollow" ) Log in

--- a/src/mobile/components/sanitize_redirect/test/index.test.js
+++ b/src/mobile/components/sanitize_redirect/test/index.test.js
@@ -40,8 +40,8 @@ describe("sanitizeRedirect", function () {
     ).should.equal("http://localhost:3003/artwork/joe-piccillo-a-riposo"))
 
   it("lets internal paths through", () =>
-    sanitizeRedirect("/log_in?redirect-to=/foo/bar").should.equal(
-      "/log_in?redirect-to=/foo/bar"
+    sanitizeRedirect("/login?redirectTo=/foo/bar").should.equal(
+      "/login?redirectTo=/foo/bar"
     ))
 
   it("blocks data urls", () =>
@@ -55,10 +55,10 @@ describe("sanitizeRedirect", function () {
   it("blocks external links that lack protocol; redirects to root", () =>
     sanitizeRedirect("//google.com").should.equal("/"))
 
-  it("blocks other protocols; redirects to root", () =>
+  it("blocks other protocols (ftp); redirects to root", () =>
     sanitizeRedirect("ftp://google.com").should.equal("/"))
 
-  it("blocks other protocols; redirects to root", () =>
+  it("blocks other protocols (javascript); redirects to root", () =>
     sanitizeRedirect("javascript:alert(1);").should.equal("/"))
 
   it("blocks malformed URLs (1)", () =>

--- a/src/v2/Apps/Auction/__tests__/routes.jest.ts
+++ b/src/v2/Apps/Auction/__tests__/routes.jest.ts
@@ -109,7 +109,7 @@ describe("Auction/routes", () => {
       )
     })
 
-    it("redirects to the login (plus redirect_uri of sale artwork bid page) if user is not signed in", async () => {
+    it("redirects to the login (plus redirectTo of sale artwork bid page) if user is not signed in", async () => {
       const fixture = mockConfirmBidResolver({
         me: null,
       })
@@ -121,7 +121,7 @@ describe("Auction/routes", () => {
       )
       // @ts-expect-error STRICT_NULL_CHECK
       expect(redirect.url).toBe(
-        "/log_in?redirect_uri=%2Fauction%2Fsaleslug%2Fbid%2Fartworkslug"
+        "/login?redirectTo=%2Fauction%2Fsaleslug%2Fbid%2Fartworkslug"
       )
     })
 

--- a/src/v2/Apps/Auction/getRedirect.ts
+++ b/src/v2/Apps/Auction/getRedirect.ts
@@ -56,7 +56,7 @@ export function confirmBidRedirect(
 
   if (!me) {
     return {
-      path: "/log_in?redirect_uri=" + encodeURIComponent(location.pathname),
+      path: "/login?redirectTo=" + encodeURIComponent(location.pathname),
       reason: "user is not signed in",
     }
   }

--- a/src/v2/Components/LoginSignUpBanner/Banner.tsx
+++ b/src/v2/Components/LoginSignUpBanner/Banner.tsx
@@ -12,10 +12,10 @@ const Container = styled(Flex)`
 export const Banner: React.FC<{}> = () => {
   return (
     <Container>
-      <BannerButton href="/sign_up" marginRight="12px">
+      <BannerButton href="/signup" marginRight="12px">
         Sign up
       </BannerButton>
-      <BannerButton href="/log_in">Log in</BannerButton>
+      <BannerButton href="/login">Log in</BannerButton>
     </Container>
   )
 }

--- a/src/v2/Components/NavBar/Menus/MobileNavMenu/__tests__/MobileNavMenu.jest.tsx
+++ b/src/v2/Components/NavBar/Menus/MobileNavMenu/__tests__/MobileNavMenu.jest.tsx
@@ -72,8 +72,8 @@ describe("MobileNavMenu", () => {
         ["/institutions", "Museums"],
         ["/consign", "Sell"],
         ["/articles", "Editorial"],
-        ["/sign_up?intent=signup&contextModule=header", "Sign up"],
-        ["/log_in?intent=login&contextModule=header", "Log in"],
+        ["/signup?intent=signup&contextModule=header", "Sign up"],
+        ["/login?intent=login&contextModule=header", "Log in"],
       ].map(link => link.join(""))
 
       const linkContainer = getMobileMenuLinkContainer()

--- a/src/v2/Utils/openAuthModal.ts
+++ b/src/v2/Utils/openAuthModal.ts
@@ -111,6 +111,6 @@ function getDesktopIntent(options: AuthModalOptions): ModalOptions {
 }
 
 export const getMobileAuthLink = (mode: ModalType, options: ModalOptions) => {
-  const path = mode === "login" ? "log_in" : "sign_up"
+  const path = mode === "login" ? "login" : "signup"
   return `/${path}?${qs.stringify(options)}`
 }


### PR DESCRIPTION
Back in https://github.com/artsy/force/pull/6969, the `/log_in` path started being redirected to `/login` for consistency. I believe this broke the intended behavior where logging in would redirect the user back to a specified URL.

In this PR, I try to update all the locations I could find that direct a visitor to `/log_in` to instead send them to `/login` directly, saving a redirect step. For good measure (and in case there are links to `/log_in?...` out there in our apps or the wild), I also update that internal redirect to pass the querystring through. When I updated links that used legacy querystring parameters like `redirect_uri`, I also switched them to `redirectTo` which seems to be our [current preference](https://github.com/artsy/force/blob/62646da8d4b62943566bba6e4fcc4313606a61f2/src/desktop/apps/authentication/routeHelpers.ts#L114).

https://artsyproduct.atlassian.net/browse/PLATFORM-3341