### PR TITLE
feat: Add structured data for partners GRO-379

### DIFF
--- a/src/v2/Apps/Collect/Components/__tests__/SeoProductsForCollections.jest.tsx
+++ b/src/v2/Apps/Collect/Components/__tests__/SeoProductsForCollections.jest.tsx
@@ -109,17 +109,17 @@ describe("Seo Products for Collection Page", () => {
     const wrapper = renderProducts()
 
     const html = wrapper.html()
-    expect(html).toContain('"name":"A fake name for collection"')
-    expect(html).toContain('"url":"A fake URL for collection"')
-    expect(html).toContain('"description":"A fake description for collection"')
+    expect(html).toContain('"name": "A fake name for collection"')
+    expect(html).toContain('"url": "A fake URL for collection"')
+    expect(html).toContain('"description": "A fake description for collection"')
   })
 
   it("renders pricing data for collections with price ranges", () => {
     const wrapper = renderProducts()
 
     const html = wrapper.html()
-    expect(html).toContain('"lowPrice":10')
-    expect(html).toContain('"highPrice":9000')
+    expect(html).toContain('"lowPrice": 10')
+    expect(html).toContain('"highPrice": 9000')
   })
 
   it("falls back to maxPrice if the ascending artwork range is missing minPrice", () => {
@@ -128,8 +128,8 @@ describe("Seo Products for Collection Page", () => {
     const wrapper = renderProducts()
 
     const html = wrapper.html()
-    expect(html).toContain('"lowPrice":25')
-    expect(html).toContain('"highPrice":9000')
+    expect(html).toContain('"lowPrice": 25')
+    expect(html).toContain('"highPrice": 9000')
   })
 
   it("falls back to minPrice if the descending artwork range is missing maxPrice", () => {
@@ -140,8 +140,8 @@ describe("Seo Products for Collection Page", () => {
     const wrapper = renderProducts()
 
     const html = wrapper.html()
-    expect(html).toContain('"lowPrice":10')
-    expect(html).toContain('"highPrice":500')
+    expect(html).toContain('"lowPrice": 10')
+    expect(html).toContain('"highPrice": 500')
   })
 
   it("renders pricing data for collections with individual prices", () => {
@@ -152,8 +152,8 @@ describe("Seo Products for Collection Page", () => {
     const wrapper = renderProducts()
 
     const html = wrapper.html()
-    expect(html).toContain('"lowPrice":15')
-    expect(html).toContain('"highPrice":30')
+    expect(html).toContain('"lowPrice": 15')
+    expect(html).toContain('"highPrice": 30')
   })
 
   describe("no prices for descending artwork", () => {
@@ -168,8 +168,8 @@ describe("Seo Products for Collection Page", () => {
       const wrapper = renderProducts()
 
       const html = wrapper.html()
-      expect(html).toContain('"lowPrice":20')
-      expect(html).toContain('"highPrice":20')
+      expect(html).toContain('"lowPrice": 20')
+      expect(html).toContain('"highPrice": 20')
     })
 
     it("renders price from ascending artwork price range", () => {
@@ -177,8 +177,8 @@ describe("Seo Products for Collection Page", () => {
       const wrapper = renderProducts()
 
       const html = wrapper.html()
-      expect(html).toContain('"lowPrice":11')
-      expect(html).toContain('"highPrice":14')
+      expect(html).toContain('"lowPrice": 11')
+      expect(html).toContain('"highPrice": 14')
     })
   })
 
@@ -194,8 +194,8 @@ describe("Seo Products for Collection Page", () => {
       const wrapper = renderProducts()
 
       const html = wrapper.html()
-      expect(html).toContain('"lowPrice":20')
-      expect(html).toContain('"highPrice":20')
+      expect(html).toContain('"lowPrice": 20')
+      expect(html).toContain('"highPrice": 20')
     })
 
     it("renders price from ascending artwork price range", () => {
@@ -205,8 +205,8 @@ describe("Seo Products for Collection Page", () => {
       const wrapper = renderProducts()
 
       const html = wrapper.html()
-      expect(html).toContain('"lowPrice":11')
-      expect(html).toContain('"highPrice":14')
+      expect(html).toContain('"lowPrice": 11')
+      expect(html).toContain('"highPrice": 14')
     })
   })
 
@@ -222,8 +222,8 @@ describe("Seo Products for Collection Page", () => {
       const wrapper = renderProducts()
 
       const html = wrapper.html()
-      expect(html).toContain('"lowPrice":42')
-      expect(html).toContain('"highPrice":420')
+      expect(html).toContain('"lowPrice": 42')
+      expect(html).toContain('"highPrice": 420')
     })
 
     it("it uses the minPrice when the ascending is a PriceRange", () => {
@@ -237,8 +237,8 @@ describe("Seo Products for Collection Page", () => {
       const wrapper = renderProducts()
 
       const html = wrapper.html()
-      expect(html).toContain('"lowPrice":42')
-      expect(html).toContain('"highPrice":420')
+      expect(html).toContain('"lowPrice": 42')
+      expect(html).toContain('"highPrice": 420')
     })
   })
 

--- a/src/v2/Apps/Partner/Components/PartnerMeta/index.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerMeta/index.tsx
@@ -4,6 +4,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { PartnerMeta_partner } from "v2/__generated__/PartnerMeta_partner.graphql"
 import { getENV } from "v2/Utils/getENV"
 import { useRouter } from "v2/System/Router/useRouter"
+import { LocalBusiness } from "v2/Components/Seo/LocalBusiness"
 
 interface PartnerMetaProps {
   partner: PartnerMeta_partner
@@ -11,9 +12,11 @@ interface PartnerMetaProps {
 
 const PartnerMeta: React.FC<PartnerMetaProps> = ({
   partner: {
-    slug,
+    locationsConnection,
     // @ts-expect-error STRICT_NULL_CHECK
     meta: { description, image, title },
+    name,
+    slug,
   },
 }) => {
   const {
@@ -27,6 +30,9 @@ const PartnerMeta: React.FC<PartnerMetaProps> = ({
   const canonicalHref = artistId
     ? `${getENV("APP_URL")}/partner/${slug}/artists/${artistId}`
     : `${getENV("APP_URL")}/partner/${slug}`
+
+  const locationEdges = locationsConnection?.edges || []
+  const partnerLocation = locationEdges[0]?.node
 
   return (
     <>
@@ -45,6 +51,7 @@ const PartnerMeta: React.FC<PartnerMetaProps> = ({
 
       {image && <Meta property="og:image" content={image} />}
       {image && <Meta name="thumbnail" content={image} />}
+      <LocalBusiness partnerLocation={partnerLocation} partnerName={name} />
     </>
   )
 }
@@ -54,12 +61,30 @@ export const PartnerMetaFragmentContainer = createFragmentContainer(
   {
     partner: graphql`
       fragment PartnerMeta_partner on Partner {
-        slug
+        locationsConnection(first: 1) {
+          edges {
+            node {
+              address
+              address2
+              city
+              coordinates {
+                lat
+                lng
+              }
+              country
+              phone
+              postalCode
+              state
+            }
+          }
+        }
         meta {
           image
           title
           description
         }
+        name
+        slug
       }
     `,
   }

--- a/src/v2/Apps/Partner/Components/PartnerMeta/index.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerMeta/index.tsx
@@ -12,13 +12,7 @@ interface PartnerMetaProps {
 }
 
 const PartnerMeta: React.FC<PartnerMetaProps> = ({
-  partner: {
-    locationsConnection,
-    // @ts-expect-error STRICT_NULL_CHECK
-    meta: { description, image, title },
-    name,
-    slug,
-  },
+  partner: { locationsConnection, meta, name, slug },
 }) => {
   const {
     match: {
@@ -36,21 +30,21 @@ const PartnerMeta: React.FC<PartnerMetaProps> = ({
 
   return (
     <>
-      <Title>{title}</Title>
-      <Meta name="description" content={description} />
+      <Title>{meta?.title}</Title>
+      <Meta name="description" content={meta?.description} />
 
-      <Meta property="og:title" content={title} />
-      <Meta property="og:description" content={description} />
+      <Meta property="og:title" content={meta?.title} />
+      <Meta property="og:description" content={meta?.description} />
       <Meta property="og:url" content={href} />
       <Meta property="og:type" content="profile" />
 
-      <Meta property="twitter:description" content={description} />
+      <Meta property="twitter:description" content={meta?.description} />
       <Meta property="twitter:card" content="summary" />
 
       <Link rel="canonical" href={canonicalHref} />
 
-      {image && <Meta property="og:image" content={image} />}
-      {image && <Meta name="thumbnail" content={image} />}
+      {meta?.image && <Meta property="og:image" content={meta?.image} />}
+      {meta?.image && <Meta name="thumbnail" content={meta?.image} />}
       <LocalBusiness partnerLocation={partnerLocation} partnerName={name} />
     </>
   )

--- a/src/v2/Apps/Partner/Components/PartnerMeta/index.tsx
+++ b/src/v2/Apps/Partner/Components/PartnerMeta/index.tsx
@@ -5,6 +5,7 @@ import { PartnerMeta_partner } from "v2/__generated__/PartnerMeta_partner.graphq
 import { getENV } from "v2/Utils/getENV"
 import { useRouter } from "v2/System/Router/useRouter"
 import { LocalBusiness } from "v2/Components/Seo/LocalBusiness"
+import { extractNodes } from "v2/Utils/extractNodes"
 
 interface PartnerMetaProps {
   partner: PartnerMeta_partner
@@ -31,8 +32,7 @@ const PartnerMeta: React.FC<PartnerMetaProps> = ({
     ? `${getENV("APP_URL")}/partner/${slug}/artists/${artistId}`
     : `${getENV("APP_URL")}/partner/${slug}`
 
-  const locationEdges = locationsConnection?.edges || []
-  const partnerLocation = locationEdges[0]?.node
+  const partnerLocation = extractNodes(locationsConnection)[0]
 
   return (
     <>

--- a/src/v2/Components/Seo/BreadCrumbList.tsx
+++ b/src/v2/Components/Seo/BreadCrumbList.tsx
@@ -14,19 +14,16 @@ interface BreadCrumbListProps {
 }
 
 const rootItem = {
-  path: "",
   name: "Artsy",
+  path: "",
 }
 
-export const computeListItems = (appUrl = APP_URL) => {
-  const items = [rootItem]
-  const listItems = items.map(({ name, path }, index) => ({
+export const computeListItems = (items, appUrl = APP_URL) => {
+  const allItems = [rootItem, ...items]
+  const listItems = allItems.map(({ name, path }, index) => ({
     "@type": "ListItem",
+    item: { "@id": `${appUrl}${path}`, name },
     position: index + 1,
-    item: {
-      "@id": `${appUrl}${path}`,
-      name,
-    },
   }))
 
   return listItems
@@ -34,7 +31,7 @@ export const computeListItems = (appUrl = APP_URL) => {
 
 export class BreadCrumbList extends Component<BreadCrumbListProps> {
   render() {
-    const listItems = computeListItems()
+    const listItems = computeListItems(this.props.items)
 
     return (
       <Meta
@@ -44,17 +41,7 @@ export class BreadCrumbList extends Component<BreadCrumbListProps> {
           __html: JSON.stringify({
             "@context": "http://schema.org",
             "@type": "BreadcrumbList",
-            itemListElement: [
-              ...listItems,
-              ...this.props.items.map(({ path, name }, index) => ({
-                "@type": "ListItem",
-                position: index + 2, // adding 2 because `position` starts with 1 and there's a top-level item.
-                item: {
-                  "@id": `${APP_URL}${path}`,
-                  name,
-                },
-              })),
-            ],
+            itemListElement: listItems,
           }),
         }}
       />

--- a/src/v2/Components/Seo/BreadCrumbList.tsx
+++ b/src/v2/Components/Seo/BreadCrumbList.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Meta } from "react-head"
+import { StructuredData } from "./StructuredData"
 import { data as sd } from "sharify"
 
 const { APP_URL } = sd
@@ -32,17 +32,10 @@ export const computeListItems = (items, appUrl = APP_URL) => {
 export const BreadCrumbList: React.FC<BreadCrumbListProps> = props => {
   const listItems = computeListItems(props.items)
 
-  return (
-    <Meta
-      tag="script"
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: JSON.stringify({
-          "@context": "http://schema.org",
-          "@type": "BreadcrumbList",
-          itemListElement: listItems,
-        }),
-      }}
-    />
-  )
+  const schemaData = {
+    "@type": "BreadcrumbList",
+    itemListElement: listItems,
+  }
+
+  return <StructuredData schemaData={schemaData} />
 }

--- a/src/v2/Components/Seo/BreadCrumbList.tsx
+++ b/src/v2/Components/Seo/BreadCrumbList.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react"
+import React from "react"
 import { Meta } from "react-head"
 import { data as sd } from "sharify"
 
@@ -29,22 +29,20 @@ export const computeListItems = (items, appUrl = APP_URL) => {
   return listItems
 }
 
-export class BreadCrumbList extends Component<BreadCrumbListProps> {
-  render() {
-    const listItems = computeListItems(this.props.items)
+export const BreadCrumbList: React.FC<BreadCrumbListProps> = props => {
+  const listItems = computeListItems(props.items)
 
-    return (
-      <Meta
-        tag="script"
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify({
-            "@context": "http://schema.org",
-            "@type": "BreadcrumbList",
-            itemListElement: listItems,
-          }),
-        }}
-      />
-    )
-  }
+  return (
+    <Meta
+      tag="script"
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify({
+          "@context": "http://schema.org",
+          "@type": "BreadcrumbList",
+          itemListElement: listItems,
+        }),
+      }}
+    />
+  )
 }

--- a/src/v2/Components/Seo/BreadCrumbList.tsx
+++ b/src/v2/Components/Seo/BreadCrumbList.tsx
@@ -13,8 +13,29 @@ interface BreadCrumbListProps {
   items: Item[]
 }
 
+const rootItem = {
+  path: "",
+  name: "Artsy",
+}
+
+export const computeListItems = (appUrl = APP_URL) => {
+  const items = [rootItem]
+  const listItems = items.map(({ name, path }, index) => ({
+    "@type": "ListItem",
+    position: index + 1,
+    item: {
+      "@id": `${appUrl}${path}`,
+      name,
+    },
+  }))
+
+  return listItems
+}
+
 export class BreadCrumbList extends Component<BreadCrumbListProps> {
   render() {
+    const listItems = computeListItems()
+
     return (
       <Meta
         tag="script"
@@ -24,14 +45,7 @@ export class BreadCrumbList extends Component<BreadCrumbListProps> {
             "@context": "http://schema.org",
             "@type": "BreadcrumbList",
             itemListElement: [
-              {
-                "@type": "ListItem",
-                position: 1,
-                item: {
-                  "@id": APP_URL,
-                  name: "Artsy",
-                },
-              },
+              ...listItems,
               ...this.props.items.map(({ path, name }, index) => ({
                 "@type": "ListItem",
                 position: index + 2, // adding 2 because `position` starts with 1 and there's a top-level item.

--- a/src/v2/Components/Seo/CreativeWork.tsx
+++ b/src/v2/Components/Seo/CreativeWork.tsx
@@ -1,18 +1,11 @@
 import React from "react"
-import { Meta } from "react-head"
+import { StructuredData } from "./StructuredData"
 
 export const CreativeWork = ({ data }) => {
-  return (
-    <Meta
-      tag="script"
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: JSON.stringify({
-          "@context": "http://schema.org",
-          "@type": "CreativeWork",
-          ...data,
-        }),
-      }}
-    />
-  )
+  const schemaData = {
+    "@type": "CreativeWork",
+    ...data,
+  }
+
+  return <StructuredData schemaData={schemaData} />
 }

--- a/src/v2/Components/Seo/LocalBusiness.tsx
+++ b/src/v2/Components/Seo/LocalBusiness.tsx
@@ -1,0 +1,96 @@
+import React from "react"
+import { StructuredData } from "./StructuredData"
+import _ from "underscore"
+
+interface PostalAddressSchemaData {
+  "@type": string
+  addressCountry: string
+  addressLocality: string
+  addressRegion: string
+  postalCode: string
+  streetAddress: string
+  telephone: string
+}
+
+interface PlaceSchemaData {
+  "@type": string
+  latitude: number
+  longitude: number
+}
+
+interface LocalBusinessSchemaData {
+  "@type": string
+  address?: PostalAddressSchemaData
+  legalName: string
+  location?: PlaceSchemaData
+  name: string
+}
+
+export const computeOptionalSchemaData = partnerLocation => {
+  let address: PostalAddressSchemaData | undefined
+  let location: PlaceSchemaData | undefined
+
+  if (partnerLocation) {
+    const {
+      address: address1,
+      address2,
+      city,
+      coordinates,
+      country,
+      phone,
+      postalCode,
+      state,
+    } = partnerLocation
+
+    const streetAddress = [address1, address2].filter(Boolean).join(", ")
+
+    const addressParts = {
+      "@type": "PostalAddress",
+      addressCountry: country,
+      addressLocality: city,
+      addressRegion: state,
+      postalCode: postalCode,
+      streetAddress,
+      telephone: phone,
+    }
+
+    address = _.pick(addressParts, _.identity)
+
+    if (coordinates?.lat && coordinates?.lng) {
+      location = {
+        "@type": "Place",
+        latitude: coordinates.lat,
+        longitude: coordinates.lng,
+      }
+    }
+  }
+
+  return { address, location }
+}
+
+interface LocalBusinessProps {
+  partnerLocation
+  partnerName
+}
+
+export const LocalBusiness: React.FC<LocalBusinessProps> = props => {
+  const { partnerLocation, partnerName } = props
+
+  const schemaData: LocalBusinessSchemaData = {
+    "@type": "LocalBusiness",
+    legalName: partnerName,
+    name: partnerName,
+  }
+
+  const { address, location } = computeOptionalSchemaData(partnerLocation)
+
+  if (address) {
+    schemaData.address = address
+  }
+
+  if (location) {
+    schemaData.location = location
+  }
+
+  return <StructuredData schemaData={schemaData} />
+}

--- a/src/v2/Components/Seo/LocalBusiness.tsx
+++ b/src/v2/Components/Seo/LocalBusiness.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { StructuredData } from "./StructuredData"
-import _ from "underscore"
+import { identity, pickBy } from "lodash"
 
 interface PostalAddressSchemaData {
   "@type": string
@@ -54,7 +54,7 @@ export const computeOptionalSchemaData = partnerLocation => {
       telephone: phone,
     }
 
-    address = _.pick(addressParts, _.identity)
+    address = pickBy(addressParts, identity) as PostalAddressSchemaData
 
     if (coordinates?.lat && coordinates?.lng) {
       location = {

--- a/src/v2/Components/Seo/Person.tsx
+++ b/src/v2/Components/Seo/Person.tsx
@@ -1,18 +1,11 @@
 import React from "react"
-import { Meta } from "react-head"
+import { StructuredData } from "./StructuredData"
 
 export const Person = ({ data }) => {
-  return (
-    <Meta
-      tag="script"
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: JSON.stringify({
-          "@context": "http://schema.org",
-          "@type": "Person",
-          ...data,
-        }),
-      }}
-    />
-  )
+  const schemaData = {
+    "@type": "Person",
+    ...data,
+  }
+
+  return <StructuredData schemaData={schemaData} />
 }

--- a/src/v2/Components/Seo/Product.tsx
+++ b/src/v2/Components/Seo/Product.tsx
@@ -1,18 +1,11 @@
 import React from "react"
-import { Meta } from "react-head"
+import { StructuredData } from "./StructuredData"
 
 export const Product = ({ data }) => {
-  return (
-    <Meta
-      tag="script"
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: JSON.stringify({
-          "@context": "http://schema.org",
-          "@type": "Product",
-          ...data,
-        }),
-      }}
-    />
-  )
+  const schemaData = {
+    "@type": "Product",
+    ...data,
+  }
+
+  return <StructuredData schemaData={schemaData} />
 }

--- a/src/v2/Components/Seo/StructuredData.tsx
+++ b/src/v2/Components/Seo/StructuredData.tsx
@@ -1,0 +1,17 @@
+import React from "react"
+import { Meta } from "react-head"
+
+export const StructuredData = props => {
+  const schemaData = {
+    "@context": "http://schema.org",
+    ...props.schemaData,
+  }
+
+  const schemaContent = JSON.stringify(schemaData, null, 2)
+
+  return (
+    <Meta tag="script" type="application/ld+json">
+      {schemaContent}
+    </Meta>
+  )
+}

--- a/src/v2/Components/Seo/__tests__/BreadCrumbList.jest.tsx
+++ b/src/v2/Components/Seo/__tests__/BreadCrumbList.jest.tsx
@@ -19,7 +19,7 @@ describe("BreadCrumbList", () => {
   it("sets the schema type", () => {
     const wrapper = getWrapper()
     const script = wrapper.find("script")
-    expect(script.text()).toMatch('"@type":"BreadcrumbList"')
+    expect(script.text()).toMatch('"@type": "BreadcrumbList"')
   })
 })
 

--- a/src/v2/Components/Seo/__tests__/BreadCrumbList.jest.tsx
+++ b/src/v2/Components/Seo/__tests__/BreadCrumbList.jest.tsx
@@ -1,6 +1,6 @@
 import { mount } from "enzyme"
 import React from "react"
-import { BreadCrumbList } from "../BreadCrumbList"
+import { BreadCrumbList, computeListItems } from "../BreadCrumbList"
 import { HeadProvider } from "react-head"
 
 describe("BreadCrumbList", () => {
@@ -20,5 +20,17 @@ describe("BreadCrumbList", () => {
     const wrapper = getWrapper()
     const script = wrapper.find("script")
     expect(script.text()).toMatch('"@type":"BreadcrumbList"')
+  })
+})
+
+describe("computeListItems", () => {
+  it("prepends a root item", () => {
+    const listItems = computeListItems("artsy.net")
+    expect(listItems.length).toEqual(1)
+    const rootItem = listItems[0]
+    expect(rootItem["@type"]).toEqual("ListItem")
+    expect(rootItem.position).toEqual(1)
+    expect(rootItem.item["@id"]).toEqual("artsy.net")
+    expect(rootItem.item.name).toEqual("Artsy")
   })
 })

--- a/src/v2/Components/Seo/__tests__/BreadCrumbList.jest.tsx
+++ b/src/v2/Components/Seo/__tests__/BreadCrumbList.jest.tsx
@@ -25,12 +25,24 @@ describe("BreadCrumbList", () => {
 
 describe("computeListItems", () => {
   it("prepends a root item", () => {
-    const listItems = computeListItems("artsy.net")
+    const items = []
+    const listItems = computeListItems(items, "artsy.net")
     expect(listItems.length).toEqual(1)
     const rootItem = listItems[0]
     expect(rootItem["@type"]).toEqual("ListItem")
     expect(rootItem.position).toEqual(1)
     expect(rootItem.item["@id"]).toEqual("artsy.net")
     expect(rootItem.item.name).toEqual("Artsy")
+  })
+
+  it("converts additional items to schema spec", () => {
+    const items = [{ path: "/artworks", name: "Artworks" }]
+    const listItems = computeListItems(items, "artsy.net")
+    expect(listItems.length).toEqual(2)
+    const artworksItem = listItems[1]
+    expect(artworksItem["@type"]).toEqual("ListItem")
+    expect(artworksItem.position).toEqual(2)
+    expect(artworksItem.item["@id"]).toEqual("artsy.net/artworks")
+    expect(artworksItem.item.name).toEqual("Artworks")
   })
 })

--- a/src/v2/Components/Seo/__tests__/BreadCrumbList.jest.tsx
+++ b/src/v2/Components/Seo/__tests__/BreadCrumbList.jest.tsx
@@ -1,0 +1,24 @@
+import { mount } from "enzyme"
+import React from "react"
+import { BreadCrumbList } from "../BreadCrumbList"
+import { HeadProvider } from "react-head"
+
+describe("BreadCrumbList", () => {
+  const defaultProps = { items: [] }
+
+  const getWrapper = (props = {}) => {
+    const wrapper = mount(
+      <HeadProvider>
+        <BreadCrumbList {...defaultProps} {...props} />
+      </HeadProvider>
+    )
+
+    return wrapper
+  }
+
+  it("sets the schema type", () => {
+    const wrapper = getWrapper()
+    const script = wrapper.find("script")
+    expect(script.text()).toMatch('"@type":"BreadcrumbList"')
+  })
+})

--- a/src/v2/Components/Seo/__tests__/CreativeWork.jest.tsx
+++ b/src/v2/Components/Seo/__tests__/CreativeWork.jest.tsx
@@ -1,0 +1,27 @@
+import { mount } from "enzyme"
+import React from "react"
+import { CreativeWork } from "../CreativeWork"
+import { HeadProvider } from "react-head"
+
+describe("CreativeWork", () => {
+  const defaultProps = { data: {} }
+
+  const getWrapper = (props = {}) => {
+    const wrapper = mount(
+      <HeadProvider>
+        <CreativeWork {...defaultProps} {...props} />
+      </HeadProvider>
+    )
+
+    return wrapper
+  }
+
+  it("sets the schema type", () => {
+    const data = { title: "Pretty Painting" }
+    const props = { data }
+    const wrapper = getWrapper(props)
+    const script = wrapper.find("script")
+    expect(script.text()).toMatch('"@type": "CreativeWork"')
+    expect(script.text()).toMatch('"title": "Pretty Painting"')
+  })
+})

--- a/src/v2/Components/Seo/__tests__/LocalBusiness.jest.tsx
+++ b/src/v2/Components/Seo/__tests__/LocalBusiness.jest.tsx
@@ -1,0 +1,121 @@
+import { mount } from "enzyme"
+import React from "react"
+import { computeOptionalSchemaData, LocalBusiness } from "../LocalBusiness"
+import { HeadProvider } from "react-head"
+
+describe("LocalBusiness", () => {
+  const defaultProps = { partnerLocation: {}, partnerName: "" }
+
+  const getWrapper = (props = {}) => {
+    const wrapper = mount(
+      <HeadProvider>
+        <LocalBusiness {...defaultProps} {...props} />
+      </HeadProvider>
+    )
+
+    return wrapper
+  }
+
+  it("sets the schema type", () => {
+    const wrapper = getWrapper()
+    const script = wrapper.find("script")
+    expect(script.text()).toMatch('"@type": "LocalBusiness"')
+  })
+
+  it("sets both the name and legal name attributes", () => {
+    const props = { partnerName: "Great Gallery", partnerLocation: undefined }
+    const wrapper = getWrapper(props)
+    const script = wrapper.find("script")
+    expect(script.text()).toMatch('"name": "Great Gallery"')
+    expect(script.text()).toMatch('"legalName": "Great Gallery"')
+  })
+
+  it("skips optional data when partnerLocation doesn't exist", () => {
+    const props = { partnerName: "Great Gallery", partnerLocation: undefined }
+    const wrapper = getWrapper(props)
+    const script = wrapper.find("script")
+    expect(script.text()).not.toMatch('"@type": "PostalAddress"')
+    expect(script.text()).not.toMatch('"@type": "Place"')
+  })
+
+  it("sets the optional data when partnerLocation and coordinates exist", () => {
+    const partnerLocation = {
+      address2: "Apt 1",
+      address: "123 Main Street",
+      city: "New York",
+      coordinates: { lat: 12, lng: 7 },
+      country: "US",
+      phone: "123-456-7890",
+      postalCode: "10001",
+      state: "NY",
+    }
+    const props = {
+      partnerLocation,
+      partnerName: "Great Gallery",
+    }
+    const wrapper = getWrapper(props)
+    const script = wrapper.find("script")
+    expect(script.text()).toMatch('"@type": "PostalAddress"')
+    expect(script.text()).toMatch('"@type": "Place"')
+  })
+})
+
+describe("computeOptionalSchemaData", () => {
+  it("returns undefined when partnerLocation doesn't exist", () => {
+    const partnerLocation = null
+    const { address, location } = computeOptionalSchemaData(partnerLocation)
+    expect(address).toEqual(undefined)
+    expect(location).toEqual(undefined)
+  })
+
+  it("returns a PostalAddress when partnerLocation exists", () => {
+    const partnerLocation = {
+      address: "123 Main Street",
+      address2: "Apt 1",
+      city: "New York",
+      country: "US",
+      phone: "123-456-7890",
+      postalCode: "10001",
+      state: "NY",
+    }
+    const { address } = computeOptionalSchemaData(partnerLocation)
+    expect(address).toEqual({
+      "@type": "PostalAddress",
+      addressCountry: "US",
+      addressLocality: "New York",
+      addressRegion: "NY",
+      postalCode: "10001",
+      streetAddress: "123 Main Street, Apt 1",
+      telephone: "123-456-7890",
+    })
+  })
+
+  it("suppresses PostalAddress attributes that do not exist", () => {
+    const partnerLocation = {
+      address: "123 Main Street",
+      address2: "Apt 1",
+      city: "New York",
+      country: "US",
+      postalCode: "10001",
+      state: "NY",
+    }
+    const { address } = computeOptionalSchemaData(partnerLocation)
+    expect(address).not.toHaveProperty("telephone")
+  })
+
+  it("returns a Place when coordinates exist", () => {
+    const partnerLocation = { coordinates: { lat: 12, lng: 7 } }
+    const { location } = computeOptionalSchemaData(partnerLocation)
+    expect(location).toEqual({
+      "@type": "Place",
+      latitude: 12,
+      longitude: 7,
+    })
+  })
+
+  it("skips Place with partial coordinate info", () => {
+    const partnerLocation = { coordinates: { lat: 12 } }
+    const { location } = computeOptionalSchemaData(partnerLocation)
+    expect(location).toEqual(undefined)
+  })
+})

--- a/src/v2/Components/Seo/__tests__/Person.jest.tsx
+++ b/src/v2/Components/Seo/__tests__/Person.jest.tsx
@@ -1,0 +1,27 @@
+import { mount } from "enzyme"
+import React from "react"
+import { Person } from "../Person"
+import { HeadProvider } from "react-head"
+
+describe("Person", () => {
+  const defaultProps = { data: {} }
+
+  const getWrapper = (props = {}) => {
+    const wrapper = mount(
+      <HeadProvider>
+        <Person {...defaultProps} {...props} />
+      </HeadProvider>
+    )
+
+    return wrapper
+  }
+
+  it("sets the schema type", () => {
+    const data = { name: "Suzy Sculptor" }
+    const props = { data }
+    const wrapper = getWrapper(props)
+    const script = wrapper.find("script")
+    expect(script.text()).toMatch('"@type": "Person"')
+    expect(script.text()).toMatch('"name": "Suzy Sculptor"')
+  })
+})

--- a/src/v2/Components/Seo/__tests__/Product.jest.tsx
+++ b/src/v2/Components/Seo/__tests__/Product.jest.tsx
@@ -1,0 +1,27 @@
+import { mount } from "enzyme"
+import React from "react"
+import { Product } from "../Product"
+import { HeadProvider } from "react-head"
+
+describe("Product", () => {
+  const defaultProps = { data: {} }
+
+  const getWrapper = (props = {}) => {
+    const wrapper = mount(
+      <HeadProvider>
+        <Product {...defaultProps} {...props} />
+      </HeadProvider>
+    )
+
+    return wrapper
+  }
+
+  it("sets the schema type", () => {
+    const data = { title: "Pretty Painting" }
+    const props = { data }
+    const wrapper = getWrapper(props)
+    const script = wrapper.find("script")
+    expect(script.text()).toMatch('"@type": "Product"')
+    expect(script.text()).toMatch('"title": "Pretty Painting"')
+  })
+})

--- a/src/v2/Components/Seo/__tests__/StructuredData.jest.tsx
+++ b/src/v2/Components/Seo/__tests__/StructuredData.jest.tsx
@@ -1,0 +1,40 @@
+import { mount } from "enzyme"
+import React from "react"
+import { StructuredData } from "../StructuredData"
+import { HeadProvider } from "react-head"
+
+describe("StructuredData", () => {
+  const defaultProps = {}
+
+  const getWrapper = (props = {}) => {
+    const wrapper = mount(
+      <HeadProvider>
+        <StructuredData {...defaultProps} {...props} />
+      </HeadProvider>
+    )
+
+    return wrapper
+  }
+
+  it("renders a script tag with the right type", () => {
+    const wrapper = getWrapper()
+    const script = wrapper.find("script")
+    expect(script).toHaveLength(1)
+    expect(script.prop("type")).toEqual("application/ld+json")
+  })
+
+  it("renders schema content", () => {
+    const schemaData = { "@type": "Object", foo: "bar" }
+    const props = { schemaData }
+    const wrapper = getWrapper(props)
+    const script = wrapper.find("script")
+    expect(script.text()).toMatch('"@type": "Object"')
+    expect(script.text()).toMatch('"foo": "bar"')
+  })
+
+  it("sets the context", () => {
+    const wrapper = getWrapper()
+    const script = wrapper.find("script")
+    expect(script.text()).toMatch('"@context": "http://schema.org"')
+  })
+})

--- a/src/v2/__generated__/PartnerApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/PartnerApp_Test_Query.graphql.ts
@@ -101,12 +101,31 @@ fragment PartnerHeader_partner on Partner {
 }
 
 fragment PartnerMeta_partner on Partner {
-  slug
+  locationsConnection(first: 1) {
+    edges {
+      node {
+        address
+        address2
+        city
+        coordinates {
+          lat
+          lng
+        }
+        country
+        phone
+        postalCode
+        state
+        id
+      }
+    }
+  }
   meta {
     image
     title
     description
   }
+  name
+  slug
 }
 */
 
@@ -143,13 +162,20 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "city",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "totalCount",
   "storageKey": null
 },
-v5 = [
-  (v4/*: any*/)
+v6 = [
+  (v5/*: any*/)
 ],
-v6 = {
+v7 = {
   "kind": "Literal",
   "name": "displayOnPartnerProfile",
   "value": true
@@ -326,7 +352,114 @@ return {
             ],
             "storageKey": null
           },
-          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              }
+            ],
+            "concreteType": "LocationConnection",
+            "kind": "LinkedField",
+            "name": "locationsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "LocationEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Location",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "address",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "address2",
+                        "storageKey": null
+                      },
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "LatLng",
+                        "kind": "LinkedField",
+                        "name": "coordinates",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lat",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lng",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "country",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "phone",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "postalCode",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "state",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "locationsConnection(first:1)"
+          },
           {
             "alias": null,
             "args": null,
@@ -360,6 +493,7 @@ return {
             "storageKey": null
           },
           (v3/*: any*/),
+          (v2/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -381,7 +515,7 @@ return {
             "name": "locationsConnection",
             "plural": false,
             "selections": [
-              (v4/*: any*/),
+              (v5/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -398,13 +532,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "city",
-                        "storageKey": null
-                      },
+                      (v4/*: any*/),
                       (v1/*: any*/)
                     ],
                     "storageKey": null
@@ -461,13 +589,13 @@ return {
             "kind": "LinkedField",
             "name": "articlesConnection",
             "plural": false,
-            "selections": (v5/*: any*/),
+            "selections": (v6/*: any*/),
             "storageKey": null
           },
           {
             "alias": "representedArtists",
             "args": [
-              (v6/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "Literal",
                 "name": "representedBy",
@@ -478,13 +606,13 @@ return {
             "kind": "LinkedField",
             "name": "artistsConnection",
             "plural": false,
-            "selections": (v5/*: any*/),
+            "selections": (v6/*: any*/),
             "storageKey": "artistsConnection(displayOnPartnerProfile:true,representedBy:true)"
           },
           {
             "alias": "notRepresentedArtists",
             "args": [
-              (v6/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "Literal",
                 "name": "hasPublishedArtworks",
@@ -500,7 +628,7 @@ return {
             "kind": "LinkedField",
             "name": "artistsConnection",
             "plural": false,
-            "selections": (v5/*: any*/),
+            "selections": (v6/*: any*/),
             "storageKey": "artistsConnection(displayOnPartnerProfile:true,hasPublishedArtworks:true,representedBy:false)"
           },
           (v1/*: any*/)
@@ -514,7 +642,7 @@ return {
     "metadata": {},
     "name": "PartnerApp_Test_Query",
     "operationKind": "query",
-    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  slug\n  meta {\n    image\n    title\n    description\n  }\n}\n"
+    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/PartnerMeta_partner.graphql.ts
+++ b/src/v2/__generated__/PartnerMeta_partner.graphql.ts
@@ -4,12 +4,30 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type PartnerMeta_partner = {
-    readonly slug: string;
+    readonly locationsConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly address: string | null;
+                readonly address2: string | null;
+                readonly city: string | null;
+                readonly coordinates: {
+                    readonly lat: number | null;
+                    readonly lng: number | null;
+                } | null;
+                readonly country: string | null;
+                readonly phone: string | null;
+                readonly postalCode: string | null;
+                readonly state: string | null;
+            } | null;
+        } | null> | null;
+    } | null;
     readonly meta: {
         readonly image: string | null;
         readonly title: string | null;
         readonly description: string | null;
     } | null;
+    readonly name: string | null;
+    readonly slug: string;
     readonly " $refType": "PartnerMeta_partner";
 };
 export type PartnerMeta_partner$data = PartnerMeta_partner;
@@ -28,10 +46,116 @@ const node: ReaderFragment = {
   "selections": [
     {
       "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "slug",
-      "storageKey": null
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 1
+        }
+      ],
+      "concreteType": "LocationConnection",
+      "kind": "LinkedField",
+      "name": "locationsConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "LocationEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Location",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "address",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "address2",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "city",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "LatLng",
+                  "kind": "LinkedField",
+                  "name": "coordinates",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "lat",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "lng",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "country",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "phone",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "postalCode",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "state",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "locationsConnection(first:1)"
     },
     {
       "alias": null,
@@ -64,9 +188,23 @@ const node: ReaderFragment = {
         }
       ],
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
     }
   ],
   "type": "Partner"
 };
-(node as any).hash = '6fda87eda7743738bcaaf192015e294e';
+(node as any).hash = 'fa6bf65fcb4cf96ca003cd619d351ea1';
 export default node;

--- a/src/v2/__generated__/partnerRoutes_PartnerQuery.graphql.ts
+++ b/src/v2/__generated__/partnerRoutes_PartnerQuery.graphql.ts
@@ -109,12 +109,31 @@ fragment PartnerHeader_partner on Partner {
 }
 
 fragment PartnerMeta_partner on Partner {
-  slug
+  locationsConnection(first: 1) {
+    edges {
+      node {
+        address
+        address2
+        city
+        coordinates {
+          lat
+          lng
+        }
+        country
+        phone
+        postalCode
+        state
+        id
+      }
+    }
+  }
   meta {
     image
     title
     description
   }
+  name
+  slug
 }
 */
 
@@ -173,13 +192,20 @@ v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "city",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "totalCount",
   "storageKey": null
 },
-v8 = [
-  (v7/*: any*/)
+v9 = [
+  (v8/*: any*/)
 ],
-v9 = {
+v10 = {
   "kind": "Literal",
   "name": "displayOnPartnerProfile",
   "value": true
@@ -346,7 +372,114 @@ return {
             ],
             "storageKey": null
           },
-          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              }
+            ],
+            "concreteType": "LocationConnection",
+            "kind": "LinkedField",
+            "name": "locationsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "LocationEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Location",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "address",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "address2",
+                        "storageKey": null
+                      },
+                      (v7/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "LatLng",
+                        "kind": "LinkedField",
+                        "name": "coordinates",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lat",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lng",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "country",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "phone",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "postalCode",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "state",
+                        "storageKey": null
+                      },
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "locationsConnection(first:1)"
+          },
           {
             "alias": null,
             "args": null,
@@ -380,6 +513,7 @@ return {
             "storageKey": null
           },
           (v6/*: any*/),
+          (v5/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -401,7 +535,7 @@ return {
             "name": "locationsConnection",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
+              (v8/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -418,13 +552,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "city",
-                        "storageKey": null
-                      },
+                      (v7/*: any*/),
                       (v4/*: any*/)
                     ],
                     "storageKey": null
@@ -481,13 +609,13 @@ return {
             "kind": "LinkedField",
             "name": "articlesConnection",
             "plural": false,
-            "selections": (v8/*: any*/),
+            "selections": (v9/*: any*/),
             "storageKey": null
           },
           {
             "alias": "representedArtists",
             "args": [
-              (v9/*: any*/),
+              (v10/*: any*/),
               {
                 "kind": "Literal",
                 "name": "representedBy",
@@ -498,13 +626,13 @@ return {
             "kind": "LinkedField",
             "name": "artistsConnection",
             "plural": false,
-            "selections": (v8/*: any*/),
+            "selections": (v9/*: any*/),
             "storageKey": "artistsConnection(displayOnPartnerProfile:true,representedBy:true)"
           },
           {
             "alias": "notRepresentedArtists",
             "args": [
-              (v9/*: any*/),
+              (v10/*: any*/),
               {
                 "kind": "Literal",
                 "name": "hasPublishedArtworks",
@@ -520,7 +648,7 @@ return {
             "kind": "LinkedField",
             "name": "artistsConnection",
             "plural": false,
-            "selections": (v8/*: any*/),
+            "selections": (v9/*: any*/),
             "storageKey": "artistsConnection(displayOnPartnerProfile:true,hasPublishedArtworks:true,representedBy:false)"
           },
           (v4/*: any*/)
@@ -534,7 +662,7 @@ return {
     "metadata": {},
     "name": "partnerRoutes_PartnerQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    partnerType\n    displayFullPartnerPage\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  slug\n  meta {\n    image\n    title\n    description\n  }\n}\n"
+    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    partnerType\n    displayFullPartnerPage\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    ...FollowProfileButton_profile\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
   }
 };
 })();


### PR DESCRIPTION
This PR adds structured data to the partner pages per the `LocalBusiness` schema.org spec:

https://schema.org/LocalBusiness

I poked around and discovered some things about the `address` and `location` attributes plus learned more about how we model partner locations so ended up pitching what you see here - we run both the `legalName` and `name` always and then conditionally run the `address` as a `PostalAddress` including phone number and conditionally run the `location` as a `Place` with lat/long in case Google will pick that up and do a map. More docs for the curious:

https://schema.org/Place
https://schema.org/PostalAddress

Note that I discovered there was no need to use the scary `dangerouslySetInnerHTML` api and instead I just ran the content right inside the `script` tag.

Looks like this:

<img width="376" alt="Screen Shot 2021-08-06 at 10 55 31 AM" src="https://user-images.githubusercontent.com/79799/128538135-7fd9d362-3168-4077-9a9d-ea9f0cdbadfa.png">

And here's the validator output:

<img width="1036" alt="Screen Shot 2021-08-06 at 11 01 30 AM" src="https://user-images.githubusercontent.com/79799/128538950-4434f845-11ae-4fcc-88a3-ae189865bc7c.png">

## Extract Stand-alone Structured Data Component

My first step here was to read the existing code for running structured data. I felt there was room for improvement there so I started this line of work by extracting a component called `StructuredData` that does the work of converting a JS object to stringified data and sets the correct context. It also encapsulates the funky `application/ld+json` content type and knows to run it as a `script` tag. I got some tests around this too.

## Migrate to Extracted Component

Once I had my extracted component I could then look at the places were I wanted to migrate away from the repetition. I started with the artist one and then did the artwork ones. Added tests here too. Easy peasy.

That left the breadcrumb one and that took a bit more doing because there was actual (untested?) behavior. So I took a few commits to extract and wrap with tests to ensure I could migrate without any regressions.

## Partner Page

At this point I was ready to add my new `LocalBusiness` component following these new patterns and then update the partner app to use it. One thing I struggled with a bit was making it so that `undefined` properties didn't come through and end up rendering to the page. I found that [Underscore `pick`](https://underscorejs.org/#pick) worked so I pulled that in - open to other ideas here!

## Testing This Change

All we can really do here is copy/paste into the validator until this lands in production. From there we can wait for Google to crawl the site and report any errors in Google Search Console which I plan to do in a week or so.

https://artsyproduct.atlassian.net/browse/GRO-379

/cc @artsy/grow-devs