### PR TITLE
feat: Ensure ip address is never null GRO-383

### DIFF
--- a/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
+++ b/src/v2/Components/Authentication/Desktop/SignUpForm.tsx
@@ -222,7 +222,8 @@ const SignUpFormFragmentContainer = createFragmentContainer(SignUpForm, {
 
 export const SignUpFormQueryRenderer: React.FC<FormProps> = passedProps => {
   const { relayEnvironment } = useSystemContext()
-  const variables = { ip: sd.IP_ADDRESS }
+  const ipAddress = sd.IP_ADDRESS || "0.0.0.0"
+  const variables = { ip: ipAddress }
 
   return (
     <QueryRenderer<SignUpFormLocationQuery>


### PR DESCRIPTION
We were seeing noise in our Sentry logs where sometimes Force would send an empty IP address to MP so this PR ensures we have a fallback. This fallback will result in the county coming back as empty:

<img width="671" alt="Screen Shot 2021-06-21 at 9 11 55 AM" src="https://user-images.githubusercontent.com/79799/122777127-5b4f6780-d271-11eb-8de7-dda16631fd6b.png">

So that seems like it solves the problem but maybe there's a better way to not make this query at all? Open to other/better ideas here!

https://artsyproduct.atlassian.net/browse/GRO-383

/cc @artsy/grow-devs