### PR TITLE
fix: Added optional parameter to updateUrl method

### DIFF
--- a/src/v2/Apps/Fair/Components/ExhibitorFilterContext.tsx
+++ b/src/v2/Apps/Fair/Components/ExhibitorFilterContext.tsx
@@ -36,7 +36,7 @@ interface ExhibitorFiltersAction {
 }
 
 export const initialExhibitorFilterState: ExhibitorFilters = {
-  sort: "-decayed_merch",
+  sort: "FEATURED_DESC",
 }
 
 export const ExhibitorFilterContext = createContext<

--- a/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
+++ b/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
@@ -195,7 +195,7 @@ const FairExhibitorsWithContext: React.FC<FairExhibitorsProps> = ({
         { text: "Relevance", value: "FEATURED_DESC" },
         { text: "Alphabetical (A-Z)", value: "NAME_ASC" },
       ]}
-      onChange={updateUrl}
+      onChange={event => updateUrl(event, { sort: "FEATURED_DESC" })}
     >
       <FairExhibitors {...props} />
     </ExhibitorFilterContextProvider>

--- a/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
+++ b/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
@@ -195,7 +195,9 @@ const FairExhibitorsWithContext: React.FC<FairExhibitorsProps> = ({
         { text: "Relevance", value: "FEATURED_DESC" },
         { text: "Alphabetical (A-Z)", value: "NAME_ASC" },
       ]}
-      onChange={event => updateUrl(event, { sort: "FEATURED_DESC" })}
+      onChange={event =>
+        updateUrl(event, { defaultValues: { sort: "FEATURED_DESC" } })
+      }
     >
       <FairExhibitors {...props} />
     </ExhibitorFilterContextProvider>

--- a/src/v2/Apps/Fair/fairRoutes.tsx
+++ b/src/v2/Apps/Fair/fairRoutes.tsx
@@ -101,7 +101,7 @@ export const fairRoutes: AppRouteConfig[] = [
           } = match
 
           if (!isValidSort(sort)) {
-            const url = buildUrl(otherQuery, pathname)
+            const url = buildUrl(otherQuery, { pathname })
             throw new RedirectException(url)
           }
 

--- a/src/v2/Components/ArtworkFilter/Utils/__tests__/isDefaultFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/Utils/__tests__/isDefaultFilter.jest.tsx
@@ -17,4 +17,25 @@ describe("isDefaultFilter", () => {
     expect(isDefaultFilter("foo" as any, "bar")).toBe(false)
     expect(isDefaultFilter("baz" as any, "bam")).toBe(false)
   })
+
+  it("returns true if custom default filter is passed, otherwise false", () => {
+    expect(isDefaultFilter("sort", "anything")).toBe(false)
+    expect(isDefaultFilter("sort", "anything", { sort: "anything" })).toBe(true)
+    expect(isDefaultFilter("page", 5)).toBe(false)
+    expect(isDefaultFilter("page", 5, { page: 5 })).toBe(true)
+  })
+
+  it("ignores passing custom default filter for array filters", () => {
+    expect(
+      isDefaultFilter("artistIDs", ["id-1", "id-2"], {
+        artistIDs: ["id-1", "id-2"],
+      })
+    ).toBe(false)
+
+    expect(
+      isDefaultFilter("artistIDs", [], {
+        artistIDs: ["id-1", "id-2"],
+      })
+    ).toBe(true)
+  })
 })

--- a/src/v2/Components/ArtworkFilter/Utils/isDefaultFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/Utils/isDefaultFilter.tsx
@@ -2,8 +2,9 @@ import { ArtworkFilters } from "../ArtworkFilterContext"
 
 export const isDefaultFilter: (
   name: keyof ArtworkFilters,
-  value: any
-) => boolean = (name, value) => {
+  value: any,
+  defaultValues?: Partial<ArtworkFilters>
+) => boolean = (name, value, defaultValues = {}) => {
   if (!value) {
     return false
   }
@@ -20,6 +21,8 @@ export const isDefaultFilter: (
       name === "artistNationalities" ||
       name === "materialsTerms":
       return value.length === 0
+    case !!defaultValues[name]:
+      return value === defaultValues[name]
     case name === "sort":
       return value === "-decayed_merch"
     case name === "medium":

--- a/src/v2/Components/ArtworkFilter/Utils/isDefaultFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/Utils/isDefaultFilter.tsx
@@ -9,6 +9,8 @@ export const isDefaultFilter: (
     return false
   }
 
+  const isCustomDefaultValuePassed = !!defaultValues[name]
+
   switch (true) {
     case name === "sizes" ||
       name === "artistIDs" ||
@@ -21,7 +23,7 @@ export const isDefaultFilter: (
       name === "artistNationalities" ||
       name === "materialsTerms":
       return value.length === 0
-    case !!defaultValues[name]:
+    case isCustomDefaultValuePassed:
       return value === defaultValues[name]
     case name === "sort":
       return value === "-decayed_merch"

--- a/src/v2/Components/ArtworkFilter/Utils/urlBuilder.tsx
+++ b/src/v2/Components/ArtworkFilter/Utils/urlBuilder.tsx
@@ -34,8 +34,10 @@ export const paramsToCamelCase = params => {
 
 export const buildUrl = (
   state: ArtworkFilters,
-  pathname?: string,
-  defaultValues?: Partial<ArtworkFilters>
+  {
+    pathname,
+    defaultValues,
+  }: { pathname?: string; defaultValues?: Partial<ArtworkFilters> }
 ): string => {
   const params = removeDefaultValues(state, defaultValues)
   const queryString = qs.stringify(paramsToSnakeCase(params))
@@ -54,7 +56,7 @@ export const updateUrl = (
   state: ArtworkFilters,
   defaultValues?: Partial<ArtworkFilters>
 ) => {
-  const url = buildUrl(state, "", defaultValues)
+  const url = buildUrl(state, { defaultValues })
 
   if (typeof window !== "undefined") {
     window.history.replaceState({}, "", url)

--- a/src/v2/Components/ArtworkFilter/Utils/urlBuilder.tsx
+++ b/src/v2/Components/ArtworkFilter/Utils/urlBuilder.tsx
@@ -32,8 +32,12 @@ export const paramsToCamelCase = params => {
   }, {})
 }
 
-export const buildUrl = (state: ArtworkFilters, pathname?: string): string => {
-  const params = removeDefaultValues(state)
+export const buildUrl = (
+  state: ArtworkFilters,
+  pathname?: string,
+  defaultValues?: Partial<ArtworkFilters>
+): string => {
+  const params = removeDefaultValues(state, defaultValues)
   const queryString = qs.stringify(paramsToSnakeCase(params))
 
   if (!pathname && typeof window !== "undefined") {
@@ -46,18 +50,24 @@ export const buildUrl = (state: ArtworkFilters, pathname?: string): string => {
   return url
 }
 
-export const updateUrl = (state: ArtworkFilters) => {
-  const url = buildUrl(state)
+export const updateUrl = (
+  state: ArtworkFilters,
+  defaultValues?: Partial<ArtworkFilters>
+) => {
+  const url = buildUrl(state, "", defaultValues)
 
   if (typeof window !== "undefined") {
     window.history.replaceState({}, "", url)
   }
 }
 
-export const removeDefaultValues = (state: ArtworkFilters) => {
+export const removeDefaultValues = (
+  state: ArtworkFilters,
+  defaultValues?: Partial<ArtworkFilters>
+) => {
   return Object.entries(state).reduce(
     (acc, [key, value]: [keyof ArtworkFilters, any]) => {
-      if (isDefaultFilter(key, value)) {
+      if (isDefaultFilter(key, value, defaultValues)) {
         return acc
       } else {
         return { ...acc, [key]: value }

--- a/src/v2/Components/ArtworkFilter/Utils/urlBuilder.tsx
+++ b/src/v2/Components/ArtworkFilter/Utils/urlBuilder.tsx
@@ -32,16 +32,21 @@ export const paramsToCamelCase = params => {
   }, {})
 }
 
+interface BuildUrlOptions {
+  pathname?: string
+  defaultValues?: Partial<ArtworkFilters>
+}
+
 export const buildUrl = (
   state: ArtworkFilters,
-  {
-    pathname,
-    defaultValues,
-  }: { pathname?: string; defaultValues?: Partial<ArtworkFilters> }
+  options?: BuildUrlOptions
 ): string => {
-  const params = removeDefaultValues(state, defaultValues)
+  const params = removeDefaultValues(state, {
+    defaultValues: options?.defaultValues,
+  })
   const queryString = qs.stringify(paramsToSnakeCase(params))
 
+  let pathname = options?.pathname
   if (!pathname && typeof window !== "undefined") {
     pathname = window.location.pathname
   }
@@ -52,11 +57,8 @@ export const buildUrl = (
   return url
 }
 
-export const updateUrl = (
-  state: ArtworkFilters,
-  defaultValues?: Partial<ArtworkFilters>
-) => {
-  const url = buildUrl(state, { defaultValues })
+export const updateUrl = (state: ArtworkFilters, options?: BuildUrlOptions) => {
+  const url = buildUrl(state, { defaultValues: options?.defaultValues })
 
   if (typeof window !== "undefined") {
     window.history.replaceState({}, "", url)
@@ -65,11 +67,11 @@ export const updateUrl = (
 
 export const removeDefaultValues = (
   state: ArtworkFilters,
-  defaultValues?: Partial<ArtworkFilters>
+  options?: BuildUrlOptions
 ) => {
   return Object.entries(state).reduce(
     (acc, [key, value]: [keyof ArtworkFilters, any]) => {
-      if (isDefaultFilter(key, value, defaultValues)) {
+      if (isDefaultFilter(key, value, options?.defaultValues)) {
         return acc
       } else {
         return { ...acc, [key]: value }

--- a/src/v2/Components/Pagination/useComputeHref.ts
+++ b/src/v2/Components/Pagination/useComputeHref.ts
@@ -26,7 +26,7 @@ export function useComputeHref() {
       page,
     }
 
-    const href = buildUrl(filterState, location?.pathname)
+    const href = buildUrl(filterState, { pathname: location?.pathname })
     return href
   }
 


### PR DESCRIPTION
Initial sort value for fair exhibitors previously was set as `-decayed_merch` in order to initially hide this param in url. That caused a bug where fetching data with invalid sort value when paginating to a new page would fail.

This PR:
- adds optional parameter `defaultValues` to `updateUrl` method so that we can hide in url filter values other than initial
- fixes initial data fetching on fair booths page by changing initial sort value that is hidden in url with the help of ^ update