### PR TITLE
fix: Lower auction count on first load to 10

### DIFF
--- a/src/v2/Apps/Auctions/Routes/CurrentAuctions.tsx
+++ b/src/v2/Apps/Auctions/Routes/CurrentAuctions.tsx
@@ -25,7 +25,7 @@ const CurrentAuctions: React.FC<CurrentAuctionsProps> = ({ viewer, relay }) => {
 
     const previousScrollY = window.scrollY
 
-    relay.loadMore(15, err => {
+    relay.loadMore(10, err => {
       setIsLoading(false)
 
       if (window.scrollY > previousScrollY) {
@@ -91,7 +91,7 @@ export const CurrentAuctionsPaginationContainer = createPaginationContainer(
     viewer: graphql`
       fragment CurrentAuctions_viewer on Viewer
         @argumentDefinitions(
-          first: { type: "Int", defaultValue: 30 }
+          first: { type: "Int", defaultValue: 10 }
           after: { type: "String" }
         ) {
         salesConnection(

--- a/src/v2/Apps/Auctions/Routes/PastAuctions.tsx
+++ b/src/v2/Apps/Auctions/Routes/PastAuctions.tsx
@@ -25,7 +25,7 @@ const PastAuctions: React.FC<PastAuctionsProps> = ({ viewer, relay }) => {
 
     const previousScrollY = window.scrollY
 
-    relay.loadMore(15, err => {
+    relay.loadMore(10, err => {
       setIsLoading(false)
 
       if (window.scrollY > previousScrollY) {
@@ -91,7 +91,7 @@ export const PastAuctionsPaginationContainer = createPaginationContainer(
     viewer: graphql`
       fragment PastAuctions_viewer on Viewer
         @argumentDefinitions(
-          first: { type: "Int", defaultValue: 30 }
+          first: { type: "Int", defaultValue: 10 }
           after: { type: "String" }
         ) {
         salesConnection(

--- a/src/v2/Apps/Auctions/Routes/UpcomingAuctions.tsx
+++ b/src/v2/Apps/Auctions/Routes/UpcomingAuctions.tsx
@@ -28,7 +28,7 @@ const UpcomingAuctions: React.FC<UpcomingAuctionsProps> = ({
 
     const previousScrollY = window.scrollY
 
-    relay.loadMore(5, err => {
+    relay.loadMore(10, err => {
       setIsLoading(false)
 
       if (window.scrollY > previousScrollY) {
@@ -94,7 +94,7 @@ export const UpcomingAuctionsPaginationContainer = createPaginationContainer(
     viewer: graphql`
       fragment UpcomingAuctions_viewer on Viewer
         @argumentDefinitions(
-          first: { type: "Int", defaultValue: 30 }
+          first: { type: "Int", defaultValue: 10 }
           after: { type: "String" }
         ) {
         salesConnection(

--- a/src/v2/__generated__/CurrentAuctions_Test_Query.graphql.ts
+++ b/src/v2/__generated__/CurrentAuctions_Test_Query.graphql.ts
@@ -32,7 +32,7 @@ fragment AuctionArtworksRail_sale on Sale {
 }
 
 fragment CurrentAuctions_viewer on Viewer {
-  salesConnection(first: 30, live: true, published: true, sort: TIMELY_AT_NAME_ASC, auctionState: OPEN) {
+  salesConnection(first: 10, live: true, published: true, sort: TIMELY_AT_NAME_ASC, auctionState: OPEN) {
     totalCount
     edges {
       node {
@@ -65,7 +65,7 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "first",
-    "value": 30
+    "value": 10
   },
   {
     "kind": "Literal",
@@ -256,7 +256,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "salesConnection(auctionState:\"OPEN\",first:30,live:true,published:true,sort:\"TIMELY_AT_NAME_ASC\")"
+            "storageKey": "salesConnection(auctionState:\"OPEN\",first:10,live:true,published:true,sort:\"TIMELY_AT_NAME_ASC\")"
           },
           {
             "alias": null,
@@ -282,7 +282,7 @@ return {
     "metadata": {},
     "name": "CurrentAuctions_Test_Query",
     "operationKind": "query",
-    "text": "query CurrentAuctions_Test_Query {\n  viewer {\n    ...CurrentAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment CurrentAuctions_viewer on Viewer {\n  salesConnection(first: 30, live: true, published: true, sort: TIMELY_AT_NAME_ASC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query CurrentAuctions_Test_Query {\n  viewer {\n    ...CurrentAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment CurrentAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: true, published: true, sort: TIMELY_AT_NAME_ASC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/CurrentAuctions_viewer.graphql.ts
+++ b/src/v2/__generated__/CurrentAuctions_viewer.graphql.ts
@@ -30,7 +30,7 @@ export type CurrentAuctions_viewer$key = {
 const node: ReaderFragment = {
   "argumentDefinitions": [
     {
-      "defaultValue": 30,
+      "defaultValue": 10,
       "kind": "LocalArgument",
       "name": "first",
       "type": "Int"
@@ -200,5 +200,5 @@ const node: ReaderFragment = {
   ],
   "type": "Viewer"
 };
-(node as any).hash = '9d7fbf0084329715051ce624d1758ea5';
+(node as any).hash = '1006d009e3c5df9ad2e6807bcee56612';
 export default node;

--- a/src/v2/__generated__/PastAuctions_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PastAuctions_Test_Query.graphql.ts
@@ -32,7 +32,7 @@ fragment AuctionArtworksRail_sale on Sale {
 }
 
 fragment PastAuctions_viewer on Viewer {
-  salesConnection(first: 30, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {
+  salesConnection(first: 10, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {
     totalCount
     edges {
       node {
@@ -64,7 +64,7 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "first",
-    "value": 30
+    "value": 10
   },
   {
     "kind": "Literal",
@@ -243,7 +243,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "salesConnection(auctionState:\"CLOSED\",first:30,live:false,sort:\"TIMELY_AT_NAME_DESC\")"
+            "storageKey": "salesConnection(auctionState:\"CLOSED\",first:10,live:false,sort:\"TIMELY_AT_NAME_DESC\")"
           },
           {
             "alias": null,
@@ -268,7 +268,7 @@ return {
     "metadata": {},
     "name": "PastAuctions_Test_Query",
     "operationKind": "query",
-    "text": "query PastAuctions_Test_Query {\n  viewer {\n    ...PastAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment PastAuctions_viewer on Viewer {\n  salesConnection(first: 30, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query PastAuctions_Test_Query {\n  viewer {\n    ...PastAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment PastAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PastAuctions_viewer.graphql.ts
+++ b/src/v2/__generated__/PastAuctions_viewer.graphql.ts
@@ -29,7 +29,7 @@ export type PastAuctions_viewer$key = {
 const node: ReaderFragment = {
   "argumentDefinitions": [
     {
-      "defaultValue": 30,
+      "defaultValue": 10,
       "kind": "LocalArgument",
       "name": "first",
       "type": "Int"
@@ -187,5 +187,5 @@ const node: ReaderFragment = {
   ],
   "type": "Viewer"
 };
-(node as any).hash = '897dce522364c5ce7cb8ee56f7dfaee3';
+(node as any).hash = 'e488ae430e93d48cda1a365fdd145a14';
 export default node;

--- a/src/v2/__generated__/UpcomingAuctions_Test_Query.graphql.ts
+++ b/src/v2/__generated__/UpcomingAuctions_Test_Query.graphql.ts
@@ -32,7 +32,7 @@ fragment AuctionArtworksRail_sale on Sale {
 }
 
 fragment UpcomingAuctions_viewer on Viewer {
-  salesConnection(first: 30, sort: START_AT_ASC, auctionState: UPCOMING) {
+  salesConnection(first: 10, sort: START_AT_ASC, auctionState: UPCOMING) {
     totalCount
     edges {
       node {
@@ -67,7 +67,7 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "first",
-    "value": 30
+    "value": 10
   },
   {
     "kind": "Literal",
@@ -255,7 +255,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "salesConnection(auctionState:\"UPCOMING\",first:30,sort:\"START_AT_ASC\")"
+            "storageKey": "salesConnection(auctionState:\"UPCOMING\",first:10,sort:\"START_AT_ASC\")"
           },
           {
             "alias": null,
@@ -279,7 +279,7 @@ return {
     "metadata": {},
     "name": "UpcomingAuctions_Test_Query",
     "operationKind": "query",
-    "text": "query UpcomingAuctions_Test_Query {\n  viewer {\n    ...UpcomingAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment UpcomingAuctions_viewer on Viewer {\n  salesConnection(first: 30, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query UpcomingAuctions_Test_Query {\n  viewer {\n    ...UpcomingAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment UpcomingAuctions_viewer on Viewer {\n  salesConnection(first: 10, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/UpcomingAuctions_viewer.graphql.ts
+++ b/src/v2/__generated__/UpcomingAuctions_viewer.graphql.ts
@@ -32,7 +32,7 @@ export type UpcomingAuctions_viewer$key = {
 const node: ReaderFragment = {
   "argumentDefinitions": [
     {
-      "defaultValue": 30,
+      "defaultValue": 10,
       "kind": "LocalArgument",
       "name": "first",
       "type": "Int"
@@ -206,5 +206,5 @@ const node: ReaderFragment = {
   ],
   "type": "Viewer"
 };
-(node as any).hash = '8cd03baa48705295b46808427e67ab54';
+(node as any).hash = '2875ec4a03832fe0d075fa608daacfdc';
 export default node;

--- a/src/v2/__generated__/auctionsRoutes_Current_AuctionsQuery.graphql.ts
+++ b/src/v2/__generated__/auctionsRoutes_Current_AuctionsQuery.graphql.ts
@@ -32,7 +32,7 @@ fragment AuctionArtworksRail_sale on Sale {
 }
 
 fragment CurrentAuctions_viewer on Viewer {
-  salesConnection(first: 30, live: true, published: true, sort: TIMELY_AT_NAME_ASC, auctionState: OPEN) {
+  salesConnection(first: 10, live: true, published: true, sort: TIMELY_AT_NAME_ASC, auctionState: OPEN) {
     totalCount
     edges {
       node {
@@ -65,7 +65,7 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "first",
-    "value": 30
+    "value": 10
   },
   {
     "kind": "Literal",
@@ -256,7 +256,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "salesConnection(auctionState:\"OPEN\",first:30,live:true,published:true,sort:\"TIMELY_AT_NAME_ASC\")"
+            "storageKey": "salesConnection(auctionState:\"OPEN\",first:10,live:true,published:true,sort:\"TIMELY_AT_NAME_ASC\")"
           },
           {
             "alias": null,
@@ -282,7 +282,7 @@ return {
     "metadata": {},
     "name": "auctionsRoutes_Current_AuctionsQuery",
     "operationKind": "query",
-    "text": "query auctionsRoutes_Current_AuctionsQuery {\n  viewer {\n    ...CurrentAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment CurrentAuctions_viewer on Viewer {\n  salesConnection(first: 30, live: true, published: true, sort: TIMELY_AT_NAME_ASC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query auctionsRoutes_Current_AuctionsQuery {\n  viewer {\n    ...CurrentAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment CurrentAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: true, published: true, sort: TIMELY_AT_NAME_ASC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/auctionsRoutes_Past_AuctionsQuery.graphql.ts
+++ b/src/v2/__generated__/auctionsRoutes_Past_AuctionsQuery.graphql.ts
@@ -32,7 +32,7 @@ fragment AuctionArtworksRail_sale on Sale {
 }
 
 fragment PastAuctions_viewer on Viewer {
-  salesConnection(first: 30, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {
+  salesConnection(first: 10, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {
     totalCount
     edges {
       node {
@@ -64,7 +64,7 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "first",
-    "value": 30
+    "value": 10
   },
   {
     "kind": "Literal",
@@ -243,7 +243,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "salesConnection(auctionState:\"CLOSED\",first:30,live:false,sort:\"TIMELY_AT_NAME_DESC\")"
+            "storageKey": "salesConnection(auctionState:\"CLOSED\",first:10,live:false,sort:\"TIMELY_AT_NAME_DESC\")"
           },
           {
             "alias": null,
@@ -268,7 +268,7 @@ return {
     "metadata": {},
     "name": "auctionsRoutes_Past_AuctionsQuery",
     "operationKind": "query",
-    "text": "query auctionsRoutes_Past_AuctionsQuery {\n  viewer {\n    ...PastAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment PastAuctions_viewer on Viewer {\n  salesConnection(first: 30, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query auctionsRoutes_Past_AuctionsQuery {\n  viewer {\n    ...PastAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment PastAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/auctionsRoutes_Upcoming_AuctionsQuery.graphql.ts
+++ b/src/v2/__generated__/auctionsRoutes_Upcoming_AuctionsQuery.graphql.ts
@@ -32,7 +32,7 @@ fragment AuctionArtworksRail_sale on Sale {
 }
 
 fragment UpcomingAuctions_viewer on Viewer {
-  salesConnection(first: 30, sort: START_AT_ASC, auctionState: UPCOMING) {
+  salesConnection(first: 10, sort: START_AT_ASC, auctionState: UPCOMING) {
     totalCount
     edges {
       node {
@@ -67,7 +67,7 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "first",
-    "value": 30
+    "value": 10
   },
   {
     "kind": "Literal",
@@ -255,7 +255,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "salesConnection(auctionState:\"UPCOMING\",first:30,sort:\"START_AT_ASC\")"
+            "storageKey": "salesConnection(auctionState:\"UPCOMING\",first:10,sort:\"START_AT_ASC\")"
           },
           {
             "alias": null,
@@ -279,7 +279,7 @@ return {
     "metadata": {},
     "name": "auctionsRoutes_Upcoming_AuctionsQuery",
     "operationKind": "query",
-    "text": "query auctionsRoutes_Upcoming_AuctionsQuery {\n  viewer {\n    ...UpcomingAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment UpcomingAuctions_viewer on Viewer {\n  salesConnection(first: 30, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query auctionsRoutes_Upcoming_AuctionsQuery {\n  viewer {\n    ...UpcomingAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment UpcomingAuctions_viewer on Viewer {\n  salesConnection(first: 10, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
We were noticing some performance problems around there being too many items on the dom. This lowers things to 10, and the user can click load more. 