### PR TITLE
Fix for edition set error when artwork has been deleted

### DIFF
--- a/src/v2/Apps/Conversation/Components/ConfirmArtworkModal.tsx
+++ b/src/v2/Apps/Conversation/Components/ConfirmArtworkModal.tsx
@@ -33,6 +33,9 @@ export const ConfirmArtworkModal: React.FC<ConfirmArtworkModalProps> = ({
   show,
   closeModal,
 }) => {
+  if (!artwork) {
+    return null
+  }
   const { editionSets, isEdition } = artwork
 
   const initialSelectedEdition =


### PR DESCRIPTION
[PURCHASE-2807]

I was seeing the following error locally. This happens when an artwork has been deleted. `Conversation` uses a snapshot of the artwork, so its fine with deletions, but the modal has its own query renderer so it errors out when it tries to get the `editionSets` of a non existent artwork. 

I had seen this before and thought I fixed it by checking that `artwork` exists before rendering the modal query renderer, but I was only checking that the _snapshot_ existed.

<img width="956" alt="Screen Shot 2021-07-06 at 1 16 19 PM" src="https://user-images.githubusercontent.com/5643895/124641690-fc871200-de5c-11eb-9871-b0a0fa0dd12d.png">


[PURCHASE-2807]: https://artsyproduct.atlassian.net/browse/PURCHASE-2807