### PR TITLE
Ignore more errors that account for ~70% of overall volume

### DIFF
--- a/src/lib/analytics/sentryFilters.ts
+++ b/src/lib/analytics/sentryFilters.ts
@@ -1,7 +1,9 @@
 export const IGNORED_ERRORS = [
+  "AbortError: Failed to execute 'fetch' on 'Window': The user aborted a request.",
   "AbortError: Fetch is aborted",
   "AbortError: Request signal is aborted",
   "AbortError: The operation was aborted",
+  "AbortError: The user aborted a request.",
   'Blocked a frame with origin "https://www.artsy.net" from accessing a cross-origin frame. Protocols, domains, and ports must match.',
   "cancelled",
   "Failed to fetch",


### PR DESCRIPTION
Following up recent efforts to filter out the noisiest and least-actionable error report ([1](https://github.com/artsy/force/pull/7802), [2](https://github.com/artsy/force/pull/7807), [3](https://github.com/artsy/force/pull/7809), [4](https://github.com/artsy/force/pull/7862)...), this PR filters out 2 additional groups of issues:
* https://sentry.io/organizations/artsynet/issues/2460304848
* https://sentry.io/organizations/artsynet/issues/2460304867

Together these account for ~70% of our quota. They had been "ignored," so weren't obvious in the Sentry UI but _do_ count against our quota.