### PR TITLE
fix(PX-4272) show cover image on mobile

### DIFF
--- a/src/v2/Apps/Partner/Components/PartnerShows/ShowBanner.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerShows/ShowBanner.tsx
@@ -117,7 +117,11 @@ const ShowBanner: React.FC<ShowBannerProps> = ({
       </Column>
       {coverImage && coverImage.medium && (
         <Column height={[280, 480]} position="relative" span={6}>
-          <SlideBox opacity={active ? 1 : 0} right={active ? 0 : "-100%"}>
+          <SlideBox
+            width="100%"
+            opacity={active ? 1 : 0}
+            right={active ? 0 : "-100%"}
+          >
             {/* @ts-expect-error STRICT_NULL_CHECK */}
             <RouterLink to={href}>
               <Image


### PR DESCRIPTION
This PR fixes the show cover image width on mobile.

JIRA - https://artsyproduct.atlassian.net/browse/PX-4272

Before
![image](https://user-images.githubusercontent.com/79979820/123799246-b1b34a80-d8f0-11eb-8eb6-d1fc21081d60.png)

Now
![image](https://user-images.githubusercontent.com/79979820/123799680-1ff80d00-d8f1-11eb-90f3-b14af9b479d7.png)
