### PR TITLE
fix[FX-2825]: reset size filter

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
@@ -146,6 +146,7 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
       sizes,
       height: "*-*",
       width: "*-*",
+      reset: false,
     }
 
     setFilters?.(newFilters, { force: false })
@@ -156,6 +157,7 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
     const newFilters = {
       ...currentlySelectedFilters?.(),
       sizes: [],
+      reset: false,
       ...mapSizeToRange(convertSizeToInches(customSize) as CustomSize),
     }
     setFilters?.(newFilters, { force: false })


### PR DESCRIPTION
**Jira**: [FX-2825](https://artsyproduct.atlassian.net/browse/FX-2825)

**Description**
When user set custom size more then one time size filter doesn't reset

*Before*
![reset-filter-before-2](https://user-images.githubusercontent.com/56556580/123423243-f7f26c00-d5c7-11eb-9810-639b35501156.gif)

*After*
![reset-filter-after](https://user-images.githubusercontent.com/56556580/123423200-ead57d00-d5c7-11eb-8c2a-11dd9678be8e.gif)
