### PR TITLE
fix: Always clear search term after navigating away from search results

### DIFF
--- a/src/v2/Components/Search/SearchBar.tsx
+++ b/src/v2/Components/Search/SearchBar.tsx
@@ -166,15 +166,19 @@ export class SearchBar extends Component<Props, State> {
     // Clear the search term once you navigate away from search results
     this.removeNavigationListener = this.props.router
       ? this.props.router.addNavigationListener(location => {
-          if (!location.pathname.startsWith("/search")) {
-            this.setState({ term: "" })
-          }
+          this.clearSearchTerm()
 
           return true
         })
       : () => {
           // noop
         }
+  }
+
+  clearSearchTerm = () => {
+    if (!location.pathname.startsWith("/search")) {
+      this.setState({ term: "" })
+    }
   }
 
   componentWillUnmount() {
@@ -270,9 +274,10 @@ export class SearchBar extends Component<Props, State> {
     },
     method,
   }) {
-    if (method === "click") return
-
+    this.clearSearchTerm()
     this.userClickedOnDescendant = true
+
+    if (method === "click") return
 
     if (this.props.router) {
       // @ts-ignore (routeConfig not found; need to update DT types)


### PR DESCRIPTION
Follows up on [CX-1761]

https://github.com/artsy/force/pull/8246 introduced a bug that prevented the `SearchBar` from clearing the search term after clicking on a suggestion item.

This fix ensures the search term gets cleared every time the user clicks on a suggestion item.


**Before:**

https://user-images.githubusercontent.com/4691889/131504182-5eec1cc6-6c6c-402d-93d6-a3413e1d4bf9.mov

**After:**


https://user-images.githubusercontent.com/4691889/131504515-13faa211-d019-4418-a7b1-e0329dad1911.mov



[CX-1761]: https://artsyproduct.atlassian.net/browse/CX-1761