### PR TITLE
fix: remove noindex from artsy metadata for Google indexing

### DIFF
--- a/src/v2/Apps/BuyerGuarantee/Components/BuyerGuaranteeMeta.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Components/BuyerGuaranteeMeta.tsx
@@ -44,7 +44,7 @@ export const BuyerGuaranteeMeta: React.FC = () => {
 
       <Meta property="twitter:site" content="@artsy" />
       <Meta property="og:type" content="website" />
-      <Meta name="robots" content="noindex, nofollow" />
+      <Meta name="robots" content="all" />
     </>
   )
 }


### PR DESCRIPTION
The Artsy guarantee page wasn't being indexed by Google due to metadata in the Buyer Guarantee .tsx file explicitly preventing this from happening. 

[This ticket](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=41&projectKey=PURCHASE&modal=detail&selectedIssue=PURCHASE-2781&sprint=613) was surfaced to remove the "noindex" and "nofollow" from the robots tag in the file. 

I have some questions about the QA process, specifically answering these questions on the jira ticket:
What's the analytics requirement, if any?
How should we QA or monitor this ticket?
Is there any performance impact?
Is there any followup (e.g. pre/post-deploy migration)?

For QA, I'm not entirely sure but it could take Google some time to scrape the artsy staging/production site once this code is merged and deployed, so might have to re-check after a couple days. Not sure though. 