### PR TITLE
Transition from legacy dependabot to native github security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    # Limit to 0 to enable only security updates:
+    open-pull-requests-limit: 0
+    assignees:
+      - icirellik
+    reviewers:
+      - artsy/platform-engineers


### PR DESCRIPTION
This transitions security updates from dependabot (which is [pending retirement](https://github.blog/2021-04-29-goodbye-dependabot-preview-hello-dependabot/)) to Github-managed.

**Step 1** (already complete): Enable "Dependabot security updates" under the repo's [Security & analysis settings](https://github.com/artsy/force/settings/security_analysis).

**Step 2** (this PR): Commit a minimal `.github/dependabot.yml` specifying `open-pull-requests-limit: 0` (this is [a hack to enable only security updates](https://stackoverflow.com/a/68254421), which can't otherwise be configured), the same assignee as currently specified [in dependabot's UI](https://app.dependabot.com/accounts/artsy/projects/105079), and the associated team as reviewers.

https://artsyproduct.atlassian.net/browse/PLATFORM-3470