### PR TITLE
feature: Preload Fonts ASAP

### DIFF
--- a/src/v2/index.ejs
+++ b/src/v2/index.ejs
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <meta charset='utf-8' />
 
-  <!-- Create preload tags for dynamic chunks -->
-  <%- htmlWebpackPlugin.tags.bodyTags.map((originalTag) => { const tag = { ...originalTag, attributes: { ...originalTag.attributes } }; tag.tagName = 'link'; tag.attributes['href'] = "<" + "%= cdnUrl %" + ">" + originalTag.attributes['src']; tag.attributes['rel'] = 'preload'; tag.attributes['as'] = 'script'; delete tag.attributes.src; return tag; }) %>
-
   <!-- Create preload tags for most common fonts -->
   <link rel="preload" href="<%%= fontUrl %>/ll-unica77_regular.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="preload" href="<%%= fontUrl %>/ll-unica77_medium.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="preload" href="<%%= fontUrl %>/ll-unica77_italic.woff2" as="font" type="font/woff2" crossorigin />
+
+  <!-- Create preload tags for dynamic chunks -->
+  <%- htmlWebpackPlugin.tags.bodyTags.map((originalTag) => { const tag = { ...originalTag, attributes: { ...originalTag.attributes } }; tag.tagName = 'link'; tag.attributes['href'] = "<" + "%= cdnUrl %" + ">" + originalTag.attributes['src']; tag.attributes['rel'] = 'preload'; tag.attributes['as'] = 'script'; delete tag.attributes.src; return tag; }) %>
 
   <link rel='apple-touch-icon' href="<%%= icons.icon152 %>" />
   <link rel='apple-touch-icon' sizes='120x120' href="<%%= icons.icon120 %>" />


### PR DESCRIPTION
Being preloading the fonts before the JS assets. With the additional 
chunks created by the new chunking algorithm, fonts are being delayed
for longer than we'd like. Overall, this should help with our initial render.