### PR TITLE
refactor: Update bid form to Palette v3

### DIFF
--- a/src/v2/Apps/Auction/Components/BidForm.tsx
+++ b/src/v2/Apps/Auction/Components/BidForm.tsx
@@ -2,10 +2,9 @@ import {
   Box,
   Button,
   Flex,
-  LargeSelect,
-  Sans,
+  Select,
+  Text,
   Separator,
-  Serif,
   Spacer,
 } from "@artsy/palette"
 import {
@@ -118,11 +117,18 @@ export const BidForm: React.FC<Props> = ({
             }}
           />
 
-          <Serif mt={4} pb={0.5} size="4t" weight="semibold" color="black100">
+          <Text
+            variant="md"
+            mt={2}
+            pb={0.5}
+            size="4t"
+            fontWeight="bold"
+            color="black100"
+          >
             Set your max bid
-          </Serif>
+          </Text>
 
-          <LargeSelect
+          <Select
             selected={values.selectedBid}
             onSelect={value => {
               onMaxBidSelect && onMaxBidSelect(value)
@@ -142,22 +148,28 @@ export const BidForm: React.FC<Props> = ({
             bidAmountMinor={parseInt(values.selectedBid)}
           />
 
-          <Spacer mt={4} />
+          <Spacer mt={2} />
 
           {requiresPaymentInformation && (
             <>
-              <Separator mb={3} />
+              <Separator mb={2} />
               <CreditCardInstructions />
 
-              <Serif mt={4} mb={2} size="4t" weight="semibold" color="black100">
+              <Text
+                variant="md"
+                mt={4}
+                mb={2}
+                size="4t"
+                fontWeight="bold"
+                color="black100"
+              >
                 Card Information
-              </Serif>
+              </Text>
 
               <CreditCardInput
                 error={{ message: errors.creditCard } as StripeError}
                 onChange={({ error }) =>
-                  // @ts-expect-error STRICT_NULL_CHECK
-                  setFieldError("creditCard", error?.message)
+                  setFieldError("creditCard", error?.message!)
                 }
               />
 
@@ -175,10 +187,10 @@ export const BidForm: React.FC<Props> = ({
             </>
           )}
 
-          <Spacer mt={3} />
+          <Spacer mt={4} />
 
           {requiresCheckbox && (
-            <Flex mb={3} flexDirection="column" justifyContent="center">
+            <Flex mb={4} flexDirection="column" justifyContent="center">
               <Box mx="auto">
                 <ConditionsOfSaleCheckbox
                   selected={values.agreeToTerms}
@@ -191,18 +203,25 @@ export const BidForm: React.FC<Props> = ({
               </Box>
 
               {touched.agreeToTerms && errors.agreeToTerms && (
-                <Sans mt={1} color="red100" size="2" textAlign="center">
+                <Text
+                  variant="md"
+                  mt={1}
+                  color="red100"
+                  size="2"
+                  textAlign="center"
+                >
                   {errors.agreeToTerms}
-                </Sans>
+                </Text>
               )}
             </Flex>
           )}
 
           <Button
-            size="large"
+            variant="primaryBlack"
             width="100%"
             loading={isSubmitting}
             type="submit"
+            mb={4}
           >
             Confirm bid
           </Button>

--- a/src/v2/Apps/Auction/Components/CreditCardInstructions.tsx
+++ b/src/v2/Apps/Auction/Components/CreditCardInstructions.tsx
@@ -1,18 +1,18 @@
-import { Serif } from "@artsy/palette"
+import { Text } from "@artsy/palette"
 import React from "react"
 
 export const CreditCardInstructions = () => {
   return (
     <>
-      <Serif size="4" color="black100">
+      <Text variant="md">
         Please enter your credit card information below. The name on your Artsy
         account must match the name on the card, and a valid credit card is
         required in order to bid.
-      </Serif>
-      <Serif size="4" mt={2} color="black100">
+      </Text>
+      <Text variant="md" mt={2}>
         Registration is free. Artsy will never charge this card without your
         permission, and you are not required to use this card to pay if you win.
-      </Serif>
+      </Text>
     </>
   )
 }

--- a/src/v2/Apps/Auction/Components/LotInfo.tsx
+++ b/src/v2/Apps/Auction/Components/LotInfo.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, ResponsiveImage, Sans, Serif } from "@artsy/palette"
+import { Box, Flex, ResponsiveImage, Text } from "@artsy/palette"
 import { LotInfo_artwork } from "v2/__generated__/LotInfo_artwork.graphql"
 import { LotInfo_saleArtwork } from "v2/__generated__/LotInfo_saleArtwork.graphql"
 import React from "react"
@@ -18,29 +18,27 @@ export const LotInfo: React.FC<Props> = ({ artwork, saleArtwork }) => {
   return (
     <Flex py={4}>
       <Box maxWidth="150px" width="100%" height="auto" p={0}>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
-        <ResponsiveImage src={artwork.imageUrl} />
+        <ResponsiveImage src={artwork.imageUrl!} />
       </Box>
-      <Flex pl={3} pt={1} flexDirection="column">
-        <Sans size="3" weight="medium" color="black100">
+      <Flex pl={2} pt={1} flexDirection="column">
+        <Text variant="md" color="black100">
           Lot {saleArtwork.lotLabel}
-        </Sans>
-        <Serif size="3" color="black100">
+        </Text>
+        <Text variant="md" color="black100">
           <i>{artwork.title}</i>
           {artwork.date && `, ${artwork.date}`}
-        </Serif>
-        <Serif size="3" color="black100">
+        </Text>
+        <Text variant="md" color="black100">
           {artwork.artistNames}
-        </Serif>
+        </Text>
         <br />
-        <Serif size="3">
-          {/* @ts-expect-error STRICT_NULL_CHECK */}
-          Current Bid: {saleArtwork.minimumNextBid.display}
-        </Serif>
+        <Text variant="md" fontWeight="bold">
+          Current Bid: {saleArtwork?.minimumNextBid?.display}
+        </Text>
         {bidCount > 0 && (
-          <Serif size="3" color="black60">
+          <Text variant="md" color="black60">
             ({bidCount} bid{bidCount > 1 && "s"})
-          </Serif>
+          </Text>
         )}
       </Flex>
     </Flex>

--- a/src/v2/Apps/Auction/Components/PricingTransparency.tsx
+++ b/src/v2/Apps/Auction/Components/PricingTransparency.tsx
@@ -1,4 +1,4 @@
-import { Flex, Sans, Serif, Spinner } from "@artsy/palette"
+import { Flex, Text, Spinner } from "@artsy/palette"
 import React from "react"
 import { graphql } from "react-relay"
 
@@ -10,7 +10,6 @@ import {
 import { SystemContextProps, withSystemContext } from "v2/System"
 import { SystemQueryRenderer as QueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
 
-const Text = props => <Serif size="3t" color="black100" {...props} />
 const Row = props => (
   <Flex flexDirection="row" justifyContent="space-between" pb={1} {...props} />
 )
@@ -20,26 +19,26 @@ export const PricingTransparency: React.FC<PricingTransparencyQueryResponse> = p
   const { calculatedCost } = props.artwork.saleArtwork
 
   return (
-    <Flex pt={3} flexDirection="column">
-      <Serif pb={1} size="4t" weight="semibold" color="black100">
+    <Flex pt={2} flexDirection="column">
+      <Text variant="md" pb={1} size="4t" fontWeight="bold" color="black100">
         Summary
-      </Serif>
+      </Text>
 
       <Row>
-        <Text>Your max bid</Text>
+        <Text variant="md">Your max bid</Text>
         <Text>{calculatedCost.bidAmount.display}</Text>
       </Row>
-      <Row pb={2}>
-        <Text>Buyer's Premium</Text>
+      <Row>
+        <Text variant="md">Buyer's Premium</Text>
         <Text>{calculatedCost.buyersPremium.display}</Text>
       </Row>
       <Row>
-        <Text>Subtotal</Text>
+        <Text variant="md">Subtotal</Text>
         <Text>{calculatedCost.subtotal.display}</Text>
       </Row>
-      <Sans size="2" color="black60">
+      <Text variant="sm" color="black60" mt={2}>
         Plus any applicable shipping, taxes, and fees.
-      </Sans>
+      </Text>
     </Flex>
   )
 }

--- a/src/v2/Apps/Auction/Routes/ConfirmBid/index.tsx
+++ b/src/v2/Apps/Auction/Routes/ConfirmBid/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Separator, Serif } from "@artsy/palette"
+import { Box, Separator, Text, ThemeProviderV3 } from "@artsy/palette"
 import { Match } from "found"
 
 import { BidderPositionQueryResponse } from "v2/__generated__/BidderPositionQuery.graphql"
@@ -323,46 +323,49 @@ export const ConfirmBidRoute: React.FC<
     return <ZendeskWrapper zdKey={sd.AUCTION_ZENDESK_KEY} />
   }
 
+  if (!artwork) {
+    return null
+  }
+
   return (
     <>
       <Title>Confirm Bid | Artsy</Title>
 
-      <Box maxWidth={550} px={[2, 0]} mx="auto" mt={[1, 0]} mb={[1, 100]}>
-        <Serif size="8">Confirm your bid</Serif>
-        <Separator />
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
-        <LotInfo artwork={artwork} saleArtwork={artwork.saleArtwork} />
-        <Separator />
-        <BidForm
-          // @ts-expect-error STRICT_NULL_CHECK
-          artworkSlug={artwork.slug}
-          initialSelectedBid={props.match?.location?.query?.bid}
-          saleArtwork={saleArtwork}
-          onSubmit={handleSubmit}
-          onMaxBidSelect={trackMaxBidSelected}
-          me={me as any}
-          trackSubmissionErrors={errors =>
-            !isEmpty(errors) && trackConfirmBidFailed(errors)
-          }
-        />
-        {renderZendeskScript()}
-      </Box>
+      <ThemeProviderV3>
+        <Box maxWidth={550} px={[2, 0]} mx="auto" mt={[1, 0]} mb={[1, 100]}>
+          <Text variant="lg">Confirm your bid</Text>
+          <Separator />
+          <LotInfo artwork={artwork} saleArtwork={artwork.saleArtwork!} />
+          <Separator />
+          <BidForm
+            artworkSlug={artwork.slug}
+            initialSelectedBid={props.match?.location?.query?.bid}
+            saleArtwork={saleArtwork}
+            onSubmit={handleSubmit}
+            onMaxBidSelect={trackMaxBidSelected}
+            me={me}
+            trackSubmissionErrors={errors => {
+              !isEmpty(errors) && trackConfirmBidFailed(errors)
+            }}
+          />
+          {renderZendeskScript()}
+        </Box>
+      </ThemeProviderV3>
     </>
   )
 }
 
 const StripeWrappedConfirmBidRoute = createStripeWrapper(ConfirmBidRoute)
 
-const TrackingWrappedConfirmBidRoute = track<ConfirmBidProps>(props => ({
-  // @ts-expect-error STRICT_NULL_CHECK
-  artwork_slug: props.artwork.slug,
-  // @ts-expect-error STRICT_NULL_CHECK
-  auction_slug: props.artwork.saleArtwork.sale.slug,
-  context_page: Schema.PageName.AuctionConfirmBidPage,
-  // @ts-expect-error STRICT_NULL_CHECK
-  sale_id: props.artwork.saleArtwork.sale.internalID,
-  user_id: props.me.internalID,
-}))(StripeWrappedConfirmBidRoute)
+const TrackingWrappedConfirmBidRoute = track<ConfirmBidProps>(
+  (props: ConfirmBidProps) => ({
+    artwork_slug: props.artwork?.slug,
+    auction_slug: props.artwork?.saleArtwork?.sale?.slug,
+    context_page: Schema.PageName.AuctionConfirmBidPage,
+    sale_id: props.artwork?.saleArtwork?.sale?.internalID,
+    user_id: props.me.internalID,
+  })
+)(StripeWrappedConfirmBidRoute)
 
 export const ConfirmBidRouteFragmentContainer = createFragmentContainer<
   ConfirmBidProps

--- a/src/v2/Apps/Order/Components/CreditCardInput.tsx
+++ b/src/v2/Apps/Order/Components/CreditCardInput.tsx
@@ -1,4 +1,4 @@
-import { BorderBox, Sans, color, themeProps } from "@artsy/palette"
+import { BorderBox, Text, color, themeProps } from "@artsy/palette"
 import { fontFamily } from "@artsy/palette/dist/platform/fonts"
 import {
   BorderProps as InputBorderProps,
@@ -63,8 +63,8 @@ export class CreditCardInput extends React.Component<
               style: {
                 base: {
                   "::placeholder": { color: color("black30") },
-                  fontFamily: fontFamily.serif.regular as string,
-                  fontSize: `${themeProps.typeSizes.serif["3t"].fontSize}px`,
+                  fontFamily: fontFamily.sans.regular as string,
+                  fontSize: `${themeProps.typeSizes.sans["6"].fontSize}px`,
                   fontSmoothing: "antialiased",
                   lineHeight: "20px",
                 },
@@ -80,9 +80,9 @@ export class CreditCardInput extends React.Component<
           />
         </StyledBorderBox>
         {message && (
-          <Sans pt={1} size="2" color="red100">
+          <Text variant="sm" color="red100">
             {message}
-          </Sans>
+          </Text>
         )}
       </>
     )

--- a/src/v2/Components/AddressForm.tsx
+++ b/src/v2/Components/AddressForm.tsx
@@ -1,6 +1,6 @@
-import { Flex, Join, Sans, Serif, Spacer } from "@artsy/palette"
+import { Flex, Join, Input, Text, Spacer } from "@artsy/palette"
 import { CountrySelect } from "v2/Components/CountrySelect"
-import Input from "v2/Components/Input"
+// import Input from "v2/Components/Input"
 import React from "react"
 import { TwoColumnSplit } from "../Apps/Order/Components/TwoColumnLayout"
 
@@ -110,15 +110,14 @@ export class AddressForm extends React.Component<
             value={this.props.value.name}
             onChange={this.changeEventHandler("name")}
             error={this.getError("name")}
-            block
           />
         </Flex>
 
         <TwoColumnSplit>
           <Flex flexDirection="column" pb={1}>
-            <Serif mb={1} size="3t" color="black100" lineHeight="1.1em">
+            <Text variant="md" color="black100" lineHeight="1.1em">
               Country
-            </Serif>
+            </Text>
             <CountrySelect
               selected={
                 lockCountryToOrigin ||
@@ -133,11 +132,11 @@ export class AddressForm extends React.Component<
             {(lockCountryToOrigin || lockCountriesToEU) && (
               <>
                 <Spacer m={0.5} />
-                <Sans size="2" color="black60">
+                <Text variant="md" color="black60">
                   {lockCountriesToEU
                     ? "Continental Europe shipping only."
                     : "Domestic shipping only."}
-                </Sans>
+                </Text>
               </>
             )}
           </Flex>
@@ -149,11 +148,9 @@ export class AddressForm extends React.Component<
               title="Postal code"
               autoCapitalize="characters"
               autoCorrect="off"
-              // @ts-expect-error STRICT_NULL_CHECK
-              value={this.props.value.postalCode}
+              value={this.props.value?.postalCode}
               onChange={this.changeEventHandler("postalCode")}
               error={this.getError("postalCode")}
-              block
             />
           </Flex>
         </TwoColumnSplit>
@@ -163,11 +160,9 @@ export class AddressForm extends React.Component<
               id="AddressForm_addressLine1"
               placeholder="Add street address"
               title="Address line 1"
-              // @ts-expect-error STRICT_NULL_CHECK
-              value={this.props.value.addressLine1}
+              value={this.props.value?.addressLine1}
               onChange={this.changeEventHandler("addressLine1")}
               error={this.getError("addressLine1")}
-              block
             />
           </Flex>
 
@@ -176,11 +171,9 @@ export class AddressForm extends React.Component<
               id="AddressForm_addressLine2"
               placeholder="Add apt, floor, suite, etc."
               title="Address line 2 (optional)"
-              // @ts-expect-error STRICT_NULL_CHECK
-              value={this.props.value.addressLine2}
+              value={this.props.value?.addressLine2}
               onChange={this.changeEventHandler("addressLine2")}
               error={this.getError("addressLine2")}
-              block
             />
           </Flex>
         </TwoColumnSplit>
@@ -190,11 +183,9 @@ export class AddressForm extends React.Component<
               id="AddressForm_city"
               placeholder="Add city"
               title="City"
-              // @ts-expect-error STRICT_NULL_CHECK
-              value={this.props.value.city}
+              value={this.props.value?.city}
               onChange={this.changeEventHandler("city")}
               error={this.getError("city")}
-              block
             />
           </Flex>
 
@@ -204,11 +195,9 @@ export class AddressForm extends React.Component<
               placeholder="Add State, province, or region"
               title="State, province, or region"
               autoCorrect="off"
-              // @ts-expect-error STRICT_NULL_CHECK
-              value={this.props.value.region}
+              value={this.props.value?.region}
               onChange={this.changeEventHandler("region")}
               error={this.getError("region")}
-              block
             />
           </Flex>
         </TwoColumnSplit>
@@ -219,15 +208,12 @@ export class AddressForm extends React.Component<
                 id="AddressForm_phoneNumber"
                 title="Phone number"
                 type="tel"
-                // @ts-expect-error STRICT_NULL_CHECK
-                description={this.phoneNumberInputDescription()}
+                description={this.phoneNumberInputDescription()!}
                 placeholder="Add phone"
                 pattern="[^a-z]+"
-                // @ts-expect-error STRICT_NULL_CHECK
-                value={this.props.value.phoneNumber}
+                value={this.props.value?.phoneNumber}
                 onChange={this.changeEventHandler("phoneNumber")}
                 error={this.getError("phoneNumber")}
-                block
               />
             </Flex>
             <Spacer mb={2} />

--- a/src/v2/Components/Auction/ConditionsOfSaleCheckbox.tsx
+++ b/src/v2/Components/Auction/ConditionsOfSaleCheckbox.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, CheckboxProps, Link, Serif } from "@artsy/palette"
+import { Checkbox, CheckboxProps, Link, Text } from "@artsy/palette"
 import React from "react"
 import { data as sd } from "sharify"
 
@@ -8,9 +8,9 @@ export const ConditionsOfSaleCheckbox: React.FC<CheckboxProps> = ({
 }) => {
   return (
     <Checkbox selected={selected} onSelect={onSelect}>
-      <Serif display="inline" color="black60" size="3t" ml={0.5}>
+      <Text variant="md" display="inline" color="black60" size="3t" ml={0.5}>
         {"Agree to "}
-        <Serif display="inline" color="black100" size="3t">
+        <Text variant="md" display="inline" color="black100" size="3t">
           <Link
             color="black100"
             href={`${sd.APP_URL}/conditions-of-sale`}
@@ -18,8 +18,8 @@ export const ConditionsOfSaleCheckbox: React.FC<CheckboxProps> = ({
           >
             Conditions of Sale
           </Link>
-        </Serif>
-      </Serif>
+        </Text>
+      </Text>
     </Checkbox>
   )
 }

--- a/src/v2/Components/CountrySelect.tsx
+++ b/src/v2/Components/CountrySelect.tsx
@@ -1,4 +1,4 @@
-import { LargeSelect } from "@artsy/palette"
+import { Select } from "@artsy/palette"
 import React from "react"
 import { PositionProps, SpaceProps } from "styled-system"
 
@@ -12,7 +12,7 @@ export interface CountrySelectProps extends PositionProps, SpaceProps {
 
 export const CountrySelect = (props: CountrySelectProps) => {
   return (
-    <LargeSelect
+    <Select
       {...props}
       options={
         props.euShippingOnly


### PR DESCRIPTION
This updates our Bids component to palette v3. 

There was an issue styling the stripe credit card input to latest; someone can return to it in time. 
 
<img width="384" alt="Screen Shot 2021-07-22 at 3 29 22 PM" src="https://user-images.githubusercontent.com/236943/126717556-1f855bac-d638-4327-b747-09b52ead7563.png">

<img width="591" alt="Screen Shot 2021-07-22 at 3 29 49 PM" src="https://user-images.githubusercontent.com/236943/126717568-90e18611-31a8-4722-b4b4-c07f27661611.png">

