### PR TITLE
fix: Remove React Spring

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@artsy/express-reloadable": "1.4.8",
     "@artsy/fresnel": "1.7.0",
     "@artsy/gemup": "0.1.0",
-    "@artsy/palette": "14.37.0",
+    "@artsy/palette": "14.38.0",
     "@artsy/passport": "1.9.0",
     "@artsy/reaction": "29.2.0",
     "@artsy/stitch": "6.3.0",

--- a/src/v2/Components/NavBar/NavItemPanel.tsx
+++ b/src/v2/Components/NavBar/NavItemPanel.tsx
@@ -1,6 +1,5 @@
 import React from "react"
-import { animated, config, useSpring } from "react-spring"
-import styled, { css } from "styled-components"
+import styled, { css, keyframes } from "styled-components"
 
 export type MenuAnchor = "left" | "right" | "center" | "full"
 
@@ -16,15 +15,11 @@ export const NavItemPanel: React.FC<NavItemPanelProps> = ({
   relativeTo,
   children,
 }) => {
-  const animation = useSpring({
-    ...(visible ? ANIMATION_STATES.visible : ANIMATION_STATES.hidden),
-    config: name =>
-      name === "opacity" ? config.stiff : { friction: 10, mass: 0.1 },
-  })
+  const animation = visible ? ANIMATION_STATES.visible : ANIMATION_STATES.hidden
 
   return (
     <AnimatedPanel
-      style={animation}
+      animation={animation}
       data-menuanchor={menuAnchor}
       data-offsetleft={relativeTo.current?.offsetLeft}
     >
@@ -33,9 +28,10 @@ export const NavItemPanel: React.FC<NavItemPanelProps> = ({
   )
 }
 
-const AnimatedPanel = styled(animated.div)<{
+const AnimatedPanel = styled.div<{
   "data-menuanchor": MenuAnchor
   "data-offsetleft"?: number
+  animation: any
 }>`
   position: absolute;
   top: 100%;
@@ -44,31 +40,55 @@ const AnimatedPanel = styled(animated.div)<{
     ({
       right: css`
         right: 0;
+        animation: ${props.animation};
       `,
       left: css`
         left: 0;
+        animation: ${props.animation};
       `,
       center: css`
         left: 0;
         margin-left: -50%;
+        animation: ${props.animation};
       `,
       full: css`
         left: 0;
         right: 0;
         margin-left: -${props["data-offsetleft"] ?? 0}px;
+        animation: ${props.animation};
       `,
     }[props["data-menuanchor"]])}
 `
 
+const fadein = keyframes`
+  0% {
+    transform: translate3d(0, -25px, 0);
+    opacity: 0;
+  }
+  100% {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
+`
+
+const fadeout = keyframes`
+  0% {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(0, -25px, 0);
+    opacity: 0;
+  }
+`
+
 const ANIMATION_STATES = {
-  hidden: {
-    display: "none",
-    opacity: 0,
-    transform: "translate3d(0, -25px, 0)",
-  },
-  visible: {
-    display: "block",
-    opacity: 1,
-    transform: "translate3d(0, 0, 0)",
-  },
+  hidden: css`
+    ${fadeout} 0.1s linear;
+    display: none;
+  `,
+  visible: css`
+    ${fadein} 0.1s linear;
+    display: block;
+  `,
 }

--- a/src/v2/Components/NavBar/NavItemPanel.tsx
+++ b/src/v2/Components/NavBar/NavItemPanel.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import styled, { css, keyframes } from "styled-components"
+import styled, { css } from "styled-components"
 
 export type MenuAnchor = "left" | "right" | "center" | "full"
 
@@ -15,11 +15,9 @@ export const NavItemPanel: React.FC<NavItemPanelProps> = ({
   relativeTo,
   children,
 }) => {
-  const animation = visible ? ANIMATION_STATES.visible : ANIMATION_STATES.hidden
-
   return (
     <AnimatedPanel
-      animation={animation}
+      className={visible ? "fadeIn" : ""}
       data-menuanchor={menuAnchor}
       data-offsetleft={relativeTo.current?.offsetLeft}
     >
@@ -31,64 +29,41 @@ export const NavItemPanel: React.FC<NavItemPanelProps> = ({
 const AnimatedPanel = styled.div<{
   "data-menuanchor": MenuAnchor
   "data-offsetleft"?: number
-  animation: any
 }>`
   position: absolute;
   top: 100%;
   z-index: 1;
+
+  /* Pre animation state */
+  visibility: hidden;
+  opacity: 0;
+  transform: translateY(-15px);
+
+  /* Animate in */
+  &.fadeIn {
+    visibility: visible;
+    transition: all 500ms cubic-bezier(0.075, 0.82, 0.365, 1); /* easeOutCirc */
+    transition-delay: 200ms;
+    transform: translateY(0px);
+    opacity: 1;
+  }
+
   ${({ ...props }) =>
     ({
       right: css`
         right: 0;
-        animation: ${props.animation};
       `,
       left: css`
         left: 0;
-        animation: ${props.animation};
       `,
       center: css`
         left: 0;
         margin-left: -50%;
-        animation: ${props.animation};
       `,
       full: css`
         left: 0;
         right: 0;
         margin-left: -${props["data-offsetleft"] ?? 0}px;
-        animation: ${props.animation};
       `,
     }[props["data-menuanchor"]])}
 `
-
-const fadein = keyframes`
-  0% {
-    transform: translate3d(0, -25px, 0);
-    opacity: 0;
-  }
-  100% {
-    transform: translate3d(0, 0, 0);
-    opacity: 1;
-  }
-`
-
-const fadeout = keyframes`
-  0% {
-    transform: translate3d(0, 0, 0);
-    opacity: 1;
-  }
-  100% {
-    transform: translate3d(0, -25px, 0);
-    opacity: 0;
-  }
-`
-
-const ANIMATION_STATES = {
-  hidden: css`
-    ${fadeout} 0.1s linear;
-    display: none;
-  `,
-  visible: css`
-    ${fadein} 0.1s linear;
-    display: block;
-  `,
-}

--- a/src/v2/System/Router/PageLoader.tsx
+++ b/src/v2/System/Router/PageLoader.tsx
@@ -1,7 +1,7 @@
 import { Box, ProgressBar } from "@artsy/palette"
 import { random } from "lodash"
 import React from "react"
-import { Spring } from "react-spring/renderprops.cjs"
+import styled, { css, keyframes } from "styled-components"
 
 interface PageLoaderProps {
   className?: string
@@ -71,33 +71,55 @@ export class PageLoader extends React.Component<
     const { progress } = this.state
     const isComplete = progress === 100
 
-    const animation = {
-      from: {
-        opacity: 0,
-        top: 0,
-      },
-      to: {
-        opacity: 1,
-        top: 0,
-      },
-    }
+    const animation = isComplete
+      ? ANIMATION_STATES.hidden
+      : ANIMATION_STATES.visible
 
     return (
       <Box width="100%" style={style} className={className}>
-        <Spring from={animation.from} to={animation.to} reverse={isComplete}>
-          {animationProps => {
-            return (
-              <Box style={animationProps} position="relative">
-                <ProgressBar
-                  percentComplete={progress}
-                  highlight="purple100"
-                  showBackground={showBackground}
-                />
-              </Box>
-            )
-          }}
-        </Spring>
+        <AnimatedBox animation={animation} position="relative">
+          <ProgressBar
+            percentComplete={progress}
+            highlight="purple100"
+            showBackground={showBackground}
+          />
+        </AnimatedBox>
       </Box>
     )
   }
 }
+
+const fadein = keyframes`
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+`
+
+const fadeout = keyframes`
+0% {
+  opacity: 1;
+}
+100% {
+  opacity: 0;
+}
+`
+
+const ANIMATION_STATES = {
+  hidden: css`
+    ${fadeout} 0.1s linear;
+  `,
+  visible: css`
+    ${fadein} 0.1s linear;
+  `,
+}
+
+const AnimatedBox = styled(Box)<{
+  animation: any
+}>`
+  ${({ ...props }) => css`
+    animation: ${props.animation};
+  `}
+`

--- a/src/v2/System/Router/PageLoader.tsx
+++ b/src/v2/System/Router/PageLoader.tsx
@@ -1,7 +1,6 @@
 import { Box, ProgressBar } from "@artsy/palette"
 import { random } from "lodash"
 import React from "react"
-import styled, { css, keyframes } from "styled-components"
 
 interface PageLoaderProps {
   className?: string
@@ -69,57 +68,15 @@ export class PageLoader extends React.Component<
   render() {
     const { showBackground, style, className } = this.props
     const { progress } = this.state
-    const isComplete = progress === 100
-
-    const animation = isComplete
-      ? ANIMATION_STATES.hidden
-      : ANIMATION_STATES.visible
 
     return (
       <Box width="100%" style={style} className={className}>
-        <AnimatedBox animation={animation} position="relative">
-          <ProgressBar
-            percentComplete={progress}
-            highlight="purple100"
-            showBackground={showBackground}
-          />
-        </AnimatedBox>
+        <ProgressBar
+          percentComplete={progress}
+          highlight="purple100"
+          showBackground={showBackground}
+        />
       </Box>
     )
   }
 }
-
-const fadein = keyframes`
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-`
-
-const fadeout = keyframes`
-0% {
-  opacity: 1;
-}
-100% {
-  opacity: 0;
-}
-`
-
-const ANIMATION_STATES = {
-  hidden: css`
-    ${fadeout} 0.1s linear;
-  `,
-  visible: css`
-    ${fadein} 0.1s linear;
-  `,
-}
-
-const AnimatedBox = styled(Box)<{
-  animation: any
-}>`
-  ${({ ...props }) => css`
-    animation: ${props.animation};
-  `}
-`

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,10 +65,10 @@
   dependencies:
     uuid "^8.3.0"
 
-"@artsy/palette@14.37.0":
-  version "14.37.0"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-14.37.0.tgz#422bb9c9d3173b90d86b80b1d04d22c736d01c1a"
-  integrity sha512-cV1+2RBDB07cc9BzkOyP8zfvz8gwTe0h+mbqNEJ7chpRjU69GleYqMt92LyhvGqdO9Jo8V3OXzklCtMVvUG6wg==
+"@artsy/palette@14.38.0":
+  version "14.38.0"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-14.38.0.tgz#d762916fa271ca28c8f770855e58f48f56981018"
+  integrity sha512-nxK7BL75yOm9x4gMIpKsrjSkaYltI3tH7QF+2S3EF8ZBJLN5BafPH1rjFX7qppq3cK6eHrdZwR5/wnsipojtug==
   dependencies:
     "@seznam/compose-react-refs" "^1.0.6"
     "@styled-system/theme-get" "^5.1.2"
@@ -80,7 +80,6 @@
     rc-slider "^8.6.2"
     react-lazy-load-image-component "1.5.0"
     react-remove-scroll "^2.3.0"
-    react-spring "^8.0.27"
     styled-bootstrap-grid "3.1.0"
     styled-system "^5.1.5"
     trunc-html "^1.1.2"
@@ -108,7 +107,7 @@
     ip "1.1.5"
     mailcheck "1.1.1"
     passport "0.3.2"
-    passport-apple "git+https://github.com/artsy/passport-apple.git#f41adb7822c8344b72bc36a7d68312f6592cb14f"
+    passport-apple "https://github.com/artsy/passport-apple#f41adb7822c8344b72bc36a7d68312f6592cb14f"
     passport-facebook "2.1.1"
     superagent "1.8.4"
     underscore.string "3.3.4"
@@ -15316,7 +15315,6 @@ pascalcase@^0.1.1:
 
 "passport-apple@git+https://github.com/artsy/passport-apple.git#f41adb7822c8344b72bc36a7d68312f6592cb14f":
   version "1.1.2"
-  uid f41adb7822c8344b72bc36a7d68312f6592cb14f
   resolved "git+https://github.com/artsy/passport-apple.git#f41adb7822c8344b72bc36a7d68312f6592cb14f"
   dependencies:
     jsonwebtoken "^8.5.1"
@@ -16831,14 +16829,6 @@ react-slick@^0.23.2:
     lodash.debounce "^4.0.8"
     prettier "^1.14.3"
     resize-observer-polyfill "^1.5.0"
-
-react-spring@^8.0.27:
-  version "8.0.27"
-  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-8.0.27.tgz#97d4dee677f41e0b2adcb696f3839680a3aa356a"
-  integrity sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    prop-types "^15.5.8"
 
 react-static-container@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This change replaces `react-spring` with styled component keyframe
animations and is necessary to remove a significant memory leak caused
by `react-spring` that is crashing our production pods.

Review App:
https://novo.artsy.net/


https://user-images.githubusercontent.com/403814/123460768-210a0100-d5b6-11eb-8912-5f56c771adbb.mov

