### PR TITLE
bugfix: [Collect] Fix image lazy load

### DIFF
--- a/src/v2/Apps/Artwork/Components/OtherWorks/RelatedWorksArtworkGrid.tsx
+++ b/src/v2/Apps/Artwork/Components/OtherWorks/RelatedWorksArtworkGrid.tsx
@@ -115,7 +115,6 @@ class RelatedWorksArtworkGrid extends React.Component<
                       // @ts-expect-error STRICT_NULL_CHECK
                       artworks={artworksConnection}
                       columnCount={[2, 3, 4, 4]}
-                      preloadImageCount={0}
                       mediator={mediator}
                       onBrickClick={this.trackBrickClick.bind(this)}
                     />

--- a/src/v2/Apps/Artwork/Components/OtherWorks/index.tsx
+++ b/src/v2/Apps/Artwork/Components/OtherWorks/index.tsx
@@ -103,7 +103,6 @@ export const OtherWorks = track()(
                     // @ts-expect-error STRICT_NULL_CHECK
                     artworks={grid.artworksConnection}
                     columnCount={[2, 3, 4, 4]}
-                    preloadImageCount={0}
                     mediator={props.mediator}
                     contextModule={contextModule}
                     onBrickClick={() =>

--- a/src/v2/Apps/FeatureAKG/Components/SelectedWorks.tsx
+++ b/src/v2/Apps/FeatureAKG/Components/SelectedWorks.tsx
@@ -25,7 +25,6 @@ const SelectedWorks: React.FC<SelectedWorksProps> = props => {
       <ArtworkGrid
         artworks={props.selectedWorks.itemsConnection}
         columnCount={[2, 3]}
-        preloadImageCount={0}
         mediator={mediator}
         onBrickClick={artwork => {
           tracking.trackEvent({

--- a/src/v2/Apps/WorksForYou/WorksForYouFeed.tsx
+++ b/src/v2/Apps/WorksForYou/WorksForYouFeed.tsx
@@ -106,7 +106,6 @@ export class WorksForYouFeed extends Component<Props, State> {
                 <ArtworkGrid
                   artworks={node.artworksConnection}
                   columnCount={3}
-                  preloadImageCount={9}
                   itemMargin={40}
                   user={this.props.user}
                 />

--- a/src/v2/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/v2/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -48,7 +48,7 @@ export class ArtworkGridContainer extends React.Component<
     columnCount: [3],
     sectionMargin: 20,
     itemMargin: 20,
-    preloadImageCount: 6,
+    preloadImageCount: 0,
   }
 
   state = {

--- a/src/v2/Components/ImageLink.tsx
+++ b/src/v2/Components/ImageLink.tsx
@@ -1,49 +1,8 @@
-import { Box, ResponsiveImage, SerifProps } from "@artsy/palette"
+import { Box, Image, SerifProps } from "@artsy/palette"
 import { RouterLink } from "v2/Artsy/Router/RouterLink"
 import React, { FC } from "react"
 import styled from "styled-components"
-import { space } from "styled-system"
 import { Media } from "v2/Utils/Responsive"
-
-const ImageContainer = styled(Box)`
-  position: relative;
-`
-
-const HubImage = styled(ResponsiveImage)`
-  vertical-align: middle;
-`
-
-const ImageOverlay = styled(Box)`
-  &::before {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    display: none;
-    color: #fff;
-    content: "";
-    background: rgba(0, 0, 0, 0.3);
-  }
-`
-
-const OuterLink = styled(RouterLink)`
-  text-decoration: none;
-
-  &:hover {
-    .title {
-      text-decoration: underline;
-    }
-
-    ${ImageOverlay} {
-      &::before {
-        display: block;
-      }
-    }
-  }
-
-  ${space}
-`
 
 interface ImageLinkProps {
   /** Source url for the image */
@@ -64,6 +23,12 @@ interface ImageLinkProps {
   onClick?: () => void
 }
 
+const ImageContainer = styled(Box)`
+  &:hover {
+    opacity: 0.9;
+  }
+`
+
 export const ImageLink: FC<ImageLinkProps> = ({
   to,
   src,
@@ -73,11 +38,9 @@ export const ImageLink: FC<ImageLinkProps> = ({
   onClick,
 }) => {
   return (
-    <OuterLink to={to} onClick={onClick}>
-      <ImageContainer>
-        <ImageOverlay>
-          <HubImage src={src} width="100%" ratio={ratio} lazyLoad />
-        </ImageOverlay>
+    <RouterLink to={to} onClick={onClick}>
+      <ImageContainer height={130}>
+        <Image src={src} height={130} lazyLoad style={{ objectFit: "cover" }} />
       </ImageContainer>
       {React.cloneElement(title, {
         // kind of like "default props" for a cloned element.
@@ -95,6 +58,6 @@ export const ImageLink: FC<ImageLinkProps> = ({
             textAlign: "center",
           })}
       </Media>
-    </OuterLink>
+    </RouterLink>
   )
 }


### PR DESCRIPTION
Fixes a bug from https://github.com/artsy/force/pull/7751 where the lazy loaded image on /collect collapsed the height during loading. Also some light simplification. 