### PR TITLE
[Purchase-2717] Update notice text in offer checkout flow

### DIFF
--- a/src/v2/Apps/Order/Routes/Offer/index.tsx
+++ b/src/v2/Apps/Order/Routes/Offer/index.tsx
@@ -268,7 +268,7 @@ export class OfferRoute extends Component<OfferProps, OfferState> {
               )}
               <Spacer mb={[2, 3]} />
               <Message p={[2, 3]}>
-                Please note that all offers are binding. If your offer is
+                Please note that all final offers are binding. If your offer is
                 accepted, your payment will be processed immediately.
                 <Text mt={1}>
                   Keep in mind making an offer doesn’t guarantee you the work,

--- a/src/v2/Apps/Order/Routes/__tests__/Offer.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Offer.jest.tsx
@@ -75,6 +75,12 @@ describe("Offer InitialMutation", () => {
       page.setOfferAmount(1023)
       expect(page.transactionSummary.text()).toContain("Your offer$1,023.00")
     })
+
+    it("shows final offer binding notice", () => {
+      expect(page.text()).toContain(
+        "Please note that all final offers are binding"
+      )
+    })
   })
 
   describe("a non-usd currency", () => {


### PR DESCRIPTION
PR addresses this [jira ticket](https://artsyproduct.atlassian.net/browse/PURCHASE-2717?atlOrigin=eyJpIjoiYWRkMmQ5MjVhMzhiNGZmMmJjNmQwMDFkZDBiYjJkYjYiLCJwIjoiaiJ9) on the purchase sprint board:

Updates: 
- a simple word change to denote "final offer" in checkout flow for the benefit of the user being informed as they write an offer 
- added a unit test to the test suite to confirm the changes to the UI/copy in the text box render as intended 

