### PR TITLE
chore(shows2): roughs in current shows

### DIFF
--- a/src/v2/Apps/Artists/Components/ArtistsArtistCard.tsx
+++ b/src/v2/Apps/Artists/Components/ArtistsArtistCard.tsx
@@ -20,7 +20,6 @@ export const ArtistsArtistCard: React.FC<ArtistsArtistCardProps> = ({
   return (
     <>
       <RouterLink
-        // @ts-expect-error STRICT_NULL_CHECK
         to={artist.href}
         noUnderline
         style={{ display: "block" }}
@@ -50,7 +49,6 @@ export const ArtistsArtistCard: React.FC<ArtistsArtistCardProps> = ({
 
       <Flex mt={1} alignItems="center" justifyContent="space-between">
         <Box mr={1}>
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
           <RouterLink to={artist.href} noUnderline style={{ display: "block" }}>
             <Text variant="md">{artist.name}</Text>
 

--- a/src/v2/Apps/Artists/Components/ArtistsCarouselCell.tsx
+++ b/src/v2/Apps/Artists/Components/ArtistsCarouselCell.tsx
@@ -32,9 +32,9 @@ const ArtistsCarouselCell: React.FC<ArtistsCarouselCellProps> = ({
       <RouterLink
         // @ts-expect-error STRICT_NULL_CHECK
         key={featuredLink.internalID}
-        // @ts-expect-error STRICT_NULL_CHECK
         to={featuredLink.href}
-        style={{ display: "block", textDecoration: "none" }}
+        display="block"
+        textDecoration="none"
       >
         <Image
           // @ts-expect-error STRICT_NULL_CHECK
@@ -63,9 +63,9 @@ const ArtistsCarouselCell: React.FC<ArtistsCarouselCellProps> = ({
         <RouterLink
           // @ts-expect-error STRICT_NULL_CHECK
           key={featuredLink.internalID}
-          // @ts-expect-error STRICT_NULL_CHECK
           to={featuredLink.href}
-          style={{ display: "block", textDecoration: "none" }}
+          dispaly="block"
+          textDecoration="none"
           // @ts-expect-error STRICT_NULL_CHECK
           aria-label={featuredLink.title}
         >

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarPartnerInfo.jest.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarPartnerInfo.jest.tsx
@@ -39,7 +39,9 @@ describe("ArtworkSidebarPartnerInfo", () => {
       const wrapper = await getWrapper(artwork)
 
       expect(wrapper.text()).toContain(artwork.sale.name)
-      expect(wrapper.find({ href: artwork.sale.href }).length).toBe(1)
+      expect(
+        wrapper.find({ href: artwork.sale.href }).hostNodes()
+      ).toHaveLength(1)
     })
   })
 
@@ -52,7 +54,9 @@ describe("ArtworkSidebarPartnerInfo", () => {
       const wrapper = await getWrapper(artwork)
 
       expect(wrapper.text()).toContain(artwork.partner.name)
-      expect(wrapper.find({ href: artwork.partner.href }).length).toBe(1)
+      expect(
+        wrapper.find({ href: artwork.partner.href }).hostNodes()
+      ).toHaveLength(1)
     })
 
     it("displays partner name without href", async () => {

--- a/src/v2/Apps/Auctions/Components/AuctionArtworksRail/AuctionArtworksRail.tsx
+++ b/src/v2/Apps/Auctions/Components/AuctionArtworksRail/AuctionArtworksRail.tsx
@@ -67,7 +67,6 @@ export const AuctionArtworksRail: React.FC<AuctionArtworksRailProps> = ({
           <Box flex="1">
             <Text as="h3" variant="lg" color="black100">
               <RouterLink
-                // @ts-expect-error STRICT_NULL_CHECK
                 to={sale.href}
                 noUnderline
                 onClick={trackViewSaleClick}
@@ -81,7 +80,6 @@ export const AuctionArtworksRail: React.FC<AuctionArtworksRailProps> = ({
           </Box>
 
           <Text variant="sm" color="black100">
-            {/* @ts-expect-error STRICT_NULL_CHECK */}
             <RouterLink to={sale.href} onClick={trackViewSaleClick}>
               View all
             </RouterLink>

--- a/src/v2/Apps/Fair/Components/FairExhibitorRail/FairExhibitorRail.tsx
+++ b/src/v2/Apps/Fair/Components/FairExhibitorRail/FairExhibitorRail.tsx
@@ -54,7 +54,6 @@ export const FairExhibitorRail: React.FC<FairExhibitorRailProps> = ({
           <Box flex="1">
             <Text as="h3" variant="lg">
               <RouterLink
-                // @ts-expect-error STRICT_NULL_CHECK
                 to={show.href}
                 noUnderline
                 onClick={() => tracking.trackEvent(tappedViewTrackingData)}

--- a/src/v2/Apps/Fair/FairApp.tsx
+++ b/src/v2/Apps/Fair/FairApp.tsx
@@ -111,7 +111,6 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
 
       <RouteTabs mb={2} fill>
         <RouteTab
-          // @ts-expect-error STRICT_NULL_CHECK
           to={fair.href}
           exact
           onClick={() => tracking.trackEvent(clickedExhibitorsTabTrackingData)}

--- a/src/v2/Apps/Fairs/Components/FairsFairBanner.tsx
+++ b/src/v2/Apps/Fairs/Components/FairsFairBanner.tsx
@@ -36,7 +36,6 @@ const FairsFairBanner: React.FC<FairsFairBannerProps> = ({ fair, ...rest }) => {
   return (
     <Box {...rest}>
       <RouterLink
-        // @ts-expect-error STRICT_NULL_CHECK
         to={fair.href}
         style={{ display: "block", textDecoration: "none" }}
         aria-label={`Go to ${fair.name}`}

--- a/src/v2/Apps/Feature/Components/FeatureFeaturedLink.tsx
+++ b/src/v2/Apps/Feature/Components/FeatureFeaturedLink.tsx
@@ -88,7 +88,6 @@ export const FeatureFeaturedLink: React.FC<FeatureFeaturedLinkProps> = ({
   return (
     <Flex flexDirection="column" {...rest}>
       {img && (
-        // @ts-expect-error STRICT_NULL_CHECK
         <Figure to={href}>
           <ResponsiveImage
             // @ts-expect-error STRICT_NULL_CHECK
@@ -110,7 +109,6 @@ export const FeatureFeaturedLink: React.FC<FeatureFeaturedLinkProps> = ({
 
       {!img && title && (
         <Text variant="title" color="black100" my={2}>
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
           <RouterLink to={href}>{title || "—"}</RouterLink>
         </Text>
       )}

--- a/src/v2/Apps/FeatureAKG/Components/FeaturedArticles.tsx
+++ b/src/v2/Apps/FeatureAKG/Components/FeaturedArticles.tsx
@@ -85,7 +85,6 @@ const FeaturedArticles: React.FC<FeaturedArticlesProps> = props => {
             return (
               <Box ml={[0, 0, 1]} key={`article-${index}`}>
                 <StyledLink
-                  // @ts-expect-error STRICT_NULL_CHECK
                   to={article.href}
                   // @ts-expect-error STRICT_NULL_CHECK
                   onClick={() => trackClick(article.href)}

--- a/src/v2/Apps/Partner/Components/PartnerArticles/ArticleCard.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArticles/ArticleCard.tsx
@@ -27,8 +27,7 @@ const ArticleCard: React.FC<ArticleCardProps> = ({ article }): JSX.Element => {
 
   return (
     <>
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
-      <RouterLink to={href} style={{ textDecoration: "none" }}>
+      <RouterLink to={href} textDecoration="none">
         {thumbnailImage && (
           <ResponsiveBox aspectWidth={4} aspectHeight={3} maxWidth="100%">
             <Image
@@ -56,8 +55,7 @@ const ArticleCard: React.FC<ArticleCardProps> = ({ article }): JSX.Element => {
         </Text>
       )}
 
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
-      <RouterLink to={href} style={{ textDecoration: "none" }}>
+      <RouterLink to={href} textDecoration="none">
         <Text as="h3" variant="title" color="black" mt={1}>
           {thumbnailTitle}
         </Text>

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistDetails.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistDetails.tsx
@@ -41,8 +41,7 @@ export const PartnerArtistDetails: React.FC<PartnerArtistDetailsProps> = ({
         <Column span={6}>
           <GridColumns gridRowGap={2}>
             <Column span={12}>
-              {/* @ts-expect-error STRICT_NULL_CHECK */}
-              <RouterLink to={href} noUnderline>
+              <RouterLink to={href} textDecoration="none">
                 <Text variant="largeTitle">{name}</Text>
               </RouterLink>
               <Text color="black60" variant="title">

--- a/src/v2/Apps/Partner/Components/PartnerShows/ShowBanner.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerShows/ShowBanner.tsx
@@ -81,8 +81,7 @@ const ShowBanner: React.FC<ShowBannerProps> = ({
           <Text textTransform="capitalize" variant="mediumText" mb={1}>
             {showType}
           </Text>
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
-          <RouterLink to={href} noUnderline>
+          <RouterLink to={href} textDecoration="none">
             {name && <Text variant="largeTitle">{name}</Text>}
             {exhibitionPeriod && (
               <Text color="black60" variant="title">
@@ -107,7 +106,6 @@ const ShowBanner: React.FC<ShowBannerProps> = ({
 
           <GridColumns mt={[2, 3]}>
             <Column span={6}>
-              {/* @ts-expect-error STRICT_NULL_CHECK */}
               <RouterLink to={href}>
                 <Button width="100%">View More</Button>
               </RouterLink>
@@ -122,7 +120,6 @@ const ShowBanner: React.FC<ShowBannerProps> = ({
             opacity={active ? 1 : 0}
             right={active ? 0 : "-100%"}
           >
-            {/* @ts-expect-error STRICT_NULL_CHECK */}
             <RouterLink to={href}>
               <Image
                 src={coverImage.medium.src}

--- a/src/v2/Apps/Partner/Components/PartnerShows/ShowCard.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerShows/ShowCard.tsx
@@ -13,8 +13,7 @@ const ShowCard: React.FC<ShowCardProps> = ({ show }): JSX.Element => {
   const showType = isFairBooth ? "fair booth" : "show"
 
   return (
-    // @ts-expect-error STRICT_NULL_CHECK
-    <RouterLink to={href} noUnderline>
+    <RouterLink to={href} textDecoration="none">
       {coverImage && (
         <ResponsiveBox
           // @ts-expect-error STRICT_NULL_CHECK

--- a/src/v2/Apps/Show/ShowSubApp.tsx
+++ b/src/v2/Apps/Show/ShowSubApp.tsx
@@ -28,7 +28,6 @@ const ShowApp: React.FC<ShowAppProps> = ({ children, show }) => {
             contextPageOwnerType,
           }}
         >
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
           <BackLink my={2} to={show.href}>
             Back to {show.name}
             {!show.isFairBooth && show.partner?.name && (

--- a/src/v2/Apps/Shows/Components/ShowsCurrentShow.tsx
+++ b/src/v2/Apps/Shows/Components/ShowsCurrentShow.tsx
@@ -25,6 +25,8 @@ const ShowsCurrentShow: React.FC<ShowsCurrentShowProps> = ({ show }) => {
   const artworks = extractNodes(show.artworksConnection)
   const count = show.artworksConnection?.totalCount ?? 0
   const remaining = count - 15
+  const dateRange = [show.startAt, show.endAt].filter(Boolean).join(" – ")
+  const subtitle = [dateRange, show.location?.city].filter(Boolean).join(", ")
 
   return (
     <>
@@ -37,14 +39,7 @@ const ShowsCurrentShow: React.FC<ShowsCurrentShowProps> = ({ show }) => {
 
         <Spacer mt={1} />
 
-        <Text variant="md">
-          {[
-            [show.startAt, show.endAt].filter(Boolean).join(" – "),
-            show.location?.city,
-          ]
-            .filter(Boolean)
-            .join(", ")}
-        </Text>
+        <Text variant="md">{subtitle}</Text>
       </RouterLink>
 
       <Spacer mt={4} />
@@ -114,7 +109,7 @@ export const ShowsCurrentShowFragmentContainer = createFragmentContainer(
   }
 )
 
-export const SHOWS_CURRENT_SHOW_PLACEHOLDER = (
+export const ShowsCurrentShowPlaceholder: React.FC = () => (
   <Skeleton>
     <SkeletonText variant="lg">Partner Name</SkeletonText>
 

--- a/src/v2/Apps/Shows/Components/ShowsCurrentShow.tsx
+++ b/src/v2/Apps/Shows/Components/ShowsCurrentShow.tsx
@@ -1,0 +1,154 @@
+import {
+  Text,
+  Spacer,
+  Button,
+  Flex,
+  Skeleton,
+  SkeletonText,
+  SkeletonBox,
+  ResponsiveBox,
+  Box,
+} from "@artsy/palette"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import GridItem from "v2/Components/Artwork/GridItem"
+import { extractNodes } from "v2/Utils/extractNodes"
+import { ShowsCurrentShow_show } from "v2/__generated__/ShowsCurrentShow_show.graphql"
+import { Masonry } from "v2/Components/Masonry"
+import { RouterLink } from "v2/System/Router/RouterLink"
+
+interface ShowsCurrentShowProps {
+  show: ShowsCurrentShow_show
+}
+
+const ShowsCurrentShow: React.FC<ShowsCurrentShowProps> = ({ show }) => {
+  const artworks = extractNodes(show.artworksConnection)
+  const count = show.artworksConnection?.totalCount ?? 0
+  const remaining = count - 15
+
+  return (
+    <>
+      <RouterLink to={show.href} textDecoration="none" display="block">
+        {show.partner?.name && <Text variant="lg">{show.partner?.name}</Text>}
+
+        <Text variant="lg" color="black60">
+          {show.name}
+        </Text>
+
+        <Spacer mt={1} />
+
+        <Text variant="md">
+          {[
+            [show.startAt, show.endAt].filter(Boolean).join(" – "),
+            show.location?.city,
+          ]
+            .filter(Boolean)
+            .join(", ")}
+        </Text>
+      </RouterLink>
+
+      <Spacer mt={4} />
+
+      <Masonry columnCount={[2, 3, 4]}>
+        {artworks.map(artwork => {
+          return (
+            <React.Fragment key={artwork.internalID}>
+              <GridItem artwork={artwork} />
+
+              <Spacer mt={4} />
+            </React.Fragment>
+          )
+        })}
+      </Masonry>
+
+      {remaining > 0 && (
+        <Flex flexDirection="column" justifyContent="center">
+          <Spacer mt={2} />
+
+          <Button
+            variant="secondaryOutline"
+            m="auto"
+            // @ts-ignore
+            as={RouterLink}
+            to={show.href}
+          >
+            {remaining} more artwork{remaining === 1 ? "" : "s"}
+          </Button>
+        </Flex>
+      )}
+    </>
+  )
+}
+
+export const ShowsCurrentShowFragmentContainer = createFragmentContainer(
+  ShowsCurrentShow,
+  {
+    show: graphql`
+      fragment ShowsCurrentShow_show on Show {
+        name
+        href
+        startAt(format: "MMM D")
+        endAt(format: "MMM D")
+        partner {
+          ... on Partner {
+            name
+          }
+          ... on ExternalPartner {
+            name
+          }
+        }
+        location {
+          city
+        }
+        artworksConnection(first: 15) {
+          totalCount
+          edges {
+            node {
+              internalID
+              ...GridItem_artwork
+            }
+          }
+        }
+      }
+    `,
+  }
+)
+
+export const SHOWS_CURRENT_SHOW_PLACEHOLDER = (
+  <Skeleton>
+    <SkeletonText variant="lg">Partner Name</SkeletonText>
+
+    <SkeletonText variant="lg">Name of the Show</SkeletonText>
+
+    <Spacer mt={1} />
+
+    <SkeletonText variant="md">Jan 0 – Feb 0, City Name</SkeletonText>
+
+    <Spacer mt={4} />
+
+    <Masonry columnCount={[2, 3, 4]}>
+      {[...new Array(11)].map((_, i) => {
+        return (
+          <Box key={i}>
+            <ResponsiveBox
+              aspectHeight={[4, 3, 3.5, 4.25, 9][i % 5]}
+              aspectWidth={[3, 4, 4.5, 3.25, 16][i % 5]}
+              maxWidth="100%"
+            >
+              <SkeletonBox width="100%" height="100%" />
+            </ResponsiveBox>
+
+            <Spacer mt={1} />
+
+            <SkeletonText variant="md">Artist Name</SkeletonText>
+            <SkeletonText variant="md">Title of Artwork, 1900</SkeletonText>
+            <SkeletonText variant="xs">Partner Name</SkeletonText>
+            <SkeletonText variant="xs">$00,000</SkeletonText>
+
+            <Spacer mt={4} />
+          </Box>
+        )
+      })}
+    </Masonry>
+  </Skeleton>
+)

--- a/src/v2/Apps/Shows/Components/ShowsCurrentShows.tsx
+++ b/src/v2/Apps/Shows/Components/ShowsCurrentShows.tsx
@@ -1,0 +1,128 @@
+import { Join, Separator } from "@artsy/palette"
+import React from "react"
+import {
+  createPaginationContainer,
+  graphql,
+  RelayPaginationProp,
+} from "react-relay"
+import { useSystemContext } from "v2/System"
+import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
+import { extractNodes } from "v2/Utils/extractNodes"
+import { ShowsCurrentShowsQuery } from "v2/__generated__/ShowsCurrentShowsQuery.graphql"
+import { ShowsCurrentShows_viewer } from "v2/__generated__/ShowsCurrentShows_viewer.graphql"
+import {
+  ShowsCurrentShowFragmentContainer,
+  SHOWS_CURRENT_SHOW_PLACEHOLDER,
+} from "./ShowsCurrentShow"
+
+interface ShowsCurrentShowsProps {
+  viewer: ShowsCurrentShows_viewer
+  relay: RelayPaginationProp
+}
+
+const ShowsCurrentShows: React.FC<ShowsCurrentShowsProps> = ({
+  viewer,
+  relay,
+}) => {
+  const shows = extractNodes(viewer.showsConnection)
+
+  return (
+    <Join separator={<Separator my={6} />}>
+      {shows.map(show => {
+        return (
+          <ShowsCurrentShowFragmentContainer
+            key={show.internalID}
+            show={show}
+          />
+        )
+      })}
+    </Join>
+  )
+}
+
+const SHOWS_CURRENT_SHOWS_QUERY = graphql`
+  query ShowsCurrentShowsQuery {
+    viewer {
+      ...ShowsCurrentShows_viewer
+    }
+  }
+`
+
+const ShowsCurrentShowsPaginationContainer = createPaginationContainer(
+  ShowsCurrentShows,
+  {
+    viewer: graphql`
+      fragment ShowsCurrentShows_viewer on Viewer
+        @argumentDefinitions(
+          first: { type: "Int", defaultValue: 10 }
+          after: { type: "String" }
+        ) {
+        showsConnection(
+          first: $first
+          after: $after
+          displayable: true
+          atAFair: false
+          sort: END_AT_ASC
+          status: CURRENT
+        ) @connection(key: "ShowsCurrentShowsQuery_showsConnection") {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          edges {
+            node {
+              internalID
+              ...ShowsCurrentShow_show
+            }
+          }
+        }
+      }
+    `,
+  },
+  {
+    direction: "forward",
+    getVariables(_, { cursor: after }, { first }) {
+      return { after, first }
+    },
+    getConnectionFromProps(props) {
+      return props.viewer.showsConnection
+    },
+    query: SHOWS_CURRENT_SHOWS_QUERY,
+  }
+)
+
+const SHOWS_CURRENT_SHOWS_PLACEHOLDER = (
+  <Join separator={<Separator my={6} />}>
+    {SHOWS_CURRENT_SHOW_PLACEHOLDER}
+    {SHOWS_CURRENT_SHOW_PLACEHOLDER}
+    {SHOWS_CURRENT_SHOW_PLACEHOLDER}
+  </Join>
+)
+
+export const ShowsCurrentShowsQueryRenderer: React.FC = () => {
+  const { relayEnvironment } = useSystemContext()
+
+  return (
+    <SystemQueryRenderer<ShowsCurrentShowsQuery>
+      environment={relayEnvironment}
+      query={SHOWS_CURRENT_SHOWS_QUERY}
+      placeholder={SHOWS_CURRENT_SHOWS_PLACEHOLDER}
+      render={({ error, props }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props) {
+          return SHOWS_CURRENT_SHOWS_PLACEHOLDER
+        }
+
+        if (props.viewer) {
+          return <ShowsCurrentShowsPaginationContainer viewer={props.viewer} />
+        }
+
+        return null
+      }}
+    />
+  )
+}

--- a/src/v2/Apps/Shows/Components/ShowsCurrentShows.tsx
+++ b/src/v2/Apps/Shows/Components/ShowsCurrentShows.tsx
@@ -12,7 +12,7 @@ import { ShowsCurrentShowsQuery } from "v2/__generated__/ShowsCurrentShowsQuery.
 import { ShowsCurrentShows_viewer } from "v2/__generated__/ShowsCurrentShows_viewer.graphql"
 import {
   ShowsCurrentShowFragmentContainer,
-  SHOWS_CURRENT_SHOW_PLACEHOLDER,
+  ShowsCurrentShowPlaceholder,
 } from "./ShowsCurrentShow"
 
 interface ShowsCurrentShowsProps {
@@ -93,9 +93,9 @@ const ShowsCurrentShowsPaginationContainer = createPaginationContainer(
 
 const SHOWS_CURRENT_SHOWS_PLACEHOLDER = (
   <Join separator={<Separator my={6} />}>
-    {SHOWS_CURRENT_SHOW_PLACEHOLDER}
-    {SHOWS_CURRENT_SHOW_PLACEHOLDER}
-    {SHOWS_CURRENT_SHOW_PLACEHOLDER}
+    <ShowsCurrentShowPlaceholder />
+    <ShowsCurrentShowPlaceholder />
+    <ShowsCurrentShowPlaceholder />
   </Join>
 )
 

--- a/src/v2/Apps/Shows/Components/ShowsHeader.tsx
+++ b/src/v2/Apps/Shows/Components/ShowsHeader.tsx
@@ -51,7 +51,7 @@ export const ShowsHeader: React.FC<ShowsHeaderProps> = ({
                       <City
                         key={city.value}
                         to={`/shows2/${city.value}`}
-                        noUnderline
+                        textDecoration="none"
                         exact
                         activeClassName="active"
                       >

--- a/src/v2/Apps/Shows/Components/ShowsMeta.tsx
+++ b/src/v2/Apps/Shows/Components/ShowsMeta.tsx
@@ -3,7 +3,7 @@ import { MetaTags } from "v2/Components/MetaTags"
 
 const TITLE = "Art Gallery Shows and Museum Exhibitions | Artsy"
 const DESCRIPTION =
-  "'Explore Artsy’s comprehensive listing of current gallery shows and museum exhibitions from around the world.'"
+  "Explore Artsy’s comprehensive listing of current gallery shows and museum exhibitions from around the world."
 
 interface ShowsMetaProps {
   cityName?: string

--- a/src/v2/Apps/Shows/Routes/ShowsIndex.tsx
+++ b/src/v2/Apps/Shows/Routes/ShowsIndex.tsx
@@ -1,4 +1,11 @@
-import { Join, Column, GridColumns, Spacer, Text } from "@artsy/palette"
+import {
+  Join,
+  Column,
+  GridColumns,
+  Spacer,
+  Text,
+  Separator,
+} from "@artsy/palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ShowsIndex_featuredShows } from "v2/__generated__/ShowsIndex_featuredShows.graphql"
@@ -6,6 +13,7 @@ import { ShowsIndex_viewer } from "v2/__generated__/ShowsIndex_viewer.graphql"
 import { ShowsFeaturedShowFragmentContainer } from "../Components/ShowsFeaturedShow"
 import { ShowsHeaderFragmentContainer } from "../Components/ShowsHeader"
 import { ShowsMeta } from "../Components/ShowsMeta"
+import { ShowsCurrentShowsQueryRenderer } from "../Components/ShowsCurrentShows"
 
 interface ShowsIndexProps {
   featuredShows: ShowsIndex_featuredShows
@@ -44,11 +52,13 @@ export const ShowsIndex: React.FC<ShowsIndexProps> = ({
           })}
         </GridColumns>
 
+        <Separator my={6} />
+
         <Text as="h2" variant="xl">
           Current Museum & Gallery Shows
         </Text>
 
-        {/* TODO */}
+        <ShowsCurrentShowsQueryRenderer />
       </Join>
     </>
   )

--- a/src/v2/Apps/ViewingRoom/Components/ViewingRoomTabBar.tsx
+++ b/src/v2/Apps/ViewingRoom/Components/ViewingRoomTabBar.tsx
@@ -9,8 +9,7 @@ import {
   color,
 } from "@artsy/palette"
 import { useIsRouteActive, useRouter } from "v2/System/Router/useRouter"
-import { RouterLink } from "v2/System/Router/RouterLink"
-import { LinkProps } from "found"
+import { RouterLink, RouterLinkProps } from "v2/System/Router/RouterLink"
 import styled from "styled-components"
 
 const TabLink = styled(RouterLink)`
@@ -18,7 +17,7 @@ const TabLink = styled(RouterLink)`
   text-decoration: none;
 `
 
-const Tab: React.FC<LinkProps> = ({ children, to }) => {
+const Tab: React.FC<RouterLinkProps> = ({ children, to }) => {
   const active = useIsRouteActive(to)
 
   const borderBottom = active

--- a/src/v2/Apps/ViewingRoom/Routes/Works/Components/ViewingRoomArtworkDetails.tsx
+++ b/src/v2/Apps/ViewingRoom/Routes/Works/Components/ViewingRoomArtworkDetails.tsx
@@ -42,7 +42,6 @@ export const ViewingRoomArtworkDetails: React.FC<ViewingRoomArtworkDetailsProps>
       )}
 
       <RouterLink
-        // @ts-expect-error STRICT_NULL_CHECK
         to={href}
         onClick={() => {
           tracking.trackEvent({

--- a/src/v2/Components/Artwork/FillwidthItem.tsx
+++ b/src/v2/Components/Artwork/FillwidthItem.tsx
@@ -111,7 +111,6 @@ export class FillwidthItemContainer extends React.Component<
       <Box className={className} width={this.imageWidth}>
         <Placeholder style={{ height: imageHeight, width: this.imageWidth }}>
           <RouterLink
-            // @ts-expect-error STRICT_NULL_CHECK
             to={artwork.href}
             onClick={() => {
               if (this.props.onClick) {

--- a/src/v2/Components/Artwork/GridItem.tsx
+++ b/src/v2/Components/Artwork/GridItem.tsx
@@ -125,7 +125,6 @@ class ArtworkGridItemContainer extends React.Component<Props, State> {
         {/* @ts-expect-error STRICT_NULL_CHECK */}
         <Placeholder style={{ paddingBottom: artwork.image.placeholder }}>
           <Link
-            // @ts-expect-error STRICT_NULL_CHECK
             to={artwork.href}
             onClick={() => {
               if (this.props.onClick) {

--- a/src/v2/Components/Artwork/Metadata.tsx
+++ b/src/v2/Components/Artwork/Metadata.tsx
@@ -32,8 +32,7 @@ export class Metadata extends React.Component<MetadataProps> {
     } = this.props
 
     return (
-      // @ts-expect-error STRICT_NULL_CHECK
-      <RouterLink to={artwork.href} noUnderline>
+      <RouterLink to={artwork.href} textDecoration="none">
         <Box textAlign="left" className={className} {...(boxProps as any)}>
           <Details
             includeLinks={false}

--- a/src/v2/Components/NavBar/NavBarPrimaryLogo.tsx
+++ b/src/v2/Components/NavBar/NavBarPrimaryLogo.tsx
@@ -1,14 +1,11 @@
 import React from "react"
 import { ArtsyMarkIcon, color, space } from "@artsy/palette"
 import styled from "styled-components"
-import { RouterLink, RouterLinkProps } from "v2/System/Router/RouterLink"
+import { RouterLink } from "v2/System/Router/RouterLink"
 
-export const NavBarPrimaryLogo: React.FC<Omit<
-  Partial<RouterLinkProps>,
-  "children"
->> = props => {
+export const NavBarPrimaryLogo: React.FC = () => {
   return (
-    <HitArea to="/" {...props}>
+    <HitArea to="/">
       <ArtsyMarkIcon height={40} width={40} name="Artsy" />
     </HitArea>
   )

--- a/src/v2/Components/__tests__/__snapshots__/Artwork.jest.tsx.snap
+++ b/src/v2/Components/__tests__/__snapshots__/Artwork.jest.tsx.snap
@@ -1,36 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Artwork renders correctly 1`] = `
-.c3 {
+.c4 {
   text-align: left;
   margin-top: 4px;
 }
 
-.c6 {
-  color: black60;
-}
-
-.c5 {
-  font-family: sans;
-}
-
 .c7 {
   color: black60;
+}
+
+.c6 {
   font-family: sans;
 }
 
 .c8 {
   color: black60;
+  font-family: sans;
+}
+
+.c9 {
+  color: black60;
   font-weight: normal;
   font-family: sans;
 }
 
-.c4 {
+.c5 {
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
+}
+
+.c3 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .c0 {
@@ -98,25 +103,22 @@ exports[`Artwork renders correctly 1`] = `
     />
   </div>
   <a
+    className="c3"
     href="/artwork/mikael-olson-some-kind-of-dinosaur"
-    style={
-      Object {
-        "textDecoration": "none",
-      }
-    }
+    textDecoration="none"
   >
     <div
-      className="c3"
+      className="c4"
     >
       <div
-        className="c4"
+        className="c5"
       >
         <div
-          className=" c5"
+          className=" c6"
           fontFamily="sans"
         >
           <div
-            className=" c5"
+            className=" c6"
             fontFamily="sans"
           >
             Mikael Olson
@@ -124,10 +126,10 @@ exports[`Artwork renders correctly 1`] = `
         </div>
       </div>
       <div
-        className="c4"
+        className="c5"
       >
         <div
-          className="c6 c7"
+          className="c7 c8"
           color="black60"
           fontFamily="sans"
         >
@@ -138,10 +140,10 @@ exports[`Artwork renders correctly 1`] = `
         </div>
       </div>
       <div
-        className="c4"
+        className="c5"
       >
         <div
-          className="c6 c7"
+          className="c7 c8"
           color="black60"
           fontFamily="sans"
         >
@@ -149,10 +151,10 @@ exports[`Artwork renders correctly 1`] = `
         </div>
       </div>
       <div
-        className="c4"
+        className="c5"
       >
         <div
-          className="c6 c8"
+          className="c7 c9"
           color="black60"
           fontFamily="sans"
           fontWeight="normal"

--- a/src/v2/System/Router/RouterLink.tsx
+++ b/src/v2/System/Router/RouterLink.tsx
@@ -1,93 +1,73 @@
-import { Link, LinkProps, LinkPropsSimple, RouterContext } from "found"
-import { omit, pick } from "lodash"
+import { Link, LinkProps, RouterContext } from "found"
 import React, { useContext } from "react"
-import { get } from "v2/Utils/get"
+import { BoxProps, boxMixin } from "@artsy/palette"
+import styled from "styled-components"
+import { compose, ResponsiveValue, system } from "styled-system"
+import { useMemo } from "react"
 
 /**
  * Wrapper component around found's <Link> component with a fallback to a normal
  * <a> tag if ouside of a routing context.
- *
- * NOTE: If using styled-components, <RouterLink> can be easily styled like so:
- *
- * const StyledLink = styled(RouterLink)`
- *   ...
- * `
  */
-export type RouterLinkProps = LinkProps &
-  React.HTMLAttributes<HTMLAnchorElement> & {
+export type RouterLinkProps = Omit<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  "href"
+> &
+  Omit<LinkProps, "to"> &
+  BoxProps & {
+    /**
+     * Simplifies `LinkProps#to` to just be a string and handle nulls, which are common
+     */
+    to: string | null
+    textDecoration?: ResponsiveValue<string>
+    /** @deprecated Use `textDecoration` */
     noUnderline?: boolean
   }
 
 export const RouterLink: React.ForwardRefExoticComponent<RouterLinkProps> = React.forwardRef(
-  ({ to, children, ...props }, ref) => {
-    const styleProps = props.noUnderline ? { textDecoration: "none" } : {}
+  ({ to, noUnderline, ...rest }, forwardedRef) => {
     const context = useContext(RouterContext)
-    const routes = get(context, c => c?.router?.matcher?.routeConfig, [])
-    const isSupportedInRouter = !!get(context, c =>
-      c?.router?.matcher?.matchRoutes(routes, to)
+    const routes = context?.router?.matcher?.routeConfig ?? []
+    const matcher = context?.router?.matcher
+    const isSupportedInRouter = useMemo(
+      () => !!matcher?.matchRoutes(routes, to),
+      [matcher, routes, to]
     )
 
-    /**
-     * Only pass found-router specific props across, props that conform to the
-     * link API found here: https://github.com/4Catalyzer/found#links
-     */
-    const handlers = Object.keys(props).reduce((acc, prop) => {
-      if (prop.startsWith("on")) {
-        // @ts-expect-error STRICT_NULL_CHECK
-        acc.push(prop)
-      }
-      return acc
-    }, [])
+    // TODO: Bulk replace
+    const deprecated = noUnderline ? { textDecoration: "none" } : {}
 
     if (isSupportedInRouter) {
-      const allowedProps = pick(props, [
-        "aria-label",
-        "Component",
-        "activeClassName",
-        "className",
-        "data-test",
-        "exact",
-        "replace",
-        "role",
-        "style",
-        "tabIndex",
-        ...handlers,
-      ])
-
       return (
-        <Link
-          ref={ref as any}
-          to={to}
-          {...allowedProps}
-          // @ts-expect-error STRICT_NULL_CHECK
-          style={{ ...styleProps, ...(props as LinkPropsSimple).style }}
-        >
-          {children}
-        </Link>
-      )
-    } else {
-      return (
-        <a
-          ref={ref}
-          href={to as string}
-          className={(props as LinkPropsSimple).className}
-          style={{ ...styleProps, ...(props as LinkPropsSimple).style }}
-          {...omit(props, [
-            "active",
-            "activeClassName",
-            "alignItems",
-            "hasLighterTextColor",
-            "justifyContent",
-            "noUnderline",
-            "textAlign",
-            "underlineBehavior",
-          ])}
-        >
-          {children}
-        </a>
+        <RouterAwareLink
+          ref={forwardedRef as any}
+          to={to ?? ""}
+          {...deprecated}
+          {...rest}
+        />
       )
     }
+
+    return (
+      <RouterUnawareLink
+        ref={forwardedRef as any}
+        href={to ?? ""}
+        {...deprecated}
+        {...rest}
+      />
+    )
   }
 )
 
 RouterLink.displayName = "RouterLink"
+
+const textDecoration = system({ textDecoration: true })
+const routerLinkMixin = compose(boxMixin, textDecoration)
+
+const RouterAwareLink = styled(Link)`
+  ${routerLinkMixin}
+`
+
+const RouterUnawareLink = styled.a`
+  ${routerLinkMixin}
+`

--- a/src/v2/System/Router/RouterLink.tsx
+++ b/src/v2/System/Router/RouterLink.tsx
@@ -1,4 +1,4 @@
-import { Link, LinkProps, RouterContext } from "found"
+import { Link, LinkPropsSimple, RouterContext } from "found"
 import React, { useContext } from "react"
 import { BoxProps, boxMixin } from "@artsy/palette"
 import styled from "styled-components"
@@ -13,7 +13,7 @@ export type RouterLinkProps = Omit<
   React.AnchorHTMLAttributes<HTMLAnchorElement>,
   "href"
 > &
-  Omit<LinkProps, "to"> &
+  Omit<LinkPropsSimple, "to"> &
   BoxProps & {
     /**
      * Simplifies `LinkProps#to` to just be a string and handle nulls, which are common

--- a/src/v2/System/Router/__tests__/RouterLink.jest.tsx
+++ b/src/v2/System/Router/__tests__/RouterLink.jest.tsx
@@ -25,7 +25,7 @@ describe("RouterLink", () => {
       // @ts-expect-error STRICT_NULL_CHECK
     ).renderUntil(enzyme => {
       try {
-        return enzyme.find(Link).length > 0
+        return enzyme.html().length > 0
       } catch {
         // Guard against enzyme == null, which is the first render pass
       }
@@ -41,10 +41,5 @@ describe("RouterLink", () => {
     const wrapper = mount(<RouterLink to="/foo">Foo</RouterLink>)
     expect(wrapper.find(Link).length).toEqual(0)
     expect(wrapper.find("a").length).toEqual(1)
-  })
-
-  it("prunes invalid props from being passed to dom", async () => {
-    const wrapper = await getWrapper({ hey: true, you: true })
-    expect(Object.keys(wrapper.find("a").props())).not.toContain(["hey", "you"])
   })
 })

--- a/src/v2/__generated__/ShowsCurrentShow_show.graphql.ts
+++ b/src/v2/__generated__/ShowsCurrentShow_show.graphql.ts
@@ -1,0 +1,184 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ShowsCurrentShow_show = {
+    readonly name: string | null;
+    readonly href: string | null;
+    readonly startAt: string | null;
+    readonly endAt: string | null;
+    readonly partner: {
+        readonly name?: string | null;
+    } | null;
+    readonly location: {
+        readonly city: string | null;
+    } | null;
+    readonly artworksConnection: {
+        readonly totalCount: number | null;
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string;
+                readonly " $fragmentRefs": FragmentRefs<"GridItem_artwork">;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "ShowsCurrentShow_show";
+};
+export type ShowsCurrentShow_show$data = ShowsCurrentShow_show;
+export type ShowsCurrentShow_show$key = {
+    readonly " $data"?: ShowsCurrentShow_show$data;
+    readonly " $fragmentRefs": FragmentRefs<"ShowsCurrentShow_show">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "MMM D"
+  }
+],
+v2 = [
+  (v0/*: any*/)
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ShowsCurrentShow_show",
+  "selections": [
+    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "href",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": (v1/*: any*/),
+      "kind": "ScalarField",
+      "name": "startAt",
+      "storageKey": "startAt(format:\"MMM D\")"
+    },
+    {
+      "alias": null,
+      "args": (v1/*: any*/),
+      "kind": "ScalarField",
+      "name": "endAt",
+      "storageKey": "endAt(format:\"MMM D\")"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "partner",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "InlineFragment",
+          "selections": (v2/*: any*/),
+          "type": "Partner"
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": (v2/*: any*/),
+          "type": "ExternalPartner"
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Location",
+      "kind": "LinkedField",
+      "name": "location",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "city",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 15
+        }
+      ],
+      "concreteType": "ArtworkConnection",
+      "kind": "LinkedField",
+      "name": "artworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "totalCount",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArtworkEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "GridItem_artwork"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "artworksConnection(first:15)"
+    }
+  ],
+  "type": "Show"
+};
+})();
+(node as any).hash = '7ccedb11f973c68631c16d4ba02a567a';
+export default node;

--- a/src/v2/__generated__/ShowsCurrentShowsQuery.graphql.ts
+++ b/src/v2/__generated__/ShowsCurrentShowsQuery.graphql.ts
@@ -1,0 +1,770 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ShowsCurrentShowsQueryVariables = {};
+export type ShowsCurrentShowsQueryResponse = {
+    readonly viewer: {
+        readonly " $fragmentRefs": FragmentRefs<"ShowsCurrentShows_viewer">;
+    } | null;
+};
+export type ShowsCurrentShowsQuery = {
+    readonly response: ShowsCurrentShowsQueryResponse;
+    readonly variables: ShowsCurrentShowsQueryVariables;
+};
+
+
+
+/*
+query ShowsCurrentShowsQuery {
+  viewer {
+    ...ShowsCurrentShows_viewer
+  }
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  artistNames
+  href
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment SaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+
+fragment ShowsCurrentShow_show on Show {
+  name
+  href
+  startAt(format: "MMM D")
+  endAt(format: "MMM D")
+  partner {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on ExternalPartner {
+      name
+      id
+    }
+    ... on Node {
+      id
+    }
+  }
+  location {
+    city
+    id
+  }
+  artworksConnection(first: 15) {
+    totalCount
+    edges {
+      node {
+        internalID
+        ...GridItem_artwork
+        id
+      }
+    }
+  }
+}
+
+fragment ShowsCurrentShows_viewer on Viewer {
+  showsConnection(first: 10, displayable: true, atAFair: false, sort: END_AT_ASC, status: CURRENT) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    edges {
+      node {
+        internalID
+        ...ShowsCurrentShow_show
+        id
+        __typename
+      }
+      cursor
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "atAFair",
+    "value": false
+  },
+  {
+    "kind": "Literal",
+    "name": "displayable",
+    "value": true
+  },
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  },
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "END_AT_ASC"
+  },
+  {
+    "kind": "Literal",
+    "name": "status",
+    "value": "CURRENT"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "MMM D"
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v7 = [
+  (v2/*: any*/)
+],
+v8 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v9 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ShowsCurrentShowsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ShowsCurrentShows_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ShowsCurrentShowsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v0/*: any*/),
+            "concreteType": "ShowConnection",
+            "kind": "LinkedField",
+            "name": "showsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ShowEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Show",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v1/*: any*/),
+                      (v2/*: any*/),
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": (v4/*: any*/),
+                        "kind": "ScalarField",
+                        "name": "startAt",
+                        "storageKey": "startAt(format:\"MMM D\")"
+                      },
+                      {
+                        "alias": null,
+                        "args": (v4/*: any*/),
+                        "kind": "ScalarField",
+                        "name": "endAt",
+                        "storageKey": "endAt(format:\"MMM D\")"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "partner",
+                        "plural": false,
+                        "selections": [
+                          (v5/*: any*/),
+                          (v6/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": (v7/*: any*/),
+                            "type": "Partner"
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": (v7/*: any*/),
+                            "type": "ExternalPartner"
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Location",
+                        "kind": "LinkedField",
+                        "name": "location",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "city",
+                            "storageKey": null
+                          },
+                          (v6/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "first",
+                            "value": 15
+                          }
+                        ],
+                        "concreteType": "ArtworkConnection",
+                        "kind": "LinkedField",
+                        "name": "artworksConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "totalCount",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtworkEdge",
+                            "kind": "LinkedField",
+                            "name": "edges",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "kind": "LinkedField",
+                                "name": "node",
+                                "plural": false,
+                                "selections": [
+                                  (v1/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "title",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "image_title",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "imageTitle",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "placeholder",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": "large"
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:\"large\")"
+                                      },
+                                      {
+                                        "alias": "aspect_ratio",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "aspectRatio",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "artistNames",
+                                    "storageKey": null
+                                  },
+                                  (v3/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "date",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "sale_message",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "saleMessage",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "cultural_maker",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "culturalMaker",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": (v8/*: any*/),
+                                    "concreteType": "Artist",
+                                    "kind": "LinkedField",
+                                    "name": "artists",
+                                    "plural": true,
+                                    "selections": [
+                                      (v6/*: any*/),
+                                      (v3/*: any*/),
+                                      (v2/*: any*/)
+                                    ],
+                                    "storageKey": "artists(shallow:true)"
+                                  },
+                                  {
+                                    "alias": "collecting_institution",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "collectingInstitution",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": (v8/*: any*/),
+                                    "concreteType": "Partner",
+                                    "kind": "LinkedField",
+                                    "name": "partner",
+                                    "plural": false,
+                                    "selections": [
+                                      (v2/*: any*/),
+                                      (v3/*: any*/),
+                                      (v6/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "type",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": "partner(shallow:true)"
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Sale",
+                                    "kind": "LinkedField",
+                                    "name": "sale",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "is_auction",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "isAuction",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": "is_closed",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "isClosed",
+                                        "storageKey": null
+                                      },
+                                      (v6/*: any*/),
+                                      {
+                                        "alias": "is_live_open",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "isLiveOpen",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": "is_open",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "isOpen",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": "is_preview",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "isPreview",
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": "display_timely_at",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "displayTimelyAt",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "sale_artwork",
+                                    "args": null,
+                                    "concreteType": "SaleArtwork",
+                                    "kind": "LinkedField",
+                                    "name": "saleArtwork",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "SaleArtworkCounts",
+                                        "kind": "LinkedField",
+                                        "name": "counts",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "alias": "bidder_positions",
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "bidderPositions",
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": "highest_bid",
+                                        "args": null,
+                                        "concreteType": "SaleArtworkHighestBid",
+                                        "kind": "LinkedField",
+                                        "name": "highestBid",
+                                        "plural": false,
+                                        "selections": (v9/*: any*/),
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "alias": "opening_bid",
+                                        "args": null,
+                                        "concreteType": "SaleArtworkOpeningBid",
+                                        "kind": "LinkedField",
+                                        "name": "openingBid",
+                                        "plural": false,
+                                        "selections": (v9/*: any*/),
+                                        "storageKey": null
+                                      },
+                                      (v6/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_inquireable",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isInquireable",
+                                    "storageKey": null
+                                  },
+                                  (v6/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "slug",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_saved",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isSaved",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": "is_biddable",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isBiddable",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": "artworksConnection(first:15)"
+                      },
+                      (v6/*: any*/),
+                      (v5/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "cursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "showsConnection(atAFair:false,displayable:true,first:10,sort:\"END_AT_ASC\",status:\"CURRENT\")"
+          },
+          {
+            "alias": null,
+            "args": (v0/*: any*/),
+            "filters": [
+              "displayable",
+              "atAFair",
+              "sort",
+              "status"
+            ],
+            "handle": "connection",
+            "key": "ShowsCurrentShowsQuery_showsConnection",
+            "kind": "LinkedHandle",
+            "name": "showsConnection"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "ShowsCurrentShowsQuery",
+    "operationKind": "query",
+    "text": "query ShowsCurrentShowsQuery {\n  viewer {\n    ...ShowsCurrentShows_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShowsCurrentShow_show on Show {\n  name\n  href\n  startAt(format: \"MMM D\")\n  endAt(format: \"MMM D\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  location {\n    city\n    id\n  }\n  artworksConnection(first: 15) {\n    totalCount\n    edges {\n      node {\n        internalID\n        ...GridItem_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment ShowsCurrentShows_viewer on Viewer {\n  showsConnection(first: 10, displayable: true, atAFair: false, sort: END_AT_ASC, status: CURRENT) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        internalID\n        ...ShowsCurrentShow_show\n        id\n        __typename\n      }\n      cursor\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'b32e9b71895699d8d424fef17b7bb9c7';
+export default node;

--- a/src/v2/__generated__/ShowsCurrentShows_viewer.graphql.ts
+++ b/src/v2/__generated__/ShowsCurrentShows_viewer.graphql.ts
@@ -1,0 +1,168 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ShowsCurrentShows_viewer = {
+    readonly showsConnection: {
+        readonly pageInfo: {
+            readonly hasNextPage: boolean;
+            readonly endCursor: string | null;
+        };
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string;
+                readonly " $fragmentRefs": FragmentRefs<"ShowsCurrentShow_show">;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "ShowsCurrentShows_viewer";
+};
+export type ShowsCurrentShows_viewer$data = ShowsCurrentShows_viewer;
+export type ShowsCurrentShows_viewer$key = {
+    readonly " $data"?: ShowsCurrentShows_viewer$data;
+    readonly " $fragmentRefs": FragmentRefs<"ShowsCurrentShows_viewer">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [
+    {
+      "defaultValue": 10,
+      "kind": "LocalArgument",
+      "name": "first",
+      "type": "Int"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "after",
+      "type": "String"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "connection": [
+      {
+        "count": "first",
+        "cursor": "after",
+        "direction": "forward",
+        "path": [
+          "showsConnection"
+        ]
+      }
+    ]
+  },
+  "name": "ShowsCurrentShows_viewer",
+  "selections": [
+    {
+      "alias": "showsConnection",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "atAFair",
+          "value": false
+        },
+        {
+          "kind": "Literal",
+          "name": "displayable",
+          "value": true
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "END_AT_ASC"
+        },
+        {
+          "kind": "Literal",
+          "name": "status",
+          "value": "CURRENT"
+        }
+      ],
+      "concreteType": "ShowConnection",
+      "kind": "LinkedField",
+      "name": "__ShowsCurrentShowsQuery_showsConnection_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ShowEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Show",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                },
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "ShowsCurrentShow_show"
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "__ShowsCurrentShowsQuery_showsConnection_connection(atAFair:false,displayable:true,sort:\"END_AT_ASC\",status:\"CURRENT\")"
+    }
+  ],
+  "type": "Viewer"
+};
+(node as any).hash = '39a18e1e1b6680eb506b335810498416';
+export default node;


### PR DESCRIPTION
https://user-images.githubusercontent.com/112297/125113730-04da8980-e0b7-11eb-9d15-06b2cc8d3285.mov

-----

In general this isn't too notable yet. I need to add pagination but pagination doesn't work in Metaphysics for the top-level `showsConnection` field. I need to wrap our shows/feed endpoint for that to work, so...

But, in particular if you could take a look at aeed09cca3105c187ca1ab02830ca2fc439aad22 — I was a little frustrated with `RouterLink` being unintuitive, so now it supports all anchor and box props and no longer will complain about null hrefs.

