### PR TITLE
feat(FX-3158): Fair exhibitors A-Z navigation

### DIFF
--- a/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
+++ b/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { Text, Flex, Swiper } from "@artsy/palette"
 import { Media } from "v2/Utils/Responsive"
+import { scrollIntoView } from "v2/Utils/scrollHelpers"
 import { ExhibitorsLetterNav_fair } from "v2/__generated__/ExhibitorsLetterNav_fair.graphql"
 
 const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("").concat(["0-9"])
@@ -28,6 +29,15 @@ export const ExhibitorsLetterNav: React.FC<ExhibitorsLetterNavProps> = ({
               title={
                 isEnabled ? `View exhibitors starting with “${letter}”` : ""
               }
+              onClick={() => {
+                if (isEnabled) {
+                  scrollIntoView({
+                    selector: `#jump--letter${letter}`,
+                    offset: 120,
+                    behavior: "smooth",
+                  })
+                }
+              }}
             >
               {letter}
             </Letter>

--- a/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
+++ b/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
@@ -1,10 +1,12 @@
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
-import { Text, Flex, Swiper } from "@artsy/palette"
+import { Text, Flex, Swiper, themeProps } from "@artsy/palette"
 import { Media } from "v2/Utils/Responsive"
 import { scrollIntoView } from "v2/Utils/scrollHelpers"
 import { ExhibitorsLetterNav_fair } from "v2/__generated__/ExhibitorsLetterNav_fair.graphql"
+import { useMatchMedia } from "v2/Utils/Hooks/useMatchMedia"
+import { MOBILE_NAV_HEIGHT, DESKTOP_NAV_BAR_HEIGHT } from "v2/Components/NavBar"
 
 const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("").concat(["0-9"])
 
@@ -17,11 +19,14 @@ export const ExhibitorsLetterNav: React.FC<ExhibitorsLetterNavProps> = ({
 }) => {
   const letters = fair?.exhibitorsGroupedByName?.map(group => group?.letter)
 
-  const Letters = props => {
+  const isMobile = useMatchMedia(themeProps.mediaQueries.xs)
+
+  const Letters = ({ withSwiper = false }) => {
     return (
-      <Flex justifyContent="space-between" {...props}>
-        {LETTERS.map(letter => {
+      <Flex justifyContent="space-between" pl={withSwiper ? 2 : 0}>
+        {LETTERS.map((letter, i) => {
           const isEnabled = letters?.includes(letter)
+          const isLast = i === LETTERS.length - 1
           return (
             <Letter
               key={letter}
@@ -29,11 +34,15 @@ export const ExhibitorsLetterNav: React.FC<ExhibitorsLetterNavProps> = ({
               title={
                 isEnabled ? `View exhibitors starting with “${letter}”` : ""
               }
+              mr={!withSwiper || isLast ? 0 : 4}
               onClick={() => {
                 if (isEnabled) {
+                  const offset = isMobile
+                    ? MOBILE_NAV_HEIGHT
+                    : DESKTOP_NAV_BAR_HEIGHT + 30
                   scrollIntoView({
                     selector: `#jump--letter${letter}`,
-                    offset: 120,
+                    offset,
                     behavior: "smooth",
                   })
                 }
@@ -51,7 +60,7 @@ export const ExhibitorsLetterNav: React.FC<ExhibitorsLetterNavProps> = ({
     <>
       <Media lessThan="md">
         <Swiper snap="start">
-          <Letters width={1300} />
+          <Letters withSwiper />
         </Swiper>
       </Media>
 
@@ -62,7 +71,7 @@ export const ExhibitorsLetterNav: React.FC<ExhibitorsLetterNavProps> = ({
   )
 }
 
-const Letter = styled(Text).attrs({ p: 1, variant: "md" })`
+const Letter = styled(Text).attrs({ variant: "md" })`
   display: inline-block;
   cursor: pointer;
   white-space: nowrap;

--- a/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
+++ b/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
@@ -1,0 +1,53 @@
+import { BoxProps, Flex, Text } from "@artsy/palette"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import styled from "styled-components"
+import { ExhibitorsLetterNav_fair } from "v2/__generated__/ExhibitorsLetterNav_fair.graphql"
+
+const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("").concat(["0-9"])
+
+interface ExhibitorsLetterNavProps extends BoxProps {
+  fair: ExhibitorsLetterNav_fair
+}
+
+export const ExhibitorsLetterNav: React.FC<ExhibitorsLetterNavProps> = ({
+  fair,
+  ...rest
+}) => {
+  const letters = fair?.exhibitorsGroupedByName?.map(group => group?.letter)
+
+  return (
+    <Flex justifyContent="space-between" {...rest}>
+      {LETTERS.map(letter => {
+        const isLetter = letters?.includes(letter)
+        return (
+          <Letter
+            key={letter}
+            color={isLetter ? "black100" : "black10"}
+            title={isLetter ? `View exhibitors starting with “${letter}”` : ""}
+          >
+            {letter}
+          </Letter>
+        )
+      })}
+    </Flex>
+  )
+}
+
+const Letter = styled(Text).attrs({ p: 1, variant: "md" })`
+  display: inline-block;
+  cursor: pointer;
+`
+
+export const ExhibitorsLetterNavFragmentContainer = createFragmentContainer(
+  ExhibitorsLetterNav,
+  {
+    fair: graphql`
+      fragment ExhibitorsLetterNav_fair on Fair {
+        exhibitorsGroupedByName {
+          letter
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
+++ b/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
@@ -57,6 +57,7 @@ const Letter = styled(Text).attrs({ p: 1, variant: "md" })`
   cursor: pointer;
   white-space: nowrap;
 `
+Letter.displayName = "Letter"
 
 export const ExhibitorsLetterNavFragmentContainer = createFragmentContainer(
   ExhibitorsLetterNav,

--- a/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
+++ b/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
@@ -1,42 +1,61 @@
-import { BoxProps, Flex, Text } from "@artsy/palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
+import { Text, Flex, Swiper } from "@artsy/palette"
+import { Media } from "v2/Utils/Responsive"
 import { ExhibitorsLetterNav_fair } from "v2/__generated__/ExhibitorsLetterNav_fair.graphql"
 
 const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("").concat(["0-9"])
 
-interface ExhibitorsLetterNavProps extends BoxProps {
+interface ExhibitorsLetterNavProps {
   fair: ExhibitorsLetterNav_fair
 }
 
 export const ExhibitorsLetterNav: React.FC<ExhibitorsLetterNavProps> = ({
   fair,
-  ...rest
 }) => {
   const letters = fair?.exhibitorsGroupedByName?.map(group => group?.letter)
 
+  const Letters = props => {
+    return (
+      <Flex justifyContent="space-between" {...props}>
+        {LETTERS.map(letter => {
+          const isEnabled = letters?.includes(letter)
+          return (
+            <Letter
+              key={letter}
+              color={isEnabled ? "black100" : "black10"}
+              title={
+                isEnabled ? `View exhibitors starting with “${letter}”` : ""
+              }
+            >
+              {letter}
+            </Letter>
+          )
+        })}
+      </Flex>
+    )
+  }
+
   return (
-    <Flex justifyContent="space-between" {...rest}>
-      {LETTERS.map(letter => {
-        const isLetter = letters?.includes(letter)
-        return (
-          <Letter
-            key={letter}
-            color={isLetter ? "black100" : "black10"}
-            title={isLetter ? `View exhibitors starting with “${letter}”` : ""}
-          >
-            {letter}
-          </Letter>
-        )
-      })}
-    </Flex>
+    <>
+      <Media lessThan="md">
+        <Swiper snap="start">
+          <Letters width={1300} />
+        </Swiper>
+      </Media>
+
+      <Media greaterThanOrEqual="md">
+        <Letters />
+      </Media>
+    </>
   )
 }
 
 const Letter = styled(Text).attrs({ p: 1, variant: "md" })`
   display: inline-block;
   cursor: pointer;
+  white-space: nowrap;
 `
 
 export const ExhibitorsLetterNavFragmentContainer = createFragmentContainer(

--- a/src/v2/Apps/Fair/Components/__tests__/ExhibitorsLetterNav.jest.tsx
+++ b/src/v2/Apps/Fair/Components/__tests__/ExhibitorsLetterNav.jest.tsx
@@ -1,0 +1,104 @@
+import React from "react"
+import { graphql } from "react-relay"
+import { MockBoot } from "v2/DevTools"
+import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
+import { ExhibitorsLetterNavFragmentContainer } from "../ExhibitorsLetterNav"
+import { ExhibitorsLetterNav_Test_Query } from "v2/__generated__/ExhibitorsLetterNav_Test_Query.graphql"
+import { Breakpoint } from "v2/Utils/Responsive"
+
+jest.unmock("react-relay")
+
+const getWrapperWithBreakpoint = (breakpoint: Breakpoint = "lg") =>
+  setupTestWrapper<ExhibitorsLetterNav_Test_Query>({
+    Component: ({ fair }) => (
+      <MockBoot breakpoint={breakpoint}>
+        <ExhibitorsLetterNavFragmentContainer fair={fair!} />
+      </MockBoot>
+    ),
+    query: graphql`
+      query ExhibitorsLetterNav_Test_Query {
+        fair(id: "one-x-artsy") {
+          ...ExhibitorsLetterNav_fair
+        }
+      }
+    `,
+  }).getWrapper
+
+describe("ExhibitorsLetterNav", () => {
+  const getWrapper = getWrapperWithBreakpoint()
+
+  it("displays letters nav", () => {
+    const wrapper = getWrapper({})
+    expect(wrapper.find("Letters").length).toBe(1)
+  })
+
+  it("displays 27 elements", () => {
+    const wrapper = getWrapper({
+      Fair: () => ({ exhibitorsGroupedByName }),
+    })
+    expect(wrapper.find("Letter").length).toBe(27)
+  })
+
+  it("displays letters with proper color", () => {
+    const wrapper = getWrapper({
+      Fair: () => ({ exhibitorsGroupedByName }),
+    })
+    const letter = wrapper.find("Letter")
+    for (let i = 0; i < 10; i++) {
+      expect(letter.at(i).prop("color")).toEqual("black10")
+    }
+    for (let i = 10; i < 13; i++) {
+      expect(letter.at(i).prop("color")).toEqual("black100")
+    }
+    for (let i = 13; i < 26; i++) {
+      expect(letter.at(i).prop("color")).toEqual("black10")
+    }
+    expect(letter.at(26).prop("color")).toEqual("black100")
+  })
+
+  it("displays letters with proper on-hover title", () => {
+    const wrapper = getWrapper({
+      Fair: () => ({ exhibitorsGroupedByName }),
+    })
+    const letter = wrapper.find("Letter")
+    for (let i = 0; i < 10; i++) {
+      expect(letter.at(i).prop("title")).toEqual("")
+    }
+    expect(letter.at(10).prop("title")).toEqual(
+      `View exhibitors starting with “K”`
+    )
+    expect(letter.at(11).prop("title")).toEqual(
+      `View exhibitors starting with “L”`
+    )
+    expect(letter.at(12).prop("title")).toEqual(
+      `View exhibitors starting with “M”`
+    )
+    for (let i = 13; i < 26; i++) {
+      expect(letter.at(i).prop("title")).toEqual("")
+    }
+    expect(letter.at(26).prop("title")).toEqual(
+      `View exhibitors starting with “0-9”`
+    )
+  })
+
+  describe("mobile", () => {
+    const getWrapper = getWrapperWithBreakpoint("sm")
+
+    it("displays swiper", () => {
+      const wrapper = getWrapper({})
+      expect(wrapper.find("Swiper").length).toBe(1)
+    })
+
+    it("displays letters with fixed width 1300", () => {
+      const wrapper = getWrapper({})
+      expect(wrapper.find("Letters").prop("width")).toBe(1300)
+    })
+  })
+})
+
+const exhibitorsGroupedByName = [
+  { letter: "K" },
+  { letter: "L" },
+  { letter: "M" },
+  { letter: "0-9" },
+]

--- a/src/v2/Apps/Fair/Components/__tests__/ExhibitorsLetterNav.jest.tsx
+++ b/src/v2/Apps/Fair/Components/__tests__/ExhibitorsLetterNav.jest.tsx
@@ -7,6 +7,9 @@ import { ExhibitorsLetterNav_Test_Query } from "v2/__generated__/ExhibitorsLette
 import { Breakpoint } from "v2/Utils/Responsive"
 
 jest.unmock("react-relay")
+jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
+  useMatchMedia: () => false,
+}))
 
 const getWrapperWithBreakpoint = (breakpoint: Breakpoint = "lg") =>
   setupTestWrapper<ExhibitorsLetterNav_Test_Query>({
@@ -87,11 +90,6 @@ describe("ExhibitorsLetterNav", () => {
     it("displays swiper", () => {
       const wrapper = getWrapper({})
       expect(wrapper.find("Swiper").length).toBe(1)
-    })
-
-    it("displays letters with fixed width 1300", () => {
-      const wrapper = getWrapper({})
-      expect(wrapper.find("Letters").prop("width")).toBe(1300)
     })
   })
 })

--- a/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
+++ b/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Box, Text } from "@artsy/palette"
+import { Box, Spacer, Text } from "@artsy/palette"
 import { graphql, createFragmentContainer } from "react-relay"
 import { FairExhibitors_fair } from "v2/__generated__/FairExhibitors_fair.graphql"
 import { FairExhibitorsGroupFragmentContainer as FairExhibitorsGroup } from "../Components/FairExhibitors"
@@ -17,6 +17,8 @@ const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair }) => {
   return (
     <>
       <Waypoint />
+
+      <Spacer mt={6} />
 
       <ExhibitorsLetterNav fair={fair} />
 

--- a/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
+++ b/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
@@ -1,10 +1,11 @@
 import React from "react"
-import { Text } from "@artsy/palette"
+import { Box, Text } from "@artsy/palette"
 import { graphql, createFragmentContainer } from "react-relay"
 import { FairExhibitors_fair } from "v2/__generated__/FairExhibitors_fair.graphql"
 import { FairExhibitorsGroupFragmentContainer as FairExhibitorsGroup } from "../Components/FairExhibitors"
 import { FairExhibitorsGroupPlaceholder } from "../Components/FairExhibitors/FairExhibitorGroupPlaceholder"
 import { useLazyLoadComponent } from "v2/Utils/Hooks/useLazyLoadComponent"
+import { ExhibitorsLetterNavFragmentContainer as ExhibitorsLetterNav } from "../Components/ExhibitorsLetterNav"
 
 interface FairExhibitorsProps {
   fair: FairExhibitors_fair
@@ -17,22 +18,25 @@ const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair }) => {
     <>
       <Waypoint />
 
+      <ExhibitorsLetterNav fair={fair} />
+
       {fair.exhibitorsGroupedByName?.map(exhibitorsGroup => {
-        if (!exhibitorsGroup?.exhibitors?.length || !exhibitorsGroup.letter) {
+        const { letter } = exhibitorsGroup!
+        if (!exhibitorsGroup?.exhibitors?.length || !letter) {
           return null
         }
 
         return (
-          <React.Fragment key={exhibitorsGroup.letter}>
+          <Box key={letter} id={`jump--letter${letter}`}>
             <Text variant="lg" my={4}>
-              {exhibitorsGroup.letter}
+              {letter}
             </Text>
             {isEnteredView ? (
               <FairExhibitorsGroup exhibitorsGroup={exhibitorsGroup} />
             ) : (
               <FairExhibitorsGroupPlaceholder />
             )}
-          </React.Fragment>
+          </Box>
         )
       })}
     </>

--- a/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
+++ b/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
@@ -51,6 +51,7 @@ export const FairExhibitorsFragmentContainer = createFragmentContainer(
           }
           ...FairExhibitorsGroup_exhibitorsGroup
         }
+        ...ExhibitorsLetterNav_fair
       }
     `,
   }

--- a/src/v2/Apps/Fair/Routes/__tests__/FairBooths.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairBooths.jest.tsx
@@ -198,11 +198,5 @@ const FAIR_BOOTHS_FIXTURE: FairBooths_QueryRawResponse = {
         },
       ],
     },
-    exhibitorsGroupedByName: [
-      { letter: "K" },
-      { letter: "L" },
-      { letter: "M" },
-      { letter: "0-9" },
-    ],
   },
 }

--- a/src/v2/Apps/Fair/Routes/__tests__/FairBooths.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairBooths.jest.tsx
@@ -198,5 +198,11 @@ const FAIR_BOOTHS_FIXTURE: FairBooths_QueryRawResponse = {
         },
       ],
     },
+    exhibitorsGroupedByName: [
+      { letter: "K" },
+      { letter: "L" },
+      { letter: "M" },
+      { letter: "0-9" },
+    ],
   },
 }

--- a/src/v2/Apps/Fair/Routes/__tests__/FairExhibitors.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairExhibitors.jest.tsx
@@ -4,6 +4,9 @@ import { FairExhibitorsFragmentContainer } from "../FairExhibitors"
 import { setupTestWrapper } from "v2/DevTools/setupTestWrapper"
 
 jest.unmock("react-relay")
+jest.mock("v2/Utils/Hooks/useMatchMedia", () => ({
+  useMatchMedia: () => false,
+}))
 
 describe("FairExhibitors", () => {
   const { getWrapper } = setupTestWrapper<FairExhibitors_Test_Query>({

--- a/src/v2/Apps/Fair/Routes/__tests__/FairExhibitors.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairExhibitors.jest.tsx
@@ -19,10 +19,45 @@ describe("FairExhibitors", () => {
   })
 
   afterEach(() => {
-    jest.resetAllMocks()
+    jest.clearAllMocks()
   })
 
-  it("renders the exhibitors group", async () => {
+  it("renders the letters nav", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.find("ExhibitorsLetterNav").length).toBe(1)
+  })
+
+  it("scrolls down the page on letter click", () => {
+    document.querySelector = jest.fn().mockReturnValue({
+      getBoundingClientRect: () => ({
+        top: 0,
+      }),
+    })
+
+    const spy = jest.fn()
+    window.scrollTo = spy
+
+    const wrapper = getWrapper({
+      Fair: () => ({
+        exhibitorsGroupedByName: [
+          {
+            letter: "D",
+            exhibitors: [
+              {
+                partnerID: "642b20aff086930012ce478f",
+              },
+            ],
+          },
+        ],
+      }),
+    })
+
+    const letter = wrapper.find("ExhibitorsLetterNav").find("Letter").at(3)
+    letter.simulate("click")
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders the exhibitors group", () => {
     const wrapper = getWrapper({
       Fair: () => ({
         exhibitorsGroupedByName: [

--- a/src/v2/__generated__/ExhibitorsLetterNav_Test_Query.graphql.ts
+++ b/src/v2/__generated__/ExhibitorsLetterNav_Test_Query.graphql.ts
@@ -1,0 +1,122 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ExhibitorsLetterNav_Test_QueryVariables = {};
+export type ExhibitorsLetterNav_Test_QueryResponse = {
+    readonly fair: {
+        readonly " $fragmentRefs": FragmentRefs<"ExhibitorsLetterNav_fair">;
+    } | null;
+};
+export type ExhibitorsLetterNav_Test_Query = {
+    readonly response: ExhibitorsLetterNav_Test_QueryResponse;
+    readonly variables: ExhibitorsLetterNav_Test_QueryVariables;
+};
+
+
+
+/*
+query ExhibitorsLetterNav_Test_Query {
+  fair(id: "one-x-artsy") {
+    ...ExhibitorsLetterNav_fair
+    id
+  }
+}
+
+fragment ExhibitorsLetterNav_fair on Fair {
+  exhibitorsGroupedByName {
+    letter
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "one-x-artsy"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ExhibitorsLetterNav_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ExhibitorsLetterNav_fair"
+          }
+        ],
+        "storageKey": "fair(id:\"one-x-artsy\")"
+      }
+    ],
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ExhibitorsLetterNav_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "FairExhibitorsGroup",
+            "kind": "LinkedField",
+            "name": "exhibitorsGroupedByName",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "letter",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "fair(id:\"one-x-artsy\")"
+      }
+    ]
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "ExhibitorsLetterNav_Test_Query",
+    "operationKind": "query",
+    "text": "query ExhibitorsLetterNav_Test_Query {\n  fair(id: \"one-x-artsy\") {\n    ...ExhibitorsLetterNav_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '84d84f3cf1aef8623fba4c87acf7ae29';
+export default node;

--- a/src/v2/__generated__/ExhibitorsLetterNav_fair.graphql.ts
+++ b/src/v2/__generated__/ExhibitorsLetterNav_fair.graphql.ts
@@ -1,0 +1,48 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ExhibitorsLetterNav_fair = {
+    readonly exhibitorsGroupedByName: ReadonlyArray<{
+        readonly letter: string | null;
+    } | null> | null;
+    readonly " $refType": "ExhibitorsLetterNav_fair";
+};
+export type ExhibitorsLetterNav_fair$data = ExhibitorsLetterNav_fair;
+export type ExhibitorsLetterNav_fair$key = {
+    readonly " $data"?: ExhibitorsLetterNav_fair$data;
+    readonly " $fragmentRefs": FragmentRefs<"ExhibitorsLetterNav_fair">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ExhibitorsLetterNav_fair",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "FairExhibitorsGroup",
+      "kind": "LinkedField",
+      "name": "exhibitorsGroupedByName",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "letter",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Fair"
+};
+(node as any).hash = '80f81b2b617cdc49ae85cd2745c5b6ac';
+export default node;

--- a/src/v2/__generated__/FairExhibitors_Test_Query.graphql.ts
+++ b/src/v2/__generated__/FairExhibitors_Test_Query.graphql.ts
@@ -28,6 +28,12 @@ query FairExhibitors_Test_Query(
   }
 }
 
+fragment ExhibitorsLetterNav_fair on Fair {
+  exhibitorsGroupedByName {
+    letter
+  }
+}
+
 fragment FairExhibitorCard_partner on Partner {
   name
   href
@@ -67,6 +73,7 @@ fragment FairExhibitors_fair on Fair {
     }
     ...FairExhibitorsGroup_exhibitorsGroup
   }
+  ...ExhibitorsLetterNav_fair
 }
 
 fragment FollowProfileButton_profile on Profile {
@@ -331,7 +338,7 @@ return {
     "metadata": {},
     "name": "FairExhibitors_Test_Query",
     "operationKind": "query",
-    "text": "query FairExhibitors_Test_Query(\n  $id: String!\n) {\n  fair(id: $id) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment FairExhibitorCard_partner on Partner {\n  name\n  href\n  internalID\n  slug\n  cities\n  profile {\n    ...FollowProfileButton_profile\n    icon {\n      cropped(width: 50, height: 50) {\n        src\n        srcSet\n      }\n    }\n    image {\n      url(version: \"medium\")\n    }\n    id\n  }\n}\n\nfragment FairExhibitorsGroup_exhibitorsGroup on FairExhibitorsGroup {\n  exhibitors {\n    partner {\n      internalID\n      ...FairExhibitorCard_partner\n      id\n    }\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n    exhibitors {\n      partnerID\n    }\n    ...FairExhibitorsGroup_exhibitorsGroup\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query FairExhibitors_Test_Query(\n  $id: String!\n) {\n  fair(id: $id) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairExhibitorCard_partner on Partner {\n  name\n  href\n  internalID\n  slug\n  cities\n  profile {\n    ...FollowProfileButton_profile\n    icon {\n      cropped(width: 50, height: 50) {\n        src\n        srcSet\n      }\n    }\n    image {\n      url(version: \"medium\")\n    }\n    id\n  }\n}\n\nfragment FairExhibitorsGroup_exhibitorsGroup on FairExhibitorsGroup {\n  exhibitors {\n    partner {\n      internalID\n      ...FairExhibitorCard_partner\n      id\n    }\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n    exhibitors {\n      partnerID\n    }\n    ...FairExhibitorsGroup_exhibitorsGroup\n  }\n  ...ExhibitorsLetterNav_fair\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairExhibitors_fair.graphql.ts
+++ b/src/v2/__generated__/FairExhibitors_fair.graphql.ts
@@ -11,6 +11,7 @@ export type FairExhibitors_fair = {
         } | null> | null;
         readonly " $fragmentRefs": FragmentRefs<"FairExhibitorsGroup_exhibitorsGroup">;
     } | null> | null;
+    readonly " $fragmentRefs": FragmentRefs<"ExhibitorsLetterNav_fair">;
     readonly " $refType": "FairExhibitors_fair";
 };
 export type FairExhibitors_fair$data = FairExhibitors_fair;
@@ -67,9 +68,14 @@ const node: ReaderFragment = {
         }
       ],
       "storageKey": null
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "ExhibitorsLetterNav_fair"
     }
   ],
   "type": "Fair"
 };
-(node as any).hash = '6f683e8763efaec111c2de24f1e4ed37';
+(node as any).hash = '4efd1803c5bcbfd143411527719035ba';
 export default node;

--- a/src/v2/__generated__/fairRoutes_FairExhibitorsQuery.graphql.ts
+++ b/src/v2/__generated__/fairRoutes_FairExhibitorsQuery.graphql.ts
@@ -28,6 +28,12 @@ query fairRoutes_FairExhibitorsQuery(
   }
 }
 
+fragment ExhibitorsLetterNav_fair on Fair {
+  exhibitorsGroupedByName {
+    letter
+  }
+}
+
 fragment FairExhibitorCard_partner on Partner {
   name
   href
@@ -67,6 +73,7 @@ fragment FairExhibitors_fair on Fair {
     }
     ...FairExhibitorsGroup_exhibitorsGroup
   }
+  ...ExhibitorsLetterNav_fair
 }
 
 fragment FollowProfileButton_profile on Profile {
@@ -331,7 +338,7 @@ return {
     "metadata": {},
     "name": "fairRoutes_FairExhibitorsQuery",
     "operationKind": "query",
-    "text": "query fairRoutes_FairExhibitorsQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment FairExhibitorCard_partner on Partner {\n  name\n  href\n  internalID\n  slug\n  cities\n  profile {\n    ...FollowProfileButton_profile\n    icon {\n      cropped(width: 50, height: 50) {\n        src\n        srcSet\n      }\n    }\n    image {\n      url(version: \"medium\")\n    }\n    id\n  }\n}\n\nfragment FairExhibitorsGroup_exhibitorsGroup on FairExhibitorsGroup {\n  exhibitors {\n    partner {\n      internalID\n      ...FairExhibitorCard_partner\n      id\n    }\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n    exhibitors {\n      partnerID\n    }\n    ...FairExhibitorsGroup_exhibitorsGroup\n  }\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query fairRoutes_FairExhibitorsQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairExhibitorCard_partner on Partner {\n  name\n  href\n  internalID\n  slug\n  cities\n  profile {\n    ...FollowProfileButton_profile\n    icon {\n      cropped(width: 50, height: 50) {\n        src\n        srcSet\n      }\n    }\n    image {\n      url(version: \"medium\")\n    }\n    id\n  }\n}\n\nfragment FairExhibitorsGroup_exhibitorsGroup on FairExhibitorsGroup {\n  exhibitors {\n    partner {\n      internalID\n      ...FairExhibitorCard_partner\n      id\n    }\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n    exhibitors {\n      partnerID\n    }\n    ...FairExhibitorsGroup_exhibitorsGroup\n  }\n  ...ExhibitorsLetterNav_fair\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
   }
 };
 })();


### PR DESCRIPTION
[FX-3158]

[FX-3158]: https://artsyproduct.atlassian.net/browse/FX-3158

**The purpose of this PR** is to add the ”A B C … X Y Z 0-9” navigator to the top of the new Exhibitors A-Z tab.
**Acceptance criteria:**  clicking on a single “letter” (A, B, C…) in the filter tab scrolls down the page

![scroll](https://user-images.githubusercontent.com/44819355/130454589-9b8bed00-c97f-4504-8bf6-160e27ad1029.gif)

![scroll-mob](https://user-images.githubusercontent.com/44819355/130454972-24e21199-829c-40aa-889d-75e9279e21cc.gif)


