### PR TITLE
fix: removes Zendesk script from auctions pages

### DIFF
--- a/src/desktop/components/main_layout/templates/scripts.jade
+++ b/src/desktop/components/main_layout/templates/scripts.jade
@@ -11,10 +11,6 @@ script( src=asset("/assets/legacy-common-react.js") )
 script( src=asset("/assets/legacy-common-utility.js") )
 script( src=asset("/assets/legacy-artsy.js") )
 
-if sd.CURRENT_PATH && sd.CURRENT_PATH.includes("/auction/") || sd.CURRENT_PATH && sd.CURRENT_PATH.includes("/auction-registration/")
-  script( id='ze-snippet' src='https://static.zdassets.com/ekr/snippet.js?key=#{sd.ZENDESK_KEY}')
-
-
 //- Marketo Tracking
 if options.marketo && !sd.THIRD_PARTIES_DISABLED
   script(type='text/javascript', src='https://d1s2w0upia4e9w.cloudfront.net/assets/conversionpath-0.3.8.min.js').

--- a/src/v2/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/v2/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -37,6 +37,8 @@ import {
   toStripeAddress,
 } from "v2/Apps/Auction/Components/Form"
 import { createStripeWrapper } from "v2/Utils/createStripeWrapper"
+import { ZendeskWrapper } from "v2/Components/ZendeskWrapper"
+import { data as sd } from "sharify"
 
 const logger = createLogger("Apps/Auction/Routes/ConfirmBid")
 
@@ -315,6 +317,12 @@ export const ConfirmBidRoute: React.FC<
     }
   }
 
+  function renderZendeskScript() {
+    if (typeof window !== "undefined" && window.zEmbed) return
+
+    return <ZendeskWrapper zdKey={sd.AUCTION_ZENDESK_KEY} />
+  }
+
   return (
     <>
       <Title>Confirm Bid | Artsy</Title>
@@ -337,6 +345,7 @@ export const ConfirmBidRoute: React.FC<
             !isEmpty(errors) && trackConfirmBidFailed(errors)
           }
         />
+        {renderZendeskScript()}
       </Box>
     </>
   )

--- a/src/v2/Components/ZendeskWrapper.tsx
+++ b/src/v2/Components/ZendeskWrapper.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import Zendesk from "react-zendesk"
 
-export const ZendeskWrapper = ({ zdKey }) => {
+export const ZendeskWrapper: React.FC<{ zdKey: string }> = ({ zdKey }) => {
   if (!zdKey) return null
   return <Zendesk defer zendeskKey={zdKey} />
 }


### PR DESCRIPTION
As a followup to #7780 the Zendesk scripts were being mounted twice on some auctions pages, this PR is a fix for that and should wrap up the work for https://artsyproduct.atlassian.net/browse/PURCHASE-2477.