### PR TITLE
feat: update fair organizer page to use organizer profile image

### DIFF
--- a/src/v2/Apps/FairOrginizer/Components/DedicatedArticlesBreadcrumbs.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/DedicatedArticlesBreadcrumbs.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Breadcrumbs, Text, Image, Flex, ArrowLeftIcon } from "@artsy/palette"
 import { RouterLink } from "v2/System/Router/RouterLink"
-import { extractNodes } from "v2/Utils/extractNodes"
 import { DedicatedArticlesBreadcrumbs_fairOrganizer } from "v2/__generated__/DedicatedArticlesBreadcrumbs_fairOrganizer.graphql"
 
 interface DedicatedArticlesBreadcrumbsProps {
@@ -12,9 +11,7 @@ interface DedicatedArticlesBreadcrumbsProps {
 export const DedicatedArticlesBreadcrumbs: React.FC<DedicatedArticlesBreadcrumbsProps> = ({
   fairOrganizer,
 }) => {
-  const { name, slug, fairsConnection } = fairOrganizer
-  const fair = extractNodes(fairsConnection)[0]
-  const { image } = fair
+  const { name, slug, profile } = fairOrganizer
 
   return (
     <Breadcrumbs
@@ -29,8 +26,8 @@ export const DedicatedArticlesBreadcrumbs: React.FC<DedicatedArticlesBreadcrumbs
           <Image
             width={30}
             height={30}
-            src={image?.resized?.src!}
-            srcSet={image?.resized?.srcSet!}
+            src={profile?.image?.resized?.src!}
+            srcSet={profile?.image?.resized?.srcSet!}
             mx={1}
           />
           <Text variant="xs">Explore {name} on Artsy</Text>
@@ -47,15 +44,11 @@ export const DedicatedArticlesBreadcrumbsFragmentContainer = createFragmentConta
       fragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {
         slug
         name
-        fairsConnection(first: 1, sort: START_AT_DESC) {
-          edges {
-            node {
-              image {
-                resized(width: 30, height: 30, version: "square") {
-                  src
-                  srcSet
-                }
-              }
+        profile {
+          image {
+            resized(width: 30, height: 30, version: "square") {
+              src
+              srcSet
             }
           }
         }

--- a/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeaderImage.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/FairOrganizerHeaderImage.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { FairOrganizerHeaderImage_fairOrganizer } from "v2/__generated__/FairOrganizerHeaderImage_fairOrganizer.graphql"
+import { FullBleedHeader } from "v2/Components/FullBleedHeader"
+
+interface FairOrganizerHeaderImageProps {
+  fairOrganizer: FairOrganizerHeaderImage_fairOrganizer
+}
+
+export const FairOrganizerHeaderImage: React.FC<FairOrganizerHeaderImageProps> = ({
+  fairOrganizer: { profile },
+}) => {
+  if (profile?.image?.url) {
+    return <FullBleedHeader src={profile?.image.url} />
+  }
+
+  return null
+}
+
+export const FairOrganizerHeaderImageFragmentContainer = createFragmentContainer(
+  FairOrganizerHeaderImage,
+  {
+    fairOrganizer: graphql`
+      fragment FairOrganizerHeaderImage_fairOrganizer on FairOrganizer {
+        profile {
+          image {
+            url(version: "wide")
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/v2/Apps/FairOrginizer/Components/__tests__/DedicatedArticlesBreadcrumbs.jest.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/__tests__/DedicatedArticlesBreadcrumbs.jest.tsx
@@ -46,14 +46,8 @@ describe("DedicatedArticlesBreadcrumbs", () => {
   it("displays image", () => {
     const wrapper = getWrapper({
       FairOrganizer: () => ({
-        fairsConnection: {
-          edges: [
-            {
-              node: {
-                image: { resized: { src: "some-src", srcSet: "some-src-set" } },
-              },
-            },
-          ],
+        profile: {
+          image: { resized: { src: "some-src", srcSet: "some-src-set" } },
         },
       }),
     })

--- a/src/v2/Apps/FairOrginizer/FairOrganizerApp.tsx
+++ b/src/v2/Apps/FairOrginizer/FairOrganizerApp.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { Box, Spacer, Title } from "@artsy/palette"
 import { FairOrganizerApp_fairOrganizer } from "v2/__generated__/FairOrganizerApp_fairOrganizer.graphql"
-import { FairHeaderImageFragmentContainer as FairHeaderImage } from "../Fair/Components/FairHeader/FairHeaderImage"
+import { FairOrganizerHeaderImageFragmentContainer as FairOrganizerHeaderImage } from "./Components/FairOrganizerHeaderImage"
 import { FairOrganizerHeaderFragmentContainer as FairOrganizerHeader } from "./Components/FairOrganizerHeader/FairOrganizerHeader"
 import { FairOrganizerPastEventsRailFragmentContainer as FairOrganizerPastEventsRail } from "./Components/FairOrganizerPastEventsRail"
 import { FairOrganizerLatestArticlesFragmentContainer as FairOrganizerLatestArticles } from "./Components/FairOrganizerLatestArticles"
@@ -14,15 +14,13 @@ interface FairOrganizerAppProps {
 const FairOrganizerApp: React.FC<FairOrganizerAppProps> = ({
   fairOrganizer,
 }) => {
-  const { fairs, name } = fairOrganizer
-  const { edges } = fairs!
-  const fair = edges?.[0]?.node!
+  const { name } = fairOrganizer
   return (
     <>
       <Title>{`${name} | Artsy`}</Title>
 
       <Box>
-        <FairHeaderImage fair={fair} />
+        <FairOrganizerHeaderImage fairOrganizer={fairOrganizer} />
 
         <Spacer mt={4} />
 
@@ -46,14 +44,8 @@ export const FairOrganizerAppFragmentContainer = createFragmentContainer(
     fairOrganizer: graphql`
       fragment FairOrganizerApp_fairOrganizer on FairOrganizer {
         name
-        fairs: fairsConnection(first: 1, sort: START_AT_DESC) {
-          edges {
-            node {
-              ...FairHeaderImage_fair
-            }
-          }
-        }
         ...FairOrganizerPastEventsRail_fairOrganizer
+        ...FairOrganizerHeaderImage_fairOrganizer
         ...FairOrganizerHeader_fairOrganizer
         ...FairOrganizerLatestArticles_fairOrganizer
       }

--- a/src/v2/Apps/FairOrginizer/__tests__/FairOrganizerApp.jest.tsx
+++ b/src/v2/Apps/FairOrginizer/__tests__/FairOrganizerApp.jest.tsx
@@ -29,7 +29,7 @@ describe("FairOrganizerApp", () => {
 
   it("renders correctly", () => {
     const wrapper = getWrapper()
-    expect(wrapper.find("FairHeaderImage").length).toBe(1)
+    expect(wrapper.find("FairOrganizerHeaderImage").length).toBe(1)
     expect(wrapper.find("FairOrganizerHeader").length).toBe(1)
     expect(wrapper.find("FairOrganizerPastEventsRail").length).toBe(1)
     expect(wrapper.find("FairOrganizerLatestArticles").length).toBe(1)

--- a/src/v2/__generated__/DedicatedArticlesBreadcrumbs_Test_Query.graphql.ts
+++ b/src/v2/__generated__/DedicatedArticlesBreadcrumbs_Test_Query.graphql.ts
@@ -27,18 +27,14 @@ query DedicatedArticlesBreadcrumbs_Test_Query {
 fragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {
   slug
   name
-  fairsConnection(first: 1, sort: START_AT_DESC) {
-    edges {
-      node {
-        image {
-          resized(width: 30, height: 30, version: "square") {
-            src
-            srcSet
-          }
-        }
-        id
+  profile {
+    image {
+      resized(width: 30, height: 30, version: "square") {
+        src
+        srcSet
       }
     }
+    id
   }
 }
 */
@@ -114,100 +110,67 @@ return {
           },
           {
             "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 1
-              },
-              {
-                "kind": "Literal",
-                "name": "sort",
-                "value": "START_AT_DESC"
-              }
-            ],
-            "concreteType": "FairConnection",
+            "args": null,
+            "concreteType": "Profile",
             "kind": "LinkedField",
-            "name": "fairsConnection",
+            "name": "profile",
             "plural": false,
             "selections": [
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "FairEdge",
+                "concreteType": "Image",
                 "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
+                "name": "image",
+                "plural": false,
                 "selections": [
                   {
                     "alias": null,
-                    "args": null,
-                    "concreteType": "Fair",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 30
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "version",
+                        "value": "square"
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 30
+                      }
+                    ],
+                    "concreteType": "ResizedImageUrl",
                     "kind": "LinkedField",
-                    "name": "node",
+                    "name": "resized",
                     "plural": false,
                     "selections": [
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "height",
-                                "value": 30
-                              },
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": "square"
-                              },
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 30
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "src",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "srcSet",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": "resized(height:30,version:\"square\",width:30)"
-                          }
-                        ],
+                        "kind": "ScalarField",
+                        "name": "src",
                         "storageKey": null
                       },
-                      (v1/*: any*/)
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "srcSet",
+                        "storageKey": null
+                      }
                     ],
-                    "storageKey": null
+                    "storageKey": "resized(height:30,version:\"square\",width:30)"
                   }
                 ],
                 "storageKey": null
-              }
+              },
+              (v1/*: any*/)
             ],
-            "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
+            "storageKey": null
           },
           (v1/*: any*/)
         ],
@@ -220,7 +183,7 @@ return {
     "metadata": {},
     "name": "DedicatedArticlesBreadcrumbs_Test_Query",
     "operationKind": "query",
-    "text": "query DedicatedArticlesBreadcrumbs_Test_Query {\n  fairOrganizer(id: \"example\") {\n    ...DedicatedArticlesBreadcrumbs_fairOrganizer\n    id\n  }\n}\n\nfragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {\n  slug\n  name\n  fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        image {\n          resized(width: 30, height: 30, version: \"square\") {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query DedicatedArticlesBreadcrumbs_Test_Query {\n  fairOrganizer(id: \"example\") {\n    ...DedicatedArticlesBreadcrumbs_fairOrganizer\n    id\n  }\n}\n\nfragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {\n  slug\n  name\n  profile {\n    image {\n      resized(width: 30, height: 30, version: \"square\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/DedicatedArticlesBreadcrumbs_fairOrganizer.graphql.ts
+++ b/src/v2/__generated__/DedicatedArticlesBreadcrumbs_fairOrganizer.graphql.ts
@@ -6,17 +6,13 @@ import { FragmentRefs } from "relay-runtime";
 export type DedicatedArticlesBreadcrumbs_fairOrganizer = {
     readonly slug: string;
     readonly name: string | null;
-    readonly fairsConnection: {
-        readonly edges: ReadonlyArray<{
-            readonly node: {
-                readonly image: {
-                    readonly resized: {
-                        readonly src: string;
-                        readonly srcSet: string;
-                    } | null;
-                } | null;
+    readonly profile: {
+        readonly image: {
+            readonly resized: {
+                readonly src: string;
+                readonly srcSet: string;
             } | null;
-        } | null> | null;
+        } | null;
     } | null;
     readonly " $refType": "DedicatedArticlesBreadcrumbs_fairOrganizer";
 };
@@ -50,102 +46,69 @@ const node: ReaderFragment = {
     },
     {
       "alias": null,
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "first",
-          "value": 1
-        },
-        {
-          "kind": "Literal",
-          "name": "sort",
-          "value": "START_AT_DESC"
-        }
-      ],
-      "concreteType": "FairConnection",
+      "args": null,
+      "concreteType": "Profile",
       "kind": "LinkedField",
-      "name": "fairsConnection",
+      "name": "profile",
       "plural": false,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "concreteType": "FairEdge",
+          "concreteType": "Image",
           "kind": "LinkedField",
-          "name": "edges",
-          "plural": true,
+          "name": "image",
+          "plural": false,
           "selections": [
             {
               "alias": null,
-              "args": null,
-              "concreteType": "Fair",
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "height",
+                  "value": 30
+                },
+                {
+                  "kind": "Literal",
+                  "name": "version",
+                  "value": "square"
+                },
+                {
+                  "kind": "Literal",
+                  "name": "width",
+                  "value": 30
+                }
+              ],
+              "concreteType": "ResizedImageUrl",
               "kind": "LinkedField",
-              "name": "node",
+              "name": "resized",
               "plural": false,
               "selections": [
                 {
                   "alias": null,
                   "args": null,
-                  "concreteType": "Image",
-                  "kind": "LinkedField",
-                  "name": "image",
-                  "plural": false,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": [
-                        {
-                          "kind": "Literal",
-                          "name": "height",
-                          "value": 30
-                        },
-                        {
-                          "kind": "Literal",
-                          "name": "version",
-                          "value": "square"
-                        },
-                        {
-                          "kind": "Literal",
-                          "name": "width",
-                          "value": 30
-                        }
-                      ],
-                      "concreteType": "ResizedImageUrl",
-                      "kind": "LinkedField",
-                      "name": "resized",
-                      "plural": false,
-                      "selections": [
-                        {
-                          "alias": null,
-                          "args": null,
-                          "kind": "ScalarField",
-                          "name": "src",
-                          "storageKey": null
-                        },
-                        {
-                          "alias": null,
-                          "args": null,
-                          "kind": "ScalarField",
-                          "name": "srcSet",
-                          "storageKey": null
-                        }
-                      ],
-                      "storageKey": "resized(height:30,version:\"square\",width:30)"
-                    }
-                  ],
+                  "kind": "ScalarField",
+                  "name": "src",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "srcSet",
                   "storageKey": null
                 }
               ],
-              "storageKey": null
+              "storageKey": "resized(height:30,version:\"square\",width:30)"
             }
           ],
           "storageKey": null
         }
       ],
-      "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
+      "storageKey": null
     }
   ],
   "type": "FairOrganizer"
 };
-(node as any).hash = '87dc3d34dbc55002ddcfe95a43e9bbb4';
+(node as any).hash = '322d075ec0670293841ce10f1aa54c40';
 export default node;

--- a/src/v2/__generated__/FairOrganizerApp_Test_Query.graphql.ts
+++ b/src/v2/__generated__/FairOrganizerApp_Test_Query.graphql.ts
@@ -48,23 +48,10 @@ fragment FairEditorialItem_article on Article {
   }
 }
 
-fragment FairHeaderImage_fair on Fair {
-  image {
-    url(version: "wide")
-  }
-}
-
 fragment FairOrganizerApp_fairOrganizer on FairOrganizer {
   name
-  fairs: fairsConnection(first: 1, sort: START_AT_DESC) {
-    edges {
-      node {
-        ...FairHeaderImage_fair
-        id
-      }
-    }
-  }
   ...FairOrganizerPastEventsRail_fairOrganizer
+  ...FairOrganizerHeaderImage_fairOrganizer
   ...FairOrganizerHeader_fairOrganizer
   ...FairOrganizerLatestArticles_fairOrganizer
 }
@@ -91,6 +78,15 @@ fragment FairOrganizerHeaderIcon_fairOrganizer on FairOrganizer {
         src
         srcSet
       }
+    }
+    id
+  }
+}
+
+fragment FairOrganizerHeaderImage_fairOrganizer on FairOrganizer {
+  profile {
+    image {
+      url(version: "wide")
     }
     id
   }
@@ -176,48 +172,40 @@ v2 = {
   "name": "sort",
   "value": "START_AT_DESC"
 },
-v3 = [
-  {
-    "kind": "Literal",
-    "name": "first",
-    "value": 1
-  },
-  (v2/*: any*/)
-],
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v6 = {
+v5 = {
   "kind": "Literal",
   "name": "width",
   "value": 325
 },
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "src",
   "storageKey": null
 },
-v8 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "srcSet",
   "storageKey": null
 },
-v9 = [
+v8 = [
   {
     "alias": null,
     "args": null,
@@ -232,30 +220,30 @@ v9 = [
     "name": "height",
     "storageKey": null
   },
-  (v7/*: any*/),
-  (v8/*: any*/)
+  (v6/*: any*/),
+  (v7/*: any*/)
 ],
-v10 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v11 = {
+v9 = {
   "kind": "Literal",
   "name": "version",
   "value": "square140"
 },
-v12 = [
-  (v7/*: any*/),
-  (v8/*: any*/)
+v10 = [
+  (v6/*: any*/),
+  (v7/*: any*/)
 ],
-v13 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
   "storageKey": null
 };
 return {
@@ -300,64 +288,6 @@ return {
         "selections": [
           (v1/*: any*/),
           {
-            "alias": "fairs",
-            "args": (v3/*: any*/),
-            "concreteType": "FairConnection",
-            "kind": "LinkedField",
-            "name": "fairsConnection",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "FairEdge",
-                "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Fair",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": "wide"
-                              }
-                            ],
-                            "kind": "ScalarField",
-                            "name": "url",
-                            "storageKey": "url(version:\"wide\")"
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v4/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
-          },
-          {
             "alias": "pastFairs",
             "args": [
               {
@@ -398,8 +328,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
+                      (v3/*: any*/),
                       (v4/*: any*/),
-                      (v5/*: any*/),
                       (v1/*: any*/),
                       {
                         "alias": null,
@@ -417,13 +347,13 @@ return {
                                 "name": "height",
                                 "value": 244
                               },
-                              (v6/*: any*/)
+                              (v5/*: any*/)
                             ],
                             "concreteType": "CroppedImageUrl",
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": "cropped(height:244,width:325)"
                           }
                         ],
@@ -440,7 +370,113 @@ return {
           },
           {
             "alias": null,
-            "args": (v3/*: any*/),
+            "args": null,
+            "concreteType": "Profile",
+            "kind": "LinkedField",
+            "name": "profile",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "image",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "version",
+                        "value": "wide"
+                      }
+                    ],
+                    "kind": "ScalarField",
+                    "name": "url",
+                    "storageKey": "url(version:\"wide\")"
+                  }
+                ],
+                "storageKey": null
+              },
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "icon",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": "desktop",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 80
+                      },
+                      (v9/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 80
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v10/*: any*/),
+                    "storageKey": "cropped(height:80,version:\"square140\",width:80)"
+                  },
+                  {
+                    "alias": "mobile",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 60
+                      },
+                      (v9/*: any*/),
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 60
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v10/*: any*/),
+                    "storageKey": "cropped(height:60,version:\"square140\",width:60)"
+                  }
+                ],
+                "storageKey": null
+              },
+              (v11/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isFollowed",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              },
+              (v2/*: any*/)
+            ],
             "concreteType": "FairConnection",
             "kind": "LinkedField",
             "name": "fairsConnection",
@@ -462,7 +498,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v10/*: any*/),
+                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -477,7 +513,7 @@ return {
                         "name": "exhibitionPeriod",
                         "storageKey": null
                       },
-                      (v4/*: any*/)
+                      (v3/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -487,82 +523,7 @@ return {
             ],
             "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
           },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "Profile",
-            "kind": "LinkedField",
-            "name": "profile",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "Image",
-                "kind": "LinkedField",
-                "name": "icon",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": "desktop",
-                    "args": [
-                      {
-                        "kind": "Literal",
-                        "name": "height",
-                        "value": 80
-                      },
-                      (v11/*: any*/),
-                      {
-                        "kind": "Literal",
-                        "name": "width",
-                        "value": 80
-                      }
-                    ],
-                    "concreteType": "CroppedImageUrl",
-                    "kind": "LinkedField",
-                    "name": "cropped",
-                    "plural": false,
-                    "selections": (v12/*: any*/),
-                    "storageKey": "cropped(height:80,version:\"square140\",width:80)"
-                  },
-                  {
-                    "alias": "mobile",
-                    "args": [
-                      {
-                        "kind": "Literal",
-                        "name": "height",
-                        "value": 60
-                      },
-                      (v11/*: any*/),
-                      {
-                        "kind": "Literal",
-                        "name": "width",
-                        "value": 60
-                      }
-                    ],
-                    "concreteType": "CroppedImageUrl",
-                    "kind": "LinkedField",
-                    "name": "cropped",
-                    "plural": false,
-                    "selections": (v12/*: any*/),
-                    "storageKey": "cropped(height:60,version:\"square140\",width:60)"
-                  }
-                ],
-                "storageKey": null
-              },
-              (v4/*: any*/),
-              (v13/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "isFollowed",
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
-          (v5/*: any*/),
+          (v4/*: any*/),
           {
             "alias": null,
             "args": [
@@ -618,9 +579,9 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
+                      (v3/*: any*/),
+                      (v11/*: any*/),
                       (v4/*: any*/),
-                      (v13/*: any*/),
-                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -628,7 +589,7 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v10/*: any*/),
+                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": [
@@ -675,7 +636,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": "cropped(height:720,width:670)"
                           },
                           {
@@ -686,13 +647,13 @@ return {
                                 "name": "height",
                                 "value": 240
                               },
-                              (v6/*: any*/)
+                              (v5/*: any*/)
                             ],
                             "concreteType": "CroppedImageUrl",
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": "cropped(height:240,width:325)"
                           }
                         ],
@@ -707,7 +668,7 @@ return {
             ],
             "storageKey": "articlesConnection(first:7,sort:\"PUBLISHED_AT_DESC\")"
           },
-          (v4/*: any*/)
+          (v3/*: any*/)
         ],
         "storageKey": "fairOrganizer(id:\"example\")"
       }
@@ -718,7 +679,7 @@ return {
     "metadata": {},
     "name": "FairOrganizerApp_Test_Query",
     "operationKind": "query",
-    "text": "query FairOrganizerApp_Test_Query {\n  fairOrganizer(id: \"example\") {\n    ...FairOrganizerApp_fairOrganizer\n    id\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairOrganizerApp_fairOrganizer on FairOrganizer {\n  name\n  fairs: fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        ...FairHeaderImage_fair\n        id\n      }\n    }\n  }\n  ...FairOrganizerPastEventsRail_fairOrganizer\n  ...FairOrganizerHeader_fairOrganizer\n  ...FairOrganizerLatestArticles_fairOrganizer\n}\n\nfragment FairOrganizerFollowButton_fairOrganizer on FairOrganizer {\n  slug\n  name\n  profile {\n    id\n    internalID\n    isFollowed\n  }\n}\n\nfragment FairOrganizerHeaderIcon_fairOrganizer on FairOrganizer {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairOrganizerHeader_fairOrganizer on FairOrganizer {\n  name\n  fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        href\n        startAt\n        exhibitionPeriod\n        id\n      }\n    }\n  }\n  ...FairOrganizerHeaderIcon_fairOrganizer\n  ...FairOrganizerFollowButton_fairOrganizer\n  ...FairOrganizerInfo_fairOrganizer\n}\n\nfragment FairOrganizerInfo_fairOrganizer on FairOrganizer {\n  about(format: HTML)\n}\n\nfragment FairOrganizerLatestArticles_fairOrganizer on FairOrganizer {\n  name\n  slug\n  articlesConnection(first: 7, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairOrganizerPastEventRailCell_fair on Fair {\n  slug\n  name\n  image {\n    cropped(width: 325, height: 244) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerPastEventsRail_fairOrganizer on FairOrganizer {\n  pastFairs: fairsConnection(first: 20, sort: START_AT_DESC, status: CLOSED, hasFullFeature: true) {\n    edges {\n      node {\n        id\n        ...FairOrganizerPastEventRailCell_fair\n      }\n    }\n  }\n}\n"
+    "text": "query FairOrganizerApp_Test_Query {\n  fairOrganizer(id: \"example\") {\n    ...FairOrganizerApp_fairOrganizer\n    id\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerApp_fairOrganizer on FairOrganizer {\n  name\n  ...FairOrganizerPastEventsRail_fairOrganizer\n  ...FairOrganizerHeaderImage_fairOrganizer\n  ...FairOrganizerHeader_fairOrganizer\n  ...FairOrganizerLatestArticles_fairOrganizer\n}\n\nfragment FairOrganizerFollowButton_fairOrganizer on FairOrganizer {\n  slug\n  name\n  profile {\n    id\n    internalID\n    isFollowed\n  }\n}\n\nfragment FairOrganizerHeaderIcon_fairOrganizer on FairOrganizer {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairOrganizerHeaderImage_fairOrganizer on FairOrganizer {\n  profile {\n    image {\n      url(version: \"wide\")\n    }\n    id\n  }\n}\n\nfragment FairOrganizerHeader_fairOrganizer on FairOrganizer {\n  name\n  fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        href\n        startAt\n        exhibitionPeriod\n        id\n      }\n    }\n  }\n  ...FairOrganizerHeaderIcon_fairOrganizer\n  ...FairOrganizerFollowButton_fairOrganizer\n  ...FairOrganizerInfo_fairOrganizer\n}\n\nfragment FairOrganizerInfo_fairOrganizer on FairOrganizer {\n  about(format: HTML)\n}\n\nfragment FairOrganizerLatestArticles_fairOrganizer on FairOrganizer {\n  name\n  slug\n  articlesConnection(first: 7, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairOrganizerPastEventRailCell_fair on Fair {\n  slug\n  name\n  image {\n    cropped(width: 325, height: 244) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerPastEventsRail_fairOrganizer on FairOrganizer {\n  pastFairs: fairsConnection(first: 20, sort: START_AT_DESC, status: CLOSED, hasFullFeature: true) {\n    edges {\n      node {\n        id\n        ...FairOrganizerPastEventRailCell_fair\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairOrganizerApp_fairOrganizer.graphql.ts
+++ b/src/v2/__generated__/FairOrganizerApp_fairOrganizer.graphql.ts
@@ -5,14 +5,7 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type FairOrganizerApp_fairOrganizer = {
     readonly name: string | null;
-    readonly fairs: {
-        readonly edges: ReadonlyArray<{
-            readonly node: {
-                readonly " $fragmentRefs": FragmentRefs<"FairHeaderImage_fair">;
-            } | null;
-        } | null> | null;
-    } | null;
-    readonly " $fragmentRefs": FragmentRefs<"FairOrganizerPastEventsRail_fairOrganizer" | "FairOrganizerHeader_fairOrganizer" | "FairOrganizerLatestArticles_fairOrganizer">;
+    readonly " $fragmentRefs": FragmentRefs<"FairOrganizerPastEventsRail_fairOrganizer" | "FairOrganizerHeaderImage_fairOrganizer" | "FairOrganizerHeader_fairOrganizer" | "FairOrganizerLatestArticles_fairOrganizer">;
     readonly " $refType": "FairOrganizerApp_fairOrganizer";
 };
 export type FairOrganizerApp_fairOrganizer$data = FairOrganizerApp_fairOrganizer;
@@ -37,58 +30,14 @@ const node: ReaderFragment = {
       "storageKey": null
     },
     {
-      "alias": "fairs",
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "first",
-          "value": 1
-        },
-        {
-          "kind": "Literal",
-          "name": "sort",
-          "value": "START_AT_DESC"
-        }
-      ],
-      "concreteType": "FairConnection",
-      "kind": "LinkedField",
-      "name": "fairsConnection",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "FairEdge",
-          "kind": "LinkedField",
-          "name": "edges",
-          "plural": true,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "Fair",
-              "kind": "LinkedField",
-              "name": "node",
-              "plural": false,
-              "selections": [
-                {
-                  "args": null,
-                  "kind": "FragmentSpread",
-                  "name": "FairHeaderImage_fair"
-                }
-              ],
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
-        }
-      ],
-      "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "FairOrganizerPastEventsRail_fairOrganizer"
     },
     {
       "args": null,
       "kind": "FragmentSpread",
-      "name": "FairOrganizerPastEventsRail_fairOrganizer"
+      "name": "FairOrganizerHeaderImage_fairOrganizer"
     },
     {
       "args": null,
@@ -103,5 +52,5 @@ const node: ReaderFragment = {
   ],
   "type": "FairOrganizer"
 };
-(node as any).hash = 'c7eca6dc37c306c58e77c7172effa4b1';
+(node as any).hash = '9e9308ba6c443b37423ab1ae3a027e09';
 export default node;

--- a/src/v2/__generated__/FairOrganizerDedicatedArticlesQuery.graphql.ts
+++ b/src/v2/__generated__/FairOrganizerDedicatedArticlesQuery.graphql.ts
@@ -35,18 +35,14 @@ query FairOrganizerDedicatedArticlesQuery(
 fragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {
   slug
   name
-  fairsConnection(first: 1, sort: START_AT_DESC) {
-    edges {
-      node {
-        image {
-          resized(width: 30, height: 30, version: "square") {
-            src
-            srcSet
-          }
-        }
-        id
+  profile {
+    image {
+      resized(width: 30, height: 30, version: "square") {
+        src
+        srcSet
       }
     }
+    id
   }
 }
 
@@ -496,88 +492,55 @@ return {
           },
           {
             "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 1
-              },
-              {
-                "kind": "Literal",
-                "name": "sort",
-                "value": "START_AT_DESC"
-              }
-            ],
-            "concreteType": "FairConnection",
+            "args": null,
+            "concreteType": "Profile",
             "kind": "LinkedField",
-            "name": "fairsConnection",
+            "name": "profile",
             "plural": false,
             "selections": [
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "FairEdge",
+                "concreteType": "Image",
                 "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
+                "name": "image",
+                "plural": false,
                 "selections": [
                   {
                     "alias": null,
-                    "args": null,
-                    "concreteType": "Fair",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 30
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "version",
+                        "value": "square"
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 30
+                      }
+                    ],
+                    "concreteType": "ResizedImageUrl",
                     "kind": "LinkedField",
-                    "name": "node",
+                    "name": "resized",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "height",
-                                "value": 30
-                              },
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": "square"
-                              },
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 30
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              (v9/*: any*/),
-                              (v10/*: any*/)
-                            ],
-                            "storageKey": "resized(height:30,version:\"square\",width:30)"
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v8/*: any*/)
+                      (v9/*: any*/),
+                      (v10/*: any*/)
                     ],
-                    "storageKey": null
+                    "storageKey": "resized(height:30,version:\"square\",width:30)"
                   }
                 ],
                 "storageKey": null
-              }
+              },
+              (v8/*: any*/)
             ],
-            "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
+            "storageKey": null
           },
           (v8/*: any*/)
         ],
@@ -590,7 +553,7 @@ return {
     "metadata": {},
     "name": "FairOrganizerDedicatedArticlesQuery",
     "operationKind": "query",
-    "text": "query FairOrganizerDedicatedArticlesQuery(\n  $id: String!\n  $first: Int\n  $page: Int\n) {\n  fairOrganizer(id: $id) {\n    ...FairOrganizerDedicatedArticles_fairOrganizer_4D1OJz\n    id\n  }\n}\n\nfragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {\n  slug\n  name\n  fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        image {\n          resized(width: 30, height: 30, version: \"square\") {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerDedicatedArticles_fairOrganizer_4D1OJz on FairOrganizer {\n  slug\n  name\n  articlesConnection(first: $first, page: $page, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n  ...DedicatedArticlesBreadcrumbs_fairOrganizer\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query FairOrganizerDedicatedArticlesQuery(\n  $id: String!\n  $first: Int\n  $page: Int\n) {\n  fairOrganizer(id: $id) {\n    ...FairOrganizerDedicatedArticles_fairOrganizer_4D1OJz\n    id\n  }\n}\n\nfragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {\n  slug\n  name\n  profile {\n    image {\n      resized(width: 30, height: 30, version: \"square\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerDedicatedArticles_fairOrganizer_4D1OJz on FairOrganizer {\n  slug\n  name\n  articlesConnection(first: $first, page: $page, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n  ...DedicatedArticlesBreadcrumbs_fairOrganizer\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairOrganizerDedicatedArticles_Test_Query.graphql.ts
+++ b/src/v2/__generated__/FairOrganizerDedicatedArticles_Test_Query.graphql.ts
@@ -27,18 +27,14 @@ query FairOrganizerDedicatedArticles_Test_Query {
 fragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {
   slug
   name
-  fairsConnection(first: 1, sort: START_AT_DESC) {
-    edges {
-      node {
-        image {
-          resized(width: 30, height: 30, version: "square") {
-            src
-            srcSet
-          }
-        }
-        id
+  profile {
+    image {
+      resized(width: 30, height: 30, version: "square") {
+        src
+        srcSet
       }
     }
+    id
   }
 }
 
@@ -463,88 +459,55 @@ return {
           },
           {
             "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 1
-              },
-              {
-                "kind": "Literal",
-                "name": "sort",
-                "value": "START_AT_DESC"
-              }
-            ],
-            "concreteType": "FairConnection",
+            "args": null,
+            "concreteType": "Profile",
             "kind": "LinkedField",
-            "name": "fairsConnection",
+            "name": "profile",
             "plural": false,
             "selections": [
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "FairEdge",
+                "concreteType": "Image",
                 "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
+                "name": "image",
+                "plural": false,
                 "selections": [
                   {
                     "alias": null,
-                    "args": null,
-                    "concreteType": "Fair",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 30
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "version",
+                        "value": "square"
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 30
+                      }
+                    ],
+                    "concreteType": "ResizedImageUrl",
                     "kind": "LinkedField",
-                    "name": "node",
+                    "name": "resized",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "height",
-                                "value": 30
-                              },
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": "square"
-                              },
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 30
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              (v6/*: any*/),
-                              (v7/*: any*/)
-                            ],
-                            "storageKey": "resized(height:30,version:\"square\",width:30)"
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v5/*: any*/)
+                      (v6/*: any*/),
+                      (v7/*: any*/)
                     ],
-                    "storageKey": null
+                    "storageKey": "resized(height:30,version:\"square\",width:30)"
                   }
                 ],
                 "storageKey": null
-              }
+              },
+              (v5/*: any*/)
             ],
-            "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
+            "storageKey": null
           },
           (v5/*: any*/)
         ],
@@ -557,7 +520,7 @@ return {
     "metadata": {},
     "name": "FairOrganizerDedicatedArticles_Test_Query",
     "operationKind": "query",
-    "text": "query FairOrganizerDedicatedArticles_Test_Query {\n  fairOrganizer(id: \"example\") {\n    ...FairOrganizerDedicatedArticles_fairOrganizer\n    id\n  }\n}\n\nfragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {\n  slug\n  name\n  fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        image {\n          resized(width: 30, height: 30, version: \"square\") {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerDedicatedArticles_fairOrganizer on FairOrganizer {\n  slug\n  name\n  articlesConnection(first: 16, page: 1, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n  ...DedicatedArticlesBreadcrumbs_fairOrganizer\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query FairOrganizerDedicatedArticles_Test_Query {\n  fairOrganizer(id: \"example\") {\n    ...FairOrganizerDedicatedArticles_fairOrganizer\n    id\n  }\n}\n\nfragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {\n  slug\n  name\n  profile {\n    image {\n      resized(width: 30, height: 30, version: \"square\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerDedicatedArticles_fairOrganizer on FairOrganizer {\n  slug\n  name\n  articlesConnection(first: 16, page: 1, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n  ...DedicatedArticlesBreadcrumbs_fairOrganizer\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/FairOrganizerHeaderImage_fairOrganizer.graphql.ts
+++ b/src/v2/__generated__/FairOrganizerHeaderImage_fairOrganizer.graphql.ts
@@ -1,0 +1,67 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type FairOrganizerHeaderImage_fairOrganizer = {
+    readonly profile: {
+        readonly image: {
+            readonly url: string | null;
+        } | null;
+    } | null;
+    readonly " $refType": "FairOrganizerHeaderImage_fairOrganizer";
+};
+export type FairOrganizerHeaderImage_fairOrganizer$data = FairOrganizerHeaderImage_fairOrganizer;
+export type FairOrganizerHeaderImage_fairOrganizer$key = {
+    readonly " $data"?: FairOrganizerHeaderImage_fairOrganizer$data;
+    readonly " $fragmentRefs": FragmentRefs<"FairOrganizerHeaderImage_fairOrganizer">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "FairOrganizerHeaderImage_fairOrganizer",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Profile",
+      "kind": "LinkedField",
+      "name": "profile",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Image",
+          "kind": "LinkedField",
+          "name": "image",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "version",
+                  "value": "wide"
+                }
+              ],
+              "kind": "ScalarField",
+              "name": "url",
+              "storageKey": "url(version:\"wide\")"
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "FairOrganizer"
+};
+(node as any).hash = '3fdef7d19c13faad6f174fc62c51b7a5';
+export default node;

--- a/src/v2/__generated__/fairOrganizerRoutes_FairOrganizerDedicatedArticles_Query.graphql.ts
+++ b/src/v2/__generated__/fairOrganizerRoutes_FairOrganizerDedicatedArticles_Query.graphql.ts
@@ -33,18 +33,14 @@ query fairOrganizerRoutes_FairOrganizerDedicatedArticles_Query(
 fragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {
   slug
   name
-  fairsConnection(first: 1, sort: START_AT_DESC) {
-    edges {
-      node {
-        image {
-          resized(width: 30, height: 30, version: "square") {
-            src
-            srcSet
-          }
-        }
-        id
+  profile {
+    image {
+      resized(width: 30, height: 30, version: "square") {
+        src
+        srcSet
       }
     }
+    id
   }
 }
 
@@ -486,88 +482,55 @@ return {
           },
           {
             "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 1
-              },
-              {
-                "kind": "Literal",
-                "name": "sort",
-                "value": "START_AT_DESC"
-              }
-            ],
-            "concreteType": "FairConnection",
+            "args": null,
+            "concreteType": "Profile",
             "kind": "LinkedField",
-            "name": "fairsConnection",
+            "name": "profile",
             "plural": false,
             "selections": [
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "FairEdge",
+                "concreteType": "Image",
                 "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
+                "name": "image",
+                "plural": false,
                 "selections": [
                   {
                     "alias": null,
-                    "args": null,
-                    "concreteType": "Fair",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 30
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "version",
+                        "value": "square"
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 30
+                      }
+                    ],
+                    "concreteType": "ResizedImageUrl",
                     "kind": "LinkedField",
-                    "name": "node",
+                    "name": "resized",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "height",
-                                "value": 30
-                              },
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": "square"
-                              },
-                              {
-                                "kind": "Literal",
-                                "name": "width",
-                                "value": 30
-                              }
-                            ],
-                            "concreteType": "ResizedImageUrl",
-                            "kind": "LinkedField",
-                            "name": "resized",
-                            "plural": false,
-                            "selections": [
-                              (v8/*: any*/),
-                              (v9/*: any*/)
-                            ],
-                            "storageKey": "resized(height:30,version:\"square\",width:30)"
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v7/*: any*/)
+                      (v8/*: any*/),
+                      (v9/*: any*/)
                     ],
-                    "storageKey": null
+                    "storageKey": "resized(height:30,version:\"square\",width:30)"
                   }
                 ],
                 "storageKey": null
-              }
+              },
+              (v7/*: any*/)
             ],
-            "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
+            "storageKey": null
           },
           (v7/*: any*/)
         ],
@@ -580,7 +543,7 @@ return {
     "metadata": {},
     "name": "fairOrganizerRoutes_FairOrganizerDedicatedArticles_Query",
     "operationKind": "query",
-    "text": "query fairOrganizerRoutes_FairOrganizerDedicatedArticles_Query(\n  $slug: String!\n  $page: Int\n) {\n  fairOrganizer(id: $slug) @principalField {\n    ...FairOrganizerDedicatedArticles_fairOrganizer_2Pg8Wv\n    id\n  }\n}\n\nfragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {\n  slug\n  name\n  fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        image {\n          resized(width: 30, height: 30, version: \"square\") {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerDedicatedArticles_fairOrganizer_2Pg8Wv on FairOrganizer {\n  slug\n  name\n  articlesConnection(first: 16, page: $page, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n  ...DedicatedArticlesBreadcrumbs_fairOrganizer\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query fairOrganizerRoutes_FairOrganizerDedicatedArticles_Query(\n  $slug: String!\n  $page: Int\n) {\n  fairOrganizer(id: $slug) @principalField {\n    ...FairOrganizerDedicatedArticles_fairOrganizer_2Pg8Wv\n    id\n  }\n}\n\nfragment DedicatedArticlesBreadcrumbs_fairOrganizer on FairOrganizer {\n  slug\n  name\n  profile {\n    image {\n      resized(width: 30, height: 30, version: \"square\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerDedicatedArticles_fairOrganizer_2Pg8Wv on FairOrganizer {\n  slug\n  name\n  articlesConnection(first: 16, page: $page, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n  ...DedicatedArticlesBreadcrumbs_fairOrganizer\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/fairOrganizerRoutes_FairOrganizerQuery.graphql.ts
+++ b/src/v2/__generated__/fairOrganizerRoutes_FairOrganizerQuery.graphql.ts
@@ -59,23 +59,10 @@ fragment FairEditorialItem_article on Article {
   }
 }
 
-fragment FairHeaderImage_fair on Fair {
-  image {
-    url(version: "wide")
-  }
-}
-
 fragment FairOrganizerApp_fairOrganizer on FairOrganizer {
   name
-  fairs: fairsConnection(first: 1, sort: START_AT_DESC) {
-    edges {
-      node {
-        ...FairHeaderImage_fair
-        id
-      }
-    }
-  }
   ...FairOrganizerPastEventsRail_fairOrganizer
+  ...FairOrganizerHeaderImage_fairOrganizer
   ...FairOrganizerHeader_fairOrganizer
   ...FairOrganizerLatestArticles_fairOrganizer
 }
@@ -102,6 +89,15 @@ fragment FairOrganizerHeaderIcon_fairOrganizer on FairOrganizer {
         src
         srcSet
       }
+    }
+    id
+  }
+}
+
+fragment FairOrganizerHeaderImage_fairOrganizer on FairOrganizer {
+  profile {
+    image {
+      url(version: "wide")
     }
     id
   }
@@ -239,27 +235,19 @@ v10 = {
   "name": "sort",
   "value": "START_AT_DESC"
 },
-v11 = [
-  {
-    "kind": "Literal",
-    "name": "first",
-    "value": 1
-  },
-  (v10/*: any*/)
-],
-v12 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v13 = {
+v12 = {
   "kind": "Literal",
   "name": "width",
   "value": 325
 },
-v14 = [
+v13 = [
   {
     "alias": null,
     "args": null,
@@ -277,7 +265,7 @@ v14 = [
   (v5/*: any*/),
   (v6/*: any*/)
 ],
-v15 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -351,6 +339,30 @@ return {
                 "args": null,
                 "concreteType": "Image",
                 "kind": "LinkedField",
+                "name": "image",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "version",
+                        "value": "wide"
+                      }
+                    ],
+                    "kind": "ScalarField",
+                    "name": "url",
+                    "storageKey": "url(version:\"wide\")"
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
                 "name": "icon",
                 "plural": false,
                 "selections": [
@@ -414,64 +426,6 @@ return {
           },
           (v9/*: any*/),
           {
-            "alias": "fairs",
-            "args": (v11/*: any*/),
-            "concreteType": "FairConnection",
-            "kind": "LinkedField",
-            "name": "fairsConnection",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "FairEdge",
-                "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Fair",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": "wide"
-                              }
-                            ],
-                            "kind": "ScalarField",
-                            "name": "url",
-                            "storageKey": "url(version:\"wide\")"
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v3/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
-          },
-          {
             "alias": "pastFairs",
             "args": [
               {
@@ -513,7 +467,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v3/*: any*/),
-                      (v12/*: any*/),
+                      (v11/*: any*/),
                       (v9/*: any*/),
                       {
                         "alias": null,
@@ -531,13 +485,13 @@ return {
                                 "name": "height",
                                 "value": 244
                               },
-                              (v13/*: any*/)
+                              (v12/*: any*/)
                             ],
                             "concreteType": "CroppedImageUrl",
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v14/*: any*/),
+                            "selections": (v13/*: any*/),
                             "storageKey": "cropped(height:244,width:325)"
                           }
                         ],
@@ -554,7 +508,14 @@ return {
           },
           {
             "alias": null,
-            "args": (v11/*: any*/),
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              },
+              (v10/*: any*/)
+            ],
             "concreteType": "FairConnection",
             "kind": "LinkedField",
             "name": "fairsConnection",
@@ -576,7 +537,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v15/*: any*/),
+                      (v14/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -601,7 +562,7 @@ return {
             ],
             "storageKey": "fairsConnection(first:1,sort:\"START_AT_DESC\")"
           },
-          (v12/*: any*/),
+          (v11/*: any*/),
           {
             "alias": null,
             "args": [
@@ -659,7 +620,7 @@ return {
                     "selections": [
                       (v3/*: any*/),
                       (v8/*: any*/),
-                      (v12/*: any*/),
+                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -667,7 +628,7 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v15/*: any*/),
+                      (v14/*: any*/),
                       {
                         "alias": null,
                         "args": [
@@ -714,7 +675,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v14/*: any*/),
+                            "selections": (v13/*: any*/),
                             "storageKey": "cropped(height:720,width:670)"
                           },
                           {
@@ -725,13 +686,13 @@ return {
                                 "name": "height",
                                 "value": 240
                               },
-                              (v13/*: any*/)
+                              (v12/*: any*/)
                             ],
                             "concreteType": "CroppedImageUrl",
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v14/*: any*/),
+                            "selections": (v13/*: any*/),
                             "storageKey": "cropped(height:240,width:325)"
                           }
                         ],
@@ -757,7 +718,7 @@ return {
     "metadata": {},
     "name": "fairOrganizerRoutes_FairOrganizerQuery",
     "operationKind": "query",
-    "text": "query fairOrganizerRoutes_FairOrganizerQuery(\n  $slug: String!\n) {\n  fairOrganizer(id: $slug) @principalField {\n    profile {\n      __typename\n      id\n    }\n    ...FairOrganizerApp_fairOrganizer\n    id\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairOrganizerApp_fairOrganizer on FairOrganizer {\n  name\n  fairs: fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        ...FairHeaderImage_fair\n        id\n      }\n    }\n  }\n  ...FairOrganizerPastEventsRail_fairOrganizer\n  ...FairOrganizerHeader_fairOrganizer\n  ...FairOrganizerLatestArticles_fairOrganizer\n}\n\nfragment FairOrganizerFollowButton_fairOrganizer on FairOrganizer {\n  slug\n  name\n  profile {\n    id\n    internalID\n    isFollowed\n  }\n}\n\nfragment FairOrganizerHeaderIcon_fairOrganizer on FairOrganizer {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairOrganizerHeader_fairOrganizer on FairOrganizer {\n  name\n  fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        href\n        startAt\n        exhibitionPeriod\n        id\n      }\n    }\n  }\n  ...FairOrganizerHeaderIcon_fairOrganizer\n  ...FairOrganizerFollowButton_fairOrganizer\n  ...FairOrganizerInfo_fairOrganizer\n}\n\nfragment FairOrganizerInfo_fairOrganizer on FairOrganizer {\n  about(format: HTML)\n}\n\nfragment FairOrganizerLatestArticles_fairOrganizer on FairOrganizer {\n  name\n  slug\n  articlesConnection(first: 7, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairOrganizerPastEventRailCell_fair on Fair {\n  slug\n  name\n  image {\n    cropped(width: 325, height: 244) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerPastEventsRail_fairOrganizer on FairOrganizer {\n  pastFairs: fairsConnection(first: 20, sort: START_AT_DESC, status: CLOSED, hasFullFeature: true) {\n    edges {\n      node {\n        id\n        ...FairOrganizerPastEventRailCell_fair\n      }\n    }\n  }\n}\n"
+    "text": "query fairOrganizerRoutes_FairOrganizerQuery(\n  $slug: String!\n) {\n  fairOrganizer(id: $slug) @principalField {\n    profile {\n      __typename\n      id\n    }\n    ...FairOrganizerApp_fairOrganizer\n    id\n  }\n}\n\nfragment FairEditorialItem_article on Article {\n  id\n  internalID\n  slug\n  title\n  href\n  publishedAt(format: \"MMMM D, YYYY\")\n  thumbnailTitle\n  thumbnailImage {\n    large: cropped(width: 670, height: 720) {\n      width\n      height\n      src\n      srcSet\n    }\n    small: cropped(width: 325, height: 240) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerApp_fairOrganizer on FairOrganizer {\n  name\n  ...FairOrganizerPastEventsRail_fairOrganizer\n  ...FairOrganizerHeaderImage_fairOrganizer\n  ...FairOrganizerHeader_fairOrganizer\n  ...FairOrganizerLatestArticles_fairOrganizer\n}\n\nfragment FairOrganizerFollowButton_fairOrganizer on FairOrganizer {\n  slug\n  name\n  profile {\n    id\n    internalID\n    isFollowed\n  }\n}\n\nfragment FairOrganizerHeaderIcon_fairOrganizer on FairOrganizer {\n  name\n  profile {\n    icon {\n      desktop: cropped(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n      mobile: cropped(width: 60, height: 60, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairOrganizerHeaderImage_fairOrganizer on FairOrganizer {\n  profile {\n    image {\n      url(version: \"wide\")\n    }\n    id\n  }\n}\n\nfragment FairOrganizerHeader_fairOrganizer on FairOrganizer {\n  name\n  fairsConnection(first: 1, sort: START_AT_DESC) {\n    edges {\n      node {\n        href\n        startAt\n        exhibitionPeriod\n        id\n      }\n    }\n  }\n  ...FairOrganizerHeaderIcon_fairOrganizer\n  ...FairOrganizerFollowButton_fairOrganizer\n  ...FairOrganizerInfo_fairOrganizer\n}\n\nfragment FairOrganizerInfo_fairOrganizer on FairOrganizer {\n  about(format: HTML)\n}\n\nfragment FairOrganizerLatestArticles_fairOrganizer on FairOrganizer {\n  name\n  slug\n  articlesConnection(first: 7, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        id\n        ...FairEditorialItem_article\n      }\n    }\n  }\n}\n\nfragment FairOrganizerPastEventRailCell_fair on Fair {\n  slug\n  name\n  image {\n    cropped(width: 325, height: 244) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairOrganizerPastEventsRail_fairOrganizer on FairOrganizer {\n  pastFairs: fairsConnection(first: 20, sort: START_AT_DESC, status: CLOSED, hasFullFeature: true) {\n    edges {\n      node {\n        id\n        ...FairOrganizerPastEventRailCell_fair\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Update the fair organizer page to use the organizer image in:

- The header hero image
- The breadcrumb link on the articles page

Jira: [FX-3276]

**Screenshots**

A few examples of the difference. Left (current / fair). Right (fair organizer).

![Screen Shot 2021-08-31 at 2 41 48 PM](https://user-images.githubusercontent.com/123595/131505130-e64751c7-3d01-4cb2-9ab8-cdff89dfa8bc.png)
![Screen Shot 2021-08-31 at 2 42 02 PM](https://user-images.githubusercontent.com/123595/131505158-f6081c0f-39a8-420d-88a4-08647fe17921.png)
![Screen Shot 2021-08-31 at 2 42 17 PM](https://user-images.githubusercontent.com/123595/131505162-b352a623-63d1-4934-b163-c9e1d08d2e2e.png)
![Screen Shot 2021-08-31 at 2 42 30 PM](https://user-images.githubusercontent.com/123595/131505164-7fb7c153-4ce8-4d97-8a46-48ca03f1f918.png)
![Screen Shot 2021-08-31 at 2 42 44 PM](https://user-images.githubusercontent.com/123595/131505167-56c24199-85e9-40d4-b898-73f338957ca7.png)
![Screen Shot 2021-08-31 at 2 42 57 PM](https://user-images.githubusercontent.com/123595/131505169-ec1626e9-a9e0-4fbd-b7e8-b5200695e28c.png)


[FX-3276]: https://artsyproduct.atlassian.net/browse/FX-3276