### PR TITLE
fix(FX-3189): Auction timer

### DIFF
--- a/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeader/FairOrganizerHeader.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeader/FairOrganizerHeader.tsx
@@ -47,7 +47,11 @@ export const FairOrganizerHeader: React.FC<FairOrganizerHeaderProps> = ({
             <Box>
               {showTimer && (
                 <>
-                  <Timer variant="lg" label="Opens in:" endDate={startAt!} />
+                  <Timer
+                    variant={["lg", "xl"]}
+                    label="Opens in:"
+                    endDate={startAt!}
+                  />
                   <Spacer mt={30} />
                 </>
               )}

--- a/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeader/FairOrganizerHeader.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeader/FairOrganizerHeader.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import moment from "moment"
+import { DateTime } from "luxon"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Box, Column, Flex, GridColumns, Spacer, Text } from "@artsy/palette"
 import { FairOrganizerHeaderIconFragmentContainer as FairOrganizerHeaderIcon } from "./FairOrganizerHeaderIcon"
@@ -8,6 +8,7 @@ import { FairOrganizerInfoFragmentContainer as FairOrganizerInfo } from "./FairO
 import { FairOrganizerHeader_fairOrganizer } from "v2/__generated__/FairOrganizerHeader_fairOrganizer.graphql"
 import { extractNodes } from "v2/Utils/extractNodes"
 import { Timer } from "v2/Components/Timer"
+import { useCurrentTime } from "v2/Utils/Hooks/useCurrentTime"
 
 interface FairOrganizerHeaderProps {
   fairOrganizer: FairOrganizerHeader_fairOrganizer
@@ -20,7 +21,8 @@ export const FairOrganizerHeader: React.FC<FairOrganizerHeaderProps> = ({
   const fair = extractNodes(fairsConnection)[0]
   const { startAt, exhibitionPeriod } = fair
 
-  const showTimer = moment().isBefore(new Date(startAt!))
+  const currentTime = useCurrentTime({ syncWithServer: true })
+  const showTimer = DateTime.fromISO(currentTime) < DateTime.fromISO(startAt!)
 
   return (
     <Box>

--- a/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeader/__tests__/FairOrganizerHeader.jest.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeader/__tests__/FairOrganizerHeader.jest.tsx
@@ -1,5 +1,5 @@
 import { graphql } from "react-relay"
-import moment from "moment"
+import { DateTime } from "luxon"
 import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
 import { FairOrganizerHeaderFragmentContainer } from "../FairOrganizerHeader"
 
@@ -43,20 +43,14 @@ describe("FairOrganizerHeader", () => {
   })
 
   it("doesn't display timer if event is passed", () => {
-    const wrapper = getWrapper({
-      Fair: () => ({
-        startAt: "2020-09-01T05:00:00+03:00",
-      }),
-    })
+    const startAt = DateTime.local().minus({ days: 1 }).toString()
+    const wrapper = getWrapper({ Fair: () => ({ startAt }) })
     expect(wrapper.find("Timer").length).toBe(0)
   })
 
   it("displays timer if event starts in future", () => {
-    const wrapper = getWrapper({
-      Fair: () => ({
-        startAt: moment().add(1, "day"),
-      }),
-    })
+    const startAt = DateTime.local().plus({ days: 1 }).toString()
+    const wrapper = getWrapper({ Fair: () => ({ startAt }) })
     expect(wrapper.find("Timer").length).toBe(1)
     expect(wrapper.text()).toContain("Opens in:")
   })

--- a/src/v2/Components/Timer.tsx
+++ b/src/v2/Components/Timer.tsx
@@ -37,7 +37,7 @@ export const Timer: React.FC<
       secondLineColor: "black100",
     },
     v3: {
-      variant: ["lg", "xl"] as TextVariant[],
+      variant,
       firstLineColor: "blue100",
       secondLineColor: "black60",
     },

--- a/src/v2/Components/Timer.tsx
+++ b/src/v2/Components/Timer.tsx
@@ -7,12 +7,7 @@ import {
   TextVariant,
   useThemeConfig,
 } from "@artsy/palette"
-import { WithCurrentTime } from "v2/Components/WithCurrentTime"
-import { DateTime, Duration } from "luxon"
-
-function padWithZero(num: number) {
-  return num.toString().padStart(2, "0")
-}
+import { useTimer } from "v2/Utils/Hooks/useTimer"
 
 const SEPARATOR = <>&nbsp;&nbsp;</>
 
@@ -32,6 +27,9 @@ export const Timer: React.FC<
   variant = "md",
   ...rest
 }) => {
+  const { hasEnded, time } = useTimer(endDate)
+  const { days, hours, minutes, seconds } = time
+
   const tokens = useThemeConfig({
     v2: {
       variant: "mediumText" as TextVariant,
@@ -46,46 +44,24 @@ export const Timer: React.FC<
   })
 
   return (
-    <WithCurrentTime syncWithServer>
-      {currentTime => {
-        const duration = Duration.fromISO(
-          DateTime.fromISO(endDate)
-            .diff(DateTime.fromISO(currentTime))
-            .toString()
-        )
+    <Flex flexDirection="column" {...rest}>
+      <Text variant={tokens.variant} color={tokens.firstLineColor}>
+        {label && (
+          <Text variant={tokens.variant} color="black100">
+            {label}
+          </Text>
+        )}
+        {days}d{SEPARATOR}
+        {hours}h{SEPARATOR}
+        {minutes}m{SEPARATOR}
+        {seconds}s
+      </Text>
 
-        const hasEnded = Math.floor(duration.seconds) <= 0
-
-        return (
-          <Flex flexDirection="column" {...rest}>
-            <Text variant={tokens.variant} color={tokens.firstLineColor}>
-              {label && (
-                <Text variant={tokens.variant} color="black100">
-                  {label}
-                </Text>
-              )}
-              {padWithZero(Math.max(0, Math.floor(duration.as("days"))))}d
-              {SEPARATOR}
-              {padWithZero(Math.max(0, Math.floor(duration.as("hours") % 24)))}h
-              {SEPARATOR}
-              {padWithZero(
-                Math.max(0, Math.floor(duration.as("minutes") % 60))
-              )}
-              m{SEPARATOR}
-              {padWithZero(
-                Math.max(0, Math.floor(duration.as("seconds") % 60))
-              )}
-              s
-            </Text>
-
-            {(labelWithTimeRemaining || labelWithoutTimeRemaining) && (
-              <Text variant={tokens.variant} color={tokens.secondLineColor}>
-                {hasEnded ? labelWithoutTimeRemaining : labelWithTimeRemaining}
-              </Text>
-            )}
-          </Flex>
-        )
-      }}
-    </WithCurrentTime>
+      {(labelWithTimeRemaining || labelWithoutTimeRemaining) && (
+        <Text variant={tokens.variant} color={tokens.secondLineColor}>
+          {hasEnded ? labelWithoutTimeRemaining : labelWithTimeRemaining}
+        </Text>
+      )}
+    </Flex>
   )
 }

--- a/src/v2/Utils/Hooks/useTimer.tsx
+++ b/src/v2/Utils/Hooks/useTimer.tsx
@@ -1,0 +1,46 @@
+import { DateTime, Duration } from "luxon"
+import { useCurrentTime } from "./useCurrentTime"
+
+interface Time {
+  days: string
+  hours: string
+  minutes: string
+  seconds: string
+}
+
+interface Timer {
+  hasEnded: boolean
+  time: Time
+}
+
+const padWithZero = (num: number) => {
+  return num.toString().padStart(2, "0")
+}
+
+const extractTime = (time: number) => {
+  return padWithZero(Math.max(0, Math.floor(time)))
+}
+
+export const useTimer = (endDate: string): Timer => {
+  const currentTime = useCurrentTime({ syncWithServer: true })
+
+  const duration = Duration.fromISO(
+    DateTime.fromISO(endDate).diff(DateTime.fromISO(currentTime)).toString()
+  )
+
+  const hasEnded = Math.floor(duration.seconds) <= 0
+
+  const days = extractTime(duration.as("days"))
+  const hours = extractTime(duration.as("hours") % 24)
+  const minutes = extractTime(duration.as("minutes") % 60)
+  const seconds = extractTime(duration.as("seconds") % 60)
+
+  const time = {
+    days,
+    hours,
+    minutes,
+    seconds,
+  }
+
+  return { hasEnded, time }
+}


### PR DESCRIPTION
[FX-3189]

This PR fixes text size of timer on auction artwork page and extracts timer logic from component to hook

**Before** 
![Screenshot 2021-08-13 at 14 54 05](https://user-images.githubusercontent.com/44819355/129353385-f2e8ac64-7550-4266-92c6-7be4788c205a.png)


**After**
![Screenshot 2021-08-13 at 14 54 25](https://user-images.githubusercontent.com/44819355/129353424-0ac7cade-c57d-41c8-aadf-6b6a8706fd10.png)


[FX-3189]: https://artsyproduct.atlassian.net/browse/FX-3189