### PR TITLE
fix(PX-4326): Don't manually override background in Pill component in SavedAddresses

### DIFF
--- a/src/v2/Apps/Order/Components/SavedAddressItem.tsx
+++ b/src/v2/Apps/Order/Components/SavedAddressItem.tsx
@@ -1,4 +1,5 @@
-import { Flex, Text, RadioProps, Pill, color } from "@artsy/palette"
+import { Flex, Text, RadioProps, Pill } from "@artsy/palette"
+import { themeGet } from "@styled-system/theme-get"
 import React from "react"
 import styled from "styled-components"
 import { SavedAddresses_me } from "v2/__generated__/SavedAddresses_me.graphql"
@@ -105,6 +106,8 @@ const EditButton = styled(Text)`
 `
 
 const StyledPill = styled(Pill)`
-  background-color: ${color("black10")} !important;
-  pointer-events: none;
+  background-color: ${themeGet("colors.black10")};
+  &:hover {
+    background-color: ${themeGet("colors.black10")};
+  }
 `

--- a/src/v2/Apps/Order/Components/SavedAddressItem.tsx
+++ b/src/v2/Apps/Order/Components/SavedAddressItem.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, RadioProps, Pill } from "@artsy/palette"
+import { Flex, Text, RadioProps } from "@artsy/palette"
 import { themeGet } from "@styled-system/theme-get"
 import React from "react"
 import styled from "styled-components"
@@ -45,6 +45,7 @@ export const SavedAddressItem: React.FC<SavedAddressItemProps> = (
                   justifyContent="row"
                   alignItems="center"
                   mb={index === 0 ? 1 : 0}
+                  height={24}
                 >
                   <Text
                     textTransform="capitalize"
@@ -54,14 +55,7 @@ export const SavedAddressItem: React.FC<SavedAddressItemProps> = (
                     {line}
                   </Text>
                   {address?.isDefault && index === 0 && (
-                    <StyledPill
-                      ml={0.5}
-                      variant="textSquare"
-                      disabled
-                      hover
-                      width={53}
-                      maxHeight={21}
-                    >
+                    <DefaultLabel>
                       <Text
                         textColor="black60"
                         variant="caption"
@@ -69,7 +63,7 @@ export const SavedAddressItem: React.FC<SavedAddressItemProps> = (
                       >
                         Default
                       </Text>
-                    </StyledPill>
+                    </DefaultLabel>
                   )}
                 </Flex>
               )
@@ -105,9 +99,12 @@ const EditButton = styled(Text)`
   }
 `
 
-const StyledPill = styled(Pill)`
+const DefaultLabel = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 0 5px;
   background-color: ${themeGet("colors.black10")};
-  &:hover {
-    background-color: ${themeGet("colors.black10")};
-  }
+  height: 24px;
+  margin-left: 5px;
+  border-radius: 2px;
 `


### PR DESCRIPTION
Jira Ticket: https://artsyproduct.atlassian.net/browse/PX-4326
Discussion: https://github.com/artsy/force/pull/7869#discussion_r669827365

This PR deletes `Pill` component usage with  `!important`  in styles and add a custom "Default" label instead of `Pill` in BNMO Checkout flow. Also, I deleted deprecated `color` and put `themeGet("colors.black10")` instead.

This PR resolves this [Jira Ticket](https://artsyproduct.atlassian.net/browse/PX-4367) too, so I closed it.

https://user-images.githubusercontent.com/55637696/129696004-8590e1b1-5a09-4900-9ded-008db9c92c84.mov




