### PR TITLE
Adds cypress smoketests from integrity

### DIFF
--- a/cypress/integration/about.spec.ts
+++ b/cypress/integration/about.spec.ts
@@ -1,0 +1,10 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+// TODO: Currently throwing error. Likely needs additional ENV var.
+describe.skip("About", () => {
+  it("/about", () => {
+    visitWithStatusRetries("about")
+    cy.get("h1").should("contain.text", "The Art WorldOnline")
+    cy.title().should("eq", "About | Artsy")
+  })
+})

--- a/cypress/integration/article.spec.ts
+++ b/cypress/integration/article.spec.ts
@@ -1,0 +1,195 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("Article", () => {
+  describe("Editorial", () => {
+    it("/article/:id - layout standard", () => {
+      visitWithStatusRetries(
+        "article/artsy-editorial-agnes-deness-manhattan-wheatfield-grown-poignant"
+      )
+      cy.get("h1").should(
+        "contain",
+        "Agnes Denes’s Manhattan Wheatfield Has Only Grown More Poignant"
+      )
+      cy.title().should(
+        "eq",
+        "Remembering Agnes Denes’s Wheatfield in Manhattan - Artsy"
+      )
+    })
+
+    it("/article/:id - layout feature", () => {
+      visitWithStatusRetries(
+        "article/artsy-editorial-inside-library-holds-worlds-rarest-colors"
+      )
+      cy.get("h1").should(
+        "contain",
+        "Inside the Library That Holds the World’s Rarest Colors"
+      )
+      cy.title().should(
+        "eq",
+        "Inside the Forbes Collection, the Library That Holds the World’s Rarest Colors - Artsy"
+      )
+    })
+
+    it("/article/:id - layout feature in series", () => {
+      visitWithStatusRetries(
+        "series/artsy-vanguard/artsy-editors-getting-their-due"
+      )
+      cy.get("h1").should("contain", "Getting Their Due")
+      cy.title().should(
+        "eq",
+        "10 Artists Finally Getting Their Due in 2018 - Artsy"
+      )
+    })
+
+    it("/news/:id", () => {
+      visitWithStatusRetries(
+        "news/artsy-editorial-whitney-museum-revealed-curators-2021-biennial"
+      )
+      cy.get("h1").should(
+        "contain",
+        "The Whitney Museum revealed the curators for its 2021 biennial."
+      )
+      cy.title().should(
+        "eq",
+        "The Whitney Museum revealed the curators for its 2021 biennial."
+      )
+    })
+
+    it("/series/:id", () => {
+      visitWithStatusRetries("series/artsy-vanguard-2019")
+      cy.get("h1").should("contain", "The Artists To Know Right Now")
+      cy.title().should(
+        "eq",
+        "The Artsy Vanguard 2019: 50 Artists to Know Right Now - Artsy"
+      )
+    })
+
+    it("/video/:id", () => {
+      visitWithStatusRetries("video/artsy-editors-future-art-carrie-mae-weems")
+      cy.get("h1").should("contain", "Carrie Mae Weems")
+      cy.title().should("eq", "Carrie Mae Weems on the Future of Art - Artsy")
+    })
+
+    describe("Classic", () => {
+      it("partner article", () => {
+        visitWithStatusRetries(
+          "v_and_a/article/victoria-and-albert-museum-sky-arts-ignition-memory-palace-at-the"
+        )
+        cy.get("h1").should("contain", "Victoria and Albert Museum (V&A)")
+        // FIXME: Wait for embedded article
+        // cy.get("h1").should(
+        //   "contain",
+        //   '"Sky Arts Ignition: Memory Palace" at the V&A',
+        // )
+        cy.title().should(
+          "eq",
+          "Victoria and Albert Museum (V&A) | Artists, Artworks, and Contact Info | Artsy"
+        )
+      })
+
+      it("Promoted content", () => {
+        visitWithStatusRetries(
+          "article/artsy-opera-gallery-founder-gilles-dyan-on-running-11-galleries-worldwide"
+        )
+        cy.get("h1").should(
+          "contain",
+          "Opera Gallery Founder Gilles Dyan on Running 11 Galleries Worldwide"
+        )
+        cy.title().should(
+          "eq",
+          "Opera Gallery Founder Gilles Dyan on Running 11 Galleries Worldwide - Artsy"
+        )
+        cy.get("a").should("contain", "Promoted Content")
+      })
+
+      it("internal channel", () => {
+        visitWithStatusRetries(
+          "article/ifpda-fine-art-print-fair-ifpda-fine-art-print-fair-announces-2019-exhibitor-list-dynamic-reboot"
+        )
+        cy.get("h1").should(
+          "contain",
+          "The IFPDA Fine Art Print Fair Announces 2019 Exhibitor List and Dynamic Reboot"
+        )
+        cy.title().should(
+          "eq",
+          "The IFPDA Fine Art Print Fair Announces 2019 Exhibitor List and Dynamic Reboot - Artsy"
+        )
+      })
+    })
+
+    describe("Editorial features", () => {
+      describe("Gender Equality", () => {
+        it("/gender-equality", () => {
+          visitWithStatusRetries("gender-equality")
+          cy.get(".SeriesHeader").should(
+            "contain",
+            "Artists For Gender Equality"
+          )
+          cy.title().should("eq", "Artists For Gender Equality")
+        })
+
+        it("/gender-equality/:slug", () => {
+          visitWithStatusRetries("gender-equality/future")
+          cy.get(".SeriesHeader").should(
+            "contain",
+            "Artists For Gender Equality"
+          )
+          cy.title().should("eq", "Artists For Gender Equality: III. Future")
+        })
+      })
+
+      describe("Artsy Vanguard 2019", () => {
+        it("/series/artsy-vanguard-2019", () => {
+          visitWithStatusRetries("series/artsy-vanguard-2019")
+          cy.get("h1").should("contain", "The Artists To Know Right Now")
+          cy.title().should(
+            "eq",
+            "The Artsy Vanguard 2019: 50 Artists to Know Right Now - Artsy"
+          )
+        })
+
+        it("/series/artsy-vanguard-2019/:slug", () => {
+          visitWithStatusRetries("series/artsy-vanguard-2019/getting-their-due")
+          cy.get("h1").should("contain", "The Artists To Know Right Now")
+          cy.title().should(
+            "eq",
+            "15 Artists Getting Their Due in 2019 - Artsy"
+          )
+        })
+      })
+
+      // TODO: Broken :'(
+      describe.skip("Venice Biennale 360", () => {
+        it("/venice-biennale", () => {
+          visitWithStatusRetries("venice-biennale")
+          cy.get(".venice-overlay__title").should(
+            "contain",
+            "Inside the Biennale"
+          )
+          cy.title().should("eq", "Venice Biennale 2017 - Artsy")
+        })
+
+        it("/venice-biennale/:slug", () => {
+          visitWithStatusRetries("venice-biennale/toward-venice")
+          cy.get(".venice-overlay__title").should(
+            "contain",
+            "Inside the Biennale"
+          )
+          cy.title().should("eq", "Venice Biennale 2017 - Artsy")
+        })
+      })
+
+      it("/2016-year-in-art", () => {
+        visitWithStatusRetries("2016-year-in-art")
+        cy.get("h1").should("contain", "The Year In Art")
+        cy.title().should("eq", "The Year in Art 2016")
+      })
+
+      it("/2015-year-in-art", () => {
+        visitWithStatusRetries("2015-year-in-art")
+        // cy.get("h1").should("contain", "2015: The Year in Art")
+        cy.title().should("eq", "2015: The Year in Art - Artsy")
+      })
+    })
+  })
+})

--- a/cypress/integration/articles.spec.ts
+++ b/cypress/integration/articles.spec.ts
@@ -1,0 +1,55 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("Articles", () => {
+  describe("Editorial", () => {
+    it("/articles", () => {
+      visitWithStatusRetries("articles")
+      cy.title().should("eq", "Editorial | Artsy")
+    })
+
+    it("/editorial", () => {
+      visitWithStatusRetries("articles")
+      cy.title().should("eq", "Editorial | Artsy")
+    })
+
+    it("/magazine", () => {
+      visitWithStatusRetries("magazine")
+      cy.title().should("eq", "Editorial | Artsy")
+    })
+
+    it("/news", () => {
+      visitWithStatusRetries("news")
+      cy.title().should("eq", "News")
+    })
+
+    describe("Editorial features", () => {
+      it("/venice-biennale-2015", () => {
+        visitWithStatusRetries("venice-biennale-2015")
+        cy.title().should("eq", "Venice Biennale 2015 Guide | Artsy")
+      })
+    })
+  })
+
+  // TODO: Currently throwing error. Likely needs additional ENV var.
+  describe.skip("Team Blogs (channels)", () => {
+    it("/artsy-education", () => {
+      visitWithStatusRetries("artsy-education")
+      cy.title().should("eq", "Artsy for Education")
+    })
+
+    it("/buying-with-artsy", () => {
+      visitWithStatusRetries("buying-with-artsy")
+      cy.title().should("eq", "Buying with Artsy")
+    })
+
+    it("/jobs", () => {
+      visitWithStatusRetries("jobs")
+      cy.title().should("eq", "Jobs | Artsy")
+    })
+
+    it("/life-at-artsy", () => {
+      visitWithStatusRetries("life-at-artsy")
+      cy.title().should("eq", "Life at Artsy")
+    })
+  })
+})

--- a/cypress/integration/artistSeries.spec.ts
+++ b/cypress/integration/artistSeries.spec.ts
@@ -1,0 +1,9 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("ArtistSeries", () => {
+  it("/artist-series/:id", () => {
+    visitWithStatusRetries("artist-series/kaws-companions")
+    cy.get("h1").should("contain", "Companions")
+    cy.title().should("contain", "KAWS")
+  })
+})

--- a/cypress/integration/artists.spec.ts
+++ b/cypress/integration/artists.spec.ts
@@ -1,0 +1,12 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("Artists", () => {
+  it("/artists", () => {
+    visitWithStatusRetries("artists")
+    cy.get("h1").should("contain", "Featured Artists")
+    cy.title().should(
+      "eq",
+      "Browse Artists on Artsy | Modern and Contemporary Artists"
+    )
+  })
+})

--- a/cypress/integration/auction.spec.ts
+++ b/cypress/integration/auction.spec.ts
@@ -1,0 +1,15 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("Auction", () => {
+  it("/auction/:id", () => {
+    visitWithStatusRetries("auction/shared-live-mocktion-k8s")
+    cy.get("h1").should("contain", "Shared Live Mocktion K8S")
+    cy.title().should("contain", "Shared Live Mocktion K8S | Artsy")
+  })
+
+  it("/sale/:id", () => {
+    visitWithStatusRetries("sale/shared-live-mocktion-k8s")
+    cy.get("h1").should("contain", "Shared Live Mocktion K8S")
+    cy.title().should("contain", "Shared Live Mocktion K8S | Artsy")
+  })
+})

--- a/cypress/integration/auctions.spec.ts
+++ b/cypress/integration/auctions.spec.ts
@@ -1,0 +1,19 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("Auctions", () => {
+  it("/auctions", () => {
+    visitWithStatusRetries("auctions")
+    cy.get("h1").should("contain", "Auctions")
+    cy.title().should(
+      "eq",
+      "Auctions on Artsy | Premium Artworks from In-Demand Artists"
+    )
+  })
+
+  // TODO: Currently throws an error. Likely needs an additional ENV var.
+  it.skip("/auction-partnerships", () => {
+    visitWithStatusRetries("auction-partnerships")
+    cy.get("h1").should("contain", "Artsy for Auctions")
+    cy.title().should("eq", "Auction Partnerships | Artsy")
+  })
+})

--- a/cypress/integration/campaign.spec.ts
+++ b/cypress/integration/campaign.spec.ts
@@ -1,0 +1,8 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("Campaigns", () => {
+  it("/campaign/:id", () => {
+    visitWithStatusRetries("art-keeps-going")
+    cy.title().should("eq", "Art Keeps Going")
+  })
+})

--- a/cypress/integration/consign.spec.ts
+++ b/cypress/integration/consign.spec.ts
@@ -1,0 +1,21 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("Consign", () => {
+  it("/consign", () => {
+    visitWithStatusRetries("consign")
+    cy.get("h1").should("contain", "Sell with Artsy")
+    cy.title().should("eq", "Sell Artwork with Artsy | Art Consignment | Artsy")
+  })
+
+  it("/consign/submission", () => {
+    visitWithStatusRetries("consign/submission")
+    cy.get(".consignments-submission-flow").should(
+      "contain",
+      "Enter the name of the artist/designer who created the work"
+    )
+    cy.title().should(
+      "eq",
+      "Sell Art from Your Collection | Consignments | Artsy"
+    )
+  })
+})

--- a/cypress/integration/contact.spec.ts
+++ b/cypress/integration/contact.spec.ts
@@ -1,0 +1,10 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+// TODO: Currently throws an error. Likely needs an additional ENV var.
+describe.skip("Contact", () => {
+  it("/contact", () => {
+    visitWithStatusRetries("contact")
+    cy.get("h1").should("contain", "Contact Us")
+    cy.title().should("eq", "Contact Us | Artsy")
+  })
+})

--- a/cypress/integration/fair.spec.ts
+++ b/cypress/integration/fair.spec.ts
@@ -1,0 +1,9 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("Fair", () => {
+  it("/fair/:fair_id", () => {
+    visitWithStatusRetries("fair/expo-chicago-2019")
+    cy.get("h1").should("contain", "EXPO CHICAGO 2019")
+    cy.title().should("eq", "EXPO CHICAGO 2019 | Artsy")
+  })
+})

--- a/cypress/integration/fairs.spec.ts
+++ b/cypress/integration/fairs.spec.ts
@@ -1,0 +1,9 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("Fairs", () => {
+  it("/fairs", () => {
+    visitWithStatusRetries("art-fairs")
+    cy.contains("Past Events").should("exist")
+    cy.title().should("eq", "Preview 60+ Top Art Fairs on Artsy | Artsy")
+  })
+})

--- a/cypress/integration/feature.spec.ts
+++ b/cypress/integration/feature.spec.ts
@@ -1,0 +1,9 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("Features", () => {
+  it("/feature/anti-racism-resources-in-the-art-world", () => {
+    visitWithStatusRetries("feature/anti-racism-resources-in-the-art-world")
+    cy.get("h1").should("contain", "Anti-Racism Resources in the Art World")
+    cy.title().should("eq", "Anti-Racism Resources in the Art World | Artsy")
+  })
+})

--- a/cypress/integration/galleries.spec.ts
+++ b/cypress/integration/galleries.spec.ts
@@ -1,0 +1,9 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("Galleries", () => {
+  it("/galleries", () => {
+    visitWithStatusRetries("galleries")
+    cy.get("h1").should("contain", "Browse Galleries")
+    cy.title().should("eq", "Galleries | Artsy")
+  })
+})

--- a/cypress/integration/gene.spec.ts
+++ b/cypress/integration/gene.spec.ts
@@ -1,0 +1,9 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("Gene", () => {
+  it("/gene/:id", () => {
+    visitWithStatusRetries("gene/contemporary-figurative-painting")
+    cy.get("h1").should("contain", "Contemporary Figurative Painting")
+    cy.title().should("eq", "Contemporary Figurative Painting | Artsy")
+  })
+})

--- a/cypress/integration/institutions.spec.ts
+++ b/cypress/integration/institutions.spec.ts
@@ -1,0 +1,16 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("Institutions", () => {
+  it("/institutions", () => {
+    visitWithStatusRetries("institutions")
+    cy.get("h1").should("contain", "Browse Institutions")
+    cy.title().should("eq", "Institutions | Artsy")
+  })
+
+  // TODO: Currently throws an error. Likely needs an additional ENV var.
+  it.skip("/institution-partnerships", () => {
+    visitWithStatusRetries("institution-partnerships")
+    cy.get("h1").should("contain", "Artsy for Museums")
+    cy.title().should("eq", "Institution Partnerships | Artsy")
+  })
+})

--- a/cypress/integration/jsonPage.spec.ts
+++ b/cypress/integration/jsonPage.spec.ts
@@ -1,0 +1,13 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+// TODO: Currently throws an error. Likely needs an additional ENV var.
+describe.skip("JSON Page", () => {
+  it("/:slug", () => {
+    visitWithStatusRetries("armory-week")
+    cy.get("#react-root").should("contain.text", "Armory Week")
+    cy.title().should(
+      "eq",
+      "The Armory Show and more on Artsy | Armory Week 2019"
+    )
+  })
+})

--- a/cypress/integration/search.spec.ts
+++ b/cypress/integration/search.spec.ts
@@ -1,0 +1,9 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("Search", () => {
+  it("/search?:query", () => {
+    visitWithStatusRetries("/search?term=andy")
+    cy.get("#react-root").should("contain", "results for \u201Candy\u201D")
+    cy.title().should("eq", "Search Results for 'andy' | Artsy")
+  })
+})

--- a/cypress/integration/tag.spec.ts
+++ b/cypress/integration/tag.spec.ts
@@ -1,0 +1,9 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("Tag", () => {
+  it("/tag/:id", () => {
+    visitWithStatusRetries("tag/orange")
+    cy.get("h1").should("contain", "Orange")
+    cy.title().should("eq", "Orange | Artsy")
+  })
+})

--- a/cypress/integration/viewingRoom.spec.ts
+++ b/cypress/integration/viewingRoom.spec.ts
@@ -1,0 +1,25 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+// import { getSingleEntity } from "utils/getSingleEntity"
+
+// TODO: Needs TEST_USER and TEST_PASSWORD configured in order to generate
+// access token for querying metaphysics for a single viewing room.
+// Reference integrity's code for the logic.
+describe.skip("Viewing Room", () => {
+  let viewingRoom: any
+  before(() => {
+    // getSingleEntity("viewing-room").then(res => {
+    //   viewingRoom = res
+    // })
+  })
+
+  it("/viewing-rooms/:id", () => {
+    // Title as rendered in HTML preserves extra whitespace
+    const inPageTitle = viewingRoom.title.trim()
+    // Title when used for page title does not preserve consecutive whitespace
+    const browserTitle = viewingRoom.title.trim().replace(/\s\s+/g, " ")
+    visitWithStatusRetries(`viewing-room/${viewingRoom.slug}`)
+
+    cy.get("h1").should("contain", inPageTitle)
+    cy.title().should("contain", browserTitle)
+  })
+})

--- a/cypress/integration/viewingRooms.spec.ts
+++ b/cypress/integration/viewingRooms.spec.ts
@@ -1,0 +1,9 @@
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
+describe("Viewing rooms", () => {
+  it("/viewing-rooms", () => {
+    visitWithStatusRetries("viewing-rooms")
+    cy.get("h1").should("contain", "Viewing Rooms")
+    cy.title().should("eq", "Artsy Viewing Rooms")
+  })
+})

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["es5", "dom"],
+    "types": ["cypress"]
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Problems
1. We have a smoke test suite in [integrity](https://github.com/artsy/integrity) that is good at identifying bugs! However, the integrity suite doesn't run on force builds, so it is not effective at blocking merges that may include errors. (Someone has to explicitly check the output).
2. Force's own smoke test suite is pretty anemic and doesn't have full coverage.
3. It's a little confusing to have the same tests in both integrity and in force, especially since both instances query the same environment (staging!).

## Solution
- This PR moves all of the smoke tests from integrity into force. An eventual follow up will remove the smoke tests from integrity entirely.
- See the notes below: A few are disabled.

## Some notes/outstanding issues
- A few of the tests are failing (disabled via `.skip` and with corresponding `//TODO:` messages) due to missing environment variables. Currently, the cypress suite runs a force server using the `.env.oss` file, but that's missing a few necessary, but secret, keys. We'll need to update our smoke test script to run force using a different set of environment variables (ideally pulling from a shared configuration).
- This incarnation of a cypress suite doesn't have any CYPRESS_ variables set up (as far as I can tell). We'll need to set up at least a `TEST_USER` and `TEST_PASSWORD` in order to pull a viewing room (to replicate integrity's behavior 1-1).
- Future tests, such as for `/user/edit` will also need to ensure that logging in works from within the cypress run (this will also require secrets available within the cypress test).