### PR TITLE
feat(FX-3064): base filter alignment + artist series

### DIFF
--- a/src/test/fixtures/aggregations.ts
+++ b/src/test/fixtures/aggregations.ts
@@ -1,0 +1,67 @@
+import { Aggregation } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
+
+export const artistAggregation: Aggregation = {
+  slice: "ARTIST",
+  counts: [
+    {
+      count: 483,
+      name: "Massimo Listri",
+      value: "massimo-listri",
+    },
+  ],
+}
+
+export const partnerAggregation: Aggregation = {
+  slice: "PARTNER",
+  counts: [
+    {
+      name: "Rago/Wright",
+      value: "rago-slash-wright",
+      count: 2,
+    },
+  ],
+}
+
+export const locationCityAggregation: Aggregation = {
+  slice: "LOCATION_CITY",
+  counts: [
+    {
+      name: "New York, NY, USA",
+      value: "New York, NY, USA",
+      count: 10,
+    },
+  ],
+}
+
+export const mediumAggregation: Aggregation = {
+  slice: "MEDIUM",
+  counts: [
+    {
+      name: "Painting",
+      value: "painting",
+      count: 472023,
+    },
+  ],
+}
+
+export const materialsTermsAggregation: Aggregation = {
+  slice: "MATERIALS_TERMS",
+  counts: [
+    {
+      name: "Canvas",
+      value: "canvas",
+      count: 17,
+    },
+  ],
+}
+
+export const artistNationalityAggregation: Aggregation = {
+  slice: "ARTIST_NATIONALITY",
+  counts: [
+    {
+      name: "American",
+      value: "American",
+      count: 21,
+    },
+  ],
+}

--- a/src/v2/Apps/ArtistSeries/__tests__/ArtistSeriesArtworksFilter.jest.tsx
+++ b/src/v2/Apps/ArtistSeries/__tests__/ArtistSeriesArtworksFilter.jest.tsx
@@ -1,0 +1,120 @@
+import { MockBoot } from "v2/DevTools"
+import React from "react"
+import { ArtistSeriesArtworksFilterRefetchContainer } from "../Components/ArtistSeriesArtworksFilter"
+import { graphql } from "react-relay"
+import { ArtistSeriesArtworksFilter_Query } from "v2/__generated__/ArtistSeriesArtworksFilter_Query.graphql"
+import { useTracking } from "v2/System/Analytics/useTracking"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import {
+  locationCityAggregation,
+  materialsTermsAggregation,
+  mediumAggregation,
+  partnerAggregation,
+} from "test/fixtures/aggregations"
+
+jest.unmock("react-relay")
+jest.mock("v2/System/Router/useRouter", () => ({
+  useRouter: () => ({
+    match: {
+      location: { query: {} },
+    },
+  }),
+}))
+jest.mock("v2/System/Analytics/useTracking")
+
+const { getWrapper } = setupTestWrapper<ArtistSeriesArtworksFilter_Query>({
+  Component: ({ artistSeries }) => (
+    <MockBoot user={{ id: "percy-z" }}>
+      <ArtistSeriesArtworksFilterRefetchContainer
+        aggregations={[
+          partnerAggregation,
+          locationCityAggregation,
+          mediumAggregation,
+          materialsTermsAggregation,
+        ]}
+        artistSeries={artistSeries!}
+      />
+    </MockBoot>
+  ),
+  query: graphql`
+    query ArtistSeriesArtworksFilter_Query($slug: ID!) {
+      artistSeries(id: $slug) {
+        ...ArtistSeriesArtworksFilter_artistSeries
+      }
+    }
+  `,
+  variables: { slug: "kaws-spongebob" },
+})
+
+describe("ArtistSeriesArtworksFilter", () => {
+  const trackEvent = jest.fn()
+
+  beforeEach(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+  })
+
+  it("renders correctly", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.find("ArtworkFilterArtworkGrid").length).toBe(1)
+    expect(wrapper.find("ArtworkGridItem").length).toBe(1)
+  })
+
+  it("renders filters in correct order", () => {
+    const wrapper = getWrapper({
+      FilterArtworksConnection: () => ({
+        counts: {
+          followedArtists: 10,
+        },
+      }),
+    })
+    const filterWrappers = wrapper.find("FilterExpandable")
+    const filters = [
+      {
+        label: "Rarity",
+        expanded: true,
+      },
+      {
+        label: "Medium",
+        expanded: true,
+      },
+      {
+        label: "Price",
+        expanded: true,
+      },
+      {
+        label: "Size",
+        expanded: true,
+      },
+      {
+        label: "Ways to Buy",
+        expanded: true,
+      },
+      {
+        label: "Material",
+      },
+      {
+        label: "Artwork Location",
+      },
+      {
+        label: "Time Period",
+      },
+      {
+        label: "Color",
+      },
+      {
+        label: "Galleries and Institutions",
+      },
+    ]
+
+    filters.forEach((filter, filterIndex) => {
+      const { label, expanded } = filter
+
+      expect(filterWrappers.at(filterIndex).prop("label")).toEqual(label)
+      expect(filterWrappers.at(filterIndex).prop("expanded")).toEqual(expanded)
+    })
+  })
+})

--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -94,14 +94,15 @@ export type Slice =
 /**
  * Possible aggregations that can be passed
  */
-export type Aggregations = Array<{
+export type Aggregation = {
   slice: Slice
   counts: Array<{
     count: number
     value: string
     name: string
   }>
-}>
+}
+export type Aggregations = Array<Aggregation>
 
 export interface Counts {
   for_sale_artworks?: number

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
@@ -94,7 +94,7 @@ export const ArtistsFilter: FC<ArtistsFilterProps> = ({
   })
 
   useEffect(() => {
-    if (relayEnvironment && user) {
+    if (artists?.counts && relayEnvironment && user) {
       fetchFollowedArtists({ relayEnvironment, fairID }).then(data => {
         setFollowedArtists(data)
       })

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx
@@ -10,18 +10,29 @@ import { ArtworkLocationFilter } from "./ArtworkLocationFilter"
 import { ArtistNationalityFilter } from "./ArtistNationalityFilter"
 import { MaterialsFilter } from "./MaterialsFilter"
 import { PartnersFilter } from "./PartnersFilter"
+import { ArtistsFilter } from "./ArtistsFilter"
+import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 
-export const ArtworkFilters: React.FC = () => {
+interface ArtworkFiltersProps {
+  user?: User
+  relayEnvironment?: RelayModernEnvironment
+}
+
+// Some filters will be rendered only if there is the necessary data in aggregations (for example, ArtistsFilter)
+export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
+  const { user, relayEnvironment } = props
+
   return (
     <>
-      <MediumFilter expanded />
-      <MaterialsFilter expanded />
-      <PriceRangeFilter />
+      <ArtistsFilter relayEnvironment={relayEnvironment} user={user} expanded />
       <AttributionClassFilter expanded />
-      <SizeFilter />
-      <WaysToBuyFilter />
-      <ArtworkLocationFilter expanded />
-      <ArtistNationalityFilter expanded />
+      <MediumFilter expanded />
+      <PriceRangeFilter expanded />
+      <SizeFilter expanded />
+      <WaysToBuyFilter expanded />
+      <MaterialsFilter />
+      <ArtistNationalityFilter />
+      <ArtworkLocationFilter />
       <TimePeriodFilter />
       <ColorFilter />
       <PartnersFilter />

--- a/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
@@ -66,7 +66,6 @@ describe("ArtworkFilter", () => {
         onFilterClick,
       })
 
-      wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
       wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
 
       expect(onFilterClick).toHaveBeenCalledWith("acquireable", true, {
@@ -111,7 +110,6 @@ describe("ArtworkFilter", () => {
         onChange,
       })
 
-      wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
       wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
 
       expect(onChange).toHaveBeenCalledWith({
@@ -170,7 +168,6 @@ describe("ArtworkFilter", () => {
         onFilterClick,
       })
 
-      wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
       wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
 
       expect(trackEvent).toHaveBeenCalledWith(
@@ -226,7 +223,6 @@ describe("ArtworkFilter", () => {
       expect(wrapper.find("FiltersWithScrollIntoView").length).toEqual(1)
       expect(document.body.style.overflowY).toEqual("hidden")
 
-      wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
       wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
       actionSheet.find("Button").last().simulate("click")
 

--- a/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilterMobileActionSheet.jest.tsx
@@ -78,10 +78,6 @@ describe("ArtworkFilterMobileActionSheet", () => {
   it("mutates staged filter state instead of 'real' filter state", () => {
     const wrapper = getWrapper()
 
-    // Expand the filters we want to make assertions about
-    wrapper.find("WaysToBuyFilter").find("ChevronIcon").simulate("click")
-    wrapper.find("SizeFilter").find("ChevronIcon").simulate("click")
-
     wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
     wrapper.find("SizeFilter").find("Checkbox").first().simulate("click")
 
@@ -101,7 +97,6 @@ describe("ArtworkFilterMobileActionSheet", () => {
 
       expect(wrapper.find("Button").last().prop("disabled")).toBeTruthy()
 
-      wrapper.find("SizeFilter").find("ChevronIcon").simulate("click")
       wrapper.find("SizeFilter").find("Checkbox").first().simulate("click")
 
       expect(wrapper.find("Button").last().prop("disabled")).toBeFalsy()

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -44,6 +44,7 @@ import { Sticky } from "v2/Components/Sticky"
 import { ScrollRefContext } from "./ArtworkFilters/useScrollContext"
 import { ArtworkSortFilter } from "./ArtworkFilters/ArtworkSortFilter"
 import { GeneArtworkFilter_gene } from "v2/__generated__/GeneArtworkFilter_gene.graphql"
+import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 
 /**
  * Primary ArtworkFilter which is wrapped with a context and refetch container.
@@ -83,15 +84,21 @@ export const ArtworkFilter: React.FC<
   )
 }
 
-const FiltersWithScrollIntoView: React.FC<{ Filters?: JSX.Element }> = ({
-  Filters,
-}) => {
+const FiltersWithScrollIntoView: React.FC<{
+  Filters?: JSX.Element
+  user?: User
+  relayEnvironment?: RelayModernEnvironment
+}> = ({ Filters, relayEnvironment, user }) => {
   const scrollRef = useRef<HTMLDivElement | null>(null)
 
   return (
     <Box ref={scrollRef as any} overflowY="scroll" height="100%">
       <ScrollRefContext.Provider value={{ scrollRef }}>
-        {Filters ? Filters : <ArtworkFilters />}
+        {Filters ? (
+          Filters
+        ) : (
+          <ArtworkFilters relayEnvironment={relayEnvironment} user={user} />
+        )}
       </ScrollRefContext.Provider>
     </Box>
   )
@@ -131,6 +138,7 @@ export const BaseArtworkFilter: React.FC<
   const [showMobileActionSheet, toggleMobileActionSheet] = useState(false)
   const filterContext = useArtworkFilterContext()
   const previousFilters = usePrevious(filterContext.filters)
+  const { user } = useSystemContext()
 
   const { filtered_artworks } = viewer
   const hasFilter = filtered_artworks && filtered_artworks.id
@@ -234,7 +242,11 @@ export const BaseArtworkFilter: React.FC<
             <ArtworkFilterMobileActionSheet
               onClose={() => toggleMobileActionSheet(false)}
             >
-              <FiltersWithScrollIntoView Filters={Filters} />
+              <FiltersWithScrollIntoView
+                Filters={Filters}
+                user={user}
+                relayEnvironment={relay.environment}
+              />
             </ArtworkFilterMobileActionSheet>
           )}
 
@@ -296,7 +308,14 @@ export const BaseArtworkFilter: React.FC<
 
         <GridColumns>
           <Column span={3} pr={tokens.pr}>
-            {Filters ? Filters : <ArtworkFilters />}
+            {Filters ? (
+              Filters
+            ) : (
+              <ArtworkFilters
+                user={user}
+                relayEnvironment={relay.environment}
+              />
+            )}
           </Column>
 
           <Column

--- a/src/v2/__generated__/ArtistSeriesArtworksFilter_Query.graphql.ts
+++ b/src/v2/__generated__/ArtistSeriesArtworksFilter_Query.graphql.ts
@@ -1,0 +1,711 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistSeriesArtworksFilter_QueryVariables = {
+    slug: string;
+};
+export type ArtistSeriesArtworksFilter_QueryResponse = {
+    readonly artistSeries: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesArtworksFilter_artistSeries">;
+    } | null;
+};
+export type ArtistSeriesArtworksFilter_Query = {
+    readonly response: ArtistSeriesArtworksFilter_QueryResponse;
+    readonly variables: ArtistSeriesArtworksFilter_QueryVariables;
+};
+
+
+
+/*
+query ArtistSeriesArtworksFilter_Query(
+  $slug: ID!
+) {
+  artistSeries(id: $slug) {
+    ...ArtistSeriesArtworksFilter_artistSeries
+  }
+}
+
+fragment ArtistSeriesArtworksFilter_artistSeries on ArtistSeries {
+  filtered_artworks: filterArtworksConnection {
+    id
+    ...ArtworkFilterArtworkGrid_filtered_artworks
+  }
+}
+
+fragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {
+  id
+  pageInfo {
+    hasNextPage
+    endCursor
+  }
+  pageCursors {
+    ...Pagination_pageCursors
+  }
+  edges {
+    node {
+      id
+    }
+  }
+  ...ArtworkGrid_artworks
+}
+
+fragment ArtworkGrid_artworks on ArtworkConnectionInterface {
+  edges {
+    __typename
+    node {
+      id
+      slug
+      href
+      internalID
+      image {
+        aspect_ratio: aspectRatio
+      }
+      ...GridItem_artwork
+    }
+    ... on Node {
+      id
+    }
+  }
+}
+
+fragment Badge_artwork on Artwork {
+  is_biddable: isBiddable
+  href
+  sale {
+    is_preview: isPreview
+    display_timely_at: displayTimelyAt
+    id
+  }
+}
+
+fragment Contact_artwork on Artwork {
+  href
+  is_inquireable: isInquireable
+  sale {
+    is_auction: isAuction
+    is_live_open: isLiveOpen
+    is_open: isOpen
+    is_closed: isClosed
+    id
+  }
+  partner(shallow: true) {
+    type
+    id
+  }
+  sale_artwork: saleArtwork {
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    counts {
+      bidder_positions: bidderPositions
+    }
+    id
+  }
+}
+
+fragment Details_artwork on Artwork {
+  href
+  title
+  date
+  sale_message: saleMessage
+  cultural_maker: culturalMaker
+  artists(shallow: true) {
+    id
+    href
+    name
+  }
+  collecting_institution: collectingInstitution
+  partner(shallow: true) {
+    name
+    href
+    id
+  }
+  sale {
+    is_auction: isAuction
+    is_closed: isClosed
+    id
+  }
+  sale_artwork: saleArtwork {
+    counts {
+      bidder_positions: bidderPositions
+    }
+    highest_bid: highestBid {
+      display
+    }
+    opening_bid: openingBid {
+      display
+    }
+    id
+  }
+}
+
+fragment GridItem_artwork on Artwork {
+  internalID
+  title
+  image_title: imageTitle
+  image {
+    placeholder
+    url(version: "large")
+    aspect_ratio: aspectRatio
+  }
+  artistNames
+  href
+  is_saved: isSaved
+  ...Metadata_artwork
+  ...SaveButton_artwork
+  ...Badge_artwork
+}
+
+fragment Metadata_artwork on Artwork {
+  ...Details_artwork
+  ...Contact_artwork
+  href
+}
+
+fragment Pagination_pageCursors on PageCursors {
+  around {
+    cursor
+    page
+    isCurrent
+  }
+  first {
+    cursor
+    page
+    isCurrent
+  }
+  last {
+    cursor
+    page
+    isCurrent
+  }
+  previous {
+    cursor
+    page
+  }
+}
+
+fragment SaveButton_artwork on Artwork {
+  id
+  internalID
+  slug
+  is_saved: isSaved
+  title
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "slug",
+    "type": "ID!"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "slug"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "page",
+  "storageKey": null
+},
+v5 = [
+  (v3/*: any*/),
+  (v4/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "isCurrent",
+    "storageKey": null
+  }
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v7 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v9 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtistSeriesArtworksFilter_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ArtistSeries",
+        "kind": "LinkedField",
+        "name": "artistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtistSeriesArtworksFilter_artistSeries"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ArtistSeriesArtworksFilter_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ArtistSeries",
+        "kind": "LinkedField",
+        "name": "artistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "alias": "filtered_artworks",
+            "args": null,
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageCursors",
+                "kind": "LinkedField",
+                "name": "pageCursors",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "around",
+                    "plural": true,
+                    "selections": (v5/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "first",
+                    "plural": false,
+                    "selections": (v5/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "last",
+                    "plural": false,
+                    "selections": (v5/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageCursor",
+                    "kind": "LinkedField",
+                    "name": "previous",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      (v6/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "aspect_ratio",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "aspectRatio",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "placeholder",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large"
+                              }
+                            ],
+                            "kind": "ScalarField",
+                            "name": "url",
+                            "storageKey": "url(version:\"large\")"
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "image_title",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "imageTitle",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "artistNames",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_saved",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isSaved",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "date",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_message",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "saleMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "cultural_maker",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "culturalMaker",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v7/*: any*/),
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artists",
+                        "plural": true,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v6/*: any*/),
+                          (v8/*: any*/)
+                        ],
+                        "storageKey": "artists(shallow:true)"
+                      },
+                      {
+                        "alias": "collecting_institution",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "collectingInstitution",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v7/*: any*/),
+                        "concreteType": "Partner",
+                        "kind": "LinkedField",
+                        "name": "partner",
+                        "plural": false,
+                        "selections": [
+                          (v8/*: any*/),
+                          (v6/*: any*/),
+                          (v2/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "type",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": "partner(shallow:true)"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "is_auction",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isAuction",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_closed",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          },
+                          (v2/*: any*/),
+                          {
+                            "alias": "is_live_open",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isLiveOpen",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_open",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isOpen",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "is_preview",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isPreview",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "display_timely_at",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "displayTimelyAt",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "sale_artwork",
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "kind": "LinkedField",
+                        "name": "saleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "kind": "LinkedField",
+                            "name": "counts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": "bidder_positions",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "bidderPositions",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "highest_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "kind": "LinkedField",
+                            "name": "highestBid",
+                            "plural": false,
+                            "selections": (v9/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "opening_bid",
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "kind": "LinkedField",
+                            "name": "openingBid",
+                            "plural": false,
+                            "selections": (v9/*: any*/),
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_inquireable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isInquireable",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_biddable",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isBiddable",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v2/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "ArtistSeriesArtworksFilter_Query",
+    "operationKind": "query",
+    "text": "query ArtistSeriesArtworksFilter_Query(\n  $slug: ID!\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesArtworksFilter_artistSeries\n  }\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries on ArtistSeries {\n  filtered_artworks: filterArtworksConnection {\n    id\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+  }
+};
+})();
+(node as any).hash = '2274d1b74fc8ac7c7c19a271ede278a0';
+export default node;


### PR DESCRIPTION
Type: **Feature**
Jira ticket: [FX-3064]

### Description
* As a user, I expect to see all relevant filters for each surface. 
* This ticket is to align our current filters with a consistent order and default open view
* All filters collapsed by default in mWeb.
* The order of filters **has been updated in the basic** [ArtworkFilters component](https://github.com/artsy/force/blob/c9e0748a5e21b05f33df6c73c65689ad93667c2f/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx), which is used in all places where filters are render (except for those where the `Filters` prop [is passed](https://github.com/artsy/force/blob/4fdfd0368a2f8f2256290e6381bedefb8180de64/src/v2/Components/ArtworkFilter/ArtworkFilters/index.tsx#L27-L38)
* Initial PR #7971 

##### Filters (Top to Bottom)
* Rarity (Default Open)
* Medium (Default Open)
* Price (Default Open)
* Size (Default Open)
* Ways to Buy (Default Open)
* Material
* Artwork Location
* Time Period
* Color 
* Galleries & Institutions

<details><summary>Changelog updates</summary>

### Web
![screencapture-localhost-5000-artist-series-kaws-sp](https://user-images.githubusercontent.com/3513494/126316783-1a25dca5-d25a-4233-b336-8fa77dcdd603.png)


#### Mobile
![screencapture-localhost-5000-artist-series-kaws-spongebob-2021-07-20-14_26_05](https://user-images.githubusercontent.com/3513494/126316754-c12b79a9-3a0f-4cc0-a84b-4332f59776a1.png)


</details>

[FX-3064]: https://artsyproduct.atlassian.net/browse/FX-3064