### PR TITLE
Kiryl zubarau/fix/px 4291 redundant empty space is displayed above the cover image

### DIFF
--- a/src/v2/Apps/Partner/Components/NavigationTabs/index.tsx
+++ b/src/v2/Apps/Partner/Components/NavigationTabs/index.tsx
@@ -2,7 +2,7 @@ import { breakpoints, DROP_SHADOW, FullBleed } from "@artsy/palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { HorizontalPadding } from "v2/Apps/Components/HorizontalPadding"
-import { MOBILE_NAV_HEIGHT, NAV_BAR_HEIGHT } from "v2/Components/NavBar"
+import { useNavBarHeight } from "v2/Components/NavBar/useNavBarHeight"
 import { RouteTab, RouteTabs } from "v2/Components/RouteTabs"
 import { Sticky } from "v2/Components/Sticky"
 import { ScrollIntoView } from "v2/Utils"
@@ -17,6 +17,8 @@ interface NavigationTabsProps {
 }
 
 export const NavigationTabs: React.FC<NavigationTabsProps> = ({ partner }) => {
+  const { mobile, desktop } = useNavBarHeight()
+
   const renderTabs = (scrollOffset: number) => {
     const {
       slug,
@@ -99,10 +101,10 @@ export const NavigationTabs: React.FC<NavigationTabsProps> = ({ partner }) => {
           >
             <HorizontalPadding maxWidth={breakpoints.xl}>
               <Media greaterThan="xs">
-                <RouteTabs fill>{renderTabs(NAV_BAR_HEIGHT)}</RouteTabs>
+                <RouteTabs fill>{renderTabs(desktop)}</RouteTabs>
               </Media>
               <Media at="xs">
-                <RouteTabs fill>{renderTabs(MOBILE_NAV_HEIGHT)}</RouteTabs>
+                <RouteTabs fill>{renderTabs(mobile)}</RouteTabs>
               </Media>
             </HorizontalPadding>
           </FullBleed>

--- a/src/v2/Apps/Partner/Components/PartnerHeader/PartnerHeaderImage.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerHeader/PartnerHeaderImage.tsx
@@ -2,11 +2,11 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { PartnerHeaderImage_profile } from "v2/__generated__/PartnerHeaderImage_profile.graphql"
 import { Box } from "@artsy/palette"
-import { MOBILE_NAV_HEIGHT, NAV_BAR_HEIGHT } from "v2/Components/NavBar"
 import {
   FullBleedHeader,
   FULL_BLEED_HEADER_HEIGHT,
 } from "v2/Components/FullBleedHeader"
+import { useNavBarHeight } from "v2/Components/NavBar/useNavBarHeight"
 
 interface PartnerHeaderImageProps {
   profile: PartnerHeaderImage_profile
@@ -15,6 +15,8 @@ interface PartnerHeaderImageProps {
 export const PartnerHeaderImage: React.FC<PartnerHeaderImageProps> = ({
   profile,
 }) => {
+  const { mobile, desktop } = useNavBarHeight()
+
   if (!profile || !profile.image) return null
   const { image } = profile
 
@@ -23,7 +25,7 @@ export const PartnerHeaderImage: React.FC<PartnerHeaderImageProps> = ({
       <Box height={FULL_BLEED_HEADER_HEIGHT} />
 
       <FullBleedHeader
-        top={[MOBILE_NAV_HEIGHT, NAV_BAR_HEIGHT]}
+        top={[mobile, desktop]}
         position="fixed"
         zIndex={-1}
         // @ts-expect-error STRICT_NULL_CHECK

--- a/src/v2/Apps/Partner/Components/ScrollToPartnerHeader/index.tsx
+++ b/src/v2/Apps/Partner/Components/ScrollToPartnerHeader/index.tsx
@@ -1,13 +1,14 @@
 import React from "react"
-import { MOBILE_NAV_HEIGHT, NAV_BAR_HEIGHT } from "v2/Components/NavBar"
 import { Clickable, BoxProps, themeProps } from "@artsy/palette"
 import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 import { scrollIntoView } from "v2/Utils/scrollHelpers"
+import { useNavBarHeight } from "v2/Components/NavBar/useNavBarHeight"
 
 export const ScrollToPartnerHeader: React.FC<BoxProps> = ({
   children,
   ...rest
 }) => {
+  const { mobile, desktop } = useNavBarHeight()
   const isMobile = useMatchMedia(themeProps.mediaQueries.xs)
 
   return (
@@ -15,7 +16,7 @@ export const ScrollToPartnerHeader: React.FC<BoxProps> = ({
       onClick={() => {
         scrollIntoView({
           selector: "#jumpto--PartnerHeader",
-          offset: isMobile ? MOBILE_NAV_HEIGHT : NAV_BAR_HEIGHT,
+          offset: isMobile ? mobile : desktop,
         })
       }}
       {...rest}

--- a/src/v2/Apps/Partner/Routes/Artists/ArtistsRoute.tsx
+++ b/src/v2/Apps/Partner/Routes/Artists/ArtistsRoute.tsx
@@ -11,10 +11,10 @@ import { PARTNER_NAV_BAR_HEIGHT } from "../../Components/NavigationTabs"
 import { graphql } from "lib/graphql"
 import { createFragmentContainer } from "react-relay"
 import { Media } from "v2/Utils/Responsive"
-import { MOBILE_NAV_HEIGHT, NAV_BAR_HEIGHT } from "v2/Components/NavBar"
 import { usePartnerArtistsLoadingContext } from "../../Utils/PartnerArtistsLoadingContext"
 import { scrollIntoView } from "v2/Utils/scrollHelpers"
 import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
+import { useNavBarHeight } from "v2/Components/NavBar/useNavBarHeight"
 
 export interface ArtistsRouteProps {
   partner: ArtistsRoute_partner
@@ -25,6 +25,7 @@ export const ArtistsRoute: React.FC<ArtistsRouteProps> = ({
   partner,
   match,
 }) => {
+  const { mobile, desktop } = useNavBarHeight()
   const isMobile = useMatchMedia(themeProps.mediaQueries.xs)
   const { isLoaded } = usePartnerArtistsLoadingContext()
 
@@ -35,10 +36,7 @@ export const ArtistsRoute: React.FC<ArtistsRouteProps> = ({
   }, [isLoaded, isMobile])
 
   const scrollIntoArtistDetails = () => {
-    const offset =
-      PARTNER_NAV_BAR_HEIGHT +
-      (isMobile ? MOBILE_NAV_HEIGHT : NAV_BAR_HEIGHT) +
-      20
+    const offset = PARTNER_NAV_BAR_HEIGHT + (isMobile ? mobile : desktop) + 20
 
     scrollIntoView({
       offset: offset,
@@ -55,7 +53,7 @@ export const ArtistsRoute: React.FC<ArtistsRouteProps> = ({
         <PartnerArtistsFragmentContainer
           scrollTo={{
             selector: "#jump--PartnerArtistDetails",
-            offset: PARTNER_NAV_BAR_HEIGHT + NAV_BAR_HEIGHT + 20,
+            offset: PARTNER_NAV_BAR_HEIGHT + desktop + 20,
           }}
           partner={partner}
         />
@@ -64,7 +62,7 @@ export const ArtistsRoute: React.FC<ArtistsRouteProps> = ({
         <PartnerArtistsFragmentContainer
           scrollTo={{
             selector: "#jump--PartnerArtistDetails",
-            offset: PARTNER_NAV_BAR_HEIGHT + MOBILE_NAV_HEIGHT + 20,
+            offset: PARTNER_NAV_BAR_HEIGHT + mobile + 20,
           }}
           partner={partner}
         />


### PR DESCRIPTION
This PR fixes empty space is displayed above the cover image on mobile. Also to fix some issues related to header height I used `useNavBarHeight`.

JIRA - https://artsyproduct.atlassian.net/browse/PX-4291

Before 
![image](https://user-images.githubusercontent.com/79979820/124152628-5f169180-da9c-11eb-8c09-a9bb726c2843.png)

Now
![image](https://user-images.githubusercontent.com/79979820/124152483-3db5a580-da9c-11eb-8c36-dc9a6281acea.png)
