### PR TITLE
feat(GRO-214): adds rails to homepage

### DIFF
--- a/src/v2/Apps/Home/Components/HomeArtworkModuleContext.tsx
+++ b/src/v2/Apps/Home/Components/HomeArtworkModuleContext.tsx
@@ -1,0 +1,249 @@
+import { Box, BaseTabs, BaseTab, Spacer, Text, Flex } from "@artsy/palette"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { RouterLink } from "v2/System/Router/RouterLink"
+import { HomeArtworkModuleContext_context } from "v2/__generated__/HomeArtworkModuleContext_context.graphql"
+
+interface HomeArtworkModuleContextProps {
+  title?: string | null
+  context: HomeArtworkModuleContext_context | null
+}
+
+const HomeArtworkModuleContext: React.FC<HomeArtworkModuleContextProps> = ({
+  title,
+  context,
+}) => {
+  if (!context && !title) return null
+
+  if (!context) {
+    return <Text variant="lg">{title}</Text>
+  }
+
+  switch (context.__typename) {
+    case "Fair": {
+      return (
+        <Flex justifyContent="space-between">
+          <Box>
+            <Text
+              variant="lg"
+              as={RouterLink}
+              // @ts-ignore
+              to={context.href}
+              noUnderline
+            >
+              {title}
+            </Text>
+
+            <Text variant="lg" color="black60">
+              {context.exhibitionPeriod}
+            </Text>
+          </Box>
+
+          <Text
+            variant="sm"
+            as={RouterLink}
+            // @ts-ignore
+            to={context.href}
+            ml={1}
+          >
+            View all
+          </Text>
+        </Flex>
+      )
+    }
+    case "Sale": {
+      return (
+        <Flex justifyContent="space-between">
+          <Box>
+            <Text
+              variant="lg"
+              as={RouterLink}
+              // @ts-ignore
+              to={context.href}
+              noUnderline
+            >
+              {title}
+            </Text>
+
+            <Text variant="lg" color="black60">
+              {context.liveStartAt
+                ? `Live bidding starts ${context.liveStartAt}`
+                : `${context.startAt} – ${context.endAt}`}
+            </Text>
+          </Box>
+
+          <Text
+            variant="sm"
+            as={RouterLink}
+            // @ts-ignore
+            to={context.href}
+            ml={1}
+          >
+            View all
+          </Text>
+        </Flex>
+      )
+    }
+    case "Gene": {
+      return (
+        <Flex justifyContent="space-between">
+          <Text
+            variant="lg"
+            as={RouterLink}
+            // @ts-ignore
+            to={context.href}
+            noUnderline
+          >
+            {title}
+          </Text>
+
+          <Text
+            variant="sm"
+            as={RouterLink}
+            // @ts-ignore
+            to={context.href}
+            ml={1}
+          >
+            View all
+          </Text>
+        </Flex>
+      )
+    }
+
+    case "HomePageRelatedArtistArtworkModule": {
+      return (
+        <>
+          {context.basedOn && (
+            <Text variant="xs" textTransform="uppercase">
+              Based on{" "}
+              <RouterLink to={context.basedOn.href ?? ""} noUnderline>
+                {context.basedOn.name}
+              </RouterLink>
+            </Text>
+          )}
+
+          <Text
+            variant="lg"
+            as={RouterLink}
+            // @ts-ignore
+            to={context.artist?.href}
+            noUnderline
+          >
+            {context.artist?.name ?? title}
+          </Text>
+        </>
+      )
+    }
+
+    case "HomePageFollowedArtistArtworkModule": {
+      return (
+        <Text
+          variant="lg"
+          as={RouterLink}
+          // @ts-ignore
+          to={context.href}
+          noUnderline
+        >
+          {title}
+        </Text>
+      )
+    }
+
+    case "FollowArtists": {
+      return (
+        <>
+          <Flex justifyContent="space-between">
+            <Text
+              variant="lg"
+              as={RouterLink}
+              // @ts-ignore
+              to="/works-for-you"
+              noUnderline
+            >
+              {title}
+            </Text>
+
+            <Text
+              variant="sm"
+              as={RouterLink}
+              // @ts-ignore
+              to="/works-for-you"
+              ml={1}
+            >
+              View all
+            </Text>
+          </Flex>
+
+          <Spacer mt={4} />
+
+          <BaseTabs>
+            {(context.artists ?? []).map((artist, i) => {
+              if (!artist || !artist.href) return <></>
+
+              return (
+                <BaseTab
+                  key={artist.href}
+                  as={RouterLink}
+                  // @ts-ignore
+                  to={artist.href}
+                >
+                  {artist.name}
+                </BaseTab>
+              )
+            })}
+          </BaseTabs>
+        </>
+      )
+    }
+    default:
+      return <Text variant="lg">{title}</Text>
+  }
+}
+
+export const HomeArtworkModuleContextFragmentContainer = createFragmentContainer(
+  HomeArtworkModuleContext,
+  {
+    context: graphql`
+      fragment HomeArtworkModuleContext_context on HomePageArtworkModuleContext {
+        __typename
+        ... on Sale {
+          href
+          liveStartAt(format: "MMM D")
+          startAt(format: "MMM D")
+          endAt(format: "MMM D")
+        }
+        ... on Fair {
+          href
+          exhibitionPeriod
+        }
+        ... on Gene {
+          href
+        }
+        ... on HomePageRelatedArtistArtworkModule {
+          artist {
+            name
+            href
+          }
+          basedOn {
+            name
+            href
+          }
+        }
+        ... on HomePageFollowedArtistArtworkModule {
+          artist {
+            href
+          }
+        }
+        ... on FollowArtists {
+          counts {
+            artists
+          }
+          artists {
+            href
+            name
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Home/Components/HomeArtworkModuleRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeArtworkModuleRail.tsx
@@ -1,0 +1,239 @@
+import { AuthContextModule, ContextModule } from "@artsy/cohesion"
+import {
+  Shelf,
+  Text,
+  Spacer,
+  Skeleton,
+  SkeletonBox,
+  SkeletonText,
+} from "@artsy/palette"
+import { compact } from "lodash"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { ShelfArtworkFragmentContainer } from "v2/Components/Artwork/ShelfArtwork"
+import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
+import { HomeArtworkModuleRail_artworkModule } from "v2/__generated__/HomeArtworkModuleRail_artworkModule.graphql"
+import { HomeArtworkModuleRailQuery } from "v2/__generated__/HomeArtworkModuleRailQuery.graphql"
+import { useSystemContext } from "v2/System"
+import { HomeArtworkModuleContextFragmentContainer } from "./HomeArtworkModuleContext"
+
+const ARTWORK_MODULES = [
+  "current_fairs",
+  "followed_artist",
+  "generic_gene", // GENERIC_GENES
+  "genes", // FOLLOWED_GENES
+  "live_auctions",
+  "recently_viewed_works",
+  "recommended_works",
+  "related_artists",
+  "saved_works",
+  "similar_to_recently_viewed",
+  "similar_to_saved_works",
+] as const
+
+const UNIMPLEMENTED_MODULES = [
+  "active_bids",
+  "followed_artists",
+  "followed_galleries",
+  "popular_artists",
+] as const
+
+const CONTEXT_MODULES: Record<
+  typeof ARTWORK_MODULES[number],
+  AuthContextModule
+> = {
+  current_fairs: ContextModule.fairRail,
+  followed_artist: ContextModule.otherWorksByArtistRail,
+  generic_gene: ContextModule.categoryRail,
+  genes: ContextModule.categoryRail,
+  live_auctions: ContextModule.liveAuctionsRail,
+  recently_viewed_works: ContextModule.recentlyViewedRail,
+  related_artists: ContextModule.relatedArtistsRail,
+  // @ts-ignore TODO: Add to AuthContextModule union
+  recommended_works: ContextModule.recommendedWorksForYouRail,
+  // @ts-ignore TODO: Add to AuthContextModule union
+  saved_works: ContextModule.recentlySavedRail,
+  // @ts-ignore TODO: Add to AuthContextModule union
+  similar_to_recently_viewed: ContextModule.similarToWorksYouViewedRail,
+  // @ts-ignore TODO: Add to AuthContextModule union
+  similar_to_saved_works: ContextModule.similarToWorksYouSavedRail,
+}
+
+interface HomeArtworkModuleRailProps {
+  artworkModule: HomeArtworkModuleRail_artworkModule
+}
+
+const HomeArtworkModuleRail: React.FC<HomeArtworkModuleRailProps> = ({
+  artworkModule,
+}) => {
+  if (
+    UNIMPLEMENTED_MODULES.includes(
+      artworkModule.key as typeof UNIMPLEMENTED_MODULES[number]
+    )
+  ) {
+    console.warn(
+      `TODO: ${artworkModule.key}:${artworkModule.context?.__typename}`
+    )
+    return null
+  }
+
+  const artworks = compact(artworkModule.results)
+
+  if (artworks.length === 0) {
+    return null
+  }
+
+  return (
+    <HomeArtworkModule
+      context={
+        <HomeArtworkModuleContextFragmentContainer
+          title={artworkModule.title}
+          context={artworkModule.context}
+        />
+      }
+    >
+      <Shelf>
+        {artworks.map(artwork => {
+          return (
+            <ShelfArtworkFragmentContainer
+              contextModule={CONTEXT_MODULES[artworkModule.key!]}
+              artwork={artwork}
+              lazyLoad
+            />
+          )
+        })}
+      </Shelf>
+    </HomeArtworkModule>
+  )
+}
+
+const HomeArtworkModuleRailFragmentContainer = createFragmentContainer(
+  HomeArtworkModuleRail,
+  {
+    artworkModule: graphql`
+      fragment HomeArtworkModuleRail_artworkModule on HomePageArtworkModule {
+        title
+        key
+        results {
+          ...ShelfArtwork_artwork
+        }
+        context {
+          __typename
+          ...HomeArtworkModuleContext_context
+        }
+      }
+    `,
+  }
+)
+
+const HomeArtworkModule: React.FC<{ context: string | JSX.Element }> = ({
+  context,
+  children,
+}) => {
+  return (
+    <>
+      {typeof context === "string" ? (
+        <Text variant="lg">{context}</Text>
+      ) : (
+        context
+      )}
+
+      <Spacer mt={4} />
+
+      {children}
+    </>
+  )
+}
+
+const HomeArtworkModuleRailPlaceholder: React.FC = () => {
+  return (
+    <Skeleton>
+      <Shelf>
+        {[...new Array(12)].map((_, i) => {
+          return (
+            <React.Fragment key={i}>
+              <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
+
+              <Spacer mt={1} />
+
+              <SkeletonText variant="md">Artist Name</SkeletonText>
+              <SkeletonText variant="md">Artwork Title</SkeletonText>
+              <SkeletonText variant="xs">Partner</SkeletonText>
+              <SkeletonText variant="xs">Price</SkeletonText>
+            </React.Fragment>
+          )
+        })}
+      </Shelf>
+    </Skeleton>
+  )
+}
+
+const HomeArtworkModulePlaceholder: React.FC<{ title: string }> = ({
+  title,
+}) => (
+  <HomeArtworkModule context={title}>
+    <HomeArtworkModuleRailPlaceholder />
+  </HomeArtworkModule>
+)
+
+interface HomeArtworkModuleRailQueryRendererProps {
+  title: string
+  params: {
+    key: string
+    id?: string | null
+    relatedArtistID?: string | null
+    followedArtistID?: string | null
+  }
+}
+
+export const HomeArtworkModuleRailQueryRenderer: React.FC<HomeArtworkModuleRailQueryRendererProps> = ({
+  title,
+  params: { key, id, relatedArtistID, followedArtistID },
+}) => {
+  const { relayEnvironment } = useSystemContext()
+
+  return (
+    <SystemQueryRenderer<HomeArtworkModuleRailQuery>
+      environment={relayEnvironment}
+      query={graphql`
+        query HomeArtworkModuleRailQuery(
+          $key: String
+          $id: String
+          $relatedArtistID: String
+          $followedArtistID: String
+        ) {
+          homePage {
+            artworkModule(
+              key: $key
+              id: $id
+              relatedArtistID: $relatedArtistID
+              followedArtistID: $followedArtistID
+            ) {
+              ...HomeArtworkModuleRail_artworkModule
+            }
+          }
+        }
+      `}
+      variables={{ key, id, relatedArtistID, followedArtistID }}
+      placeholder={<HomeArtworkModulePlaceholder title={title} />}
+      render={({ error, props }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props) {
+          return <HomeArtworkModulePlaceholder title={title} />
+        }
+
+        if (props.homePage.artworkModule) {
+          return (
+            <HomeArtworkModuleRailFragmentContainer
+              artworkModule={props.homePage.artworkModule}
+            />
+          )
+        }
+      }}
+    />
+  )
+}

--- a/src/v2/Apps/Home/Components/HomeArtworkModules.tsx
+++ b/src/v2/Apps/Home/Components/HomeArtworkModules.tsx
@@ -1,0 +1,77 @@
+import React from "react"
+import { Join, Spacer } from "@artsy/palette"
+import { createFragmentContainer, graphql } from "react-relay"
+import { HomeArtworkModules_homePage } from "v2/__generated__/HomeArtworkModules_homePage.graphql"
+import { HomeArtworkModuleRailQueryRenderer } from "./HomeArtworkModuleRail"
+
+interface HomeArtworkModulesProps {
+  homePage: HomeArtworkModules_homePage
+}
+
+const HomeArtworkModules: React.FC<HomeArtworkModulesProps> = ({
+  homePage,
+}) => {
+  if (!homePage.artworkModules || homePage.artworkModules.length === 0) {
+    return null
+  }
+  return (
+    <Join separator={<Spacer mt={6} />}>
+      {homePage.artworkModules.map((artworkModule, i) => {
+        if (!artworkModule || !artworkModule.title || !artworkModule.key) {
+          return null
+        }
+
+        return (
+          <React.Fragment key={artworkModule.title ?? i}>
+            <HomeArtworkModuleRailQueryRenderer
+              title={artworkModule.title}
+              params={{
+                key: artworkModule.key,
+                id: artworkModule.params?.internalID,
+                relatedArtistID: artworkModule.params?.relatedArtistID,
+                followedArtistID: artworkModule.params?.followedArtistID,
+              }}
+            />
+          </React.Fragment>
+        )
+      })}
+    </Join>
+  )
+}
+
+export const HomeArtworkModulesFragmentContainer = createFragmentContainer(
+  HomeArtworkModules,
+  {
+    homePage: graphql`
+      fragment HomeArtworkModules_homePage on HomePage {
+        artworkModules(
+          maxRails: -1
+          maxFollowedGeneRails: -1
+          order: [
+            ACTIVE_BIDS
+            RECENTLY_VIEWED_WORKS
+            SIMILAR_TO_RECENTLY_VIEWED
+            SAVED_WORKS
+            SIMILAR_TO_SAVED_WORKS
+            FOLLOWED_ARTISTS
+            FOLLOWED_GALLERIES
+            RECOMMENDED_WORKS
+            RELATED_ARTISTS
+            LIVE_AUCTIONS
+            CURRENT_FAIRS
+            FOLLOWED_GENES
+            GENERIC_GENES
+          ]
+        ) {
+          title
+          key
+          params {
+            internalID
+            relatedArtistID
+            followedArtistID
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Home/Components/HomeFeaturedCategoriesRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedCategoriesRail.tsx
@@ -1,0 +1,163 @@
+import {
+  Box,
+  Flex,
+  Image,
+  Shelf,
+  Spacer,
+  SkeletonBox,
+  SkeletonText,
+  Text,
+} from "@artsy/palette"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { useSystemContext } from "v2/System"
+import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
+import { cropped } from "v2/Utils/resized"
+import { HomeFeaturedCategoriesRail_marketingCollections } from "v2/__generated__/HomeFeaturedCategoriesRail_marketingCollections.graphql"
+import { HomeFeaturedCategoriesRailQuery } from "v2/__generated__/HomeFeaturedCategoriesRailQuery.graphql"
+import { RouterLink } from "v2/System/Router/RouterLink"
+
+interface HomeFeaturedCategoriesRailProps {
+  marketingCollections: HomeFeaturedCategoriesRail_marketingCollections
+}
+
+export const HomeFeaturedCategoriesRail: React.FC<HomeFeaturedCategoriesRailProps> = ({
+  marketingCollections,
+}) => {
+  if (marketingCollections.length === 0) return null
+
+  return (
+    <Shelf>
+      {marketingCollections.map(collection => {
+        const image = collection.thumbnail
+          ? cropped(collection.thumbnail, {
+              width: 325,
+              height: 244,
+            })
+          : null
+
+        return (
+          <RouterLink
+            key={collection.slug}
+            to={`/gene/${collection.slug}`}
+            style={{
+              display: "block",
+              textDecoration: "none",
+            }}
+          >
+            {image ? (
+              <Image
+                src={image.src}
+                srcSet={image.srcSet}
+                width={325}
+                height={244}
+                lazyLoad
+                alt=""
+                style={{ display: "block" }}
+              />
+            ) : (
+              <Box width={325} height={244} bg="black10" />
+            )}
+
+            <Spacer mt={2} />
+
+            <Text variant="lg">{collection.title}</Text>
+          </RouterLink>
+        )
+      })}
+    </Shelf>
+  )
+}
+
+export const HomeFeaturedCategoriesRailFragmentContainer = createFragmentContainer(
+  HomeFeaturedCategoriesRail,
+  {
+    marketingCollections: graphql`
+      fragment HomeFeaturedCategoriesRail_marketingCollections on MarketingCollection
+        @relay(plural: true) {
+        slug
+        title
+        thumbnail
+      }
+    `,
+  }
+)
+
+const HomeFeaturedCategories: React.FC = ({ children }) => {
+  return (
+    <>
+      <Flex justifyContent="space-between">
+        <Text variant="lg">Featured Categories</Text>
+        <Text variant="md">
+          <RouterLink to="/categories">View all categories</RouterLink>
+        </Text>
+      </Flex>
+
+      <Spacer mt={4} />
+
+      {children}
+    </>
+  )
+}
+
+const HomeFeaturedCategoriesRailPlaceholder: React.FC = () => {
+  return (
+    <Shelf>
+      {[...new Array(8)].map((_, i) => {
+        return (
+          <React.Fragment key={i}>
+            <SkeletonBox width={325} height={244} />
+
+            <Spacer mt={2} />
+
+            <SkeletonText variant="lg">Collection Title</SkeletonText>
+          </React.Fragment>
+        )
+      })}
+    </Shelf>
+  )
+}
+
+const PLACEHOLDER = (
+  <HomeFeaturedCategories>
+    <HomeFeaturedCategoriesRailPlaceholder />
+  </HomeFeaturedCategories>
+)
+
+export const HomeFeaturedCategoriesRailQueryRenderer = () => {
+  const { relayEnvironment } = useSystemContext()
+
+  return (
+    <SystemQueryRenderer<HomeFeaturedCategoriesRailQuery>
+      environment={relayEnvironment}
+      query={graphql`
+        query HomeFeaturedCategoriesRailQuery {
+          marketingHubCollections {
+            ...HomeFeaturedCategoriesRail_marketingCollections
+          }
+        }
+      `}
+      placeholder={PLACEHOLDER}
+      render={({ error, props }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props) {
+          return PLACEHOLDER
+        }
+
+        if (props.marketingHubCollections) {
+          return (
+            <HomeFeaturedCategories>
+              <HomeFeaturedCategoriesRailFragmentContainer
+                marketingCollections={props.marketingHubCollections}
+              />
+            </HomeFeaturedCategories>
+          )
+        }
+      }}
+    />
+  )
+}

--- a/src/v2/Apps/Home/HomeApp.tsx
+++ b/src/v2/Apps/Home/HomeApp.tsx
@@ -5,6 +5,7 @@ import { Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "v2/System/useSystemContext"
 import { HomeApp_homePage } from "v2/__generated__/HomeApp_homePage.graphql"
+import { HomeArtworkModulesFragmentContainer } from "./Components/HomeArtworkModules"
 import { HomeFeaturedCategoriesRailQueryRenderer } from "./Components/HomeFeaturedCategoriesRail"
 import { HomeHeroUnitFragmentContainer } from "./Components/HomeHeroUnit"
 import { HomeInfoBlurb } from "./Components/HomeInfoBlurb"
@@ -38,6 +39,8 @@ export const HomeApp: React.FC<HomeAppProps> = ({ homePage }) => {
         </GridColumns>
 
         {!isLoggedIn && <HomeFeaturedCategoriesRailQueryRenderer />}
+
+        <HomeArtworkModulesFragmentContainer homePage={homePage} />
       </Join>
     </>
   )
@@ -50,6 +53,7 @@ export const HomeAppFragmentContainer = createFragmentContainer(HomeApp, {
         internalID
         ...HomeHeroUnit_heroUnit
       }
+      ...HomeArtworkModules_homePage
     }
   `,
 })

--- a/src/v2/Apps/Home/HomeApp.tsx
+++ b/src/v2/Apps/Home/HomeApp.tsx
@@ -1,10 +1,11 @@
-import { Column, GridColumns, Spacer } from "@artsy/palette"
+import { Column, GridColumns, Spacer, Join } from "@artsy/palette"
 import { compact } from "lodash"
 import React from "react"
 import { Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "v2/System/useSystemContext"
 import { HomeApp_homePage } from "v2/__generated__/HomeApp_homePage.graphql"
+import { HomeFeaturedCategoriesRailQueryRenderer } from "./Components/HomeFeaturedCategoriesRail"
 import { HomeHeroUnitFragmentContainer } from "./Components/HomeHeroUnit"
 import { HomeInfoBlurb } from "./Components/HomeInfoBlurb"
 
@@ -13,9 +14,9 @@ interface HomeAppProps {
 }
 
 export const HomeApp: React.FC<HomeAppProps> = ({ homePage }) => {
-  const heroUnits = compact(homePage.heroUnits?.slice(0, 2)) ?? []
-
   const { isLoggedIn } = useSystemContext()
+
+  const heroUnits = compact(homePage.heroUnits?.slice(0, 2)) ?? []
 
   return (
     <>
@@ -23,25 +24,21 @@ export const HomeApp: React.FC<HomeAppProps> = ({ homePage }) => {
 
       <Spacer mt={4} />
 
-      {!isLoggedIn && (
-        <>
-          <HomeInfoBlurb />
+      <Join separator={<Spacer mt={6} />}>
+        {!isLoggedIn && <HomeInfoBlurb />}
 
-          <Spacer mt={6} />
-        </>
-      )}
+        <GridColumns gridRowGap={6}>
+          {heroUnits.map(heroUnit => {
+            return (
+              <Column key={heroUnit.internalID} span={6}>
+                <HomeHeroUnitFragmentContainer heroUnit={heroUnit} />
+              </Column>
+            )
+          })}
+        </GridColumns>
 
-      <GridColumns gridRowGap={6}>
-        {heroUnits.map(heroUnit => {
-          return (
-            <Column key={heroUnit.internalID} span={6}>
-              <HomeHeroUnitFragmentContainer heroUnit={heroUnit} />
-            </Column>
-          )
-        })}
-      </GridColumns>
-
-      <Spacer mt={6} />
+        {!isLoggedIn && <HomeFeaturedCategoriesRailQueryRenderer />}
+      </Join>
     </>
   )
 }

--- a/src/v2/Apps/Home/__tests__/HomeArtworkModuleContext.jest.tsx
+++ b/src/v2/Apps/Home/__tests__/HomeArtworkModuleContext.jest.tsx
@@ -1,0 +1,148 @@
+import React from "react"
+import { graphql } from "relay-runtime"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { HomeArtworkModuleContextFragmentContainer } from "../Components/HomeArtworkModuleContext"
+import { HomeArtworkModuleContext_Test_Query } from "v2/__generated__/HomeArtworkModuleContext_Test_Query.graphql"
+
+jest.unmock("react-relay")
+
+let title = "Example"
+
+const { getWrapper } = setupTestWrapper<HomeArtworkModuleContext_Test_Query>({
+  Component: props => {
+    const context = props.homePage!.artworkModules![0]!.context!
+    return (
+      <HomeArtworkModuleContextFragmentContainer
+        title={title}
+        context={context}
+      />
+    )
+  },
+  query: graphql`
+    query HomeArtworkModuleContext_Test_Query {
+      homePage {
+        artworkModules {
+          context {
+            ...HomeArtworkModuleContext_context
+          }
+        }
+      }
+    }
+  `,
+})
+
+describe("HomeArtworkModuleContext", () => {
+  describe("Gene", () => {
+    it("renders correctly", () => {
+      title = "Example Gene"
+
+      const wrapper = getWrapper({
+        HomePageArtworkModule: () => ({
+          context: {
+            __typename: "Gene",
+            href: "/gene/example-gene",
+          },
+        }),
+      })
+
+      expect(wrapper.text()).toContain("Example Gene")
+      expect(wrapper.text()).toContain("View all")
+      expect(wrapper.html()).toContain("/gene/example-gene")
+    })
+  })
+
+  describe("Fair", () => {
+    it("renders correctly", () => {
+      title = "Example Fair"
+
+      const wrapper = getWrapper({
+        HomePageArtworkModule: () => ({
+          context: {
+            __typename: "Fair",
+            href: "/fair/example-fair",
+            exhibitionPeriod: "June 9–12",
+          },
+        }),
+      })
+
+      expect(wrapper.text()).toContain("Example Fair")
+      expect(wrapper.text()).toContain("June 9–12")
+      expect(wrapper.text()).toContain("View all")
+      expect(wrapper.html()).toContain("/fair/example-fair")
+    })
+  })
+
+  describe("Sale", () => {
+    it("renders correctly", () => {
+      title = "Example Sale"
+
+      const wrapper = getWrapper({
+        HomePageArtworkModule: () => ({
+          context: {
+            __typename: "Sale",
+            href: "/sale/example-sale",
+          },
+        }),
+      })
+
+      expect(wrapper.text()).toContain("Example Sale")
+      expect(wrapper.text()).toContain("Live bidding starts")
+      expect(wrapper.text()).toContain("View all")
+      expect(wrapper.html()).toContain("/sale/example-sale")
+    })
+  })
+
+  describe("HomePageRelatedArtistArtworkModule", () => {
+    it("renders correctly", () => {
+      title = "Example"
+
+      const wrapper = getWrapper({
+        HomePageArtworkModule: () => ({
+          context: {
+            __typename: "HomePageRelatedArtistArtworkModule",
+            artist: {
+              name: "New Artist",
+              href: "/artist/new-artist",
+            },
+            basedOn: {
+              name: "Familiar Artist",
+              href: "/artist/familiar-artist",
+            },
+          },
+        }),
+      })
+
+      expect(wrapper.text()).toContain("Based on Familiar Artist")
+      expect(wrapper.text()).toContain("New Artist")
+      expect(wrapper.html()).toContain("/artist/familiar-artist")
+      expect(wrapper.html()).toContain("/artist/new-artist")
+    })
+  })
+
+  describe("FollowArtists", () => {
+    it("renders correctly", () => {
+      title = "New Works By Artists You Follow"
+
+      const wrapper = getWrapper({
+        HomePageArtworkModule: () => ({
+          context: {
+            __typename: "FollowArtists",
+            artists: [
+              { href: "/artist/example-1", name: "First Example" },
+              { href: "/artist/example-2", name: "Second Example" },
+              { href: "/artist/example-3", name: "Third Example" },
+            ],
+          },
+        }),
+      })
+
+      expect(wrapper.text()).toContain("New Works By Artists You Follow")
+      expect(wrapper.text()).toContain("First Example")
+      expect(wrapper.html()).toContain("/artist/example-1")
+      expect(wrapper.text()).toContain("Second Example")
+      expect(wrapper.html()).toContain("/artist/example-2")
+      expect(wrapper.text()).toContain("Third Example")
+      expect(wrapper.html()).toContain("/artist/example-3")
+    })
+  })
+})

--- a/src/v2/__generated__/HomeApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/HomeApp_Test_Query.graphql.ts
@@ -29,6 +29,20 @@ fragment HomeApp_homePage on HomePage {
     ...HomeHeroUnit_heroUnit
     id
   }
+  ...HomeArtworkModules_homePage
+}
+
+fragment HomeArtworkModules_homePage on HomePage {
+  artworkModules(maxRails: -1, maxFollowedGeneRails: -1, order: [ACTIVE_BIDS, RECENTLY_VIEWED_WORKS, SIMILAR_TO_RECENTLY_VIEWED, SAVED_WORKS, SIMILAR_TO_SAVED_WORKS, FOLLOWED_ARTISTS, FOLLOWED_GALLERIES, RECOMMENDED_WORKS, RELATED_ARTISTS, LIVE_AUCTIONS, CURRENT_FAIRS, FOLLOWED_GENES, GENERIC_GENES]) {
+    title
+    key
+    params {
+      internalID
+      relatedArtistID
+      followedArtistID
+    }
+    id
+  }
 }
 
 fragment HomeHeroUnit_heroUnit on HomePageHeroUnit {
@@ -42,7 +56,29 @@ fragment HomeHeroUnit_heroUnit on HomePageHeroUnit {
 }
 */
 
-const node: ConcreteRequest = {
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
   "fragment": {
     "argumentDefinitions": [],
     "kind": "Fragment",
@@ -96,13 +132,7 @@ const node: ConcreteRequest = {
             "name": "heroUnits",
             "plural": true,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "internalID",
-                "storageKey": null
-              },
+              (v0/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -117,13 +147,7 @@ const node: ConcreteRequest = {
                 "name": "heading",
                 "storageKey": null
               },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "title",
-                "storageKey": null
-              },
+              (v1/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -152,15 +176,85 @@ const node: ConcreteRequest = {
                 "name": "creditLine",
                 "storageKey": null
               },
+              (v2/*: any*/)
+            ],
+            "storageKey": "heroUnits(platform:\"DESKTOP\")"
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "maxFollowedGeneRails",
+                "value": -1
+              },
+              {
+                "kind": "Literal",
+                "name": "maxRails",
+                "value": -1
+              },
+              {
+                "kind": "Literal",
+                "name": "order",
+                "value": [
+                  "ACTIVE_BIDS",
+                  "RECENTLY_VIEWED_WORKS",
+                  "SIMILAR_TO_RECENTLY_VIEWED",
+                  "SAVED_WORKS",
+                  "SIMILAR_TO_SAVED_WORKS",
+                  "FOLLOWED_ARTISTS",
+                  "FOLLOWED_GALLERIES",
+                  "RECOMMENDED_WORKS",
+                  "RELATED_ARTISTS",
+                  "LIVE_AUCTIONS",
+                  "CURRENT_FAIRS",
+                  "FOLLOWED_GENES",
+                  "GENERIC_GENES"
+                ]
+              }
+            ],
+            "concreteType": "HomePageArtworkModule",
+            "kind": "LinkedField",
+            "name": "artworkModules",
+            "plural": true,
+            "selections": [
+              (v1/*: any*/),
               {
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
-                "name": "id",
+                "name": "key",
                 "storageKey": null
-              }
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "HomePageModulesParams",
+                "kind": "LinkedField",
+                "name": "params",
+                "plural": false,
+                "selections": [
+                  (v0/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "relatedArtistID",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "followedArtistID",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v2/*: any*/)
             ],
-            "storageKey": "heroUnits(platform:\"DESKTOP\")"
+            "storageKey": "artworkModules(maxFollowedGeneRails:-1,maxRails:-1,order:[\"ACTIVE_BIDS\",\"RECENTLY_VIEWED_WORKS\",\"SIMILAR_TO_RECENTLY_VIEWED\",\"SAVED_WORKS\",\"SIMILAR_TO_SAVED_WORKS\",\"FOLLOWED_ARTISTS\",\"FOLLOWED_GALLERIES\",\"RECOMMENDED_WORKS\",\"RELATED_ARTISTS\",\"LIVE_AUCTIONS\",\"CURRENT_FAIRS\",\"FOLLOWED_GENES\",\"GENERIC_GENES\"])"
           }
         ],
         "storageKey": null
@@ -172,8 +266,9 @@ const node: ConcreteRequest = {
     "metadata": {},
     "name": "HomeApp_Test_Query",
     "operationKind": "query",
-    "text": "query HomeApp_Test_Query {\n  homePage {\n    ...HomeApp_homePage\n  }\n}\n\nfragment HomeApp_homePage on HomePage {\n  heroUnits(platform: DESKTOP) {\n    internalID\n    ...HomeHeroUnit_heroUnit\n    id\n  }\n}\n\nfragment HomeHeroUnit_heroUnit on HomePageHeroUnit {\n  backgroundImageURL\n  heading\n  title\n  subtitle\n  linkText\n  href\n  creditLine\n}\n"
+    "text": "query HomeApp_Test_Query {\n  homePage {\n    ...HomeApp_homePage\n  }\n}\n\nfragment HomeApp_homePage on HomePage {\n  heroUnits(platform: DESKTOP) {\n    internalID\n    ...HomeHeroUnit_heroUnit\n    id\n  }\n  ...HomeArtworkModules_homePage\n}\n\nfragment HomeArtworkModules_homePage on HomePage {\n  artworkModules(maxRails: -1, maxFollowedGeneRails: -1, order: [ACTIVE_BIDS, RECENTLY_VIEWED_WORKS, SIMILAR_TO_RECENTLY_VIEWED, SAVED_WORKS, SIMILAR_TO_SAVED_WORKS, FOLLOWED_ARTISTS, FOLLOWED_GALLERIES, RECOMMENDED_WORKS, RELATED_ARTISTS, LIVE_AUCTIONS, CURRENT_FAIRS, FOLLOWED_GENES, GENERIC_GENES]) {\n    title\n    key\n    params {\n      internalID\n      relatedArtistID\n      followedArtistID\n    }\n    id\n  }\n}\n\nfragment HomeHeroUnit_heroUnit on HomePageHeroUnit {\n  backgroundImageURL\n  heading\n  title\n  subtitle\n  linkText\n  href\n  creditLine\n}\n"
   }
 };
+})();
 (node as any).hash = '9c9536c0844e490ee34ef63884748eae';
 export default node;

--- a/src/v2/__generated__/HomeApp_homePage.graphql.ts
+++ b/src/v2/__generated__/HomeApp_homePage.graphql.ts
@@ -8,6 +8,7 @@ export type HomeApp_homePage = {
         readonly internalID: string;
         readonly " $fragmentRefs": FragmentRefs<"HomeHeroUnit_heroUnit">;
     } | null> | null;
+    readonly " $fragmentRefs": FragmentRefs<"HomeArtworkModules_homePage">;
     readonly " $refType": "HomeApp_homePage";
 };
 export type HomeApp_homePage$data = HomeApp_homePage;
@@ -52,9 +53,14 @@ const node: ReaderFragment = {
         }
       ],
       "storageKey": "heroUnits(platform:\"DESKTOP\")"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "HomeArtworkModules_homePage"
     }
   ],
   "type": "HomePage"
 };
-(node as any).hash = '0e3bf7e8c8be3fbc6ddb48bac59c5d9b';
+(node as any).hash = '4afef225f829c8e9e1bff45e92cc35d4';
 export default node;

--- a/src/v2/__generated__/HomeArtworkModuleContext_Test_Query.graphql.ts
+++ b/src/v2/__generated__/HomeArtworkModuleContext_Test_Query.graphql.ts
@@ -1,0 +1,359 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeArtworkModuleContext_Test_QueryVariables = {};
+export type HomeArtworkModuleContext_Test_QueryResponse = {
+    readonly homePage: {
+        readonly artworkModules: ReadonlyArray<{
+            readonly context: {
+                readonly " $fragmentRefs": FragmentRefs<"HomeArtworkModuleContext_context">;
+            } | null;
+        } | null> | null;
+    } | null;
+};
+export type HomeArtworkModuleContext_Test_Query = {
+    readonly response: HomeArtworkModuleContext_Test_QueryResponse;
+    readonly variables: HomeArtworkModuleContext_Test_QueryVariables;
+};
+
+
+
+/*
+query HomeArtworkModuleContext_Test_Query {
+  homePage {
+    artworkModules {
+      context {
+        __typename
+        ...HomeArtworkModuleContext_context
+        ... on Node {
+          id
+        }
+      }
+      id
+    }
+  }
+}
+
+fragment HomeArtworkModuleContext_context on HomePageArtworkModuleContext {
+  __typename
+  ... on Sale {
+    href
+    liveStartAt(format: "MMM D")
+    startAt(format: "MMM D")
+    endAt(format: "MMM D")
+  }
+  ... on Fair {
+    href
+    exhibitionPeriod
+  }
+  ... on Gene {
+    href
+  }
+  ... on HomePageRelatedArtistArtworkModule {
+    artist {
+      name
+      href
+      id
+    }
+    basedOn {
+      name
+      href
+      id
+    }
+  }
+  ... on HomePageFollowedArtistArtworkModule {
+    artist {
+      href
+      id
+    }
+  }
+  ... on FollowArtists {
+    counts {
+      artists
+    }
+    artists {
+      href
+      name
+      id
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "MMM D"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = [
+  (v3/*: any*/),
+  (v1/*: any*/),
+  (v0/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "HomeArtworkModuleContext_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "HomePage",
+        "kind": "LinkedField",
+        "name": "homePage",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "HomePageArtworkModule",
+            "kind": "LinkedField",
+            "name": "artworkModules",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "context",
+                "plural": false,
+                "selections": [
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "HomeArtworkModuleContext_context"
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "HomeArtworkModuleContext_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "HomePage",
+        "kind": "LinkedField",
+        "name": "homePage",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "HomePageArtworkModule",
+            "kind": "LinkedField",
+            "name": "artworkModules",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "context",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  (v0/*: any*/),
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v1/*: any*/),
+                      {
+                        "alias": null,
+                        "args": (v2/*: any*/),
+                        "kind": "ScalarField",
+                        "name": "liveStartAt",
+                        "storageKey": "liveStartAt(format:\"MMM D\")"
+                      },
+                      {
+                        "alias": null,
+                        "args": (v2/*: any*/),
+                        "kind": "ScalarField",
+                        "name": "startAt",
+                        "storageKey": "startAt(format:\"MMM D\")"
+                      },
+                      {
+                        "alias": null,
+                        "args": (v2/*: any*/),
+                        "kind": "ScalarField",
+                        "name": "endAt",
+                        "storageKey": "endAt(format:\"MMM D\")"
+                      }
+                    ],
+                    "type": "Sale"
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v1/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "exhibitionPeriod",
+                        "storageKey": null
+                      }
+                    ],
+                    "type": "Fair"
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v1/*: any*/)
+                    ],
+                    "type": "Gene"
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artist",
+                        "plural": false,
+                        "selections": (v4/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "basedOn",
+                        "plural": false,
+                        "selections": (v4/*: any*/),
+                        "storageKey": null
+                      }
+                    ],
+                    "type": "HomePageRelatedArtistArtworkModule"
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artist",
+                        "plural": false,
+                        "selections": [
+                          (v1/*: any*/),
+                          (v0/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "type": "HomePageFollowedArtistArtworkModule"
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "FollowArtistCounts",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "artists",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artists",
+                        "plural": true,
+                        "selections": [
+                          (v1/*: any*/),
+                          (v3/*: any*/),
+                          (v0/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "type": "FollowArtists"
+                  }
+                ],
+                "storageKey": null
+              },
+              (v0/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "HomeArtworkModuleContext_Test_Query",
+    "operationKind": "query",
+    "text": "query HomeArtworkModuleContext_Test_Query {\n  homePage {\n    artworkModules {\n      context {\n        __typename\n        ...HomeArtworkModuleContext_context\n        ... on Node {\n          id\n        }\n      }\n      id\n    }\n  }\n}\n\nfragment HomeArtworkModuleContext_context on HomePageArtworkModuleContext {\n  __typename\n  ... on Sale {\n    href\n    liveStartAt(format: \"MMM D\")\n    startAt(format: \"MMM D\")\n    endAt(format: \"MMM D\")\n  }\n  ... on Fair {\n    href\n    exhibitionPeriod\n  }\n  ... on Gene {\n    href\n  }\n  ... on HomePageRelatedArtistArtworkModule {\n    artist {\n      name\n      href\n      id\n    }\n    basedOn {\n      name\n      href\n      id\n    }\n  }\n  ... on HomePageFollowedArtistArtworkModule {\n    artist {\n      href\n      id\n    }\n  }\n  ... on FollowArtists {\n    counts {\n      artists\n    }\n    artists {\n      href\n      name\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '071cd01e4b5a94b922694ffeba6ff41d';
+export default node;

--- a/src/v2/__generated__/HomeArtworkModuleContext_context.graphql.ts
+++ b/src/v2/__generated__/HomeArtworkModuleContext_context.graphql.ts
@@ -1,0 +1,236 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeArtworkModuleContext_context = {
+    readonly __typename: "Sale";
+    readonly href: string | null;
+    readonly liveStartAt: string | null;
+    readonly startAt: string | null;
+    readonly endAt: string | null;
+    readonly " $refType": "HomeArtworkModuleContext_context";
+} | {
+    readonly __typename: "Fair";
+    readonly href: string | null;
+    readonly exhibitionPeriod: string | null;
+    readonly " $refType": "HomeArtworkModuleContext_context";
+} | {
+    readonly __typename: "Gene";
+    readonly href: string | null;
+    readonly " $refType": "HomeArtworkModuleContext_context";
+} | {
+    readonly __typename: "HomePageRelatedArtistArtworkModule";
+    readonly artist: {
+        readonly name: string | null;
+        readonly href: string | null;
+    } | null;
+    readonly basedOn: {
+        readonly name: string | null;
+        readonly href: string | null;
+    } | null;
+    readonly " $refType": "HomeArtworkModuleContext_context";
+} | {
+    readonly __typename: "HomePageFollowedArtistArtworkModule";
+    readonly artist: {
+        readonly href: string | null;
+    } | null;
+    readonly " $refType": "HomeArtworkModuleContext_context";
+} | {
+    readonly __typename: "FollowArtists";
+    readonly counts: {
+        readonly artists: number | null;
+    } | null;
+    readonly artists: ReadonlyArray<{
+        readonly href: string | null;
+        readonly name: string | null;
+    } | null> | null;
+    readonly " $refType": "HomeArtworkModuleContext_context";
+} | {
+    /*This will never be '%other', but we need some
+    value in case none of the concrete values match.*/
+    readonly __typename: "%other";
+    readonly " $refType": "HomeArtworkModuleContext_context";
+};
+export type HomeArtworkModuleContext_context$data = HomeArtworkModuleContext_context;
+export type HomeArtworkModuleContext_context$key = {
+    readonly " $data"?: HomeArtworkModuleContext_context$data;
+    readonly " $fragmentRefs": FragmentRefs<"HomeArtworkModuleContext_context">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "MMM D"
+  }
+],
+v2 = [
+  (v0/*: any*/)
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = [
+  (v3/*: any*/),
+  (v0/*: any*/)
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "HomeArtworkModuleContext_context",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "__typename",
+      "storageKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        (v0/*: any*/),
+        {
+          "alias": null,
+          "args": (v1/*: any*/),
+          "kind": "ScalarField",
+          "name": "liveStartAt",
+          "storageKey": "liveStartAt(format:\"MMM D\")"
+        },
+        {
+          "alias": null,
+          "args": (v1/*: any*/),
+          "kind": "ScalarField",
+          "name": "startAt",
+          "storageKey": "startAt(format:\"MMM D\")"
+        },
+        {
+          "alias": null,
+          "args": (v1/*: any*/),
+          "kind": "ScalarField",
+          "name": "endAt",
+          "storageKey": "endAt(format:\"MMM D\")"
+        }
+      ],
+      "type": "Sale"
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        (v0/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "exhibitionPeriod",
+          "storageKey": null
+        }
+      ],
+      "type": "Fair"
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": (v2/*: any*/),
+      "type": "Gene"
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Artist",
+          "kind": "LinkedField",
+          "name": "artist",
+          "plural": false,
+          "selections": (v4/*: any*/),
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Artist",
+          "kind": "LinkedField",
+          "name": "basedOn",
+          "plural": false,
+          "selections": (v4/*: any*/),
+          "storageKey": null
+        }
+      ],
+      "type": "HomePageRelatedArtistArtworkModule"
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Artist",
+          "kind": "LinkedField",
+          "name": "artist",
+          "plural": false,
+          "selections": (v2/*: any*/),
+          "storageKey": null
+        }
+      ],
+      "type": "HomePageFollowedArtistArtworkModule"
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "FollowArtistCounts",
+          "kind": "LinkedField",
+          "name": "counts",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "artists",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Artist",
+          "kind": "LinkedField",
+          "name": "artists",
+          "plural": true,
+          "selections": [
+            (v0/*: any*/),
+            (v3/*: any*/)
+          ],
+          "storageKey": null
+        }
+      ],
+      "type": "FollowArtists"
+    }
+  ],
+  "type": "HomePageArtworkModuleContext"
+};
+})();
+(node as any).hash = '66f17120f8df3a09aa6bdde2eca3e82e';
+export default node;

--- a/src/v2/__generated__/HomeArtworkModuleRailQuery.graphql.ts
+++ b/src/v2/__generated__/HomeArtworkModuleRailQuery.graphql.ts
@@ -1,0 +1,840 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeArtworkModuleRailQueryVariables = {
+    key?: string | null;
+    id?: string | null;
+    relatedArtistID?: string | null;
+    followedArtistID?: string | null;
+};
+export type HomeArtworkModuleRailQueryResponse = {
+    readonly homePage: {
+        readonly artworkModule: {
+            readonly " $fragmentRefs": FragmentRefs<"HomeArtworkModuleRail_artworkModule">;
+        } | null;
+    } | null;
+};
+export type HomeArtworkModuleRailQuery = {
+    readonly response: HomeArtworkModuleRailQueryResponse;
+    readonly variables: HomeArtworkModuleRailQueryVariables;
+};
+
+
+
+/*
+query HomeArtworkModuleRailQuery(
+  $key: String
+  $id: String
+  $relatedArtistID: String
+  $followedArtistID: String
+) {
+  homePage {
+    artworkModule(key: $key, id: $id, relatedArtistID: $relatedArtistID, followedArtistID: $followedArtistID) {
+      ...HomeArtworkModuleRail_artworkModule
+      id
+    }
+  }
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+}
+
+fragment HomeArtworkModuleContext_context on HomePageArtworkModuleContext {
+  __typename
+  ... on Sale {
+    href
+    liveStartAt(format: "MMM D")
+    startAt(format: "MMM D")
+    endAt(format: "MMM D")
+  }
+  ... on Fair {
+    href
+    exhibitionPeriod
+  }
+  ... on Gene {
+    href
+  }
+  ... on HomePageRelatedArtistArtworkModule {
+    artist {
+      name
+      href
+      id
+    }
+    basedOn {
+      name
+      href
+      id
+    }
+  }
+  ... on HomePageFollowedArtistArtworkModule {
+    artist {
+      href
+      id
+    }
+  }
+  ... on FollowArtists {
+    counts {
+      artists
+    }
+    artists {
+      href
+      name
+      id
+    }
+  }
+}
+
+fragment HomeArtworkModuleRail_artworkModule on HomePageArtworkModule {
+  title
+  key
+  results {
+    ...ShelfArtwork_artwork
+    id
+  }
+  context {
+    __typename
+    ...HomeArtworkModuleContext_context
+    ... on Node {
+      id
+    }
+  }
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment SaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment ShelfArtwork_artwork on Artwork {
+  image {
+    resized(width: 200) {
+      src
+      srcSet
+      width
+      height
+    }
+    aspectRatio
+    height
+  }
+  imageTitle
+  title
+  href
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  ...Badge_artwork
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "key",
+    "type": "String"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id",
+    "type": "String"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "relatedArtistID",
+    "type": "String"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "followedArtistID",
+    "type": "String"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "followedArtistID",
+    "variableName": "followedArtistID"
+  },
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  },
+  {
+    "kind": "Variable",
+    "name": "key",
+    "variableName": "key"
+  },
+  {
+    "kind": "Variable",
+    "name": "relatedArtistID",
+    "variableName": "relatedArtistID"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "height",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v5 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v8 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v9 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "MMM D"
+  }
+],
+v10 = [
+  (v7/*: any*/),
+  (v4/*: any*/),
+  (v6/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "HomeArtworkModuleRailQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "HomePage",
+        "kind": "LinkedField",
+        "name": "homePage",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v1/*: any*/),
+            "concreteType": "HomePageArtworkModule",
+            "kind": "LinkedField",
+            "name": "artworkModule",
+            "plural": false,
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "HomeArtworkModuleRail_artworkModule"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "HomeArtworkModuleRailQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "HomePage",
+        "kind": "LinkedField",
+        "name": "homePage",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v1/*: any*/),
+            "concreteType": "HomePageArtworkModule",
+            "kind": "LinkedField",
+            "name": "artworkModule",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "key",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Artwork",
+                "kind": "LinkedField",
+                "name": "results",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "width",
+                            "value": 200
+                          }
+                        ],
+                        "concreteType": "ResizedImageUrl",
+                        "kind": "LinkedField",
+                        "name": "resized",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "src",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "srcSet",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "width",
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": "resized(width:200)"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "aspectRatio",
+                        "storageKey": null
+                      },
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "imageTitle",
+                    "storageKey": null
+                  },
+                  (v2/*: any*/),
+                  (v4/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "date",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "sale_message",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "saleMessage",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "cultural_maker",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "culturalMaker",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": (v5/*: any*/),
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "artists",
+                    "plural": true,
+                    "selections": [
+                      (v6/*: any*/),
+                      (v4/*: any*/),
+                      (v7/*: any*/)
+                    ],
+                    "storageKey": "artists(shallow:true)"
+                  },
+                  {
+                    "alias": "collecting_institution",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "collectingInstitution",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": (v5/*: any*/),
+                    "concreteType": "Partner",
+                    "kind": "LinkedField",
+                    "name": "partner",
+                    "plural": false,
+                    "selections": [
+                      (v7/*: any*/),
+                      (v4/*: any*/),
+                      (v6/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "type",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "partner(shallow:true)"
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Sale",
+                    "kind": "LinkedField",
+                    "name": "sale",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": "is_auction",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isAuction",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_closed",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isClosed",
+                        "storageKey": null
+                      },
+                      (v6/*: any*/),
+                      {
+                        "alias": "is_live_open",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isLiveOpen",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_open",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isOpen",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_preview",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isPreview",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "display_timely_at",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "displayTimelyAt",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "sale_artwork",
+                    "args": null,
+                    "concreteType": "SaleArtwork",
+                    "kind": "LinkedField",
+                    "name": "saleArtwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SaleArtworkCounts",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "bidder_positions",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "bidderPositions",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "highest_bid",
+                        "args": null,
+                        "concreteType": "SaleArtworkHighestBid",
+                        "kind": "LinkedField",
+                        "name": "highestBid",
+                        "plural": false,
+                        "selections": (v8/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "opening_bid",
+                        "args": null,
+                        "concreteType": "SaleArtworkOpeningBid",
+                        "kind": "LinkedField",
+                        "name": "openingBid",
+                        "plural": false,
+                        "selections": (v8/*: any*/),
+                        "storageKey": null
+                      },
+                      (v6/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "is_inquireable",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isInquireable",
+                    "storageKey": null
+                  },
+                  (v6/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "internalID",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "slug",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "is_saved",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isSaved",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "is_biddable",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isBiddable",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "context",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  (v6/*: any*/),
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": (v9/*: any*/),
+                        "kind": "ScalarField",
+                        "name": "liveStartAt",
+                        "storageKey": "liveStartAt(format:\"MMM D\")"
+                      },
+                      {
+                        "alias": null,
+                        "args": (v9/*: any*/),
+                        "kind": "ScalarField",
+                        "name": "startAt",
+                        "storageKey": "startAt(format:\"MMM D\")"
+                      },
+                      {
+                        "alias": null,
+                        "args": (v9/*: any*/),
+                        "kind": "ScalarField",
+                        "name": "endAt",
+                        "storageKey": "endAt(format:\"MMM D\")"
+                      }
+                    ],
+                    "type": "Sale"
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "exhibitionPeriod",
+                        "storageKey": null
+                      }
+                    ],
+                    "type": "Fair"
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v4/*: any*/)
+                    ],
+                    "type": "Gene"
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artist",
+                        "plural": false,
+                        "selections": (v10/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "basedOn",
+                        "plural": false,
+                        "selections": (v10/*: any*/),
+                        "storageKey": null
+                      }
+                    ],
+                    "type": "HomePageRelatedArtistArtworkModule"
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artist",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          (v6/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "type": "HomePageFollowedArtistArtworkModule"
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "FollowArtistCounts",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "artists",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artists",
+                        "plural": true,
+                        "selections": [
+                          (v4/*: any*/),
+                          (v7/*: any*/),
+                          (v6/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "type": "FollowArtists"
+                  }
+                ],
+                "storageKey": null
+              },
+              (v6/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "HomeArtworkModuleRailQuery",
+    "operationKind": "query",
+    "text": "query HomeArtworkModuleRailQuery(\n  $key: String\n  $id: String\n  $relatedArtistID: String\n  $followedArtistID: String\n) {\n  homePage {\n    artworkModule(key: $key, id: $id, relatedArtistID: $relatedArtistID, followedArtistID: $followedArtistID) {\n      ...HomeArtworkModuleRail_artworkModule\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment HomeArtworkModuleContext_context on HomePageArtworkModuleContext {\n  __typename\n  ... on Sale {\n    href\n    liveStartAt(format: \"MMM D\")\n    startAt(format: \"MMM D\")\n    endAt(format: \"MMM D\")\n  }\n  ... on Fair {\n    href\n    exhibitionPeriod\n  }\n  ... on Gene {\n    href\n  }\n  ... on HomePageRelatedArtistArtworkModule {\n    artist {\n      name\n      href\n      id\n    }\n    basedOn {\n      name\n      href\n      id\n    }\n  }\n  ... on HomePageFollowedArtistArtworkModule {\n    artist {\n      href\n      id\n    }\n  }\n  ... on FollowArtists {\n    counts {\n      artists\n    }\n    artists {\n      href\n      name\n      id\n    }\n  }\n}\n\nfragment HomeArtworkModuleRail_artworkModule on HomePageArtworkModule {\n  title\n  key\n  results {\n    ...ShelfArtwork_artwork\n    id\n  }\n  context {\n    __typename\n    ...HomeArtworkModuleContext_context\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  image {\n    resized(width: 200) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n"
+  }
+};
+})();
+(node as any).hash = 'e60fbd85d83306ee9e5e3d3c22cf46e3';
+export default node;

--- a/src/v2/__generated__/HomeArtworkModuleRail_artworkModule.graphql.ts
+++ b/src/v2/__generated__/HomeArtworkModuleRail_artworkModule.graphql.ts
@@ -1,0 +1,89 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeArtworkModuleRail_artworkModule = {
+    readonly title: string | null;
+    readonly key: string | null;
+    readonly results: ReadonlyArray<{
+        readonly " $fragmentRefs": FragmentRefs<"ShelfArtwork_artwork">;
+    } | null> | null;
+    readonly context: {
+        readonly __typename: string;
+        readonly " $fragmentRefs": FragmentRefs<"HomeArtworkModuleContext_context">;
+    } | null;
+    readonly " $refType": "HomeArtworkModuleRail_artworkModule";
+};
+export type HomeArtworkModuleRail_artworkModule$data = HomeArtworkModuleRail_artworkModule;
+export type HomeArtworkModuleRail_artworkModule$key = {
+    readonly " $data"?: HomeArtworkModuleRail_artworkModule$data;
+    readonly " $fragmentRefs": FragmentRefs<"HomeArtworkModuleRail_artworkModule">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "HomeArtworkModuleRail_artworkModule",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "key",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Artwork",
+      "kind": "LinkedField",
+      "name": "results",
+      "plural": true,
+      "selections": [
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "ShelfArtwork_artwork"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "context",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "__typename",
+          "storageKey": null
+        },
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "HomeArtworkModuleContext_context"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "HomePageArtworkModule"
+};
+(node as any).hash = 'd9316b2be561839830e72fa16dd4650a';
+export default node;

--- a/src/v2/__generated__/HomeArtworkModules_homePage.graphql.ts
+++ b/src/v2/__generated__/HomeArtworkModules_homePage.graphql.ts
@@ -1,0 +1,123 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeArtworkModules_homePage = {
+    readonly artworkModules: ReadonlyArray<{
+        readonly title: string | null;
+        readonly key: string | null;
+        readonly params: {
+            readonly internalID: string | null;
+            readonly relatedArtistID: string | null;
+            readonly followedArtistID: string | null;
+        } | null;
+    } | null> | null;
+    readonly " $refType": "HomeArtworkModules_homePage";
+};
+export type HomeArtworkModules_homePage$data = HomeArtworkModules_homePage;
+export type HomeArtworkModules_homePage$key = {
+    readonly " $data"?: HomeArtworkModules_homePage$data;
+    readonly " $fragmentRefs": FragmentRefs<"HomeArtworkModules_homePage">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "HomeArtworkModules_homePage",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "maxFollowedGeneRails",
+          "value": -1
+        },
+        {
+          "kind": "Literal",
+          "name": "maxRails",
+          "value": -1
+        },
+        {
+          "kind": "Literal",
+          "name": "order",
+          "value": [
+            "ACTIVE_BIDS",
+            "RECENTLY_VIEWED_WORKS",
+            "SIMILAR_TO_RECENTLY_VIEWED",
+            "SAVED_WORKS",
+            "SIMILAR_TO_SAVED_WORKS",
+            "FOLLOWED_ARTISTS",
+            "FOLLOWED_GALLERIES",
+            "RECOMMENDED_WORKS",
+            "RELATED_ARTISTS",
+            "LIVE_AUCTIONS",
+            "CURRENT_FAIRS",
+            "FOLLOWED_GENES",
+            "GENERIC_GENES"
+          ]
+        }
+      ],
+      "concreteType": "HomePageArtworkModule",
+      "kind": "LinkedField",
+      "name": "artworkModules",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "title",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "key",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "HomePageModulesParams",
+          "kind": "LinkedField",
+          "name": "params",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "internalID",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "relatedArtistID",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "followedArtistID",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "artworkModules(maxFollowedGeneRails:-1,maxRails:-1,order:[\"ACTIVE_BIDS\",\"RECENTLY_VIEWED_WORKS\",\"SIMILAR_TO_RECENTLY_VIEWED\",\"SAVED_WORKS\",\"SIMILAR_TO_SAVED_WORKS\",\"FOLLOWED_ARTISTS\",\"FOLLOWED_GALLERIES\",\"RECOMMENDED_WORKS\",\"RELATED_ARTISTS\",\"LIVE_AUCTIONS\",\"CURRENT_FAIRS\",\"FOLLOWED_GENES\",\"GENERIC_GENES\"])"
+    }
+  ],
+  "type": "HomePage"
+};
+(node as any).hash = 'bba750b3cf8adc7e51dbfe6b7f7e0cc0';
+export default node;

--- a/src/v2/__generated__/HomeFeaturedCategoriesRailQuery.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedCategoriesRailQuery.graphql.ts
@@ -1,0 +1,116 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeFeaturedCategoriesRailQueryVariables = {};
+export type HomeFeaturedCategoriesRailQueryResponse = {
+    readonly marketingHubCollections: ReadonlyArray<{
+        readonly " $fragmentRefs": FragmentRefs<"HomeFeaturedCategoriesRail_marketingCollections">;
+    }>;
+};
+export type HomeFeaturedCategoriesRailQuery = {
+    readonly response: HomeFeaturedCategoriesRailQueryResponse;
+    readonly variables: HomeFeaturedCategoriesRailQueryVariables;
+};
+
+
+
+/*
+query HomeFeaturedCategoriesRailQuery {
+  marketingHubCollections {
+    ...HomeFeaturedCategoriesRail_marketingCollections
+    id
+  }
+}
+
+fragment HomeFeaturedCategoriesRail_marketingCollections on MarketingCollection {
+  slug
+  title
+  thumbnail
+}
+*/
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "HomeFeaturedCategoriesRailQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "MarketingCollection",
+        "kind": "LinkedField",
+        "name": "marketingHubCollections",
+        "plural": true,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "HomeFeaturedCategoriesRail_marketingCollections"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "HomeFeaturedCategoriesRailQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "MarketingCollection",
+        "kind": "LinkedField",
+        "name": "marketingHubCollections",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "title",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "thumbnail",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "HomeFeaturedCategoriesRailQuery",
+    "operationKind": "query",
+    "text": "query HomeFeaturedCategoriesRailQuery {\n  marketingHubCollections {\n    ...HomeFeaturedCategoriesRail_marketingCollections\n    id\n  }\n}\n\nfragment HomeFeaturedCategoriesRail_marketingCollections on MarketingCollection {\n  slug\n  title\n  thumbnail\n}\n"
+  }
+};
+(node as any).hash = '66d9e324f7e944a3f069a7bd0a8589da';
+export default node;

--- a/src/v2/__generated__/HomeFeaturedCategoriesRail_marketingCollections.graphql.ts
+++ b/src/v2/__generated__/HomeFeaturedCategoriesRail_marketingCollections.graphql.ts
@@ -1,0 +1,53 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type HomeFeaturedCategoriesRail_marketingCollections = ReadonlyArray<{
+    readonly slug: string;
+    readonly title: string;
+    readonly thumbnail: string | null;
+    readonly " $refType": "HomeFeaturedCategoriesRail_marketingCollections";
+}>;
+export type HomeFeaturedCategoriesRail_marketingCollections$data = HomeFeaturedCategoriesRail_marketingCollections;
+export type HomeFeaturedCategoriesRail_marketingCollections$key = ReadonlyArray<{
+    readonly " $data"?: HomeFeaturedCategoriesRail_marketingCollections$data;
+    readonly " $fragmentRefs": FragmentRefs<"HomeFeaturedCategoriesRail_marketingCollections">;
+}>;
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "HomeFeaturedCategoriesRail_marketingCollections",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "thumbnail",
+      "storageKey": null
+    }
+  ],
+  "type": "MarketingCollection"
+};
+(node as any).hash = 'c7463c911981070e26e7cf97df7063c3';
+export default node;

--- a/src/v2/__generated__/homeRoutes_HomeQuery.graphql.ts
+++ b/src/v2/__generated__/homeRoutes_HomeQuery.graphql.ts
@@ -29,6 +29,20 @@ fragment HomeApp_homePage on HomePage {
     ...HomeHeroUnit_heroUnit
     id
   }
+  ...HomeArtworkModules_homePage
+}
+
+fragment HomeArtworkModules_homePage on HomePage {
+  artworkModules(maxRails: -1, maxFollowedGeneRails: -1, order: [ACTIVE_BIDS, RECENTLY_VIEWED_WORKS, SIMILAR_TO_RECENTLY_VIEWED, SAVED_WORKS, SIMILAR_TO_SAVED_WORKS, FOLLOWED_ARTISTS, FOLLOWED_GALLERIES, RECOMMENDED_WORKS, RELATED_ARTISTS, LIVE_AUCTIONS, CURRENT_FAIRS, FOLLOWED_GENES, GENERIC_GENES]) {
+    title
+    key
+    params {
+      internalID
+      relatedArtistID
+      followedArtistID
+    }
+    id
+  }
 }
 
 fragment HomeHeroUnit_heroUnit on HomePageHeroUnit {
@@ -42,7 +56,29 @@ fragment HomeHeroUnit_heroUnit on HomePageHeroUnit {
 }
 */
 
-const node: ConcreteRequest = {
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
   "fragment": {
     "argumentDefinitions": [],
     "kind": "Fragment",
@@ -96,13 +132,7 @@ const node: ConcreteRequest = {
             "name": "heroUnits",
             "plural": true,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "internalID",
-                "storageKey": null
-              },
+              (v0/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -117,13 +147,7 @@ const node: ConcreteRequest = {
                 "name": "heading",
                 "storageKey": null
               },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "title",
-                "storageKey": null
-              },
+              (v1/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -152,15 +176,85 @@ const node: ConcreteRequest = {
                 "name": "creditLine",
                 "storageKey": null
               },
+              (v2/*: any*/)
+            ],
+            "storageKey": "heroUnits(platform:\"DESKTOP\")"
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "maxFollowedGeneRails",
+                "value": -1
+              },
+              {
+                "kind": "Literal",
+                "name": "maxRails",
+                "value": -1
+              },
+              {
+                "kind": "Literal",
+                "name": "order",
+                "value": [
+                  "ACTIVE_BIDS",
+                  "RECENTLY_VIEWED_WORKS",
+                  "SIMILAR_TO_RECENTLY_VIEWED",
+                  "SAVED_WORKS",
+                  "SIMILAR_TO_SAVED_WORKS",
+                  "FOLLOWED_ARTISTS",
+                  "FOLLOWED_GALLERIES",
+                  "RECOMMENDED_WORKS",
+                  "RELATED_ARTISTS",
+                  "LIVE_AUCTIONS",
+                  "CURRENT_FAIRS",
+                  "FOLLOWED_GENES",
+                  "GENERIC_GENES"
+                ]
+              }
+            ],
+            "concreteType": "HomePageArtworkModule",
+            "kind": "LinkedField",
+            "name": "artworkModules",
+            "plural": true,
+            "selections": [
+              (v1/*: any*/),
               {
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
-                "name": "id",
+                "name": "key",
                 "storageKey": null
-              }
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "HomePageModulesParams",
+                "kind": "LinkedField",
+                "name": "params",
+                "plural": false,
+                "selections": [
+                  (v0/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "relatedArtistID",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "followedArtistID",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v2/*: any*/)
             ],
-            "storageKey": "heroUnits(platform:\"DESKTOP\")"
+            "storageKey": "artworkModules(maxFollowedGeneRails:-1,maxRails:-1,order:[\"ACTIVE_BIDS\",\"RECENTLY_VIEWED_WORKS\",\"SIMILAR_TO_RECENTLY_VIEWED\",\"SAVED_WORKS\",\"SIMILAR_TO_SAVED_WORKS\",\"FOLLOWED_ARTISTS\",\"FOLLOWED_GALLERIES\",\"RECOMMENDED_WORKS\",\"RELATED_ARTISTS\",\"LIVE_AUCTIONS\",\"CURRENT_FAIRS\",\"FOLLOWED_GENES\",\"GENERIC_GENES\"])"
           }
         ],
         "storageKey": null
@@ -172,8 +266,9 @@ const node: ConcreteRequest = {
     "metadata": {},
     "name": "homeRoutes_HomeQuery",
     "operationKind": "query",
-    "text": "query homeRoutes_HomeQuery {\n  homePage {\n    ...HomeApp_homePage\n  }\n}\n\nfragment HomeApp_homePage on HomePage {\n  heroUnits(platform: DESKTOP) {\n    internalID\n    ...HomeHeroUnit_heroUnit\n    id\n  }\n}\n\nfragment HomeHeroUnit_heroUnit on HomePageHeroUnit {\n  backgroundImageURL\n  heading\n  title\n  subtitle\n  linkText\n  href\n  creditLine\n}\n"
+    "text": "query homeRoutes_HomeQuery {\n  homePage {\n    ...HomeApp_homePage\n  }\n}\n\nfragment HomeApp_homePage on HomePage {\n  heroUnits(platform: DESKTOP) {\n    internalID\n    ...HomeHeroUnit_heroUnit\n    id\n  }\n  ...HomeArtworkModules_homePage\n}\n\nfragment HomeArtworkModules_homePage on HomePage {\n  artworkModules(maxRails: -1, maxFollowedGeneRails: -1, order: [ACTIVE_BIDS, RECENTLY_VIEWED_WORKS, SIMILAR_TO_RECENTLY_VIEWED, SAVED_WORKS, SIMILAR_TO_SAVED_WORKS, FOLLOWED_ARTISTS, FOLLOWED_GALLERIES, RECOMMENDED_WORKS, RELATED_ARTISTS, LIVE_AUCTIONS, CURRENT_FAIRS, FOLLOWED_GENES, GENERIC_GENES]) {\n    title\n    key\n    params {\n      internalID\n      relatedArtistID\n      followedArtistID\n    }\n    id\n  }\n}\n\nfragment HomeHeroUnit_heroUnit on HomePageHeroUnit {\n  backgroundImageURL\n  heading\n  title\n  subtitle\n  linkText\n  href\n  creditLine\n}\n"
   }
 };
+})();
 (node as any).hash = '83fb37cbb8d89ef7ca1795aabc613ed6';
 export default node;


### PR DESCRIPTION
This PR gets a bunch of the artwork rails on the page:

https://user-images.githubusercontent.com/112297/122962707-ad68b980-d353-11eb-89f6-62dac59f150e.mov

-----

Remaining:
- [ ] Shows grid
- [ ] Articles grid
- [ ]  `active_bids` module
- [ ] `followed_artists` module
- [ ] `followed_galleries` module
- [ ] `popular_artists` module

I think some of those modules might be artwork rails as well; I just haven't tracked them down yet.
