### PR TITLE
feature: Pod Stabilization (Staging)

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -83,7 +83,7 @@ spec:
                       - foreground
 
 ---
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: force-web
@@ -95,7 +95,16 @@ spec:
     name: force-web
   minReplicas: 2
   maxReplicas: 3
-  targetCPUUtilizationPercentage: 70
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 1800
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 70
+        type: Utilization
+    type: Resource
 
 ---
 apiVersion: v1


### PR DESCRIPTION
This change alters the force pod autoscaler to wait 30 minutes before
removing nodes after a scaleUp event. Looking at the graphs in Datadog
there is a significant amount of pod trashing and this will remediate
that.

This change does not alter upscale timing which will stay at
"immediate".