### PR TITLE
feat(FX-3229): add hover state for links

### DIFF
--- a/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeader/FairOrganizerInfo.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeader/FairOrganizerInfo.tsx
@@ -3,6 +3,8 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { Join, Spacer } from "@artsy/palette"
 import { InfoSection } from "v2/Components/InfoSection"
 import { FairOrganizerInfo_fairOrganizer } from "v2/__generated__/FairOrganizerInfo_fairOrganizer.graphql"
+import styled from "styled-components"
+import { themeGet } from "@styled-system/theme-get"
 
 interface FairOrganizerInfoProps {
   fairOrganizer: FairOrganizerInfo_fairOrganizer
@@ -14,10 +16,21 @@ export const FairOrganizerInfo: React.FC<FairOrganizerInfoProps> = ({
   const { about } = fairOrganizer
   return (
     <Join separator={<Spacer mt={2} />}>
-      {about && <InfoSection type="html" label="About" info={about} />}
+      {about && (
+        <InfoSectionContainer>
+          <InfoSection type="html" label="About" info={about} />
+        </InfoSectionContainer>
+      )}
     </Join>
   )
 }
+
+const InfoSectionContainer = styled.div`
+  a:hover:not(:disabled) {
+    text-decoration: underline;
+    color: ${themeGet("colors.blue100")};
+  }
+`
 
 export const FairOrganizerInfoFragmentContainer = createFragmentContainer(
   FairOrganizerInfo,


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [FX-3229]

### Description
As a user
When I hover the mouse cursor over the link in about section
It should get the hover state (`blue100` color)

### Demo
https://user-images.githubusercontent.com/3513494/131135932-a7b96e97-2cba-43c8-ade1-2903cd42f874.mp4


[FX-3229]: https://artsyproduct.atlassian.net/browse/FX-3229