### PR TITLE
GRO-378: Missed one copy update for GRO378

### DIFF
--- a/src/v2/Apps/Artist/Routes/Overview/Components/ArtistWorksForSaleRail.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/Components/ArtistWorksForSaleRail.tsx
@@ -34,7 +34,7 @@ const ArtistWorksForSaleRail: React.FC<ArtistWorksForSaleRailProps> = ({
     <>
       <Flex justifyContent="space-between">
         <Text variant="lg" mb={4} as="h2">
-          Works for Sale
+          Works for sale
         </Text>
 
         <RouterLink

--- a/src/v2/Apps/Artist/Routes/Overview/Components/__tests__/ArtistWorksForSaleRail.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/Components/__tests__/ArtistWorksForSaleRail.jest.tsx
@@ -48,7 +48,7 @@ describe("ArtistWorksForSaleRail", () => {
         slug: "artistSlug",
       }),
     })
-    expect(wrapper.text()).toContain("Works for Sale")
+    expect(wrapper.text()).toContain("Works for sale")
     expect(wrapper.find("RouterLink").length).toBe(3)
     expect(wrapper.find("RouterLink").at(0).props().to).toContain(
       "/artist/artistSlug/works-for-sale"


### PR DESCRIPTION
Missed one copy update for GRO-378.

Needed to update the `Works for Sale` rail to have sentence casing. So now should be `Works for sale`.