### PR TITLE
fix: do not require config for createRelaySSREnvironment

### DIFF
--- a/src/v2/System/Relay/createRelaySSREnvironment.ts
+++ b/src/v2/System/Relay/createRelaySSREnvironment.ts
@@ -20,11 +20,6 @@ import { searchBarImmediateResolveMiddleware } from "./middleware/searchBarImmed
 import createLogger from "v2/Utils/logger"
 import { getENV } from "v2/Utils/getENV"
 
-import {
-  NETWORK_CACHE_SIZE as DEFAULT_NETWORK_CACHE_SIZE,
-  NETWORK_CACHE_TTL as DEFAULT_NETWORK_CACHE_TTL,
-} from "../../../config"
-
 const logger = createLogger("v2/System/Relay/createRelaySSREnvironment")
 
 const isServer = typeof window === "undefined"
@@ -103,8 +98,8 @@ export function createRelaySSREnvironment(config: Config = {}) {
     }),
     relaySSRMiddleware.getMiddleware(),
     cacheMiddleware({
-      size: Number(getENV("NETWORK_CACHE_SIZE")) ?? DEFAULT_NETWORK_CACHE_SIZE,
-      ttl: Number(getENV("NETWORK_CACHE_TTL")) ?? DEFAULT_NETWORK_CACHE_TTL,
+      size: Number(getENV("NETWORK_CACHE_SIZE")) ?? 2000, // max 2000 requests
+      ttl: Number(getENV("NETWORK_CACHE_TTL")) ?? 3600000, // 1 hour
       clearOnMutation: true,
       disableServerSideCache: !!user, // disable server-side cache if logged in
       onInit: queryResponseCache => {


### PR DESCRIPTION
https://artsy.slack.com/archives/C02BC3HEJ/p1627303585123800

We started to see alerts showing up on staging about [requiring config on the clients](https://github.com/artsy/force/blob/735db9e91e1e3e46b5951987d0f693e9be9de339/src/config.ts#L12). This was an existing behavior (so likely not relevant to [this refactor](https://github.com/artsy/force/pull/8062)), and reverting 
 https://github.com/artsy/force/pull/8057/commits/64f8e0a904028bf870473992e5102a2285295275 fixes it on my local.

I'm not up-to-date about how `createRelaySSREnvironment` is used on the client side or if this alert still makes sense in our current setup. We can follow up separately and revisit.


<img width="676" alt="Bildschirmfoto 2021-07-26 um 14 45 46" src="https://user-images.githubusercontent.com/796573/127041505-a37bf735-d403-4138-9cb0-e7366ed6523f.png">
