### PR TITLE
Render “respond-to/confirm offer” page in modal

### DIFF
--- a/src/v2/Apps/Conversation/Components/ConversationCTA.tsx
+++ b/src/v2/Apps/Conversation/Components/ConversationCTA.tsx
@@ -10,11 +10,13 @@ import { useSystemContext } from "v2/System/useSystemContext"
 interface ConversationCTAProps {
   conversation: ConversationCTA_conversation
   openInquiryModal: () => void
+  openOrderModal: () => void
 }
 
 export const ConversationCTA: React.FC<ConversationCTAProps> = ({
   conversation,
   openInquiryModal,
+  openOrderModal,
 }) => {
   // Determine whether we have a conversation about an artwork
 
@@ -51,6 +53,7 @@ export const ConversationCTA: React.FC<ConversationCTAProps> = ({
           kind={kind}
           activeOrder={activeOrder}
           conversationID={conversationID}
+          openOrderModal={() => openOrderModal()}
         />
       )
     }

--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -178,7 +178,7 @@ export const Details: FC<DetailsProps> = ({
               <a href={item.href}>
                 <Box height="80px" width="80px">
                   {/* @ts-expect-error STRICT_NULL_CHECK */}
-                  <ResponsiveImage src={item.image.thumbnailUrl} />
+                  <ResponsiveImage src={item.image?.thumbnailUrl} />
                 </Box>
               </a>
               <Flex flexDirection="column" ml={1}>

--- a/src/v2/Apps/Conversation/Components/OrderModal.tsx
+++ b/src/v2/Apps/Conversation/Components/OrderModal.tsx
@@ -1,0 +1,32 @@
+import { Modal, ModalWidth } from "@artsy/palette"
+import React from "react"
+import styled from "styled-components"
+
+export const StyledIframe = styled("iframe")`
+  height: 60vh;
+  border: none;
+`
+
+export interface OrderModalProps {
+  show: boolean
+  closeModal: () => void
+  title: string
+  path: string
+  orderID: string
+}
+
+export const OrderModal: React.FC<OrderModalProps> = ({
+  show,
+  closeModal,
+  title,
+  path,
+}) => (
+  <Modal
+    modalWidth={ModalWidth.Wide}
+    show={show}
+    onClose={closeModal}
+    title={title}
+  >
+    <StyledIframe src={`${path}?isModal=true`}></StyledIframe>
+  </Modal>
+)

--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -64,10 +64,17 @@ interface ReplyProps {
   onScroll?: () => void
   refetch: RelayRefetchProp["refetch"]
   openInquiryModal: () => void
+  openOrderModal: () => void
 }
 
 export const Reply: React.FC<ReplyProps> = props => {
-  const { environment, conversation, onScroll, openInquiryModal } = props
+  const {
+    environment,
+    conversation,
+    onScroll,
+    openInquiryModal,
+    openOrderModal,
+  } = props
   const [buttonDisabled, setButtonDisabled] = useState(true)
   const [loading, setLoading] = useState(false)
   const [showModal, setShowModal] = useState(false)
@@ -146,6 +153,7 @@ export const Reply: React.FC<ReplyProps> = props => {
         <ConversationCTAFragmentContainer
           conversation={conversation}
           openInquiryModal={() => openInquiryModal()}
+          openOrderModal={() => openOrderModal()}
         />
         <StyledFlex p={1}>
           <FullWidthFlex width="100%">

--- a/src/v2/Apps/Conversation/Components/ReviewOfferCTA.tsx
+++ b/src/v2/Apps/Conversation/Components/ReviewOfferCTA.tsx
@@ -14,7 +14,6 @@ import React from "react"
 import styled from "styled-components"
 import { useTracking } from "react-tracking"
 import { CommerceBuyerOfferActionEnum } from "v2/__generated__/ConversationCTA_conversation.graphql"
-import { useRouter } from "v2/System/Router/useRouter"
 
 export const ClickableFlex = styled(Flex)`
   cursor: pointer;
@@ -24,19 +23,20 @@ export interface ReviewOfferCTAProps {
   conversationID: string
   kind: CommerceBuyerOfferActionEnum
   activeOrder: {
-    internalID: string
     stateExpiresAt: string | null
     lastOffer?: { createdAt: string } | null
     offers?: { edges: { length: number } | null } | null
   }
+  openOrderModal: () => void
 }
 
 export const ReviewOfferCTA: React.FC<ReviewOfferCTAProps> = ({
   conversationID,
   activeOrder,
   kind,
+  openOrderModal,
 }) => {
-  const { internalID: orderID, offers } = activeOrder
+  const { offers } = activeOrder
   const { trackEvent } = useTracking()
 
   const { hoursTillEnd, minutes } = useEventTiming({
@@ -54,8 +54,6 @@ export const ReviewOfferCTA: React.FC<ReviewOfferCTAProps> = ({
     message: string
     subMessage: string
     Icon: React.FC<IconProps>
-    url: string
-    modalTitle: string
   }
 
   switch (kind) {
@@ -66,8 +64,6 @@ export const ReviewOfferCTA: React.FC<ReviewOfferCTAProps> = ({
         subMessage:
           "Unable to process payment for accepted offer. Update payment method.",
         Icon: AlertCircleFillIcon,
-        url: `/orders/${orderID}/payment/new`,
-        modalTitle: "Update Payment Details",
       }
       break
     }
@@ -77,8 +73,6 @@ export const ReviewOfferCTA: React.FC<ReviewOfferCTAProps> = ({
         message: `${offerType} Received`,
         subMessage: `The offer expires in ${expiresIn}`,
         Icon: AlertCircleFillIcon,
-        url: `/orders/${orderID}`,
-        modalTitle: "Review Offer",
       }
       break
     }
@@ -88,8 +82,6 @@ export const ReviewOfferCTA: React.FC<ReviewOfferCTAProps> = ({
         message: `Congratulations! ${offerType} Accepted`,
         subMessage: "Tap to view",
         Icon: MoneyFillIcon,
-        url: `/orders/${orderID}`,
-        modalTitle: "Offer Accepted",
       }
       break
     }
@@ -99,8 +91,6 @@ export const ReviewOfferCTA: React.FC<ReviewOfferCTAProps> = ({
         message: `Offer Accepted - Confirm total`,
         subMessage: `The offer expires in ${expiresIn}`,
         Icon: AlertCircleFillIcon,
-        url: `/orders/${orderID}`,
-        modalTitle: "Review Offer",
       }
       break
     }
@@ -110,8 +100,6 @@ export const ReviewOfferCTA: React.FC<ReviewOfferCTAProps> = ({
         message: `Counteroffer Received - Confirm Total`,
         subMessage: `The offer expires in ${expiresIn}`,
         Icon: AlertCircleFillIcon,
-        url: `/orders/${orderID}`,
-        modalTitle: "Review Offer",
       }
       break
     }
@@ -121,8 +109,6 @@ export const ReviewOfferCTA: React.FC<ReviewOfferCTAProps> = ({
         message: `Offer Accepted`,
         subMessage: "Tap to view",
         Icon: MoneyFillIcon,
-        url: `/orders/${orderID}`,
-        modalTitle: "Offer Accepted",
       }
       break
     }
@@ -132,54 +118,47 @@ export const ReviewOfferCTA: React.FC<ReviewOfferCTAProps> = ({
     }
   }
 
-  const {
-    message,
-    subMessage,
-    backgroundColor,
-    Icon,
-    url,
-    modalTitle,
-  } = ctaAttributes
+  const { message, subMessage, backgroundColor, Icon } = ctaAttributes
 
-  const navigateToConversation = (path: string, title: string) => {
+  const openModal = () => {
     trackEvent(
       tappedViewOffer({
         impulse_conversation_id: conversationID,
         cta: message,
       })
     )
-
-    const { router } = useRouter()
-    router.push(`${path}?orderID=foo&title=bar`)
+    openOrderModal()
   }
 
   return (
-    <ClickableFlex
-      px={2}
-      py={1}
-      justifyContent="space-between"
-      alignItems="center"
-      bg={backgroundColor}
-      flexDirection="row"
-      minHeight={60}
-      onClick={() => {
-        navigateToConversation(url, modalTitle)
-      }}
-    >
-      <Flex flexDirection="row">
-        <Icon mt="3px" fill="white100" />
-        <Flex flexDirection="column" pl={1}>
-          <Text color="white100" variant="mediumText">
-            {message}
-          </Text>
-          <Text color="white100" variant="caption">
-            {subMessage}
-          </Text>
+    <>
+      <ClickableFlex
+        px={2}
+        py={1}
+        justifyContent="space-between"
+        alignItems="center"
+        bg={backgroundColor}
+        flexDirection="row"
+        minHeight={60}
+        onClick={() => {
+          openModal()
+        }}
+      >
+        <Flex flexDirection="row">
+          <Icon mt="3px" fill="white100" />
+          <Flex flexDirection="column" pl={1}>
+            <Text color="white100" variant="mediumText">
+              {message}
+            </Text>
+            <Text color="white100" variant="caption">
+              {subMessage}
+            </Text>
+          </Flex>
         </Flex>
-      </Flex>
-      <Flex>
-        <ArrowRightIcon fill="white100" />
-      </Flex>
-    </ClickableFlex>
+        <Flex>
+          <ArrowRightIcon fill="white100" />
+        </Flex>
+      </ClickableFlex>
+    </>
   )
 }

--- a/src/v2/Apps/Conversation/Components/__tests__/ConversationCTA.jest.tsx
+++ b/src/v2/Apps/Conversation/Components/__tests__/ConversationCTA.jest.tsx
@@ -16,6 +16,7 @@ describe("ConversationCTA", () => {
         <ConversationCTAFragmentContainer
           conversation={props.me.conversation}
           openInquiryModal={jest.fn()}
+          openOrderModal={jest.fn()}
         />
       )
     },
@@ -158,5 +159,20 @@ describe("ConversationCTA", () => {
     })
 
     expect(wrapper.find("ReviewOfferCTA").length).toBe(0)
+  })
+
+  it("clicking the review offer CTA opens the order modal", () => {
+    const wrapper = getWrapper({
+      Conversation: () => ({
+        activeOrders: {
+          edges: [{ node: { buyerAction: "OFFER_RECEIVED" } }],
+        },
+      }),
+    })
+    wrapper.find("ReviewOfferCTA").simulate("click")
+
+    setTimeout(() => {
+      expect(wrapper.find("StyledIframe").length).toBe(1)
+    }, 0)
   })
 })

--- a/src/v2/Apps/Conversation/Utils/returnOrderModalDetails.tsx
+++ b/src/v2/Apps/Conversation/Utils/returnOrderModalDetails.tsx
@@ -1,0 +1,71 @@
+import { CommerceBuyerOfferActionEnum } from "v2/__generated__/ConversationCTA_conversation.graphql"
+
+export const returnOrderModalDetails = ({
+  kind,
+  orderID,
+}: {
+  kind: CommerceBuyerOfferActionEnum
+  orderID: string
+}) => {
+  let ctaAttributes: {
+    url: string
+    modalTitle: string
+  }
+
+  switch (kind) {
+    case "PAYMENT_FAILED": {
+      ctaAttributes = {
+        url: `/orders/${orderID}/payment/new`,
+        modalTitle: "Update Payment Details",
+      }
+      break
+    }
+    case "OFFER_RECEIVED": {
+      ctaAttributes = {
+        url: `/orders/${orderID}/respond`,
+        modalTitle: "Review Offer",
+      }
+      break
+    }
+    case "OFFER_ACCEPTED": {
+      ctaAttributes = {
+        url: `/orders/${orderID}/status`,
+        modalTitle: "Offer Accepted",
+      }
+      break
+    }
+    case "OFFER_ACCEPTED_CONFIRM_NEEDED": {
+      ctaAttributes = {
+        url: `/orders/${orderID}/respond`,
+        modalTitle: "Review Offer",
+      }
+      break
+    }
+    case "OFFER_RECEIVED_CONFIRM_NEEDED": {
+      ctaAttributes = {
+        url: `/orders/${orderID}/respond`,
+        modalTitle: "Review Offer",
+      }
+      break
+    }
+    case "PROVISIONAL_OFFER_ACCEPTED": {
+      ctaAttributes = {
+        url: `/orders/${orderID}/status`,
+        modalTitle: "Offer Accepted",
+      }
+      break
+    }
+    default: {
+      // this should never happen
+      // return null
+      return {}
+    }
+  }
+
+  const { url, modalTitle } = ctaAttributes
+
+  return {
+    url,
+    modalTitle,
+  }
+}

--- a/src/v2/Apps/Conversation/__tests__/Reply.jest.tsx
+++ b/src/v2/Apps/Conversation/__tests__/Reply.jest.tsx
@@ -34,6 +34,9 @@ describe("Reply", () => {
           openInquiryModal={() => {
             jest.fn
           }}
+          openOrderModal={() => {
+            jest.fn
+          }}
           environment={{} as Environment}
           refetch={() => ({ dispose: jest.fn })}
         />

--- a/src/v2/Apps/Order/OrderApp.tsx
+++ b/src/v2/Apps/Order/OrderApp.tsx
@@ -125,18 +125,22 @@ class OrderApp extends React.Component<OrderAppProps, {}> {
     }
 
     const stripePromise = loadStripe(sd.STRIPE_PUBLISHABLE_KEY)
+
+    const isModal = this.props.match?.location.query.isModal ? true : false
+
     return (
       <SystemContextConsumer>
         {({ isEigen, mediator }) => {
           // @ts-expect-error STRICT_NULL_CHECK
           this.mediator = mediator
+
           return (
             <Box>
               {/* FIXME: remove once we refactor out legacy backbone code.
-                  Add place to attach legacy flash message, used in legacy inquiry flow
-              */}
+                    Add place to attach legacy flash message, used in legacy inquiry flow
+                */}
               <div id="main-layout-flash" />
-              <MinimalNavBar to={artworkHref}>
+              <MinimalNavBar to={artworkHref} isBlank={isModal}>
                 <Title>Checkout | Artsy</Title>
                 {isEigen ? (
                   <Meta
@@ -157,7 +161,9 @@ class OrderApp extends React.Component<OrderAppProps, {}> {
                     </AppContainer>
                   </Elements>
                 </SafeAreaContainer>
-                <StickyFooter orderType={order.mode} artworkId={artworkId} />
+                {!isModal && (
+                  <StickyFooter orderType={order.mode} artworkId={artworkId} />
+                )}
                 <ConnectedModalDialog />
               </MinimalNavBar>
             </Box>

--- a/src/v2/Components/NavBar/MinimalNavBar.tsx
+++ b/src/v2/Components/NavBar/MinimalNavBar.tsx
@@ -6,6 +6,7 @@ import { useSystemContext } from "v2/System"
 interface MinimalNavBarProps {
   to: string
   children: React.ReactNode
+  isBlank?: boolean
 }
 
 export const MinimalNavBar: React.FC<MinimalNavBarProps> = props => {
@@ -20,7 +21,7 @@ export const MinimalNavBar: React.FC<MinimalNavBarProps> = props => {
       width="100%"
       pt={4}
     >
-      {!isEigen && (
+      {!props.isBlank && !isEigen && (
         <Box height={70} px={[2, 4]}>
           <RouterLink
             to={props.to}

--- a/src/v2/__generated__/ConversationPageQuery.graphql.ts
+++ b/src/v2/__generated__/ConversationPageQuery.graphql.ts
@@ -182,6 +182,18 @@ fragment Conversation_conversation on Conversation {
   initialMessage
   lastMessageID
   unread
+  orderConnection(first: 10, states: [APPROVED, FULFILLED, SUBMITTED, REFUNDED]) {
+    edges {
+      node {
+        __typename
+        internalID
+        ... on CommerceOfferOrder {
+          buyerAction
+        }
+        id
+      }
+    }
+  }
   messagesConnection(first: 30, sort: DESC) {
     pageInfo {
       startCursor
@@ -507,6 +519,30 @@ v19 = [
   {
     "kind": "Literal",
     "name": "first",
+    "value": 10
+  },
+  {
+    "kind": "Literal",
+    "name": "states",
+    "value": [
+      "APPROVED",
+      "FULFILLED",
+      "SUBMITTED",
+      "REFUNDED"
+    ]
+  }
+],
+v20 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "buyerAction",
+  "storageKey": null
+},
+v21 = [
+  {
+    "kind": "Literal",
+    "name": "first",
     "value": 30
   },
   {
@@ -515,14 +551,14 @@ v19 = [
     "value": "DESC"
   }
 ],
-v20 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v21 = {
+v23 = {
   "alias": "thumbnailUrl",
   "args": [
     {
@@ -535,7 +571,7 @@ v21 = {
   "name": "url",
   "storageKey": "url(version:\"small\")"
 },
-v22 = [
+v24 = [
   {
     "alias": null,
     "args": null,
@@ -544,7 +580,7 @@ v22 = [
     "storageKey": null
   }
 ],
-v23 = [
+v25 = [
   {
     "kind": "Literal",
     "name": "shallow",
@@ -812,6 +848,49 @@ return {
               {
                 "alias": null,
                 "args": (v19/*: any*/),
+                "concreteType": "CommerceOrderConnectionWithTotalCount",
+                "kind": "LinkedField",
+                "name": "orderConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "CommerceOrderEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v8/*: any*/),
+                          (v4/*: any*/),
+                          (v3/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v20/*: any*/)
+                            ],
+                            "type": "CommerceOfferOrder"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "orderConnection(first:10,states:[\"APPROVED\",\"FULFILLED\",\"SUBMITTED\",\"REFUNDED\"])"
+              },
+              {
+                "alias": null,
+                "args": (v21/*: any*/),
                 "concreteType": "MessageConnection",
                 "kind": "LinkedField",
                 "name": "messagesConnection",
@@ -930,7 +1009,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v19/*: any*/),
+                "args": (v21/*: any*/),
                 "filters": [],
                 "handle": "connection",
                 "key": "Messages_messagesConnection",
@@ -962,7 +1041,7 @@ return {
                           (v9/*: any*/),
                           (v10/*: any*/),
                           (v11/*: any*/),
-                          (v20/*: any*/),
+                          (v22/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -993,7 +1072,7 @@ return {
                                 "name": "url",
                                 "storageKey": "url(version:[\"large\"])"
                               },
-                              (v21/*: any*/)
+                              (v23/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1008,12 +1087,12 @@ return {
                               (v8/*: any*/),
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v22/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "type": "Money"
                               },
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v22/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "type": "PriceRange"
                               }
                             ],
@@ -1035,14 +1114,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v23/*: any*/),
+                            "args": (v25/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v3/*: any*/),
-                              (v20/*: any*/),
+                              (v22/*: any*/),
                               (v5/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -1056,14 +1135,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v23/*: any*/),
+                            "args": (v25/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v5/*: any*/),
-                              (v20/*: any*/),
+                              (v22/*: any*/),
                               (v3/*: any*/),
                               {
                                 "alias": null,
@@ -1148,7 +1227,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v22/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -1158,7 +1237,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v22/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "storageKey": null
                               },
                               (v3/*: any*/)
@@ -1217,7 +1296,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v20/*: any*/),
+                          (v22/*: any*/),
                           (v5/*: any*/),
                           (v13/*: any*/),
                           {
@@ -1228,7 +1307,7 @@ return {
                             "name": "coverImage",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/)
+                              (v23/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -1243,23 +1322,7 @@ return {
               },
               {
                 "alias": "activeOrders",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "first",
-                    "value": 10
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "states",
-                    "value": [
-                      "APPROVED",
-                      "FULFILLED",
-                      "SUBMITTED",
-                      "REFUNDED"
-                    ]
-                  }
-                ],
+                "args": (v19/*: any*/),
                 "concreteType": "CommerceOrderConnectionWithTotalCount",
                 "kind": "LinkedField",
                 "name": "orderConnection",
@@ -1308,13 +1371,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "buyerAction",
-                                "storageKey": null
-                              },
+                              (v20/*: any*/),
                               {
                                 "alias": null,
                                 "args": [
@@ -1382,7 +1439,7 @@ return {
     "metadata": {},
     "name": "ConversationPageQuery",
     "operationKind": "query",
-    "text": "query ConversationPageQuery(\n  $conversationID: String!\n) {\n  me {\n    ...Conversation_me_3oGfhn\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment ConversationCTA_conversation on Conversation {\n  internalID\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        internalID\n        isOfferableFromInquiry\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  activeOrders: orderConnection(first: 10, states: [APPROVED, FULFILLED, SUBMITTED, REFUNDED]) {\n    edges {\n      node {\n        __typename\n        internalID\n        state\n        stateReason\n        stateExpiresAt\n        ... on CommerceOfferOrder {\n          buyerAction\n          offers(first: 5) {\n            edges {\n              node {\n                internalID\n                id\n              }\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ConversationList_me on Me {\n  conversationsConnection(first: 25) {\n    edges {\n      cursor\n      node {\n        id\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment ConversationMessages_messages on MessageConnection {\n  edges {\n    node {\n      id\n      internalID\n      createdAt\n      isFromUser\n      body\n      ...Message_message\n    }\n  }\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversation_conversation on Conversation {\n  id\n  internalID\n  from {\n    name\n    email\n    id\n  }\n  to {\n    name\n    initials\n    id\n  }\n  initialMessage\n  lastMessageID\n  unread\n  messagesConnection(first: 30, sort: DESC) {\n    pageInfo {\n      startCursor\n      endCursor\n      hasPreviousPage\n      hasNextPage\n    }\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    ...ConversationMessages_messages\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        internalID\n        id\n        date\n        title\n        artistNames\n        href\n        isOfferableFromInquiry\n        image {\n          url(version: [\"large\"])\n        }\n        listPrice {\n          __typename\n          ... on Money {\n            display\n          }\n          ... on PriceRange {\n            display\n          }\n        }\n      }\n      ... on Show {\n        id\n        fair {\n          name\n          exhibitionPeriod\n          location {\n            city\n            id\n          }\n          id\n        }\n        href\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  ...ConversationCTA_conversation\n}\n\nfragment Conversation_me_3oGfhn on Me {\n  ...ConversationList_me\n  conversation(id: $conversationID) {\n    internalID\n    ...Conversation_conversation\n    ...ConversationCTA_conversation\n    ...Details_conversation\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Details_conversation on Conversation {\n  to {\n    name\n    initials\n    id\n  }\n  messagesConnection(first: 30, sort: DESC) {\n    edges {\n      node {\n        attachments {\n          id\n          contentType\n          fileName\n          downloadURL\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        href\n        ...Metadata_artwork\n        image {\n          thumbnailUrl: url(version: \"small\")\n        }\n      }\n      ... on Show {\n        href\n        image: coverImage {\n          thumbnailUrl: url(version: \"small\")\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    contentType\n    fileName\n    downloadURL\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n"
+    "text": "query ConversationPageQuery(\n  $conversationID: String!\n) {\n  me {\n    ...Conversation_me_3oGfhn\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment ConversationCTA_conversation on Conversation {\n  internalID\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        internalID\n        isOfferableFromInquiry\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  activeOrders: orderConnection(first: 10, states: [APPROVED, FULFILLED, SUBMITTED, REFUNDED]) {\n    edges {\n      node {\n        __typename\n        internalID\n        state\n        stateReason\n        stateExpiresAt\n        ... on CommerceOfferOrder {\n          buyerAction\n          offers(first: 5) {\n            edges {\n              node {\n                internalID\n                id\n              }\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ConversationList_me on Me {\n  conversationsConnection(first: 25) {\n    edges {\n      cursor\n      node {\n        id\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment ConversationMessages_messages on MessageConnection {\n  edges {\n    node {\n      id\n      internalID\n      createdAt\n      isFromUser\n      body\n      ...Message_message\n    }\n  }\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversation_conversation on Conversation {\n  id\n  internalID\n  from {\n    name\n    email\n    id\n  }\n  to {\n    name\n    initials\n    id\n  }\n  initialMessage\n  lastMessageID\n  unread\n  orderConnection(first: 10, states: [APPROVED, FULFILLED, SUBMITTED, REFUNDED]) {\n    edges {\n      node {\n        __typename\n        internalID\n        ... on CommerceOfferOrder {\n          buyerAction\n        }\n        id\n      }\n    }\n  }\n  messagesConnection(first: 30, sort: DESC) {\n    pageInfo {\n      startCursor\n      endCursor\n      hasPreviousPage\n      hasNextPage\n    }\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    ...ConversationMessages_messages\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        internalID\n        id\n        date\n        title\n        artistNames\n        href\n        isOfferableFromInquiry\n        image {\n          url(version: [\"large\"])\n        }\n        listPrice {\n          __typename\n          ... on Money {\n            display\n          }\n          ... on PriceRange {\n            display\n          }\n        }\n      }\n      ... on Show {\n        id\n        fair {\n          name\n          exhibitionPeriod\n          location {\n            city\n            id\n          }\n          id\n        }\n        href\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  ...ConversationCTA_conversation\n}\n\nfragment Conversation_me_3oGfhn on Me {\n  ...ConversationList_me\n  conversation(id: $conversationID) {\n    internalID\n    ...Conversation_conversation\n    ...ConversationCTA_conversation\n    ...Details_conversation\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Details_conversation on Conversation {\n  to {\n    name\n    initials\n    id\n  }\n  messagesConnection(first: 30, sort: DESC) {\n    edges {\n      node {\n        attachments {\n          id\n          contentType\n          fileName\n          downloadURL\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        href\n        ...Metadata_artwork\n        image {\n          thumbnailUrl: url(version: \"small\")\n        }\n      }\n      ... on Show {\n        href\n        image: coverImage {\n          thumbnailUrl: url(version: \"small\")\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    contentType\n    fileName\n    downloadURL\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/ConversationPaginationQuery.graphql.ts
+++ b/src/v2/__generated__/ConversationPaginationQuery.graphql.ts
@@ -101,6 +101,18 @@ fragment Conversation_conversation_2QE1um on Conversation {
   initialMessage
   lastMessageID
   unread
+  orderConnection(first: 10, states: [APPROVED, FULFILLED, SUBMITTED, REFUNDED]) {
+    edges {
+      node {
+        __typename
+        internalID
+        ... on CommerceOfferOrder {
+          buyerAction
+        }
+        id
+      }
+    }
+  }
   messagesConnection(first: $count, after: $after, sort: DESC) {
     pageInfo {
       startCursor
@@ -253,6 +265,30 @@ v7 = {
   "storageKey": null
 },
 v8 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  },
+  {
+    "kind": "Literal",
+    "name": "states",
+    "value": [
+      "APPROVED",
+      "FULFILLED",
+      "SUBMITTED",
+      "REFUNDED"
+    ]
+  }
+],
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "buyerAction",
+  "storageKey": null
+},
+v10 = [
   (v2/*: any*/),
   {
     "kind": "Variable",
@@ -265,14 +301,14 @@ v8 = [
     "value": "DESC"
   }
 ],
-v9 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v10 = [
+v12 = [
   {
     "alias": null,
     "args": null,
@@ -392,6 +428,49 @@ return {
               {
                 "alias": null,
                 "args": (v8/*: any*/),
+                "concreteType": "CommerceOrderConnectionWithTotalCount",
+                "kind": "LinkedField",
+                "name": "orderConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "CommerceOrderEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v3/*: any*/),
+                          (v5/*: any*/),
+                          (v4/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v9/*: any*/)
+                            ],
+                            "type": "CommerceOfferOrder"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "orderConnection(first:10,states:[\"APPROVED\",\"FULFILLED\",\"SUBMITTED\",\"REFUNDED\"])"
+              },
+              {
+                "alias": null,
+                "args": (v10/*: any*/),
                 "concreteType": "MessageConnection",
                 "kind": "LinkedField",
                 "name": "messagesConnection",
@@ -540,7 +619,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v8/*: any*/),
+                "args": (v10/*: any*/),
                 "filters": [],
                 "handle": "connection",
                 "key": "Messages_messagesConnection",
@@ -590,7 +669,7 @@ return {
                             "name": "artistNames",
                             "storageKey": null
                           },
-                          (v9/*: any*/),
+                          (v11/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -635,12 +714,12 @@ return {
                               (v3/*: any*/),
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v10/*: any*/),
+                                "selections": (v12/*: any*/),
                                 "type": "Money"
                               },
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v10/*: any*/),
+                                "selections": (v12/*: any*/),
                                 "type": "PriceRange"
                               }
                             ],
@@ -691,7 +770,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v9/*: any*/),
+                          (v11/*: any*/),
                           (v6/*: any*/),
                           {
                             "alias": null,
@@ -722,23 +801,7 @@ return {
               },
               {
                 "alias": "activeOrders",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "first",
-                    "value": 10
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "states",
-                    "value": [
-                      "APPROVED",
-                      "FULFILLED",
-                      "SUBMITTED",
-                      "REFUNDED"
-                    ]
-                  }
-                ],
+                "args": (v8/*: any*/),
                 "concreteType": "CommerceOrderConnectionWithTotalCount",
                 "kind": "LinkedField",
                 "name": "orderConnection",
@@ -787,13 +850,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "buyerAction",
-                                "storageKey": null
-                              },
+                              (v9/*: any*/),
                               {
                                 "alias": null,
                                 "args": [
@@ -860,7 +917,7 @@ return {
     "metadata": {},
     "name": "ConversationPaginationQuery",
     "operationKind": "query",
-    "text": "query ConversationPaginationQuery(\n  $count: Int\n  $after: String\n  $conversationID: ID!\n) {\n  node(id: $conversationID) {\n    __typename\n    ...Conversation_conversation_2QE1um\n    id\n  }\n}\n\nfragment ConversationCTA_conversation on Conversation {\n  internalID\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        internalID\n        isOfferableFromInquiry\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  activeOrders: orderConnection(first: 10, states: [APPROVED, FULFILLED, SUBMITTED, REFUNDED]) {\n    edges {\n      node {\n        __typename\n        internalID\n        state\n        stateReason\n        stateExpiresAt\n        ... on CommerceOfferOrder {\n          buyerAction\n          offers(first: 5) {\n            edges {\n              node {\n                internalID\n                id\n              }\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ConversationMessages_messages on MessageConnection {\n  edges {\n    node {\n      id\n      internalID\n      createdAt\n      isFromUser\n      body\n      ...Message_message\n    }\n  }\n}\n\nfragment Conversation_conversation_2QE1um on Conversation {\n  id\n  internalID\n  from {\n    name\n    email\n    id\n  }\n  to {\n    name\n    initials\n    id\n  }\n  initialMessage\n  lastMessageID\n  unread\n  messagesConnection(first: $count, after: $after, sort: DESC) {\n    pageInfo {\n      startCursor\n      endCursor\n      hasPreviousPage\n      hasNextPage\n    }\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    ...ConversationMessages_messages\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        internalID\n        id\n        date\n        title\n        artistNames\n        href\n        isOfferableFromInquiry\n        image {\n          url(version: [\"large\"])\n        }\n        listPrice {\n          __typename\n          ... on Money {\n            display\n          }\n          ... on PriceRange {\n            display\n          }\n        }\n      }\n      ... on Show {\n        id\n        fair {\n          name\n          exhibitionPeriod\n          location {\n            city\n            id\n          }\n          id\n        }\n        href\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  ...ConversationCTA_conversation\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    contentType\n    fileName\n    downloadURL\n  }\n}\n"
+    "text": "query ConversationPaginationQuery(\n  $count: Int\n  $after: String\n  $conversationID: ID!\n) {\n  node(id: $conversationID) {\n    __typename\n    ...Conversation_conversation_2QE1um\n    id\n  }\n}\n\nfragment ConversationCTA_conversation on Conversation {\n  internalID\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        internalID\n        isOfferableFromInquiry\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  activeOrders: orderConnection(first: 10, states: [APPROVED, FULFILLED, SUBMITTED, REFUNDED]) {\n    edges {\n      node {\n        __typename\n        internalID\n        state\n        stateReason\n        stateExpiresAt\n        ... on CommerceOfferOrder {\n          buyerAction\n          offers(first: 5) {\n            edges {\n              node {\n                internalID\n                id\n              }\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ConversationMessages_messages on MessageConnection {\n  edges {\n    node {\n      id\n      internalID\n      createdAt\n      isFromUser\n      body\n      ...Message_message\n    }\n  }\n}\n\nfragment Conversation_conversation_2QE1um on Conversation {\n  id\n  internalID\n  from {\n    name\n    email\n    id\n  }\n  to {\n    name\n    initials\n    id\n  }\n  initialMessage\n  lastMessageID\n  unread\n  orderConnection(first: 10, states: [APPROVED, FULFILLED, SUBMITTED, REFUNDED]) {\n    edges {\n      node {\n        __typename\n        internalID\n        ... on CommerceOfferOrder {\n          buyerAction\n        }\n        id\n      }\n    }\n  }\n  messagesConnection(first: $count, after: $after, sort: DESC) {\n    pageInfo {\n      startCursor\n      endCursor\n      hasPreviousPage\n      hasNextPage\n    }\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    ...ConversationMessages_messages\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        internalID\n        id\n        date\n        title\n        artistNames\n        href\n        isOfferableFromInquiry\n        image {\n          url(version: [\"large\"])\n        }\n        listPrice {\n          __typename\n          ... on Money {\n            display\n          }\n          ... on PriceRange {\n            display\n          }\n        }\n      }\n      ... on Show {\n        id\n        fair {\n          name\n          exhibitionPeriod\n          location {\n            city\n            id\n          }\n          id\n        }\n        href\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  ...ConversationCTA_conversation\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    contentType\n    fileName\n    downloadURL\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/Conversation_conversation.graphql.ts
+++ b/src/v2/__generated__/Conversation_conversation.graphql.ts
@@ -3,6 +3,7 @@
 
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type CommerceBuyerOfferActionEnum = "OFFER_ACCEPTED" | "OFFER_ACCEPTED_CONFIRM_NEEDED" | "OFFER_RECEIVED" | "OFFER_RECEIVED_CONFIRM_NEEDED" | "PAYMENT_FAILED" | "PROVISIONAL_OFFER_ACCEPTED" | "%future added value";
 export type Conversation_conversation = {
     readonly id: string;
     readonly internalID: string | null;
@@ -17,6 +18,14 @@ export type Conversation_conversation = {
     readonly initialMessage: string;
     readonly lastMessageID: string | null;
     readonly unread: boolean | null;
+    readonly orderConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string;
+                readonly buyerAction?: CommerceBuyerOfferActionEnum | null;
+            } | null;
+        } | null> | null;
+    } | null;
     readonly messagesConnection: {
         readonly pageInfo: {
             readonly startCursor: string | null;
@@ -222,6 +231,69 @@ return {
       "kind": "ScalarField",
       "name": "unread",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 10
+        },
+        {
+          "kind": "Literal",
+          "name": "states",
+          "value": [
+            "APPROVED",
+            "FULFILLED",
+            "SUBMITTED",
+            "REFUNDED"
+          ]
+        }
+      ],
+      "concreteType": "CommerceOrderConnectionWithTotalCount",
+      "kind": "LinkedField",
+      "name": "orderConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "CommerceOrderEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": null,
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v1/*: any*/),
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "buyerAction",
+                      "storageKey": null
+                    }
+                  ],
+                  "type": "CommerceOfferOrder"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "orderConnection(first:10,states:[\"APPROVED\",\"FULFILLED\",\"SUBMITTED\",\"REFUNDED\"])"
     },
     {
       "alias": "messagesConnection",
@@ -490,5 +562,5 @@ return {
   "type": "Conversation"
 };
 })();
-(node as any).hash = '62c9a8c2bb10cd0b2bd37a60633f4685';
+(node as any).hash = '16294fcf61d677540f345ac2050d4728';
 export default node;

--- a/src/v2/__generated__/conversationRoutes_DetailQuery.graphql.ts
+++ b/src/v2/__generated__/conversationRoutes_DetailQuery.graphql.ts
@@ -182,6 +182,18 @@ fragment Conversation_conversation on Conversation {
   initialMessage
   lastMessageID
   unread
+  orderConnection(first: 10, states: [APPROVED, FULFILLED, SUBMITTED, REFUNDED]) {
+    edges {
+      node {
+        __typename
+        internalID
+        ... on CommerceOfferOrder {
+          buyerAction
+        }
+        id
+      }
+    }
+  }
   messagesConnection(first: 30, sort: DESC) {
     pageInfo {
       startCursor
@@ -507,6 +519,30 @@ v19 = [
   {
     "kind": "Literal",
     "name": "first",
+    "value": 10
+  },
+  {
+    "kind": "Literal",
+    "name": "states",
+    "value": [
+      "APPROVED",
+      "FULFILLED",
+      "SUBMITTED",
+      "REFUNDED"
+    ]
+  }
+],
+v20 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "buyerAction",
+  "storageKey": null
+},
+v21 = [
+  {
+    "kind": "Literal",
+    "name": "first",
     "value": 30
   },
   {
@@ -515,14 +551,14 @@ v19 = [
     "value": "DESC"
   }
 ],
-v20 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v21 = {
+v23 = {
   "alias": "thumbnailUrl",
   "args": [
     {
@@ -535,7 +571,7 @@ v21 = {
   "name": "url",
   "storageKey": "url(version:\"small\")"
 },
-v22 = [
+v24 = [
   {
     "alias": null,
     "args": null,
@@ -544,7 +580,7 @@ v22 = [
     "storageKey": null
   }
 ],
-v23 = [
+v25 = [
   {
     "kind": "Literal",
     "name": "shallow",
@@ -812,6 +848,49 @@ return {
               {
                 "alias": null,
                 "args": (v19/*: any*/),
+                "concreteType": "CommerceOrderConnectionWithTotalCount",
+                "kind": "LinkedField",
+                "name": "orderConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "CommerceOrderEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v8/*: any*/),
+                          (v4/*: any*/),
+                          (v3/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v20/*: any*/)
+                            ],
+                            "type": "CommerceOfferOrder"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "orderConnection(first:10,states:[\"APPROVED\",\"FULFILLED\",\"SUBMITTED\",\"REFUNDED\"])"
+              },
+              {
+                "alias": null,
+                "args": (v21/*: any*/),
                 "concreteType": "MessageConnection",
                 "kind": "LinkedField",
                 "name": "messagesConnection",
@@ -930,7 +1009,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v19/*: any*/),
+                "args": (v21/*: any*/),
                 "filters": [],
                 "handle": "connection",
                 "key": "Messages_messagesConnection",
@@ -962,7 +1041,7 @@ return {
                           (v9/*: any*/),
                           (v10/*: any*/),
                           (v11/*: any*/),
-                          (v20/*: any*/),
+                          (v22/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -993,7 +1072,7 @@ return {
                                 "name": "url",
                                 "storageKey": "url(version:[\"large\"])"
                               },
-                              (v21/*: any*/)
+                              (v23/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1008,12 +1087,12 @@ return {
                               (v8/*: any*/),
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v22/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "type": "Money"
                               },
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v22/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "type": "PriceRange"
                               }
                             ],
@@ -1035,14 +1114,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v23/*: any*/),
+                            "args": (v25/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v3/*: any*/),
-                              (v20/*: any*/),
+                              (v22/*: any*/),
                               (v5/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -1056,14 +1135,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v23/*: any*/),
+                            "args": (v25/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v5/*: any*/),
-                              (v20/*: any*/),
+                              (v22/*: any*/),
                               (v3/*: any*/),
                               {
                                 "alias": null,
@@ -1148,7 +1227,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v22/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -1158,7 +1237,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v22/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "storageKey": null
                               },
                               (v3/*: any*/)
@@ -1217,7 +1296,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v20/*: any*/),
+                          (v22/*: any*/),
                           (v5/*: any*/),
                           (v13/*: any*/),
                           {
@@ -1228,7 +1307,7 @@ return {
                             "name": "coverImage",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/)
+                              (v23/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -1243,23 +1322,7 @@ return {
               },
               {
                 "alias": "activeOrders",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "first",
-                    "value": 10
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "states",
-                    "value": [
-                      "APPROVED",
-                      "FULFILLED",
-                      "SUBMITTED",
-                      "REFUNDED"
-                    ]
-                  }
-                ],
+                "args": (v19/*: any*/),
                 "concreteType": "CommerceOrderConnectionWithTotalCount",
                 "kind": "LinkedField",
                 "name": "orderConnection",
@@ -1308,13 +1371,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "buyerAction",
-                                "storageKey": null
-                              },
+                              (v20/*: any*/),
                               {
                                 "alias": null,
                                 "args": [
@@ -1382,7 +1439,7 @@ return {
     "metadata": {},
     "name": "conversationRoutes_DetailQuery",
     "operationKind": "query",
-    "text": "query conversationRoutes_DetailQuery(\n  $conversationID: String!\n) {\n  me {\n    ...Conversation_me_3oGfhn\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment ConversationCTA_conversation on Conversation {\n  internalID\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        internalID\n        isOfferableFromInquiry\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  activeOrders: orderConnection(first: 10, states: [APPROVED, FULFILLED, SUBMITTED, REFUNDED]) {\n    edges {\n      node {\n        __typename\n        internalID\n        state\n        stateReason\n        stateExpiresAt\n        ... on CommerceOfferOrder {\n          buyerAction\n          offers(first: 5) {\n            edges {\n              node {\n                internalID\n                id\n              }\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ConversationList_me on Me {\n  conversationsConnection(first: 25) {\n    edges {\n      cursor\n      node {\n        id\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment ConversationMessages_messages on MessageConnection {\n  edges {\n    node {\n      id\n      internalID\n      createdAt\n      isFromUser\n      body\n      ...Message_message\n    }\n  }\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversation_conversation on Conversation {\n  id\n  internalID\n  from {\n    name\n    email\n    id\n  }\n  to {\n    name\n    initials\n    id\n  }\n  initialMessage\n  lastMessageID\n  unread\n  messagesConnection(first: 30, sort: DESC) {\n    pageInfo {\n      startCursor\n      endCursor\n      hasPreviousPage\n      hasNextPage\n    }\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    ...ConversationMessages_messages\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        internalID\n        id\n        date\n        title\n        artistNames\n        href\n        isOfferableFromInquiry\n        image {\n          url(version: [\"large\"])\n        }\n        listPrice {\n          __typename\n          ... on Money {\n            display\n          }\n          ... on PriceRange {\n            display\n          }\n        }\n      }\n      ... on Show {\n        id\n        fair {\n          name\n          exhibitionPeriod\n          location {\n            city\n            id\n          }\n          id\n        }\n        href\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  ...ConversationCTA_conversation\n}\n\nfragment Conversation_me_3oGfhn on Me {\n  ...ConversationList_me\n  conversation(id: $conversationID) {\n    internalID\n    ...Conversation_conversation\n    ...ConversationCTA_conversation\n    ...Details_conversation\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Details_conversation on Conversation {\n  to {\n    name\n    initials\n    id\n  }\n  messagesConnection(first: 30, sort: DESC) {\n    edges {\n      node {\n        attachments {\n          id\n          contentType\n          fileName\n          downloadURL\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        href\n        ...Metadata_artwork\n        image {\n          thumbnailUrl: url(version: \"small\")\n        }\n      }\n      ... on Show {\n        href\n        image: coverImage {\n          thumbnailUrl: url(version: \"small\")\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    contentType\n    fileName\n    downloadURL\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n"
+    "text": "query conversationRoutes_DetailQuery(\n  $conversationID: String!\n) {\n  me {\n    ...Conversation_me_3oGfhn\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment ConversationCTA_conversation on Conversation {\n  internalID\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        internalID\n        isOfferableFromInquiry\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  activeOrders: orderConnection(first: 10, states: [APPROVED, FULFILLED, SUBMITTED, REFUNDED]) {\n    edges {\n      node {\n        __typename\n        internalID\n        state\n        stateReason\n        stateExpiresAt\n        ... on CommerceOfferOrder {\n          buyerAction\n          offers(first: 5) {\n            edges {\n              node {\n                internalID\n                id\n              }\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ConversationList_me on Me {\n  conversationsConnection(first: 25) {\n    edges {\n      cursor\n      node {\n        id\n        internalID\n        lastMessage\n        ...ConversationSnippet_conversation\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment ConversationMessages_messages on MessageConnection {\n  edges {\n    node {\n      id\n      internalID\n      createdAt\n      isFromUser\n      body\n      ...Message_message\n    }\n  }\n}\n\nfragment ConversationSnippet_conversation on Conversation {\n  internalID\n  to {\n    name\n    id\n  }\n  lastMessage\n  lastMessageAt\n  unread\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        date\n        title\n        artistNames\n        image {\n          url\n        }\n      }\n      ... on Show {\n        fair {\n          name\n          id\n        }\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Conversation_conversation on Conversation {\n  id\n  internalID\n  from {\n    name\n    email\n    id\n  }\n  to {\n    name\n    initials\n    id\n  }\n  initialMessage\n  lastMessageID\n  unread\n  orderConnection(first: 10, states: [APPROVED, FULFILLED, SUBMITTED, REFUNDED]) {\n    edges {\n      node {\n        __typename\n        internalID\n        ... on CommerceOfferOrder {\n          buyerAction\n        }\n        id\n      }\n    }\n  }\n  messagesConnection(first: 30, sort: DESC) {\n    pageInfo {\n      startCursor\n      endCursor\n      hasPreviousPage\n      hasNextPage\n    }\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    ...ConversationMessages_messages\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        internalID\n        id\n        date\n        title\n        artistNames\n        href\n        isOfferableFromInquiry\n        image {\n          url(version: [\"large\"])\n        }\n        listPrice {\n          __typename\n          ... on Money {\n            display\n          }\n          ... on PriceRange {\n            display\n          }\n        }\n      }\n      ... on Show {\n        id\n        fair {\n          name\n          exhibitionPeriod\n          location {\n            city\n            id\n          }\n          id\n        }\n        href\n        name\n        coverImage {\n          url\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n  ...ConversationCTA_conversation\n}\n\nfragment Conversation_me_3oGfhn on Me {\n  ...ConversationList_me\n  conversation(id: $conversationID) {\n    internalID\n    ...Conversation_conversation\n    ...ConversationCTA_conversation\n    ...Details_conversation\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Details_conversation on Conversation {\n  to {\n    name\n    initials\n    id\n  }\n  messagesConnection(first: 30, sort: DESC) {\n    edges {\n      node {\n        attachments {\n          id\n          contentType\n          fileName\n          downloadURL\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  items {\n    item {\n      __typename\n      ... on Artwork {\n        href\n        ...Metadata_artwork\n        image {\n          thumbnailUrl: url(version: \"small\")\n        }\n      }\n      ... on Show {\n        href\n        image: coverImage {\n          thumbnailUrl: url(version: \"small\")\n        }\n      }\n      ... on Node {\n        id\n      }\n    }\n  }\n}\n\nfragment Message_message on Message {\n  internalID\n  body\n  createdAt\n  isFromUser\n  from {\n    name\n    email\n  }\n  attachments {\n    id\n    contentType\n    fileName\n    downloadURL\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n"
   }
 };
 })();


### PR DESCRIPTION
# [PURCHASE-2712]

As a collector I want to be presented with the contents of “respond-to/confirm offer“ page in modal form when clicking on the CTA to follow these actions.

Acceptance criteria:
- ”Respond-to/confirm offer“ page should render in modal.

- CTA should trigger modal on ”respond-to/confirm offer“ state.

I wasn't sure what tests were needed for this work, as the modal only contains an iframe, but if anyone has any suggestions I'm open!

<img width="1169" alt="Screen Shot 2021-06-22 at 3 26 17 PM" src="https://user-images.githubusercontent.com/5643895/122987308-748a0e00-d36e-11eb-938f-8793c39534f3.png">


[PURCHASE-2712]: https://artsyproduct.atlassian.net/browse/PURCHASE-2712