### PR TITLE
Revert "feat(FX-3118): make fair tabs sticky"

### DIFF
--- a/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
+++ b/src/v2/Apps/Fair/Components/ExhibitorsLetterNav.tsx
@@ -23,7 +23,7 @@ export const ExhibitorsLetterNav: React.FC<ExhibitorsLetterNavProps> = ({
 
   const Letters = ({ withSwiper = false }) => {
     return (
-      <Flex justifyContent="space-between" my={1} pl={withSwiper ? 2 : 0}>
+      <Flex justifyContent="space-between" pl={withSwiper ? 2 : 0}>
         {LETTERS.map((letter, i) => {
           const isEnabled = letters?.includes(letter)
           const isLast = i === LETTERS.length - 1
@@ -38,8 +38,8 @@ export const ExhibitorsLetterNav: React.FC<ExhibitorsLetterNavProps> = ({
               onClick={() => {
                 if (isEnabled) {
                   const offset = isMobile
-                    ? MOBILE_NAV_HEIGHT + 70
-                    : DESKTOP_NAV_BAR_HEIGHT + 120
+                    ? MOBILE_NAV_HEIGHT
+                    : DESKTOP_NAV_BAR_HEIGHT + 30
                   scrollIntoView({
                     selector: `#jump--letter${letter}`,
                     offset,

--- a/src/v2/Apps/Fair/FairApp.tsx
+++ b/src/v2/Apps/Fair/FairApp.tsx
@@ -21,7 +21,6 @@ import { userIsAdmin } from "v2/Utils/user"
 import { FairHeaderImageFragmentContainer } from "./Components/FairHeader/FairHeaderImage"
 import { FairHeaderFragmentContainer } from "./Components/FairHeader"
 import { data as sd } from "sharify"
-import { Sticky, StickyProvider } from "v2/Components/Sticky"
 
 interface FairAppProps {
   fair: FairApp_fair
@@ -62,66 +61,64 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
   const enableFairPageExhibitorsTab = sd.ENABLE_FAIR_PAGE_EXHIBITORS_TAB
 
   return (
-    <StickyProvider>
+    <>
       <FairMetaFragmentContainer fair={fair} />
 
       <FairHeaderImageFragmentContainer fair={fair} />
 
       <FairHeaderFragmentContainer fair={fair} />
 
-      <Sticky>
-        <RouteTabs pt={2} fill>
-          <RouteTab
-            to={fairHref}
-            exact
-            onClick={trackTabData(fairHref, "Overview", ContextModule.fairInfo)}
-          >
-            Overview
-          </RouteTab>
+      <RouteTabs my={[0, 2]} fill>
+        <RouteTab
+          to={fairHref}
+          exact
+          onClick={trackTabData(fairHref, "Overview", ContextModule.fairInfo)}
+        >
+          Overview
+        </RouteTab>
 
-          {enableFairPageExhibitorsTab && (
-            <RouteTab
-              to={`${fairHref}/exhibitors`}
-              exact
-              onClick={trackTabData(
-                `${fairHref}/exhibitors`,
-                "Exhibitors",
-                ContextModule.exhibitorsTab
-              )}
-            >
-              Exhibitors A-Z
-            </RouteTab>
+        {enableFairPageExhibitorsTab && (
+          <RouteTab
+            to={`${fairHref}/exhibitors`}
+            exact
+            onClick={trackTabData(
+              `${fairHref}/exhibitors`,
+              "Exhibitors",
+              ContextModule.exhibitorsTab
+            )}
+          >
+            Exhibitors A-Z
+          </RouteTab>
+        )}
+
+        <RouteTab
+          to={`${fairHref}/booths`}
+          exact
+          onClick={trackTabData(
+            `${fairHref}/booths`,
+            "Booths",
+            "boothsTab" as ContextModule
           )}
+        >
+          Booths
+        </RouteTab>
 
-          <RouteTab
-            to={`${fairHref}/booths`}
-            exact
-            onClick={trackTabData(
-              `${fairHref}/booths`,
-              "Booths",
-              "boothsTab" as ContextModule
-            )}
-          >
-            Booths
-          </RouteTab>
-
-          <RouteTab
-            to={`${fairHref}/artworks`}
-            exact
-            onClick={trackTabData(
-              `${fairHref}/artworks`,
-              "Artworks",
-              ContextModule.artworksTab
-            )}
-          >
-            Artworks
-            <Text display="inline">&nbsp;({artworkCount})</Text>
-          </RouteTab>
-        </RouteTabs>
-      </Sticky>
+        <RouteTab
+          to={`${fairHref}/artworks`}
+          exact
+          onClick={trackTabData(
+            `${fairHref}/artworks`,
+            "Artworks",
+            ContextModule.artworksTab
+          )}
+        >
+          Artworks
+          <Text display="inline">&nbsp;({artworkCount})</Text>
+        </RouteTab>
+      </RouteTabs>
 
       {children}
-    </StickyProvider>
+    </>
   )
 }
 

--- a/src/v2/Apps/Fair/Routes/FairBooths.tsx
+++ b/src/v2/Apps/Fair/Routes/FairBooths.tsx
@@ -113,7 +113,7 @@ const FairBooths: React.FC<FairBoothsProps> = ({ fair, relay }) => {
       </Media>
 
       <Media greaterThan="xs">
-        <Flex my={4} justifyContent="flex-end">
+        <Flex justifyContent="flex-end">
           <FairBoothSortFilter />
         </Flex>
       </Media>

--- a/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
+++ b/src/v2/Apps/Fair/Routes/FairExhibitors.tsx
@@ -6,7 +6,6 @@ import { FairExhibitorsGroupFragmentContainer as FairExhibitorsGroup } from "../
 import { FairExhibitorsGroupPlaceholder } from "../Components/FairExhibitors/FairExhibitorGroupPlaceholder"
 import { useLazyLoadComponent } from "v2/Utils/Hooks/useLazyLoadComponent"
 import { ExhibitorsLetterNavFragmentContainer as ExhibitorsLetterNav } from "../Components/ExhibitorsLetterNav"
-import { Sticky } from "v2/Components/Sticky"
 
 interface FairExhibitorsProps {
   fair: FairExhibitors_fair
@@ -19,11 +18,9 @@ const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair }) => {
     <>
       <Waypoint />
 
-      <Spacer mt={4} />
+      <Spacer mt={6} />
 
-      <Sticky mx={[0, 4]}>
-        <ExhibitorsLetterNav fair={fair} />
-      </Sticky>
+      <ExhibitorsLetterNav fair={fair} />
 
       {fair.exhibitorsGroupedByName?.map(exhibitorsGroup => {
         const { letter } = exhibitorsGroup!

--- a/src/v2/Components/Sticky/Sticky.tsx
+++ b/src/v2/Components/Sticky/Sticky.tsx
@@ -1,10 +1,10 @@
 import styled from "styled-components"
-import { Box, BoxProps } from "@artsy/palette"
+import { Box } from "@artsy/palette"
 import React, { useEffect, useRef, useState } from "react"
 import { useSticky } from "./StickyProvider"
 import { useNavBarHeight } from "../NavBar/useNavBarHeight"
 
-export const Sticky: React.FC<BoxProps> = ({ children, ...rest }) => {
+export const Sticky: React.FC = ({ children }) => {
   const sentinelRef = useRef<HTMLDivElement | null>(null)
   const containerRef = useRef<HTMLDivElement | null>(null)
 
@@ -56,7 +56,6 @@ export const Sticky: React.FC<BoxProps> = ({ children, ...rest }) => {
       />
 
       <Container
-        {...(stuck ? rest : {})}
         ref={containerRef as any}
         bg="white100"
         position={stuck ? "fixed" : "static"}


### PR DESCRIPTION
Reverts artsy/force#8258

Have to revert unfortunately due to some QA feedback from Jonathan & @thomasmeerschwam:

> The tabs should maintain the 12col structure, though there should be a drop-shadow that spans 100%
>
> https://www.figma.com/file/aM3b5sodn04vMTigbQXACi/Fairs-2021?node-id=3904%3A12987

Hoping to get this back out soon!

cc/ @tr-ann 