### PR TITLE
(PLATFORM-3537) feat: login form supports on-demand otp

### DIFF
--- a/src/v2/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/v2/Components/Authentication/Desktop/LoginForm.tsx
@@ -24,8 +24,8 @@ interface ConditionalOtpInputProps {
 }
 
 const ConditionalOtpInput: React.FC<ConditionalOtpInputProps> = props => {
-  const [showOtpInput, setShowOtpInput] = useState(false)
-  const [showOtpOnDemandPrompt, setShowOtpOnDemandPrompt] = useState(false)
+  const [showOtpInput, setShowOtpInput] = useState(true)
+  const [showOtpOnDemandPrompt, setShowOtpOnDemandPrompt] = useState(true)
   const {
     errors,
     values,
@@ -48,7 +48,7 @@ const ConditionalOtpInput: React.FC<ConditionalOtpInputProps> = props => {
     <>
       {showOtpOnDemandPrompt && (
         <Message>
-          This login requires additional authroization. Please check your email
+          This login requires additional authorization. Please check your email
           for a one-time authentication code.
         </Message>
       )}

--- a/src/v2/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/v2/Components/Authentication/Desktop/LoginForm.tsx
@@ -24,8 +24,8 @@ interface ConditionalOtpInputProps {
 }
 
 const ConditionalOtpInput: React.FC<ConditionalOtpInputProps> = props => {
-  const [showOtpInput, setShowOtpInput] = useState(true)
-  const [showOtpOnDemandPrompt, setShowOtpOnDemandPrompt] = useState(true)
+  const [showOtpInput, setShowOtpInput] = useState(false)
+  const [showOtpOnDemandPrompt, setShowOtpOnDemandPrompt] = useState(false)
   const {
     errors,
     values,

--- a/src/v2/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/v2/Components/Authentication/Desktop/LoginForm.tsx
@@ -17,7 +17,10 @@ import QuickInput from "v2/Components/QuickInput"
 import { Formik, FormikProps, useFormikContext } from "formik"
 import React, { Component, useEffect, useState } from "react"
 import { recaptcha } from "v2/Utils/recaptcha"
-import { isOtpError } from "v2/Components/Authentication/helpers"
+import {
+  isOtpError,
+  isMissingOnDemandOtpError,
+} from "v2/Components/Authentication/helpers"
 
 interface ConditionalOtpInputProps {
   error: string
@@ -36,12 +39,8 @@ const ConditionalOtpInput: React.FC<ConditionalOtpInputProps> = props => {
   const { error } = props
 
   if (!showOtpInput) {
-    if (error === "missing two-factor authentication code") {
-      setShowOtpInput(true)
-    } else if (error === "missing on-demand authentication code") {
-      setShowOtpInput(true)
-      setShowOtpOnDemandPrompt(true)
-    }
+    if (isOtpError(error)) setShowOtpInput(true)
+    if (isMissingOnDemandOtpError(error)) setShowOtpOnDemandPrompt(true)
   }
 
   return (

--- a/src/v2/Components/Authentication/Desktop/LoginForm.tsx
+++ b/src/v2/Components/Authentication/Desktop/LoginForm.tsx
@@ -78,6 +78,10 @@ export interface LoginFormState {
   otpRequired: boolean
 }
 
+interface SubmitValues extends InputValues {
+  otpRequired: boolean
+}
+
 export class LoginForm extends Component<FormProps, LoginFormState> {
   state = {
     error: this.props.error,
@@ -94,8 +98,11 @@ export class LoginForm extends Component<FormProps, LoginFormState> {
         isLoading: true,
       },
       () => {
-        values.otpRequired = this.state.otpRequired
-        this.props.handleSubmit?.(values, formikBag)
+        const submitValues: SubmitValues = {
+          ...values,
+          otpRequired: this.state.otpRequired,
+        }
+        this.props.handleSubmit?.(submitValues, formikBag)
       }
     )
   }

--- a/src/v2/Components/Authentication/Types.ts
+++ b/src/v2/Components/Authentication/Types.ts
@@ -12,7 +12,6 @@ export interface InputValues {
   email?: string
   password?: string
   otp_attempt?: string
-  otpRequired?: boolean
   accepted_terms_of_service?: boolean
   agreed_to_receive_emails?: boolean
 }

--- a/src/v2/Components/Authentication/helpers.ts
+++ b/src/v2/Components/Authentication/helpers.ts
@@ -1,6 +1,7 @@
 import { helpersEmailQuery } from "v2/__generated__/helpersEmailQuery.graphql"
 import { graphql } from "react-relay"
 import { fetchQuery } from "relay-runtime"
+import { errorMessageForBidding } from "v2/Apps/Auction/Components/Form"
 
 export const handleSubmit = (
   url: string,
@@ -82,4 +83,10 @@ export const isOtpError = (errorMessage: string): boolean => {
   ]
 
   return otpErrorMessages.includes(errorMessage)
+}
+
+export const isMissingOnDemandOtpError = (errorMessage: string): boolean => {
+  const missingOnDemandOtpError = "missing on-demand authentication code"
+
+  return errorMessage === missingOnDemandOtpError
 }

--- a/src/v2/Components/Authentication/helpers.ts
+++ b/src/v2/Components/Authentication/helpers.ts
@@ -74,3 +74,12 @@ export const checkEmail = ({
     }
   })
 }
+
+export const isOtpError = (errorMessage: string): boolean => {
+  const otpErrorMessages = [
+    "missing two-factor authentication code",
+    "missing on-demand authentication code",
+  ]
+
+  return otpErrorMessages.includes(errorMessage)
+}

--- a/src/v2/Components/Authentication/helpers.ts
+++ b/src/v2/Components/Authentication/helpers.ts
@@ -1,7 +1,6 @@
 import { helpersEmailQuery } from "v2/__generated__/helpersEmailQuery.graphql"
 import { graphql } from "react-relay"
 import { fetchQuery } from "relay-runtime"
-import { errorMessageForBidding } from "v2/Apps/Auction/Components/Form"
 
 export const handleSubmit = (
   url: string,


### PR DESCRIPTION
This PR enables Force to handle on-demand otp related errors, which were enabled in Gravity in this [PR](https://github.com/artsy/gravity/pull/14395/files).

When we are ready to enable this functionality we will set `enforces_on_demand_otp` to `true` on the `ClientApplicaiton`. This will be tested out in staging before being set on production.

When an on-demand otp is required from the User, they will see the following prompt:
<img width="360" alt="Screen Shot 2021-09-03 at 3 10 34 PM" src="https://user-images.githubusercontent.com/38149304/132055346-63014a7f-74d2-4f43-b97b-10fc7083835c.png">






