### PR TITLE
GRO-469: Updated Trending Lots to remove closed lots

### DIFF
--- a/src/v2/Apps/Auctions/Components/TrendingLots/TrendingLots.tsx
+++ b/src/v2/Apps/Auctions/Components/TrendingLots/TrendingLots.tsx
@@ -22,15 +22,18 @@ const TrendingLots: React.FC<TrendingLotsProps> = ({ viewer }) => {
 
   const nodes = extractNodes(viewer.trendingLotsConnection)
 
-  if (nodes.length === 0) {
+  const liveSaleArtworks = nodes.filter(node => {
+    return !node.sale?.isClosed
+  })
+
+  if (nodes.length === 0 || liveSaleArtworks.length === 0) {
     return <CuratorialRailsZeroState />
   }
 
   return (
     <>
       <Text as="h3" variant="lg" color="black100" mt={6}>
-        Trending lots{" "}
-        <Sup color="brand">{viewer.trendingLotsConnection?.edges?.length}</Sup>
+        Trending lots <Sup color="brand">{liveSaleArtworks?.length}</Sup>
       </Text>
 
       <Text as="h3" variant="lg" color="black60">
@@ -40,7 +43,7 @@ const TrendingLots: React.FC<TrendingLotsProps> = ({ viewer }) => {
       <Spacer mb={4} />
 
       <Shelf>
-        {nodes.map((node, index) => {
+        {liveSaleArtworks.map((node, index) => {
           return (
             <ShelfArtworkFragmentContainer
               artwork={node}
@@ -84,6 +87,9 @@ export const TrendingLotsFragmentContainer = createFragmentContainer(
               internalID
               slug
               ...ShelfArtwork_artwork @arguments(width: 325)
+              sale {
+                isClosed
+              }
             }
           }
         }

--- a/src/v2/Apps/Auctions/Components/TrendingLots/__tests__/TrendingLots.jest.tsx
+++ b/src/v2/Apps/Auctions/Components/TrendingLots/__tests__/TrendingLots.jest.tsx
@@ -61,7 +61,6 @@ describe("TrendingLots", () => {
 
   it("renders the correct components", () => {
     const wrapper = getWrapper()
-    expect(wrapper.html()).toContain("Works with the most bids today")
     expect(wrapper.find("Carousel")).toBeDefined()
     expect(wrapper.find("FillwidthItem")).toBeDefined()
   })

--- a/src/v2/__generated__/AuctionsApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/AuctionsApp_Test_Query.graphql.ts
@@ -225,6 +225,10 @@ fragment TrendingLots_viewer on Viewer {
         internalID
         slug
         ...ShelfArtwork_artwork_20bRBg
+        sale {
+          isClosed
+          id
+        }
         id
       }
       id
@@ -291,32 +295,204 @@ v5 = {
 v6 = {
   "alias": null,
   "args": null,
-  "kind": "ScalarField",
-  "name": "href",
+  "concreteType": "Image",
+  "kind": "LinkedField",
+  "name": "image",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "width",
+          "value": 325
+        }
+      ],
+      "concreteType": "ResizedImageUrl",
+      "kind": "LinkedField",
+      "name": "resized",
+      "plural": false,
+      "selections": [
+        (v3/*: any*/),
+        (v4/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "width",
+          "storageKey": null
+        },
+        (v5/*: any*/)
+      ],
+      "storageKey": "resized(width:325)"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "aspectRatio",
+      "storageKey": null
+    },
+    (v5/*: any*/)
+  ],
   "storageKey": null
 },
-v7 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true
-  }
-],
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "imageTitle",
+  "storageKey": null
+},
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "title",
   "storageKey": null
 },
 v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v10 = {
+  "alias": "is_saved",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isSaved",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "date",
+  "storageKey": null
+},
+v12 = {
+  "alias": "sale_message",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "saleMessage",
+  "storageKey": null
+},
+v13 = {
+  "alias": "cultural_maker",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "culturalMaker",
+  "storageKey": null
+},
+v14 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v16 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v10 = [
+v17 = {
+  "alias": null,
+  "args": (v14/*: any*/),
+  "concreteType": "Artist",
+  "kind": "LinkedField",
+  "name": "artists",
+  "plural": true,
+  "selections": [
+    (v15/*: any*/),
+    (v9/*: any*/),
+    (v16/*: any*/)
+  ],
+  "storageKey": "artists(shallow:true)"
+},
+v18 = {
+  "alias": "collecting_institution",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "collectingInstitution",
+  "storageKey": null
+},
+v19 = {
+  "alias": null,
+  "args": (v14/*: any*/),
+  "concreteType": "Partner",
+  "kind": "LinkedField",
+  "name": "partner",
+  "plural": false,
+  "selections": [
+    (v16/*: any*/),
+    (v9/*: any*/),
+    (v15/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "type",
+      "storageKey": null
+    }
+  ],
+  "storageKey": "partner(shallow:true)"
+},
+v20 = {
+  "alias": "is_auction",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isAuction",
+  "storageKey": null
+},
+v21 = {
+  "alias": "is_closed",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isClosed",
+  "storageKey": null
+},
+v22 = {
+  "alias": "is_live_open",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isLiveOpen",
+  "storageKey": null
+},
+v23 = {
+  "alias": "is_open",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isOpen",
+  "storageKey": null
+},
+v24 = {
+  "alias": "is_preview",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isPreview",
+  "storageKey": null
+},
+v25 = {
+  "alias": "display_timely_at",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "displayTimelyAt",
+  "storageKey": null
+},
+v26 = [
   {
     "alias": null,
     "args": null,
@@ -325,270 +501,71 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = {
-  "alias": null,
+v27 = {
+  "alias": "sale_artwork",
   "args": null,
-  "concreteType": "Artwork",
+  "concreteType": "SaleArtwork",
   "kind": "LinkedField",
-  "name": "node",
+  "name": "saleArtwork",
   "plural": false,
   "selections": [
-    (v1/*: any*/),
-    (v2/*: any*/),
     {
       "alias": null,
       "args": null,
-      "concreteType": "Image",
+      "concreteType": "SaleArtworkCounts",
       "kind": "LinkedField",
-      "name": "image",
+      "name": "counts",
       "plural": false,
       "selections": [
         {
-          "alias": null,
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "width",
-              "value": 325
-            }
-          ],
-          "concreteType": "ResizedImageUrl",
-          "kind": "LinkedField",
-          "name": "resized",
-          "plural": false,
-          "selections": [
-            (v3/*: any*/),
-            (v4/*: any*/),
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "width",
-              "storageKey": null
-            },
-            (v5/*: any*/)
-          ],
-          "storageKey": "resized(width:325)"
-        },
-        {
-          "alias": null,
+          "alias": "bidder_positions",
           "args": null,
           "kind": "ScalarField",
-          "name": "aspectRatio",
-          "storageKey": null
-        },
-        (v5/*: any*/)
-      ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "imageTitle",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "title",
-      "storageKey": null
-    },
-    (v6/*: any*/),
-    {
-      "alias": "is_saved",
-      "args": null,
-      "kind": "ScalarField",
-      "name": "isSaved",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "date",
-      "storageKey": null
-    },
-    {
-      "alias": "sale_message",
-      "args": null,
-      "kind": "ScalarField",
-      "name": "saleMessage",
-      "storageKey": null
-    },
-    {
-      "alias": "cultural_maker",
-      "args": null,
-      "kind": "ScalarField",
-      "name": "culturalMaker",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": (v7/*: any*/),
-      "concreteType": "Artist",
-      "kind": "LinkedField",
-      "name": "artists",
-      "plural": true,
-      "selections": [
-        (v8/*: any*/),
-        (v6/*: any*/),
-        (v9/*: any*/)
-      ],
-      "storageKey": "artists(shallow:true)"
-    },
-    {
-      "alias": "collecting_institution",
-      "args": null,
-      "kind": "ScalarField",
-      "name": "collectingInstitution",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": (v7/*: any*/),
-      "concreteType": "Partner",
-      "kind": "LinkedField",
-      "name": "partner",
-      "plural": false,
-      "selections": [
-        (v9/*: any*/),
-        (v6/*: any*/),
-        (v8/*: any*/),
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "type",
-          "storageKey": null
-        }
-      ],
-      "storageKey": "partner(shallow:true)"
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "Sale",
-      "kind": "LinkedField",
-      "name": "sale",
-      "plural": false,
-      "selections": [
-        {
-          "alias": "is_auction",
-          "args": null,
-          "kind": "ScalarField",
-          "name": "isAuction",
-          "storageKey": null
-        },
-        {
-          "alias": "is_closed",
-          "args": null,
-          "kind": "ScalarField",
-          "name": "isClosed",
-          "storageKey": null
-        },
-        (v8/*: any*/),
-        {
-          "alias": "is_live_open",
-          "args": null,
-          "kind": "ScalarField",
-          "name": "isLiveOpen",
-          "storageKey": null
-        },
-        {
-          "alias": "is_open",
-          "args": null,
-          "kind": "ScalarField",
-          "name": "isOpen",
-          "storageKey": null
-        },
-        {
-          "alias": "is_preview",
-          "args": null,
-          "kind": "ScalarField",
-          "name": "isPreview",
-          "storageKey": null
-        },
-        {
-          "alias": "display_timely_at",
-          "args": null,
-          "kind": "ScalarField",
-          "name": "displayTimelyAt",
+          "name": "bidderPositions",
           "storageKey": null
         }
       ],
       "storageKey": null
     },
     {
-      "alias": "sale_artwork",
+      "alias": "highest_bid",
       "args": null,
-      "concreteType": "SaleArtwork",
+      "concreteType": "SaleArtworkHighestBid",
       "kind": "LinkedField",
-      "name": "saleArtwork",
+      "name": "highestBid",
       "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "SaleArtworkCounts",
-          "kind": "LinkedField",
-          "name": "counts",
-          "plural": false,
-          "selections": [
-            {
-              "alias": "bidder_positions",
-              "args": null,
-              "kind": "ScalarField",
-              "name": "bidderPositions",
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
-        },
-        {
-          "alias": "highest_bid",
-          "args": null,
-          "concreteType": "SaleArtworkHighestBid",
-          "kind": "LinkedField",
-          "name": "highestBid",
-          "plural": false,
-          "selections": (v10/*: any*/),
-          "storageKey": null
-        },
-        {
-          "alias": "opening_bid",
-          "args": null,
-          "concreteType": "SaleArtworkOpeningBid",
-          "kind": "LinkedField",
-          "name": "openingBid",
-          "plural": false,
-          "selections": (v10/*: any*/),
-          "storageKey": null
-        },
-        (v8/*: any*/)
-      ],
+      "selections": (v26/*: any*/),
       "storageKey": null
     },
     {
-      "alias": "is_inquireable",
+      "alias": "opening_bid",
       "args": null,
-      "kind": "ScalarField",
-      "name": "isInquireable",
+      "concreteType": "SaleArtworkOpeningBid",
+      "kind": "LinkedField",
+      "name": "openingBid",
+      "plural": false,
+      "selections": (v26/*: any*/),
       "storageKey": null
     },
-    (v8/*: any*/),
-    {
-      "alias": "is_biddable",
-      "args": null,
-      "kind": "ScalarField",
-      "name": "isBiddable",
-      "storageKey": null
-    }
+    (v15/*: any*/)
   ],
   "storageKey": null
 },
-v12 = [
+v28 = {
+  "alias": "is_inquireable",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isInquireable",
+  "storageKey": null
+},
+v29 = {
+  "alias": "is_biddable",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isBiddable",
+  "storageKey": null
+},
+v30 = [
   {
     "alias": null,
     "args": null,
@@ -597,13 +574,58 @@ v12 = [
     "name": "edges",
     "plural": true,
     "selections": [
-      (v11/*: any*/),
-      (v8/*: any*/)
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          (v2/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
+          (v8/*: any*/),
+          (v9/*: any*/),
+          (v10/*: any*/),
+          (v11/*: any*/),
+          (v12/*: any*/),
+          (v13/*: any*/),
+          (v17/*: any*/),
+          (v18/*: any*/),
+          (v19/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Sale",
+            "kind": "LinkedField",
+            "name": "sale",
+            "plural": false,
+            "selections": [
+              (v20/*: any*/),
+              (v21/*: any*/),
+              (v15/*: any*/),
+              (v22/*: any*/),
+              (v23/*: any*/),
+              (v24/*: any*/),
+              (v25/*: any*/)
+            ],
+            "storageKey": null
+          },
+          (v27/*: any*/),
+          (v28/*: any*/),
+          (v15/*: any*/),
+          (v29/*: any*/)
+        ],
+        "storageKey": null
+      },
+      (v15/*: any*/)
     ],
     "storageKey": null
   }
 ],
-v13 = [
+v31 = [
   (v3/*: any*/),
   (v4/*: any*/)
 ];
@@ -671,7 +693,7 @@ return {
             "kind": "LinkedField",
             "name": "saleArtworksConnection",
             "plural": false,
-            "selections": (v12/*: any*/),
+            "selections": (v30/*: any*/),
             "storageKey": "saleArtworksConnection(first:50,includeArtworksByFollowedArtists:true,isAuction:true,liveSale:true)"
           },
           {
@@ -715,8 +737,60 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v11/*: any*/),
-                  (v8/*: any*/)
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v1/*: any*/),
+                      (v2/*: any*/),
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v9/*: any*/),
+                      (v10/*: any*/),
+                      (v11/*: any*/),
+                      (v12/*: any*/),
+                      (v13/*: any*/),
+                      (v17/*: any*/),
+                      (v18/*: any*/),
+                      (v19/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          (v20/*: any*/),
+                          (v21/*: any*/),
+                          (v15/*: any*/),
+                          (v22/*: any*/),
+                          (v23/*: any*/),
+                          (v24/*: any*/),
+                          (v25/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v27/*: any*/),
+                      (v28/*: any*/),
+                      (v15/*: any*/),
+                      (v29/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v15/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -737,7 +811,7 @@ return {
             "kind": "LinkedField",
             "name": "saleArtworksConnection",
             "plural": false,
-            "selections": (v12/*: any*/),
+            "selections": (v30/*: any*/),
             "storageKey": "saleArtworksConnection(first:50,geneIDs:\"highlights-at-auction\")"
           },
           {
@@ -799,7 +873,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "cropped",
                                 "plural": false,
-                                "selections": (v13/*: any*/),
+                                "selections": (v31/*: any*/),
                                 "storageKey": "cropped(height:100,width:330)"
                               }
                             ],
@@ -812,7 +886,7 @@ return {
                             "name": "formattedStartDateTime",
                             "storageKey": null
                           },
-                          (v9/*: any*/),
+                          (v16/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -821,12 +895,12 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v9/*: any*/),
-                              (v8/*: any*/)
+                              (v16/*: any*/),
+                              (v15/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v8/*: any*/)
+                          (v15/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -879,13 +953,13 @@ return {
                                     "kind": "LinkedField",
                                     "name": "resized",
                                     "plural": false,
-                                    "selections": (v13/*: any*/),
+                                    "selections": (v31/*: any*/),
                                     "storageKey": "resized(height:55,width:55)"
                                   }
                                 ],
                                 "storageKey": null
                               },
-                              (v8/*: any*/)
+                              (v15/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -903,7 +977,7 @@ return {
                             "kind": "LinkedField",
                             "name": "currentBid",
                             "plural": false,
-                            "selections": (v10/*: any*/),
+                            "selections": (v26/*: any*/),
                             "storageKey": null
                           },
                           (v1/*: any*/),
@@ -943,7 +1017,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "sellingPrice",
                                 "plural": false,
-                                "selections": (v10/*: any*/),
+                                "selections": (v26/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -957,7 +1031,7 @@ return {
                             "storageKey": null
                           },
                           (v2/*: any*/),
-                          (v8/*: any*/)
+                          (v15/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -967,7 +1041,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v8/*: any*/)
+              (v15/*: any*/)
             ],
             "storageKey": null
           }
@@ -981,7 +1055,7 @@ return {
     "metadata": {},
     "name": "AuctionsApp_Test_Query",
     "operationKind": "query",
-    "text": "query AuctionsApp_Test_Query {\n  viewer {\n    ...AuctionsApp_viewer\n  }\n}\n\nfragment AuctionsApp_viewer on Viewer {\n  ...WorksByArtistsYouFollowRail_viewer\n  ...TrendingLots_viewer\n  ...StandoutLots_viewer\n  me {\n    ...MyBids_me\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment MyBidsBidHeader_sale on Sale {\n  coverImage {\n    cropped(width: 330, height: 100) {\n      src\n      srcSet\n    }\n  }\n  formattedStartDateTime\n  name\n  partner {\n    name\n    id\n  }\n  slug\n}\n\nfragment MyBidsBidItem_saleArtwork on SaleArtwork {\n  artwork {\n    artistNames\n    image {\n      resized(width: 55, height: 55) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  estimate\n  currentBid {\n    display\n  }\n  internalID\n  isHighestBidder\n  isWatching\n  lotState {\n    bidCount\n    sellingPrice {\n      display\n    }\n  }\n  position\n  slug\n}\n\nfragment MyBids_me on Me {\n  myBids {\n    active {\n      sale {\n        slug\n        ...MyBidsBidHeader_sale\n        id\n      }\n      saleArtworks {\n        ...MyBidsBidItem_saleArtwork\n        id\n      }\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_20bRBg on Artwork {\n  image {\n    resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment StandoutLots_viewer on Viewer {\n  standoutLotsConnection: saleArtworksConnection(first: 50, geneIDs: \"highlights-at-auction\") {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment TrendingLots_viewer on Viewer {\n  trendingLotsConnection: saleArtworksConnection(first: 50, sort: \"-bidder_positions_count\") {\n    edges {\n      counts {\n        bidderPositions\n      }\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment WorksByArtistsYouFollowRail_viewer on Viewer {\n  saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 50) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query AuctionsApp_Test_Query {\n  viewer {\n    ...AuctionsApp_viewer\n  }\n}\n\nfragment AuctionsApp_viewer on Viewer {\n  ...WorksByArtistsYouFollowRail_viewer\n  ...TrendingLots_viewer\n  ...StandoutLots_viewer\n  me {\n    ...MyBids_me\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment MyBidsBidHeader_sale on Sale {\n  coverImage {\n    cropped(width: 330, height: 100) {\n      src\n      srcSet\n    }\n  }\n  formattedStartDateTime\n  name\n  partner {\n    name\n    id\n  }\n  slug\n}\n\nfragment MyBidsBidItem_saleArtwork on SaleArtwork {\n  artwork {\n    artistNames\n    image {\n      resized(width: 55, height: 55) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  estimate\n  currentBid {\n    display\n  }\n  internalID\n  isHighestBidder\n  isWatching\n  lotState {\n    bidCount\n    sellingPrice {\n      display\n    }\n  }\n  position\n  slug\n}\n\nfragment MyBids_me on Me {\n  myBids {\n    active {\n      sale {\n        slug\n        ...MyBidsBidHeader_sale\n        id\n      }\n      saleArtworks {\n        ...MyBidsBidItem_saleArtwork\n        id\n      }\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_20bRBg on Artwork {\n  image {\n    resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment StandoutLots_viewer on Viewer {\n  standoutLotsConnection: saleArtworksConnection(first: 50, geneIDs: \"highlights-at-auction\") {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment TrendingLots_viewer on Viewer {\n  trendingLotsConnection: saleArtworksConnection(first: 50, sort: \"-bidder_positions_count\") {\n    edges {\n      counts {\n        bidderPositions\n      }\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        sale {\n          isClosed\n          id\n        }\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment WorksByArtistsYouFollowRail_viewer on Viewer {\n  saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 50) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/TrendingLots_Test_Query.graphql.ts
+++ b/src/v2/__generated__/TrendingLots_Test_Query.graphql.ts
@@ -141,6 +141,10 @@ fragment TrendingLots_viewer on Viewer {
         internalID
         slug
         ...ShelfArtwork_artwork_20bRBg
+        sale {
+          isClosed
+          id
+        }
         id
       }
       id
@@ -494,6 +498,13 @@ return {
                             "kind": "ScalarField",
                             "name": "displayTimelyAt",
                             "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
                           }
                         ],
                         "storageKey": null
@@ -583,7 +594,7 @@ return {
     "metadata": {},
     "name": "TrendingLots_Test_Query",
     "operationKind": "query",
-    "text": "query TrendingLots_Test_Query {\n  viewer {\n    ...TrendingLots_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_20bRBg on Artwork {\n  image {\n    resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment TrendingLots_viewer on Viewer {\n  trendingLotsConnection: saleArtworksConnection(first: 50, sort: \"-bidder_positions_count\") {\n    edges {\n      counts {\n        bidderPositions\n      }\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query TrendingLots_Test_Query {\n  viewer {\n    ...TrendingLots_viewer\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_20bRBg on Artwork {\n  image {\n    resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment TrendingLots_viewer on Viewer {\n  trendingLotsConnection: saleArtworksConnection(first: 50, sort: \"-bidder_positions_count\") {\n    edges {\n      counts {\n        bidderPositions\n      }\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        sale {\n          isClosed\n          id\n        }\n        id\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/TrendingLots_viewer.graphql.ts
+++ b/src/v2/__generated__/TrendingLots_viewer.graphql.ts
@@ -12,6 +12,9 @@ export type TrendingLots_viewer = {
             readonly node: {
                 readonly internalID: string;
                 readonly slug: string;
+                readonly sale: {
+                    readonly isClosed: boolean | null;
+                } | null;
                 readonly " $fragmentRefs": FragmentRefs<"ShelfArtwork_artwork">;
             } | null;
         } | null> | null;
@@ -100,6 +103,24 @@ const node: ReaderFragment = {
                   "storageKey": null
                 },
                 {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Sale",
+                  "kind": "LinkedField",
+                  "name": "sale",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "isClosed",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
                   "args": [
                     {
                       "kind": "Literal",
@@ -122,5 +143,5 @@ const node: ReaderFragment = {
   ],
   "type": "Viewer"
 };
-(node as any).hash = '55ba411be6f10fbc7513da073d357cde';
+(node as any).hash = 'b1b4ae5c3bc22a7a2bbd6bf93450912f';
 export default node;

--- a/src/v2/__generated__/auctionsRoutes_AuctionsQuery.graphql.ts
+++ b/src/v2/__generated__/auctionsRoutes_AuctionsQuery.graphql.ts
@@ -225,6 +225,10 @@ fragment TrendingLots_viewer on Viewer {
         internalID
         slug
         ...ShelfArtwork_artwork_20bRBg
+        sale {
+          isClosed
+          id
+        }
         id
       }
       id
@@ -291,32 +295,204 @@ v5 = {
 v6 = {
   "alias": null,
   "args": null,
-  "kind": "ScalarField",
-  "name": "href",
+  "concreteType": "Image",
+  "kind": "LinkedField",
+  "name": "image",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "width",
+          "value": 325
+        }
+      ],
+      "concreteType": "ResizedImageUrl",
+      "kind": "LinkedField",
+      "name": "resized",
+      "plural": false,
+      "selections": [
+        (v3/*: any*/),
+        (v4/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "width",
+          "storageKey": null
+        },
+        (v5/*: any*/)
+      ],
+      "storageKey": "resized(width:325)"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "aspectRatio",
+      "storageKey": null
+    },
+    (v5/*: any*/)
+  ],
   "storageKey": null
 },
-v7 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true
-  }
-],
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "imageTitle",
+  "storageKey": null
+},
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "title",
   "storageKey": null
 },
 v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v10 = {
+  "alias": "is_saved",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isSaved",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "date",
+  "storageKey": null
+},
+v12 = {
+  "alias": "sale_message",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "saleMessage",
+  "storageKey": null
+},
+v13 = {
+  "alias": "cultural_maker",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "culturalMaker",
+  "storageKey": null
+},
+v14 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v16 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v10 = [
+v17 = {
+  "alias": null,
+  "args": (v14/*: any*/),
+  "concreteType": "Artist",
+  "kind": "LinkedField",
+  "name": "artists",
+  "plural": true,
+  "selections": [
+    (v15/*: any*/),
+    (v9/*: any*/),
+    (v16/*: any*/)
+  ],
+  "storageKey": "artists(shallow:true)"
+},
+v18 = {
+  "alias": "collecting_institution",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "collectingInstitution",
+  "storageKey": null
+},
+v19 = {
+  "alias": null,
+  "args": (v14/*: any*/),
+  "concreteType": "Partner",
+  "kind": "LinkedField",
+  "name": "partner",
+  "plural": false,
+  "selections": [
+    (v16/*: any*/),
+    (v9/*: any*/),
+    (v15/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "type",
+      "storageKey": null
+    }
+  ],
+  "storageKey": "partner(shallow:true)"
+},
+v20 = {
+  "alias": "is_auction",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isAuction",
+  "storageKey": null
+},
+v21 = {
+  "alias": "is_closed",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isClosed",
+  "storageKey": null
+},
+v22 = {
+  "alias": "is_live_open",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isLiveOpen",
+  "storageKey": null
+},
+v23 = {
+  "alias": "is_open",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isOpen",
+  "storageKey": null
+},
+v24 = {
+  "alias": "is_preview",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isPreview",
+  "storageKey": null
+},
+v25 = {
+  "alias": "display_timely_at",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "displayTimelyAt",
+  "storageKey": null
+},
+v26 = [
   {
     "alias": null,
     "args": null,
@@ -325,270 +501,71 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = {
-  "alias": null,
+v27 = {
+  "alias": "sale_artwork",
   "args": null,
-  "concreteType": "Artwork",
+  "concreteType": "SaleArtwork",
   "kind": "LinkedField",
-  "name": "node",
+  "name": "saleArtwork",
   "plural": false,
   "selections": [
-    (v1/*: any*/),
-    (v2/*: any*/),
     {
       "alias": null,
       "args": null,
-      "concreteType": "Image",
+      "concreteType": "SaleArtworkCounts",
       "kind": "LinkedField",
-      "name": "image",
+      "name": "counts",
       "plural": false,
       "selections": [
         {
-          "alias": null,
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "width",
-              "value": 325
-            }
-          ],
-          "concreteType": "ResizedImageUrl",
-          "kind": "LinkedField",
-          "name": "resized",
-          "plural": false,
-          "selections": [
-            (v3/*: any*/),
-            (v4/*: any*/),
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "width",
-              "storageKey": null
-            },
-            (v5/*: any*/)
-          ],
-          "storageKey": "resized(width:325)"
-        },
-        {
-          "alias": null,
+          "alias": "bidder_positions",
           "args": null,
           "kind": "ScalarField",
-          "name": "aspectRatio",
-          "storageKey": null
-        },
-        (v5/*: any*/)
-      ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "imageTitle",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "title",
-      "storageKey": null
-    },
-    (v6/*: any*/),
-    {
-      "alias": "is_saved",
-      "args": null,
-      "kind": "ScalarField",
-      "name": "isSaved",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "date",
-      "storageKey": null
-    },
-    {
-      "alias": "sale_message",
-      "args": null,
-      "kind": "ScalarField",
-      "name": "saleMessage",
-      "storageKey": null
-    },
-    {
-      "alias": "cultural_maker",
-      "args": null,
-      "kind": "ScalarField",
-      "name": "culturalMaker",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": (v7/*: any*/),
-      "concreteType": "Artist",
-      "kind": "LinkedField",
-      "name": "artists",
-      "plural": true,
-      "selections": [
-        (v8/*: any*/),
-        (v6/*: any*/),
-        (v9/*: any*/)
-      ],
-      "storageKey": "artists(shallow:true)"
-    },
-    {
-      "alias": "collecting_institution",
-      "args": null,
-      "kind": "ScalarField",
-      "name": "collectingInstitution",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": (v7/*: any*/),
-      "concreteType": "Partner",
-      "kind": "LinkedField",
-      "name": "partner",
-      "plural": false,
-      "selections": [
-        (v9/*: any*/),
-        (v6/*: any*/),
-        (v8/*: any*/),
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "type",
-          "storageKey": null
-        }
-      ],
-      "storageKey": "partner(shallow:true)"
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "Sale",
-      "kind": "LinkedField",
-      "name": "sale",
-      "plural": false,
-      "selections": [
-        {
-          "alias": "is_auction",
-          "args": null,
-          "kind": "ScalarField",
-          "name": "isAuction",
-          "storageKey": null
-        },
-        {
-          "alias": "is_closed",
-          "args": null,
-          "kind": "ScalarField",
-          "name": "isClosed",
-          "storageKey": null
-        },
-        (v8/*: any*/),
-        {
-          "alias": "is_live_open",
-          "args": null,
-          "kind": "ScalarField",
-          "name": "isLiveOpen",
-          "storageKey": null
-        },
-        {
-          "alias": "is_open",
-          "args": null,
-          "kind": "ScalarField",
-          "name": "isOpen",
-          "storageKey": null
-        },
-        {
-          "alias": "is_preview",
-          "args": null,
-          "kind": "ScalarField",
-          "name": "isPreview",
-          "storageKey": null
-        },
-        {
-          "alias": "display_timely_at",
-          "args": null,
-          "kind": "ScalarField",
-          "name": "displayTimelyAt",
+          "name": "bidderPositions",
           "storageKey": null
         }
       ],
       "storageKey": null
     },
     {
-      "alias": "sale_artwork",
+      "alias": "highest_bid",
       "args": null,
-      "concreteType": "SaleArtwork",
+      "concreteType": "SaleArtworkHighestBid",
       "kind": "LinkedField",
-      "name": "saleArtwork",
+      "name": "highestBid",
       "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "SaleArtworkCounts",
-          "kind": "LinkedField",
-          "name": "counts",
-          "plural": false,
-          "selections": [
-            {
-              "alias": "bidder_positions",
-              "args": null,
-              "kind": "ScalarField",
-              "name": "bidderPositions",
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
-        },
-        {
-          "alias": "highest_bid",
-          "args": null,
-          "concreteType": "SaleArtworkHighestBid",
-          "kind": "LinkedField",
-          "name": "highestBid",
-          "plural": false,
-          "selections": (v10/*: any*/),
-          "storageKey": null
-        },
-        {
-          "alias": "opening_bid",
-          "args": null,
-          "concreteType": "SaleArtworkOpeningBid",
-          "kind": "LinkedField",
-          "name": "openingBid",
-          "plural": false,
-          "selections": (v10/*: any*/),
-          "storageKey": null
-        },
-        (v8/*: any*/)
-      ],
+      "selections": (v26/*: any*/),
       "storageKey": null
     },
     {
-      "alias": "is_inquireable",
+      "alias": "opening_bid",
       "args": null,
-      "kind": "ScalarField",
-      "name": "isInquireable",
+      "concreteType": "SaleArtworkOpeningBid",
+      "kind": "LinkedField",
+      "name": "openingBid",
+      "plural": false,
+      "selections": (v26/*: any*/),
       "storageKey": null
     },
-    (v8/*: any*/),
-    {
-      "alias": "is_biddable",
-      "args": null,
-      "kind": "ScalarField",
-      "name": "isBiddable",
-      "storageKey": null
-    }
+    (v15/*: any*/)
   ],
   "storageKey": null
 },
-v12 = [
+v28 = {
+  "alias": "is_inquireable",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isInquireable",
+  "storageKey": null
+},
+v29 = {
+  "alias": "is_biddable",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isBiddable",
+  "storageKey": null
+},
+v30 = [
   {
     "alias": null,
     "args": null,
@@ -597,13 +574,58 @@ v12 = [
     "name": "edges",
     "plural": true,
     "selections": [
-      (v11/*: any*/),
-      (v8/*: any*/)
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          (v2/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
+          (v8/*: any*/),
+          (v9/*: any*/),
+          (v10/*: any*/),
+          (v11/*: any*/),
+          (v12/*: any*/),
+          (v13/*: any*/),
+          (v17/*: any*/),
+          (v18/*: any*/),
+          (v19/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Sale",
+            "kind": "LinkedField",
+            "name": "sale",
+            "plural": false,
+            "selections": [
+              (v20/*: any*/),
+              (v21/*: any*/),
+              (v15/*: any*/),
+              (v22/*: any*/),
+              (v23/*: any*/),
+              (v24/*: any*/),
+              (v25/*: any*/)
+            ],
+            "storageKey": null
+          },
+          (v27/*: any*/),
+          (v28/*: any*/),
+          (v15/*: any*/),
+          (v29/*: any*/)
+        ],
+        "storageKey": null
+      },
+      (v15/*: any*/)
     ],
     "storageKey": null
   }
 ],
-v13 = [
+v31 = [
   (v3/*: any*/),
   (v4/*: any*/)
 ];
@@ -671,7 +693,7 @@ return {
             "kind": "LinkedField",
             "name": "saleArtworksConnection",
             "plural": false,
-            "selections": (v12/*: any*/),
+            "selections": (v30/*: any*/),
             "storageKey": "saleArtworksConnection(first:50,includeArtworksByFollowedArtists:true,isAuction:true,liveSale:true)"
           },
           {
@@ -715,8 +737,60 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v11/*: any*/),
-                  (v8/*: any*/)
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v1/*: any*/),
+                      (v2/*: any*/),
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v9/*: any*/),
+                      (v10/*: any*/),
+                      (v11/*: any*/),
+                      (v12/*: any*/),
+                      (v13/*: any*/),
+                      (v17/*: any*/),
+                      (v18/*: any*/),
+                      (v19/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          (v20/*: any*/),
+                          (v21/*: any*/),
+                          (v15/*: any*/),
+                          (v22/*: any*/),
+                          (v23/*: any*/),
+                          (v24/*: any*/),
+                          (v25/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v27/*: any*/),
+                      (v28/*: any*/),
+                      (v15/*: any*/),
+                      (v29/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v15/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -737,7 +811,7 @@ return {
             "kind": "LinkedField",
             "name": "saleArtworksConnection",
             "plural": false,
-            "selections": (v12/*: any*/),
+            "selections": (v30/*: any*/),
             "storageKey": "saleArtworksConnection(first:50,geneIDs:\"highlights-at-auction\")"
           },
           {
@@ -799,7 +873,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "cropped",
                                 "plural": false,
-                                "selections": (v13/*: any*/),
+                                "selections": (v31/*: any*/),
                                 "storageKey": "cropped(height:100,width:330)"
                               }
                             ],
@@ -812,7 +886,7 @@ return {
                             "name": "formattedStartDateTime",
                             "storageKey": null
                           },
-                          (v9/*: any*/),
+                          (v16/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -821,12 +895,12 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v9/*: any*/),
-                              (v8/*: any*/)
+                              (v16/*: any*/),
+                              (v15/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v8/*: any*/)
+                          (v15/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -879,13 +953,13 @@ return {
                                     "kind": "LinkedField",
                                     "name": "resized",
                                     "plural": false,
-                                    "selections": (v13/*: any*/),
+                                    "selections": (v31/*: any*/),
                                     "storageKey": "resized(height:55,width:55)"
                                   }
                                 ],
                                 "storageKey": null
                               },
-                              (v8/*: any*/)
+                              (v15/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -903,7 +977,7 @@ return {
                             "kind": "LinkedField",
                             "name": "currentBid",
                             "plural": false,
-                            "selections": (v10/*: any*/),
+                            "selections": (v26/*: any*/),
                             "storageKey": null
                           },
                           (v1/*: any*/),
@@ -943,7 +1017,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "sellingPrice",
                                 "plural": false,
-                                "selections": (v10/*: any*/),
+                                "selections": (v26/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -957,7 +1031,7 @@ return {
                             "storageKey": null
                           },
                           (v2/*: any*/),
-                          (v8/*: any*/)
+                          (v15/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -967,7 +1041,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v8/*: any*/)
+              (v15/*: any*/)
             ],
             "storageKey": null
           }
@@ -981,7 +1055,7 @@ return {
     "metadata": {},
     "name": "auctionsRoutes_AuctionsQuery",
     "operationKind": "query",
-    "text": "query auctionsRoutes_AuctionsQuery {\n  viewer {\n    ...AuctionsApp_viewer\n  }\n}\n\nfragment AuctionsApp_viewer on Viewer {\n  ...WorksByArtistsYouFollowRail_viewer\n  ...TrendingLots_viewer\n  ...StandoutLots_viewer\n  me {\n    ...MyBids_me\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment MyBidsBidHeader_sale on Sale {\n  coverImage {\n    cropped(width: 330, height: 100) {\n      src\n      srcSet\n    }\n  }\n  formattedStartDateTime\n  name\n  partner {\n    name\n    id\n  }\n  slug\n}\n\nfragment MyBidsBidItem_saleArtwork on SaleArtwork {\n  artwork {\n    artistNames\n    image {\n      resized(width: 55, height: 55) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  estimate\n  currentBid {\n    display\n  }\n  internalID\n  isHighestBidder\n  isWatching\n  lotState {\n    bidCount\n    sellingPrice {\n      display\n    }\n  }\n  position\n  slug\n}\n\nfragment MyBids_me on Me {\n  myBids {\n    active {\n      sale {\n        slug\n        ...MyBidsBidHeader_sale\n        id\n      }\n      saleArtworks {\n        ...MyBidsBidItem_saleArtwork\n        id\n      }\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_20bRBg on Artwork {\n  image {\n    resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment StandoutLots_viewer on Viewer {\n  standoutLotsConnection: saleArtworksConnection(first: 50, geneIDs: \"highlights-at-auction\") {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment TrendingLots_viewer on Viewer {\n  trendingLotsConnection: saleArtworksConnection(first: 50, sort: \"-bidder_positions_count\") {\n    edges {\n      counts {\n        bidderPositions\n      }\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment WorksByArtistsYouFollowRail_viewer on Viewer {\n  saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 50) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query auctionsRoutes_AuctionsQuery {\n  viewer {\n    ...AuctionsApp_viewer\n  }\n}\n\nfragment AuctionsApp_viewer on Viewer {\n  ...WorksByArtistsYouFollowRail_viewer\n  ...TrendingLots_viewer\n  ...StandoutLots_viewer\n  me {\n    ...MyBids_me\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment MyBidsBidHeader_sale on Sale {\n  coverImage {\n    cropped(width: 330, height: 100) {\n      src\n      srcSet\n    }\n  }\n  formattedStartDateTime\n  name\n  partner {\n    name\n    id\n  }\n  slug\n}\n\nfragment MyBidsBidItem_saleArtwork on SaleArtwork {\n  artwork {\n    artistNames\n    image {\n      resized(width: 55, height: 55) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  estimate\n  currentBid {\n    display\n  }\n  internalID\n  isHighestBidder\n  isWatching\n  lotState {\n    bidCount\n    sellingPrice {\n      display\n    }\n  }\n  position\n  slug\n}\n\nfragment MyBids_me on Me {\n  myBids {\n    active {\n      sale {\n        slug\n        ...MyBidsBidHeader_sale\n        id\n      }\n      saleArtworks {\n        ...MyBidsBidItem_saleArtwork\n        id\n      }\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork_20bRBg on Artwork {\n  image {\n    resized(width: 325) {\n      src\n      srcSet\n      width\n      height\n    }\n    aspectRatio\n    height\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment StandoutLots_viewer on Viewer {\n  standoutLotsConnection: saleArtworksConnection(first: 50, geneIDs: \"highlights-at-auction\") {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment TrendingLots_viewer on Viewer {\n  trendingLotsConnection: saleArtworksConnection(first: 50, sort: \"-bidder_positions_count\") {\n    edges {\n      counts {\n        bidderPositions\n      }\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        sale {\n          isClosed\n          id\n        }\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment WorksByArtistsYouFollowRail_viewer on Viewer {\n  saleArtworksConnection(includeArtworksByFollowedArtists: true, isAuction: true, liveSale: true, first: 50) {\n    edges {\n      node {\n        internalID\n        slug\n        ...ShelfArtwork_artwork_20bRBg\n        id\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
This is for [GRO-469].

We wanted to update Trending Lots to remove any closed lots from being displayed.

Note: Currently we do not have any "Trending Lots" in staging that are open. So we do not have local screen shots to show other then the empty state curatorial rail.

[GRO-469]: https://artsyproduct.atlassian.net/browse/GRO-469