### PR TITLE
feat(PURCHASE-2895): Remove back to artsy button

### DIFF
--- a/src/v2/Apps/Order/Routes/Status/index.tsx
+++ b/src/v2/Apps/Order/Routes/Status/index.tsx
@@ -12,6 +12,7 @@ import {
   media,
 } from "@artsy/palette"
 import styled from "styled-components"
+import { RouterLink } from "v2/System/Router/RouterLink"
 import { TransactionDetailsSummaryItemFragmentContainer as TransactionDetailsSummaryItem } from "v2/Apps/Order/Components/TransactionDetailsSummaryItem"
 import { TwoColumnLayout } from "v2/Apps/Order/Components/TwoColumnLayout"
 import { get } from "v2/Utils/get"
@@ -174,7 +175,7 @@ export class StatusRoute extends Component<StatusProps> {
         return {
           title: "Offer expired",
           description: (
-            <>The seller’s offer expired because you didn’t respond iFn time.</>
+            <>The seller’s offer expired because you didn’t respond in time.</>
           ),
           showTransactionSummary: false,
         }
@@ -255,13 +256,8 @@ export class StatusRoute extends Component<StatusProps> {
     }
 
     return (
-      <Button
-        onClick={() => {
-          window.location.href = "/"
-        }}
-        variant="primaryBlack"
-        width="100%"
-      >
+      // @ts-ignore
+      <Button as={RouterLink} to="/" variant="primaryBlack" width="100%">
         Back to Artsy
       </Button>
     )

--- a/src/v2/Apps/Order/Routes/Status/index.tsx
+++ b/src/v2/Apps/Order/Routes/Status/index.tsx
@@ -1,3 +1,7 @@
+import React, { Component } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { Title } from "react-head"
+import { Router, Match } from "found"
 import {
   Button,
   Flex,
@@ -7,20 +11,16 @@ import {
   Spacer,
   media,
 } from "@artsy/palette"
-import { Status_order } from "v2/__generated__/Status_order.graphql"
+import styled from "styled-components"
 import { TransactionDetailsSummaryItemFragmentContainer as TransactionDetailsSummaryItem } from "v2/Apps/Order/Components/TransactionDetailsSummaryItem"
 import { TwoColumnLayout } from "v2/Apps/Order/Components/TwoColumnLayout"
-import { Router } from "found"
-import React, { Component } from "react"
-import { Title } from "react-head"
-import { createFragmentContainer, graphql } from "react-relay"
-import styled from "styled-components"
 import { get } from "v2/Utils/get"
 import createLogger from "v2/Utils/logger"
 import { ArtworkSummaryItemFragmentContainer as ArtworkSummaryItem } from "../../Components/ArtworkSummaryItem"
 import { CreditCardSummaryItemFragmentContainer as CreditCardSummaryItem } from "../../Components/CreditCardSummaryItem"
 import { ShippingSummaryItemFragmentContainer as ShippingSummaryItem } from "../../Components/ShippingSummaryItem"
 import { SystemContextConsumer } from "v2/System/SystemContext"
+import { Status_order } from "v2/__generated__/Status_order.graphql"
 
 const logger = createLogger("Order/Routes/Status/index.tsx")
 
@@ -34,6 +34,7 @@ interface StatusPageConfig {
 export interface StatusProps {
   order: Status_order
   router: Router
+  match: Match
 }
 
 export class StatusRoute extends Component<StatusProps> {
@@ -173,7 +174,7 @@ export class StatusRoute extends Component<StatusProps> {
         return {
           title: "Offer expired",
           description: (
-            <>The seller’s offer expired because you didn’t respond in time.</>
+            <>The seller’s offer expired because you didn’t respond iFn time.</>
           ),
           showTransactionSummary: false,
         }
@@ -233,9 +234,41 @@ export class StatusRoute extends Component<StatusProps> {
     )
   }
 
+  shouldButtonDisplay(): React.ReactNode | null {
+    const {
+      match,
+      order: { stateReason },
+    } = this.props
+    const isModal = !!match?.location.query.isModal
+    const declinedStatuses = [
+      "buyer_rejected",
+      "seller_rejected_offer_too_low",
+      "seller_rejected_shipping_unavailable",
+      "seller_rejected",
+      "seller_rejected_artwork_unavailable",
+      "seller_rejected_other",
+    ]
+    const isDeclined = declinedStatuses.includes(stateReason!)
+
+    if (isModal || isDeclined) {
+      return null
+    }
+
+    return (
+      <Button
+        onClick={() => {
+          window.location.href = "/"
+        }}
+        variant="primaryBlack"
+        width="100%"
+      >
+        Back to Artsy
+      </Button>
+    )
+  }
+
   render() {
     const { order } = this.props
-
     const flowName = order.mode === "OFFER" ? "Offer" : "Order"
     const {
       title,
@@ -277,16 +310,8 @@ export class StatusRoute extends Component<StatusProps> {
                             showOfferNote={showOfferNote}
                           />
                         </Flex>
-                      ) : isEigen ? null : (
-                        <Button
-                          onClick={() => {
-                            window.location.href = "/"
-                          }}
-                          variant="primaryBlack"
-                          width="100%"
-                        >
-                          Back to Artsy
-                        </Button>
+                      ) : (
+                        isEigen && this.shouldButtonDisplay()
                       )}
                     </Join>
                   </>


### PR DESCRIPTION
**JIRA** -> [Remove Back to Artsy link from inquiry checkout counteroffer modal](https://artsyproduct.atlassian.net/jira/software/c/projects/PURCHASE/boards/41?modal=detail&selectedIssue=PURCHASE-2895&assignee=60469b1e43eac6006f636d07)

**What I've done**:
- removed the `go back to artsy` button from the modal offer status, when buyer/seller declines a counteroffer
- refactored code
- added isModal checker due this behavior won't just be for declined statuses, the CTA opens the page modally whenever the partner takes any action

**GIF**
![ezgif com-gif-maker](https://user-images.githubusercontent.com/79980131/131694522-dd3a2b1b-44ba-422e-929d-8e111590f336.gif)

p.s. sorry for the fast gif... just wanted to show that we don't have a button for declined offers from now :)
