### PR TITLE
WIP - feature: Webpack Build Stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -256,6 +256,7 @@
     "@babel/preset-react": "7.12.13",
     "@babel/preset-typescript": "7.13.0",
     "@babel/register": "7.13.8",
+    "@datadog/build-plugin": "^0.4.3",
     "@graphql-inspector/core": "1.14.0",
     "@loadable/babel-plugin": "5.13.2",
     "@loadable/webpack-plugin": "5.14.0",

--- a/webpack/plugins/datadog.js
+++ b/webpack/plugins/datadog.js
@@ -1,0 +1,30 @@
+// @ts-check
+
+import { BuildPlugin } from "@datadog/build-plugin/dist/webpack"
+import merge from "webpack-merge"
+import { env } from "../utils/env"
+
+export function metrics(config, build) {
+  if (!env.enableWebpackDatadog || !env.datadogKey) {
+    return config
+  }
+
+  return merge.smart(config, {
+    plugins: [
+      new BuildPlugin(
+        env.datadogKey
+          ? {
+              datadog: {
+                apiKey: env.datadogKey,
+                prefix: "webpack.force",
+                tags: [
+                  `build:${build}`,
+                  `env:${process.env.NODE_ENV || "development"}`,
+                ],
+              },
+            }
+          : {}
+      ),
+    ],
+  })
+}

--- a/webpack/utils/env.js
+++ b/webpack/utils/env.js
@@ -9,7 +9,9 @@ const env = {
   buildLegacyClient: yn(process.env.BUILD_LEGACY_CLIENT, { default: false }),
   buildClient: yn(process.env.BUILD_CLIENT, { default: false }),
   buildServer: yn(process.env.BUILD_SERVER, { default: false }),
+  datadogKey: process.env.WEBPACK_DATADOG_KEY,
   enableWebpackAnalyze: yn(process.env.WEBPACK_ANALYZE, { default: false }),
+  enableWebpackDatadog: yn(process.env.WEBPACK_DATADOG, { default: true }),
   enableWebpackDumpConfig: process.env.WEBPACK_DUMP_CONFIG,
   fastProductionBuild: yn(process.env.WEBPACK_FAST_PRODUCTION_BUILD, {
     default: false,
@@ -21,7 +23,8 @@ const env = {
   nodeEnv: process.env.NODE_ENV,
   onCi: yn(process.env.CI, { default: false }),
   port: process.env.PORT || "5000",
-  webpackCiCpuLimit: Number.parseInt(process.env.WEBPACK_CI_CPU_LIMIT || "") || 4,
+  webpackCiCpuLimit:
+    Number.parseInt(process.env.WEBPACK_CI_CPU_LIMIT || "") || 4,
   webpackBundleSplit: yn(process.env.WEBPACK_BUNDLE_SPLIT, { default: true }),
   webpackConcatenate: yn(process.env.WEBPACK_CONCATENATE, { default: true }),
   webpackDebug: yn(process.env.WEBPACK_DEBUG),
@@ -49,6 +52,8 @@ if (env.onCi || env.logConfig) {
   console.log("  WEBPACK_BUNDLE_SPLIT".padEnd(35), chalk.yellow(env.webpackBundleSplit))
   console.log("  WEBPACK_CI_CPU_LIMIT".padEnd(35), chalk.yellow(env.webpackCiCpuLimit))
   console.log("  WEBPACK_CONCATENATE".padEnd(35), chalk.yellow(env.webpackConcatenate))
+  console.log("  WEBPACK_DATADOG_KEY".padEnd(35), chalk.yellow(env.datadogKey))
+  console.log("  WEBPACK_DATADOG".padEnd(35), chalk.yellow(env.enableWebpackDatadog))
   console.log("  WEBPACK_DEBUG".padEnd(35), chalk.yellow(env.webpackDebug))
   console.log("  WEBPACK_DEVTOOL".padEnd(35), chalk.yellow(env.webpackDevtool))
   console.log("  WEBPACK_DUMP_CONFIG".padEnd(35), chalk.yellow(env.enableWebpackDumpConfig))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,6 +1435,14 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@datadog/build-plugin@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@datadog/build-plugin/-/build-plugin-0.4.3.tgz#3c96e780d6429f90b0718f534452bb7936c4f469"
+  integrity sha512-32thfW5m3NwOy8mkxFZ7uxqmDJ6eDGRZ6eP6Wq3G7ojRVUp95NjPhda+3T+Xr23xev8DdRBBaVCIFiiw5HMO7A==
+  dependencies:
+    chalk "2.3.1"
+    fs-extra "7.0.1"
+
 "@emmetio/extract-abbreviation@0.1.6":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@emmetio/extract-abbreviation/-/extract-abbreviation-0.1.6.tgz#e4a9856c1057f0aff7d443b8536477c243abe28c"
@@ -5900,6 +5908,15 @@ center-align@^0.1.1:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
+chalk@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
+  integrity sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==
+  dependencies:
+    ansi-styles "^3.2.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.2.0"
+
 chalk@2.3.x:
   version "2.3.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
@@ -9639,6 +9656,15 @@ fs-exists-sync@^0.1.0:
   resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
   integrity sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=
 
+fs-extra@7.0.1, fs-extra@^7.0.0, fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^0.30.0:
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
@@ -9654,15 +9680,6 @@ fs-extra@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
-fs-extra@^7.0.0, fs-extra@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
-  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -19045,7 +19062,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^5.0.0, supports-color@^5.3.0, supports-color@^5.5.0:
+supports-color@^5.0.0, supports-color@^5.2.0, supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==


### PR DESCRIPTION
Enables detailed Webpack build stats and sends them along to Datadog.

From time to time it comes up in conversation that the force build is slow
on X's computer, or that a change to the build configuration has impacted
developer experience. 

If we collect the build stats and send them to Datadog we will be able to
detect anomalies and find ways to remediate them.

An incomplete Dashboard: [link](https://app.datadoghq.com/dashboard/bt2-c8n-vpp?from_ts=1626993129102&to_ts=1627079529102&live=true)

TODO:

[ ] Add shared datadog secret
[ ] Track CI builds separately