### PR TITLE
fix: login spinner handles repeat error responses

### DIFF
--- a/src/v2/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/v2/Components/Authentication/Desktop/LoginForm.tsx
@@ -108,7 +108,7 @@ export class LoginForm extends Component<FormProps, LoginFormState> {
             if (globalError) {
               this.setState({ isLoading: false })
             }
-          }, [globalError])
+          }, [globalError, status])
 
           const handleChange = e => {
             setStatus(null)


### PR DESCRIPTION
This PR addresses a bug introduced in the [PR](https://github.com/artsy/force/pull/7800) that displayed the submit button spinner while the page redirect was being completed. 

Issue
The submit spinner would spin indefinitely if the same error response was received a second time (e.g., the user input the wrong username, password, or otp twice in a row). 

This was the result of the `isLoading` flag not being reset to `false` upon the second submission. This has been resolved by adding the formik `status` prop to the `useEffect` subscriptions. 

Before:
![before](https://user-images.githubusercontent.com/38149304/130472075-b1241e08-15a9-4545-9091-6a747aa56041.gif)

After:
![after](https://user-images.githubusercontent.com/38149304/130472084-c5565c89-26ae-4fc0-a65f-8ec970ff7237.gif)
