### PR TITLE
fix: the sending message container in a conversation overlaps the last message

### DIFF
--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -48,8 +48,6 @@ const Conversation: React.FC<ConversationProps> = props => {
     userHasLabFeature(user, "Web Inquiry Checkout") &&
     isArtworkOfferable
 
-  // Keeping track of this for scroll on send
-  const [lastMessageID, setLastMessageID] = useState<string | null>("")
   const [showConfirmArtworkModal, setShowConfirmArtworkModal] = useState<
     boolean
   >(false)
@@ -58,7 +56,6 @@ const Conversation: React.FC<ConversationProps> = props => {
 
   const scrollToBottom = () => {
     if (bottomOfMessageContainer.current) {
-      setLastMessageID(conversation?.lastMessageID)
       setTimeout(() => {
         bottomOfMessageContainer!.current!.scrollIntoView({
           behavior: "smooth",
@@ -67,7 +64,7 @@ const Conversation: React.FC<ConversationProps> = props => {
     }
   }
 
-  useEffect(scrollToBottom, [conversation, lastMessageID])
+  useEffect(scrollToBottom, [conversation])
 
   useEffect(() => {
     UpdateConversation(relay.environment, conversation)

--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -141,16 +141,7 @@ export const Reply: React.FC<ReplyProps> = props => {
           text: "Discard message",
         }}
       />
-      <Flex
-        right={[0, null]}
-        zIndex={[null, 2]}
-        position={["fixed", "fixed", "static", "static"]}
-        bottom={0}
-        left={0}
-        flexShrink={0}
-        flexDirection="column"
-        background="white"
-      >
+      <Flex zIndex={[null, 2]} flexDirection="column" background="white">
         <ShadowSeparator />
         <ConversationCTAFragmentContainer
           conversation={conversation}

--- a/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
+++ b/src/v2/Apps/Conversation/Routes/Conversation/index.tsx
@@ -8,6 +8,7 @@ import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import { Media } from "v2/Utils/Responsive"
 import { DetailsFragmentContainer as Details } from "../../Components/Details"
 import styled from "styled-components"
+import { themeGet } from "@styled-system/theme-get"
 interface ConversationRouteProps {
   me: Conversation_me
   conversationID: string
@@ -17,6 +18,9 @@ interface ConversationRouteProps {
 
 const ConstrainedHeightContainer = styled(Box)`
   height: calc(100vh - 103px);
+  @media ${themeGet("mediaQueries.xs")} {
+    height: calc(100vh - 60px);
+  }
 `
 
 const ConversationContainer = styled(Flex)`


### PR DESCRIPTION
**JIRA** -> [Inbox: Inquiry checkout: Mobile view: the latest message is overlapped by "The Artsy Guarantee" panel](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=41&projectKey=PURCHASE&modal=detail&selectedIssue=PURCHASE-2794&assignee=60469b1e43eac6006f636d07)

**Notes**:
The overlapping problem was in fixed position of sending message container with make offer button. Fixed position pulled the container out of the stream, so the chat container filled the space under it.
**Before**:
![Screen Shot 2021-07-09 at 2 05 38 PM](https://user-images.githubusercontent.com/79980131/125068956-c34ddc80-e0be-11eb-99e4-64a16596d7c2.png)
**After**: 
![Screen Shot 2021-07-09 at 2 11 05 PM](https://user-images.githubusercontent.com/79980131/125069522-833b2980-e0bf-11eb-95e9-d898a638bf3a.png)

Other problem was in the empty after sending message container in a mobile media screen:
![Screen Shot 2021-07-09 at 2 13 51 PM](https://user-images.githubusercontent.com/79980131/125069804-e88f1a80-e0bf-11eb-86d2-27bd83c196a8.png)

was fixed by adding the media query:
```
const ConstrainedHeightContainer = styled(Box)`
  height: calc(100vh - 103px);
  @media ${themeGet("mediaQueries.xs")} {
    height: calc(100vh - 60px);
  }
`
```
GIF:
![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/79980131/125068267-f93e9100-e0bd-11eb-9bfb-0b45e740444c.gif)
