### PR TITLE
fix: Increase artist auction results default end date

### DIFF
--- a/src/v2/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
+++ b/src/v2/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
@@ -2,6 +2,9 @@ import React, { useContext, useReducer, useState } from "react"
 import { omit } from "lodash"
 import useDeepCompareEffect from "use-deep-compare-effect"
 
+const MIN_START_DATE = 0
+const MAX_END_DATE = 10000
+
 export interface AuctionResultsFilters {
   organizations?: string[]
   categories?: string[]
@@ -21,8 +24,8 @@ interface AuctionResultsFiltersState extends AuctionResultsFilters {
  * Initial filter state
  */
 export const initialAuctionResultsFilterState = ({
-  startDate = null,
-  endDate = null,
+  startDate = MIN_START_DATE,
+  endDate = MAX_END_DATE,
 }: {
   startDate?: number | null
   endDate?: number | null

--- a/src/v2/Apps/Artist/artistRoutes.tsx
+++ b/src/v2/Apps/Artist/artistRoutes.tsx
@@ -9,6 +9,9 @@ import { paramsToCamelCase } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { initialAuctionResultsFilterState } from "./Routes/AuctionResults/AuctionResultsFilterContext"
 import { allowedAuctionResultFilters } from "./Utils/allowedAuctionResultFilters"
 
+const MIN_START_DATE = 0
+const MAX_END_DATE = 10000
+
 const ArtistApp = loadable(
   () => import(/* webpackChunkName: "artistBundle" */ "./ArtistApp"),
   {
@@ -154,8 +157,9 @@ export const artistRoutes: AppRouteConfig[] = [
           return {
             artistID,
             ...initialAuctionResultsFilterState({
-              startDate: 0,
-              endDate: 6000,
+              // Setting start date and min date here because Relay fails when we don't pass any values.
+              startDate: MIN_START_DATE,
+              endDate: MAX_END_DATE,
             }),
             ...allowedAuctionResultFilters(urlFilterState),
           }

--- a/src/v2/Apps/Artist/artistRoutes.tsx
+++ b/src/v2/Apps/Artist/artistRoutes.tsx
@@ -157,7 +157,7 @@ export const artistRoutes: AppRouteConfig[] = [
           return {
             artistID,
             ...initialAuctionResultsFilterState({
-              // Setting start date and min date here because Relay fails when we don't pass any values.
+              // Setting start date and end date here because Relay fails when we don't pass any values.
               startDate: MIN_START_DATE,
               endDate: MAX_END_DATE,
             }),

--- a/src/v2/Apps/Artist/artistRoutes.tsx
+++ b/src/v2/Apps/Artist/artistRoutes.tsx
@@ -9,9 +9,6 @@ import { paramsToCamelCase } from "v2/Components/ArtworkFilter/Utils/urlBuilder"
 import { initialAuctionResultsFilterState } from "./Routes/AuctionResults/AuctionResultsFilterContext"
 import { allowedAuctionResultFilters } from "./Utils/allowedAuctionResultFilters"
 
-const MIN_START_DATE = 0
-const MAX_END_DATE = 10000
-
 const ArtistApp = loadable(
   () => import(/* webpackChunkName: "artistBundle" */ "./ArtistApp"),
   {
@@ -156,11 +153,7 @@ export const artistRoutes: AppRouteConfig[] = [
 
           return {
             artistID,
-            ...initialAuctionResultsFilterState({
-              // Setting start date and end date here because Relay fails when we don't pass any values.
-              startDate: MIN_START_DATE,
-              endDate: MAX_END_DATE,
-            }),
+            ...initialAuctionResultsFilterState({}),
             ...allowedAuctionResultFilters(urlFilterState),
           }
         },

--- a/src/v2/Apps/Artist/artistRoutes.tsx
+++ b/src/v2/Apps/Artist/artistRoutes.tsx
@@ -155,7 +155,7 @@ export const artistRoutes: AppRouteConfig[] = [
             artistID,
             ...initialAuctionResultsFilterState({
               startDate: 0,
-              endDate: 0,
+              endDate: 6000,
             }),
             ...allowedAuctionResultFilters(urlFilterState),
           }


### PR DESCRIPTION
Addresses [CX-1874]

Increases artist auction result's default createdBeforeYear value to fix a bug where recent auction results were filtered out on initial load.

[CX-1874]: https://artsyproduct.atlassian.net/browse/CX-1874