### PR TITLE
Bugfix: fix refetching on scroll in conversation list

### DIFF
--- a/src/v2/Apps/Conversation/Components/ConversationList.tsx
+++ b/src/v2/Apps/Conversation/Components/ConversationList.tsx
@@ -13,7 +13,6 @@ import { ConversationListHeader } from "./ConversationListHeader"
 const Container = styled(Box)`
   height: 100%;
   overflow: hidden;
-  border-bottom: 30px solid ${color("white100")};
   border-right: 1px solid ${color("black10")};
   ${media.xs`
     border-right: none;
@@ -71,10 +70,10 @@ const ConversationList: React.FC<ConversationsProps> = props => {
   }
 
   return (
-    <Container width={["100%", "100%", "375px"]} onScroll={handleScroll}>
+    <Container width={["100%", "100%", "375px"]}>
       <>
         <ConversationListHeader />
-        <ScrollContainer>
+        <ScrollContainer onScroll={handleScroll}>
           {/* @ts-expect-error STRICT_NULL_CHECK */}
           {conversations.map(edge => (
             <ConversationSnippet


### PR DESCRIPTION
[PURCHASE-2806]

Shoutout to @xtina-starr for finding this solution!

Conversations weren't refetching on scroll, and we realized that the `onScroll` method wasn't being hit. Moving the onScroll to a different container fixed this issue, and we were able to trace it back to this PR: https://github.com/artsy/force/pull/6135

[PURCHASE-2806]: https://artsyproduct.atlassian.net/browse/PURCHASE-2806