### PR TITLE
(HOLD) patch: React Spring - WeakSet

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -14,6 +14,18 @@ Tell us when we can remove this hack.
 
 > 👀 When adding a new item, see comment on top of file for template.
 
+## patches/react-spring+8.0.27.patch
+
+#### Explanation/Context:
+
+The `react-spring` library leaks locally due to a cleanup routine that only executes in `componentWillUnmount`, this patches the controller cache `Set` to be a `WeakSet` so that references are no longer held onto when the components have been garbage collected.
+
+Slack: https://artsy.slack.com/archives/CA8SANW3W/p1624453974296000
+
+#### When can we remove this:
+
+When we have removed the references to `react-spring` from `@artsy/palette`
+
 ## patches/relay-mock-network-layer+2.0.0.patch
 
 #### Explanation/Context:

--- a/patches/react-spring+8.0.27.patch
+++ b/patches/react-spring+8.0.27.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-spring/web.cjs.js b/node_modules/react-spring/web.cjs.js
+index bb958d1..8e3ce85 100644
+--- a/node_modules/react-spring/web.cjs.js
++++ b/node_modules/react-spring/web.cjs.js
+@@ -424,7 +424,7 @@ var createAnimatedComponent = function createAnimatedComponent(Component) {
+ };
+ 
+ var active = false;
+-var controllers = new Set();
++var controllers = new WeakSet();
+ 
+ var update = function update() {
+   if (!active) return false;


### PR DESCRIPTION
Update react-spring to use a WeakSet so that it doesn't indefinitely
hold references to each animation controller it creates. The controllers
are only cleaned up during `componentWillUnmount` which is why we
are seeing this leak during SSR.