### PR TITLE
fix: Cookie Export

### DIFF
--- a/src/desktop/components/cookies/index.ts
+++ b/src/desktop/components/cookies/index.ts
@@ -14,6 +14,6 @@ const TEST_STUB = ({
 
 export const get = IS_TEST_ENV ? TEST_STUB.get : cookiejs.get
 export const set = IS_TEST_ENV ? TEST_STUB.set : cookiejs.set
-export const expires = IS_TEST_ENV ? TEST_STUB.expire : cookiejs.expire
+export const expire = IS_TEST_ENV ? TEST_STUB.expire : cookiejs.expire
 
 export default IS_TEST_ENV ? TEST_STUB : cookiejs


### PR DESCRIPTION
Renames `expires` to `expire` which was incorrectly spelled during decaffeination.