### PR TITLE
GRO-378: Copy Script changes suggested for Artist and associated pages

### DIFF
--- a/cypress/integration/artist.spec.js
+++ b/cypress/integration/artist.spec.js
@@ -19,6 +19,6 @@ describe("/artist/:id", () => {
   it("renders page content", () => {
     cy.get("h1").should("contain", "Pablo Picasso")
     cy.get("h2").should("contain", "Spanish, 1881–1973")
-    cy.get("h2").should("contain", "Notable Works")
+    cy.get("h2").should("contain", "Notable works")
   })
 })

--- a/cypress/integration/artist.spec.js
+++ b/cypress/integration/artist.spec.js
@@ -1,5 +1,4 @@
-import { artworkGridRenders } from "../helpers/artworkGridRenders"
-
+/* eslint-disable jest/expect-expect */
 describe("/artist/:id", () => {
   before(() => {
     cy.visit("/artist/pablo-picasso")

--- a/cypress/integration/collect.spec.js
+++ b/cypress/integration/collect.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable jest/expect-expect */
 import { artworkGridRenders } from "../helpers/artworkGridRenders"
 
 describe("/collect", () => {

--- a/src/v2/Apps/Artist/ArtistApp.tsx
+++ b/src/v2/Apps/Artist/ArtistApp.tsx
@@ -62,7 +62,7 @@ const ArtistApp: React.FC<ArtistAppProps> = ({ artist, children, match }) => {
         {showArtworksTab && (
           <RouteTab to={`/artist/${artist.slug}/works-for-sale`}>
             {artist?.counts?.forSaleArtworks! > 0
-              ? `Works for sale (${artist?.counts?.forSaleArtworks?.toLocaleString()})`
+              ? `Works for Sale (${artist?.counts?.forSaleArtworks?.toLocaleString()})`
               : "Artworks"}
           </RouteTab>
         )}

--- a/src/v2/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
+++ b/src/v2/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
@@ -66,7 +66,7 @@ const ArtistHeader: React.FC<ArtistHeaderProps> = ({ artist }) => {
                   color="black60"
                   textAlign={["center", "left"]}
                 >
-                  {formatFollowerCount(artist.counts.follows)} Following
+                  {formatFollowerCount(artist.counts.follows)} Followers
                 </Text>
               </Column>
             )}

--- a/src/v2/Apps/Artist/Components/ArtistHeader/__tests__/ArtistHeader.jest.tsx
+++ b/src/v2/Apps/Artist/Components/ArtistHeader/__tests__/ArtistHeader.jest.tsx
@@ -58,7 +58,7 @@ describe("ArtistHeader", () => {
     expect(
       wrapper.find("ArtistFollowArtistButtonFragmentContainer").length
     ).toBe(1)
-    expect(wrapper.text()).toContain("111 Following")
+    expect(wrapper.text()).toContain("111 Followers")
     expect(wrapper.text()).toContain("biographyBlurbText")
     expect(
       wrapper.find("SelectedCareerAchievementsFragmentContainer").length
@@ -82,6 +82,6 @@ describe("ArtistHeader", () => {
       }),
     })
 
-    expect(wrapper.text()).not.toContain("0 Following")
+    expect(wrapper.text()).not.toContain("0 Followers")
   })
 })

--- a/src/v2/Apps/Artist/Routes/Overview/Components/ArtistNotableWorksRail.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/Components/ArtistNotableWorksRail.tsx
@@ -34,7 +34,7 @@ const ArtistNotableWorksRail: React.FC<ArtistNotableWorksRailProps> = ({
     <>
       <Flex justifyContent="space-between">
         <Text variant="lg" mb={2} as="h2">
-          Notable Works
+          Notable works
         </Text>
 
         <RouterLink

--- a/src/v2/Apps/Artist/Routes/Overview/Components/ArtistRelatedArtistsRail.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/Components/ArtistRelatedArtistsRail.tsx
@@ -32,7 +32,7 @@ const ArtistRelatedArtistsRail: React.FC<ArtistRelatedArtistsRailProps> = ({
   return (
     <>
       <Text variant="lg" mb={4} as="h2">
-        Related Artists
+        Related artists
       </Text>
 
       <Shelf alignItems="flex-start" data-test="relatedArtistsRail">

--- a/src/v2/Apps/Artist/Routes/Overview/Components/__tests__/ArtistNotableWorksRail.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/Components/__tests__/ArtistNotableWorksRail.jest.tsx
@@ -48,7 +48,7 @@ describe("ArtistNotableWorksRail", () => {
         slug: "artistSlug",
       }),
     })
-    expect(wrapper.text()).toContain("Notable Works")
+    expect(wrapper.text()).toContain("Notable works")
     expect(wrapper.find("RouterLink").length).toBe(3)
     expect(wrapper.find("RouterLink").at(0).props().to).toContain(
       "/artist/artistSlug/works-for-sale"

--- a/src/v2/Apps/Artist/__tests__/ArtistApp.jest.tsx
+++ b/src/v2/Apps/Artist/__tests__/ArtistApp.jest.tsx
@@ -119,7 +119,7 @@ describe("ArtistApp", () => {
           },
         }),
       })
-      expect(wrapper.find("RouteTab").at(1).text()).toBe("Works for sale (20)")
+      expect(wrapper.find("RouteTab").at(1).text()).toBe("Works for Sale (20)")
     })
   })
 

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercial.tsx
@@ -459,7 +459,7 @@ export class ArtworkSidebarCommercialContainer extends React.Component<
               size="medium"
               onClick={this.handleInquiry.bind(this)}
             >
-              Contact gallery
+              Contact Gallery
             </Button>
           )}
 

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercial.jest.tsx
@@ -118,7 +118,7 @@ describe("ArtworkSidebarCommercial", () => {
 
     expect(wrapper.text()).not.toContain("20 × 24 in")
     expect(wrapper.text()).not.toContain("50.8 × 61 cm")
-    expect(wrapper.text()).toContain("Contact gallery")
+    expect(wrapper.text()).toContain("Contact Gallery")
   })
 
   it("displays artwork enrolled in Buy Now", async () => {
@@ -151,7 +151,7 @@ describe("ArtworkSidebarCommercial", () => {
     const wrapper = getWrapper(artwork)
 
     expect(wrapper.text()).toContain("Make offer")
-    expect(wrapper.text()).not.toContain("Contact gallery")
+    expect(wrapper.text()).not.toContain("Contact Gallery")
   })
 
   it("displays artwork enrolled in both Buy Now and Make Offer", async () => {

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/InDemandNow/ConsignInDemandNow.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/InDemandNow/ConsignInDemandNow.tsx
@@ -172,7 +172,7 @@ const InDemandNowLarge: React.FC<
         </Text>
         <Flex>
           <BlueChipIcon width={15} height={15} fill="white100" mr={0.3} />{" "}
-          <Text variant="small">Blue Chip Representation</Text>
+          <Text variant="small">Blue-Chip Representation</Text>
         </Flex>
 
         <Spacer mt={4} />
@@ -291,7 +291,7 @@ const InDemandNowSmall: React.FC<
         </Text>
         <Flex>
           <BlueChipIcon width={15} height={15} fill="white100" mr={0.3} />{" "}
-          <Text variant="small">Blue Chip Representation</Text>
+          <Text variant="small">Blue-Chip Representation</Text>
         </Flex>
 
         <Spacer mt={3} />

--- a/src/v2/Components/ArtistMarketInsights.tsx
+++ b/src/v2/Components/ArtistMarketInsights.tsx
@@ -12,7 +12,7 @@ export interface MarketInsightsProps {
 }
 
 export const CATEGORIES = {
-  "blue-chip": "Blue chip",
+  "blue-chip": "Blue-chip",
   "top-established": "Established",
   "top-emerging": "Emerging",
 }

--- a/src/v2/Components/ArtistSeriesRail/__tests__/ArtistSeriesItem.jest.tsx
+++ b/src/v2/Components/ArtistSeriesRail/__tests__/ArtistSeriesItem.jest.tsx
@@ -28,7 +28,7 @@ describe("Artist Series Rail Item", () => {
     jest.clearAllMocks()
   })
 
-  it("tracks the analytics properties when an artwork is clicked on the Notable Works rail", () => {
+  it("tracks the analytics properties when an artwork is clicked on the Notable works rail", () => {
     const component = mount(
       <AnalyticsContext.Provider
         value={{

--- a/src/v2/Components/SelectedCareerAchievements.tsx
+++ b/src/v2/Components/SelectedCareerAchievements.tsx
@@ -24,7 +24,7 @@ export interface SelectedCareerAchievementsProps extends SpaceProps {
 }
 
 const CATEGORIES = {
-  "blue-chip": "Blue chip representation",
+  "blue-chip": "Blue-chip representation",
   "top-established": "Established representation",
   "top-emerging": "Emerging representation",
 }
@@ -157,7 +157,7 @@ export class SelectedCareerAchievements extends React.Component<
         {this.props.onlyCareerHighlights ? (
           <>
             <Text variant="lg" mb={4}>
-              Career Highlights
+              Career highlights
             </Text>
             <Flex flexWrap="wrap" pr={2}>
               {this.props.artist?.insights?.map(insight => {

--- a/src/v2/Components/__stories__/Headers.story.tsx
+++ b/src/v2/Components/__stories__/Headers.story.tsx
@@ -197,7 +197,7 @@ const BioExample = () => {
       <Text variant="sm">
         £549k Auction Record
         <br />
-        Blue Chip Representation
+        Blue-Chip Representation
       </Text>
     </>
   )

--- a/src/v2/Components/__tests__/SelectedCareerAchievements.jest.tsx
+++ b/src/v2/Components/__tests__/SelectedCareerAchievements.jest.tsx
@@ -39,7 +39,7 @@ describe("SelectedCareerAchievements", () => {
 
     const text = careerHighlightsText(wrapper)
 
-    expect(text).toContain("Blue chip representation")
+    expect(text).toContain("Blue-chip representation")
     expect(text).toContain("High auction record")
     expect(text).toContain("Collected by a major institution")
     expect(text).toContain("Solo show at a major institution")


### PR DESCRIPTION
This covers the following copy script changes:
__________________________

Artwork page

CTAs should be title case (ie “Contact Gallery”)

Artist page

Cap “sale” in the part next to “Overview” → “Works for Sale”

Sentence case all “sub headers” — ie “Notable works,” “Career highlights,”  “Works for sale,” “Related artists” (“Shows/Articles featuring ____” is already sentence case)

“Followers” instead of "Following" for `ArtistHeader`

Hyphenate “blue-chip” before noun

