### PR TITLE
fix: modified styles for countdown items

### DIFF
--- a/src/desktop/components/clock/index.styl
+++ b/src/desktop/components/clock/index.styl
@@ -15,9 +15,14 @@
   list-style none
   text-transform capitalize
 
+  :first-child
+    margin-left: 0
+
   li
     display inline-block
+    text-align center
     vertical-align top
+    margin getSpace(0, 0.5)
 
     small
       text('mediumText')


### PR DESCRIPTION
The countdown on fair organizer pages looks  off. It looks like the letters/numbers are too close to each other. These pages are promoted widely by fair organizers.

https://artsyproduct.atlassian.net/browse/FX-2709

**Before**
![image](https://user-images.githubusercontent.com/56556580/121209587-9e7a0580-c883-11eb-9c97-ec706fcaa6bd.png)

**After**
![image](https://user-images.githubusercontent.com/56556580/121209635-ab96f480-c883-11eb-896f-0c7fb6d14d66.png)
