### PR TITLE
fix: size events fire only by changes explicitly

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
@@ -17,6 +17,7 @@ import {
 import { NumericInput } from "./PriceRangeFilter"
 import { Media } from "v2/Utils/Responsive"
 import { FilterExpandable } from "./FilterExpandable"
+import { isString } from "lodash"
 
 const SIZES = [
   { displayName: "Small (under 40cm)", name: "SMALL" },
@@ -84,7 +85,7 @@ const getValue = (value: CustomRange[number]) => {
   return value === "*" || value === 0 ? "" : value
 }
 
-const isEmptyRange = value => value === undefined || value === "*-*"
+const isCustomSize = (value?: string) => isString(value) && value !== "*-*"
 
 export interface SizeFilterProps {
   expanded?: boolean
@@ -146,8 +147,13 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
     const newFilters = {
       ...currentlySelectedFilters?.(),
       sizes,
-      height: isEmptyRange(height) ? height : "*-*",
-      width: isEmptyRange(width) ? width : "*-*",
+    }
+
+    if (isCustomSize(height)) {
+      newFilters.height = "*-*"
+    }
+    if (isCustomSize(width)) {
+      newFilters.width = "*-*"
     }
 
     setFilters?.(newFilters, { force: false })
@@ -155,19 +161,20 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
   }
 
   const handleClick = () => {
-    const { height: heightRange, width: widthRange } = mapSizeToRange(
+    const { height: newHeightValue, width: newWidthValue } = mapSizeToRange(
       convertSizeToInches(customSize) as CustomSize
     )
 
     const newFilters = {
       ...currentlySelectedFilters?.(),
       sizes: [],
-      width:
-        isEmptyRange(width) && isEmptyRange(widthRange) ? width : widthRange,
-      height:
-        isEmptyRange(heightRange) && isEmptyRange(heightRange)
-          ? height
-          : heightRange,
+    }
+
+    if (isCustomSize(newWidthValue) || isCustomSize(width)) {
+      newFilters.width = newWidthValue
+    }
+    if (isCustomSize(newHeightValue) || isCustomSize(height)) {
+      newFilters.height = newHeightValue
     }
 
     setFilters?.(newFilters, { force: false })

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
@@ -84,6 +84,8 @@ const getValue = (value: CustomRange[number]) => {
   return value === "*" || value === 0 ? "" : value
 }
 
+const isEmptyRange = value => value === undefined || value === "*-*"
+
 export interface SizeFilterProps {
   expanded?: boolean
 }
@@ -144,9 +146,8 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
     const newFilters = {
       ...currentlySelectedFilters?.(),
       sizes,
-      height: "*-*",
-      width: "*-*",
-      reset: false,
+      height: isEmptyRange(height) ? height : "*-*",
+      width: isEmptyRange(width) ? width : "*-*",
     }
 
     setFilters?.(newFilters, { force: false })
@@ -154,12 +155,21 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
   }
 
   const handleClick = () => {
+    const { height: heightRange, width: widthRange } = mapSizeToRange(
+      convertSizeToInches(customSize) as CustomSize
+    )
+
     const newFilters = {
       ...currentlySelectedFilters?.(),
       sizes: [],
-      reset: false,
-      ...mapSizeToRange(convertSizeToInches(customSize) as CustomSize),
+      width:
+        isEmptyRange(width) && isEmptyRange(widthRange) ? width : widthRange,
+      height:
+        isEmptyRange(heightRange) && isEmptyRange(heightRange)
+          ? height
+          : heightRange,
     }
+
     setFilters?.(newFilters, { force: false })
     setMode("done")
   }
@@ -173,8 +183,11 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
     // if filter state is being reset, then also clear local input state
     if (reset) {
       setCustomSize({ height: ["*", "*"], width: ["*", "*"] })
+
+      const newF = { ...currentlySelectedFilters?.(), reset: false }
+      setFilters?.(newF, { force: false })
     }
-  }, [reset])
+  }, [currentlySelectedFilters, reset, setFilters])
 
   const selection = currentlySelectedFilters?.().sizes
   const customHeight = currentlySelectedFilters?.().height

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
@@ -176,6 +176,9 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
     if (isCustomSize(newHeightValue) || isCustomSize(height)) {
       newFilters.height = newHeightValue
     }
+    if (reset) {
+      delete newFilters.reset
+    }
 
     setFilters?.(newFilters, { force: false })
     setMode("done")
@@ -190,11 +193,8 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
     // if filter state is being reset, then also clear local input state
     if (reset) {
       setCustomSize({ height: ["*", "*"], width: ["*", "*"] })
-
-      const newFilters = { ...currentlySelectedFilters?.(), reset: false }
-      setFilters?.(newFilters, { force: false })
     }
-  }, [currentlySelectedFilters, reset, setFilters])
+  }, [reset])
 
   const selection = currentlySelectedFilters?.().sizes
   const customHeight = currentlySelectedFilters?.().height

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
@@ -184,8 +184,8 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
     if (reset) {
       setCustomSize({ height: ["*", "*"], width: ["*", "*"] })
 
-      const newF = { ...currentlySelectedFilters?.(), reset: false }
-      setFilters?.(newF, { force: false })
+      const newFilters = { ...currentlySelectedFilters?.(), reset: false }
+      setFilters?.(newFilters, { force: false })
     }
   }, [currentlySelectedFilters, reset, setFilters])
 

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter.jest.tsx
@@ -70,6 +70,36 @@ describe("SizeFilter", () => {
     expect(wrapper.text()).toContain("Width")
   })
 
+  it("size selection don't change empty custom size", async () => {
+    const wrapper = getWrapper()
+
+    await wrapper.find("Checkbox").at(0).simulate("click")
+    expect(context.filters?.sizes).toEqual(["SMALL"])
+
+    expect(context.filters?.height).toEqual(undefined)
+    expect(context.filters?.width).toEqual(undefined)
+  })
+
+  it("width changes don't fire height changes", async () => {
+    const wrapper = getWrapper()
+
+    wrapper
+      .find("button")
+      .filterWhere(n => n.text() === "Show custom size")
+      .simulate("click")
+
+    simulateTyping(wrapper, "width_min", "12")
+    simulateTyping(wrapper, "width_max", "16")
+
+    await wrapper
+      .find("button")
+      .filterWhere(n => n.text() === "Set size")
+      .simulate("click")
+
+    expect(context.filters?.width).toEqual("4.72-6.3")
+    expect(context.filters?.height).toEqual(undefined)
+  })
+
   describe("filter values", () => {
     it("are updated", async () => {
       const wrapper = getWrapper()
@@ -117,7 +147,6 @@ describe("SizeFilter", () => {
       expect(context.filters?.sizes).toEqual([])
       // assert conversion centimeters to inches
       expect(context.filters?.height).toEqual("4.72-9.45")
-      expect(context.filters?.width).toEqual("*-*")
     })
   })
 

--- a/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
@@ -60,7 +60,7 @@ describe("ArtworkFilterMobileActionSheet", () => {
 
     expect(context.stagedFilters).toEqual({
       ...initialArtworkFilterState,
-      reset: true,
+      reset: false,
     })
   })
 

--- a/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
@@ -60,7 +60,7 @@ describe("ArtworkFilterMobileActionSheet", () => {
 
     expect(context.stagedFilters).toEqual({
       ...initialArtworkFilterState,
-      reset: false,
+      reset: true,
     })
   })
 


### PR DESCRIPTION
Jira: [FX-2826](https://artsyproduct.atlassian.net/browse/FX-2826), [FX-2827](https://artsyproduct.atlassian.net/browse/FX-2827)

Solution for issues:
- user select/unselect small/medium/large size and filter fires events for custom width/height -- if custom width/height have null value (it may be undefined or *-*) and new value is also null, they don't update, in other way width/height should reset
- user select a custom width and filter fire event for custom height -- if custom height have null value and new value is also null, it don't update (the same for width)

**Before**
Selecting size fires additional analytics events
Ex. selecting medium size fire events for custom width/height
![image](https://user-images.githubusercontent.com/56556580/123912837-3308ec80-d986-11eb-8fdd-2d16ec99c21c.png)
![image](https://user-images.githubusercontent.com/56556580/123912910-47e58000-d986-11eb-9b9b-e719e70db8ba.png)

**After**
Size events fire only by changes explicitly
![image](https://user-images.githubusercontent.com/56556580/123913183-95fa8380-d986-11eb-89f4-9650ea06a144.png)


**Additional**
Fix the bug with reset flag (when user clear all flags the _Apply_ button can not be clicked, so the filters don't apply)