### PR TITLE
fix: set width for past event text

### DIFF
--- a/src/v2/Apps/FairOrginizer/Components/FairOrganizerPastEventRailCell.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/FairOrganizerPastEventRailCell.tsx
@@ -25,7 +25,7 @@ export const FairOrganizerPastEventRailCell: React.FC<FairOrganizerPastEventRail
       ) : (
         <Box width={325} height={244} bg="black10" />
       )}
-      <Text variant="xl" mt={1}>
+      <Text variant="xl" width={325} mt={1}>
         {fair.name}
       </Text>
     </RouterLink>


### PR DESCRIPTION
The type of this PR is: **Fix**

### Before
<img width="1045" alt="Screenshot 2021-08-27 at 16 59 31" src="https://user-images.githubusercontent.com/3513494/131139103-e91a1a8d-2fb1-4cdb-bc39-534c96de3a8e.png">


### After
<img width="1218" alt="Screenshot 2021-08-27 at 16 58 34" src="https://user-images.githubusercontent.com/3513494/131138973-f67873c8-1a00-4ee7-8792-a73f20d5923e.png">