### PR TITLE
fix(FX-3077): make images lazy load

### DIFF
--- a/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorCard.tsx
+++ b/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorCard.tsx
@@ -71,7 +71,8 @@ export const FairExhibitorCard: React.FC<FairExhibitorCardProps> = ({
         <Flex mb={1} flex={1}>
           <BorderBox width={52} height={52} p={0} mr={1}>
             {profile?.icon?.cropped && (
-              <img
+              <Image
+                lazyLoad
                 src={profile?.icon?.cropped?.src}
                 srcSet={profile?.icon?.cropped?.srcSet}
                 alt={`Logo of ${name}`}
@@ -118,6 +119,7 @@ export const FairExhibitorCard: React.FC<FairExhibitorCardProps> = ({
             <ResponsiveBox aspectWidth={400} aspectHeight={250} maxHeight={400}>
               {profile?.image?.url ? (
                 <Image
+                  lazyLoad
                   width="100%"
                   height="100%"
                   src={profile.image.url}

--- a/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorGroupPlaceholder.tsx
+++ b/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorGroupPlaceholder.tsx
@@ -16,7 +16,7 @@ export const FairExhibitorsGroupPlaceholder: React.FC = () => {
       <GridColumns>
         {[...new Array(4)].map((_, i) => {
           return (
-            <Column key={i} span={[12, 6, 3]}>
+            <Column key={i} span={[12, 3]}>
               <Flex mb={1}>
                 <SkeletonBox width={50} height={50} mr={1} />
                 <Box>

--- a/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorsGroup.tsx
+++ b/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorsGroup.tsx
@@ -19,7 +19,7 @@ export const FairExhibitorsGroup: React.FC<FairExhibitorsGroupProps> = ({
         }
 
         return (
-          <Column key={exhibitor.partner.internalID} span={[12, 6, 3]}>
+          <Column key={exhibitor.partner.internalID} span={[12, 3]}>
             <FairExhibitorCard partner={exhibitor.partner} />
           </Column>
         )


### PR DESCRIPTION
Jira: [FX-3077](https://artsyproduct.atlassian.net/browse/FX-3077)

Changes done after failed [QA](https://artsyproduct.atlassian.net/browse/FX-3077?focusedCommentId=40596)

### Changes
- Images are lazy load
- Show 4 partner cards until the XS viewport

### Demo

https://user-images.githubusercontent.com/56556580/131655061-8a415a14-bcf7-418c-8cee-0c10dd403b49.mov



