### PR TITLE
fix: [PURCHASE-2817] AdressForm inputs caret

### DIFF
--- a/src/v2/Apps/Order/Components/PaymentPicker.tsx
+++ b/src/v2/Apps/Order/Components/PaymentPicker.tsx
@@ -252,6 +252,7 @@ export class PaymentPicker extends React.Component<
       addressErrors,
       addressTouched,
       creditCardSelection,
+      hideBillingAddress,
     } = this.state
     const {
       me: { creditCards },
@@ -348,7 +349,7 @@ export class PaymentPicker extends React.Component<
               <>
                 <Spacer mb={2} />
                 <Checkbox
-                  selected={this.state.hideBillingAddress}
+                  selected={hideBillingAddress}
                   onSelect={this.handleChangeHideBillingAddress.bind(this)}
                   data-test="BillingAndShippingAreTheSame"
                 >
@@ -363,6 +364,7 @@ export class PaymentPicker extends React.Component<
                 errors={addressErrors}
                 touched={addressTouched}
                 onChange={this.onAddressChange}
+                isCollapsed={hideBillingAddress}
                 billing
               />
               <Spacer mb={2} />

--- a/src/v2/Apps/Order/Components/PhoneNumberForm.tsx
+++ b/src/v2/Apps/Order/Components/PhoneNumberForm.tsx
@@ -1,5 +1,4 @@
-import { Flex } from "@artsy/palette"
-import Input from "v2/Components/Input"
+import { Flex, Input } from "@artsy/palette"
 import React from "react"
 
 export type PhoneNumber = string
@@ -61,7 +60,6 @@ export class PhoneNumberForm extends React.Component<
           value={this.props.value}
           onChange={this.changeEventHandler()}
           error={this.getError()}
-          block
         />
       </Flex>
     )

--- a/src/v2/Apps/Order/Components/__tests__/PaymentPicker.jest.tsx
+++ b/src/v2/Apps/Order/Components/__tests__/PaymentPicker.jest.tsx
@@ -1,4 +1,4 @@
-import { BorderedRadio, Checkbox, Collapse, Link } from "@artsy/palette"
+import { BorderedRadio, Checkbox, Collapse, Link, Input } from "@artsy/palette"
 import { PaymentPicker_me } from "v2/__generated__/PaymentPicker_me.graphql"
 import { PaymentPickerTestQueryRawResponse } from "v2/__generated__/PaymentPickerTestQuery.graphql"
 import {
@@ -15,7 +15,6 @@ import {
   validAddress,
 } from "v2/Components/__tests__/Utils/addressForm"
 import { Address, AddressForm } from "v2/Components/AddressForm"
-import { Input } from "v2/Components/Input"
 import { createTestEnv } from "v2/DevTools/createTestEnv"
 import { RootTestPage } from "v2/DevTools/RootTestPage"
 import { graphql } from "react-relay"

--- a/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/v2/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -13,8 +13,7 @@ import {
   validAddress,
 } from "v2/Components/__tests__/Utils/addressForm"
 import { CountrySelect } from "v2/Components/CountrySelect"
-import Input from "v2/Components/Input"
-import { Input as paletteInput } from "@artsy/palette"
+import { Input } from "@artsy/palette"
 import { createTestEnv } from "v2/DevTools/createTestEnv"
 import { graphql } from "react-relay"
 import {
@@ -1122,7 +1121,7 @@ describe("Shipping", () => {
         expect(
           page
             .find("AddressModal")
-            .find(paletteInput)
+            .find(Input)
             .map(input => input.props().value)
         ).toMatchInlineSnapshot(`
           Array [

--- a/src/v2/Components/AddressForm.tsx
+++ b/src/v2/Components/AddressForm.tsx
@@ -1,6 +1,5 @@
-import { Flex, Join, Sans, Serif, Spacer } from "@artsy/palette"
+import { Flex, Join, Sans, Serif, Spacer, Input } from "@artsy/palette"
 import { CountrySelect } from "v2/Components/CountrySelect"
-import Input from "v2/Components/Input"
 import React from "react"
 import { TwoColumnSplit } from "../Apps/Order/Components/TwoColumnLayout"
 
@@ -85,9 +84,9 @@ export class AddressForm extends React.Component<
     )
   }
 
-  phoneNumberInputDescription = (): string | null => {
+  phoneNumberInputDescription = (): string | undefined => {
     if (this.props.billing && this.props.showPhoneNumberInput) {
-      return null
+      return
     } else {
       return "Required for shipping logistics"
     }
@@ -98,6 +97,8 @@ export class AddressForm extends React.Component<
     const lockCountryToOrigin = onlyLocalShipping && !this.props.euOrigin
     const lockCountriesToEU = onlyLocalShipping && this.props.euOrigin
 
+    const { address } = this.state
+
     return (
       <Join separator={<Spacer mb={2} />}>
         <Flex flexDirection="column">
@@ -106,11 +107,9 @@ export class AddressForm extends React.Component<
             placeholder="Add full name"
             title={this.props.billing ? "Name on card" : "Full name"}
             autoCorrect="off"
-            // @ts-expect-error STRICT_NULL_CHECK
-            value={this.props.value.name}
+            value={address.name}
             onChange={this.changeEventHandler("name")}
             error={this.getError("name")}
-            block
           />
         </Flex>
 
@@ -149,11 +148,9 @@ export class AddressForm extends React.Component<
               title="Postal code"
               autoCapitalize="characters"
               autoCorrect="off"
-              // @ts-expect-error STRICT_NULL_CHECK
-              value={this.props.value.postalCode}
+              value={address.postalCode}
               onChange={this.changeEventHandler("postalCode")}
               error={this.getError("postalCode")}
-              block
             />
           </Flex>
         </TwoColumnSplit>
@@ -163,11 +160,9 @@ export class AddressForm extends React.Component<
               id="AddressForm_addressLine1"
               placeholder="Add street address"
               title="Address line 1"
-              // @ts-expect-error STRICT_NULL_CHECK
-              value={this.props.value.addressLine1}
+              value={address.addressLine1}
               onChange={this.changeEventHandler("addressLine1")}
               error={this.getError("addressLine1")}
-              block
             />
           </Flex>
 
@@ -176,11 +171,9 @@ export class AddressForm extends React.Component<
               id="AddressForm_addressLine2"
               placeholder="Add apt, floor, suite, etc."
               title="Address line 2 (optional)"
-              // @ts-expect-error STRICT_NULL_CHECK
-              value={this.props.value.addressLine2}
+              value={address.addressLine2}
               onChange={this.changeEventHandler("addressLine2")}
               error={this.getError("addressLine2")}
-              block
             />
           </Flex>
         </TwoColumnSplit>
@@ -190,11 +183,9 @@ export class AddressForm extends React.Component<
               id="AddressForm_city"
               placeholder="Add city"
               title="City"
-              // @ts-expect-error STRICT_NULL_CHECK
-              value={this.props.value.city}
+              value={address.city}
               onChange={this.changeEventHandler("city")}
               error={this.getError("city")}
-              block
             />
           </Flex>
 
@@ -204,11 +195,9 @@ export class AddressForm extends React.Component<
               placeholder="Add State, province, or region"
               title="State, province, or region"
               autoCorrect="off"
-              // @ts-expect-error STRICT_NULL_CHECK
-              value={this.props.value.region}
+              value={address.region}
               onChange={this.changeEventHandler("region")}
               error={this.getError("region")}
-              block
             />
           </Flex>
         </TwoColumnSplit>
@@ -219,15 +208,12 @@ export class AddressForm extends React.Component<
                 id="AddressForm_phoneNumber"
                 title="Phone number"
                 type="tel"
-                // @ts-expect-error STRICT_NULL_CHECK
                 description={this.phoneNumberInputDescription()}
                 placeholder="Add phone"
                 pattern="[^a-z]+"
-                // @ts-expect-error STRICT_NULL_CHECK
-                value={this.props.value.phoneNumber}
+                value={address.phoneNumber}
                 onChange={this.changeEventHandler("phoneNumber")}
                 error={this.getError("phoneNumber")}
-                block
               />
             </Flex>
             <Spacer mb={2} />

--- a/src/v2/Components/AddressForm.tsx
+++ b/src/v2/Components/AddressForm.tsx
@@ -38,6 +38,7 @@ export interface AddressFormProps {
   domesticOnly?: boolean
   euOrigin?: boolean
   showPhoneNumberInput?: boolean
+  isCollapsed?: boolean
   shippingCountry?: string
   errors: AddressErrors
   touched: AddressTouched
@@ -56,6 +57,12 @@ export class AddressForm extends React.Component<
       ...emptyAddress,
       ...this.props.value,
     },
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.isCollapsed !== this.props.isCollapsed) {
+      this.setState({ address: { ...emptyAddress } })
+    }
   }
 
   changeEventHandler = (key: keyof Address) => (
@@ -93,9 +100,10 @@ export class AddressForm extends React.Component<
   }
 
   render() {
-    const onlyLocalShipping = !this.props.billing && !!this.props.domesticOnly
-    const lockCountryToOrigin = onlyLocalShipping && !this.props.euOrigin
-    const lockCountriesToEU = onlyLocalShipping && this.props.euOrigin
+    const { billing, domesticOnly, euOrigin } = this.props
+    const onlyLocalShipping = !billing && !!domesticOnly
+    const lockCountryToOrigin = onlyLocalShipping && !euOrigin
+    const lockCountriesToEU = onlyLocalShipping && euOrigin
 
     const { address } = this.state
 

--- a/src/v2/Components/__tests__/Utils/addressForm.ts
+++ b/src/v2/Components/__tests__/Utils/addressForm.ts
@@ -1,6 +1,6 @@
 import { Address } from "v2/Components/AddressForm"
 import { CountrySelect } from "v2/Components/CountrySelect"
-import Input from "v2/Components/Input"
+import { Input } from "@artsy/palette"
 
 export const validAddress: Address = {
   name: "Artsy UK Ltd",


### PR DESCRIPTION
JIRA -> [Unexpected behavior when entering text in the shipping form](https://artsyproduct.atlassian.net/browse/PURCHASE-2817)

The bug was about weird input caret behavior of AddressForm component. It jumps to the end every re-render, so when a user wants to add a text somewhere in a middle of text, then the caret jumps to the end after first element input.

The problem was in 2 sources of truth. We have AdrdessForm state, where we store the values of inputs, and also we store the same data higher in the parent. And in the value attributes of each input in AddressForm `props.data` was passed, not `state.data`, that’s why it cause such a strange behavior. So, the fix is easy, just to replace `this.props.value` with `this.state.value`.

GIF:
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/79980131/127008944-51bc5c8c-bb0a-4e50-9f70-4dd4f67de2e3.gif)

