### PR TITLE
fix(PURCHASE-2821): Forward search string in order "respond" step redirects

### DIFF
--- a/src/v2/Apps/Order/OrderApp.tsx
+++ b/src/v2/Apps/Order/OrderApp.tsx
@@ -132,7 +132,7 @@ class OrderApp extends React.Component<OrderAppProps, {}> {
 
     const stripePromise = loadStripe(sd.STRIPE_PUBLISHABLE_KEY)
 
-    const isModal = this.props.match?.location.query.isModal ? true : false
+    const isModal = !!this.props.match?.location.query.isModal
 
     return (
       <SystemContextConsumer>

--- a/src/v2/Apps/Order/Routes/Respond/index.tsx
+++ b/src/v2/Apps/Order/Routes/Respond/index.tsx
@@ -25,7 +25,7 @@ import {
 import { track } from "v2/System"
 import * as Schema from "v2/System/Analytics/Schema"
 import { CountdownTimer } from "v2/Components/CountdownTimer"
-import { Router } from "found"
+import { RouterState } from "found"
 import React, { Component } from "react"
 import { RelayProp, createFragmentContainer, graphql } from "react-relay"
 import createLogger from "v2/Utils/logger"
@@ -40,10 +40,9 @@ import {
 import { ShippingSummaryItemFragmentContainer as ShippingSummaryItem } from "../../Components/ShippingSummaryItem"
 import { BuyerGuarantee } from "../../Components/BuyerGuarantee"
 
-export interface RespondProps {
+export interface RespondProps extends RouterState {
   order: Respond_order
   relay?: RelayProp
-  router: Router
   dialog: Dialog
   commitMutation: CommitMutation
   isCommittingMutation: boolean
@@ -119,16 +118,18 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
       highSpeedBumpEncountered,
     } = this.state
 
+    const search = this.props.match?.location.search || ""
+
     if (responseOption === "ACCEPT") {
       this.props.router.push(
-        `/orders/${this.props.order.internalID}/review/accept`
+        `/orders/${this.props.order.internalID}/review/accept${search}`
       )
       return
     }
 
     if (responseOption === "DECLINE") {
       this.props.router.push(
-        `/orders/${this.props.order.internalID}/review/decline`
+        `/orders/${this.props.order.internalID}/review/decline${search}`
       )
       return
     }
@@ -177,7 +178,7 @@ export class RespondRoute extends Component<RespondProps, RespondState> {
       }
 
       this.props.router.push(
-        `/orders/${this.props.order.internalID}/review/counter`
+        `/orders/${this.props.order.internalID}/review/counter${search}`
       )
     } catch (error) {
       logger.error(error)


### PR DESCRIPTION
Solves https://artsyproduct.atlassian.net/browse/PURCHASE-2821
Collector sends an offer in inquiry, gallery sends a counteroffer, the collector opens counteroffer respond modal and sees there "respond" step (without a header and a footer, as intended)
![image](https://user-images.githubusercontent.com/19696618/126410213-3308851a-6361-4596-b392-984276886f85.png)
After accepting, declining, or sending a counteroffer the modal gets a header and a footer as on a full page. 
![image](https://user-images.githubusercontent.com/19696618/126410318-5f93c50f-f76e-4419-b8ef-53850573f08e.png)
That happens because the "isModal" state is passing in the search string and moving to the next step is handled by the router without preserving the search string. 

This PR resolves this issue by passing the current search string to a new route on redirect. 
As a result: 
![image](https://user-images.githubusercontent.com/19696618/126410809-21f3bb62-e778-4521-882c-386a2139cefb.png)


