### PR TITLE
Remove the Help chat bubble from Inquiry checkout modal

### DIFF
--- a/src/v2/Apps/Order/OrderApp.tsx
+++ b/src/v2/Apps/Order/OrderApp.tsx
@@ -145,7 +145,7 @@ class OrderApp extends React.Component<OrderAppProps, {}> {
                     content="width=device-width, initial-scale=1, maximum-scale=5 viewport-fit=cover"
                   />
                 )}
-                {!isEigen && this.renderZendeskScript()}
+                {!isEigen && !isModal && this.renderZendeskScript()}
                 <SafeAreaContainer>
                   <Elements stripe={stripePromise}>
                     <AppContainer>

--- a/src/v2/Apps/Order/__tests__/OrderApp.jest.tsx
+++ b/src/v2/Apps/Order/__tests__/OrderApp.jest.tsx
@@ -571,6 +571,15 @@ describe("OrderApp", () => {
     expect(subject.find("ZendeskWrapper")).toHaveLength(1)
   })
 
+  it("does not show the Zendesk chat integration button if in a modal", () => {
+    const props = getProps()
+    const subject = getWrapper({
+      props: { ...props, location: { query: { isModal: true } } },
+    })
+
+    expect(subject.find("ZendeskWrapper")).toHaveLength(1)
+  })
+
   it("shows an error page if the order is missing", () => {
     const props = getProps()
     const subject = getWrapper({


### PR DESCRIPTION
[PURCHASE-2879]

*No screenshots because help chat doesn't render locally*

Current behavior:

Given a buyer has submitted an offer through an inquiry,
And they have received a counteroffer from the seller,
When they open the counteroffer modal,
Then the Help chat bubble renders at the bottom right of the modal.

Improved behavior:

Given a buyer has submitted an offer through an inquiry,
And they have received a counteroffer from the seller,
When they open the counteroffer modal,
Then the Help chat bubble does not render.



[PURCHASE-2879]: https://artsyproduct.atlassian.net/browse/PURCHASE-2879