### PR TITLE
fix: (GRO-384) jsx-a11y/anchor-is-valid linter error in auth footer

### DIFF
--- a/src/v2/Components/Authentication/Footer.tsx
+++ b/src/v2/Components/Authentication/Footer.tsx
@@ -1,8 +1,9 @@
-import { Box, Flex, Link } from "@artsy/palette"
+import { Box, Flex, Clickable, Sans } from "@artsy/palette"
 import React from "react"
-import { data as sd } from "sharify"
+import styled from "styled-components"
 import { CaptchaTerms, FooterText } from "./commonElements"
 import { ModalType } from "./Types"
+import { themeGet } from "@styled-system/theme-get"
 
 interface FooterProps {
   handleTypeChange?: (modalType: ModalType) => void
@@ -12,6 +13,12 @@ interface FooterProps {
   onFacebookLogin?: (e: any) => void
   showRecaptchaDisclaimer?: boolean
 }
+
+const ClickableText = styled(Sans)`
+  &:hover {
+    color: ${themeGet("colors.black100")};
+  }
+`
 
 export const Footer = (props: FooterProps) => {
   const {
@@ -25,40 +32,36 @@ export const Footer = (props: FooterProps) => {
 
   switch (mode) {
     case "login": {
-      const thirdPartyLogin = sd.ENABLE_SIGN_IN_WITH_APPLE ? (
-        <FooterText>
-          {"Log in using "}
-          <Link color="black60" onClick={onAppleLogin}>
-            Apple
-          </Link>{" "}
-          {" or "}
-          <Link color="black60" onClick={onFacebookLogin}>
-            Facebook
-          </Link>{" "}
-          {". "}
-        </FooterText>
-      ) : (
-        <FooterText>
-          {"Log in using "}
-          <Link color="black60" onClick={onFacebookLogin}>
-            Facebook
-          </Link>
-          {". "}
-        </FooterText>
-      )
       return (
         <Flex flexDirection={inline ? "row" : "column"} justifyContent="center">
-          {thirdPartyLogin}
           <FooterText>
-            {"Don’t have an account? "}
-            <Link
+            {"Log in using "}
+            <Clickable
               color="black60"
+              textDecoration="underline"
+              onClick={onAppleLogin}
+            >
+              <ClickableText size="2">Apple</ClickableText>
+            </Clickable>{" "}
+            {" or "}
+            <Clickable
+              color="black60"
+              textDecoration="underline"
+              onClick={onFacebookLogin}
+            >
+              <ClickableText size="2">Facebook</ClickableText>
+            </Clickable>
+            {". "}
+            {"Don’t have an account? "}
+            <Clickable
+              color="black60"
+              textDecoration="underline"
               // @ts-expect-error STRICT_NULL_CHECK
               onClick={() => handleTypeChange("signup" as ModalType)}
               data-test="signup"
             >
-              Sign up.
-            </Link>
+              <ClickableText size="2">Sign up.</ClickableText>
+            </Clickable>
           </FooterText>
         </Flex>
       )
@@ -68,54 +71,55 @@ export const Footer = (props: FooterProps) => {
         <Box textAlign="center">
           <FooterText>
             {"Don’t need to reset? "}
-            <Link
+            <Clickable
               color="black60"
+              textDecoration="underline"
               // @ts-expect-error STRICT_NULL_CHECK
               onClick={() => handleTypeChange("login" as ModalType)}
               data-test="login"
             >
-              Log in
-            </Link>
+              <ClickableText size="2">Log in</ClickableText>
+            </Clickable>
             {" or "}
-            <Link
+            <Clickable
               color="black60"
+              textDecoration="underline"
               // @ts-expect-error STRICT_NULL_CHECK
               onClick={() => handleTypeChange("signup" as ModalType)}
               data-test="signup"
             >
-              sign up.
-            </Link>
+              <ClickableText size="2">sign up.</ClickableText>
+            </Clickable>
           </FooterText>
         </Box>
       )
     }
     default: {
-      const thirdPartySignUp = sd.ENABLE_SIGN_IN_WITH_APPLE ? (
-        <FooterText>
-          {"Sign up using "}
-          <Link color="black60" onClick={onAppleLogin}>
-            Apple
-          </Link>{" "}
-          {" or "}
-          <Link color="black60" onClick={onFacebookLogin}>
-            Facebook
-          </Link>{" "}
-          {". "}
-        </FooterText>
-      ) : (
-        <FooterText>
-          <Link color="black60" onClick={onFacebookLogin}>
-            Sign up using Facebook.
-          </Link>{" "}
-        </FooterText>
-      )
       return (
         <Box>
           <Flex
             flexDirection={inline ? "row" : "column"}
             justifyContent="center"
           >
-            {thirdPartySignUp}
+            <FooterText>
+              {"Sign up using "}
+              <Clickable
+                color="black60"
+                textDecoration="underline"
+                onClick={onAppleLogin}
+              >
+                <ClickableText size="2">Apple</ClickableText>
+              </Clickable>{" "}
+              {" or "}
+              <Clickable
+                color="black60"
+                textDecoration="underline"
+                onClick={onFacebookLogin}
+              >
+                <ClickableText size="2">Facebook</ClickableText>
+              </Clickable>
+              {". "}
+            </FooterText>
           </Flex>
           <Flex
             flexDirection={inline ? "row" : "column"}
@@ -123,14 +127,15 @@ export const Footer = (props: FooterProps) => {
           >
             <FooterText>
               {"Already have an account? "}
-              <Link
+              <Clickable
                 color="black60"
+                textDecoration="underline"
                 // @ts-expect-error STRICT_NULL_CHECK
                 onClick={() => handleTypeChange("login" as ModalType)}
                 data-test="login"
               >
-                Log in.
-              </Link>
+                <ClickableText size="2">Log in.</ClickableText>
+              </Clickable>
             </FooterText>
           </Flex>
           {showRecaptchaDisclaimer && <CaptchaTerms />}

--- a/src/v2/Components/Authentication/__tests__/Desktop/ForgotPasswordForm.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/Desktop/ForgotPasswordForm.jest.tsx
@@ -1,7 +1,7 @@
 import { ForgotPasswordForm } from "v2/Components/Authentication/Desktop/ForgotPasswordForm"
 import { mount } from "enzyme"
 import React from "react"
-import { Link } from "@artsy/palette"
+import { Clickable } from "@artsy/palette"
 import { Footer } from "v2/Components/Authentication/Footer"
 
 jest.mock("sharify", () => ({ data: { RECAPTCHA_KEY: "recaptcha-api-key" } }))
@@ -83,12 +83,12 @@ describe("ForgotPasswordForm", () => {
   })
 
   it("can switch to login form", () => {
-    getWrapper().find(Footer).find(Link).at(0).simulate("click")
+    getWrapper().find(Footer).find(Clickable).at(0).simulate("click")
     expect(props.handleTypeChange).toBeCalledWith("login")
   })
 
   it("can switch to signup form", () => {
-    getWrapper().find(Footer).find(Link).at(1).simulate("click")
+    getWrapper().find(Footer).find(Clickable).at(1).simulate("click")
     expect(props.handleTypeChange).toBeCalledWith("signup")
   })
 })

--- a/src/v2/Components/Authentication/__tests__/Desktop/LoginForm.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/Desktop/LoginForm.jest.tsx
@@ -146,7 +146,7 @@ describe("LoginForm", () => {
 
     it("does not render email errors for social sign ups", done => {
       const wrapper = getWrapper()
-      const socialLink = wrapper.find("Link").at(1)
+      const socialLink = wrapper.find("Clickable").at(0)
       socialLink.simulate("click")
       wrapper.update()
 

--- a/src/v2/Components/Authentication/__tests__/Desktop/SignUpForm.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/Desktop/SignUpForm.jest.tsx
@@ -11,7 +11,6 @@ jest.unmock("react-relay")
 jest.mock("sharify", () => ({
   data: {
     RECAPTCHA_KEY: "recaptcha-api-key",
-    ENABLE_SIGN_IN_WITH_APPLE: true,
   },
 }))
 
@@ -102,11 +101,11 @@ describe("SignUpForm", () => {
   })
 
   describe("signup with Apple", () => {
-    it("calls apple callback on tapping link", done => {
+    it("calls apple callback on tapping the button", done => {
       passedProps.values.accepted_terms_of_service = true
       const wrapper = getWrapper()
 
-      const appleLink = wrapper.find("Link").at(3)
+      const appleLink = wrapper.find("Clickable").at(0)
       expect(appleLink.text()).toEqual("Apple")
       appleLink.simulate("click")
 
@@ -116,11 +115,25 @@ describe("SignUpForm", () => {
       })
     })
 
+    it("calls facebook callback on tapping the button", done => {
+      passedProps.values.accepted_terms_of_service = true
+      const wrapper = getWrapper()
+
+      const appleLink = wrapper.find("Clickable").at(1)
+      expect(appleLink.text()).toEqual("Facebook")
+      appleLink.simulate("click")
+
+      setTimeout(() => {
+        expect(passedProps.onFacebookLogin).toHaveBeenCalled()
+        done()
+      })
+    })
+
     it("does not call apple callback without accepting terms", done => {
       passedProps.values.accepted_terms_of_service = false
       const wrapper = getWrapper()
 
-      const appleLink = wrapper.find("Link").at(3)
+      const appleLink = wrapper.find("Clickable").at(0)
       expect(appleLink.text()).toEqual("Apple")
       appleLink.simulate("click")
 
@@ -134,7 +147,7 @@ describe("SignUpForm", () => {
       passedProps.values.accepted_terms_of_service = false
       const wrapper = getWrapper()
 
-      const appleLink = wrapper.find("Link").at(3)
+      const appleLink = wrapper.find("Clickable").at(0)
       expect(appleLink.text()).toEqual("Apple")
       appleLink.simulate("click")
 

--- a/src/v2/Components/Authentication/__tests__/FormSwitcher.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/FormSwitcher.jest.tsx
@@ -1,5 +1,5 @@
 import { ContextModule, Intent } from "@artsy/cohesion"
-import { Link } from "@artsy/palette"
+import { Clickable } from "@artsy/palette"
 import QuickInput from "v2/Components/QuickInput"
 import { mount } from "enzyme"
 import React from "react"
@@ -80,7 +80,7 @@ describe("FormSwitcher", () => {
         type: ModalType.login,
       })
 
-      wrapper.find(Link).at(3).simulate("click")
+      wrapper.find(Clickable).at(2).simulate("click")
 
       expect(window.location.assign).toHaveBeenCalledWith(
         "/signup?contextModule=header&copy=Foo%20Bar&destination=%2Fcollect&intent=followArtist&redirectTo=%2Ffoo&triggerSeconds=1"
@@ -92,7 +92,7 @@ describe("FormSwitcher", () => {
         type: ModalType.login,
       })
 
-      wrapper.find(Link).at(3).simulate("click")
+      wrapper.find(Clickable).at(2).simulate("click")
 
       expect((wrapper.state() as any).type).toMatch("signup")
       expect(wrapper.props().handleTypeChange).toBeCalled()
@@ -113,12 +113,11 @@ describe("FormSwitcher", () => {
           forgot: "/forgot",
           login: "/login",
           signup: "/signup",
-          twitter: "/users/auth/twitter",
         },
         type: ModalType.login,
       })
 
-      wrapper.find(Link).at(1).simulate("click")
+      wrapper.find(Clickable).at(0).simulate("click")
 
       expect(wrapper.props().onSocialAuthEvent).toHaveBeenCalledWith(
         expect.objectContaining({


### PR DESCRIPTION
This PR contains the "_Secondary Change_" part of a reverted PR [#7821](https://github.com/artsy/force/pull/7821).

From the [description of reverted PR](https://github.com/artsy/force/pull/7811):

> When committing my changes I experienced an error during the pre-commit hook that executes yarn lint --fix:

```
error  Anchor used as a button. Anchors are primarily expected to navigate. Use the button element instead. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md  jsx-a11y/anchor-is-valid
```

> I reached out to [#dev-help](https://artsy.slack.com/archives/CP9P4KR35/p1623862247122500) and the recommendation was to replace the `<Link>` component with `<Clickable>`. The scope of this change affects only src/v2/Components/Authentication/Footer.tsx elements. This change also affected a number of tests that were updated in this PR. I tried to keep the behavior and look exactly how it was before.

Find the [review app here](https://jsx-a11y.artsy.net/).
[Integrity change that goes along with this](https://github.com/artsy/integrity/pull/233).