### PR TITLE
fix(PX-4367): BNMO Checkout flow: Shipping step: Delivery address: redundant shadow for "Default" label

### DIFF
--- a/src/v2/Apps/Order/Components/SavedAddressItem.tsx
+++ b/src/v2/Apps/Order/Components/SavedAddressItem.tsx
@@ -60,6 +60,7 @@ export const SavedAddressItem: React.FC<SavedAddressItemProps> = (
                       hover
                       width={53}
                       maxHeight={21}
+                      style={{ boxShadow: "none" }}
                     >
                       <Text
                         textColor="black60"
@@ -106,5 +107,4 @@ const EditButton = styled(Text)`
 
 const StyledPill = styled(Pill)`
   background-color: ${color("black10")} !important;
-  pointer-events: none;
 `


### PR DESCRIPTION
Jira Ticket: https://artsyproduct.atlassian.net/browse/PX-4367

This PR fixes redundant shadow for the "Default" label in BNMO Checkout flow. Also, I deleted the unused style: `pointer-events: none` because Pill prop `disabled` already did this

<details>
  <summary>Before</summary>

https://user-images.githubusercontent.com/55637696/128016948-d456b0e8-1dca-4315-b867-c40b690ad53b.mov
</details>

<details>
  <summary>After</summary>

https://user-images.githubusercontent.com/55637696/128016894-c133e9db-e028-41ef-a322-81f341f4b13f.mov
</details>