### PR TITLE
fix(FX-2825): analytics event for clearing custom size

### DIFF
--- a/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -23,11 +23,8 @@ export const initialArtworkFilterState: ArtworkFilters = {
   locationCities: [],
   artistNationalities: [],
   materialsTerms: [],
-
-  // TODO: Remove these unneeded default props
-  // height: "*-*",
-  // price_range: "*-*",
-  // width: "*-*",
+  height: "*-*",
+  width: "*-*",
 }
 
 /**

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
@@ -84,7 +84,6 @@ const hasValue = (size: CustomSize) => {
 const getValue = (value: CustomRange[number]) => {
   return value === "*" || value === 0 ? "" : value
 }
-
 const isCustomSize = (value?: string) => isString(value) && value !== "*-*"
 
 export interface SizeFilterProps {
@@ -104,7 +103,7 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
     width: parseRange(width) as CustomRange,
   }
 
-  const [showCustom, setShowCustom] = useState(!!hasValue(initialCustomSize))
+  const [showCustom, setShowCustom] = useState(isCustomSize)
   const [customSize, setCustomSize] = useState<CustomSize>(
     hasValue(initialCustomSize) ? initialCustomSize : DEFAULT_CUSTOM_SIZE
   )
@@ -147,13 +146,8 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
     const newFilters = {
       ...currentlySelectedFilters?.(),
       sizes,
-    }
-
-    if (isCustomSize(height)) {
-      newFilters.height = "*-*"
-    }
-    if (isCustomSize(width)) {
-      newFilters.width = "*-*"
+      height: "*-*",
+      width: "*-*",
     }
 
     setFilters?.(newFilters, { force: false })
@@ -161,21 +155,12 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
   }
 
   const handleClick = () => {
-    const { height: newHeightValue, width: newWidthValue } = mapSizeToRange(
-      convertSizeToInches(customSize) as CustomSize
-    )
-
     const newFilters = {
       ...currentlySelectedFilters?.(),
       sizes: [],
+      ...mapSizeToRange(convertSizeToInches(customSize) as CustomSize),
     }
 
-    if (isCustomSize(newWidthValue) || isCustomSize(width)) {
-      newFilters.width = newWidthValue
-    }
-    if (isCustomSize(newHeightValue) || isCustomSize(height)) {
-      newFilters.height = newHeightValue
-    }
     if (reset) {
       delete newFilters.reset
     }

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
@@ -103,7 +103,9 @@ export const SizeFilter: React.FC<SizeFilterProps> = ({ expanded }) => {
     width: parseRange(width) as CustomRange,
   }
 
-  const [showCustom, setShowCustom] = useState(isCustomSize)
+  const [showCustom, setShowCustom] = useState(
+    isCustomSize(width) || isCustomSize(height)
+  )
   const [customSize, setCustomSize] = useState<CustomSize>(
     hasValue(initialCustomSize) ? initialCustomSize : DEFAULT_CUSTOM_SIZE
   )

--- a/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter.jest.tsx
@@ -76,8 +76,8 @@ describe("SizeFilter", () => {
     await wrapper.find("Checkbox").at(0).simulate("click")
     expect(context.filters?.sizes).toEqual(["SMALL"])
 
-    expect(context.filters?.height).toEqual(undefined)
-    expect(context.filters?.width).toEqual(undefined)
+    expect(context.filters?.height).toEqual("*-*")
+    expect(context.filters?.width).toEqual("*-*")
   })
 
   it("width changes don't fire height changes", async () => {
@@ -97,7 +97,7 @@ describe("SizeFilter", () => {
       .simulate("click")
 
     expect(context.filters?.width).toEqual("4.72-6.3")
-    expect(context.filters?.height).toEqual(undefined)
+    expect(context.filters?.height).toEqual("*-*")
   })
 
   describe("filter values", () => {

--- a/src/v2/Components/ArtworkFilter/Utils/__tests__/urlFragmentFromState.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/Utils/__tests__/urlFragmentFromState.jest.tsx
@@ -15,7 +15,7 @@ describe("urlFragmentFromState", () => {
     }
 
     expect(urlFragmentFromState(artworkFilterState)).toEqual(
-      "priceRange=100-200&height=300-400&width=500-600"
+      "height=300-400&width=500-600&priceRange=100-200"
     )
   })
 })

--- a/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
+++ b/src/v2/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
@@ -7,6 +7,7 @@ import React from "react"
 import { ArtworkQueryFilter } from "../ArtworkQueryFilter"
 import { ArtworkFilterFixture } from "./fixtures/ArtworkFilter.fixture"
 import { Pagination } from "v2/Components/Pagination"
+import { initialArtworkFilterState } from "../ArtworkFilterContext"
 
 jest.unmock("react-relay")
 jest.mock("v2/System/Analytics/useTracking")
@@ -76,19 +77,8 @@ describe("ArtworkFilter", () => {
       const { current, changed } = trackEvent.mock.calls[0][0]
 
       expect(JSON.parse(current)).toMatchObject({
+        ...initialArtworkFilterState,
         acquireable: true,
-        majorPeriods: [],
-        page: 1,
-        sizes: [],
-        sort: "-decayed_merch",
-        artistIDs: [],
-        attributionClass: [],
-        partnerIDs: [],
-        additionalGeneIDs: [],
-        colors: [],
-        locationCities: [],
-        artistNationalities: [],
-        materialsTerms: [],
       })
 
       expect(JSON.parse(changed)).toMatchObject({
@@ -132,19 +122,8 @@ describe("ArtworkFilter", () => {
       wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
 
       expect(onFilterClick).toHaveBeenCalledWith("acquireable", true, {
+        ...initialArtworkFilterState,
         acquireable: true,
-        majorPeriods: [],
-        page: 1,
-        sizes: [],
-        sort: "-decayed_merch",
-        artistIDs: [],
-        attributionClass: [],
-        partnerIDs: [],
-        additionalGeneIDs: [],
-        colors: [],
-        locationCities: [],
-        artistNationalities: [],
-        materialsTerms: [],
       })
     })
 
@@ -176,19 +155,8 @@ describe("ArtworkFilter", () => {
       wrapper.find("WaysToBuyFilter").find("Checkbox").first().simulate("click")
 
       expect(onChange).toHaveBeenCalledWith({
+        ...initialArtworkFilterState,
         acquireable: true,
-        majorPeriods: [],
-        page: 1,
-        sizes: [],
-        sort: "-decayed_merch",
-        artistIDs: [],
-        attributionClass: [],
-        partnerIDs: [],
-        additionalGeneIDs: [],
-        colors: [],
-        locationCities: [],
-        artistNationalities: [],
-        materialsTerms: [],
       })
     })
 
@@ -210,18 +178,8 @@ describe("ArtworkFilter", () => {
       wrapper.find("Select").find("option").at(1).simulate("change")
 
       expect(onChange).toHaveBeenCalledWith({
-        majorPeriods: [],
-        page: 1,
-        sizes: [],
+        ...initialArtworkFilterState,
         sort: "-partner_updated_at",
-        artistIDs: [],
-        attributionClass: [],
-        partnerIDs: [],
-        additionalGeneIDs: [],
-        colors: [],
-        locationCities: [],
-        artistNationalities: [],
-        materialsTerms: [],
       })
     })
   })


### PR DESCRIPTION
### Jira: [FX-2825](https://artsyproduct.atlassian.net/browse/FX-2825)

### Description
- User selects a custom size filter (custom width/height)
- User then clicks “clear all” filters
- No analytics event is fired to clear width/height

### Changes

- Set initial values for custom width/height to artworks filter state

**Note**: this bug can be solved by 2 ways ([described here](https://artsy.slack.com/archives/C9SATFLUU/p1627657974044000))

### Demo
When user set custom size and then clear all filters the analytics event is fired

![image](https://user-images.githubusercontent.com/56556580/128035904-f24e30cc-d23e-4567-8bf7-ddaf0401a699.png)
