### PR TITLE
fix: put back the 'log in to request condition report' cta

### DIFF
--- a/src/v2/Apps/Artwork/Components/ArtworkDetails/RequestConditionReport.tsx
+++ b/src/v2/Apps/Artwork/Components/ArtworkDetails/RequestConditionReport.tsx
@@ -28,7 +28,7 @@ const logger = createLogger(
 
 interface RequestConditionReportProps {
   artwork: RequestConditionReport_artwork
-  me: RequestConditionReport_me
+  me: RequestConditionReport_me | null
 }
 
 export const RequestConditionReport: React.FC<RequestConditionReportProps> = props => {
@@ -219,7 +219,7 @@ export const RequestConditionReportQueryRenderer: React.FC<{
         }
       `}
       render={({ props }) => {
-        if (props && props.artwork && props.me) {
+        if (props && props.artwork) {
           return (
             <RequestConditionReportFragmentContainer
               artwork={props.artwork}


### PR DESCRIPTION
Integrity tests have been failing for several days, due to a change in #8099 that prevented render of the "Log in to request condition report" CTA when users weren't logged in. 

This PR walks back part of that change so that the `RequestConditionReport` will be rendered even when the `me` sub-query from relay is null, which is the case when a user is unauthenticated.

[Slack thread for context](https://artsy.slack.com/archives/CNRF89P7Y/p1628008959005500)

## Proof that the button is back

![image](https://user-images.githubusercontent.com/1627089/128215157-0acc8139-8e96-4af1-ba41-f41cc027e86e.png)

