### PR TITLE
feature: Webpack Bundle Split Flag

### DIFF
--- a/webpack/envs/clientCommonConfig.js
+++ b/webpack/envs/clientCommonConfig.js
@@ -1,7 +1,8 @@
 // @ts-check
-const crypto = require("crypto")
+import crypto from 'crypto'
+import { env } from "../utils/env"
 
-const FRAMEWORK_BUNDLES = ["react", "react-dom"]
+const FRAMEWORK_BUNDLES = ["react", "react-dom", "@sentry"]
 
 const TOTAL_PAGES = 12
 
@@ -84,7 +85,7 @@ export const clientChunks = {
     },
   },
   maxInitialRequests: 20,
-  maxSize: 307200, // 300 KiB
+  maxSize: env.webpackBundleSplit ? 307200 : undefined, // 300 KiB
   // A chunk should be at least 100KiB before using splitChunks
-  minSize: 102400,
+  minSize: env.webpackBundleSplit ? 102400 : undefined,
 }

--- a/webpack/utils/env.js
+++ b/webpack/utils/env.js
@@ -21,8 +21,8 @@ const env = {
   nodeEnv: process.env.NODE_ENV,
   onCi: yn(process.env.CI, { default: false }),
   port: process.env.PORT || "5000",
-  // @ts-expect-error STRICT_NULL_CHECK
-  webpackCiCpuLimit: Number.parseInt(process.env.WEBPACK_CI_CPU_LIMIT) || 4,
+  webpackCiCpuLimit: Number.parseInt(process.env.WEBPACK_CI_CPU_LIMIT || "") || 4,
+  webpackBundleSplit: yn(process.env.WEBPACK_BUNDLE_SPLIT, { default: true }),
   webpackConcatenate: yn(process.env.WEBPACK_CONCATENATE, { default: true }),
   webpackDebug: yn(process.env.WEBPACK_DEBUG),
   webpackDevtool: process.env.WEBPACK_DEVTOOL,
@@ -46,6 +46,7 @@ if (env.onCi || env.logConfig) {
   console.log("  NODE_ENV".padEnd(35), chalk.yellow(env.nodeEnv))
   console.log("  PORT".padEnd(35), chalk.yellow(env.port))
   console.log("  WEBPACK_ANALYZE".padEnd(35), chalk.yellow(env.enableWebpackAnalyze))
+  console.log("  WEBPACK_BUNDLE_SPLIT".padEnd(35), chalk.yellow(env.webpackBundleSplit))
   console.log("  WEBPACK_CI_CPU_LIMIT".padEnd(35), chalk.yellow(env.webpackCiCpuLimit))
   console.log("  WEBPACK_CONCATENATE".padEnd(35), chalk.yellow(env.webpackConcatenate))
   console.log("  WEBPACK_DEBUG".padEnd(35), chalk.yellow(env.webpackDebug))


### PR DESCRIPTION
This adds a flag to allow disabling size based bundle splitting, this
can help when debugging and doing bundle analysis.