### PR TITLE
Deploy (search fix)

### DIFF
--- a/src/v2/Components/Search/SearchBar.tsx
+++ b/src/v2/Components/Search/SearchBar.tsx
@@ -166,19 +166,15 @@ export class SearchBar extends Component<Props, State> {
     // Clear the search term once you navigate away from search results
     this.removeNavigationListener = this.props.router
       ? this.props.router.addNavigationListener(location => {
-          this.clearSearchTerm()
+          if (!location.pathname.startsWith("/search")) {
+            this.setState({ term: "" })
+          }
 
           return true
         })
       : () => {
           // noop
         }
-  }
-
-  clearSearchTerm = () => {
-    if (!location.pathname.startsWith("/search")) {
-      this.setState({ term: "" })
-    }
   }
 
   componentWillUnmount() {
@@ -253,7 +249,7 @@ export class SearchBar extends Component<Props, State> {
       [
         {
           suggestion: {
-            node: { href, displayType, id, __typename },
+            node: { href, displayType, id },
           },
           suggestionIndex,
         },
@@ -261,7 +257,7 @@ export class SearchBar extends Component<Props, State> {
     ) => ({
       action_type: Schema.ActionType.SelectedItemFromSearch,
       destination_path:
-        __typename === "Artist" ? `${href}/works-for-sale` : href,
+        displayType === "Artist" ? `${href}/works-for-sale` : href,
       item_id: id,
       item_number: suggestionIndex,
       item_type: displayType,
@@ -270,14 +266,11 @@ export class SearchBar extends Component<Props, State> {
   )
   onSuggestionSelected({
     suggestion: {
-      node: { href, __typename },
+      node: { href, displayType },
     },
-    method,
   }) {
-    this.clearSearchTerm()
     this.userClickedOnDescendant = true
-
-    if (method === "click") return
+    const newHref = displayType === "Artist" ? `${href}/works-for-sale` : href
 
     if (this.props.router) {
       // @ts-ignore (routeConfig not found; need to update DT types)
@@ -285,19 +278,19 @@ export class SearchBar extends Component<Props, State> {
       // @ts-ignore (matchRoutes not found; need to update DT types)
       const isSupportedInRouter = !!this.props.router.matcher.matchRoutes(
         routes,
-        href
+        newHref
       )
 
       // Check if url exists within the global router context
       if (isSupportedInRouter) {
-        this.props.router.push(href)
+        this.props.router.push(newHref)
         this.onBlur({})
       } else {
-        window.location.assign(href)
+        window.location.assign(newHref)
       }
       // Outside of router context
     } else {
-      window.location.assign(href)
+      window.location.assign(newHref)
     }
   }
 
@@ -327,9 +320,6 @@ export class SearchBar extends Component<Props, State> {
     return displayLabel
   }
 
-  getLabel = ({ displayType, __typename }) =>
-    displayType || (__typename === "Artist" ? "Artist" : null)
-
   renderSuggestion = (edge, rest) => {
     const renderer = edge.node.isFirstItem
       ? this.renderFirstSuggestion
@@ -339,38 +329,29 @@ export class SearchBar extends Component<Props, State> {
   }
 
   renderFirstSuggestion = (edge, { query, isHighlighted }) => {
-    const { displayLabel, href } = edge.node
-
-    const label = this.getLabel(edge.node)
-
+    const { displayLabel, displayType, href } = edge.node
     return (
       <FirstSuggestionItem
         display={displayLabel}
         href={href}
         isHighlighted={isHighlighted}
-        label={label}
+        label={displayType}
         query={query}
       />
     )
   }
 
   renderDefaultSuggestion = (edge, { query, isHighlighted }) => {
-    const { displayLabel, href, counts } = edge.node
-
-    const label = this.getLabel(edge.node)
-
-    const showArtworksButton = !!counts?.artworks
-    const showAuctionResultsButton = !!counts?.auctionResults
+    const { displayLabel, displayType, href } = edge.node
+    const newHref = displayType === "Artist" ? `${href}/works-for-sale` : href
 
     return (
       <SuggestionItem
         display={displayLabel}
-        href={href}
+        href={newHref}
         isHighlighted={isHighlighted}
-        label={label}
+        label={displayType}
         query={query}
-        showArtworksButton={showArtworksButton}
-        showAuctionResultsButton={showAuctionResultsButton}
       />
     )
   }
@@ -483,16 +464,9 @@ export const SearchBarRefetchContainer = createRefetchContainer(
             node {
               displayLabel
               href
-              __typename
               ... on SearchableItem {
                 displayType
                 slug
-              }
-              ... on Artist {
-                counts {
-                  artworks
-                  auctionResults
-                }
               }
             }
           }

--- a/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
+++ b/src/v2/Components/Search/Suggestions/SuggestionItem.tsx
@@ -1,17 +1,9 @@
-import {
-  ArtworkIcon,
-  AuctionIcon,
-  Clickable,
-  Flex,
-  Pill,
-  Text,
-} from "@artsy/palette"
+import { Text } from "@artsy/palette"
 import match from "autosuggest-highlight/match"
 import parse from "autosuggest-highlight/parse"
 import React from "react"
 import styled from "styled-components"
 import { RouterLink } from "v2/System/Router/RouterLink"
-import { useRouter } from "v2/System/Router/useRouter"
 
 interface SuggestionItemProps {
   display: string
@@ -19,8 +11,6 @@ interface SuggestionItemProps {
   isHighlighted: boolean
   label: string
   query: string
-  showArtworksButton?: boolean
-  showAuctionResultsButton?: boolean
 }
 
 export const FirstSuggestionItem: React.FC<SuggestionItemProps> = ({
@@ -41,21 +31,11 @@ export const FirstSuggestionItem: React.FC<SuggestionItemProps> = ({
 }
 
 export const SuggestionItem: React.FC<SuggestionItemProps> = props => {
-  const {
-    href,
-    isHighlighted,
-    showArtworksButton,
-    showAuctionResultsButton,
-  } = props
+  const { href, isHighlighted } = props
 
   return (
     <SuggestionItemLink to={href} bg={isHighlighted ? "black5" : "white100"}>
       <DefaultSuggestion {...props} />
-      <QuickNavigation
-        href={href}
-        showArtworksButton={!!showArtworksButton}
-        showAuctionResultsButton={!!showAuctionResultsButton}
-      />
     </SuggestionItemLink>
   )
 }
@@ -96,47 +76,5 @@ const DefaultSuggestion: React.FC<SuggestionItemProps> = ({
         {label}
       </Text>
     </>
-  )
-}
-
-const QuickNavigation: React.FC<{
-  href: string
-  showArtworksButton: boolean
-  showAuctionResultsButton: boolean
-}> = ({ href, showArtworksButton, showAuctionResultsButton }) => {
-  if (!showArtworksButton && !showAuctionResultsButton) return null
-
-  return (
-    <Flex mt={1}>
-      {!!showArtworksButton && (
-        <QuickNavigationItem to={`${href}/works-for-sale`}>
-          <ArtworkIcon mr={0.5} />
-          Artworks
-        </QuickNavigationItem>
-      )}
-      {!!showAuctionResultsButton && (
-        <QuickNavigationItem to={`${href}/auction-results`}>
-          <AuctionIcon mr={0.5} />
-          Auction Results
-        </QuickNavigationItem>
-      )}
-    </Flex>
-  )
-}
-
-const QuickNavigationItem: React.FC<{ to: string }> = ({ children, to }) => {
-  const { router } = useRouter()
-
-  const onClick = event => {
-    event.preventDefault()
-
-    router ? router.push(to) : window.location.assign(to)
-  }
-  return (
-    <Clickable display="flex" onClick={onClick} as="div">
-      <Pill variant="textSquare" mr="1">
-        <Flex alignItems="center">{children}</Flex>
-      </Pill>
-    </Clickable>
   )
 }

--- a/src/v2/Components/Search/__tests__/SearchBar.jest.tsx
+++ b/src/v2/Components/Search/__tests__/SearchBar.jest.tsx
@@ -4,21 +4,15 @@ import {
   SearchBarRefetchContainer as SearchBar,
   getSearchTerm,
 } from "v2/Components/Search/SearchBar"
+import { SuggestionItem } from "v2/Components/Search/Suggestions/SuggestionItem"
 import { renderRelayTree } from "v2/DevTools"
 import { MockBoot } from "v2/DevTools/MockBoot"
 import { ReactWrapper } from "enzyme"
 import React from "react"
 import { graphql } from "react-relay"
 import { flushPromiseQueue } from "v2/DevTools"
+import { mockLocation } from "v2/DevTools/mockLocation"
 
-const mockPush = jest.fn()
-jest.mock("v2/System/Router/useRouter", () => ({
-  useRouter: () => ({
-    router: {
-      push: mockPush,
-    },
-  }),
-}))
 jest.unmock("react-relay")
 
 const searchResults: SearchBarTestQueryRawResponse["viewer"] = {
@@ -32,30 +26,6 @@ const searchResults: SearchBarTestQueryRawResponse["viewer"] = {
           displayType: "Cat",
           slug: "percy-z",
           id: "opaque-searchable-item-id",
-        },
-      },
-      {
-        node: {
-          displayLabel: "Banksy",
-          href: "/artist/banksy",
-          __typename: "Artist",
-          counts: {
-            artworks: 3390,
-            auctionResults: 734,
-          },
-          id: "opaque-searchable-item-id2",
-        },
-      },
-      {
-        node: {
-          displayLabel: "Not Banksy",
-          href: "/artist/not-banksy",
-          __typename: "Artist",
-          counts: {
-            artworks: 0,
-            auctionResults: 0,
-          },
-          id: "opaque-searchable-item-id3",
         },
       },
     ],
@@ -108,34 +78,6 @@ describe("SearchBar", () => {
     expect(component.text()).toContain("Cat")
   })
 
-  it("displays quick navigation links only for artists with artworks or auction results", async () => {
-    const component = await getWrapper(searchResults)
-
-    simulateTyping(component, "blah") // Any text of non-zero length.
-    await flushPromiseQueue()
-
-    const quickNavigationItems = component.find("QuickNavigationItem")
-
-    expect(quickNavigationItems.length).toBe(2)
-    expect(quickNavigationItems.at(0).text()).toContain("Artworks")
-    expect(quickNavigationItems.at(1).text()).toContain("Auction Results")
-  })
-
-  it("navigates when clicking quick navigation items", async () => {
-    const component = await getWrapper(searchResults)
-
-    simulateTyping(component, "blah") // Any text of non-zero length.
-    await flushPromiseQueue()
-
-    const quickNavigationItems = component.find("QuickNavigationItem")
-
-    quickNavigationItems.at(0).simulate("click")
-    expect(mockPush).toHaveBeenCalledWith("/artist/banksy/works-for-sale")
-
-    quickNavigationItems.at(1).simulate("click")
-    expect(mockPush).toHaveBeenCalledWith("/artist/banksy/auction-results")
-  })
-
   it("displays long placeholder text at sizes greater than xs", async () => {
     const component = await getWrapper(searchResults)
     await flushPromiseQueue()
@@ -149,6 +91,18 @@ describe("SearchBar", () => {
     await flushPromiseQueue()
 
     expect(component.find(Input).props().placeholder).toBe("Search Artsy")
+  })
+
+  it("navigates the user when clicking on an item", async () => {
+    const component = await getWrapper(searchResults)
+
+    simulateTyping(component, "blah") // Any text of non-zero length.
+    await flushPromiseQueue()
+
+    mockLocation()
+    component.find(SuggestionItem).at(0).simulate("click")
+
+    expect(window.location.assign).toHaveBeenCalledWith("/cat/percy-z")
   })
 
   it("highlights matching parts of suggestions", async () => {

--- a/src/v2/__generated__/SearchBarRefetchQuery.graphql.ts
+++ b/src/v2/__generated__/SearchBarRefetchQuery.graphql.ts
@@ -33,18 +33,12 @@ fragment SearchBar_viewer_2Mejjw on Viewer {
   searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {
     edges {
       node {
+        __typename
         displayLabel
         href
-        __typename
         ... on SearchableItem {
           displayType
           slug
-        }
-        ... on Artist {
-          counts {
-            artworks
-            auctionResults
-          }
         }
         ... on Node {
           id
@@ -170,6 +164,13 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
+                            "name": "__typename",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
                             "name": "displayLabel",
                             "storageKey": null
                           },
@@ -178,13 +179,6 @@ return {
                             "args": null,
                             "kind": "ScalarField",
                             "name": "href",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "__typename",
                             "storageKey": null
                           },
                           {
@@ -213,37 +207,6 @@ return {
                               }
                             ],
                             "type": "SearchableItem"
-                          },
-                          {
-                            "kind": "InlineFragment",
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "ArtistCounts",
-                                "kind": "LinkedField",
-                                "name": "counts",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "artworks",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "auctionResults",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "type": "Artist"
                           }
                         ],
                         "storageKey": null
@@ -266,7 +229,7 @@ return {
     "metadata": {},
     "name": "SearchBarRefetchQuery",
     "operationKind": "query",
-    "text": "query SearchBarRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        displayLabel\n        href\n        __typename\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Artist {\n          counts {\n            artworks\n            auctionResults\n          }\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query SearchBarRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/SearchBarSuggestQuery.graphql.ts
+++ b/src/v2/__generated__/SearchBarSuggestQuery.graphql.ts
@@ -33,18 +33,12 @@ fragment SearchBar_viewer_2Mejjw on Viewer {
   searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {
     edges {
       node {
+        __typename
         displayLabel
         href
-        __typename
         ... on SearchableItem {
           displayType
           slug
-        }
-        ... on Artist {
-          counts {
-            artworks
-            auctionResults
-          }
         }
         ... on Node {
           id
@@ -170,6 +164,13 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
+                            "name": "__typename",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
                             "name": "displayLabel",
                             "storageKey": null
                           },
@@ -178,13 +179,6 @@ return {
                             "args": null,
                             "kind": "ScalarField",
                             "name": "href",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "__typename",
                             "storageKey": null
                           },
                           {
@@ -213,37 +207,6 @@ return {
                               }
                             ],
                             "type": "SearchableItem"
-                          },
-                          {
-                            "kind": "InlineFragment",
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "ArtistCounts",
-                                "kind": "LinkedField",
-                                "name": "counts",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "artworks",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "auctionResults",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "type": "Artist"
                           }
                         ],
                         "storageKey": null
@@ -266,7 +229,7 @@ return {
     "metadata": {},
     "name": "SearchBarSuggestQuery",
     "operationKind": "query",
-    "text": "query SearchBarSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        displayLabel\n        href\n        __typename\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Artist {\n          counts {\n            artworks\n            auctionResults\n          }\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query SearchBarSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/SearchBarTestQuery.graphql.ts
+++ b/src/v2/__generated__/SearchBarTestQuery.graphql.ts
@@ -17,25 +17,16 @@ export type SearchBarTestQueryRawResponse = {
         readonly searchConnection: ({
             readonly edges: ReadonlyArray<({
                 readonly node: ({
+                    readonly __typename: "SearchableItem";
                     readonly displayLabel: string | null;
                     readonly href: string | null;
-                    readonly __typename: "SearchableItem";
                     readonly id: string | null;
                     readonly displayType: string | null;
                     readonly slug: string;
                 } | {
+                    readonly __typename: string | null;
                     readonly displayLabel: string | null;
                     readonly href: string | null;
-                    readonly __typename: "Artist";
-                    readonly id: string | null;
-                    readonly counts: ({
-                        readonly artworks: number | null;
-                        readonly auctionResults: number | null;
-                    }) | null;
-                } | {
-                    readonly displayLabel: string | null;
-                    readonly href: string | null;
-                    readonly __typename: string;
                     readonly id: string | null;
                 }) | null;
             }) | null> | null;
@@ -64,18 +55,12 @@ fragment SearchBar_viewer_2Mejjw on Viewer {
   searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {
     edges {
       node {
+        __typename
         displayLabel
         href
-        __typename
         ... on SearchableItem {
           displayType
           slug
-        }
-        ... on Artist {
-          counts {
-            artworks
-            auctionResults
-          }
         }
         ... on Node {
           id
@@ -201,6 +186,13 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
+                            "name": "__typename",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
                             "name": "displayLabel",
                             "storageKey": null
                           },
@@ -209,13 +201,6 @@ return {
                             "args": null,
                             "kind": "ScalarField",
                             "name": "href",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "__typename",
                             "storageKey": null
                           },
                           {
@@ -244,37 +229,6 @@ return {
                               }
                             ],
                             "type": "SearchableItem"
-                          },
-                          {
-                            "kind": "InlineFragment",
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "ArtistCounts",
-                                "kind": "LinkedField",
-                                "name": "counts",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "artworks",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "auctionResults",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "type": "Artist"
                           }
                         ],
                         "storageKey": null
@@ -297,7 +251,7 @@ return {
     "metadata": {},
     "name": "SearchBarTestQuery",
     "operationKind": "query",
-    "text": "query SearchBarTestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        displayLabel\n        href\n        __typename\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Artist {\n          counts {\n            artworks\n            auctionResults\n          }\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query SearchBarTestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n) {\n  viewer {\n    ...SearchBar_viewer_2Mejjw\n  }\n}\n\nfragment SearchBar_viewer_2Mejjw on Viewer {\n  searchConnection(query: $term, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        href\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/SearchBar_viewer.graphql.ts
+++ b/src/v2/__generated__/SearchBar_viewer.graphql.ts
@@ -9,13 +9,8 @@ export type SearchBar_viewer = {
             readonly node: {
                 readonly displayLabel: string | null;
                 readonly href: string | null;
-                readonly __typename: string;
                 readonly displayType?: string | null;
                 readonly slug?: string;
-                readonly counts?: {
-                    readonly artworks: number | null;
-                    readonly auctionResults: number | null;
-                } | null;
             } | null;
         } | null> | null;
     } | null;
@@ -108,13 +103,6 @@ const node: ReaderFragment = {
                       "storageKey": null
                     },
                     {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "__typename",
-                      "storageKey": null
-                    },
-                    {
                       "kind": "InlineFragment",
                       "selections": [
                         {
@@ -133,37 +121,6 @@ const node: ReaderFragment = {
                         }
                       ],
                       "type": "SearchableItem"
-                    },
-                    {
-                      "kind": "InlineFragment",
-                      "selections": [
-                        {
-                          "alias": null,
-                          "args": null,
-                          "concreteType": "ArtistCounts",
-                          "kind": "LinkedField",
-                          "name": "counts",
-                          "plural": false,
-                          "selections": [
-                            {
-                              "alias": null,
-                              "args": null,
-                              "kind": "ScalarField",
-                              "name": "artworks",
-                              "storageKey": null
-                            },
-                            {
-                              "alias": null,
-                              "args": null,
-                              "kind": "ScalarField",
-                              "name": "auctionResults",
-                              "storageKey": null
-                            }
-                          ],
-                          "storageKey": null
-                        }
-                      ],
-                      "type": "Artist"
                     }
                   ],
                   "storageKey": null
@@ -179,5 +136,5 @@ const node: ReaderFragment = {
   ],
   "type": "Viewer"
 };
-(node as any).hash = 'a6694021e48afcf170cda92cb611ed97';
+(node as any).hash = '3aeb38b1dc5d0bfda3a165193d2b7a27';
 export default node;


### PR DESCRIPTION
* Revert "fix: Always clear search term after navigating away from search results (#8309)"

This reverts commit ed7e907f4791589867deaba40fc0fb52cc6f60b8.

* Revert "Merge pull request #8246 from artsy/olerichter00/CX-1761/add-quick-navigation-to-search-items"

This reverts commit 74809b11f914bd013c5750977daf328b1315d803, reversing
changes made to 028f7eddd1268f57b656b3cae859b99bd87088f1.