### PR TITLE
GRO-466: Seeing Spacing Issues with Auction Rails

### DIFF
--- a/src/v2/Apps/Auctions/Routes/CurrentAuctions.tsx
+++ b/src/v2/Apps/Auctions/Routes/CurrentAuctions.tsx
@@ -46,7 +46,16 @@ const CurrentAuctions: React.FC<CurrentAuctionsProps> = ({ viewer, relay }) => {
   if (nodes.length === 0) {
     return (
       <Box>
-        <Text>No current auctions.</Text>
+        <Text
+          as="h3"
+          color="black60"
+          mb={12}
+          mt={6}
+          textAlign="center"
+          variant="mediumText"
+        >
+          No current auctions.
+        </Text>
       </Box>
     )
   }

--- a/src/v2/Apps/Auctions/Routes/PastAuctions.tsx
+++ b/src/v2/Apps/Auctions/Routes/PastAuctions.tsx
@@ -46,7 +46,16 @@ const PastAuctions: React.FC<PastAuctionsProps> = ({ viewer, relay }) => {
   if (nodes.length === 0) {
     return (
       <Box>
-        <Text>No past auctions.</Text>
+        <Text
+          as="h3"
+          color="black60"
+          mb={12}
+          mt={6}
+          textAlign="center"
+          variant="mediumText"
+        >
+          No past auctions.
+        </Text>
       </Box>
     )
   }

--- a/src/v2/Apps/Auctions/Routes/UpcomingAuctions.tsx
+++ b/src/v2/Apps/Auctions/Routes/UpcomingAuctions.tsx
@@ -49,7 +49,16 @@ const UpcomingAuctions: React.FC<UpcomingAuctionsProps> = ({
   if (nodes.length === 0) {
     return (
       <Box>
-        <Text>No upcoming auctions.</Text>
+        <Text
+          as="h3"
+          color="black60"
+          mb={12}
+          mt={6}
+          textAlign="center"
+          variant="mediumText"
+        >
+          No upcoming auctions.
+        </Text>
       </Box>
     )
   }


### PR DESCRIPTION
[GRO-466]

This is to resolve the bug we are seeing that is causing spacing issues with the Current/Past/Upcoming Auction Rails.

Current Behavior:
<img width="1764" alt="Screen Shot 2021-08-23 at 9 56 15 AM" src="https://user-images.githubusercontent.com/30025439/130487150-94494ff0-10df-4c1b-a504-035db9af1a77.png">

New Behavior:
<img width="1750" alt="Screen Shot 2021-08-23 at 9 56 04 AM" src="https://user-images.githubusercontent.com/30025439/130487200-488c9a6e-356b-4155-983d-b4377892b183.png">
