### PR TITLE
sentry: Add `Illegal Invocation` to list

### DIFF
--- a/src/lib/analytics/sentryFilters.ts
+++ b/src/lib/analytics/sentryFilters.ts
@@ -8,6 +8,7 @@ export const IGNORED_ERRORS = [
   "cancelled",
   "Failed to fetch",
   "gpt/pubads_impl",
+  "Illegal invocation", // From   "gpt/pubads_impl", script (3rd party)
   "Non-Error exception captured",
   "Non-Error promise rejection captured",
   "Origin is not allowed by Access-Control-Allow-Origin",


### PR DESCRIPTION
Noticing that this error keeps spamming sentry, and is coming from a 3rd party script. 