### PR TITLE
FX-3066 feat: Auction House filter is not expanded by default

### DIFF
--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/AuctionHouseFilter.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/AuctionHouseFilter.tsx
@@ -30,7 +30,7 @@ export const AuctionHouseFilter: React.FC = () => {
   }
 
   return (
-    <FilterExpandable label="Auction House" expanded>
+    <FilterExpandable label="Auction House">
       <Flex flexDirection="column" alignItems="left">
         <ShowMore>
           {auctionHouses.map((checkbox, index) => {

--- a/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
@@ -7,6 +7,7 @@ import React from "react"
 import { act } from "react-dom/test-utils"
 import { graphql } from "react-relay"
 import { useTracking } from "react-tracking"
+import { Expandable } from "@artsy/palette"
 import { Breakpoint } from "v2/Utils/Responsive"
 import { openAuthModal } from "v2/Utils/openAuthModal"
 import { Pagination } from "v2/Components/Pagination"
@@ -290,13 +291,14 @@ describe("AuctionResults", () => {
         describe("auction house filter", () => {
           it("triggers relay refetch with organization list, and re-shows sign up to see price", done => {
             const filter = wrapper.find("AuctionHouseFilter")
+            filter.find(Expandable).find("button").simulate("click")
 
-            const checkboxes = filter.find("Checkbox")
+            const checkboxes = wrapper
+              .find("AuctionHouseFilter")
+              .find("Checkbox")
 
             checkboxes.at(1).simulate("click")
-
             checkboxes.at(2).simulate("click")
-
             checkboxes.at(1).simulate("click")
 
             setTimeout(() => {
@@ -327,6 +329,11 @@ describe("AuctionResults", () => {
 
               done()
             })
+          })
+
+          it("is not expanded by default", () => {
+            const filter = wrapper.find("AuctionHouseFilter")
+            expect(filter.find(Expandable).prop("expanded")).toEqual(false)
           })
         })
         describe("size filter", () => {


### PR DESCRIPTION
[FX-3066]

Before
![Screenshot 2021-07-15 at 14 24 41](https://user-images.githubusercontent.com/44819355/125780415-9419de23-d673-405c-b870-0aab6ba8e7fa.png)


After
![Screenshot 2021-07-15 at 14 23 12](https://user-images.githubusercontent.com/44819355/125780229-6e961b36-9a87-49b8-8839-1c0c72739590.png)


[FX-3066]: https://artsyproduct.atlassian.net/browse/FX-3066