### PR TITLE
chore: removes icon fonts preload

### DIFF
--- a/src/v2/Utils/LegacyArtworkDllContainer.tsx
+++ b/src/v2/Utils/LegacyArtworkDllContainer.tsx
@@ -22,13 +22,6 @@ export class LegacyArtworkDllContainer extends React.Component {
   }
 
   addLegacyStyles() {
-    if (!document.getElementById("legacyIconFont")) {
-      document.head.insertAdjacentHTML(
-        "beforeend",
-        `<link id="legacyIconFont" rel="preload" href="${sd.WEBFONT_URL}/artsy-icons.woff2" as="font" type="font/woff2" crossorigin />`
-      )
-    }
-
     if (!document.getElementById("legacyArtworkPageStyles")) {
       document.head.insertAdjacentHTML(
         "beforeend",


### PR DESCRIPTION
So the places the icon font is used on the artwork page are modal and once they appear on page the font will load, so there shouldn't be a need to preload this.