### PR TITLE
feat(FX-3049): nav bar update

### DIFF
--- a/src/v2/Components/NavBar/Menus/DropDownMenu/__tests__/DropDownMenu.jest.tsx
+++ b/src/v2/Components/NavBar/Menus/DropDownMenu/__tests__/DropDownMenu.jest.tsx
@@ -37,21 +37,23 @@ describe("DropDownMenu", () => {
     const linkMenuItems = wrapper.find("LinkMenuItem")
     const viewAllMenuItems = wrapper.find("ViewAllMenuItem")
 
-    expect(linkMenuItems.length).toBe(4)
-    expect(linkMenuItems.at(0).text()).toContain("New This Week")
-    expect(linkMenuItems.at(0).prop("href")).toEqual(
+    expect(linkMenuItems.length).toBe(5)
+    expect(linkMenuItems.at(0).text()).toContain("Trove")
+    expect(linkMenuItems.at(0).prop("href")).toEqual("/gene/trove")
+    expect(linkMenuItems.at(1).text()).toContain("New This Week")
+    expect(linkMenuItems.at(1).prop("href")).toEqual(
       "/collection/new-this-week"
     )
-    expect(linkMenuItems.at(1).text()).toContain("What’s Trending")
-    expect(linkMenuItems.at(1).prop("href")).toEqual(
+    expect(linkMenuItems.at(2).text()).toContain("Trending on Artsy")
+    expect(linkMenuItems.at(2).prop("href")).toEqual(
       "/collection/highlights-this-month"
     )
-    expect(linkMenuItems.at(2).text()).toContain("Exclusively on Artsy")
-    expect(linkMenuItems.at(2).prop("href")).toEqual(
+    expect(linkMenuItems.at(3).text()).toContain("Exclusively on Artsy")
+    expect(linkMenuItems.at(3).prop("href")).toEqual(
       "/collection/exclusively-on-artsy"
     )
-    expect(linkMenuItems.at(3).text()).toContain("Limited Editions")
-    expect(linkMenuItems.at(3).prop("href")).toEqual(
+    expect(linkMenuItems.at(4).text()).toContain("Limited Editions")
+    expect(linkMenuItems.at(4).prop("href")).toEqual(
       "/collection/limited-edition-works"
     )
 
@@ -64,7 +66,7 @@ describe("DropDownMenu", () => {
     const wrapper = getWrapper()
     const dropDownSection = wrapper.find(DropDownSection)
 
-    expect(dropDownSection.length).toBe(4)
+    expect(dropDownSection.length).toBe(5)
   })
 
   it("doesn't render ArtistsLetterNav inside artworks dropdown", () => {

--- a/src/v2/Components/NavBar/menuData.ts
+++ b/src/v2/Components/NavBar/menuData.ts
@@ -25,20 +25,16 @@ export const ARTISTS_SUBMENU_DATA: MenuLinkData = {
     title: "Artists",
     links: [
       {
-        text: "Portrayals of Queer Love",
-        href: "/collection/queer-love-pride-month-2020",
+        text: "In-Demand Artists",
+        href: "/collection/in-demand-artists",
       },
       {
-        text: "Contemporary Women Surrealists",
-        href: "/collection/contemporary-women-surrealists",
+        text: "Artist's We're Eyeing",
+        href: "/collection/artists-we-are-eyeing",
       },
       {
-        text: "Black Figurative Painters on the Rise",
-        href: "/collection/black-figurative-painters",
-      },
-      {
-        text: "Modern & Contemporary Masters",
-        href: "/collection/master-works",
+        text: "Artsy Vanguard Artists",
+        href: "/collection/artsy-vanguard-artists",
         dividerBelow: true,
       },
       {
@@ -66,10 +62,43 @@ export const ARTISTS_SUBMENU_DATA: MenuLinkData = {
         },
       },
       {
-        text: "Artist Nationality & Region",
+        text: "Popular Categories",
         menu: {
-          title: "Artist Nationality & Region",
+          title: "Popular Categories",
           links: [
+            {
+              text: "New From Emerging Artists",
+              href: "/collection/new-from-emerging-artists",
+            },
+            {
+              text: "Modern & Contemporary Masters",
+              href: "/collection/master-works",
+            },
+            {
+              text: "Limited-Edition Prints by Leading Artists",
+              href: "/collection/limited-edition-prints-trending-artists",
+            },
+            {
+              text: "Black Figurative Painters",
+              href: "/collection/black-figurative-painters",
+            },
+            {
+              text: "Women Artists to Watch",
+              href: "/collection/women-painters-on-the-rise",
+            },
+          ],
+        },
+        dividerBelow: true,
+      },
+      {
+        text: "Artist Nationality or Ethicity",
+        menu: {
+          title: "Artist Nationality or Ethicity",
+          links: [
+            {
+              text: "American",
+              href: "/collect?artist_nationalities%5B0%5D=American",
+            },
             {
               text: "African",
               href: "/collection/african-artists",
@@ -79,8 +108,8 @@ export const ARTISTS_SUBMENU_DATA: MenuLinkData = {
               href: "/collection/asian-artists",
             },
             {
-              text: "Australian & Oceanian",
-              href: "/collection/oceanian-artists",
+              text: "British",
+              href: "/collect?artist_nationalities%5B0%5D=British",
             },
             {
               text: "European",
@@ -94,10 +123,6 @@ export const ARTISTS_SUBMENU_DATA: MenuLinkData = {
               text: "Middle Eastern",
               href: "/collection/middle-eastern-artists",
             },
-            {
-              text: "North American",
-              href: "/collection/north-american-artists",
-            },
           ],
         },
       },
@@ -107,64 +132,35 @@ export const ARTISTS_SUBMENU_DATA: MenuLinkData = {
           title: "Featured Artists",
           links: [
             {
-              text: "Agnes Martin",
-              href: "/artist/agnes-martin/works-for-sale",
+              text: "Derrick Adams",
+              href: "/artist/derrick-adams/works-for-sale",
             },
             {
-              text: "Julie Mehretu",
-              href: "/artist/julie-mehretu/works-for-sale",
+              text: "Bridget Riley",
+              href: "/artist/bridget-riley/works-for-sale",
             },
             {
-              text: "Eddie Martinez",
-              href: "/artist/eddie-martinez/works-for-sale",
+              text: "Frank Stella",
+              href: "/artist/frank-stella/works-for-sale",
             },
             {
-              text: "Otis Kwame Kye Quaicoe",
-              href: "/artist/otis-kwame-kye-quaicoe/works-for-sale",
+              text: "Julian Opie",
+              href: "/artist/julian-opie/works-for-sale",
             },
             {
-              text: "Zanele Muholi",
-              href: "/artist/zanele-muholi/works-for-sale",
+              text: "Judy Chicago",
+              href: "/artist/judy-chicago/works-for-sale",
             },
             {
-              text: "Lee Ufan",
-              href: "/artist/lee-ufan/works-for-sale",
+              text: "Etel Adnan",
+              href: "/artist/etel-adnan/works-for-sale",
             },
             {
-              text: "Massimo Vitali",
-              href: "/artist/massimo-vitali/works-for-sale",
+              text: "Mickalene Thomas",
+              href: "/artist/mickalene-thomas/works-for-sale",
             },
           ],
         },
-      },
-      {
-        text: "Top Categories",
-        menu: {
-          title: "Top Categories",
-          links: [
-            {
-              text: "In-Demand Artists",
-              href: "/collection/in-demand-artists",
-            },
-            {
-              text: "Emerging Painters",
-              href: "/collection/emerging-painters",
-            },
-            {
-              text: "Critically Acclaimed Photographers",
-              href: "/collection/critically-acclaimed-photographers",
-            },
-            {
-              text: "Notable Street Artists",
-              href: "/collection/notable-street-artists",
-            },
-            {
-              text: "Limited-Edition Prints by Leading Artists",
-              href: "/collection/limited-edition-prints-trending-artists",
-            },
-          ],
-        },
-        dividerBelow: true,
       },
       {
         text: "View all artists",
@@ -180,11 +176,15 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
     title: "Artworks",
     links: [
       {
+        text: "Trove",
+        href: "/gene/trove",
+      },
+      {
         text: "New This Week",
         href: "/collection/new-this-week",
       },
       {
-        text: "What’s Trending",
+        text: "Trending on Artsy",
         href: "/collection/highlights-this-month",
       },
       {
@@ -214,7 +214,7 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
               href: "/collection/gallery-show-highlights",
             },
             {
-              text: "Nonprofit Shops",
+              text: "Non-profit Shops",
               href: "/collection/nonprofit-shops",
             },
           ],
@@ -270,8 +270,8 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
               href: "/collection/sculpture",
             },
             {
-              text: "Drawing",
-              href: "/collection/drawing",
+              text: "Work on Paper",
+              href: "/collection/works-on-paper",
             },
             {
               text: "Mixed Media",
@@ -320,6 +320,30 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
           ],
         },
         dividerBelow: true,
+      },
+      {
+        text: "Subject Matter",
+        menu: {
+          title: "Subject Matter",
+          links: [
+            {
+              text: "Abstract Art",
+              href: "/gene/abstract-art",
+            },
+            {
+              text: "Figurative Art",
+              href: "/gene/figurative-art",
+            },
+            {
+              text: "Landscapes",
+              href: "/gene/landscapes",
+            },
+            {
+              text: "Still Life",
+              href: "/gene/still-life",
+            },
+          ],
+        },
       },
       { text: "View all artworks", href: "/collect" },
     ],

--- a/src/v2/Components/NavBar/menuData.ts
+++ b/src/v2/Components/NavBar/menuData.ts
@@ -29,7 +29,7 @@ export const ARTISTS_SUBMENU_DATA: MenuLinkData = {
         href: "/collection/in-demand-artists",
       },
       {
-        text: "Artist's We're Eyeing",
+        text: "Artists We're Eyeing",
         href: "/collection/artists-we-are-eyeing",
       },
       {
@@ -270,7 +270,7 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
               href: "/collection/sculpture",
             },
             {
-              text: "Work on Paper",
+              text: "Works on Paper",
               href: "/collection/works-on-paper",
             },
             {


### PR DESCRIPTION
Jira: [FX-3049](https://artsyproduct.atlassian.net/browse/FX-3049)

Description:
The Curatorial team is requesting an update to the Artworks and Artists Nav Bars at the top of artsy.net. We've reviewed the performance of existing categories and collections, and removed low performing content and introduced new content that has historically performed well. We're hoping that this update can take place in early Q3.

Link to requested updates: https://docs.google.com/spreadsheets/d/1EOYineDRM9QTfNE7gUyO3pnqKUrr_pgekCHYsWsxK-U/edit#gid=0


_ARTIST_
**Artist Nav Before:**
![image](https://user-images.githubusercontent.com/56556580/125620777-f8dc4222-5a78-48bf-9365-254c3c747634.png)

**Artist Nav After:**
![image](https://user-images.githubusercontent.com/56556580/125620890-a08c0b3c-a2a4-421f-870e-4b3f13e459f5.png)

_ARTWORK_
**Artwork Nav Before**
![image](https://user-images.githubusercontent.com/56556580/125620843-768e1b9d-6c34-4315-905a-0897847f8d25.png)

**Artwork Nav After**
![image](https://user-images.githubusercontent.com/56556580/125620927-fa7787d1-4805-4f0b-923e-a6078601d24c.png)


