### PR TITLE
fix: stop fair organizer page from crashing with no articles

### DIFF
--- a/src/v2/Apps/FairOrginizer/Components/FairOrganizerLatestArticles.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/FairOrganizerLatestArticles.tsx
@@ -16,6 +16,11 @@ export const FairOrganizerLatestArticles: React.FC<FairOrganizerLatestArticlesPr
 }) => {
   const { articlesConnection, name, slug } = fairOrganizer
   const articles = extractNodes(articlesConnection)
+
+  if (articles.length === 0) {
+    return null
+  }
+
   const [latestArticle, ...otherArticles] = articles
   const { leftColumn, rightColumn } = getArticlesColumns(otherArticles)
 

--- a/src/v2/Apps/FairOrginizer/Components/__tests__/FairOrganizerLatestArticles.jest.tsx
+++ b/src/v2/Apps/FairOrginizer/Components/__tests__/FairOrganizerLatestArticles.jest.tsx
@@ -24,6 +24,13 @@ const { getWrapper } = setupTestWrapper<FairOrganizerLatestArticles_Test_Query>(
 )
 
 describe("FairOrganizerLatestArticles", () => {
+  it("does not render if no articles are present", () => {
+    const wrapper = getWrapper({
+      FairOrganizer: () => ({ articlesConnection: { edges: [] } }),
+    })
+    expect(wrapper.html()).toBe("")
+  })
+
   it("renders a section title with the fair name", () => {
     const wrapper = getWrapper({
       FairOrganizer: () => ({ name: "Art Paris" }),


### PR DESCRIPTION
A newly-created Fair Organizer was failing to load on production with 500 errors. After investigating, @dblandin and I figured out that the problem was that we assumed that all fair organizers had associated articles. 

Slack thread: https://artsy.slack.com/archives/C9SATFLUU/p1630573114272300