### PR TITLE
chore(PLATFORM-3512): fail gracefully if webpack compiling in dev mode

### DIFF
--- a/webpack/index.js
+++ b/webpack/index.js
@@ -71,7 +71,7 @@ function getClientConfig() {
 function generateEnvBasedConfig() {
   if (env.isDevelopment) {
     console.log(
-      chalk.red("Webpack: Compiling is not supported in development mode.")
+      chalk.red("Error: Attempting to create a production build while `NODE_ENV=development` is unsupported. To fix, set `NODE_ENV=production` and rerun the command.")
     )
     process.exit(1)
   }

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -70,7 +70,10 @@ function getClientConfig() {
 
 function generateEnvBasedConfig() {
   if (env.isDevelopment) {
-    return {}
+    console.log(
+      chalk.red("Webpack: Compiling is not supported in development mode.")
+    )
+    process.exit(1)
   }
 
   // Verify that only a single build is selected.


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3512

A couple of weeks back I was trying to build/run force in production mode (locally) and ran into some errors that took a while to figure out. Turns out I made some wrong assumptions and was using `.env` incorrectly.

Let's log a message when `NODE_ENV=development` within `.env` and trying to build force in `prod` mode. Also instead of `return{}`, let's use `process.exit` for a more graceful shutdown.

Before change:
```sh
➜  force git:(ovasdi/PLATFORM-3512/webpack-node-env) yarn start:prod
yarn run v1.22.11
$ yarn build:assets:legacy && yarn build:assets && yarn build:server && SESSION_LOCAL_INSECURE=true NODE_ENV=production yarn start
$ NODE_ENV=production BUILD_LEGACY_CLIENT=true yarn webpack
$ node --max_old_space_size=4096 -r @babel/register node_modules/.bin/webpack --config ./webpack
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
...
ERROR in ./src/index.js
Module not found: Error: Can't resolve './desktop' in '/Users/ozzievasdi/code/force/src'
 @ ./src/index.js 14:0-40 37:8-24

ERROR in ./src/index.js
Module not found: Error: Can't resolve './lib/datadog' in '/Users/ozzievasdi/code/force/src'
 @ ./src/index.js 5:0-22
...
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

After change:
```sh
➜  force git:(ovasdi/PLATFORM-3512/webpack-node-env) ✗ yarn start:prod
yarn run v1.22.11
$ yarn build:assets:legacy && yarn build:assets && yarn build:server && SESSION_LOCAL_INSECURE=true NODE_ENV=production yarn start
$ NODE_ENV=production BUILD_LEGACY_CLIENT=true yarn webpack
$ node --max_old_space_size=4096 -r @babel/register node_modules/.bin/webpack --config ./webpack
fail more gracefuly when webpack compiling in development mode
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Webpack: Starting ...
Error: Attempting to create a production build while `NODE_ENV=development` is unsupported. To fix, set `NODE_ENV=production` and rerun the command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```