### PR TITLE
feature: Manual Heap Dumps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -240,4 +240,4 @@ COPY --chown=deploy:deploy --from=builder /app/server.dist.js.map .
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 # TODO: Reduce production memory, this is not a concern
-CMD ["node", "--max_old_space_size=3072", "./server.dist.js"]
+CMD ["node", "--max_old_space_size=3072", "--heapsnapshot-signal=USR2", "./server.dist.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -240,4 +240,4 @@ COPY --chown=deploy:deploy --from=builder /app/server.dist.js.map .
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 # TODO: Reduce production memory, this is not a concern
-CMD ["node", "--max_old_space_size=3072", "--heapsnapshot-signal=USR2", "./server.dist.js"]
+CMD ["node", "--max_old_space_size=3072", "--heapsnapshot-signal=SIGUSR2", "./server.dist.js"]


### PR DESCRIPTION
Node 12 supports a command-line option to capture manual heap
snapshots. This change enables this functionality using the standard
`USR2` signal and allows profiling of pods in production.