### PR TITLE
fix(FX-2759): update aggregations in context

### DIFF
--- a/src/v2/Apps/ArtistSeries/Components/ArtistSeriesArtworksFilter.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/ArtistSeriesArtworksFilter.tsx
@@ -48,7 +48,7 @@ const ArtistSeriesArtworksFilter: React.FC<ArtistSeriesArtworksFilterProps> = pr
           aggregations: ["TOTAL"],
           first: 20,
         }}
-      ></BaseArtworkFilter>
+      />
     </ArtworkFilterContextProvider>
   )
 }

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -1,5 +1,5 @@
 import { omit } from "lodash"
-import React, { useContext, useReducer, useState } from "react"
+import React, { useContext, useEffect, useReducer, useState } from "react"
 import useDeepCompareEffect from "use-deep-compare-effect"
 import { hasFilters } from "./Utils/hasFilters"
 import { isDefaultFilter } from "./Utils/isDefaultFilter"
@@ -232,6 +232,10 @@ export const ArtworkFilterContextProvider: React.FC<
   const [shouldStageFilterChanges, setShouldStageFilterChanges] = useState(
     false
   )
+
+  useEffect(() => {
+    setAggregations(aggregations)
+  }, [aggregations])
 
   useDeepCompareEffect(() => {
     if (onChange) {

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -1,11 +1,5 @@
 import { omit } from "lodash"
-import React, {
-  useContext,
-  useEffect,
-  useReducer,
-  useRef,
-  useState,
-} from "react"
+import React, { useContext, useReducer, useState } from "react"
 import useDeepCompareEffect from "use-deep-compare-effect"
 import { hasFilters } from "./Utils/hasFilters"
 import { isDefaultFilter } from "./Utils/isDefaultFilter"
@@ -136,7 +130,6 @@ export interface ArtworkFilterContextProps {
   // Sorting
   sortOptions?: SortOptions
   aggregations?: Aggregations
-  setAggregations?: (aggregations: Aggregations) => void
   counts?: Counts
   setCounts?: (counts: Counts) => void
 
@@ -232,21 +225,11 @@ export const ArtworkFilterContextProvider: React.FC<
 
   const [stagedArtworkFilterState, stage] = useReducer(artworkFilterReducer, {})
 
-  const didMountRef = useRef(false)
-
   // TODO: Consolidate this into additional reducer
-  const [filterAggregations, setAggregations] = useState(aggregations)
   const [artworkCounts, setCounts] = useState(counts)
   const [shouldStageFilterChanges, setShouldStageFilterChanges] = useState(
     false
   )
-
-  useEffect(() => {
-    if (didMountRef.current) {
-      setAggregations(aggregations)
-    }
-    didMountRef.current = true
-  }, [aggregations])
 
   useDeepCompareEffect(() => {
     if (onChange) {
@@ -280,8 +263,7 @@ export const ArtworkFilterContextProvider: React.FC<
 
     // Sorting
     sortOptions,
-    aggregations: filterAggregations,
-    setAggregations,
+    aggregations,
     counts: artworkCounts,
     setCounts,
 

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -1,5 +1,11 @@
 import { omit } from "lodash"
-import React, { useContext, useEffect, useReducer, useState } from "react"
+import React, {
+  useContext,
+  useEffect,
+  useReducer,
+  useRef,
+  useState,
+} from "react"
 import useDeepCompareEffect from "use-deep-compare-effect"
 import { hasFilters } from "./Utils/hasFilters"
 import { isDefaultFilter } from "./Utils/isDefaultFilter"
@@ -226,6 +232,8 @@ export const ArtworkFilterContextProvider: React.FC<
 
   const [stagedArtworkFilterState, stage] = useReducer(artworkFilterReducer, {})
 
+  const didMountRef = useRef(false)
+
   // TODO: Consolidate this into additional reducer
   const [filterAggregations, setAggregations] = useState(aggregations)
   const [artworkCounts, setCounts] = useState(counts)
@@ -234,7 +242,10 @@ export const ArtworkFilterContextProvider: React.FC<
   )
 
   useEffect(() => {
-    setAggregations(aggregations)
+    if (didMountRef.current) {
+      setAggregations(aggregations)
+    }
+    didMountRef.current = true
   }, [aggregations])
 
   useDeepCompareEffect(() => {


### PR DESCRIPTION
Jira: [FX-2759](https://artsyproduct.atlassian.net/browse/FX-2759)

Aggregations is not part of context state, but only props. So they update after each receiving response from server

Description of issue:
When you search some artist series and then search another one, the aggregations don't update 

Result of fix:
Aggregations update after each search