### PR TITLE
fix(FX-3207): align carousel items on fair organizer page

### DIFF
--- a/src/v2/Apps/FairOrginizer/Components/FairOrganizerPastEventsRail.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/FairOrganizerPastEventsRail.tsx
@@ -22,7 +22,7 @@ export const FairOrganizerPastEventsRail: React.FC<FairOrganizerPastEventsRailPr
       <Text variant="lg" as="h3" mb={4}>
         Past Events
       </Text>
-      <Shelf>
+      <Shelf alignItems="flex-start">
         {pastFairs.map(fair => {
           return <FairOrganizerPastEventRailCell key={fair.id} fair={fair} />
         })}


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->
This PR resolves [FX-3207]

### Description
The images in the events carousel should sit next to each other in the row. The text should sit below the images and can push the scroll bar down as needed.

### Demo
<img width="1280" alt="web" src="https://user-images.githubusercontent.com/3513494/130438854-7085f238-233a-4cb2-adff-34667e2c8cd1.png">

<img width="228" alt="mobile" src="https://user-images.githubusercontent.com/3513494/130438846-1bc2134c-cf6c-4f34-80d6-c829590a4eee.png">

[FX-3207]: https://artsyproduct.atlassian.net/browse/FX-3207