### PR TITLE
Revert "FX-3071 feat: Added pagination to fair booths page"

### DIFF
--- a/src/v2/Apps/Fair/Components/ExhibitorFilterContext.tsx
+++ b/src/v2/Apps/Fair/Components/ExhibitorFilterContext.tsx
@@ -6,7 +6,6 @@ import { SortOptions } from "v2/Components/SortFilter"
 
 export interface ExhibitorFilters {
   sort?: string
-  page?: number
 }
 
 export interface ExhibitorFiltersState extends ExhibitorFilters {
@@ -38,7 +37,6 @@ interface ExhibitorFiltersAction {
 
 export const initialExhibitorFilterState: ExhibitorFilters = {
   sort: "-decayed_merch",
-  page: 1,
 }
 
 export const ExhibitorFilterContext = createContext<
@@ -113,11 +111,7 @@ const exhibitorFilterReducer = (
     case "SET": {
       const { name, value } = action.payload
 
-      let filterState: ExhibitorFilters = { page: 1 }
-
-      if (name === "page") {
-        filterState[name] = Number(value)
-      }
+      let filterState: ExhibitorFilters = {}
 
       const primitiveFilterTypes: Array<keyof ExhibitorFilters> = ["sort"]
       primitiveFilterTypes.forEach(filter => {

--- a/src/v2/Apps/Fair/Routes/FairExhibitorsQuery.tsx
+++ b/src/v2/Apps/Fair/Routes/FairExhibitorsQuery.tsx
@@ -4,11 +4,12 @@ export const FairExhibitorsQuery = graphql`
   query FairExhibitorsQuery(
     $id: String!
     $first: Int
-    $page: Int
+    $after: String
     $sort: ShowSorts
   ) {
     fair(id: $id) {
-      ...FairExhibitors_fair @arguments(first: $first, page: $page, sort: $sort)
+      ...FairExhibitors_fair
+        @arguments(first: $first, after: $after, sort: $sort)
     }
   }
 `

--- a/src/v2/Apps/Fair/fairRoutes.tsx
+++ b/src/v2/Apps/Fair/fairRoutes.tsx
@@ -72,20 +72,19 @@ export const fairRoutes: AppRouteConfig[] = [
           FairExhibitorsRoute.preload()
         },
         prepareVariables: ({ slug }, { location }) => {
-          let { sort, page } = location.query
+          let { sort } = location.query
           if (!isValidSort(sort)) {
             sort = defaultSort
           }
-          return { sort, page, slug }
+          return { sort, slug }
         },
         query: graphql`
           query fairRoutes_FairExhibitorsQuery(
             $slug: String!
-            $page: Int
             $sort: ShowSorts
           ) {
             fair(id: $slug) @principalField {
-              ...FairExhibitors_fair @arguments(sort: $sort, page: $page)
+              ...FairExhibitors_fair @arguments(sort: $sort)
             }
           }
         `,

--- a/src/v2/__generated__/FairExhibitorsQuery.graphql.ts
+++ b/src/v2/__generated__/FairExhibitorsQuery.graphql.ts
@@ -7,7 +7,7 @@ export type ShowSorts = "END_AT_ASC" | "END_AT_DESC" | "FEATURED_ASC" | "FEATURE
 export type FairExhibitorsQueryVariables = {
     id: string;
     first?: number | null;
-    page?: number | null;
+    after?: string | null;
     sort?: ShowSorts | null;
 };
 export type FairExhibitorsQueryResponse = {
@@ -26,11 +26,11 @@ export type FairExhibitorsQuery = {
 query FairExhibitorsQuery(
   $id: String!
   $first: Int
-  $page: Int
+  $after: String
   $sort: ShowSorts
 ) {
   fair(id: $id) {
-    ...FairExhibitors_fair_1HMhop
+    ...FairExhibitors_fair_dWkdd
     id
   }
 }
@@ -57,15 +57,9 @@ fragment FairExhibitorRail_show on Show {
   }
 }
 
-fragment FairExhibitors_fair_1HMhop on Fair {
+fragment FairExhibitors_fair_dWkdd on Fair {
   slug
-  exhibitors: showsConnection(sort: $sort, first: $first, page: $page, totalCount: true) {
-    pageInfo {
-      hasNextPage
-    }
-    pageCursors {
-      ...Pagination_pageCursors
-    }
+  exhibitors: showsConnection(sort: $sort, first: $first, after: $after, totalCount: true) {
     edges {
       node {
         id
@@ -85,30 +79,14 @@ fragment FairExhibitors_fair_1HMhop on Fair {
           }
         }
         ...FairExhibitorRail_show
+        __typename
       }
+      cursor
     }
-  }
-}
-
-fragment Pagination_pageCursors on PageCursors {
-  around {
-    cursor
-    page
-    isCurrent
-  }
-  first {
-    cursor
-    page
-    isCurrent
-  }
-  last {
-    cursor
-    page
-    isCurrent
-  }
-  previous {
-    cursor
-    page
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
   }
 }
 */
@@ -130,8 +108,8 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "page",
-    "type": "Int"
+    "name": "after",
+    "type": "String"
   },
   {
     "defaultValue": null,
@@ -149,13 +127,13 @@ v1 = [
 ],
 v2 = {
   "kind": "Variable",
-  "name": "first",
-  "variableName": "first"
+  "name": "after",
+  "variableName": "after"
 },
 v3 = {
   "kind": "Variable",
-  "name": "page",
-  "variableName": "page"
+  "name": "first",
+  "variableName": "first"
 },
 v4 = {
   "kind": "Variable",
@@ -169,39 +147,31 @@ v5 = {
   "name": "slug",
   "storageKey": null
 },
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "cursor",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "page",
-  "storageKey": null
-},
-v8 = [
-  (v6/*: any*/),
-  (v7/*: any*/),
+v6 = [
+  (v2/*: any*/),
+  (v3/*: any*/),
+  (v4/*: any*/),
   {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "isCurrent",
-    "storageKey": null
+    "kind": "Literal",
+    "name": "totalCount",
+    "value": true
   }
 ],
-v9 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v10 = [
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -257,93 +227,12 @@ return {
           (v5/*: any*/),
           {
             "alias": "exhibitors",
-            "args": [
-              (v2/*: any*/),
-              (v3/*: any*/),
-              (v4/*: any*/),
-              {
-                "kind": "Literal",
-                "name": "totalCount",
-                "value": true
-              }
-            ],
+            "args": (v6/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "PageInfo",
-                "kind": "LinkedField",
-                "name": "pageInfo",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "hasNextPage",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "PageCursors",
-                "kind": "LinkedField",
-                "name": "pageCursors",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PageCursor",
-                    "kind": "LinkedField",
-                    "name": "around",
-                    "plural": true,
-                    "selections": (v8/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PageCursor",
-                    "kind": "LinkedField",
-                    "name": "first",
-                    "plural": false,
-                    "selections": (v8/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PageCursor",
-                    "kind": "LinkedField",
-                    "name": "last",
-                    "plural": false,
-                    "selections": (v8/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PageCursor",
-                    "kind": "LinkedField",
-                    "name": "previous",
-                    "plural": false,
-                    "selections": [
-                      (v6/*: any*/),
-                      (v7/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
               {
                 "alias": null,
                 "args": null,
@@ -360,7 +249,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v9/*: any*/),
+                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -387,22 +276,16 @@ return {
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "__typename",
-                            "storageKey": null
-                          },
-                          (v9/*: any*/),
+                          (v8/*: any*/),
+                          (v7/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v10/*: any*/),
+                            "selections": (v9/*: any*/),
                             "type": "Partner"
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v10/*: any*/),
+                            "selections": (v9/*: any*/),
                             "type": "ExternalPartner"
                           }
                         ],
@@ -422,8 +305,41 @@ return {
                         "kind": "ScalarField",
                         "name": "href",
                         "storageKey": null
-                      }
+                      },
+                      (v8/*: any*/)
                     ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "cursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
                     "storageKey": null
                   }
                 ],
@@ -432,7 +348,19 @@ return {
             ],
             "storageKey": null
           },
-          (v9/*: any*/)
+          {
+            "alias": "exhibitors",
+            "args": (v6/*: any*/),
+            "filters": [
+              "sort",
+              "totalCount"
+            ],
+            "handle": "connection",
+            "key": "FairExhibitorsQuery_exhibitors",
+            "kind": "LinkedHandle",
+            "name": "showsConnection"
+          },
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
@@ -443,9 +371,9 @@ return {
     "metadata": {},
     "name": "FairExhibitorsQuery",
     "operationKind": "query",
-    "text": "query FairExhibitorsQuery(\n  $id: String!\n  $first: Int\n  $page: Int\n  $sort: ShowSorts\n) {\n  fair(id: $id) {\n    ...FairExhibitors_fair_1HMhop\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  slug\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair_1HMhop on Fair {\n  slug\n  exhibitors: showsConnection(sort: $sort, first: $first, page: $page, totalCount: true) {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query FairExhibitorsQuery(\n  $id: String!\n  $first: Int\n  $after: String\n  $sort: ShowSorts\n) {\n  fair(id: $id) {\n    ...FairExhibitors_fair_dWkdd\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  slug\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair_dWkdd on Fair {\n  slug\n  exhibitors: showsConnection(sort: $sort, first: $first, after: $after, totalCount: true) {\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '49b59f53dae7b90af4100b8610e879ac';
+(node as any).hash = '38ad647ea133984ebba4657c2ef1ed6f';
 export default node;

--- a/src/v2/__generated__/FairExhibitors_Query.graphql.ts
+++ b/src/v2/__generated__/FairExhibitors_Query.graphql.ts
@@ -7,7 +7,7 @@ export type ShowSorts = "END_AT_ASC" | "END_AT_DESC" | "FEATURED_ASC" | "FEATURE
 export type FairExhibitors_QueryVariables = {
     id: string;
     first?: number | null;
-    page?: number | null;
+    after?: string | null;
     sort?: ShowSorts | null;
 };
 export type FairExhibitors_QueryResponse = {
@@ -19,30 +19,6 @@ export type FairExhibitors_QueryRawResponse = {
     readonly fair: ({
         readonly slug: string;
         readonly exhibitors: ({
-            readonly pageInfo: {
-                readonly hasNextPage: boolean;
-            };
-            readonly pageCursors: {
-                readonly around: ReadonlyArray<{
-                    readonly cursor: string;
-                    readonly page: number;
-                    readonly isCurrent: boolean;
-                }>;
-                readonly first: ({
-                    readonly cursor: string;
-                    readonly page: number;
-                    readonly isCurrent: boolean;
-                }) | null;
-                readonly last: ({
-                    readonly cursor: string;
-                    readonly page: number;
-                    readonly isCurrent: boolean;
-                }) | null;
-                readonly previous: ({
-                    readonly cursor: string;
-                    readonly page: number;
-                }) | null;
-            };
             readonly edges: ReadonlyArray<({
                 readonly node: ({
                     readonly id: string;
@@ -64,8 +40,14 @@ export type FairExhibitors_QueryRawResponse = {
                     readonly internalID: string;
                     readonly slug: string;
                     readonly href: string | null;
+                    readonly __typename: "Show";
                 }) | null;
+                readonly cursor: string;
             }) | null> | null;
+            readonly pageInfo: {
+                readonly endCursor: string | null;
+                readonly hasNextPage: boolean;
+            };
         }) | null;
         readonly id: string | null;
     }) | null;
@@ -82,11 +64,11 @@ export type FairExhibitors_Query = {
 query FairExhibitors_Query(
   $id: String!
   $first: Int
-  $page: Int
+  $after: String
   $sort: ShowSorts
 ) {
   fair(id: $id) {
-    ...FairExhibitors_fair_1HMhop
+    ...FairExhibitors_fair_dWkdd
     id
   }
 }
@@ -113,15 +95,9 @@ fragment FairExhibitorRail_show on Show {
   }
 }
 
-fragment FairExhibitors_fair_1HMhop on Fair {
+fragment FairExhibitors_fair_dWkdd on Fair {
   slug
-  exhibitors: showsConnection(sort: $sort, first: $first, page: $page, totalCount: true) {
-    pageInfo {
-      hasNextPage
-    }
-    pageCursors {
-      ...Pagination_pageCursors
-    }
+  exhibitors: showsConnection(sort: $sort, first: $first, after: $after, totalCount: true) {
     edges {
       node {
         id
@@ -141,30 +117,14 @@ fragment FairExhibitors_fair_1HMhop on Fair {
           }
         }
         ...FairExhibitorRail_show
+        __typename
       }
+      cursor
     }
-  }
-}
-
-fragment Pagination_pageCursors on PageCursors {
-  around {
-    cursor
-    page
-    isCurrent
-  }
-  first {
-    cursor
-    page
-    isCurrent
-  }
-  last {
-    cursor
-    page
-    isCurrent
-  }
-  previous {
-    cursor
-    page
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
   }
 }
 */
@@ -186,8 +146,8 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "page",
-    "type": "Int"
+    "name": "after",
+    "type": "String"
   },
   {
     "defaultValue": null,
@@ -205,13 +165,13 @@ v1 = [
 ],
 v2 = {
   "kind": "Variable",
-  "name": "first",
-  "variableName": "first"
+  "name": "after",
+  "variableName": "after"
 },
 v3 = {
   "kind": "Variable",
-  "name": "page",
-  "variableName": "page"
+  "name": "first",
+  "variableName": "first"
 },
 v4 = {
   "kind": "Variable",
@@ -225,39 +185,31 @@ v5 = {
   "name": "slug",
   "storageKey": null
 },
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "cursor",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "page",
-  "storageKey": null
-},
-v8 = [
-  (v6/*: any*/),
-  (v7/*: any*/),
+v6 = [
+  (v2/*: any*/),
+  (v3/*: any*/),
+  (v4/*: any*/),
   {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "isCurrent",
-    "storageKey": null
+    "kind": "Literal",
+    "name": "totalCount",
+    "value": true
   }
 ],
-v9 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v10 = [
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -313,93 +265,12 @@ return {
           (v5/*: any*/),
           {
             "alias": "exhibitors",
-            "args": [
-              (v2/*: any*/),
-              (v3/*: any*/),
-              (v4/*: any*/),
-              {
-                "kind": "Literal",
-                "name": "totalCount",
-                "value": true
-              }
-            ],
+            "args": (v6/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "PageInfo",
-                "kind": "LinkedField",
-                "name": "pageInfo",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "hasNextPage",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "PageCursors",
-                "kind": "LinkedField",
-                "name": "pageCursors",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PageCursor",
-                    "kind": "LinkedField",
-                    "name": "around",
-                    "plural": true,
-                    "selections": (v8/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PageCursor",
-                    "kind": "LinkedField",
-                    "name": "first",
-                    "plural": false,
-                    "selections": (v8/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PageCursor",
-                    "kind": "LinkedField",
-                    "name": "last",
-                    "plural": false,
-                    "selections": (v8/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PageCursor",
-                    "kind": "LinkedField",
-                    "name": "previous",
-                    "plural": false,
-                    "selections": [
-                      (v6/*: any*/),
-                      (v7/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
               {
                 "alias": null,
                 "args": null,
@@ -416,7 +287,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v9/*: any*/),
+                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -443,22 +314,16 @@ return {
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "__typename",
-                            "storageKey": null
-                          },
-                          (v9/*: any*/),
+                          (v8/*: any*/),
+                          (v7/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v10/*: any*/),
+                            "selections": (v9/*: any*/),
                             "type": "Partner"
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v10/*: any*/),
+                            "selections": (v9/*: any*/),
                             "type": "ExternalPartner"
                           }
                         ],
@@ -478,8 +343,41 @@ return {
                         "kind": "ScalarField",
                         "name": "href",
                         "storageKey": null
-                      }
+                      },
+                      (v8/*: any*/)
                     ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "cursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
                     "storageKey": null
                   }
                 ],
@@ -488,7 +386,19 @@ return {
             ],
             "storageKey": null
           },
-          (v9/*: any*/)
+          {
+            "alias": "exhibitors",
+            "args": (v6/*: any*/),
+            "filters": [
+              "sort",
+              "totalCount"
+            ],
+            "handle": "connection",
+            "key": "FairExhibitorsQuery_exhibitors",
+            "kind": "LinkedHandle",
+            "name": "showsConnection"
+          },
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
@@ -499,9 +409,9 @@ return {
     "metadata": {},
     "name": "FairExhibitors_Query",
     "operationKind": "query",
-    "text": "query FairExhibitors_Query(\n  $id: String!\n  $first: Int\n  $page: Int\n  $sort: ShowSorts\n) {\n  fair(id: $id) {\n    ...FairExhibitors_fair_1HMhop\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  slug\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair_1HMhop on Fair {\n  slug\n  exhibitors: showsConnection(sort: $sort, first: $first, page: $page, totalCount: true) {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query FairExhibitors_Query(\n  $id: String!\n  $first: Int\n  $after: String\n  $sort: ShowSorts\n) {\n  fair(id: $id) {\n    ...FairExhibitors_fair_dWkdd\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  slug\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair_dWkdd on Fair {\n  slug\n  exhibitors: showsConnection(sort: $sort, first: $first, after: $after, totalCount: true) {\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '8fd8155d6c4dec71d2acf1dec6f0cf2b';
+(node as any).hash = 'b2bfb1f8c654c92799ea39b5242f2163';
 export default node;

--- a/src/v2/__generated__/FairExhibitors_fair.graphql.ts
+++ b/src/v2/__generated__/FairExhibitors_fair.graphql.ts
@@ -6,12 +6,6 @@ import { FragmentRefs } from "relay-runtime";
 export type FairExhibitors_fair = {
     readonly slug: string;
     readonly exhibitors: {
-        readonly pageInfo: {
-            readonly hasNextPage: boolean;
-        };
-        readonly pageCursors: {
-            readonly " $fragmentRefs": FragmentRefs<"Pagination_pageCursors">;
-        };
         readonly edges: ReadonlyArray<{
             readonly node: {
                 readonly id: string;
@@ -61,14 +55,25 @@ return {
       "type": "Int"
     },
     {
-      "defaultValue": 1,
+      "defaultValue": null,
       "kind": "LocalArgument",
-      "name": "page",
-      "type": "Int"
+      "name": "after",
+      "type": "String"
     }
   ],
   "kind": "Fragment",
-  "metadata": null,
+  "metadata": {
+    "connection": [
+      {
+        "count": "first",
+        "cursor": "after",
+        "direction": "forward",
+        "path": [
+          "exhibitors"
+        ]
+      }
+    ]
+  },
   "name": "FairExhibitors_fair",
   "selections": [
     {
@@ -83,16 +88,6 @@ return {
       "args": [
         {
           "kind": "Variable",
-          "name": "first",
-          "variableName": "first"
-        },
-        {
-          "kind": "Variable",
-          "name": "page",
-          "variableName": "page"
-        },
-        {
-          "kind": "Variable",
           "name": "sort",
           "variableName": "sort"
         },
@@ -104,43 +99,9 @@ return {
       ],
       "concreteType": "ShowConnection",
       "kind": "LinkedField",
-      "name": "showsConnection",
+      "name": "__FairExhibitorsQuery_exhibitors_connection",
       "plural": false,
       "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "PageInfo",
-          "kind": "LinkedField",
-          "name": "pageInfo",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "hasNextPage",
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "PageCursors",
-          "kind": "LinkedField",
-          "name": "pageCursors",
-          "plural": false,
-          "selections": [
-            {
-              "args": null,
-              "kind": "FragmentSpread",
-              "name": "Pagination_pageCursors"
-            }
-          ],
-          "storageKey": null
-        },
         {
           "alias": null,
           "args": null,
@@ -198,11 +159,50 @@ return {
                   "storageKey": null
                 },
                 {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                },
+                {
                   "args": null,
                   "kind": "FragmentSpread",
                   "name": "FairExhibitorRail_show"
                 }
               ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
               "storageKey": null
             }
           ],
@@ -215,5 +215,5 @@ return {
   "type": "Fair"
 };
 })();
-(node as any).hash = 'a592977087f2ee380e24d6f9cf299413';
+(node as any).hash = '6cbe334b06fc8fe681ee99d67114931c';
 export default node;

--- a/src/v2/__generated__/fairRoutes_FairExhibitorsQuery.graphql.ts
+++ b/src/v2/__generated__/fairRoutes_FairExhibitorsQuery.graphql.ts
@@ -6,7 +6,6 @@ import { FragmentRefs } from "relay-runtime";
 export type ShowSorts = "END_AT_ASC" | "END_AT_DESC" | "FEATURED_ASC" | "FEATURED_DESC" | "FEATURED_DESC_END_AT_DESC" | "NAME_ASC" | "NAME_DESC" | "PARTNER_ASC" | "SORTABLE_NAME_ASC" | "SORTABLE_NAME_DESC" | "START_AT_ASC" | "START_AT_DESC" | "UPDATED_AT_ASC" | "UPDATED_AT_DESC" | "%future added value";
 export type fairRoutes_FairExhibitorsQueryVariables = {
     slug: string;
-    page?: number | null;
     sort?: ShowSorts | null;
 };
 export type fairRoutes_FairExhibitorsQueryResponse = {
@@ -24,11 +23,10 @@ export type fairRoutes_FairExhibitorsQuery = {
 /*
 query fairRoutes_FairExhibitorsQuery(
   $slug: String!
-  $page: Int
   $sort: ShowSorts
 ) {
   fair(id: $slug) @principalField {
-    ...FairExhibitors_fair_20XdsY
+    ...FairExhibitors_fair_2GL9EE
     id
   }
 }
@@ -55,15 +53,9 @@ fragment FairExhibitorRail_show on Show {
   }
 }
 
-fragment FairExhibitors_fair_20XdsY on Fair {
+fragment FairExhibitors_fair_2GL9EE on Fair {
   slug
-  exhibitors: showsConnection(sort: $sort, first: 15, page: $page, totalCount: true) {
-    pageInfo {
-      hasNextPage
-    }
-    pageCursors {
-      ...Pagination_pageCursors
-    }
+  exhibitors: showsConnection(sort: $sort, first: 15, totalCount: true) {
     edges {
       node {
         id
@@ -83,30 +75,14 @@ fragment FairExhibitors_fair_20XdsY on Fair {
           }
         }
         ...FairExhibitorRail_show
+        __typename
       }
+      cursor
     }
-  }
-}
-
-fragment Pagination_pageCursors on PageCursors {
-  around {
-    cursor
-    page
-    isCurrent
-  }
-  first {
-    cursor
-    page
-    isCurrent
-  }
-  last {
-    cursor
-    page
-    isCurrent
-  }
-  previous {
-    cursor
-    page
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
   }
 }
 */
@@ -118,12 +94,6 @@ var v0 = [
     "kind": "LocalArgument",
     "name": "slug",
     "type": "String!"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "page",
-    "type": "Int"
   },
   {
     "defaultValue": null,
@@ -141,54 +111,44 @@ v1 = [
 ],
 v2 = {
   "kind": "Variable",
-  "name": "page",
-  "variableName": "page"
-},
-v3 = {
-  "kind": "Variable",
   "name": "sort",
   "variableName": "sort"
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "cursor",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "page",
-  "storageKey": null
-},
-v7 = [
-  (v5/*: any*/),
-  (v6/*: any*/),
+v4 = [
   {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "isCurrent",
-    "storageKey": null
+    "kind": "Literal",
+    "name": "first",
+    "value": 15
+  },
+  (v2/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "totalCount",
+    "value": true
   }
 ],
-v8 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v9 = [
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v7 = [
   {
     "alias": null,
     "args": null,
@@ -214,8 +174,7 @@ return {
         "selections": [
           {
             "args": [
-              (v2/*: any*/),
-              (v3/*: any*/)
+              (v2/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "FairExhibitors_fair"
@@ -240,100 +199,15 @@ return {
         "name": "fair",
         "plural": false,
         "selections": [
-          (v4/*: any*/),
+          (v3/*: any*/),
           {
             "alias": "exhibitors",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 15
-              },
-              (v2/*: any*/),
-              (v3/*: any*/),
-              {
-                "kind": "Literal",
-                "name": "totalCount",
-                "value": true
-              }
-            ],
+            "args": (v4/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "PageInfo",
-                "kind": "LinkedField",
-                "name": "pageInfo",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "hasNextPage",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "PageCursors",
-                "kind": "LinkedField",
-                "name": "pageCursors",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PageCursor",
-                    "kind": "LinkedField",
-                    "name": "around",
-                    "plural": true,
-                    "selections": (v7/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PageCursor",
-                    "kind": "LinkedField",
-                    "name": "first",
-                    "plural": false,
-                    "selections": (v7/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PageCursor",
-                    "kind": "LinkedField",
-                    "name": "last",
-                    "plural": false,
-                    "selections": (v7/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PageCursor",
-                    "kind": "LinkedField",
-                    "name": "previous",
-                    "plural": false,
-                    "selections": [
-                      (v5/*: any*/),
-                      (v6/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
               {
                 "alias": null,
                 "args": null,
@@ -350,7 +224,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v8/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -377,22 +251,16 @@ return {
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "__typename",
-                            "storageKey": null
-                          },
-                          (v8/*: any*/),
+                          (v6/*: any*/),
+                          (v5/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v9/*: any*/),
+                            "selections": (v7/*: any*/),
                             "type": "Partner"
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v9/*: any*/),
+                            "selections": (v7/*: any*/),
                             "type": "ExternalPartner"
                           }
                         ],
@@ -405,15 +273,48 @@ return {
                         "name": "internalID",
                         "storageKey": null
                       },
-                      (v4/*: any*/),
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
                         "name": "href",
                         "storageKey": null
-                      }
+                      },
+                      (v6/*: any*/)
                     ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "cursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
                     "storageKey": null
                   }
                 ],
@@ -422,7 +323,19 @@ return {
             ],
             "storageKey": null
           },
-          (v8/*: any*/)
+          {
+            "alias": "exhibitors",
+            "args": (v4/*: any*/),
+            "filters": [
+              "sort",
+              "totalCount"
+            ],
+            "handle": "connection",
+            "key": "FairExhibitorsQuery_exhibitors",
+            "kind": "LinkedHandle",
+            "name": "showsConnection"
+          },
+          (v5/*: any*/)
         ],
         "storageKey": null
       }
@@ -433,9 +346,9 @@ return {
     "metadata": {},
     "name": "fairRoutes_FairExhibitorsQuery",
     "operationKind": "query",
-    "text": "query fairRoutes_FairExhibitorsQuery(\n  $slug: String!\n  $page: Int\n  $sort: ShowSorts\n) {\n  fair(id: $slug) @principalField {\n    ...FairExhibitors_fair_20XdsY\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  slug\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair_20XdsY on Fair {\n  slug\n  exhibitors: showsConnection(sort: $sort, first: 15, page: $page, totalCount: true) {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query fairRoutes_FairExhibitorsQuery(\n  $slug: String!\n  $sort: ShowSorts\n) {\n  fair(id: $slug) @principalField {\n    ...FairExhibitors_fair_2GL9EE\n    id\n  }\n}\n\nfragment FairExhibitorRail_show on Show {\n  internalID\n  slug\n  href\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      id\n    }\n  }\n  counts {\n    artworks\n  }\n}\n\nfragment FairExhibitors_fair_2GL9EE on Fair {\n  slug\n  exhibitors: showsConnection(sort: $sort, first: 15, totalCount: true) {\n    edges {\n      node {\n        id\n        counts {\n          artworks\n        }\n        partner {\n          __typename\n          ... on Partner {\n            id\n          }\n          ... on ExternalPartner {\n            id\n          }\n          ... on Node {\n            id\n          }\n        }\n        ...FairExhibitorRail_show\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = 'b4272f44722040e242be328ed5f25748';
+(node as any).hash = '5c82e3c9fea3b4cc8bd08d4a06447a0b';
 export default node;


### PR DESCRIPTION
Reverts artsy/force#8037

Already rolled back in production. Reverting to unblock the deployment pipeline.

> I think I found a bug with the new page-based pagination on the fair page. Looks like the pagination component isn’t rendering correctly when you move from page to page - seems to always render as if the first page is active. It seems to work fine when I switch to A-Z sorting or when I switch back to Relevance (sort shows up in the URL).

Source: [Slack](https://artsy.slack.com/archives/C9SATFLUU/p1626863639057300).