### PR TITLE
sentry: Add dedupe lib and filter out issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@loadable/component": "5.14.1",
     "@loadable/server": "5.14.0",
     "@sentry/browser": "6.7.1",
+    "@sentry/integrations": "^6.7.2",
     "@sentry/node": "^6.7.1",
     "@sentry/tracing": "^6.7.1",
     "@stripe/react-stripe-js": "1.1.2",

--- a/src/lib/analytics/sentryFilters.ts
+++ b/src/lib/analytics/sentryFilters.ts
@@ -5,6 +5,8 @@ export const IGNORED_ERRORS = [
   'Blocked a frame with origin "https://www.artsy.net" from accessing a cross-origin frame. Protocols, domains, and ports must match.',
   "cancelled",
   "Failed to fetch",
+  "Non-Error exception captured",
+  "Non-Error promise rejection captured",
   "Origin is not allowed by Access-Control-Allow-Origin",
   "pktAnnotationHighlighter", // Pocket ios app errors on opening articles
   "Request has been terminated Possible causes: the network is offline, Origin is not allowed by Access-Control-Allow-Origin",
@@ -17,10 +19,10 @@ export const IGNORED_ERRORS = [
 export const ALLOWED_URLS = [/(.*).?artsy.net/i, /(.*).?cloudfront.com/i]
 
 export const DENIED_URLS = [
-  /(.*).?dca0.com/i,
-  /(.*).?sail-personalize.com/i,
-  /(.*).?doubleclick.net/i,
-  /(.*).?googletagservices.com/i,
-  /(.*).?getletterpress.com/i,
   /(.*).?braze.com/i,
+  /(.*).?dca0.com/i,
+  /(.*).?doubleclick.net/i,
+  /(.*).?getletterpress.com/i,
+  /(.*).?googletagservices.com/i,
+  /(.*).?sail-personalize.com/i,
 ]

--- a/src/lib/setupSentryClient.ts
+++ b/src/lib/setupSentryClient.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/browser"
 import { Integrations } from "@sentry/tracing"
+import { Dedupe } from "@sentry/integrations"
 import {
   ALLOWED_URLS,
   DENIED_URLS,
@@ -12,6 +13,6 @@ export function setupSentryClient(sd) {
     denyUrls: DENIED_URLS,
     dsn: sd.SENTRY_PUBLIC_DSN,
     ignoreErrors: IGNORED_ERRORS,
-    integrations: [new Integrations.BrowserTracing()],
+    integrations: [new Integrations.BrowserTracing(), new Dedupe()],
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2241,6 +2241,16 @@
     "@sentry/utils" "6.7.1"
     tslib "^1.9.3"
 
+"@sentry/integrations@^6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-6.7.2.tgz#1ddfb165b4aee42d0e9d9ef531c5ded8a73cbd61"
+  integrity sha512-IvOLqKVTxPxSJLbKVEe15BjvotnWBs86h5MJx3DLA/1HLP4xtUOvFsdmuMLJij5PtFG10HuUpRn8acEh5h9PTw==
+  dependencies:
+    "@sentry/types" "6.7.2"
+    "@sentry/utils" "6.7.2"
+    localforage "^1.8.1"
+    tslib "^1.9.3"
+
 "@sentry/minimal@6.7.1":
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.7.1.tgz#babf85ee2f167e9dcf150d750d7a0b250c98449c"
@@ -2281,12 +2291,25 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.7.1.tgz#c8263e1886df5e815570c4668eb40a1cfaa1c88b"
   integrity sha512-9AO7HKoip2MBMNQJEd6+AKtjj2+q9Ze4ooWUdEvdOVSt5drg7BGpK221/p9JEOyJAZwEPEXdcMd3VAIMiOb4MA==
 
+"@sentry/types@6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.7.2.tgz#8108272c98ad7784ddf9ddda0b7bdc6880ed6e50"
+  integrity sha512-h21Go/PfstUN+ZV6SbwRSZVg9GXRJWdLfHoO5PSVb3TVEMckuxk8tAE57/u+UZDwX8wu+Xyon2TgsKpiWKxqUg==
+
 "@sentry/utils@6.7.1":
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.7.1.tgz#909184ad580f0f6375e1e4d4a6ffd33dfe64a4d1"
   integrity sha512-Tq2otdbWlHAkctD+EWTYKkEx6BL1Qn3Z/imkO06/PvzpWvVhJWQ5qHAzz5XnwwqNHyV03KVzYB6znq1Bea9HuA==
   dependencies:
     "@sentry/types" "6.7.1"
+    tslib "^1.9.3"
+
+"@sentry/utils@6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.7.2.tgz#c7f957ebe16de3e701a0c5477ac2dba04e7b4b68"
+  integrity sha512-9COL7aaBbe61Hp5BlArtXZ1o/cxli1NGONLPrVT4fMyeQFmLonhUiy77NdsW19XnvhvaA+2IoV5dg3dnFiF/og==
+  dependencies:
+    "@sentry/types" "6.7.2"
     tslib "^1.9.3"
 
 "@seznam/compose-react-refs@^1.0.6":
@@ -10810,6 +10833,11 @@ imagesloaded@^4.1.0:
   dependencies:
     ev-emitter "^1.0.0"
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
+
 immer@8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
@@ -13122,6 +13150,13 @@ li@^1.3.0:
   resolved "https://registry.yarnpkg.com/li/-/li-1.3.0.tgz#22c59bcaefaa9a8ef359cf759784e4bf106aea1b"
   integrity sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs=
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=
+  dependencies:
+    immediate "~3.0.5"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -13260,6 +13295,13 @@ loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
+
+localforage@^1.8.1:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.9.0.tgz#f3e4d32a8300b362b4634cc4e066d9d00d2f09d1"
+  integrity sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Address voluminous issues around `Non-Error promise rejection captured with value: Object Not Found`, which are eating up much of our quota. See [example](https://sentry.io/organizations/artsynet/issues/2460521645/?project=28316&query=is%3Aunresolved&sort=freq&statsPeriod=90d).

Followed instructions from this [sentry thread](https://forum.sentry.io/t/unhandledrejection-non-error-promise-rejection-captured-with-value/14062/13), and added the [dedupe integration](https://docs.sentry.io/platforms/javascript/configuration/integrations/plugin/#dedupe) to help clean up logs.