### PR TITLE
feat: Disable search box for marketing page GRO-485

### DIFF
--- a/src/desktop/apps/articles/templates/meta/team_channel.jade
+++ b/src/desktop/apps/articles/templates/meta/team_channel.jade
@@ -17,3 +17,5 @@ meta( property="og:url", content="#{sd.APP_URL}/#{channel.get('slug')}" )
 meta( property="og:image", content=asset('/images/og_image.jpg') )
 meta( property="og:type", content="website" )
 meta( property="twitter:card", content="summary" )
+if sd.CURRENT_PATH == '/buying-with-artsy'
+  meta( name="google" content="nositelinkssearchbox" )


### PR DESCRIPTION
This is a quick PR to just add a particular meta tag to a marketing page. The goal here is to signal to Google that we don't want the Buying with Artsy marketing page to show up as a site link.

Looks like this:

<img width="499" alt="Screen Shot 2021-08-16 at 4 55 58 PM" src="https://user-images.githubusercontent.com/79799/129634350-a0e82f20-628d-42be-b435-f08437b54fb7.png">


https://artsyproduct.atlassian.net/browse/GRO-485

/cc @artsy/grow-devs