### PR TITLE
feat(FX-3079): rename exhibitors tab to booths

### DIFF
--- a/src/v2/Apps/Fair/FairApp.tsx
+++ b/src/v2/Apps/Fair/FairApp.tsx
@@ -115,7 +115,7 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
           exact
           onClick={() => tracking.trackEvent(clickedExhibitorsTabTrackingData)}
         >
-          Exhibitors
+          Booths
         </RouteTab>
 
         <RouteTab

--- a/src/v2/Apps/Fair/__tests__/FairApp.jest.tsx
+++ b/src/v2/Apps/Fair/__tests__/FairApp.jest.tsx
@@ -103,11 +103,11 @@ describe("FairApp", () => {
     expect(html).not.toContain("Big Artists, Small Sculptures")
   })
 
-  it("renders the exhibitors tab by default", () => {
+  it("renders the exhibitors (booths) tab by default", () => {
     const wrapper = getWrapper()
     const html = wrapper.html()
 
-    expect(html).toContain("Exhibitors")
+    expect(html).toContain("Booths")
   })
 
   it("sets a title tag", () => {
@@ -118,23 +118,23 @@ describe("FairApp", () => {
     expect(wrapper.find(Title).prop("children")).toEqual("Miart 2020 | Artsy")
   })
 
-  it("renders the exhibitors tab with an appropriate href", () => {
+  it("renders the exhibitors (booths) tab with an appropriate href", () => {
     const wrapper = getWrapper({
       Fair: () => ({
         href: "/fair/miart-2020",
       }),
     })
 
-    const exhibitorsTab = wrapper
+    const boothsTab = wrapper
       .find("RouteTab")
-      .findWhere(t => !!t.text().match("Exhibitors"))
+      .findWhere(t => !!t.text().match("Booths"))
       .first()
 
-    expect(exhibitorsTab.text()).toContain("Exhibitors")
-    expect(exhibitorsTab.props().to).toEqual("/fair/miart-2020")
+    expect(boothsTab.text()).toContain("Booths")
+    expect(boothsTab.props().to).toEqual("/fair/miart-2020")
   })
 
-  it("tracks clicks to the exhibitors tab", () => {
+  it("tracks clicks to the exhibitors (booths) tab", () => {
     const wrapper = getWrapper({
       Fair: () => ({
         internalID: "bson-fair",
@@ -143,12 +143,12 @@ describe("FairApp", () => {
       }),
     })
 
-    const exhibitorsTab = wrapper
+    const boothsTab = wrapper
       .find("RouteTab")
-      .findWhere(t => t.text() === "Exhibitors")
+      .findWhere(t => t.text() === "Booths")
       .first()
 
-    exhibitorsTab.simulate("click")
+    boothsTab.simulate("click")
 
     expect(trackEvent).toHaveBeenCalledWith({
       action: "clickedNavigationTab",


### PR DESCRIPTION
Jira: [FX-3079](https://artsyproduct.atlassian.net/browse/FX-3079)

**Description**
Current exhibitors tab on fair page should have a new header title
See [Figma](https://www.figma.com/file/aM3b5sodn04vMTigbQXACi/Fairs-2021?node-id=2891%3A0) for reference


**Changes**
- Renamed tab title
- Updated tests for fair tabs


**Before**
![image](https://user-images.githubusercontent.com/56556580/126291343-0d69550d-2ab3-46f5-9764-df6fe174ea57.png)


 **After**
![image](https://user-images.githubusercontent.com/56556580/126291389-70b19a6a-467d-4e68-b4bd-a0455bd1d994.png)
