### PR TITLE
fix: selecting size generate events for custom size

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
@@ -144,18 +144,14 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
     const newFilters = {
       ...currentlySelectedFilters?.(),
       sizes,
-      height: "*-*",
-      width: "*-*",
     }
 
     setFilters?.(newFilters, { force: false })
-    setCustomSize({ height: ["*", "*"], width: ["*", "*"] })
   }
 
   const handleClick = () => {
     const newFilters = {
       ...currentlySelectedFilters?.(),
-      sizes: [],
       ...mapSizeToRange(convertSizeToInches(customSize) as CustomSize),
     }
     setFilters?.(newFilters, { force: false })

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter.jest.tsx
@@ -92,7 +92,7 @@ describe("SizeFilter", () => {
         .filterWhere(n => n.text() === "Set size")
         .simulate("click")
 
-      expect(context.filters?.sizes).toEqual([])
+      expect(context.filters?.sizes).toEqual(["SMALL"])
       // assert conversion from centimeters to inches
       expect(context.filters?.height).toEqual("4.72-6.3")
       expect(context.filters?.width).toEqual("4.72-6.3")
@@ -108,6 +108,8 @@ describe("SizeFilter", () => {
 
       simulateTyping(wrapper, "height_min", "12")
       simulateTyping(wrapper, "height_max", "24")
+      simulateTyping(wrapper, "width_min", "")
+      simulateTyping(wrapper, "width_max", "")
 
       await wrapper
         .find("button")


### PR DESCRIPTION
[FX-2826](https://artsyproduct.atlassian.net/browse/FX-2826)

**Description**
When user select small/medium/large size, generates also events for custom size

**Before**
![2826-before](https://user-images.githubusercontent.com/56556580/123756487-a4349b00-d8c5-11eb-97bd-19abe6e12676.gif)

**After**
![2826-after](https://user-images.githubusercontent.com/56556580/123756507-a8f94f00-d8c5-11eb-9c1c-52fffed115b0.gif)

