### PR TITLE
feat(FX-3062): fair artworks alignment

### DIFF
--- a/src/v2/Apps/Fair/Routes/FairArtworks.tsx
+++ b/src/v2/Apps/Fair/Routes/FairArtworks.tsx
@@ -47,22 +47,23 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
   // in <ArtistsFilter />. So, pass as props for now.
   const Filters = (
     <>
+      <PartnersFilter label="Exhibitors" placeholder="Search" expanded />
       <ArtistsFilter
         fairID={fair.internalID}
         relayEnvironment={relayEnvironment}
         user={user}
+        expanded
       />
-      <MediumFilter expanded />
-      <MaterialsFilter expanded />
-      <PriceRangeFilter />
       <AttributionClassFilter expanded />
-      <SizeFilter />
-      <WaysToBuyFilter />
-      <ArtworkLocationFilter expanded />
-      <ArtistNationalityFilter expanded />
+      <MediumFilter expanded />
+      <PriceRangeFilter expanded />
+      <SizeFilter expanded />
+      <WaysToBuyFilter expanded />
+      <MaterialsFilter />
+      <ArtistNationalityFilter />
+      <ArtworkLocationFilter />
       <TimePeriodFilter />
       <ColorFilter />
-      <PartnersFilter />
     </>
   )
 
@@ -85,12 +86,7 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
         sidebarAggregations.aggregations as SharedArtworkFilterContextProps["aggregations"]
       }
     >
-      <BaseArtworkFilter
-        mt={6}
-        relay={relay}
-        viewer={fair}
-        Filters={Filters}
-      ></BaseArtworkFilter>
+      <BaseArtworkFilter mt={6} relay={relay} viewer={fair} Filters={Filters} />
     </ArtworkFilterContextProvider>
   )
 }

--- a/src/v2/Apps/Fair/Routes/FairArtworks.tsx
+++ b/src/v2/Apps/Fair/Routes/FairArtworks.tsx
@@ -47,7 +47,7 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
   // in <ArtistsFilter />. So, pass as props for now.
   const Filters = (
     <>
-      <PartnersFilter label="Exhibitors" placeholder="Search" expanded />
+      <PartnersFilter label="Exhibitors" expanded />
       <ArtistsFilter
         fairID={fair.internalID}
         relayEnvironment={relayEnvironment}

--- a/src/v2/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
@@ -60,9 +60,10 @@ describe("FairArtworks", () => {
 
   it("includes the artist filter", async () => {
     const wrapper = await getWrapper()
-    expect(wrapper.find("ArtistsFilter").length).toBe(1)
-    wrapper.find("ArtistsFilter").find("ChevronIcon").simulate("click")
-    expect(wrapper.find("ArtistsFilter").text()).toMatch(
+    const artistFilter = wrapper.find("ArtistsFilter")
+    expect(artistFilter.length).toBe(1)
+    artistFilter.find("ChevronIcon").simulate("click")
+    expect(artistFilter.find("Checkbox").at(0).text()).toMatch(
       "Artists I follow (10)"
     )
   })

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/FilterExpandable.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/FilterExpandable.tsx
@@ -2,21 +2,21 @@ import {
   Box,
   Expandable,
   ExpandableProps,
-  themeProps,
   useThemeConfig,
 } from "@artsy/palette"
 import React, { useEffect, useRef, useState } from "react"
-import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
 import { getElementParams } from "./helpers"
 import { useScrollRefContext } from "./useScrollContext"
+import { data as sd } from "sharify"
 
-export const FilterExpandable: React.FC<ExpandableProps> = props => {
+export const FilterExpandable: React.FC<ExpandableProps> = ({
+  expanded,
+  ...rest
+}) => {
   const tokens = useThemeConfig({
     v2: { mb: 1 },
     v3: { mb: 6 },
   })
-
-  const isScrollIntoViewEnabled = useMatchMedia(themeProps.mediaQueries.xs)
 
   const ctx = useScrollRefContext()
   const scrollRef = ctx?.scrollRef
@@ -24,7 +24,8 @@ export const FilterExpandable: React.FC<ExpandableProps> = props => {
   const filterRef = useRef<HTMLDivElement | null>(null)
   const anchorRef = useRef<HTMLDivElement | null>(null)
 
-  const [open, setOpen] = useState(!!props.expanded)
+  const isExpanded = sd.IS_MOBILE ? false : !!expanded
+  const [open, setOpen] = useState(isExpanded)
 
   useEffect(() => {
     if (open && scrollRef?.current) {
@@ -40,15 +41,22 @@ export const FilterExpandable: React.FC<ExpandableProps> = props => {
         anchorRef.current?.scrollIntoView({ block: "end" })
       }
     }
-  }, [open])
+  }, [open, scrollRef])
 
   const onClick = () => {
-    isScrollIntoViewEnabled && setOpen(open => !open)
+    if (sd.IS_MOBILE) {
+      setOpen(open => !open)
+    }
   }
 
   return (
     <Box ref={filterRef as any}>
-      <Expandable mb={tokens.mb} onClick={onClick} {...props} />
+      <Expandable
+        mb={tokens.mb}
+        expanded={isExpanded}
+        onClick={onClick}
+        {...rest}
+      />
       <div ref={anchorRef}></div>
     </Box>
   )

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
@@ -4,20 +4,18 @@ import { ResultsFilter } from "./ResultsFilter"
 export interface PartnersFilterProps {
   expanded?: boolean
   label?: string
-  placeholder?: string
 }
 
 export const PartnersFilter: React.FC<PartnersFilterProps> = ({
   expanded,
   label = "Galleries and institutions",
-  placeholder = "Enter a gallery",
 }) => {
   return (
     <ResultsFilter
       facetName="partnerIDs"
       slice="PARTNER"
       label={label}
-      placeholder={placeholder}
+      placeholder="Enter a gallery"
       expanded={expanded}
     />
   )

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
@@ -3,15 +3,21 @@ import { ResultsFilter } from "./ResultsFilter"
 
 export interface PartnersFilterProps {
   expanded?: boolean
+  label?: string
+  placeholder?: string
 }
 
-export const PartnersFilter: React.FC<PartnersFilterProps> = ({ expanded }) => {
+export const PartnersFilter: React.FC<PartnersFilterProps> = ({
+  expanded,
+  label = "Galleries and institutions",
+  placeholder = "Enter a gallery",
+}) => {
   return (
     <ResultsFilter
       facetName="partnerIDs"
       slice="PARTNER"
-      label="Galleries and institutions"
-      placeholder="Enter a gallery"
+      label={label}
+      placeholder={placeholder}
       expanded={expanded}
     />
   )

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/FilterExpandable.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/FilterExpandable.jest.tsx
@@ -1,29 +1,35 @@
-import { Breakpoint } from "@artsy/palette"
 import { mount } from "enzyme"
 import React from "react"
 import { FilterExpandable } from "../FilterExpandable"
+import { data as sd } from "sharify"
 
-jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
-  useMatchMedia: () => ({}),
-}))
+jest.mock("sharify")
 
 describe("FilterExpandable", () => {
-  const getWrapper = (breakpoint: Breakpoint = "xl") => {
+  const getWrapper = () => {
     return mount(
-      <FilterExpandable expanded={false}>
-        <></>
+      <FilterExpandable expanded={true}>
+        <span>Some render content</span>
       </FilterExpandable>
     )
   }
 
-  let wrapper
-
   beforeEach(() => {
-    wrapper = getWrapper()
+    sd.IS_MOBILE = false
   })
 
   it("renders correctly", () => {
+    const wrapper = getWrapper()
+
     expect(wrapper.find("Expandable")).toHaveLength(1)
     expect(wrapper.find("Expandable").prop("onClick")).toBeTruthy()
+    expect(wrapper.find("span").length).toBe(1)
+  })
+
+  it("should be hidden by default for mobile devices", () => {
+    sd.IS_MOBILE = true
+    const wrapper = getWrapper()
+
+    expect(wrapper.find("span").length).toBe(0)
   })
 })

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/PartnersFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/PartnersFilter.jest.tsx
@@ -52,4 +52,23 @@ describe("PartnersFilter", () => {
       expect(wrapper.find("Checkbox").length).not.toBe(0)
     })
   })
+
+  it("renders custom label", () => {
+    const wrapper = getWrapper({ aggregations }, { label: "Custom label" })
+    const header = wrapper.find("Clickable").at(0)
+    const headerLabel = header.find("Text")
+
+    expect(headerLabel.text()).toEqual("Custom label")
+  })
+
+  it("renders custom placeholder", () => {
+    const wrapper = getWrapper(
+      { aggregations },
+      { expanded: true, placeholder: "Custom placeholder" }
+    )
+
+    expect(wrapper.find("input").prop("placeholder")).toEqual(
+      "Custom placeholder"
+    )
+  })
 })

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/PartnersFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/PartnersFilter.jest.tsx
@@ -60,15 +60,4 @@ describe("PartnersFilter", () => {
 
     expect(headerLabel.text()).toEqual("Custom label")
   })
-
-  it("renders custom placeholder", () => {
-    const wrapper = getWrapper(
-      { aggregations },
-      { expanded: true, placeholder: "Custom placeholder" }
-    )
-
-    expect(wrapper.find("input").prop("placeholder")).toEqual(
-      "Custom placeholder"
-    )
-  })
 })


### PR DESCRIPTION
Type: **Feature**
Jira: [FX-3062]

### Description
* As a user, I expect to see all relevant filters for each surface. 
* All filters collapsed **by default in mWeb**.

#### Filters (Top to Bottom)
1. Exhibitors (Default Open)
2. Artists (Default Open)
3. Rarity (Default Open)
4. Medium (Default Open)
5. Price (Default Open)
6. Size (Default Open)
7. Ways to Buy (Default Open)
8. Material
9. Artist Nationality & Ethnicity
10. Artwork Location
11. Time Period
12. Color

#### Demo
<details>
  <summary>Web</summary>

![filters-web](https://user-images.githubusercontent.com/3513494/125296416-f26a8500-e32e-11eb-8f9e-df361c6e190a.png)


</details>
<details>
  <summary>Mobile</summary>

![filters-mobile](https://user-images.githubusercontent.com/3513494/125296447-fa2a2980-e32e-11eb-91ab-ed7581e4a346.png)

</details>

[FX-3062]: https://artsyproduct.atlassian.net/browse/FX-3062