### PR TITLE
fix (CX-1618): change label name for auction house filter

### DIFF
--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/AuctionHouseFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/AuctionHouseFilter.tsx
@@ -25,7 +25,7 @@ export const AuctionHouseFilter: React.FC = () => {
   }
 
   return (
-    <FilterExpandable label="Auction house" expanded>
+    <FilterExpandable label="Auction House" expanded>
       <Flex flexDirection="column" alignItems="left">
         <ShowMore>
           {auctionHouses.map((checkbox, index) => {

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/AuctionHouseFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/AuctionHouseFilter.tsx
@@ -25,7 +25,7 @@ export const AuctionHouseFilter: React.FC = () => {
   }
 
   return (
-    <FilterExpandable label="Medium" expanded>
+    <FilterExpandable label="Auction house" expanded>
       <Flex flexDirection="column" alignItems="left">
         <ShowMore>
           {auctionHouses.map((checkbox, index) => {


### PR DESCRIPTION
Addresses [CX-1618]

**Description**
The label for the "Auction house" filter for "auction results" should be "Auction house" instead of "medium".
The bug was introduced in this PR: https://github.com/artsy/force/pull/7719/files

**The issue**
![image](https://user-images.githubusercontent.com/27921300/122957170-f6376700-d381-11eb-8caf-6806047d25f4.png)

**The fix**
![Screenshot 2021-06-22 at 17 48 05](https://user-images.githubusercontent.com/27921300/122957254-0e0eeb00-d382-11eb-906a-e4ae0ae4c6a7.png)


[CX-1618]: https://artsyproduct.atlassian.net/browse/CX-1618