### PR TITLE
fix(FX-2806): refactor auction results filters

### DIFF
--- a/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -1,4 +1,4 @@
-import { ContextModule, Intent } from "@artsy/cohesion"
+import React, { useContext, useState } from "react"
 import {
   Box,
   Column,
@@ -9,11 +9,11 @@ import {
   Text,
 } from "@artsy/palette"
 import { isEqual } from "lodash"
-import React, { useContext, useState } from "react"
 import { Title } from "react-head"
-import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { useTracking } from "react-tracking"
 import useDeepCompareEffect from "use-deep-compare-effect"
+import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
+import { ContextModule, Intent } from "@artsy/cohesion"
 import { ModalType } from "v2/Components/Authentication/Types"
 import { LoadingArea } from "v2/Components/LoadingArea"
 import { PaginationFragmentContainer as Pagination } from "v2/Components/Pagination"
@@ -53,14 +53,12 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
 }) => {
   const { user, mediator } = useContext(SystemContext)
   const filterContext = useAuctionResultsFilterContext()
-  // @ts-expect-error STRICT_NULL_CHECK
-  const { pageInfo } = artist.auctionResultsConnection
-  const { hasNextPage, endCursor } = pageInfo
+  const { pageInfo } = artist.auctionResultsConnection ?? {}
+  const { hasNextPage, endCursor } = pageInfo ?? {}
   const artistName = artist.name
 
   const loadNext = () => {
-    // @ts-expect-error STRICT_NULL_CHECK
-    const nextPageNum = filterContext.filters.pageAndCursor.page + 1
+    const nextPageNum = Number(filterContext.filters?.pageAndCursor?.page) + 1
     if (hasNextPage) {
       loadPage(endCursor, nextPageNum)
     }
@@ -72,7 +70,10 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
       behavior: "smooth",
       offset: 150,
     })
-    filterContext.setFilter("pageAndCursor", { cursor: cursor, page: pageNum })
+    filterContext.setFilter?.("pageAndCursor", {
+      cursor: cursor,
+      page: pageNum,
+    })
   }
 
   const [isLoading, setIsLoading] = useState(false)
@@ -87,14 +88,12 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
     auctionResultsFilterResetState
   )
 
-  const previousFilters = usePrevious(filterContext.filters)
+  const previousFilters = usePrevious(filterContext.filters) ?? {}
 
   // TODO: move this and artwork copy to util?
   useDeepCompareEffect(() => {
-    // @ts-expect-error STRICT_NULL_CHECK
-    Object.entries(filterContext.filters).forEach(
+    Object.entries(filterContext.filters ?? {}).forEach(
       ([filterKey, currentFilter]) => {
-        // @ts-expect-error STRICT_NULL_CHECK
         const previousFilter = previousFilters[filterKey]
         const filtersHaveUpdated = !isEqual(currentFilter, previousFilter)
 
@@ -118,8 +117,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
             action_type:
               AnalyticsSchema.ActionType.AuctionResultFilterParamChanged,
             changed: JSON.stringify({
-              // @ts-expect-error STRICT_NULL_CHECK
-              [filterKey]: filterContext.filters[filterKey],
+              [filterKey]: filterContext.filters?.[filterKey],
             }),
             context_page: AnalyticsSchema.PageName.ArtistAuctionResults,
             current: JSON.stringify(filterContext.filters),
@@ -134,8 +132,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
     setIsLoading(true)
 
     const relayParams = {
-      // @ts-expect-error STRICT_NULL_CHECK
-      after: filterContext.filters.pageAndCursor.cursor,
+      after: filterContext.filters?.pageAndCursor?.cursor,
       artistID: artist.slug,
       artistInternalID: artist.internalID,
       before: null,
@@ -157,8 +154,9 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
     })
   }
 
-  // @ts-expect-error STRICT_NULL_CHECK
-  const auctionResultsLength = artist.auctionResultsConnection.edges.length
+  const auctionResultsLength = Number(
+    artist.auctionResultsConnection?.edges?.length
+  )
 
   const titleString = `${artist.name} - Auction Results on Artsy`
 
@@ -239,7 +237,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
 
           <Pagination
             getHref={() => ""}
-            hasNextPage={pageInfo.hasNextPage}
+            hasNextPage={Boolean(pageInfo?.hasNextPage)}
             // @ts-expect-error STRICT_NULL_CHECK
             pageCursors={artist.auctionResultsConnection.pageCursors}
             onClick={(_cursor, page) => loadPage(_cursor, page)}
@@ -261,14 +259,12 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
 export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
   (props: AuctionResultsProps) => {
     const { startAt, endAt } =
-      // @ts-expect-error STRICT_NULL_CHECK
-      props.artist.auctionResultsConnection.createdYearRange ?? {}
+      props.artist.auctionResultsConnection?.createdYearRange ?? {}
+
     return (
       <AuctionResultsFilterContextProvider
         filters={{
-          // @ts-expect-error STRICT_NULL_CHECK
           earliestCreatedYear: startAt,
-          // @ts-expect-error STRICT_NULL_CHECK
           latestCreatedYear: endAt,
         }}
       >

--- a/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -58,7 +58,8 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
   const artistName = artist.name
 
   const loadNext = () => {
-    const nextPageNum = Number(filterContext.filters?.pageAndCursor?.page) + 1
+    const currentPageNumber = filterContext.filters?.pageAndCursor?.page ?? 0
+    const nextPageNum = currentPageNumber + 1
     if (hasNextPage) {
       loadPage(endCursor, nextPageNum)
     }
@@ -154,9 +155,8 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
     })
   }
 
-  const auctionResultsLength = Number(
-    artist.auctionResultsConnection?.edges?.length
-  )
+  const auctionResultsLength =
+    artist.auctionResultsConnection?.edges?.length ?? 0
 
   const titleString = `${artist.name} - Auction Results on Artsy`
 

--- a/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -27,7 +27,7 @@ import { ArtistAuctionResults_artist } from "v2/__generated__/ArtistAuctionResul
 import { ArtistAuctionResultItemFragmentContainer as AuctionResultItem } from "./ArtistAuctionResultItem"
 import {
   AuctionResultsFilterContextProvider,
-  auctionResultsFilterResetState,
+  initialAuctionResultsFilterState,
   useAuctionResultsFilterContext,
 } from "./AuctionResultsFilterContext"
 import { AuctionFilterMobileActionSheet } from "./Components/AuctionFilterMobileActionSheet"
@@ -52,13 +52,17 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
   relay,
 }) => {
   const { user, mediator } = useContext(SystemContext)
-  const filterContext = useAuctionResultsFilterContext()
+  const {
+    filters,
+    setFilter,
+    currentlySelectedFilters,
+  } = useAuctionResultsFilterContext()
   const { pageInfo } = artist.auctionResultsConnection ?? {}
   const { hasNextPage, endCursor } = pageInfo ?? {}
   const artistName = artist.name
 
   const loadNext = () => {
-    const currentPageNumber = filterContext.filters?.pageAndCursor?.page ?? 0
+    const currentPageNumber = filters?.pageAndCursor?.page ?? 0
     const nextPageNum = currentPageNumber + 1
     if (hasNextPage) {
       loadPage(endCursor, nextPageNum)
@@ -71,7 +75,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
       behavior: "smooth",
       offset: 150,
     })
-    filterContext.setFilter?.("pageAndCursor", {
+    setFilter?.("pageAndCursor", {
       cursor: cursor,
       page: pageNum,
     })
@@ -83,57 +87,62 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
 
   const tracking = useTracking()
 
+  const { startAt, endAt } =
+    artist.auctionResultsConnection?.createdYearRange ?? {}
+  const auctionResultsFilterResetState = initialAuctionResultsFilterState(
+    endAt,
+    startAt
+  )
+
   // Is current filter state different from the default (reset) state?
   const filtersAtDefault = isEqual(
-    filterContext.filters,
+    currentlySelectedFilters?.(),
     auctionResultsFilterResetState
   )
 
-  const previousFilters = usePrevious(filterContext.filters) ?? {}
+  const previousFilters = usePrevious(filters) ?? {}
 
   // TODO: move this and artwork copy to util?
   useDeepCompareEffect(() => {
-    Object.entries(filterContext.filters ?? {}).forEach(
-      ([filterKey, currentFilter]) => {
-        const previousFilter = previousFilters[filterKey]
-        const filtersHaveUpdated = !isEqual(currentFilter, previousFilter)
+    Object.entries(filters ?? {}).forEach(([filterKey, currentFilter]) => {
+      const previousFilter = previousFilters[filterKey]
+      const filtersHaveUpdated = !isEqual(currentFilter, previousFilter)
 
-        if (filtersHaveUpdated) {
-          fetchResults()
+      if (filtersHaveUpdated) {
+        fetchResults()
 
-          // If user is not logged-in, show auth modal, but only if it was never shown before.
-          if (!user && !authShownForFiltering) {
-            // @ts-expect-error STRICT_NULL_CHECK
-            openAuthModal(mediator, {
-              contextModule: ContextModule.auctionResults,
-              copy: `Sign up to see auction results for ${artistName}`,
-              intent: Intent.viewAuctionResults,
-              mode: ModalType.signup,
-            })
-            // Remember to not show auth modal again for this activity.
-            toggleAuthShowForFiltering(true)
-          }
-
-          tracking.trackEvent({
-            action_type:
-              AnalyticsSchema.ActionType.AuctionResultFilterParamChanged,
-            changed: JSON.stringify({
-              [filterKey]: filterContext.filters?.[filterKey],
-            }),
-            context_page: AnalyticsSchema.PageName.ArtistAuctionResults,
-            current: JSON.stringify(filterContext.filters),
+        // If user is not logged-in, show auth modal, but only if it was never shown before.
+        if (!user && !authShownForFiltering) {
+          // @ts-expect-error STRICT_NULL_CHECK
+          openAuthModal(mediator, {
+            contextModule: ContextModule.auctionResults,
+            copy: `Sign up to see auction results for ${artistName}`,
+            intent: Intent.viewAuctionResults,
+            mode: ModalType.signup,
           })
+          // Remember to not show auth modal again for this activity.
+          toggleAuthShowForFiltering(true)
         }
+
+        tracking.trackEvent({
+          action_type:
+            AnalyticsSchema.ActionType.AuctionResultFilterParamChanged,
+          changed: JSON.stringify({
+            [filterKey]: filters?.[filterKey],
+          }),
+          context_page: AnalyticsSchema.PageName.ArtistAuctionResults,
+          current: JSON.stringify(filters),
+        })
       }
-    )
-  }, [filterContext.filters])
+    })
+  }, [filters])
 
   // TODO: move this and artwork copy to util? (pass loading state setter)
   function fetchResults() {
     setIsLoading(true)
 
     const relayParams = {
-      after: filterContext.filters?.pageAndCursor?.cursor,
+      after: filters?.pageAndCursor?.cursor,
       artistID: artist.slug,
       artistInternalID: artist.internalID,
       before: null,
@@ -143,7 +152,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
 
     const relayRefetchVariables = {
       ...relayParams,
-      ...filterContext.filters,
+      ...filters,
     }
 
     relay.refetch(relayRefetchVariables, null, error => {
@@ -263,10 +272,8 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
 
     return (
       <AuctionResultsFilterContextProvider
-        filters={{
-          earliestCreatedYear: startAt,
-          latestCreatedYear: endAt,
-        }}
+        earliestCreatedYear={startAt}
+        latestCreatedYear={endAt}
       >
         <AuctionResultsContainer {...props} />
       </AuctionResultsFilterContextProvider>

--- a/src/v2/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
@@ -260,7 +260,7 @@ const AuctionResultsFilterReducer = (
 
       // do not allow a real cursor to be set for page 1. to agree with initial
       // filter state.
-      if (filterState.pageAndCursor && filterState.pageAndCursor.page === 1) {
+      if (filterState.pageAndCursor?.page === 1) {
         filterState.pageAndCursor.cursor = null
       }
 

--- a/src/v2/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
@@ -1,13 +1,12 @@
 import React, { useContext, useReducer, useState } from "react"
 import { omit } from "lodash"
 import useDeepCompareEffect from "use-deep-compare-effect"
-import { StringifyOptions } from "querystring"
 
 export interface AuctionResultsFilters {
   organizations?: string[]
   categories?: string[]
   sizes?: string[]
-  keyword?: StringifyOptions
+  keyword?: string
   pageAndCursor?: { page: number; cursor: string | null }
   sort?: string
   createdAfterYear?: number | null
@@ -28,7 +27,7 @@ export const initialAuctionResultsFilterState = (
   organizations: [],
   categories: [],
   sizes: [],
-  keyword: undefined,
+  keyword: "",
   pageAndCursor: { page: 1, cursor: null },
   sort: "DATE_DESC",
   createdAfterYear,

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/ArtistAuctionResultsCount.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/ArtistAuctionResultsCount.tsx
@@ -1,7 +1,7 @@
-import { Sans } from "@artsy/palette"
-import { ArtistAuctionResultsCount_results } from "v2/__generated__/ArtistAuctionResultsCount_results.graphql"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { Sans } from "@artsy/palette"
+import { ArtistAuctionResultsCount_results } from "v2/__generated__/ArtistAuctionResultsCount_results.graphql"
 
 interface ArtistAuctionResultsCountProps {
   results: ArtistAuctionResultsCount_results
@@ -12,8 +12,7 @@ export const ArtistAuctionResultsCount = ({
 }: ArtistAuctionResultsCountProps) => {
   return (
     <Sans size="2" weight="medium">
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
-      {`Showing ${results.totalCount.toLocaleString()} results`}
+      {`Showing ${results.totalCount?.toLocaleString() || ""} results`}
     </Sans>
   )
 }

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/ArtistAuctionResultsCount.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/ArtistAuctionResultsCount.tsx
@@ -12,7 +12,7 @@ export const ArtistAuctionResultsCount = ({
 }: ArtistAuctionResultsCountProps) => {
   return (
     <Sans size="2" weight="medium">
-      {`Showing ${results.totalCount?.toLocaleString() || ""} results`}
+      {`Showing ${results.totalCount?.toLocaleString() ?? 0} results`}
     </Sans>
   )
 }

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilterMobileActionSheet.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilterMobileActionSheet.tsx
@@ -1,50 +1,151 @@
-import { Box, Button, Sans } from "@artsy/palette"
-import { MobileTopBar } from "v2/Components/MobileTopBar"
-import React, { SFC } from "react"
+import React, { FC, useEffect, useRef } from "react"
+import { isEqual, omit } from "lodash"
 import styled from "styled-components"
-import { useAuctionResultsFilterContext } from "../AuctionResultsFilterContext"
+import {
+  useAuctionResultsFilterContext,
+  initialAuctionResultsFilterState,
+} from "../AuctionResultsFilterContext"
+import {
+  Box,
+  Button,
+  Clickable,
+  Flex,
+  ModalBase,
+  color,
+  Sans,
+} from "@artsy/palette"
 
-export const AuctionFilterMobileActionSheet: SFC<{
+export const AuctionFilterMobileActionSheet: FC<{
   children: JSX.Element
   onClose: () => void
 }> = ({ children, onClose }) => {
   const filterContext = useAuctionResultsFilterContext()
 
+  const contentRef = useRef<HTMLDivElement | null>(null)
+
+  // This reflects our zero state for this UI which doesn't include the keyword
+  const isReset = isEqual(
+    omit(filterContext.stagedFilters, "reset", "keyword"),
+    initialAuctionResultsFilterState
+  )
+
+  const handleScrollToTop = () => {
+    if (!contentRef.current) return
+    contentRef.current.scrollTop = 0
+  }
+
+  const isFiltersChanged = !isEqual(
+    filterContext.filters,
+    filterContext.stagedFilters
+  )
+
+  useEffect(() => {
+    // While mobile sheet is mounted, the effect of the user's filter selections
+    // should be merely staged until the Apply button is pressed, rather than
+    // applied immediately. Therefore…
+    //
+    // On mount, enter staged mode, and initialize a set of staged filter
+    // changes from the current filter choices.
+    filterContext.setShouldStageFilterChanges?.(true)
+    filterContext.setStagedFilters?.(filterContext.filters || {})
+
+    // On unmount, exit staged mode.
+    return () => {
+      filterContext.setShouldStageFilterChanges?.(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const applyFilters = () => {
+    // On apply, replace the actual filter state with the
+    // hitherto staged filters
+    filterContext.setFilters?.(filterContext.stagedFilters || {}, {
+      force: true,
+    })
+    onClose()
+  }
+
   return (
-    <Container mt={6}>
-      <MobileTopBar>
+    <ModalBase
+      onClose={onClose}
+      dialogProps={{
+        width: "100%",
+        height: "100%",
+        background: color("white100"),
+        flexDirection: "column",
+      }}
+    >
+      <Header p={1}>
         <Button
           variant="noOutline"
           size="small"
-          onClick={() => filterContext.resetFilters()}
+          onClick={() => {
+            // On close, abandon any staged filter changes
+            filterContext.setStagedFilters?.({})
+            onClose()
+          }}
         >
-          Reset
+          Cancel
         </Button>
-        <Sans size="3" weight="medium">
-          Filter
-        </Sans>
-        <Button variant="primaryBlack" size="small" onClick={() => onClose()}>
-          Apply
-        </Button>
-      </MobileTopBar>
 
-      <Box p={2} mt={2}>
-        {children}
-      </Box>
-    </Container>
+        <Clickable flex="1" width="100%" onClick={handleScrollToTop}>
+          <FilterTitle size="3" weight="medium" textAlign="center">
+            Filter
+          </FilterTitle>
+        </Clickable>
+
+        <Button
+          size="small"
+          variant="secondaryGray"
+          disabled={isReset}
+          onClick={() => {
+            // On clear, reset (staged) filter changes to initial state
+            filterContext.resetFilters?.()
+          }}
+        >
+          Clear all
+        </Button>
+      </Header>
+
+      <Content ref={contentRef as any}>
+        <Box width="100%" px={2} pt={2}>
+          {children}
+        </Box>
+      </Content>
+
+      <Footer p={1}>
+        <Button
+          variant="primaryBlack"
+          width="100%"
+          disabled={!isFiltersChanged}
+          onClick={applyFilters}
+        >
+          Show Results
+        </Button>
+      </Footer>
+    </ModalBase>
   )
 }
 
-const Container = styled(Box)`
-  position: fixed;
-
-  /* The z-index after Force's mobile top-nav header */
-  z-index: 971;
-  top: 0;
-  left: 0;
+const Header = styled(Flex)`
   width: 100%;
-  height: 100%;
-  background-color: white;
+  align-items: center;
+  border-bottom: 1px solid ${color("black10")};
+`
+
+const Footer = styled(Flex)`
+  width: 100%;
+`
+
+const Content = styled(Flex)`
+  flex: 1;
+  width: 100%;
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
 `
+
+const FilterTitle = styled(Sans)`
+  flex: 1;
+`
+
+FilterTitle.displayName = "FilterTitle"

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilterMobileActionSheet.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilterMobileActionSheet.tsx
@@ -47,7 +47,7 @@ export const AuctionFilterMobileActionSheet: FC<{
     // On mount, enter staged mode, and initialize a set of staged filter
     // changes from the current filter choices.
     filterContext.setShouldStageFilterChanges?.(true)
-    filterContext.setStagedFilters?.(filterContext.filters || {})
+    filterContext.setStagedFilters?.(filterContext.filters ?? {})
 
     // On unmount, exit staged mode.
     return () => {
@@ -59,7 +59,7 @@ export const AuctionFilterMobileActionSheet: FC<{
   const applyFilters = () => {
     // On apply, replace the actual filter state with the
     // hitherto staged filters
-    filterContext.setFilters?.(filterContext.stagedFilters || {}, {
+    filterContext.setFilters?.(filterContext.stagedFilters ?? {}, {
       force: true,
     })
     onClose()

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/AuctionHouseFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/AuctionHouseFilter.tsx
@@ -18,11 +18,11 @@ export const AuctionHouseFilter: React.FC = () => {
   const { organizations } = currentlySelectedFilters?.() || {}
 
   const toggleSelection = (selected: boolean, name: string) => {
-    let selectedOrganizations = organizations?.slice()
+    let selectedOrganizations = organizations?.slice() ?? []
     if (selected) {
-      selectedOrganizations?.push(name)
+      selectedOrganizations.push(name)
     } else {
-      selectedOrganizations = selectedOrganizations?.filter(
+      selectedOrganizations = selectedOrganizations.filter(
         item => item !== name
       )
     }

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/AuctionHouseFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/AuctionHouseFilter.tsx
@@ -11,17 +11,22 @@ const auctionHouses = [
 ]
 
 export const AuctionHouseFilter: React.FC = () => {
-  const filterContext = useAuctionResultsFilterContext()
+  const {
+    currentlySelectedFilters,
+    setFilter,
+  } = useAuctionResultsFilterContext()
+  const { organizations } = currentlySelectedFilters?.() || {}
 
-  const toggleSelection = (selected, name) => {
-    // @ts-expect-error STRICT_NULL_CHECK
-    let organizations = filterContext.filters.organizations.slice()
+  const toggleSelection = (selected: boolean, name: string) => {
+    let selectedOrganizations = organizations?.slice()
     if (selected) {
-      organizations.push(name)
+      selectedOrganizations?.push(name)
     } else {
-      organizations = organizations.filter(item => item !== name)
+      selectedOrganizations = selectedOrganizations?.filter(
+        item => item !== name
+      )
     }
-    filterContext.setFilter("organizations", organizations)
+    setFilter?.("organizations", selectedOrganizations)
   }
 
   return (
@@ -32,12 +37,11 @@ export const AuctionHouseFilter: React.FC = () => {
             const { name } = checkbox
             const props = {
               key: index,
-              onSelect: selected => {
+              onSelect: (selected: boolean) => {
                 toggleSelection(selected, name)
               },
               my: 1,
-              // @ts-expect-error STRICT_NULL_CHECK
-              selected: filterContext.filters.organizations.includes(name),
+              selected: organizations?.includes(name),
             }
             return <Checkbox {...props}>{name}</Checkbox>
           })}

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/MediumFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/MediumFilter.tsx
@@ -14,17 +14,20 @@ const categoryMap = [
 ]
 
 export const MediumFilter: React.FC = () => {
-  const filterContext = useAuctionResultsFilterContext()
+  const {
+    currentlySelectedFilters,
+    setFilter,
+  } = useAuctionResultsFilterContext()
+  const { categories } = currentlySelectedFilters?.() || {}
 
-  const toggleSelection = (selected, name) => {
-    // @ts-expect-error STRICT_NULL_CHECK
-    let categories = filterContext.filters.categories.slice()
+  const toggleSelection = (selected: boolean, name: string) => {
+    let selectedCategories = categories?.slice()
     if (selected) {
-      categories.push(name)
+      selectedCategories?.push(name)
     } else {
-      categories = categories.filter(item => item !== name)
+      selectedCategories = selectedCategories?.filter(item => item !== name)
     }
-    filterContext.setFilter("categories", categories)
+    setFilter?.("categories", selectedCategories)
   }
 
   return (
@@ -35,12 +38,11 @@ export const MediumFilter: React.FC = () => {
             const { name, displayName } = checkbox
             const props = {
               key: index,
-              onSelect: selected => {
+              onSelect: (selected: boolean) => {
                 toggleSelection(selected, name)
               },
               my: 1,
-              // @ts-expect-error STRICT_NULL_CHECK
-              selected: filterContext.filters.categories.includes(name),
+              selected: categories?.includes(name),
             }
             return <Checkbox {...props}>{displayName}</Checkbox>
           })}

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SizeFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SizeFilter.tsx
@@ -22,11 +22,11 @@ export const SizeFilter: React.FC = () => {
   const filters = currentlySelectedFilters?.()
 
   const toggleSelection = (selected: boolean, name: string) => {
-    let sizes = filters?.sizes?.slice()
+    let sizes = filters?.sizes?.slice() ?? []
     if (selected) {
-      sizes?.push(name)
+      sizes.push(name)
     } else {
-      sizes = sizes?.filter(item => item !== name)
+      sizes = sizes.filter(item => item !== name)
     }
     setFilter?.("sizes", sizes)
   }

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SizeFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SizeFilter.tsx
@@ -1,7 +1,8 @@
-import { Checkbox, Flex, Text } from "@artsy/palette"
 import React from "react"
+import { Checkbox, Flex, Text } from "@artsy/palette"
 import { FilterExpandable } from "v2/Components/ArtworkFilter/ArtworkFilters/FilterExpandable"
 import { ShowMore } from "v2/Components/ArtworkFilter/ArtworkFilters/ShowMore"
+import { useAuctionResultsFilterContext } from "../../AuctionResultsFilterContext"
 
 const sizeMap = [
   { displayName: "Small (under 40cm)", name: "SMALL" },
@@ -9,28 +10,25 @@ const sizeMap = [
   { displayName: "Large (over 100cm)", name: "LARGE" },
 ]
 
-type BaseFilterContext<T> = () => {
-  filters?: any
-  setFilter: (key: string, value: any) => void
-}
-
 /**
  * Note: This implementation was cloned to:
  * src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
  */
-export const SizeFilter: React.FC<{
-  useFilterContext: BaseFilterContext<{ sizes: string[] }>
-}> = ({ useFilterContext }) => {
-  const filterContext = useFilterContext()
+export const SizeFilter: React.FC = () => {
+  const {
+    currentlySelectedFilters,
+    setFilter,
+  } = useAuctionResultsFilterContext()
+  const filters = currentlySelectedFilters?.()
 
-  const toggleSelection = (selected, name) => {
-    let sizes = filterContext.filters.sizes.slice()
+  const toggleSelection = (selected: boolean, name: string) => {
+    let sizes = filters?.sizes?.slice()
     if (selected) {
-      sizes.push(name)
+      sizes?.push(name)
     } else {
-      sizes = sizes.filter(item => item !== name)
+      sizes = sizes?.filter(item => item !== name)
     }
-    filterContext.setFilter("sizes", sizes)
+    setFilter?.("sizes", sizes)
   }
 
   return (
@@ -44,11 +42,11 @@ export const SizeFilter: React.FC<{
             const { name, displayName } = checkbox
             const props = {
               key: index,
-              onSelect: selected => {
+              onSelect: (selected: boolean) => {
                 toggleSelection(selected, name)
               },
               my: 1,
-              selected: filterContext.filters.sizes.includes(name),
+              selected: filters?.sizes?.includes(name),
             }
             return <Checkbox {...props}>{displayName}</Checkbox>
           })}

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/YearCreated.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/YearCreated.tsx
@@ -1,6 +1,6 @@
+import React, { useMemo } from "react"
 import { Box, Checkbox, Flex, Select, Spacer } from "@artsy/palette"
 import { FilterResetLink } from "v2/Components/FilterResetLink"
-import React, { useMemo } from "react"
 import createLogger from "v2/Utils/logger"
 import { useAuctionResultsFilterContext } from "../../AuctionResultsFilterContext"
 import { FilterExpandable } from "v2/Components/ArtworkFilter/ArtworkFilters/FilterExpandable"
@@ -20,36 +20,35 @@ const buildDateRange = (startYear: number, endYear: number) =>
   })
 
 export const YearCreated: React.FC = () => {
-  const filterContext = useAuctionResultsFilterContext()
+  const {
+    currentlySelectedFilters,
+    setFilter,
+  } = useAuctionResultsFilterContext()
 
   const {
-    // @ts-expect-error STRICT_NULL_CHECK
     earliestCreatedYear,
-    // @ts-expect-error STRICT_NULL_CHECK
     latestCreatedYear,
-    // @ts-expect-error STRICT_NULL_CHECK
     createdAfterYear,
-    // @ts-expect-error STRICT_NULL_CHECK
     createdBeforeYear,
-    // @ts-expect-error STRICT_NULL_CHECK
     allowEmptyCreatedDates,
-  } = filterContext?.filters
+  } = currentlySelectedFilters?.() || {}
 
   const hasChanges =
     earliestCreatedYear !== createdAfterYear ||
     latestCreatedYear !== createdBeforeYear
 
-  const fullDateRange = useMemo(
-    () => buildDateRange(earliestCreatedYear, latestCreatedYear),
-    [earliestCreatedYear, latestCreatedYear]
-  )
+  const fullDateRange = useMemo(() => {
+    if (earliestCreatedYear && latestCreatedYear) {
+      return buildDateRange(earliestCreatedYear, latestCreatedYear)
+    } else return []
+  }, [earliestCreatedYear, latestCreatedYear])
 
   const resetFilter = useMemo(
     () => () => {
-      filterContext.setFilter("createdAfterYear", earliestCreatedYear)
-      filterContext.setFilter("createdBeforeYear", latestCreatedYear)
+      setFilter?.("createdAfterYear", earliestCreatedYear)
+      setFilter?.("createdBeforeYear", latestCreatedYear)
     },
-    [earliestCreatedYear, latestCreatedYear, filterContext]
+    [earliestCreatedYear, latestCreatedYear, setFilter]
   )
 
   if (
@@ -69,7 +68,7 @@ export const YearCreated: React.FC = () => {
               title="Earliest"
               options={fullDateRange}
               onSelect={(year: string) => {
-                filterContext.setFilter("createdAfterYear", parseInt(year))
+                setFilter?.("createdAfterYear", parseInt(year))
               }}
               selected={`${createdAfterYear}`}
             />
@@ -78,7 +77,7 @@ export const YearCreated: React.FC = () => {
               title="Latest"
               options={fullDateRange}
               onSelect={(year: string) => {
-                filterContext.setFilter("createdBeforeYear", parseInt(year))
+                setFilter?.("createdBeforeYear", parseInt(year))
               }}
               selected={`${createdBeforeYear}`}
             />
@@ -92,7 +91,7 @@ export const YearCreated: React.FC = () => {
           <Checkbox
             selected={allowEmptyCreatedDates}
             onSelect={(allowEmpty: boolean) => {
-              filterContext.setFilter("allowEmptyCreatedDates", allowEmpty)
+              setFilter?.("allowEmptyCreatedDates", allowEmpty)
             }}
           >
             Include unspecified dates

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/YearCreated.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/YearCreated.tsx
@@ -40,7 +40,9 @@ export const YearCreated: React.FC = () => {
   const fullDateRange = useMemo(() => {
     if (earliestCreatedYear && latestCreatedYear) {
       return buildDateRange(earliestCreatedYear, latestCreatedYear)
-    } else return []
+    } else {
+      return []
+    }
   }, [earliestCreatedYear, latestCreatedYear])
 
   const resetFilter = useMemo(

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/YearCreated.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/YearCreated.tsx
@@ -23,15 +23,12 @@ export const YearCreated: React.FC = () => {
   const {
     currentlySelectedFilters,
     setFilter,
-  } = useAuctionResultsFilterContext()
-
-  const {
     earliestCreatedYear,
     latestCreatedYear,
-    createdAfterYear,
-    createdBeforeYear,
-    allowEmptyCreatedDates,
-  } = currentlySelectedFilters?.() || {}
+  } = useAuctionResultsFilterContext()
+
+  const { createdAfterYear, createdBeforeYear, allowEmptyCreatedDates } =
+    currentlySelectedFilters?.() || {}
 
   const hasChanges =
     earliestCreatedYear !== createdAfterYear ||

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/index.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/index.tsx
@@ -3,13 +3,12 @@ import { AuctionHouseFilter } from "./AuctionHouseFilter"
 import { MediumFilter } from "./MediumFilter"
 import { SizeFilter } from "./SizeFilter"
 import { YearCreated } from "./YearCreated"
-import { useAuctionResultsFilterContext } from "v2/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext"
 
 export const AuctionFilters: React.FC = () => {
   return (
     <>
       <MediumFilter />
-      <SizeFilter useFilterContext={useAuctionResultsFilterContext} />
+      <SizeFilter />
       <YearCreated />
       <AuctionHouseFilter />
     </>

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/KeywordFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/KeywordFilter.tsx
@@ -9,7 +9,7 @@ export const KeywordFilter: React.FC = () => {
   const filterContext = useAuctionResultsFilterContext()
 
   const updateKeywordFilter = (text: string) => {
-    filterContext.setFilter("keyword", text)
+    filterContext.setFilter?.("keyword", text)
   }
 
   const handleChangeText = useMemo(

--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/SortSelect.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/SortSelect.tsx
@@ -1,4 +1,4 @@
-import { Select, Flex, SelectProps } from "@artsy/palette"
+import { Select, SelectProps } from "@artsy/palette"
 import React from "react"
 import { Media } from "v2/Utils/Responsive"
 import { useAuctionResultsFilterContext } from "../AuctionResultsFilterContext"
@@ -28,7 +28,7 @@ export const SortSelect = () => {
     options: SORTS,
     selected: filterContext?.filters?.sort,
     onSelect: sort => {
-      filterContext.setFilter("sort", sort)
+      filterContext.setFilter?.("sort", sort)
     },
   }
   return (
@@ -40,21 +40,5 @@ export const SortSelect = () => {
         <Select {...props} title="Sort:" />
       </Media>
     </>
-  )
-
-  return (
-    <Flex>
-      <Select
-        width="auto"
-        variant="inline"
-        title="Sort"
-        options={SORTS}
-        // @ts-expect-error STRICT_NULL_CHECK
-        selected={filterContext.filters.sort}
-        onSelect={sort => {
-          filterContext.setFilter("sort", sort)
-        }}
-      />
-    </Flex>
   )
 }

--- a/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
@@ -119,9 +119,10 @@ describe("AuctionResults", () => {
     })
 
     it("renders either realized price, bought in, or price not avail", () => {
-      expect(wrapper.html()).toContain("Price not available")
-      expect(wrapper.html()).toContain("Bought in")
-      expect(wrapper.html()).toContain("Realized Price")
+      const html = wrapper.html()
+      expect(html).toContain("Price not available")
+      expect(html).toContain("Bought in")
+      expect(html).toContain("Realized Price")
     })
 
     it("renders proper select options", () => {
@@ -137,13 +138,11 @@ describe("AuctionResults", () => {
         wrapper.update()
         const html = wrapper.html()
         const data =
-          // @ts-expect-error STRICT_NULL_CHECK
-          AuctionResultsFixture.artist.auctionResultsConnection.edges[0].node
+          AuctionResultsFixture.artist?.auctionResultsConnection?.edges?.[0]
+            ?.node
         expect(html).toContain("Artwork Info")
-        // @ts-expect-error STRICT_NULL_CHECK
-        expect(html).toContain(data.dimension_text)
-        // @ts-expect-error STRICT_NULL_CHECK
-        expect(html).toContain(data.description)
+        expect(html).toContain(data?.dimension_text)
+        expect(html).toContain(data?.description)
       })
     })
 
@@ -240,8 +239,6 @@ describe("AuctionResults", () => {
                 pageAndCursor: { page: 1, cursor: null },
                 sort: "DATE_DESC",
                 allowEmptyCreatedDates: true,
-                earliestCreatedYear: 1880,
-                latestCreatedYear: 1973,
                 createdAfterYear: 1880,
                 createdBeforeYear: 1973,
               })
@@ -387,8 +384,6 @@ describe("AuctionResults", () => {
                 categories: [],
                 createdAfterYear: 1880,
                 createdBeforeYear: 1973,
-                earliestCreatedYear: 1880,
-                latestCreatedYear: 1973,
                 allowEmptyCreatedDates: true,
               })
 
@@ -418,8 +413,6 @@ describe("AuctionResults", () => {
                 ...defaultRelayParams,
                 createdAfterYear: 1900,
                 createdBeforeYear: 1960,
-                earliestCreatedYear: 1880,
-                latestCreatedYear: 1973,
               })
             )
 

--- a/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResultsFilterContext.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResultsFilterContext.jest.tsx
@@ -25,166 +25,61 @@ describe("AuctionResultsFilterContext", () => {
 
   it("boots with default filters", async () => {
     getWrapper()
-    expect(context.filters).toEqual(initialAuctionResultsFilterState)
+    expect(context.filters).toEqual(
+      initialAuctionResultsFilterState(null, null)
+    )
   })
 
   describe("behaviors", () => {
-    // it("#onFilterClick", () => {
-    //   const spy = jest.fn()
-    //   getWrapper({ onFilterClick: spy })
-    //   context.onFilterClick("color", "purple", initialAuctionResultsFilterState)
-    //   expect(spy).toHaveBeenCalledWith(
-    //     "color",
-    //     "purple",
-    //     initialAuctionResultsFilterState
-    //   )
-    // })
-
-    it("#setFilter", done => {
-      getWrapper()
-      act(() => {
-        context.setFilter("pageAndCursor", { page: 10, cursor: null })
-        setTimeout(() => {
-          // @ts-expect-error STRICT_NULL_CHECK
-          expect(context.filters.pageAndCursor).toEqual({
-            page: 10,
-            cursor: null,
+    it("#setFilter", () => {
+      return new Promise<void>(done => {
+        getWrapper()
+        act(() => {
+          context.setFilter?.("pageAndCursor", { page: 10, cursor: null })
+          setTimeout(() => {
+            expect(context.filters?.pageAndCursor).toEqual({
+              page: 10,
+              cursor: null,
+            })
+            done()
           })
-          done()
         })
       })
     })
 
-    it("#setFilter resets pagination", done => {
-      getWrapper({
-        filters: {
-          pageAndCursor: { page: 10, cursor: null },
-        },
-      })
-      act(() => {
-        // @ts-expect-error STRICT_NULL_CHECK
-        expect(context.filters.pageAndCursor.page).toEqual(10)
-        context.setFilter("sort", "relevant")
-        setTimeout(() => {
-          // @ts-expect-error STRICT_NULL_CHECK
-          expect(context.filters.pageAndCursor).toEqual({
-            page: 1,
-            cursor: null,
+    it("#setFilter resets pagination", () => {
+      return new Promise<void>(done => {
+        getWrapper({
+          filters: {
+            pageAndCursor: { page: 10, cursor: null },
+          },
+        })
+        act(() => {
+          expect(context.filters?.pageAndCursor?.page).toEqual(10)
+          context.setFilter?.("sort", "relevant")
+          setTimeout(() => {
+            expect(context.filters?.pageAndCursor).toEqual({
+              page: 1,
+              cursor: null,
+            })
+            done()
           })
-          done()
         })
       })
     })
 
     describe("#setFilter for allowEmptyCreatedDates", () => {
-      it("should set allowEmptyCreatedDates to false", done => {
-        getWrapper({
-          filters: {
-            allowEmptyCreatedDates: true,
-          },
-        })
-        act(() => {
-          context.setFilter("allowEmptyCreatedDates", false)
-          setTimeout(() => {
-            // @ts-expect-error STRICT_NULL_CHECK
-            expect(context.filters.allowEmptyCreatedDates).toEqual(false)
-            done()
+      it("should set allowEmptyCreatedDates to false", () => {
+        return new Promise<void>(done => {
+          getWrapper({
+            filters: {
+              allowEmptyCreatedDates: true,
+            },
           })
-        })
-      })
-    })
-
-    describe("#setFilter for createdAfterYear", () => {
-      it("should set createdBeforeYear if it is not already provided", done => {
-        getWrapper({
-          filters: {
-            latestCreatedYear: 2000,
-          },
-        })
-        act(() => {
-          context.setFilter("createdAfterYear", 1990)
-          setTimeout(() => {
-            // @ts-expect-error STRICT_NULL_CHECK
-            expect(context.filters.createdAfterYear).toEqual(1990)
-            // @ts-expect-error STRICT_NULL_CHECK
-            expect(context.filters.createdBeforeYear).toEqual(2000)
-            done()
-          })
-        })
-      })
-
-      it("should set createdBeforeYear to its value if createdBeforeYear is less", done => {
-        getWrapper({
-          filters: {
-            createdBeforeYear: 2000,
-          },
-        })
-        act(() => {
-          context.setFilter("createdAfterYear", 2001)
-          setTimeout(() => {
-            // @ts-expect-error STRICT_NULL_CHECK
-            expect(context.filters.createdAfterYear).toEqual(2001)
-            // @ts-expect-error STRICT_NULL_CHECK
-            expect(context.filters.createdBeforeYear).toEqual(2001)
-            done()
-          })
-        })
-      })
-    })
-
-    describe("#setFilter for createdBeforeYear", () => {
-      it("should set createdAfterYear if it is not already provided", done => {
-        getWrapper({
-          filters: {
-            earliestCreatedYear: 1990,
-          },
-        })
-        act(() => {
-          context.setFilter("createdBeforeYear", 2000)
-          setTimeout(() => {
-            // @ts-expect-error STRICT_NULL_CHECK
-            expect(context.filters.createdBeforeYear).toEqual(2000)
-            // @ts-expect-error STRICT_NULL_CHECK
-            expect(context.filters.createdAfterYear).toEqual(1990)
-            done()
-          })
-        })
-      })
-
-      it("should set createdAfterYear to its value if createdAfterYear is greater", done => {
-        getWrapper({
-          filters: {
-            createdAfterYear: 2000,
-          },
-        })
-        act(() => {
-          context.setFilter("createdBeforeYear", 1990)
-          setTimeout(() => {
-            // @ts-expect-error STRICT_NULL_CHECK
-            expect(context.filters.createdBeforeYear).toEqual(1990)
-            // @ts-expect-error STRICT_NULL_CHECK
-            expect(context.filters.createdAfterYear).toEqual(1990)
-            done()
-          })
-        })
-      })
-    })
-
-    it("#unsetFilter", done => {
-      getWrapper()
-      act(() => {
-        context.setFilter("pageAndCursor", { page: 10, cursor: null })
-        setTimeout(() => {
-          // @ts-expect-error STRICT_NULL_CHECK
-          expect(context.filters.pageAndCursor.page).toEqual(10)
           act(() => {
-            context.unsetFilter("pageAndCursor")
+            context.setFilter?.("allowEmptyCreatedDates", false)
             setTimeout(() => {
-              // @ts-expect-error STRICT_NULL_CHECK
-              expect(context.filters.pageAndCursor).toEqual({
-                page: 1,
-                cursor: null,
-              })
+              expect(context.filters?.allowEmptyCreatedDates).toEqual(false)
               done()
             })
           })
@@ -192,24 +87,118 @@ describe("AuctionResultsFilterContext", () => {
       })
     })
 
-    it("#unsetFilter resets pagination", done => {
-      getWrapper({
-        filters: {
-          pageAndCursor: { page: 10, cursor: null },
-          sort: "relevant",
-        },
-      })
-      act(() => {
-        // @ts-expect-error STRICT_NULL_CHECK
-        expect(context.filters.pageAndCursor.page).toEqual(10)
-        context.unsetFilter("sort")
-        setTimeout(() => {
-          // @ts-expect-error STRICT_NULL_CHECK
-          expect(context.filters.pageAndCursor).toEqual({
-            page: 1,
-            cursor: null,
+    describe("#setFilter for createdAfterYear", () => {
+      it("should set createdBeforeYear if it is not already provided", () => {
+        return new Promise<void>(done => {
+          getWrapper({
+            latestCreatedYear: 2000,
           })
-          done()
+          act(() => {
+            context.setFilter?.("createdAfterYear", 1990)
+            setTimeout(() => {
+              expect(context.filters?.createdAfterYear).toEqual(1990)
+              expect(context.filters?.createdBeforeYear).toEqual(2000)
+              done()
+            })
+          })
+        })
+      })
+
+      it("should set createdBeforeYear to its value if createdBeforeYear is less", () => {
+        return new Promise<void>(done => {
+          getWrapper({
+            filters: {
+              createdBeforeYear: 2000,
+            },
+          })
+          act(() => {
+            context.setFilter?.("createdAfterYear", 2001)
+            setTimeout(() => {
+              expect(context.filters?.createdAfterYear).toEqual(2001)
+              expect(context.filters?.createdBeforeYear).toEqual(2001)
+              done()
+            })
+          })
+        })
+      })
+    })
+
+    describe("#setFilter for createdBeforeYear", () => {
+      it("should set createdAfterYear if it is not already provided", () => {
+        return new Promise<void>(done => {
+          getWrapper({
+            earliestCreatedYear: 1990,
+          })
+          act(() => {
+            context.setFilter?.("createdBeforeYear", 2000)
+            setTimeout(() => {
+              expect(context.filters?.createdBeforeYear).toEqual(2000)
+              expect(context.filters?.createdAfterYear).toEqual(1990)
+              done()
+            })
+          })
+        })
+      })
+
+      it("should set createdAfterYear to its value if createdAfterYear is greater", () => {
+        return new Promise<void>(done => {
+          getWrapper({
+            filters: {
+              createdAfterYear: 2000,
+            },
+          })
+          act(() => {
+            context.setFilter?.("createdBeforeYear", 1990)
+            setTimeout(() => {
+              expect(context.filters?.createdBeforeYear).toEqual(1990)
+              expect(context.filters?.createdAfterYear).toEqual(1990)
+              done()
+            })
+          })
+        })
+      })
+    })
+
+    it("#unsetFilter", () => {
+      return new Promise<void>(done => {
+        getWrapper()
+        act(() => {
+          context.setFilter?.("pageAndCursor", { page: 10, cursor: null })
+          setTimeout(() => {
+            expect(context.filters?.pageAndCursor?.page).toEqual(10)
+            act(() => {
+              context.unsetFilter?.("pageAndCursor")
+              setTimeout(() => {
+                expect(context.filters?.pageAndCursor).toEqual({
+                  page: 1,
+                  cursor: null,
+                })
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
+
+    it("#unsetFilter resets pagination", () => {
+      return new Promise<void>(done => {
+        getWrapper({
+          filters: {
+            pageAndCursor: { page: 10, cursor: null },
+            sort: "relevant",
+          },
+        })
+        act(() => {
+          expect(context.filters?.pageAndCursor?.page).toEqual(10)
+          context.unsetFilter?.("sort")
+          setTimeout(() => {
+            expect(context.filters?.pageAndCursor).toEqual({
+              page: 1,
+              cursor: null,
+            })
+            done()
+          })
         })
       })
     })
@@ -217,17 +206,18 @@ describe("AuctionResultsFilterContext", () => {
     it("#resetFilters", () => {
       getWrapper({
         filters: {
-          ...initialAuctionResultsFilterState,
+          ...initialAuctionResultsFilterState(null, null),
           organizations: [],
         },
       })
-      // @ts-expect-error STRICT_NULL_CHECK
-      expect(context.filters.organizations).toEqual([])
+      expect(context.filters?.organizations).toEqual([])
 
       act(() => {
-        context.resetFilters()
+        context.resetFilters?.()
         setTimeout(() => {
-          expect(context.filters).toEqual(initialAuctionResultsFilterState)
+          expect(context.filters).toEqual(
+            initialAuctionResultsFilterState(null, null)
+          )
         })
       })
     })

--- a/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResultsFilterContext.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResultsFilterContext.jest.tsx
@@ -31,194 +31,250 @@ describe("AuctionResultsFilterContext", () => {
   })
 
   describe("behaviors", () => {
-    it("#setFilter", () => {
-      return new Promise<void>(done => {
-        getWrapper()
-        act(() => {
-          context.setFilter?.("pageAndCursor", { page: 10, cursor: null })
-          setTimeout(() => {
-            expect(context.filters?.pageAndCursor).toEqual({
-              page: 10,
-              cursor: null,
+    describe("when not in staged mode", () => {
+      it("#setFilter", () => {
+        return new Promise<void>(done => {
+          getWrapper()
+          act(() => {
+            context.setFilter?.("pageAndCursor", { page: 10, cursor: null })
+            setTimeout(() => {
+              expect(context.filters?.pageAndCursor).toEqual({
+                page: 10,
+                cursor: null,
+              })
+              done()
             })
-            done()
           })
         })
       })
-    })
 
-    it("#setFilter resets pagination", () => {
-      return new Promise<void>(done => {
-        getWrapper({
-          filters: {
-            pageAndCursor: { page: 10, cursor: null },
-          },
-        })
-        act(() => {
-          expect(context.filters?.pageAndCursor?.page).toEqual(10)
-          context.setFilter?.("sort", "relevant")
-          setTimeout(() => {
-            expect(context.filters?.pageAndCursor).toEqual({
-              page: 1,
-              cursor: null,
-            })
-            done()
-          })
-        })
-      })
-    })
-
-    describe("#setFilter for allowEmptyCreatedDates", () => {
-      it("should set allowEmptyCreatedDates to false", () => {
+      it("#setFilter resets pagination", () => {
         return new Promise<void>(done => {
           getWrapper({
             filters: {
-              allowEmptyCreatedDates: true,
+              pageAndCursor: { page: 10, cursor: null },
             },
           })
           act(() => {
-            context.setFilter?.("allowEmptyCreatedDates", false)
-            setTimeout(() => {
-              expect(context.filters?.allowEmptyCreatedDates).toEqual(false)
-              done()
-            })
-          })
-        })
-      })
-    })
-
-    describe("#setFilter for createdAfterYear", () => {
-      it("should set createdBeforeYear if it is not already provided", () => {
-        return new Promise<void>(done => {
-          getWrapper({
-            latestCreatedYear: 2000,
-          })
-          act(() => {
-            context.setFilter?.("createdAfterYear", 1990)
-            setTimeout(() => {
-              expect(context.filters?.createdAfterYear).toEqual(1990)
-              expect(context.filters?.createdBeforeYear).toEqual(2000)
-              done()
-            })
-          })
-        })
-      })
-
-      it("should set createdBeforeYear to its value if createdBeforeYear is less", () => {
-        return new Promise<void>(done => {
-          getWrapper({
-            filters: {
-              createdBeforeYear: 2000,
-            },
-          })
-          act(() => {
-            context.setFilter?.("createdAfterYear", 2001)
-            setTimeout(() => {
-              expect(context.filters?.createdAfterYear).toEqual(2001)
-              expect(context.filters?.createdBeforeYear).toEqual(2001)
-              done()
-            })
-          })
-        })
-      })
-    })
-
-    describe("#setFilter for createdBeforeYear", () => {
-      it("should set createdAfterYear if it is not already provided", () => {
-        return new Promise<void>(done => {
-          getWrapper({
-            earliestCreatedYear: 1990,
-          })
-          act(() => {
-            context.setFilter?.("createdBeforeYear", 2000)
-            setTimeout(() => {
-              expect(context.filters?.createdBeforeYear).toEqual(2000)
-              expect(context.filters?.createdAfterYear).toEqual(1990)
-              done()
-            })
-          })
-        })
-      })
-
-      it("should set createdAfterYear to its value if createdAfterYear is greater", () => {
-        return new Promise<void>(done => {
-          getWrapper({
-            filters: {
-              createdAfterYear: 2000,
-            },
-          })
-          act(() => {
-            context.setFilter?.("createdBeforeYear", 1990)
-            setTimeout(() => {
-              expect(context.filters?.createdBeforeYear).toEqual(1990)
-              expect(context.filters?.createdAfterYear).toEqual(1990)
-              done()
-            })
-          })
-        })
-      })
-    })
-
-    it("#unsetFilter", () => {
-      return new Promise<void>(done => {
-        getWrapper()
-        act(() => {
-          context.setFilter?.("pageAndCursor", { page: 10, cursor: null })
-          setTimeout(() => {
             expect(context.filters?.pageAndCursor?.page).toEqual(10)
+            context.setFilter?.("sort", "relevant")
+            setTimeout(() => {
+              expect(context.filters?.pageAndCursor).toEqual({
+                page: 1,
+                cursor: null,
+              })
+              done()
+            })
+          })
+        })
+      })
+
+      describe("#setFilter for allowEmptyCreatedDates", () => {
+        it("should set allowEmptyCreatedDates to false", () => {
+          return new Promise<void>(done => {
+            getWrapper({
+              filters: {
+                allowEmptyCreatedDates: true,
+              },
+            })
             act(() => {
-              context.unsetFilter?.("pageAndCursor")
+              context.setFilter?.("allowEmptyCreatedDates", false)
               setTimeout(() => {
-                expect(context.filters?.pageAndCursor).toEqual({
-                  page: 1,
-                  cursor: null,
-                })
+                expect(context.filters?.allowEmptyCreatedDates).toEqual(false)
                 done()
               })
             })
           })
         })
       })
-    })
 
-    it("#unsetFilter resets pagination", () => {
-      return new Promise<void>(done => {
+      describe("#setFilter for createdAfterYear", () => {
+        it("should set createdBeforeYear if it is not already provided", () => {
+          return new Promise<void>(done => {
+            getWrapper({
+              latestCreatedYear: 2000,
+            })
+            act(() => {
+              context.setFilter?.("createdAfterYear", 1990)
+              setTimeout(() => {
+                expect(context.filters?.createdAfterYear).toEqual(1990)
+                expect(context.filters?.createdBeforeYear).toEqual(2000)
+                done()
+              })
+            })
+          })
+        })
+
+        it("should set createdBeforeYear to its value if createdBeforeYear is less", () => {
+          return new Promise<void>(done => {
+            getWrapper({
+              filters: {
+                createdBeforeYear: 2000,
+              },
+            })
+            act(() => {
+              context.setFilter?.("createdAfterYear", 2001)
+              setTimeout(() => {
+                expect(context.filters?.createdAfterYear).toEqual(2001)
+                expect(context.filters?.createdBeforeYear).toEqual(2001)
+                done()
+              })
+            })
+          })
+        })
+      })
+
+      describe("#setFilter for createdBeforeYear", () => {
+        it("should set createdAfterYear if it is not already provided", () => {
+          return new Promise<void>(done => {
+            getWrapper({
+              earliestCreatedYear: 1990,
+            })
+            act(() => {
+              context.setFilter?.("createdBeforeYear", 2000)
+              setTimeout(() => {
+                expect(context.filters?.createdBeforeYear).toEqual(2000)
+                expect(context.filters?.createdAfterYear).toEqual(1990)
+                done()
+              })
+            })
+          })
+        })
+
+        it("should set createdAfterYear to its value if createdAfterYear is greater", () => {
+          return new Promise<void>(done => {
+            getWrapper({
+              filters: {
+                createdAfterYear: 2000,
+              },
+            })
+            act(() => {
+              context.setFilter?.("createdBeforeYear", 1990)
+              setTimeout(() => {
+                expect(context.filters?.createdBeforeYear).toEqual(1990)
+                expect(context.filters?.createdAfterYear).toEqual(1990)
+                done()
+              })
+            })
+          })
+        })
+      })
+
+      it("#unsetFilter", () => {
+        return new Promise<void>(done => {
+          getWrapper()
+          act(() => {
+            context.setFilter?.("pageAndCursor", { page: 10, cursor: null })
+            setTimeout(() => {
+              expect(context.filters?.pageAndCursor?.page).toEqual(10)
+              act(() => {
+                context.unsetFilter?.("pageAndCursor")
+                setTimeout(() => {
+                  expect(context.filters?.pageAndCursor).toEqual({
+                    page: 1,
+                    cursor: null,
+                  })
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
+
+      it("#unsetFilter resets pagination", () => {
+        return new Promise<void>(done => {
+          getWrapper({
+            filters: {
+              pageAndCursor: { page: 10, cursor: null },
+              sort: "relevant",
+            },
+          })
+          act(() => {
+            expect(context.filters?.pageAndCursor?.page).toEqual(10)
+            context.unsetFilter?.("sort")
+            setTimeout(() => {
+              expect(context.filters?.pageAndCursor).toEqual({
+                page: 1,
+                cursor: null,
+              })
+              done()
+            })
+          })
+        })
+      })
+
+      it("#resetFilters", () => {
         getWrapper({
           filters: {
-            pageAndCursor: { page: 10, cursor: null },
-            sort: "relevant",
+            ...initialAuctionResultsFilterState(null, null),
+            organizations: [],
           },
         })
+        expect(context.filters?.organizations).toEqual([])
+
         act(() => {
-          expect(context.filters?.pageAndCursor?.page).toEqual(10)
-          context.unsetFilter?.("sort")
+          context.resetFilters?.()
           setTimeout(() => {
-            expect(context.filters?.pageAndCursor).toEqual({
-              page: 1,
-              cursor: null,
-            })
-            done()
+            expect(context.filters).toEqual(
+              initialAuctionResultsFilterState(null, null)
+            )
           })
         })
       })
     })
 
-    it("#resetFilters", () => {
-      getWrapper({
-        filters: {
-          ...initialAuctionResultsFilterState(null, null),
-          organizations: [],
-        },
-      })
-      expect(context.filters?.organizations).toEqual([])
+    describe("when in staged mode", () => {
+      beforeEach(() => {
+        let filters = {
+          ...initialAuctionResultsFilterState?.(null, null),
+          categories: ["painting"],
+        }
 
-      act(() => {
-        context.resetFilters?.()
-        setTimeout(() => {
-          expect(context.filters).toEqual(
-            initialAuctionResultsFilterState(null, null)
-          )
+        getWrapper({ filters })
+        act(() => {
+          context.setShouldStageFilterChanges?.(true)
+          context.setFilters?.(filters)
         })
+      })
+
+      test("#setFilter sets only staged filters", () => {
+        act(() => {
+          context.setFilter?.("categories", "sculpture")
+        })
+        expect(context.filters?.categories).not.toEqual("sculpture")
+        expect(context.stagedFilters?.categories).toEqual("sculpture")
+      })
+
+      test("#unsetFilter unsets only staged filters", () => {
+        act(() => {
+          context.unsetFilter?.("categories")
+        })
+        expect(context.filters?.categories).toEqual(["painting"])
+        expect(context.stagedFilters?.categories).not.toEqual(["painting"])
+      })
+
+      test("#resetFilters resets only staged filters", () => {
+        act(() => {
+          context.resetFilters?.()
+        })
+        expect(context.filters).not.toEqual({
+          ...initialAuctionResultsFilterState?.(null, null),
+          reset: true,
+        })
+        expect(context.stagedFilters).toEqual({
+          ...initialAuctionResultsFilterState?.(null, null),
+          reset: true,
+        })
+      })
+
+      test("#currentlySelectedFilters returns the staged filters", () => {
+        act(() => {
+          context.setFilter?.("categories", "photography")
+        })
+        expect(context.currentlySelectedFilters?.()).toEqual(
+          context.stagedFilters
+        )
       })
     })
   })

--- a/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/SizeFilter.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/SizeFilter.jest.tsx
@@ -1,10 +1,10 @@
 import { mount } from "enzyme"
 import React from "react"
 import {
-  ArtworkFilterContextProps,
-  ArtworkFilterContextProvider,
-  useArtworkFilterContext,
-} from "v2/Components/ArtworkFilter/ArtworkFilterContext"
+  AuctionResultsFilterContextProps,
+  AuctionResultsFilterContextProvider,
+  useAuctionResultsFilterContext,
+} from "../AuctionResultsFilterContext"
 import { SizeFilter } from "../Components/AuctionFilters/SizeFilter"
 
 jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
@@ -12,30 +12,28 @@ jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
 }))
 
 describe("SizeFilter", () => {
-  let context: ArtworkFilterContextProps
+  let context: AuctionResultsFilterContextProps
 
   const getWrapper = () => {
     return mount(
-      <ArtworkFilterContextProvider>
+      <AuctionResultsFilterContextProvider>
         <SizeFilterTest />
-      </ArtworkFilterContextProvider>
+      </AuctionResultsFilterContextProvider>
     )
   }
 
   const SizeFilterTest = () => {
-    context = useArtworkFilterContext()
-    return <SizeFilter useFilterContext={useArtworkFilterContext} />
+    context = useAuctionResultsFilterContext()
+    return <SizeFilter />
   }
 
   it("updates context on filter change", async () => {
     const wrapper = getWrapper() as any
 
     await wrapper.find("Checkbox").at(0).simulate("click")
-    // @ts-expect-error STRICT_NULL_CHECK
-    expect(context.filters.sizes).toEqual(["SMALL"])
+    expect(context.filters?.sizes).toEqual(["SMALL"])
 
     await wrapper.find("Checkbox").at(2).simulate("click")
-    // @ts-expect-error STRICT_NULL_CHECK
-    expect(context.filters.sizes).toEqual(["SMALL", "LARGE"])
+    expect(context.filters?.sizes).toEqual(["SMALL", "LARGE"])
   })
 })


### PR DESCRIPTION
Jira: [FX-2806](https://artsyproduct.atlassian.net/browse/FX-2806)

**The purpose of the task:** refactor mobile filters on artist auction results page

Done work:
- The filters style are the same as on other mobile surfaces (ex. artist artworks)
- The filters has staged state
- Solved are most of STRICT_NULL_CHECK errors


**The filters before:**
![image](https://user-images.githubusercontent.com/56556580/125082059-6575c080-e0cf-11eb-946b-c93fc039d391.png)

**The filters after:**
![image](https://user-images.githubusercontent.com/56556580/125082098-77576380-e0cf-11eb-9749-984d91d93d42.png)
