### PR TITLE
feature: Redis Page Cache

### DIFF
--- a/src/lib/cacheClient.tsx
+++ b/src/lib/cacheClient.tsx
@@ -1,5 +1,6 @@
 import createLogger from "v2/Utils/logger"
 import { cache as artsyCache } from "./cache"
+
 interface RedisCache {
   get: (key: string) => Promise<string>
   set: (

--- a/src/lib/middleware/memoryPageCache.ts
+++ b/src/lib/middleware/memoryPageCache.ts
@@ -9,14 +9,18 @@ import {
   MEMORY_PAGE_CACHE_TTL_MINUTES,
   MEMORY_PAGE_CACHE_LIMIT,
 } from "../../config"
+import {
+  attachResponseHandler,
+  attachResponseRecorder,
+} from "./pageCacheCommon"
 
-const debugLog = util.debuglog("cache")
+const debugLog = util.debuglog("memoryCache")
 
 const ENABLED_AB_TESTS = Object.keys(
   require("desktop/components/split_test/running_tests.coffee")
 ).sort()
 
-const memCache = new MemoryCache({
+const memoryCache = new MemoryCache({
   maxKeys: MEMORY_PAGE_CACHE_LIMIT,
   stdTTL: MEMORY_PAGE_CACHE_TTL_MINUTES,
 })
@@ -60,35 +64,17 @@ export function memoryPageCacheMiddleware(
   // originalUrl includes the request parameters.
   // http://expressjs.com/en/api.html#req.originalUrl
   const cacheKey = `${abTestPrefix},${req.originalUrl}`
-  const cachedRes = memCache.has(cacheKey)
-    ? memCache.get<Buffer>(cacheKey)
+  const cachedRes = memoryCache.has(cacheKey)
+    ? memoryCache.get<Buffer>(cacheKey)
     : undefined
 
   let sentCachedResponse = false
-  const chunks: Buffer[] = []
   if (!cachedRes) {
-    const defaultWrite = res.write
-    const defaultEnd = res.end
-
-    // @ts-ignore
-    res.write = (...restArgs) => {
-      if (restArgs[0]) {
-        chunks.push(new Buffer(restArgs[0]))
-      }
-      defaultWrite.apply(res, restArgs)
-    }
-
-    // @ts-ignore
-    res.end = (...restArgs) => {
-      if (restArgs.length > 1 && restArgs[0]) {
-        chunks.push(new Buffer(restArgs[0]))
-      }
-      defaultEnd.apply(res, restArgs)
-    }
+    attachResponseRecorder(res)
   }
 
   // Register callback to write rendered page data to cache.
-  res.once("finish", () => {
+  attachResponseHandler(res, (body, res) => {
     if (res._headers["content-type"] !== "text/html; charset=utf-8") {
       return
     }
@@ -98,21 +84,20 @@ export function memoryPageCacheMiddleware(
 
     if (!sentCachedResponse) {
       debugLog(`[Mem Cache]: Writing to cache ${cacheKey}`)
-      const body = Buffer.concat(chunks)
-      memCache.set(cacheKey, body)
-      memCache.logStats()
+      memoryCache.set(cacheKey, body)
+      memoryCache.logStats()
     } else {
       debugLog(`[Mem Cache]: Refreshing cache ${cacheKey}`)
-      memCache.refresh(cacheKey)
+      memoryCache.refresh(cacheKey)
     }
   })
 
   if (cachedRes) {
     debugLog(`[Mem Cache]: Reading from cache ${cacheKey}`)
     sentCachedResponse = true
-    setTimingHeader(res, "cacheHit")
+    setTimingHeader(res, "memoryCacheHit")
     return res.send(cachedRes.toString("utf-8"))
   }
-  setTimingHeader(res, "cacheMiss")
+  setTimingHeader(res, "memoryCacheMiss")
   next()
 }

--- a/src/lib/middleware/pageCacheCommon.ts
+++ b/src/lib/middleware/pageCacheCommon.ts
@@ -1,0 +1,50 @@
+import type { ArtsyResponse } from "./artsyExpress"
+
+export type CacheRecorder = (body: Buffer, res: ArtsyResponse) => void
+
+// The buffer to store the response.
+const chunks: Buffer[] = []
+
+/**
+ * We only want to attach one response recorder in the event that there are
+ * multiple response handlers.
+ */
+let responseHandlerAttached = false
+export const attachResponseRecorder = (res: ArtsyResponse) => {
+  if (responseHandlerAttached) return
+
+  const defaultWrite = res.write
+  const defaultEnd = res.end
+
+  // @ts-ignore
+  res.write = (...restArgs) => {
+    if (restArgs[0]) {
+      chunks.push(new Buffer(restArgs[0]))
+    }
+    defaultWrite.apply(res, restArgs)
+  }
+
+  // @ts-ignore
+  res.end = (...restArgs) => {
+    if (restArgs.length > 1 && restArgs[0]) {
+      chunks.push(new Buffer(restArgs[0]))
+    }
+    defaultEnd.apply(res, restArgs)
+  }
+
+  responseHandlerAttached = true
+}
+
+/**
+ * Attaches a response handler that will receive the response output when the
+ * request is completed.
+ */
+export const attachResponseHandler = (
+  res: ArtsyResponse,
+  cb: CacheRecorder
+) => {
+  res.once("finish", () => {
+    const body = Buffer.concat(chunks)
+    cb(body, res)
+  })
+}

--- a/src/lib/middleware/redisPageCache.ts
+++ b/src/lib/middleware/redisPageCache.ts
@@ -1,8 +1,9 @@
 import type { NextFunction } from "express"
 import type { ArtsyRequest, ArtsyResponse } from "./artsyExpress"
 
-import { getContextPageFromReq } from "lib/getContextPage"
-import { cache } from "lib/cache"
+import { setTimingHeader } from "./serverTimingHeaders"
+import { getContextPageFromReq } from "../getContextPage"
+import { cache } from "../cache"
 import {
   PAGE_CACHE_ENABLED,
   PAGE_CACHE_EXPIRY_SECONDS,
@@ -11,102 +12,141 @@ import {
   PAGE_CACHE_TYPES,
   PAGE_CACHE_VERSION,
 } from "../../config"
+import {
+  attachResponseHandler,
+  attachResponseRecorder,
+} from "./pageCacheCommon"
+import util from "util"
 
-const runningTests = Object.keys(
+const debugLog = util.debuglog("redisCache")
+
+const ENABLED_AB_TESTS = Object.keys(
   require("desktop/components/split_test/running_tests.coffee")
 ).sort()
 const cacheablePageTypes: string[] = PAGE_CACHE_TYPES.split("|")
 
 // Middleware will `next` and do nothing if any of the following is true:
 //
-// * page cache feature is disabled.
-// * a user is signed in.
-// * this isnt a supported cacheable path (there is an allow-list set in ENV).
-// * the page content is uncached.
-// * the cache errors.
-export async function pageCacheMiddleware(
+// - A page is not a GET request
+// - A user is signed in
+// - The page type is not enabled.
+//
+// If the page is cachable there are two flows:
+//
+// If the page is not in the cache, then the response will be recorded for the
+// next request.
+//
+// If the page is in the cache, then an attempt to retrieve serve the response
+// from redis will be made and if successful then the response will be served.
+// Otherwise it will be recored.
+export function redisPageCacheMiddleware(
   req: ArtsyRequest,
   res: ArtsyResponse,
   next: NextFunction
 ) {
   if (!PAGE_CACHE_ENABLED) return next()
 
+  // Only cache GETS
+  if (req.method.toLowerCase() !== "get") {
+    debugLog(`[Redis Page Cache]: Skipping method not GET ${req.method}`)
+    return next()
+  }
+
+  // Skip authenticated users.
+  if (!!req.user) {
+    debugLog("[Redis Page Cache]: Skipping authenticated")
+    return next()
+  }
+
   // Returns true if the page type corresponding to `url` is configured cacheable.
   const isCacheablePageType = (req: ArtsyRequest) => {
     const { pageType } = getContextPageFromReq(req)
-
     return cacheablePageTypes.includes(pageType)
   }
   if (!isCacheablePageType(req)) return next()
 
-  const hasUser = !!req.user
-  if (hasUser) return next()
-
   // Generate cache key that includes all currently running AB tests and outcomes.
-  const runningTestsCacheKey = runningTests
-    .map(test => {
+  const abTestPrefix =
+    ENABLED_AB_TESTS.map(test => {
       const outcome = res.locals.sd[test.toUpperCase()]
       return `${test}:${outcome}`
-    })
-    .join("|")
+    }).join("|") || "none"
 
   // `key` should be a full URL w/ query params, and not a path.
   // This is to separate URL's like `/collect` and `/collect?acquireable=true`.
   const cacheKey = (key: string) => {
-    return [PAGE_CACHE_NAMESPACE, runningTestsCacheKey, PAGE_CACHE_VERSION, key]
+    return [PAGE_CACHE_NAMESPACE, abTestPrefix, PAGE_CACHE_VERSION, key]
       .filter(Boolean)
       .join("|")
   }
 
-  // `key` is the full URL.
-  const cacheHtmlForPage = ({ status, key, html }) => {
-    if (status !== 200) return
-
-    cache.set(cacheKey(key), html, PAGE_CACHE_EXPIRY_SECONDS)
-  }
-
   const cacheKeyForRequest = cacheKey(req.url)
 
-  // Register callback to write rendered page data to cache.
-  res.once("finish", () => {
-    if (res.locals.PAGE_CACHE) {
-      // eslint-disable-next-line no-console
-      console.log(`[Page Cache]: Writing ${cacheKeyForRequest} to cache`)
-      cacheHtmlForPage(res.locals.PAGE_CACHE)
+  // Ensure the response is recored and Rregister callback to write page data
+  // to the cache.
+  let cachedResponseServed = false
+  attachResponseRecorder(res)
+  attachResponseHandler(res, (body: Buffer, res: ArtsyResponse) => {
+    // Do not recache a cached response.
+    // TODO: Possibly refresh the ttl
+    if (cachedResponseServed) {
+      return
     }
+
+    if (res._headers["content-type"] !== "text/html; charset=utf-8") {
+      return
+    }
+    if (res.statusCode !== 200) {
+      return
+    }
+
+    debugLog(`[Redis Page Cache]: Writing ${cacheKeyForRequest} to cache`)
+    cache.set(cacheKeyForRequest, body, PAGE_CACHE_EXPIRY_SECONDS)
   })
 
-  try {
-    await new Promise<void>((resolve, reject) => {
-      // Cache timeout handler, will reject if hit.
-      let timeoutId = setTimeout(() => {
-        // @ts-expect-error STRICT_NULL_CHECK
-        timeoutId = null
-        const error = new Error(
-          `Timeout of ${PAGE_CACHE_RETRIEVAL_TIMEOUT_MS}ms, skipping...`
-        )
-        reject(error)
-      }, PAGE_CACHE_RETRIEVAL_TIMEOUT_MS)
+  new Promise<void>((resolve, reject) => {
+    // Cache timeout handler, will reject if hit.
+    let timeoutId: NodeJS.Timeout | null = setTimeout(() => {
+      timeoutId = null
+      setTimingHeader(res, "redisCacheMiss")
+      const error = new Error(
+        `Timeout of ${PAGE_CACHE_RETRIEVAL_TIMEOUT_MS}ms, skipping...`
+      )
+      reject(error)
+    }, PAGE_CACHE_RETRIEVAL_TIMEOUT_MS)
 
-      const handleCacheGet = (_err, html) => {
-        if (!timeoutId) return // Already timed out.
-
-        clearTimeout(timeoutId)
-
-        if (html) {
-          // eslint-disable-next-line no-console
-          console.log(`[Page Cache]: Reading ${cacheKeyForRequest} from cache`)
-          return res.send(html)
-        }
-
-        resolve()
+    // Redis callback
+    const handleCacheGet = (err, html) => {
+      if (err) {
+        setTimingHeader(res, "redisCacheMiss")
+        reject(err)
+        return
       }
 
-      cache.get(cacheKey(req.url), handleCacheGet)
+      // Already timed out.
+      if (!timeoutId) {
+        return
+      }
+
+      clearTimeout(timeoutId)
+
+      if (html) {
+        debugLog(`[Redis Page Cache]: Reading ${cacheKeyForRequest} from cache`)
+        cachedResponseServed = true
+        setTimingHeader(res, "redisCacheHit")
+        return res.send(html.toString("utf-8"))
+      }
+
+      setTimingHeader(res, "redisCacheMiss")
+      resolve()
+    }
+
+    cache.get(cacheKeyForRequest, handleCacheGet)
+  })
+    .catch(e => {
+      debugLog(`[Redis Page Cache Middleware]: ${e.message}`)
     })
-  } catch (e) {
-    console.error(`[Page Cache Middleware]: ${e.message}`)
-  } finally {
-    next()
-  }
+    .finally(() => {
+      next()
+    })
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -58,7 +58,7 @@ import { downcaseMiddleware } from "./lib/middleware/downcase"
 import { hardcodedRedirectsMiddleware } from "./lib/middleware/hardcodedRedirects"
 import { localsMiddleware } from "./lib/middleware/locals"
 import { marketingModalsMiddleware } from "./lib/middleware/marketingModals"
-import { pageCacheMiddleware } from "./lib/middleware/redisPageCache"
+import { redisPageCacheMiddleware } from "./lib/middleware/redisPageCache"
 import { sameOriginMiddleware } from "./lib/middleware/sameOrigin"
 import { unsupportedBrowserMiddleware } from "./lib/middleware/unsupportedBrowser"
 import { backboneSync } from "lib/backboneSync"
@@ -284,6 +284,6 @@ function applyCacheMiddleware(app) {
     })
   }
 
-  app.use(pageCacheMiddleware)
+  app.use(redisPageCacheMiddleware)
   app.use(cachableRoutes, memoryPageCacheMiddleware)
 }

--- a/src/v2/Utils/logger.ts
+++ b/src/v2/Utils/logger.ts
@@ -1,6 +1,6 @@
 import { sendErrorToService } from "v2/Utils/errors"
 
-export const shouldCaptureError = (environment: string) =>
+export const shouldCaptureError = (environment: string = "development") =>
   environment === "staging" || environment === "production"
 
 export default function createLogger(namespace = "") {
@@ -17,7 +17,6 @@ export default function createLogger(namespace = "") {
     error: (...errors) => {
       const error = errors.find(e => e instanceof Error)
 
-      // @ts-expect-error STRICT_NULL_CHECK
       if (error && shouldCaptureError(process.env.NODE_ENV)) {
         sendErrorToService(error)
       }


### PR DESCRIPTION
Updates the existing redis page cache to record responses from the new
server middleware architecture, this code previously no longer worked.

See previous PR for additional details:

https://github.com/artsy/force/pull/5047