### PR TITLE
fix(PURCHASE-2810): unwanted redirect to conversations from eigen

### DIFF
--- a/src/v2/Apps/Order/Routes/Review/index.tsx
+++ b/src/v2/Apps/Order/Routes/Review/index.tsx
@@ -125,7 +125,7 @@ export class ReviewRoute extends Component<ReviewProps> {
             }
           })
       } else {
-        this.props.order.conversation
+        this.props.order.conversation && !this.props.isEigen
           ? this.props.router.push(
               `/user/conversations/${this.props.order.conversation.internalID}`
             )


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/PURCHASE-2810

Add check for the eigen to prevent unwanted redirect to the conversation. Instead, the user stays at the order status page.