### PR TITLE
feat: Rearrange sign up field order GRO-269

### DIFF
--- a/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
@@ -126,6 +126,17 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
               <QuickInput
                 autoFocus
                 block
+                error={nameErrorMessage}
+                label="Name"
+                name="name"
+                onBlur={handleBlur}
+                onChange={handleChange}
+                placeholder="Enter your full name"
+                type="text"
+                value={values.name}
+              />
+              <QuickInput
+                block
                 error={emailErrorMessage}
                 label="Email"
                 name="email"
@@ -145,17 +156,6 @@ export class SignUpForm extends Component<SignUpFormProps, SignUpFormState> {
                 placeholder="Enter a password"
                 showPasswordMessage
                 value={values.password}
-              />
-              <QuickInput
-                block
-                error={nameErrorMessage}
-                label="Name"
-                name="name"
-                onBlur={handleBlur}
-                onChange={handleChange}
-                placeholder="Enter your full name"
-                type="text"
-                value={values.name}
               />
               <TermsOfServiceCheckbox
                 checked={values.accepted_terms_of_service}


### PR DESCRIPTION
After some non-zero amount of panic that maybe we leaked user passwords, we discovered that a cohort of users had entered their password into the name field. 😝 

It's understandable because so many sign up forms ask you to enter and then re-enter your password so people are probably just really used to that flow. So then all this PR does is pull that name field up to first place. Our theory is that this change will prevent users from making this mistake in the future. It's also more natural to ask for name first.

More chatter here:

https://artsy.slack.com/archives/CTZA5NBB9/p1617135285003100

Looks like this:

<img width="490" alt="Screen Shot 2021-06-15 at 2 54 02 PM" src="https://user-images.githubusercontent.com/79799/122115625-4cd4fc00-cdea-11eb-9f0a-2dd35baba439.png">


https://artsyproduct.atlassian.net/browse/GRO-269

/cc @artsy/grow-devs @isakelaris 