### PR TITLE
fix: news articles layout on Eigen

### DIFF
--- a/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
+++ b/src/desktop/apps/article/components/InfiniteScrollNewsArticle.tsx
@@ -250,12 +250,16 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
   }
 
   render() {
-    const { isMobile } = this.props
+    const { isEigen, isMobile } = this.props
     const { date } = this.state
 
     return (
-      <NewsContainer isMobile={isMobile || false} id="article-root">
-        <NewsNav date={date} positionTop={56} />
+      <NewsContainer
+        isEigen={isEigen || false}
+        isMobile={isMobile || false}
+        id="article-root"
+      >
+        {!isEigen && <NewsNav date={date} positionTop={56} />}
         {this.renderContent()}
         {this.renderWaypoint()}
       </NewsContainer>
@@ -263,6 +267,7 @@ export class InfiniteScrollNewsArticle extends Component<Props, State> {
   }
 }
 
-const NewsContainer = styled.div<{ isMobile: boolean }>`
-  margin-top: ${props => (props.isMobile ? "100" : "200")}px;
+const NewsContainer = styled.div<{ isMobile: boolean; isEigen: boolean }>`
+  margin-top: ${props =>
+    props.isEigen ? "0" : props.isMobile ? "100" : "200"}px;
 `


### PR DESCRIPTION
Addresses [CX-1601]

## Description

Fixes the layout issue by hiding the news article navigation and sets the top margin to `0` on Eigen.

<img width="376" alt="Screenshot 2021-06-15 at 17 55 48" src="https://user-images.githubusercontent.com/4691889/122086155-b9a8c000-ce03-11eb-8e24-586cb4f1644c.png">


[CX-1601]: https://artsyproduct.atlassian.net/browse/CX-1601