### PR TITLE
feat(viewing room): redirect viewing room route /works to /artworks

### DIFF
--- a/src/v2/Apps/ViewingRoom/Components/ViewingRoomTabBar.tsx
+++ b/src/v2/Apps/ViewingRoom/Components/ViewingRoomTabBar.tsx
@@ -60,7 +60,7 @@ export const ViewingRoomTabBar: React.FC<FlexProps> = props => {
     >
       <Flex width={["100%", 720]}>
         <Tab to={`/viewing-room/${slug}`}>Statement</Tab>
-        <Tab to={`/viewing-room/${slug}/works`}>Works</Tab>
+        <Tab to={`/viewing-room/${slug}/artworks`}>Works</Tab>
       </Flex>
     </Flex>
   )

--- a/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
+++ b/src/v2/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
@@ -223,7 +223,7 @@ describe("ViewingRoomApp", () => {
         expect(wrapper.find("Tab").length).toBe(2)
         const html = wrapper.html()
         expect(html).toContain(`href="/viewing-room/${slug}"`)
-        expect(html).toContain(`href="/viewing-room/${slug}/works"`)
+        expect(html).toContain(`href="/viewing-room/${slug}/artworks"`)
       })
     })
   })

--- a/src/v2/Apps/ViewingRoom/viewingRoomRoutes.tsx
+++ b/src/v2/Apps/ViewingRoom/viewingRoomRoutes.tsx
@@ -1,4 +1,5 @@
 import loadable from "@loadable/component"
+import { RedirectException } from "found"
 import { graphql } from "react-relay"
 import { AppRouteConfig } from "v2/System/Router/Route"
 
@@ -92,6 +93,12 @@ export const viewingRoomRoutes: AppRouteConfig[] = [
       },
       {
         path: "works",
+        render: () => {
+          throw new RedirectException("artworks", 301)
+        },
+      },
+      {
+        path: "artworks",
         Component: WorksRoute,
         ignoreScrollBehavior: true,
         query: graphql`


### PR DESCRIPTION
[FX-3200]

The URL structures of viewing room works tab were not consistent on Eigen and Force:

This worked in Force but not Eigen: https://www.artsy.net/viewing-room/pearl-lam-galleries-mr-doodle-the-pop-heart-collection/works

And this worked in Eigen but not Force: https://www.artsy.net/viewing-room/pearl-lam-galleries-mr-doodle-the-pop-heart-collection/artworks

This PR changes url structure for viewing room works tab in Force(`:id/works` → `:id/artworks`)  so that this page will be accessible everywhere via the same url

Demo

![artworks](https://user-images.githubusercontent.com/44819355/131157862-83e39c8c-b26d-479f-87b0-d331866a2dde.gif)

Redirect

![redirect](https://user-images.githubusercontent.com/44819355/131159234-02b7c8ec-4ee8-4435-83cc-c53e3f40abbe.gif)


