### PR TITLE
feat(PX-4133): Collector sees updated address form styling

### DIFF
--- a/src/v2/Apps/Order/Components/AddressModal.tsx
+++ b/src/v2/Apps/Order/Components/AddressModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { Button, Input, Modal, Spacer, Text } from "@artsy/palette"
+import { Button, Input, Modal, ModalWidth, Spacer, Text } from "@artsy/palette"
 import { SavedAddressType } from "../Utils/shippingAddressUtils"
 import { Formik, FormikHelpers, FormikProps } from "formik"
 import {
@@ -64,7 +64,12 @@ export const AddressModal: React.FC<Props> = ({
   const [createUpdateError, setCreateUpdateError] = useState<string>(null)
 
   return (
-    <Modal title={title} show={show} onClose={closeModal}>
+    <Modal
+      title={title}
+      show={show}
+      onClose={closeModal}
+      modalWidth={ModalWidth.Wide}
+    >
       <Formik
         initialValues={createMutation ? { country: "US" } : address}
         validate={validator}
@@ -116,13 +121,12 @@ export const AddressModal: React.FC<Props> = ({
             <Text data-test="credit-card-error" color="red" my={2}>
               {createUpdateError}
             </Text>
-            <Text color="black60" mb={1}>
-              All fields marked * are mandatory
-            </Text>
             <AddressModalFields />
-            <Spacer mb={1} />
+            <Spacer mb={2} />
             <Input
-              title="Phone number *"
+              title="Phone number"
+              description="Required for shipping logistics"
+              placeholder="Add phone number"
               name="phoneNumber"
               type="tel"
               onChange={formik.handleChange}
@@ -138,7 +142,7 @@ export const AddressModal: React.FC<Props> = ({
               width="100%"
               mt={2}
             >
-              Save changes
+              Save
             </Button>
           </form>
         )}

--- a/src/v2/Apps/Order/Components/SavedAddressItem.tsx
+++ b/src/v2/Apps/Order/Components/SavedAddressItem.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, RadioProps, Banner } from "@artsy/palette"
+import { Flex, Text, RadioProps, Pill } from "@artsy/palette"
 import React from "react"
 import styled from "styled-components"
 import { SavedAddresses_me } from "v2/__generated__/SavedAddresses_me.graphql"
@@ -48,13 +48,7 @@ export const SavedAddressItem: React.FC<SavedAddressItemProps> = (
                     {line}
                   </Text>
                   {address?.isDefault && index === 0 && (
-                    <Banner
-                      ml={0.5}
-                      variant="defaultLight"
-                      px={0.5}
-                      py={0.2}
-                      borderRadius={2}
-                    >
+                    <Pill ml={0.5} variant="textSquare" hover focus>
                       <Text
                         textColor="black60"
                         variant="caption"
@@ -62,7 +56,7 @@ export const SavedAddressItem: React.FC<SavedAddressItemProps> = (
                       >
                         Default
                       </Text>
-                    </Banner>
+                    </Pill>
                   )}
                 </Flex>
               )

--- a/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -631,10 +631,10 @@ describe("Shipping", () => {
         ).toMatchInlineSnapshot(`
           Array [
             "Test Name",
-            "28001",
             "1 Main St",
-            "",
             "Madrid",
+            "28001",
+            "",
             "",
             "555-555-5555",
           ]

--- a/src/v2/Components/Address/AddressModalFields.tsx
+++ b/src/v2/Components/Address/AddressModalFields.tsx
@@ -1,5 +1,14 @@
 import React from "react"
-import { Input, Spacer, Text } from "@artsy/palette"
+import {
+  Box,
+  Column,
+  Flex,
+  GridColumns,
+  Input,
+  Join,
+  Spacer,
+  Text,
+} from "@artsy/palette"
 import { useFormikContext } from "formik"
 import { SavedAddressType } from "v2/Apps/Order/Utils/shippingAddressUtils"
 import { CountrySelect } from "../CountrySelect"
@@ -15,70 +24,88 @@ export const AddressModalFields: React.FC = props => {
   } = useFormikContext<SavedAddressType>()
   return (
     <>
-      <Input
-        id="name"
-        name="name"
-        type="text"
-        title="Full Name *"
-        onChange={handleChange}
-        onBlur={handleBlur}
-        error={touched.name && errors.name}
-        value={values?.name}
-      />
-      <Spacer mb={1} />
-      <Input
-        name="postalCode"
-        title="Postal Code *"
-        onChange={handleChange}
-        onBlur={handleBlur}
-        error={touched.postalCode && errors.postalCode}
-        value={values?.postalCode}
-      />
-      <Spacer mb={1} />
-      <Input
-        title="Address Line 1 *"
-        name="addressLine1"
-        onChange={handleChange}
-        onBlur={handleBlur}
-        error={touched.addressLine1 && errors.addressLine1}
-        value={values?.addressLine1}
-      />
-      <Spacer mb={1} />
-      <Input
-        title="Address Line 2"
-        name="addressLine2"
-        onChange={handleChange}
-        onBlur={handleBlur}
-        error={touched.addressLine2 && errors.addressLine2}
-        value={values?.addressLine2}
-      />
-      <Spacer mb={1} />
-      <Input
-        title="City *"
-        name="city"
-        onChange={handleChange}
-        onBlur={handleBlur}
-        error={touched.city && errors.city}
-        value={values?.city}
-      />
-      <Spacer mb={1} />
-      <Input
-        title="Region *"
-        name="region"
-        onChange={handleChange}
-        onBlur={handleBlur}
-        error={touched.region && errors.region}
-        value={values?.region}
-      />
-      <Spacer mb={1} />
-      <Text>Country *</Text>
-      <CountrySelect
-        selected={values?.country}
-        onSelect={countryCode => {
-          setFieldValue("country", countryCode)
-        }}
-        error={touched.country && errors.country}
-      />
+      <Flex flexDirection="column">
+        <Input
+          title="Full name"
+          placeholder="Enter name"
+          id="name"
+          name="name"
+          type="text"
+          onChange={handleChange}
+          onBlur={handleBlur}
+          error={touched.name && errors.name}
+          value={values?.name}
+        />
+      </Flex>
+      <GridColumns mt={2}>
+        <Column span={6}>
+          <Flex flexDirection="column">
+            <Join separator={<Spacer mb={2} />}>
+              <Box>
+                <Text mb={0.5}>Country</Text>
+                <CountrySelect
+                  selected={values?.country}
+                  onSelect={countryCode => {
+                    setFieldValue("country", countryCode)
+                  }}
+                  error={touched.country && errors.country}
+                />
+              </Box>
+              <Input
+                title="Address Line 1"
+                placeholder="Add address"
+                name="addressLine1"
+                onChange={handleChange}
+                onBlur={handleBlur}
+                error={touched.addressLine1 && errors.addressLine1}
+                value={values?.addressLine1}
+              />
+              <Input
+                title="City"
+                placeholder="Enter city"
+                name="city"
+                onChange={handleChange}
+                onBlur={handleBlur}
+                error={touched.city && errors.city}
+                value={values?.city}
+              />
+            </Join>
+          </Flex>
+        </Column>
+        <Column span={6}>
+          <Flex flexDirection="column">
+            <Join separator={<Spacer mb={2} />}>
+              <Input
+                title="Postal Code"
+                placeholder="Add postal code"
+                name="postalCode"
+                onChange={handleChange}
+                onBlur={handleBlur}
+                error={touched.postalCode && errors.postalCode}
+                value={values?.postalCode}
+              />
+              <Input
+                title="Address Line 2 (optional)"
+                placeholder="Add address line 2"
+                name="addressLine2"
+                onChange={handleChange}
+                onBlur={handleBlur}
+                error={touched.addressLine2 && errors.addressLine2}
+                value={values?.addressLine2}
+              />
+              <Input
+                title="State, provence, or region"
+                placeholder="Add state, provence, or region"
+                name="region"
+                onChange={handleChange}
+                onBlur={handleBlur}
+                error={touched.region && errors.region}
+                value={values?.region}
+              />
+            </Join>
+          </Flex>
+        </Column>
+      </GridColumns>
     </>
   )
 }

--- a/src/v2/Components/Address/AddressModalFields.tsx
+++ b/src/v2/Components/Address/AddressModalFields.tsx
@@ -94,8 +94,8 @@ export const AddressModalFields: React.FC = props => {
                 value={values?.addressLine2}
               />
               <Input
-                title="State, provence, or region"
-                placeholder="Add state, provence, or region"
+                title="State, province, or region"
+                placeholder="Add state, province, or region"
                 name="region"
                 onChange={handleChange}
                 onBlur={handleBlur}


### PR DESCRIPTION
Updated design for address form

JIRA: https://artsyproduct.atlassian.net/browse/PX-4133

While I was working on this task, I had two questions:
1) How I can set modal width like in Figma ? ("618px").  Is it necessary? Because I can only choose from the available values:
`export declare enum ModalWidth {
    Narrow = "300px",
    Normal = "440px",
    Wide = "900px"
}`
or I can set `isWide` prop.
2) In Figma all input titles are bold. But I think I can't set bold prop into input title by using `Input` props... If needed bold font like in Figma, I can delete `title="Address Line 1"` and create `<Text variant="mediumText">Address Line 1</Text>`
But I think separating title from Input is bad practice. What should I do in the end?



![image](https://user-images.githubusercontent.com/55637696/121668842-5f7ec680-cab4-11eb-8164-155e4efa436e.png)



