### PR TITLE
fix: Fix cropping artwork in narrow viewport (PURCHASE-2741)

### DIFF
--- a/src/v2/Apps/Conversation/Components/Item.tsx
+++ b/src/v2/Apps/Conversation/Components/Item.tsx
@@ -58,14 +58,14 @@ export const Item: React.FC<ItemProps> = props => {
       <Link
         href={item.href}
         underlineBehavior="none"
-        style={{ alignSelf: "flex-end" }}
+        style={{ alignSelf: "flex-end", maxWidth: "100%" }}
         mb={1}
       >
         <Flex flexDirection="column">
           <Image
             src={getImage(item)}
             alt={item.__typename === "Artwork" ? item.title : item.name}
-            width="350px"
+            style={{ maxWidth: "350px" }}
             borderRadius="15px 15px 0 0"
           />
           <Flex


### PR DESCRIPTION
fixes https://artsyproduct.atlassian.net/browse/PURCHASE-2741

Change styles to limit the width of an artwork image in conversation to fit a narrow viewport
![image](https://user-images.githubusercontent.com/19696618/122050958-b8b86400-cdec-11eb-8ecf-3f34cf9b8542.png)
