### PR TITLE
feature: Server Timing Headers

### DIFF
--- a/src/desktop/apps/art_keeps_going/routes.tsx
+++ b/src/desktop/apps/art_keeps_going/routes.tsx
@@ -4,11 +4,12 @@ import { featureAKGRoutes } from "v2/Apps/FeatureAKG/featureAKGRoutes"
 // @ts-ignore
 import JSONPage from "../../components/json_page"
 import React from "react"
-import { NextFunction, Request, Response } from "express"
+import { NextFunction } from "express"
+import type { ArtsyRequest, ArtsyResponse } from "lib/middleware/artsyExpress"
 
 export const landingPage = async (
-  req: Request,
-  res: Response,
+  req: ArtsyRequest,
+  res: ArtsyResponse,
   next: NextFunction
 ) => {
   try {

--- a/src/desktop/apps/fair_redirect/__tests__/fairRedirectionMiddleware.jest.ts
+++ b/src/desktop/apps/fair_redirect/__tests__/fairRedirectionMiddleware.jest.ts
@@ -3,19 +3,19 @@ import { ArtsyRequest, ArtsyResponse } from "lib/middleware/artsyExpress"
 import { fairRedirectionMiddleware } from "../fairRedirectionMiddleware"
 
 describe("fairRedirectionMiddleware", () => {
-  let req: Partial<ArtsyRequest>
-  let res: Partial<ArtsyResponse>
+  let req: ArtsyRequest
+  let res: ArtsyResponse
   let next: jest.Mock<NextFunction>
 
   beforeEach(() => {
     jest.resetModules()
 
-    req = {
+    req = ({
       params: { id: "big-expo" },
       route: "/:id",
-    }
+    } as unknown) as ArtsyRequest
 
-    res = {
+    res = ({
       locals: {
         profile: {
           get: jest.fn(attr => {
@@ -25,7 +25,7 @@ describe("fairRedirectionMiddleware", () => {
         },
       },
       redirect: jest.fn(),
-    }
+    } as unknown) as ArtsyResponse
 
     next = jest.fn()
   })

--- a/src/desktop/apps/fair_redirect/fairRedirectionMiddleware.ts
+++ b/src/desktop/apps/fair_redirect/fairRedirectionMiddleware.ts
@@ -2,8 +2,8 @@ import { NextFunction } from "express"
 import { ArtsyRequest, ArtsyResponse } from "lib/middleware/artsyExpress"
 
 export const fairRedirectionMiddleware = (
-  req: Partial<ArtsyRequest>,
-  res: Partial<ArtsyResponse>,
+  req: ArtsyRequest,
+  res: ArtsyResponse,
   next: NextFunction
 ): void => {
   const isFairProfile = res.locals?.profile?.get("owner_type") === "Fair"
@@ -13,7 +13,6 @@ export const fairRedirectionMiddleware = (
   const fairSlug: string | null = res.locals.profile.get("owner")?.id
 
   if (!fairSlug) {
-    // @ts-expect-error STRICT_NULL_CHECK
     return res.redirect(302, "/art-fairs")
   }
 
@@ -21,16 +20,13 @@ export const fairRedirectionMiddleware = (
 
   // this matches all /:id/info/* requests
   if (req.route.path === "/:id/:tab*" && res.locals.tab === "info") {
-    // @ts-expect-error STRICT_NULL_CHECK
     return res.redirect(301, `/fair/${fairSlug}/info`)
   }
 
   // this matches /:id/browse/artworks, but not /:id/browse/exhibitors
   if (req.route.path === "/:id/browse/*" && req.params["0"] === "artworks") {
-    // @ts-expect-error STRICT_NULL_CHECK
     return res.redirect(301, `/fair/${fairSlug}/artworks`)
   }
 
-  // @ts-expect-error STRICT_NULL_CHECK
   return res.redirect(301, basePath)
 }

--- a/src/desktop/apps/partner_redirect/__tests__/partnerRedirectionMiddleware.jest.ts
+++ b/src/desktop/apps/partner_redirect/__tests__/partnerRedirectionMiddleware.jest.ts
@@ -3,14 +3,14 @@ import { ArtsyRequest, ArtsyResponse } from "lib/middleware/artsyExpress"
 import { partnerRedirectionMiddleware } from "../partnerRedirectionMiddleware"
 
 describe("partnerRedirectionMiddleware", () => {
-  let req: Partial<ArtsyRequest>
-  let res: Partial<ArtsyResponse>
+  let req: ArtsyRequest
+  let res: ArtsyResponse
   let next: jest.Mock<NextFunction>
 
   beforeEach(() => {
     jest.resetModules()
 
-    res = {
+    res = ({
       locals: {
         profile: {
           isPartner: jest.fn(() => {
@@ -22,7 +22,7 @@ describe("partnerRedirectionMiddleware", () => {
         },
       },
       redirect: jest.fn(),
-    }
+    } as unknown) as ArtsyResponse
 
     next = jest.fn()
   })
@@ -99,7 +99,11 @@ describe("partnerRedirectionMiddleware", () => {
   ])(
     "redirects %s to %s",
     (route: string, result: string, path: string, params: any) => {
-      req = { route: { path: route }, path, params }
+      req = ({
+        route: { path: route },
+        path,
+        params,
+      } as unknown) as ArtsyRequest
 
       partnerRedirectionMiddleware(req, res, next)
 
@@ -108,7 +112,7 @@ describe("partnerRedirectionMiddleware", () => {
   )
 
   it("does not redirect is not a partner", () => {
-    res = {
+    res = ({
       locals: {
         profile: {
           isPartner: jest.fn(() => {
@@ -117,7 +121,7 @@ describe("partnerRedirectionMiddleware", () => {
         },
       },
       redirect: jest.fn(),
-    }
+    } as unknown) as ArtsyResponse
 
     partnerRedirectionMiddleware(req, res, next)
 

--- a/src/desktop/apps/partner_redirect/partnerRedirectionMiddleware.ts
+++ b/src/desktop/apps/partner_redirect/partnerRedirectionMiddleware.ts
@@ -2,8 +2,8 @@ import { NextFunction } from "express"
 import { ArtsyRequest, ArtsyResponse } from "lib/middleware/artsyExpress"
 
 export const partnerRedirectionMiddleware = (
-  req: Partial<ArtsyRequest>,
-  res: Partial<ArtsyResponse>,
+  req: ArtsyRequest,
+  res: ArtsyResponse,
   next: NextFunction
 ) => {
   if (!res.locals?.profile?.isPartner() || !res.redirect) return next()

--- a/src/lib/middleware/artsyExpress.ts
+++ b/src/lib/middleware/artsyExpress.ts
@@ -2,14 +2,18 @@ import type { Request, Response } from "express"
 
 export interface ArtsyRequest extends Request {
   _parsedUrl?: any
-  timedout?: any
-  session?: any
   id?: any
+  session?: any
+  timedout?: any
   user?: any
 }
 
 export interface ArtsyResponse extends Response {
+  _headers: any[]
+  backboneError?: any
   cookie: any
   locals: any
-  backboneError?: any
+  perfStart: any
+  serverTimingHeaders?: Map<string, number | null>
+  serverTimingHeadersWritten?: boolean
 }

--- a/src/lib/middleware/serverTimingHeaders.ts
+++ b/src/lib/middleware/serverTimingHeaders.ts
@@ -1,0 +1,52 @@
+import type { NextFunction } from "express"
+import type { ArtsyRequest, ArtsyResponse } from "./artsyExpress"
+
+export function setTimingHeader(
+  res: ArtsyResponse,
+  name: string,
+  durationMilli: number | null = null
+) {
+  if (res.serverTimingHeadersWritten) {
+    console.warn(
+      `Header: ${name} will not be sent, response headers have already been sent.`
+    )
+  }
+  res.serverTimingHeaders!.set(name, durationMilli)
+}
+
+export function serverTimingHeaders(
+  req: ArtsyRequest,
+  res: ArtsyResponse,
+  next: NextFunction
+) {
+  if (req.query.serverTiming !== "true") {
+    return next()
+  }
+
+  res.perfStart = Date.now()
+  res.serverTimingHeaders = new Map<string, number | null>()
+
+  const defaultWritehead = res.writeHead
+
+  res.writeHead = function () {
+    const perfEnd = Date.now()
+    setTimingHeader(res, "total", perfEnd - res.perfStart)
+
+    const timingHeaders: string[] = []
+    for (const key of res.serverTimingHeaders!.keys()) {
+      const duration = res.serverTimingHeaders!.get(key)
+
+      if (duration === null) {
+        timingHeaders.push(key)
+      } else {
+        timingHeaders.push(`${key};dur=${duration}`)
+      }
+    }
+
+    res.serverTimingHeadersWritten = true
+    res.set("Server-Timing", timingHeaders.join(", "))
+
+    return defaultWritehead.apply(this, arguments)
+  }
+  next()
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -45,6 +45,7 @@ import { pageCacheMiddleware } from "./lib/middleware/pageCache"
 import { sameOriginMiddleware } from "./lib/middleware/sameOrigin"
 import { unsupportedBrowserMiddleware } from "./lib/middleware/unsupportedBrowser"
 import { backboneSync } from "lib/backboneSync"
+import { serverTimingHeaders } from "lib/middleware/serverTimingHeaders"
 
 // App-specific V2 server-side functionality
 import { artistMiddleware } from "lib/middleware/artistMiddleware"
@@ -68,6 +69,8 @@ const {
 } = config
 
 export function initializeMiddleware(app) {
+  app.use(serverTimingHeaders)
+
   app.set("trust proxy", true)
 
   // Setup error handling

--- a/src/v2/System/Router/__tests__/buildServerApp.jest.tsx
+++ b/src/v2/System/Router/__tests__/buildServerApp.jest.tsx
@@ -14,7 +14,8 @@ import ReactDOMServer from "react-dom/server"
 import { Title } from "react-head"
 import { graphql } from "react-relay"
 import { Media } from "v2/Utils/Responsive"
-import { Request, Response } from "express"
+import { Request } from "express"
+import type { ArtsyResponse } from "lib/middleware/artsyExpress"
 import { createMockNetworkLayer } from "v2/DevTools/createMockNetworkLayer"
 
 jest.unmock("react-relay")
@@ -34,7 +35,7 @@ jest.mock("@loadable/server", () => ({
 const defaultComponent = () => <div>hi!</div>
 
 describe("buildServerApp", () => {
-  let res: Response
+  let res: ArtsyResponse
   let req: Request
   let options: Pick<
     ServerRouterConfig,
@@ -45,7 +46,7 @@ describe("buildServerApp", () => {
   beforeEach(() => {
     res = {
       locals: { sd: {} },
-    } as Response
+    } as ArtsyResponse
     let req = ({
       path: "/",
       url: "/",

--- a/src/v2/System/Router/buildServerApp.tsx
+++ b/src/v2/System/Router/buildServerApp.tsx
@@ -12,7 +12,7 @@ import {
   getFarceResult,
 } from "found/server"
 import qs from "qs"
-import { Request, Response } from "express"
+import type { ArtsyRequest, ArtsyResponse } from "lib/middleware/artsyExpress"
 import { createQueryMiddleware } from "farce"
 
 import { createRelaySSREnvironment } from "v2/System/Relay/createRelaySSREnvironment"
@@ -49,8 +49,8 @@ const MediaStyle = createMediaStyle()
 const logger = createLogger("Artsy/Router/buildServerApp.tsx")
 
 export interface ServerRouterConfig extends RouterConfig {
-  req: Request
-  res: Response
+  req: ArtsyRequest
+  res: ArtsyResponse
   routes: AppRouteConfig[]
   context?: {
     injectedData?: any

--- a/src/v2/server.ts
+++ b/src/v2/server.ts
@@ -1,5 +1,6 @@
 import sharify from "sharify"
-import type { NextFunction, Request, Response } from "express"
+import type { NextFunction } from "express"
+import type { ArtsyRequest, ArtsyResponse } from "lib/middleware/artsyExpress"
 import { buildServerApp } from "v2/System/Router/server"
 import { getAppRoutes } from "v2/routes"
 import { flatten } from "lodash"
@@ -55,77 +56,80 @@ if (appRoutes) {
 /**
  * Mount routes that will connect to global SSR router
  */
-app.get(flatRoutes, async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const {
-      status,
-      styleTags,
-      scripts,
-      redirect,
-      bodyHTML,
-      headTags,
-    } = await buildServerApp(
-      {
-        req,
-        res,
-        routes,
-      },
-      "loadable-novo-stats.json",
-      "public/assets",
-      "/assets"
-    )
-
-    if (redirect) {
-      res.redirect(status ?? 302, redirect.url)
-      return
-    }
-
-    const headTagsString = ReactDOM.renderToString(headTags as any)
-    const sharifyData = res.locals.sharify.script()
-
-    const { APP_URL, CURRENT_PATH, WEBFONT_URL } = sharify.data
-
-    const options = {
-      cdnUrl: NODE_ENV === "production" ? CDN_URL : "",
-      content: {
-        body: bodyHTML,
-        data: sharifyData,
-        head: headTagsString,
+app.get(
+  flatRoutes,
+  async (req: ArtsyRequest, res: ArtsyResponse, next: NextFunction) => {
+    try {
+      const {
+        status,
+        styleTags,
         scripts,
-        style: styleTags,
-      },
-      disable: {
-        analytics: getServerParam(req, "disableAnalytics") === "true",
-        postie: getServerParam(req, "disablePostie") === "true",
-        segment: getServerParam(req, "disableSegment") === "true",
-        stripe: getServerParam(req, "disableStripe") === "true",
-      },
-      env: NODE_ENV,
-      fontUrl: WEBFONT_URL,
-      icons: {
-        // TODO: Move to new assset pipeline, this adds the CDN for images.
-        favicon: res.locals.asset("/images/favicon.ico"),
-        icon120: res.locals.asset("/images/icon-120.png"),
-        icon152: res.locals.asset("/images/icon-152.png"),
-        icon76: res.locals.asset("/images/icon-76.png"),
-      },
-      manifest: {
-        browserConfig: NOVO_MANIFEST.lookup("/images/browserconfig.xml"),
-        openSearch: NOVO_MANIFEST.lookup("/images/opensearch.xml"),
-      },
-      meta: {
-        appleItunesApp: `${APP_URL}${CURRENT_PATH}`,
-      },
-      // TODO: Post-release review that sharify is still used in the template.
-      sd: sharify.data,
-    }
+        redirect,
+        bodyHTML,
+        headTags,
+      } = await buildServerApp(
+        {
+          req,
+          res,
+          routes,
+        },
+        "loadable-novo-stats.json",
+        "public/assets",
+        "/assets"
+      )
 
-    res.render(`${PUBLIC_DIR}/index.ejs`, options)
-  } catch (error) {
-    console.error(error)
-    next(error)
+      if (redirect) {
+        res.redirect(status ?? 302, redirect.url)
+        return
+      }
+
+      const headTagsString = ReactDOM.renderToString(headTags as any)
+      const sharifyData = res.locals.sharify.script()
+
+      const { APP_URL, CURRENT_PATH, WEBFONT_URL } = sharify.data
+
+      const options = {
+        cdnUrl: NODE_ENV === "production" ? CDN_URL : "",
+        content: {
+          body: bodyHTML,
+          data: sharifyData,
+          head: headTagsString,
+          scripts,
+          style: styleTags,
+        },
+        disable: {
+          analytics: getServerParam(req, "disableAnalytics") === "true",
+          postie: getServerParam(req, "disablePostie") === "true",
+          segment: getServerParam(req, "disableSegment") === "true",
+          stripe: getServerParam(req, "disableStripe") === "true",
+        },
+        env: NODE_ENV,
+        fontUrl: WEBFONT_URL,
+        icons: {
+          // TODO: Move to new assset pipeline, this adds the CDN for images.
+          favicon: res.locals.asset("/images/favicon.ico"),
+          icon120: res.locals.asset("/images/icon-120.png"),
+          icon152: res.locals.asset("/images/icon-152.png"),
+          icon76: res.locals.asset("/images/icon-76.png"),
+        },
+        manifest: {
+          browserConfig: NOVO_MANIFEST.lookup("/images/browserconfig.xml"),
+          openSearch: NOVO_MANIFEST.lookup("/images/opensearch.xml"),
+        },
+        meta: {
+          appleItunesApp: `${APP_URL}${CURRENT_PATH}`,
+        },
+        // TODO: Post-release review that sharify is still used in the template.
+        sd: sharify.data,
+      }
+
+      res.render(`${PUBLIC_DIR}/index.ejs`, options)
+    } catch (error) {
+      console.error(error)
+      next(error)
+    }
   }
-})
+)
 
 // This export form is required for express-reloadable
 // TODO: Remove when no longer needed for hot reloading


### PR DESCRIPTION
Enables server timing headers to help identify performance issues. Then
headers when enabled follow the Server Timing spec:

https://w3c.github.io/server-timing/#the-server-timing-header-field

Additionally, there is a separate commit that correctly sets the types for
Response and Request options to fix type errors.

<img width="1347" alt="server-timing" src="https://user-images.githubusercontent.com/403814/126359861-0f5b4dcb-5ea4-4748-b188-14bedb3396a7.png">
