### PR TITLE
chore: Move sentry url filter to allow-list

### DIFF
--- a/src/lib/analytics/sentryFilters.ts
+++ b/src/lib/analytics/sentryFilters.ts
@@ -14,6 +14,8 @@ export const IGNORED_ERRORS = [
   "TypeError Qg.m(gpt/pubads_impl_2021052601)",
 ]
 
+export const ALLOWED_URLS = [/(.*).?artsy.net/i, /(.*).?cloudfront.com/i]
+
 export const DENIED_URLS = [
   /(.*).?dca0.com/i,
   /(.*).?sail-personalize.com/i,

--- a/src/lib/setupSentryClient.ts
+++ b/src/lib/setupSentryClient.ts
@@ -1,9 +1,14 @@
 import * as Sentry from "@sentry/browser"
 import { Integrations } from "@sentry/tracing"
-import { DENIED_URLS, IGNORED_ERRORS } from "./analytics/sentryFilters"
+import {
+  ALLOWED_URLS,
+  DENIED_URLS,
+  IGNORED_ERRORS,
+} from "./analytics/sentryFilters"
 
 export function setupSentryClient(sd) {
   Sentry.init({
+    allowUrls: ALLOWED_URLS,
     denyUrls: DENIED_URLS,
     dsn: sd.SENTRY_PUBLIC_DSN,
     ignoreErrors: IGNORED_ERRORS,


### PR DESCRIPTION
Following the guide [in the docs](https://docs.sentry.io/platforms/javascript/configuration/filtering/#decluttering-sentry), it looks like we can allow-list urls for sentry logging. 

For now, lets only look for errors from `artsy.net` and `cloudfront` (which hosts our .js assets). 

```js
const ALLOWED_URLS = [
  /(.*).?artsy.net/i, 
  /(.*).?cloudfront.com/i
]
```

There's the potential risk that we might be covering up an issue from our 3rd-party scripts, but in practice we would see if those scripts weren't loading just by looking in our browser inspector (which folks have open all the time) and most errors that we're seeing in Sentry originate from deeply buried stack-traces from those libs.

Some examples:
- https://sentry.io/organizations/artsynet/issues/2460352029/?project=28316&query=is%3Aunresolved&statsPeriod=90d
- https://sentry.io/organizations/artsynet/issues/2460336576/?project=28316&query=is%3Aunresolved&statsPeriod=90d
- https://sentry.io/organizations/artsynet/issues/2382102658/?project=28316&query=is%3Aunresolved&statsPeriod=90d 