### PR TITLE
feat(GRO-403): fleshes out meta tags

### DIFF
--- a/src/desktop/components/fair_week_marketing/__tests__/BannerPopUp.jest.tsx
+++ b/src/desktop/components/fair_week_marketing/__tests__/BannerPopUp.jest.tsx
@@ -9,7 +9,7 @@ jest.mock("sharify", () => ({
       {
         slug: "ca3",
         copy: "Discover and Buy Works from Art Fairs",
-        image: "http://files.artsy.net/images/art-fair.jpg",
+        image: "https://files.artsy.net/images/art-fair.jpg",
       },
     ],
   },
@@ -42,7 +42,7 @@ describe("BannerPopUp", () => {
     expect(mediator.trigger).toBeCalledWith("open:auth", {
       copy: "Discover and Buy Works from Art Fairs",
       destination: "https://artsy.net/",
-      image: "http://files.artsy.net/images/art-fair.jpg",
+      image: "https://files.artsy.net/images/art-fair.jpg",
       intent: "viewFair",
       mode: "signup",
       contextModule: "bannerPopUp",

--- a/src/v2/Apps/ArtistSeries/Components/ArtistSeriesMeta.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/ArtistSeriesMeta.tsx
@@ -1,9 +1,8 @@
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { Meta, Title } from "react-head"
 import { ArtistSeriesMeta_artistSeries } from "v2/__generated__/ArtistSeriesMeta_artistSeries.graphql"
 import { truncate } from "lodash"
-import { Link } from "react-head"
+import { MetaTags } from "v2/Components/MetaTags"
 
 interface ArtistSeriesMetaProps {
   artistSeries: ArtistSeriesMeta_artistSeries
@@ -20,17 +19,13 @@ export const ArtistSeriesMeta: React.FC<ArtistSeriesMetaProps> = props => {
     `${descriptionFirstSentence}${artistSeries.description}`,
     { length: 160, separator: " " }
   )
-  const canonicalRef = `/artist-series/${artistSeries.slug}`
+
   return (
-    <>
-      <Title>{title}</Title>
-      <Meta name="description" content={description} />
-      <Meta property="og:title" content={title} />
-      <Meta property="og:description" content={description} />
-      <Meta property="twitter:title" content={title} />
-      <Meta property="twitter:description" content={description} />
-      <Link rel="canonical" href={canonicalRef} />
-    </>
+    <MetaTags
+      title={title}
+      description={description}
+      pathname={`/artist-series/${artistSeries.slug}`}
+    />
   )
 }
 

--- a/src/v2/Apps/BuyerGuarantee/Components/BuyerGuaranteeMeta.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Components/BuyerGuaranteeMeta.tsx
@@ -8,7 +8,7 @@ export const BuyerGuaranteeMeta: React.FC = () => {
   const href = `${getENV("APP_URL")}/buyer-guarantee`
   const description =
     "Artsy is the safest place to buy the art you love. Every purchase made exclusively with Artsy’s secure checkout benefits from our full suite of buyer protections."
-  const src = cropped("http://files.artsy.net/buyerGuaranteeHeroImage.jpg", {
+  const src = cropped("https://files.artsy.net/buyerGuaranteeHeroImage.jpg", {
     width: 1600,
     height: 800,
   })

--- a/src/v2/Apps/Fairs/Components/FairsPhonePromo.tsx
+++ b/src/v2/Apps/Fairs/Components/FairsPhonePromo.tsx
@@ -13,7 +13,7 @@ export const FairsPhonePromo: React.FC<BoxProps> = props => {
         <Image
           width={155}
           height={223}
-          src="http://files.artsy.net/images/fair-iphone-promo-large.jpg"
+          src="https://files.artsy.net/images/fair-iphone-promo-large.jpg"
           alt="Artsy for iPhone"
         />
 

--- a/src/v2/Apps/FeatureAKG/__tests__/FeatureAKGRoute.jest.tsx
+++ b/src/v2/Apps/FeatureAKG/__tests__/FeatureAKGRoute.jest.tsx
@@ -909,16 +909,16 @@ const defaultData = {
     title: "Selected Works",
   },
   video_1: {
-    small_src: "http://files.artsy.net/video_1_small.mp4",
-    large_src: "http://files.artsy.net/video_1_large.mp4",
+    small_src: "https://files.artsy.net/video_1_small.mp4",
+    large_src: "https://files.artsy.net/video_1_large.mp4",
   },
   video_2: {
-    small_src: "http://files.artsy.net/video_2_small.mp4",
-    large_src: "http://files.artsy.net/video_2_large.mp4",
+    small_src: "https://files.artsy.net/video_2_small.mp4",
+    large_src: "https://files.artsy.net/video_2_large.mp4",
   },
   hero_video: {
-    small_src: "http://files.artsy.net/hero_video_small.mp4",
-    large_src: "http://files.artsy.net/hero_video_large.mp4",
+    small_src: "https://files.artsy.net/hero_video_small.mp4",
+    large_src: "https://files.artsy.net/hero_video_large.mp4",
   },
 }
 

--- a/src/v2/Apps/Gene/Components/GeneMeta.tsx
+++ b/src/v2/Apps/Gene/Components/GeneMeta.tsx
@@ -1,33 +1,22 @@
 import React from "react"
-import { Link, Meta, Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { GeneMeta_gene } from "v2/__generated__/GeneMeta_gene.graphql"
-import { getENV } from "v2/Utils/getENV"
+import { MetaTags } from "v2/Components/MetaTags"
 
 interface GeneMetaProps {
   gene: GeneMeta_gene
 }
 
 const GeneMeta: React.FC<GeneMetaProps> = ({ gene }) => {
-  const title = `${gene.name} | Artsy`
   const fallbackDescription = `Explore ${gene.name} art on Artsy. Browse works by size, price, and medium.`
-  const description = gene.meta.description || fallbackDescription
-  const href = `${getENV("APP_URL")}/${gene.href}`
-  const image = gene.image?.cropped?.src
 
   return (
-    <>
-      <Title>{title}</Title>
-      <Meta property="og:title" content={title} />
-      <Meta name="description" content={description} />
-      <Meta property="og:description" content={description} />
-      <Meta property="twitter:description" content={description} />
-      <Link rel="canonical" href={href} />
-      <Meta property="og:url" content={href} />
-      <Meta property="og:type" content="website" />
-      <Meta property="twitter:card" content="summary" />
-      {image && <Meta property="og:image" content={image} />}
-    </>
+    <MetaTags
+      title={`${gene.name} | Artsy`}
+      description={gene.meta.description || fallbackDescription}
+      pathname={gene.href}
+      imageURL={gene.image?.cropped?.src}
+    />
   )
 }
 

--- a/src/v2/Apps/Gene/Routes/__tests__/GeneShow.jest.tsx
+++ b/src/v2/Apps/Gene/Routes/__tests__/GeneShow.jest.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { Meta } from "react-head"
 import { GeneShowFragmentContainer } from "../GeneShow"
 import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
@@ -48,11 +47,9 @@ describe("GeneShow", () => {
       }),
     })
 
-    for (let i = 1; i <= 3; i++) {
-      expect(wrapper.find(Meta).at(i).prop("content")).toEqual(
-        "Gene Meta Description"
-      )
-    }
+    expect(wrapper.find('Meta[name="description"]').first().html()).toEqual(
+      '<meta name="description" content="Gene Meta Description">'
+    )
   })
 
   it("renders fallback meta description", () => {
@@ -63,10 +60,8 @@ describe("GeneShow", () => {
       }),
     })
 
-    for (let i = 1; i <= 3; i++) {
-      expect(wrapper.find(Meta).at(i).prop("content")).toEqual(
-        "Explore Design art on Artsy. Browse works by size, price, and medium."
-      )
-    }
+    expect(wrapper.find('Meta[name="description"]').first().html()).toEqual(
+      '<meta name="description" content="Explore Design art on Artsy. Browse works by size, price, and medium.">'
+    )
   })
 })

--- a/src/v2/Apps/Home/Components/HomeMeta.tsx
+++ b/src/v2/Apps/Home/Components/HomeMeta.tsx
@@ -1,0 +1,11 @@
+import React from "react"
+import { MetaTags } from "v2/Components/MetaTags"
+
+export const HomeMeta: React.FC = () => {
+  return (
+    <MetaTags
+      title="Artsy - Discover & Buy Art"
+      description="Artsy is the world’s largest online art marketplace. Browse over 1 million artworks by iconic and emerging artists from 4000+ galleries and top auction houses."
+    />
+  )
+}

--- a/src/v2/Apps/Home/HomeApp.tsx
+++ b/src/v2/Apps/Home/HomeApp.tsx
@@ -1,6 +1,5 @@
 import { Spacer, Join, Separator } from "@artsy/palette"
 import React from "react"
-import { Title } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "v2/System/useSystemContext"
 import { HomeApp_homePage } from "v2/__generated__/HomeApp_homePage.graphql"
@@ -11,6 +10,7 @@ import { HomeHeroUnitsFragmentContainer } from "./Components/HomeHeroUnits/HomeH
 import { HomeFeaturedShowsLazyQueryRenderer } from "./Components/HomeFeaturedShows"
 import { HomeFeaturedArticlesLazyQueryRenderer } from "./Components/HomeFeaturedArticles"
 import { HomeFeaturedEventsRailFragmentContainer } from "./Components/HomeFeaturedEventsRail"
+import { HomeMeta } from "./Components/HomeMeta"
 
 interface HomeAppProps {
   homePage: HomeApp_homePage | null
@@ -22,7 +22,7 @@ export const HomeApp: React.FC<HomeAppProps> = ({ homePage, orderedSet }) => {
 
   return (
     <>
-      <Title>Artsy - Discover & Buy Art</Title>
+      <HomeMeta />
 
       <Spacer mt={[2, 0]} />
 

--- a/src/v2/Components/MetaTags.tsx
+++ b/src/v2/Components/MetaTags.tsx
@@ -1,0 +1,76 @@
+import React from "react"
+import { Title, Meta, Link } from "react-head"
+import { getENV } from "v2/Utils/getENV"
+import { cropped } from "v2/Utils/resized"
+
+const DEFAULT_TITLE = "Artsy - Discover & Buy Art"
+const DEFAULT_DESCRIPTION =
+  "Artsy is the world’s largest online art marketplace. Browse over 1 million artworks by iconic and emerging artists from 4000+ galleries and top auction houses."
+const DEFAULT_IMAGE_URL = "https://files.artsy.net/images/og_image.jpeg"
+const DEFAULT_PATHNAME = "/"
+
+interface MetaTagsProps {
+  title?: string | null
+  /** Target a character length of 50–160 characters */
+  description?: string | null
+  /** Will be cropped to 1200 × 630 (1.9:1) */
+  imageURL?: string | null
+  /** Path relative to www.artsy.net */
+  pathname?: string | null
+  /** Include a `noindex, nofollow` meta tag */
+  blockRobots?: boolean
+}
+
+export const MetaTags: React.FC<MetaTagsProps> = ({
+  title: _title,
+  description: _description,
+  imageURL: _imageURL,
+  pathname: _pathname,
+  blockRobots,
+}) => {
+  const title = _title ?? DEFAULT_TITLE
+  const description = _description ?? DEFAULT_DESCRIPTION
+  const imageURL = _imageURL ?? DEFAULT_IMAGE_URL
+  const pathname = _pathname ?? DEFAULT_PATHNAME
+
+  const href = [
+    getENV("APP_URL"),
+    pathname.startsWith("/") ? pathname : `/${pathname}`,
+  ].join("")
+
+  const src = imageURL
+    ? cropped(imageURL, { width: 1200, height: 630 }).src
+    : null
+
+  const card =
+    !src || imageURL === DEFAULT_IMAGE_URL ? "summary" : "summary_large_image"
+
+  return (
+    <>
+      {/* Primary meta tags */}
+      <Title>{title}</Title>
+      <Meta name="title" content={title} />
+      <Meta name="description" content={description} />
+      <Link rel="canonical" href={href} />
+
+      {/* Open Graph / Facebook */}
+      <Meta property="og:type" content="website" />
+      <Meta property="og:url" content={href} />
+      <Meta property="og:title" content={title} />
+      <Meta property="og:site_name" content="Artsy" />
+      <Meta property="og:description" content={description} />
+      <Meta property="og:image" content={src} />
+
+      {/* Twitter */}
+      <Meta property="twitter:title" content={title} />
+      <Meta property="twitter:card" content={card} />
+      <Meta property="twitter:url" content={href} />
+      <Meta property="twitter:site" content="@artsy" />
+      <Meta property="twitter:description" content={description} />
+      <Meta property="twitter:image" content={src} />
+
+      {/* Other */}
+      {blockRobots && <Meta name="robots" content="noindex, nofollow" />}
+    </>
+  )
+}

--- a/src/v2/Components/RelatedCollectionsRail/__tests__/RelatedCollectionsRail.jest.tsx
+++ b/src/v2/Components/RelatedCollectionsRail/__tests__/RelatedCollectionsRail.jest.tsx
@@ -60,7 +60,7 @@ describe.skip("CollectionsRail", () => {
     const collectionsCopy = clone(props.collections)
     collectionsCopy.push({
       slug: "jasper-johns-flags2",
-      headerImage: "http://files.artsy.net/images/jasperjohnsflag.png",
+      headerImage: "https://files.artsy.net/images/jasperjohnsflag.png",
       title: "Jasper Johns: Flags Part 2",
       price_guidance: 1000,
       artworksConnection: null,
@@ -95,7 +95,7 @@ describe.skip("CollectionsRail", () => {
       const collectionsCopy = clone(props.collections)
       collectionsCopy.push({
         slug: "jasper-johns-flags2",
-        headerImage: "http://files.artsy.net/images/jasperjohnsflag.png",
+        headerImage: "https://files.artsy.net/images/jasperjohnsflag.png",
         title: "Jasper Johns: Flags Part 2",
         price_guidance: 1000,
         artworksConnection: {

--- a/src/v2/Components/__tests__/MetaTags.jest.tsx
+++ b/src/v2/Components/__tests__/MetaTags.jest.tsx
@@ -1,0 +1,279 @@
+import React from "react"
+import { mount } from "enzyme"
+import { MetaTags } from "../MetaTags"
+import { MockBoot } from "v2/DevTools"
+
+jest.mock("v2/Utils/getENV", () => ({
+  getENV: () => "https://www.artsy.net",
+}))
+
+describe("MetaTags", () => {
+  const getTags = () => {
+    const meta = [...document.getElementsByTagName("meta")].map(tag => ({
+      name: tag.getAttribute("name"),
+      property: tag.getAttribute("property"),
+      content: tag.getAttribute("content"),
+    }))
+
+    const links = [...document.getElementsByTagName("link")].map(tag => ({
+      rel: tag.getAttribute("rel"),
+      href: tag.getAttribute("href"),
+    }))
+
+    const title = document.getElementsByTagName("title")[0].textContent
+
+    return { meta, links, title }
+  }
+
+  afterEach(() => {
+    document.getElementsByTagName("html")[0].innerHTML = ""
+  })
+
+  it("renders the appropriate meta tags with sane defaults", () => {
+    mount(
+      <MockBoot>
+        <MetaTags />
+      </MockBoot>
+    )
+
+    const tags = getTags()
+
+    expect(tags.title).toEqual("Artsy - Discover & Buy Art")
+
+    expect(tags.links).toEqual([
+      { href: "https://www.artsy.net/", rel: "canonical" },
+    ])
+
+    expect(tags.meta).toEqual([
+      { name: "title", property: null, content: "Artsy - Discover & Buy Art" },
+      {
+        name: "description",
+        property: null,
+        content:
+          "Artsy is the world’s largest online art marketplace. Browse over 1 million artworks by iconic and emerging artists from 4000+ galleries and top auction houses.",
+      },
+      { name: null, property: "og:type", content: "website" },
+      { name: null, property: "og:url", content: "https://www.artsy.net/" },
+      {
+        name: null,
+        property: "og:title",
+        content: "Artsy - Discover & Buy Art",
+      },
+      { name: null, property: "og:site_name", content: "Artsy" },
+      {
+        name: null,
+        property: "og:description",
+        content:
+          "Artsy is the world’s largest online art marketplace. Browse over 1 million artworks by iconic and emerging artists from 4000+ galleries and top auction houses.",
+      },
+      {
+        name: null,
+        property: "og:image",
+        content:
+          "?resize_to=fill&src=https%3A%2F%2Ffiles.artsy.net%2Fimages%2Fog_image.jpeg&width=1200&height=630&quality=80",
+      },
+      {
+        name: null,
+        property: "twitter:title",
+        content: "Artsy - Discover & Buy Art",
+      },
+      { name: null, property: "twitter:card", content: "summary" },
+      {
+        name: null,
+        property: "twitter:url",
+        content: "https://www.artsy.net/",
+      },
+      { name: null, property: "twitter:site", content: "@artsy" },
+      {
+        name: null,
+        property: "twitter:description",
+        content:
+          "Artsy is the world’s largest online art marketplace. Browse over 1 million artworks by iconic and emerging artists from 4000+ galleries and top auction houses.",
+      },
+      {
+        name: null,
+        property: "twitter:image",
+        content:
+          "?resize_to=fill&src=https%3A%2F%2Ffiles.artsy.net%2Fimages%2Fog_image.jpeg&width=1200&height=630&quality=80",
+      },
+    ])
+  })
+
+  it("renders the appropriate meta tags when passed props", () => {
+    mount(
+      <MockBoot>
+        <MetaTags
+          title="My Example Title | Artsy"
+          description="My example description."
+          imageURL="https://example.com/example.jpg"
+          pathname="/artist/example-artist"
+        />
+      </MockBoot>
+    )
+
+    const tags = getTags()
+
+    expect(tags.title).toEqual("My Example Title | Artsy")
+
+    expect(tags.links).toEqual([
+      { href: "https://www.artsy.net/artist/example-artist", rel: "canonical" },
+    ])
+
+    expect(tags.meta).toEqual([
+      { name: "title", property: null, content: "My Example Title | Artsy" },
+      {
+        name: "description",
+        property: null,
+        content: "My example description.",
+      },
+      { name: null, property: "og:type", content: "website" },
+      {
+        name: null,
+        property: "og:url",
+        content: "https://www.artsy.net/artist/example-artist",
+      },
+      { name: null, property: "og:title", content: "My Example Title | Artsy" },
+      { name: null, property: "og:site_name", content: "Artsy" },
+      {
+        name: null,
+        property: "og:description",
+        content: "My example description.",
+      },
+      {
+        name: null,
+        property: "og:image",
+        content:
+          "?resize_to=fill&src=https%3A%2F%2Fexample.com%2Fexample.jpg&width=1200&height=630&quality=80",
+      },
+      {
+        name: null,
+        property: "twitter:title",
+        content: "My Example Title | Artsy",
+      },
+      { name: null, property: "twitter:card", content: "summary_large_image" },
+      {
+        name: null,
+        property: "twitter:url",
+        content: "https://www.artsy.net/artist/example-artist",
+      },
+      { name: null, property: "twitter:site", content: "@artsy" },
+      {
+        name: null,
+        property: "twitter:description",
+        content: "My example description.",
+      },
+      {
+        name: null,
+        property: "twitter:image",
+        content:
+          "?resize_to=fill&src=https%3A%2F%2Fexample.com%2Fexample.jpg&width=1200&height=630&quality=80",
+      },
+    ])
+  })
+
+  it("optionally renders a noindex meta tag for robots", () => {
+    mount(
+      <MockBoot>
+        <MetaTags blockRobots />
+      </MockBoot>
+    )
+
+    const tags = getTags()
+
+    expect(tags.meta.find(tag => tag.name === "robots")).toEqual({
+      name: "robots",
+      property: null,
+      content: "noindex, nofollow",
+    })
+  })
+
+  it("can deal with pathnames without a leading slash", () => {
+    mount(
+      <MockBoot>
+        <MetaTags pathname="foobar" />
+      </MockBoot>
+    )
+
+    const tags = getTags()
+
+    expect(tags.links.find(tag => tag.rel === "canonical")).toEqual({
+      href: "https://www.artsy.net/foobar",
+      rel: "canonical",
+    })
+  })
+
+  it("deals with nulls by falling back to defaults", () => {
+    mount(
+      <MockBoot>
+        <MetaTags
+          title={null}
+          description={null}
+          imageURL={null}
+          pathname={null}
+        />
+      </MockBoot>
+    )
+
+    const tags = getTags()
+
+    expect(tags.title).toEqual("Artsy - Discover & Buy Art")
+
+    expect(tags.links).toEqual([
+      { href: "https://www.artsy.net/", rel: "canonical" },
+    ])
+
+    expect(tags.meta).toEqual([
+      { name: "title", property: null, content: "Artsy - Discover & Buy Art" },
+      {
+        name: "description",
+        property: null,
+        content:
+          "Artsy is the world’s largest online art marketplace. Browse over 1 million artworks by iconic and emerging artists from 4000+ galleries and top auction houses.",
+      },
+      { name: null, property: "og:type", content: "website" },
+      { name: null, property: "og:url", content: "https://www.artsy.net/" },
+      {
+        name: null,
+        property: "og:title",
+        content: "Artsy - Discover & Buy Art",
+      },
+      { name: null, property: "og:site_name", content: "Artsy" },
+      {
+        name: null,
+        property: "og:description",
+        content:
+          "Artsy is the world’s largest online art marketplace. Browse over 1 million artworks by iconic and emerging artists from 4000+ galleries and top auction houses.",
+      },
+      {
+        name: null,
+        property: "og:image",
+        content:
+          "?resize_to=fill&src=https%3A%2F%2Ffiles.artsy.net%2Fimages%2Fog_image.jpeg&width=1200&height=630&quality=80",
+      },
+      {
+        name: null,
+        property: "twitter:title",
+        content: "Artsy - Discover & Buy Art",
+      },
+      { name: null, property: "twitter:card", content: "summary" },
+      {
+        name: null,
+        property: "twitter:url",
+        content: "https://www.artsy.net/",
+      },
+      { name: null, property: "twitter:site", content: "@artsy" },
+      {
+        name: null,
+        property: "twitter:description",
+        content:
+          "Artsy is the world’s largest online art marketplace. Browse over 1 million artworks by iconic and emerging artists from 4000+ galleries and top auction houses.",
+      },
+      {
+        name: null,
+        property: "twitter:image",
+        content:
+          "?resize_to=fill&src=https%3A%2F%2Ffiles.artsy.net%2Fimages%2Fog_image.jpeg&width=1200&height=630&quality=80",
+      },
+    ])
+  })
+})


### PR DESCRIPTION
This implements a generic meta tag component and then uses it on the new homepage. I realize that these are kind of fiddly tedious to set up. Easy to forget things, image specifications, etc... so this takes the guess work out of it.

I've included usage in a couple other places. I'll have to go around and replace *all* meta tag components, which I'll do in a separate PR.