### PR TITLE
feat: artsy.net cookie consent.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -118,6 +118,7 @@ export const MOBILE_MEDIA_QUERY: any = "only screen and (max-width: 640px)"
 export const NETWORK_CACHE_SIZE: any = 2000
 export const NETWORK_CACHE_TTL: any = 3600000
 export const NODE_ENV: any = "development"
+export const ONETRUST_SCRIPT_ID: any = null
 export const OPENREDIS_URL: any = null
 export const PAGE_CACHE_ENABLED: any = false
 export const PAGE_CACHE_EXPIRY_SECONDS: any = 600

--- a/src/desktop/components/main_layout/templates/head.jade
+++ b/src/desktop/components/main_layout/templates/head.jade
@@ -1,3 +1,10 @@
+//- onetrust cookie consent, must be the first js loaded.
+if ( !sd.THIRD_PARTIES_DISABLED && sd.ONETRUST_SCRIPT_ID )
+  script( src="https://cdn.cookielaw.org/consent/#{sd.ONETRUST_SCRIPT_ID}/OtAutoBlock.js", type="text/javascript" )
+  script( src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js", type="text/javascript", charset="UTF-8", data-domain-script="#{sd.ONETRUST_SCRIPT_ID}" )
+  script( type="text/javascript" ).
+    function OptanonWrapper() {}
+
 include ../../prevent_right_click/index
 link( rel='apple-touch-icon', href=asset('/images/icon-152.png') )
 link( rel='apple-touch-icon', sizes='120x120', href=asset('/images/icon-120.png') )

--- a/src/lib/setup_sharify.js
+++ b/src/lib/setup_sharify.js
@@ -79,6 +79,7 @@ sharify.data = _.extend(
     "NETWORK_CACHE_TTL",
     "NODE_ENV",
     "NOTIFICATION_COUNT",
+    "ONETRUST_SCRIPT_ID",
     "PARSELY_KEY",
     "PC_ARTSY_CHANNEL",
     "PC_AUCTION_CHANNEL",

--- a/src/mobile/components/layout/templates/head.jade
+++ b/src/mobile/components/layout/templates/head.jade
@@ -1,3 +1,10 @@
+//- onetrust cookie consent, must be the first js loaded.
+if ( !sd.THIRD_PARTIES_DISABLED && sd.ONETRUST_SCRIPT_ID )
+  script( src="https://cdn.cookielaw.org/consent/#{sd.ONETRUST_SCRIPT_ID}/OtAutoBlock.js", type="text/javascript" )
+  script( src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js", type="text/javascript", charset="UTF-8", data-domain-script="#{sd.ONETRUST_SCRIPT_ID}" )
+  script( type="text/javascript" ).
+    function OptanonWrapper() {}
+
 title Artsy - Discover Fine Art
 meta( name="viewport", content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" )
 meta( name="google-site-verification" content="0wcwrQSIrrBNXss78bJW8AOXg2Vdhh8BhYkoeZLqS80" )

--- a/src/v2/index.ejs
+++ b/src/v2/index.ejs
@@ -2,6 +2,18 @@
 <html>
 
 <head>
+
+  <!-- onetrust cookie consent, must be the first js loaded -->
+  <%% if ( !disable.onetrust && !sd.THIRD_PARTIES_DISABLED && sd.ONETRUST_SCRIPT_ID ) { %>
+    <script src="https://cdn.cookielaw.org/consent/<%%= sd.ONETRUST_SCRIPT_ID %>/OtAutoBlock.js" type="text/javascript" >
+    </script>
+    <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="<%%= sd.ONETRUST_SCRIPT_ID %>" >
+    </script>
+    <script type="text/javascript">
+      function OptanonWrapper() { }
+    </script>
+  <%% } %>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <meta charset='utf-8' />
 

--- a/src/v2/server.ts
+++ b/src/v2/server.ts
@@ -71,6 +71,7 @@ app.get(
         disable: {
           analytics: getServerParam(req, "disableAnalytics") === "true",
           onetrust: getServerParam(req, "disableOneTrust") === "true",
+          onetrust: getServerParam(req, "onetrust") === "true",
           postie: getServerParam(req, "disablePostie") === "true",
           segment: getServerParam(req, "disableSegment") === "true",
           stripe: getServerParam(req, "disableStripe") === "true",

--- a/src/v2/server.ts
+++ b/src/v2/server.ts
@@ -70,7 +70,7 @@ app.get(
         },
         disable: {
           analytics: getServerParam(req, "disableAnalytics") === "true",
-          onetrust: getServerParam(req, "onetrust") === "true",
+          onetrust: getServerParam(req, "disableOneTrust") === "true",
           postie: getServerParam(req, "disablePostie") === "true",
           segment: getServerParam(req, "disableSegment") === "true",
           stripe: getServerParam(req, "disableStripe") === "true",

--- a/src/v2/server.ts
+++ b/src/v2/server.ts
@@ -71,7 +71,6 @@ app.get(
         disable: {
           analytics: getServerParam(req, "disableAnalytics") === "true",
           onetrust: getServerParam(req, "disableOneTrust") === "true",
-          onetrust: getServerParam(req, "onetrust") === "true",
           postie: getServerParam(req, "disablePostie") === "true",
           segment: getServerParam(req, "disableSegment") === "true",
           stripe: getServerParam(req, "disableStripe") === "true",

--- a/src/v2/server.ts
+++ b/src/v2/server.ts
@@ -70,6 +70,7 @@ app.get(
         },
         disable: {
           analytics: getServerParam(req, "disableAnalytics") === "true",
+          onetrust: getServerParam(req, "onetrust") === "true",
           postie: getServerParam(req, "disablePostie") === "true",
           segment: getServerParam(req, "disableSegment") === "true",
           stripe: getServerParam(req, "disableStripe") === "true",


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3176

Add OneTrust javascripts and attempt to make them fire first on page load. This is to implement [Cookie Consent](https://www.notion.so/artsy/Cookie-Consent-01dace52a765476ea4e9353260ce9a7f). The tags are copied from [OneTrust's UI](https://app-eu.onetrust.com/cookies/websites).  Over there we configure consent banner, preference-center, cookie-blocking, and other things. The scripts implement those settings. Generally, changes on their UI take effect only when the scripts are re-published, here:

![Screenshot from 2021-08-30 16-19-51](https://user-images.githubusercontent.com/63004951/131400086-da48b09b-70dd-4beb-b89b-a40c88f32913.png)

There  are 2 set of scripts, `Test` and `Production`. They differ only in an ID which is parameterized into the `ONETRUST_SCRIPT_ID` ENV var whose presence in config enables the scripts.

- `Test` tag ID: `12abb958-ed18-407e-8829-ea60cdd69a86-test` <--- we will use for staging
- `Productio` tag ID: `12abb958-ed18-407e-8829-ea60cdd69a86` <--- use for production

After this PR is merged, we will enable the tag in staging by:

```
hokusai staging env set ONETRUST_SCRIPT_ID=12abb958-ed18-407e-8829-ea60cdd69a86-test
```
Then we will announce to a broader (than previous announcements) audience and have them test on staging.

Once that's cleared, we will enable in production by:

```
hokusai staging env set ONETRUST_SCRIPT_ID=12abb958-ed18-407e-8829-ea60cdd69a86
```