### PR TITLE
fix(artwork): fixes preload srcset

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkLightbox.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkLightbox.tsx
@@ -39,7 +39,14 @@ const ArtworkLightbox: React.FC<ArtworkLightboxProps> = ({
 
   return (
     <>
-      {isDefault && <Link rel="preload" as="image" href={image.src} />}
+      {isDefault && (
+        <Link
+          rel="preload"
+          as="image"
+          href={image.src}
+          imagesrcset={image.srcSet}
+        />
+      )}
 
       <Clickable
         display="flex"


### PR DESCRIPTION
Embarrassed I didn't catch this sooner: When I switched this component to use a `srcSet` also required was updating the preload tag to support it. So on 2x screens we've been preloading the 1x then not using it.