### PR TITLE
feat(FX-2789): filter facet names title

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtistNationalityFilter.tsx
@@ -12,7 +12,7 @@ export const ArtistNationalityFilter: React.FC<ArtistNationalityFilterProps> = (
     <ResultsFilter
       facetName="artistNationalities"
       slice="ARTIST_NATIONALITY"
-      label="Artist nationality or ethnicity"
+      label="Artist Nationality or Ethnicity"
       placeholder="Enter a nationality or ethnicity"
       expanded={expanded}
     />

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter.tsx
@@ -12,7 +12,7 @@ export const ArtworkLocationFilter: React.FC<ArtworkLocationFilterProps> = ({
     <ResultsFilter
       facetName="locationCities"
       slice="LOCATION_CITY"
-      label="Artwork location"
+      label="Artwork Location"
       placeholder="Enter a city"
       expanded={expanded}
     />

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/PartnersFilter.tsx
@@ -8,7 +8,7 @@ export interface PartnersFilterProps {
 
 export const PartnersFilter: React.FC<PartnersFilterProps> = ({
   expanded,
-  label = "Galleries and institutions",
+  label = "Galleries and Institutions",
 }) => {
   return (
     <ResultsFilter

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
@@ -60,7 +60,7 @@ export const TimePeriodFilter: FC<TimePeriodFilterProps> = ({ expanded }) => {
 
   return (
     <FilterExpandable
-      label="Time period"
+      label="Time Period"
       expanded={hasMajorPeriodFilter || expanded}
     >
       <Flex flexDirection="column">

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter.tsx
@@ -72,7 +72,7 @@ export const WaysToBuyFilter: FC<WaysToBuyFilterProps> = ({ expanded }) => {
     !!selection.inquireableOnly
 
   return (
-    <FilterExpandable label="Ways to buy" expanded={hasSelection || expanded}>
+    <FilterExpandable label="Ways to Buy" expanded={hasSelection || expanded}>
       <Flex flexDirection="column">
         {checkboxes.map((checkbox, index) => {
           return (

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ResultsFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/ResultsFilter.jest.tsx
@@ -15,7 +15,7 @@ describe("ArtworkLocationFilter", () => {
           facetName="locationCities"
           slice="LOCATION_CITY"
           placeholder="Enter a city"
-          label="Artwork location"
+          label="Artwork Location"
           expanded
         />
       </ArtworkFilterContextProvider>
@@ -39,7 +39,7 @@ describe("ArtworkLocationFilter", () => {
     })
 
     // Expandable title
-    expect(wrapper.text()).toContain("Artwork location")
+    expect(wrapper.text()).toContain("Artwork Location")
 
     // Input placeholder
     expect(wrapper.find("input").prop("placeholder")).toContain("Enter a city")


### PR DESCRIPTION
Jira: [FX-2789](https://artsyproduct.atlassian.net/browse/FX-2789)

Description:
The purpose of this ticket is to ensure that the filter facets (options) on web and iOS are sentence cased to match the [Artsy Copy Style Guide](https://docs.google.com/document/d/1NoBSYM-EBA4b6rdux-8CQJWneXcglISHzZNvSkKFDh0/edit#heading=h.1bm808xl0evg).

The work done:
- Updated titles for artwork filters
![image](https://user-images.githubusercontent.com/56556580/125960829-b6415022-1e45-44b8-9ddb-da24b26d6550.png)
![image](https://user-images.githubusercontent.com/56556580/125960873-87bfda74-f148-46ab-9ffe-499b605f6c35.png)

- Updated titles for artist auction results filters
![image](https://user-images.githubusercontent.com/56556580/125960581-91213a63-6915-4d24-b6ba-677457e81b4e.png)


