### PR TITLE
refactor: migrates Shipping app to use Palette V3

### DIFF
--- a/src/v2/Apps/Order/Components/AddressModal.tsx
+++ b/src/v2/Apps/Order/Components/AddressModal.tsx
@@ -178,7 +178,6 @@ export const AddressModal: React.FC<Props> = ({
                   {createUpdateError}
                 </Banner>
               )}
-
               <AddressModalFields />
               <Spacer mb={2} />
               <Input

--- a/src/v2/Apps/Order/Components/SavedAddressItem.tsx
+++ b/src/v2/Apps/Order/Components/SavedAddressItem.tsx
@@ -1,7 +1,14 @@
-import { Flex, Text, RadioProps } from "@artsy/palette"
+import {
+  Flex,
+  Text,
+  RadioProps,
+  useThemeConfig,
+  TextVariant,
+  getThemeConfig,
+} from "@artsy/palette"
 import { themeGet } from "@styled-system/theme-get"
 import React from "react"
-import styled from "styled-components"
+import styled, { css } from "styled-components"
 import { SavedAddresses_me } from "v2/__generated__/SavedAddresses_me.graphql"
 
 type AddressNode = NonNullable<
@@ -38,6 +45,17 @@ export const SavedAddressItem: React.FC<SavedAddressItemProps> = (
     .join(", ")
   const nameAndAddressLine = [name, addressLine1, addressLine2, addressLine3]
 
+  const styles = useThemeConfig({
+    v2: {
+      smVariant: "text" as TextVariant,
+      xsVariant: "caption" as TextVariant,
+    },
+    v3: {
+      smVariant: "sm" as TextVariant,
+      xsVariant: "xs" as TextVariant,
+    },
+  })
+
   return (
     <Flex width="100%">
       <Flex flexDirection="column">
@@ -55,7 +73,7 @@ export const SavedAddressItem: React.FC<SavedAddressItemProps> = (
                   <Text
                     textTransform="capitalize"
                     textColor={index === 0 ? "black100" : "black60"}
-                    variant="sm"
+                    variant={styles.smVariant}
                   >
                     {line}
                   </Text>
@@ -63,7 +81,7 @@ export const SavedAddressItem: React.FC<SavedAddressItemProps> = (
                     <DefaultLabel>
                       <Text
                         textColor="black60"
-                        variant="caption"
+                        variant={styles.xsVariant}
                         display="inline"
                       >
                         Default
@@ -73,10 +91,16 @@ export const SavedAddressItem: React.FC<SavedAddressItemProps> = (
                 </Flex>
               )
           )}
-        <Text textColor="black60" textTransform="capitalize">
+        <Text
+          textColor="black60"
+          textTransform="capitalize"
+          variant={styles.smVariant}
+        >
           {formattedAddressLine}
         </Text>
-        <Text textColor="black60">{phoneNumber}</Text>
+        <Text textColor="black60" variant={styles.smVariant}>
+          {phoneNumber}
+        </Text>
       </Flex>
       <EditButton
         position="absolute"
@@ -89,7 +113,7 @@ export const SavedAddressItem: React.FC<SavedAddressItemProps> = (
           handleClickEdit(index)
         }}
         textColor="blue100"
-        variant="sm"
+        variant={styles.smVariant}
         data-test="editAddressInShipping"
       >
         Edit
@@ -105,11 +129,19 @@ const EditButton = styled(Text)`
 `
 
 const DefaultLabel = styled.div`
+  ${props => {
+    const states = getThemeConfig(props, {
+      v2: { borderRadius: "2px", padding: "0 5px" },
+      v3: { borderRadius: "12px", padding: "5px 10px" },
+    })
+    return css`
+      border-radius: ${states.borderRadius};
+      padding: ${states.padding};
+    `
+  }}
   display: flex;
   align-items: center;
-  padding: 0 5px;
   background-color: ${themeGet("colors.black10")};
   height: 24px;
-  margin-left: 5px;
-  border-radius: 2px;
+  margin-left: 10px;
 `

--- a/src/v2/Apps/Order/Components/SavedAddresses.tsx
+++ b/src/v2/Apps/Order/Components/SavedAddresses.tsx
@@ -10,6 +10,8 @@ import {
   BorderBox,
   Join,
   Clickable,
+  useThemeConfig,
+  TextVariant,
 } from "@artsy/palette"
 import React, { useState } from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
@@ -160,6 +162,15 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
     onShowToast && onShowToast(true, "Saved")
   }
 
+  const styles = useThemeConfig({
+    v2: {
+      variant: "text" as TextVariant,
+    },
+    v3: {
+      variant: "sm" as TextVariant,
+    },
+  })
+
   const collectorProfileAddressItems = addressList.map((address, index) => {
     if (!address) {
       return null
@@ -185,7 +196,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
             <Box mr={[3, 1]}>
               <Text
                 onClick={() => handleSetDefaultAddress(address.internalID)}
-                variant="text"
+                variant={styles.variant}
                 color="black60"
                 style={{
                   cursor: "pointer",
@@ -201,7 +212,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
               onClick={() => handleEditAddress(address, index)}
             >
               <Text
-                variant="text"
+                variant={styles.variant}
                 color="blue100"
                 style={{
                   cursor: "pointer",
@@ -218,7 +229,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
               onClick={() => handleDeleteAddress(address.internalID)}
             >
               <Text
-                variant="text"
+                variant={styles.variant}
                 color="red100"
                 style={{
                   cursor: "pointer",
@@ -240,7 +251,6 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
           data-test="profileButton"
           mt={2}
           variant="primaryBlack"
-          size="large"
           onClick={() => {
             setShowAddressModal(true),
               setModalDetails({

--- a/src/v2/Apps/Shipping/shippingRoutes.tsx
+++ b/src/v2/Apps/Shipping/shippingRoutes.tsx
@@ -14,6 +14,7 @@ const ShippingApp = loadable(
 
 export const shippingRoutes: AppRouteConfig[] = [
   {
+    theme: "v3",
     // TODO: update route to /user/shipping and remove stitched route to launch
     path: "/user/shipping",
     getComponent: () => ShippingApp,

--- a/src/v2/Components/Address/AddressModalFields.tsx
+++ b/src/v2/Components/Address/AddressModalFields.tsx
@@ -51,7 +51,7 @@ export const AddressModalFields: React.FC = () => {
         />
       </Flex>
       <GridColumns mt={[1, 2]}>
-        <Column span={12}>
+        <Column span={6}>
           <Box>
             <Text
               textTransform={styles.textTransform}
@@ -69,7 +69,7 @@ export const AddressModalFields: React.FC = () => {
             />
           </Box>
         </Column>
-        <Column span={12}>
+        <Column span={6}>
           <Input
             title="Postal Code"
             placeholder="Add postal code"
@@ -83,7 +83,7 @@ export const AddressModalFields: React.FC = () => {
       </GridColumns>
 
       <GridColumns mt={[1, 2]}>
-        <Column span={12}>
+        <Column span={6}>
           <Input
             title="Address Line 1"
             placeholder="Add address"
@@ -94,7 +94,7 @@ export const AddressModalFields: React.FC = () => {
             value={values?.addressLine1}
           />
         </Column>
-        <Column span={12}>
+        <Column span={6}>
           <Input
             title="Address Line 2 (optional)"
             placeholder="Add address line 2"
@@ -107,7 +107,7 @@ export const AddressModalFields: React.FC = () => {
         </Column>
       </GridColumns>
       <GridColumns mt={[1, 2]}>
-        <Column span={12}>
+        <Column span={6}>
           <Input
             title="City"
             placeholder="Enter city"
@@ -118,7 +118,7 @@ export const AddressModalFields: React.FC = () => {
             value={values?.city}
           />
         </Column>
-        <Column span={12}>
+        <Column span={6}>
           <Input
             title="State, province, or region"
             placeholder="Add state, province, or region"

--- a/src/v2/Components/Payment/PaymentModal.tsx
+++ b/src/v2/Components/Payment/PaymentModal.tsx
@@ -161,7 +161,7 @@ export const PaymentModal: React.FC<PaymentModalProps> = props => {
     }
   }
   return (
-    <Modal title="Add credit card" show={show} onClose={closeModal}>
+    <Modal isWide title="Add credit card" show={show} onClose={closeModal}>
       <Formik
         initialValues={{
           country: "US",

--- a/src/v2/Components/UserSettings/UserSettingsAddresses.tsx
+++ b/src/v2/Components/UserSettings/UserSettingsAddresses.tsx
@@ -1,4 +1,4 @@
-import { Box, Theme, Text } from "@artsy/palette"
+import { Box, Text } from "@artsy/palette"
 import { SavedAddressesFragmentContainer as SavedAddresses } from "v2/Apps/Order/Components/SavedAddresses"
 import { renderWithLoadProgress } from "v2/System/Relay/renderWithLoadProgress"
 import { SystemContextProps } from "v2/System"
@@ -41,27 +41,25 @@ export const UserSettingsAddresses: React.FC<UserSettingsAddressesProps> = props
   }
 
   return (
-    <Theme>
-      <Box maxWidth={940} mb={3}>
-        <Text variant="subtitle" mb={3}>
-          Saved Addresses
-        </Text>
-        <ToastComponent
-          showNotification={notificationState.notificationVisible}
-          notificationAction={notificationState.action}
-          duration={5000}
-          title="Address Successfully"
-          onCloseToast={onCloseToast}
-        />
-        <SavedAddresses
-          // @ts-expect-error STRICT_NULL_CHECK
-          me={me}
-          onShowToast={onShowToast}
-          inCollectorProfile
-          {...props}
-        />
-      </Box>
-    </Theme>
+    <Box maxWidth={940} mb={3}>
+      <Text variant="lg" my={4}>
+        Saved Addresses
+      </Text>
+      <ToastComponent
+        showNotification={notificationState.notificationVisible}
+        notificationAction={notificationState.action}
+        duration={5000}
+        title="Address Successfully"
+        onCloseToast={onCloseToast}
+      />
+      <SavedAddresses
+        // @ts-expect-error STRICT_NULL_CHECK
+        me={me}
+        onShowToast={onShowToast}
+        inCollectorProfile
+        {...props}
+      />
+    </Box>
   )
 }
 


### PR DESCRIPTION
[PURCHASE-2876]
Migrate Shipping app on force to use Palette V3.

__Before:__
<img width="1171" alt="Screen Shot 2021-08-30 at 1 40 04 PM" src="https://user-images.githubusercontent.com/5643895/131382761-6a2b12bd-9515-4c4c-b8b2-afb969db6dff.png">
<img width="1112" alt="Screen Shot 2021-08-30 at 1 52 44 PM" src="https://user-images.githubusercontent.com/5643895/131382833-b8581ab1-cbc3-40f2-878b-dd96d6458338.png">

__After:__
<img width="1053" alt="Screen Shot 2021-08-30 at 1 26 40 PM" src="https://user-images.githubusercontent.com/5643895/131382683-8a2c9647-ba80-419f-928f-f7b9db285cc5.png">
<img width="1025" alt="Screen Shot 2021-08-30 at 1 26 34 PM" src="https://user-images.githubusercontent.com/5643895/131382716-f2dbf330-137a-4957-b145-c4ab3732a9b6.png">


[PURCHASE-2876]: https://artsyproduct.atlassian.net/browse/PURCHASE-2876