### PR TITLE
fix: add extra decimal to fix rounding issue

### DIFF
--- a/src/v2/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
+++ b/src/v2/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
@@ -135,7 +135,7 @@ export const ArtistHeaderFragmentContainer = createFragmentContainer(
           edges {
             node {
               price_realized: priceRealized {
-                display(format: "0a")
+                display(format: "0.0a")
               }
               organization
               sale_date: saleDate(format: "YYYY")

--- a/src/v2/Components/ArtistMarketInsights.tsx
+++ b/src/v2/Components/ArtistMarketInsights.tsx
@@ -157,7 +157,7 @@ export const ArtistMarketInsightsFragmentContainer = createFragmentContainer(
           edges {
             node {
               price_realized: priceRealized {
-                display(format: "0a")
+                display(format: "0.0a")
               }
               organization
               sale_date: saleDate(format: "YYYY")

--- a/src/v2/Components/SelectedCareerAchievements.tsx
+++ b/src/v2/Components/SelectedCareerAchievements.tsx
@@ -228,7 +228,7 @@ export const SelectedCareerAchievementsFragmentContainer = createFragmentContain
           edges {
             node {
               price_realized: priceRealized {
-                display(format: "0a")
+                display(format: "0.0a")
               }
               organization
               sale_date: saleDate(format: "YYYY")


### PR DESCRIPTION
Career highlights and auction results records are rounding up to next million making the record inaccurate, this is the quick fix which is to add an extra decimal to the display $7m -> $6.5m