### PR TITLE
hokusai: Readd git deploy tags

### DIFF
--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -1,5 +1,6 @@
 project-name: force
 pre-deploy: yarn publish-assets
 hokusai-required-version: ">=0.5.8"
+git-remote: git@github.com:artsy/force.git
 template-config-files:
   - s3://artsy-citadel/k8s/hokusai-vars.yml


### PR DESCRIPTION
This re-adds git deploy tags that were removed in https://github.com/artsy/force/pull/3988. (Git tags are common across hokusai repos.)