### PR TITLE
fix(PURCHASE-2768): Anchoring of Nav items to the correct section

### DIFF
--- a/src/v2/Components/RouteTabs.tsx
+++ b/src/v2/Components/RouteTabs.tsx
@@ -11,28 +11,38 @@ export const RouteTab: React.FC<BaseTabProps & RouterLinkProps> = ({
   ...rest
 }) => {
   const tracking = useTracking()
-
+  const ref = React.useRef() as React.MutableRefObject<HTMLDivElement>
   const options = {
     exact: rest.exact !== undefined ? rest.exact : true,
   }
 
+  const isRouteActive = useIsRouteActive(to, options)
+
+  React.useEffect(() => {
+    if (isRouteActive && ref?.current) {
+      ref.current.scrollIntoView()
+    }
+  }, [isRouteActive])
+
   return (
-    <BaseTab
-      as={RouterLink}
-      // @ts-ignore
-      to={to}
-      active={useIsRouteActive(to, options)}
-      onClick={() => {
-        tracking.trackEvent({
-          action_type: AnalyticsSchema.ActionType.Click,
-          destination_path: to,
-          subject: children as string,
-        })
-      }}
-      {...rest}
-    >
-      {children}
-    </BaseTab>
+    <div ref={ref}>
+      <BaseTab
+        as={RouterLink}
+        // @ts-ignore
+        to={to}
+        active={isRouteActive}
+        onClick={() => {
+          tracking.trackEvent({
+            action_type: AnalyticsSchema.ActionType.Click,
+            destination_path: to,
+            subject: children as string,
+          })
+        }}
+        {...rest}
+      >
+        {children}
+      </BaseTab>
+    </div>
   )
 }
 

--- a/src/v2/Components/RouteTabs.tsx
+++ b/src/v2/Components/RouteTabs.tsx
@@ -11,38 +11,27 @@ export const RouteTab: React.FC<BaseTabProps & RouterLinkProps> = ({
   ...rest
 }) => {
   const tracking = useTracking()
-  const ref = React.useRef() as React.MutableRefObject<HTMLDivElement>
   const options = {
     exact: rest.exact !== undefined ? rest.exact : true,
   }
 
-  const isRouteActive = useIsRouteActive(to, options)
-
-  React.useEffect(() => {
-    if (isRouteActive && ref?.current) {
-      ref.current.scrollIntoView()
-    }
-  }, [isRouteActive])
-
   return (
-    <div ref={ref}>
-      <BaseTab
-        as={RouterLink}
-        // @ts-ignore
-        to={to}
-        active={isRouteActive}
-        onClick={() => {
-          tracking.trackEvent({
-            action_type: AnalyticsSchema.ActionType.Click,
-            destination_path: to,
-            subject: children as string,
-          })
-        }}
-        {...rest}
-      >
-        {children}
-      </BaseTab>
-    </div>
+    <BaseTab
+      as={RouterLink}
+      // @ts-ignore
+      to={to}
+      active={useIsRouteActive(to, options)}
+      onClick={() => {
+        tracking.trackEvent({
+          action_type: AnalyticsSchema.ActionType.Click,
+          destination_path: to,
+          subject: children as string,
+        })
+      }}
+      {...rest}
+    >
+      {children}
+    </BaseTab>
   )
 }
 

--- a/src/v2/Components/RouteTabs.tsx
+++ b/src/v2/Components/RouteTabs.tsx
@@ -11,6 +11,7 @@ export const RouteTab: React.FC<BaseTabProps & RouterLinkProps> = ({
   ...rest
 }) => {
   const tracking = useTracking()
+
   const options = {
     exact: rest.exact !== undefined ? rest.exact : true,
   }

--- a/src/v2/Components/UserSettings/UserSettingsTabs.tsx
+++ b/src/v2/Components/UserSettings/UserSettingsTabs.tsx
@@ -58,7 +58,6 @@ export const UserSettingsTabs: React.FC<UserSettingsTabsProps> = track()(
             const isActive = tabClass(route.url, route) === "active"
             const { ref } = useScrollIntoView(isActive)
             return (
-              // @ts-ignore
               <Box ref={ref} key={index}>
                 <RouteTab className={tabClass(route.url, route)} to={route.url}>
                   {route.name}

--- a/src/v2/Components/UserSettings/UserSettingsTabs.tsx
+++ b/src/v2/Components/UserSettings/UserSettingsTabs.tsx
@@ -42,6 +42,22 @@ const tabClass = (tabUrl, route) => {
   return currentRoute === tabUrl ? "active" : undefined
 }
 
+const useScrollIntoView = (isRouteActive: boolean) => {
+  const ref = React.useRef() as React.MutableRefObject<HTMLDivElement>
+  React.useEffect(() => {
+    if (isRouteActive && ref?.current) {
+      ref.current?.scrollIntoView &&
+        ref.current.scrollIntoView({
+          behavior: "smooth",
+          block: "end",
+          inline: "nearest",
+        })
+    }
+  }, [isRouteActive])
+
+  return { ref }
+}
+
 export const UserSettingsTabs: React.FC<UserSettingsTabsProps> = track()(
   ({ username }) => {
     return (
@@ -53,15 +69,17 @@ export const UserSettingsTabs: React.FC<UserSettingsTabsProps> = track()(
         </Box>
 
         <RouteTabs>
-          {routes.map((route, index) => (
-            <RouteTab
-              key={index}
-              className={tabClass(route.url, route)}
-              to={route.url}
-            >
-              {route.name}
-            </RouteTab>
-          ))}
+          {routes.map((route, index) => {
+            const isActive = tabClass(route.url, route) === "active"
+            const { ref } = useScrollIntoView(isActive)
+            return (
+              <div ref={ref} key={index}>
+                <RouteTab className={tabClass(route.url, route)} to={route.url}>
+                  {route.name}
+                </RouteTab>
+              </div>
+            )
+          })}
         </RouteTabs>
       </Box>
     )

--- a/src/v2/Components/UserSettings/UserSettingsTabs.tsx
+++ b/src/v2/Components/UserSettings/UserSettingsTabs.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { track } from "v2/System"
 import { RouteTab, RouteTabs } from "v2/Components/RouteTabs"
 import { Box, Text } from "@artsy/palette"
+import { useScrollIntoView } from "v2/Utils/scrollHelpers"
 
 interface UserSettingsTabsProps {
   route?: string
@@ -40,22 +41,6 @@ const tabClass = (tabUrl, route) => {
     typeof window === "undefined" ? route : window.location.pathname
 
   return currentRoute === tabUrl ? "active" : undefined
-}
-
-const useScrollIntoView = (isRouteActive: boolean) => {
-  const ref = React.useRef() as React.MutableRefObject<HTMLDivElement>
-  React.useEffect(() => {
-    if (isRouteActive && ref?.current) {
-      ref.current?.scrollIntoView &&
-        ref.current.scrollIntoView({
-          behavior: "smooth",
-          block: "end",
-          inline: "start",
-        })
-    }
-  }, [isRouteActive])
-
-  return { ref }
 }
 
 export const UserSettingsTabs: React.FC<UserSettingsTabsProps> = track()(

--- a/src/v2/Components/UserSettings/UserSettingsTabs.tsx
+++ b/src/v2/Components/UserSettings/UserSettingsTabs.tsx
@@ -58,11 +58,11 @@ export const UserSettingsTabs: React.FC<UserSettingsTabsProps> = track()(
             const isActive = tabClass(route.url, route) === "active"
             const { ref } = useScrollIntoView(isActive)
             return (
-              <div ref={ref} key={index}>
+              <Box ref={ref} key={index}>
                 <RouteTab className={tabClass(route.url, route)} to={route.url}>
                   {route.name}
                 </RouteTab>
-              </div>
+              </Box>
             )
           })}
         </RouteTabs>

--- a/src/v2/Components/UserSettings/UserSettingsTabs.tsx
+++ b/src/v2/Components/UserSettings/UserSettingsTabs.tsx
@@ -50,7 +50,7 @@ const useScrollIntoView = (isRouteActive: boolean) => {
         ref.current.scrollIntoView({
           behavior: "smooth",
           block: "end",
-          inline: "nearest",
+          inline: "start",
         })
     }
   }, [isRouteActive])

--- a/src/v2/Components/UserSettings/UserSettingsTabs.tsx
+++ b/src/v2/Components/UserSettings/UserSettingsTabs.tsx
@@ -58,6 +58,7 @@ export const UserSettingsTabs: React.FC<UserSettingsTabsProps> = track()(
             const isActive = tabClass(route.url, route) === "active"
             const { ref } = useScrollIntoView(isActive)
             return (
+              // @ts-ignore
               <Box ref={ref} key={index}>
                 <RouteTab className={tabClass(route.url, route)} to={route.url}>
                   {route.name}

--- a/src/v2/Utils/scrollHelpers.ts
+++ b/src/v2/Utils/scrollHelpers.ts
@@ -1,3 +1,5 @@
+import React from "react"
+
 const getElementPosition = $element => {
   const rect = $element.getBoundingClientRect()
   return {
@@ -23,4 +25,20 @@ export const scrollIntoView = (props: ScrollIntoViewProps) => {
       ...rest,
     })
   }
+}
+
+export const useScrollIntoView = (isRouteActive: boolean) => {
+  const ref = React.useRef() as React.MutableRefObject<HTMLDivElement>
+  React.useEffect(() => {
+    if (isRouteActive && ref?.current) {
+      ref.current?.scrollIntoView &&
+        ref.current.scrollIntoView({
+          behavior: "smooth",
+          block: "end",
+          inline: "start",
+        })
+    }
+  }, [isRouteActive])
+
+  return { ref }
 }

--- a/src/v2/Utils/scrollHelpers.ts
+++ b/src/v2/Utils/scrollHelpers.ts
@@ -28,7 +28,7 @@ export const scrollIntoView = (props: ScrollIntoViewProps) => {
 }
 
 export const useScrollIntoView = (isRouteActive: boolean) => {
-  const ref = React.useRef() as React.MutableRefObject<HTMLDivElement>
+  const ref = React.useRef() as any
   React.useEffect(() => {
     if (isRouteActive && ref?.current) {
       ref.current?.scrollIntoView &&

--- a/src/v2/Utils/scrollHelpers.ts
+++ b/src/v2/Utils/scrollHelpers.ts
@@ -35,7 +35,7 @@ export const useScrollIntoView = (isRouteActive: boolean) => {
         ref.current.scrollIntoView({
           behavior: "smooth",
           block: "end",
-          inline: "start",
+          inline: "center",
         })
     }
   }, [isRouteActive])


### PR DESCRIPTION
# Description

Resolves [PURCHASE-2768](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=41&projectKey=PURCHASE&modal=detail&selectedIssue=PURCHASE-2768)

**Problem:** When a user selects Payments & Shipping from the burger menu they arrive at the ‘My Profile’ page with the wrong horizontal nav item in view. The right item is selected but not in view.

**Solution:** Adds scrollIntoView on active tab

### Video

https://user-images.githubusercontent.com/21178754/126458687-b9a1c798-020c-4359-95ae-4c8d036e15e6.mov


