### PR TITLE
fix: check locations is not empty before usage

### DIFF
--- a/src/v2/Apps/Partner/partnerRoutes.tsx
+++ b/src/v2/Apps/Partner/partnerRoutes.tsx
@@ -351,7 +351,7 @@ export const partnerRoutes: AppRouteConfig[] = [
             return undefined
           }
 
-          if (partner.locations.totalCount === 0) {
+          if (!partner.locations || partner.locations.totalCount === 0) {
             throw new RedirectException(
               `/partner/${match.params.partnerId}`,
               302


### PR DESCRIPTION
This PR fixes a Sentry error that happened on the partner profile page.

Sentry error - https://sentry.io/organizations/artsynet/issues/2514889208/?project=28316&query=is%3Aunresolved+url%3A%22https%3A%2F%2Fwww.artsy.net%2Fpartner%2F%2A%22&statsPeriod=14d