### PR TITLE
fix: Do not escape structured data GRO-478

### DIFF
--- a/src/v2/Components/Seo/StructuredData.tsx
+++ b/src/v2/Components/Seo/StructuredData.tsx
@@ -8,10 +8,13 @@ export const StructuredData = props => {
   }
 
   const schemaContent = JSON.stringify(schemaData, null, 2)
+  const dangerousHtml = { __html: schemaContent }
 
   return (
-    <Meta tag="script" type="application/ld+json">
-      {schemaContent}
-    </Meta>
+    <Meta
+      dangerouslySetInnerHTML={dangerousHtml}
+      tag="script"
+      type="application/ld+json"
+    />
   )
 }


### PR DESCRIPTION
Over on https://github.com/artsy/force/pull/8150 I confidently declared that we did not have to use `dangerouslySetInnerHTML` but I was wrong! After landing that PR and deploying to production I did a little QA and noticed some problems:

<img width="1302" alt="Screen Shot 2021-08-11 at 10 17 22 AM" src="https://user-images.githubusercontent.com/79799/129056532-b98e794d-211b-4f75-826b-e3d5f881c5de.png">
<img width="1302" alt="Screen Shot 2021-08-11 at 10 17 31 AM" src="https://user-images.githubusercontent.com/79799/129056538-de4e3043-4372-4f6b-b352-7e039a02ac4d.png">

So then I opened a partner page and viewed the source:

<img width="527" alt="Screen Shot 2021-08-11 at 10 17 46 AM" src="https://user-images.githubusercontent.com/79799/129056541-e1b8931a-3d03-47f8-851b-0899c6dfb315.png">

Yep, that's escaped, ugh.

So all this PR does is revert back to using that `dangerouslySetInnerHTML` method of writing out the structured data and now we are back to this:

<img width="325" alt="Screen Shot 2021-08-11 at 10 17 59 AM" src="https://user-images.githubusercontent.com/79799/129056543-5f0b2838-3195-4598-b191-50abc31bbffc.png">
 


https://artsyproduct.atlassian.net/browse/GRO-478

/cc @artsy/grow-devs