### PR TITLE
fix: TOS checkbox links (GRO-359)

### DIFF
--- a/src/v2/Components/Authentication/TermsOfServiceCheckbox.tsx
+++ b/src/v2/Components/Authentication/TermsOfServiceCheckbox.tsx
@@ -21,7 +21,7 @@ const GdprLabel = color => {
         href="https://www.artsy.net/terms"
         target="_blank"
         color={color}
-        underlineBehavior="hover"
+        underlineBehavior="default"
       >
         Terms of Use
       </Link>
@@ -30,7 +30,7 @@ const GdprLabel = color => {
         href="https://www.artsy.net/privacy"
         target="_blank"
         color={color}
-        underlineBehavior="hover"
+        underlineBehavior="default"
       >
         Privacy Policy
       </Link>
@@ -39,7 +39,7 @@ const GdprLabel = color => {
         href="https://www.artsy.net/conditions-of-sale"
         target="_blank"
         color={color}
-        underlineBehavior="hover"
+        underlineBehavior="default"
       >
         Conditions of Sale
       </Link>
@@ -56,7 +56,7 @@ const FallbackLabel = color => {
         href="https://www.artsy.net/terms"
         target="_blank"
         color={color}
-        underlineBehavior="hover"
+        underlineBehavior="default"
       >
         Terms of Use
       </Link>
@@ -65,7 +65,7 @@ const FallbackLabel = color => {
         href="https://www.artsy.net/privacy"
         target="_blank"
         color={color}
-        underlineBehavior="hover"
+        underlineBehavior="default"
       >
         Privacy Policy
       </Link>
@@ -74,7 +74,7 @@ const FallbackLabel = color => {
         href="https://www.artsy.net/conditions-of-sale"
         target="_blank"
         color={color}
-        underlineBehavior="hover"
+        underlineBehavior="default"
       >
         Conditions of Sale
       </Link>

--- a/src/v2/Components/Authentication/TermsOfServiceCheckbox.tsx
+++ b/src/v2/Components/Authentication/TermsOfServiceCheckbox.tsx
@@ -17,21 +17,11 @@ const GdprLabel = color => {
   return (
     <>
       {"By checking this box, you consent to our "}
-      <Link
-        href="https://www.artsy.net/terms"
-        target="_blank"
-        color={color}
-        underlineBehavior="default"
-      >
+      <Link href="https://www.artsy.net/terms" target="_blank" color={color}>
         Terms of Use
       </Link>
       {", "}
-      <Link
-        href="https://www.artsy.net/privacy"
-        target="_blank"
-        color={color}
-        underlineBehavior="default"
-      >
+      <Link href="https://www.artsy.net/privacy" target="_blank" color={color}>
         Privacy Policy
       </Link>
       {", and "}
@@ -39,7 +29,6 @@ const GdprLabel = color => {
         href="https://www.artsy.net/conditions-of-sale"
         target="_blank"
         color={color}
-        underlineBehavior="default"
       >
         Conditions of Sale
       </Link>
@@ -52,21 +41,11 @@ const FallbackLabel = color => {
   return (
     <>
       {"I agree to the "}
-      <Link
-        href="https://www.artsy.net/terms"
-        target="_blank"
-        color={color}
-        underlineBehavior="default"
-      >
+      <Link href="https://www.artsy.net/terms" target="_blank" color={color}>
         Terms of Use
       </Link>
       {", "}
-      <Link
-        href="https://www.artsy.net/privacy"
-        target="_blank"
-        color={color}
-        underlineBehavior="default"
-      >
+      <Link href="https://www.artsy.net/privacy" target="_blank" color={color}>
         Privacy Policy
       </Link>
       {", and "}
@@ -74,7 +53,6 @@ const FallbackLabel = color => {
         href="https://www.artsy.net/conditions-of-sale"
         target="_blank"
         color={color}
-        underlineBehavior="default"
       >
         Conditions of Sale
       </Link>


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GRO-359

~This change sets the Terms of Service checkbox link underline behavior to default which displays underlines under links.~
This change removes Terms of Service checkbox link `underlineBehavior` prop which defaults to links having andunderline.

:

| `underlineBehavior=default`  |  prop removed |
|---|---|
| GDPR sign up modal <img width="328" alt="Screen Shot 2021-06-15 at 1 54 15 PM" src="https://user-images.githubusercontent.com/29984068/122105479-d1be1680-cde6-11eb-90fc-5e68173ff274.png"> | GDPR sign up modal <img width="328" alt="Screen Shot 2021-06-15 at 3 43 55 PM" src="https://user-images.githubusercontent.com/29984068/122114136-f1f2d300-cdf0-11eb-9472-237588f13de3.png"> |
| US sign up modal <img width="326" alt="Screen Shot 2021-06-15 at 1 54 53 PM" src="https://user-images.githubusercontent.com/29984068/122105539-e8fd0400-cde6-11eb-8cdc-47dd7f383ffa.png"> | US sign up modal <img width="326" alt="Screen Shot 2021-06-15 at 3 44 22 PM" src="https://user-images.githubusercontent.com/29984068/122115273-464a8280-cdf2-11eb-8bd3-3ede1e327080.png"> |

~I noticed that removing the prop entirely accomplishes the same and that we don't have any links with `underlineBehavior=default` across the code base. Would it be better to remove those props entirely from the TOS checkbox links?~