### PR TITLE
fix[FX-1758]: adds og meta tags to collection pages

### DIFF
--- a/src/v2/Apps/Collect/Routes/Collection/index.tsx
+++ b/src/v2/Apps/Collect/Routes/Collection/index.tsx
@@ -69,6 +69,10 @@ export const CollectionApp: React.FC<CollectionAppProps> = props => {
       <Meta property="og:url" content={collectionHref} />
       <Meta property="og:image" content={socialImage} />
       <Meta property="og:description" content={metadataDescription} />
+      <Meta property="og:title" content={title} />
+      <Meta property="og:type" content="website" />
+      <Meta property="og:site_name" content="Artsy" />
+      <Meta property="twitter:card" content="summary_large_image" />
       <Meta property="twitter:description" content={metadataDescription} />
       <Link rel="canonical" href={collectionHref} />
       <BreadCrumbList


### PR DESCRIPTION
So turns out that in order to display a card for a tweet, Twitter demands that you add a `twitter:card` meta tag. We didn't add this tag on collection pages, so they looked terrible in tweets.

Tested using https://cards-dev.twitter.com/validator and [ngrok](https://ngrok.com/docs) for port forwarding.

One note: when I tested [this collection](https://www.artsy.net/collection/bridget-riley-black-and-white), I received the following warning:

```
WARN:  The image URL http://files.artsy.net/images/bridget-riley-black-white.png specified by the 'og:image' metatag may be restricted by the site's robots.txt file, which will prevent Twitter from fetching it.
```

So we _might_ still have problems if an image was uploaded using [Vanity](https://vanity.artsy.net/).

Before:
<img width="1792" alt="Screen Shot 2021-07-27 at 7 28 14 PM" src="https://user-images.githubusercontent.com/5361806/127200237-d952fda1-4fa2-4cd3-a722-a3a0de8d738b.png">

After:
<img width="1792" alt="Screen Shot 2021-07-27 at 7 27 43 PM" src="https://user-images.githubusercontent.com/5361806/127200185-de9d1e3a-a3c3-4a19-8409-8ae0bd7fb716.png">


Jira ticket: [FX-1758](https://artsyproduct.atlassian.net/browse/FX-1758)