### PR TITLE
feat(FX-3061, FX-3087): update filters order for partner works

### DIFF
--- a/src/v2/Apps/Partner/Routes/Works/index.tsx
+++ b/src/v2/Apps/Partner/Routes/Works/index.tsx
@@ -1,14 +1,18 @@
 import React from "react"
 import { createRefetchContainer, RelayRefetchProp } from "react-relay"
 import { graphql } from "relay-runtime"
-import { Articles_partner } from "v2/__generated__/Articles_partner.graphql"
-import { ArtworkFilterContextProvider } from "v2/Components/ArtworkFilter/ArtworkFilterContext"
+import { Works_partner } from "v2/__generated__/Works_partner.graphql"
+import {
+  ArtworkFilterContextProvider,
+  Counts,
+  SharedArtworkFilterContextProps,
+} from "v2/Components/ArtworkFilter/ArtworkFilterContext"
 import { BaseArtworkFilter } from "v2/Components/ArtworkFilter"
 import { updateUrl } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { Match, RouterState, withRouter } from "found"
 
 interface PartnerArtworkFilterProps {
-  partner: Articles_partner
+  partner: Works_partner
   relay: RelayRefetchProp
   match?: Match
 }
@@ -18,6 +22,8 @@ export const Artworks: React.FC<PartnerArtworkFilterProps> = ({
   relay,
   match,
 }) => {
+  const { sidebar } = partner
+
   return (
     <ArtworkFilterContextProvider
       filters={match && match.location.query}
@@ -31,8 +37,12 @@ export const Artworks: React.FC<PartnerArtworkFilterProps> = ({
         { text: "Artwork year (asc.)", value: "year" },
       ]}
       onChange={updateUrl}
+      aggregations={
+        sidebar?.aggregations as SharedArtworkFilterContextProps["aggregations"]
+      }
+      counts={sidebar?.counts as Counts}
     >
-      <BaseArtworkFilter relay={relay} offset={200} viewer={partner as any} />
+      <BaseArtworkFilter relay={relay} offset={200} viewer={partner} />
     </ArtworkFilterContextProvider>
   )
 }
@@ -43,12 +53,31 @@ export const ArtworksRefetchContainer = createRefetchContainer(
   {
     partner: graphql`
       fragment Works_partner on Partner
-        @argumentDefinitions(input: { type: "FilterArtworksInput" }) {
+        @argumentDefinitions(
+          input: { type: "FilterArtworksInput" }
+          aggregations: { type: "[ArtworkAggregation]" }
+          shouldFetchCounts: { type: "Boolean!", defaultValue: false }
+        ) {
         slug
         internalID
+        sidebar: filterArtworksConnection(
+          first: 1
+          aggregations: $aggregations
+        ) {
+          counts @include(if: $shouldFetchCounts) {
+            followedArtists
+          }
+          aggregations {
+            slice
+            counts {
+              name
+              value
+              count
+            }
+          }
+        }
         filtered_artworks: filterArtworksConnection(first: 30, input: $input) {
           id
-
           ...ArtworkFilterArtworkGrid_filtered_artworks
         }
       }

--- a/src/v2/Apps/Partner/Routes/__tests__/Works.jest.tsx
+++ b/src/v2/Apps/Partner/Routes/__tests__/Works.jest.tsx
@@ -1,0 +1,122 @@
+import { MockBoot } from "v2/DevTools"
+import React from "react"
+import { ArtworksRefetchContainer } from "../Works"
+import { graphql } from "react-relay"
+import { Works_Query } from "v2/__generated__/Works_Query.graphql"
+import { useTracking } from "v2/System/Analytics/useTracking"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import {
+  artistAggregation,
+  artistNationalityAggregation,
+  materialsTermsAggregation,
+  mediumAggregation,
+} from "test/fixtures/aggregations"
+
+jest.unmock("react-relay")
+jest.mock("v2/System/Router/useRouter", () => ({
+  useRouter: () => ({
+    match: {
+      location: { query: {} },
+    },
+  }),
+}))
+jest.mock("v2/System/Analytics/useTracking")
+jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
+  useMatchMedia: () => ({}),
+}))
+
+const { getWrapper } = setupTestWrapper<Works_Query>({
+  Component: ({ partner }) => (
+    <MockBoot user={{ id: "percy-z" }}>
+      <ArtworksRefetchContainer partner={partner!} />
+    </MockBoot>
+  ),
+  query: graphql`
+    query Works_Query($partnerId: String!) {
+      partner(id: $partnerId) {
+        ...Works_partner
+      }
+    }
+  `,
+  variables: { partnerId: "pontone-gallery" },
+})
+
+describe("PartnerArtworks", () => {
+  const trackEvent = jest.fn()
+
+  beforeEach(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+  })
+
+  it("renders correctly", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.find("ArtworkFilterArtworkGrid").length).toBe(1)
+    expect(wrapper.find("ArtworkGridItem").length).toBe(1)
+  })
+
+  it("renders filters in correct order", () => {
+    const wrapper = getWrapper({
+      FilterArtworksConnection: () => ({
+        counts: {
+          followedArtists: 10,
+        },
+        aggregations: [
+          artistAggregation,
+          mediumAggregation,
+          materialsTermsAggregation,
+          artistNationalityAggregation,
+        ],
+      }),
+    })
+    const filterWrappers = wrapper.find("FilterExpandable")
+    const filters = [
+      {
+        label: "Artists",
+        expanded: true,
+      },
+      {
+        label: "Rarity",
+        expanded: true,
+      },
+      {
+        label: "Medium",
+        expanded: true,
+      },
+      {
+        label: "Price",
+        expanded: true,
+      },
+      {
+        label: "Size",
+        expanded: true,
+      },
+      {
+        label: "Ways to Buy",
+        expanded: true,
+      },
+      {
+        label: "Material",
+      },
+      {
+        label: "Artist Nationality or Ethnicity",
+      },
+      {
+        label: "Time Period",
+      },
+      {
+        label: "Color",
+      },
+    ]
+
+    filters.forEach((filter, filterIndex) => {
+      const { label, expanded } = filter
+
+      expect(filterWrappers.at(filterIndex).prop("label")).toEqual(label)
+      expect(filterWrappers.at(filterIndex).prop("expanded")).toEqual(expanded)
+    })
+  })
+})

--- a/src/v2/Apps/Partner/partnerRoutes.tsx
+++ b/src/v2/Apps/Partner/partnerRoutes.tsx
@@ -209,6 +209,17 @@ export const partnerRoutes: AppRouteConfig[] = [
         },
         prepareVariables: (data, props) => {
           const filterStateFromUrl = props.location ? props.location.query : {}
+          const aggregations = [
+            "TOTAL",
+            "MEDIUM",
+            "MATERIALS_TERMS",
+            "ARTIST_NATIONALITY",
+            "ARTIST",
+          ]
+
+          if (!!props.context.user) {
+            aggregations.push("FOLLOWED_ARTISTS")
+          }
 
           const filterParams = {
             ...initialArtworkFilterState,
@@ -216,10 +227,10 @@ export const partnerRoutes: AppRouteConfig[] = [
           }
 
           return {
-            input: {
-              ...allowedFilters(filterParams),
-            },
+            aggregations,
+            input: allowedFilters(filterParams),
             partnerId: data.partnerId,
+            shouldFetchCounts: !!props.context.user,
           }
         },
         ignoreScrollBehavior: true,
@@ -227,9 +238,16 @@ export const partnerRoutes: AppRouteConfig[] = [
           query partnerRoutes_WorksQuery(
             $partnerId: String!
             $input: FilterArtworksInput
+            $aggregations: [ArtworkAggregation]
+            $shouldFetchCounts: Boolean!
           ) {
             partner(id: $partnerId) @principalField {
-              ...Works_partner @arguments(input: $input)
+              ...Works_partner
+                @arguments(
+                  input: $input
+                  aggregations: $aggregations
+                  shouldFetchCounts: $shouldFetchCounts
+                )
               displayWorksSection
               counts {
                 eligibleArtworks

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -45,6 +45,7 @@ import { ScrollRefContext } from "./ArtworkFilters/useScrollContext"
 import { ArtworkSortFilter } from "./ArtworkFilters/ArtworkSortFilter"
 import { GeneArtworkFilter_gene } from "v2/__generated__/GeneArtworkFilter_gene.graphql"
 import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
+import { Works_partner } from "v2/__generated__/Works_partner.graphql"
 
 /**
  * Primary ArtworkFilter which is wrapped with a context and refetch container.
@@ -116,6 +117,7 @@ export const BaseArtworkFilter: React.FC<
       | FairArtworks_fair
       | ShowArtworks_show
       | GeneArtworkFilter_gene
+      | Works_partner
     Filters?: JSX.Element
     offset?: number
   }

--- a/src/v2/__generated__/Works_Query.graphql.ts
+++ b/src/v2/__generated__/Works_Query.graphql.ts
@@ -3,80 +3,27 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
-export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
-export type FilterArtworksInput = {
-    acquireable?: boolean | null;
-    additionalGeneIDs?: Array<string | null> | null;
-    after?: string | null;
-    aggregationPartnerCities?: Array<string | null> | null;
-    aggregations?: Array<ArtworkAggregation | null> | null;
-    artistID?: string | null;
-    artistIDs?: Array<string | null> | null;
-    artistNationalities?: Array<string | null> | null;
-    artistSeriesID?: string | null;
-    atAuction?: boolean | null;
-    attributionClass?: Array<string | null> | null;
-    before?: string | null;
-    color?: string | null;
-    colors?: Array<string | null> | null;
-    dimensionRange?: string | null;
-    excludeArtworkIDs?: Array<string | null> | null;
-    extraAggregationGeneIDs?: Array<string | null> | null;
-    first?: number | null;
-    forSale?: boolean | null;
-    geneID?: string | null;
-    geneIDs?: Array<string | null> | null;
-    height?: string | null;
-    includeArtworksByFollowedArtists?: boolean | null;
-    includeMediumFilterInAggregation?: boolean | null;
-    inquireableOnly?: boolean | null;
-    keyword?: string | null;
-    keywordMatchExact?: boolean | null;
-    last?: number | null;
-    locationCities?: Array<string | null> | null;
-    majorPeriods?: Array<string | null> | null;
-    marketable?: boolean | null;
-    materialsTerms?: Array<string | null> | null;
-    medium?: string | null;
-    offerable?: boolean | null;
-    page?: number | null;
-    partnerCities?: Array<string | null> | null;
-    partnerID?: string | null;
-    partnerIDs?: Array<string | null> | null;
-    period?: string | null;
-    periods?: Array<string | null> | null;
-    priceRange?: string | null;
-    saleID?: string | null;
-    size?: number | null;
-    sizes?: Array<ArtworkSizes | null> | null;
-    sort?: string | null;
-    tagID?: string | null;
-    width?: string | null;
-};
-export type WorksQueryVariables = {
+export type Works_QueryVariables = {
     partnerId: string;
-    input?: FilterArtworksInput | null;
 };
-export type WorksQueryResponse = {
+export type Works_QueryResponse = {
     readonly partner: {
         readonly " $fragmentRefs": FragmentRefs<"Works_partner">;
     } | null;
 };
-export type WorksQuery = {
-    readonly response: WorksQueryResponse;
-    readonly variables: WorksQueryVariables;
+export type Works_Query = {
+    readonly response: Works_QueryResponse;
+    readonly variables: Works_QueryVariables;
 };
 
 
 
 /*
-query WorksQuery(
+query Works_Query(
   $partnerId: String!
-  $input: FilterArtworksInput
 ) {
   partner(id: $partnerId) {
-    ...Works_partner_2VV6jB
+    ...Works_partner
     id
   }
 }
@@ -244,7 +191,7 @@ fragment SaveButton_artwork on Artwork {
   title
 }
 
-fragment Works_partner_2VV6jB on Partner {
+fragment Works_partner on Partner {
   slug
   internalID
   sidebar: filterArtworksConnection(first: 1) {
@@ -258,7 +205,7 @@ fragment Works_partner_2VV6jB on Partner {
     }
     id
   }
-  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {
+  filtered_artworks: filterArtworksConnection(first: 30) {
     id
     ...ArtworkFilterArtworkGrid_filtered_artworks
   }
@@ -272,12 +219,6 @@ var v0 = [
     "kind": "LocalArgument",
     "name": "partnerId",
     "type": "String!"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "input",
-    "type": "FilterArtworksInput"
   }
 ],
 v1 = [
@@ -288,55 +229,50 @@ v1 = [
   }
 ],
 v2 = {
-  "kind": "Variable",
-  "name": "input",
-  "variableName": "input"
-},
-v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v8 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v9 = [
+v8 = [
+  (v6/*: any*/),
   (v7/*: any*/),
-  (v8/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -345,21 +281,21 @@ v9 = [
     "storageKey": null
   }
 ],
-v10 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v11 = [
+v10 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v12 = [
+v11 = [
   {
     "alias": null,
     "args": null,
@@ -373,7 +309,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "WorksQuery",
+    "name": "Works_Query",
     "selections": [
       {
         "alias": null,
@@ -384,9 +320,7 @@ return {
         "plural": false,
         "selections": [
           {
-            "args": [
-              (v2/*: any*/)
-            ],
+            "args": null,
             "kind": "FragmentSpread",
             "name": "Works_partner"
           }
@@ -400,7 +334,7 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "WorksQuery",
+    "name": "Works_Query",
     "selections": [
       {
         "alias": null,
@@ -410,8 +344,8 @@ return {
         "name": "partner",
         "plural": false,
         "selections": [
+          (v2/*: any*/),
           (v3/*: any*/),
-          (v4/*: any*/),
           {
             "alias": "sidebar",
             "args": [
@@ -449,7 +383,7 @@ return {
                     "name": "counts",
                     "plural": true,
                     "selections": [
-                      (v5/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -470,7 +404,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/)
+              (v5/*: any*/)
             ],
             "storageKey": "filterArtworksConnection(first:1)"
           },
@@ -481,15 +415,14 @@ return {
                 "kind": "Literal",
                 "name": "first",
                 "value": 30
-              },
-              (v2/*: any*/)
+              }
             ],
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              (v6/*: any*/),
+              (v5/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -530,7 +463,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v9/*: any*/),
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -540,7 +473,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v9/*: any*/),
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -550,7 +483,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v9/*: any*/),
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -561,8 +494,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v7/*: any*/),
-                      (v8/*: any*/)
+                      (v6/*: any*/),
+                      (v7/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -585,10 +518,10 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
+                      (v5/*: any*/),
+                      (v2/*: any*/),
+                      (v9/*: any*/),
                       (v3/*: any*/),
-                      (v10/*: any*/),
-                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -678,15 +611,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v11/*: any*/),
+                        "args": (v10/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v6/*: any*/),
-                          (v10/*: any*/),
-                          (v5/*: any*/)
+                          (v5/*: any*/),
+                          (v9/*: any*/),
+                          (v4/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -699,15 +632,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v11/*: any*/),
+                        "args": (v10/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
+                          (v4/*: any*/),
+                          (v9/*: any*/),
                           (v5/*: any*/),
-                          (v10/*: any*/),
-                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -740,7 +673,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v6/*: any*/),
+                          (v5/*: any*/),
                           {
                             "alias": "is_live_open",
                             "args": null,
@@ -805,7 +738,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v12/*: any*/),
+                            "selections": (v11/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -815,10 +748,10 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v12/*: any*/),
+                            "selections": (v11/*: any*/),
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v5/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -839,14 +772,14 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v6/*: any*/)
+                  (v5/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
-            "storageKey": null
+            "storageKey": "filterArtworksConnection(first:30)"
           },
-          (v6/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": null
       }
@@ -855,11 +788,11 @@ return {
   "params": {
     "id": null,
     "metadata": {},
-    "name": "WorksQuery",
+    "name": "Works_Query",
     "operationKind": "query",
-    "text": "query WorksQuery(\n  $partnerId: String!\n  $input: FilterArtworksInput\n) {\n  partner(id: $partnerId) {\n    ...Works_partner_2VV6jB\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Works_partner_2VV6jB on Partner {\n  slug\n  internalID\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
+    "text": "query Works_Query(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) {\n    ...Works_partner\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Works_partner on Partner {\n  slug\n  internalID\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '85d92aa482ec23e5196f240bc840fa29';
+(node as any).hash = 'f8d19367a66ab707a456ff2c2cc833e5';
 export default node;

--- a/src/v2/__generated__/Works_partner.graphql.ts
+++ b/src/v2/__generated__/Works_partner.graphql.ts
@@ -3,9 +3,23 @@
 
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 export type Works_partner = {
     readonly slug: string;
     readonly internalID: string;
+    readonly sidebar: {
+        readonly counts?: {
+            readonly followedArtists: number | null;
+        } | null;
+        readonly aggregations: ReadonlyArray<{
+            readonly slice: ArtworkAggregation | null;
+            readonly counts: ReadonlyArray<{
+                readonly name: string;
+                readonly value: string;
+                readonly count: number;
+            } | null> | null;
+        } | null> | null;
+    } | null;
     readonly filtered_artworks: {
         readonly id: string;
         readonly " $fragmentRefs": FragmentRefs<"ArtworkFilterArtworkGrid_filtered_artworks">;
@@ -27,6 +41,18 @@ const node: ReaderFragment = {
       "kind": "LocalArgument",
       "name": "input",
       "type": "FilterArtworksInput"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "aggregations",
+      "type": "[ArtworkAggregation]"
+    },
+    {
+      "defaultValue": false,
+      "kind": "LocalArgument",
+      "name": "shouldFetchCounts",
+      "type": "Boolean!"
     }
   ],
   "kind": "Fragment",
@@ -45,6 +71,103 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "ScalarField",
       "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": "sidebar",
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "aggregations",
+          "variableName": "aggregations"
+        },
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 1
+        }
+      ],
+      "concreteType": "FilterArtworksConnection",
+      "kind": "LinkedField",
+      "name": "filterArtworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArtworksAggregationResults",
+          "kind": "LinkedField",
+          "name": "aggregations",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "slice",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "AggregationCount",
+              "kind": "LinkedField",
+              "name": "counts",
+              "plural": true,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "value",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "count",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "condition": "shouldFetchCounts",
+          "kind": "Condition",
+          "passingValue": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "FilterArtworksCounts",
+              "kind": "LinkedField",
+              "name": "counts",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "followedArtists",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ]
+        }
+      ],
       "storageKey": null
     },
     {
@@ -84,5 +207,5 @@ const node: ReaderFragment = {
   ],
   "type": "Partner"
 };
-(node as any).hash = '304a9a0e45f6bb548c04d030a63ddd11';
+(node as any).hash = '0176c7bc06efb1faeb063ac7e49a0428';
 export default node;

--- a/src/v2/__generated__/partnerRoutes_WorksQuery.graphql.ts
+++ b/src/v2/__generated__/partnerRoutes_WorksQuery.graphql.ts
@@ -57,6 +57,8 @@ export type FilterArtworksInput = {
 export type partnerRoutes_WorksQueryVariables = {
     partnerId: string;
     input?: FilterArtworksInput | null;
+    aggregations?: Array<ArtworkAggregation | null> | null;
+    shouldFetchCounts: boolean;
 };
 export type partnerRoutes_WorksQueryResponse = {
     readonly partner: {
@@ -78,9 +80,11 @@ export type partnerRoutes_WorksQuery = {
 query partnerRoutes_WorksQuery(
   $partnerId: String!
   $input: FilterArtworksInput
+  $aggregations: [ArtworkAggregation]
+  $shouldFetchCounts: Boolean!
 ) {
   partner(id: $partnerId) @principalField {
-    ...Works_partner_2VV6jB
+    ...Works_partner_3TMxyn
     displayWorksSection
     counts {
       eligibleArtworks
@@ -252,9 +256,23 @@ fragment SaveButton_artwork on Artwork {
   title
 }
 
-fragment Works_partner_2VV6jB on Partner {
+fragment Works_partner_3TMxyn on Partner {
   slug
   internalID
+  sidebar: filterArtworksConnection(first: 1, aggregations: $aggregations) {
+    counts @include(if: $shouldFetchCounts) {
+      followedArtists
+    }
+    aggregations {
+      slice
+      counts {
+        name
+        value
+        count
+      }
+    }
+    id
+  }
   filtered_artworks: filterArtworksConnection(first: 30, input: $input) {
     id
     ...ArtworkFilterArtworkGrid_filtered_artworks
@@ -275,6 +293,18 @@ var v0 = [
     "kind": "LocalArgument",
     "name": "input",
     "type": "FilterArtworksInput"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "aggregations",
+    "type": "[ArtworkAggregation]"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "shouldFetchCounts",
+    "type": "Boolean!"
   }
 ],
 v1 = [
@@ -311,47 +341,59 @@ v3 = {
 },
 v4 = {
   "kind": "Variable",
+  "name": "aggregations",
+  "variableName": "aggregations"
+},
+v5 = {
+  "kind": "Variable",
   "name": "input",
   "variableName": "input"
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cursor",
+  "name": "name",
   "storageKey": null
 },
 v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v10 = [
-  (v8/*: any*/),
-  (v9/*: any*/),
+v12 = [
+  (v10/*: any*/),
+  (v11/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -360,28 +402,21 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v12 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v13 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v14 = [
+v15 = [
   {
     "alias": null,
     "args": null,
@@ -409,7 +444,13 @@ return {
           (v3/*: any*/),
           {
             "args": [
-              (v4/*: any*/)
+              (v4/*: any*/),
+              (v5/*: any*/),
+              {
+                "kind": "Variable",
+                "name": "shouldFetchCounts",
+                "variableName": "shouldFetchCounts"
+              }
             ],
             "kind": "FragmentSpread",
             "name": "Works_partner"
@@ -434,8 +475,96 @@ return {
         "name": "partner",
         "plural": false,
         "selections": [
-          (v5/*: any*/),
           (v6/*: any*/),
+          (v7/*: any*/),
+          {
+            "alias": "sidebar",
+            "args": [
+              (v4/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              }
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArtworksAggregationResults",
+                "kind": "LinkedField",
+                "name": "aggregations",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "slice",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AggregationCount",
+                    "kind": "LinkedField",
+                    "name": "counts",
+                    "plural": true,
+                    "selections": [
+                      (v8/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "value",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "count",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v9/*: any*/),
+              {
+                "condition": "shouldFetchCounts",
+                "kind": "Condition",
+                "passingValue": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FilterArtworksCounts",
+                    "kind": "LinkedField",
+                    "name": "counts",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "followedArtists",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ]
+              }
+            ],
+            "storageKey": null
+          },
           {
             "alias": "filtered_artworks",
             "args": [
@@ -444,14 +573,14 @@ return {
                 "name": "first",
                 "value": 30
               },
-              (v4/*: any*/)
+              (v5/*: any*/)
             ],
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
+              (v9/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -492,7 +621,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v10/*: any*/),
+                    "selections": (v12/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -502,7 +631,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v10/*: any*/),
+                    "selections": (v12/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -512,7 +641,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v10/*: any*/),
+                    "selections": (v12/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -523,8 +652,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v8/*: any*/),
-                      (v9/*: any*/)
+                      (v10/*: any*/),
+                      (v11/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -547,10 +676,10 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v7/*: any*/),
-                      (v5/*: any*/),
-                      (v11/*: any*/),
+                      (v9/*: any*/),
                       (v6/*: any*/),
+                      (v13/*: any*/),
+                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -640,15 +769,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v12/*: any*/),
+                        "args": (v14/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v7/*: any*/),
-                          (v11/*: any*/),
-                          (v13/*: any*/)
+                          (v9/*: any*/),
+                          (v13/*: any*/),
+                          (v8/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -661,15 +790,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v12/*: any*/),
+                        "args": (v14/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
+                          (v8/*: any*/),
                           (v13/*: any*/),
-                          (v11/*: any*/),
-                          (v7/*: any*/),
+                          (v9/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -702,7 +831,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v7/*: any*/),
+                          (v9/*: any*/),
                           {
                             "alias": "is_live_open",
                             "args": null,
@@ -767,7 +896,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v14/*: any*/),
+                            "selections": (v15/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -777,10 +906,10 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v14/*: any*/),
+                            "selections": (v15/*: any*/),
                             "storageKey": null
                           },
-                          (v7/*: any*/)
+                          (v9/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -801,7 +930,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v7/*: any*/)
+                  (v9/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -810,7 +939,7 @@ return {
           },
           (v2/*: any*/),
           (v3/*: any*/),
-          (v7/*: any*/)
+          (v9/*: any*/)
         ],
         "storageKey": null
       }
@@ -821,9 +950,9 @@ return {
     "metadata": {},
     "name": "partnerRoutes_WorksQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_WorksQuery(\n  $partnerId: String!\n  $input: FilterArtworksInput\n) {\n  partner(id: $partnerId) @principalField {\n    ...Works_partner_2VV6jB\n    displayWorksSection\n    counts {\n      eligibleArtworks\n    }\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Works_partner_2VV6jB on Partner {\n  slug\n  internalID\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
+    "text": "query partnerRoutes_WorksQuery(\n  $partnerId: String!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n  $shouldFetchCounts: Boolean!\n) {\n  partner(id: $partnerId) @principalField {\n    ...Works_partner_3TMxyn\n    displayWorksSection\n    counts {\n      eligibleArtworks\n    }\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image {\n        aspect_ratio: aspectRatio\n      }\n      ...GridItem_artwork\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  image_title: imageTitle\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio: aspectRatio\n  }\n  artistNames\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment Works_partner_3TMxyn on Partner {\n  slug\n  internalID\n  sidebar: filterArtworksConnection(first: 1, aggregations: $aggregations) {\n    counts @include(if: $shouldFetchCounts) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '12a6ff8ed103c7b7e65f770e2857c726';
+(node as any).hash = '54ff8997bbd1ddd6d2c5f81d87313eb1';
 export default node;


### PR DESCRIPTION
Type: **Feature**
Jira ticket: [FX-3061], [FX-3087]

### Description
* As a user, I expect to see all relevant filters for each surface. 
* This ticket is to align our current filters with a consistent order and default open view
* All filters collapsed by default in mWeb.
* Initial PR #7971 

##### Filters (Top to Bottom)
* Filters (Top to Bottom)
* Artists (Default Open)
* Rarity (Default Open)
* Medium (Default Open)
* Price (Default Open)
* Size (Default Open)
* Ways to Buy (Default Open)
* Material
* Artist Nationality & Ethnicity
* Time Period
* Color 

<details><summary>UI updates</summary>

### Web
![screencapture-localhost-5000-partner-pontone-galle](https://user-images.githubusercontent.com/3513494/126328845-546cf61f-10ef-48ba-9c1a-cd495517e93f.png)


#### Mobile
![screencapture-localhost-5000-partner-pontone-gallery-works-2021-07-20-15_59_59](https://user-images.githubusercontent.com/3513494/126328866-6259526e-d10b-4d1b-a345-b6797a6da3b7.png)

</details>


[FX-3061]: https://artsyproduct.atlassian.net/browse/FX-3061
[FX-3087]: https://artsyproduct.atlassian.net/browse/FX-3087