### PR TITLE
feature: Pod Scaling Stabilization (Production)

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -79,7 +79,7 @@ spec:
                     values:
                       - foreground
 ---
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: force-web
@@ -91,7 +91,16 @@ spec:
     name: force-web
   minReplicas: 3
   maxReplicas: 20
-  targetCPUUtilizationPercentage: 70
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 1800
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 70
+        type: Utilization
+    type: Resource
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This change alters the force pod autoscaler to wait 30 minutes before
removing nodes after a scaleUp event. Looking at the graphs in Datadog
there is a significant amount of pod trashing and this will remediate
that.

This change does not alter upscale timing which will stay at
"immediate".