### PR TITLE
fix(FX-3244): Fix artists search results pagination

### DIFF
--- a/src/v2/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
+++ b/src/v2/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
@@ -34,7 +34,7 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
     this.state = { isLoading: false, page: (page && parseInt(page, 10)) || 1 }
   }
 
-  toggleLoading = isLoading => {
+  toggleLoading = (isLoading): void => {
     this.setState(
       {
         isLoading,
@@ -43,7 +43,7 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
     )
   }
 
-  loadNext = () => {
+  loadNext = (): void => {
     const { viewer } = this.props
     const { searchConnection } = viewer
 
@@ -56,7 +56,7 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
     }
   }
 
-  getQueryParam = (paramName: string) => {
+  getQueryParam = (paramName: string): string => {
     const {
       match: { location },
     } = this.props
@@ -72,7 +72,7 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
     return artists
   }
 
-  loadPage = (page: number) => {
+  loadPage = (page: number): void => {
     this.toggleLoading(true)
 
     const term = this.getQueryParam("term")

--- a/src/v2/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
+++ b/src/v2/Apps/Search/Routes/Artists/SearchResultsArtists.tsx
@@ -24,8 +24,7 @@ const PAGE_SIZE = 10
 export class SearchResultsArtistsRoute extends React.Component<Props, State> {
   state: State = {
     isLoading: false,
-    // @ts-expect-error STRICT_NULL_CHECK
-    page: null,
+    page: 1,
   }
 
   constructor(props) {
@@ -49,9 +48,8 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
     const { searchConnection } = viewer
 
     const {
-      // @ts-expect-error STRICT_NULL_CHECK
       pageInfo: { hasNextPage },
-    } = searchConnection
+    } = searchConnection!
 
     if (hasNextPage) {
       this.loadPage(this.state.page + 1)
@@ -62,9 +60,16 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
     const {
       match: { location },
     } = this.props
-    // @ts-expect-error STRICT_NULL_CHECK
-    const param = get(location, l => l.query)[paramName]
-    return param
+    const param = get(location, l => l.query)?.[paramName]
+    return param ?? ""
+  }
+
+  getArtists = () => {
+    const { viewer } = this.props
+    const artists = get(viewer, v => v?.searchConnection?.edges, [])?.map(
+      e => e!.node
+    )
+    return artists
   }
 
   loadPage = (page: number) => {
@@ -100,66 +105,49 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
 
   renderArtists() {
     const { viewer } = this.props
-    const term = this.getQueryParam("term")
     const { searchConnection } = viewer
-
-    // @ts-expect-error STRICT_NULL_CHECK
-    const artists = get(viewer, v => v.searchConnection.edges, []).map(
-      // @ts-expect-error STRICT_NULL_CHECK
-      e => e.node
-    )
+    const term = this.getQueryParam("term")
+    const artists = this.getArtists()
 
     return (
       <>
-        {artists.map((artist, index) => {
-          // @ts-expect-error STRICT_NULL_CHECK
-          const worksForSaleHref = artist.href + "/works-for-sale"
+        {artists?.map((artist, index) => {
+          const worksForSaleHref = artist!.href + "/works-for-sale"
           return (
             <Box key={index}>
               {/* @ts-expect-error STRICT_NULL_CHECK */}
               <GenericSearchResultItem
-                // @ts-expect-error STRICT_NULL_CHECK
-                name={artist.name}
-                // @ts-expect-error STRICT_NULL_CHECK
-                description={artist.bio}
-                // @ts-expect-error STRICT_NULL_CHECK
-                imageUrl={artist.imageUrl}
+                name={artist!.name}
+                description={artist!.bio}
+                imageUrl={artist!.imageUrl}
                 entityType="Artist"
                 href={worksForSaleHref}
                 index={index}
                 term={term}
-                // @ts-expect-error STRICT_NULL_CHECK
-                id={artist.internalID}
+                id={artist!.internalID}
               />
               {index < artists.length - 1 && <Separator />}
             </Box>
           )
         })}
         <Pagination
-          // @ts-expect-error STRICT_NULL_CHECK
-          pageCursors={searchConnection.pageCursors}
+          pageCursors={searchConnection!.pageCursors}
           onClick={(_cursor, page) => this.loadPage(page)}
           onNext={this.loadNext}
           scrollTo="#jumpto--searchResultTabs"
-          // @ts-expect-error STRICT_NULL_CHECK
-          hasNextPage={searchConnection.pageInfo.hasNextPage}
+          hasNextPage={searchConnection!.pageInfo.hasNextPage}
         />
       </>
     )
   }
 
   render() {
-    const { viewer } = this.props
+    const artists = this.getArtists()
     const term = this.getQueryParam("term")
 
-    // @ts-expect-error STRICT_NULL_CHECK
-    const artists = get(viewer, v => v.searchConnection.edges, []).map(
-      // @ts-expect-error STRICT_NULL_CHECK
-      e => e.node
-    )
     return (
       <LoadingArea isLoading={this.state.isLoading}>
-        {artists.length === 0 ? (
+        {artists!.length === 0 ? (
           <Box mt={3}>
             <ZeroState term={term} />
           </Box>

--- a/src/v2/__generated__/SearchResultsArtistsQuery.graphql.ts
+++ b/src/v2/__generated__/SearchResultsArtistsQuery.graphql.ts
@@ -5,9 +5,6 @@ import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type SearchResultsArtistsQueryVariables = {
     first?: number | null;
-    last?: number | null;
-    after?: string | null;
-    before?: string | null;
     term: string;
     page?: number | null;
 };
@@ -26,14 +23,11 @@ export type SearchResultsArtistsQuery = {
 /*
 query SearchResultsArtistsQuery(
   $first: Int
-  $last: Int
-  $after: String
-  $before: String
   $term: String!
   $page: Int
 ) {
   viewer {
-    ...SearchResultsArtists_viewer_3D3mrw
+    ...SearchResultsArtists_viewer_2aqsc5
   }
 }
 
@@ -59,11 +53,10 @@ fragment Pagination_pageCursors on PageCursors {
   }
 }
 
-fragment SearchResultsArtists_viewer_3D3mrw on Viewer {
-  searchConnection(query: $term, first: $first, after: $after, before: $before, last: $last, page: $page, entities: [ARTIST]) @principalField {
+fragment SearchResultsArtists_viewer_2aqsc5 on Viewer {
+  searchConnection(query: $term, first: $first, page: $page, entities: [ARTIST]) @principalField {
     pageInfo {
       hasNextPage
-      endCursor
     }
     pageCursors {
       ...Pagination_pageCursors
@@ -98,24 +91,6 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "last",
-    "type": "Int"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "after",
-    "type": "String"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "before",
-    "type": "String"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
     "name": "term",
     "type": "String!"
   },
@@ -128,46 +103,31 @@ var v0 = [
 ],
 v1 = {
   "kind": "Variable",
-  "name": "after",
-  "variableName": "after"
-},
-v2 = {
-  "kind": "Variable",
-  "name": "before",
-  "variableName": "before"
-},
-v3 = {
-  "kind": "Variable",
   "name": "first",
   "variableName": "first"
 },
-v4 = {
-  "kind": "Variable",
-  "name": "last",
-  "variableName": "last"
-},
-v5 = {
+v2 = {
   "kind": "Variable",
   "name": "page",
   "variableName": "page"
 },
-v6 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v7 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v8 = [
-  (v6/*: any*/),
-  (v7/*: any*/),
+v5 = [
+  (v3/*: any*/),
+  (v4/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -195,9 +155,6 @@ return {
             "args": [
               (v1/*: any*/),
               (v2/*: any*/),
-              (v3/*: any*/),
-              (v4/*: any*/),
-              (v5/*: any*/),
               {
                 "kind": "Variable",
                 "name": "term",
@@ -230,8 +187,6 @@ return {
           {
             "alias": null,
             "args": [
-              (v1/*: any*/),
-              (v2/*: any*/),
               {
                 "kind": "Literal",
                 "name": "entities",
@@ -239,9 +194,8 @@ return {
                   "ARTIST"
                 ]
               },
-              (v3/*: any*/),
-              (v4/*: any*/),
-              (v5/*: any*/),
+              (v1/*: any*/),
+              (v2/*: any*/),
               {
                 "kind": "Variable",
                 "name": "query",
@@ -267,13 +221,6 @@ return {
                     "kind": "ScalarField",
                     "name": "hasNextPage",
                     "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "endCursor",
-                    "storageKey": null
                   }
                 ],
                 "storageKey": null
@@ -293,7 +240,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v8/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -303,7 +250,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v8/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -313,7 +260,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v8/*: any*/),
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -324,8 +271,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
-                      (v7/*: any*/)
+                      (v3/*: any*/),
+                      (v4/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -422,9 +369,9 @@ return {
     "metadata": {},
     "name": "SearchResultsArtistsQuery",
     "operationKind": "query",
-    "text": "query SearchResultsArtistsQuery(\n  $first: Int\n  $last: Int\n  $after: String\n  $before: String\n  $term: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_3D3mrw\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SearchResultsArtists_viewer_3D3mrw on Viewer {\n  searchConnection(query: $term, first: $first, after: $after, before: $before, last: $last, page: $page, entities: [ARTIST]) @principalField {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query SearchResultsArtistsQuery(\n  $first: Int\n  $term: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_2aqsc5\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SearchResultsArtists_viewer_2aqsc5 on Viewer {\n  searchConnection(query: $term, first: $first, page: $page, entities: [ARTIST]) @principalField {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '02345ec0391a8b94f74dde5fb12c4441';
+(node as any).hash = '1a305f085d21620ca6699008672efc1f';
 export default node;

--- a/src/v2/__generated__/SearchResultsArtists_viewer.graphql.ts
+++ b/src/v2/__generated__/SearchResultsArtists_viewer.graphql.ts
@@ -7,7 +7,6 @@ export type SearchResultsArtists_viewer = {
     readonly searchConnection: {
         readonly pageInfo: {
             readonly hasNextPage: boolean;
-            readonly endCursor: string | null;
         };
         readonly pageCursors: {
             readonly " $fragmentRefs": FragmentRefs<"Pagination_pageCursors">;
@@ -49,24 +48,6 @@ const node: ReaderFragment = {
     {
       "defaultValue": null,
       "kind": "LocalArgument",
-      "name": "last",
-      "type": "Int"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "after",
-      "type": "String"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "before",
-      "type": "String"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
       "name": "page",
       "type": "Int"
     }
@@ -79,16 +60,6 @@ const node: ReaderFragment = {
       "alias": null,
       "args": [
         {
-          "kind": "Variable",
-          "name": "after",
-          "variableName": "after"
-        },
-        {
-          "kind": "Variable",
-          "name": "before",
-          "variableName": "before"
-        },
-        {
           "kind": "Literal",
           "name": "entities",
           "value": [
@@ -99,11 +70,6 @@ const node: ReaderFragment = {
           "kind": "Variable",
           "name": "first",
           "variableName": "first"
-        },
-        {
-          "kind": "Variable",
-          "name": "last",
-          "variableName": "last"
         },
         {
           "kind": "Variable",
@@ -134,13 +100,6 @@ const node: ReaderFragment = {
               "args": null,
               "kind": "ScalarField",
               "name": "hasNextPage",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "endCursor",
               "storageKey": null
             }
           ],
@@ -231,5 +190,5 @@ const node: ReaderFragment = {
   ],
   "type": "Viewer"
 };
-(node as any).hash = '204321838585efb41c817e25978acad1';
+(node as any).hash = 'e56ba60404a845353821326cf3f1a678';
 export default node;

--- a/src/v2/__generated__/searchRoutes_SearchResultsArtistsQuery.graphql.ts
+++ b/src/v2/__generated__/searchRoutes_SearchResultsArtistsQuery.graphql.ts
@@ -55,7 +55,6 @@ fragment SearchResultsArtists_viewer_2zsz5P on Viewer {
   searchConnection(query: $keyword, first: 10, page: $page, entities: [ARTIST]) @principalField {
     pageInfo {
       hasNextPage
-      endCursor
     }
     pageCursors {
       ...Pagination_pageCursors
@@ -212,13 +211,6 @@ return {
                     "kind": "ScalarField",
                     "name": "hasNextPage",
                     "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "endCursor",
-                    "storageKey": null
                   }
                 ],
                 "storageKey": null
@@ -367,7 +359,7 @@ return {
     "metadata": {},
     "name": "searchRoutes_SearchResultsArtistsQuery",
     "operationKind": "query",
-    "text": "query searchRoutes_SearchResultsArtistsQuery(\n  $keyword: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_2zsz5P\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SearchResultsArtists_viewer_2zsz5P on Viewer {\n  searchConnection(query: $keyword, first: 10, page: $page, entities: [ARTIST]) @principalField {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query searchRoutes_SearchResultsArtistsQuery(\n  $keyword: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_2zsz5P\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SearchResultsArtists_viewer_2zsz5P on Viewer {\n  searchConnection(query: $keyword, first: 10, page: $page, entities: [ARTIST]) @principalField {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
[FX-3244]

Pagination on artists search results page was broken as `term` param was missing in `refetchVariables` when refetching data

This fixes broken behavior and also makes some refactoring 

**Before**

https://user-images.githubusercontent.com/44819355/131660081-f68d1044-2551-450e-afee-fc5afcab86f8.mp4


**After**

![pag-2](https://user-images.githubusercontent.com/44819355/131657923-02763f7f-3c0e-44a2-80c7-bac46943eb4a.gif)
