### PR TITLE
feature: Minimize Moment Timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -355,6 +355,7 @@
     "mocha": "3.4.1",
     "mocha-junit-reporter": "1.22.0",
     "mocha-multi-reporters": "1.1.7",
+    "moment-timezone-data-webpack-plugin": "1.5.0",
     "nyc": "13.3.0",
     "patch-package": "6.2.0",
     "postinstall-prepare": "1.0.1",

--- a/webpack/envs/clientDevelopmentConfig.js
+++ b/webpack/envs/clientDevelopmentConfig.js
@@ -24,6 +24,7 @@ import {
   mjsLoader,
 } from "./commonLoaders"
 import { standardPlugins } from "./commonPlugins"
+import { clientPlugins } from "./clientPlugins"
 import { clientChunks } from "./clientCommonConfig"
 
 export const clientDevelopmentConfig = {
@@ -53,6 +54,7 @@ export const clientDevelopmentConfig = {
   },
   plugins: [
     ...standardPlugins,
+    ...clientPlugins,
     new webpack.HotModuleReplacementPlugin(),
     new ForkTsCheckerWebpackPlugin({
       checkSyntacticErrors: true,

--- a/webpack/envs/clientPlugins.js
+++ b/webpack/envs/clientPlugins.js
@@ -1,0 +1,17 @@
+// @ts-check
+
+import MomentTimezoneDataPlugin from "moment-timezone-data-webpack-plugin"
+const currentYear = new Date().getFullYear()
+
+export const clientPlugins = [
+  // To include only specific zones, use the matchZones option
+  new MomentTimezoneDataPlugin({
+    matchZones: /^America\/New_York/,
+  }),
+
+  // To keep all zones but limit data to specific years, use the year range options
+  new MomentTimezoneDataPlugin({
+    startYear: currentYear - 5,
+    endYear: currentYear + 5,
+  }),
+]

--- a/webpack/envs/clientProductionConfig.js
+++ b/webpack/envs/clientProductionConfig.js
@@ -22,6 +22,7 @@ import {
   standardStats,
 } from "./commonEnv"
 import { standardPlugins } from "./commonPlugins"
+import { clientPlugins } from "./clientPlugins"
 import { clientChunks } from "./clientCommonConfig"
 
 export const clientProductionConfig = {
@@ -50,6 +51,7 @@ export const clientProductionConfig = {
   },
   plugins: [
     ...standardPlugins,
+    ...clientPlugins,
     new LoadablePlugin({
       filename: "loadable-novo-stats.json",
       path: path.resolve(basePath, "public", "assets"),

--- a/yarn.lock
+++ b/yarn.lock
@@ -9184,7 +9184,7 @@ find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
 
-find-cache-dir@^3.3.1:
+find-cache-dir@^3.0.0, find-cache-dir@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880"
   integrity sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==
@@ -14164,6 +14164,14 @@ module-details-from-path@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
   integrity sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=
+
+moment-timezone-data-webpack-plugin@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/moment-timezone-data-webpack-plugin/-/moment-timezone-data-webpack-plugin-1.5.0.tgz#229d98f36662adc41d7d30b154c81ec98e0c589d"
+  integrity sha512-eidUVGn6Fc8jR0tBf8xAhBR1C3jqknFJe0rfzThnglnJjmzqTXRYVTOeobUzWvlEfgTSu+b0W7GgOdqAWvGbYA==
+  dependencies:
+    find-cache-dir "^3.0.0"
+    make-dir "^3.0.0"
 
 moment-timezone@0.5.25:
   version "0.5.25"


### PR DESCRIPTION
Moment Timezone provides a webpack plugin that minimizes the timezone
data we need to include client-side, this adds the plugin and limits the
timezones to the only one that is used in v2 apps `America/New_York`

Timezone data from 32 KiB gzip -> 300 bytes gzip

Before
![moment-timezone-old](https://user-images.githubusercontent.com/403814/129300878-aa327a96-0d63-4bf1-8794-0baacb54dfd7.png)

After
![moment-timezone-new](https://user-images.githubusercontent.com/403814/129300895-b194b699-cd47-441b-8d00-8b00d02b1e76.png)
