### PR TITLE
moved timestamp to above order update and fixed mo button styling

### DIFF
--- a/src/v2/Apps/Conversation/Components/OpenInquiryModalButton.tsx
+++ b/src/v2/Apps/Conversation/Components/OpenInquiryModalButton.tsx
@@ -1,12 +1,19 @@
 import { OpenInquiryModalButtonQuery } from "v2/__generated__/OpenInquiryModalButtonQuery.graphql"
-import { Button, CheckCircleIcon, Flex, Text } from "@artsy/palette"
+import { Button, CheckCircleIcon, Flex, Separator, Text } from "@artsy/palette"
 import React, { useEffect } from "react"
 import { graphql } from "react-relay"
 import { Link } from "@artsy/palette"
 import { useSystemContext } from "v2/System"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
+import styled from "styled-components"
 import { useTracking } from "react-tracking"
 import { tappedMakeOffer } from "@artsy/cohesion"
+
+export const ShadowSeparator = styled(Separator)`
+  box-shadow: 0 -1px 1px rgba(50, 50, 50, 0.1);
+  width: 100%;
+  height: 0;
+`
 
 export interface OpenInquiryModalButtonProps {
   openInquiryModal: () => void
@@ -30,6 +37,7 @@ export const OpenInquiryModalButton: React.FC<OpenInquiryModalButtonProps> = ({
 
   return (
     <>
+      <ShadowSeparator />
       <Flex flexDirection="column" p={1}>
         <Flex flexDirection="row">
           <CheckCircleIcon mr={1} />

--- a/src/v2/Apps/Conversation/Components/OrderUpdate.tsx
+++ b/src/v2/Apps/Conversation/Components/OrderUpdate.tsx
@@ -62,6 +62,12 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event }) => {
   }
   return (
     <Flex flexDirection="column">
+      <TimeSince
+        style={{ alignSelf: "center" }}
+        time={event.createdAt}
+        exact
+        mb={1}
+      />
       <Flex px={2} justifyContent="center" flexDirection="row">
         <Flex flexDirection="row">
           <Icon mt="1px" fill={color} />
@@ -72,12 +78,6 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event }) => {
           </Flex>
         </Flex>
       </Flex>
-      <TimeSince
-        style={{ alignSelf: "center" }}
-        time={event.createdAt}
-        exact
-        mb={1}
-      />
       <Spacer mb={5} />
     </Flex>
   )

--- a/src/v2/Apps/Conversation/Components/Reply.tsx
+++ b/src/v2/Apps/Conversation/Components/Reply.tsx
@@ -7,7 +7,6 @@ import {
   media,
   space,
   themeProps,
-  Separator,
 } from "@artsy/palette"
 import { Conversation_conversation } from "v2/__generated__/Conversation_conversation.graphql"
 import React, { useRef, useState } from "react"
@@ -21,12 +20,6 @@ import {
 } from "@artsy/cohesion"
 import { RightProps } from "styled-system"
 import { ConversationCTAFragmentContainer } from "./ConversationCTA"
-
-export const ShadowSeparator = styled(Separator)`
-  box-shadow: 0 -1px 1px rgba(50, 50, 50, 0.1);
-  width: 100%;
-  height: 0;
-`
 
 const StyledFlex = styled(Flex)<FlexProps & RightProps>`
   border-top: 1px solid ${color("black10")};
@@ -142,7 +135,6 @@ export const Reply: React.FC<ReplyProps> = props => {
         }}
       />
       <Flex zIndex={[null, 2]} flexDirection="column" background="white">
-        <ShadowSeparator />
         <ConversationCTAFragmentContainer
           conversation={conversation}
           openInquiryModal={() => openInquiryModal()}


### PR DESCRIPTION
# [PURCHASE-2816] 
Incorrect timestamp location when submitting an offer in inquiry

Expected behavior:
The inline offer status is preceded by the time stamp

Actual behavior:
The inline offer status is followed by the time stamp

__Before:__
<img width="663" alt="Screen Shot 2021-07-19 at 2 32 43 PM" src="https://user-images.githubusercontent.com/5643895/126210402-cfa0e507-57ee-4a11-aeb3-5d9ff280f6f0.png">

__After:__
<img width="714" alt="Screen Shot 2021-07-19 at 2 32 35 PM" src="https://user-images.githubusercontent.com/5643895/126210472-5567685f-1c49-491b-a9e5-35069ae34983.png">

# [PURCHASE-2825]
Extra border shadow is still there even when MO button isn't visible

__Before:__
<img width="958" alt="Screen Shot 2021-07-19 at 2 32 52 PM" src="https://user-images.githubusercontent.com/5643895/126210383-09127cfe-e120-44e9-bd85-a15124926b42.png">

__After:__
<img width="935" alt="Screen Shot 2021-07-19 at 2 33 01 PM" src="https://user-images.githubusercontent.com/5643895/126210370-061566be-e6e5-43ac-831f-77522d07edac.png">




[PURCHASE-2816]: https://artsyproduct.atlassian.net/browse/PURCHASE-2816
[PURCHASE-2825]: https://artsyproduct.atlassian.net/browse/PURCHASE-2825