### PR TITLE
fix[PURCHASE-2793]: remove unwanted warning on redirect from the orders page

### DIFF
--- a/src/v2/Apps/Order/OrderApp.tsx
+++ b/src/v2/Apps/Order/OrderApp.tsx
@@ -87,15 +87,19 @@ class OrderApp extends React.Component<OrderAppProps, {}> {
   }
 
   onTransition = newLocation => {
-    if (newLocation === null || !newLocation.pathname.includes("/orders/")) {
-      // leaving the order page, closing, or refreshing
-      const route = findCurrentRoute(this.props.match)
-      // @ts-expect-error STRICT_NULL_CHECK
-      if (route.shouldWarnBeforeLeaving) {
-        return "Are you sure you want to leave? Your changes will not be saved."
-      }
+    const isToTheSameApp = newLocation?.pathname?.includes("/orders/")
+    const isRedirect = newLocation?.action === "PUSH"
+
+    if (isToTheSameApp || isRedirect) {
+      return true
     }
-    return true
+
+    // leaving the order page, closing, or refreshing
+    const route = findCurrentRoute(this.props.match)
+
+    if (route?.shouldWarnBeforeLeaving) {
+      return "Are you sure you want to leave? Your changes will not be saved."
+    }
   }
 
   renderZendeskScript() {

--- a/src/v2/Apps/Order/OrderApp.tsx
+++ b/src/v2/Apps/Order/OrderApp.tsx
@@ -100,6 +100,8 @@ class OrderApp extends React.Component<OrderAppProps, {}> {
     if (route?.shouldWarnBeforeLeaving) {
       return "Are you sure you want to leave? Your changes will not be saved."
     }
+
+    return true
   }
 
   renderZendeskScript() {


### PR DESCRIPTION
solves [PURCHASE-2793](https://artsyproduct.atlassian.net/browse/PURCHASE-2793)

After the collector completes creating an order from the inquiry (using a button in conversation with the seller) user is redirected back to the conversation page. This redirect is interrupted by an "unsaved data" warning that makes no sense as the collector already completed the editing order at the moment. 

Solution: add check for "PUSH" action on the orders app to prevent "unsaved changes" warning on the application page.  