### PR TITLE
Style fixes for inbox

### DIFF
--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -132,7 +132,7 @@ const Conversation: React.FC<ConversationProps> = props => {
       />
       <NoScrollFlex flexDirection="column" width="100%">
         <MessageContainer ref={scrollContainer}>
-          <Box pb={[6, 6, 6, 0]}>
+          <Box pb={[6, 6, 6, 0]} pr={1}>
             <Spacer mt={["75px", "75px", 2]} />
             <Flex flexDirection="column" width="100%" px={1}>
               {showBuyerGuaranteeMessage && <BuyerGuaranteeMessage />}

--- a/src/v2/Apps/Conversation/Components/ConversationHeader.tsx
+++ b/src/v2/Apps/Conversation/Components/ConversationHeader.tsx
@@ -39,7 +39,7 @@ export const ConversationHeader: FC<ConversationHeaderProps> = props => {
   const { partnerName, showDetails, setShowDetails } = props
   return (
     <>
-      <Media between={["xs", "md"]}>
+      <Media between={["xs", "sm"]}>
         <SmallConversationHeader
           showDetails={showDetails}
           setShowDetails={setShowDetails}

--- a/src/v2/Apps/Conversation/Components/ConversationListHeader.tsx
+++ b/src/v2/Apps/Conversation/Components/ConversationListHeader.tsx
@@ -7,6 +7,7 @@ export const ConversationListHeader: FC = props => {
     <Flex
       justifyContent="flex-end"
       flexDirection="column"
+      mt="1px"
       height={LARGE_SCREEN_HEADER_HEIGHT}
       {...props}
     >

--- a/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Title } from "@artsy/palette"
+import { Box, Flex, FullBleed, Title } from "@artsy/palette"
 import { Conversation_me } from "v2/__generated__/Conversation_me.graphql"
 import { ConversationPaginationContainer as Conversation } from "v2/Apps/Conversation/Components/Conversation"
 import { ConversationListPaginationContainer as ConversationList } from "v2/Apps/Conversation/Components/ConversationList"
@@ -16,7 +16,7 @@ interface ConversationRouteProps {
 }
 
 const ConstrainedHeightContainer = styled(Box)`
-  height: calc(100vh - 60px);
+  height: calc(100vh - 103px);
 `
 
 const ConversationContainer = styled(Flex)`
@@ -36,31 +36,33 @@ export const ConversationRoute: React.FC<ConversationRouteProps> = props => {
 
   return (
     <>
-      <Title>Inbox | Artsy</Title>
-      <ConstrainedHeightContainer>
-        <ConversationContainer>
-          <Media greaterThan="sm">
-            <ConversationList
-              me={me as any}
+      <FullBleed>
+        <Title>Inbox | Artsy</Title>
+        <ConstrainedHeightContainer>
+          <ConversationContainer>
+            <Media greaterThan="sm">
+              <ConversationList
+                me={me as any}
+                // @ts-expect-error STRICT_NULL_CHECK
+                selectedConversationID={me.conversation.internalID}
+              />
+            </Media>
+            <Conversation
               // @ts-expect-error STRICT_NULL_CHECK
-              selectedConversationID={me.conversation.internalID}
+              conversation={me.conversation}
+              showDetails={showDetails}
+              setShowDetails={setShowDetails}
+              refetch={props.relay.refetch}
             />
-          </Media>
-          <Conversation
-            // @ts-expect-error STRICT_NULL_CHECK
-            conversation={me.conversation}
-            showDetails={showDetails}
-            setShowDetails={setShowDetails}
-            refetch={props.relay.refetch}
-          />
-          <Details
-            // @ts-expect-error STRICT_NULL_CHECK
-            conversation={me.conversation}
-            showDetails={showDetails}
-            setShowDetails={setShowDetails}
-          />
-        </ConversationContainer>
-      </ConstrainedHeightContainer>
+            <Details
+              // @ts-expect-error STRICT_NULL_CHECK
+              conversation={me.conversation}
+              showDetails={showDetails}
+              setShowDetails={setShowDetails}
+            />
+          </ConversationContainer>
+        </ConstrainedHeightContainer>
+      </FullBleed>
     </>
   )
 }


### PR DESCRIPTION
[PURCHASE-2748]

There are broken styles on Inbox from the new site header and sitewide margins, as well as others

- scrollbar where there shouldn't be

- extra margins pushing sidebar inward/looking weird

- breakpoint issues - header disappears at one point

- The conversation list header and the conversation header are slightly misaligned with on another

_Before:_
<img width="1183" alt="Screen Shot 2021-06-16 at 3 24 32 PM" src="https://user-images.githubusercontent.com/5643895/122400517-ca634e00-cf49-11eb-9024-6f6c7697595d.png">

_After:_
<img width="1181" alt="Screen Shot 2021-06-16 at 3 24 46 PM" src="https://user-images.githubusercontent.com/5643895/122400530-cd5e3e80-cf49-11eb-8b20-324f2444686a.png">



[PURCHASE-2748]: https://artsyproduct.atlassian.net/browse/PURCHASE-2748