### PR TITLE
feature: Enable Lodash Currying

### DIFF
--- a/webpack/envs/clientPlugins.js
+++ b/webpack/envs/clientPlugins.js
@@ -7,6 +7,7 @@ const currentYear = new Date().getFullYear()
 
 export const clientPlugins = [
   new LodashModuleReplacementPlugin({
+    currying: true,
     shorthands: true,
   }),
   // To include only specific zones, use the matchZones option


### PR DESCRIPTION
**Description**

This PR enables Lodash currying in the `lodash-webpack-plugin`. This functionality 
is required for `.reverse()` to work.

There may be a couple of extra feature sets that will need enabling to support all of
the features we used from Ldoash. These will be enabled as needed to limit how
much scope is brought into our client bundles.