### PR TITLE
fix: sanitizes inputs

### DIFF
--- a/src/v2/Apps/Artists/artistsRoutes.tsx
+++ b/src/v2/Apps/Artists/artistsRoutes.tsx
@@ -61,7 +61,7 @@ export const artistsRoutes: AppRouteConfig[] = [
           return {
             ...params,
             ...props,
-            page: props.location.query.page ?? 1,
+            page: parseInt(props.location.query.page, 10) || 1,
             size: 100,
           }
         },

--- a/src/v2/Components/ArtworkFilter/Utils/__tests__/allowedFilters.jest.ts
+++ b/src/v2/Components/ArtworkFilter/Utils/__tests__/allowedFilters.jest.ts
@@ -21,4 +21,38 @@ describe("allowedFilters", () => {
       width: "*-*",
     })
   })
+
+  it("coerces numeric inputs", () => {
+    expect(
+      allowedFilters({
+        first: 100,
+        last: "7.999",
+        page: "9",
+        size: "foobar",
+      })
+    ).toEqual({
+      first: 100,
+      last: 7,
+      page: 9,
+      size: 1,
+    })
+  })
+
+  it("coerces boolean inputs", () => {
+    expect(
+      allowedFilters({
+        acquireable: "true",
+        atAuction: "false",
+        forSale: 1,
+        includeArtworksByFollowedArtists: "",
+        includeMediumFilterInAggregation: "garbage",
+      })
+    ).toEqual({
+      acquireable: true,
+      atAuction: false,
+      forSale: false,
+      includeArtworksByFollowedArtists: false,
+      includeMediumFilterInAggregation: false,
+    })
+  })
 })

--- a/src/v2/Components/ArtworkFilter/Utils/allowedFilters.ts
+++ b/src/v2/Components/ArtworkFilter/Utils/allowedFilters.ts
@@ -1,16 +1,49 @@
-export const allowedFilters = filterParams => {
-  return Object.keys(filterParams)
-    .filter(key => supportedInputArgs.includes(key))
-    .reduce((obj, key) => {
-      obj[key] = filterParams[key]
+export const allowedFilters = (
+  filterParams: Record<string, any> = {}
+): Record<string, any> => {
+  return Object.keys(filterParams).reduce((obj, key) => {
+    // Filter out unsupported arguments
+    if (!SUPPORTED_INPUT_ARGS.includes(key)) {
       return obj
-    }, {})
+    }
+
+    // Coerce integers
+    if (INTEGER_INPUT_ARGS.includes(key)) {
+      obj[key] = parseInt(filterParams[key], 10) || 1
+      return obj
+    }
+
+    // Coerce booleans
+    if (BOOLEAN_INPUT_ARGS.includes(key)) {
+      const value = filterParams[key]
+      obj[key] = value === "true" || value === true
+      return obj
+    }
+
+    obj[key] = filterParams[key]
+    return obj
+  }, {})
 }
 
-// This corresponds to all the allowed inputs to the
-// filtered artworks connection. This can be used as an
-// allow-list when passing filter state from a URL.
-const supportedInputArgs = [
+const INTEGER_INPUT_ARGS = ["first", "last", "page", "size"]
+
+const BOOLEAN_INPUT_ARGS = [
+  "acquireable",
+  "atAuction",
+  "forSale",
+  "includeArtworksByFollowedArtists",
+  "includeMediumFilterInAggregation",
+  "inquireableOnly",
+  "keywordMatchExact",
+  "marketable",
+  "offerable",
+]
+
+/**
+ * This corresponds to all the allowed inputs to the filtered artworks connection.
+ * This can be used as an allow-list when passing filter state from a URL.
+ */
+const SUPPORTED_INPUT_ARGS = [
   "acquireable",
   "additionalGeneIDs",
   "after",


### PR DESCRIPTION
Re: https://artsy.slack.com/archives/C2TQ4PT8R/p1624812250180200

Anytime we don't sanitize inputs like this, Force will 500. But, these are at least easy to spot: anytime there's a variable input on a route query that isn't `String` — we need to prepare the input in some way. There's probably a few more of these lurking around so feel free to point any out.