### PR TITLE
fix: address line rendering

### DIFF
--- a/src/v2/Apps/Partner/Components/PartnerHeader/PartnerHeaderAddress.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerHeader/PartnerHeaderAddress.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import styled from "styled-components"
-import { uniq } from "lodash"
+import { compact, uniq } from "lodash"
 import { media } from "@artsy/palette"
 import { PartnerHeader_partner } from "v2/__generated__/PartnerHeader_partner.graphql"
 
@@ -14,10 +14,12 @@ export const TextWithNoWrap = styled.span`
 export const PartnerHeaderAddress: React.FC<
   PartnerHeader_partner["locations"]
 > = ({ edges }) => {
+  const cities = uniq(compact(edges?.map(edge => edge?.node?.city?.trim())))
+  if (!cities || cities.length === 0) return null
+
   return (
     <>
-      {/* @ts-expect-error STRICT_NULL_CHECK */}
-      {uniq(edges.map(edge => edge.node.city?.trim()))
+      {cities
         .filter(city => !!city)
         .map<React.ReactNode>((city, index) => (
           <TextWithNoWrap key={`${city}${index}`}>{city}</TextWithNoWrap>

--- a/src/v2/Apps/Partner/Components/__tests__/PartnerHeader.jest.tsx
+++ b/src/v2/Apps/Partner/Components/__tests__/PartnerHeader.jest.tsx
@@ -136,6 +136,26 @@ describe("PartnerHeader", () => {
     )
   })
 
+  it("does not display address", () => {
+    const wrapper = getWrapper({
+      Partner: () => ({
+        name: "White cube",
+        locations: {
+          totalCount: 1,
+          edges: [
+            {
+              node: {
+                city: null,
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    expect(wrapper.find(PartnerHeaderAddress).text()).toContain("")
+  })
+
   it("displays links to partner profile page", () => {
     const wrapper = getWrapper({
       Partner: () => ({


### PR DESCRIPTION
This PR fixes partner profile page rendering if does not have a specified city.

![image](https://user-images.githubusercontent.com/79979820/126204159-92b2846e-aba5-437d-bd15-06e4362ccf4e.png)
