### PR TITLE
chore: update base filters order

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
@@ -94,7 +94,7 @@ export const ArtistsFilter: FC<ArtistsFilterProps> = ({
   })
 
   useEffect(() => {
-    if (relayEnvironment && user) {
+    if (artists?.counts && relayEnvironment && user) {
       fetchFollowedArtists({ relayEnvironment, fairID }).then(data => {
         setFollowedArtists(data)
       })

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
@@ -10,18 +10,28 @@ import { ArtworkLocationFilter } from "./ArtworkLocationFilter"
 import { ArtistNationalityFilter } from "./ArtistNationalityFilter"
 import { MaterialsFilter } from "./MaterialsFilter"
 import { PartnersFilter } from "./PartnersFilter"
+import { ArtistsFilter } from "./ArtistsFilter"
+import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 
-export const ArtworkFilters: React.FC = () => {
+interface ArtworkFiltersProps {
+  user?: User
+  relayEnvironment?: RelayModernEnvironment
+}
+
+export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
+  const { user, relayEnvironment } = props
+
   return (
     <>
-      <MediumFilter expanded />
-      <MaterialsFilter expanded />
-      <PriceRangeFilter />
+      <ArtistsFilter relayEnvironment={relayEnvironment} user={user} expanded />
       <AttributionClassFilter expanded />
-      <SizeFilter />
-      <WaysToBuyFilter />
-      <ArtworkLocationFilter expanded />
-      <ArtistNationalityFilter expanded />
+      <MediumFilter expanded />
+      <PriceRangeFilter expanded />
+      <SizeFilter expanded />
+      <WaysToBuyFilter expanded />
+      <MaterialsFilter />
+      <ArtistNationalityFilter />
+      <ArtworkLocationFilter />
       <TimePeriodFilter />
       <ColorFilter />
       <PartnersFilter />

--- a/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
@@ -66,7 +66,6 @@ describe("ArtworkFilter", () => {
         onFilterClick,
       })
 
-      wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
       wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
 
       expect(onFilterClick).toHaveBeenCalledWith("acquireable", true, {
@@ -111,7 +110,6 @@ describe("ArtworkFilter", () => {
         onChange,
       })
 
-      wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
       wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
 
       expect(onChange).toHaveBeenCalledWith({
@@ -170,7 +168,6 @@ describe("ArtworkFilter", () => {
         onFilterClick,
       })
 
-      wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
       wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
 
       expect(trackEvent).toHaveBeenCalledWith(
@@ -226,7 +223,6 @@ describe("ArtworkFilter", () => {
       expect(wrapper.find("FiltersWithScrollIntoView").length).toEqual(1)
       expect(document.body.style.overflowY).toEqual("hidden")
 
-      wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
       wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
       actionSheet.find("Button").last().simulate("click")
 

--- a/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
@@ -78,10 +78,6 @@ describe("ArtworkFilterMobileActionSheet", () => {
   it("mutates staged filter state instead of 'real' filter state", () => {
     const wrapper = getWrapper()
 
-    // Expand the filters we want to make assertions about
-    wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
-    wrapper.find("SizeFilter").find("ChevronIcon").simulate("click")
-
     wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
     wrapper.find("SizeFilter").find("Checkbox").first().simulate("click")
 
@@ -101,7 +97,6 @@ describe("ArtworkFilterMobileActionSheet", () => {
 
       expect(wrapper.find("Button").last().prop("disabled")).toBeTruthy()
 
-      wrapper.find("SizeFilter").find("ChevronIcon").simulate("click")
       wrapper.find("SizeFilter").find("Checkbox").first().simulate("click")
 
       expect(wrapper.find("Button").last().prop("disabled")).toBeFalsy()

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -44,6 +44,7 @@ import { allowedFilters } from "./Utils/allowedFilters"
 import { Sticky } from "v2/Components/Sticky"
 import { ScrollRefContext } from "./ArtworkFilters/useScrollContext"
 import { GeneArtworkFilter_gene } from "v2/__generated__/GeneArtworkFilter_gene.graphql"
+import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 
 /**
  * Primary ArtworkFilter which is wrapped with a context and refetch container.
@@ -83,15 +84,21 @@ export const ArtworkFilter: React.FC<
   )
 }
 
-const FiltersWithScrollIntoView: React.FC<{ Filters?: JSX.Element }> = ({
-  Filters,
-}) => {
+const FiltersWithScrollIntoView: React.FC<{
+  Filters?: JSX.Element
+  user?: User
+  relayEnvironment?: RelayModernEnvironment
+}> = ({ Filters, relayEnvironment, user }) => {
   const scrollRef = useRef<HTMLDivElement | null>(null)
 
   return (
     <Box ref={scrollRef as any} overflowY="scroll" height="100%">
       <ScrollRefContext.Provider value={{ scrollRef }}>
-        {Filters ? Filters : <ArtworkFilters />}
+        {Filters ? (
+          Filters
+        ) : (
+          <ArtworkFilters relayEnvironment={relayEnvironment} user={user} />
+        )}
       </ScrollRefContext.Provider>
     </Box>
   )
@@ -131,6 +138,7 @@ export const BaseArtworkFilter: React.FC<
   const [showMobileActionSheet, toggleMobileActionSheet] = useState(false)
   const filterContext = useArtworkFilterContext()
   const previousFilters = usePrevious(filterContext.filters)
+  const { user } = useSystemContext()
 
   const { filtered_artworks } = viewer
   const hasFilter = filtered_artworks && filtered_artworks.id
@@ -234,7 +242,11 @@ export const BaseArtworkFilter: React.FC<
             <ArtworkFilterMobileActionSheet
               onClose={() => toggleMobileActionSheet(false)}
             >
-              <FiltersWithScrollIntoView Filters={Filters} />
+              <FiltersWithScrollIntoView
+                Filters={Filters}
+                user={user}
+                relayEnvironment={relay.environment}
+              />
             </ArtworkFilterMobileActionSheet>
           )}
 
@@ -296,7 +308,14 @@ export const BaseArtworkFilter: React.FC<
 
         <GridColumns>
           <Column span={3} pr={tokens.pr}>
-            {Filters ? Filters : <ArtworkFilters />}
+            {Filters ? (
+              Filters
+            ) : (
+              <ArtworkFilters
+                user={user}
+                relayEnvironment={relay.environment}
+              />
+            )}
           </Column>
 
           <Column span={9}>


### PR DESCRIPTION
Type: **Chore**
### Description
Changing the order of filters in the base component, which is used by default if the `Filters` prop [was not passed](https://github.com/artsy/force/blob/dimatretyak/feat/base-filter-alignment/src/v2/Components/ArtworkFilter/index.tsx#L311-L317)