### PR TITLE
fix(footer): lazyloads app icons and adds alt text

### DIFF
--- a/src/v2/Components/DownloadAppBadge.tsx
+++ b/src/v2/Components/DownloadAppBadge.tsx
@@ -3,14 +3,14 @@ import track, { useTracking } from "react-tracking"
 import { clickedAppDownload, ContextModule } from "@artsy/cohesion"
 import { useAnalyticsContext } from "v2/System"
 import Events from "v2/Utils/Events"
-import { Image, Link, LinkProps } from "@artsy/palette"
+import { Link, LinkProps } from "@artsy/palette"
 import { Device } from "v2/Utils/Hooks/useDeviceDetection"
 
 // SVGs are referenced as files because:
 // - We don't need flexibility here; never changing color, etc.
 // - Avoids adding ~15kb to every page load
 // - Can be cached
-// - Ideally, can be lazyLoaded (see note below)
+// - Can be lazyloaded
 
 const DOWNLOAD_IOS_APP_BADGE =
   "https://files.artsy.net/images/download-ios-app.svg"
@@ -62,20 +62,22 @@ export const DownloadAppBadge: React.FC<DownloadAppBadgeProps> = track(null, {
       {...rest}
     >
       {device === Device.iPhone && (
-        <Image
+        <img
           src={DOWNLOAD_IOS_APP_BADGE}
           width={120}
           height={40}
-          // TODO: Unable to use lazyLoad due to transparency
+          alt="Download on the App Store"
+          loading="lazy"
         />
       )}
 
       {device === Device.Android && (
-        <Image
+        <img
           src={DOWNLOAD_ANDROID_APP_BADGE}
           width={136}
           height={40}
-          // TODO: Unable to use lazyLoad due to transparency
+          alt="Get it on Google Play"
+          loading="lazy"
         />
       )}
     </Link>


### PR DESCRIPTION
Checks off some minor lighthouse report dings.

We can't use Palette's `Image` component to lazyLoad  because of the rounded corners on these (see: [image grievances](https://artsyproduct.atlassian.net/browse/DSWGW-79)), but we can just use a native img tag with `loading="lazy"`.

Also adds the appropriate alt text.