### PR TITLE
router: Move cacheable routes file and cleanup naming

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -72,9 +72,9 @@ import { handleArtworkImageDownload } from "lib/middleware/artworkMiddleware"
 import { searchMiddleware } from "lib/middleware/searchMiddleware"
 import { splitTestMiddleware } from "desktop/components/split_test/splitTestMiddleware"
 import { IGNORED_ERRORS } from "lib/analytics/sentryFilters"
+import { getCacheableRoutes } from "v2/System/Router/getCacheableRoutes"
 
 // Find the v2 routes, we will not be testing memory caching for legacy pages.
-import { getRouteList } from "v2/routes"
 
 const CurrentUser = require("./lib/current_user.coffee")
 
@@ -270,11 +270,11 @@ function applyStaticAssetMiddlewares(app) {
 function applyCacheMiddleware(app) {
   // For full page cache testing, find all the modern routes and enable pages we
   // would like to test.
-  let cachableModernRoutes: string[] = getRouteList()
+  let cachableRoutes: string[] = getCacheableRoutes()
 
   if (MEMORY_PAGE_URL_FILTER && MEMORY_PAGE_URL_FILTER.split(",").length > 0) {
     const cacheFilters = MEMORY_PAGE_URL_FILTER.split(",")
-    cachableModernRoutes = cachableModernRoutes.filter(route => {
+    cachableRoutes = cachableRoutes.filter(route => {
       for (const cacheFilter of cacheFilters) {
         if (route.startsWith(cacheFilter)) {
           return true
@@ -285,5 +285,5 @@ function applyCacheMiddleware(app) {
   }
 
   app.use(pageCacheMiddleware)
-  app.use(cachableModernRoutes, memoryPageCacheMiddleware)
+  app.use(cachableRoutes, memoryPageCacheMiddleware)
 }

--- a/src/v2/System/Router/getCacheableRoutes.ts
+++ b/src/v2/System/Router/getCacheableRoutes.ts
@@ -1,0 +1,20 @@
+import { getAppRoutes } from "v2/routes"
+
+export function getCacheableRoutes(): string[] {
+  let flatRoutes: string[] = []
+  const appRoutes = getAppRoutes()[0]
+  if (appRoutes) {
+    appRoutes.children?.forEach(route => {
+      const childRoutes =
+        route.children
+          ?.map(child => child.path)
+          .filter(route => route !== "/" && route !== "*")
+          .map(childPath => route.path + "/" + childPath) || []
+      flatRoutes = flatRoutes.concat(childRoutes).concat(route.path || [])
+    })
+  } else {
+    flatRoutes = []
+  }
+
+  return flatRoutes
+}

--- a/src/v2/routes.tsx
+++ b/src/v2/routes.tsx
@@ -67,22 +67,3 @@ export function getAppRoutes(): AppRouteConfig[] {
     { routes: debugRoutes },
   ])
 }
-
-export function getRouteList(): string[] {
-  let flatRoutes: string[] = []
-  const appRoutes = getAppRoutes()[0]
-  if (appRoutes) {
-    appRoutes.children?.forEach(route => {
-      const childRoutes =
-        route.children
-          ?.map(child => child.path)
-          .filter(route => route !== "/" && route !== "*")
-          .map(childPath => route.path + "/" + childPath) || []
-      flatRoutes = flatRoutes.concat(childRoutes).concat(route.path || [])
-    })
-  } else {
-    flatRoutes = []
-  }
-
-  return flatRoutes
-}

--- a/src/v2/server.ts
+++ b/src/v2/server.ts
@@ -2,12 +2,13 @@ import sharify from "sharify"
 import type { NextFunction } from "express"
 import type { ArtsyRequest, ArtsyResponse } from "lib/middleware/artsyExpress"
 import { buildServerApp } from "v2/System/Router/server"
-import { getAppRoutes, getRouteList } from "v2/routes"
+import { getAppRoutes } from "v2/routes"
 import ReactDOM from "react-dom/server"
 import loadAssetManifest from "lib/manifest"
 import express from "express"
 import path from "path"
 import { getServerParam } from "./Utils/getServerParam"
+import { getCacheableRoutes } from "./System/Router/getCacheableRoutes"
 
 // TODO: Use the same variables as the asset middleware. Both config and sharify
 // have a default CDN_URL while this does not.
@@ -22,13 +23,13 @@ if (!NOVO_MANIFEST) {
 
 const app = express()
 const routes = getAppRoutes()
-const routeList = getRouteList()
+const cacheableRoutes = getCacheableRoutes()
 
 /**
  * Mount routes that will connect to global SSR router
  */
 app.get(
-  routeList,
+  cacheableRoutes,
   async (req: ArtsyRequest, res: ArtsyResponse, next: NextFunction) => {
     try {
       const {


### PR DESCRIPTION
Noticed implementation details started leaking into our routes file. Moved that to somewhere more appropriate and then made the naming consistent across all call sites, so that its clear there's a difference between routes and those that map to our new full-page cache implementation.  