### PR TITLE
bugfix: [Artist] Hide overview tab if no content

### DIFF
--- a/src/v2/Apps/Artist/Routes/Overview/Utils/hasOverviewContent.ts
+++ b/src/v2/Apps/Artist/Routes/Overview/Utils/hasOverviewContent.ts
@@ -1,20 +1,21 @@
+import { ArtistApp_sharedMetadata } from "v2/__generated__/ArtistApp_sharedMetadata.graphql"
+
 export const hasOverviewContent = ({
   statuses,
   related,
   biographyBlurb,
-}: {
-  statuses: { shows: boolean; cv: boolean; articles: boolean }
-  related: { genes?: { edges?: ReadonlyArray<any> } }
-  biographyBlurb: { text?: string }
-}) => {
+}: Pick<
+  ArtistApp_sharedMetadata,
+  "statuses" | "related" | "biographyBlurb"
+>): boolean => {
   const showArtistBio = biographyBlurb && Boolean(biographyBlurb.text)
   const showRelatedCategories = related?.genes?.edges?.length! > 0
 
-  return (
+  return Boolean(
     showArtistBio ||
-    showRelatedCategories ||
-    statuses.articles ||
-    statuses.cv ||
-    statuses.shows
+      showRelatedCategories ||
+      statuses?.articles ||
+      statuses?.cv ||
+      statuses?.shows
   )
 }

--- a/src/v2/Apps/Artist/__tests__/ArtistApp.jest.tsx
+++ b/src/v2/Apps/Artist/__tests__/ArtistApp.jest.tsx
@@ -65,6 +65,51 @@ describe("ArtistApp", () => {
       )
     })
 
+    describe("hiding main tabs", () => {
+      it("hides tabs overview tab when appropriate", () => {
+        mockfindCurrentRoute.mockImplementation(() => ({}))
+        const wrapper = getWrapper({
+          Artist: () => ({
+            biographyBlurb: null,
+            related: null,
+            statuses: {
+              articles: false,
+              cv: false,
+              shows: false,
+            },
+          }),
+        })
+        expect(wrapper.find("RouteTab").at(0).text()).toBe("Artworks")
+        expect(wrapper.find("RouteTab").at(1).text()).toBe("Auction results")
+      })
+
+      it("hides works-for-sale tab when appropriate", () => {
+        mockfindCurrentRoute.mockImplementation(() => ({}))
+        const wrapper = getWrapper({
+          Artist: () => ({
+            statuses: {
+              artworks: false,
+            },
+          }),
+        })
+        expect(wrapper.find("RouteTab").at(0).text()).toBe("Overview")
+        expect(wrapper.find("RouteTab").at(1).text()).toBe("Auction results")
+      })
+
+      it("hides auction results tab when appropriate", () => {
+        mockfindCurrentRoute.mockImplementation(() => ({}))
+        const wrapper = getWrapper({
+          Artist: () => ({
+            statuses: {
+              auctionLots: false,
+            },
+          }),
+        })
+        expect(wrapper.find("RouteTab").at(0).text()).toBe("Overview")
+        expect(wrapper.find("RouteTab").at(1).text()).toBe("Artworks")
+      })
+    })
+
     it("renders the correct for sale artwork tab count", () => {
       mockfindCurrentRoute.mockImplementation(() => ({}))
       const wrapper = getWrapper({

--- a/src/v2/Apps/Artist/artistRoutes.tsx
+++ b/src/v2/Apps/Artist/artistRoutes.tsx
@@ -93,47 +93,7 @@ export const artistRoutes: AppRouteConfig[] = [
       query artistRoutes_TopLevelQuery($artistID: String!) {
         artist(id: $artistID) @principalField {
           ...ArtistApp_artist
-          slug
-          statuses {
-            shows
-            cv(minShowCount: 0)
-            articles
-          }
-          counts {
-            forSaleArtworks
-          }
-          related {
-            genes {
-              edges {
-                node {
-                  slug
-                }
-              }
-            }
-          }
-          highlights {
-            # Alias due to obscure Graphql validation warning
-            artistPartnersConnection: partnersConnection(
-              first: 10
-              displayOnPartnerProfile: true
-              representedBy: true
-              partnerCategory: ["blue-chip", "top-established", "top-emerging"]
-            ) {
-              edges {
-                node {
-                  categories {
-                    slug
-                  }
-                }
-              }
-            }
-          }
-          insights {
-            type
-          }
-          biographyBlurb(format: HTML, partnerBio: false) {
-            text
-          }
+          ...ArtistApp_sharedMetadata @relay(mask: false) # used to determine redirects and renderability
         }
       }
     `,
@@ -168,7 +128,7 @@ export const artistRoutes: AppRouteConfig[] = [
             $artistID: String!
             $input: FilterArtworksInput
             $aggregations: [ArtworkAggregation]
-          ) @raw_response_type {
+          ) {
             artist(id: $artistID) {
               ...ArtistWorksForSaleRoute_artist
                 @arguments(input: $input, aggregations: $aggregations)

--- a/src/v2/__generated__/ArtistApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ArtistApp_Test_Query.graphql.ts
@@ -25,19 +25,52 @@ query ArtistApp_Test_Query {
 }
 
 fragment ArtistApp_artist on Artist {
-  ...ArtistMeta_artist
-  ...ArtistHeader_artist
-  ...BackLink_artist
-  counts {
-    forSaleArtworks
-  }
-  internalID
-  name
   slug
   statuses {
+    shows
+    cv(minShowCount: 0)
+    articles
     artworks
     auctionLots
   }
+  counts {
+    forSaleArtworks
+  }
+  related {
+    genes {
+      edges {
+        node {
+          slug
+          id
+        }
+      }
+    }
+  }
+  highlights {
+    artistPartnersConnection: partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: ["blue-chip", "top-established", "top-emerging"]) {
+      edges {
+        node {
+          categories {
+            slug
+            id
+          }
+          id
+        }
+        id
+      }
+    }
+  }
+  insights {
+    type
+  }
+  biographyBlurb(format: HTML, partnerBio: false) {
+    text
+  }
+  ...ArtistMeta_artist
+  ...ArtistHeader_artist
+  ...BackLink_artist
+  internalID
+  name
 }
 
 fragment ArtistFollowArtistButton_artist on Artist {
@@ -257,24 +290,112 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "artworks",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "href",
+  "name": "id",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "description",
+  "name": "__typename",
   "storageKey": null
 },
 v5 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 10
+},
+v6 = [
+  {
+    "kind": "Literal",
+    "name": "displayOnPartnerProfile",
+    "value": true
+  },
+  (v5/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "partnerCategory",
+    "value": [
+      "blue-chip",
+      "top-established",
+      "top-emerging"
+    ]
+  },
+  {
+    "kind": "Literal",
+    "name": "representedBy",
+    "value": true
+  }
+],
+v7 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Partner",
+  "kind": "LinkedField",
+  "name": "node",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "PartnerCategory",
+      "kind": "LinkedField",
+      "name": "categories",
+      "plural": true,
+      "selections": [
+        (v1/*: any*/),
+        (v3/*: any*/)
+      ],
+      "storageKey": null
+    },
+    (v3/*: any*/)
+  ],
+  "storageKey": null
+},
+v8 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "PartnerArtistEdge",
+    "kind": "LinkedField",
+    "name": "edges",
+    "plural": true,
+    "selections": [
+      (v7/*: any*/),
+      (v3/*: any*/)
+    ],
+    "storageKey": null
+  }
+],
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v12 = {
   "alias": "large",
   "args": [
     {
@@ -287,34 +408,15 @@ v5 = {
   "name": "url",
   "storageKey": "url(version:\"large\")"
 },
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "artworks",
-  "storageKey": null
-},
-v7 = {
-  "kind": "Literal",
-  "name": "first",
-  "value": 10
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "__typename",
-  "storageKey": null
-},
-v9 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "major",
   "storageKey": null
 },
-v10 = [
-  (v9/*: any*/),
+v14 = [
+  (v13/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -323,7 +425,7 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = {
+v15 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
@@ -343,60 +445,6 @@ v11 = {
       "kind": "ScalarField",
       "name": "url",
       "storageKey": "url(version:\"small\")"
-    },
-    (v5/*: any*/)
-  ],
-  "storageKey": null
-},
-v12 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v13 = [
-  {
-    "kind": "Literal",
-    "name": "displayOnPartnerProfile",
-    "value": true
-  },
-  (v7/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "partnerCategory",
-    "value": [
-      "blue-chip",
-      "top-established",
-      "top-emerging"
-    ]
-  },
-  {
-    "kind": "Literal",
-    "name": "representedBy",
-    "value": true
-  }
-],
-v14 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "Partner",
-  "kind": "LinkedField",
-  "name": "node",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "PartnerCategory",
-      "kind": "LinkedField",
-      "name": "categories",
-      "plural": true,
-      "selections": [
-        (v1/*: any*/),
-        (v12/*: any*/)
-      ],
-      "storageKey": null
     },
     (v12/*: any*/)
   ],
@@ -443,276 +491,6 @@ return {
         "plural": false,
         "selections": [
           (v1/*: any*/),
-          (v2/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "nationality",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "birthday",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "deathday",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "gender",
-            "storageKey": null
-          },
-          (v3/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "ArtistMeta",
-            "kind": "LinkedField",
-            "name": "meta",
-            "plural": false,
-            "selections": [
-              (v4/*: any*/)
-            ],
-            "storageKey": null
-          },
-          {
-            "alias": "alternate_names",
-            "args": null,
-            "kind": "ScalarField",
-            "name": "alternateNames",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "Image",
-            "kind": "LinkedField",
-            "name": "image",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "versions",
-                "storageKey": null
-              },
-              (v5/*: any*/),
-              {
-                "alias": "square",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "version",
-                    "value": "square"
-                  }
-                ],
-                "kind": "ScalarField",
-                "name": "url",
-                "storageKey": "url(version:\"square\")"
-              }
-            ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "ArtistCounts",
-            "kind": "LinkedField",
-            "name": "counts",
-            "plural": false,
-            "selections": [
-              (v6/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "follows",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "forSaleArtworks",
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "blurb",
-            "storageKey": null
-          },
-          {
-            "alias": "artworks_connection",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "filter",
-                "value": "IS_FOR_SALE"
-              },
-              (v7/*: any*/),
-              {
-                "kind": "Literal",
-                "name": "published",
-                "value": true
-              }
-            ],
-            "concreteType": "ArtworkConnection",
-            "kind": "LinkedField",
-            "name": "artworksConnection",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "ArtworkEdge",
-                "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Artwork",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "title",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "date",
-                        "storageKey": null
-                      },
-                      (v4/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "category",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "price_currency",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "priceCurrency",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": null,
-                        "kind": "LinkedField",
-                        "name": "listPrice",
-                        "plural": false,
-                        "selections": [
-                          (v8/*: any*/),
-                          {
-                            "kind": "InlineFragment",
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Money",
-                                "kind": "LinkedField",
-                                "name": "minPrice",
-                                "plural": false,
-                                "selections": (v10/*: any*/),
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Money",
-                                "kind": "LinkedField",
-                                "name": "maxPrice",
-                                "plural": false,
-                                "selections": [
-                                  (v9/*: any*/)
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "type": "PriceRange"
-                          },
-                          {
-                            "kind": "InlineFragment",
-                            "selections": (v10/*: any*/),
-                            "type": "Money"
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "availability",
-                        "storageKey": null
-                      },
-                      (v3/*: any*/),
-                      (v11/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Partner",
-                        "kind": "LinkedField",
-                        "name": "partner",
-                        "plural": false,
-                        "selections": [
-                          (v2/*: any*/),
-                          (v3/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Profile",
-                            "kind": "LinkedField",
-                            "name": "profile",
-                            "plural": false,
-                            "selections": [
-                              (v11/*: any*/),
-                              (v12/*: any*/)
-                            ],
-                            "storageKey": null
-                          },
-                          (v12/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      (v12/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": "artworksConnection(filter:\"IS_FOR_SALE\",first:10,published:true)"
-          },
           {
             "alias": null,
             "args": null,
@@ -755,7 +533,80 @@ return {
                 "name": "auctionLots",
                 "storageKey": null
               },
-              (v6/*: any*/)
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistCounts",
+            "kind": "LinkedField",
+            "name": "counts",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "forSaleArtworks",
+                "storageKey": null
+              },
+              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "follows",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistRelatedData",
+            "kind": "LinkedField",
+            "name": "related",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "GeneConnection",
+                "kind": "LinkedField",
+                "name": "genes",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "GeneEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Gene",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v1/*: any*/),
+                          (v3/*: any*/),
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
             ],
             "storageKey": null
           },
@@ -768,8 +619,18 @@ return {
             "plural": false,
             "selections": [
               {
+                "alias": "artistPartnersConnection",
+                "args": (v6/*: any*/),
+                "concreteType": "PartnerArtistConnection",
+                "kind": "LinkedField",
+                "name": "partnersConnection",
+                "plural": false,
+                "selections": (v8/*: any*/),
+                "storageKey": "partnersConnection(displayOnPartnerProfile:true,first:10,partnerCategory:[\"blue-chip\",\"top-established\",\"top-emerging\"],representedBy:true)"
+              },
+              {
                 "alias": null,
-                "args": (v13/*: any*/),
+                "args": (v6/*: any*/),
                 "concreteType": "PartnerArtistConnection",
                 "kind": "LinkedField",
                 "name": "partnersConnection",
@@ -783,14 +644,47 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v8/*: any*/),
-                      (v12/*: any*/),
-                      (v14/*: any*/)
+                      (v4/*: any*/),
+                      (v3/*: any*/),
+                      (v7/*: any*/)
                     ],
                     "storageKey": null
                   }
                 ],
                 "storageKey": "partnersConnection(displayOnPartnerProfile:true,first:10,partnerCategory:[\"blue-chip\",\"top-established\",\"top-emerging\"],representedBy:true)"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistInsight",
+            "kind": "LinkedField",
+            "name": "insights",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "type",
+                "storageKey": null
+              },
+              (v4/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "label",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "entities",
+                "storageKey": null
               }
             ],
             "storageKey": null
@@ -838,48 +732,83 @@ return {
             ],
             "storageKey": "biographyBlurb(format:\"HTML\",partnerBio:false)"
           },
+          (v9/*: any*/),
           {
             "alias": null,
             "args": null,
-            "concreteType": "ArtistRelatedData",
+            "kind": "ScalarField",
+            "name": "nationality",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "birthday",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "deathday",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "gender",
+            "storageKey": null
+          },
+          (v10/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistMeta",
             "kind": "LinkedField",
-            "name": "related",
+            "name": "meta",
+            "plural": false,
+            "selections": [
+              (v11/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": "alternate_names",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "alternateNames",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
             "plural": false,
             "selections": [
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "GeneConnection",
-                "kind": "LinkedField",
-                "name": "genes",
-                "plural": false,
-                "selections": [
+                "kind": "ScalarField",
+                "name": "versions",
+                "storageKey": null
+              },
+              (v12/*: any*/),
+              {
+                "alias": "square",
+                "args": [
                   {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "GeneEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Gene",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": [
-                          (v8/*: any*/),
-                          (v12/*: any*/)
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "square"
                   }
                 ],
-                "storageKey": null
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": "url(version:\"square\")"
               }
             ],
             "storageKey": null
@@ -887,35 +816,165 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "ArtistInsight",
+            "kind": "ScalarField",
+            "name": "blurb",
+            "storageKey": null
+          },
+          {
+            "alias": "artworks_connection",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "filter",
+                "value": "IS_FOR_SALE"
+              },
+              (v5/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "published",
+                "value": true
+              }
+            ],
+            "concreteType": "ArtworkConnection",
             "kind": "LinkedField",
-            "name": "insights",
-            "plural": true,
+            "name": "artworksConnection",
+            "plural": false,
             "selections": [
-              (v8/*: any*/),
               {
                 "alias": null,
                 "args": null,
-                "kind": "ScalarField",
-                "name": "type",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "label",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "entities",
+                "concreteType": "ArtworkEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "date",
+                        "storageKey": null
+                      },
+                      (v11/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "category",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "price_currency",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "priceCurrency",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "listPrice",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Money",
+                                "kind": "LinkedField",
+                                "name": "minPrice",
+                                "plural": false,
+                                "selections": (v14/*: any*/),
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Money",
+                                "kind": "LinkedField",
+                                "name": "maxPrice",
+                                "plural": false,
+                                "selections": [
+                                  (v13/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "PriceRange"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": (v14/*: any*/),
+                            "type": "Money"
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "availability",
+                        "storageKey": null
+                      },
+                      (v10/*: any*/),
+                      (v15/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Partner",
+                        "kind": "LinkedField",
+                        "name": "partner",
+                        "plural": false,
+                        "selections": [
+                          (v9/*: any*/),
+                          (v10/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Profile",
+                            "kind": "LinkedField",
+                            "name": "profile",
+                            "plural": false,
+                            "selections": [
+                              (v15/*: any*/),
+                              (v3/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
                 "storageKey": null
               }
             ],
-            "storageKey": null
+            "storageKey": "artworksConnection(filter:\"IS_FOR_SALE\",first:10,published:true)"
           },
           {
             "alias": null,
@@ -1015,7 +1074,7 @@ return {
                         "name": "saleDate",
                         "storageKey": "saleDate(format:\"YYYY\")"
                       },
-                      (v12/*: any*/)
+                      (v3/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1035,26 +1094,12 @@ return {
             "selections": [
               {
                 "alias": null,
-                "args": (v13/*: any*/),
+                "args": (v6/*: any*/),
                 "concreteType": "PartnerArtistConnection",
                 "kind": "LinkedField",
                 "name": "partnersConnection",
                 "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PartnerArtistEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      (v14/*: any*/),
-                      (v12/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
+                "selections": (v8/*: any*/),
                 "storageKey": "partnersConnection(displayOnPartnerProfile:true,first:10,partnerCategory:[\"blue-chip\",\"top-established\",\"top-emerging\"],representedBy:true)"
               }
             ],
@@ -1074,7 +1119,7 @@ return {
             "name": "formattedNationalityAndBirthday",
             "storageKey": null
           },
-          (v12/*: any*/)
+          (v3/*: any*/)
         ],
         "storageKey": "artist(id:\"example\")"
       }
@@ -1085,7 +1130,7 @@ return {
     "metadata": {},
     "name": "ArtistApp_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistApp_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  ...BackLink_artist\n  counts {\n    forSaleArtworks\n  }\n  internalID\n  name\n  slug\n  statuses {\n    artworks\n    auctionLots\n  }\n}\n\nfragment ArtistFollowArtistButton_artist on Artist {\n  internalID\n  slug\n  name\n  isFollowed\n}\n\nfragment ArtistHeader_artist on Artist {\n  ...ArtistFollowArtistButton_artist\n  ...SelectedCareerAchievements_artist\n  artistHighlights: highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n  imageUrl\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n    forSaleArtworks\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    credit\n    partnerID\n    text\n  }\n}\n\nfragment ArtistMetaCanonicalLink_artist on Artist {\n  slug\n  statuses {\n    shows\n    cv(minShowCount: 0)\n    articles\n    auctionLots\n    artworks\n  }\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        __typename\n        id\n      }\n    }\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n  }\n  related {\n    genes {\n      edges {\n        node {\n          __typename\n          id\n        }\n      }\n    }\n  }\n  insights {\n    __typename\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  meta {\n    description\n  }\n  alternate_names: alternateNames\n  image {\n    versions\n    large: url(version: \"large\")\n    square: url(version: \"square\")\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection: artworksConnection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency: priceCurrency\n        listPrice {\n          __typename\n          ... on PriceRange {\n            minPrice {\n              major\n              currencyCode\n            }\n            maxPrice {\n              major\n            }\n          }\n          ... on Money {\n            major\n            currencyCode\n          }\n        }\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtistMetaCanonicalLink_artist\n}\n\nfragment BackLink_artist on Artist {\n  name\n  slug\n}\n\nfragment SelectedCareerAchievements_artist on Artist {\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n    label\n    entities\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n  slug\n}\n"
+    "text": "query ArtistApp_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  slug\n  statuses {\n    shows\n    cv(minShowCount: 0)\n    articles\n    artworks\n    auctionLots\n  }\n  counts {\n    forSaleArtworks\n  }\n  related {\n    genes {\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n  }\n  highlights {\n    artistPartnersConnection: partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n  }\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  ...BackLink_artist\n  internalID\n  name\n}\n\nfragment ArtistFollowArtistButton_artist on Artist {\n  internalID\n  slug\n  name\n  isFollowed\n}\n\nfragment ArtistHeader_artist on Artist {\n  ...ArtistFollowArtistButton_artist\n  ...SelectedCareerAchievements_artist\n  artistHighlights: highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n  imageUrl\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n    forSaleArtworks\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    credit\n    partnerID\n    text\n  }\n}\n\nfragment ArtistMetaCanonicalLink_artist on Artist {\n  slug\n  statuses {\n    shows\n    cv(minShowCount: 0)\n    articles\n    auctionLots\n    artworks\n  }\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        __typename\n        id\n      }\n    }\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n  }\n  related {\n    genes {\n      edges {\n        node {\n          __typename\n          id\n        }\n      }\n    }\n  }\n  insights {\n    __typename\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  meta {\n    description\n  }\n  alternate_names: alternateNames\n  image {\n    versions\n    large: url(version: \"large\")\n    square: url(version: \"square\")\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection: artworksConnection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency: priceCurrency\n        listPrice {\n          __typename\n          ... on PriceRange {\n            minPrice {\n              major\n              currencyCode\n            }\n            maxPrice {\n              major\n            }\n          }\n          ... on Money {\n            major\n            currencyCode\n          }\n        }\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtistMetaCanonicalLink_artist\n}\n\nfragment BackLink_artist on Artist {\n  name\n  slug\n}\n\nfragment SelectedCareerAchievements_artist on Artist {\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n    label\n    entities\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n  slug\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/ArtistApp_sharedMetadata.graphql.ts
+++ b/src/v2/__generated__/ArtistApp_sharedMetadata.graphql.ts
@@ -3,14 +3,12 @@
 
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type ArtistApp_artist = {
+export type ArtistApp_sharedMetadata = {
     readonly slug: string;
     readonly statuses: {
         readonly shows: boolean | null;
         readonly cv: boolean | null;
         readonly articles: boolean | null;
-        readonly artworks: boolean | null;
-        readonly auctionLots: boolean | null;
     } | null;
     readonly counts: {
         readonly forSaleArtworks: number | null;
@@ -41,15 +39,12 @@ export type ArtistApp_artist = {
     readonly biographyBlurb: {
         readonly text: string | null;
     } | null;
-    readonly internalID: string;
-    readonly name: string | null;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistMeta_artist" | "ArtistHeader_artist" | "BackLink_artist">;
-    readonly " $refType": "ArtistApp_artist";
+    readonly " $refType": "ArtistApp_sharedMetadata";
 };
-export type ArtistApp_artist$data = ArtistApp_artist;
-export type ArtistApp_artist$key = {
-    readonly " $data"?: ArtistApp_artist$data;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistApp_artist">;
+export type ArtistApp_sharedMetadata$data = ArtistApp_sharedMetadata;
+export type ArtistApp_sharedMetadata$key = {
+    readonly " $data"?: ArtistApp_sharedMetadata$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistApp_sharedMetadata">;
 };
 
 
@@ -69,7 +64,7 @@ return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
-  "name": "ArtistApp_artist",
+  "name": "ArtistApp_sharedMetadata",
   "selections": [
     (v0/*: any*/),
     {
@@ -105,20 +100,6 @@ return {
           "args": null,
           "kind": "ScalarField",
           "name": "articles",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "artworks",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "auctionLots",
           "storageKey": null
         }
       ],
@@ -310,39 +291,10 @@ return {
         }
       ],
       "storageKey": "biographyBlurb(format:\"HTML\",partnerBio:false)"
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "internalID",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "name",
-      "storageKey": null
-    },
-    {
-      "args": null,
-      "kind": "FragmentSpread",
-      "name": "ArtistMeta_artist"
-    },
-    {
-      "args": null,
-      "kind": "FragmentSpread",
-      "name": "ArtistHeader_artist"
-    },
-    {
-      "args": null,
-      "kind": "FragmentSpread",
-      "name": "BackLink_artist"
     }
   ],
   "type": "Artist"
 };
 })();
-(node as any).hash = 'a21c7efae92fa9bb9dffb510abc41558';
+(node as any).hash = '7f0b4ccb7b8d65fb7eab207aab721621';
 export default node;

--- a/src/v2/__generated__/artistRoutes_TopLevelQuery.graphql.ts
+++ b/src/v2/__generated__/artistRoutes_TopLevelQuery.graphql.ts
@@ -103,19 +103,52 @@ query artistRoutes_TopLevelQuery(
 }
 
 fragment ArtistApp_artist on Artist {
-  ...ArtistMeta_artist
-  ...ArtistHeader_artist
-  ...BackLink_artist
-  counts {
-    forSaleArtworks
-  }
-  internalID
-  name
   slug
   statuses {
+    shows
+    cv(minShowCount: 0)
+    articles
     artworks
     auctionLots
   }
+  counts {
+    forSaleArtworks
+  }
+  related {
+    genes {
+      edges {
+        node {
+          slug
+          id
+        }
+      }
+    }
+  }
+  highlights {
+    artistPartnersConnection: partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: ["blue-chip", "top-established", "top-emerging"]) {
+      edges {
+        node {
+          categories {
+            slug
+            id
+          }
+          id
+        }
+        id
+      }
+    }
+  }
+  insights {
+    type
+  }
+  biographyBlurb(format: HTML, partnerBio: false) {
+    text
+  }
+  ...ArtistMeta_artist
+  ...ArtistHeader_artist
+  ...BackLink_artist
+  internalID
+  name
 }
 
 fragment ArtistFollowArtistButton_artist on Artist {
@@ -433,24 +466,85 @@ v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "artworks",
   "storageKey": null
 },
 v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "href",
+  "name": "id",
   "storageKey": null
 },
 v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "description",
+  "name": "__typename",
   "storageKey": null
 },
 v16 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Partner",
+  "kind": "LinkedField",
+  "name": "node",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "PartnerCategory",
+      "kind": "LinkedField",
+      "name": "categories",
+      "plural": true,
+      "selections": [
+        (v2/*: any*/),
+        (v14/*: any*/)
+      ],
+      "storageKey": null
+    },
+    (v14/*: any*/)
+  ],
+  "storageKey": null
+},
+v17 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "PartnerArtistEdge",
+    "kind": "LinkedField",
+    "name": "edges",
+    "plural": true,
+    "selections": [
+      (v16/*: any*/),
+      (v14/*: any*/)
+    ],
+    "storageKey": null
+  }
+],
+v18 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v19 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v20 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v21 = {
   "alias": "large",
   "args": [
     {
@@ -463,29 +557,15 @@ v16 = {
   "name": "url",
   "storageKey": "url(version:\"large\")"
 },
-v17 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "artworks",
-  "storageKey": null
-},
-v18 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "__typename",
-  "storageKey": null
-},
-v19 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "major",
   "storageKey": null
 },
-v20 = [
-  (v19/*: any*/),
+v23 = [
+  (v22/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -494,7 +574,7 @@ v20 = [
     "storageKey": null
   }
 ],
-v21 = {
+v24 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
@@ -515,57 +595,10 @@ v21 = {
       "name": "url",
       "storageKey": "url(version:\"small\")"
     },
-    (v16/*: any*/)
+    (v21/*: any*/)
   ],
   "storageKey": null
-},
-v22 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v23 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "Partner",
-  "kind": "LinkedField",
-  "name": "node",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "PartnerCategory",
-      "kind": "LinkedField",
-      "name": "categories",
-      "plural": true,
-      "selections": [
-        (v2/*: any*/),
-        (v22/*: any*/)
-      ],
-      "storageKey": null
-    },
-    (v22/*: any*/)
-  ],
-  "storageKey": null
-},
-v24 = [
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "PartnerArtistEdge",
-    "kind": "LinkedField",
-    "name": "edges",
-    "plural": true,
-    "selections": [
-      (v23/*: any*/),
-      (v22/*: any*/)
-    ],
-    "storageKey": null
-  }
-];
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -755,7 +788,195 @@ return {
         "plural": false,
         "selections": [
           (v2/*: any*/),
-          (v13/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistStatuses",
+            "kind": "LinkedField",
+            "name": "statuses",
+            "plural": false,
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "auctionLots",
+                "storageKey": null
+              },
+              (v13/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistCounts",
+            "kind": "LinkedField",
+            "name": "counts",
+            "plural": false,
+            "selections": [
+              (v6/*: any*/),
+              (v13/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "follows",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistRelatedData",
+            "kind": "LinkedField",
+            "name": "related",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "GeneConnection",
+                "kind": "LinkedField",
+                "name": "genes",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "GeneEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Gene",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v14/*: any*/),
+                          (v15/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistHighlights",
+            "kind": "LinkedField",
+            "name": "highlights",
+            "plural": false,
+            "selections": [
+              {
+                "alias": "artistPartnersConnection",
+                "args": (v9/*: any*/),
+                "concreteType": "PartnerArtistConnection",
+                "kind": "LinkedField",
+                "name": "partnersConnection",
+                "plural": false,
+                "selections": (v17/*: any*/),
+                "storageKey": "partnersConnection(displayOnPartnerProfile:true,first:10,partnerCategory:[\"blue-chip\",\"top-established\",\"top-emerging\"],representedBy:true)"
+              },
+              {
+                "alias": null,
+                "args": (v9/*: any*/),
+                "concreteType": "PartnerArtistConnection",
+                "kind": "LinkedField",
+                "name": "partnersConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PartnerArtistEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      (v15/*: any*/),
+                      (v14/*: any*/),
+                      (v16/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "partnersConnection(displayOnPartnerProfile:true,first:10,partnerCategory:[\"blue-chip\",\"top-established\",\"top-emerging\"],representedBy:true)"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistInsight",
+            "kind": "LinkedField",
+            "name": "insights",
+            "plural": true,
+            "selections": [
+              (v10/*: any*/),
+              (v15/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "label",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "entities",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": (v11/*: any*/),
+            "concreteType": "ArtistBlurb",
+            "kind": "LinkedField",
+            "name": "biographyBlurb",
+            "plural": false,
+            "selections": [
+              (v12/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "credit",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "partnerID",
+                "storageKey": null
+              }
+            ],
+            "storageKey": "biographyBlurb(format:\"HTML\",partnerBio:false)"
+          },
+          (v18/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -784,7 +1005,7 @@ return {
             "name": "gender",
             "storageKey": null
           },
-          (v14/*: any*/),
+          (v19/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -793,7 +1014,7 @@ return {
             "name": "meta",
             "plural": false,
             "selections": [
-              (v15/*: any*/)
+              (v20/*: any*/)
             ],
             "storageKey": null
           },
@@ -819,7 +1040,7 @@ return {
                 "name": "versions",
                 "storageKey": null
               },
-              (v16/*: any*/),
+              (v21/*: any*/),
               {
                 "alias": "square",
                 "args": [
@@ -833,26 +1054,6 @@ return {
                 "name": "url",
                 "storageKey": "url(version:\"square\")"
               }
-            ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "ArtistCounts",
-            "kind": "LinkedField",
-            "name": "counts",
-            "plural": false,
-            "selections": [
-              (v17/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "follows",
-                "storageKey": null
-              },
-              (v6/*: any*/)
             ],
             "storageKey": null
           },
@@ -913,7 +1114,7 @@ return {
                         "name": "date",
                         "storageKey": null
                       },
-                      (v15/*: any*/),
+                      (v20/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -936,7 +1137,7 @@ return {
                         "name": "listPrice",
                         "plural": false,
                         "selections": [
-                          (v18/*: any*/),
+                          (v15/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "selections": [
@@ -947,7 +1148,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "minPrice",
                                 "plural": false,
-                                "selections": (v20/*: any*/),
+                                "selections": (v23/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -958,7 +1159,7 @@ return {
                                 "name": "maxPrice",
                                 "plural": false,
                                 "selections": [
-                                  (v19/*: any*/)
+                                  (v22/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -967,7 +1168,7 @@ return {
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v20/*: any*/),
+                            "selections": (v23/*: any*/),
                             "type": "Money"
                           }
                         ],
@@ -980,8 +1181,8 @@ return {
                         "name": "availability",
                         "storageKey": null
                       },
-                      (v14/*: any*/),
-                      (v21/*: any*/),
+                      (v19/*: any*/),
+                      (v24/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -990,8 +1191,8 @@ return {
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v13/*: any*/),
-                          (v14/*: any*/),
+                          (v18/*: any*/),
+                          (v19/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1000,16 +1201,16 @@ return {
                             "name": "profile",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/),
-                              (v22/*: any*/)
+                              (v24/*: any*/),
+                              (v14/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v22/*: any*/)
+                          (v14/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v22/*: any*/)
+                      (v14/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1018,174 +1219,6 @@ return {
               }
             ],
             "storageKey": "artworksConnection(filter:\"IS_FOR_SALE\",first:10,published:true)"
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "ArtistStatuses",
-            "kind": "LinkedField",
-            "name": "statuses",
-            "plural": false,
-            "selections": [
-              (v3/*: any*/),
-              (v4/*: any*/),
-              (v5/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "auctionLots",
-                "storageKey": null
-              },
-              (v17/*: any*/)
-            ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "ArtistHighlights",
-            "kind": "LinkedField",
-            "name": "highlights",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": (v9/*: any*/),
-                "concreteType": "PartnerArtistConnection",
-                "kind": "LinkedField",
-                "name": "partnersConnection",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PartnerArtistEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      (v18/*: any*/),
-                      (v22/*: any*/),
-                      (v23/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": "partnersConnection(displayOnPartnerProfile:true,first:10,partnerCategory:[\"blue-chip\",\"top-established\",\"top-emerging\"],representedBy:true)"
-              },
-              {
-                "alias": "artistPartnersConnection",
-                "args": (v9/*: any*/),
-                "concreteType": "PartnerArtistConnection",
-                "kind": "LinkedField",
-                "name": "partnersConnection",
-                "plural": false,
-                "selections": (v24/*: any*/),
-                "storageKey": "partnersConnection(displayOnPartnerProfile:true,first:10,partnerCategory:[\"blue-chip\",\"top-established\",\"top-emerging\"],representedBy:true)"
-              }
-            ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": (v11/*: any*/),
-            "concreteType": "ArtistBlurb",
-            "kind": "LinkedField",
-            "name": "biographyBlurb",
-            "plural": false,
-            "selections": [
-              (v12/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "credit",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "partnerID",
-                "storageKey": null
-              }
-            ],
-            "storageKey": "biographyBlurb(format:\"HTML\",partnerBio:false)"
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "ArtistRelatedData",
-            "kind": "LinkedField",
-            "name": "related",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "GeneConnection",
-                "kind": "LinkedField",
-                "name": "genes",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "GeneEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Gene",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": [
-                          (v18/*: any*/),
-                          (v22/*: any*/),
-                          (v2/*: any*/)
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "ArtistInsight",
-            "kind": "LinkedField",
-            "name": "insights",
-            "plural": true,
-            "selections": [
-              (v18/*: any*/),
-              (v10/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "label",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "entities",
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
           },
           {
             "alias": null,
@@ -1285,7 +1318,7 @@ return {
                         "name": "saleDate",
                         "storageKey": "saleDate(format:\"YYYY\")"
                       },
-                      (v22/*: any*/)
+                      (v14/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1310,7 +1343,7 @@ return {
                 "kind": "LinkedField",
                 "name": "partnersConnection",
                 "plural": false,
-                "selections": (v24/*: any*/),
+                "selections": (v17/*: any*/),
                 "storageKey": "partnersConnection(displayOnPartnerProfile:true,first:10,partnerCategory:[\"blue-chip\",\"top-established\",\"top-emerging\"],representedBy:true)"
               }
             ],
@@ -1330,7 +1363,7 @@ return {
             "name": "formattedNationalityAndBirthday",
             "storageKey": null
           },
-          (v22/*: any*/)
+          (v14/*: any*/)
         ],
         "storageKey": null
       }
@@ -1341,9 +1374,9 @@ return {
     "metadata": {},
     "name": "artistRoutes_TopLevelQuery",
     "operationKind": "query",
-    "text": "query artistRoutes_TopLevelQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) @principalField {\n    ...ArtistApp_artist\n    slug\n    statuses {\n      shows\n      cv(minShowCount: 0)\n      articles\n    }\n    counts {\n      forSaleArtworks\n    }\n    related {\n      genes {\n        edges {\n          node {\n            slug\n            id\n          }\n        }\n      }\n    }\n    highlights {\n      artistPartnersConnection: partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n        edges {\n          node {\n            categories {\n              slug\n              id\n            }\n            id\n          }\n          id\n        }\n      }\n    }\n    insights {\n      type\n    }\n    biographyBlurb(format: HTML, partnerBio: false) {\n      text\n    }\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  ...BackLink_artist\n  counts {\n    forSaleArtworks\n  }\n  internalID\n  name\n  slug\n  statuses {\n    artworks\n    auctionLots\n  }\n}\n\nfragment ArtistFollowArtistButton_artist on Artist {\n  internalID\n  slug\n  name\n  isFollowed\n}\n\nfragment ArtistHeader_artist on Artist {\n  ...ArtistFollowArtistButton_artist\n  ...SelectedCareerAchievements_artist\n  artistHighlights: highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n  imageUrl\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n    forSaleArtworks\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    credit\n    partnerID\n    text\n  }\n}\n\nfragment ArtistMetaCanonicalLink_artist on Artist {\n  slug\n  statuses {\n    shows\n    cv(minShowCount: 0)\n    articles\n    auctionLots\n    artworks\n  }\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        __typename\n        id\n      }\n    }\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n  }\n  related {\n    genes {\n      edges {\n        node {\n          __typename\n          id\n        }\n      }\n    }\n  }\n  insights {\n    __typename\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  meta {\n    description\n  }\n  alternate_names: alternateNames\n  image {\n    versions\n    large: url(version: \"large\")\n    square: url(version: \"square\")\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection: artworksConnection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency: priceCurrency\n        listPrice {\n          __typename\n          ... on PriceRange {\n            minPrice {\n              major\n              currencyCode\n            }\n            maxPrice {\n              major\n            }\n          }\n          ... on Money {\n            major\n            currencyCode\n          }\n        }\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtistMetaCanonicalLink_artist\n}\n\nfragment BackLink_artist on Artist {\n  name\n  slug\n}\n\nfragment SelectedCareerAchievements_artist on Artist {\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n    label\n    entities\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n  slug\n}\n"
+    "text": "query artistRoutes_TopLevelQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) @principalField {\n    ...ArtistApp_artist\n    slug\n    statuses {\n      shows\n      cv(minShowCount: 0)\n      articles\n    }\n    counts {\n      forSaleArtworks\n    }\n    related {\n      genes {\n        edges {\n          node {\n            slug\n            id\n          }\n        }\n      }\n    }\n    highlights {\n      artistPartnersConnection: partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n        edges {\n          node {\n            categories {\n              slug\n              id\n            }\n            id\n          }\n          id\n        }\n      }\n    }\n    insights {\n      type\n    }\n    biographyBlurb(format: HTML, partnerBio: false) {\n      text\n    }\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  slug\n  statuses {\n    shows\n    cv(minShowCount: 0)\n    articles\n    artworks\n    auctionLots\n  }\n  counts {\n    forSaleArtworks\n  }\n  related {\n    genes {\n      edges {\n        node {\n          slug\n          id\n        }\n      }\n    }\n  }\n  highlights {\n    artistPartnersConnection: partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n  }\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  ...BackLink_artist\n  internalID\n  name\n}\n\nfragment ArtistFollowArtistButton_artist on Artist {\n  internalID\n  slug\n  name\n  isFollowed\n}\n\nfragment ArtistHeader_artist on Artist {\n  ...ArtistFollowArtistButton_artist\n  ...SelectedCareerAchievements_artist\n  artistHighlights: highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n  imageUrl\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n    forSaleArtworks\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    credit\n    partnerID\n    text\n  }\n}\n\nfragment ArtistMetaCanonicalLink_artist on Artist {\n  slug\n  statuses {\n    shows\n    cv(minShowCount: 0)\n    articles\n    auctionLots\n    artworks\n  }\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        __typename\n        id\n      }\n    }\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n  }\n  related {\n    genes {\n      edges {\n        node {\n          __typename\n          id\n        }\n      }\n    }\n  }\n  insights {\n    __typename\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  meta {\n    description\n  }\n  alternate_names: alternateNames\n  image {\n    versions\n    large: url(version: \"large\")\n    square: url(version: \"square\")\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection: artworksConnection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency: priceCurrency\n        listPrice {\n          __typename\n          ... on PriceRange {\n            minPrice {\n              major\n              currencyCode\n            }\n            maxPrice {\n              major\n            }\n          }\n          ... on Money {\n            major\n            currencyCode\n          }\n        }\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtistMetaCanonicalLink_artist\n}\n\nfragment BackLink_artist on Artist {\n  name\n  slug\n}\n\nfragment SelectedCareerAchievements_artist on Artist {\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  insights {\n    type\n    label\n    entities\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n  slug\n}\n"
   }
 };
 })();
-(node as any).hash = '2aebc2692118d387b2cbdbc334fdbb4f';
+(node as any).hash = '5c1ea791ec15928f323bab7f5226e88e';
 export default node;

--- a/src/v2/__generated__/artistRoutes_WorksForSaleQuery.graphql.ts
+++ b/src/v2/__generated__/artistRoutes_WorksForSaleQuery.graphql.ts
@@ -64,141 +64,9 @@ export type artistRoutes_WorksForSaleQueryResponse = {
         readonly " $fragmentRefs": FragmentRefs<"ArtistWorksForSaleRoute_artist">;
     } | null;
 };
-export type artistRoutes_WorksForSaleQueryRawResponse = {
-    readonly artist: ({
-        readonly artistSeriesConnection: ({
-            readonly edges: ReadonlyArray<({
-                readonly node: ({
-                    readonly internalID: string;
-                    readonly title: string;
-                    readonly slug: string;
-                    readonly featured: boolean;
-                    readonly artworksCountMessage: string | null;
-                    readonly image: ({
-                        readonly cropped: ({
-                            readonly width: number;
-                            readonly height: number;
-                            readonly src: string;
-                            readonly srcSet: string;
-                        }) | null;
-                    }) | null;
-                }) | null;
-            }) | null> | null;
-        }) | null;
-        readonly internalID: string;
-        readonly slug: string;
-        readonly name: string | null;
-        readonly isFollowed: boolean | null;
-        readonly counts: ({
-            readonly partner_shows: number | null;
-            readonly for_sale_artworks: number | null;
-            readonly ecommerce_artworks: number | null;
-            readonly auction_artworks: number | null;
-            readonly artworks: number | null;
-            readonly has_make_offer_artworks: boolean | null;
-            readonly forSaleArtworks: number | null;
-        }) | null;
-        readonly filtered_artworks: ({
-            readonly id: string;
-            readonly pageInfo: {
-                readonly hasNextPage: boolean;
-                readonly endCursor: string | null;
-            };
-            readonly pageCursors: {
-                readonly around: ReadonlyArray<{
-                    readonly cursor: string;
-                    readonly page: number;
-                    readonly isCurrent: boolean;
-                }>;
-                readonly first: ({
-                    readonly cursor: string;
-                    readonly page: number;
-                    readonly isCurrent: boolean;
-                }) | null;
-                readonly last: ({
-                    readonly cursor: string;
-                    readonly page: number;
-                    readonly isCurrent: boolean;
-                }) | null;
-                readonly previous: ({
-                    readonly cursor: string;
-                    readonly page: number;
-                }) | null;
-            };
-            readonly edges: ReadonlyArray<({
-                readonly node: ({
-                    readonly id: string;
-                    readonly slug: string;
-                    readonly href: string | null;
-                    readonly internalID: string;
-                    readonly image: ({
-                        readonly aspect_ratio: number;
-                        readonly placeholder: string | null;
-                        readonly url: string | null;
-                    }) | null;
-                    readonly title: string | null;
-                    readonly image_title: string | null;
-                    readonly date: string | null;
-                    readonly sale_message: string | null;
-                    readonly cultural_maker: string | null;
-                    readonly artists: ReadonlyArray<({
-                        readonly id: string;
-                        readonly href: string | null;
-                        readonly name: string | null;
-                    }) | null> | null;
-                    readonly collecting_institution: string | null;
-                    readonly partner: ({
-                        readonly name: string | null;
-                        readonly href: string | null;
-                        readonly id: string | null;
-                        readonly type: string | null;
-                    }) | null;
-                    readonly sale: ({
-                        readonly is_auction: boolean | null;
-                        readonly is_closed: boolean | null;
-                        readonly id: string | null;
-                        readonly is_live_open: boolean | null;
-                        readonly is_open: boolean | null;
-                        readonly is_preview: boolean | null;
-                        readonly display_timely_at: string | null;
-                    }) | null;
-                    readonly sale_artwork: ({
-                        readonly counts: ({
-                            readonly bidder_positions: number | null;
-                        }) | null;
-                        readonly highest_bid: ({
-                            readonly display: string | null;
-                        }) | null;
-                        readonly opening_bid: ({
-                            readonly display: string | null;
-                        }) | null;
-                        readonly id: string | null;
-                    }) | null;
-                    readonly is_inquireable: boolean | null;
-                    readonly is_saved: boolean | null;
-                    readonly is_biddable: boolean | null;
-                }) | null;
-                readonly id: string | null;
-            }) | null> | null;
-        }) | null;
-        readonly sidebarAggregations: ({
-            readonly aggregations: ReadonlyArray<({
-                readonly slice: ArtworkAggregation | null;
-                readonly counts: ReadonlyArray<({
-                    readonly name: string;
-                    readonly value: string;
-                    readonly count: number;
-                }) | null> | null;
-            }) | null> | null;
-            readonly id: string | null;
-        }) | null;
-        readonly id: string;
-    }) | null;
-};
 export type artistRoutes_WorksForSaleQuery = {
     readonly response: artistRoutes_WorksForSaleQueryResponse;
     readonly variables: artistRoutes_WorksForSaleQueryVariables;
-    readonly rawResponse: artistRoutes_WorksForSaleQueryRawResponse;
 };
 
 
@@ -1241,5 +1109,5 @@ return {
   }
 };
 })();
-(node as any).hash = '707ad1822b63dffa6d54e5909656ec52';
+(node as any).hash = '946941c63f590a00c44f3606c4a4c337';
 export default node;


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GRO-392 

Fixes an issue reported here: https://artsy.slack.com/archives/C01ADJNCS5D/p1624285854225600.

When we don't have enough content to render the overview page, we redirect to works-for-sale. However, we weren't hiding the overview navigation tab, leading to confusing UX. 

Example url: https://staging.artsy.net/artist/madc/works-for-sale

<img width="1680" alt="Screen Shot 2021-06-21 at 2 53 39 PM" src="https://user-images.githubusercontent.com/236943/122832619-7daca980-d2a0-11eb-8f21-443dc803b634.png">
