### PR TITLE
fix(types): passes through system query renderer types

### DIFF
--- a/src/v2/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
@@ -252,7 +252,7 @@ export const MarketStatsQueryRenderer: React.FC<{
 
         return (
           <MarketStatsFragmentContainer
-            priceInsightsConnection={props.priceInsightsConnection}
+            priceInsightsConnection={props.priceInsightsConnection!}
           />
         )
       }}

--- a/src/v2/Apps/Artist/Routes/Overview/Components/IconicCollectionsRail/ArtistIconicCollectionsRail.tsx
+++ b/src/v2/Apps/Artist/Routes/Overview/Components/IconicCollectionsRail/ArtistIconicCollectionsRail.tsx
@@ -10,6 +10,7 @@ import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { data as sd } from "sharify"
 import { useTracking } from "react-tracking"
 import { LoadingPlaceholder } from "./LoadingPlaceholder"
+import { ArtistIconicCollectionsRailQuery } from "v2/__generated__/ArtistIconicCollectionsRailQuery.graphql"
 
 interface ArtistIconicCollectionsRailProps {
   marketingCollections: ArtistIconicCollectionsRail_marketingCollections
@@ -123,7 +124,7 @@ export const ArtistIconicCollectionsRailQueryRenderer = props => {
   const { relayEnvironment } = useSystemContext()
 
   return (
-    <SystemQueryRenderer
+    <SystemQueryRenderer<ArtistIconicCollectionsRailQuery>
       environment={relayEnvironment}
       variables={{
         artistID: props.artistID, // Refers to `internalID`, not `slug`

--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/RequestConditionReport.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/RequestConditionReport.tsx
@@ -219,7 +219,7 @@ export const RequestConditionReportQueryRenderer: React.FC<{
         }
       `}
       render={({ props }) => {
-        if (props) {
+        if (props && props.artwork && props.me) {
           return (
             <RequestConditionReportFragmentContainer
               artwork={props.artwork}

--- a/src/v2/Apps/Artwork/Components/ArtworkSidebarClassificationsModal.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkSidebarClassificationsModal.tsx
@@ -120,7 +120,7 @@ export const ArtworkSidebarClassificationsModalQueryRenderer: React.FC<Omit<
         return (
           <ArtworkSidebarClassificationsModalFragmentContainer
             {...rest}
-            {...props}
+            viewer={props.viewer!}
           />
         )
       }}

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/InDemandNow/ConsignInDemandNow.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/InDemandNow/ConsignInDemandNow.tsx
@@ -126,10 +126,10 @@ const ConsignInDemandNowQueryRenderer: React.FC = () => {
         return (
           <>
             <Media greaterThanOrEqual="md">
-              <InDemandNowLarge {...props} />
+              <InDemandNowLarge {...props!} />
             </Media>
             <Media lessThan="md">
-              <InDemandNowSmall {...props} />
+              <InDemandNowSmall {...props!} />
             </Media>
           </>
         )

--- a/src/v2/Apps/Consign/Routes/MarketingLanding/Components/InDemandNow/ConsignTopArtists.tsx
+++ b/src/v2/Apps/Consign/Routes/MarketingLanding/Components/InDemandNow/ConsignTopArtists.tsx
@@ -74,7 +74,7 @@ const ConsignTopArtistsQueryRenderer: React.FC = () => {
           return null
         }
 
-        return <TopArtists {...props} />
+        return <TopArtists {...props!} />
       }}
     />
   )

--- a/src/v2/Apps/Home/Components/HomeArtworkModuleRail.tsx
+++ b/src/v2/Apps/Home/Components/HomeArtworkModuleRail.tsx
@@ -224,7 +224,7 @@ export const HomeArtworkModuleRailQueryRenderer: React.FC<HomeArtworkModuleRailQ
           return <HomeArtworkModulePlaceholder title={title} />
         }
 
-        if (props.homePage.artworkModule) {
+        if (props.homePage?.artworkModule) {
           return (
             <HomeArtworkModuleRailFragmentContainer
               artworkModule={props.homePage.artworkModule}

--- a/src/v2/Apps/Home/Components/HomeFeaturedArticles.tsx
+++ b/src/v2/Apps/Home/Components/HomeFeaturedArticles.tsx
@@ -9,6 +9,7 @@ import {
   SkeletonText,
   Shelf,
 } from "@artsy/palette"
+import { compact } from "lodash"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useSystemContext } from "v2/System"
@@ -174,7 +175,9 @@ export const HomeFeaturedArticlesQueryRenderer: React.FC = () => {
 
         if (props.articles) {
           return (
-            <HomeFeaturedArticlesFragmentContainer articles={props.articles} />
+            <HomeFeaturedArticlesFragmentContainer
+              articles={compact(props.articles)}
+            />
           )
         }
 

--- a/src/v2/Apps/Partner/Components/Overview/ArtworksRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/ArtworksRail.tsx
@@ -131,7 +131,9 @@ export const ArtworksRailRenderer: React.FC<
         if (error || !props)
           return <ArtworksRailPlaceholder {...rest} count={15} />
 
-        return <ArtworksRailFragmentContainer {...rest} {...props} />
+        return (
+          <ArtworksRailFragmentContainer {...rest} partner={props.partner!} />
+        )
       }}
     />
   )

--- a/src/v2/Apps/Partner/Components/Overview/NearbyGalleriesRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/NearbyGalleriesRail.tsx
@@ -98,7 +98,7 @@ export const NearbyGalleriesRailRenderer: React.FC<
           <NearbyGalleriesRailFragmentContainer
             {...rest}
             {...props}
-            partners={props?.partnersConnection?.edges}
+            partners={compact(props?.partnersConnection?.edges)}
           />
         )
       }}

--- a/src/v2/Apps/Partner/Components/Overview/ShowBannersRail/ShowBannersRail.tsx
+++ b/src/v2/Apps/Partner/Components/Overview/ShowBannersRail/ShowBannersRail.tsx
@@ -170,7 +170,10 @@ export const ShowBannersRailRenderer: React.FC<
 
         return (
           <PartnerShowBannersContextProvider>
-            <ShowBannersRailFragmentContainer {...rest} {...props} />
+            <ShowBannersRailFragmentContainer
+              {...rest}
+              partner={props.partner!}
+            />
           </PartnerShowBannersContextProvider>
         )
       }}

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistDetails.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistDetails.tsx
@@ -142,7 +142,7 @@ export const PartnerArtistDetailsRenderer: React.FC<{
             {...rest}
             {...props}
             partnerId={partnerId}
-            partnerArtist={props?.partner?.artistsConnection?.edges[0]}
+            partnerArtist={props?.partner?.artistsConnection?.edges?.[0]!}
           />
         )
       }}

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetailsList/PartnerArtistDetailsList.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistDetailsList/PartnerArtistDetailsList.tsx
@@ -154,7 +154,10 @@ export const PartnerArtistDetailsListRenderer: React.FC<{
           return <PartnerArtistDetailsListPlaceholder count={PAGE_SIZE} />
 
         return (
-          <PartnerArtistDetailsListPaginationContainer {...rest} {...props} />
+          <PartnerArtistDetailsListPaginationContainer
+            {...rest}
+            partner={props.partner!}
+          />
         )
       }}
     />

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtists.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtists.tsx
@@ -92,7 +92,9 @@ export const PartnerArtistsRenderer: React.FC<{
       render={({ error, props }) => {
         if (error || !props) return <PartnerArtistListPlaceholder />
 
-        return <PartnerArtistsFragmentContainer {...rest} {...props} />
+        return (
+          <PartnerArtistsFragmentContainer {...rest} partner={props.partner!} />
+        )
       }}
     />
   )

--- a/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarousel.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerArtists/PartnerArtistsCarousel/PartnerArtistsCarousel.tsx
@@ -128,7 +128,12 @@ export const PartnerArtistsCarouselRenderer: React.FC<{
         if (error || !props)
           return <PartnerArtistsCarouselPlaceholder count={PAGE_SIZE} />
 
-        return <PartnerArtistsCarouselFragmentContainer {...rest} {...props} />
+        return (
+          <PartnerArtistsCarouselFragmentContainer
+            {...rest}
+            partner={props.partner!}
+          />
+        )
       }}
     />
   )

--- a/src/v2/Apps/Partner/Components/PartnerShows/ShowPaginatedEvents.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerShows/ShowPaginatedEvents.tsx
@@ -207,7 +207,11 @@ export const ShowPaginatedEventsRenderer: React.FC<ShowPaginatedEventsRendererPr
         if (error || !props) return null
 
         return (
-          <ShowEventsRefetchContainer {...rest} {...props} paramsPage={page} />
+          <ShowEventsRefetchContainer
+            {...rest}
+            partner={props.partner!}
+            paramsPage={page!}
+          />
         )
       }}
     />

--- a/src/v2/Apps/WorksForYou/index.tsx
+++ b/src/v2/Apps/WorksForYou/index.tsx
@@ -74,14 +74,14 @@ export class WorksForYou extends Component<Props> {
                             <WorksForYouArtistFeed
                               // @ts-expect-error STRICT_NULL_CHECK
                               artistID={this.props.artistID}
-                              viewer={props.viewer}
+                              viewer={props.viewer!}
                               forSale={forSale}
                               user={user}
                             />
                           ) : (
                             <WorksForYouFeed
                               user={user}
-                              viewer={props.viewer}
+                              viewer={props.viewer!}
                             />
                           )}
                         </Box>

--- a/src/v2/Components/ArtworkGridExample.tsx
+++ b/src/v2/Components/ArtworkGridExample.tsx
@@ -24,7 +24,10 @@ export function ArtworkGridExample(props: {
       render={readyState => {
         return (
           readyState.props && (
-            <ArtworkGrid {...readyState.props.artist} {...props} />
+            <ArtworkGrid
+              artworks={readyState.props.artist?.artworks!}
+              {...props}
+            />
           )
         )
       }}

--- a/src/v2/Components/AuctionTimer.tsx
+++ b/src/v2/Components/AuctionTimer.tsx
@@ -98,7 +98,7 @@ export const AuctionTimerQueryRenderer = ({ saleID }: { saleID: string }) => {
         }
       `}
       render={({ props }) => {
-        return props && <AuctionTimerFragmentContainer sale={props.sale} />
+        return props && <AuctionTimerFragmentContainer sale={props.sale!} />
       }}
     />
   )

--- a/src/v2/Components/FlashBanner/index.tsx
+++ b/src/v2/Components/FlashBanner/index.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useMemo } from "react"
 import qs from "qs"
 import { graphql } from "react-relay"
 import { Banner } from "@artsy/palette"
@@ -8,7 +8,7 @@ import { AnalyticsSchema as Schema, track } from "v2/System/Analytics"
 import { SystemQueryRenderer } from "v2/System/Relay/SystemQueryRenderer"
 import { isServer } from "lib/isServer"
 import { EmailConfirmationLinkExpired } from "./EmailConfirmationLinkExpired"
-import { useMemo } from "react"
+import { FlashBannerQuery } from "v2/__generated__/FlashBannerQuery.graphql"
 
 interface FlashBannerProps {
   contentCode?: string
@@ -86,7 +86,7 @@ export const FlashBannerQueryRenderer: React.FC = () => {
   if (isServer) return null
 
   return user ? (
-    <SystemQueryRenderer
+    <SystemQueryRenderer<FlashBannerQuery>
       environment={relayEnvironment}
       query={graphql`
         query FlashBannerQuery {
@@ -96,9 +96,16 @@ export const FlashBannerQueryRenderer: React.FC = () => {
         }
       `}
       render={({ props, error }) => {
-        if (error) console.error(error)
+        if (error) {
+          console.error(error)
+          return null
+        }
 
-        return <TrackedFlashBanner {...props} />
+        if (!props?.me) {
+          return null
+        }
+
+        return <TrackedFlashBanner me={props.me} />
       }}
     />
   ) : (

--- a/src/v2/Components/FollowArtistPopover/index.tsx
+++ b/src/v2/Components/FollowArtistPopover/index.tsx
@@ -88,7 +88,7 @@ export const FollowArtistPopoverQueryRenderer = ({
         return (
           props && (
             <FollowArtistPopoverFragmentContainer
-              artist={props.artist}
+              artist={props.artist!}
               user={user}
             />
           )

--- a/src/v2/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/v2/Components/FollowButton/FollowArtistButton.tsx
@@ -273,7 +273,12 @@ export const FollowArtistButtonQueryRenderer: React.FC<
           return <FollowArtistButtonFragmentContainer {...rest} artist={null} />
         }
 
-        return <FollowArtistButtonFragmentContainer {...rest} {...props} />
+        return (
+          <FollowArtistButtonFragmentContainer
+            {...rest}
+            artist={props.artist!}
+          />
+        )
       }}
     />
   )

--- a/src/v2/Components/Onboarding/ArtistsStep/ArtistSearchResults.tsx
+++ b/src/v2/Components/Onboarding/ArtistsStep/ArtistSearchResults.tsx
@@ -233,7 +233,7 @@ const ArtistSearchResultsComponent: React.SFC<
               onArtistFollow={onArtistFollow}
               onNoResults={onNoResults}
               term={term}
-              viewer={props.viewer}
+              viewer={props.viewer!}
             />
           )
         } else {

--- a/src/v2/Components/Onboarding/ArtistsStep/PopularArtists.tsx
+++ b/src/v2/Components/Onboarding/ArtistsStep/PopularArtists.tsx
@@ -219,7 +219,8 @@ const PopularArtistsComponent: React.SFC<
           return (
             <PopularArtistContentContainer
               onArtistFollow={onArtistFollow}
-              popular_artists={props.highlights.popular_artists}
+              // @ts-ignore FIXME: The types in this component are pretty far gone
+              popular_artists={props.highlights?.popular_artists!}
             />
           )
         } else {

--- a/src/v2/Components/Onboarding/GenesStep/GeneSearchResults.tsx
+++ b/src/v2/Components/Onboarding/GenesStep/GeneSearchResults.tsx
@@ -224,7 +224,7 @@ const GeneSearchResultsComponent: React.SFC<
               onGeneFollow={onGeneFollow}
               onNoResults={onNoResults}
               term={term}
-              viewer={props.viewer}
+              viewer={props.viewer!}
             />
           )
         } else {

--- a/src/v2/Components/Onboarding/GenesStep/SuggestedGenes.tsx
+++ b/src/v2/Components/Onboarding/GenesStep/SuggestedGenes.tsx
@@ -187,7 +187,8 @@ const SuggestedGenesComponent: React.SFC<
           return (
             <SuggestedGenesContainer
               onGeneFollow={onGeneFollow}
-              suggested_genes={props.highlights.suggested_genes}
+              // @ts-ignore // FIXME: The types in this file are pretty far gone
+              suggested_genes={props.highlights?.suggested_genes!}
             />
           )
         } else {

--- a/src/v2/Components/RecentlyViewed/RecentlyViewed.tsx
+++ b/src/v2/Components/RecentlyViewed/RecentlyViewed.tsx
@@ -99,7 +99,7 @@ export const RecentlyViewedQueryRenderer = () => {
           return <RecentlyViewedPlaceholder />
         }
 
-        return <RecentlyViewedFragmentContainer {...props} />
+        return <RecentlyViewedFragmentContainer me={props.me!} />
       }}
     />
   )

--- a/src/v2/Components/RecentlyViewed/RecentlyViewedV2.tsx
+++ b/src/v2/Components/RecentlyViewed/RecentlyViewedV2.tsx
@@ -112,11 +112,11 @@ export const RecentlyViewedV2QueryRenderer = () => {
           return null
         }
 
-        if (!props) {
+        if (!props || !props.me) {
           return <RecentlyViewedV2Placeholder />
         }
 
-        return <RecentlyViewedV2FragmentContainer {...props} />
+        return <RecentlyViewedV2FragmentContainer me={props.me} />
       }}
     />
   )

--- a/src/v2/DevTools/__tests__/renderRelayTree.jest.tsx
+++ b/src/v2/DevTools/__tests__/renderRelayTree.jest.tsx
@@ -1,8 +1,10 @@
+/* eslint-disable jsx-a11y/alt-text */
 import { MockRelayRendererFixturesArtistQueryRawResponse } from "v2/__generated__/MockRelayRendererFixturesArtistQuery.graphql"
 import { MockRelayRendererFixturesQueryRawResponse } from "v2/__generated__/MockRelayRendererFixturesQuery.graphql"
 import React from "react"
 import { renderRelayTree } from "../renderRelayTree"
 import { Artwork, query, renderToString } from "./MockRelayRendererFixtures"
+import { flushPromiseQueue } from "../flushPromiseQueue"
 
 jest.unmock("react-relay")
 
@@ -31,6 +33,9 @@ describe("renderRelayTree", () => {
       query,
       mockData,
     })
+
+    await flushPromiseQueue()
+
     expect(tree.html()).toEqual(
       renderToString(
         <div>

--- a/src/v2/System/Relay/RootQueryRenderer.tsx
+++ b/src/v2/System/Relay/RootQueryRenderer.tsx
@@ -4,14 +4,14 @@ import {
   withSystemContext,
 } from "v2/System"
 import React from "react"
-// FIXME: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37950
-// @ts-ignore
-import { QueryRendererProps } from "react-relay"
 import { OperationType } from "relay-runtime"
-import { SystemQueryRenderer } from "./SystemQueryRenderer"
+import {
+  SystemQueryRenderer,
+  SystemQueryRendererProps,
+} from "./SystemQueryRenderer"
 
 type Props<T extends OperationType> = SystemContextProps &
-  Omit<QueryRendererProps<T>, "environment">
+  SystemQueryRendererProps<T>
 
 class Renderer<T extends OperationType> extends React.Component<Props<T>> {
   redner() {


### PR DESCRIPTION
I cherry-picked these off my working branch because it turned into a _thing_. Noticing props being cast as `any` led me to fix the typing in `SystemQueryRenderer` which pulled on a bit of a thread.

For the most part I'm just asserting the existence of a bunch of props, which _should_ be more or less OK, the nullable fields from Metaphysics tend to be incorrect for the most part. I had to use a `ts-ignore` or two in Onboarding where the types are pretty rough from a bunch of other ignores in the file.