### PR TITLE
chore(GRO-452): preloads unica italic

### DIFF
--- a/src/v2/index.ejs
+++ b/src/v2/index.ejs
@@ -11,6 +11,7 @@
   <!-- Create preload tags for most common fonts -->
   <link rel="preload" href="<%%= fontUrl %>/ll-unica77_regular.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="preload" href="<%%= fontUrl %>/ll-unica77_medium.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="<%%= fontUrl %>/ll-unica77_italic.woff2" as="font" type="font/woff2" crossorigin />
 
   <link rel='apple-touch-icon' href="<%%= icons.icon152 %>" />
   <link rel='apple-touch-icon' sizes='120x120' href="<%%= icons.icon120 %>" />


### PR DESCRIPTION
Closes: [GRO-452](https://artsyproduct.atlassian.net/browse/GRO-452)

There is an ongoing design issue with the goal of removing italics completely, but for the time being this font is used prominently on every page, so it makes sense to preload it in the meantime.