### PR TITLE
[GRO-460] Update image/copy in homepage banner for logged out users

### DIFF
--- a/cypress/integration/home.spec.ts
+++ b/cypress/integration/home.spec.ts
@@ -3,9 +3,6 @@ import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
 describe("Home", () => {
   it("/", () => {
     visitWithStatusRetries("/")
-    cy.get("h1").should(
-      "contain",
-      "Collect art from leading galleries, fairs, and auctions"
-    )
+    cy.get("h1").should("contain", "Collect art by the world's leading artists")
   })
 })

--- a/src/v2/Apps/Home/Components/HomeHeroUnits/HomeHeroUnit.tsx
+++ b/src/v2/Apps/Home/Components/HomeHeroUnits/HomeHeroUnit.tsx
@@ -276,10 +276,9 @@ export const HomeHeroUnitFragmentContainer = createFragmentContainer(
 )
 
 export const LOGGED_OUT_HERO_UNIT: StaticHeroUnit = {
-  title: "Collect art from leading galleries, fairs, and auctions",
+  title: "Collect art by the world's leading artists",
   subtitle: "Sign up to get updates about your favorite artists",
   href: "/signup",
   linkText: "Sign up",
-  backgroundImageURL:
-    "https://files.artsy.net/images/alexander-calder-rouge-triomphant-triumphant-red-1959-1965.jpg",
+  backgroundImageURL: "http://files.artsy.net/homepage/signup-banner.png",
 }

--- a/src/v2/Apps/Home/Components/HomeHeroUnits/HomeHeroUnit.tsx
+++ b/src/v2/Apps/Home/Components/HomeHeroUnits/HomeHeroUnit.tsx
@@ -277,7 +277,7 @@ export const HomeHeroUnitFragmentContainer = createFragmentContainer(
 
 export const LOGGED_OUT_HERO_UNIT: StaticHeroUnit = {
   title: "Collect art by the world's leading artists",
-  subtitle: "Sign up to get updates about your favorite artists",
+  subtitle: "Register for updates on available works, market news, and more.",
   href: "/signup",
   linkText: "Sign up",
   backgroundImageURL: "http://files.artsy.net/homepage/signup-banner.png",


### PR DESCRIPTION
Marketing banners are updated in the admin tool but the sign up banner for logged out users is hardcoded in the Home app. Looking in the code, it seems to me the reason why this is hardcoded is because it renders conditionally based on the isLoggedOut user status... but I don't see why this can't also be moved into the admin app? The copy lives in something called a HeroUnit, which is just a statically-typed object. I'm not sure how admin app stuff gets into force, but I could probably figure it out.  

Waiting on new sub-header copy from the brand team and then this pr is ready to go. 

### Screenshots
<img width="1214" alt="Screen Shot 2021-08-16 at 10 54 06 AM" src="https://user-images.githubusercontent.com/23108927/129587742-08fbf598-e258-45cc-b6f6-90be82022964.png">
