### PR TITLE
fix: use sharify instance from res.locals (PURCHASE-2924)

### DIFF
--- a/src/v2/server.ts
+++ b/src/v2/server.ts
@@ -1,4 +1,3 @@
-import sharify from "sharify"
 import type { NextFunction } from "express"
 import type { ArtsyRequest, ArtsyResponse } from "lib/middleware/artsyExpress"
 import { buildServerApp } from "v2/System/Router/server"
@@ -56,7 +55,7 @@ app.get(
       }
 
       const headTagsString = ReactDOM.renderToString(headTags as any)
-      const sharifyData = res.locals.sharify.script()
+      const sharify = res.locals.sharify
 
       const { APP_URL, CURRENT_PATH, WEBFONT_URL } = sharify.data
 
@@ -64,7 +63,7 @@ app.get(
         cdnUrl: NODE_ENV === "production" ? CDN_URL : "",
         content: {
           body: bodyHTML,
-          data: sharifyData,
+          data: sharify.script(),
           head: headTagsString,
           scripts,
           style: styleTags,


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/PURCHASE-2924

The [previous attempt](https://github.com/artsy/force/pull/8345) to exclude cookie consents JS for Eigen didn't work. The reason was that we [used a new instance of sharify](https://github.com/artsy/force/blob/07ddb110a241bebb9e948493321d81f5fef0e1a7/src/v2/server.ts#L96), which didn't go through the [bootstrap process](https://github.com/artsy/force/blob/6045498ca44242ca0d556b67f94ac24dc00d8074/src/middleware.ts#L106) that `res.locals.sharify` did. Therefore, `sd.Eigen` wasn't present.

This updates the use of sharify in v2 server to always use the instance from `res.locals.sharify`, instead of importing a new instance again. Looks like this also fixes `CURRENT_PATH` that `apple-itunes-app` meta tag relies on.

![cookie-consents-app](https://user-images.githubusercontent.com/796573/132390460-aa311bc9-d8f9-4abd-801b-aca1143b07d4.gif)
