### PR TITLE
fix: if we are in eigen, disable onetrust.

### DIFF
--- a/src/desktop/components/main_layout/templates/head.jade
+++ b/src/desktop/components/main_layout/templates/head.jade
@@ -1,5 +1,5 @@
 //- onetrust cookie consent, must be the first js loaded.
-if ( !sd.THIRD_PARTIES_DISABLED && sd.ONETRUST_SCRIPT_ID )
+if ( !sd.THIRD_PARTIES_DISABLED && !sd.EIGEN && sd.ONETRUST_SCRIPT_ID )
   script( src="https://cdn.cookielaw.org/consent/#{sd.ONETRUST_SCRIPT_ID}/OtAutoBlock.js", type="text/javascript" )
   script( src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js", type="text/javascript", charset="UTF-8", data-domain-script="#{sd.ONETRUST_SCRIPT_ID}" )
   script( type="text/javascript" ).

--- a/src/mobile/components/layout/templates/head.jade
+++ b/src/mobile/components/layout/templates/head.jade
@@ -1,5 +1,5 @@
 //- onetrust cookie consent, must be the first js loaded.
-if ( !sd.THIRD_PARTIES_DISABLED && sd.ONETRUST_SCRIPT_ID )
+if ( !sd.THIRD_PARTIES_DISABLED && !sd.EIGEN && sd.ONETRUST_SCRIPT_ID )
   script( src="https://cdn.cookielaw.org/consent/#{sd.ONETRUST_SCRIPT_ID}/OtAutoBlock.js", type="text/javascript" )
   script( src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js", type="text/javascript", charset="UTF-8", data-domain-script="#{sd.ONETRUST_SCRIPT_ID}" )
   script( type="text/javascript" ).

--- a/src/v2/index.ejs
+++ b/src/v2/index.ejs
@@ -4,7 +4,7 @@
 <head>
 
   <!-- onetrust cookie consent, must be the first js loaded -->
-  <%% if ( !disable.onetrust && !sd.THIRD_PARTIES_DISABLED && sd.ONETRUST_SCRIPT_ID ) { %>
+  <%% if ( !disable.onetrust && !sd.THIRD_PARTIES_DISABLED && !sd.EIGEN && sd.ONETRUST_SCRIPT_ID ) { %>
     <script src="https://cdn.cookielaw.org/consent/<%%= sd.ONETRUST_SCRIPT_ID %>/OtAutoBlock.js" type="text/javascript" >
     </script>
     <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="<%%= sd.ONETRUST_SCRIPT_ID %>" >


### PR DESCRIPTION
We [released](https://github.com/artsy/force/pull/7841) Cookie Consent to staging, and [it's noticed](https://artsy.slack.com/archives/CA8SANW3W/p1630595596158400) that the banner is being shown in mobile app's webviews. We are not ready to implement Consent in the app, so let's disable.