### PR TITLE
feat(FX-3118): make fair tabs sticky

### DIFF
--- a/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
+++ b/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
@@ -23,7 +23,7 @@ export const ExhibitorsLetterNav: React.FC<ExhibitorsLetterNavProps> = ({
 
   const Letters = ({ withSwiper = false }) => {
     return (
-      <Flex justifyContent="space-between" pl={withSwiper ? 2 : 0}>
+      <Flex justifyContent="space-between" my={1} pl={withSwiper ? 2 : 0}>
         {LETTERS.map((letter, i) => {
           const isEnabled = letters?.includes(letter)
           const isLast = i === LETTERS.length - 1
@@ -38,8 +38,8 @@ export const ExhibitorsLetterNav: React.FC<ExhibitorsLetterNavProps> = ({
               onClick={() => {
                 if (isEnabled) {
                   const offset = isMobile
-                    ? MOBILE_NAV_HEIGHT
-                    : DESKTOP_NAV_BAR_HEIGHT + 30
+                    ? MOBILE_NAV_HEIGHT + 70
+                    : DESKTOP_NAV_BAR_HEIGHT + 120
                   scrollIntoView({
                     selector: `#jump--letter${letter}`,
                     offset,

--- a/src/v2/Apps/Fair/FairApp.tsx
+++ b/src/v2/Apps/Fair/FairApp.tsx
@@ -21,6 +21,7 @@ import { userIsAdmin } from "v2/Utils/user"
 import { FairHeaderImageFragmentContainer } from "./Components/FairHeader/FairHeaderImage"
 import { FairHeaderFragmentContainer } from "./Components/FairHeader"
 import { data as sd } from "sharify"
+import { Sticky, StickyProvider } from "v2/Components/Sticky"
 
 interface FairAppProps {
   fair: FairApp_fair
@@ -61,64 +62,66 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
   const enableFairPageExhibitorsTab = sd.ENABLE_FAIR_PAGE_EXHIBITORS_TAB
 
   return (
-    <>
+    <StickyProvider>
       <FairMetaFragmentContainer fair={fair} />
 
       <FairHeaderImageFragmentContainer fair={fair} />
 
       <FairHeaderFragmentContainer fair={fair} />
 
-      <RouteTabs my={[0, 2]} fill>
-        <RouteTab
-          to={fairHref}
-          exact
-          onClick={trackTabData(fairHref, "Overview", ContextModule.fairInfo)}
-        >
-          Overview
-        </RouteTab>
-
-        {enableFairPageExhibitorsTab && (
+      <Sticky>
+        <RouteTabs pt={2} fill>
           <RouteTab
-            to={`${fairHref}/exhibitors`}
+            to={fairHref}
+            exact
+            onClick={trackTabData(fairHref, "Overview", ContextModule.fairInfo)}
+          >
+            Overview
+          </RouteTab>
+
+          {enableFairPageExhibitorsTab && (
+            <RouteTab
+              to={`${fairHref}/exhibitors`}
+              exact
+              onClick={trackTabData(
+                `${fairHref}/exhibitors`,
+                "Exhibitors",
+                ContextModule.exhibitorsTab
+              )}
+            >
+              Exhibitors A-Z
+            </RouteTab>
+          )}
+
+          <RouteTab
+            to={`${fairHref}/booths`}
             exact
             onClick={trackTabData(
-              `${fairHref}/exhibitors`,
-              "Exhibitors",
-              ContextModule.exhibitorsTab
+              `${fairHref}/booths`,
+              "Booths",
+              "boothsTab" as ContextModule
             )}
           >
-            Exhibitors A-Z
+            Booths
           </RouteTab>
-        )}
 
-        <RouteTab
-          to={`${fairHref}/booths`}
-          exact
-          onClick={trackTabData(
-            `${fairHref}/booths`,
-            "Booths",
-            "boothsTab" as ContextModule
-          )}
-        >
-          Booths
-        </RouteTab>
-
-        <RouteTab
-          to={`${fairHref}/artworks`}
-          exact
-          onClick={trackTabData(
-            `${fairHref}/artworks`,
-            "Artworks",
-            ContextModule.artworksTab
-          )}
-        >
-          Artworks
-          <Text display="inline">&nbsp;({artworkCount})</Text>
-        </RouteTab>
-      </RouteTabs>
+          <RouteTab
+            to={`${fairHref}/artworks`}
+            exact
+            onClick={trackTabData(
+              `${fairHref}/artworks`,
+              "Artworks",
+              ContextModule.artworksTab
+            )}
+          >
+            Artworks
+            <Text display="inline">&nbsp;({artworkCount})</Text>
+          </RouteTab>
+        </RouteTabs>
+      </Sticky>
 
       {children}
-    </>
+    </StickyProvider>
   )
 }
 

--- a/src/v2/Apps/Fair/Routes/FairBooths.tsx
+++ b/src/v2/Apps/Fair/Routes/FairBooths.tsx
@@ -113,7 +113,7 @@ const FairBooths: React.FC<FairBoothsProps> = ({ fair, relay }) => {
       </Media>
 
       <Media greaterThan="xs">
-        <Flex justifyContent="flex-end">
+        <Flex my={4} justifyContent="flex-end">
           <FairBoothSortFilter />
         </Flex>
       </Media>

--- a/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
+++ b/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
@@ -6,6 +6,7 @@ import { FairExhibitorsGroupFragmentContainer as FairExhibitorsGroup } from "../
 import { FairExhibitorsGroupPlaceholder } from "../Components/FairExhibitors/FairExhibitorGroupPlaceholder"
 import { useLazyLoadComponent } from "v2/Utils/Hooks/useLazyLoadComponent"
 import { ExhibitorsLetterNavFragmentContainer as ExhibitorsLetterNav } from "../Components/ExhibitorsLetterNav"
+import { Sticky } from "v2/Components/Sticky"
 
 interface FairExhibitorsProps {
   fair: FairExhibitors_fair
@@ -18,9 +19,11 @@ const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair }) => {
     <>
       <Waypoint />
 
-      <Spacer mt={6} />
+      <Spacer mt={4} />
 
-      <ExhibitorsLetterNav fair={fair} />
+      <Sticky mx={[0, 4]}>
+        <ExhibitorsLetterNav fair={fair} />
+      </Sticky>
 
       {fair.exhibitorsGroupedByName?.map(exhibitorsGroup => {
         const { letter } = exhibitorsGroup!

--- a/src/v2/Components/Sticky/Sticky.tsx
+++ b/src/v2/Components/Sticky/Sticky.tsx
@@ -1,10 +1,10 @@
 import styled from "styled-components"
-import { Box } from "@artsy/palette"
+import { Box, BoxProps } from "@artsy/palette"
 import React, { useEffect, useRef, useState } from "react"
 import { useSticky } from "./StickyProvider"
 import { useNavBarHeight } from "../NavBar/useNavBarHeight"
 
-export const Sticky: React.FC = ({ children }) => {
+export const Sticky: React.FC<BoxProps> = ({ children, ...rest }) => {
   const sentinelRef = useRef<HTMLDivElement | null>(null)
   const containerRef = useRef<HTMLDivElement | null>(null)
 
@@ -56,6 +56,7 @@ export const Sticky: React.FC = ({ children }) => {
       />
 
       <Container
+        {...(stuck ? rest : {})}
         ref={containerRef as any}
         bg="white100"
         position={stuck ? "fixed" : "static"}


### PR DESCRIPTION
Jira: [FX-3118](https://artsyproduct.atlassian.net/browse/FX-3118)

### Description
The purpose of the ticket is make fair tabs and A-Z exhibitors navigation sticky.

### Changes
- Added Sticky component where necessary
- Added Box props for <Sticky /> to custom sticky component
- mini refactor: added spacing to Booths tab (sort was very close to tabs)

### Demo
_Desktop_

https://user-images.githubusercontent.com/56556580/130620242-c907a5c6-a76e-4ff8-903e-2515f83f4c5d.mov



_Mobile_

https://user-images.githubusercontent.com/56556580/130620430-5171f949-9c2a-41f8-b6d4-9054afc28ec9.mov

