### PR TITLE
fix(loadenv): prevent modifying already set env vars

### DIFF
--- a/src/dev.js
+++ b/src/dev.js
@@ -1,11 +1,11 @@
 // @ts-check
 
+require("./lib/loadenv")
 require("coffeescript/register")
 require("@babel/register")({
   extensions: [".ts", ".js", ".tsx", ".jsx"],
   plugins: ["babel-plugin-dynamic-import-node"],
 })
-require("./lib/loadenv")
 
 const express = require("express")
 const path = require("path")

--- a/src/dev.js
+++ b/src/dev.js
@@ -1,11 +1,11 @@
 // @ts-check
 
-require("./lib/loadenv")
 require("coffeescript/register")
 require("@babel/register")({
   extensions: [".ts", ".js", ".tsx", ".jsx"],
   plugins: ["babel-plugin-dynamic-import-node"],
 })
+require("./lib/loadenv")
 
 const express = require("express")
 const path = require("path")

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 // @ts-check
 
+import "./lib/loadenv"
 // This must come before any other instrumented module.
 // See https://docs.datadoghq.com/tracing/languages/nodejs/ for more info.
 import "./lib/datadog"
-import "./lib/loadenv"
 
 // Needs to be first, due to sharify side-effects.
 import { initializeMiddleware } from "./middleware"

--- a/src/lib/loadenv.js
+++ b/src/lib/loadenv.js
@@ -3,25 +3,31 @@
 const { readFileSync, accessSync, constants } = require("fs")
 const { parse } = require("dotenv")
 
-const shared = checkFileExistsSync(".env.shared")
-  ? parse(readFileSync(".env.shared"))
-  : {}
-const env = checkFileExistsSync(".env") ? parse(readFileSync(".env")) : {}
+function loadEnv(env) {
+  return checkFileExistsSync(env) ? parse(readFileSync(env)) : {}
+}
 
-// merge env files and update process.env if mergedEnv is not empty
-let mergedEnv = { ...shared, ...env }
-if (Object.keys(mergedEnv).length !== 0) {
-  for (const k in mergedEnv) {
-    process.env[k] = mergedEnv[k]
+function applyToEnv(config) {
+  if (Object.keys(config).length !== 0) {
+    for (const k in config) {
+      if (!process.env[k]) {
+        process.env[k] = config[k]
+      }
+    }
   }
 }
 
 function checkFileExistsSync(filepath) {
-  let flag = true
   try {
     accessSync(filepath, constants.F_OK)
   } catch (e) {
-    flag = false
+    return false
   }
-  return flag
+  return true
 }
+
+// Load the default envs and apply to process.env
+applyToEnv({
+  ...loadEnv(".env.shared"),
+  ...loadEnv(".env"),
+})

--- a/webpack/utils/env.js
+++ b/webpack/utils/env.js
@@ -16,7 +16,9 @@ function loadEnv(env) {
 function applyToEnv(config) {
   if (Object.keys(config).length !== 0) {
     for (const k in config) {
-      process.env[k] = config[k]
+      if (!process.env[k]) {
+        process.env[k] = config[k]
+      }
     }
   }
 }


### PR DESCRIPTION
This CL adds a condition to `lib/loadenv` and `utils/env` that prevents overwriting existing env vars that are already set. This matches the same rule that `dotenv` package adheres to: [never modify any environment variables that have already been set](https://github.com/motdotla/dotenv#what-happens-to-environment-variables-that-were-already-set). The `package.json` scripts that export `NODE_ENV=production` will now behave as expected even if a contributor has `NODE_ENV=development` in `.env`.

Additionally:
- updated `loadenv` to match the implementation in `utils/env` as I find it better
- moved the `loadenv` imports to the top of the files