### PR TITLE
feat(FX-2994): location filter at fair artworks filters

### DIFF
--- a/src/v2/Apps/Fair/Routes/FairArtworks.tsx
+++ b/src/v2/Apps/Fair/Routes/FairArtworks.tsx
@@ -23,6 +23,7 @@ import { PartnersFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/Partn
 import { ArtistNationalityFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter"
 import { MaterialsFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/MaterialsFilter"
 import { SizeFilter2 } from "v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter2"
+import { ArtworkLocationFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter"
 
 interface FairArtworksFilterProps {
   fair: FairArtworks_fair
@@ -62,6 +63,7 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
       {showNewFilters ? <SizeFilter2 /> : <SizeFilter />}
       <WaysToBuyFilter />
       {showNewFilters && <ArtistNationalityFilter expanded />}
+      <ArtworkLocationFilter expanded />
       <TimePeriodFilter />
       <ColorFilter />
       {showNewFilters ? <PartnersFilter /> : <GalleryFilter />}

--- a/src/v2/Apps/Fair/fairRoutes.tsx
+++ b/src/v2/Apps/Fair/fairRoutes.tsx
@@ -159,7 +159,12 @@ function initializeVariablesWithFilterState({ slug }, props) {
     initialFilterStateFromUrl
   )
 
-  let aggregations: string[] = ["TOTAL", "MAJOR_PERIOD", "ARTIST"]
+  let aggregations: string[] = [
+    "TOTAL",
+    "MAJOR_PERIOD",
+    "ARTIST",
+    "LOCATION_CITY",
+  ]
   const additionalAggregations = getENV("ENABLE_NEW_ARTWORK_FILTERS")
     ? ["ARTIST_NATIONALITY", "MATERIALS_TERMS", "PARTNER"]
     : ["GALLERY"]


### PR DESCRIPTION
Added location filter to fair artworks
Jira: [FX-2994]

**Before**
*filters without location filter*
![image](https://user-images.githubusercontent.com/56556580/121897545-2b610b00-cd2b-11eb-9bc4-96fae2a927ff.png)

**After**
![image](https://user-images.githubusercontent.com/56556580/121897853-724f0080-cd2b-11eb-8fd3-845846e26396.png)




[FX-2994]: https://artsyproduct.atlassian.net/browse/FX-2994