### PR TITLE
fix(fair organizer): sort fairs by -start_at to determine upcoming show

### DIFF
--- a/src/v2/Apps/FairOrginizer/Components/DedicatedArticlesBreadcrumbs.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/DedicatedArticlesBreadcrumbs.tsx
@@ -47,7 +47,7 @@ export const DedicatedArticlesBreadcrumbsFragmentContainer = createFragmentConta
       fragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {
         slug
         name
-        fairsConnection(first: 1) {
+        fairsConnection(first: 1, sort: START_AT_DESC) {
           edges {
             node {
               image {

--- a/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeader/FairOrganizerHeader.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeader/FairOrganizerHeader.tsx
@@ -86,7 +86,7 @@ export const FairOrganizerHeaderFragmentContainer = createFragmentContainer(
     fairOrganizer: graphql`
       fragment FairOrganizerHeader_fairOrganizer on FairOrganizer {
         name
-        fairsConnection(first: 1) {
+        fairsConnection(first: 1, sort: START_AT_DESC) {
           edges {
             node {
               href

--- a/src/v2/Apps/FairOrginizer/FairOrganizerApp.tsx
+++ b/src/v2/Apps/FairOrginizer/FairOrganizerApp.tsx
@@ -49,7 +49,7 @@ export const FairOrganizerAppFragmentContainer = createFragmentContainer(
     fairOrganizer: graphql`
       fragment FairOrganizerApp_fairOrganizer on FairOrganizer {
         name
-        fairs: fairsConnection(first: 1) {
+        fairs: fairsConnection(first: 1, sort: START_AT_DESC) {
           edges {
             node {
               ...FairHeaderImage_fair

--- a/src/v2/__generated__/DedicatedArticlesBreadcrumbs_Test_Query.graphql.ts
+++ b/src/v2/__generated__/DedicatedArticlesBreadcrumbs_Test_Query.graphql.ts
@@ -27,7 +27,7 @@ query DedicatedArticlesBreadcrumbs_Test_Query {
 fragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {
   slug
   name
-  fairsConnection(first: 1) {
+  fairsConnection(first: 1, sort: START_AT_DESC) {
     edges {
       node {
         image {
@@ -119,6 +119,11 @@ return {
                 "kind": "Literal",
                 "name": "first",
                 "value": 1
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "START_AT_DESC"
               }
             ],
             "concreteType": "FairConnection",
@@ -202,7 +207,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "fairsConnection(first:1)"
+            "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
           },
           (v1/*: any*/)
         ],
@@ -215,7 +220,7 @@ return {
     "metadata": {},
     "name": "DedicatedArticlesBreadcrumbs_Test_Query",
     "operationKind": "query",
-    "text": "query DedicatedArticlesBreadcrumbs_Test_Query {\n  fairOrganizer(id: \"example\") {\n    ...DedicatedArticlesBreadcrumbs_fairOrganizer\n    id\n  }\n}\n\nfragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {\n  slug\n  name\n  fairsConnection(first: 1) {\n    edges {\n      node {\n        image {\n          resized(width: 30, height: 30, version: \"square\") {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query DedicatedArticlesBreadcrumbs_Test_Query {\n  fairOrganizer(id: \"example\") {\n    ...DedicatedArticlesBreadcrumbs_fairOrganizer\n    id\n  }\n}\n\nfragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {\n  slug\n  name\n  fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        image {\n          resized(width: 30, height: 30, version: \"square\") {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/DedicatedArticlesBreadcrumbs_fairOrganizer.graphql.ts
+++ b/src/v2/__generated__/DedicatedArticlesBreadcrumbs_fairOrganizer.graphql.ts
@@ -55,6 +55,11 @@ const node: ReaderFragment = {
           "kind": "Literal",
           "name": "first",
           "value": 1
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "START_AT_DESC"
         }
       ],
       "concreteType": "FairConnection",
@@ -137,10 +142,10 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "fairsConnection(first:1)"
+      "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
     }
   ],
   "type": "FairOrganizer"
 };
-(node as any).hash = 'bfc8dab1efec5d889e13834e9faefd2f';
+(node as any).hash = '87dc3d34dbc55002ddcfe95a43e9bbb4';
 export default node;

--- a/src/v2/__generated__/FairOrganizerApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/FairOrganizerApp_Test_Query.graphql.ts
@@ -62,7 +62,7 @@ fragment FairHeaderImage_fair on Fair {
 
 fragment FairOrganizerApp_fairOrganizer on FairOrganizer {
   name
-  fairs: fairsConnection(first: 1) {
+  fairs: fairsConnection(first: 1, sort: START_AT_DESC) {
     edges {
       node {
         ...FairHeaderImage_fair
@@ -107,7 +107,7 @@ fragment FairOrganizerHeaderIcon_fairOrganizer on FairOrganizer {
 
 fragment FairOrganizerHeader_fairOrganizer on FairOrganizer {
   name
-  fairsConnection(first: 1) {
+  fairsConnection(first: 1, sort: START_AT_DESC) {
     edges {
       node {
         href
@@ -171,7 +171,12 @@ var v0 = [
     "value": "example"
   }
 ],
-v1 = [
+v1 = {
+  "kind": "Literal",
+  "name": "sort",
+  "value": "START_AT_DESC"
+},
+v2 = [
   {
     "kind": "Literal",
     "name": "fairOrganizerID",
@@ -187,83 +192,80 @@ v1 = [
     "name": "hasFullFeature",
     "value": true
   },
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "START_AT_DESC"
-  },
+  (v1/*: any*/),
   {
     "kind": "Literal",
     "name": "status",
     "value": "CLOSED"
   }
 ],
-v2 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v3 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 1
-  }
+  },
+  (v1/*: any*/)
 ],
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "kind": "Literal",
   "name": "version",
   "value": "square140"
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "src",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "srcSet",
   "storageKey": null
 },
-v9 = [
-  (v7/*: any*/),
-  (v8/*: any*/)
+v10 = [
+  (v8/*: any*/),
+  (v9/*: any*/)
 ],
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v12 = [
+v13 = [
   {
     "alias": null,
     "args": null,
@@ -278,10 +280,10 @@ v12 = [
     "name": "height",
     "storageKey": null
   },
-  (v7/*: any*/),
-  (v8/*: any*/)
+  (v8/*: any*/),
+  (v9/*: any*/)
 ],
-v13 = {
+v14 = {
   "kind": "Literal",
   "name": "width",
   "value": 325
@@ -311,7 +313,7 @@ return {
       },
       {
         "alias": "pastFairs",
-        "args": (v1/*: any*/),
+        "args": (v2/*: any*/),
         "concreteType": "FairConnection",
         "kind": "LinkedField",
         "name": "fairsConnection",
@@ -342,10 +344,10 @@ return {
         "name": "fairOrganizer",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
+          (v3/*: any*/),
           {
             "alias": "fairs",
-            "args": (v3/*: any*/),
+            "args": (v4/*: any*/),
             "concreteType": "FairConnection",
             "kind": "LinkedField",
             "name": "fairsConnection",
@@ -391,7 +393,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v4/*: any*/)
+                      (v5/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -399,11 +401,11 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "fairsConnection(first:1)"
+            "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
           },
           {
             "alias": null,
-            "args": (v3/*: any*/),
+            "args": (v4/*: any*/),
             "concreteType": "FairConnection",
             "kind": "LinkedField",
             "name": "fairsConnection",
@@ -425,7 +427,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
+                      (v6/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -440,7 +442,7 @@ return {
                         "name": "exhibitionPeriod",
                         "storageKey": null
                       },
-                      (v4/*: any*/)
+                      (v5/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -448,7 +450,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "fairsConnection(first:1)"
+            "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
           },
           {
             "alias": null,
@@ -474,7 +476,7 @@ return {
                         "name": "height",
                         "value": 80
                       },
-                      (v6/*: any*/),
+                      (v7/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
@@ -485,7 +487,7 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v9/*: any*/),
+                    "selections": (v10/*: any*/),
                     "storageKey": "cropped(height:80,version:\"square140\",width:80)"
                   },
                   {
@@ -496,7 +498,7 @@ return {
                         "name": "height",
                         "value": 60
                       },
-                      (v6/*: any*/),
+                      (v7/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
@@ -507,14 +509,14 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v9/*: any*/),
+                    "selections": (v10/*: any*/),
                     "storageKey": "cropped(height:60,version:\"square140\",width:60)"
                   }
                 ],
                 "storageKey": null
               },
-              (v4/*: any*/),
-              (v10/*: any*/),
+              (v5/*: any*/),
+              (v11/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -525,7 +527,7 @@ return {
             ],
             "storageKey": null
           },
-          (v11/*: any*/),
+          (v12/*: any*/),
           {
             "alias": null,
             "args": [
@@ -581,9 +583,9 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
-                      (v10/*: any*/),
+                      (v5/*: any*/),
                       (v11/*: any*/),
+                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -591,7 +593,7 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v5/*: any*/),
+                      (v6/*: any*/),
                       {
                         "alias": null,
                         "args": [
@@ -638,7 +640,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v12/*: any*/),
+                            "selections": (v13/*: any*/),
                             "storageKey": "cropped(height:720,width:670)"
                           },
                           {
@@ -649,13 +651,13 @@ return {
                                 "name": "height",
                                 "value": 240
                               },
-                              (v13/*: any*/)
+                              (v14/*: any*/)
                             ],
                             "concreteType": "CroppedImageUrl",
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v12/*: any*/),
+                            "selections": (v13/*: any*/),
                             "storageKey": "cropped(height:240,width:325)"
                           }
                         ],
@@ -670,13 +672,13 @@ return {
             ],
             "storageKey": "articlesConnection(first:7,sort:\"PUBLISHED_AT_DESC\")"
           },
-          (v4/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": "fairOrganizer(id:\"example\")"
       },
       {
         "alias": "pastFairs",
-        "args": (v1/*: any*/),
+        "args": (v2/*: any*/),
         "concreteType": "FairConnection",
         "kind": "LinkedField",
         "name": "fairsConnection",
@@ -698,9 +700,9 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v4/*: any*/),
-                  (v11/*: any*/),
-                  (v2/*: any*/),
+                  (v5/*: any*/),
+                  (v12/*: any*/),
+                  (v3/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -717,13 +719,13 @@ return {
                             "name": "height",
                             "value": 244
                           },
-                          (v13/*: any*/)
+                          (v14/*: any*/)
                         ],
                         "concreteType": "CroppedImageUrl",
                         "kind": "LinkedField",
                         "name": "cropped",
                         "plural": false,
-                        "selections": (v12/*: any*/),
+                        "selections": (v13/*: any*/),
                         "storageKey": "cropped(height:244,width:325)"
                       }
                     ],
@@ -745,7 +747,7 @@ return {
     "metadata": {},
     "name": "FairOrganizerApp_Test_Query",
     "operationKind": "query",
-    "text": "query FairOrganizerApp_Test_Query {\n  fairOrganizer(id: \"example\") {\n    ...FairOrganizerApp_fairOrganizer\n    id\n  }\n  pastFairs: fairsConnection(first: 20, fairOrganizerID: \"example\", sort: START_AT_DESC, status: CLOSED, hasFullFeature: true) {\n    ...FairOrganizerApp_pastFairs\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairOrganizerApp_fairOrganizer on FairOrganizer {\n  name\n  fairs: fairsConnection(first: 1) {\n    edges {\n      node {\n        ...FairHeaderImage_fair\n        id\n      }\n    }\n  }\n  ...FairOrganizerHeader_fairOrganizer\n  ...FairOrganizerLatestArticles_fairOrganizer\n}\n\nfragment FairOrganizerApp_pastFairs on FairConnection {\n  ...FairOrganizerPastEventsRail_fairs\n}\n\nfragment FairOrganizerFollowButton_fairOrganizer on FairOrganizer {\n  slug\n  name\n  profile {\n    id\n    internalID\n    isFollowed\n  }\n}\n\nfragment FairOrganizerHeaderIcon_fairOrganizer on FairOrganizer {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairOrganizerHeader_fairOrganizer on FairOrganizer {\n  name\n  fairsConnection(first: 1) {\n    edges {\n      node {\n        href\n        startAt\n        exhibitionPeriod\n        id\n      }\n    }\n  }\n  ...FairOrganizerHeaderIcon_fairOrganizer\n  ...FairOrganizerFollowButton_fairOrganizer\n  ...FairOrganizerInfo_fairOrganizer\n}\n\nfragment FairOrganizerInfo_fairOrganizer on FairOrganizer {\n  about(format: HTML)\n}\n\nfragment FairOrganizerLatestArticles_fairOrganizer on FairOrganizer {\n  name\n  slug\n  articlesConnection(first: 7, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairOrganizerPastEventRailCell_fair on Fair {\n  slug\n  name\n  image {\n    cropped(width: 325, height: 244) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerPastEventsRail_fairs on FairConnection {\n  edges {\n    node {\n      id\n      ...FairOrganizerPastEventRailCell_fair\n    }\n  }\n}\n"
+    "text": "query FairOrganizerApp_Test_Query {\n  fairOrganizer(id: \"example\") {\n    ...FairOrganizerApp_fairOrganizer\n    id\n  }\n  pastFairs: fairsConnection(first: 20, fairOrganizerID: \"example\", sort: START_AT_DESC, status: CLOSED, hasFullFeature: true) {\n    ...FairOrganizerApp_pastFairs\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairOrganizerApp_fairOrganizer on FairOrganizer {\n  name\n  fairs: fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        ...FairHeaderImage_fair\n        id\n      }\n    }\n  }\n  ...FairOrganizerHeader_fairOrganizer\n  ...FairOrganizerLatestArticles_fairOrganizer\n}\n\nfragment FairOrganizerApp_pastFairs on FairConnection {\n  ...FairOrganizerPastEventsRail_fairs\n}\n\nfragment FairOrganizerFollowButton_fairOrganizer on FairOrganizer {\n  slug\n  name\n  profile {\n    id\n    internalID\n    isFollowed\n  }\n}\n\nfragment FairOrganizerHeaderIcon_fairOrganizer on FairOrganizer {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairOrganizerHeader_fairOrganizer on FairOrganizer {\n  name\n  fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        href\n        startAt\n        exhibitionPeriod\n        id\n      }\n    }\n  }\n  ...FairOrganizerHeaderIcon_fairOrganizer\n  ...FairOrganizerFollowButton_fairOrganizer\n  ...FairOrganizerInfo_fairOrganizer\n}\n\nfragment FairOrganizerInfo_fairOrganizer on FairOrganizer {\n  about(format: HTML)\n}\n\nfragment FairOrganizerLatestArticles_fairOrganizer on FairOrganizer {\n  name\n  slug\n  articlesConnection(first: 7, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairOrganizerPastEventRailCell_fair on Fair {\n  slug\n  name\n  image {\n    cropped(width: 325, height: 244) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerPastEventsRail_fairs on FairConnection {\n  edges {\n    node {\n      id\n      ...FairOrganizerPastEventRailCell_fair\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairOrganizerApp_fairOrganizer.graphql.ts
+++ b/src/v2/__generated__/FairOrganizerApp_fairOrganizer.graphql.ts
@@ -43,6 +43,11 @@ const node: ReaderFragment = {
           "kind": "Literal",
           "name": "first",
           "value": 1
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "START_AT_DESC"
         }
       ],
       "concreteType": "FairConnection",
@@ -78,7 +83,7 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "fairsConnection(first:1)"
+      "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
     },
     {
       "args": null,
@@ -93,5 +98,5 @@ const node: ReaderFragment = {
   ],
   "type": "FairOrganizer"
 };
-(node as any).hash = '8687a595dac0cb26a28dfb09317e7c93';
+(node as any).hash = 'e19102e3e74bef5faf62cbc69989d027';
 export default node;

--- a/src/v2/__generated__/FairOrganizerDedicatedArticlesQuery.graphql.ts
+++ b/src/v2/__generated__/FairOrganizerDedicatedArticlesQuery.graphql.ts
@@ -35,7 +35,7 @@ query FairOrganizerDedicatedArticlesQuery(
 fragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {
   slug
   name
-  fairsConnection(first: 1) {
+  fairsConnection(first: 1, sort: START_AT_DESC) {
     edges {
       node {
         image {
@@ -501,6 +501,11 @@ return {
                 "kind": "Literal",
                 "name": "first",
                 "value": 1
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "START_AT_DESC"
               }
             ],
             "concreteType": "FairConnection",
@@ -572,7 +577,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "fairsConnection(first:1)"
+            "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
           },
           (v8/*: any*/)
         ],
@@ -585,7 +590,7 @@ return {
     "metadata": {},
     "name": "FairOrganizerDedicatedArticlesQuery",
     "operationKind": "query",
-    "text": "query FairOrganizerDedicatedArticlesQuery(\n  $id: String!\n  $first: Int\n  $page: Int\n) {\n  fairOrganizer(id: $id) {\n    ...FairOrganizerDedicatedArticles_fairOrganizer_4D1OJz\n    id\n  }\n}\n\nfragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {\n  slug\n  name\n  fairsConnection(first: 1) {\n    edges {\n      node {\n        image {\n          resized(width: 30, height: 30, version: \"square\") {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerDedicatedArticles_fairOrganizer_4D1OJz on FairOrganizer {\n  slug\n  name\n  articlesConnection(first: $first, page: $page, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n  ...DedicatedArticlesBreadcrumbs_fairOrganizer\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query FairOrganizerDedicatedArticlesQuery(\n  $id: String!\n  $first: Int\n  $page: Int\n) {\n  fairOrganizer(id: $id) {\n    ...FairOrganizerDedicatedArticles_fairOrganizer_4D1OJz\n    id\n  }\n}\n\nfragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {\n  slug\n  name\n  fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        image {\n          resized(width: 30, height: 30, version: \"square\") {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerDedicatedArticles_fairOrganizer_4D1OJz on FairOrganizer {\n  slug\n  name\n  articlesConnection(first: $first, page: $page, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n  ...DedicatedArticlesBreadcrumbs_fairOrganizer\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairOrganizerDedicatedArticles_Test_Query.graphql.ts
+++ b/src/v2/__generated__/FairOrganizerDedicatedArticles_Test_Query.graphql.ts
@@ -27,7 +27,7 @@ query FairOrganizerDedicatedArticles_Test_Query {
 fragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {
   slug
   name
-  fairsConnection(first: 1) {
+  fairsConnection(first: 1, sort: START_AT_DESC) {
     edges {
       node {
         image {
@@ -468,6 +468,11 @@ return {
                 "kind": "Literal",
                 "name": "first",
                 "value": 1
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "START_AT_DESC"
               }
             ],
             "concreteType": "FairConnection",
@@ -539,7 +544,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "fairsConnection(first:1)"
+            "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
           },
           (v5/*: any*/)
         ],
@@ -552,7 +557,7 @@ return {
     "metadata": {},
     "name": "FairOrganizerDedicatedArticles_Test_Query",
     "operationKind": "query",
-    "text": "query FairOrganizerDedicatedArticles_Test_Query {\n  fairOrganizer(id: \"example\") {\n    ...FairOrganizerDedicatedArticles_fairOrganizer\n    id\n  }\n}\n\nfragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {\n  slug\n  name\n  fairsConnection(first: 1) {\n    edges {\n      node {\n        image {\n          resized(width: 30, height: 30, version: \"square\") {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerDedicatedArticles_fairOrganizer on FairOrganizer {\n  slug\n  name\n  articlesConnection(first: 16, page: 1, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n  ...DedicatedArticlesBreadcrumbs_fairOrganizer\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query FairOrganizerDedicatedArticles_Test_Query {\n  fairOrganizer(id: \"example\") {\n    ...FairOrganizerDedicatedArticles_fairOrganizer\n    id\n  }\n}\n\nfragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {\n  slug\n  name\n  fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        image {\n          resized(width: 30, height: 30, version: \"square\") {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerDedicatedArticles_fairOrganizer on FairOrganizer {\n  slug\n  name\n  articlesConnection(first: 16, page: 1, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n  ...DedicatedArticlesBreadcrumbs_fairOrganizer\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairOrganizerHeader_Test_Query.graphql.ts
+++ b/src/v2/__generated__/FairOrganizerHeader_Test_Query.graphql.ts
@@ -53,7 +53,7 @@ fragment FairOrganizerHeaderIcon_fairOrganizer on FairOrganizer {
 
 fragment FairOrganizerHeader_fairOrganizer on FairOrganizer {
   name
-  fairsConnection(first: 1) {
+  fairsConnection(first: 1, sort: START_AT_DESC) {
     edges {
       node {
         href
@@ -163,6 +163,11 @@ return {
                 "kind": "Literal",
                 "name": "first",
                 "value": 1
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "START_AT_DESC"
               }
             ],
             "concreteType": "FairConnection",
@@ -215,7 +220,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "fairsConnection(first:1)"
+            "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
           },
           {
             "alias": null,
@@ -329,7 +334,7 @@ return {
     "metadata": {},
     "name": "FairOrganizerHeader_Test_Query",
     "operationKind": "query",
-    "text": "query FairOrganizerHeader_Test_Query {\n  fairOrganizer(id: \"example\") {\n    ...FairOrganizerHeader_fairOrganizer\n    id\n  }\n}\n\nfragment FairOrganizerFollowButton_fairOrganizer on FairOrganizer {\n  slug\n  name\n  profile {\n    id\n    internalID\n    isFollowed\n  }\n}\n\nfragment FairOrganizerHeaderIcon_fairOrganizer on FairOrganizer {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairOrganizerHeader_fairOrganizer on FairOrganizer {\n  name\n  fairsConnection(first: 1) {\n    edges {\n      node {\n        href\n        startAt\n        exhibitionPeriod\n        id\n      }\n    }\n  }\n  ...FairOrganizerHeaderIcon_fairOrganizer\n  ...FairOrganizerFollowButton_fairOrganizer\n  ...FairOrganizerInfo_fairOrganizer\n}\n\nfragment FairOrganizerInfo_fairOrganizer on FairOrganizer {\n  about(format: HTML)\n}\n"
+    "text": "query FairOrganizerHeader_Test_Query {\n  fairOrganizer(id: \"example\") {\n    ...FairOrganizerHeader_fairOrganizer\n    id\n  }\n}\n\nfragment FairOrganizerFollowButton_fairOrganizer on FairOrganizer {\n  slug\n  name\n  profile {\n    id\n    internalID\n    isFollowed\n  }\n}\n\nfragment FairOrganizerHeaderIcon_fairOrganizer on FairOrganizer {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairOrganizerHeader_fairOrganizer on FairOrganizer {\n  name\n  fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        href\n        startAt\n        exhibitionPeriod\n        id\n      }\n    }\n  }\n  ...FairOrganizerHeaderIcon_fairOrganizer\n  ...FairOrganizerFollowButton_fairOrganizer\n  ...FairOrganizerInfo_fairOrganizer\n}\n\nfragment FairOrganizerInfo_fairOrganizer on FairOrganizer {\n  about(format: HTML)\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairOrganizerHeader_fairOrganizer.graphql.ts
+++ b/src/v2/__generated__/FairOrganizerHeader_fairOrganizer.graphql.ts
@@ -45,6 +45,11 @@ const node: ReaderFragment = {
           "kind": "Literal",
           "name": "first",
           "value": 1
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "START_AT_DESC"
         }
       ],
       "concreteType": "FairConnection",
@@ -96,7 +101,7 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "fairsConnection(first:1)"
+      "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
     },
     {
       "args": null,
@@ -116,5 +121,5 @@ const node: ReaderFragment = {
   ],
   "type": "FairOrganizer"
 };
-(node as any).hash = 'e34147f32210f9efac602b17ea212108';
+(node as any).hash = '75d33688c6accfce21edc2a10fc1f6ec';
 export default node;

--- a/src/v2/__generated__/fairOrganizerRoutes_FairOrganizerDedicatedArticles_Query.graphql.ts
+++ b/src/v2/__generated__/fairOrganizerRoutes_FairOrganizerDedicatedArticles_Query.graphql.ts
@@ -33,7 +33,7 @@ query fairOrganizerRoutes_FairOrganizerDedicatedArticles_Query(
 fragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {
   slug
   name
-  fairsConnection(first: 1) {
+  fairsConnection(first: 1, sort: START_AT_DESC) {
     edges {
       node {
         image {
@@ -491,6 +491,11 @@ return {
                 "kind": "Literal",
                 "name": "first",
                 "value": 1
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "START_AT_DESC"
               }
             ],
             "concreteType": "FairConnection",
@@ -562,7 +567,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "fairsConnection(first:1)"
+            "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
           },
           (v7/*: any*/)
         ],
@@ -575,7 +580,7 @@ return {
     "metadata": {},
     "name": "fairOrganizerRoutes_FairOrganizerDedicatedArticles_Query",
     "operationKind": "query",
-    "text": "query fairOrganizerRoutes_FairOrganizerDedicatedArticles_Query(\n  $slug: String!\n  $page: Int\n) {\n  fairOrganizer(id: $slug) @principalField {\n    ...FairOrganizerDedicatedArticles_fairOrganizer_2Pg8Wv\n    id\n  }\n}\n\nfragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {\n  slug\n  name\n  fairsConnection(first: 1) {\n    edges {\n      node {\n        image {\n          resized(width: 30, height: 30, version: \"square\") {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerDedicatedArticles_fairOrganizer_2Pg8Wv on FairOrganizer {\n  slug\n  name\n  articlesConnection(first: 16, page: $page, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n  ...DedicatedArticlesBreadcrumbs_fairOrganizer\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query fairOrganizerRoutes_FairOrganizerDedicatedArticles_Query(\n  $slug: String!\n  $page: Int\n) {\n  fairOrganizer(id: $slug) @principalField {\n    ...FairOrganizerDedicatedArticles_fairOrganizer_2Pg8Wv\n    id\n  }\n}\n\nfragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {\n  slug\n  name\n  fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        image {\n          resized(width: 30, height: 30, version: \"square\") {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerDedicatedArticles_fairOrganizer_2Pg8Wv on FairOrganizer {\n  slug\n  name\n  articlesConnection(first: 16, page: $page, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n  ...DedicatedArticlesBreadcrumbs_fairOrganizer\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/fairOrganizerRoutes_FairOrganizerQuery.graphql.ts
+++ b/src/v2/__generated__/fairOrganizerRoutes_FairOrganizerQuery.graphql.ts
@@ -73,7 +73,7 @@ fragment FairHeaderImage_fair on Fair {
 
 fragment FairOrganizerApp_fairOrganizer on FairOrganizer {
   name
-  fairs: fairsConnection(first: 1) {
+  fairs: fairsConnection(first: 1, sort: START_AT_DESC) {
     edges {
       node {
         ...FairHeaderImage_fair
@@ -118,7 +118,7 @@ fragment FairOrganizerHeaderIcon_fairOrganizer on FairOrganizer {
 
 fragment FairOrganizerHeader_fairOrganizer on FairOrganizer {
   name
-  fairsConnection(first: 1) {
+  fairsConnection(first: 1, sort: START_AT_DESC) {
     edges {
       node {
         href
@@ -197,7 +197,12 @@ v2 = {
   "name": "__typename",
   "storageKey": null
 },
-v3 = [
+v3 = {
+  "kind": "Literal",
+  "name": "sort",
+  "value": "START_AT_DESC"
+},
+v4 = [
   {
     "kind": "Variable",
     "name": "fairOrganizerID",
@@ -213,83 +218,80 @@ v3 = [
     "name": "hasFullFeature",
     "value": true
   },
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "START_AT_DESC"
-  },
+  (v3/*: any*/),
   {
     "kind": "Literal",
     "name": "status",
     "value": "CLOSED"
   }
 ],
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "kind": "Literal",
   "name": "version",
   "value": "square140"
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "src",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "srcSet",
   "storageKey": null
 },
-v8 = [
-  (v6/*: any*/),
-  (v7/*: any*/)
+v9 = [
+  (v7/*: any*/),
+  (v8/*: any*/)
 ],
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v11 = [
+v12 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 1
-  }
+  },
+  (v3/*: any*/)
 ],
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v14 = [
+v15 = [
   {
     "alias": null,
     "args": null,
@@ -304,10 +306,10 @@ v14 = [
     "name": "height",
     "storageKey": null
   },
-  (v6/*: any*/),
-  (v7/*: any*/)
+  (v7/*: any*/),
+  (v8/*: any*/)
 ],
-v15 = {
+v16 = {
   "kind": "Literal",
   "name": "width",
   "value": 325
@@ -349,7 +351,7 @@ return {
       },
       {
         "alias": "pastFairs",
-        "args": (v3/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": "FairConnection",
         "kind": "LinkedField",
         "name": "fairsConnection",
@@ -389,7 +391,7 @@ return {
             "plural": false,
             "selections": [
               (v2/*: any*/),
-              (v4/*: any*/),
+              (v5/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -406,7 +408,7 @@ return {
                         "name": "height",
                         "value": 80
                       },
-                      (v5/*: any*/),
+                      (v6/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
@@ -417,7 +419,7 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v8/*: any*/),
+                    "selections": (v9/*: any*/),
                     "storageKey": "cropped(height:80,version:\"square140\",width:80)"
                   },
                   {
@@ -428,7 +430,7 @@ return {
                         "name": "height",
                         "value": 60
                       },
-                      (v5/*: any*/),
+                      (v6/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "width",
@@ -439,13 +441,13 @@ return {
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v8/*: any*/),
+                    "selections": (v9/*: any*/),
                     "storageKey": "cropped(height:60,version:\"square140\",width:60)"
                   }
                 ],
                 "storageKey": null
               },
-              (v9/*: any*/),
+              (v10/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -456,10 +458,10 @@ return {
             ],
             "storageKey": null
           },
-          (v10/*: any*/),
+          (v11/*: any*/),
           {
             "alias": "fairs",
-            "args": (v11/*: any*/),
+            "args": (v12/*: any*/),
             "concreteType": "FairConnection",
             "kind": "LinkedField",
             "name": "fairsConnection",
@@ -505,7 +507,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v4/*: any*/)
+                      (v5/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -513,11 +515,11 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "fairsConnection(first:1)"
+            "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
           },
           {
             "alias": null,
-            "args": (v11/*: any*/),
+            "args": (v12/*: any*/),
             "concreteType": "FairConnection",
             "kind": "LinkedField",
             "name": "fairsConnection",
@@ -539,7 +541,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v12/*: any*/),
+                      (v13/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -554,7 +556,7 @@ return {
                         "name": "exhibitionPeriod",
                         "storageKey": null
                       },
-                      (v4/*: any*/)
+                      (v5/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -562,9 +564,9 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "fairsConnection(first:1)"
+            "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
           },
-          (v13/*: any*/),
+          (v14/*: any*/),
           {
             "alias": null,
             "args": [
@@ -620,9 +622,9 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
-                      (v9/*: any*/),
-                      (v13/*: any*/),
+                      (v5/*: any*/),
+                      (v10/*: any*/),
+                      (v14/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -630,7 +632,7 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v12/*: any*/),
+                      (v13/*: any*/),
                       {
                         "alias": null,
                         "args": [
@@ -677,7 +679,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v14/*: any*/),
+                            "selections": (v15/*: any*/),
                             "storageKey": "cropped(height:720,width:670)"
                           },
                           {
@@ -688,13 +690,13 @@ return {
                                 "name": "height",
                                 "value": 240
                               },
-                              (v15/*: any*/)
+                              (v16/*: any*/)
                             ],
                             "concreteType": "CroppedImageUrl",
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v14/*: any*/),
+                            "selections": (v15/*: any*/),
                             "storageKey": "cropped(height:240,width:325)"
                           }
                         ],
@@ -709,13 +711,13 @@ return {
             ],
             "storageKey": "articlesConnection(first:7,sort:\"PUBLISHED_AT_DESC\")"
           },
-          (v4/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": null
       },
       {
         "alias": "pastFairs",
-        "args": (v3/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": "FairConnection",
         "kind": "LinkedField",
         "name": "fairsConnection",
@@ -737,9 +739,9 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v4/*: any*/),
-                  (v13/*: any*/),
-                  (v10/*: any*/),
+                  (v5/*: any*/),
+                  (v14/*: any*/),
+                  (v11/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -756,13 +758,13 @@ return {
                             "name": "height",
                             "value": 244
                           },
-                          (v15/*: any*/)
+                          (v16/*: any*/)
                         ],
                         "concreteType": "CroppedImageUrl",
                         "kind": "LinkedField",
                         "name": "cropped",
                         "plural": false,
-                        "selections": (v14/*: any*/),
+                        "selections": (v15/*: any*/),
                         "storageKey": "cropped(height:244,width:325)"
                       }
                     ],
@@ -784,7 +786,7 @@ return {
     "metadata": {},
     "name": "fairOrganizerRoutes_FairOrganizerQuery",
     "operationKind": "query",
-    "text": "query fairOrganizerRoutes_FairOrganizerQuery(\n  $slug: String!\n) {\n  fairOrganizer(id: $slug) @principalField {\n    profile {\n      __typename\n      id\n    }\n    ...FairOrganizerApp_fairOrganizer\n    id\n  }\n  pastFairs: fairsConnection(first: 20, fairOrganizerID: $slug, sort: START_AT_DESC, status: CLOSED, hasFullFeature: true) {\n    ...FairOrganizerApp_pastFairs\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairOrganizerApp_fairOrganizer on FairOrganizer {\n  name\n  fairs: fairsConnection(first: 1) {\n    edges {\n      node {\n        ...FairHeaderImage_fair\n        id\n      }\n    }\n  }\n  ...FairOrganizerHeader_fairOrganizer\n  ...FairOrganizerLatestArticles_fairOrganizer\n}\n\nfragment FairOrganizerApp_pastFairs on FairConnection {\n  ...FairOrganizerPastEventsRail_fairs\n}\n\nfragment FairOrganizerFollowButton_fairOrganizer on FairOrganizer {\n  slug\n  name\n  profile {\n    id\n    internalID\n    isFollowed\n  }\n}\n\nfragment FairOrganizerHeaderIcon_fairOrganizer on FairOrganizer {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairOrganizerHeader_fairOrganizer on FairOrganizer {\n  name\n  fairsConnection(first: 1) {\n    edges {\n      node {\n        href\n        startAt\n        exhibitionPeriod\n        id\n      }\n    }\n  }\n  ...FairOrganizerHeaderIcon_fairOrganizer\n  ...FairOrganizerFollowButton_fairOrganizer\n  ...FairOrganizerInfo_fairOrganizer\n}\n\nfragment FairOrganizerInfo_fairOrganizer on FairOrganizer {\n  about(format: HTML)\n}\n\nfragment FairOrganizerLatestArticles_fairOrganizer on FairOrganizer {\n  name\n  slug\n  articlesConnection(first: 7, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairOrganizerPastEventRailCell_fair on Fair {\n  slug\n  name\n  image {\n    cropped(width: 325, height: 244) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerPastEventsRail_fairs on FairConnection {\n  edges {\n    node {\n      id\n      ...FairOrganizerPastEventRailCell_fair\n    }\n  }\n}\n"
+    "text": "query fairOrganizerRoutes_FairOrganizerQuery(\n  $slug: String!\n) {\n  fairOrganizer(id: $slug) @principalField {\n    profile {\n      __typename\n      id\n    }\n    ...FairOrganizerApp_fairOrganizer\n    id\n  }\n  pastFairs: fairsConnection(first: 20, fairOrganizerID: $slug, sort: START_AT_DESC, status: CLOSED, hasFullFeature: true) {\n    ...FairOrganizerApp_pastFairs\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairOrganizerApp_fairOrganizer on FairOrganizer {\n  name\n  fairs: fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        ...FairHeaderImage_fair\n        id\n      }\n    }\n  }\n  ...FairOrganizerHeader_fairOrganizer\n  ...FairOrganizerLatestArticles_fairOrganizer\n}\n\nfragment FairOrganizerApp_pastFairs on FairConnection {\n  ...FairOrganizerPastEventsRail_fairs\n}\n\nfragment FairOrganizerFollowButton_fairOrganizer on FairOrganizer {\n  slug\n  name\n  profile {\n    id\n    internalID\n    isFollowed\n  }\n}\n\nfragment FairOrganizerHeaderIcon_fairOrganizer on FairOrganizer {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairOrganizerHeader_fairOrganizer on FairOrganizer {\n  name\n  fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        href\n        startAt\n        exhibitionPeriod\n        id\n      }\n    }\n  }\n  ...FairOrganizerHeaderIcon_fairOrganizer\n  ...FairOrganizerFollowButton_fairOrganizer\n  ...FairOrganizerInfo_fairOrganizer\n}\n\nfragment FairOrganizerInfo_fairOrganizer on FairOrganizer {\n  about(format: HTML)\n}\n\nfragment FairOrganizerLatestArticles_fairOrganizer on FairOrganizer {\n  name\n  slug\n  articlesConnection(first: 7, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairOrganizerPastEventRailCell_fair on Fair {\n  slug\n  name\n  image {\n    cropped(width: 325, height: 244) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerPastEventsRail_fairs on FairConnection {\n  edges {\n    node {\n      id\n      ...FairOrganizerPastEventRailCell_fair\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The default fair sort in Gravity is -created_at. When looking for an upcoming fair for an organizer, we currently fetch the first fair and check if the start time is in the future. If a past fair is created after a future fair, we might be checking the wrong entity in the system.

This updates the GraphQL query to sort fair results by `-start_at` to mimic the behavior in the previous implementation [here][commit].

Related to https://github.com/artsy/metaphysics/pull/3377

Jira 🔒 : [FX-3243]

[commit]: https://github.com/artsy/force/blob/4de69dfc0d2d26cbe43b7e5ffefc0a88e44333ac/src/desktop/apps/fair_organizer/routes.coffee#L36-L41

[FX-3243]: https://artsyproduct.atlassian.net/browse/FX-3243

### Before

![Screen Shot 2021-08-31 at 12 57 47 PM](https://user-images.githubusercontent.com/123595/131493567-249e93dd-edf5-46c5-b13d-e766ae739148.png)


### After

![Screen Shot 2021-08-31 at 1 09 15 PM](https://user-images.githubusercontent.com/123595/131493580-85bff611-c49e-4e80-a68b-241d90f34c50.png)