### PR TITLE
feat(inquiry): implements commercial interest step

### DIFF
--- a/src/v2/Components/Inquiry/__tests__/views/InquiryCommercialInterest.jest.tsx
+++ b/src/v2/Components/Inquiry/__tests__/views/InquiryCommercialInterest.jest.tsx
@@ -1,0 +1,64 @@
+import React from "react"
+import { mount } from "enzyme"
+import { InquiryCommercialInterest } from "../../views/InquiryCommercialInterest"
+import { useUpdateMyUserProfile } from "../../useUpdateMyUserProfile"
+import { useInquiryContext } from "../../InquiryContext"
+import { flushPromiseQueue } from "v2/DevTools"
+
+jest.mock("../../useUpdateMyUserProfile")
+jest.mock("../../InquiryContext")
+
+describe("InquiryCommercialInterest", () => {
+  const mockSubmitUpdateMyUserProfile = jest
+    .fn()
+    .mockReturnValue(Promise.resolve())
+
+  const mockNext = jest.fn()
+
+  beforeEach(() => {
+    ;(useUpdateMyUserProfile as jest.Mock).mockImplementation(() => ({
+      submitUpdateMyUserProfile: mockSubmitUpdateMyUserProfile,
+    }))
+    ;(useInquiryContext as jest.Mock).mockImplementation(() => ({
+      next: mockNext,
+    }))
+  })
+
+  afterEach(() => {
+    mockSubmitUpdateMyUserProfile.mockReset()
+    mockNext.mockReset()
+  })
+
+  it("renders correctly", () => {
+    const wrapper = mount(<InquiryCommercialInterest />)
+
+    expect(wrapper.html()).toContain(
+      "Have you bought art from a gallery or auction house before?"
+    )
+    expect(wrapper.find("button")).toHaveLength(2)
+  })
+
+  it("updates the collector profile when clicked", () => {
+    const wrapper = mount(<InquiryCommercialInterest />)
+
+    expect(mockSubmitUpdateMyUserProfile).not.toBeCalled()
+
+    wrapper.find("button").first().simulate("click")
+
+    expect(mockSubmitUpdateMyUserProfile).toBeCalledWith({ collectorLevel: 3 })
+  })
+
+  it("moves to the next step when any option is clicked", async () => {
+    const wrapper = mount(<InquiryCommercialInterest />)
+
+    expect(mockSubmitUpdateMyUserProfile).not.toBeCalled()
+    expect(mockNext).not.toBeCalled()
+
+    wrapper.find("button").last().simulate("click")
+
+    await flushPromiseQueue()
+
+    expect(mockSubmitUpdateMyUserProfile).toBeCalledWith({ collectorLevel: 2 })
+    expect(mockNext).toBeCalled()
+  })
+})

--- a/src/v2/Components/Inquiry/useUpdateMyUserProfile.tsx
+++ b/src/v2/Components/Inquiry/useUpdateMyUserProfile.tsx
@@ -1,0 +1,38 @@
+import { commitMutation, graphql } from "relay-runtime"
+import { useSystemContext } from "v2/System"
+import {
+  useUpdateMyUserProfileMutation,
+  UpdateMyProfileInput,
+} from "v2/__generated__/useUpdateMyUserProfileMutation.graphql"
+
+export const useUpdateMyUserProfile = () => {
+  const { relayEnvironment } = useSystemContext()
+
+  const submitUpdateMyUserProfile = (input: UpdateMyProfileInput = {}) => {
+    return new Promise((resolve, reject) => {
+      commitMutation<useUpdateMyUserProfileMutation>(relayEnvironment!, {
+        onError: reject,
+        onCompleted: (res, errors) => {
+          if (errors !== null) {
+            reject(errors)
+            return
+          }
+
+          resolve(res)
+        },
+        mutation: graphql`
+          mutation useUpdateMyUserProfileMutation(
+            $input: UpdateMyProfileInput!
+          ) {
+            updateMyUserProfile(input: $input) {
+              clientMutationId
+            }
+          }
+        `,
+        variables: { input },
+      })
+    })
+  }
+
+  return { submitUpdateMyUserProfile }
+}

--- a/src/v2/Components/Inquiry/views/InquiryCommercialInterest.tsx
+++ b/src/v2/Components/Inquiry/views/InquiryCommercialInterest.tsx
@@ -1,18 +1,68 @@
-import { Button, Text } from "@artsy/palette"
+import { Banner, Button, Text } from "@artsy/palette"
 import React from "react"
+import { useState } from "react"
 import { useInquiryContext } from "../InquiryContext"
+import { useUpdateMyUserProfile } from "../useUpdateMyUserProfile"
+
+enum Mode {
+  Pending,
+  Loading3,
+  Loading2,
+  Success,
+  Error,
+}
 
 export const InquiryCommercialInterest: React.FC = () => {
   const { next } = useInquiryContext()
 
+  const [mode, setMode] = useState(Mode.Pending)
+
+  const { submitUpdateMyUserProfile } = useUpdateMyUserProfile()
+
+  const handleClick = (value: 2 | 3) => async () => {
+    setMode({ 2: Mode.Loading2, 3: Mode.Loading3 }[value])
+
+    try {
+      await submitUpdateMyUserProfile({ collectorLevel: value })
+      setMode(Mode.Success)
+      next()
+    } catch (err) {
+      console.error(err)
+      setMode(Mode.Error)
+    }
+  }
+
   return (
     <>
-      <Text variant="sm" mb={1}>
-        CommercialInterest
+      <Text variant="lg" mb={2}>
+        Have you bought art from a gallery or auction house before?
       </Text>
 
-      <Button width="100%" onClick={next}>
-        Next
+      {mode === Mode.Error && (
+        <Banner variant="error" dismissable my={2}>
+          Something went wrong. Please try again.
+        </Banner>
+      )}
+
+      <Button
+        variant="secondaryOutline"
+        width="100%"
+        onClick={handleClick(3)}
+        loading={mode === Mode.Loading3}
+        disabled={mode === Mode.Success || mode === Mode.Loading2}
+        mb={1}
+      >
+        Yes
+      </Button>
+
+      <Button
+        variant="secondaryOutline"
+        width="100%"
+        onClick={handleClick(2)}
+        loading={mode === Mode.Loading2}
+        disabled={mode === Mode.Success || mode === Mode.Loading3}
+      >
+        Not yet
       </Button>
     </>
   )

--- a/src/v2/__generated__/useUpdateMyUserProfileMutation.graphql.ts
+++ b/src/v2/__generated__/useUpdateMyUserProfileMutation.graphql.ts
@@ -1,0 +1,121 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type UpdateMyProfileInput = {
+    clientMutationId?: string | null;
+    collectorLevel?: number | null;
+    completedOnboarding?: boolean | null;
+    email?: string | null;
+    emailFrequency?: string | null;
+    location?: EditableLocation | null;
+    name?: string | null;
+    password?: string | null;
+    phone?: string | null;
+    priceRangeMax?: number | null;
+    priceRangeMin?: number | null;
+    receiveLotOpeningSoonNotification?: boolean | null;
+    receiveNewSalesNotification?: boolean | null;
+    receiveNewWorksNotification?: boolean | null;
+    receiveOutbidNotification?: boolean | null;
+    receivePromotionNotification?: boolean | null;
+    receivePurchaseNotification?: boolean | null;
+    receiveSaleOpeningClosingNotification?: boolean | null;
+};
+export type EditableLocation = {
+    address?: string | null;
+    address2?: string | null;
+    city?: string | null;
+    country?: string | null;
+    postalCode?: string | null;
+    state?: string | null;
+    stateCode?: string | null;
+    summary?: string | null;
+};
+export type useUpdateMyUserProfileMutationVariables = {
+    input: UpdateMyProfileInput;
+};
+export type useUpdateMyUserProfileMutationResponse = {
+    readonly updateMyUserProfile: {
+        readonly clientMutationId: string | null;
+    } | null;
+};
+export type useUpdateMyUserProfileMutation = {
+    readonly response: useUpdateMyUserProfileMutationResponse;
+    readonly variables: useUpdateMyUserProfileMutationVariables;
+};
+
+
+
+/*
+mutation useUpdateMyUserProfileMutation(
+  $input: UpdateMyProfileInput!
+) {
+  updateMyUserProfile(input: $input) {
+    clientMutationId
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input",
+    "type": "UpdateMyProfileInput!"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpdateMyProfilePayload",
+    "kind": "LinkedField",
+    "name": "updateMyUserProfile",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "clientMutationId",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useUpdateMyUserProfileMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "useUpdateMyUserProfileMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "id": null,
+    "metadata": {},
+    "name": "useUpdateMyUserProfileMutation",
+    "operationKind": "mutation",
+    "text": "mutation useUpdateMyUserProfileMutation(\n  $input: UpdateMyProfileInput!\n) {\n  updateMyUserProfile(input: $input) {\n    clientMutationId\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '69ea3f3647ec583546e80aa54ebcdbe4';
+export default node;


### PR DESCRIPTION
Alright first step is an easy one. Thankfully the MP mutation supports `collectorLevel`, though I'm going to have to update it for the others.

https://user-images.githubusercontent.com/112297/130658630-5fabbb50-72fb-4526-bd9d-a82345470d54.mov

I'll PR `BasicInfo` next. (which is the next screen you see in that recording)