### PR TITLE
fix: Hide current password input in settings form conditionally

### DIFF
--- a/src/desktop/apps/user/components/password/index.jade
+++ b/src/desktop/apps/user/components/password/index.jade
@@ -23,18 +23,26 @@ form.settings-password__form.stacked-form(
   .form-errors.js-form-errors
     //- Rendered client-side
 
-  label.avant-garde-form-label( for='current-password' )
-    | Current Password
-  input.bordered-input(
-    id='current-password'
-    name='current_password'
-    type='password'
-    autocomplete='on'
-    pattern='.{8,}'
-    title='8 characters minimum'
-    autofocus
-    required
-  )
+  if user.get('has_password')
+    label.avant-garde-form-label( for='current-password' )
+      | Current Password
+    input.bordered-input(
+      id='current-password'
+      name='current_password'
+      type='password'
+      autocomplete='on'
+      pattern='.{8,}'
+      title='8 characters minimum'
+      autofocus
+      required
+    )
+  else
+    input.bordered-input(
+      id='current-password'
+      name='current_password'
+      type='hidden'
+      value=''
+    )
 
   label.avant-garde-form-label( for='new_password' )
     | New Password

--- a/src/desktop/apps/user/components/password/view.coffee
+++ b/src/desktop/apps/user/components/password/view.coffee
@@ -34,5 +34,6 @@ module.exports = class SettingsPasswordView extends GenericFormView
   , 300
 
   render: ->
-    @$el.html template()
+    @$el.html template
+      user: @user
     this


### PR DESCRIPTION
Addresses [CX-294]

## Description

Hides current password input in the settings page if the user account doesn't have a password. This case can happen if the user created the account with a 3rd party provider which doesn't require a password.

Currently, the user has to enter an arbitrary password in the "current password" field to pass the form validation when creating a password for an account without a password.

![Screenshot 2021-08-09 at 10 27 36](https://user-images.githubusercontent.com/4691889/128678435-086e1641-aa40-47b9-b572-bfa28ddec40d.png)



[CX-294]: https://artsyproduct.atlassian.net/browse/CX-294