### PR TITLE
chore: Remove unused code based on #7797 

### DIFF
--- a/src/v2/Apps/Order/Components/SavedAddresses.tsx
+++ b/src/v2/Apps/Order/Components/SavedAddresses.tsx
@@ -31,7 +31,6 @@ const PAGE_SIZE = 30
 interface SavedAddressesProps {
   me: SavedAddresses_me
   onSelect?: (string) => void
-  handleClickEdit: (number) => void
   inCollectorProfile: boolean
   commitMutation?: CommitMutation
   relay: RelayRefetchProp
@@ -58,14 +57,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
   const [showAddressModal, setShowAddressModal] = useState<boolean>(false)
   const [address, setAddress] = useState(null as Address)
   const logger = createLogger("SavedAddresses.tsx")
-  const {
-    onSelect,
-    me,
-    inCollectorProfile,
-    relay,
-    onAddressDelete,
-    handleClickEdit,
-  } = props
+  const { onSelect, me, inCollectorProfile, relay, onAddressDelete } = props
   const addressList = me?.addressConnection?.edges ?? []
   const { relayEnvironment } = useSystemContext()
 
@@ -94,7 +86,6 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
   }
 
   const handleEditAddress = (address: Address, index: number) => {
-    handleClickEdit(index)
     setShowAddressModal(true)
     setModalDetails({
       addressModalTitle: "Edit address",

--- a/src/v2/Apps/Order/Components/__tests__/SavedAddresses.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/SavedAddresses.jest.tsx
@@ -21,11 +21,7 @@ class SavedAddressesTestPage extends RootTestPage {
 describe("Saved Addresses mutations", () => {
   const { mutations, buildPage } = createTestEnv({
     Component: (props: any) => (
-      <SavedAddressesFragmentContainer
-        inCollectorProfile
-        handleClickEdit={() => {}}
-        {...props}
-      />
+      <SavedAddressesFragmentContainer inCollectorProfile {...props} />
     ),
     defaultData: userAddressMutation,
     TestPage: SavedAddressesTestPage,

--- a/src/v2/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/v2/Apps/Order/Routes/Shipping/index.tsx
@@ -88,9 +88,7 @@ export interface ShippingState {
   addressErrors: AddressErrors
   addressTouched: AddressTouched
   selectedSavedAddress: string
-  editAddressIndex: number
   saveAddress: boolean
-  showModal: boolean
 }
 
 const logger = createLogger("Order/Routes/Shipping/index.tsx")
@@ -110,9 +108,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
     phoneNumberError: "",
     phoneNumberTouched: false,
     selectedSavedAddress: defaultShippingAddressIndex(this.props.me),
-    editAddressIndex: -1,
     saveAddress: true,
-    showModal: false,
   }
 
   get touchedAddress() {
@@ -233,7 +229,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
             }
           }, // onError
           this.props.me, // me
-          () => this.setState({ showModal: false }) // closeModal
+          () => {} // closeModal
         )
       }
 
@@ -274,10 +270,6 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
     } else {
       this.props.dialog.showErrorDialog()
     }
-  }
-
-  handleClickEdit = (value: number) => {
-    this.setState({ editAddressIndex: value, showModal: true })
   }
 
   onAddressChange: AddressChangeHandler = (address, key) => {
@@ -406,7 +398,6 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
                   <SavedAddresses
                     me={this.props.me}
                     onSelect={value => onSelectSavedAddress(value)}
-                    handleClickEdit={this.handleClickEdit}
                     inCollectorProfile={false}
                     onAddressDelete={this.handleAddressDelete}
                   />

--- a/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -611,7 +611,6 @@ describe("Shipping", () => {
           .find(`[data-test="editAddressInShipping"]`)
           .first()
           .simulate("click")
-        expect(page.find(ShippingRoute).state().editAddressIndex).toBe(0)
         expect(
           page.find("AddressModal").at(0).props().modalDetails
         ).toStrictEqual({
@@ -621,12 +620,10 @@ describe("Shipping", () => {
       })
 
       it("opens modal with current address values", async () => {
-        expect(page.find(ShippingRoute).state().editAddressIndex).toBe(-1)
         await page
           .find(`[data-test="editAddressInShipping"]`)
           .first()
           .simulate("click")
-        expect(page.find(ShippingRoute).state().editAddressIndex).toBe(0)
 
         expect(page.find("AddressModal").length).toBe(1)
         expect(

--- a/src/v2/Components/UserSettings/UserSettingsAddresses.tsx
+++ b/src/v2/Components/UserSettings/UserSettingsAddresses.tsx
@@ -19,7 +19,6 @@ interface UserSettingsAddressesProps extends SystemContextProps {
 }
 
 export const UserSettingsAddresses: React.FC<UserSettingsAddressesProps> = props => {
-  const handleClickEdit = () => {}
   const { me } = props
 
   return (
@@ -31,7 +30,6 @@ export const UserSettingsAddresses: React.FC<UserSettingsAddressesProps> = props
         <SavedAddresses
           // @ts-expect-error STRICT_NULL_CHECK
           me={me}
-          handleClickEdit={handleClickEdit}
           inCollectorProfile
           {...props}
         />


### PR DESCRIPTION
In #7797 [I mentioned that I thought we could clean up a few more stateful properties](https://github.com/artsy/force/pull/7797#discussion_r660128541) in the `Shipping` route component, because they're being set but never read. This PR does that!

@Serge0n you're closer to this work, let me know if I'm missing something and these things can't be removed. 

I created the PR based on the branch for #7797, so this _could_ be merged into that branch before it's merged, if we want. Or we could merge this into master after #7797 is merged. 