### PR TITLE
feat: fetch bid data for auction artworks on mWeb

### DIFF
--- a/src/desktop/apps/auction/components/artwork_browser/__tests__/fixtures/followedArtistSaleArtworks.js
+++ b/src/desktop/apps/auction/components/artwork_browser/__tests__/fixtures/followedArtistSaleArtworks.js
@@ -2,9 +2,6 @@ export const followedArtistSaleArtworks = [
   {
     id: "svend-aage-larsen-surrealism",
     lot_label: "1",
-    counts: {
-      bidder_positions: 0,
-    },
     current_bid: {
       display: "CHF 550",
     },
@@ -13,8 +10,11 @@ export const followedArtistSaleArtworks = [
       title: "Surrealism",
       date: "",
       sale_message: "Contact For Price",
-      is_in_auction: true,
       is_sold: false,
+      sale: {
+        is_auction: true,
+        is_closed: false,
+      },
       artists: [
         {
           id: "svend-aage-larsen",
@@ -54,14 +54,22 @@ export const followedArtistSaleArtworks = [
       },
       href: "/artwork/svend-aage-larsen-surrealism",
       is_acquireable: false,
+      sale_artwork: {
+        counts: {
+          bidder_positions: 0,
+        },
+        highest_bid: {
+          display: "$750",
+        },
+        opening_bid: {
+          display: "$300",
+        },
+      },
     },
   },
   {
     id: "emile-gsell-untitled",
     lot_label: "2",
-    counts: {
-      bidder_positions: 0,
-    },
     current_bid: {
       display: "CHF 5,000",
     },
@@ -70,8 +78,11 @@ export const followedArtistSaleArtworks = [
       title: "Untitled",
       date: "",
       sale_message: "Contact For Price",
-      is_in_auction: true,
       is_sold: false,
+      sale: {
+        is_auction: true,
+        is_closed: false,
+      },
       artists: [
         {
           id: "emile-gsell",
@@ -111,6 +122,17 @@ export const followedArtistSaleArtworks = [
       },
       href: "/artwork/emile-gsell-untitled",
       is_acquireable: false,
+      sale_artwork: {
+        counts: {
+          bidder_positions: 0,
+        },
+        highest_bid: {
+          display: "$700",
+        },
+        opening_bid: {
+          display: "$500",
+        },
+      },
     },
   },
 ]

--- a/src/desktop/apps/auction/components/artwork_browser/main/artwork/BidStatus.js
+++ b/src/desktop/apps/auction/components/artwork_browser/main/artwork/BidStatus.js
@@ -2,6 +2,7 @@ import PropTypes from "prop-types"
 import React from "react"
 import block from "bem-cn-lite"
 import { connect } from "react-redux"
+import { get } from "lodash"
 
 function BidStatus(props) {
   const { isSold, currentBidDisplay, bidLabel } = props
@@ -30,16 +31,15 @@ BidStatus.propTypes = {
 
 const mapStateToProps = (state, props) => {
   const {
-    artworkItem: { artwork, counts = {}, current_bid },
+    artworkItem: { artwork, counts, current_bid },
   } = props
-
-  const { bidder_positions } = counts
-
   let bidLabel
+  const bidCounts = get(artwork, "sale_artwork.counts") || counts
+  const bidderPositions = get(bidCounts, "bidder_positions")
 
-  if (counts && bidder_positions) {
-    const bidOrBids = bidder_positions > 1 ? "Bids" : "Bid"
-    bidLabel = `(${bidder_positions} ${bidOrBids})`
+  if (bidderPositions) {
+    const bidOrBids = bidderPositions > 1 ? "Bids" : "Bid"
+    bidLabel = `(${bidderPositions} ${bidOrBids})`
   } else {
     bidLabel = ""
   }

--- a/src/desktop/apps/auction/queries/worksByFollowedArtists.js
+++ b/src/desktop/apps/auction/queries/worksByFollowedArtists.js
@@ -17,9 +17,6 @@ export const worksByFollowedArtists = `
       hits {
         id
         lot_label
-        counts {
-          bidder_positions
-        }
         current_bid {
           display
         }
@@ -28,8 +25,11 @@ export const worksByFollowedArtists = `
           title
           date
           sale_message
-          is_in_auction
           is_sold
+          sale {
+            is_auction
+            is_closed
+          }
           artists {
             id
             name
@@ -56,6 +56,17 @@ export const worksByFollowedArtists = `
           }
           href
           is_acquireable
+          sale_artwork {
+            counts {
+              bidder_positions
+            }
+            highest_bid {
+              display
+            }
+            opening_bid {
+              display
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Jira ticket: [FX-2356]

### Description
As a logged in user
When I visit an auction sale page that has at least 1 work by an artist I follow
I should see consistent metadata for the work in the rail and the work in the artwork grid

#### Web
<img width="1226" alt="Roseberys: Modern   Contemporary Prints   Multiples | Artsy 2021-07-06 16-26-57" src="https://user-images.githubusercontent.com/3513494/124608201-3238f480-de77-11eb-88d4-96d31f0c27f2.png">

#### Mobile
<img width="241" alt="Roseberys: Modern   Contemporary Prints   Multiples | Artsy 2021-07-06 16-28-03" src="https://user-images.githubusercontent.com/3513494/124608316-4b41a580-de77-11eb-8af0-ac19189ee569.png">


[FX-2356]: https://artsyproduct.atlassian.net/browse/FX-2356