### PR TITLE
refactor: removes remaining instances of deprecated responsive image

### DIFF
--- a/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignHeader/ArtistConsignHeaderImages.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/Components/ArtistConsignHeader/ArtistConsignHeaderImages.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, ResponsiveImage } from "@artsy/palette"
+import { Box, Flex } from "@artsy/palette"
 import { ArtistConsignHeaderImages_artist } from "v2/__generated__/ArtistConsignHeaderImages_artist.graphql"
 import { last } from "lodash"
 import React from "react"
@@ -72,9 +72,12 @@ interface ImageProps {
 }
 const LeftImagePhoto: React.FC<ImageProps> = ({ image }) => {
   return (
-    <ResponsiveImage
-      src={image.resized.url}
+    <div
       style={{
+        width: "100%",
+        paddingBottom: "100%",
+        backgroundImage: `url(${image.resized.url})`,
+        backgroundSize: "contain",
         backgroundPosition: "left",
         transformOrigin: "left",
       }}
@@ -83,7 +86,16 @@ const LeftImagePhoto: React.FC<ImageProps> = ({ image }) => {
 }
 
 const RightImagePhoto: React.FC<ImageProps> = ({ image }) => {
-  return <ResponsiveImage src={image.resized.url} />
+  return (
+    <div
+      style={{
+        width: "100%",
+        paddingBottom: "100%",
+        backgroundImage: `url(${image.resized.url})`,
+        backgroundSize: "contain",
+      }}
+    />
+  )
 }
 
 const LeftImage = styled(Box)`

--- a/src/v2/Apps/Artist/Routes/Consign/__tests__/ArtistConsignRoute.jest.tsx
+++ b/src/v2/Apps/Artist/Routes/Consign/__tests__/ArtistConsignRoute.jest.tsx
@@ -64,13 +64,6 @@ describe("ConsignRoute", () => {
       expect(wrapper.find("ArtistConsignHeader").text()).toContain("Alex Katz")
     })
 
-    it("displays two images in header", async () => {
-      const wrapper = await getWrapper()
-      expect(
-        wrapper.find("ArtistConsignHeader").find("ResponsiveImage").length
-      ).toEqual(2)
-    })
-
     it("links out to consign page", async () => {
       const wrapper = await getWrapper()
       expect(

--- a/src/v2/Apps/Auction/Components/LotInfo.tsx
+++ b/src/v2/Apps/Auction/Components/LotInfo.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, ResponsiveImage, Sans, Serif } from "@artsy/palette"
+import { Box, Flex, Sans, Serif } from "@artsy/palette"
 import { LotInfo_artwork } from "v2/__generated__/LotInfo_artwork.graphql"
 import { LotInfo_saleArtwork } from "v2/__generated__/LotInfo_saleArtwork.graphql"
 import React from "react"
@@ -18,8 +18,14 @@ export const LotInfo: React.FC<Props> = ({ artwork, saleArtwork }) => {
   return (
     <Flex py={4}>
       <Box maxWidth="150px" width="100%" height="auto" p={0}>
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
-        <ResponsiveImage src={artwork.imageUrl} />
+        <div
+          style={{
+            width: "100%",
+            paddingBottom: "100%",
+            backgroundImage: `url(${artwork.imageUrl})`,
+            backgroundSize: "contain",
+          }}
+        />
       </Box>
       <Flex pl={3} pt={1} flexDirection="column">
         <Sans size="3" weight="medium" color="black100">

--- a/src/v2/Apps/Conversation/Components/Details.tsx
+++ b/src/v2/Apps/Conversation/Components/Details.tsx
@@ -7,7 +7,6 @@ import {
   Join,
   Link,
   QuestionCircleIcon,
-  ResponsiveImage,
   Sans,
   Separator,
   Spacer,
@@ -177,8 +176,14 @@ export const Details: FC<DetailsProps> = ({
               {/* @ts-expect-error STRICT_NULL_CHECK */}
               <a href={item.href}>
                 <Box height="80px" width="80px">
-                  {/* @ts-expect-error STRICT_NULL_CHECK */}
-                  <ResponsiveImage src={item.image?.thumbnailUrl} />
+                  <div
+                    style={{
+                      width: "100%",
+                      paddingBottom: "100%",
+                      backgroundImage: `url(${item.image?.thumbnailUrl})`,
+                      backgroundSize: "contain",
+                    }}
+                  />
                 </Box>
               </a>
               <Flex flexDirection="column" ml={1}>

--- a/src/v2/Apps/FeatureAKG/Components/Feature.tsx
+++ b/src/v2/Apps/FeatureAKG/Components/Feature.tsx
@@ -1,4 +1,4 @@
-import { Box, ResponsiveImage, Sans, Serif } from "@artsy/palette"
+import { Box, Sans, Serif } from "@artsy/palette"
 import { Feature_viewer } from "v2/__generated__/Feature_viewer.graphql"
 import { FeaturedArticlesFragmentContainer as FeaturedArticles } from "v2/Apps/FeatureAKG/Components/FeaturedArticles"
 import { FeaturedArtists } from "v2/Apps/FeatureAKG/Components/FeaturedArtists"
@@ -244,7 +244,14 @@ const StyledVideo = styled("video")`
 const ImageSection: React.FC<{ src: string; aspectRatio: number }> = props => {
   return (
     <BorderedSection>
-      <ResponsiveImage src={props.src} ratio={props.aspectRatio} />
+      <div
+        style={{
+          width: "100%",
+          paddingBottom: `${props.aspectRatio * 100}%`,
+          backgroundImage: `url(${props.src})`,
+          backgroundSize: "contain",
+        }}
+      />
     </BorderedSection>
   )
 }
@@ -293,8 +300,15 @@ export const FeaturedContentLink: React.FC<FeaturedLinkType> = props => {
       }
     >
       <Box position="relative">
-        {/* @ts-expect-error STRICT_NULL_CHECK */}
-        <ResponsiveImage src={croppedUrl} ratio={height / width} />
+        <div
+          style={{
+            width: "100%",
+            paddingBottom: `${(height / width) * 100}%`,
+            backgroundImage: `url(${croppedUrl})`,
+            backgroundSize: "contain",
+          }}
+        />
+
         <ImageOverlayText maxWidth="150px">
           <BlockText size="2" color="white">
             {props.title}

--- a/src/v2/Apps/FeatureAKG/Components/FeaturedArticles.tsx
+++ b/src/v2/Apps/FeatureAKG/Components/FeaturedArticles.tsx
@@ -1,13 +1,4 @@
-import {
-  Box,
-  Col,
-  Flex,
-  Grid,
-  Image,
-  ResponsiveImage,
-  Row,
-  Sans,
-} from "@artsy/palette"
+import { Box, Col, Flex, Grid, Image, Row, Sans } from "@artsy/palette"
 import { FeaturedArticles_articles } from "v2/__generated__/FeaturedArticles_articles.graphql"
 import { StyledLink } from "./StyledLink"
 import { AnalyticsSchema } from "v2/System"
@@ -60,10 +51,15 @@ const FeaturedArticles: React.FC<FeaturedArticlesProps> = props => {
               onClick={() => trackClick(firstArticle.href)}
             >
               {firstArticleImage && (
-                <ResponsiveImage
-                  // @ts-expect-error STRICT_NULL_CHECK
-                  src={firstArticle.thumbnailImage.cropped.url}
-                  ratio={firstArticleImage.height / firstArticleImage.width}
+                <div
+                  style={{
+                    width: "100%",
+                    paddingBottom: `${
+                      (firstArticleImage.height / firstArticleImage.width) * 100
+                    }%`,
+                    backgroundImage: `url(${firstArticle?.thumbnailImage?.cropped?.url})`,
+                    backgroundSize: "contain",
+                  }}
                 />
               )}
               <Sans size={["4t", "4t", "6"]} my={1}>

--- a/src/v2/Apps/ViewingRoom/Components/ViewingRoomHeader.tsx
+++ b/src/v2/Apps/ViewingRoom/Components/ViewingRoomHeader.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Box, Flex, Link, ResponsiveImage, Sans, color } from "@artsy/palette"
+import { Box, Flex, Link, Sans, color } from "@artsy/palette"
 import { DESKTOP_NAV_BAR_HEIGHT, MOBILE_NAV_HEIGHT } from "v2/Components/NavBar"
 import { Media } from "v2/Utils/Responsive"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -69,14 +69,13 @@ const ViewingRoomHeaderLarge: React.FC<ViewingRoomHeaderProps> = props => {
       }}
     >
       <Box width="50%" style={{ overflow: "hidden" }}>
-        <ResponsiveImage
-          // @ts-expect-error STRICT_NULL_CHECK
-          src={heroImageURL}
-          lazyLoad={false}
+        <div
           style={{
+            backgroundImage: `url(${heroImageURL})`,
             backgroundSize: "cover",
             backgroundPosition: "center",
             height: "100%",
+            paddingBottom: "100%",
           }}
         />
       </Box>
@@ -124,13 +123,13 @@ const ViewingRoomHeaderSmall: React.FC<ViewingRoomHeaderProps> = props => {
         position: "relative",
       }}
     >
-      <ResponsiveImage
-        // @ts-expect-error STRICT_NULL_CHECK
-        src={heroImageURL}
+      <div
         style={{
+          backgroundImage: `url(${heroImageURL})`,
           backgroundSize: "cover",
           backgroundPosition: "center",
           height: "100%",
+          paddingBottom: "100%",
         }}
       />
 

--- a/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
@@ -130,8 +130,8 @@ describe("ViewingRoomApp", () => {
       describe("desktop", () => {
         it("renders correctly", async () => {
           const wrapper = await getWrapper()
-          expect(wrapper.find("ResponsiveImage").length).toBe(1)
           const html = wrapper.html()
+          expect(html).toContain("background-image: url")
           expect(html).toContain("Guy Yanai")
           expect(html).toContain("Subscription Demo GG")
           expect(html).toContain("Opens in 8 days")
@@ -141,8 +141,8 @@ describe("ViewingRoomApp", () => {
       describe("mobile", () => {
         it("renders correctly", async () => {
           const wrapper = await getWrapper()
-          expect(wrapper.find("ResponsiveImage").length).toBe(1)
           const html = wrapper.html()
+          expect(html).toContain("background-image: url")
           expect(html).toContain("Guy Yanai")
           expect(html).toContain("Subscription Demo GG")
           expect(html).toContain("Opens in 8 days")
@@ -196,8 +196,8 @@ describe("ViewingRoomApp", () => {
       describe("desktop", () => {
         it("renders correctly", async () => {
           const wrapper = await getWrapper()
-          expect(wrapper.find("ResponsiveImage").length).toBe(1)
           const html = wrapper.html()
+          expect(html).toContain("background-image: url")
           expect(html).toContain("Guy Yanai")
           expect(html).toContain("Subscription Demo GG")
           expect(html).toContain("Closes in 1 month")
@@ -207,8 +207,9 @@ describe("ViewingRoomApp", () => {
       describe("mobile", () => {
         it("renders correctly", async () => {
           const wrapper = await getWrapper()
-          expect(wrapper.find("ResponsiveImage").length).toBe(1)
+
           const html = wrapper.html()
+          expect(html).toContain("background-image: url")
           expect(html).toContain("Guy Yanai")
           expect(html).toContain("Subscription Demo GG")
           expect(html).toContain("Closes in 1 month")
@@ -272,8 +273,8 @@ describe("ViewingRoomApp", () => {
       describe("desktop", () => {
         it("renders correctly", async () => {
           const wrapper = await getWrapper()
-          expect(wrapper.find("ResponsiveImage").length).toBe(1)
           const html = wrapper.html()
+          expect(html).toContain("background-image: url")
           expect(html).toContain("Guy Yanai")
           expect(html).toContain("Subscription Demo GG")
           expect(html).toContain("Closed")
@@ -283,8 +284,8 @@ describe("ViewingRoomApp", () => {
       describe("mobile", () => {
         it("renders correctly", async () => {
           const wrapper = await getWrapper()
-          expect(wrapper.find("ResponsiveImage").length).toBe(1)
           const html = wrapper.html()
+          expect(html).toContain("background-image: url")
           expect(html).toContain("Guy Yanai")
           expect(html).toContain("Subscription Demo GG")
           expect(html).toContain("Closed")


### PR DESCRIPTION
In an effort to fix an issue with Image width & height I'm removing this old `ResponsiveImage` component that shouldn't ever be used. Replaced with one-off inline styles.