### PR TITLE
fix: Remove Underscore from Asset Bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test:ci:mocha": "NODE_ENV=test yarn mocha src/**/*.test.js src/**/*.test.ts",
     "type-check": "tsc",
     "unlink-all": "yalc remove --all && yarn --check-files",
-    "stats:assets": "WEBPACK_STATS=normal NODE_ENV=production BUILD_CLIENT=true node --max_old_space_size=4096 -r dotenv/config -r @babel/register node_modules/.bin/webpack --profile --json --config ./webpack > stats.json",
+    "stats:assets": "WEBPACK_CONCATENATE=false WEBPACK_STATS=normal NODE_ENV=production BUILD_CLIENT=true node --max_old_space_size=4096 -r dotenv/config -r @babel/register node_modules/.bin/webpack --profile --json --config ./webpack > stats.json",
     "storybook": "start-storybook -p 6006",
     "webpack": "node --max_old_space_size=4096 -r dotenv/config -r @babel/register node_modules/.bin/webpack --config ./webpack"
   },

--- a/src/lib/cache.js
+++ b/src/lib/cache.js
@@ -8,7 +8,7 @@
  * without redis when necessary.
  */
 
-const _ = require("underscore")
+const _ = require("lodash")
 const { NODE_ENV, OPENREDIS_URL, DEFAULT_CACHE_TIME } = process.env
 
 class Cache {

--- a/src/v2/Apps/Partner/Components/Overview/NearbyGalleriesRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/NearbyGalleriesRail.tsx
@@ -8,7 +8,7 @@ import { useSystemContext } from "v2/System"
 import { NearbyGalleryCardFragmentContainer } from "./NearbyGalleryCard"
 import { NearbyGalleriesRailPlaceholder } from "./NearbyGalleriesRailPlaceholder"
 import { SystemQueryRenderer as QueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
-import { compact } from "underscore"
+import { compact } from "lodash"
 
 interface NearbyGalleriesRailProps extends BoxProps {
   partners: NearbyGalleriesRail_partners

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
@@ -1,6 +1,6 @@
 import { Checkbox, Flex, useThemeConfig } from "@artsy/palette"
 import React, { FC } from "react"
-import { intersection } from "underscore"
+import { intersection } from "lodash"
 import { useArtworkFilterContext } from "../ArtworkFilterContext"
 import { FilterExpandable } from "./FilterExpandable"
 import { INITIAL_ITEMS_TO_SHOW, ShowMore } from "./ShowMore"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15313,9 +15313,9 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
-"passport-apple@git+https://github.com/artsy/passport-apple.git#f41adb7822c8344b72bc36a7d68312f6592cb14f":
+"passport-apple@https://github.com/artsy/passport-apple#f41adb7822c8344b72bc36a7d68312f6592cb14f":
   version "1.1.2"
-  resolved "git+https://github.com/artsy/passport-apple.git#f41adb7822c8344b72bc36a7d68312f6592cb14f"
+  resolved "https://github.com/artsy/passport-apple#f41adb7822c8344b72bc36a7d68312f6592cb14f"
   dependencies:
     jsonwebtoken "^8.5.1"
     passport-oauth2 "^1.5.0"


### PR DESCRIPTION
This change removes underscore from the asset bundle decreasing it's
size by 30KB gzip.