### PR TITLE
feat: Preload default artwork image to speed up LCP GRO-382

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkMeta.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkMeta.tsx
@@ -37,6 +37,7 @@ export class ArtworkMeta extends Component<ArtworkMetaProps> {
     if (is_shareable && imageURL) {
       return (
         <>
+          <Link rel="preload" as="image" href={imageURL} />
           <Meta property="twitter:card" content="summary_large_image" />
           <Meta property="og:image" content={imageURL} />
           {/* @ts-expect-error STRICT_NULL_CHECK */}

--- a/src/v2/Apps/Artwork/Components/ArtworkMeta.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkMeta.tsx
@@ -37,7 +37,6 @@ export class ArtworkMeta extends Component<ArtworkMetaProps> {
     if (is_shareable && imageURL) {
       return (
         <>
-          <Link rel="preload" as="image" href={imageURL} />
           <Meta property="twitter:card" content="summary_large_image" />
           <Meta property="og:image" content={imageURL} />
           {/* @ts-expect-error STRICT_NULL_CHECK */}

--- a/src/v2/Components/Lightbox/Lightbox.tsx
+++ b/src/v2/Components/Lightbox/Lightbox.tsx
@@ -1,4 +1,5 @@
 import { Box, Flex, Image, color, space } from "@artsy/palette"
+import { Link } from "react-head"
 import { withSystemContext } from "v2/System"
 import * as Schema from "v2/System/Analytics/Schema"
 import FadeTransition from "v2/Components/Animation/FadeTransition"
@@ -312,6 +313,7 @@ class LightboxComponent extends React.Component<LightboxProps, LightboxState> {
     if (!this.state.element) {
       return (
         <Flex justifyContent="center" height={height} alignItems="center">
+          <Link rel="preload" as="image" href={src} />
           <StyledImage
             style={{ cursor: enabled ? "zoom-in" : "auto" }}
             alt={imageAlt}
@@ -332,6 +334,7 @@ class LightboxComponent extends React.Component<LightboxProps, LightboxState> {
           height={height}
           onClick={enabled ? this.show.bind(this) : null}
         >
+          <Link rel="preload" as="image" href={src} />
           <StyledImage
             key={src}
             style={{ cursor: enabled ? "zoom-in" : "auto" }}

--- a/src/v2/Components/Lightbox/Lightbox.tsx
+++ b/src/v2/Components/Lightbox/Lightbox.tsx
@@ -313,7 +313,7 @@ class LightboxComponent extends React.Component<LightboxProps, LightboxState> {
     if (!this.state.element) {
       return (
         <Flex justifyContent="center" height={height} alignItems="center">
-          <Link rel="preload" as="image" href={src} />
+          {isDefault && <Link rel="preload" as="image" href={src} />}
           <StyledImage
             style={{ cursor: enabled ? "zoom-in" : "auto" }}
             alt={imageAlt}
@@ -334,7 +334,7 @@ class LightboxComponent extends React.Component<LightboxProps, LightboxState> {
           height={height}
           onClick={enabled ? this.show.bind(this) : null}
         >
-          <Link rel="preload" as="image" href={src} />
+          {isDefault && <Link rel="preload" as="image" href={src} />}
           <StyledImage
             key={src}
             style={{ cursor: enabled ? "zoom-in" : "auto" }}

--- a/src/v2/Components/Lightbox/__tests__/Lightbox.jest.tsx
+++ b/src/v2/Components/Lightbox/__tests__/Lightbox.jest.tsx
@@ -1,0 +1,25 @@
+import { MockBoot } from "v2/DevTools/MockBoot"
+import { mount } from "enzyme"
+import React from "react"
+import { Lightbox } from "../Lightbox"
+
+describe("Lightbox", () => {
+  const getWrapper = props =>
+    mount(
+      <MockBoot>
+        <Lightbox {...props} />
+      </MockBoot>
+    )
+
+  describe("preloading", () => {
+    it("preloads the default image", () => {
+      const wrapper = getWrapper({ isDefault: true })
+      expect(wrapper.find("Link")).toHaveLength(1)
+    })
+
+    it("skips preloading the other images", () => {
+      const wrapper = getWrapper({ isDefault: false })
+      expect(wrapper.find("Link")).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds a preload tag for the default artwork image.

## Artwork Images Confuse Me

I figured what you see here in this diff would be all that's required for this task, but I'm confused because the image urls don't match:

```js
$('img[data-is-default=true]').src
"https://d32dm0rphc51dk.cloudfront.net/RtSWWtWGDI11QPzBuW4dsA/large.jpg"
$('link[as=image]').href
"https://d196wkiy8qx2u5.cloudfront.net/?resize_to=fit&width=640&height=394&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FRtSWWtWGDI11QPzBuW4dsA%2Flarge.jpg"
```

So there's something where the image url I have access to is a meta image? @dzucconi do you know what's going on here?

https://artsyproduct.atlassian.net/browse/GRO-382

/cc @artsy/grow-devs