### PR TITLE
fix(GRO-367): AuthBanner shouldn't be fixed

### DIFF
--- a/src/v2/Apps/Components/AppShell.tsx
+++ b/src/v2/Apps/Components/AppShell.tsx
@@ -1,13 +1,8 @@
-import { Box, Flex, Theme } from "@artsy/palette"
+import { Flex, Theme } from "@artsy/palette"
 import { NetworkOfflineMonitor } from "v2/System/Router/NetworkOfflineMonitor"
 import { findCurrentRoute } from "v2/System/Router/Utils/findCurrentRoute"
 import { useMaybeReloadAfterInquirySignIn } from "v2/System/Router/Utils/useMaybeReloadAfterInquirySignIn"
-import {
-  NAV_BAR_HEIGHT,
-  NavBar,
-  MOBILE_NAV_HEIGHT,
-  MOBILE_LOGGED_IN_NAV_HEIGHT,
-} from "v2/Components/NavBar"
+import { NavBar } from "v2/Components/NavBar"
 import { Match } from "found"
 import { isFunction } from "lodash"
 import { Footer } from "v2/Components/Footer"
@@ -20,6 +15,7 @@ import { useRouteComplete } from "v2/Utils/Hooks/useRouteComplete"
 import { useAuthIntent } from "v2/Utils/Hooks/useAuthIntent"
 import { AuthBanner } from "v2/Components/AuthBanner"
 import { Media } from "v2/Utils/Responsive"
+import { SkipLink } from "v2/Components/SkipLink"
 
 const logger = createLogger("Apps/Components/AppShell")
 
@@ -79,53 +75,49 @@ export const AppShell: React.FC<AppShellProps> = props => {
   useMaybeReloadAfterInquirySignIn()
 
   return (
-    <Flex
-      width="100%"
-      // Prevents horizontal scrollbars from `FullBleed` + persistent vertical scrollbars
-      overflowX="hidden"
-      // Implements "Sticky footer" pattern
-      // https://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/
-      minHeight="100vh"
-      flexDirection="column"
-    >
-      <Box
-        pb={[
-          isLoggedIn ? MOBILE_LOGGED_IN_NAV_HEIGHT : MOBILE_NAV_HEIGHT,
-          NAV_BAR_HEIGHT,
-        ]}
+    <>
+      <Flex
+        width="100%"
+        // Prevents horizontal scrollbars from `FullBleed` + persistent vertical scrollbars
+        overflowX="hidden"
+        // Implements "Sticky footer" pattern
+        // https://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/
+        minHeight="100vh"
+        flexDirection="column"
       >
-        <Box left={0} position="fixed" width="100%" zIndex={100}>
-          <Media at="xs">{!isLoggedIn && <AuthBanner />}</Media>
-          <NavBar />
-        </Box>
-      </Box>
+        <SkipLink />
 
-      <Theme theme={theme}>
-        <>
-          <Flex
-            as="main"
-            id="main"
-            // Occupies available vertical space
-            flex={1}
-          >
-            <AppContainer maxWidth={appContainerMaxWidth}>
-              <HorizontalPadding>{children}</HorizontalPadding>
-            </AppContainer>
-          </Flex>
+        <Media at="xs">{!isLoggedIn && <AuthBanner />}</Media>
 
-          <NetworkOfflineMonitor />
+        <NavBar />
 
-          {showFooter && (
-            <Flex bg="white100">
-              <AppContainer>
-                <HorizontalPadding>
-                  <Footer />
-                </HorizontalPadding>
+        <Theme theme={theme}>
+          <>
+            <Flex
+              as="main"
+              id="main"
+              // Occupies available vertical space
+              flex={1}
+            >
+              <AppContainer maxWidth={appContainerMaxWidth}>
+                <HorizontalPadding>{children}</HorizontalPadding>
               </AppContainer>
             </Flex>
-          )}
-        </>
-      </Theme>
-    </Flex>
+
+            <NetworkOfflineMonitor />
+
+            {showFooter && (
+              <Flex bg="white100">
+                <AppContainer>
+                  <HorizontalPadding>
+                    <Footer />
+                  </HorizontalPadding>
+                </AppContainer>
+              </Flex>
+            )}
+          </>
+        </Theme>
+      </Flex>
+    </>
   )
 }

--- a/src/v2/Apps/Partner/PartnerApp.tsx
+++ b/src/v2/Apps/Partner/PartnerApp.tsx
@@ -7,7 +7,6 @@ import { PartnerApp_partner } from "v2/__generated__/PartnerApp_partner.graphql"
 import { PartnerHeaderImageFragmentContainer as PartnerHeaderImage } from "./Components/PartnerHeader/PartnerHeaderImage"
 import styled from "styled-components"
 import { PartnerMetaFragmentContainer } from "./Components/PartnerMeta"
-import { StickyProvider } from "v2/Components/Sticky"
 import { PartnerArtistsLoadingContextProvider } from "./Utils/PartnerArtistsLoadingContext"
 
 export interface PartnerAppProps {
@@ -31,26 +30,24 @@ export const PartnerApp: React.FC<PartnerAppProps> = ({
 
   return (
     <PartnerArtistsLoadingContextProvider>
-      <StickyProvider>
-        {profile && <PartnerHeaderImage profile={profile} />}
+      {profile && <PartnerHeaderImage profile={profile} />}
 
-        <Flex position="relative" flexDirection="column">
-          <Foreground />
-          <Box zIndex={1} position="relative">
-            <PartnerMetaFragmentContainer partner={partner} />
+      <Flex position="relative" flexDirection="column">
+        <Foreground />
+        <Box zIndex={1} position="relative">
+          <PartnerMetaFragmentContainer partner={partner} />
 
-            <PartnerHeader partner={partner} />
+          <PartnerHeader partner={partner} />
 
-            <FullBleed mb={[2, 4]}>
-              <Separator />
-            </FullBleed>
+          <FullBleed mb={[2, 4]}>
+            <Separator />
+          </FullBleed>
 
-            {fullProfileEligible && <NavigationTabs partner={partner} />}
+          {fullProfileEligible && <NavigationTabs partner={partner} />}
 
-            {children}
-          </Box>
-        </Flex>
-      </StickyProvider>
+          {children}
+        </Box>
+      </Flex>
     </PartnerArtistsLoadingContextProvider>
   )
 }

--- a/src/v2/Components/AuthBanner.tsx
+++ b/src/v2/Components/AuthBanner.tsx
@@ -9,11 +9,11 @@ export const AuthBanner: React.FC = () => {
         <Button
           // @ts-ignore
           as={RouterLink}
-          to="/signup"
+          to="/login"
           variant="secondaryOutline"
           flex={1}
         >
-          Sign up
+          Log in
         </Button>
 
         <Spacer ml={1} />
@@ -21,10 +21,10 @@ export const AuthBanner: React.FC = () => {
         <Button
           // @ts-ignore
           as={RouterLink}
-          to="/login"
+          to="/signup"
           flex={1}
         >
-          Log in
+          Sign up
         </Button>
       </Flex>
 

--- a/src/v2/Components/NavBar/NavBar.tsx
+++ b/src/v2/Components/NavBar/NavBar.tsx
@@ -18,13 +18,13 @@ import { track, useTracking } from "v2/System/Analytics"
 import Events from "v2/Utils/Events"
 import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 import { NavBarPrimaryLogo } from "./NavBarPrimaryLogo"
-import { NavBarSkipLink } from "./NavBarSkipLink"
 import { LoggedInActionsQueryRenderer as LoggedInActions } from "./LoggedInActions"
 import {
   NAV_BAR_TOP_TIER_HEIGHT,
   NAV_BAR_BOTTOM_TIER_HEIGHT,
 } from "./constants"
 import { ScrollIntoView } from "v2/Utils"
+import { Sticky } from "v2/Components/Sticky"
 
 /**
  * Old Force pages have the navbar height hardcoded in several places. If
@@ -85,9 +85,7 @@ export const NavBar: React.FC = track(
   }
 
   return (
-    <>
-      <NavBarSkipLink />
-
+    <Sticky zIndex={2}>
       <header>
         <NavBarContainer as="nav">
           <NavBarTier height={NAV_BAR_TOP_TIER_HEIGHT}>
@@ -277,7 +275,7 @@ export const NavBar: React.FC = track(
           )}
         </NavBarContainer>
       </header>
-    </>
+    </Sticky>
   )
 })
 

--- a/src/v2/Components/SkipLink.tsx
+++ b/src/v2/Components/SkipLink.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import styled from "styled-components"
 import { Text, color, space } from "@artsy/palette"
 
-export const NavBarSkipLink: React.FC = () => {
+export const SkipLink: React.FC = () => {
   return (
     <Container href="#main">
       <Text variant="text">Skip to Main Content</Text>
@@ -10,7 +10,7 @@ export const NavBarSkipLink: React.FC = () => {
   )
 }
 
-NavBarSkipLink.displayName = "NavBarSkipLink"
+SkipLink.displayName = "SkipLink"
 
 const Container = styled.a`
   display: block;

--- a/src/v2/Components/Sticky/Sticky.tsx
+++ b/src/v2/Components/Sticky/Sticky.tsx
@@ -1,25 +1,24 @@
 import styled from "styled-components"
-import { Box } from "@artsy/palette"
+import { Box, BoxProps } from "@artsy/palette"
 import React, { useEffect, useRef, useState } from "react"
 import { useSticky } from "./StickyProvider"
-import { useNavBarHeight } from "../NavBar/useNavBarHeight"
 
-export const Sticky: React.FC = ({ children }) => {
+interface StickyProps extends BoxProps {}
+
+export const Sticky: React.FC<StickyProps> = ({ children, ...rest }) => {
   const sentinelRef = useRef<HTMLDivElement | null>(null)
   const containerRef = useRef<HTMLDivElement | null>(null)
 
   const [stuck, setStuck] = useState(false)
 
-  const { mobile, desktop } = useNavBarHeight()
-
   useEffect(() => {
     if (sentinelRef.current === null) return
-
     if (!("IntersectionObserver" in window)) return
 
     const observer = new IntersectionObserver(
       entries => {
         const [entry] = entries
+
         if (
           // Intersecting
           entry.intersectionRatio === 0 &&
@@ -50,19 +49,20 @@ export const Sticky: React.FC = ({ children }) => {
 
   return (
     <>
-      <Sentinel
-        ref={sentinelRef as any}
-        top={[-(mobile + offsetTop), -(desktop + offsetTop)]}
-      />
+      <Sentinel ref={sentinelRef as any} top={[-offsetTop, -offsetTop]} />
 
-      <Container
+      <Box
         ref={containerRef as any}
         bg="white100"
         position={stuck ? "fixed" : "static"}
-        top={[mobile + offsetTop, desktop + offsetTop]}
+        top={[offsetTop, offsetTop]}
+        zIndex={1}
+        left={0}
+        right={0}
+        {...rest}
       >
         {typeof children === "function" ? children({ stuck }) : children}
-      </Container>
+      </Box>
 
       {stuck && (
         // Insert placeholder the same height as the container to prevent scroll from changing
@@ -71,12 +71,6 @@ export const Sticky: React.FC = ({ children }) => {
     </>
   )
 }
-
-export const Container = styled(Box)`
-  z-index: 1;
-  left: 0;
-  right: 0;
-`
 
 // This <div> is positioned such that when it leaves the top of
 // the browser the <Container> reaches it's `top` value and sticking.

--- a/src/v2/System/Router/Boot.tsx
+++ b/src/v2/System/Router/Boot.tsx
@@ -1,4 +1,4 @@
-import { Grid, Theme, injectGlobalStyles, themeProps } from "@artsy/palette"
+import { Theme, injectGlobalStyles, themeProps } from "@artsy/palette"
 import { SystemContextProvider, track } from "v2/System"
 import { AppRouteConfig } from "v2/System/Router/Route"
 import React, { useEffect } from "react"
@@ -6,12 +6,10 @@ import { HeadProvider } from "react-head"
 import { Environment } from "relay-runtime"
 import { data as sd } from "sharify"
 import { Provider as StateProvider } from "unstated"
-import { BreakpointVisualizer } from "v2/Utils/BreakpointVisualizer"
 import Events from "v2/Utils/Events"
 import { getENV } from "v2/Utils/getENV"
 import { ErrorBoundary } from "./ErrorBoundary"
 import { FocusVisible } from "v2/Components/FocusVisible"
-
 import {
   MatchingMediaQueries,
   MediaContextProvider,
@@ -22,6 +20,7 @@ import { ClientContext } from "desktop/lib/buildClientAppContext"
 import { FlashMessage } from "v2/Components/Modal/FlashModal"
 import { SiftContainer } from "v2/Utils/SiftContainer"
 import { setupSentry } from "lib/setupSentry"
+import { StickyProvider } from "v2/Components/Sticky"
 
 export interface BootProps {
   children: React.ReactNode
@@ -76,16 +75,13 @@ export const Boot = track(null, {
                     mediaQueries={themeProps.mediaQueries}
                     initialMatchingMediaQueries={onlyMatchMediaQueries as any}
                   >
-                    <Grid fluid maxWidth="100%">
+                    <StickyProvider>
                       <GlobalStyles />
                       <FlashMessage />
                       <FocusVisible />
                       <SiftContainer />
                       {children}
-                      {process.env.NODE_ENV === "development" && (
-                        <BreakpointVisualizer />
-                      )}
-                    </Grid>
+                    </StickyProvider>
                   </ResponsiveProvider>
                 </MediaContextProvider>
               </ErrorBoundary>

--- a/src/v2/Utils/Hooks/useMatchMedia.ts
+++ b/src/v2/Utils/Hooks/useMatchMedia.ts
@@ -20,13 +20,12 @@ import { useEffect, useState } from "react"
  */
 export function useMatchMedia(
   mediaQueryString: string,
-  { initialMatches = null } = {}
+  { initialMatches = false } = {}
 ) {
-  const [matches, setMatches] = useState(initialMatches)
+  const [matches, setMatches] = useState<boolean>(initialMatches)
 
   useEffect(() => {
     const mediaQueryList = window.matchMedia(mediaQueryString)
-    // @ts-expect-error STRICT_NULL_CHECK
     setMatches(mediaQueryList.matches)
     const handleChange = event => setMatches(event.matches)
 


### PR DESCRIPTION
Closes: [GRO-367](https://artsyproduct.atlassian.net/browse/GRO-367)

https://user-images.githubusercontent.com/112297/121929196-ef1fb180-cd0e-11eb-8d0a-16441cd8b737.mov

Draft because I'm debating what to do with the sticky image attachment header in the partner app.

A minor side effect of this approach is that on desktop in Chrome/FF if you scroll down quickly and for some reason are staring at the top nav you might see it jump a pixel or two. Since `IntersectionObserver` is async, it can be a bit behind. Interestingly in Safari it is rock solid. I don't think this is a huge issue since you really have to be looking for it to notice, but I'm pointing it out as a potential drawback.