### PR TITLE
chore: render Zendesk chat in checkout flow regardless of artwork price

### DIFF
--- a/src/v2/Apps/Order/OrderApp.tsx
+++ b/src/v2/Apps/Order/OrderApp.tsx
@@ -109,30 +109,6 @@ class OrderApp extends React.Component<OrderAppProps, {}> {
   }
 
   renderZendeskScript() {
-    const artwork = get(
-      this.props,
-      // @ts-expect-error STRICT_NULL_CHECK
-      props => props.order.lineItems.edges[0].node.artwork
-    )
-    // @ts-expect-error STRICT_NULL_CHECK
-    const { listPrice, priceCurrency } = artwork
-
-    const BNMO_CURRENCY_THRESHOLDS = {
-      USD: 10000,
-      EUR: 8000,
-      HKD: 77000,
-      GBP: 7000,
-    }
-
-    // This accounts for exact price and price ranges
-    const artworkPrice = listPrice?.major
-      ? listPrice.major
-      : listPrice.minPrice?.major
-
-    if (!BNMO_CURRENCY_THRESHOLDS[priceCurrency]) return
-    if (!artworkPrice || artworkPrice < BNMO_CURRENCY_THRESHOLDS[priceCurrency])
-      return
-
     if (typeof window !== "undefined" && window.zEmbed) return
 
     return <ZendeskWrapper />
@@ -183,6 +159,7 @@ class OrderApp extends React.Component<OrderAppProps, {}> {
                     content="width=device-width, initial-scale=1, maximum-scale=5 viewport-fit=cover"
                   />
                 )}
+                {!isEigen && this.renderZendeskScript()}
                 <SafeAreaContainer>
                   <Elements stripe={stripePromise}>
                     <AppContainer>
@@ -222,17 +199,6 @@ graphql`
             slug
             is_acquireable: isAcquireable
             is_offerable: isOfferable
-            priceCurrency
-            listPrice {
-              ... on Money {
-                major
-              }
-              ... on PriceRange {
-                minPrice {
-                  major
-                }
-              }
-            }
           }
         }
       }

--- a/src/v2/Apps/Order/__tests__/OrderApp.jest.tsx
+++ b/src/v2/Apps/Order/__tests__/OrderApp.jest.tsx
@@ -107,11 +107,6 @@ describe("OrderApp routing redirects", () => {
                   id: "artwork-id",
                   is_acquireable: true,
                   is_offerable: true,
-                  listPrice: {
-                    __typename: "Money",
-                    major: 12000,
-                  },
-                  priceCurrency: "USD",
                   slug: "artwork-id",
                 },
                 id: "node id",
@@ -545,6 +540,12 @@ describe("OrderApp", () => {
     expect(subject.text()).toMatch(
       "Need help? Visit our help center or ask a question."
     )
+  })
+
+  it("shows the Zendesk chat integration button", () => {
+    const props = getProps() as any
+    const subject = getWrapper({ props }) as any
+    expect(subject.find("ZendeskWrapper")).toHaveLength(1)
   })
 
   it("opens inquiry questionaire modal when user clicks on 'ask a question'", () => {

--- a/src/v2/__generated__/OrderApp_order.graphql.ts
+++ b/src/v2/__generated__/OrderApp_order.graphql.ts
@@ -14,13 +14,6 @@ export type OrderApp_order = {
                     readonly slug: string;
                     readonly is_acquireable: boolean | null;
                     readonly is_offerable: boolean | null;
-                    readonly priceCurrency: string | null;
-                    readonly listPrice: {
-                        readonly major?: number;
-                        readonly minPrice?: {
-                            readonly major: number;
-                        } | null;
-                    } | null;
                 } | null;
             } | null;
         } | null> | null;
@@ -35,17 +28,7 @@ export type OrderApp_order$key = {
 
 
 
-const node: ReaderFragment = (function(){
-var v0 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "major",
-    "storageKey": null
-  }
-];
-return {
+const node: ReaderFragment = {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
@@ -117,45 +100,6 @@ return {
                       "kind": "ScalarField",
                       "name": "isOfferable",
                       "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "priceCurrency",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "concreteType": null,
-                      "kind": "LinkedField",
-                      "name": "listPrice",
-                      "plural": false,
-                      "selections": [
-                        {
-                          "kind": "InlineFragment",
-                          "selections": (v0/*: any*/),
-                          "type": "Money"
-                        },
-                        {
-                          "kind": "InlineFragment",
-                          "selections": [
-                            {
-                              "alias": null,
-                              "args": null,
-                              "concreteType": "Money",
-                              "kind": "LinkedField",
-                              "name": "minPrice",
-                              "plural": false,
-                              "selections": (v0/*: any*/),
-                              "storageKey": null
-                            }
-                          ],
-                          "type": "PriceRange"
-                        }
-                      ],
-                      "storageKey": null
                     }
                   ],
                   "storageKey": null
@@ -172,6 +116,5 @@ return {
   ],
   "type": "CommerceOrder"
 };
-})();
-(node as any).hash = '1435cbb481415bcd88f4a1c3cbe81bbf';
+(node as any).hash = '22f0547ca97d2ba0d33dbc5db1aa4c77';
 export default node;

--- a/src/v2/__generated__/orderRoutes_OrderQuery.graphql.ts
+++ b/src/v2/__generated__/orderRoutes_OrderQuery.graphql.ts
@@ -28,13 +28,6 @@ export type orderRoutes_OrderQueryResponse = {
                         readonly href: string | null;
                         readonly is_acquireable: boolean | null;
                         readonly is_offerable: boolean | null;
-                        readonly priceCurrency: string | null;
-                        readonly listPrice: {
-                            readonly major?: number;
-                            readonly minPrice?: {
-                                readonly major: number;
-                            } | null;
-                        } | null;
                     } | null;
                 } | null;
             } | null> | null;
@@ -76,18 +69,6 @@ export type orderRoutes_OrderQueryRawResponse = {
                         readonly href: string | null;
                         readonly is_acquireable: boolean | null;
                         readonly is_offerable: boolean | null;
-                        readonly priceCurrency: string | null;
-                        readonly listPrice: ({
-                            readonly __typename: "Money";
-                            readonly major: number;
-                        } | {
-                            readonly __typename: "PriceRange";
-                            readonly minPrice: ({
-                                readonly major: number;
-                            }) | null;
-                        } | {
-                            readonly __typename: string | null;
-                        }) | null;
                     }) | null;
                     readonly id: string | null;
                 }) | null;
@@ -127,18 +108,6 @@ export type orderRoutes_OrderQueryRawResponse = {
                         readonly href: string | null;
                         readonly is_acquireable: boolean | null;
                         readonly is_offerable: boolean | null;
-                        readonly priceCurrency: string | null;
-                        readonly listPrice: ({
-                            readonly __typename: "Money";
-                            readonly major: number;
-                        } | {
-                            readonly __typename: "PriceRange";
-                            readonly minPrice: ({
-                                readonly major: number;
-                            }) | null;
-                        } | {
-                            readonly __typename: string | null;
-                        }) | null;
                     }) | null;
                     readonly id: string | null;
                 }) | null;
@@ -198,18 +167,6 @@ query orderRoutes_OrderQuery(
             href
             is_acquireable: isAcquireable
             is_offerable: isOfferable
-            priceCurrency
-            listPrice {
-              __typename
-              ... on Money {
-                major
-              }
-              ... on PriceRange {
-                minPrice {
-                  major
-                }
-              }
-            }
           }
           id
         }
@@ -326,68 +283,31 @@ v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "priceCurrency",
-  "storageKey": null
-},
-v14 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "major",
-    "storageKey": null
-  }
-],
-v15 = {
-  "kind": "InlineFragment",
-  "selections": (v14/*: any*/),
-  "type": "Money"
-},
-v16 = {
-  "kind": "InlineFragment",
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "Money",
-      "kind": "LinkedField",
-      "name": "minPrice",
-      "plural": false,
-      "selections": (v14/*: any*/),
-      "storageKey": null
-    }
-  ],
-  "type": "PriceRange"
-},
-v17 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "createdAt",
   "storageKey": null
 },
-v18 = [
+v14 = [
   (v3/*: any*/),
-  (v17/*: any*/)
+  (v13/*: any*/)
 ],
-v19 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "awaitingResponseFrom",
   "storageKey": null
 },
-v20 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v21 = [
+v17 = [
   (v3/*: any*/),
-  (v17/*: any*/),
-  (v20/*: any*/)
+  (v13/*: any*/),
+  (v16/*: any*/)
 ];
 return {
   "fragment": {
@@ -456,21 +376,7 @@ return {
                           (v9/*: any*/),
                           (v10/*: any*/),
                           (v11/*: any*/),
-                          (v12/*: any*/),
-                          (v13/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": null,
-                            "kind": "LinkedField",
-                            "name": "listPrice",
-                            "plural": false,
-                            "selections": [
-                              (v15/*: any*/),
-                              (v16/*: any*/)
-                            ],
-                            "storageKey": null
-                          }
+                          (v12/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -505,7 +411,7 @@ return {
                 "kind": "LinkedField",
                 "name": "myLastOffer",
                 "plural": false,
-                "selections": (v18/*: any*/),
+                "selections": (v14/*: any*/),
                 "storageKey": null
               },
               {
@@ -515,10 +421,10 @@ return {
                 "kind": "LinkedField",
                 "name": "lastOffer",
                 "plural": false,
-                "selections": (v18/*: any*/),
+                "selections": (v14/*: any*/),
                 "storageKey": null
               },
-              (v19/*: any*/)
+              (v15/*: any*/)
             ],
             "type": "CommerceOfferOrder"
           }
@@ -543,7 +449,7 @@ return {
         "plural": false,
         "selections": [
           (v1/*: any*/),
-          (v20/*: any*/)
+          (v16/*: any*/)
         ],
         "storageKey": null
       },
@@ -594,29 +500,14 @@ return {
                         "plural": false,
                         "selections": [
                           (v9/*: any*/),
-                          (v20/*: any*/),
+                          (v16/*: any*/),
                           (v10/*: any*/),
                           (v11/*: any*/),
-                          (v12/*: any*/),
-                          (v13/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": null,
-                            "kind": "LinkedField",
-                            "name": "listPrice",
-                            "plural": false,
-                            "selections": [
-                              (v7/*: any*/),
-                              (v15/*: any*/),
-                              (v16/*: any*/)
-                            ],
-                            "storageKey": null
-                          }
+                          (v12/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v20/*: any*/)
+                      (v16/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -635,11 +526,11 @@ return {
             "plural": false,
             "selections": [
               (v3/*: any*/),
-              (v20/*: any*/)
+              (v16/*: any*/)
             ],
             "storageKey": null
           },
-          (v20/*: any*/),
+          (v16/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
@@ -650,7 +541,7 @@ return {
                 "kind": "LinkedField",
                 "name": "myLastOffer",
                 "plural": false,
-                "selections": (v21/*: any*/),
+                "selections": (v17/*: any*/),
                 "storageKey": null
               },
               {
@@ -660,10 +551,10 @@ return {
                 "kind": "LinkedField",
                 "name": "lastOffer",
                 "plural": false,
-                "selections": (v21/*: any*/),
+                "selections": (v17/*: any*/),
                 "storageKey": null
               },
-              (v19/*: any*/)
+              (v15/*: any*/)
             ],
             "type": "CommerceOfferOrder"
           }
@@ -677,7 +568,7 @@ return {
     "metadata": {},
     "name": "orderRoutes_OrderQuery",
     "operationKind": "query",
-    "text": "query orderRoutes_OrderQuery(\n  $orderID: ID!\n) {\n  me {\n    name\n    id\n  }\n  order: commerceOrder(id: $orderID) @principalField {\n    __typename\n    internalID\n    mode\n    state\n    lastTransactionFailed\n    ... on CommerceOfferOrder {\n      myLastOffer {\n        internalID\n        createdAt\n        id\n      }\n      lastOffer {\n        internalID\n        createdAt\n        id\n      }\n      awaitingResponseFrom\n    }\n    requestedFulfillment {\n      __typename\n    }\n    lineItems {\n      edges {\n        node {\n          artwork {\n            slug\n            id\n            href\n            is_acquireable: isAcquireable\n            is_offerable: isOfferable\n            priceCurrency\n            listPrice {\n              __typename\n              ... on Money {\n                major\n              }\n              ... on PriceRange {\n                minPrice {\n                  major\n                }\n              }\n            }\n          }\n          id\n        }\n      }\n    }\n    creditCard {\n      internalID\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query orderRoutes_OrderQuery(\n  $orderID: ID!\n) {\n  me {\n    name\n    id\n  }\n  order: commerceOrder(id: $orderID) @principalField {\n    __typename\n    internalID\n    mode\n    state\n    lastTransactionFailed\n    ... on CommerceOfferOrder {\n      myLastOffer {\n        internalID\n        createdAt\n        id\n      }\n      lastOffer {\n        internalID\n        createdAt\n        id\n      }\n      awaitingResponseFrom\n    }\n    requestedFulfillment {\n      __typename\n    }\n    lineItems {\n      edges {\n        node {\n          artwork {\n            slug\n            id\n            href\n            is_acquireable: isAcquireable\n            is_offerable: isOfferable\n          }\n          id\n        }\n      }\n    }\n    creditCard {\n      internalID\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Zendesk collector chat within Checkout flow regardless of price. Previously we only rendered the chat option when the artwork price was over $10,000 USD or its equivalent.

<img width="1235" alt="Screen Shot 2021-06-07 at 12 32 56 PM" src="https://user-images.githubusercontent.com/10385964/121077452-7eb3e600-c78c-11eb-9a4e-5620b78a6d31.png">


https://artsyproduct.atlassian.net/browse/PURCHASE-2693