### PR TITLE
feat(FX-3208): hide empty about section

### DIFF
--- a/src/v2/Apps/Fair/Components/FairOverview/FairAbout.tsx
+++ b/src/v2/Apps/Fair/Components/FairOverview/FairAbout.tsx
@@ -1,11 +1,12 @@
-import React, { useMemo } from "react"
-import { Column, GridColumns, Separator, Spacer, Text } from "@artsy/palette"
-import { moment } from "desktop/lib/template_modules"
+import React from "react"
+import { Column, GridColumns, Spacer, Text } from "@artsy/palette"
 import { some } from "lodash"
+import { DateTime } from "luxon"
 import { InfoSection } from "v2/Components/InfoSection"
 import { FairTimerFragmentContainer as FairTimer } from "./FairTimer"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairAbout_fair } from "v2/__generated__/FairAbout_fair.graphql"
+import { useCurrentTime } from "v2/Utils/Hooks/useCurrentTime"
 
 const aboutInfoTypes = [
   "about",
@@ -36,12 +37,11 @@ const FairAbout: React.FC<FairAboutProps> = ({ fair }) => {
     tickets,
     endAt,
   } = fair
+  const currentTime = useCurrentTime({ syncWithServer: true })
 
-  const hasEnded = endAt && moment().isAfter(new Date(endAt))
-  const hasAboutContent = useMemo(
-    () => some(aboutInfoTypes, field => !!fair[field]),
-    [fair]
-  )
+  const hasEnded =
+    endAt && DateTime.fromISO(endAt) < DateTime.fromISO(currentTime)
+  const hasAboutContent = some(aboutInfoTypes, field => !!fair[field])
 
   if (hasEnded && !hasAboutContent) {
     return null
@@ -89,8 +89,6 @@ const FairAbout: React.FC<FairAboutProps> = ({ fair }) => {
           </Column>
         )}
       </GridColumns>
-
-      <Separator my={4} />
     </>
   )
 }

--- a/src/v2/Apps/Fair/Components/FairOverview/FairAbout.tsx
+++ b/src/v2/Apps/Fair/Components/FairOverview/FairAbout.tsx
@@ -1,0 +1,116 @@
+import React, { useMemo } from "react"
+import { Column, GridColumns, Separator, Spacer, Text } from "@artsy/palette"
+import { moment } from "desktop/lib/template_modules"
+import { some } from "lodash"
+import { InfoSection } from "v2/Components/InfoSection"
+import { FairTimerFragmentContainer as FairTimer } from "./FairTimer"
+import { createFragmentContainer, graphql } from "react-relay"
+import { FairAbout_fair } from "v2/__generated__/FairAbout_fair.graphql"
+
+const aboutInfoTypes = [
+  "about",
+  "tagline",
+  "location.summary",
+  "ticketsLink",
+  "hours",
+  "links",
+  "contact",
+  "summary",
+  "tickets",
+]
+
+interface FairAboutProps {
+  fair: FairAbout_fair
+}
+
+const FairAbout: React.FC<FairAboutProps> = ({ fair }) => {
+  const {
+    about,
+    tagline,
+    location,
+    ticketsLink,
+    hours,
+    links,
+    contact,
+    summary,
+    tickets,
+    endAt,
+  } = fair
+
+  const hasEnded = endAt && moment().isAfter(new Date(endAt))
+  const hasAboutContent = useMemo(
+    () => some(aboutInfoTypes, field => !!fair[field]),
+    [fair]
+  )
+
+  if (hasEnded && !hasAboutContent) {
+    return null
+  }
+
+  return (
+    <>
+      <GridColumns mt={[2, 4]}>
+        {!hasEnded && (
+          <Column span={6}>
+            <FairTimer fair={fair} />
+          </Column>
+        )}
+
+        {hasAboutContent && (
+          <Column span={hasEnded ? 12 : 6}>
+            <Text variant="md" textTransform="uppercase">
+              About
+            </Text>
+            <Spacer mt={2} />
+
+            {summary && <InfoSection type="html" info={summary} />}
+            {about && <InfoSection type="html" info={about} />}
+            {tagline && <InfoSection type="text" info={tagline} />}
+            {location?.summary && (
+              <InfoSection
+                label="Location"
+                type="text"
+                info={location.summary}
+              />
+            )}
+            {hours && <InfoSection label="Hours" type="html" info={hours} />}
+            {tickets && (
+              <InfoSection label="Tickets" type="html" info={tickets} />
+            )}
+            {ticketsLink && (
+              <a href={ticketsLink}>
+                <Text variant="md">Buy Tickets</Text>
+              </a>
+            )}
+            {links && <InfoSection label="Links" type="html" info={links} />}
+            {contact && (
+              <InfoSection label="Contact" type="html" info={contact} />
+            )}
+          </Column>
+        )}
+      </GridColumns>
+
+      <Separator my={4} />
+    </>
+  )
+}
+
+export const FairAboutFragmentContainer = createFragmentContainer(FairAbout, {
+  fair: graphql`
+    fragment FairAbout_fair on Fair {
+      ...FairTimer_fair
+      endAt
+      about(format: HTML)
+      tagline
+      location {
+        summary
+      }
+      ticketsLink
+      hours(format: HTML)
+      links(format: HTML)
+      tickets(format: HTML)
+      summary(format: HTML)
+      contact(format: HTML)
+    }
+  `,
+})

--- a/src/v2/Apps/Fair/Components/FairOverview/FairOverview.tsx
+++ b/src/v2/Apps/Fair/Components/FairOverview/FairOverview.tsx
@@ -1,12 +1,5 @@
 import React from "react"
-import {
-  Box,
-  BoxProps,
-  GridColumns,
-  Column,
-  Text,
-  Spacer,
-} from "@artsy/palette"
+import { Box, BoxProps, Text, Spacer, Separator } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import {
   FairEditorialFragmentContainer,
@@ -17,72 +10,23 @@ import { FairFollowedArtistsFragmentContainer } from "./FairFollowedArtists"
 import { useSystemContext } from "v2/System"
 import { RouterLink } from "v2/System/Router/RouterLink"
 import { FairOverview_fair } from "v2/__generated__/FairOverview_fair.graphql"
-import { InfoSection } from "v2/Components/InfoSection"
-import { moment } from "desktop/lib/template_modules"
-import { FairTimerFragmentContainer as FairTimer } from "./FairTimer"
+import { FairAboutFragmentContainer as FairAbout } from "./FairAbout"
 
 interface FairOverviewProps extends BoxProps {
   fair: FairOverview_fair
 }
 
 const FairOverview: React.FC<FairOverviewProps> = ({ fair }) => {
-  const {
-    about,
-    tagline,
-    location,
-    ticketsLink,
-    hours,
-    links,
-    contact,
-    summary,
-    tickets,
-    endAt,
-  } = fair
-
   const { user } = useSystemContext()
   const hasArticles = (fair.articlesConnection?.edges?.length ?? 0) > 0
   const hasCollections = (fair.marketingCollections?.length ?? 0) > 0
-  const hasEnded = endAt && moment().isAfter(new Date(endAt))
 
   return (
     <Box>
-      <GridColumns mt={[2, 4]}>
-        {!hasEnded && (
-          <Column span={6}>
-            <FairTimer fair={fair} />
-          </Column>
-        )}
-
-        <Column span={hasEnded ? 12 : 6}>
-          <Text variant="md" textTransform="uppercase">
-            About
-          </Text>
-          <Spacer mt={2} />
-
-          {summary && <InfoSection type="html" info={summary} />}
-          {about && <InfoSection type="html" info={about} />}
-          {tagline && <InfoSection type="text" info={tagline} />}
-          {location?.summary && (
-            <InfoSection label="Location" type="text" info={location.summary} />
-          )}
-          {hours && <InfoSection label="Hours" type="html" info={hours} />}
-          {tickets && (
-            <InfoSection label="Tickets" type="html" info={tickets} />
-          )}
-          {ticketsLink && (
-            <a href={ticketsLink}>
-              <Text variant="md">Buy Tickets</Text>
-            </a>
-          )}
-          {links && <InfoSection label="Links" type="html" info={links} />}
-          {contact && (
-            <InfoSection label="Contact" type="html" info={contact} />
-          )}
-        </Column>
-      </GridColumns>
+      <FairAbout fair={fair} />
 
       {hasArticles && (
-        <Box my={4} pt={4} borderTop="1px solid" borderColor="black10">
+        <Box my={4}>
           <Box display="flex" justifyContent="space-between">
             {(fair.articlesConnection?.totalCount ?? 0) >
               FAIR_EDITORIAL_AMOUNT && (
@@ -97,26 +41,21 @@ const FairOverview: React.FC<FairOverviewProps> = ({ fair }) => {
       )}
 
       {hasCollections && (
-        <Box my={4} pt={4} borderTop="1px solid" borderColor="black10">
-          <Text variant="lg" as="h3" mb={2}>
-            Curated Highlights
-          </Text>
+        <>
+          <Separator my={4} />
+          <Box my={4}>
+            <Text variant="lg" as="h3" mb={4}>
+              Curated Highlights
+            </Text>
 
-          <FairCollectionsFragmentContainer fair={fair} />
-        </Box>
+            <FairCollectionsFragmentContainer fair={fair} />
+          </Box>
+        </>
       )}
 
-      {!!user && (
-        <FairFollowedArtistsFragmentContainer
-          fair={fair}
-          my={2}
-          pt={2}
-          borderTop="1px solid"
-          borderColor="black10"
-        />
-      )}
+      {!!user && <FairFollowedArtistsFragmentContainer fair={fair} my={2} />}
 
-      <Spacer my={[4, 80]} />
+      <Spacer my={[4, 6]} />
     </Box>
   )
 }
@@ -129,15 +68,9 @@ export const FairOverviewFragmentContainer = createFragmentContainer(
         ...FairEditorial_fair
         ...FairCollections_fair
         ...FairFollowedArtists_fair
-        ...FairTimer_fair
-        endAt
+        ...FairAbout_fair
         href
-        about(format: HTML)
         slug
-        tagline
-        location {
-          summary
-        }
         articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {
           totalCount
           edges {
@@ -147,12 +80,6 @@ export const FairOverviewFragmentContainer = createFragmentContainer(
         marketingCollections(size: 5) {
           id
         }
-        ticketsLink
-        hours(format: HTML)
-        links(format: HTML)
-        tickets(format: HTML)
-        summary(format: HTML)
-        contact(format: HTML)
       }
     `,
   }

--- a/src/v2/Apps/Fair/Components/FairOverview/FairOverview.tsx
+++ b/src/v2/Apps/Fair/Components/FairOverview/FairOverview.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Box, BoxProps, Text, Spacer, Separator } from "@artsy/palette"
+import { Box, BoxProps, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import {
   FairEditorialFragmentContainer,
@@ -41,21 +41,16 @@ const FairOverview: React.FC<FairOverviewProps> = ({ fair }) => {
       )}
 
       {hasCollections && (
-        <>
-          <Separator my={4} />
-          <Box my={4}>
-            <Text variant="lg" as="h3" mb={4}>
-              Curated Highlights
-            </Text>
+        <Box my={6}>
+          <Text variant="lg" as="h3" mb={4}>
+            Curated Highlights
+          </Text>
 
-            <FairCollectionsFragmentContainer fair={fair} />
-          </Box>
-        </>
+          <FairCollectionsFragmentContainer fair={fair} />
+        </Box>
       )}
 
-      {!!user && <FairFollowedArtistsFragmentContainer fair={fair} my={2} />}
-
-      <Spacer my={[4, 6]} />
+      {!!user && <FairFollowedArtistsFragmentContainer fair={fair} my={6} />}
     </Box>
   )
 }

--- a/src/v2/__generated__/FairAbout_fair.graphql.ts
+++ b/src/v2/__generated__/FairAbout_fair.graphql.ts
@@ -1,0 +1,135 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type FairAbout_fair = {
+    readonly endAt: string | null;
+    readonly about: string | null;
+    readonly tagline: string | null;
+    readonly location: {
+        readonly summary: string | null;
+    } | null;
+    readonly ticketsLink: string | null;
+    readonly hours: string | null;
+    readonly links: string | null;
+    readonly tickets: string | null;
+    readonly summary: string | null;
+    readonly contact: string | null;
+    readonly " $fragmentRefs": FragmentRefs<"FairTimer_fair">;
+    readonly " $refType": "FairAbout_fair";
+};
+export type FairAbout_fair$data = FairAbout_fair;
+export type FairAbout_fair$key = {
+    readonly " $data"?: FairAbout_fair$data;
+    readonly " $fragmentRefs": FragmentRefs<"FairAbout_fair">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "FairAbout_fair",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": (v0/*: any*/),
+      "kind": "ScalarField",
+      "name": "about",
+      "storageKey": "about(format:\"HTML\")"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "tagline",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Location",
+      "kind": "LinkedField",
+      "name": "location",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "summary",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "ticketsLink",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": (v0/*: any*/),
+      "kind": "ScalarField",
+      "name": "hours",
+      "storageKey": "hours(format:\"HTML\")"
+    },
+    {
+      "alias": null,
+      "args": (v0/*: any*/),
+      "kind": "ScalarField",
+      "name": "links",
+      "storageKey": "links(format:\"HTML\")"
+    },
+    {
+      "alias": null,
+      "args": (v0/*: any*/),
+      "kind": "ScalarField",
+      "name": "tickets",
+      "storageKey": "tickets(format:\"HTML\")"
+    },
+    {
+      "alias": null,
+      "args": (v0/*: any*/),
+      "kind": "ScalarField",
+      "name": "summary",
+      "storageKey": "summary(format:\"HTML\")"
+    },
+    {
+      "alias": null,
+      "args": (v0/*: any*/),
+      "kind": "ScalarField",
+      "name": "contact",
+      "storageKey": "contact(format:\"HTML\")"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "FairTimer_fair"
+    }
+  ],
+  "type": "Fair"
+};
+})();
+(node as any).hash = '58288f7223f1d4b678b49e925f7baea7';
+export default node;

--- a/src/v2/__generated__/FairOverview_Test_Query.graphql.ts
+++ b/src/v2/__generated__/FairOverview_Test_Query.graphql.ts
@@ -98,6 +98,23 @@ fragment Details_artwork on Artwork {
   }
 }
 
+fragment FairAbout_fair on Fair {
+  ...FairTimer_fair
+  endAt
+  about(format: HTML)
+  tagline
+  location {
+    summary
+    id
+  }
+  ticketsLink
+  hours(format: HTML)
+  links(format: HTML)
+  tickets(format: HTML)
+  summary(format: HTML)
+  contact(format: HTML)
+}
+
 fragment FairCollection_collection on MarketingCollection {
   id
   slug
@@ -181,16 +198,9 @@ fragment FairOverview_fair on Fair {
   ...FairEditorial_fair
   ...FairCollections_fair
   ...FairFollowedArtists_fair
-  ...FairTimer_fair
-  endAt
+  ...FairAbout_fair
   href
-  about(format: HTML)
   slug
-  tagline
-  location {
-    summary
-    id
-  }
   articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {
     totalCount
     edges {
@@ -200,12 +210,6 @@ fragment FairOverview_fair on Fair {
   marketingCollections(size: 5) {
     id
   }
-  ticketsLink
-  hours(format: HTML)
-  links(format: HTML)
-  tickets(format: HTML)
-  summary(format: HTML)
-  contact(format: HTML)
 }
 
 fragment FairTimer_fair on Fair {
@@ -897,7 +901,6 @@ return {
             "name": "endAt",
             "storageKey": null
           },
-          (v5/*: any*/),
           {
             "alias": null,
             "args": (v11/*: any*/),
@@ -973,6 +976,7 @@ return {
             "name": "contact",
             "storageKey": "contact(format:\"HTML\")"
           },
+          (v5/*: any*/),
           (v1/*: any*/)
         ],
         "storageKey": "fair(id:\"example\")"
@@ -984,7 +988,7 @@ return {
     "metadata": {},
     "name": "FairOverview_Test_Query",
     "operationKind": "query",
-    "text": "query FairOverview_Test_Query {\n  fair(id: \"example\") {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  artworks: artworksConnection(first: 3) {\n    counts {\n      total\n    }\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 5) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  internalID\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      artwork: node {\n        internalID\n        slug\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairEditorial_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  ...FairTimer_fair\n  endAt\n  href\n  about(format: HTML)\n  slug\n  tagline\n  location {\n    summary\n    id\n  }\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 5) {\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  summary(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairTimer_fair on Fair {\n  endAt\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query FairOverview_Test_Query {\n  fair(id: \"example\") {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairAbout_fair on Fair {\n  ...FairTimer_fair\n  endAt\n  about(format: HTML)\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  summary(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  artworks: artworksConnection(first: 3) {\n    counts {\n      total\n    }\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 5) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  internalID\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      artwork: node {\n        internalID\n        slug\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairEditorial_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  ...FairAbout_fair\n  href\n  slug\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 5) {\n    id\n  }\n}\n\nfragment FairTimer_fair on Fair {\n  endAt\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairOverview_fair.graphql.ts
+++ b/src/v2/__generated__/FairOverview_fair.graphql.ts
@@ -4,14 +4,8 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type FairOverview_fair = {
-    readonly endAt: string | null;
     readonly href: string | null;
-    readonly about: string | null;
     readonly slug: string;
-    readonly tagline: string | null;
-    readonly location: {
-        readonly summary: string | null;
-    } | null;
     readonly articlesConnection: {
         readonly totalCount: number | null;
         readonly edges: ReadonlyArray<{
@@ -21,13 +15,7 @@ export type FairOverview_fair = {
     readonly marketingCollections: ReadonlyArray<{
         readonly id: string;
     } | null>;
-    readonly ticketsLink: string | null;
-    readonly hours: string | null;
-    readonly links: string | null;
-    readonly tickets: string | null;
-    readonly summary: string | null;
-    readonly contact: string | null;
-    readonly " $fragmentRefs": FragmentRefs<"FairEditorial_fair" | "FairCollections_fair" | "FairFollowedArtists_fair" | "FairTimer_fair">;
+    readonly " $fragmentRefs": FragmentRefs<"FairEditorial_fair" | "FairCollections_fair" | "FairFollowedArtists_fair" | "FairAbout_fair">;
     readonly " $refType": "FairOverview_fair";
 };
 export type FairOverview_fair$data = FairOverview_fair;
@@ -38,15 +26,7 @@ export type FairOverview_fair$key = {
 
 
 
-const node: ReaderFragment = (function(){
-var v0 = [
-  {
-    "kind": "Literal",
-    "name": "format",
-    "value": "HTML"
-  }
-];
-return {
+const node: ReaderFragment = {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
@@ -56,53 +36,14 @@ return {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
-      "name": "endAt",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
       "name": "href",
       "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": (v0/*: any*/),
-      "kind": "ScalarField",
-      "name": "about",
-      "storageKey": "about(format:\"HTML\")"
     },
     {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
       "name": "slug",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "tagline",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "Location",
-      "kind": "LinkedField",
-      "name": "location",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "summary",
-          "storageKey": null
-        }
-      ],
       "storageKey": null
     },
     {
@@ -177,48 +118,6 @@ return {
       "storageKey": "marketingCollections(size:5)"
     },
     {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "ticketsLink",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": (v0/*: any*/),
-      "kind": "ScalarField",
-      "name": "hours",
-      "storageKey": "hours(format:\"HTML\")"
-    },
-    {
-      "alias": null,
-      "args": (v0/*: any*/),
-      "kind": "ScalarField",
-      "name": "links",
-      "storageKey": "links(format:\"HTML\")"
-    },
-    {
-      "alias": null,
-      "args": (v0/*: any*/),
-      "kind": "ScalarField",
-      "name": "tickets",
-      "storageKey": "tickets(format:\"HTML\")"
-    },
-    {
-      "alias": null,
-      "args": (v0/*: any*/),
-      "kind": "ScalarField",
-      "name": "summary",
-      "storageKey": "summary(format:\"HTML\")"
-    },
-    {
-      "alias": null,
-      "args": (v0/*: any*/),
-      "kind": "ScalarField",
-      "name": "contact",
-      "storageKey": "contact(format:\"HTML\")"
-    },
-    {
       "args": null,
       "kind": "FragmentSpread",
       "name": "FairEditorial_fair"
@@ -236,11 +135,10 @@ return {
     {
       "args": null,
       "kind": "FragmentSpread",
-      "name": "FairTimer_fair"
+      "name": "FairAbout_fair"
     }
   ],
   "type": "Fair"
 };
-})();
-(node as any).hash = '9c35ed40fd5b58e9a2c2471792a7757c';
+(node as any).hash = '112a3a3be891f13c1d83a1c981c9aece';
 export default node;

--- a/src/v2/__generated__/fairRoutes_FairOverviewQuery.graphql.ts
+++ b/src/v2/__generated__/fairRoutes_FairOverviewQuery.graphql.ts
@@ -102,6 +102,23 @@ fragment Details_artwork on Artwork {
   }
 }
 
+fragment FairAbout_fair on Fair {
+  ...FairTimer_fair
+  endAt
+  about(format: HTML)
+  tagline
+  location {
+    summary
+    id
+  }
+  ticketsLink
+  hours(format: HTML)
+  links(format: HTML)
+  tickets(format: HTML)
+  summary(format: HTML)
+  contact(format: HTML)
+}
+
 fragment FairCollection_collection on MarketingCollection {
   id
   slug
@@ -185,16 +202,9 @@ fragment FairOverview_fair on Fair {
   ...FairEditorial_fair
   ...FairCollections_fair
   ...FairFollowedArtists_fair
-  ...FairTimer_fair
-  endAt
+  ...FairAbout_fair
   href
-  about(format: HTML)
   slug
-  tagline
-  location {
-    summary
-    id
-  }
   articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {
     totalCount
     edges {
@@ -204,12 +214,6 @@ fragment FairOverview_fair on Fair {
   marketingCollections(size: 5) {
     id
   }
-  ticketsLink
-  hours(format: HTML)
-  links(format: HTML)
-  tickets(format: HTML)
-  summary(format: HTML)
-  contact(format: HTML)
 }
 
 fragment FairTimer_fair on Fair {
@@ -909,7 +913,6 @@ return {
             "name": "endAt",
             "storageKey": null
           },
-          (v6/*: any*/),
           {
             "alias": null,
             "args": (v12/*: any*/),
@@ -985,6 +988,7 @@ return {
             "name": "contact",
             "storageKey": "contact(format:\"HTML\")"
           },
+          (v6/*: any*/),
           (v2/*: any*/)
         ],
         "storageKey": null
@@ -996,7 +1000,7 @@ return {
     "metadata": {},
     "name": "fairRoutes_FairOverviewQuery",
     "operationKind": "query",
-    "text": "query fairRoutes_FairOverviewQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  artworks: artworksConnection(first: 3) {\n    counts {\n      total\n    }\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 5) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  internalID\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      artwork: node {\n        internalID\n        slug\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairEditorial_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  ...FairTimer_fair\n  endAt\n  href\n  about(format: HTML)\n  slug\n  tagline\n  location {\n    summary\n    id\n  }\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 5) {\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  summary(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairTimer_fair on Fair {\n  endAt\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
+    "text": "query fairRoutes_FairOverviewQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable: isInquireable\n  sale {\n    is_auction: isAuction\n    is_live_open: isLiveOpen\n    is_open: isOpen\n    is_closed: isClosed\n    id\n  }\n  partner(shallow: true) {\n    type\n    id\n  }\n  sale_artwork: saleArtwork {\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n}\n\nfragment FairAbout_fair on Fair {\n  ...FairTimer_fair\n  endAt\n  about(format: HTML)\n  tagline\n  location {\n    summary\n    id\n  }\n  ticketsLink\n  hours(format: HTML)\n  links(format: HTML)\n  tickets(format: HTML)\n  summary(format: HTML)\n  contact(format: HTML)\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  artworks: artworksConnection(first: 3) {\n    counts {\n      total\n    }\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 5) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairEditorial_fair on Fair {\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  internalID\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      artwork: node {\n        internalID\n        slug\n        ...FillwidthItem_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairEditorial_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  ...FairAbout_fair\n  href\n  slug\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 5) {\n    id\n  }\n}\n\nfragment FairTimer_fair on Fair {\n  endAt\n}\n\nfragment FillwidthItem_artwork on Artwork {\n  image {\n    url(version: \"larger\")\n    aspectRatio\n  }\n  imageTitle\n  title\n  href\n  is_saved: isSaved\n  ...Metadata_artwork\n  ...SaveButton_artwork\n  ...Badge_artwork\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  is_saved: isSaved\n  title\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Jira: [FX-3208](https://artsyproduct.atlassian.net/browse/FX-3208)

### Description
The purpose of the ticket is hide About header if no about content present (example below)
![image](https://user-images.githubusercontent.com/56556580/130458780-985dfd87-8a96-4fd1-b0c9-a0942cf78e62.png)


### Changes
- Added condition to render About info
- Move About content to separate component
- Refactor spaces between Overview tab sections (replace borders with `<Separator />`)


### Demo
_Desktop_
![image](https://user-images.githubusercontent.com/56556580/130459134-85422619-6c6f-455d-ac9d-d106429c54c8.png)


_Mobile_
![image](https://user-images.githubusercontent.com/56556580/130459207-89bd5637-c387-4916-bd26-ac46adcab6e4.png)

