### PR TITLE
Fix: Refresh conversation page on modal close

### DIFF
--- a/src/v2/Apps/Conversation/Components/Conversation.tsx
+++ b/src/v2/Apps/Conversation/Components/Conversation.tsx
@@ -228,7 +228,10 @@ const Conversation: React.FC<ConversationProps> = props => {
           orderID={orderID}
           title={modalTitle!}
           show={showOrderModal}
-          closeModal={() => setShowOrderModal(false)}
+          closeModal={() => {
+            refreshData()
+            setShowOrderModal(false)
+          }}
         />
       )}
     </Flex>


### PR DESCRIPTION
# PURCHASE-2881

paired with @copperkraft 

No status refresh after seller accepts or declines an offer

Current behaviour:

Given a seller made an offer,
And the buyer made a counteroffer,
When the seller declines or accepts the counteroffer,
Then  you close the counteroffer review modal,
And the conversation page does not refresh,
And the "counteroffer received" status persists until manual refresh.

Improved behaviour:

Given a seller made an offer,
And the buyer made a counteroffer,
When the seller declines or accepts the counteroffer,
Then you close the counteroffer review modal,
And the conversation page refreshes,
And the "counteroffer received" status changes into "Offer declined" or "Offer accepted" accordingly.