### PR TITLE
fix(navbar): prevents doubled auth buttons

### DIFF
--- a/src/v2/Apps/Components/AppShell.tsx
+++ b/src/v2/Apps/Components/AppShell.tsx
@@ -18,6 +18,8 @@ import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
 import { AppContainer } from "./AppContainer"
 import { useRouteComplete } from "v2/Utils/Hooks/useRouteComplete"
 import { useAuthIntent } from "v2/Utils/Hooks/useAuthIntent"
+import { AuthBanner } from "v2/Components/AuthBanner"
+import { Media } from "v2/Utils/Responsive"
 
 const logger = createLogger("Apps/Components/AppShell")
 
@@ -93,6 +95,7 @@ export const AppShell: React.FC<AppShellProps> = props => {
         ]}
       >
         <Box left={0} position="fixed" width="100%" zIndex={100}>
+          <Media at="xs">{!isLoggedIn && <AuthBanner />}</Media>
           <NavBar />
         </Box>
       </Box>

--- a/src/v2/Components/AuthBanner.tsx
+++ b/src/v2/Components/AuthBanner.tsx
@@ -2,19 +2,28 @@ import React from "react"
 import { Flex, Button, Separator, Spacer } from "@artsy/palette"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
 
-export const NavBarAuthBanner: React.FC = () => {
+export const AuthBanner: React.FC = () => {
   return (
     <>
       <Flex bg="white100" p={1}>
-        {/* @ts-ignore */}
-        <Button as={RouterLink} to="/signup" flex={1}>
+        <Button
+          // @ts-ignore
+          as={RouterLink}
+          to="/signup"
+          variant="secondaryOutline"
+          flex={1}
+        >
           Sign up
         </Button>
 
         <Spacer ml={1} />
 
-        {/* @ts-ignore */}
-        <Button as={RouterLink} to="/login" flex={1}>
+        <Button
+          // @ts-ignore
+          as={RouterLink}
+          to="/login"
+          flex={1}
+        >
           Log in
         </Button>
       </Flex>

--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -25,8 +25,6 @@ import {
   NAV_BAR_BOTTOM_TIER_HEIGHT,
 } from "./constants"
 import { ScrollIntoView } from "v2/Utils"
-import { Media } from "v2/Utils/Responsive"
-import { NavBarAuthBanner } from "./NavBarAuthBanner"
 
 /**
  * Old Force pages have the navbar height hardcoded in several places. If
@@ -91,8 +89,6 @@ export const NavBar: React.FC = track(
       <NavBarSkipLink />
 
       <header>
-        <Media at="xs">{!isLoggedIn && <NavBarAuthBanner />}</Media>
-
         <NavBarContainer as="nav">
           <NavBarTier height={NAV_BAR_TOP_TIER_HEIGHT}>
             <NavSection ml={[0.5, 2]} mr={0.5}>

--- a/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
+++ b/src/v2/Components/NavBar/__tests__/NavBar.jest.tsx
@@ -138,7 +138,7 @@ describe("NavBar", () => {
   describe("mediator actions", () => {
     it("calls login auth action on login button click", () => {
       const wrapper = getWrapper()
-      wrapper.find("Button").at(2).simulate("click")
+      wrapper.find("Button").at(0).simulate("click")
       expect(mediator.trigger).toBeCalledWith("open:auth", {
         contextModule: "header",
         intent: "login",
@@ -148,7 +148,7 @@ describe("NavBar", () => {
 
     it("calls signup auth action on signup button click", () => {
       const wrapper = getWrapper()
-      wrapper.find("Button").at(3).simulate("click")
+      wrapper.find("Button").at(1).simulate("click")
       expect(mediator.trigger).toBeCalledWith("open:auth", {
         contextModule: "header",
         intent: "signup",


### PR DESCRIPTION
So — since I moved this to the NavBar it was appearing on legacy pages too. Moved it back and will address some other issues tomorrow. This just prevents the doubling so that we can get a deploy in tonight.

One thing to note that is for sure a problem: on legacy pages we actually don't have a position fixed nav — this is fine but I'm assuming we would want to collapse this too as you scroll. The logged out view on a small phone is going to have a *tiny* screen area if we don't.