### PR TITLE
chore: Remove @artsy/reaction from v2 Bundle

### DIFF
--- a/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
+++ b/src/v2/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
@@ -14,7 +14,7 @@ import {
   themeProps,
   VerifiedIcon,
 } from "@artsy/palette"
-import { Media } from "@artsy/reaction/dist/Utils/Responsive"
+import { Media } from "v2/Utils/Responsive"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { resize } from "v2/Utils/resizer"
 import { FullBleedHeader } from "v2/Components/FullBleedHeader"


### PR DESCRIPTION
This change uses an existing local file over the same file in
`@artsy/reaction` thus eliminating it from the v2 bundle.