### PR TITLE
minor edits following turn-key merge

### DIFF
--- a/docs/env_configuration.md
+++ b/docs/env_configuration.md
@@ -1,18 +1,18 @@
 ## Shared Configuration
 
-Force uses [shared configuration](https://github.com/artsy/README/blob/main/playbooks/development-environments.md#shared-configuration) to distribute common and sensitive configuration values. The [setup script](../scripts/setup.sh) will download `.shared.env` and also initialize a `.env` (from `.env.example`) for developer custom configuration and any overrides.
+Force uses [shared configuration](https://github.com/artsy/README/blob/main/playbooks/development-environments.md#shared-configuration) to distribute common and sensitive configuration values. The [setup script](../scripts/setup.sh) will download `.env.shared` and also initialize a `.env` (from `.env.example`) for developer custom configuration and any overrides.
 
 ## Adding an ENV var
 
 ### Server side only
 
-1. Add the variable to `.shared.env` file and [update the S3 version](https://github.com/artsy/README/blob/main/playbooks/development-environments.md#shared-configuration).
+1. Add the variable to `.env.shared` file and [update the S3 version](https://github.com/artsy/README/blob/main/playbooks/development-environments.md#shared-configuration).
 1. Edit `src/desktop/config.coffee` and `src/mobile/config.coffee` to include default for your env variable. You can safely use `null` to indicate an empty variable.
 1. Use it in the runtime via `/src/config.js`
 
 ### Server + Client
 
-1. Add the variable to your `.shared.env` file and [update the S3 version](https://github.com/artsy/README/blob/main/playbooks/development-environments.md#shared-configuration).
+1. Add the variable to your `.env.shared` file and [update the S3 version](https://github.com/artsy/README/blob/main/playbooks/development-environments.md#shared-configuration).
 1. Edit `src/desktop/config.coffee` and `src/mobile/config.coffee` to include default for your env variable. You can safely use `null` to indicate an empty variable.
 1. Edit `src/lib/setup_sharify.js` to export your env variable to the client runtime
 1. You can access it via `sd.[YOUR_VAR]` in client code

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "publish-assets:local": "yarn clean && yarn build:assets:legacy && yarn build:assets && yarn publish-assets",
     "relay": "relay-compiler",
     "sentry": "scripts/sentry.sh",
+    "sync-env": "aws s3 cp s3://artsy-citadel/dev/.env.force .env.shared && echo 'ENV sync complete.'",
     "start": "scripts/start.sh",
     "start:dev": "concurrently 'yarn start:dev:relay' 'yarn start:dev:server'",
     "start:dev:server": "NODE_ENV=development node --max_old_space_size=3072 ./src/dev.js",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,12 +7,8 @@
 set -e
 
 # Install yarn if it does not exist.
-if ! yarn versions &> /dev/null; then
-  echo 'yarn is required for setup, installing...'
-  if ! brew --version &> /dev/null; then
-    echo 'brew is required to install yarn, see https://docs.brew.sh/Installation'
-    exit 0
-  fi
+if ! which yarn > /dev/null; then
+  echo 'yarn is required for setup, installing with brew...'
   brew install yarn
 fi
 
@@ -23,7 +19,7 @@ if [[ ! -z $NVM_DIR ]]; then # skip if nvm is not available
 fi
 
 echo "Installing dependencies..."
-yarn install || echo 'Unable to install dependencies using yarn!'
+yarn install
 
 # For more info on shared configuration see:
 # https://github.com/artsy/force/blob/master/docs/env_configuration.md


### PR DESCRIPTION
This is a quick followup to https://github.com/artsy/force/pull/8031 merge and also to bring us in line with similar changes being made in [this MP pr](https://github.com/artsy/metaphysics/pull/3300)

* fix typos in docs
* add `sync-env` script to provide alternative way to update `.env.shared` via `yarn`
* simplify setup script by letting commands fail organically notifying the user when `brew` is missing or `yarn` is missing.