### PR TITLE
Install yarn conditionally

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -12,12 +12,8 @@ if [[ ! -z $NVM_DIR ]]; then # skip if nvm is not available
   nvm install
 fi
 
-# Install yarn if it does not exist, otherwise ensure its up-to-date.
-echo "Installing yarn"
-npm install --global yarn@latest
-
 echo "Installing dependencies..."
-yarn install
+yarn install || (npm install --global yarn@latest && yarn install)
 
 # For more info on shared configuration see:
 # https://github.com/artsy/force/blob/master/docs/env_configuration.md


### PR DESCRIPTION
I updated the general setup script to install yarn because I think it's
easier to do as much of that generalized setup as possible in the same
place.

The change here includes a fall-back to install yarn if it hasn't
already been installed specifically for individuals who might come to
this repository without following the generalized setup script in
potential, i.e. external contributors.

Secondarily, I don't think we should force anyone who runs this script
to update to the latest version of yarn if the version they have will
function.

Depends on: https://github.com/artsy/potential/pull/411 (kinda)