### PR TITLE
feat(purchase-2708): add artwork editions

### DIFF
--- a/src/v2/Apps/Conversation/Components/ConfirmArtworkModal.tsx
+++ b/src/v2/Apps/Conversation/Components/ConfirmArtworkModal.tsx
@@ -7,7 +7,7 @@ import {
   Spacer,
   Text,
 } from "@artsy/palette"
-import React from "react"
+import React, { useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "v2/System"
 import { renderWithLoadProgress } from "v2/System/Relay/renderWithLoadProgress"
@@ -19,7 +19,7 @@ import {
 import { ConfirmArtworkModal_artwork } from "v2/__generated__/ConfirmArtworkModal_artwork.graphql"
 import { ConfirmArtworkButtonFragmentContainer } from "./ConfirmArtworkButton"
 import { CollapsibleArtworkDetailsFragmentContainer } from "./CollapsibleArtworkDetails"
-
+import { EditionSelectBoxFragmentContainer } from "./EditionSelectBox"
 export interface ConfirmArtworkModalProps {
   artwork: ConfirmArtworkModal_artwork
   conversationID: string
@@ -32,39 +32,70 @@ export const ConfirmArtworkModal: React.FC<ConfirmArtworkModalProps> = ({
   conversationID,
   show,
   closeModal,
-}) => (
-  <Modal
-    show={show}
-    onClose={closeModal}
-    title="Confirm Artwork"
-    FixedButton={
-      <Flex flexGrow={1}>
-        <Button variant="secondaryOutline" flexGrow={1} onClick={closeModal}>
-          Cancel
-        </Button>
-        <Spacer m="20px" />
-        <ConfirmArtworkButtonFragmentContainer
-          artwork={artwork}
-          conversationID={conversationID}
-          editionSetID={null}
-        />
-      </Flex>
+}) => {
+  const { editionSets, isEdition } = artwork
+
+  const initialSelectedEdition =
+    editionSets?.length === 1 ? editionSets[0]!.internalID : null
+
+  const [selectedEdition, setSelectedEdition] = useState<string | null>(
+    initialSelectedEdition
+  )
+
+  const selectEdition = (editionSetID: string, isAvailable?: boolean) => {
+    if (isAvailable) {
+      setSelectedEdition(editionSetID)
     }
-  >
-    <Text color="black60" variant="subtitle" mb="30px">
-      Make sure the artwork below matches the intended work you’re making an
-      offer on.
-    </Text>
+  }
 
-    <CollapsibleArtworkDetailsFragmentContainer artwork={artwork} />
-    <Separator />
-
-    <Message mt="20px" mx="20px">
-      Making an offer doesn’t guarantee you the work, as the seller might be
-      receiving competing offers.
-    </Message>
-  </Modal>
-)
+  return (
+    <Modal
+      show={show}
+      onClose={closeModal}
+      title="Confirm Artwork"
+      FixedButton={
+        <Flex flexGrow={1}>
+          <Button variant="secondaryOutline" flexGrow={1} onClick={closeModal}>
+            Cancel
+          </Button>
+          <Spacer m="20px" />
+          <ConfirmArtworkButtonFragmentContainer
+            artwork={artwork}
+            disabled={!!isEdition && !selectedEdition}
+            conversationID={conversationID}
+            editionSetID={selectedEdition || null}
+          />
+        </Flex>
+      }
+    >
+      <Text color="black60" variant="subtitle" mb="30px">
+        Make sure the artwork below matches the intended work you’re making an
+        offer on.
+      </Text>
+      <CollapsibleArtworkDetailsFragmentContainer artwork={artwork} />
+      <Separator />
+      {!!isEdition && editionSets?.length && (
+        <Flex flexDirection="column">
+          <Text mx={2} mt={2} mb={1}>
+            Which edition are you interested in?
+          </Text>
+          {editionSets?.map(edition => (
+            <EditionSelectBoxFragmentContainer
+              edition={edition!}
+              selected={edition!.internalID === selectedEdition}
+              onSelect={selectEdition}
+              key={`edition-set-${edition?.internalID}`}
+            />
+          ))}
+        </Flex>
+      )}
+      <Message mt="20px" mx="20px">
+        Making an offer doesn’t guarantee you the work, as the seller might be
+        receiving competing offers.
+      </Message>
+    </Modal>
+  )
+}
 
 export const ConfirmArtworkModalFragmentContainer = createFragmentContainer(
   ConfirmArtworkModal,
@@ -77,20 +108,7 @@ export const ConfirmArtworkModalFragmentContainer = createFragmentContainer(
         isEdition
         editionSets {
           internalID
-          editionOf
-          isOfferableFromInquiry
-          listPrice {
-            ... on Money {
-              display
-            }
-            ... on PriceRange {
-              display
-            }
-          }
-          dimensions {
-            cm
-            in
-          }
+          ...EditionSelectBox_edition
         }
       }
     `,

--- a/src/v2/Apps/Conversation/Components/ConversationCTA.tsx
+++ b/src/v2/Apps/Conversation/Components/ConversationCTA.tsx
@@ -4,8 +4,8 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ReviewOfferCTA } from "./ReviewOfferCTA"
 import { OpenInquiryModalButtonQueryRenderer } from "./OpenInquiryModalButton"
-// import { userHasLabFeature } from "v2/Utils/user"
-// import { useSystemContext } from "v2/System/useSystemContext"
+import { userHasLabFeature } from "v2/Utils/user"
+import { useSystemContext } from "v2/System/useSystemContext"
 
 interface ConversationCTAProps {
   conversation: ConversationCTA_conversation
@@ -24,13 +24,13 @@ export const ConversationCTA: React.FC<ConversationCTAProps> = ({
 
   let CTA: JSX.Element | null = null
 
-  // const { user } = useSystemContext()
-  // const inquiryCheckoutEnabled = userHasLabFeature(
-  //   user!,
-  //   "Web Inquiry Checkout"
-  // )
+  const { user } = useSystemContext()
+  const inquiryCheckoutEnabled = userHasLabFeature(
+    user!,
+    "Web Inquiry Checkout"
+  )
 
-  if (true && artwork) {
+  if (inquiryCheckoutEnabled && artwork) {
     // artworkID is guaranteed to be present if `isOfferableFromInquiry` was present.
     const conversationID = conversation.internalID!
     const activeOrder = extractNodes(conversation.activeOrders)[0]

--- a/src/v2/Apps/Conversation/Components/ConversationCTA.tsx
+++ b/src/v2/Apps/Conversation/Components/ConversationCTA.tsx
@@ -4,8 +4,8 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ReviewOfferCTA } from "./ReviewOfferCTA"
 import { OpenInquiryModalButtonQueryRenderer } from "./OpenInquiryModalButton"
-import { userHasLabFeature } from "v2/Utils/user"
-import { useSystemContext } from "v2/System/useSystemContext"
+// import { userHasLabFeature } from "v2/Utils/user"
+// import { useSystemContext } from "v2/System/useSystemContext"
 
 interface ConversationCTAProps {
   conversation: ConversationCTA_conversation
@@ -24,13 +24,13 @@ export const ConversationCTA: React.FC<ConversationCTAProps> = ({
 
   let CTA: JSX.Element | null = null
 
-  const { user } = useSystemContext()
-  const inquiryCheckoutEnabled = userHasLabFeature(
-    user!,
-    "Web Inquiry Checkout"
-  )
+  // const { user } = useSystemContext()
+  // const inquiryCheckoutEnabled = userHasLabFeature(
+  //   user!,
+  //   "Web Inquiry Checkout"
+  // )
 
-  if (inquiryCheckoutEnabled && artwork) {
+  if (true && artwork) {
     // artworkID is guaranteed to be present if `isOfferableFromInquiry` was present.
     const conversationID = conversation.internalID!
     const activeOrder = extractNodes(conversation.activeOrders)[0]

--- a/src/v2/Apps/Conversation/Components/EditionSelectBox.tsx
+++ b/src/v2/Apps/Conversation/Components/EditionSelectBox.tsx
@@ -1,0 +1,86 @@
+import { Box, BorderBox, color, Flex, Text, Radio } from "@artsy/palette"
+import React from "react"
+import styled from "styled-components"
+import { createFragmentContainer, graphql } from "react-relay"
+
+import { EditionSelectBox_edition } from "v2/__generated__/EditionSelectBox_edition.graphql"
+
+const UnavailableIndicator = styled(Box)`
+  height: 8px;
+  width: 8px;
+  border-radius: 4px;
+  background-color: ${color("red100")};
+  margin-right: 6px;
+`
+
+interface Props {
+  edition: EditionSelectBox_edition
+  selected: boolean
+  onSelect: (editionSetId: string, isAvailable: boolean) => void
+}
+
+export const EditionSelectBox: React.FC<Props> = ({
+  edition,
+  selected,
+  onSelect,
+}) => {
+  const isOfferable = !!edition.isOfferableFromInquiry
+
+  return (
+    <BorderBox
+      onClick={() => {
+        onSelect(edition.internalID, isOfferable)
+      }}
+      mx={2}
+      mb={1}
+      flexDirection="row"
+      alignItems="start"
+    >
+      <Radio disabled={!isOfferable} selected={selected} />
+      <Flex flexGrow={1} flexDirection="column">
+        <Text color={isOfferable ? "black100" : "black30"}>
+          {edition.dimensions?.in}
+        </Text>
+        <Text color={isOfferable ? "black60" : "black30"}>
+          {edition.dimensions?.cm}
+        </Text>
+        <Text color={isOfferable ? "black60" : "black30"}>
+          {edition.editionOf}
+        </Text>
+      </Flex>
+      {isOfferable ? (
+        <Text>{edition.listPrice?.display || "Contact for price"}</Text>
+      ) : (
+        <Flex flexDirection="row" alignItems="baseline">
+          <UnavailableIndicator />
+          <Text>Unavailable</Text>
+        </Flex>
+      )}
+    </BorderBox>
+  )
+}
+
+export const EditionSelectBoxFragmentContainer = createFragmentContainer(
+  EditionSelectBox,
+  {
+    edition: graphql`
+      fragment EditionSelectBox_edition on EditionSet {
+        internalID
+        editionOf
+        isOfferableFromInquiry
+        listPrice {
+          ... on Money {
+            display
+          }
+          ... on PriceRange {
+            display
+          }
+        }
+        dimensions {
+          cm
+          in
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Conversation/Components/__tests__/ConfirmArtwork.jest.tsx
+++ b/src/v2/Apps/Conversation/Components/__tests__/ConfirmArtwork.jest.tsx
@@ -1,5 +1,6 @@
 import { ConfirmArtworkModalFragmentContainer } from "../ConfirmArtworkModal"
 import { CollapsibleArtworkDetails } from "../CollapsibleArtworkDetails"
+import { EditionSelectBoxFragmentContainer } from "../EditionSelectBox"
 import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
 
@@ -54,5 +55,118 @@ describe("ConfirmArtworkModal", () => {
     details.update()
     expect(details.text()).toContain("Certificate of Authenticity")
     expect(details.text()).toContain("33 x 33 in\n33 x 33 cm")
+  })
+})
+
+describe("Artwork editions", () => {
+  const mockEditions = getWrapper({
+    Artwork: () => ({
+      isEdition: true,
+      editionSets: [
+        {
+          internalID: "edition-1",
+          isOfferableFromInquiry: true,
+        },
+        {
+          internalID: "edition-2",
+          isOfferableFromInquiry: true,
+        },
+      ],
+    }),
+  })
+
+  const mockSingleEdition = getWrapper({
+    Artwork: () => ({
+      isEdition: true,
+      editionSets: [
+        {
+          internalID: "edition-1",
+          isOfferableFromInquiry: true,
+          listPrice: {
+            display: "$100",
+          },
+          editionOf: "Edition of 50",
+          dimensions: {
+            cm: "70 × 25 × 35 cm",
+            in: "27 3/5 × 9 4/5 × 13 4/5 in",
+          },
+        },
+      ],
+    }),
+  })
+
+  const unavailableEdition = getWrapper({
+    Artwork: () => ({
+      editionSets: [
+        {
+          isOfferableFromInquiry: false,
+        },
+      ],
+    }),
+  })
+
+  const nullListPriceEdition = getWrapper({
+    Artwork: () => ({
+      editionSets: [
+        {
+          listPrice: {
+            display: null,
+          },
+        },
+      ],
+    }),
+  })
+
+  it("An Edition renders correctly", () => {
+    const edition = mockSingleEdition.find(EditionSelectBoxFragmentContainer)
+
+    expect(edition).toHaveLength(1)
+    expect(edition.find("Radio")).toHaveLength(1)
+    expect(edition.find("Text").at(0).text()).toEqual(
+      "27 3/5 × 9 4/5 × 13 4/5 in"
+    )
+    expect(edition.find("Text").at(1).text()).toEqual("70 × 25 × 35 cm")
+    expect(edition.find("Text").at(2).text()).toEqual("Edition of 50")
+    expect(edition.find("Text").at(3).text()).toEqual("$100")
+  })
+
+  it("One edition is always selected", () => {
+    const edition = mockSingleEdition.find(EditionSelectBoxFragmentContainer)
+
+    expect(edition.props().selected).toEqual(true)
+    expect(edition.find("Radio").props().selected).toEqual(true)
+  })
+
+  it("Display edititon as disabled when it is not available", () => {
+    const edition = unavailableEdition.find(EditionSelectBoxFragmentContainer)
+
+    expect(edition.find("Radio").props().disabled).toEqual(true)
+    expect(edition.find("Text").at(3).text()).toEqual("Unavailable")
+  })
+
+  it("Display 'Contact for price' if a price not set in listPrice", () => {
+    const edition = nullListPriceEdition.find(EditionSelectBoxFragmentContainer)
+
+    expect(edition.find("Text").at(3).text()).toEqual("Contact for price")
+  })
+
+  it("Can select editions", () => {
+    const editions = mockEditions.find(EditionSelectBoxFragmentContainer)
+    const firstEdition = editions.find(EditionSelectBoxFragmentContainer).at(0)
+    const secondEdition = editions.find(EditionSelectBoxFragmentContainer).at(1)
+
+    expect(firstEdition.props().selected).toEqual(false)
+    expect(secondEdition.props().selected).toEqual(false)
+
+    firstEdition.find("BorderBox").simulate("click")
+    setTimeout(() => {
+      expect(firstEdition.props().selected).toEqual(true)
+    })
+
+    secondEdition.find("BorderBox").simulate("click")
+    setTimeout(() => {
+      expect(secondEdition.props().selected).toEqual(true)
+      expect(firstEdition.props().selected).toEqual(false)
+    })
   })
 })

--- a/src/v2/__generated__/ConfirmArtworkModalQuery.graphql.ts
+++ b/src/v2/__generated__/ConfirmArtworkModalQuery.graphql.ts
@@ -79,22 +79,27 @@ fragment ConfirmArtworkModal_artwork on Artwork {
   isEdition
   editionSets {
     internalID
-    editionOf
-    isOfferableFromInquiry
-    listPrice {
-      __typename
-      ... on Money {
-        display
-      }
-      ... on PriceRange {
-        display
-      }
-    }
-    dimensions {
-      cm
-      in
-    }
+    ...EditionSelectBox_edition
     id
+  }
+}
+
+fragment EditionSelectBox_edition on EditionSet {
+  internalID
+  editionOf
+  isOfferableFromInquiry
+  listPrice {
+    __typename
+    ... on Money {
+      display
+    }
+    ... on PriceRange {
+      display
+    }
+  }
+  dimensions {
+    cm
+    in
   }
 }
 */
@@ -477,7 +482,7 @@ return {
     "metadata": {},
     "name": "ConfirmArtworkModalQuery",
     "operationKind": "query",
-    "text": "query ConfirmArtworkModalQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ConfirmArtworkModal_artwork\n    id\n  }\n}\n\nfragment CollapsibleArtworkDetails_artwork on Artwork {\n  image {\n    resized(width: 40, height: 40) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  internalID\n  title\n  date\n  saleMessage\n  attributionClass {\n    name\n    id\n  }\n  category\n  manufacturer\n  publisher\n  medium\n  conditionDescription {\n    details\n  }\n  certificateOfAuthenticity {\n    details\n  }\n  framed {\n    details\n  }\n  dimensions {\n    in\n    cm\n  }\n  signatureInfo {\n    details\n  }\n  artistNames\n}\n\nfragment ConfirmArtworkButton_artwork on Artwork {\n  internalID\n}\n\nfragment ConfirmArtworkModal_artwork on Artwork {\n  ...CollapsibleArtworkDetails_artwork\n  ...ConfirmArtworkButton_artwork\n  internalID\n  isEdition\n  editionSets {\n    internalID\n    editionOf\n    isOfferableFromInquiry\n    listPrice {\n      __typename\n      ... on Money {\n        display\n      }\n      ... on PriceRange {\n        display\n      }\n    }\n    dimensions {\n      cm\n      in\n    }\n    id\n  }\n}\n"
+    "text": "query ConfirmArtworkModalQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) {\n    ...ConfirmArtworkModal_artwork\n    id\n  }\n}\n\nfragment CollapsibleArtworkDetails_artwork on Artwork {\n  image {\n    resized(width: 40, height: 40) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  internalID\n  title\n  date\n  saleMessage\n  attributionClass {\n    name\n    id\n  }\n  category\n  manufacturer\n  publisher\n  medium\n  conditionDescription {\n    details\n  }\n  certificateOfAuthenticity {\n    details\n  }\n  framed {\n    details\n  }\n  dimensions {\n    in\n    cm\n  }\n  signatureInfo {\n    details\n  }\n  artistNames\n}\n\nfragment ConfirmArtworkButton_artwork on Artwork {\n  internalID\n}\n\nfragment ConfirmArtworkModal_artwork on Artwork {\n  ...CollapsibleArtworkDetails_artwork\n  ...ConfirmArtworkButton_artwork\n  internalID\n  isEdition\n  editionSets {\n    internalID\n    ...EditionSelectBox_edition\n    id\n  }\n}\n\nfragment EditionSelectBox_edition on EditionSet {\n  internalID\n  editionOf\n  isOfferableFromInquiry\n  listPrice {\n    __typename\n    ... on Money {\n      display\n    }\n    ... on PriceRange {\n      display\n    }\n  }\n  dimensions {\n    cm\n    in\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/ConfirmArtworkModal_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ConfirmArtworkModal_Test_Query.graphql.ts
@@ -75,22 +75,27 @@ fragment ConfirmArtworkModal_artwork on Artwork {
   isEdition
   editionSets {
     internalID
-    editionOf
-    isOfferableFromInquiry
-    listPrice {
-      __typename
-      ... on Money {
-        display
-      }
-      ... on PriceRange {
-        display
-      }
-    }
-    dimensions {
-      cm
-      in
-    }
+    ...EditionSelectBox_edition
     id
+  }
+}
+
+fragment EditionSelectBox_edition on EditionSet {
+  internalID
+  editionOf
+  isOfferableFromInquiry
+  listPrice {
+    __typename
+    ... on Money {
+      display
+    }
+    ... on PriceRange {
+      display
+    }
+  }
+  dimensions {
+    cm
+    in
   }
 }
 */
@@ -465,7 +470,7 @@ return {
     "metadata": {},
     "name": "ConfirmArtworkModal_Test_Query",
     "operationKind": "query",
-    "text": "query ConfirmArtworkModal_Test_Query {\n  artwork(id: \"xxx\") {\n    ...ConfirmArtworkModal_artwork\n    id\n  }\n}\n\nfragment CollapsibleArtworkDetails_artwork on Artwork {\n  image {\n    resized(width: 40, height: 40) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  internalID\n  title\n  date\n  saleMessage\n  attributionClass {\n    name\n    id\n  }\n  category\n  manufacturer\n  publisher\n  medium\n  conditionDescription {\n    details\n  }\n  certificateOfAuthenticity {\n    details\n  }\n  framed {\n    details\n  }\n  dimensions {\n    in\n    cm\n  }\n  signatureInfo {\n    details\n  }\n  artistNames\n}\n\nfragment ConfirmArtworkButton_artwork on Artwork {\n  internalID\n}\n\nfragment ConfirmArtworkModal_artwork on Artwork {\n  ...CollapsibleArtworkDetails_artwork\n  ...ConfirmArtworkButton_artwork\n  internalID\n  isEdition\n  editionSets {\n    internalID\n    editionOf\n    isOfferableFromInquiry\n    listPrice {\n      __typename\n      ... on Money {\n        display\n      }\n      ... on PriceRange {\n        display\n      }\n    }\n    dimensions {\n      cm\n      in\n    }\n    id\n  }\n}\n"
+    "text": "query ConfirmArtworkModal_Test_Query {\n  artwork(id: \"xxx\") {\n    ...ConfirmArtworkModal_artwork\n    id\n  }\n}\n\nfragment CollapsibleArtworkDetails_artwork on Artwork {\n  image {\n    resized(width: 40, height: 40) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  internalID\n  title\n  date\n  saleMessage\n  attributionClass {\n    name\n    id\n  }\n  category\n  manufacturer\n  publisher\n  medium\n  conditionDescription {\n    details\n  }\n  certificateOfAuthenticity {\n    details\n  }\n  framed {\n    details\n  }\n  dimensions {\n    in\n    cm\n  }\n  signatureInfo {\n    details\n  }\n  artistNames\n}\n\nfragment ConfirmArtworkButton_artwork on Artwork {\n  internalID\n}\n\nfragment ConfirmArtworkModal_artwork on Artwork {\n  ...CollapsibleArtworkDetails_artwork\n  ...ConfirmArtworkButton_artwork\n  internalID\n  isEdition\n  editionSets {\n    internalID\n    ...EditionSelectBox_edition\n    id\n  }\n}\n\nfragment EditionSelectBox_edition on EditionSet {\n  internalID\n  editionOf\n  isOfferableFromInquiry\n  listPrice {\n    __typename\n    ... on Money {\n      display\n    }\n    ... on PriceRange {\n      display\n    }\n  }\n  dimensions {\n    cm\n    in\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/ConfirmArtworkModal_artwork.graphql.ts
+++ b/src/v2/__generated__/ConfirmArtworkModal_artwork.graphql.ts
@@ -8,15 +8,7 @@ export type ConfirmArtworkModal_artwork = {
     readonly isEdition: boolean | null;
     readonly editionSets: ReadonlyArray<{
         readonly internalID: string;
-        readonly editionOf: string | null;
-        readonly isOfferableFromInquiry: boolean | null;
-        readonly listPrice: {
-            readonly display?: string | null;
-        } | null;
-        readonly dimensions: {
-            readonly cm: string | null;
-            readonly in: string | null;
-        } | null;
+        readonly " $fragmentRefs": FragmentRefs<"EditionSelectBox_edition">;
     } | null> | null;
     readonly " $fragmentRefs": FragmentRefs<"CollapsibleArtworkDetails_artwork" | "ConfirmArtworkButton_artwork">;
     readonly " $refType": "ConfirmArtworkModal_artwork";
@@ -36,16 +28,7 @@ var v0 = {
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
-},
-v1 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-];
+};
 return {
   "argumentDefinitions": [],
   "kind": "Fragment",
@@ -70,64 +53,9 @@ return {
       "selections": [
         (v0/*: any*/),
         {
-          "alias": null,
           "args": null,
-          "kind": "ScalarField",
-          "name": "editionOf",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "isOfferableFromInquiry",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": null,
-          "kind": "LinkedField",
-          "name": "listPrice",
-          "plural": false,
-          "selections": [
-            {
-              "kind": "InlineFragment",
-              "selections": (v1/*: any*/),
-              "type": "Money"
-            },
-            {
-              "kind": "InlineFragment",
-              "selections": (v1/*: any*/),
-              "type": "PriceRange"
-            }
-          ],
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "dimensions",
-          "kind": "LinkedField",
-          "name": "dimensions",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "cm",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "in",
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
+          "kind": "FragmentSpread",
+          "name": "EditionSelectBox_edition"
         }
       ],
       "storageKey": null
@@ -146,5 +74,5 @@ return {
   "type": "Artwork"
 };
 })();
-(node as any).hash = '8d9646495e546189524d9e579463a5e8';
+(node as any).hash = 'c0d50a29df5a5234fd379374324d3f3b';
 export default node;

--- a/src/v2/__generated__/EditionSelectBox_edition.graphql.ts
+++ b/src/v2/__generated__/EditionSelectBox_edition.graphql.ts
@@ -1,0 +1,115 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type EditionSelectBox_edition = {
+    readonly internalID: string;
+    readonly editionOf: string | null;
+    readonly isOfferableFromInquiry: boolean | null;
+    readonly listPrice: {
+        readonly display?: string | null;
+    } | null;
+    readonly dimensions: {
+        readonly cm: string | null;
+        readonly in: string | null;
+    } | null;
+    readonly " $refType": "EditionSelectBox_edition";
+};
+export type EditionSelectBox_edition$data = EditionSelectBox_edition;
+export type EditionSelectBox_edition$key = {
+    readonly " $data"?: EditionSelectBox_edition$data;
+    readonly " $fragmentRefs": FragmentRefs<"EditionSelectBox_edition">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "EditionSelectBox_edition",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "editionOf",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isOfferableFromInquiry",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "listPrice",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "InlineFragment",
+          "selections": (v0/*: any*/),
+          "type": "Money"
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": (v0/*: any*/),
+          "type": "PriceRange"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "dimensions",
+      "kind": "LinkedField",
+      "name": "dimensions",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "cm",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "in",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "EditionSet"
+};
+})();
+(node as any).hash = 'bed44602aa3d225b35cb8b5a9aa189a0';
+export default node;


### PR DESCRIPTION
JIRA -> [Select edition in confirm artwork modal
](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=41&projectKey=PURCHASE&modal=detail&selectedIssue=PURCHASE-2708)

Added the ability to display selection boxes of artworks editions to the confirm artwork modal.

Figma design screenshot:

![Screen Shot 2021-06-25 at 4 50 18 PM](https://user-images.githubusercontent.com/79980131/123434785-84eff200-d5d5-11eb-827b-fcd9dc45e1ef.png)

GIF:

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/79980131/123434270-f54a4380-d5d4-11eb-85b6-7a9c1d37a1cf.gif)
