### PR TITLE
feat: Improve unsubscribe fallback GRO-475

### DIFF
--- a/src/v2/Apps/Unsubscribe/UnsubscribeApp.tsx
+++ b/src/v2/Apps/Unsubscribe/UnsubscribeApp.tsx
@@ -7,6 +7,14 @@ import { UnsubscribeApp_me } from "v2/__generated__/UnsubscribeApp_me.graphql"
 import { UnsubscribeLoggedInFragmentContainer } from "./Components/UnsubscribeLoggedIn"
 import { UnsubscribeLoggedOut } from "./Components/UnsubscribeLoggedOut"
 
+const UnsubscribeFallback = () => {
+  return (
+    <Message variant="error" my={4}>
+      Unable to update your email preferences
+    </Message>
+  )
+}
+
 interface UnsubscribeAppProps {
   me: UnsubscribeApp_me | null
 }
@@ -16,11 +24,7 @@ export const UnsubscribeApp: React.FC<UnsubscribeAppProps> = ({ me }) => {
   const { authentication_token: authenticationToken } = match.location.query
 
   if (!me && !authenticationToken) {
-    return (
-      <Message variant="error" my={4}>
-        Unable to update your email preferences
-      </Message>
-    )
+    return <UnsubscribeFallback />
   }
 
   return (

--- a/src/v2/Apps/Unsubscribe/UnsubscribeApp.tsx
+++ b/src/v2/Apps/Unsubscribe/UnsubscribeApp.tsx
@@ -10,7 +10,7 @@ import { UnsubscribeLoggedOut } from "./Components/UnsubscribeLoggedOut"
 const UnsubscribeFallback = () => {
   return (
     <Message variant="error" my={4}>
-      Unable to update your email preferences
+      Please sign in to update your email preferences
     </Message>
   )
 }

--- a/src/v2/Apps/Unsubscribe/UnsubscribeApp.tsx
+++ b/src/v2/Apps/Unsubscribe/UnsubscribeApp.tsx
@@ -22,26 +22,22 @@ interface UnsubscribeAppProps {
 export const UnsubscribeApp: React.FC<UnsubscribeAppProps> = ({ me }) => {
   const { match } = useRouter()
   const { authentication_token: authenticationToken } = match.location.query
-
-  if (!me && !authenticationToken) {
-    return <UnsubscribeFallback />
-  }
+  const showFallback = !me && !authenticationToken
+  const showLoggedIn = me && !authenticationToken
+  const showLoggedOut = !me && authenticationToken
 
   return (
     <>
+      {showFallback && <UnsubscribeFallback />}
       <Title>Email Preferences | Artsy</Title>
-
       <GridColumns my={4}>
         <Column span={6}>
           <Text variant="xl" as="h1">
             Email Preferences
           </Text>
-
           <Spacer mt={6} />
-
-          {me ? (
-            <UnsubscribeLoggedInFragmentContainer me={me} />
-          ) : (
+          {showLoggedIn && <UnsubscribeLoggedInFragmentContainer me={me!} />}
+          {showLoggedOut && (
             <UnsubscribeLoggedOut authenticationToken={authenticationToken} />
           )}
         </Column>

--- a/src/v2/Apps/Unsubscribe/__tests__/UnsubscribeApp.jest.tsx
+++ b/src/v2/Apps/Unsubscribe/__tests__/UnsubscribeApp.jest.tsx
@@ -79,11 +79,11 @@ describe("UnsubscribeApp", () => {
     expect(wrapper.find("UnsubscribeFallback")).toHaveLength(0)
   })
 
-  it("renders error message without a user or token", () => {
+  it("renders the fallback message without a user or token", () => {
     mockUseRouter.mockImplementation(() => emptyQuery)
     const wrapper = bootAndMount({ me: null })
 
-    expect(wrapper.find("UnsubscribeLoggedInFragmentContainer")).toHaveLength(0)
+    expect(wrapper.find("UnsubscribeLoggedIn")).toHaveLength(0)
     expect(wrapper.find("UnsubscribeLoggedOut")).toHaveLength(0)
     expect(wrapper.find("UnsubscribeFallback")).toHaveLength(1)
   })

--- a/src/v2/Apps/Unsubscribe/__tests__/UnsubscribeApp.jest.tsx
+++ b/src/v2/Apps/Unsubscribe/__tests__/UnsubscribeApp.jest.tsx
@@ -1,0 +1,88 @@
+import { MockBoot } from "v2/DevTools"
+import React from "react"
+import { mount } from "enzyme"
+import {
+  UnsubscribeApp,
+  UnsubscribeAppFragmentContainer,
+} from "../UnsubscribeApp"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { graphql } from "react-relay"
+import { UnsubscribeApp_Test_Query } from "v2/__generated__/UnsubscribeApp_Test_Query.graphql"
+import { useRouter } from "v2/System/Router/useRouter"
+
+const mockUseRouter = useRouter as jest.Mock
+
+jest.unmock("react-relay")
+jest.mock("v2/System/Router/useRouter")
+
+const { getWrapper } = setupTestWrapper<UnsubscribeApp_Test_Query>({
+  Component: props => (
+    <MockBoot>
+      <UnsubscribeAppFragmentContainer {...props} />
+    </MockBoot>
+  ),
+  query: graphql`
+    query UnsubscribeApp_Test_Query {
+      me {
+        ...UnsubscribeApp_me
+      }
+    }
+  `,
+})
+
+const bootAndMount = props => {
+  const wrapper = mount(
+    <MockBoot>
+      <UnsubscribeApp {...props} />
+    </MockBoot>
+  )
+
+  return wrapper
+}
+
+describe("UnsubscribeApp", () => {
+  const emptyQuery = {
+    match: {
+      location: {
+        query: {},
+      },
+    },
+  }
+
+  const queryWithToken = {
+    match: {
+      location: {
+        query: { authentication_token: "abc123" },
+      },
+    },
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders the logged in version with a user", () => {
+    mockUseRouter.mockImplementation(() => emptyQuery)
+    const wrapper = getWrapper()
+
+    expect(wrapper.find("UnsubscribeLoggedIn")).toHaveLength(1)
+    expect(wrapper.find("UnsubscribeLoggedOut")).toHaveLength(0)
+  })
+
+  it("renders the logged out version with a token", () => {
+    mockUseRouter.mockImplementation(() => queryWithToken)
+    const wrapper = bootAndMount({ me: null })
+
+    expect(wrapper.find("UnsubscribeLoggedIn")).toHaveLength(0)
+    expect(wrapper.find("UnsubscribeLoggedOut")).toHaveLength(1)
+  })
+
+  it("renders error message without a user or token", () => {
+    mockUseRouter.mockImplementation(() => emptyQuery)
+    const wrapper = bootAndMount({ me: null })
+
+    expect(wrapper.find("UnsubscribeLoggedInFragmentContainer")).toHaveLength(0)
+    expect(wrapper.find("UnsubscribeLoggedOut")).toHaveLength(0)
+    expect(wrapper.text()).toMatch("Unable to update your email preferences")
+  })
+})

--- a/src/v2/Apps/Unsubscribe/__tests__/UnsubscribeApp.jest.tsx
+++ b/src/v2/Apps/Unsubscribe/__tests__/UnsubscribeApp.jest.tsx
@@ -67,6 +67,7 @@ describe("UnsubscribeApp", () => {
 
     expect(wrapper.find("UnsubscribeLoggedIn")).toHaveLength(1)
     expect(wrapper.find("UnsubscribeLoggedOut")).toHaveLength(0)
+    expect(wrapper.find("UnsubscribeFallback")).toHaveLength(0)
   })
 
   it("renders the logged out version with a token", () => {
@@ -75,6 +76,7 @@ describe("UnsubscribeApp", () => {
 
     expect(wrapper.find("UnsubscribeLoggedIn")).toHaveLength(0)
     expect(wrapper.find("UnsubscribeLoggedOut")).toHaveLength(1)
+    expect(wrapper.find("UnsubscribeFallback")).toHaveLength(0)
   })
 
   it("renders error message without a user or token", () => {
@@ -83,6 +85,6 @@ describe("UnsubscribeApp", () => {
 
     expect(wrapper.find("UnsubscribeLoggedInFragmentContainer")).toHaveLength(0)
     expect(wrapper.find("UnsubscribeLoggedOut")).toHaveLength(0)
-    expect(wrapper.text()).toMatch("Unable to update your email preferences")
+    expect(wrapper.find("UnsubscribeFallback")).toHaveLength(1)
   })
 })

--- a/src/v2/__generated__/UnsubscribeApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/UnsubscribeApp_Test_Query.graphql.ts
@@ -1,0 +1,105 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type UnsubscribeApp_Test_QueryVariables = {};
+export type UnsubscribeApp_Test_QueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"UnsubscribeApp_me">;
+    } | null;
+};
+export type UnsubscribeApp_Test_Query = {
+    readonly response: UnsubscribeApp_Test_QueryResponse;
+    readonly variables: UnsubscribeApp_Test_QueryVariables;
+};
+
+
+
+/*
+query UnsubscribeApp_Test_Query {
+  me {
+    ...UnsubscribeApp_me
+    id
+  }
+}
+
+fragment UnsubscribeApp_me on Me {
+  ...UnsubscribeLoggedIn_me
+}
+
+fragment UnsubscribeLoggedIn_me on Me {
+  id
+  emailFrequency
+}
+*/
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "UnsubscribeApp_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "UnsubscribeApp_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "UnsubscribeApp_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "emailFrequency",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "UnsubscribeApp_Test_Query",
+    "operationKind": "query",
+    "text": "query UnsubscribeApp_Test_Query {\n  me {\n    ...UnsubscribeApp_me\n    id\n  }\n}\n\nfragment UnsubscribeApp_me on Me {\n  ...UnsubscribeLoggedIn_me\n}\n\nfragment UnsubscribeLoggedIn_me on Me {\n  id\n  emailFrequency\n}\n"
+  }
+};
+(node as any).hash = '33275dda085642475124554543905b22';
+export default node;


### PR DESCRIPTION
We discovered some traffic was making it to our unsubscribe page without a token so this PR aims to improve that UX by nudging them to log in. Once they are logged in, then the page will behave as expected and they can change their email frequency. Here's how the fallback page looks:

<img width="944" alt="Screen Shot 2021-08-10 at 3 19 15 PM" src="https://user-images.githubusercontent.com/79799/128929380-34f6c7e2-2835-42a0-96d9-53403ab414cb.png">

In terms of the actual code here my approach was:

* add some specs for the three paths through this component
* extract the existing fallback component
* update that fallback component

And that's it!

https://artsyproduct.atlassian.net/browse/GRO-475

/cc @artsy/grow-devs @isakelaris 