### PR TITLE
chore: (GRO-384) removes left over feature flag reference in tests

### DIFF
--- a/src/v2/Components/Authentication/__tests__/FormSwitcher.jest.tsx
+++ b/src/v2/Components/Authentication/__tests__/FormSwitcher.jest.tsx
@@ -10,12 +10,6 @@ import { FormSwitcher } from "../FormSwitcher"
 import { ModalType } from "../Types"
 import { mockLocation } from "v2/DevTools/mockLocation"
 
-jest.mock("sharify", () => ({
-  data: {
-    ENABLE_SIGN_IN_WITH_APPLE: true,
-  },
-}))
-
 describe("FormSwitcher", () => {
   const getWrapper = (props: any = {}) =>
     mount(


### PR DESCRIPTION
This removes a no longer needed feature flag reference that was removed in an [earlier PR](https://github.com/artsy/force/pull/7833).
