### PR TITLE
fix(unsubscribe): clears up logic when presenting opt out form

### DIFF
--- a/src/v2/Apps/Unsubscribe/UnsubscribeApp.tsx
+++ b/src/v2/Apps/Unsubscribe/UnsubscribeApp.tsx
@@ -7,41 +7,44 @@ import { UnsubscribeApp_me } from "v2/__generated__/UnsubscribeApp_me.graphql"
 import { UnsubscribeLoggedInFragmentContainer } from "./Components/UnsubscribeLoggedIn"
 import { UnsubscribeLoggedOut } from "./Components/UnsubscribeLoggedOut"
 
-const UnsubscribeFallback = () => {
-  return (
-    <Message variant="error" my={4}>
-      Please sign in to update your email preferences
-    </Message>
-  )
-}
-
 interface UnsubscribeAppProps {
   me: UnsubscribeApp_me | null
 }
 
 export const UnsubscribeApp: React.FC<UnsubscribeAppProps> = ({ me }) => {
   const { match } = useRouter()
+
   const { authentication_token: authenticationToken } = match.location.query
-  const showFallback = !me && !authenticationToken
-  const showLoggedIn = me && !authenticationToken
-  const showLoggedOut = !me && authenticationToken
 
   return (
     <>
-      {showFallback && <UnsubscribeFallback />}
       <Title>Email Preferences | Artsy</Title>
-      <GridColumns my={4}>
-        <Column span={6}>
-          <Text variant="xl" as="h1">
-            Email Preferences
-          </Text>
-          <Spacer mt={6} />
-          {showLoggedIn && <UnsubscribeLoggedInFragmentContainer me={me!} />}
-          {showLoggedOut && (
-            <UnsubscribeLoggedOut authenticationToken={authenticationToken} />
-          )}
-        </Column>
-      </GridColumns>
+
+      {!me && !authenticationToken ? (
+        // Is logged out and doesn't have token: can't update anything
+        <Message variant="error" my={4}>
+          Please sign in to update your email preferences
+        </Message>
+      ) : (
+        // Either logged in or logged out with a token
+        <GridColumns my={4}>
+          <Column span={6}>
+            <Text variant="xl" as="h1">
+              Email Preferences
+            </Text>
+
+            <Spacer mt={6} />
+
+            {!!me ? (
+              // If we're logged in, always favor the more detailed preferences
+              <UnsubscribeLoggedInFragmentContainer me={me} />
+            ) : (
+              // Otherwise simply show the opt-out
+              <UnsubscribeLoggedOut authenticationToken={authenticationToken} />
+            )}
+          </Column>
+        </GridColumns>
+      )}
     </>
   )
 }

--- a/src/v2/Apps/Unsubscribe/__tests__/UnsubscribeApp.jest.tsx
+++ b/src/v2/Apps/Unsubscribe/__tests__/UnsubscribeApp.jest.tsx
@@ -61,30 +61,37 @@ describe("UnsubscribeApp", () => {
     jest.clearAllMocks()
   })
 
-  it("renders the logged in version with a user", () => {
-    mockUseRouter.mockImplementation(() => emptyQuery)
-    const wrapper = getWrapper()
+  describe("logged in", () => {
+    it("allows the user to manage their email preferences", () => {
+      mockUseRouter.mockImplementation(() => emptyQuery)
+      const wrapper = getWrapper()
+      const html = wrapper.html()
 
-    expect(wrapper.find("UnsubscribeLoggedIn")).toHaveLength(1)
-    expect(wrapper.find("UnsubscribeLoggedOut")).toHaveLength(0)
-    expect(wrapper.find("UnsubscribeFallback")).toHaveLength(0)
+      expect(html).toContain("Email Preferences")
+      expect(html).toContain("Email frequency")
+    })
   })
 
-  it("renders the logged out version with a token", () => {
-    mockUseRouter.mockImplementation(() => queryWithToken)
-    const wrapper = bootAndMount({ me: null })
+  describe("logged out; has token", () => {
+    it("allows the user to opt-out of all email", () => {
+      mockUseRouter.mockImplementation(() => queryWithToken)
+      const wrapper = bootAndMount({ me: null })
+      const html = wrapper.html()
 
-    expect(wrapper.find("UnsubscribeLoggedIn")).toHaveLength(0)
-    expect(wrapper.find("UnsubscribeLoggedOut")).toHaveLength(1)
-    expect(wrapper.find("UnsubscribeFallback")).toHaveLength(0)
+      expect(html).toContain("Email Preferences")
+      expect(html).toContain("Opt out of all email")
+    })
   })
 
-  it("renders the fallback message without a user or token", () => {
-    mockUseRouter.mockImplementation(() => emptyQuery)
-    const wrapper = bootAndMount({ me: null })
+  describe("logged out; no token", () => {
+    it("renders the fallback message", () => {
+      mockUseRouter.mockImplementation(() => emptyQuery)
+      const wrapper = bootAndMount({ me: null })
+      const html = wrapper.html()
 
-    expect(wrapper.find("UnsubscribeLoggedIn")).toHaveLength(0)
-    expect(wrapper.find("UnsubscribeLoggedOut")).toHaveLength(0)
-    expect(wrapper.find("UnsubscribeFallback")).toHaveLength(1)
+      expect(html).toContain("Please sign in to update your email preferences")
+
+      expect(html).not.toContain("Email Preferences")
+    })
   })
 })


### PR DESCRIPTION
Isabelle caught this issue where if you were logged in AND had a token we wouldn't show anything. This PR fixes that to prefer the logged in email options.