### PR TITLE
fix: refactor filters on artist auction results screen

### DIFF
--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilterMobileActionSheet.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilterMobileActionSheet.tsx
@@ -2,28 +2,21 @@ import { Box, Button, Sans } from "@artsy/palette"
 import { MobileTopBar } from "v2/Components/MobileTopBar"
 import React, { SFC } from "react"
 import styled from "styled-components"
-import { useAuctionResultsFilterContext } from "../AuctionResultsFilterContext"
 
 export const AuctionFilterMobileActionSheet: SFC<{
   children: JSX.Element
   onClose: () => void
 }> = ({ children, onClose }) => {
-  const filterContext = useAuctionResultsFilterContext()
-
   return (
     <Container mt={6}>
       <MobileTopBar>
-        <Button
-          variant="noOutline"
-          size="small"
-          onClick={() => filterContext.resetFilters()}
-        >
-          Reset
+        <Button variant="noOutline" size="small" onClick={onClose}>
+          Cancel
         </Button>
         <Sans size="3" weight="medium">
           Filter
         </Sans>
-        <Button variant="primaryBlack" size="small" onClick={() => onClose()}>
+        <Button variant="primaryBlack" size="small" onClick={onClose}>
           Apply
         </Button>
       </MobileTopBar>


### PR DESCRIPTION
Jira: [FX-2806](https://artsyproduct.atlassian.net/browse/FX-2806)

The purpose of the task is replace 'Reset' button with 'Cancel' button, but I have unsolved question ([described here](https://artsy.slack.com/archives/C9SATFLUU/p1625236217017300))

**Before**
![image](https://user-images.githubusercontent.com/56556580/124437806-1e5e9700-dd80-11eb-9522-c76facfaf4da.png)


**After**
![image](https://user-images.githubusercontent.com/56556580/124437901-37ffde80-dd80-11eb-8d5a-cd83a750af00.png)

