### PR TITLE
fix: prevents popover from showing unless you are logged in

### DIFF
--- a/src/v2/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/v2/Components/FollowButton/FollowArtistButton.tsx
@@ -182,7 +182,7 @@ export class FollowArtistButton extends React.Component<Props> {
         >
           {({ anchorRef, onVisible }) => {
             const openSuggestions = () => {
-              if (triggerSuggestions && !artist?.is_followed) {
+              if (!!user && triggerSuggestions && !artist?.is_followed) {
                 onVisible()
               }
             }


### PR DESCRIPTION
Minor thing I noticed looking into the integrity failure. I don't believe this is related to that failure, but 🤷 