### PR TITLE
[WIP] feat(FX-3064): update filter orders for artist series

### DIFF
--- a/src/v2/Apps/ArtistSeries/Components/ArtistSeriesArtworksFilter.tsx
+++ b/src/v2/Apps/ArtistSeries/Components/ArtistSeriesArtworksFilter.tsx
@@ -8,6 +8,16 @@ import { updateUrl } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { Match, RouterState, withRouter } from "found"
 import React from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
+import { MediumFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/MediumFilter"
+import { PriceRangeFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter"
+import { WaysToBuyFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter"
+import { TimePeriodFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter"
+import { ColorFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ColorFilter"
+import { AttributionClassFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/AttributionClassFilter"
+import { PartnersFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/PartnersFilter"
+import { MaterialsFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/MaterialsFilter"
+import { ArtworkLocationFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter"
+import { SizeFilter } from "v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter"
 
 interface ArtistSeriesArtworksFilterProps {
   artistSeries: ArtistSeriesArtworksFilter_artistSeries
@@ -25,6 +35,21 @@ const ArtistSeriesArtworksFilter: React.FC<ArtistSeriesArtworksFilterProps> = pr
   // If there was an error fetching the filter,
   // we still want to render the rest of the page.
   if (!hasFilter) return null
+
+  const Filters = (
+    <>
+      <AttributionClassFilter expanded />
+      <MediumFilter expanded />
+      <PriceRangeFilter expanded />
+      <SizeFilter expanded />
+      <WaysToBuyFilter expanded />
+      <MaterialsFilter />
+      <ArtworkLocationFilter />
+      <TimePeriodFilter />
+      <ColorFilter />
+      <PartnersFilter />
+    </>
+  )
 
   return (
     <ArtworkFilterContextProvider
@@ -48,6 +73,7 @@ const ArtistSeriesArtworksFilter: React.FC<ArtistSeriesArtworksFilterProps> = pr
           aggregations: ["TOTAL"],
           first: 20,
         }}
+        Filters={Filters}
       />
     </ArtworkFilterContextProvider>
   )

--- a/src/v2/Apps/ArtistSeries/__tests__/ArtistSeriesArtworksFilter.jest.tsx
+++ b/src/v2/Apps/ArtistSeries/__tests__/ArtistSeriesArtworksFilter.jest.tsx
@@ -1,0 +1,243 @@
+import { MockBoot, renderRelayTree } from "v2/DevTools"
+import React from "react"
+import { ArtistSeriesArtworksFilterRefetchContainer } from "../Components/ArtistSeriesArtworksFilter"
+import { graphql } from "react-relay"
+import { ArtistSeriesArtworksFilter_QueryRawResponse } from "v2/__generated__/ArtistSeriesArtworksFilter_Query.graphql"
+import { useTracking } from "v2/System/Analytics/useTracking"
+
+jest.unmock("react-relay")
+jest.mock("v2/System/Router/useRouter", () => ({
+  useRouter: () => ({
+    match: {
+      location: { query: {} },
+    },
+  }),
+}))
+jest.mock("v2/System/Analytics/useTracking")
+jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
+  useMatchMedia: () => ({}),
+}))
+
+describe("ArtistSeriesArtworksFilter", () => {
+  const trackEvent = jest.fn()
+
+  beforeEach(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+  })
+
+  const getWrapper = async (
+    response: ArtistSeriesArtworksFilter_QueryRawResponse = RESPONSE_FIXTURE
+  ) => {
+    return renderRelayTree({
+      Component: ({ artistSeries }) => {
+        return (
+          <MockBoot user={{ id: "percy-z" }}>
+            <ArtistSeriesArtworksFilterRefetchContainer
+              aggregations={artistSeries.sidebarAggregations.aggregations}
+              artistSeries={artistSeries}
+            />
+          </MockBoot>
+        )
+      },
+      query: graphql`
+        query ArtistSeriesArtworksFilter_Query($slug: ID!) @raw_response_type {
+          artistSeries(id: $slug) @principalField {
+            ...ArtistSeriesArtworksFilter_artistSeries
+            sidebarAggregations: filterArtworksConnection(first: 1) {
+              aggregations {
+                slice
+                counts {
+                  name
+                  value
+                  count
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: { slug: "kaws-spongebob" },
+      mockData: response,
+    })
+  }
+
+  it("renders correctly", async () => {
+    const wrapper = await getWrapper()
+    expect(wrapper.find("ArtworkFilterArtworkGrid").length).toBe(1)
+    expect(wrapper.find("GridItem__ArtworkGridItem").length).toBe(1)
+  })
+
+  it("renders filters in correct order", async () => {
+    const wrapper = await getWrapper()
+    const filterWrappers = wrapper.find("FilterExpandable")
+    const filters = [
+      {
+        label: "Rarity",
+        expanded: true,
+      },
+      {
+        label: "Medium",
+        expanded: true,
+      },
+      {
+        label: "Price",
+        expanded: true,
+      },
+      {
+        label: "Size",
+        expanded: true,
+      },
+      {
+        label: "Ways to buy",
+        expanded: true,
+      },
+      {
+        label: "Material",
+      },
+      {
+        label: "Artwork location",
+      },
+      {
+        label: "Time period",
+      },
+      {
+        label: "Color",
+      },
+      {
+        label: "Galleries and institutions",
+      },
+    ]
+
+    filters.forEach((filter, filterIndex) => {
+      const { label, expanded } = filter
+
+      expect(filterWrappers.at(filterIndex).prop("label")).toEqual(label)
+      expect(filterWrappers.at(filterIndex).prop("expanded")).toEqual(expanded)
+    })
+  })
+})
+
+const RESPONSE_FIXTURE: ArtistSeriesArtworksFilter_QueryRawResponse = {
+  artistSeries: {
+    sidebarAggregations: {
+      id: "sidebar-id",
+      aggregations: [
+        {
+          slice: "PARTNER",
+          counts: [
+            {
+              name: "Ross+Kramer Gallery",
+              value: "ross-plus-kramer-gallery",
+              count: 4,
+            },
+          ],
+        },
+        {
+          slice: "LOCATION_CITY",
+          counts: [
+            {
+              name: "New York, NY, USA",
+              value: "New York, NY, USA",
+              count: 4,
+            },
+          ],
+        },
+        {
+          slice: "MEDIUM",
+          counts: [
+            {
+              name: "Prints",
+              value: "prints",
+              count: 25,
+            },
+          ],
+        },
+        {
+          slice: "MATERIALS_TERMS",
+          counts: [
+            {
+              name: "Screen print",
+              value: "screen print",
+              count: 22,
+            },
+          ],
+        },
+        {
+          slice: "MAJOR_PERIOD",
+          counts: [
+            {
+              name: "2010",
+              value: "2010",
+              count: 25,
+            },
+          ],
+        },
+      ],
+    },
+    filtered_artworks: {
+      id: "id",
+      pageInfo: {
+        hasNextPage: false,
+        endCursor: "endCursor",
+      },
+      pageCursors: {
+        around: [
+          {
+            cursor: "cursor",
+            page: 1,
+            isCurrent: true,
+          },
+        ],
+        first: null,
+        last: null,
+        previous: null,
+      },
+      edges: [
+        {
+          id: "node-id",
+          node: {
+            id: "node-id",
+            slug: "kaws-kawsbob-black-1",
+            href: "/artwork/kaws-kawsbob-black-1",
+            internalID: "5ae9b5f41a1e8613605274de",
+            image: {
+              aspect_ratio: 1,
+              placeholder: "100%",
+              url:
+                "https://d32dm0rphc51dk.cloudfront.net/ufFlHZO7t5LVMTq6RBILXQ/large.jpg",
+            },
+            title: "Kawsbob Black",
+            image_title: "KAWS, ‘Kawsbob Black’, 2011",
+            artistNames: "KAWS",
+            date: "2011",
+            sale_message: "Sold",
+            cultural_maker: null,
+            artists: [
+              {
+                id: "artist-id",
+                href: "/artist/kaws",
+                name: "KAWS",
+              },
+            ],
+            collecting_institution: null,
+            partner: {
+              name: "Dope! Gallery",
+              href: "/dope-gallery",
+              id: "partner-id",
+              type: "Gallery",
+            },
+            sale: null,
+            sale_artwork: null,
+            is_inquireable: true,
+            is_saved: false,
+            is_biddable: false,
+          },
+        },
+      ],
+    },
+  },
+}

--- a/src/v2/__generated__/ArtistSeriesArtworksFilter_Query.graphql.ts
+++ b/src/v2/__generated__/ArtistSeriesArtworksFilter_Query.graphql.ts
@@ -1,0 +1,908 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
+export type ArtistSeriesArtworksFilter_QueryVariables = {
+    slug: string;
+};
+export type ArtistSeriesArtworksFilter_QueryResponse = {
+    readonly artistSeries: {
+        readonly sidebarAggregations: {
+            readonly aggregations: ReadonlyArray<{
+                readonly slice: ArtworkAggregation | null;
+                readonly counts: ReadonlyArray<{
+                    readonly name: string;
+                    readonly value: string;
+                    readonly count: number;
+                } | null> | null;
+            } | null> | null;
+        } | null;
+        readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesArtworksFilter_artistSeries">;
+    } | null;
+};
+export type ArtistSeriesArtworksFilter_QueryRawResponse = {
+    readonly artistSeries: ({
+        readonly filtered_artworks: ({
+            readonly id: string;
+            readonly pageInfo: {
+                readonly hasNextPage: boolean;
+                readonly endCursor: string | null;
+            };
+            readonly pageCursors: {
+                readonly around: ReadonlyArray<{
+                    readonly cursor: string;
+                    readonly page: number;
+                    readonly isCurrent: boolean;
+                }>;
+                readonly first: ({
+                    readonly cursor: string;
+                    readonly page: number;
+                    readonly isCurrent: boolean;
+                }) | null;
+                readonly last: ({
+                    readonly cursor: string;
+                    readonly page: number;
+                    readonly isCurrent: boolean;
+                }) | null;
+                readonly previous: ({
+                    readonly cursor: string;
+                    readonly page: number;
+                }) | null;
+            };
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly id: string;
+                    readonly slug: string;
+                    readonly href: string | null;
+                    readonly internalID: string;
+                    readonly image: ({
+                        readonly aspect_ratio: number;
+                        readonly placeholder: string | null;
+                        readonly url: string | null;
+                    }) | null;
+                    readonly title: string | null;
+                    readonly image_title: string | null;
+                    readonly artistNames: string | null;
+                    readonly date: string | null;
+                    readonly sale_message: string | null;
+                    readonly cultural_maker: string | null;
+                    readonly artists: ReadonlyArray<({
+                        readonly id: string;
+                        readonly href: string | null;
+                        readonly name: string | null;
+                    }) | null> | null;
+                    readonly collecting_institution: string | null;
+                    readonly partner: ({
+                        readonly name: string | null;
+                        readonly href: string | null;
+                        readonly id: string | null;
+                        readonly type: string | null;
+                    }) | null;
+                    readonly sale: ({
+                        readonly is_auction: boolean | null;
+                        readonly is_closed: boolean | null;
+                        readonly id: string | null;
+                        readonly is_live_open: boolean | null;
+                        readonly is_open: boolean | null;
+                        readonly is_preview: boolean | null;
+                        readonly display_timely_at: string | null;
+                    }) | null;
+                    readonly sale_artwork: ({
+                        readonly counts: ({
+                            readonly bidder_positions: number | null;
+                        }) | null;
+                        readonly highest_bid: ({
+                            readonly display: string | null;
+                        }) | null;
+                        readonly opening_bid: ({
+                            readonly display: string | null;
+                        }) | null;
+                        readonly id: string | null;
+                    }) | null;
+                    readonly is_inquireable: boolean | null;
+                    readonly is_saved: boolean | null;
+                    readonly is_biddable: boolean | null;
+                }) | null;
+                readonly id: string | null;
+            }) | null> | null;
+        }) | null;
+        readonly sidebarAggregations: ({
+            readonly aggregations: ReadonlyArray<({
+                readonly slice: ArtworkAggregation | null;
+                readonly counts: ReadonlyArray<({
+                    readonly name: string;
+                    readonly value: string;
+                    readonly count: number;
+                }) | null> | null;
+            }) | null> | null;
+            readonly id: string | null;
+        }) | null;
+    }) | null;
+};
+export type ArtistSeriesArtworksFilter_Query = {
+    readonly response: ArtistSeriesArtworksFilter_QueryResponse;
+    readonly variables: ArtistSeriesArtworksFilter_QueryVariables;
+    readonly rawResponse: ArtistSeriesArtworksFilter_QueryRawResponse;
+};
+
+
+
+/*
+query ArtistSeriesArtworksFilter_Query(
+  $slug: ID!
+) {
+  artistSeries(id: $slug) @principalField {
+    ...ArtistSeriesArtworksFilter_artistSeries
+    sidebarAggregations: filterArtworksConnection(first: 1) {
+      aggregations {
+        slice
+        counts {
+          name
+          value
+          count
+        }
+      }
+      id
+    }
+  }
+}
+
+fragment ArtistSeriesArtworksFilter_artistSeries on ArtistSeries {
+  filtered_artworks: filterArtworksConnection {
+    id
+    ...ArtworkFilterArtworkGrid_filtered_artworks
+  }
+}
+
+fragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {
+  id
+  pageInfo {
+    hasNextPage
+    endCursor
+  }
+  pageCursors {
+    ...Pagination_pageCursors
+  }
+  edges {
+    node {
+      id
+    }
+  }
+  ...ArtworkGrid_artworks
+}
+
+fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
+  edges {
+    __typename
+    node {
+      id
+      slug
+      href
+      internalID
+      image {
+        aspect_ratio: aspectRatio
+      }
+      ...GridItem_artwork
+    }
+    ... on Node {
+      id
+    }
+  }
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  artistNames
+  href
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
+  }
+}
+
+fragment SaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "slug",
+    "type": "ID!"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "slug"
+  }
+],
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 1
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArtworksAggregationResults",
+  "kind": "LinkedField",
+  "name": "aggregations",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slice",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AggregationCount",
+      "kind": "LinkedField",
+      "name": "counts",
+      "plural": true,
+      "selections": [
+        (v3/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "value",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "page",
+  "storageKey": null
+},
+v8 = [
+  (v6/*: any*/),
+  (v7/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "isCurrent",
+    "storageKey": null
+  }
+],
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v10 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v11 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtistSeriesArtworksFilter_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ArtistSeries",
+        "kind": "LinkedField",
+        "name": "artistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "alias": "sidebarAggregations",
+            "args": (v2/*: any*/),
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              (v4/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(first:1)"
+          },
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtistSeriesArtworksFilter_artistSeries"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ArtistSeriesArtworksFilter_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ArtistSeries",
+        "kind": "LinkedField",
+        "name": "artistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "alias": "filtered_artworks",
+            "args": null,
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageCursors",
+                "kind": "LinkedField",
+                "name": "pageCursors",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "around",
+                    "plural": true,
+                    "selections": (v8/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "first",
+                    "plural": false,
+                    "selections": (v8/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "last",
+                    "plural": false,
+                    "selections": (v8/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "previous",
+                    "plural": false,
+                    "selections": [
+                      (v6/*: any*/),
+                      (v7/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      (v9/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "aspect_ratio",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "aspectRatio",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "placeholder",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large"
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:\"large\")"
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "image_title",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "imageTitle",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "artistNames",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "date",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_message",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "saleMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "cultural_maker",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "culturalMaker",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v10/*: any*/),
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artists",
+                        "plural": true,
+                        "selections": [
+                          (v5/*: any*/),
+                          (v9/*: any*/),
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": "artists(shallow:true)"
+                      },
+                      {
+                        "alias": "collecting_institution",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "collectingInstitution",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v10/*: any*/),
+                        "concreteType": "Partner",
+                        "kind": "LinkedField",
+                        "name": "partner",
+                        "plural": false,
+                        "selections": [
+                          (v3/*: any*/),
+                          (v9/*: any*/),
+                          (v5/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "type",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": "partner(shallow:true)"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "is_auction",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isAuction",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_closed",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          },
+                          (v5/*: any*/),
+                          {
+                            "alias": "is_live_open",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isLiveOpen",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_open",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isOpen",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_preview",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isPreview",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "display_timely_at",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "displayTimelyAt",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_artwork",
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "kind": "LinkedField",
+                        "name": "saleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "kind": "LinkedField",
+                            "name": "counts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": "bidder_positions",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "bidderPositions",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "highest_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "kind": "LinkedField",
+                            "name": "highestBid",
+                            "plural": false,
+                            "selections": (v11/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "opening_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "kind": "LinkedField",
+                            "name": "openingBid",
+                            "plural": false,
+                            "selections": (v11/*: any*/),
+                            "storageKey": null
+                          },
+                          (v5/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_inquireable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isInquireable",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_saved",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isSaved",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_biddable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isBiddable",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v5/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": "sidebarAggregations",
+            "args": (v2/*: any*/),
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              (v4/*: any*/),
+              (v5/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(first:1)"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "ArtistSeriesArtworksFilter_Query",
+    "operationKind": "query",
+    "text": "query ArtistSeriesArtworksFilter_Query(\n  $slug: ID!\n) {\n  artistSeries(id: $slug) @principalField {\n    ...ArtistSeriesArtworksFilter_artistSeries\n    sidebarAggregations: filterArtworksConnection(first: 1) {\n      aggregations {\n        slice\n        counts {\n          name\n          value\n          count\n        }\n      }\n      id\n    }\n  }\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries on ArtistSeries {\n  filtered_artworks: filterArtworksConnection {\n    id\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+  }
+};
+})();
+(node as any).hash = '40b70ae092a7f010e9923a133d9e9eea';
+export default node;


### PR DESCRIPTION
Type: **Feature**
Jira: [FX-3064]

### Description
As a user, I expect to see all relevant filters for each surface. 

#### Filters (Top to Bottom)
1. Rarity (Default Open)
2. Medium (Default Open)
3. Price (Default Open)
4. Size (Default Open)
5. Ways to Buy (Default Open)
6. Material
7. Artwork Location
8. Time Period
9. Color 
10. Galleries & Institutions

#### Demo
<details>
  <summary>Web</summary>

![web](https://user-images.githubusercontent.com/3513494/125454771-e3d100c0-d658-4752-9303-563979665682.png)

</details>
<details>
  <summary>Mobile</summary>

![mobile](https://user-images.githubusercontent.com/3513494/125454802-f5a99d6a-60fc-49e9-8019-7ace2d742f52.png)


</details>

[FX-3064]: https://artsyproduct.atlassian.net/browse/FX-3064