### PR TITLE
fix: align columns on auction results page

### DIFF
--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
@@ -87,7 +87,7 @@ export const MarketStats: React.FC<MarketStatsProps> = ({
       {/* Market Stats Values */}
       <GridColumns gridRowGap={[2, 2]} gridColumnGap={[0, 2]}>
         <Column
-          span={2}
+          span={3}
           justifyContent="flex-end"
           display="flex"
           flexDirection="column"
@@ -108,7 +108,7 @@ export const MarketStats: React.FC<MarketStatsProps> = ({
             }}
           />
         </Column>
-        <Column span={10}>
+        <Column span={9}>
           <GridColumns gridRowGap={[2, 2]} gridColumnGap={[0, 2]}>
             <Column
               span={6}
@@ -117,20 +117,29 @@ export const MarketStats: React.FC<MarketStatsProps> = ({
               flexDirection="column"
             >
               <GridColumns gridRowGap={[2, 2]} gridColumnGap={[0, 2]}>
-                <Column span={[6]}>
+                <Column
+                  span={[6]}
+                  justifyContent="flex-end"
+                  display="flex"
+                  flexDirection="column"
+                >
                   <Text variant={["xs", "sm"]} pb={[0.5, 1]}>
                     Yearly lots sold
                   </Text>
                   <Text
                     variant={["xxl", "xxl"]}
                     style={{ whiteSpace: "nowrap" }}
-                    data-test-id="annualLotsSold"
                   >
                     {selectedPriceInsight.annualLotsSold}
                   </Text>
                 </Column>
 
-                <Column span={[6]}>
+                <Column
+                  span={[6]}
+                  justifyContent="flex-end"
+                  display="flex"
+                  flexDirection="column"
+                >
                   <Text variant={["xs", "sm"]} pb={[0.5, 1]}>
                     Sell-through rate
                   </Text>


### PR DESCRIPTION
Addresses [CX-1412]

## Description

Aligns the columns of the market stats section to the columns of the auction result section (see comments in  [CX-1412] for more context).

<img width="1154" alt="Screenshot 2021-06-22 at 15 47 47" src="https://user-images.githubusercontent.com/4691889/122936828-c1231880-d371-11eb-86f8-988601ecae3a.png">

[CX-1412]: https://artsyproduct.atlassian.net/browse/CX-1412