### PR TITLE
fix: Make app route scroll behavior consistent

### DIFF
--- a/src/v2/Apps/Artist/artistRoutes.tsx
+++ b/src/v2/Apps/Artist/artistRoutes.tsx
@@ -86,6 +86,7 @@ export const artistRoutes: AppRouteConfig[] = [
   {
     path: "/artist/:artistID",
     theme: "v3",
+    ignoreScrollBehaviorBetweenChildren: true,
     getComponent: () => ArtistApp,
     prepare: () => {
       ArtistApp.preload()
@@ -120,7 +121,6 @@ export const artistRoutes: AppRouteConfig[] = [
       {
         path: "works-for-sale",
         theme: "v3",
-        ignoreScrollBehavior: true,
         getComponent: () => WorksForSaleRoute,
         prepare: () => {
           WorksForSaleRoute.preload()
@@ -142,7 +142,6 @@ export const artistRoutes: AppRouteConfig[] = [
       {
         path: "auction-results",
         theme: "v3",
-        ignoreScrollBehavior: false,
         getComponent: () => AuctionResultsRoute,
         prepare: () => {
           AuctionResultsRoute.preload()

--- a/src/v2/Apps/Auctions/auctionsRoutes.tsx
+++ b/src/v2/Apps/Auctions/auctionsRoutes.tsx
@@ -52,6 +52,7 @@ export const auctionsRoutes: AppRouteConfig[] = [
   {
     path: "/auctions",
     theme: "v3",
+    ignoreScrollBehaviorBetweenChildren: true,
     getComponent: () => AuctionsApp,
     prepare: () => {
       AuctionsApp.preload()
@@ -69,7 +70,6 @@ export const auctionsRoutes: AppRouteConfig[] = [
         path: "", // represents current auctions aka /auctions/current
         theme: "v3",
         Component: CurrentAuctionsPaginationContainer,
-        ignoreScrollBehavior: true,
         query: graphql`
           query auctionsRoutes_Current_AuctionsQuery {
             viewer {
@@ -82,7 +82,6 @@ export const auctionsRoutes: AppRouteConfig[] = [
         path: "upcoming",
         theme: "v3",
         Component: UpcomingAuctionsPaginationContainer,
-        ignoreScrollBehavior: true,
         query: graphql`
           query auctionsRoutes_Upcoming_AuctionsQuery {
             viewer {
@@ -95,7 +94,6 @@ export const auctionsRoutes: AppRouteConfig[] = [
         path: "past",
         theme: "v3",
         Component: PastAuctionsPaginationContainer,
-        ignoreScrollBehavior: true,
         query: graphql`
           query auctionsRoutes_Past_AuctionsQuery {
             viewer {
@@ -108,7 +106,6 @@ export const auctionsRoutes: AppRouteConfig[] = [
         path: "auctions",
         theme: "v3",
         getComponent: () => AuctionsRoute,
-        ignoreScrollBehavior: true,
         query: graphql`
           query auctionsRoutes_Auctions_AuctionsQuery {
             viewer {
@@ -121,7 +118,6 @@ export const auctionsRoutes: AppRouteConfig[] = [
         path: "artworks",
         theme: "v3",
         getComponent: () => ArtworksRoute,
-        ignoreScrollBehavior: true,
         query: graphql`
           query auctionsRoutes_Artworks_AuctionsQuery {
             viewer {

--- a/src/v2/Apps/Conversation/conversationRoutes.tsx
+++ b/src/v2/Apps/Conversation/conversationRoutes.tsx
@@ -40,6 +40,7 @@ export const conversationRoutes: AppRouteConfig[] = [
     path: "/user/conversations/:conversationID",
     displayFullPage: true,
     hideFooter: true,
+    ignoreScrollBehavior: true,
     Component: loadable(
       () =>
         import(
@@ -65,6 +66,5 @@ export const conversationRoutes: AppRouteConfig[] = [
     cacheConfig: {
       force: true,
     },
-    ignoreScrollBehavior: true,
   },
 ]

--- a/src/v2/Apps/Partner/partnerRoutes.tsx
+++ b/src/v2/Apps/Partner/partnerRoutes.tsx
@@ -65,9 +65,9 @@ const ContactRoute = loadable(
 
 export const partnerRoutes: AppRouteConfig[] = [
   {
-    scrollToTop: true,
-    getComponent: () => PartnerApp,
     path: "/partner/:partnerId",
+    ignoreScrollBehaviorBetweenChildren: true,
+    getComponent: () => PartnerApp,
     prepare: () => {
       PartnerApp.preload()
     },
@@ -105,8 +105,8 @@ export const partnerRoutes: AppRouteConfig[] = [
     },
     children: [
       {
-        getComponent: () => OverviewRoute,
         path: "",
+        getComponent: () => OverviewRoute,
         prepare: () => {
           OverviewRoute.preload()
         },
@@ -119,57 +119,17 @@ export const partnerRoutes: AppRouteConfig[] = [
         `,
       },
       {
-        getComponent: () => ArticlesRoute,
-        path: "articles",
-        prepare: () => {
-          ArticlesRoute.preload()
-        },
-        ignoreScrollBehavior: true,
-        prepareVariables: (params, { location }) => {
-          return {
-            ...params,
-            page: location.query.page,
-          }
-        },
-        query: graphql`
-          query partnerRoutes_ArticlesQuery($partnerId: String!, $page: Int) {
-            partner(id: $partnerId) @principalField {
-              articles: articlesConnection(first: 0) {
-                totalCount
-              }
-              ...Articles_partner @arguments(page: $page)
-            }
-          }
-        `,
-        render: ({ Component, props, match }) => {
-          if (!(Component && props)) {
-            return
-          }
-
-          const { partner } = props as any
-
-          if (!partner) {
-            return
-          }
-
-          const {
-            articles: { totalCount },
-          } = partner
-
-          if (!totalCount) {
-            throw new RedirectException(
-              `/partner/${match.params.partnerId}`,
-              302
-            )
-          }
-
-          return <Component {...props} />
+        path: "overview",
+        render: props => {
+          throw new RedirectException(
+            `/partner/${props.match.params.partnerId}`,
+            302
+          )
         },
       },
       {
-        getComponent: () => ShowsRoute,
         path: "shows",
-        ignoreScrollBehavior: true,
+        getComponent: () => ShowsRoute,
         prepare: () => {
           ShowsRoute.preload()
         },
@@ -209,9 +169,8 @@ export const partnerRoutes: AppRouteConfig[] = [
         },
       },
       {
-        getComponent: () => ViewinRoomsRoute,
         path: "viewing-rooms",
-        ignoreScrollBehavior: true,
+        getComponent: () => ViewinRoomsRoute,
         prepare: () => {
           ViewinRoomsRoute.preload()
         },
@@ -237,8 +196,8 @@ export const partnerRoutes: AppRouteConfig[] = [
         },
       },
       {
-        getComponent: () => WorksRoute,
         path: "works",
+        getComponent: () => WorksRoute,
         prepare: () => {
           WorksRoute.preload()
         },
@@ -268,7 +227,6 @@ export const partnerRoutes: AppRouteConfig[] = [
             shouldFetchCounts: !!props.context.user,
           }
         },
-        ignoreScrollBehavior: true,
         query: graphql`
           query partnerRoutes_WorksQuery(
             $partnerId: String!
@@ -317,12 +275,11 @@ export const partnerRoutes: AppRouteConfig[] = [
         },
       },
       {
-        getComponent: () => ArtistsRoute,
         path: "artists/:artistId?",
+        getComponent: () => ArtistsRoute,
         prepare: () => {
           ArtistsRoute.preload()
         },
-        ignoreScrollBehavior: true,
         query: graphql`
           query partnerRoutes_ArtistsQuery($partnerId: String!) {
             partner(id: $partnerId) @principalField {
@@ -359,12 +316,58 @@ export const partnerRoutes: AppRouteConfig[] = [
         },
       },
       {
-        getComponent: () => ContactRoute,
+        path: "articles",
+        getComponent: () => ArticlesRoute,
+        prepare: () => {
+          ArticlesRoute.preload()
+        },
+        prepareVariables: (params, { location }) => {
+          return {
+            ...params,
+            page: location.query.page,
+          }
+        },
+        query: graphql`
+          query partnerRoutes_ArticlesQuery($partnerId: String!, $page: Int) {
+            partner(id: $partnerId) @principalField {
+              articles: articlesConnection(first: 0) {
+                totalCount
+              }
+              ...Articles_partner @arguments(page: $page)
+            }
+          }
+        `,
+        render: ({ Component, props, match }) => {
+          if (!(Component && props)) {
+            return
+          }
+
+          const { partner } = props as any
+
+          if (!partner) {
+            return
+          }
+
+          const {
+            articles: { totalCount },
+          } = partner
+
+          if (!totalCount) {
+            throw new RedirectException(
+              `/partner/${match.params.partnerId}`,
+              302
+            )
+          }
+
+          return <Component {...props} />
+        },
+      },
+      {
         path: "contact",
+        getComponent: () => ContactRoute,
         prepare: () => {
           ContactRoute.preload()
         },
-        ignoreScrollBehavior: true,
         query: graphql`
           query partnerRoutes_ContactQuery($partnerId: String!) {
             partner(id: $partnerId) @principalField {
@@ -394,15 +397,6 @@ export const partnerRoutes: AppRouteConfig[] = [
           }
 
           return <Component {...props} />
-        },
-      },
-      {
-        path: "overview",
-        render: props => {
-          throw new RedirectException(
-            `/partner/${props.match.params.partnerId}`,
-            302
-          )
         },
       },
     ],

--- a/src/v2/Apps/ViewingRoom/viewingRoomRoutes.tsx
+++ b/src/v2/Apps/ViewingRoom/viewingRoomRoutes.tsx
@@ -68,6 +68,7 @@ export const viewingRoomRoutes: AppRouteConfig[] = [
   {
     path: "/viewing-room/:slug",
     getComponent: () => ViewingRoomApp,
+    ignoreScrollBehaviorBetweenChildren: true,
     prepare: () => {
       ViewingRoomApp.preload()
     },
@@ -93,7 +94,6 @@ export const viewingRoomRoutes: AppRouteConfig[] = [
       {
         path: "works",
         Component: WorksRoute,
-        ignoreScrollBehavior: true,
         query: graphql`
           query viewingRoomRoutes_ViewingRoomWorksRouteQuery($slug: ID!) {
             viewingRoom(id: $slug) {

--- a/src/v2/System/Router/Utils/__tests__/cleanObject.jest.ts
+++ b/src/v2/System/Router/Utils/__tests__/cleanObject.jest.ts
@@ -1,0 +1,9 @@
+import { cleanObject } from "v2/Utils/cleanObject"
+
+describe("cleanObject", () => {
+  it("cleans null and undefined object keys", () => {
+    expect(cleanObject({ foo: "bar", baz: null, bam: undefined })).toEqual({
+      foo: "bar",
+    })
+  })
+})

--- a/src/v2/System/Router/Utils/shouldUpdateScroll.tsx
+++ b/src/v2/System/Router/Utils/shouldUpdateScroll.tsx
@@ -1,3 +1,6 @@
+import { isEqual } from "lodash"
+import { cleanObject } from "v2/Utils/cleanObject"
+
 /**
  * Handler for `found-scroll` used for determining if scroll management should
  * be applied on route change, based on keys attached to a route.
@@ -26,9 +29,18 @@ export function shouldUpdateScroll(prevRenderArgs, currentRenderArgs) {
   const { routes } = currentRenderArgs
 
   try {
-    // If true, don't reset scroll position on route change
+    // If true, don't reset scroll position on route change, no matter what
     if (routes?.some(route => route.ignoreScrollBehavior)) {
       return false
+    }
+
+    // If params are changing between routes, we're likely transitioning between
+    // different types of pages, or different artists / artworks (but the same
+    // page), etc, so in that case we generally always want to jump to top
+    const prevParams = cleanObject(prevRenderArgs?.params)
+    const currentParams = cleanObject(currentRenderArgs?.params)
+    if (!isEqual(prevParams, currentParams)) {
+      return true
     }
 
     if (routes.some(route => route.scrollToTop)) {

--- a/src/v2/Utils/cleanObject.ts
+++ b/src/v2/Utils/cleanObject.ts
@@ -1,0 +1,8 @@
+import { pickBy, identity } from "lodash"
+
+/**
+ * Removes null and undefined values from an object
+ */
+export function cleanObject(obj) {
+  return pickBy(obj, identity)
+}

--- a/webpack/envs/clientPlugins.js
+++ b/webpack/envs/clientPlugins.js
@@ -7,6 +7,7 @@ const currentYear = new Date().getFullYear()
 
 export const clientPlugins = [
   new LodashModuleReplacementPlugin({
+    collections: true,
     currying: true,
     flattening: true,
     shorthands: true,


### PR DESCRIPTION
This follows up on work completed in https://github.com/artsy/force/pull/8283 by making all of our various apps' scroll behavior consistent, and makes an additional change around ensuring that if there are new route params (new `:artistId` / `:artworkId`, etc) then the scroll position is reset. 

**In short, the flow is:**
- user scrolls half way down page, clicks an artist
- first render of artist page should reset scroll position to the top
- user scrolls down and clicks inner-page tabs (works for sale etc)
- scroll position is preserved 
- user clicks back to overview 
- scroll position is preserved 
- user scrolls down to related artists, clicks a related artist 
- new artist page renders, page scrolls to top 

![flow](https://user-images.githubusercontent.com/236943/131182903-3f20edde-7511-4ad1-bf7a-2ff3742fd65b.gif)
