### PR TITLE
fix(show): improves install shots display

### DIFF
--- a/src/v2/Apps/Show/Components/ShowInstallShots.tsx
+++ b/src/v2/Apps/Show/Components/ShowInstallShots.tsx
@@ -52,9 +52,14 @@ export const ShowInstallShots: React.FC<ShowInstallShotsProps> = ({
                 src={image.desktop.src}
                 srcSet={image.desktop.srcSet}
                 width={[image.mobile.width, image.desktop.width]}
-                maxHeight={[300, 480]}
-                style={{ display: "block", objectFit: "contain" }}
+                height={[image.mobile.height, image.desktop.height]}
+                style={{
+                  display: "block",
+                  objectFit: "contain",
+                  backgroundColor: "rgba(0, 0, 0, 0.1)",
+                }}
                 alt={`${show.name}, installation view`}
+                lazyLoad={i > 2}
               />
 
               {image.caption && (
@@ -63,7 +68,7 @@ export const ShowInstallShots: React.FC<ShowInstallShotsProps> = ({
                   mt={1}
                   color="black60"
                   textAlign="left"
-                  width={image.desktop.width}
+                  width={[image.mobile.width, image.desktop.width]}
                   title={image.caption}
                   overflowEllipsis
                 >


### PR DESCRIPTION
This fixes a minor issue [that was raised earlier today](https://artsy.slack.com/archives/C7LEJU1QU/p1626446421334700) regarding the install shot captions overflowing on mobile breakpoints. This also fixes the collapsing containers so as to prevent the page shift from occurring, and lazy loads images outside the viewport.