### PR TITLE
FX-2849 feat: Artwork grids page change event

### DIFF
--- a/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
@@ -52,6 +52,69 @@ describe("ArtworkFilter", () => {
     })
   })
 
+  describe("tracks clicks", () => {
+    it("on filter", async () => {
+      const onFilterClick = jest.fn()
+      const wrapper = await getWrapper("lg", {
+        onFilterClick,
+      })
+
+      wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
+
+      expect(trackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "commercialFilterParamsChanged",
+          context_module: "artworkGrid",
+          context_owner_id: undefined,
+          context_owner_slug: undefined,
+          context_owner_type: "home",
+          // `current` and `changed` are sent as
+          // JSON blobs, and verified below
+        })
+      )
+
+      const { current, changed } = trackEvent.mock.calls[0][0]
+
+      expect(JSON.parse(current)).toMatchObject({
+        acquireable: true,
+        majorPeriods: [],
+        page: 1,
+        sizes: [],
+        sort: "-decayed_merch",
+        artistIDs: [],
+        attributionClass: [],
+        partnerIDs: [],
+        additionalGeneIDs: [],
+        colors: [],
+        locationCities: [],
+        artistNationalities: [],
+        materialsTerms: [],
+      })
+
+      expect(JSON.parse(changed)).toMatchObject({
+        acquireable: true,
+      })
+    })
+
+    it("on page change", async () => {
+      const wrapper = await getWrapper()
+
+      wrapper.find("Page a").at(2).simulate("click", { button: 0 })
+
+      expect(trackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "clickedChangePage",
+          context_module: "artworkGrid",
+          context_page_owner_id: undefined,
+          context_page_owner_slug: undefined,
+          context_page_owner_type: "home",
+          page_current: 1,
+          page_changed: 3,
+        })
+      )
+    })
+  })
+
   describe("desktop", () => {
     it("renders default UI items", async () => {
       const wrapper = await getWrapper()
@@ -159,49 +222,6 @@ describe("ArtworkFilter", () => {
         locationCities: [],
         artistNationalities: [],
         materialsTerms: [],
-      })
-    })
-
-    it("tracks clicks", async () => {
-      const onFilterClick = jest.fn()
-      const wrapper = await getWrapper("lg", {
-        onFilterClick,
-      })
-
-      wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
-
-      expect(trackEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          action: "commercialFilterParamsChanged",
-          context_module: "artworkGrid",
-          context_owner_id: undefined,
-          context_owner_slug: undefined,
-          context_owner_type: "home",
-          // `current` and `changed` are sent as
-          // JSON blobs, and verified below
-        })
-      )
-
-      const { current, changed } = trackEvent.mock.calls[0][0]
-
-      expect(JSON.parse(current)).toMatchObject({
-        acquireable: true,
-        majorPeriods: [],
-        page: 1,
-        sizes: [],
-        sort: "-decayed_merch",
-        artistIDs: [],
-        attributionClass: [],
-        partnerIDs: [],
-        additionalGeneIDs: [],
-        colors: [],
-        locationCities: [],
-        artistNationalities: [],
-        materialsTerms: [],
-      })
-
-      expect(JSON.parse(changed)).toMatchObject({
-        acquireable: true,
       })
     })
   })

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -173,8 +173,7 @@ export const BaseArtworkFilter: React.FC<
   useDeepCompareEffect(() => {
     Object.entries(filterContext.filters ?? {}).forEach(
       ([filterKey, currentFilter]) => {
-        // @ts-expect-error STRICT_NULL_CHECK
-        const previousFilter = previousFilters[filterKey]
+        const previousFilter = previousFilters?.[filterKey]
         const filtersHaveUpdated = !isEqual(currentFilter, previousFilter)
 
         if (filtersHaveUpdated) {
@@ -194,13 +193,11 @@ export const BaseArtworkFilter: React.FC<
             tracking.trackEvent(
               commercialFilterParamsChanged({
                 changed: JSON.stringify({
-                  // @ts-expect-error STRICT_NULL_CHECK
-                  [filterKey]: filterContext.filters[filterKey],
+                  [filterKey]: filterContext.filters?.[filterKey],
                 }),
                 contextOwnerId: contextPageOwnerId,
                 contextOwnerSlug: contextPageOwnerSlug,
-                // @ts-expect-error STRICT_NULL_CHECK
-                contextOwnerType: contextPageOwnerType,
+                contextOwnerType: contextPageOwnerType!,
                 current: JSON.stringify(filterContext.filters),
               })
             )

--- a/src/v2/Components/ArtworkFilter/index.tsx
+++ b/src/v2/Components/ArtworkFilter/index.tsx
@@ -41,6 +41,7 @@ import {
   commercialFilterParamsChanged,
   ActionType,
   ContextModule,
+  ClickedChangePage,
 } from "@artsy/cohesion"
 import { allowedFilters } from "./Utils/allowedFilters"
 import { Sticky } from "v2/Components/Sticky"
@@ -180,15 +181,17 @@ export const BaseArtworkFilter: React.FC<
           fetchResults()
 
           if (filterKey === "page") {
-            tracking.trackEvent({
+            const pageTrackingParams: ClickedChangePage = {
               action: ActionType.clickedChangePage,
               context_module: ContextModule.artworkGrid,
-              context_page_owner_type: contextPageOwnerType,
+              context_page_owner_type: contextPageOwnerType!,
               context_page_owner_id: contextPageOwnerId,
               context_page_owner_slug: contextPageOwnerSlug,
               page_current: previousFilter,
               page_changed: currentFilter,
-            })
+            }
+
+            tracking.trackEvent(pageTrackingParams)
           } else {
             tracking.trackEvent(
               commercialFilterParamsChanged({


### PR DESCRIPTION
[FX-2849]

### Description
Currently when user changes page on an artwork grid on web, we fire a `Commercial_filter_params_changed` event. We should fire a different event because a page change is not a filter change.

#### This PR separates page change event

![Screenshot 2021-07-27 at 14 39 00](https://user-images.githubusercontent.com/44819355/127147577-9d61b144-73bb-48f8-a6d1-40f8a4a56471.png)




[FX-2849]: https://artsyproduct.atlassian.net/browse/FX-2849