### PR TITLE
feat(FX-3249): updated exhibitors tab style

### DIFF
--- a/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorCard.tsx
+++ b/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorCard.tsx
@@ -1,12 +1,5 @@
 import React from "react"
-import {
-  Box,
-  Flex,
-  ResponsiveBox,
-  Image,
-  Text,
-  BorderBox,
-} from "@artsy/palette"
+import { Box, Flex, Image, Text, BorderBox } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useAnalyticsContext, useSystemContext, useTracking } from "v2/System"
 import {
@@ -17,7 +10,6 @@ import {
   PageOwnerType,
 } from "@artsy/cohesion"
 import { FairExhibitorCard_partner } from "v2/__generated__/FairExhibitorCard_partner.graphql"
-import { Media } from "v2/Utils/Responsive"
 import { FollowProfileButtonFragmentContainer as FollowProfileButton } from "v2/Components/FollowButton/FollowProfileButton"
 import { RouterLink } from "v2/System/Router/RouterLink"
 
@@ -51,7 +43,7 @@ export const FairExhibitorCard: React.FC<FairExhibitorCardProps> = ({
     action: ActionType.clickedPartnerCard,
   }
 
-  const partnerAddress = (cities: (string | null)[]) => {
+  const partnerAddress = (cities: readonly (string | null)[]) => {
     const visibleCities = cities?.slice(0, VISIBLE_CITIES_NUM).join(", ")
 
     if (cities.length > VISIBLE_CITIES_NUM) {
@@ -62,75 +54,51 @@ export const FairExhibitorCard: React.FC<FairExhibitorCardProps> = ({
   }
 
   return (
-    <Box>
-      <RouterLink
-        to={partner.href}
-        noUnderline
-        onClick={() => tracking.trackEvent(tappedPartnerTrackingData)}
-      >
-        <Flex mb={1} flex={1}>
-          <BorderBox width={52} height={52} p={0} mr={1}>
-            {profile?.icon?.cropped && (
-              <Image
-                lazyLoad
-                src={profile?.icon?.cropped?.src}
-                srcSet={profile?.icon?.cropped?.srcSet}
-                alt={`Logo of ${name}`}
-                width={50}
-                height={50}
-              />
-            )}
-          </BorderBox>
-          <Box overflow="hidden">
-            <Text variant="md" overflowEllipsis>
-              {name}
-            </Text>
-            {cities?.length ? (
-              <Text variant="md" color="black60" overflowEllipsis>
-                {partnerAddress([...cities])}
-              </Text>
-            ) : null}
-          </Box>
-          {partner.profile && (
-            <Box order={2} ml="auto">
-              <FollowProfileButton
-                profile={partner.profile}
-                user={user}
-                contextModule={ContextModule.partnerHeader}
-                buttonProps={{
-                  size: "small",
-                  variant: "secondaryOutline",
-                  width: 70,
-                  height: 30,
-                }}
-              />
-            </Box>
+    <RouterLink
+      to={partner.href}
+      noUnderline
+      onClick={() => tracking.trackEvent(tappedPartnerTrackingData)}
+    >
+      <Flex mb={1} flex={1}>
+        <BorderBox width={52} height={52} p={0} mr={1}>
+          {profile?.icon?.cropped && (
+            <Image
+              lazyLoad
+              src={profile?.icon?.cropped?.src}
+              srcSet={profile?.icon?.cropped?.srcSet}
+              alt={`Logo of ${name}`}
+              width={50}
+              height={50}
+            />
           )}
-        </Flex>
-      </RouterLink>
-
-      <Media greaterThan="xs">
-        <RouterLink
-          to={partner.href}
-          noUnderline
-          onClick={() => tracking.trackEvent(tappedPartnerTrackingData)}
-        >
-          <BorderBox p={0}>
-            <ResponsiveBox aspectWidth={400} aspectHeight={250} maxHeight={400}>
-              {profile?.image?.url ? (
-                <Image
-                  lazyLoad
-                  width="100%"
-                  height="100%"
-                  src={profile.image.url}
-                  alt={`Profile image for ${name}`}
-                />
-              ) : null}
-            </ResponsiveBox>
-          </BorderBox>
-        </RouterLink>
-      </Media>
-    </Box>
+        </BorderBox>
+        <Box>
+          <Text variant="md" overflow="clip">
+            {name}
+          </Text>
+          {cities?.length ? (
+            <Text variant="md" color="black60" overflow="clip">
+              {partnerAddress(cities)}
+            </Text>
+          ) : null}
+        </Box>
+        {partner.profile && (
+          <Box order={2} ml="auto">
+            <FollowProfileButton
+              profile={partner.profile}
+              user={user}
+              contextModule={ContextModule.partnerHeader}
+              buttonProps={{
+                size: "small",
+                variant: "secondaryOutline",
+                width: 70,
+                height: 30,
+              }}
+            />
+          </Box>
+        )}
+      </Flex>
+    </RouterLink>
   )
 }
 
@@ -151,9 +119,6 @@ export const FairExhibitorCardFragmentContainer = createFragmentContainer(
               src
               srcSet
             }
-          }
-          image {
-            url(version: "medium")
           }
         }
       }

--- a/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorCard.tsx
+++ b/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorCard.tsx
@@ -44,7 +44,7 @@ export const FairExhibitorCard: React.FC<FairExhibitorCardProps> = ({
   }
 
   const partnerAddress = (cities: readonly (string | null)[]) => {
-    const visibleCities = cities?.slice(0, VISIBLE_CITIES_NUM).join(", ")
+    const visibleCities = cities.slice(0, VISIBLE_CITIES_NUM).join(", ")
 
     if (cities.length > VISIBLE_CITIES_NUM) {
       return `${visibleCities}, +${cities.length - VISIBLE_CITIES_NUM} more`

--- a/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorGroupPlaceholder.tsx
+++ b/src/v2/Apps/Fair/Components/FairExhibitors/FairExhibitorGroupPlaceholder.tsx
@@ -4,11 +4,9 @@ import {
   Column,
   Flex,
   GridColumns,
-  ResponsiveBox,
   SkeletonBox,
   SkeletonText,
 } from "@artsy/palette"
-import { Media } from "v2/Utils/Responsive"
 
 export const FairExhibitorsGroupPlaceholder: React.FC = () => {
   return (
@@ -23,17 +21,10 @@ export const FairExhibitorsGroupPlaceholder: React.FC = () => {
                   <SkeletonText variant="md">Partner Name</SkeletonText>
                   <SkeletonText variant="md">Partner Address</SkeletonText>
                 </Box>
+                <SkeletonText variant="lg" m="auto" mt={0} mr={0}>
+                  Follow
+                </SkeletonText>
               </Flex>
-
-              <Media greaterThan="xs">
-                <SkeletonBox mb={1}>
-                  <ResponsiveBox
-                    aspectWidth={400}
-                    aspectHeight={250}
-                    maxHeight={400}
-                  />
-                </SkeletonBox>
-              </Media>
             </Column>
           )
         })}

--- a/src/v2/Apps/Fair/Routes/__tests__/FairExhibitors.jest.tsx
+++ b/src/v2/Apps/Fair/Routes/__tests__/FairExhibitors.jest.tsx
@@ -26,7 +26,7 @@ describe("FairExhibitors", () => {
   })
 
   it("renders the letters nav", () => {
-    const wrapper = getWrapper()
+    const wrapper = getWrapper(FAIR_FIXTURE)
     expect(wrapper.find("ExhibitorsLetterNav").length).toBe(1)
   })
 
@@ -40,55 +40,65 @@ describe("FairExhibitors", () => {
     const spy = jest.fn()
     window.scrollTo = spy
 
-    const wrapper = getWrapper({
-      Fair: () => ({
-        exhibitorsGroupedByName: [
-          {
-            letter: "D",
-            exhibitors: [
-              {
-                partnerID: "642b20aff086930012ce478f",
-              },
-            ],
-          },
-        ],
-      }),
-    })
+    const wrapper = getWrapper(FAIR_FIXTURE)
 
     const letter = wrapper.find("ExhibitorsLetterNav").find("Letter").at(3)
+
     letter.simulate("click")
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
   it("renders the exhibitors group", () => {
-    const wrapper = getWrapper({
-      Fair: () => ({
-        exhibitorsGroupedByName: [
-          {
-            letter: "A",
-            exhibitors: [
-              {
-                partnerID: "600b45afd086930012ce478c",
-              },
-            ],
-          },
-          {
-            letter: "C",
-            exhibitors: [
-              {
-                partnerID: "551db9a6726169422f4d0600",
-              },
-              {
-                partnerID: "5694406501925b322c00010b",
-              },
-            ],
-          },
-        ],
-      }),
-    })
+    const wrapper = getWrapper(FAIR_FIXTURE)
 
     const exhibitorsGroups = wrapper.find("FairExhibitorsGroupPlaceholder")
 
-    expect(exhibitorsGroups.length).toBe(2)
+    expect(exhibitorsGroups.length).toBe(3)
   })
 })
+
+const FAIR_FIXTURE = {
+  Fair: () => ({
+    exhibitorsGroupedByName: [
+      {
+        letter: "A",
+        exhibitors: [
+          {
+            partner: {
+              internalID: "551db9a6726169422f4d0600",
+              cities: [],
+            },
+          },
+          {
+            partner: {
+              internalID: "5a2025c78b0c144e0bba965e",
+              cities: [],
+            },
+          },
+        ],
+      },
+      {
+        letter: "C",
+        exhibitors: [
+          {
+            partner: {
+              internalID: "5266d825a09a67eac50001f1",
+              cities: [],
+            },
+          },
+        ],
+      },
+      {
+        letter: "D",
+        exhibitors: [
+          {
+            partner: {
+              internalID: "5694406501925b322c00010b",
+              cities: [],
+            },
+          },
+        ],
+      },
+    ],
+  }),
+}

--- a/src/v2/__generated__/FairExhibitorCard_partner.graphql.ts
+++ b/src/v2/__generated__/FairExhibitorCard_partner.graphql.ts
@@ -16,9 +16,6 @@ export type FairExhibitorCard_partner = {
                 readonly srcSet: string;
             } | null;
         } | null;
-        readonly image: {
-            readonly url: string | null;
-        } | null;
         readonly " $fragmentRefs": FragmentRefs<"FollowProfileButton_profile">;
     } | null;
     readonly " $refType": "FairExhibitorCard_partner";
@@ -128,30 +125,6 @@ const node: ReaderFragment = {
           "storageKey": null
         },
         {
-          "alias": null,
-          "args": null,
-          "concreteType": "Image",
-          "kind": "LinkedField",
-          "name": "image",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": [
-                {
-                  "kind": "Literal",
-                  "name": "version",
-                  "value": "medium"
-                }
-              ],
-              "kind": "ScalarField",
-              "name": "url",
-              "storageKey": "url(version:\"medium\")"
-            }
-          ],
-          "storageKey": null
-        },
-        {
           "args": null,
           "kind": "FragmentSpread",
           "name": "FollowProfileButton_profile"
@@ -162,5 +135,5 @@ const node: ReaderFragment = {
   ],
   "type": "Partner"
 };
-(node as any).hash = '4d8c07f04dcc1695cdfc31d30913a3ff';
+(node as any).hash = 'c2363ecbd67e4e3dd672a11dcbb7e08d';
 export default node;

--- a/src/v2/__generated__/FairExhibitors_Test_Query.graphql.ts
+++ b/src/v2/__generated__/FairExhibitors_Test_Query.graphql.ts
@@ -48,9 +48,6 @@ fragment FairExhibitorCard_partner on Partner {
         srcSet
       }
     }
-    image {
-      url(version: "medium")
-    }
     id
   }
 }
@@ -289,30 +286,6 @@ return {
                               }
                             ],
                             "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Image",
-                            "kind": "LinkedField",
-                            "name": "image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "medium"
-                                  }
-                                ],
-                                "kind": "ScalarField",
-                                "name": "url",
-                                "storageKey": "url(version:\"medium\")"
-                              }
-                            ],
-                            "storageKey": null
                           }
                         ],
                         "storageKey": null
@@ -338,7 +311,7 @@ return {
     "metadata": {},
     "name": "FairExhibitors_Test_Query",
     "operationKind": "query",
-    "text": "query FairExhibitors_Test_Query(\n  $id: String!\n) {\n  fair(id: $id) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairExhibitorCard_partner on Partner {\n  name\n  href\n  internalID\n  slug\n  cities\n  profile {\n    ...FollowProfileButton_profile\n    icon {\n      cropped(width: 50, height: 50) {\n        src\n        srcSet\n      }\n    }\n    image {\n      url(version: \"medium\")\n    }\n    id\n  }\n}\n\nfragment FairExhibitorsGroup_exhibitorsGroup on FairExhibitorsGroup {\n  exhibitors {\n    partner {\n      internalID\n      ...FairExhibitorCard_partner\n      id\n    }\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n    exhibitors {\n      partnerID\n    }\n    ...FairExhibitorsGroup_exhibitorsGroup\n  }\n  ...ExhibitorsLetterNav_fair\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query FairExhibitors_Test_Query(\n  $id: String!\n) {\n  fair(id: $id) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairExhibitorCard_partner on Partner {\n  name\n  href\n  internalID\n  slug\n  cities\n  profile {\n    ...FollowProfileButton_profile\n    icon {\n      cropped(width: 50, height: 50) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairExhibitorsGroup_exhibitorsGroup on FairExhibitorsGroup {\n  exhibitors {\n    partner {\n      internalID\n      ...FairExhibitorCard_partner\n      id\n    }\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n    exhibitors {\n      partnerID\n    }\n    ...FairExhibitorsGroup_exhibitorsGroup\n  }\n  ...ExhibitorsLetterNav_fair\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
   }
 };
 })();

--- a/src/v2/__generated__/fairRoutes_FairExhibitorsQuery.graphql.ts
+++ b/src/v2/__generated__/fairRoutes_FairExhibitorsQuery.graphql.ts
@@ -48,9 +48,6 @@ fragment FairExhibitorCard_partner on Partner {
         srcSet
       }
     }
-    image {
-      url(version: "medium")
-    }
     id
   }
 }
@@ -289,30 +286,6 @@ return {
                               }
                             ],
                             "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Image",
-                            "kind": "LinkedField",
-                            "name": "image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "version",
-                                    "value": "medium"
-                                  }
-                                ],
-                                "kind": "ScalarField",
-                                "name": "url",
-                                "storageKey": "url(version:\"medium\")"
-                              }
-                            ],
-                            "storageKey": null
                           }
                         ],
                         "storageKey": null
@@ -338,7 +311,7 @@ return {
     "metadata": {},
     "name": "fairRoutes_FairExhibitorsQuery",
     "operationKind": "query",
-    "text": "query fairRoutes_FairExhibitorsQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairExhibitorCard_partner on Partner {\n  name\n  href\n  internalID\n  slug\n  cities\n  profile {\n    ...FollowProfileButton_profile\n    icon {\n      cropped(width: 50, height: 50) {\n        src\n        srcSet\n      }\n    }\n    image {\n      url(version: \"medium\")\n    }\n    id\n  }\n}\n\nfragment FairExhibitorsGroup_exhibitorsGroup on FairExhibitorsGroup {\n  exhibitors {\n    partner {\n      internalID\n      ...FairExhibitorCard_partner\n      id\n    }\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n    exhibitors {\n      partnerID\n    }\n    ...FairExhibitorsGroup_exhibitorsGroup\n  }\n  ...ExhibitorsLetterNav_fair\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
+    "text": "query fairRoutes_FairExhibitorsQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairExhibitors_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairExhibitorCard_partner on Partner {\n  name\n  href\n  internalID\n  slug\n  cities\n  profile {\n    ...FollowProfileButton_profile\n    icon {\n      cropped(width: 50, height: 50) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment FairExhibitorsGroup_exhibitorsGroup on FairExhibitorsGroup {\n  exhibitors {\n    partner {\n      internalID\n      ...FairExhibitorCard_partner\n      id\n    }\n  }\n}\n\nfragment FairExhibitors_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n    exhibitors {\n      partnerID\n    }\n    ...FairExhibitorsGroup_exhibitorsGroup\n  }\n  ...ExhibitorsLetterNav_fair\n}\n\nfragment FollowProfileButton_profile on Profile {\n  id\n  slug\n  name\n  internalID\n  is_followed: isFollowed\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Jira: [FX-3249](https://artsyproduct.atlassian.net/browse/FX-3249)

### Description
The exhibitors listed in the A-Z tab should be formatted as per the latest 8/23 “Work in Progress” figma file. In particular we shouldn't display exhibitors image.

[Figma spec](https://www.figma.com/file/aM3b5sodn04vMTigbQXACi/Fairs-2021?node-id=3904%3A8029)

### Changes
- Removed image from exhibitor card
- Wrap text when overflow
- Updated exhibitors placeholder

### Demo
![image](https://user-images.githubusercontent.com/56556580/131836220-886da85d-69b3-41fa-ae0f-00f2ee84e49d.png)

