### PR TITLE
GRO-376: Artist has displayed CV even without Career Highlights

### DIFF
--- a/src/v2/Components/SelectedCareerAchievements.tsx
+++ b/src/v2/Components/SelectedCareerAchievements.tsx
@@ -112,7 +112,14 @@ export class SelectedCareerAchievements extends React.Component<
       !hasSections(this.props.artist) &&
       (!this.props.artist.insights || this.props.artist.insights.length === 0)
     ) {
-      return null
+      return (
+        <>
+          <RouterLink to={`${this.props.artist.slug}/cv`}>
+            <ChevronButton>See all past shows and fair booths</ChevronButton>
+          </RouterLink>
+          <Spacer my={4} />
+        </>
+      )
     }
 
     if (this.props.themeVersion === "v2") {

--- a/src/v2/Components/__tests__/SelectedCareerAchievements.jest.tsx
+++ b/src/v2/Components/__tests__/SelectedCareerAchievements.jest.tsx
@@ -104,6 +104,21 @@ describe("SelectedCareerAchievements", () => {
 
     expect(text.length).toEqual(0)
   })
+
+  it("renders the Artists CV RouterLink regardless of career achievements", async () => {
+    // @ts-expect-error STRICT_NULL_CHECK
+    wrapper = await getWrapper({
+      ...artistResponse,
+      auctionResultsConnection: null,
+      highlights: {
+        // @ts-expect-error STRICT_NULL_CHECK
+        ...artistResponse.highlights,
+        partnersConnection: null,
+      },
+      insights: null,
+    })
+    expect(wrapper.find("RouterLink").length).toBe(1)
+  })
 })
 
 const artistResponse: SelectedCareerAchievementsTestQueryRawResponse["artist"] = {

--- a/src/v2/Components/__tests__/SelectedCareerAchievements.jest.tsx
+++ b/src/v2/Components/__tests__/SelectedCareerAchievements.jest.tsx
@@ -69,7 +69,7 @@ describe("SelectedCareerAchievements", () => {
     expect(text).toContain("Included in a major biennial")
   })
 
-  // TODO
+  // TODO https://artsyproduct.atlassian.net/browse/GRO-393
   it("doesn't render selected career achievements if no auction results, partner highlights, or insights", async () => {
     // @ts-expect-error STRICT_NULL_CHECK
     wrapper = await getWrapper({
@@ -87,7 +87,7 @@ describe("SelectedCareerAchievements", () => {
     expect(text.length).toEqual(0)
   })
 
-  // TODO
+  // TODO https://artsyproduct.atlassian.net/browse/GRO-393
   it("doesn't render selected career achievements if no auction results or partner highlights and insights is null", async () => {
     // @ts-expect-error STRICT_NULL_CHECK
     wrapper = await getWrapper({
@@ -105,7 +105,8 @@ describe("SelectedCareerAchievements", () => {
     expect(text.length).toEqual(0)
   })
 
-  it("renders the Artists CV RouterLink regardless of career achievements", async () => {
+  // TODO https://artsyproduct.atlassian.net/browse/GRO-393
+  it("renders the Artists CV link regardless of career achievements", async () => {
     // @ts-expect-error STRICT_NULL_CHECK
     wrapper = await getWrapper({
       ...artistResponse,
@@ -118,6 +119,7 @@ describe("SelectedCareerAchievements", () => {
       insights: null,
     })
     expect(wrapper.find("RouterLink").length).toBe(1)
+    expect(wrapper.find("RouterLink").props().to).toBe(`foo/cv`)
   })
 })
 


### PR DESCRIPTION
This is an update to fix the bug noticed on the Artist page. The career highlights portion usually includes a link to a CV for artists to view "See all past shows and fair booths" link. But artists without career highlights were not able to have this CV link.

This adds in the "See all past shows and fair booths" link for artists regardless if they have highlights or not.

Past Behavior:
<img width="883" alt="Screen Shot 2021-06-21 at 2 46 22 PM" src="https://user-images.githubusercontent.com/30025439/122831951-7b961b00-d29f-11eb-80b4-b2c1343a0fb0.png">

New Behavior: 
<img width="928" alt="Screen Shot 2021-06-21 at 2 33 41 PM" src="https://user-images.githubusercontent.com/30025439/122831961-80f36580-d29f-11eb-9c56-de80755a468e.png">
